### PR TITLE
test(solver): cover variadic tail inference arity

### DIFF
--- a/crates/tsz-solver/tests/infer_pattern_variadic_residual_tests.rs
+++ b/crates/tsz-solver/tests/infer_pattern_variadic_residual_tests.rs
@@ -154,3 +154,189 @@ fn conditional_infer_head_empty_source_takes_false_branch() {
         TypeId::NEVER
     );
 }
+
+// =============================================================================
+// Tail inference: concrete fixed-element tuples
+// =============================================================================
+
+#[test]
+fn conditional_infer_tail_of_three_element_tuple_is_two_element_tuple() {
+    let interner = TypeInterner::new();
+    let infer_h = infer_var(&interner, "_H");
+    let infer_rest = infer_var(&interner, "Rest");
+
+    let extends_tuple = interner.tuple(vec![tuple_elem(infer_h), rest_tuple_elem(infer_rest)]);
+    let source = interner.tuple(vec![
+        tuple_elem(TypeId::STRING),
+        tuple_elem(TypeId::NUMBER),
+        tuple_elem(TypeId::BOOLEAN),
+    ]);
+    let cond = ConditionalType {
+        check_type: source,
+        extends_type: extends_tuple,
+        true_type: infer_rest,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let expected = interner.tuple(vec![
+        tuple_elem(TypeId::NUMBER),
+        tuple_elem(TypeId::BOOLEAN),
+    ]);
+    assert_eq!(
+        evaluate_type(&interner, interner.conditional(cond)),
+        expected,
+        "Tail<[string, number, boolean]> should produce [number, boolean]"
+    );
+}
+
+#[test]
+fn conditional_infer_tail_of_two_element_tuple_is_one_element_tuple() {
+    let interner = TypeInterner::new();
+    let infer_h = infer_var(&interner, "_H");
+    let infer_rest = infer_var(&interner, "Rest");
+
+    let extends_tuple = interner.tuple(vec![tuple_elem(infer_h), rest_tuple_elem(infer_rest)]);
+    let source = interner.tuple(vec![tuple_elem(TypeId::STRING), tuple_elem(TypeId::NUMBER)]);
+    let cond = ConditionalType {
+        check_type: source,
+        extends_type: extends_tuple,
+        true_type: infer_rest,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let expected = interner.tuple(vec![tuple_elem(TypeId::NUMBER)]);
+    assert_eq!(
+        evaluate_type(&interner, interner.conditional(cond)),
+        expected,
+        "Tail<[string, number]> should produce [number]"
+    );
+}
+
+#[test]
+fn conditional_infer_tail_of_single_element_tuple_is_empty_tuple() {
+    let interner = TypeInterner::new();
+    let infer_h = infer_var(&interner, "_H");
+    let infer_rest = infer_var(&interner, "Rest");
+
+    let extends_tuple = interner.tuple(vec![tuple_elem(infer_h), rest_tuple_elem(infer_rest)]);
+    let source = interner.tuple(vec![tuple_elem(TypeId::STRING)]);
+    let cond = ConditionalType {
+        check_type: source,
+        extends_type: extends_tuple,
+        true_type: infer_rest,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let expected = interner.tuple(vec![]);
+    assert_eq!(
+        evaluate_type(&interner, interner.conditional(cond)),
+        expected,
+        "Tail<[string]> should produce []"
+    );
+}
+
+#[test]
+fn conditional_infer_prepend_inferred_tail_is_flattened_into_result_tuple() {
+    // Source=[number,boolean,string], Rest=[boolean,string] after matching head.
+    // True branch [string, ...Rest] must flatten to [string, boolean, string].
+    let interner = TypeInterner::new();
+    let infer_h = infer_var(&interner, "_H");
+    let infer_rest = infer_var(&interner, "Rest");
+
+    let extends_tuple = interner.tuple(vec![tuple_elem(infer_h), rest_tuple_elem(infer_rest)]);
+    let source = interner.tuple(vec![
+        tuple_elem(TypeId::NUMBER),
+        tuple_elem(TypeId::BOOLEAN),
+        tuple_elem(TypeId::STRING),
+    ]);
+    let true_branch = interner.tuple(vec![
+        tuple_elem(TypeId::STRING),
+        rest_tuple_elem(infer_rest),
+    ]);
+    let cond = ConditionalType {
+        check_type: source,
+        extends_type: extends_tuple,
+        true_type: true_branch,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let expected = interner.tuple(vec![
+        tuple_elem(TypeId::STRING),
+        tuple_elem(TypeId::BOOLEAN),
+        tuple_elem(TypeId::STRING),
+    ]);
+    assert_eq!(
+        evaluate_type(&interner, interner.conditional(cond)),
+        expected,
+        "[string, ...Rest] where Rest=[boolean,string] should produce [string, boolean, string]"
+    );
+}
+
+#[test]
+fn evaluate_spread_of_concrete_tuple_flattens_inline() {
+    let interner = TypeInterner::new();
+    let inner = interner.tuple(vec![
+        tuple_elem(TypeId::NUMBER),
+        tuple_elem(TypeId::BOOLEAN),
+    ]);
+    let spread_tuple = interner.tuple(vec![tuple_elem(TypeId::STRING), rest_tuple_elem(inner)]);
+
+    let expected = interner.tuple(vec![
+        tuple_elem(TypeId::STRING),
+        tuple_elem(TypeId::NUMBER),
+        tuple_elem(TypeId::BOOLEAN),
+    ]);
+    assert_eq!(
+        evaluate_type(&interner, spread_tuple),
+        expected,
+        "[string, ...[number, boolean]] should evaluate to [string, number, boolean]"
+    );
+}
+
+#[test]
+fn conditional_infer_tail_applied_to_previous_tail_preserves_arity() {
+    // Tail<Tail<[string, number, boolean]>> must be [boolean], not [number, boolean].
+    // Validates that chained infer bindings produce independent residuals.
+    let interner = TypeInterner::new();
+    let infer_h = infer_var(&interner, "_H");
+    let infer_rest = infer_var(&interner, "Rest");
+    let extends_tuple = interner.tuple(vec![tuple_elem(infer_h), rest_tuple_elem(infer_rest)]);
+
+    let source1 = interner.tuple(vec![
+        tuple_elem(TypeId::STRING),
+        tuple_elem(TypeId::NUMBER),
+        tuple_elem(TypeId::BOOLEAN),
+    ]);
+    let cond1 = ConditionalType {
+        check_type: source1,
+        extends_type: extends_tuple,
+        true_type: infer_rest,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+    let tail1 = evaluate_type(&interner, interner.conditional(cond1));
+
+    let infer_h2 = infer_var(&interner, "_H2");
+    let infer_rest2 = infer_var(&interner, "Rest2");
+    let extends_tuple2 =
+        interner.tuple(vec![tuple_elem(infer_h2), rest_tuple_elem(infer_rest2)]);
+    let cond2 = ConditionalType {
+        check_type: tail1,
+        extends_type: extends_tuple2,
+        true_type: infer_rest2,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+    let tail2 = evaluate_type(&interner, interner.conditional(cond2));
+
+    let expected = interner.tuple(vec![tuple_elem(TypeId::BOOLEAN)]);
+    assert_eq!(
+        tail2,
+        expected,
+        "Tail<Tail<[string, number, boolean]>> should produce [boolean]"
+    );
+}

--- a/crates/tsz-solver/tests/infer_pattern_variadic_residual_tests.rs
+++ b/crates/tsz-solver/tests/infer_pattern_variadic_residual_tests.rs
@@ -322,8 +322,7 @@ fn conditional_infer_tail_applied_to_previous_tail_preserves_arity() {
 
     let infer_h2 = infer_var(&interner, "_H2");
     let infer_rest2 = infer_var(&interner, "Rest2");
-    let extends_tuple2 =
-        interner.tuple(vec![tuple_elem(infer_h2), rest_tuple_elem(infer_rest2)]);
+    let extends_tuple2 = interner.tuple(vec![tuple_elem(infer_h2), rest_tuple_elem(infer_rest2)]);
     let cond2 = ConditionalType {
         check_type: tail1,
         extends_type: extends_tuple2,
@@ -335,8 +334,7 @@ fn conditional_infer_tail_applied_to_previous_tail_preserves_arity() {
 
     let expected = interner.tuple(vec![tuple_elem(TypeId::BOOLEAN)]);
     assert_eq!(
-        tail2,
-        expected,
+        tail2, expected,
         "Tail<Tail<[string, number, boolean]>> should produce [boolean]"
     );
 }


### PR DESCRIPTION
## Agent
AgentName: Studio-manager

## Track
Track 4 solver evaluation test-coverage PR.

## Invariant
When a conditional type infers `[infer Head, ...infer Rest]` from a fixed-element tuple, `tsc` preserves the residual tail arity and element order; this PR preserves coverage for that solver-owned variadic tuple evaluation behavior without changing implementation logic.

## Scope
- Adds focused solver regression coverage in `crates/tsz-solver/tests/infer_pattern_variadic_residual_tests.rs`.
- Covers concrete tuple tails of length 0, 1, and 2, true-branch tuple spreading of an inferred tail, direct concrete tuple spread flattening, and chained tail inference preserving independent residuals.
- No checker, solver, emitter, benchmark, or architecture implementation changes.

## Project Corpus Impact
- Row: kysely-project.
- Bug family: variadic tuple tail inference / tuple spread arity preservation.
- Evidence: issue #10833 tracked this family for Kysely-style generic composition; the branch is test-only coverage for the solved/closed behavior and does not change project-row results by itself.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(conditional_infer_tail_of_three_element_tuple_is_two_element_tuple) or test(conditional_infer_tail_of_two_element_tuple_is_one_element_tuple) or test(conditional_infer_tail_of_single_element_tuple_is_empty_tuple) or test(conditional_infer_prepend_inferred_tail_is_flattened_into_result_tuple) or test(evaluate_spread_of_concrete_tuple_flattens_inline) or test(conditional_infer_tail_applied_to_previous_tail_preserves_arity)'` -> 6 passed, 6498 skipped.

## Coordination Notes
- Created from existing remote branch `claude/busy-lamport-c6kF2` during remote-branch pruning because it had a useful diff and no prior PR history.
- Branch head: `067182c2b3`.
- Related issue: #10833 is already closed; this PR preserves focused regression coverage for the behavior.
- This is not WIP and contains no implementation or solver-policy change.
