### PR TITLE
feat(emit): report strict output-surgery warnings in json

### DIFF
--- a/docs/architecture/EMIT_ARCHITECTURE.md
+++ b/docs/architecture/EMIT_ARCHITECTURE.md
@@ -291,7 +291,10 @@ stdout or a JSON report when CI or agent handoffs need machine-readable counts
 for unallowlisted, over-allowlist, and stale-allowlist failures. Use
 `--fail-on-warnings` in debt-removal PRs or focused gates that need exhausted
 category/global budget pressure to fail even when every call is still
-allowlisted.
+allowlisted. With `--json` or `--json-report`, strict warning failure is
+reported as `ok: false` with `status: "warning_failed"` while
+`output_surgery_status` remains `"passed"` unless unallowlisted, stale, or
+over-cap surgery is present.
 
 ### 7.1 SourceWriter
 

--- a/scripts/emit/audit-output-surgery.py
+++ b/scripts/emit/audit-output-surgery.py
@@ -444,6 +444,8 @@ def build_json_report(
     allowlist: dict[str, AllowEntry],
     failures: list[str],
     git_context: Optional[dict[str, object]] = None,
+    warning_messages: Optional[list[str]] = None,
+    fail_on_warnings: bool = False,
 ) -> dict[str, object]:
     counts = grouped_counts(findings)
     summary = summarize_failures(failures)
@@ -457,12 +459,32 @@ def build_json_report(
     ]
     warning_count = len(exhausted_categories)
     allowlist_pressure_status = classify_allowlist_pressure(budget, exhausted_categories)
+    warnings = (
+        warning_messages if warning_messages is not None else warning_failures(file_summaries)
+    )
+    strict_warning_failed = fail_on_warnings and bool(warnings)
+    if failures:
+        status = "failed"
+    elif strict_warning_failed:
+        status = "warning_failed"
+    else:
+        status = "passed"
+    if strict_warning_failed:
+        strict_warning_status = "failed"
+    elif warnings:
+        strict_warning_status = "warn"
+    else:
+        strict_warning_status = "clear"
     return {
-        "ok": not failures,
-        "status": "failed" if failures else "passed",
+        "ok": not failures and not strict_warning_failed,
+        "status": status,
         "output_surgery_status": "failed" if failures else "passed",
         "warning_count": warning_count,
         "warning_status": "warn" if warning_count else "clear",
+        "fail_on_warnings": fail_on_warnings,
+        "strict_warning_status": strict_warning_status,
+        "warning_failures": warnings,
+        "warning_failure_count": len(warnings),
         "git_context": git_context if git_context is not None else build_git_context(),
         "total_findings": len(findings),
         "files_with_findings": len(counts),
@@ -567,7 +589,15 @@ def main(argv: list[str] | None = None) -> int:
     findings = scan()
     allowlist = load_allowlist()
     failures = audit(findings, allowlist)
-    json_report = build_json_report(findings, allowlist, failures)
+    file_summaries = build_file_summaries(grouped_counts(findings), allowlist)
+    warnings = warning_failures(file_summaries)
+    json_report = build_json_report(
+        findings,
+        allowlist,
+        failures,
+        warning_messages=warnings,
+        fail_on_warnings=args.fail_on_warnings,
+    )
 
     if args.json_report is not None:
         write_json_report(args.json_report, json_report)
@@ -603,8 +633,6 @@ def main(argv: list[str] | None = None) -> int:
     if not args.json:
         pass_summary = format_pass_summary(findings, failures, allowlist)
         print(pass_summary)
-    file_summaries = build_file_summaries(grouped_counts(findings), allowlist)
-    warnings = warning_failures(file_summaries)
     if args.fail_on_warnings and warnings:
         print("\nOutput-surgery audit warnings failed by --fail-on-warnings:", file=sys.stderr)
         for warning in warnings:

--- a/scripts/emit/test_output_surgery_audit.py
+++ b/scripts/emit/test_output_surgery_audit.py
@@ -414,6 +414,40 @@ class OutputSurgeryAuditTests(unittest.TestCase):
         self.assertIn("allowlist_pressure_status=blocked", stdout.getvalue())
         self.assertIn("Output-surgery audit warnings failed", stderr.getvalue())
 
+    def test_json_fail_on_warnings_reports_strict_warning_failure(self):
+        findings = [
+            self.audit.Finding("a.rs", 1, "replacen", "output = output.replacen(&a, &b, 1);"),
+        ]
+        allowlist = {
+            "a.rs": self.audit.AllowEntry("dts-output-surgery", 1, "existing debt"),
+        }
+
+        with (
+            patch.object(self.audit, "scan", return_value=findings),
+            patch.object(self.audit, "load_allowlist", return_value=allowlist),
+            patch.object(self.audit, "build_git_context", return_value={"head": "abc123"}),
+            redirect_stdout(io.StringIO()) as stdout,
+            redirect_stderr(io.StringIO()) as stderr,
+        ):
+            status = self.audit.main(["--json", "--fail-on-warnings"])
+
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(status, 2)
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["status"], "warning_failed")
+        self.assertEqual(payload["output_surgery_status"], "passed")
+        self.assertTrue(payload["fail_on_warnings"])
+        self.assertEqual(payload["strict_warning_status"], "failed")
+        self.assertEqual(payload["warning_failure_count"], 1)
+        self.assertEqual(
+            payload["warning_failures"],
+            [
+                "allowlist pressure is blocked; exhausted categories: "
+                "dts-output-surgery"
+            ],
+        )
+        self.assertIn("Output-surgery audit warnings failed", stderr.getvalue())
+
     def test_default_mode_allows_warnings(self):
         findings = [
             self.audit.Finding("a.rs", 1, "replacen", "output = output.replacen(&a, &b, 1);"),


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 9/10 emit architecture guardrail artifact contract.

## Invariant
When output-surgery debt is still allowlisted but a focused strict gate requests `--fail-on-warnings`, the machine-readable audit artifact must report the strict warning failure directly instead of requiring consumers to infer it from exit status. The output-surgery audit owns this contract; emitter behavior is unchanged.

## Scope
- Add strict warning status fields to `scripts/emit/audit-output-surgery.py` JSON output.
- Preserve `output_surgery_status: "passed"` when only exhausted allowlist pressure fails strict mode.
- Add unit coverage for `--json --fail-on-warnings`.
- Document the strict JSON contract in `docs/architecture/EMIT_ARCHITECTURE.md`.

## Project Corpus Impact
- Row: n/a
- Bug family: output-surgery pressure / emit architecture guardrail artifact contract
- Impact: no compiler behavior change; this sharpens machine-readable evidence for Studio-C/resource-region debt and future focused gates.

## Verification
- `python3 scripts/emit/test_output_surgery_audit.py`
- `python3 scripts/emit/audit-output-surgery.py`
- `python3 scripts/emit/audit-output-surgery.py --json --fail-on-warnings >/tmp/tsz-output-surgery-strict.json; code=$?; ...` observed `exit_code=2`, `ok=False`, `status=warning_failed`, `output_surgery_status=passed`, `strict_warning_status=failed`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- `wc -l scripts/emit/audit-output-surgery.py scripts/emit/test_output_surgery_audit.py docs/architecture/EMIT_ARCHITECTURE.md`

## Coordination Notes
- Remote body, label, base, and head verified for `c250a8ee63f9dc82b38b3e54db707c2f52983fa0`.
- Coordinates with the freshly exhausted `resource-region-output-surgery` budget by making strict-mode JSON artifacts self-describing for CI and agent handoffs.
- No output-surgery allowlist cap increase and no emitter behavior change.