### PR TITLE
chore(bench): guard fixture reclone paths

### DIFF
--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -265,14 +265,14 @@ tsz_ensure_git_fixture() {
   mkdir -p "$(dirname "$dir")"
   if [[ ! -d "$dir/.git" ]]; then
     echo "Cloning ${name} fixture..."
-    rm -rf "$dir"
+    tsz_remove_fixture_dir "$name" "$dir"
     git clone --quiet --no-tags --depth 1 "$repo" "$dir"
   fi
 
   if [[ "$reclone_dirty" == "1" ]] \
     && [[ -n "$(git -C "$dir" status --porcelain 2>/dev/null)" ]]; then
     echo "${name} fixture is dirty; recloning for reproducibility..."
-    rm -rf "$dir"
+    tsz_remove_fixture_dir "$name" "$dir"
     git clone --quiet --no-tags --depth 1 "$repo" "$dir"
   fi
 
@@ -285,6 +285,45 @@ tsz_ensure_git_fixture() {
       git -C "$dir" checkout --quiet --detach FETCH_HEAD
     fi
   fi
+}
+
+tsz_physical_path_for_maybe_missing() {
+  local path="$1"
+  local parent base parent_physical
+
+  [[ -n "$path" ]] || return 1
+  parent="$(dirname "$path")"
+  base="$(basename "$path")"
+  parent_physical="$(cd "$parent" && pwd -P)" || return 1
+  printf '%s/%s\n' "$parent_physical" "$base"
+}
+
+tsz_remove_fixture_dir() {
+  local name="$1"
+  local dir="$2"
+  local target root cwd home
+
+  target="$(tsz_physical_path_for_maybe_missing "$dir")" || {
+    echo "Refusing to remove ${name} fixture with unresolved path: $dir" >&2
+    return 1
+  }
+  root="$(cd "$TSZ_PROJECT_FIXTURES_ROOT" && pwd -P)"
+  home="${HOME:-}"
+  case "$target" in
+    ""|"/"|"$home"|"$root")
+      echo "Refusing to remove unsafe ${name} fixture path: $target" >&2
+      return 1
+      ;;
+  esac
+
+  cwd="$(pwd -P)"
+  case "$cwd" in
+    "$target"|"$target"/*)
+      cd "$root"
+      ;;
+  esac
+
+  rm -rf "$target"
 }
 
 tsz_rxjs_src_root() {


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Studio-B performance infrastructure / benchmark harness reliability.

## Invariant
When a benchmark fixture needs to be cloned or recloned, the fixture helper may remove only the intended fixture directory; it must refuse unsafe paths such as the workspace root and must leave a fixture cwd before deleting that fixture. This PR changes only the shared benchmark/project fixture helper.

## Scope
- Harden `scripts/bench/project-fixtures.sh` fixture removal used by benchmark and project-compile fixture setup.
- Add physical-path normalization, unsafe target rejection, and cwd escape before `rm -rf`.

## Project Corpus Impact
- Row: `ts-toolbelt-project`
- Bug family: benchmark harness fixture reclone / canonical artifact validity
- Evidence: before this patch, a dirty fixture reclone during `scripts/safe-run.sh ./scripts/bench/perf-hotspots.sh --filter '^ts-toolbelt-project$' --json-file /private/tmp/studio-b-main-12425-ts-toolbelt.json` produced an invalid row with `tsz exit codes 0|127; tsgo exit codes 127`, `MODULE_NOT_FOUND` for `scripts/ci/project-compatibility.mjs`, and `uv_cwd` after the current working directory was removed. After this patch, the same filtered row completed and wrote `/private/tmp/studio-b-hardened-fixture-ts-toolbelt.json` plus `/private/tmp/studio-b-hardened-fixture-ts-toolbelt.tsgo-winners.json`.

## Verification
- `bash -n scripts/bench/project-fixtures.sh`
- `bash -c 'set -euo pipefail; tmp=$(mktemp -d /tmp/tsz-fixture-guard.XXXXXX); mkdir -p "$tmp/fixture/sub"; source scripts/bench/project-fixtures.sh; cd "$tmp/fixture/sub"; tsz_remove_fixture_dir smoke "$tmp/fixture"; pwd >/dev/null; test ! -e "$tmp/fixture"; cd "$TSZ_PROJECT_FIXTURES_ROOT"; ! tsz_remove_fixture_dir unsafe "$PWD"; rm -rf "$tmp"'`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`
- `scripts/safe-run.sh ./scripts/bench/perf-hotspots.sh --filter '^ts-toolbelt-project$' --json-file /private/tmp/studio-b-hardened-fixture-ts-toolbelt.json`
- `scripts/safe-run.sh env TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 TSZ_PERF_COUNTERS=1 .target-bench/dist/tsz --extendedDiagnostics --noEmit -p .target-bench/external/ts-toolbelt/tsconfig.flat.json > /private/tmp/studio-b-hardened-fixture-ts-toolbelt.perf.txt 2>&1`
- Pre-rebase PR-head checks passed on `baf696ae10fc355ff42ecd6e878a8e01268e34f7`; after rebase to `origin/main` (`c0ff45cfcc`), local `bash -n`, fixture-removal smoke test, and `git diff --check` passed on `9878fa805d`.

## Coordination Notes
- Ready for Studio-manager review/queue consideration.
- This does not claim a speedup. The latest valid row still has a target gap: `ts-toolbelt-project` `tsz_ms=8349.51`, `tsgo_ms=235.70`, `winner=tsgo`, `factor=35.42x`; attribution still points at recursive type-evaluation pressure (`Record` body_validation ~489.64ms, `_Pick` body ~372.88ms, application intern calls 205077, conditional intern calls 217427).
- Label audit also found unrelated PR #12432 missing its canonical owner label; I added `agent:M1-Opus` and reran the audit successfully.

