### PR TITLE
chore(bench): add project row summary help

### DIFF
--- a/scripts/bench/project-row-summary.mjs
+++ b/scripts/bench/project-row-summary.mjs
@@ -28,6 +28,15 @@ import {
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
+const USAGE = `Usage: project-row-summary.mjs [--markdown] [--json] [--help]
+
+Print project-row coverage across benchmark, compile-guard, fixture, and
+compatibility-corpus surfaces.
+
+Options:
+  --markdown  Print a GitHub-flavored markdown table.
+  --json      Print a machine-readable coverage report.
+  --help      Show this help text.`;
 
 // Rows intentionally excluded from certain surfaces.
 export const BENCH_RUNNER_EXCLUDED_ROWS = new Set([
@@ -306,14 +315,23 @@ export function appendStepSummary(coverage, stepSummaryPath) {
   fs.appendFileSync(stepSummaryPath, `${formatMarkdown(coverage)}\n`);
 }
 
+export function formatUsage() {
+  return USAGE;
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const args = process.argv.slice(2);
+  const help = args.includes("--help") || args.includes("-h");
+  if (help) {
+    process.stdout.write(`${formatUsage()}\n`);
+    process.exit(0);
+  }
   const markdown = args.includes("--markdown");
   const json = args.includes("--json");
   const unknownArgs = args.filter((a) => a !== "--markdown" && a !== "--json");
   if (unknownArgs.length > 0) {
     process.stderr.write(`Unknown arguments: ${unknownArgs.join(", ")}\n`);
-    process.stderr.write("Usage: project-row-summary.mjs [--markdown] [--json]\n");
+    process.stderr.write(`${formatUsage()}\n`);
     process.exit(2);
   }
   if (markdown && json) {

--- a/scripts/bench/test-project-row-summary.mjs
+++ b/scripts/bench/test-project-row-summary.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   BENCH_RUNNER_EXCLUDED_ROWS,
   COMPILE_GUARD_EXCLUDED_ROWS,
@@ -16,6 +18,7 @@ import {
   formatJson,
   formatMarkdown,
   formatPlainText,
+  formatUsage,
   rowRequiresFixtureSource,
 } from "./project-row-summary.mjs";
 import {
@@ -24,6 +27,8 @@ import {
   PROJECT_ROW_DEFINITIONS,
   REQUIRED_PROJECT_ROWS,
 } from "./project-rows.mjs";
+
+const SCRIPT_PATH = fileURLToPath(new URL("./project-row-summary.mjs", import.meta.url));
 
 // Baseline surface data built from the live project-rows.mjs exports.
 function baseSurfaces() {
@@ -314,6 +319,23 @@ function baseSurfaces() {
   assert.ok(summary.includes("## Project Row Coverage"), "step summary missing markdown heading");
   assert.ok(summary.includes(`All ${PROJECT_ROW_DEFINITIONS.length} rows consistent`), "step summary missing clean summary");
   fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// Help output is available for cycle and CI users without running the summary.
+{
+  const usage = formatUsage();
+  assert.ok(usage.includes("Usage: project-row-summary.mjs"), "usage missing command");
+  assert.ok(usage.includes("--markdown"), "usage missing --markdown");
+  assert.ok(usage.includes("--json"), "usage missing --json");
+  assert.ok(usage.includes("--help"), "usage missing --help");
+
+  const result = spawnSync(process.execPath, [SCRIPT_PATH, "--help"], {
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0);
+  assert.equal(result.stderr, "");
+  assert.ok(result.stdout.includes("Usage: project-row-summary.mjs"));
+  assert.ok(result.stdout.includes("compatibility-corpus surfaces"));
 }
 
 // Extractor: bench runner rows from shell snippet.


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 9/10 benchmark/project-row infrastructure polish.

## Invariant
When `project-row-summary.mjs` is used as a Start Every Cycle and CI artifact command, users and agents can ask for help without running the row summary or receiving a usage-error exit. The project-row summary script owns this CLI contract; row coverage semantics are unchanged.

## Scope
- Add `--help`/`-h` handling to `scripts/bench/project-row-summary.mjs`.
- Reuse the full usage text for unknown-argument failures.
- Add process-level test coverage for `--help`.

## Project Corpus Impact
- Row: n/a
- Bug family: project-row metadata / benchmark artifact tooling
- Impact: no project-row coverage or compiler behavior change; improves operator discoverability for the row-summary guardrail used in launch cycles and CI.

## Verification
- `node scripts/bench/test-project-row-summary.mjs`
- `node scripts/bench/project-row-summary.mjs --help`
- `node scripts/bench/project-row-summary.mjs --json` observed `ok=true status=passed rowCount=12 driftCount=0`
- `git diff --check`
- `wc -l scripts/bench/project-row-summary.mjs scripts/bench/test-project-row-summary.mjs`

## Coordination Notes
- Remote body, label, base, and head verified for `f24c0cf93cbbab7acb9b836445fbff72b3c04252`.
- No overlap with open Studio-B #12425 or Studio-C #12423 behavior work.
- This PR only changes the benchmark guardrail CLI contract.