### PR TITLE
fix(parser): scope rest-parameter trailing-comma TS1013 to non-ambient code (#12370)

### DIFF
--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -1071,6 +1071,18 @@ impl ParserState {
         (self.context_flags & CONTEXT_FLAG_AMBIENT) != 0
     }
 
+    /// Check whether the code currently being parsed is ambient — i.e. nodes
+    /// produced here would carry `tsc`'s `NodeFlags.Ambient`. This is true inside
+    /// a `declare` declaration (tracked by [`CONTEXT_FLAG_AMBIENT`]) or anywhere
+    /// in a declaration file (the whole `.d.ts` is parsed as ambient). Grammar
+    /// checks that `tsc` skips in ambient contexts (e.g. the trailing comma after
+    /// a rest parameter, TS1013) should consult this. The cheap context-flag check
+    /// is ordered first so the file-name test is only reached when needed.
+    #[inline]
+    pub(crate) fn in_ambient_declaration(&self) -> bool {
+        self.in_ambient_context() || self.is_declaration_file()
+    }
+
     /// Check if we're currently parsing inside a parenthesized expression.
     #[inline]
     pub(crate) const fn in_parenthesized_expression_context(&self) -> bool {

--- a/crates/tsz-parser/src/parser/state_statements_class.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class.rs
@@ -436,7 +436,29 @@ impl ParserState {
                 break;
             }
 
+            let comma_pos = self.token_pos();
             let has_comma = self.parse_optional(SyntaxKind::CommaToken);
+
+            // TS1013: A rest parameter or binding pattern may not have a trailing comma.
+            // tsc's grammar check (`checkGrammarParameterList`) skips this diagnostic when
+            // the rest parameter is in an ambient context — i.e. it carries `NodeFlags.Ambient`
+            // (a `declare` declaration or anywhere in a `.d.ts` file). There tsc tolerates a
+            // trailing comma after the rest element to keep formatters and idiomatic multi-line
+            // signatures valid (e.g. `@types/node`'s `pipeline` overloads).
+            if is_rest_param
+                && has_comma
+                && (self.is_token(SyntaxKind::CloseParenToken)
+                    || self.is_token(SyntaxKind::EndOfFileToken))
+                && !self.in_ambient_declaration()
+            {
+                use tsz_common::diagnostics::diagnostic_codes;
+                self.parse_error_at(
+                    comma_pos,
+                    1,
+                    "A rest parameter or binding pattern may not have a trailing comma.",
+                    diagnostic_codes::A_REST_PARAMETER_OR_BINDING_PATTERN_MAY_NOT_HAVE_A_TRAILING_COMMA,
+                );
+            }
 
             if !has_comma {
                 if recover_tail_from_stray_colon && self.is_token(SyntaxKind::EndOfFileToken) {

--- a/crates/tsz-parser/src/parser/state_types_jsx.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx.rs
@@ -344,7 +344,30 @@ impl ParserState {
             );
             params.push(param);
 
-            if !self.parse_optional(SyntaxKind::CommaToken) {
+            let comma_pos = self.token_pos();
+            let has_comma = self.parse_optional(SyntaxKind::CommaToken);
+
+            // TS1013: A rest parameter or binding pattern may not have a trailing comma.
+            // Function/constructor type signatures (`(...a,) => T`, `new (...a,) => T`)
+            // share `tsc`'s rule: the trailing comma after a rest element is an error in
+            // non-ambient code but tolerated in an ambient declaration. See the mirroring
+            // check in `parse_parameter_list`.
+            if dot_dot_dot
+                && has_comma
+                && (self.is_token(SyntaxKind::CloseParenToken)
+                    || self.is_token(SyntaxKind::EndOfFileToken))
+                && !self.in_ambient_declaration()
+            {
+                use tsz_common::diagnostics::diagnostic_codes;
+                self.parse_error_at(
+                    comma_pos,
+                    1,
+                    "A rest parameter or binding pattern may not have a trailing comma.",
+                    diagnostic_codes::A_REST_PARAMETER_OR_BINDING_PATTERN_MAY_NOT_HAVE_A_TRAILING_COMMA,
+                );
+            }
+
+            if !has_comma {
                 break;
             }
         }

--- a/crates/tsz-parser/tests/rest_param_trailing_comma_tests.rs
+++ b/crates/tsz-parser/tests/rest_param_trailing_comma_tests.rs
@@ -1,9 +1,9 @@
 //! Tests for TS1013 (trailing comma after rest) specifically in function
 //! parameter lists vs binding patterns.
 //!
-//! ECMAScript 2017+ allows trailing commas after rest parameters in function
-//! signatures. TypeScript inherits this rule: `f(...args,)` is valid.
-//! Binding pattern rests (`{...x,}`, `[...x,]`) remain illegal per spec.
+//! TypeScript reports TS1013 for trailing commas after rest parameters in
+//! non-ambient function signatures, but suppresses the diagnostic for ambient
+//! declarations. Binding pattern rests (`{...x,}`, `[...x,]`) remain illegal.
 
 use crate::parser::test_fixture::parse_source;
 
@@ -16,23 +16,23 @@ fn has_code(source: &str, code: u32) -> bool {
     error_codes(source).contains(&code)
 }
 
-// --- function parameter rest: trailing comma is VALID ---
+// --- non-ambient function parameter rest: trailing comma is INVALID ---
 
 #[test]
-fn test_function_rest_trailing_comma_no_ts1013() {
+fn test_function_rest_trailing_comma_ts1013() {
     // Plain function signature
     assert!(
-        !has_code("function f(...args: number[],): void {}", 1013),
-        "trailing comma after rest param must NOT be TS1013 in function"
+        has_code("function f(...args: number[],): void {}", 1013),
+        "trailing comma after rest param must be TS1013 in non-ambient function"
     );
 }
 
 #[test]
-fn test_arrow_rest_trailing_comma_no_ts1013() {
+fn test_arrow_rest_trailing_comma_ts1013() {
     // Arrow function
     assert!(
-        !has_code("const f = (...args: string[],) => {};", 1013),
-        "trailing comma after rest param must NOT be TS1013 in arrow"
+        has_code("const f = (...args: string[],) => {};", 1013),
+        "trailing comma after rest param must be TS1013 in non-ambient arrow"
     );
 }
 
@@ -46,11 +46,11 @@ fn test_call_signature_rest_trailing_comma_no_ts1013() {
 }
 
 #[test]
-fn test_method_rest_trailing_comma_no_ts1013() {
+fn test_method_rest_trailing_comma_ts1013() {
     // Class method
     assert!(
-        !has_code("class C { m(...a: boolean[],): void {} }", 1013),
-        "trailing comma after rest param must NOT be TS1013 in class method"
+        has_code("class C { m(...a: boolean[],): void {} }", 1013),
+        "trailing comma after rest param must be TS1013 in non-ambient class method"
     );
 }
 

--- a/crates/tsz-parser/tests/trailing_comma_tests.rs
+++ b/crates/tsz-parser/tests/trailing_comma_tests.rs
@@ -3,11 +3,166 @@
 //! These tests verify that the parser correctly identifies trailing commas
 //! in various contexts where TypeScript allows them.
 
-use crate::parser::test_fixture::parse_source;
+use crate::parser::test_fixture::{parse_source, parse_source_named};
 
 fn parse_code(code: &str) -> Vec<crate::parser::ParseDiagnostic> {
     let (parser, _root) = parse_source(code);
     parser.get_diagnostics().to_vec()
+}
+
+/// Count TS1013 ("A rest parameter or binding pattern may not have a trailing comma")
+/// diagnostics produced when parsing `code` under `file_name`.
+fn rest_trailing_comma_errors(file_name: &str, code: &str) -> usize {
+    let (parser, _root) = parse_source_named(file_name, code);
+    parser
+        .get_diagnostics()
+        .iter()
+        .filter(|d| d.code == 1013)
+        .count()
+}
+
+/// In non-ambient contexts, `tsc` reports TS1013 for a trailing comma after a
+/// rest parameter. These mirror the `tsc` oracle (TypeScript 6.0.x).
+#[test]
+fn test_rest_trailing_comma_errors_in_non_ambient_contexts() {
+    let cases = [
+        ("function declaration", "function f(...a: number[],) {}"),
+        ("arrow function", "const f = (...a: number[],) => {};"),
+        ("class method", "class C { m(...a: number[],) {} }"),
+        (
+            "interface method signature",
+            "interface I { m(...a: number[],): void; }",
+        ),
+        ("function type alias", "type F = (...a: number[],) => void;"),
+        (
+            "constructor type alias",
+            "type C = new (...a: number[],) => object;",
+        ),
+        (
+            "interface call signature",
+            "interface I { (...a: number[],): void; }",
+        ),
+        (
+            "interface construct signature",
+            "interface I { new (...a: number[],): object; }",
+        ),
+        (
+            "plain (non-declare) namespace function",
+            "namespace N { export function f(...a: number[],) {} }",
+        ),
+        (
+            "overload signature",
+            "function f(...a: number[],): void;\nfunction f(...a: number[]): void {}",
+        ),
+    ];
+    for (label, code) in cases {
+        assert_eq!(
+            rest_trailing_comma_errors("test.ts", code),
+            1,
+            "expected exactly one TS1013 for {label}: {code:?}",
+        );
+    }
+}
+
+/// In ambient contexts (inside `declare ...` or anywhere in a `.d.ts` file),
+/// `tsc` tolerates a trailing comma after a rest parameter and emits no TS1013.
+/// This is the real-world `@types/node` `pipeline`-overload shape from the bug.
+#[test]
+fn test_rest_trailing_comma_allowed_in_ambient_contexts() {
+    // `declare`-modified declarations inside a regular `.ts` file.
+    let ts_cases = [
+        (
+            "declare function",
+            "declare function f(...a: number[],): void;",
+        ),
+        (
+            "declare namespace function",
+            "declare namespace N { function f(...a: number[],): void; }",
+        ),
+        (
+            "declare class method",
+            "declare class C { m(...a: number[],): void; }",
+        ),
+        (
+            "declare const function type",
+            "declare const f: (...a: number[],) => void;",
+        ),
+        (
+            "declare const constructor type",
+            "declare const C: new (...a: number[],) => object;",
+        ),
+        (
+            "declare module function",
+            "declare module \"m\" { export function f(...a: number[],): void; }",
+        ),
+    ];
+    for (label, code) in ts_cases {
+        assert_eq!(
+            rest_trailing_comma_errors("test.ts", code),
+            0,
+            "expected no TS1013 for ambient {label}: {code:?}",
+        );
+    }
+
+    // Everything in a declaration file is ambient, even without `declare`.
+    let dts_cases = [
+        (
+            "declaration-file function (pipeline shape)",
+            "declare function pipeline(\n    stream1: unknown,\n    ...streams: Array<unknown>,\n): unknown;",
+        ),
+        (
+            "declaration-file interface method",
+            "interface I { m(...a: number[],): void; }",
+        ),
+        (
+            "declaration-file function type alias",
+            "type F = (...a: number[],) => void;",
+        ),
+        (
+            "declaration-file constructor type alias",
+            "type C = new (...a: number[],) => object;",
+        ),
+        (
+            "declaration-file call signature",
+            "interface I { (...a: number[],): void; }",
+        ),
+        (
+            "declaration-file plain function",
+            "declare function f(...a: number[],): void;",
+        ),
+    ];
+    for (label, code) in dts_cases {
+        assert_eq!(
+            rest_trailing_comma_errors("test.d.ts", code),
+            0,
+            "expected no TS1013 for {label} in a .d.ts file: {code:?}",
+        );
+    }
+}
+
+/// The ambient exception is specific to the trailing comma: a rest parameter
+/// that is *not* last must still report TS1014 in every context, and a trailing
+/// comma after a non-rest parameter is always fine.
+#[test]
+fn test_rest_parameter_grammar_unaffected_by_ambient_exception() {
+    // Rest-not-last still errors (TS1014) even in ambient contexts.
+    let (parser, _root) = parse_source_named(
+        "test.d.ts",
+        "declare function f(...a: number[], b: number): void;",
+    );
+    let ts1014 = parser
+        .get_diagnostics()
+        .iter()
+        .filter(|d| d.code == 1014)
+        .count();
+    assert_eq!(ts1014, 1, "rest-not-last should still emit TS1014 in .d.ts");
+
+    // Trailing comma after a non-rest final parameter never emits TS1013.
+    assert_eq!(
+        rest_trailing_comma_errors("test.ts", "function f(a: number, b: number,) {}"),
+        0,
+        "trailing comma after a non-rest parameter must not emit TS1013",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Fixes #12370. `tsz` reported `TS1013` ("A rest parameter or binding pattern may not have a trailing comma") on a rest parameter followed by a trailing comma even in ambient code, while `tsc` accepts it there. This produced a false positive on idiomatic declaration files — most notably `@types/node`'s multi-line `pipeline` overloads, which every `@types/node` consumer parses.

While confirming the oracle against `tsc@6.0.2`, I found a **symmetric** bug in the opposite direction and fixed both so the parser matches `tsc` in every context.

## Structural Rule
When a rest parameter is the last parameter and is followed by a trailing comma, `tsc` reports `TS1013` **only in non-ambient code**. Its grammar check (`checkGrammarParameterList`) guards the diagnostic with `!(parameter.flags & NodeFlags.Ambient)`: a node is ambient inside a `declare` declaration or anywhere in a `.d.ts` file. `tsz` emits this in the parser, so the parser must consult the same ambient state.

`When a rest parameter has a trailing comma in an ambient declaration, tsc accepts it; tsz now accepts it through the parser's in_ambient_declaration() gate.`

## Owner Layer
Parser (`tsz_parser`) — `tsz` emits `TS1013` during parsing, matching where the diagnostic already lived.

## Scope
- `parse_parameter_list` (function/arrow/method/call-sig/construct-sig/method-sig params): suppress `TS1013` in ambient contexts (the reported false positive).
- `parse_type_parameter_list` (bare function/constructor **type** signatures `(...a,) => T`, `new (...a,) => T`): these never emitted `TS1013` at all — a false **negative**. Added the symmetric check so type-position signatures match `tsc` in both directions.
- New `ParserState::in_ambient_declaration()` predicate = `in_ambient_context() || is_declaration_file()` (cheap flag short-circuits the file-name test). Both sites share it.
- **Intentionally not changed:** binding-pattern rest commas (`[a, ...r,]`, `{a, ...r,}`). `tsc` reports `TS1013` for these in *every* context including `.d.ts` (verified), so their unguarded emission is correct.

## Adjacent-Case Matrix (verified against `tsc@6.0.2`)
| Construct | non-ambient `.ts` | `declare` / `.d.ts` |
|---|---|---|
| function decl / arrow / method | TS1013 | none |
| interface method / call / construct sig | TS1013 | none |
| function type / constructor type alias | TS1013 | none |
| plain (non-`declare`) namespace function | TS1013 | n/a |
| rest-not-last (`...a, b`) | TS1014 (unchanged) | TS1014 (unchanged) |
| array/object binding rest comma | TS1013 | TS1013 (unchanged) |

`tsz` now matches every row.

## Invariant
Parity with `tsc`. No semantic widening, no identifier/file-name string heuristics — the gate reads only the existing ambient context flag and the declaration-file predicate. `TS1014` (rest-must-be-last) and binding-pattern `TS1013` are untouched.

## Project Corpus Impact
- Row: n/a
- Bug family: parser — rest-parameter trailing comma (TS1013) ambient exception

Strictly reduces false positives on `.d.ts`-heavy rows (anything depending on `@types/node`) and closes a parser false negative; both move toward `tsc`. No required project row is affected and none should regress.

## Verification
- `cargo test -p tsz-parser --lib` — 1351 passed, 0 failed (against current `main` @ 9601b47).
- New table-driven regression tests in `crates/tsz-parser/tests/trailing_comma_tests.rs` cover the full matrix above (non-ambient → exactly one `TS1013`; `declare`/`.d.ts` → none; `TS1014` and non-rest trailing comma unaffected).
- `cargo clippy -p tsz-parser --lib` — no warnings in changed files.
- Oracle established by running `tsc@6.0.2` on each case.
- Reviewed with `/simplify` (extracted the shared `in_ambient_declaration()` helper, ordered the cheap check first); converged.

## Coordination Notes
- Issue #12370 labeled `WIP` for the duration of this work.
- Rebased onto latest `main` (9601b47) and force-pushed; branch is 0 behind / 1 ahead, no merge conflict. The change is confined to the rest-parameter trailing-comma grammar check and does not overlap the recovered-accessor lint cleanup (different functions/files).
- Canonical ownership label `agent:Studio-manager` applied by the owner; `AgentName` below is contributor context.

AgentName: Studio-manager
ContributorIdentity: ClaudeOpus-BugHunt-20260604
Track: parser / diagnostics parity

