### PR TITLE
fix(checker): stop suppressing intersection-with-indexed-access source mismatches

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1471,6 +1471,10 @@ name = "intersection_mapped_alias_indexed_access_tests"
 path = "tests/intersection_mapped_alias_indexed_access_tests.rs"
 
 [[test]]
+name = "intersection_indexed_access_source_suppression_tests"
+path = "tests/intersection_indexed_access_source_suppression_tests.rs"
+
+[[test]]
 name = "cross_file_js_ts_class_merge_ts2451_suppression_tests"
 path = "tests/cross_file_js_ts_class_merge_ts2451_suppression_tests.rs"
 

--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -794,26 +794,6 @@ impl<'a> CheckerState<'a> {
                     evaluated_target_for_infer_suppression,
                 );
 
-        // Suppress TS2322 for source types that are intersections containing indexed access
-        // types with unresolved type parameters (e.g., `Partial<T>[K] & ({} | null)`).
-        // These types may not be properly evaluated when assignability is checked, leading
-        // to false positives when the intersection should actually be assignable.
-        let source_is_intersection_with_indexed_access = || -> bool {
-            if let Some(members) =
-                crate::query_boundaries::common::intersection_members(self.ctx.types, source)
-            {
-                members.iter().any(|&member| {
-                    crate::query_boundaries::common::is_index_access_type(self.ctx.types, member)
-                        && crate::query_boundaries::common::contains_type_parameters(
-                            self.ctx.types,
-                            member,
-                        )
-                })
-            } else {
-                false
-            }
-        };
-
         // Suppress TS2322 for callable types with generic type parameters from outer
         // context. Skip the suppression when both sides have their own signature-level
         // type params — the solver handles generic-to-generic comparison correctly.
@@ -1098,8 +1078,9 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        // Pre-compute for two uses: the intersection-suppression guard and an early-exit
-        // before the more expensive should_suppress_for_complex_type call for structural targets.
+        // Structural targets (mapped/intersection/conditional/string-intrinsic) require
+        // property-level checking; they must not take the complex-generic suppression
+        // early-exit below — the solver decides those relations directly.
         let target_is_structural = is_structural_target_that_must_not_be_suppressed(target);
         let target_is_template_literal_from_bare_type_param =
             crate::query_boundaries::common::is_template_literal_type(self.ctx.types, target)
@@ -1112,11 +1093,6 @@ impl<'a> CheckerState<'a> {
             && !target_is_template_literal_from_bare_type_param;
 
         matches!(source, TypeId::ERROR)
-            // Suppress for intersection-with-indexed-access sources only when the target is NOT
-            // a structural type requiring property-level checking (mapped, intersection,
-            // conditional, string intrinsic). For those targets the solver handles the check
-            // directly and this suppression would hide real property mismatches.
-            || (source_is_intersection_with_indexed_access() && !target_is_structural)
             || matches!(target, TypeId::ERROR | TypeId::ANY)
             || contains_error_application(target)
             // any is assignable to everything except never — tsc reports TS2322 for any→never

--- a/crates/tsz-checker/tests/intersection_indexed_access_source_suppression_tests.rs
+++ b/crates/tsz-checker/tests/intersection_indexed_access_source_suppression_tests.rs
@@ -1,0 +1,199 @@
+//! Regression coverage for issue #11581 (case family `checker-22-20`):
+//! "intersection fallback hides root property mismatch".
+//!
+//! Structural rule: when the *source* of an assignment is an intersection whose
+//! members include an unresolved indexed-access type (`T[K]` with free type
+//! parameters), tsz must still run the structural property relation against the
+//! target. The solver resolves `T[K]` through its constraint/apparent type, so a
+//! blanket "intersection-with-indexed-access source" suppression only hides
+//! genuine property mismatches that `tsc` reports.
+//!
+//! Before this fix `should_suppress_assignability_diagnostic` carried a clause
+//! `source_is_intersection_with_indexed_access()` that suppressed TS2322/TS2741
+//! for *any* such source whose target was not already a structural type. That hid
+//! real errors for plain-object and intersection targets, e.g.
+//! `T[K] & { tag: string }` assigned to `{ id: string }`.
+//!
+//! These run under the lib-less checker harness, so they use user-defined mapped
+//! types instead of the lib `Partial`/`Record` (issue #9648 notes the rule is not
+//! `Record`-specific). Anti-hardcoding (§25): binder/type-parameter names vary
+//! across cases and positive controls bracket every negative.
+
+use tsz_checker::test_utils::{
+    check_source_diagnostics, diagnostic_code_message_refs, has_any_diagnostic_code,
+};
+
+/// The structural assignability families this regression watches: `TS2322`
+/// (value mismatch) and `TS2741` (missing required property). `tsc` picks either
+/// depending on whether the failure is a missing key or a value clash, so the
+/// assertions key on the *family* to stay robust to elaboration choice.
+const ASSIGNABILITY_CODES: &[u32] = &[2322, 2741];
+
+fn assert_error(source: &str) {
+    let diags = check_source_diagnostics(source);
+    assert!(
+        has_any_diagnostic_code(&diags, ASSIGNABILITY_CODES),
+        "expected TS2322/TS2741 for index-access intersection mismatch; got: {:?}",
+        diagnostic_code_message_refs(&diags)
+    );
+}
+
+fn assert_no_error(source: &str) {
+    let diags = check_source_diagnostics(source);
+    assert!(
+        !has_any_diagnostic_code(&diags, ASSIGNABILITY_CODES),
+        "expected no assignability error; got: {:?}",
+        diagnostic_code_message_refs(&diags)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative cases: tsc reports a structural mismatch and tsz must too.
+// ---------------------------------------------------------------------------
+
+/// `T[K] & { tag: string }` lacks `id`, so assigning to `{ id: string }` must
+/// report the missing/invalid property (tsc: TS2741).
+#[test]
+fn index_access_intersection_source_missing_property_reports_error() {
+    assert_error(
+        r#"
+        function f<T extends { id: number }, K extends keyof T>(x: T[K] & { tag: string }) {
+            const y: { id: string } = x;
+        }
+        "#,
+    );
+}
+
+/// The intersection carries `id: string`; the target wants `id: number`, so the
+/// value types clash (tsc: TS2322).
+#[test]
+fn index_access_intersection_source_mismatched_property_reports_error() {
+    assert_error(
+        r#"
+        function f<T extends { id: number }, K extends keyof T>(x: T[K] & { id: string }) {
+            const y: { id: number } = x;
+        }
+        "#,
+    );
+}
+
+/// User-defined `MyPartial<T>[K] & ({} | null)` — the exact shape the old code
+/// comment claimed "should actually be assignable", which tsc nonetheless
+/// rejects against a concrete object target.
+#[test]
+fn partial_like_index_access_intersection_source_reports_error() {
+    assert_error(
+        r#"
+        type MyPartial<U> = { [P in keyof U]?: U[P] };
+        function g<S extends { a: number }, Q extends keyof S>(x: MyPartial<S>[Q] & ({} | null)) {
+            const y: { a: number } = x;
+        }
+        "#,
+    );
+}
+
+/// Mapped-type target must also see the mismatch (control that the
+/// already-shipped `target_is_structural` carve-out still works alongside the
+/// broadened rule).
+#[test]
+fn index_access_intersection_source_mapped_target_reports_error() {
+    assert_error(
+        r#"
+        type Box<U> = { [P in keyof U]: U[P] };
+        function f<T extends { id: number }, K extends keyof T>(x: T[K] & { tag: string }) {
+            const y: Box<{ id: string }> = x;
+        }
+        "#,
+    );
+}
+
+/// Intersection target (a second structural shape) must surface the mismatch.
+#[test]
+fn index_access_intersection_source_intersection_target_reports_error() {
+    assert_error(
+        r#"
+        function f<T extends { id: number }, K extends keyof T>(x: T[K] & { tag: string }) {
+            const y: { id: string } & { extra?: 1 } = x;
+        }
+        "#,
+    );
+}
+
+/// Anti-hardcoding: renamed binders/type parameters must behave identically.
+#[test]
+fn index_access_intersection_source_renamed_binders_reports_error() {
+    assert_error(
+        r#"
+        function transform<Elem extends { id: number }, Prop extends keyof Elem>(
+            value: Elem[Prop] & { tag: string },
+        ) {
+            const out: { id: string } = value;
+        }
+        "#,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive controls: tsc accepts; the broadened rule must NOT introduce false
+// positives. These are the cases the suppression was nominally protecting.
+// ---------------------------------------------------------------------------
+
+/// Identity assignment to the same index-access intersection stays assignable.
+#[test]
+fn index_access_intersection_source_identity_target_is_assignable() {
+    assert_no_error(
+        r#"
+        function f<T extends { a: number }, K extends keyof T>(x: T[K] & { tag: string }) {
+            const y: T[K] & { tag: string } = x;
+        }
+        "#,
+    );
+}
+
+/// Assigning to the bare index-access component stays assignable.
+#[test]
+fn index_access_intersection_source_bare_index_target_is_assignable() {
+    assert_no_error(
+        r#"
+        function f<T extends { a: number }, K extends keyof T>(x: T[K] & { tag: string }) {
+            const y: T[K] = x;
+        }
+        "#,
+    );
+}
+
+/// Assigning to the empty object type stays assignable.
+#[test]
+fn index_access_intersection_source_empty_object_target_is_assignable() {
+    assert_no_error(
+        r#"
+        function f<T extends { a: number }, K extends keyof T>(x: T[K] & { tag: string }) {
+            const y: {} = x;
+        }
+        "#,
+    );
+}
+
+/// Assigning to the literal-only sibling member stays assignable.
+#[test]
+fn index_access_intersection_source_sibling_member_target_is_assignable() {
+    assert_no_error(
+        r#"
+        function f<T extends { a: number }, K extends keyof T>(x: T[K] & { tag: string }) {
+            const y: { tag: string } = x;
+        }
+        "#,
+    );
+}
+
+/// Compatible concrete object: the contributed value matches, so no error.
+#[test]
+fn index_access_intersection_source_compatible_object_target_is_assignable() {
+    assert_no_error(
+        r#"
+        function f<T extends { id: number }, K extends keyof T>(x: T[K] & { id: number }) {
+            const y: { id: number } = x;
+        }
+        "#,
+    );
+}


### PR DESCRIPTION
Fixes #11581 (case family `checker-22-20`).

AgentName: M1-B
ContributorIdentity: claude-opus
Track: M1-B / conformance (assignability diagnostics)
Invariant: match `tsc` — never silence a structural property mismatch that `tsc` reports.

## Scope

`should_suppress_assignability_diagnostic` carried a blanket clause that suppressed `TS2322`/`TS2741` whenever the assignment **source** was an intersection containing an indexed-access type with free type parameters (`T[K] & { … }`). A recent change only exempted *structural* targets (mapped / conditional / intersection / string-intrinsic), so the clause still hid real property mismatches for **plain-object**, **intersection**, and other concrete targets.

The solver now resolves `T[K]` through its constraint / apparent type, so this suppression no longer prevents any genuine false positive — it only swallows errors `tsc` reports. The `Partial<T>[K] & ({} | null)` shape the code comment itself cited as "should actually be assignable" in fact errors in `tsc`; the premise was wrong.

## Structural rule

When the source is an intersection containing an unresolved indexed-access member, run the structural property relation against the target — do **not** suppress. The removed clause is deleted along with its now-dead `source_is_intersection_with_indexed_access` closure. `target_is_structural` remains load-bearing for the separate complex-generic suppression carve-out.

Owner layer: checker / assignability suppression gateway (`crates/tsz-checker/src/assignability/assignability_checker.rs`).

## Adjacent-case matrix (tsc 6.0.2 vs tsz, sources shaped `T[K] & {…}`)

| target shape | tsc | tsz before | tsz after |
|---|---|---|---|
| plain object, missing prop | TS2741 | (none) | TS2741 |
| plain object, mismatched value | TS2322 | (none) | TS2322 |
| `MyPartial<T>[K] & ({}\|null)` -> object | TS2322 | (none) | TS2322 |
| mapped target, missing prop | TS2741 | (none) | TS2741 |
| intersection target, mismatch | TS2322 | (none) | TS2322 |
| renamed binders | TS2741 | (none) | TS2741 |
| identity / bare `T[K]` / `{}` / sibling member / compatible object (controls) | (none) | (none) | (none) |

Every assignable control stays accepted — removing the clause introduces **zero** new false positives.

## Verification

- New regression suite `intersection_indexed_access_source_suppression_tests.rs` (11 cases: missing / mismatched / compatible value × plain-object, mapped, intersection targets, renamed binders, `Partial`-like shape, plus 5 positive controls) — all pass.
- Ran the relevant assignability/indexed-access/intersection/mapped/keyof checker test binaries (`ts2322_tests`, `intersection_*`, `homomorphic_indexed_access*`, `index_signature_argument_assignability`, `ts7053_*`, `same_generic_application_assign_outcome`, etc.) — green. The 8 pre-existing failures in `ts2322_tests::index_access_type_parameter_mismatch_elaboration` reproduce identically on `main` (283 passed / 8 failed before and after) and are unrelated to this change.
- `cargo clippy -p tsz-checker --lib --test …` and `cargo fmt --check` clean.
- Original issue witness now emits the expected `TS2322` (`id.value` number vs string).

## Project Corpus Impact

- Row: nextjs
- Bug family: checker-22-20

Targets the `nextjs` project-row `checker-22-20` mismatch and its consolidated duplicate witnesses (#10953, #10996, #11039, #11081, #11123, #11165, #11207, #11249, #11293). Broadens diagnostic coverage; no suppression added. No project-row baselines edited.

## Coordination Notes

Anti-hardcoding: no identifier/file-name literals; the printer is not consulted; tests vary binder/type-parameter names and bracket negatives with positive controls. Known remaining edge (separate root cause, not addressed here): a **union** target whose source is `T[K] & {…}` still under-reports — that path is a solver union-relation resolution gap rather than this suppression, and is left for a follow-up.

https://claude.ai/code/session_01UocXM4Txj1xXY36iLFHQgz

