### PR TITLE
fix(parser): remove redundant recovered accessor clones

### DIFF
--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -118,31 +118,29 @@ impl ParserState {
         modifiers: Vec<NodeIndex>,
     ) -> NodeIndex {
         match self.token() {
-            SyntaxKind::FunctionKeyword => self.parse_function_declaration_with_async(
-                false,
-                Some(self.make_node_list(modifiers.clone())),
-            ),
+            SyntaxKind::FunctionKeyword => self
+                .parse_function_declaration_with_async(false, Some(self.make_node_list(modifiers))),
             SyntaxKind::ClassKeyword => self.parse_class_declaration_with_modifiers(
                 start_pos,
-                Some(self.make_node_list(modifiers.clone())),
+                Some(self.make_node_list(modifiers)),
             ),
             SyntaxKind::InterfaceKeyword => self.parse_interface_declaration_with_modifiers(
                 start_pos,
-                Some(self.make_node_list(modifiers.clone())),
+                Some(self.make_node_list(modifiers)),
             ),
             SyntaxKind::TypeKeyword => self.parse_type_alias_declaration_with_modifiers(
                 start_pos,
-                Some(self.make_node_list(modifiers.clone())),
+                Some(self.make_node_list(modifiers)),
             ),
             SyntaxKind::EnumKeyword => self.parse_enum_declaration_with_modifiers(
                 start_pos,
-                Some(self.make_node_list(modifiers.clone())),
+                Some(self.make_node_list(modifiers)),
             ),
             SyntaxKind::NamespaceKeyword
             | SyntaxKind::ModuleKeyword
             | SyntaxKind::GlobalKeyword => self.parse_module_declaration_with_modifiers(
                 start_pos,
-                Some(self.make_node_list(modifiers.clone())),
+                Some(self.make_node_list(modifiers)),
             ),
             SyntaxKind::VarKeyword
             | SyntaxKind::LetKeyword
@@ -150,18 +148,18 @@ impl ParserState {
             | SyntaxKind::UsingKeyword
             | SyntaxKind::AwaitKeyword => self.parse_variable_statement_with_modifiers(
                 Some(start_pos),
-                Some(self.make_node_list(modifiers.clone())),
+                Some(self.make_node_list(modifiers)),
             ),
             SyntaxKind::ImportKeyword => {
                 if self.look_ahead_is_import_equals() {
                     self.parse_import_equals_declaration_with_modifiers(
                         start_pos,
-                        Some(self.make_node_list(modifiers.clone())),
+                        Some(self.make_node_list(modifiers)),
                     )
                 } else {
                     self.parse_import_declaration_with_modifiers(
                         start_pos,
-                        Some(self.make_node_list(modifiers.clone())),
+                        Some(self.make_node_list(modifiers)),
                     )
                 }
             }


### PR DESCRIPTION
## Agent
AgentName: Studio-manager

## Track
PR manager lint unblock for queued/ready PRs after #12429 landed.

## Invariant
When recovered top-level `accessor` parser modifiers are routed to a declaration parser, each match arm consumes the modifier list exactly once; this PR removes redundant `Vec` clones without changing parser behavior or emitted AST shape.

## Scope
- `crates/tsz-parser/src/parser/state_statements_keywords.rs`: remove the redundant `modifiers.clone()` calls that clippy now rejects in the recovered-accessor routing helper.

## Project Corpus Impact
- Row: n/a.
- Bug family: n/a.
- Evidence: lint-only parser cleanup; no project-row semantics, diagnostics, emit output, or benchmark configuration changed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `scripts/safe-run.sh cargo clippy -p tsz-parser --all-targets -- -D warnings`
- `scripts/safe-run.sh cargo nextest run -p tsz-parser accessor_on_top_level_function --no-fail-fast`

## Coordination Notes
- Unblocks ready PRs whose CI lint jobs are failing on current `origin/main` after #12429.
- No solver, checker, emit policy, or project corpus behavior changes.
