### PR TITLE
fix(checker): detect readonly index/element write through deferred mapped applications

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1911,6 +1911,10 @@ name = "ts2542_readonly_index_coemission_tests"
 path = "tests/ts2542_readonly_index_coemission_tests.rs"
 
 [[test]]
+name = "readonly_deferred_mapped_application_index_write_tests"
+path = "tests/readonly_deferred_mapped_application_index_write_tests.rs"
+
+[[test]]
 name = "issue_7681_super_decorator_tests"
 path = "tests/issue_7681_super_decorator_tests.rs"
 

--- a/crates/tsz-checker/src/state/state_checking/readonly.rs
+++ b/crates/tsz-checker/src/state/state_checking/readonly.rs
@@ -376,43 +376,42 @@ impl<'a> CheckerState<'a> {
                     // evaluates to a readonly tuple, resolve it so a fixed-element
                     // write is recognized as a readonly named-property write
                     // (TS2540). Other shapes (e.g. `ReadonlyArray<T>`, which is an
-                    // index signature) keep their existing unevaluated handling.
+                    // index signature) are already detected on the unevaluated
+                    // application below.
                     let object_type = self.resolve_readonly_tuple_application(object_type);
 
                     let index_type = self.get_type_of_node(access.name_or_argument);
-                    if let Some(name) = self.get_readonly_element_access_name(
+                    // Primary classification on the (tuple-resolved) declared
+                    // type. This already covers concretely-resolved shapes:
+                    // named aliases, `ReadonlyArray<T>`, `readonly T[]`, and
+                    // readonly tuples.
+                    if let Some(diag) = self.emit_readonly_element_access_diag(
                         object_type,
                         access.name_or_argument,
                         index_type,
+                        target_idx,
                     ) {
-                        // TS2542: use specific diagnostic for readonly index signatures.
-                        // Check if the property resolved through an index signature
-                        // (either the explicit "index signature" sentinel or via
-                        // from_index_signature on a named property).
-                        //
-                        // Exception: readonly tuple fixed elements (e.g., v[0] on
-                        // `readonly [number, number, ...number[]]`) are named properties
-                        // even though resolve_array_property reports from_index_signature.
-                        let from_idx_sig =
-                            self.readonly_element_access_from_index_signature(object_type, &name);
-                        if from_idx_sig {
-                            // tsc anchors TS2542 at the full element access expression
-                            self.error_readonly_index_signature_at(object_type, target_idx);
-                            return ReadonlyAssignmentDiagnostic::IndexSignature;
-                        } else {
-                            // tsc anchors TS2540 at the argument expression inside
-                            // the brackets (e.g., the `0` in `v[0]`), not the full
-                            // element access expression.
-                            self.error_readonly_property_at(&name, access.name_or_argument);
-                            return ReadonlyAssignmentDiagnostic::NamedProperty;
-                        }
+                        return diag;
                     }
-                    // Check for mapped types with explicit readonly modifier (e.g., Readonly<T>).
-                    // This handles Application types like Readonly<T> where T is generic,
-                    // which require TypeEnvironment evaluation to resolve the base type alias.
-                    if self.is_readonly_mapped_type(object_type) {
-                        self.error_readonly_index_signature_at(object_type, target_idx);
-                        return ReadonlyAssignmentDiagnostic::IndexSignature;
+                    // Fallback: a property (or variable) whose declared type is a
+                    // deferred mapped/alias application — `Readonly<number[]>`,
+                    // a user `{ readonly [K in keyof T]: ... }` alias, etc. — is
+                    // left as an unevaluated `Application` by `get_type_of_node`,
+                    // so the primary classification above misses its readonly
+                    // index signature / named property. Evaluate to the
+                    // structural shape and retry, mirroring tsc which classifies
+                    // the resolved type. This is purely additive: it only runs
+                    // when the declared form exposed no readonly write.
+                    let resolved = self.resolve_readonly_element_access_target(object_type);
+                    if resolved != object_type
+                        && let Some(diag) = self.emit_readonly_element_access_diag(
+                            resolved,
+                            access.name_or_argument,
+                            index_type,
+                            target_idx,
+                        )
+                    {
+                        return diag;
                     }
                     // Check AST-level interface readonly for element access (obj["x"])
                     if let Some(name) = self.get_literal_string_from_node(access.name_or_argument) {
@@ -1384,6 +1383,53 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// Classify a readonly element/index-access write for `object_type`,
+    /// emitting TS2542 (readonly index signature) or TS2540 (readonly named
+    /// property) and returning the matching diagnostic variant, or `None` when
+    /// `object_type` exposes no readonly write at this access.
+    ///
+    /// Shared by the declared-type path and the deferred-application fallback so
+    /// both classify identically.
+    fn emit_readonly_element_access_diag(
+        &mut self,
+        object_type: TypeId,
+        index_expr: NodeIndex,
+        index_type: TypeId,
+        target_idx: NodeIndex,
+    ) -> Option<ReadonlyAssignmentDiagnostic> {
+        if let Some(name) =
+            self.get_readonly_element_access_name(object_type, index_expr, index_type)
+        {
+            // TS2542: use the specific diagnostic for readonly index signatures.
+            // Check if the property resolved through an index signature (either
+            // the explicit "index signature" sentinel or via from_index_signature
+            // on a named property).
+            //
+            // Exception: readonly tuple fixed elements (e.g., v[0] on
+            // `readonly [number, number, ...number[]]`) are named properties
+            // even though resolve_array_property reports from_index_signature.
+            let from_idx_sig =
+                self.readonly_element_access_from_index_signature(object_type, &name);
+            if from_idx_sig {
+                // tsc anchors TS2542 at the full element access expression.
+                self.error_readonly_index_signature_at(object_type, target_idx);
+                return Some(ReadonlyAssignmentDiagnostic::IndexSignature);
+            }
+            // tsc anchors TS2540 at the argument expression inside the brackets
+            // (e.g., the `0` in `v[0]`), not the full element access expression.
+            self.error_readonly_property_at(&name, index_expr);
+            return Some(ReadonlyAssignmentDiagnostic::NamedProperty);
+        }
+        // Mapped types with an explicit readonly modifier (e.g., Readonly<T>).
+        // This handles Application types like Readonly<T> where T is generic,
+        // which require TypeEnvironment evaluation to resolve the base type alias.
+        if self.is_readonly_mapped_type(object_type) {
+            self.error_readonly_index_signature_at(object_type, target_idx);
+            return Some(ReadonlyAssignmentDiagnostic::IndexSignature);
+        }
+        None
+    }
+
     /// If `type_id` is an unevaluated type-alias application that evaluates to a
     /// readonly tuple, return the evaluated readonly tuple; otherwise return
     /// `type_id` unchanged. Used so an inline `Readonly<[a, b]>` element write is
@@ -1399,6 +1445,53 @@ impl<'a> CheckerState<'a> {
         let is_readonly_tuple = readonly_inner_type(self.ctx.types, resolved)
             .is_some_and(|inner| tuple_list_id(self.ctx.types, inner).is_some());
         if is_readonly_tuple { resolved } else { type_id }
+    }
+
+    /// If `type_id` is an unevaluated type-alias / mapped-type application that
+    /// evaluates to a concrete indexable shape (an object, array, or tuple —
+    /// possibly `readonly`), return the evaluated shape so the element/index
+    /// access readonly checks operate on the resolved structural type.
+    /// Otherwise return `type_id` unchanged.
+    ///
+    /// `get_type_of_node` resolves a *named* type alias eagerly, but leaves an
+    /// inline application — `Readonly<number[]>`, a user `{ readonly [K in
+    /// keyof T]: ... }` mapped alias, or a property whose declared type is such
+    /// an application — as an unevaluated `Application`. The readonly index/
+    /// element write check (TS2542 for a readonly index signature, TS2540 for a
+    /// readonly named property reached via a literal element key) needs the
+    /// structural form to detect the `readonly` modifier, mirroring tsc which
+    /// always classifies the resolved type. The assignability and property/
+    /// method-lookup paths already evaluate these applications; only the
+    /// index-write check lagged, so e.g. `(r.b as RO<number[]>)[0] = 1` was
+    /// silently accepted.
+    ///
+    /// Adoption is gated on the evaluation producing a concrete shape: a still
+    /// unresolved generic application (e.g. `Readonly<T>` with free `T`) is left
+    /// untouched so generic-only handling (TS2862) is unaffected, and a `-readonly`
+    /// (mutable) result simply produces no diagnostic downstream.
+    fn resolve_readonly_element_access_target(&mut self, type_id: TypeId) -> TypeId {
+        use crate::query_boundaries::common::{
+            array_element_type, object_shape_for_type, readonly_inner_type, tuple_list_id,
+        };
+        use crate::query_boundaries::type_checking_utilities::application_base;
+
+        if application_base(self.ctx.types, type_id).is_none() {
+            return type_id;
+        }
+        let resolved = self.evaluate_type_with_env(type_id);
+        // A no-op evaluation leaves the original `Application`, which fails the
+        // `application_base(resolved).is_none()` gate below and falls through to
+        // returning `type_id` — so no separate unchanged-result check is needed.
+        let resolved_is_concrete_shape = application_base(self.ctx.types, resolved).is_none()
+            && (object_shape_for_type(self.ctx.types, resolved).is_some()
+                || array_element_type(self.ctx.types, resolved).is_some()
+                || tuple_list_id(self.ctx.types, resolved).is_some()
+                || readonly_inner_type(self.ctx.types, resolved).is_some());
+        if resolved_is_concrete_shape {
+            resolved
+        } else {
+            type_id
+        }
     }
 
     fn is_readonly_mapped_type(&mut self, type_id: TypeId) -> bool {

--- a/crates/tsz-checker/tests/readonly_deferred_mapped_application_index_write_tests.rs
+++ b/crates/tsz-checker/tests/readonly_deferred_mapped_application_index_write_tests.rs
@@ -1,0 +1,197 @@
+//! Readonly element/index-access writes through *deferred* mapped/alias
+//! applications.
+//!
+//! Structural rule: when the target of an element-access assignment resolves
+//! (after evaluating a deferred `Application`/`Lazy` type) to a `readonly`
+//! array / readonly index signature, `tsc` reports TS2542; when it resolves to
+//! an object with a `readonly` named property reached via a literal element
+//! key, `tsc` reports TS2540. tsz's element-write check previously only
+//! evaluated the deferred application when it resolved to a readonly *tuple*,
+//! so a property whose declared type was a deferred mapped/alias application
+//! resolving to a readonly *array* (e.g. ts-essentials' `DeepReadonly`) was
+//! silently writable.
+//!
+//! Binder names are varied across cases so the rule is structural and not keyed
+//! to any particular alias/property/type-parameter spelling (anti-hardcoding).
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_codes(source)
+        .into_iter()
+        // 2318 = "Cannot find global type" noise in minimal-lib harness runs.
+        .filter(|&code| code != 2318)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Positive: readonly index signature (TS2542) through a deferred application.
+// ---------------------------------------------------------------------------
+
+/// A property whose declared type is a user homomorphic readonly mapped alias
+/// applied to an array stays a deferred `Application`; writing an element must
+/// still report TS2542.
+#[test]
+fn user_readonly_mapped_alias_over_array_property_emits_2542() {
+    let source = r#"
+type Frozen<Shape> = { readonly [Key in keyof Shape]: Shape[Key] };
+type Wrapper = { items: Frozen<number[]> };
+declare const w: Wrapper;
+w.items[0] = 1;
+"#;
+    let codes = codes(source);
+    assert!(
+        codes.contains(&2542),
+        "readonly mapped alias over array element write must emit TS2542. Got: {codes:?}"
+    );
+}
+
+/// Same rule with completely different binder names — proves it is structural.
+#[test]
+fn user_readonly_mapped_alias_over_array_property_emits_2542_renamed() {
+    let source = r#"
+type Locked<Rec> = { readonly [P in keyof Rec]: Rec[P] };
+type Holder = { payload: Locked<string[]> };
+declare const h: Holder;
+h.payload[2] = "x";
+"#;
+    let codes = codes(source);
+    assert!(
+        codes.contains(&2542),
+        "renamed readonly mapped alias over array element write must emit TS2542. Got: {codes:?}"
+    );
+}
+
+/// An inline application directly as the variable annotation (no named alias
+/// wrapper) is also a deferred `Application`; the element write must emit TS2542.
+#[test]
+fn inline_readonly_mapped_application_variable_emits_2542() {
+    let source = r#"
+type ReadonlyMap<Src> = { readonly [Member in keyof Src]: Src[Member] };
+declare const direct: ReadonlyMap<number[]>;
+direct[0] = 1;
+"#;
+    let codes = codes(source);
+    assert!(
+        codes.contains(&2542),
+        "inline readonly mapped application element write must emit TS2542. Got: {codes:?}"
+    );
+}
+
+/// A conditional type whose chosen branch is a homomorphic readonly mapped type
+/// over an array — the ts-essentials `DeepReadonly` shape — nested one object
+/// hop deep. This is the original witness from the bug report.
+#[test]
+fn deep_readonly_nested_array_leaf_emits_2542() {
+    let source = r#"
+type DeepReadonly<T> = T extends object
+    ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+    : T;
+type Model = DeepReadonly<{ tags: number[] }>;
+declare const m: Model;
+m.tags[0] = 1;
+"#;
+    let codes = codes(source);
+    assert!(
+        codes.contains(&2542),
+        "DeepReadonly nested array leaf element write must emit TS2542. Got: {codes:?}"
+    );
+}
+
+/// A conditional alias whose true branch is a readonly mapped array, used as a
+/// property type (no recursion). Renamed binders.
+#[test]
+fn conditional_readonly_array_branch_property_emits_2542() {
+    let source = r#"
+type Harden<Value> = Value extends unknown[]
+    ? { readonly [Slot in keyof Value]: Value[Slot] }
+    : Value;
+type Box = { contents: Harden<string[]> };
+declare const b: Box;
+b.contents[0] = "y";
+"#;
+    let codes = codes(source);
+    assert!(
+        codes.contains(&2542),
+        "conditional readonly-array branch element write must emit TS2542. Got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive: readonly named property (TS2540) via literal element key through a
+// deferred object application.
+// ---------------------------------------------------------------------------
+
+/// A readonly mapped alias over an *object* reached via a string-literal
+/// element key must report TS2540 (named property), not TS2542.
+#[test]
+fn user_readonly_mapped_alias_over_object_element_key_emits_2540() {
+    let source = r#"
+type Frozen<Shape> = { readonly [Key in keyof Shape]: Shape[Key] };
+type Wrapper = { inner: Frozen<{ field: number }> };
+declare const w: Wrapper;
+w.inner["field"] = 1;
+"#;
+    let codes = codes(source);
+    assert!(
+        codes.contains(&2540),
+        "readonly mapped object element-key write must emit TS2540. Got: {codes:?}"
+    );
+    assert!(
+        !codes.contains(&2542),
+        "readonly named-property write must not be classified as an index signature (TS2542). Got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative: mutable applications must NOT produce a readonly diagnostic.
+// ---------------------------------------------------------------------------
+
+/// An identity (non-readonly) mapped alias over an array stays writable.
+#[test]
+fn mutable_mapped_alias_over_array_property_no_readonly_error() {
+    let source = r#"
+type Identity<Shape> = { [Key in keyof Shape]: Shape[Key] };
+type Wrapper = { items: Identity<number[]> };
+declare const w: Wrapper;
+w.items[0] = 1;
+"#;
+    let codes = codes(source);
+    assert!(
+        !codes.contains(&2542) && !codes.contains(&2540),
+        "mutable mapped alias over array element write must not emit a readonly diagnostic. Got: {codes:?}"
+    );
+}
+
+/// A `-readonly` mapped alias removes the modifier and must stay writable even
+/// when applied to an already-`readonly` array.
+#[test]
+fn minus_readonly_mapped_alias_over_readonly_array_no_error() {
+    let source = r#"
+type Thaw<Shape> = { -readonly [Key in keyof Shape]: Shape[Key] };
+type Wrapper = { items: Thaw<readonly number[]> };
+declare const w: Wrapper;
+w.items[0] = 1;
+"#;
+    let codes = codes(source);
+    assert!(
+        !codes.contains(&2542) && !codes.contains(&2540),
+        "-readonly mapped alias element write must not emit a readonly diagnostic. Got: {codes:?}"
+    );
+}
+
+/// A deep *mutable* mapped/conditional alias must stay writable through nesting.
+#[test]
+fn deep_mutable_nested_array_leaf_no_error() {
+    let source = r#"
+type DeepClone<T> = T extends object ? { [K in keyof T]: DeepClone<T[K]> } : T;
+type Model = DeepClone<{ tags: number[] }>;
+declare const m: Model;
+m.tags[0] = 1;
+"#;
+    let codes = codes(source);
+    assert!(
+        !codes.contains(&2542) && !codes.contains(&2540),
+        "deep mutable nested array leaf write must not emit a readonly diagnostic. Got: {codes:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-B
Runner: confident-hawking

## Track
Conformance / checker false-negative burn-down — mapped/keyof modifier-intent family. Advances the `ts-essentials-project` row tracked by #10792 and the mapped/keyof modifier family in #8432.

## Invariant
When the target of an element-access assignment resolves — after evaluating a deferred `Application`/`Lazy` type — to a `readonly` array / readonly index signature, `tsc` reports **TS2542**; when it resolves to an object with a `readonly` named property reached via a literal element key, `tsc` reports **TS2540**. tsz must classify the write off the *resolved* structural type, not the unevaluated alias/mapped application.

## Structural rule
When the declared type of an element-access write target is a deferred mapped/alias application (`Readonly&lt;number[]&gt;`, a user `{ readonly [K in keyof T]: ... }` alias, or a property/variable whose annotation is such an application) that evaluates to a `readonly` array (index signature) or a `readonly` object property, `tsc` rejects the write (TS2542 / TS2540); tsz now does the same through the checker readonly-assignment boundary (`crates/tsz-checker/src/state/state_checking/readonly.rs`).

Previously the element-write check only evaluated the deferred application when it resolved to a readonly **tuple** (`resolve_readonly_tuple_application`), so readonly **arrays** / index signatures behind a deferred application stayed unevaluated and were silently writable. The assignability and property/method-lookup paths already evaluated these applications — only the index-write check lagged.

Witness (the original report shape — the `ts-essentials` `DeepReadonly` utility):

- `type DeepReadonly&lt;T&gt; = T extends object ? { readonly [K in keyof T]: DeepReadonly&lt;T[K]&gt; } : T;`
  then `declare const r: DeepReadonly&lt;{ b: number[] }&gt;; r.b[0] = 1;` → tsc: **TS2542**; tsz (before): accepted.
- `type RO&lt;X&gt; = { readonly [K in keyof X]: X[K] };` then `declare const s: RO&lt;number[]&gt;; s[0] = 1;` → tsc: **TS2542**; tsz (before): accepted.
- `declare const t: { b: RO&lt;{ x: number }&gt; }; t.b["x"] = 1;` → tsc: **TS2540**; tsz (before): accepted.

## Scope
- `crates/tsz-checker/src/state/state_checking/readonly.rs`
  - Factor the readonly element/index-access classification into `emit_readonly_element_access_diag` (shared by the declared-type path and the fallback so both classify identically).
  - Add `resolve_readonly_element_access_target`: evaluate a deferred `Application` and adopt the result only when it is a concrete object/array/tuple shape.
  - The ELEMENT_ACCESS branch now classifies on the declared (tuple-resolved) type first, then — only when that exposes no readonly write — falls back to the evaluated structural shape. Purely additive.
- `crates/tsz-checker/tests/readonly_deferred_mapped_application_index_write_tests.rs` (new) + `Cargo.toml` `[[test]]` entry — regression coverage.

## Project Corpus Impact
- Row: `ts-essentials-project` (#10792). `ts-essentials`' flagship utilities are recursive readonly mapped types (`DeepReadonly`, `MarkReadonly`); this restores the missing TS2542/TS2540 on readonly array/property writes reached through them. The row can only be fully confirmed with the external fixture (not present in the sandbox), so #10792 stays open for the row owner.
- Bug family: mapped/keyof operations losing `readonly` modifier intent (#8432).
- The change is additive (it only *adds* a readonly diagnostic where the declared form exposed none) and is gated on the deferred evaluation producing a concrete shape, so already-correct paths (`ReadonlyArray&lt;T&gt;`, `readonly T[]`, named aliases, readonly tuples) and generic / `-readonly` (mutable) cases are unchanged. No false positives observed.

## Verification
- `cargo fmt -p tsz-checker --check` — clean.
- `cargo clippy -p tsz-checker --tests` — clean.
- `python3 scripts/arch/arch_guard.py` — guardrails passed.
- `cargo test -p tsz-checker --test readonly_deferred_mapped_application_index_write_tests` — 9 passed.
- Regression suites unchanged: `ts2540_readonly_tests` (42), `mapped_readonly_tuple_tests` (9), `ts2862_generic_class_index_write_tests` (7), `ts2339_readonly_array_mutating_methods_tests` (27), `homomorphic_mapped_keyof_modifier_tests` (9), `recursive_conditional_mapped_infer_tests` (7), `inline_mapped_array_return_tests` (4), `readonly_tuple_to_array_constraint_tests` (5). The two tests failing in this sandbox (`ts2542_readonly_index_coemission_tests::readonly_array_generic_index_write_wrong_type_emits_2322_and_2542`, `deeply_nested_conditional_mapped_recursion_tests::nested_record_conditional_type_still_errors_on_leaf_mismatch`) fail identically on clean `main` here (sandbox lacks the lib `Readonly`/`ReadonlyArray` definitions) — not introduced by this change.
- Differential testing vs `tsc` 6.0.2 across positive (TS2542 array index sig + TS2540 object element key, recursive `DeepReadonly`, conditional branches, renamed binders), negative (mutable mapped, `-readonly`, `Partial`, plain arrays), and control (`ReadonlyArray`, `readonly T[]`, named aliases) cases — all match.

## Coordination Notes
- AgentName: confident-hawking. Re-claimed #10792 (added `WIP`, left canonical `agent:Studio-B` untouched) after the prior `confident-hawking` claim was released post-#12354; no open PR referenced it.
- Rebased onto `origin/main` (`3e5fd62`); no conflicts.
- Anti-hardcoding: no user-name/file-name literals, no rendered-type/diagnostic-string predicates; tests vary binder names to prove the rule is structural; negative/fallback cases covered.
- Three `/simplify` passes applied (removed a redundant early-return; confirmed `evaluate_type_with_env` is memoized so no caching refactor is warranted; the precise 4-way shape check and additive two-resolver design are deliberate).

Refs #10792, #8432
