### PR TITLE
feat(emit): add output-surgery json stdout

### DIFF
--- a/docs/architecture/EMIT_ARCHITECTURE.md
+++ b/docs/architecture/EMIT_ARCHITECTURE.md
@@ -279,15 +279,16 @@ strings. Existing semantic output surgery is migration debt tracked by:
 
 ```bash
 python3 scripts/emit/audit-output-surgery.py
+python3 scripts/emit/audit-output-surgery.py --json
 python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery.json
 python3 scripts/emit/audit-output-surgery.py --fail-on-warnings
 ```
 
 The audit ratchets current debt by file and category. New semantic
 `replace`/`replacen`/`replace_range` usage must either remove existing debt or
-be explicitly categorized with a removal reason in the allowlist. Use the JSON
-report when CI or agent handoffs need machine-readable counts for
-unallowlisted, over-allowlist, and stale-allowlist failures. Use
+be explicitly categorized with a removal reason in the allowlist. Use JSON
+stdout or a JSON report when CI or agent handoffs need machine-readable counts
+for unallowlisted, over-allowlist, and stale-allowlist failures. Use
 `--fail-on-warnings` in debt-removal PRs or focused gates that need exhausted
 category/global budget pressure to fail even when every call is still
 allowlisted.
@@ -504,7 +505,7 @@ For any non-trivial emitter PR, ask:
 7. Does this maintain source map accuracy through `SourceWriter`?
 8. Does this keep new target logic in `EmitTargetFacts`/`EmitPlan` instead of
    scattering raw target gates?
-9. Does `python3 scripts/emit/audit-output-surgery.py --json-report <path>`
+9. Does `python3 scripts/emit/audit-output-surgery.py --json`
    still pass, or fail only with known ratcheted debt, without increasing
    output-surgery debt?
 

--- a/docs/development/TOOLING.md
+++ b/docs/development/TOOLING.md
@@ -56,6 +56,30 @@ Generates an HTML/text report of crate dependencies and boundary compliance.
 python3 scripts/arch/render_architecture_report.py
 ```
 
+### `scripts/emit/audit-output-surgery.py`
+
+Audits emitter string rewrites that change already-emitted JS/DTS output and
+tracks the ratcheted allowlist budget.
+
+```bash
+# Run the guard
+python3 scripts/emit/audit-output-surgery.py
+
+# Emit machine-readable output-surgery pressure
+python3 scripts/emit/audit-output-surgery.py --json
+
+# Persist a report artifact while preserving the guard exit code
+python3 scripts/emit/audit-output-surgery.py --json-report artifacts/output_surgery_report.json
+
+# Fail when allowlisted debt exhausts category/global pressure budget
+python3 scripts/emit/audit-output-surgery.py --fail-on-warnings
+```
+
+The JSON payload includes `status`, `output_surgery_status`, git context,
+allowlist budget counters, category pressure, failures, files, and individual
+findings. Use `--json` for direct agent/CI probes and `--json-report` when a PR
+or workflow needs an artifact.
+
 ## Quality And Performance Tooling
 
 These tools are additive guardrails. Normal PR CI keeps the fast path focused on

--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -545,6 +545,11 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--list", action="store_true", help="print all tracked findings")
     parser.add_argument(
+        "--json",
+        action="store_true",
+        help="print a machine-readable report to stdout",
+    )
+    parser.add_argument(
         "--json-report",
         type=pathlib.Path,
         help="write a machine-readable report before exiting",
@@ -562,11 +567,15 @@ def main(argv: list[str] | None = None) -> int:
     findings = scan()
     allowlist = load_allowlist()
     failures = audit(findings, allowlist)
+    json_report = build_json_report(findings, allowlist, failures)
 
     if args.json_report is not None:
-        write_json_report(args.json_report, build_json_report(findings, allowlist, failures))
+        write_json_report(args.json_report, json_report)
 
-    if args.list or failures:
+    if args.json:
+        print(json.dumps(json_report, indent=2, sort_keys=True))
+
+    if not args.json and (args.list or failures):
         print_report(findings, allowlist)
 
     if failures:
@@ -591,8 +600,9 @@ def main(argv: list[str] | None = None) -> int:
             print(f"  - {failure}", file=sys.stderr)
         return 1
 
-    pass_summary = format_pass_summary(findings, failures, allowlist)
-    print(pass_summary)
+    if not args.json:
+        pass_summary = format_pass_summary(findings, failures, allowlist)
+        print(pass_summary)
     file_summaries = build_file_summaries(grouped_counts(findings), allowlist)
     warnings = warning_failures(file_summaries)
     if args.fail_on_warnings and warnings:

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -434,6 +434,52 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         self.assertIn("warning_status=warn", stdout.getvalue())
         self.assertEqual(stderr.getvalue(), "")
 
+    def test_json_mode_writes_stdout_report_without_text_summary(self):
+        findings = [
+            self.audit.Finding("a.rs", 1, "replacen", "output = output.replacen(&a, &b, 1);"),
+        ]
+        allowlist = {
+            "a.rs": self.audit.AllowEntry("dts-output-surgery", 2, "existing debt"),
+        }
+
+        with (
+            patch.object(self.audit, "scan", return_value=findings),
+            patch.object(self.audit, "load_allowlist", return_value=allowlist),
+            patch.object(self.audit, "build_git_context", return_value={"head": "abc123"}),
+            redirect_stdout(io.StringIO()) as stdout,
+            redirect_stderr(io.StringIO()) as stderr,
+        ):
+            status = self.audit.main(["--json"])
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(status, 0)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["git_context"], {"head": "abc123"})
+        self.assertEqual(payload["allowlisted_calls"], 1)
+        self.assertNotIn("Output-surgery audit passed", stdout.getvalue())
+        self.assertEqual(stderr.getvalue(), "")
+
+    def test_json_mode_preserves_failure_exit_and_stderr_summary(self):
+        findings = [
+            self.audit.Finding("a.rs", 1, "replacen", "output = output.replacen(&a, &b, 1);"),
+        ]
+
+        with (
+            patch.object(self.audit, "scan", return_value=findings),
+            patch.object(self.audit, "load_allowlist", return_value={}),
+            patch.object(self.audit, "build_git_context", return_value={"head": "abc123"}),
+            redirect_stdout(io.StringIO()) as stdout,
+            redirect_stderr(io.StringIO()) as stderr,
+        ):
+            status = self.audit.main(["--json"])
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(status, 1)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["unallowlisted_calls"], 1)
+        self.assertNotIn("a.rs [UNALLOWLISTED]", stdout.getvalue())
+        self.assertIn("Output-surgery audit failed", stderr.getvalue())
+
     def test_write_json_report_creates_parent_and_writes_json(self):
         with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
             report_path = pathlib.Path(temp_dir) / "nested" / "report.json"


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 6 emit/DTS architecture tooling: output-surgery pressure evidence.

## Invariant
When Studio agents or CI need output-surgery pressure evidence, the existing audit report schema should be available directly from the audit owner without parsing human text; this PR exposes the emitter audit JSON on stdout while preserving the existing file report and exit-code behavior.

## Scope
- Add `--json` stdout mode to `scripts/emit/audit-output-surgery.py`.
- Cover clean and failing JSON stdout behavior in `scripts/emit/test_output_surgery_audit.py`.
- Document output-surgery audit JSON evidence in tooling and emit architecture docs.

## Project Corpus Impact
- Row: n/a
- Bug family: output-surgery pressure reporting
- Evidence: Tooling-only guardrail change; project row metadata and compiler behavior are unchanged. Cycle start row summary remained all 12 rows consistent across surfaces.

## Verification
- `python3 scripts/emit/test_output_surgery_audit.py`
- `python3 scripts/emit/audit-output-surgery.py --json > /tmp/tsz-output-surgery-stdout.json && python3 -m json.tool /tmp/tsz-output-surgery-stdout.json > /tmp/tsz-output-surgery-stdout.pretty.json && python3 - <<'PY' ... PY` (reported `passed passed 4 6 available`)
- `python3 scripts/emit/audit-output-surgery.py`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-report.json && python3 - <<'PY' ... PY` (reported `passed passed 2`)
- `git diff --check`
- `wc -l scripts/emit/audit-output-surgery.py scripts/emit/test_output_surgery_audit.py docs/development/TOOLING.md docs/architecture/EMIT_ARCHITECTURE.md`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- No overlap with Studio-C emit parity PRs #12415 and #12411; this is audit/reporting infrastructure only.
- Ready for normal CI/review on head `e53566f167`.