### PR TITLE
Suppress JSX intrinsic collection protocol noise

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/jsx.rs
@@ -152,18 +152,18 @@ pub(crate) fn missing_props_are_intrinsic_collection_protocol_noise(
         return false;
     }
     let mut has_iterator = false;
-    let mut has_collection_member = false;
+    let mut collection_member_count = 0;
     for prop in props {
         let name = db.resolve_atom_ref(prop.name);
         match (prop.is_symbol_named, name.as_ref()) {
             (true, "[Symbol.iterator]") => has_iterator = true,
             (false, "join" | "length" | "next" | "slice") => {
-                has_collection_member = true;
+                collection_member_count += 1;
             }
             _ => return false,
         }
     }
-    has_iterator && has_collection_member
+    (has_iterator && collection_member_count > 0) || collection_member_count >= 2
 }
 
 pub(crate) fn contains_error_type_in_args(db: &dyn TypeDatabase, type_id: TypeId) -> bool {

--- a/crates/tsz-cli/tests/driver_tests_parts/part_02.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_02.rs
@@ -1485,6 +1485,59 @@ fn compile_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts7006() {
 }
 
 #[test]
+fn compile_contextually_typed_jsx_children2_include_project_has_no_ts2739() {
+    let Some(mut source) = load_typescript_fixture(
+        "TypeScript/tests/cases/compiler/contextuallyTypedJsxChildren2.tsx",
+    ) else {
+        return;
+    };
+    let Some(react16) = load_typescript_fixture("TypeScript/tests/lib/react16.d.ts") else {
+        return;
+    };
+
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    source = source.replace("\"/.lib/react16.d.ts\"", "\"./.lib/react16.d.ts\"");
+
+    write_file(&base.join("test.tsx"), &source);
+    write_file(&base.join(".lib/react16.d.ts"), &react16);
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "es2015",
+            "strict": true,
+            "jsx": "react",
+            "esModuleInterop": true,
+            "noEmit": true,
+            "skipLibCheck": true
+          },
+          "include": ["*.ts", "*.tsx", "*.js", "*.jsx", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+          "exclude": ["node_modules"]
+        }"#,
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    let ts2739: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| {
+            d.code == diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE
+        })
+        .collect();
+
+    assert!(
+        ts2739.is_empty(),
+        "Expected include-glob react16 JSX children fixture to avoid TS2739, got diagnostics: {:?}\nfiles_read: {:?}\nfile_infos: {:?}",
+        result.diagnostics,
+        result.files_read,
+        result.file_infos
+    );
+}
+
+#[test]
 fn compile_react16_automatic_jsx_intrinsics_keep_children_and_img_src() {
     let Some(react16) = load_typescript_fixture("TypeScript/tests/lib/react16.d.ts") else {
         return;
@@ -1776,4 +1829,3 @@ fn compile_excessive_stack_depth_flat_array_fixture_reports_normalized_jsx_key_t
         result.file_infos
     );
 }
-

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -75,7 +75,6 @@ TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 # fixtures are same-code/fingerprint drift in mapped, conditional, inference,
 # JSX, variance, and recursive relation-policy families tracked by #8432; keep
 # them visible here until the owning parity fixes remove them.
-TypeScript/tests/cases/compiler/contextuallyTypedJsxChildren2.tsx
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/inferFromNestedSameShapeTuple.ts
 TypeScript/tests/cases/compiler/promisesWithConstraints.ts


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Checker diagnostics / accepted-regression burn-down

## Invariant
When lowercase intrinsic JSX props differ only by collection/iterator protocol members leaked through React intrinsic attribute surfaces, `tsc` accepts the tag; tsz suppresses that JSX props-validation diagnostic through the structural query-boundary helper, without fixture-name or user-name checks.

## Scope
- Relax `missing_props_are_intrinsic_collection_protocol_noise` to accept all-collection-member required-prop sets.
- Add an include-glob CLI regression for `contextuallyTypedJsxChildren2.tsx`.
- Remove that fixture from `conformance-accepted-regressions.txt`.

## Project Corpus Impact
- Row: n/a
- Bug family: JSX diagnostic parity / accepted-regression burn-down
- Evidence: Diagnostic-only conformance cleanup; no emit or project-row behavior changes intended.

## Verification
- `scripts/safe-run.sh cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-cli -E 'test(compile_contextually_typed_jsx_children2_include_project_has_no_ts2739)' --no-fail-fast`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter contextuallyTypedJsxChildren2 --workers 1 --verbose --print-fingerprints`
- `python3 scripts/conformance/query-conformance.py --dashboard` (accepted-regression gate: 12 listed tests)

## Coordination Notes
- AgentName: M1-A.
- Burns down one #8432 accepted-regression row; remaining strictness rows stay visible in the ledger.
- Manager body cleanup only; implementation ownership remains with M1-A.
