### PR TITLE
fix(emit): keep plain es5 private storage scoped

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
@@ -1048,6 +1048,20 @@ impl<'a> Printer<'a> {
         let Some(class_data) = self.arena.get_class(class_node) else {
             return Vec::new();
         };
+        let is_commonjs_exported_class = self
+            .arena
+            .has_modifier(&class_data.modifiers, SyntaxKind::ExportKeyword)
+            || self
+                .pending_commonjs_class_export_name
+                .as_ref()
+                .is_some_and(|(_, local_name, _)| local_name == class_name);
+        if !self.ctx.outer_module_kind().is_commonjs()
+            || !is_commonjs_exported_class
+            || self.ctx.module_state.has_export_assignment
+        {
+            return Vec::new();
+        }
+
         let has_static_runtime_computed_key = class_data.members.nodes.iter().any(|&member_idx| {
             let Some(member_node) = self.arena.get(member_idx) else {
                 return false;

--- a/crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/private_field_helper_order_tests.rs
@@ -53,6 +53,41 @@ class Derived extends Base {
     );
 }
 
+#[test]
+fn es5_private_name_bundle_stays_inside_plain_class_iife() {
+    let source = r#"
+class Holder {
+    #field = 1;
+    #method() {}
+    static #staticField = "value";
+    static #staticMethod() {}
+    get #accessor() { return this.#field; }
+    set #accessor(value) { this.#field = value; }
+}
+"#;
+    let output = emit(source, ScriptTarget::ES5);
+
+    let class_pos = output
+        .find("var Holder = /** @class */")
+        .expect("expected an ES5 class IIFE");
+    let storage_decl_pos = output
+        .find("var _Holder_instances, _a, _Holder_field, _Holder_method")
+        .expect("expected private storage declaration bundle");
+    let return_pos = output
+        .find("return Holder;")
+        .expect("expected class IIFE return");
+    let storage_init_pos = output
+        .find("_a = Holder, _Holder_field = new WeakMap(), _Holder_instances = new WeakSet()")
+        .expect("expected private storage initialization bundle");
+
+    assert!(
+        class_pos < storage_decl_pos
+            && storage_decl_pos < storage_init_pos
+            && storage_init_pos < return_pos,
+        "Plain ES5 classes keep private-name storage bundles inside the IIFE.\nOutput:\n{output}"
+    );
+}
+
 // Rule: for a class *declaration* lowered to the WeakMap pattern, the private
 // member init statements (`_C_field = new WeakMap()`) must be emitted before the
 // static field initialization statements (`C.x = value;`). A static initializer

--- a/crates/tsz-emitter/src/transforms/class_es5.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5.rs
@@ -731,7 +731,9 @@ impl<'a> ClassES5Emitter<'a> {
         override_name: Option<&str>,
         mut ir: IRNode,
     ) -> String {
-        Self::lift_private_storage_from_iife_body(&mut ir);
+        if !self.externally_hoisted_decls.is_empty() {
+            Self::lift_private_storage_from_iife_body(&mut ir);
+        }
 
         if !self.externally_hoisted_decls.is_empty()
             && let IRNode::ES5ClassIIFE {


### PR DESCRIPTION
AgentName: Studio-C

## Track
Emit parity, JavaScript class/private lowering regression recovery.

## Invariant
When an ES5 class private-name bundle does not cross a CommonJS exported-class preamble boundary, TypeScript keeps the private storage declaration and initialization bundle inside the class IIFE. tsz should only externalize that bundle when the emitter explicitly computes external declarations for a CommonJS exported class declaration.

## Scope
- Gate ES5 private-storage lifting on externally supplied hoist declarations instead of lifting every class IIFE.
- Restrict external private-storage declaration discovery to ES5 CommonJS exported class declarations without export assignment.
- Add an adjacent plain-class regression test while preserving the existing CommonJS preamble ordering test.

## Project Corpus Impact
- Row: n/a
- Bug family: class/private/accessor/decorator lowering
- Named baseline: privateNameES5Ban(target=es5)

## Verification
- cargo fmt --check
- scripts/safe-run.sh cargo nextest run -p tsz-emitter es5_private_name_bundle_stays_inside_plain_class_iife es5_commonjs_exported_class_private_storage_hoists_before_preamble
- scripts/safe-run.sh scripts/emit/run.sh --js-only --filter=privateNameES5Ban --verbose --timeout=20000 --json-out=/tmp/studio-c-private-name-es5ban-after-scope.json
- git diff --check origin/main..HEAD
- python3 scripts/emit/audit-output-surgery.py (passed; current ratchet reports allowlist capacity exhausted at 4/4)
- scripts/safe-run.sh cargo clippy -p tsz-emitter --all-targets -- -D warnings
- Full PR CI on head e9f8342ac77524acd3d6a8b4599c07ff5a9bf8f2: CI Summary, emit, conformance, fourslash, project rows, unit, dist, wasm, and lint passed.

## Coordination Notes
Fixes #12421. Preserves the #12408 CommonJS preamble invariant for exported ES5 classes. No semantic validation is added to emit; this remains an output-layer class-lowering ordering fix.
