### PR TITLE
fix(binder): keep external-module exports out of the ambient global scope

### DIFF
--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -69,16 +69,16 @@ impl BinderState {
     /// `global_file_locals_index` fallback).
     ///
     /// Mirrors [`Symbol::is_cross_file_global`] so that index agrees with
-    /// `program.globals`: a module's pure type-only top-level exports stay
-    /// file-scoped. Only symbols genuinely declared in this file are
-    /// classified; lib symbols and globals folded in from other files (which
-    /// carry a different `decl_file_idx`) are always kept, so lib/global
-    /// resolution is unaffected. A raw, unmerged per-file binder leaves
+    /// `program.globals`: a module's top-level exports (value or type) stay
+    /// file-scoped and are reachable only through an explicit import. Only
+    /// symbols genuinely declared in this file are classified; lib symbols and
+    /// globals folded in from other files (which carry a different
+    /// `decl_file_idx`) are always kept, so lib/global resolution is
+    /// unaffected. A raw, unmerged per-file binder leaves
     /// `decl_file_idx == u32::MAX` while owning all of its locals.
     #[must_use]
     pub fn cross_file_local_is_visible(
         &self,
-        arena: Option<&NodeArena>,
         file_idx: usize,
         name: &str,
         sym_id: SymbolId,
@@ -92,12 +92,8 @@ impl BinderState {
         if sym.decl_file_idx != u32::MAX && sym.decl_file_idx != file_idx as u32 {
             return true;
         }
-        let is_declaration_file = arena
-            .and_then(|arena| arena.source_files.first())
-            .is_some_and(|sf| sf.is_declaration_file);
         sym.is_cross_file_global(
             self.is_external_module,
-            is_declaration_file,
             self.global_augmentations.contains_key(name),
         )
     }

--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -356,13 +356,16 @@ impl Symbol {
     ///
     /// Script files (`is_external_module == false`) contribute every top-level
     /// declaration to the ambient global scope. External modules do not: a
-    /// reference to a module's top-level name from a *sibling* file is only
-    /// legal when the name was imported, so a module's pure type-only exports
-    /// (e.g. `export type`/`export interface`) must stay file-scoped — an
-    /// unqualified reference elsewhere is `TS2304`. Value-bearing exports,
-    /// module/namespace declarations, UMD exports, and global augmentations
-    /// remain cross-file visible because the CommonJS/export-assignment and
-    /// declaration-emit paths rely on reaching them by name across files.
+    /// module's top-level names — including its value exports — are reachable
+    /// from a *sibling* file only through an explicit `import`. An unqualified
+    /// reference elsewhere is `TS2304`, and the name must never silently bind
+    /// to a value export of an installed-but-unimported package (issue #12372:
+    /// a bare `Symbol` must resolve to the global `SymbolConstructor`, not to a
+    /// transitive package's exported `Symbol` function).
+    ///
+    /// The only ways an external module seeds the global scope are the ones
+    /// `tsc` honors: a UMD global (`export as namespace X`) and a `declare
+    /// global` augmentation. Everything else stays module-scoped.
     ///
     /// This single predicate governs both `program.globals` seeding and the
     /// `global_file_locals_index` cross-file fallback so the two tables agree.
@@ -370,15 +373,10 @@ impl Symbol {
     pub const fn is_cross_file_global(
         &self,
         is_external_module: bool,
-        is_declaration_file: bool,
         is_global_augmentation: bool,
     ) -> bool {
         let is_alias = self.has_any_flags(symbol_flags::ALIAS);
-        let has_value = self.has_any_flags(symbol_flags::VALUE) && self.is_exported;
-        let is_module_decl = self.has_any_flags(symbol_flags::MODULE);
-        (!is_alias && (!is_external_module || is_declaration_file || has_value || is_module_decl))
-            || self.is_umd_export
-            || is_global_augmentation
+        (!is_alias && !is_external_module) || self.is_umd_export || is_global_augmentation
     }
 
     /// Record a declaration and its stable source span.

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -655,13 +655,8 @@ impl<'a> CheckerContext<'a> {
         };
 
         for (file_idx, binder) in binders.iter().enumerate() {
-            let arena = self
-                .all_arenas
-                .as_ref()
-                .and_then(|a| a.get(file_idx))
-                .map(Arc::as_ref);
             for (name, &sym_id) in binder.file_locals.iter() {
-                if !binder.cross_file_local_is_visible(arena, file_idx, name, sym_id) {
+                if !binder.cross_file_local_is_visible(file_idx, name, sym_id) {
                     continue;
                 }
                 file_locals_index

--- a/crates/tsz-checker/src/context/program_context.rs
+++ b/crates/tsz-checker/src/context/program_context.rs
@@ -422,9 +422,8 @@ impl ProgramContext {
             .collect();
 
         for (file_idx, binder) in self.all_binders.iter().enumerate() {
-            let arena = self.all_arenas.get(file_idx).map(Arc::as_ref);
             for (name, &sym_id) in binder.file_locals.iter() {
-                if !binder.cross_file_local_is_visible(arena, file_idx, name, sym_id) {
+                if !binder.cross_file_local_is_visible(file_idx, name, sym_id) {
                     continue;
                 }
                 file_locals_index

--- a/crates/tsz-core/src/parallel/core/bind_result_reducer.rs
+++ b/crates/tsz-core/src/parallel/core/bind_result_reducer.rs
@@ -1207,35 +1207,26 @@ impl BindResultReducer {
                     if let Some(&new_sym_id) = id_remap.get(old_sym_id) {
                         // User symbol - use remapped ID
                         remapped_file_locals.set(name.clone(), new_sym_id);
-                        // Script-file top-levels are globally visible by default. For ordinary
-                        // external modules, keep pure type-only top-level declarations file-scoped so
-                        // unimported type aliases/interfaces do not leak across files. Value-bearing
-                        // exports still stay visible because CommonJS/export-assignment and declaration
-                        // emit paths rely on them being reachable cross-file. This shares the single
-                        // `Symbol::is_cross_file_global` predicate with the checker's
-                        // `global_file_locals_index` builders so both cross-file tables agree.
+                        // Script-file top-levels are globally visible by default. External
+                        // modules contribute nothing to the ambient global scope except UMD
+                        // globals (`export as namespace`) and `declare global` augmentations —
+                        // their value and type exports are reachable only through an explicit
+                        // import, so an unimported package's export must never leak as a global
+                        // (issue #12372). This shares the single `Symbol::is_cross_file_global`
+                        // predicate with the checker's `global_file_locals_index` builders so
+                        // both cross-file tables agree.
                         let sym_info = self.global_symbols.get(new_sym_id);
                         let is_umd = sym_info.is_some_and(|s| s.is_umd_export);
-                        let is_declaration_file = result
-                            .arena
-                            .source_files
-                            .first()
-                            .is_some_and(|sf| sf.is_declaration_file);
                         let is_global_augmentation = result.global_augmentations.contains_key(name);
                         let is_truly_global = match sym_info {
                             Some(s) => s.is_cross_file_global(
                                 result.is_external_module,
-                                is_declaration_file,
                                 is_global_augmentation,
                             ),
                             // When the merged symbol is unavailable, fall back to the
                             // flagless classification (equivalent to a symbol with no
                             // flags set), preserving the original behavior.
-                            None => {
-                                !result.is_external_module
-                                    || is_declaration_file
-                                    || is_global_augmentation
-                            }
+                            None => !result.is_external_module || is_global_augmentation,
                         };
                         if is_truly_global {
                             // UMD namespace exports (`export as namespace Foo`) use

--- a/crates/tsz-core/tests/parallel_tests_parts/part_01.rs
+++ b/crates/tsz-core/tests/parallel_tests_parts/part_01.rs
@@ -1712,7 +1712,13 @@ fn test_compile_large_program() {
 
 #[test]
 fn test_compile_with_exports() {
-    // Test that export function/class/const are properly bound
+    // Test that export function/class/const are properly bound — and stay
+    // module-scoped. Per tsc, the top-level exports of an external module are
+    // NOT ambient globals: an unqualified reference to `add`/`Calculator`/`PI`
+    // from a sibling file is a `TS2304` unless imported. They must therefore
+    // never leak into `program.globals` (the same fallback that an unimported
+    // package's `Symbol` export wrongly polluted in #12372), and remain
+    // reachable only through their module's export table.
     let files = vec![
         (
             "a.ts".to_string(),
@@ -1728,18 +1734,27 @@ fn test_compile_with_exports() {
     let program = compile_files(files);
 
     assert_eq!(program.files.len(), 3);
-    // All exported declarations should be in globals
+    // External-module exports must NOT seed the ambient global scope.
+    for name in ["add", "Calculator", "PI"] {
+        assert!(
+            !program.globals.has(name),
+            "external-module export '{name}' must not leak into program globals"
+        );
+    }
+    // They remain reachable through their module's export table.
+    let exported_somewhere =
+        |name: &str| program.module_exports.values().any(|table| table.has(name));
     assert!(
-        program.globals.has("add"),
-        "Exported function 'add' should be in globals"
+        exported_somewhere("add"),
+        "Exported function 'add' should be reachable as a module export"
     );
     assert!(
-        program.globals.has("Calculator"),
-        "Exported class 'Calculator' should be in globals"
+        exported_somewhere("Calculator"),
+        "Exported class 'Calculator' should be reachable as a module export"
     );
     assert!(
-        program.globals.has("PI"),
-        "Exported const 'PI' should be in globals"
+        exported_somewhere("PI"),
+        "Exported const 'PI' should be reachable as a module export"
     );
 }
 

--- a/crates/tsz-core/tests/parallel_tests_parts/part_05.rs
+++ b/crates/tsz-core/tests/parallel_tests_parts/part_05.rs
@@ -903,10 +903,14 @@ export const unset = Symbol.for('@ts-pattern/unset');
 
     let program = merge_bind_results(parse_and_bind_parallel_with_libs(files, &lib_files));
 
-    // The unimported module's `Symbol` export must not pollute the global scope.
+    // The unimported module's value exports must not pollute the global scope.
+    // `Type` does not collide with any lib global, so its presence in `globals`
+    // is a direct witness of the leak. (`Symbol` legitimately stays in globals
+    // via the lib's `declare var Symbol`; the bug was the module export
+    // *overwriting* that lib binding.)
     assert!(
-        !program.globals.has("Symbol"),
-        "unimported external-module value export `Symbol` leaked into program globals"
+        !program.globals.has("Type"),
+        "unimported external-module value export `Type` leaked into program globals"
     );
 
     let options = CheckerOptions {

--- a/crates/tsz-core/tests/parallel_tests_parts/part_05.rs
+++ b/crates/tsz-core/tests/parallel_tests_parts/part_05.rs
@@ -852,3 +852,80 @@ fn test_dep_graph_deterministic_across_runs() {
     assert_eq!(topo1.order, topo2.order);
     assert_eq!(topo1.is_acyclic, topo2.is_acyclic);
 }
+
+/// Regression for #12372: a bare value identifier referenced without an import
+/// must resolve against globals only — never against a named value export of an
+/// installed-but-unimported external module. Here an unimported `typebox`-style
+/// `.d.ts` module exports a `Symbol` function; the consumer references bare
+/// `Symbol.for(...)`, which must bind to the global `SymbolConstructor`.
+#[test]
+fn test_check_files_parallel_bare_symbol_ignores_unimported_module_value_export() {
+    let lib_files = vec![std::sync::Arc::new(
+        crate::lib_loader::LibFile::from_source(
+            "lib.es2015.symbol.d.ts".to_string(),
+            r#"
+interface Symbol {
+    readonly description: string | undefined;
+    toString(): string;
+}
+interface SymbolConstructor {
+    readonly prototype: Symbol;
+    (description?: string | number): symbol;
+    for(key: string): symbol;
+    keyFor(sym: symbol): string | undefined;
+}
+declare var Symbol: SymbolConstructor;
+"#
+            .to_string(),
+        ),
+    )];
+
+    let files = vec![
+        (
+            "node_modules/@sinclair/typebox/index.d.ts".to_string(),
+            r#"
+export interface SchemaOptions { title?: string; }
+export interface TSymbol { kind: string; }
+export declare function Symbol(options?: SchemaOptions): TSymbol;
+export declare const Type: { String(): TSymbol; };
+"#
+            .to_string(),
+        ),
+        (
+            "src/symbols.ts".to_string(),
+            r#"
+export const matcher = Symbol.for('@ts-pattern/matcher');
+export const unset = Symbol.for('@ts-pattern/unset');
+"#
+            .to_string(),
+        ),
+    ];
+
+    let program = merge_bind_results(parse_and_bind_parallel_with_libs(files, &lib_files));
+
+    // The unimported module's `Symbol` export must not pollute the global scope.
+    assert!(
+        !program.globals.has("Symbol"),
+        "unimported external-module value export `Symbol` leaked into program globals"
+    );
+
+    let options = CheckerOptions {
+        target: ScriptTarget::ESNext,
+        module: ModuleKind::ESNext,
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    let result = check_files_parallel(&program, &options, &lib_files);
+    let consumer_2339: Vec<_> = result
+        .file_results
+        .iter()
+        .filter(|file| file.file_name.ends_with("symbols.ts"))
+        .flat_map(|file| file.diagnostics.iter())
+        .filter(|diag| diag.code == 2339)
+        .collect();
+
+    assert!(
+        consumer_2339.is_empty(),
+        "bare `Symbol.for` must resolve to the global SymbolConstructor; got {consumer_2339:#?}"
+    );
+}


### PR DESCRIPTION
AgentName: M4-Opus

## Summary

Fixes #12372. A bare value identifier referenced **without an import** must
resolve against globals only (lib + ambient + `declare global`). It must never
bind to a value export of an installed-but-unimported package. In
`gvergnaud/ts-pattern`, bare `Symbol` was binding to `@sinclair/typebox`'s
exported `Symbol(options?: SchemaOptions): TSymbol` (a *transitive*, never
imported dep), producing four false `TS2339` on `Symbol.for(...)`.

## Structural rule

> When a top-level declaration belongs to an external module, it is reachable
> from a sibling file only through an explicit `import` — its value **and** type
> exports stay module-scoped. The only ways an external module seeds the ambient
> global scope are the ones `tsc` honors: a UMD global (`export as namespace X`)
> and a `declare global` augmentation. Script files (non-modules) still
> contribute every top-level declaration.

`tsz`'s `Symbol::is_cross_file_global` predicate was over-broad: for an external
module it also returned `true` for any exported value (`has_value`), any
declaration-file export (`is_declaration_file`), and any module declaration
(`is_module_decl`). The merge reducer then inserted those names into
`program.globals`, and a non-UMD insert **overwrites** — so typebox's `Symbol`
clobbered the lib's `SymbolConstructor`, dropping `.for`.

## Owner layer

Binder — `Symbol::is_cross_file_global`, the single predicate that governs both
`program.globals` seeding (parallel `bind_result_reducer`) and the checker's
`global_file_locals_index` cross-file fallback, so the two tables stay in
agreement.

## Fix

- Restrict the predicate to `(!is_alias && !is_external_module) || is_umd_export
  || is_global_augmentation`.
- Drop the now-dead `is_declaration_file` parameter and the `arena` argument
  threaded through `cross_file_local_is_visible` (and its two call sites).
- Align the reducer's flagless `None` fallback to the same rule.

Import resolution is unaffected: it traverses module export tables
(`resolve_import_target_from_file` / `module_exports`), not `globals`.

## Adjacent-case matrix

- Value export of external module → module-scoped (was leaking). ✔
- Type-only export of external `.d.ts` module → module-scoped (was leaking via
  `is_declaration_file`). ✔
- Script-file top-levels → still global. ✔
- UMD (`export as namespace`) → still global, first-in-wins. ✔
- `declare global` augmentation → still global. ✔
- Renamed binder (typebox's non-colliding `Type` export) → not global. ✔

## Project Corpus Impact

- Row: ts-pattern (gvergnaud/ts-pattern @ c92ca43)
- Bug family: binder global-vs-module name resolution (#12372)

Removes the four `Symbol.for` `TS2339` false positives in `ts-pattern`'s
`src/internals/symbols.ts` and the downstream cascade they seeded
(`helpers.ts`, `types/helpers.ts:110`). No global row should regress: imports,
UMD, and `declare global` paths are untouched.

## Verification

- New production-path regression (`parse_and_bind_parallel_with_libs` + merge +
  `check_files_parallel`): an unimported typebox-style `.d.ts` exporting
  `Symbol`/`Type`; asserts `Type` does not enter `program.globals` and the
  consumer's bare `Symbol.for` produces no `TS2339`. Fails on `main`, passes
  here.
- Updated `test_compile_with_exports` to assert external-module exports stay
  module-scoped (reachable via export tables, absent from `globals`).
- `cargo test -p tsz-core --lib`: 3248 pass. The 31 remaining failures
  (`source_map_*` parity, 3 `checker_state_*`, plus a pre-existing
  `cross_file_intrinsic_identifier` TS2536) reproduce identically on `main`
  with the fix reverted — pre-existing/environmental, not caused by this change.
- Focused `tsz-checker` suites (shadowed-Symbol, lib-global shadowing,
  ambient-module value export, CommonJS require, export-star/module
  augmentation, cross-file augmentation/cycle, missing global type): green.

## Coordination Notes

AgentName: M4-Opus
Track: binder / symbol resolution (lane `agent:M4-Opus`)
Invariant: external-module exports never seed the ambient global scope; only script files, UMD globals, and `declare global` do.
Scope: `is_cross_file_global` + its two cross-file index builders and the parallel reducer; no checker/solver algorithm changes.

Closes #12372.
