### PR TITLE
fix(emit): scope private destructuring receiver prealloc

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/constructor_temp_estimation.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/constructor_temp_estimation.rs
@@ -23,6 +23,184 @@ impl<'a> Printer<'a> {
         }
     }
 
+    pub(in crate::emitter) fn estimate_private_destructuring_receiver_temps_in_function_body(
+        &self,
+        node: &Node,
+    ) -> usize {
+        match node.kind {
+            kind if kind == syntax_kind_ext::BLOCK => {
+                let Some(block) = self.arena.get_block(node) else {
+                    return 0;
+                };
+                block
+                    .statements
+                    .nodes
+                    .iter()
+                    .map(|&stmt_idx| {
+                        self.estimate_private_destructuring_receiver_temps_in_statement(stmt_idx)
+                    })
+                    .sum()
+            }
+            _ => 0,
+        }
+    }
+
+    fn estimate_private_destructuring_receiver_temps_in_statement(
+        &self,
+        stmt_idx: NodeIndex,
+    ) -> usize {
+        let Some(stmt_node) = self.arena.get(stmt_idx) else {
+            return 0;
+        };
+
+        match stmt_node.kind {
+            kind if kind == syntax_kind_ext::EXPRESSION_STATEMENT => {
+                let Some(expr_stmt) = self.arena.get_expression_statement(stmt_node) else {
+                    return 0;
+                };
+                self.estimate_private_destructuring_receiver_temps_in_expression(
+                    expr_stmt.expression,
+                )
+            }
+            kind if kind == syntax_kind_ext::BLOCK => {
+                self.estimate_private_destructuring_receiver_temps_in_function_body(stmt_node)
+            }
+            _ => 0,
+        }
+    }
+
+    fn estimate_private_destructuring_receiver_temps_in_expression(
+        &self,
+        node_idx: NodeIndex,
+    ) -> usize {
+        let Some(node) = self.arena.get(node_idx) else {
+            return 0;
+        };
+        match node.kind {
+            kind if kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
+                let Some(paren) = self.arena.get_parenthesized(node) else {
+                    return 0;
+                };
+                self.estimate_private_destructuring_receiver_temps_in_expression(paren.expression)
+            }
+            kind if kind == syntax_kind_ext::BINARY_EXPRESSION => {
+                let Some(binary) = self.arena.get_binary_expr(node) else {
+                    return 0;
+                };
+                if binary.operator_token == SyntaxKind::CommaToken as u16 {
+                    return self
+                        .estimate_private_destructuring_receiver_temps_in_expression(binary.left)
+                        + self.estimate_private_destructuring_receiver_temps_in_expression(
+                            binary.right,
+                        );
+                }
+                if binary.operator_token != SyntaxKind::EqualsToken as u16 {
+                    return 0;
+                }
+                let Some(left_node) = self.arena.get(binary.left) else {
+                    return 0;
+                };
+                if matches!(
+                    left_node.kind,
+                    syntax_kind_ext::ARRAY_BINDING_PATTERN
+                        | syntax_kind_ext::OBJECT_BINDING_PATTERN
+                        | syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+                        | syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                ) {
+                    self.estimate_native_private_destructuring_receiver_temps(binary.left)
+                } else {
+                    0
+                }
+            }
+            _ => 0,
+        }
+    }
+
+    fn estimate_native_private_destructuring_receiver_temps(&self, node_idx: NodeIndex) -> usize {
+        if node_idx.is_none() {
+            return 0;
+        }
+        if self.native_private_destructuring_receiver_needs_temp(node_idx) {
+            return 1;
+        }
+
+        let Some(node) = self.arena.get(node_idx) else {
+            return 0;
+        };
+        match node.kind {
+            kind if kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION => {
+                let Some(paren) = self.arena.get_parenthesized(node) else {
+                    return 0;
+                };
+                self.estimate_native_private_destructuring_receiver_temps(paren.expression)
+            }
+            kind if kind == syntax_kind_ext::TYPE_ASSERTION
+                || kind == syntax_kind_ext::AS_EXPRESSION
+                || kind == syntax_kind_ext::SATISFIES_EXPRESSION =>
+            {
+                let Some(assertion) = self.arena.get_type_assertion(node) else {
+                    return 0;
+                };
+                self.estimate_native_private_destructuring_receiver_temps(assertion.expression)
+            }
+            kind if kind == syntax_kind_ext::BINARY_EXPRESSION => {
+                let Some(binary) = self.arena.get_binary_expr(node) else {
+                    return 0;
+                };
+                if binary.operator_token == SyntaxKind::EqualsToken as u16 {
+                    self.estimate_native_private_destructuring_receiver_temps(binary.left)
+                } else {
+                    0
+                }
+            }
+            kind if kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+                || kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION =>
+            {
+                let Some(literal) = self.arena.get_literal_expr(node) else {
+                    return 0;
+                };
+                literal
+                    .elements
+                    .nodes
+                    .iter()
+                    .map(|&element| {
+                        self.estimate_native_private_destructuring_receiver_temps(element)
+                    })
+                    .sum()
+            }
+            kind if kind == syntax_kind_ext::OBJECT_BINDING_PATTERN
+                || kind == syntax_kind_ext::ARRAY_BINDING_PATTERN =>
+            {
+                let Some(pattern) = self.arena.get_binding_pattern(node) else {
+                    return 0;
+                };
+                pattern
+                    .elements
+                    .nodes
+                    .iter()
+                    .map(|&element| {
+                        self.estimate_native_private_destructuring_receiver_temps(element)
+                    })
+                    .sum()
+            }
+            kind if kind == syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                let Some(prop) = self.arena.get_property_assignment(node) else {
+                    return 0;
+                };
+                self.estimate_native_private_destructuring_receiver_temps(prop.initializer)
+            }
+            kind if kind == syntax_kind_ext::SPREAD_ELEMENT
+                || kind == syntax_kind_ext::SPREAD_ASSIGNMENT =>
+            {
+                let Some(spread) = self.arena.get_spread(node) else {
+                    return 0;
+                };
+                self.estimate_native_private_destructuring_receiver_temps(spread.expression)
+            }
+            _ => 0,
+        }
+    }
+
     fn estimate_constructor_assignment_temps_in_statement(&self, stmt_idx: NodeIndex) -> usize {
         let Some(stmt_node) = self.arena.get(stmt_idx) else {
             return 0;

--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -430,7 +430,7 @@ impl<'a> Printer<'a> {
             let prev_declared = std::mem::take(&mut self.declared_namespace_names);
             if let Some(body_node) = self.arena.get(method.body) {
                 let temp_count =
-                    self.estimate_assignment_destructuring_temps_in_constructor(body_node);
+                    self.estimate_private_destructuring_receiver_temps_in_function_body(body_node);
                 if temp_count > 0 {
                     self.preallocate_assignment_temps(temp_count);
                 }

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -221,6 +221,14 @@ impl<'a> Printer<'a> {
             })
     }
 
+    pub(in crate::emitter) fn native_private_destructuring_receiver_needs_temp(
+        &self,
+        idx: NodeIndex,
+    ) -> bool {
+        self.try_extract_private_field_access(idx)
+            .is_some_and(|access| !self.receiver_is_plain_identifier(access.expression))
+    }
+
     fn private_member_is_static(&self, clean_name: &str) -> bool {
         let Some((_, class_alias)) = self.private_static_class_alias.as_ref() else {
             return false;

--- a/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_tagged_template_tests.rs
@@ -349,6 +349,26 @@ class A {
 }
 
 #[test]
+fn instance_private_field_destructuring_method_keeps_plain_receiver_direct() {
+    let source = r#"
+class A {
+    #field;
+    static test(_a) {
+        [_a.#field] = [2];
+    }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES2015);
+
+    assert!(
+        output.contains(
+            "static test(_a) {\n        [({ set value(_b) { __classPrivateFieldSet(_a, _A_field, _b, \"f\"); } }).value] = [2];\n    }"
+        ),
+        "Instance private field destructuring in methods should not reserve a receiver temp for plain identifier receivers.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn static_private_async_generator_helpers_preserve_function_kind() {
     let source = r#"
 const Widget = class {


### PR DESCRIPTION
AgentName: Studio-C

## Track
Track 9 Emit JS regression fix

## Invariant
ES2015 private-field destructuring method preallocation reserves only receiver temps that native private destructuring lowering actually allocates. Plain identifier receivers stay direct so setter value temp names remain aligned with tsc, while constructor destructuring keeps its broader preallocation behavior.

## Scope
- Added a native private-destructuring receiver temp helper beside the existing broad constructor helper.
- Switched method-body private destructuring preallocation to count native receiver temps instead of constructor assignment temps.
- Added an emitter unit test for instance private destructuring in static methods with a plain identifier receiver.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit ES2015 private-field destructured-binding temp reservation regression
- Evidence: `scripts/emit/run.sh --js-only --filter=privateNameFieldDestructuredBinding --verbose --timeout=20000 --json-out=/tmp/studio-c-regress-private-name-binding-after3.json` passed 3/3; `scripts/emit/run.sh --js-only --filter=privateWriteOnlyAccessorRead --verbose --timeout=20000 --skip-build --json-out=/tmp/studio-c-private-write-after-native-prealloc.json` passed 1/1.

## Verification
- `cargo fmt --check`
- `scripts/emit/run.sh --js-only --filter=privateNameFieldDestructuredBinding --verbose --timeout=20000 --json-out=/tmp/studio-c-regress-private-name-binding-after3.json`
- `scripts/emit/run.sh --js-only --filter=privateWriteOnlyAccessorRead --verbose --timeout=20000 --skip-build --json-out=/tmp/studio-c-private-write-after-native-prealloc.json`
- `cargo nextest run -p tsz-emitter instance_private_field_destructuring_method_keeps_plain_receiver_direct private_accessor_object_rest_assignment_uses_setter_target`
- `git diff --check`

## Coordination Notes
AgentName: Studio-C. Fixes #12412 and preserves the #12407 target row `privateWriteOnlyAccessorRead`. This is intentionally narrow so #12408 and #12411 remain non-overlapping emit follow-ups.
