### PR TITLE
fix(emit): ignore comment braces in class recovery

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_recovery.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_recovery.rs
@@ -83,6 +83,7 @@ impl<'a> Printer<'a> {
         let mut recovered = Vec::new();
         let mut pending_empty_enum: Option<(String, bool)> = None;
         let mut pending_empty_class: Option<(String, bool)> = None;
+        let mut in_block_comment = false;
         for line in source.lines() {
             let trimmed = line.trim();
             if let Some((class_name, has_body)) = pending_empty_class.as_mut() {
@@ -133,13 +134,7 @@ impl<'a> Printer<'a> {
             {
                 recovered.push(stmt);
             }
-            for ch in line.chars() {
-                match ch {
-                    '{' => depth += 1,
-                    '}' => depth -= 1,
-                    _ => {}
-                }
-            }
+            depth += class_recovery_brace_delta(line, &mut in_block_comment);
         }
         recovered
     }
@@ -224,4 +219,60 @@ impl<'a> Printer<'a> {
 
         Some(format!("{{\n    {inner};\n}}"))
     }
+}
+
+fn class_recovery_brace_delta(line: &str, in_block_comment: &mut bool) -> i32 {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    let mut delta = 0;
+    let mut quote: Option<u8> = None;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        if *in_block_comment {
+            if b == b'*' && bytes.get(i + 1) == Some(&b'/') {
+                *in_block_comment = false;
+                i += 2;
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+
+        if let Some(q) = quote {
+            if b == b'\\' {
+                i += 2;
+                continue;
+            }
+            if b == q {
+                quote = None;
+            }
+            i += 1;
+            continue;
+        }
+
+        match b {
+            b'\'' | b'"' | b'`' => {
+                quote = Some(b);
+                i += 1;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'/') => break,
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                *in_block_comment = true;
+                i += 2;
+            }
+            b'{' => {
+                delta += 1;
+                i += 1;
+            }
+            b'}' => {
+                delta -= 1;
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+
+    delta
 }

--- a/crates/tsz-emitter/tests/module_commonjs_tests.rs
+++ b/crates/tsz-emitter/tests/module_commonjs_tests.rs
@@ -354,6 +354,53 @@ fn test_collect_export_names_ignores_type_only_declarations() {
 }
 
 #[test]
+fn test_collect_export_names_ignores_type_only_exported_namespace() {
+    let export_names = parse_collect_exports(
+        "export namespace N { export type X = number; export interface I {} }",
+    );
+    assert!(
+        export_names.is_empty(),
+        "Expected no runtime exports for a namespace with only type members"
+    );
+}
+
+#[test]
+fn cjs_erases_type_only_export_star_and_namespace() {
+    let output = print_commonjs(
+        "export type * from \"./types\";\nexport namespace N { export type X = number; }\n",
+    );
+
+    assert!(
+        output.contains("Object.defineProperty(exports, \"__esModule\", { value: true });"),
+        "Type-only module syntax should still mark the file as an ES module.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("exports.N"),
+        "Type-only namespace exports should not emit CommonJS runtime exports.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("(function (N)"),
+        "Type-only namespace exports should not emit a namespace IIFE.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn cjs_namespace_class_method_body_does_not_leak_to_namespace_tail() {
+    let output = print_commonjs(
+        "namespace N { export class C implements I { constructor(public logger: L) {} private m(p: P): string { var leaked: T = null; return null; } } }",
+    );
+
+    assert!(
+        !output.contains("var leaked:"),
+        "Method-local declarations must stay inside the class method body.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("m(p)"),
+        "The class method should still be emitted.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn test_collect_export_names_ignores_declare_exports() {
     let export_names = parse_collect_exports(
         "export declare const foo: number; export declare function bar(): void;",


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Track 9 / Track 10 emit parity: parser/recovery JavaScript emit plus stale type-only namespace re-export guard for #11358.

## Invariant
When a malformed class-body recovery scan sees braces inside comments or string-like text, `tsc` keeps method-local declarations inside their methods; this PR makes tsz count only real source braces in the class recovery helper so recovered class-body statements are not synthesized from commented blocks.

## Scope
- `crates/tsz-emitter/src/emitter/declarations/class/emit_es6_recovery.rs`: make class recovery brace depth ignore line comments, block comments, and quoted text.
- `crates/tsz-emitter/tests/module_commonjs_tests.rs`: add focused CommonJS guards for type-only exported namespaces and namespace class method locals.
- No checker/solver semantic validation and no output surgery changes.

## Project Corpus Impact
- Row: type-fest-project context from #11358 is covered by a focused guard; current `origin/main` already elides the minimal type-only namespace/export-star repro.
- Bug family: parser/recovery emit (`parserindenter`) improves from fail to pass under the focused JS emit filter.
- Baseline family: parser/recovery emit (`parserindenter`) improves from fail to pass under the focused JS emit filter.
- No project-row fixture configuration or benchmark metadata changed.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter cjs_namespace_class_method_body_does_not_leak_to_namespace_tail cjs_erases_type_only_export_star_and_namespace test_collect_export_names_ignores_type_only_exported_namespace --no-fail-fast`
- `scripts/emit/run.sh --filter=parserindenter --js-only --verbose --json-out=/tmp/tsz-parserindenter-after-final.json`
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-output-surgery-11358-parserindenter.json`
- `git diff --check`
- File-size check: `emit_es6_recovery.rs` 278 lines; `module_commonjs_tests.rs` 618 lines.

## Coordination Notes
- Addresses the live `parserindenter` JS emit failure family without touching semantic validation.
- #11358 appears stale on the minimal repro after recent emit work; this PR adds a guard and should close it after merge if CI agrees.
- Output-surgery audit remains at the existing exhausted cap: total_findings=4, allowlisted_calls=4, unallowlisted_calls=0.