### PR TITLE
ci: skip queue invalidation for ineligible PRs

### DIFF
--- a/scripts/ci/poor-mans-merge-queue.mjs
+++ b/scripts/ci/poor-mans-merge-queue.mjs
@@ -442,6 +442,22 @@ export function queueSkipReason(pr, requiredState, base, queueLabel = DEFAULT_QU
   return null;
 }
 
+export function queueInvalidationSkipReason(pr, base, queueLabel = DEFAULT_QUEUE_LABEL) {
+  if (pr.baseRefName !== base) return `base is ${pr.baseRefName || "(unknown)"}, not ${base}`;
+  if (pr.isDraft) return "draft PR";
+  if (pr.isCrossRepository) return "cross-repository PR";
+  const readinessFailures = readyStateFailures({
+    number: pr.number,
+    title: pr.title,
+    body: pr.body || "",
+    draft: pr.isDraft,
+    labels: labelNames(pr.labels),
+  });
+  if (readinessFailures.length) return `ready-state WIP marker: ${readinessFailures.join(", ")}`;
+  if (!hasQueueLabel(pr.labels, queueLabel)) return `missing ${queueLabel} label`;
+  return null;
+}
+
 export function normalizeRestPullRequest(pr, repository, statusCheckRollup = undefined) {
   const baseRepository = pr.base?.repo?.full_name || repository;
   const headRepository = pr.head?.repo?.full_name || "";
@@ -810,6 +826,15 @@ function invalidatePullRequest(repository, pr, options) {
   const detailed = pr.statusCheckRollup ? pr : readPullRequest(repository, pr.number);
   const activeRun = activePendingQueueRun(repository, detailed, options);
   if (activeRun) return { invalidated: false, skipped: true, activeRun };
+  const ineligibleReason = queueInvalidationSkipReason(detailed, options.base, options.queueLabel);
+  if (ineligibleReason) {
+    return {
+      invalidated: false,
+      skipped: false,
+      skippedIneligible: true,
+      reason: ineligibleReason,
+    };
+  }
   postStatus(
     repository,
     pr.headRefOid,
@@ -825,12 +850,14 @@ function invalidateOpen(repository, options) {
   const prs = readPullRequests(repository, options.base, options.maxPrs);
   let invalidated = 0;
   let skippedActiveRuns = 0;
+  let skippedIneligible = 0;
   for (const pr of prs) {
     const result = invalidatePullRequest(repository, pr, options);
     if (result?.invalidated) invalidated += 1;
     if (result?.skipped) skippedActiveRuns += 1;
+    if (result?.skippedIneligible) skippedIneligible += 1;
   }
-  return { invalidated, skippedActiveRuns };
+  return { invalidated, skippedActiveRuns, skippedIneligible };
 }
 
 function cleanupQueueBranches(repository, options) {
@@ -1170,6 +1197,9 @@ export function formatResult(result, options) {
     lines.push(`Invalidated ${result.invalidated} open PR head(s).`);
     if (result.skippedActiveRuns) {
       lines.push(`Preserved ${result.skippedActiveRuns} active queue run status(es).`);
+    }
+    if (result.skippedIneligible) {
+      lines.push(`Skipped ${result.skippedIneligible} PR head(s) not eligible for the queue.`);
     }
   } else if (result.cleanupQueueBranches) {
     if (result.dryRun) {

--- a/scripts/ci/test-poor-mans-merge-queue.mjs
+++ b/scripts/ci/test-poor-mans-merge-queue.mjs
@@ -16,6 +16,7 @@ import {
   parseArgs,
   queueBranchMetadata,
   queueBranchPrNumber,
+  queueInvalidationSkipReason,
   queueRunIsActive,
   queueSkipReason,
   readPaginatedObjectArray,
@@ -277,6 +278,14 @@ assert.equal(queueSkipReason(pr({ labels: ["WIP"] }), { kind: "passed" }, "main"
 assert.equal(queueSkipReason(pr(), { kind: "pending", reason: "pending checks" }, "main"), "pending checks");
 assert.equal(queueSkipReason(pr(), { kind: "passed" }, "main"), null);
 assert.equal(queueSkipReason({ ...pr(), statusCheckRollup: undefined }, { kind: "passed" }, "main"), null);
+assert.equal(queueInvalidationSkipReason(pr({ isDraft: true }), "main"), "draft PR");
+assert.equal(queueInvalidationSkipReason(pr({ labels: [] }), "main"), "missing merge-queue label");
+assert.equal(queueInvalidationSkipReason(pr({ labels: ["WIP"] }), "main"), "ready-state WIP marker: WIP label");
+assert.equal(queueInvalidationSkipReason(pr(), "main"), null);
+assert.equal(
+  queueInvalidationSkipReason(pr({ labels: ["ready-to-merge"] }), "main", "ready-to-merge"),
+  null,
+);
 assert.deepEqual(
   normalizeRestPullRequest({
     auto_merge: { merge_method: "squash" },
@@ -436,8 +445,17 @@ assert.match(
   formatResult({
     invalidated: 12,
     skippedActiveRuns: 2,
+    skippedIneligible: 3,
   }, parseArgs(["--repository", "owner/repo", "--invalidate-open"])),
   /Preserved 2 active queue run status/,
+);
+assert.match(
+  formatResult({
+    invalidated: 12,
+    skippedActiveRuns: 2,
+    skippedIneligible: 3,
+  }, parseArgs(["--repository", "owner/repo", "--invalidate-open"])),
+  /Skipped 3 PR head\(s\) not eligible for the queue/,
 );
 
 const cleanupFormat = formatResult({


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
CI/queue coordination infrastructure

## Invariant
When a PR is draft, WIP, wrong-base, cross-repo, or missing `merge-queue`, it is not queue-eligible; queue invalidation must not publish a fresh pending `Queue Tested` status to that head. Only queue-eligible PR heads should be marked waiting for synthetic merge.

## Scope
- Add a queue eligibility skip reason helper for invalidation.
- Preserve active pending queue runs, then skip ineligible PRs instead of repainting `Queue Tested` as pending.
- Count skipped ineligible heads in dry-run output and cover the behavior in queue tests.

## Project Corpus Impact
- Row: n/a
- Bug family: merge queue metadata reliability / queue status invalidation
- Evidence: tooling-only change; project row metadata unchanged. Dry-run evidence showed #12411 skipped as `missing merge-queue label` and #12419 skipped as `draft PR`.

## Verification
- `node scripts/ci/test-poor-mans-merge-queue.mjs`
- `git diff --check`
- `wc -l scripts/ci/poor-mans-merge-queue.mjs scripts/ci/test-poor-mans-merge-queue.mjs`
- `node scripts/ci/poor-mans-merge-queue.mjs --repository mohsen1/tsz --base main --dry-run --verbose --max-prs 10`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Remote PR body, label, and head metadata verified after creation.
- Addresses stale pending `Queue Tested` noise observed on #12419 draft and #12411 unqueued without mutating those PRs.
- Future invalidations stop repainting non-queued PRs pending.
