### PR TITLE
fix(emit): skip parsed members in class recovery tail

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
@@ -1035,10 +1035,10 @@ impl<'a> Printer<'a> {
             return;
         }
 
-        if !self
+        if self
             .arena
             .get(class_idx)
-            .is_some_and(|node| node.kind == syntax_kind_ext::CLASS_DECLARATION)
+            .is_none_or(|node| node.kind != syntax_kind_ext::CLASS_DECLARATION)
         {
             return;
         }
@@ -1191,10 +1191,10 @@ impl<'a> Printer<'a> {
             && !self
                 .arena
                 .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
-            && !self
+            && self
                 .arena
                 .get(prop.name)
-                .is_some_and(|n| n.kind == SyntaxKind::PrivateIdentifier as u16)
+                .is_none_or(|n| n.kind != SyntaxKind::PrivateIdentifier as u16)
     }
 
     pub(in crate::emitter) fn es5_class_externally_hoisted_decls(

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_recovery.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_recovery.rs
@@ -78,14 +78,37 @@ impl<'a> Printer<'a> {
         let Some(source) = text.get(start..end) else {
             return Vec::new();
         };
+        let member_spans: Vec<(u32, u32)> = self
+            .arena
+            .get_class(node)
+            .map(|class| {
+                class
+                    .members
+                    .nodes
+                    .iter()
+                    .filter_map(|&member_idx| {
+                        let member_node = self.arena.get(member_idx)?;
+                        Some((member_node.pos, member_node.end))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
 
         let mut depth = 0_i32;
         let mut recovered = Vec::new();
         let mut pending_empty_enum: Option<(String, bool)> = None;
         let mut pending_empty_class: Option<(String, bool)> = None;
         let mut in_block_comment = false;
+        let mut line_offset = 0usize;
         for line in source.lines() {
             let trimmed = line.trim();
+            let trimmed_start = line.len().saturating_sub(line.trim_start().len());
+            let trimmed_pos = node
+                .pos
+                .saturating_add((line_offset + trimmed_start) as u32);
+            let inside_member_span = member_spans.iter().any(|&(member_start, member_end)| {
+                member_start <= trimmed_pos && trimmed_pos < member_end
+            });
             if let Some((class_name, has_body)) = pending_empty_class.as_mut() {
                 if depth == 2 && trimmed == "}" {
                     if !*has_body {
@@ -114,27 +137,38 @@ impl<'a> Printer<'a> {
                     *has_body = true;
                 }
             }
-            if depth == 1
+            if !inside_member_span
+                && depth == 1
                 && (trimmed.starts_with("function ")
                     || (trimmed.starts_with("var ")
                         && !trimmed.contains("//")
                         && !trimmed.contains("()")))
             {
                 recovered.push(trimmed.replace("{}", "{ }"));
-            } else if depth == 1
+            } else if !inside_member_span
+                && depth == 1
                 && let Some(enum_name) = self.recovered_class_body_empty_enum_name(trimmed)
             {
                 pending_empty_enum = Some((enum_name, false));
-            } else if depth == 1
+            } else if !inside_member_span
+                && depth == 1
                 && let Some(class_name) = self.recovered_class_body_empty_class_name(trimmed)
             {
                 pending_empty_class = Some((class_name, false));
-            } else if depth == 1
+            } else if !inside_member_span
+                && depth == 1
                 && let Some(stmt) = self.recovered_public_class_block(trimmed)
             {
                 recovered.push(stmt);
             }
             depth += class_recovery_brace_delta(line, &mut in_block_comment);
+            line_offset += line.len();
+            if source.as_bytes().get(line_offset) == Some(&b'\r') {
+                line_offset += 1;
+            }
+            if source.as_bytes().get(line_offset) == Some(&b'\n') {
+                line_offset += 1;
+            }
         }
         recovered
     }

--- a/crates/tsz-emitter/src/emitter/source_file/parser_recovery_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/parser_recovery_tests.rs
@@ -56,3 +56,33 @@ x;
 ";
     assert_eq!(output, expected);
 }
+
+#[test]
+fn namespace_class_method_local_vars_do_not_recover_as_namespace_tail() {
+    let source = "\
+namespace Formatting {
+    export class Indenter {
+        method(tokenStartPosition: number, childTokenStartPosition: number/*?*/): number/*?*/ {
+            // misleading recovery depth }
+            var indentationDeltaSize = this.offsetIndentationDeltas.GetValue(tokenStartPosition);
+            return indentationDeltaSize;
+        }
+    }
+}
+";
+    let output = emit_es2015(source);
+    let expected = "\
+var Formatting;
+(function (Formatting) {
+    class Indenter {
+        method(tokenStartPosition, childTokenStartPosition /*?*/) {
+            // misleading recovery depth }
+            var indentationDeltaSize = this.offsetIndentationDeltas.GetValue(tokenStartPosition);
+            return indentationDeltaSize;
+        }
+    }
+    Formatting.Indenter = Indenter;
+})(Formatting || (Formatting = {}));
+";
+    assert_eq!(output, expected);
+}


### PR DESCRIPTION
AgentName: Studio-C

Track: emit parser-recovery tech debt (#9336)

Invariant: Parser-recovery class-body tail emit may preserve truly invalid class-body declarations, but it must not re-emit statements that already belong to parsed class members. When a recovery depth scan sees a line whose trimmed source position is inside a parsed member span, tsc treats it as owned by that member body; tsz now skips class-tail recovery for that line through the ES2015 class recovery owner.

Scope:
- Build parsed class member spans before scanning source text in `recovered_class_body_statements`.
- Gate recovered class-body function/var/empty enum/empty class/public block candidates on being outside those member spans.
- Add a focused namespace/class regression where a method-body comment containing `}` previously made a local `var` look like class-tail recovery.
- Apply adjacent clippy `is_none_or` simplifications required by the lint gate.

## Project Corpus Impact
- Row: n/a
- Bug family: parser/recovery emit
- Notes: Emit-only parser recovery slice. The targeted real-world parser fixture `parserindenter` now passes JS emit locally; no project corpus rows were run locally.

Verification:
- `cargo fmt --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter namespace_class_method_local_vars_do_not_recover_as_namespace_tail --no-fail-fast`
- `scripts/emit/run.sh --filter=parserindenter --js-only --verbose --json-out=/tmp/tsz-9336-parserindenter-after3.json`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`

Coordination Notes: Fixes the active #9336 WIP slice for the remaining parser/recovery emit family failure. Structural rule is span-based, not source-name or fixture-name based; no emitter output surgery and no semantic validation added.