### PR TITLE
test(checker): cover mapped predicate flow joins

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1255,15 +1255,6 @@ pub(crate) fn is_tuple_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::is_tuple_type(db, type_id)
 }
 
-/// `true` when `type_id` is an anonymous object type, or a union / intersection
-/// that contains one (recursing through nested unions / intersections).
-pub(crate) fn union_or_intersection_mentions_object(
-    db: &dyn TypeDatabase,
-    type_id: TypeId,
-) -> bool {
-    tsz_solver::type_queries::union_or_intersection_mentions_object(db, type_id)
-}
-
 pub(crate) fn is_intersection_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::is_intersection_type(db, type_id)
 }

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -19,6 +19,15 @@ pub(crate) fn assignment_numeric_display_children(
     tsz_solver::type_queries::assignment_numeric_display_children(db, type_id)
 }
 
+/// `true` when `type_id` is an anonymous object type, or a union / intersection
+/// that contains one (recursing through nested unions / intersections).
+pub(crate) fn union_or_intersection_mentions_object(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> bool {
+    tsz_solver::type_queries::union_or_intersection_mentions_object(db, type_id)
+}
+
 pub(crate) fn is_typeof_result_union(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     const STRING: u8 = 1 << 0;
     const NUMBER: u8 = 1 << 1;

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -2708,7 +2708,12 @@ impl<'a> CheckerState<'a> {
                     .and_then(|_| self.ctx.binder.get_symbol(sym_id))
                     .is_some_and(|symbol| {
                         symbol.declarations.iter().any(|&decl_idx| {
-                            self.alias_declaration_body_is_computed(decl_idx, result)
+                            super::source_alias_attribution::alias_declaration_body_is_computed(
+                                self.ctx.arena,
+                                self.ctx.types,
+                                decl_idx,
+                                result,
+                            )
                         })
                     });
                 if body_is_computed {
@@ -2744,81 +2749,6 @@ impl<'a> CheckerState<'a> {
         }
 
         result
-    }
-
-    /// Decide whether a type-alias declaration body is a reducing operator whose
-    /// `result` tsc renders structurally (without an `aliasSymbol`), so the
-    /// definition store should mark `result` as a "computed" body.
-    ///
-    /// - An **intersection** drops the alias name only when it collapses to a
-    ///   union of purely primitive/literal members (`T1 & ("a"|"b")` →
-    ///   `"a"|"b"`); a distribution into object-typed members keeps the name.
-    /// - A **conditional** or **indexed access** resolves *away* into its branch
-    ///   / element type and never carries the alias's `aliasSymbol`, so tsc
-    ///   renders the evaluated underlying type — scalar, literal, `never`,
-    ///   union, tuple, array, or function (verified against tsc 6.0.2:
-    ///   `type P = true extends true ? [string, number] : never` elaborates as
-    ///   `[string, number]`). This is gated to results that do **not** mention
-    ///   an anonymous object type: an object result re-resolves eagerly and is
-    ///   surfaced through the reverse `find_def_for_type` lookup, where marking
-    ///   the shared shape mis-routes the alias name onto an unrelated holder.
-    ///   The deferred-body display path (`TypeFormatter`) already renders those
-    ///   object results structurally without this provenance flag. The other
-    ///   exclusion is a result that stayed a deferred conditional / indexed
-    ///   access (an operand could not be resolved), no more informative than the
-    ///   alias name.
-    fn alias_declaration_body_is_computed(
-        &self,
-        decl_idx: tsz_parser::parser::NodeIndex,
-        result: TypeId,
-    ) -> bool {
-        use tsz_parser::parser::syntax_kind_ext;
-        let Some(decl_node) = self.ctx.arena.get(decl_idx) else {
-            return false;
-        };
-        let Some(type_alias) = self.ctx.arena.get_type_alias(decl_node) else {
-            return false;
-        };
-        let Some(body_node) = self.ctx.arena.get(type_alias.type_node) else {
-            return false;
-        };
-        match body_node.kind {
-            syntax_kind_ext::INTERSECTION_TYPE => self.result_is_primitive_literal_union(result),
-            syntax_kind_ext::CONDITIONAL_TYPE | syntax_kind_ext::INDEXED_ACCESS_TYPE => {
-                !crate::query_boundaries::common::is_conditional_type(self.ctx.types, result)
-                    && !crate::query_boundaries::common::is_index_access_type(
-                        self.ctx.types,
-                        result,
-                    )
-                    && !crate::query_boundaries::common::union_or_intersection_mentions_object(
-                        self.ctx.types,
-                        result,
-                    )
-            }
-            _ => false,
-        }
-    }
-
-    /// `true` when `ty` is a union whose members are all primitives, literals,
-    /// or `never` — the "trivial reduction" shape an intersection drops its
-    /// alias name for (`T1 & ("a"|"b")` → `"a"|"b"`). A non-union result returns
-    /// `false`: a single primitive/literal is already handled by the formatter's
-    /// intrinsic/literal check.
-    fn result_is_primitive_literal_union(&self, ty: TypeId) -> bool {
-        crate::query_boundaries::common::union_members(self.ctx.types, ty).is_some_and(|members| {
-            members.iter().all(|&m| {
-                crate::query_boundaries::common::literal_value(self.ctx.types, m).is_some()
-                    || m == TypeId::STRING
-                    || m == TypeId::NUMBER
-                    || m == TypeId::BOOLEAN
-                    || m == TypeId::BIGINT
-                    || m == TypeId::SYMBOL
-                    || m == TypeId::UNDEFINED
-                    || m == TypeId::NULL
-                    || m == TypeId::VOID
-                    || m == TypeId::NEVER
-            })
-        })
     }
 
     /// Resolve a `typeof X` type query with flow-sensitive narrowing.

--- a/crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs
@@ -15,6 +15,8 @@ use tsz_common::perf_counters::{
 use tsz_parser::NodeIndex;
 use tsz_parser::parser::node::{NodeAccess, NodeArena, TypeAliasData};
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::TypeId;
+use tsz_solver::construction::TypeDatabase;
 
 pub(crate) fn record_source_alias_rejection_kinds(
     arena: &NodeArena,
@@ -79,6 +81,63 @@ pub(crate) fn record_source_alias_rejection_kinds(
             type_node_is_lowerable,
         );
     }
+}
+
+/// Decide whether a type-alias declaration body is a reducing operator whose
+/// `result` tsc renders structurally (without an `aliasSymbol`), so the
+/// definition store should mark `result` as a "computed" body.
+///
+/// - An **intersection** drops the alias name only when it collapses to a
+///   union of purely primitive/literal members (`T1 & ("a"|"b")` ->
+///   `"a"|"b"`); a distribution into object-typed members keeps the name.
+/// - A **conditional** or **indexed access** resolves away into its branch /
+///   element type and never carries the alias's `aliasSymbol`, so tsc renders
+///   the evaluated underlying type. Object results are excluded because a
+///   shared object shape is painted through the reverse `find_def_for_type`
+///   lookup, where marking it would mis-route the alias name.
+pub(crate) fn alias_declaration_body_is_computed(
+    arena: &NodeArena,
+    db: &dyn TypeDatabase,
+    decl_idx: NodeIndex,
+    result: TypeId,
+) -> bool {
+    let Some(decl_node) = arena.get(decl_idx) else {
+        return false;
+    };
+    let Some(type_alias) = arena.get_type_alias(decl_node) else {
+        return false;
+    };
+    let Some(body_node) = arena.get(type_alias.type_node) else {
+        return false;
+    };
+    match body_node.kind {
+        syntax_kind_ext::INTERSECTION_TYPE => result_is_primitive_literal_union(db, result),
+        syntax_kind_ext::CONDITIONAL_TYPE | syntax_kind_ext::INDEXED_ACCESS_TYPE => {
+            !crate::query_boundaries::common::is_conditional_type(db, result)
+                && !crate::query_boundaries::common::is_index_access_type(db, result)
+                && !crate::query_boundaries::diagnostics::union_or_intersection_mentions_object(
+                    db, result,
+                )
+        }
+        _ => false,
+    }
+}
+
+fn result_is_primitive_literal_union(db: &dyn TypeDatabase, ty: TypeId) -> bool {
+    crate::query_boundaries::common::union_members(db, ty).is_some_and(|members| {
+        members.iter().all(|&m| {
+            crate::query_boundaries::common::literal_value(db, m).is_some()
+                || m == TypeId::STRING
+                || m == TypeId::NUMBER
+                || m == TypeId::BOOLEAN
+                || m == TypeId::BIGINT
+                || m == TypeId::SYMBOL
+                || m == TypeId::UNDEFINED
+                || m == TypeId::NULL
+                || m == TypeId::VOID
+                || m == TypeId::NEVER
+        })
+    })
 }
 
 #[derive(Copy, Clone)]

--- a/crates/tsz-checker/tests/ts2339_user_defined_predicate_primitive_or_object_tests.rs
+++ b/crates/tsz-checker/tests/ts2339_user_defined_predicate_primitive_or_object_tests.rs
@@ -321,3 +321,49 @@ function f(v: string | NotIndexed) {
     let d = diagnostics(source);
     assert_has_code_message(&d, 2339, "'NotIndexed'");
 }
+
+// ---------------------------------------------------------------------------
+// Case 9 (#11580): predicate functions produced by a mapped type must preserve
+// their property-specific `value is T[K]` facts across `&&` boolean joins. The
+// checker owns applying the flow fact to the property access sites; the solver
+// owns the predicate target type.
+// ---------------------------------------------------------------------------
+#[test]
+fn case_9_mapped_predicate_calls_survive_boolean_join_for_same_object() {
+    let source = r#"
+type Predicates<T> = { [K in keyof T]: (value: unknown) => value is T[K] };
+
+declare const predicates: Predicates<{ id: string; count: number }>;
+declare const input: { id: unknown; count: unknown };
+
+if (predicates.id(input.id) && predicates.count(input.count)) {
+    const id: string = input.id;
+    const count: number = input.count;
+}
+"#;
+    let d = diagnostics(source);
+    assert_no_code(&d, 2322);
+}
+
+// ---------------------------------------------------------------------------
+// Case 10: same structural rule with renamed binders and a wrapper alias around
+// the mapped predicate table. This guards against recognizing only the exact
+// `Predicates`/`id`/`count` names from the row witness.
+// ---------------------------------------------------------------------------
+#[test]
+fn case_10_wrapped_mapped_predicate_calls_keep_renamed_property_facts() {
+    let source = r#"
+type GuardTable<T> = { [P in keyof T]: (subject: unknown) => subject is T[P] };
+type Boxed<T> = { guards: GuardTable<T> };
+
+declare const registry: Boxed<{ slug: "next"; active: boolean }>;
+declare const row: { slug: unknown; active: unknown };
+
+if (registry.guards.slug(row.slug) && registry.guards.active(row.active)) {
+    const slug: "next" = row.slug;
+    const active: boolean = row.active;
+}
+"#;
+    let d = diagnostics(source);
+    assert_no_code(&d, 2322);
+}


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
M1-B checker flow/narrowing handoff plus query-boundary cleanup for #11580 / #8225.

## Invariant
When mapped predicate calls prove properties of the same source object across an `&&` boolean join, `tsc` keeps the property-specific `value is T[K]` facts available inside the true branch. This PR makes that checker flow invariant executable while preserving solver-owned predicate target semantics through the existing type-predicate/flow boundary.

For the lint unblock, when source-alias computed-body attribution needs syntax/provenance classification, checker registration stays orchestration-only and delegates the classification to the source-alias attribution helper; diagnostic-only object-shape queries live under the diagnostic boundary instead of the broad common quarantine.

## Scope
- Adds the canonical `Predicates<T>` mapped-predicate join witness from #11580.
- Adds a renamed/wrapped predicate-table adjacency to guard against name-specific handling.
- Moves alias computed-body attribution out of `type_analysis/core.rs` into `source_alias_attribution.rs`.
- Moves `union_or_intersection_mentions_object` from `query_boundaries/common.rs` to the diagnostic boundary.
- Relaxes the `list-owned-work` subprocess test timeout to avoid CI-load false negatives after the lint suite reaches that test group.

## Project Corpus Impact
- Row: `nextjs`.
- Bug family: checker-21-20, mapped predicate flow/narrowing at boolean joins.
- Evidence: the reduced witness already passes on current main, so this is a ratchet and does not claim the `nextjs` row or #11580 is fixed.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `scripts/arch/check-checker-boundaries.sh`
- `python3 scripts/arch/arch_guard.py`
- `python3 scripts/agents/test_list_owned_work.py`
- `scripts/safe-run.sh --limit 75% -- cargo nextest run -p tsz-checker --test ts2339_user_defined_predicate_primitive_or_object_tests`

## Coordination Notes
- #11580 remains open for the row-derived failing fixture; this PR covers the consolidated representative shape and renamed adjacency.
- The checker cleanup clears the current lint line-ratchet failure: `common.rs` 1915/1920 and `type_analysis/core.rs` 2773/2798 after cleanup.
- Avoids solver-policy changes; no M4 coordination needed.