### PR TITLE
fix(emit): hoist es5 computed class temps

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
@@ -178,16 +178,7 @@ impl<'a> Printer<'a> {
                     self.next_disposable_env_id,
                     blocked_disposable_names,
                 );
-                let externally_hoisted_decls =
-                    self.es5_class_externally_hoisted_decls(idx, &class_name);
-                if !externally_hoisted_decls.is_empty() {
-                    for decl in &externally_hoisted_decls {
-                        if !self.hoisted_assignment_temps.contains(decl) {
-                            self.hoisted_assignment_temps.push(decl.clone());
-                        }
-                    }
-                    es5_emitter.set_externally_hoisted_decls(externally_hoisted_decls);
-                }
+                self.configure_es5_class_external_hoists(&mut es5_emitter, idx, &class_name, class);
                 es5_emitter.set_indent_level(self.writer.indent_level());
                 es5_emitter.set_transforms(self.transforms.clone());
                 es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
@@ -398,16 +389,7 @@ impl<'a> Printer<'a> {
             es5_emitter
                 .set_disposable_env_context(self.next_disposable_env_id, blocked_disposable_names);
             if let Some(class_name) = self.get_identifier_text_opt(class.name) {
-                let externally_hoisted_decls =
-                    self.es5_class_externally_hoisted_decls(idx, &class_name);
-                if !externally_hoisted_decls.is_empty() {
-                    for decl in &externally_hoisted_decls {
-                        if !self.hoisted_assignment_temps.contains(decl) {
-                            self.hoisted_assignment_temps.push(decl.clone());
-                        }
-                    }
-                    es5_emitter.set_externally_hoisted_decls(externally_hoisted_decls);
-                }
+                self.configure_es5_class_external_hoists(&mut es5_emitter, idx, &class_name, class);
             }
             es5_emitter.set_indent_level(self.writer.indent_level());
             // Pass transform directives to the ClassES5Emitter
@@ -1032,6 +1014,187 @@ impl<'a> Printer<'a> {
             }
         }
         unreachable!("unbounded class temp suffix search should always find a name")
+    }
+
+    pub(in crate::emitter) fn configure_es5_class_external_hoists(
+        &mut self,
+        es5_emitter: &mut ClassES5Emitter<'a>,
+        class_idx: NodeIndex,
+        class_name: &str,
+        class_data: &ClassData,
+    ) {
+        let externally_hoisted_decls =
+            self.es5_class_externally_hoisted_decls(class_idx, class_name);
+        if !externally_hoisted_decls.is_empty() {
+            for decl in &externally_hoisted_decls {
+                if !self.hoisted_assignment_temps.contains(decl) {
+                    self.hoisted_assignment_temps.push(decl.clone());
+                }
+            }
+            es5_emitter.set_externally_hoisted_decls(externally_hoisted_decls);
+            return;
+        }
+
+        if !self
+            .arena
+            .get(class_idx)
+            .is_some_and(|node| node.kind == syntax_kind_ext::CLASS_DECLARATION)
+        {
+            return;
+        }
+
+        let externally_hoisted_decls =
+            self.es5_class_current_counter_computed_temp_decls(class_name, class_data);
+        if externally_hoisted_decls.is_empty() {
+            return;
+        }
+
+        for decl in &externally_hoisted_decls {
+            if !self.hoisted_assignment_temps.contains(decl) {
+                self.hoisted_assignment_temps.push(decl.clone());
+            }
+        }
+        es5_emitter.set_externally_hoisted_decls(externally_hoisted_decls);
+    }
+
+    fn es5_class_current_counter_computed_temp_decls(
+        &mut self,
+        class_name: &str,
+        class_data: &ClassData,
+    ) -> Vec<String> {
+        let first_computed_instance_auto_accessor =
+            self.first_es5_computed_instance_auto_accessor(class_data);
+        let mut temp_name_index = self.ctx.destructuring_state.temp_var_counter;
+        let mut decls = Vec::new();
+
+        for &member_idx in &class_data.members.nodes {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                continue;
+            };
+            if member_node.kind != syntax_kind_ext::PROPERTY_DECLARATION {
+                continue;
+            }
+            let Some(prop) = self.arena.get_property_decl(member_node) else {
+                continue;
+            };
+            if !self.es5_class_property_has_runtime_effect(member_node, prop) {
+                continue;
+            }
+            let Some(name_node) = self.arena.get(prop.name) else {
+                continue;
+            };
+            if !self.es5_computed_name_needs_temp(name_node) {
+                continue;
+            }
+            let computed_temp = next_es5_temp_name(&mut temp_name_index);
+
+            if first_computed_instance_auto_accessor == Some(member_idx)
+                && let Some(storage_name) =
+                    self.es5_auto_accessor_storage_name(class_data, class_name, member_idx)
+            {
+                decls.push(storage_name);
+            }
+            decls.push(computed_temp);
+        }
+
+        decls
+    }
+
+    fn first_es5_computed_instance_auto_accessor(
+        &self,
+        class_data: &ClassData,
+    ) -> Option<NodeIndex> {
+        class_data.members.nodes.iter().find_map(|&member_idx| {
+            let member_node = self.arena.get(member_idx)?;
+            if member_node.kind != syntax_kind_ext::PROPERTY_DECLARATION {
+                return None;
+            }
+            let prop = self.arena.get_property_decl(member_node)?;
+            if self.es5_auto_accessor_participates_in_storage_naming(prop)
+                && !self.arena.is_static(&prop.modifiers)
+                && self
+                    .arena
+                    .get(prop.name)
+                    .is_some_and(|name| name.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME)
+            {
+                Some(member_idx)
+            } else {
+                None
+            }
+        })
+    }
+
+    fn es5_auto_accessor_storage_name(
+        &self,
+        class_data: &ClassData,
+        class_name: &str,
+        target_member_idx: NodeIndex,
+    ) -> Option<String> {
+        let has_static_auto_accessor = class_data.members.nodes.iter().any(|&member_idx| {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                return false;
+            };
+            if member_node.kind != syntax_kind_ext::PROPERTY_DECLARATION {
+                return false;
+            }
+            let Some(prop) = self.arena.get_property_decl(member_node) else {
+                return false;
+            };
+            self.es5_auto_accessor_participates_in_storage_naming(prop)
+                && self.arena.is_static(&prop.modifiers)
+        });
+        let mut generated_name_index = if has_static_auto_accessor { 1 } else { 0 };
+
+        for &member_idx in &class_data.members.nodes {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                continue;
+            };
+            if member_node.kind != syntax_kind_ext::PROPERTY_DECLARATION {
+                continue;
+            }
+            let Some(prop) = self.arena.get_property_decl(member_node) else {
+                continue;
+            };
+            if !self.es5_auto_accessor_participates_in_storage_naming(prop) {
+                continue;
+            }
+            let Some(name_node) = self.arena.get(prop.name) else {
+                continue;
+            };
+            let storage_part = if name_node.kind == SyntaxKind::Identifier as u16 {
+                self.arena
+                    .get_identifier(name_node)
+                    .map(|id| id.escaped_text.clone())?
+            } else {
+                let name = es5_generated_auto_accessor_name(generated_name_index);
+                generated_name_index += 1;
+                name
+            };
+
+            if member_idx == target_member_idx {
+                return Some(format!("_{class_name}_{storage_part}_accessor_storage"));
+            }
+        }
+
+        None
+    }
+
+    fn es5_auto_accessor_participates_in_storage_naming(
+        &self,
+        prop: &tsz_parser::parser::node::PropertyDeclData,
+    ) -> bool {
+        self.arena
+            .has_modifier(&prop.modifiers, SyntaxKind::AccessorKeyword)
+            && !self
+                .arena
+                .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
+            && !self
+                .arena
+                .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
+            && !self
+                .arena
+                .get(prop.name)
+                .is_some_and(|n| n.kind == SyntaxKind::PrivateIdentifier as u16)
     }
 
     pub(in crate::emitter) fn es5_class_externally_hoisted_decls(

--- a/crates/tsz-emitter/src/emitter/transform_dispatch.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch.rs
@@ -3,7 +3,6 @@
 //! Contains the `EmitDirective` enum and all methods related to applying
 //! transform directives during emission (Phase 2 architecture).
 
-use super::declarations::class::class_has_self_references;
 use super::*;
 use crate::emitter::core::PrivateMemberInfo;
 use crate::transforms::emit_utils::{get_extends_expression_index, hygienic_temp_name};
@@ -21,6 +20,9 @@ mod transform_dispatch_chain;
 
 #[path = "transform_dispatch_class_binding.rs"]
 mod transform_dispatch_class_binding;
+
+#[path = "transform_dispatch_es5_class.rs"]
+mod transform_dispatch_es5_class;
 
 impl<'a> Printer<'a> {
     // =========================================================================
@@ -884,171 +886,6 @@ impl<'a> Printer<'a> {
         self.ctx
             .block_scope_state
             .reserve_names(es5_emitter.block_scope_reserved_names());
-    }
-
-    fn emit_es5_class_output(
-        &mut self,
-        es5_emitter: &mut ClassES5Emitter<'a>,
-        class_node: NodeIndex,
-        binding_name: Option<&str>,
-    ) -> String {
-        if let Some(binding_name) = binding_name {
-            es5_emitter.emit_class_with_binding_name(class_node, binding_name)
-        } else {
-            es5_emitter.emit_class(class_node)
-        }
-    }
-
-    /// Create an ES5 class emitter pre-configured with decorator info for the given class.
-    fn create_es5_class_emitter_with_decorators(
-        &mut self,
-        class_node: NodeIndex,
-    ) -> ClassES5Emitter<'a> {
-        let mut es5_emitter = ClassES5Emitter::new(self.arena);
-        es5_emitter.set_temp_var_counter(self.ctx.destructuring_state.temp_var_counter);
-        es5_emitter
-            .set_async_generator_inner_name_counts(self.async_generator_inner_name_counts.clone());
-        self.configure_es5_class_emitter_disposable_context(&mut es5_emitter);
-        if let Some(class_node_ref) = self.arena.get(class_node)
-            && let Some(class_data) = self.arena.get_class(class_node_ref)
-        {
-            let class_name = self.get_identifier_text_idx(class_data.name);
-            let externally_hoisted_decls =
-                self.es5_class_externally_hoisted_decls(class_node, &class_name);
-            if !externally_hoisted_decls.is_empty() {
-                for decl in &externally_hoisted_decls {
-                    if !self.hoisted_assignment_temps.contains(decl) {
-                        self.hoisted_assignment_temps.push(decl.clone());
-                    }
-                }
-                es5_emitter.set_externally_hoisted_decls(externally_hoisted_decls);
-            }
-        }
-        es5_emitter.set_indent_level(self.writer.indent_level());
-        es5_emitter.set_transforms(self.transforms.clone());
-        es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
-        es5_emitter.set_use_define_for_class_fields(self.ctx.options.use_define_for_class_fields);
-        if self.ctx.options.import_helpers && self.ctx.is_effectively_commonjs() {
-            es5_emitter.set_tslib_prefix(true);
-            es5_emitter.set_tslib_import_binding(self.commonjs_tslib_import_binding.clone());
-        }
-        es5_emitter.set_printer_options(self.ctx.options.clone());
-        es5_emitter.set_module_kind(self.ctx.outer_module_kind());
-        if let Some(text) = self.source_text_for_map() {
-            if self.writer.has_source_map() {
-                es5_emitter.set_source_map_context(text, self.writer.current_source_index());
-            } else {
-                es5_emitter.set_source_text(text);
-            }
-        }
-        if !self.commonjs_named_import_substitutions.is_empty() {
-            es5_emitter.set_commonjs_import_substitutions(
-                self.commonjs_named_import_substitutions.clone(),
-            );
-        }
-
-        if self.ctx.target_es5
-            && !self.ctx.options.legacy_decorators
-            && let Some(class_node_ref) = self.arena.get(class_node)
-            && let Some(class_data) = self.arena.get_class(class_node_ref)
-            && self.class_has_tc39_decorator_nodes(class_data)
-        {
-            es5_emitter.set_tc39_decorators(true);
-        }
-
-        // Pass legacy decorator info so __decorate calls are emitted inside the IIFE
-        if self.ctx.options.legacy_decorators
-            && let Some(class_node_ref) = self.arena.get(class_node)
-            && let Some(class_data) = self.arena.get_class(class_node_ref)
-        {
-            let class_decorators = self.collect_class_decorators(&class_data.modifiers);
-            let class_self_alias = if !class_decorators.is_empty() {
-                self.get_identifier_text_opt(class_data.name)
-                    .filter(|class_name| {
-                        class_has_self_references(
-                            self.arena,
-                            self.source_text_for_map(),
-                            class_name,
-                            &class_data.members.nodes,
-                        )
-                    })
-                    .map(|class_name| self.make_unique_name_from_base(&class_name))
-            } else {
-                None
-            };
-            let has_member_decorators = class_data.members.nodes.iter().any(|&m_idx| {
-                let Some(m_node) = self.arena.get(m_idx) else {
-                    return false;
-                };
-                let mods = match m_node.kind {
-                    k if k == syntax_kind_ext::METHOD_DECLARATION => self
-                        .arena
-                        .get_method_decl(m_node)
-                        .and_then(|m| m.modifiers.as_ref()),
-                    k if k == syntax_kind_ext::PROPERTY_DECLARATION => self
-                        .arena
-                        .get_property_decl(m_node)
-                        .and_then(|p| p.modifiers.as_ref()),
-                    k if k == syntax_kind_ext::GET_ACCESSOR
-                        || k == syntax_kind_ext::SET_ACCESSOR =>
-                    {
-                        self.arena
-                            .get_accessor(m_node)
-                            .and_then(|a| a.modifiers.as_ref())
-                    }
-                    _ => None,
-                };
-                let has_member_dec = mods.is_some_and(|m| {
-                    m.nodes.iter().any(|&mod_idx| {
-                        self.arena
-                            .get(mod_idx)
-                            .is_some_and(|n| n.kind == syntax_kind_ext::DECORATOR)
-                    })
-                });
-                if has_member_dec {
-                    return true;
-                }
-                // Also check for parameter decorators on methods and constructors
-                let params = match m_node.kind {
-                    k if k == syntax_kind_ext::METHOD_DECLARATION => {
-                        self.arena.get_method_decl(m_node).map(|m| &m.parameters)
-                    }
-                    k if k == syntax_kind_ext::CONSTRUCTOR => {
-                        self.arena.get_constructor(m_node).map(|c| &c.parameters)
-                    }
-                    _ => None,
-                };
-                params.is_some_and(|p| {
-                    p.nodes.iter().any(|&param_idx| {
-                        let Some(param_node) = self.arena.get(param_idx) else {
-                            return false;
-                        };
-                        let Some(param) = self.arena.get_parameter(param_node) else {
-                            return false;
-                        };
-                        param.modifiers.as_ref().is_some_and(|m| {
-                            m.nodes.iter().any(|&mod_idx| {
-                                self.arena
-                                    .get(mod_idx)
-                                    .is_some_and(|n| n.kind == syntax_kind_ext::DECORATOR)
-                            })
-                        })
-                    })
-                })
-            });
-            if !class_decorators.is_empty() || has_member_decorators {
-                es5_emitter.set_decorator_info(ClassDecoratorInfo {
-                    class_decorators,
-                    has_member_decorators,
-                    emit_decorator_metadata: self.ctx.options.emit_decorator_metadata,
-                });
-                if let Some(alias) = class_self_alias {
-                    es5_emitter.set_class_self_reference_alias(alias);
-                }
-            }
-        }
-
-        es5_emitter
     }
 
     pub(in crate::emitter) fn class_has_tc39_decorator_nodes(

--- a/crates/tsz-emitter/src/emitter/transform_dispatch_es5_class.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch_es5_class.rs
@@ -1,0 +1,166 @@
+//! ES5 class emitter helpers split out of `transform_dispatch.rs`.
+
+use super::declarations::class::class_has_self_references;
+use super::*;
+
+impl<'a> Printer<'a> {
+    pub(in crate::emitter) fn emit_es5_class_output(
+        &mut self,
+        es5_emitter: &mut ClassES5Emitter<'a>,
+        class_node: NodeIndex,
+        binding_name: Option<&str>,
+    ) -> String {
+        if let Some(binding_name) = binding_name {
+            es5_emitter.emit_class_with_binding_name(class_node, binding_name)
+        } else {
+            es5_emitter.emit_class(class_node)
+        }
+    }
+
+    /// Create an ES5 class emitter pre-configured with decorator info for the given class.
+    pub(in crate::emitter) fn create_es5_class_emitter_with_decorators(
+        &mut self,
+        class_node: NodeIndex,
+    ) -> ClassES5Emitter<'a> {
+        let mut es5_emitter = ClassES5Emitter::new(self.arena);
+        es5_emitter.set_temp_var_counter(self.ctx.destructuring_state.temp_var_counter);
+        es5_emitter
+            .set_async_generator_inner_name_counts(self.async_generator_inner_name_counts.clone());
+        self.configure_es5_class_emitter_disposable_context(&mut es5_emitter);
+        if let Some(class_node_ref) = self.arena.get(class_node)
+            && let Some(class_data) = self.arena.get_class(class_node_ref)
+        {
+            let class_name = self.get_identifier_text_idx(class_data.name);
+            self.configure_es5_class_external_hoists(
+                &mut es5_emitter,
+                class_node,
+                &class_name,
+                class_data,
+            );
+        }
+        es5_emitter.set_indent_level(self.writer.indent_level());
+        es5_emitter.set_transforms(self.transforms.clone());
+        es5_emitter.set_remove_comments(self.ctx.options.remove_comments);
+        es5_emitter.set_use_define_for_class_fields(self.ctx.options.use_define_for_class_fields);
+        if self.ctx.options.import_helpers && self.ctx.is_effectively_commonjs() {
+            es5_emitter.set_tslib_prefix(true);
+            es5_emitter.set_tslib_import_binding(self.commonjs_tslib_import_binding.clone());
+        }
+        es5_emitter.set_printer_options(self.ctx.options.clone());
+        es5_emitter.set_module_kind(self.ctx.outer_module_kind());
+        if let Some(text) = self.source_text_for_map() {
+            if self.writer.has_source_map() {
+                es5_emitter.set_source_map_context(text, self.writer.current_source_index());
+            } else {
+                es5_emitter.set_source_text(text);
+            }
+        }
+        if !self.commonjs_named_import_substitutions.is_empty() {
+            es5_emitter.set_commonjs_import_substitutions(
+                self.commonjs_named_import_substitutions.clone(),
+            );
+        }
+
+        if self.ctx.target_es5
+            && !self.ctx.options.legacy_decorators
+            && let Some(class_node_ref) = self.arena.get(class_node)
+            && let Some(class_data) = self.arena.get_class(class_node_ref)
+            && self.class_has_tc39_decorator_nodes(class_data)
+        {
+            es5_emitter.set_tc39_decorators(true);
+        }
+
+        if self.ctx.options.legacy_decorators
+            && let Some(class_node_ref) = self.arena.get(class_node)
+            && let Some(class_data) = self.arena.get_class(class_node_ref)
+        {
+            let class_decorators = self.collect_class_decorators(&class_data.modifiers);
+            let class_self_alias = if !class_decorators.is_empty() {
+                self.get_identifier_text_opt(class_data.name)
+                    .filter(|class_name| {
+                        class_has_self_references(
+                            self.arena,
+                            self.source_text_for_map(),
+                            class_name,
+                            &class_data.members.nodes,
+                        )
+                    })
+                    .map(|class_name| self.make_unique_name_from_base(&class_name))
+            } else {
+                None
+            };
+            let has_member_decorators = class_data.members.nodes.iter().any(|&m_idx| {
+                let Some(m_node) = self.arena.get(m_idx) else {
+                    return false;
+                };
+                let mods = match m_node.kind {
+                    k if k == syntax_kind_ext::METHOD_DECLARATION => self
+                        .arena
+                        .get_method_decl(m_node)
+                        .and_then(|m| m.modifiers.as_ref()),
+                    k if k == syntax_kind_ext::PROPERTY_DECLARATION => self
+                        .arena
+                        .get_property_decl(m_node)
+                        .and_then(|p| p.modifiers.as_ref()),
+                    k if k == syntax_kind_ext::GET_ACCESSOR
+                        || k == syntax_kind_ext::SET_ACCESSOR =>
+                    {
+                        self.arena
+                            .get_accessor(m_node)
+                            .and_then(|a| a.modifiers.as_ref())
+                    }
+                    _ => None,
+                };
+                let has_member_dec = mods.is_some_and(|m| {
+                    m.nodes.iter().any(|&mod_idx| {
+                        self.arena
+                            .get(mod_idx)
+                            .is_some_and(|n| n.kind == syntax_kind_ext::DECORATOR)
+                    })
+                });
+                if has_member_dec {
+                    return true;
+                }
+
+                let params = match m_node.kind {
+                    k if k == syntax_kind_ext::METHOD_DECLARATION => {
+                        self.arena.get_method_decl(m_node).map(|m| &m.parameters)
+                    }
+                    k if k == syntax_kind_ext::CONSTRUCTOR => {
+                        self.arena.get_constructor(m_node).map(|c| &c.parameters)
+                    }
+                    _ => None,
+                };
+                params.is_some_and(|p| {
+                    p.nodes.iter().any(|&param_idx| {
+                        let Some(param_node) = self.arena.get(param_idx) else {
+                            return false;
+                        };
+                        let Some(param) = self.arena.get_parameter(param_node) else {
+                            return false;
+                        };
+                        param.modifiers.as_ref().is_some_and(|m| {
+                            m.nodes.iter().any(|&mod_idx| {
+                                self.arena
+                                    .get(mod_idx)
+                                    .is_some_and(|n| n.kind == syntax_kind_ext::DECORATOR)
+                            })
+                        })
+                    })
+                })
+            });
+            if !class_decorators.is_empty() || has_member_decorators {
+                es5_emitter.set_decorator_info(ClassDecoratorInfo {
+                    class_decorators,
+                    has_member_decorators,
+                    emit_decorator_metadata: self.ctx.options.emit_decorator_metadata,
+                });
+                if let Some(alias) = class_self_alias {
+                    es5_emitter.set_class_self_reference_alias(alias);
+                }
+            }
+        }
+
+        es5_emitter
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit/DTS parity: JavaScript emit ES5 class temp/hoist scheduling.

## Invariant
When an ES5 class declaration has runtime computed property names, tsc declares the computed key temps in the file hoist and the lowered class consumes those same temps; this PR makes tsz route ES5 class-declaration computed temp declarations through the shared class external-hoist coordinator.

## Scope
- crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
- crates/tsz-emitter/src/emitter/transform_dispatch.rs
- crates/tsz-emitter/src/emitter/transform_dispatch_es5_class.rs

## Project Corpus Impact
- Row: n/a
- Bug family: JavaScript emit ES5 computed class temp hoist ordering
- Evidence: emit-baseline-only change; targeted local emit rows defineProperty, autoAccessor5, and staticPropertyNameConflicts now pass.

## Verification
- cargo fmt --check
- git diff --check
- ./scripts/emit/run.sh --js-only --filter=defineProperty --verbose --timeout=20000 --json-out=/tmp/studio-c-js-defineProperty-rebased2.json
- ./scripts/emit/run.sh --skip-build --js-only --filter=autoAccessor5 --verbose --timeout=20000 --json-out=/tmp/studio-c-js-autoAccessor5-rebased2.json
- ./scripts/emit/run.sh --skip-build --js-only --filter=staticPropertyNameConflicts --verbose --timeout=20000 --json-out=/tmp/studio-c-js-staticPropertyNameConflicts-rebased2.json
- ./scripts/emit/run.sh --skip-build --js-only --filter=privateNameES5Ban --verbose --timeout=20000 --json-out=/tmp/studio-c-js-privateNameES5Ban-rebased2.json
- cargo check -p tsz-emitter

## Coordination Notes
- AgentName: Studio-C
- Open overlap checked: #12429 remains draft/WIP for parser/source recovery and label contract cleanup; this PR is a non-overlapping ES5 class temp hoist slice.
- Split transform_dispatch ES5 class emitter setup into a 166-line helper so edited files stay under the 2000-line cap.
- Rebased onto origin/main at c11efee3a6 before force-pushing head 4795e7fecd.
- Marked ready for full CI/manager review; Studio-C did not add merge-queue.