### PR TITLE
ci: refresh PR body gates on edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, edited]
   merge_group:
   push:
     branches:
@@ -71,6 +71,16 @@ jobs:
             required_summary=true
             compiler_checks_required=false
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            if [[ "${{ github.event.action }}" == "edited" ]]; then
+              # Body/title edits can repair AgentName, project-corpus, or WIP
+              # metadata without changing the PR head SHA. Refresh only the
+              # metadata gates so stale failed PR-body checks can clear without
+              # asking agents to push a no-op code commit.
+              echo "PR metadata edited — refreshing body/ready-state checks without heavy CI."
+              should_run=false
+              full_run=false
+              compiler_checks_required=false
+            fi
             # The `labeled` event triggers on every label add. We only care
             # about the `ci-approved` label (used to opt fork PRs into CI).
             # For any other label, this would just duplicate the existing

--- a/scripts/ci/test-pr-ready-state.mjs
+++ b/scripts/ci/test-pr-ready-state.mjs
@@ -10,6 +10,7 @@ import { normalizePullRequest, readyStateFailures } from "./check-pr-ready-state
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
 const SCRIPT = path.join(ROOT, "scripts", "ci", "check-pr-ready-state.mjs");
+const CI_WORKFLOW = path.join(ROOT, ".github", "workflows", "ci.yml");
 
 function readyPr(overrides = {}) {
   return {
@@ -129,3 +130,15 @@ const passingDraft = runFixture(readyPr({
 }));
 assert.equal(passingDraft.status, 0, passingDraft.stderr);
 assert.match(passingDraft.stdout, /Ready-state WIP check passed/);
+
+const ciWorkflow = fs.readFileSync(CI_WORKFLOW, "utf8");
+assert.match(
+  ciWorkflow,
+  /pull_request:\s*\n\s*types:\s*\[[^\]]*\bedited\b[^\]]*\]/,
+  "CI should rerun PR metadata gates after body/title edits",
+);
+assert.match(
+  ciWorkflow,
+  /github\.event\.action }}"\s*==\s*"edited"[\s\S]+?PR metadata edited[\s\S]+?should_run=false[\s\S]+?compiler_checks_required=false/,
+  "edited PR events should refresh body/ready-state gates without heavy CI",
+);


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Studio coordination / CI metadata-gate reliability.

## Invariant
When a ready PR fixes `AgentName`, Project Corpus Impact, title, or WIP/blocker metadata through a body/title edit, CI should refresh the PR-body and ready-state gates for the same head SHA without requiring a no-op code push or rerunning heavy compiler suites.

## Scope
- Add `edited` to the CI `pull_request` event types.
- Treat edited PR events as metadata-only in the CI gate (`should_run=false`, `full_run=false`, `compiler_checks_required=false`).
- Add focused assertions in `scripts/ci/test-pr-ready-state.mjs` to keep the edited-event trigger and metadata-only branch in place.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI metadata-gate only; no compiler behavior, project-row metadata, benchmark execution, or emit output path changes.

## Verification
- `node scripts/ci/test-pr-ready-state.mjs`
- `git diff --check`
- `wc -l .github/workflows/ci.yml scripts/ci/test-pr-ready-state.mjs`

## Coordination Notes
- Observed live Studio-C PR #12415 had a stale `project-corpus-pr-body` failure after its body was updated to include the required fields; this PR fixes the cross-lane CI trigger gap so future body/title repairs refresh the gate directly.
- Overlap checked against open PRs: #12415 and #12411 are Studio-C emit work; this PR only changes CI metadata-gate behavior and its test.
- `scripts/agents/ensure-agent-labels.sh --audit` passes with no findings.
