### PR TITLE
docs(arch): document guard report evidence

### DIFF
--- a/docs/development/TOOLING.md
+++ b/docs/development/TOOLING.md
@@ -29,9 +29,24 @@ Python-based architecture guard that validates import patterns across the entire
 # Run the guard
 python3 scripts/arch/arch_guard.py
 
+# Emit machine-readable guard status
+python3 scripts/arch/arch_guard.py --json
+
+# Persist a report artifact while preserving the guard exit code
+python3 scripts/arch/arch_guard.py --json-report artifacts/arch_guard_report.json
+
+# Render the CheckerContext field lifetime manifest
+python3 scripts/arch/arch_guard.py --checker-context-lifetime-table
+
 # Run its test suite
 python3 scripts/arch/test_arch_guard.py
 ```
+
+The JSON payload includes `status`, `arch_guard_status`, git context, total
+matched debt, and per-check failures. Use `--json-report` for CI artifacts or
+PR evidence when changing boundary ratchets, LSP/WASM/compiler-service
+front-door rules, checker context lifetime ownership, or output-surgery-adjacent
+architecture caps.
 
 ### `scripts/arch/render_architecture_report.py`
 


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Architecture guardrail / compiler-service boundary evidence documentation.

## Invariant
When architecture, LSP/WASM/compiler-service, checker-context lifetime, or boundary-ratchet work needs evidence, the documented tooling should point to the structured `arch_guard.py` report modes that already preserve guard status and git context.

## Scope
- Document `python3 scripts/arch/arch_guard.py --json`.
- Document `python3 scripts/arch/arch_guard.py --json-report artifacts/arch_guard_report.json`.
- Document `python3 scripts/arch/arch_guard.py --checker-context-lifetime-table`.
- Clarify what the JSON payload is meant to support in PR/CI evidence.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs-only architecture tooling guidance; no compiler behavior, project-row metadata, benchmark execution, or emit output path changes.

## Verification
- `python3 scripts/arch/arch_guard.py --json > /tmp/tsz-arch-guard-stdout.json` plus JSON parse of `status`, `arch_guard_status`, `failure_count`, and `failed_hit_count`
- `python3 scripts/arch/arch_guard.py --json-report /tmp/tsz-arch-guard-report.json`
- `python3 scripts/arch/arch_guard.py --checker-context-lifetime-table | sed -n '1,5p'`
- `git diff --check`
- `wc -l docs/development/TOOLING.md`

## Coordination Notes
- Overlap checked against open PRs: only #12411 remains open and is Studio-C emit work; this PR is docs-only architecture tooling guidance.
- `scripts/agents/ensure-agent-labels.sh --audit` passes with no findings.
- Ready for docs/architecture tooling review once CI is green.
