### PR TITLE
fix(checker): reset instantiation fuel between top-level statements (#10677)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -27,6 +27,16 @@ slow-timeout = { period = "120s", terminate-after = 2 }
 filter = 'test(/^no_false_ts2322_generic_conditional_default_/) | test(real_ts2322_is_still_reported_with_conditional_default) | test(explicit_third_arg_mismatch_still_errors)'
 threads-required = "num-test-threads"
 
+# Issue #10677 regression. Faithfully reproducing the per-file
+# instantiation-fuel exhaustion requires evaluating ~2000 generic Applications
+# of the kysely builder machinery before the target statement, so the test is
+# intentionally heavy. Give it the longer slow-timeout and run it alone to
+# avoid memory pressure from co-tenant heavy tests.
+[[profile.default.overrides]]
+filter = 'test(fuel_drained_earlier_statements_keep_select_callback_context)'
+slow-timeout = { period = "120s", terminate-after = 2 }
+threads-required = "num-test-threads"
+
 [profile.default.junit]
 path = "target/nextest/default/junit.xml"
 
@@ -47,6 +57,12 @@ slow-timeout = { period = "120s", terminate-after = 2 }
 
 [[profile.ci.overrides]]
 filter = 'test(/^no_false_ts2322_generic_conditional_default_/) | test(real_ts2322_is_still_reported_with_conditional_default) | test(explicit_third_arg_mismatch_still_errors)'
+threads-required = "num-test-threads"
+
+# Issue #10677 regression — see the matching default-profile override.
+[[profile.ci.overrides]]
+filter = 'test(fuel_drained_earlier_statements_keep_select_callback_context)'
+slow-timeout = { period = "120s", terminate-after = 2 }
 threads-required = "num-test-threads"
 
 # Quick profile for fast feedback during development

--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -2084,3 +2084,7 @@ path = "tests/type_guard_mutable_field_probe_tests.rs"
 [[test]]
 name = "index_signature_type_check_probe_tests"
 path = "tests/index_signature_type_check_probe_tests.rs"
+
+[[test]]
+name = "fuel_budget_callback_context_tests"
+path = "tests/fuel_budget_callback_context_tests.rs"

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -420,6 +420,19 @@ impl<'a> CheckerState<'a> {
             // diagnostics (issue #12144).  The inner worklist guards inside
             // `ensure_refs_resolved` still bound the work per statement.
             crate::state_domain::type_environment::lazy::reset_global_resolution_fuel();
+            // Likewise reset the session's generic-instantiation fuel between
+            // top-level statements. This budget (`MAX_GLOBAL_INSTANTIATION_FUEL`)
+            // is cumulative per file, so a statement that performs heavy generic
+            // Application evaluation (deep builder/query chains, large keyof
+            // unions) can exhaust it and leave `instantiation_limits_exceeded()`
+            // true for every following statement. When that happens, contextual
+            // typing of later callback arguments bails to `any`, which spuriously
+            // strips parameter context (TS7006) and then reports TS2347 on the
+            // now-"untyped" generic calls inside the callback (issue #10677). The
+            // per-context `MAX_INSTANTIATION_DEPTH` and session depth limit still
+            // bound the work performed within any single statement.
+            self.ctx.eval_session.reset_instantiation_fuel();
+            self.ctx.depth_exceeded.set(false);
             self.check_statement(stmt_idx);
             if !self.statement_falls_through(stmt_idx) {
                 self.ctx.is_unreachable = true;

--- a/crates/tsz-checker/tests/fuel_budget_callback_context_tests.rs
+++ b/crates/tsz-checker/tests/fuel_budget_callback_context_tests.rs
@@ -1,0 +1,111 @@
+//! Regression coverage for issue #10677.
+//!
+//! The solver bounds generic `Application` evaluation with a per-file
+//! instantiation-fuel budget (`MAX_GLOBAL_INSTANTIATION_FUEL`). That budget is
+//! cumulative across every top-level statement in a file. Before the fix, a
+//! file whose earlier statements performed heavy generic evaluation (deep
+//! builder/query chains over large `keyof` unions — kysely is the canonical
+//! witness) could exhaust the budget, leaving `instantiation_limits_exceeded()`
+//! permanently true. Every following statement then resolved generic builder
+//! receiver types to opaque/`any`, so contextual typing of a later callback
+//! argument collapsed: the callback parameter was reported as implicitly `any`
+//! (TS7006) and the generic calls inside the callback were then treated as
+//! untyped, spuriously reporting TS2347.
+//!
+//! The checker now resets the session instantiation fuel between top-level
+//! statements (mirroring the existing per-statement resolution-fuel reset for
+//! issue #12144), so one statement can no longer starve the next.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::{
+    check_source_with_libs, diagnostic_line_column, load_default_lib_files,
+};
+
+/// The kysely query-builder type machinery (`selectFrom`/`innerJoin`/`select`
+/// with template-literal column references and conditional/mapped result
+/// aliases). Evaluating these generic applications is exactly the kind of work
+/// that spends the session instantiation-fuel budget.
+const PRELUDE: &str = include_str!("kysely_prelude.txt");
+
+fn strict_default_lib_diagnostics(source: &str) -> Vec<Diagnostic> {
+    let lib_files = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            no_implicit_any: true,
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+        &lib_files,
+    )
+    .into_iter()
+    .filter(|diagnostic| diagnostic.code != 2318)
+    .collect()
+}
+
+fn format_diagnostics(source: &str, diagnostics: &[Diagnostic]) -> Vec<String> {
+    diagnostics
+        .iter()
+        .map(|diagnostic| {
+            let (line, column) = diagnostic_line_column(source, diagnostic);
+            format!(
+                "TS{} at {line}:{column}: {}",
+                diagnostic.code, diagnostic.message_text
+            )
+        })
+        .collect()
+}
+
+/// Earlier statements drain the per-file instantiation-fuel budget; the final
+/// `.select` callback must still receive its contextual parameter type instead
+/// of degrading to implicit `any` and reporting a false TS2347 on the generic
+/// `$castTo<...>()` calls inside the callback.
+#[test]
+fn fuel_drained_earlier_statements_keep_select_callback_context() {
+    let mut schema = String::from("type FuelDB = {\n");
+    for i in 0..3 {
+        schema.push_str(&format!(
+            "  \"tbl{i}\": {{ id: number; name: string; ref_id: number; kind: \"k{i}\"; note: string }};\n"
+        ));
+    }
+    schema.push_str("};\ndeclare const fdb: QueryCreator<FuelDB>;\n");
+
+    // Each of these statements evaluates fresh, uncached generic Applications
+    // (distinct table alias per statement), spending instantiation fuel. The
+    // count is chosen to push the cumulative total comfortably past the 2000
+    // budget before the target statement is reached.
+    let mut drainer = String::new();
+    for k in 0..130 {
+        drainer.push_str(&format!(
+            "fdb.selectFrom(\"tbl0 as q{k}\").select([\"q{k}.name as n{k}\"]);\n"
+        ));
+    }
+
+    // The target statement mirrors kysely's `mssql-introspector.ts` `select`
+    // callback: a chain of joins/`$if` callbacks followed by a `select`
+    // callback that builds expressions with generic `$castTo<...>()` calls.
+    let target = r#"
+fdb.selectFrom("tbl0 as a0")
+  .innerJoin("tbl1 as a1", "a1.ref_id", "a0.id")
+  .leftJoin("tbl2 as a2", (join) => join.onRef("a2.ref_id", "=", "a0.id"))
+  .$if(!withInternalKyselyTables, (qb) => qb.where("a0.name", "!=", "x"))
+  .select((eb) => [
+    "a0.name as name0",
+    "a1.name as name1",
+    eb.ref("a0.kind").$castTo<FuelDB["tbl0"]["kind"]>().as("a0_kind"),
+    eb.ref("a1.id").$castTo<number>().as("a1_id"),
+  ]);
+"#;
+
+    let source = format!("{PRELUDE}\n{schema}\n{drainer}\n{target}");
+
+    let diagnostics = strict_default_lib_diagnostics(&source);
+    assert!(
+        !diagnostics.iter().any(|d| matches!(d.code, 7006 | 2347)),
+        "fuel exhausted by earlier statements must not strip callback context. Got: {:#?}",
+        format_diagnostics(&source, &diagnostics)
+    );
+}

--- a/crates/tsz-checker/tests/kysely_prelude.txt
+++ b/crates/tsz-checker/tests/kysely_prelude.txt
@@ -1,0 +1,236 @@
+
+type SelectType<T> = T;
+type DrainOuterGeneric<T> = [T] extends [unknown] ? T : never;
+type Nullable<T> = { [K in keyof T]: T[K] | null };
+type ShallowRecord<K extends keyof any, T> = DrainOuterGeneric<{ [P in K]: T }>;
+
+type AnyColumn<DB, TB extends keyof DB> = {
+  [T in TB]: keyof DB[T]
+}[TB] & string;
+
+type ExtractColumnType<DB, TB extends keyof DB, C> = {
+  [T in TB]: C extends keyof DB[T] ? DB[T][C] : never
+}[TB];
+
+type AnyColumnWithTable<DB, TB extends keyof DB> = {
+  [T in TB]: `${T & string}.${keyof DB[T] & string}`
+}[TB];
+
+type AnyAliasedColumn<DB, TB extends keyof DB> =
+  `${AnyColumn<DB, TB>} as ${string}`;
+
+type AnyAliasedColumnWithTable<DB, TB extends keyof DB> =
+  `${AnyColumnWithTable<DB, TB>} as ${string}`;
+
+interface AliasedExpression<T, A extends string> {
+  expressionType?: T;
+  alias: A;
+}
+
+interface ExpressionWrapper<DB, TB extends keyof DB, T> {
+  $castTo<C>(): ExpressionWrapper<DB, TB, C>;
+  as<A extends string>(alias: A): AliasedExpression<T, A>;
+}
+
+interface ExpressionBuilder<DB, TB extends keyof DB> {
+  ref<RE extends StringReference<DB, TB>>(
+    reference: RE,
+  ): ExpressionWrapper<DB, TB, ExtractTypeFromReferenceExpression<DB, TB, RE>>;
+}
+
+type StringReference<DB, TB extends keyof DB> =
+  | AnyColumn<DB, TB>
+  | AnyColumnWithTable<DB, TB>;
+
+type ExtractTypeFromReferenceExpression<DB, TB extends keyof DB, RE> =
+  SelectType<ExtractTypeFromStringReference<DB, TB, RE>>;
+
+type ExtractTypeFromStringReference<DB, TB extends keyof DB, RE> =
+  RE extends `${infer T}.${infer C}`
+    ? T extends TB
+      ? C extends keyof DB[T]
+        ? DB[T][C]
+        : never
+      : never
+    : RE extends AnyColumn<DB, TB>
+      ? ExtractColumnType<DB, TB, RE>
+      : unknown;
+
+type AliasedExpressionFactory<DB, TB extends keyof DB> = (
+  eb: ExpressionBuilder<DB, TB>,
+) => AliasedExpression<any, any>;
+
+type AliasedExpressionOrFactory<DB, TB extends keyof DB> =
+  | AliasedExpression<any, any>
+  | AliasedExpressionFactory<DB, TB>;
+
+type AnyAliasedTable<DB> = `${keyof DB & string} as ${string}`;
+type TableExpression<DB, TB extends keyof DB> =
+  | keyof DB & string
+  | AnyAliasedTable<DB>
+  | AliasedExpressionOrFactory<DB, TB>;
+
+type TableExpressionOrList<DB, TB extends keyof DB> =
+  | TableExpression<DB, TB>
+  | ReadonlyArray<TableExpression<DB, TB>>;
+
+type ExtractAliasFromTableExpression<DB, TE> = TE extends string
+  ? TE extends `${string} as ${infer TA}`
+    ? TA
+    : TE extends keyof DB
+      ? TE
+      : never
+  : TE extends AliasedExpression<any, infer QA>
+    ? QA
+    : TE extends (qb: any) => AliasedExpression<any, infer QA>
+      ? QA
+      : never;
+
+type ExtractRowTypeFromTableExpression<DB, TE, A extends keyof any> =
+  TE extends `${infer T} as ${infer TA}`
+    ? TA extends A
+      ? T extends keyof DB
+        ? DB[T]
+        : never
+      : never
+    : TE extends A
+      ? TE extends keyof DB
+        ? DB[TE]
+        : never
+      : never;
+
+type From<DB, TE> = DrainOuterGeneric<{
+  [C in keyof DB | ExtractAliasFromTableExpression<DB, TE>]:
+    C extends ExtractAliasFromTableExpression<DB, TE>
+      ? ExtractRowTypeFromTableExpression<DB, TE, C>
+      : C extends keyof DB
+        ? DB[C]
+        : never
+}>;
+
+type FromTables<DB, TB extends keyof DB, TE> =
+  TB | ExtractAliasFromTableExpression<DB, TE>;
+
+type SelectExpression<DB, TB extends keyof DB> =
+  | AnyAliasedColumnWithTable<DB, TB>
+  | AnyAliasedColumn<DB, TB>
+  | AnyColumnWithTable<DB, TB>
+  | AnyColumn<DB, TB>
+  | AliasedExpressionOrFactory<DB, TB>;
+
+type ExtractAliasFromSelectExpression<SE> = SE extends string
+  ? SE extends `${string}.${infer C} as ${infer A}`
+    ? A
+    : SE extends `${string}.${infer C}`
+      ? C
+      : SE
+  : SE extends AliasedExpression<any, infer EA>
+    ? EA
+    : SE extends (qb: any) => AliasedExpression<any, infer EA>
+      ? EA
+      : never;
+
+type ExtractTypeFromSelectExpression<DB, TB extends keyof DB, SE> =
+  SE extends string
+    ? ExtractTypeFromStringSelectExpression<DB, TB, SE>
+    : SE extends (eb: any) => AliasedExpression<infer O, any>
+      ? O
+      : SE extends AliasedExpression<infer O, any>
+        ? O
+        : never;
+
+type ExtractTypeFromStringSelectExpression<DB, TB extends keyof DB, SE> =
+  SE extends `${infer T}.${infer C} as ${string}`
+    ? T extends TB
+      ? C extends keyof DB[T]
+        ? DB[T][C]
+        : never
+      : never
+    : SE extends `${infer C} as ${string}`
+      ? C extends AnyColumn<DB, TB>
+        ? ExtractColumnType<DB, TB, C>
+        : never
+      : SE extends `${infer T}.${infer C}`
+        ? T extends TB
+          ? C extends keyof DB[T]
+            ? DB[T][C]
+            : never
+          : never
+        : SE extends AnyColumn<DB, TB>
+          ? ExtractColumnType<DB, TB, SE>
+          : never;
+
+type KyselySelection<DB, TB extends keyof DB, SE> = {
+  [E in SE as ExtractAliasFromSelectExpression<E>]:
+    SelectType<ExtractTypeFromSelectExpression<DB, TB, E>>
+};
+
+type CallbackSelection<DB, TB extends keyof DB, CB> =
+  CB extends (eb: any) => ReadonlyArray<infer SE>
+    ? KyselySelection<DB, TB, SE>
+    : never;
+
+interface JoinBuilder<DB, TB extends keyof DB> {
+  onRef(lhs: AnyColumnWithTable<DB, TB>, op: string, rhs: AnyColumnWithTable<DB, TB>): JoinBuilder<DB, TB>;
+  on(lhs: AnyColumnWithTable<DB, TB>, op: string, rhs: unknown): JoinBuilder<DB, TB>;
+}
+
+type JoinCallback<DB, TB extends keyof DB, TE> = (
+  join: JoinBuilder<From<DB, TE>, FromTables<DB, TB, TE>>,
+) => JoinBuilder<From<DB, TE>, FromTables<DB, TB, TE>>;
+
+interface SelectQueryBuilder<DB, TB extends keyof DB, O> {
+  innerJoin<TE extends TableExpression<DB, TB>>(
+    table: TE,
+    k1: AnyColumnWithTable<From<DB, TE>, FromTables<DB, TB, TE>>,
+    k2: AnyColumnWithTable<From<DB, TE>, FromTables<DB, TB, TE>>,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>;
+  innerJoin<TE extends TableExpression<DB, TB>>(
+    table: TE,
+    callback: JoinCallback<DB, TB, TE>,
+  ): SelectQueryBuilderWithInnerJoin<DB, TB, O, TE>;
+  leftJoin<TE extends TableExpression<DB, TB>>(
+    table: TE,
+    callback: JoinCallback<DB, TB, TE>,
+  ): SelectQueryBuilderWithLeftJoin<DB, TB, O, TE>;
+  $if<O2>(
+    condition: boolean,
+    callback: (qb: this) => SelectQueryBuilder<any, any, O & O2>,
+  ): SelectQueryBuilder<DB, TB, O & Partial<Omit<O2, keyof O>>>;
+  where(lhs: AnyColumnWithTable<DB, TB>, op: string, rhs: unknown): this;
+  select<SE extends SelectExpression<DB, TB>>(
+    selections: ReadonlyArray<SE>,
+  ): SelectQueryBuilder<DB, TB, O & KyselySelection<DB, TB, SE>>;
+  select<CB extends (eb: ExpressionBuilder<DB, TB>) => ReadonlyArray<SelectExpression<DB, TB>>>(
+    callback: CB,
+  ): SelectQueryBuilder<DB, TB, O & CallbackSelection<DB, TB, CB>>;
+}
+
+type SelectQueryBuilderWithInnerJoin<DB, TB extends keyof DB, O, TE> =
+  TE extends `${infer T} as ${infer A}`
+    ? T extends keyof DB
+      ? SelectQueryBuilder<DB & ShallowRecord<A, DB[T]>, TB | A, O>
+      : never
+    : never;
+
+type SelectQueryBuilderWithLeftJoin<DB, TB extends keyof DB, O, TE> =
+  TE extends `${infer T} as ${infer A}`
+    ? T extends keyof DB
+      ? SelectQueryBuilder<DB & ShallowRecord<A, Nullable<DB[T]>>, TB | A, O>
+      : never
+    : never;
+
+declare class QueryCreator<DB> {
+  selectFrom<TE extends TableExpressionOrList<DB, never>>(
+    from: TE,
+  ): SelectFrom<DB, never, TE>;
+}
+
+type SelectFrom<DB, TB extends keyof DB, TE> =
+  TE extends `${infer T} as ${infer A}`
+    ? T extends keyof DB
+      ? SelectQueryBuilder<DB & ShallowRecord<A, DB[T]>, TB | A, {}>
+      : never
+    : never;
+
+declare const withInternalKyselyTables: boolean;


### PR DESCRIPTION
## Agent
AgentName: M4-A

## Track
Conformance / checker false-positive burn-down. Fixes #10677 (kysely-project row), root-cause-adjacent to #8773 / #10661.

## Invariant
When a TypeScript file's earlier top-level statements perform heavy generic
`Application` evaluation, `tsc` still contextually types callback parameters in
later statements; `tsz` must not let one statement's instantiation work starve
the next. The checker now resets the session generic-instantiation fuel (and the
`depth_exceeded` flag) between top-level statements, owned by the checker
statement-checking loop, mirroring the existing per-statement
`reset_global_resolution_fuel()` reset added for #12144.

## Structural rule
When a callback argument's contextual parameter type requires evaluating a
deferred generic `Application` (e.g. a builder/query chain return type), `tsc`
resolves it under per-instantiation-chain depth limits. `tsz` instead bounds it
with a per-file cumulative fuel budget (`MAX_GLOBAL_INSTANTIATION_FUEL = 2000`).
Once earlier statements exhaust that budget, `instantiation_limits_exceeded()`
stays true: `evaluate_application_type` returns receiver types opaque, the
builder method's signature can no longer be resolved, the callback parameter
degrades to implicit `any` (false **TS7006**), and the generic calls inside the
callback (`eb.ref(...).$castTo()`) are then treated as untyped, emitting a
false **TS2347**. The fix scopes the fuel budget per top-level statement so it
can no longer leak across statement boundaries.

## Scope
- `crates/tsz-checker/src/state/state_checking/source_file.rs` — reset
  `eval_session` instantiation fuel + `depth_exceeded` between top-level
  statements (2 lines + comment), adjacent to the existing #12144 resolution-fuel
  reset.
- `crates/tsz-checker/tests/fuel_budget_callback_context_tests.rs` — new
  regression test.
- `crates/tsz-checker/tests/kysely_prelude.txt` — shared kysely builder type
  fixture used by the test.
- `.config/nextest.toml` — register the (intentionally heavy) regression test
  with the longer slow-timeout and serialized execution in both the `default`
  and `ci` profiles.
- `crates/tsz-checker/Cargo.toml` — `[[test]]` entry.

## Project Corpus Impact
- Row: `kysely-project` — clears false TS2347/TS7006 at `mssql-introspector.ts`.
- Bug family: contextual typing of callback parameters collapsing to implicit
  `any` after per-file instantiation-fuel exhaustion (false TS7006 → false
  TS2347 on generic calls inside the callback).
- The fix only *relaxes* a budget (each statement gets a fresh instantiation
  budget instead of inheriting an exhausted one), so it can only remove false
  positives, never add diagnostics. The result-evaluation cache persists across
  statements, so no generic instantiation work is redone — only the fuel counter
  resets. Large real-world files that previously bailed early after cumulative
  exhaustion will now do the (correct) full work per statement; broad
  conformance/emit/project suites in ready-review CI should confirm no row
  regressions or timeouts.

## Verification
- `cargo test -p tsz-checker --test fuel_budget_callback_context_tests` — passes
  with the fix (~94s); reproduces TS7006×3 + TS2347×2 with the fix reverted.
- `cargo test -p tsz-checker --test kysely_callback_context_tests` — 9 passed.
- `cargo test -p tsz-checker --test contextual_typing_tests` — 77 passed.
- `cargo test -p tsz-checker --test call_resolution_regression_tests` — 171 passed.
- `cargo test -p tsz-checker --test generic_call_inference_tests` — 6 pre-existing
  failures, identical with the fix stashed (not caused by this change).
- `cargo fmt -p tsz-checker --check` and `cargo clippy -p tsz-checker --lib`
  clean.
- `depth_exceeded` is only read to *emit* TS2589 (never for silent degradation),
  so per-statement reset preserves correct TS2589 emission for genuinely deep
  single statements.

## Coordination Notes
- AgentName: M4-A
- Rebased onto `origin/main` at `7a9ce63`; no conflicts.
- No checker/solver type-algorithm changes beyond the budget-reset boundary; no
  TS2347 emission logic touched (the upstream `any` cause is fixed instead of
  suppressing the diagnostic).

Closes #10677