### PR TITLE
docs(emit): ratchet output-surgery capacity

### DIFF
--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -59,7 +59,7 @@ artifacts are triage inputs only, not current public truth.
 | Declaration emit | `99.5%` (`1,661 / 1,669`) in README/public aggregate and checked detail |
 | Fourslash / language service | `99.9%` (`6,558 / 6,562`) |
 | Open bug issues | `68` open `bug` issues in live GitHub orientation (point-in-time count; drifts daily) |
-| Output-surgery audit | green: `0` unallowlisted calls, `0` stale allowlist entries; allowlisted resource-region calls ratcheted to `4 / 6` with `2` remaining budget slots |
+| Output-surgery audit | passing: `0` unallowlisted calls, `0` stale allowlist entries; resource-region output surgery is capped at `4 / 4` with `0` remaining budget slots |
 
 Conformance remains a hard regression gate. It is no longer the sole readiness
 signal. The primary readiness signal for this phase is whether tsz can
@@ -126,11 +126,11 @@ changes the picture.
    `13,468 / 13,530` and declaration emit `1,661 / 1,669`. DTS still needs to
    move away from late semantic discovery during printing toward a precomputed
    declaration/public-API summary.
-8. Output-surgery audit is green again: the current audit reports `0`
-   unallowlisted calls and `0` stale allowlist entries. Resource-region
-   output-surgery is now `4 / 6`; Studio emit work should keep ratcheting it
-   down and must not spend the remaining capacity without an owner, removal
-   condition, and counter update.
+8. Output-surgery audit is passing with exhausted pressure: the current audit
+   reports `0` unallowlisted calls and `0` stale allowlist entries. Resource-region
+   output-surgery is now `4 / 4`; Studio emit work should keep ratcheting it
+   down, and any cap increase must name an owner, removal condition, and
+   counter update.
 9. Conformance is no longer the dominant progress signal but it remains a hard
    regression gate. The current diagnostic gap is zero tests; broad
    checker/solver changes must preserve that floor while moving project rows

--- a/scripts/emit/output-surgery-allowlist.txt
+++ b/scripts/emit/output-surgery-allowlist.txt
@@ -2,4 +2,4 @@
 # Current semantic rewrites over already-emitted JS/DTS. This file is a ratchet:
 # counts may go down as plan/IR/declaration-summary work removes debt; new or
 # increased counts require an explicit category and removal reason.
-crates/tsz-emitter/src/emitter/source_file/top_level_using.rs|resource-region-output-surgery|6|top-level using region rewrites emitted strings; migrate to disposable-region plan
+crates/tsz-emitter/src/emitter/source_file/top_level_using.rs|resource-region-output-surgery|4|top-level using region rewrites emitted strings; migrate to disposable-region plan


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 9/10 emit architecture ratchet / Studio output-surgery debt.

## Invariant
When the output-surgery audit observes 4 live resource-region rewrites, the allowlist must cap that category at 4 rather than preserving unused capacity. This PR makes future emit work remove debt or explicitly justify a cap increase through the output-surgery audit boundary.

## Scope
- Ratchet `scripts/emit/output-surgery-allowlist.txt` from 6 allowed resource-region calls to the 4 live calls.
- Update the roadmap current metric from `4 / 6` available pressure to `4 / 4` exhausted pressure.
- No emitter behavior changes.

## Project Corpus Impact
- Row: n/a
- Bug family: output-surgery pressure / emit architecture guardrail
- Evidence: `python3 scripts/emit/audit-output-surgery.py` passes with `allowlisted_calls=4`, `allowlist_cap=4`, `remaining_allowlist_capacity=0`, `allowlist_pressure_status=blocked`, and `warning_count=1`.

## Verification
- `python3 scripts/emit/test_output_surgery_audit.py`
- `python3 scripts/emit/audit-output-surgery.py`
- `python3 scripts/emit/audit-output-surgery.py --json`
- `git diff --check`
- `wc -l scripts/emit/output-surgery-allowlist.txt docs/plan/ROADMAP.md scripts/emit/test_output_surgery_audit.py scripts/emit/audit-output-surgery.py`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Remote PR body, ownership label, and exact head metadata verified after creation.
- Coordinates with Studio-C by removing spare output-surgery capacity; future resource-region rewrites now require either debt removal or an explicit cap-increase justification.
