### PR TITLE
ci: add daily-release automation

### DIFF
--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -1,0 +1,353 @@
+name: Daily Release
+
+# Daily automation for the `try-tsz` release cadence.
+#
+# Two independent jobs:
+#
+#   bump-pr   (schedule + workflow_dispatch)
+#     If `main` has commits past the latest `vX.Y.Z` tag, compute the next
+#     patch version, edit `Cargo.toml` and `Cargo.lock` in lockstep, push a
+#     branch, and open a `chore(release): bump try-tsz publish version to …`
+#     PR with the `merge-queue` label. Poor Man's Merge Queue does the rest.
+#
+#   tag-on-merge   (push to main)
+#     When a release-bump commit merges to `main`, extract the version from
+#     the commit title, create `vX.Y.Z`, and explicitly dispatch `release.yml`
+#     and `npm-publish.yml`. We dispatch instead of relying on the tag-push
+#     trigger because GITHUB_TOKEN pushes do not cascade workflow_runs.
+#
+# Both jobs prefer the PAT-backed `TSZ_PR_AUTOMATION_TOKEN` when present so
+# that branch pushes / tag pushes trigger required-check workflows; they fall
+# back to GITHUB_TOKEN otherwise (in which case downstream workflows are
+# launched via explicit `gh workflow run`).
+
+on:
+  schedule:
+    # 09:00 UTC daily — picks a quiet window after most contributor pushes,
+    # before bench/conformance dashboards re-snapshot.
+    - cron: "0 9 * * *"
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_bump:
+        description: "Force a bump even if main has no commits past the latest tag"
+        type: boolean
+        default: false
+      dry_run:
+        description: "Report intent without pushing branches/tags or opening PRs"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: daily-release-${{ github.event_name }}
+  cancel-in-progress: false
+
+jobs:
+  bump-pr:
+    name: Open daily release-bump PR
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ secrets.TSZ_PR_AUTOMATION_TOKEN || github.token }}
+
+      - name: Detect commits since latest release tag
+        id: detect
+        shell: bash
+        env:
+          FORCE_BUMP: ${{ inputs.force_bump }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force origin
+          # Highest semver tag matching v*.*.*; sort -V handles 0.1.10 > 0.1.9.
+          latest_tag="$(git tag --list 'v*.*.*' | sort -V | tail -n1)"
+          if [[ -z "$latest_tag" ]]; then
+            echo "No prior v*.*.* tag found; treating every commit as releasable."
+            commits_since="$(git rev-list HEAD | wc -l | tr -d ' ')"
+            latest_tag="v0.0.0"
+          else
+            commits_since="$(git rev-list "${latest_tag}..HEAD" | wc -l | tr -d ' ')"
+          fi
+          echo "latest_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+          echo "commits_since=${commits_since}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$commits_since" == "0" && "${FORCE_BUMP}" != "true" ]]; then
+            echo "No new commits since ${latest_tag}; skipping bump."
+            echo "should_bump=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "should_bump=true" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next version
+        id: version
+        if: steps.detect.outputs.should_bump == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          current="$(grep -E '^version = ' Cargo.toml | head -n1 | sed -E 's/version = "([^"]+)"/\1/')"
+          IFS='.' read -r major minor patch <<<"$current"
+          next="${major}.${minor}.$((patch + 1))"
+          echo "current=${current}" >> "$GITHUB_OUTPUT"
+          echo "next=${next}" >> "$GITHUB_OUTPUT"
+          echo "branch=automation/release-bump-${next}" >> "$GITHUB_OUTPUT"
+          echo "Bumping ${current} -> ${next}"
+
+      - name: Edit Cargo.toml and Cargo.lock
+        if: steps.detect.outputs.should_bump == 'true'
+        shell: bash
+        env:
+          CURRENT: ${{ steps.version.outputs.current }}
+          NEXT: ${{ steps.version.outputs.next }}
+        run: |
+          set -euo pipefail
+          # Cargo.toml: workspace.package.version + every in-tree tsz-* dep pin.
+          # The 0.1.13 → 0.1.14 bump (PR #12368) replaced exactly 11 occurrences;
+          # we replicate that shape and fail loudly if the count drifts.
+          before=$(grep -c "\"${CURRENT}\"" Cargo.toml || true)
+          sed -i.bak "s/\"${CURRENT}\"/\"${NEXT}\"/g" Cargo.toml
+          rm -f Cargo.toml.bak
+          after=$(grep -c "\"${NEXT}\"" Cargo.toml || true)
+          if [[ "$before" != "$after" ]]; then
+            echo "Cargo.toml: replaced $before occurrences of ${CURRENT}; ended with $after of ${NEXT}." >&2
+            exit 1
+          fi
+          # Cargo.lock: every `version = "X"` line that sits directly under a
+          # `name = "tsz-*"` line. We confirm each match by structural pairing.
+          python3 - <<'PY'
+          import os
+          import re
+          import sys
+
+          current = os.environ["CURRENT"]
+          next_v = os.environ["NEXT"]
+          path = "Cargo.lock"
+          with open(path, "r", encoding="utf-8") as f:
+              lines = f.read().splitlines()
+
+          replaced = 0
+          for i, line in enumerate(lines):
+              if not line.startswith('name = "tsz'):
+                  continue
+              # Find the next `version = "..."` line in this crate block.
+              for j in range(i + 1, min(i + 10, len(lines))):
+                  if lines[j].startswith("version = "):
+                      if lines[j] == f'version = "{current}"':
+                          lines[j] = f'version = "{next_v}"'
+                          replaced += 1
+                      break
+
+          if replaced == 0:
+              print("No tsz-* crate at version", current, "found in Cargo.lock", file=sys.stderr)
+              sys.exit(1)
+
+          with open(path, "w", encoding="utf-8") as f:
+              f.write("\n".join(lines) + "\n")
+          print(f"Cargo.lock: replaced {replaced} tsz-* crate versions {current} -> {next_v}")
+          PY
+
+          echo "Cargo.toml diff:"
+          git --no-pager diff -- Cargo.toml
+          echo "Cargo.lock diff (first 30 lines):"
+          git --no-pager diff -- Cargo.lock | head -n 30
+
+      - name: Push branch and open PR
+        if: steps.detect.outputs.should_bump == 'true' && (inputs.dry_run != true)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.TSZ_PR_AUTOMATION_TOKEN || github.token }}
+          NEXT: ${{ steps.version.outputs.next }}
+          CURRENT: ${{ steps.version.outputs.current }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+          LATEST_TAG: ${{ steps.detect.outputs.latest_tag }}
+          COMMITS_SINCE: ${{ steps.detect.outputs.commits_since }}
+        run: |
+          set -euo pipefail
+          git config user.name "tsz-release-bot"
+          git config user.email "tsz-release-bot@users.noreply.github.com"
+
+          # If the branch already exists, the previous day's bump may not have
+          # merged. Either close it as superseded by a new one or recycle it.
+          # Simplest: prefix with date so each day is its own attempt.
+          stamp="$(date -u +%Y%m%d)"
+          branch_with_date="${BRANCH}-${stamp}"
+          if git ls-remote --exit-code --heads origin "${branch_with_date}" >/dev/null 2>&1; then
+            echo "Branch ${branch_with_date} already exists on origin; nothing to do."
+            exit 0
+          fi
+          git checkout -b "${branch_with_date}"
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore(release): bump try-tsz publish version to ${NEXT}"
+          git push -u origin "${branch_with_date}"
+
+          body=$(cat <<EOF
+          AgentName: tsz-release-bot
+
+          ## Track
+          Release
+
+          ## Invariant
+          Daily automated release of \`try-tsz\` to npm. Bumps the workspace
+          version from \`${CURRENT}\` to \`${NEXT}\` and lets the merge queue
+          land it. The follow-up \`tag-on-merge\` job in \`daily-release.yml\`
+          tags the merge commit and dispatches \`release.yml\` plus
+          \`npm-publish.yml\`.
+
+          Commits accumulated since \`${LATEST_TAG}\`: ${COMMITS_SINCE}.
+
+          ## Scope
+          Mechanical version bump only:
+          - \`Cargo.toml\`: \`workspace.package.version\` plus every \`tsz-*\`
+            pin in \`[workspace.dependencies]\` move \`${CURRENT}\` → \`${NEXT}\`.
+          - \`Cargo.lock\`: each \`tsz-*\` workspace crate's \`version\` line
+            moves \`${CURRENT}\` → \`${NEXT}\`. Replacements are structurally
+            paired to the preceding \`name = "tsz-*"\` line; a paired-count
+            mismatch fails the workflow.
+
+          No semantic, build, or script changes.
+
+          ## Project Corpus Impact
+          - Row: n/a
+          - Bug family: n/a
+
+          ## Verification
+          - Cargo.toml occurrence count of \`${CURRENT}\` before vs. \`${NEXT}\`
+            after must match (enforced by the workflow).
+          - Cargo.lock replacements are paired with their \`name = "tsz-*"\`
+            header (Python pairing script in the workflow).
+
+          ## Coordination Notes
+          - On merge, \`daily-release.yml\`'s \`tag-on-merge\` job pushes
+            \`v${NEXT}\` and dispatches \`release.yml\` and \`npm-publish.yml\`.
+          - To skip a day's release, close this PR; the next scheduled run
+            opens a new one with the next patch.
+          EOF
+          )
+          gh pr create \
+            --base main \
+            --head "${branch_with_date}" \
+            --title "chore(release): bump try-tsz publish version to ${NEXT}" \
+            --body "${body}" \
+            --label merge-queue
+
+      - name: Summary
+        if: always()
+        shell: bash
+        env:
+          SHOULD_BUMP: ${{ steps.detect.outputs.should_bump }}
+          CURRENT: ${{ steps.version.outputs.current }}
+          NEXT: ${{ steps.version.outputs.next }}
+          COMMITS_SINCE: ${{ steps.detect.outputs.commits_since }}
+          LATEST_TAG: ${{ steps.detect.outputs.latest_tag }}
+        run: |
+          {
+            echo "## Daily release bump"
+            echo ""
+            echo "- latest tag: \`${LATEST_TAG:-none}\`"
+            echo "- commits since tag: ${COMMITS_SINCE:-?}"
+            echo "- should bump: ${SHOULD_BUMP:-?}"
+            if [[ "${SHOULD_BUMP:-}" == "true" ]]; then
+              echo "- ${CURRENT:-?} → ${NEXT:-?}"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  tag-on-merge:
+    name: Tag release on merge
+    if: |
+      github.event_name == 'push' &&
+      startsWith(github.event.head_commit.message, 'chore(release): bump try-tsz publish version to ')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          fetch-tags: true
+          token: ${{ secrets.TSZ_PR_AUTOMATION_TOKEN || github.token }}
+
+      - name: Extract version from commit title
+        id: parse
+        shell: bash
+        env:
+          MSG: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+          # Title looks like: "chore(release): bump try-tsz publish version to 0.1.15 (#12345)"
+          version="$(printf '%s' "$MSG" | head -n1 | sed -E 's/^chore\(release\): bump try-tsz publish version to ([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Could not extract semver from commit title: ${MSG}" >&2
+            exit 1
+          fi
+          tag="v${version}"
+          # Cross-check: Cargo.toml workspace version must match.
+          ws_version="$(grep -E '^version = ' Cargo.toml | head -n1 | sed -E 's/version = "([^"]+)"/\1/')"
+          if [[ "$ws_version" != "$version" ]]; then
+            echo "Commit title says ${version} but Cargo.toml workspace version is ${ws_version}; refusing to tag." >&2
+            exit 1
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if tag already exists
+        id: tag_check
+        shell: bash
+        env:
+          TAG: ${{ steps.parse.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git rev-parse --verify "refs/tags/${TAG}" >/dev/null 2>&1 || \
+             git ls-remote --tags --exit-code origin "${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists; nothing to do."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.tag_check.outputs.exists != 'true'
+        shell: bash
+        env:
+          TAG: ${{ steps.parse.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git config user.name "tsz-release-bot"
+          git config user.email "tsz-release-bot@users.noreply.github.com"
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin "${TAG}"
+
+      - name: Dispatch release workflows
+        if: steps.tag_check.outputs.exists != 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.TSZ_PR_AUTOMATION_TOKEN || github.token }}
+          TAG: ${{ steps.parse.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Belt-and-braces: even when the PAT is configured, explicit dispatch
+          # makes the trigger source legible and avoids the GITHUB_TOKEN
+          # cascade-suppression edge case. Both workflows accept a `tag` input.
+          gh workflow run release.yml --ref "${TAG}" -f tag="${TAG}" || true
+          gh workflow run npm-publish.yml --ref "${TAG}" -f tag="${TAG}" || true
+
+      - name: Summary
+        if: always()
+        shell: bash
+        env:
+          TAG: ${{ steps.parse.outputs.tag }}
+          EXISTS: ${{ steps.tag_check.outputs.exists }}
+        run: |
+          {
+            echo "## Tag-on-merge"
+            echo ""
+            echo "- tag: \`${TAG:-?}\`"
+            echo "- already existed: ${EXISTS:-?}"
+          } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
AgentName: Studio-manager
ContributorIdentity: ClaudeOpus-DailyRelease

## Track
Release / CI

## Invariant
`try-tsz` ships a new npm release on a daily cadence whenever there are commits past the latest `v*.*.*` tag — without a maintainer having to author the bump PR or push a tag by hand. The shape of the bump PR matches the existing manual pattern (PR #12320, #12368), so the existing `project-corpus-pr-body` and `Poor Man's Merge Queue` gates keep working unchanged.

## Scope
New file `.github/workflows/daily-release.yml`. Two jobs:

1. **`bump-pr`** — `schedule: 0 9 * * *` + `workflow_dispatch`.
   - Compares `HEAD` to the highest-semver `v*.*.*` tag. If `commits_since == 0`, skips.
   - Computes next patch (e.g. `0.1.14 → 0.1.15`).
   - Edits `Cargo.toml` in-place via `sed` and validates the occurrence count round-trips (`before == after`).
   - Edits `Cargo.lock` via a Python pairing script that only rewrites `version = "X"` lines directly under a `name = "tsz-*"` line — same structural rule we hand-applied for 0.1.14.
   - Pushes `automation/release-bump-<next>-<yyyymmdd>` and opens a PR with `merge-queue` label and a body containing every required field for `project-corpus-pr-body` (`AgentName:` plain field + `## Project Corpus Impact` / `Row:` / `Bug family:`).

2. **`tag-on-merge`** — `push: branches: main`, gated on the commit title matching `chore(release): bump try-tsz publish version to X.Y.Z`.
   - Extracts the version, cross-checks `Cargo.toml` workspace version, and refuses to tag on mismatch.
   - Pushes `vX.Y.Z` and explicitly `gh workflow run release.yml` + `npm-publish.yml` with the tag input. The explicit dispatch is necessary because tag pushes by `GITHUB_TOKEN` do not cascade other workflows; explicit dispatch sidesteps that and stays correct even when the optional `TSZ_PR_AUTOMATION_TOKEN` PAT is configured.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a

Pure CI plumbing. No checker/solver/binder/emitter/parser/scanner change.

## Verification
- Python `Cargo.lock` script tested locally against current `main` (`0.1.14 → 0.1.15`): replaced exactly 13 `tsz-*` crate version lines, structural diff matches the manual 0.1.13 → 0.1.14 bump.
- `Cargo.toml` sed pattern: current main has exactly 11 `"0.1.14"` occurrences in `Cargo.toml`, matching the prior bump shape; the workflow fails closed if the count doesn't round-trip.
- YAML parses cleanly via PyYAML.
- Trigger surface: only `schedule`, `workflow_dispatch`, and `push: branches: main` (the last one gated by a job-level `if` on commit title prefix), so non-release pushes are no-ops.

## Coordination Notes
- The first scheduled run lands tomorrow (2026-06-05 at 09:00 UTC); it will only open a PR if there are commits past `v0.1.14`.
- Maintainer dial-in: set `TSZ_PR_AUTOMATION_TOKEN` PAT secret if you want the bump-PR branch push to trigger required-check workflows on its own; without the PAT, the merge queue still picks up the PR via `pull_request` events from the original push.
- To skip a day, close the open release-bump PR; the next scheduled run opens a new one with the next patch.
- To pause the cadence, disable the workflow run via the Actions UI or delete this file.
