### PR TITLE
fix(solver): elaborate mapped-type-alias mismatches structurally

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -9,12 +9,34 @@ use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     fn application_base_for_property_mismatch_display(&self, type_id: TypeId) -> Option<TypeId> {
-        crate::query_boundaries::common::application_info(self.ctx.types, type_id)
-            .or_else(|| {
-                let alias = self.ctx.types.get_display_alias(type_id)?;
-                crate::query_boundaries::common::application_info(self.ctx.types, alias)
-            })
-            .map(|(base, _)| base)
+        // Resolve to the application form, either directly or through the type's
+        // display alias (the structural value may carry an `Id<…>` alias).
+        let (app_type, base) = if let Some((base, _)) =
+            crate::query_boundaries::common::application_info(self.ctx.types, type_id)
+        {
+            (type_id, base)
+        } else {
+            let alias = self.ctx.types.get_display_alias(type_id)?;
+            let (base, _) =
+                crate::query_boundaries::common::application_info(self.ctx.types, alias)?;
+            (alias, base)
+        };
+        // Homomorphic/structural mapped-type aliases (`Partial<X>`, `Readonly<X>`,
+        // a user `type F<T> = { [K in keyof T]… }`, or recursive ones like
+        // `type Id<T> = { [K in keyof T]: Id<T[K]> }`) are NOT nominal generic
+        // references. tsc elaborates their mismatches structurally — drilling
+        // into `Types of property 'p'` / `The types of 'a.b'` chains — rather
+        // than collapsing to a single covariant type-argument line. Excluding
+        // them here routes the four call sites that gate the type-argument fast
+        // path into the structural property-chain elaboration instead.
+        if crate::query_boundaries::common::application_base_is_mapped_type(
+            self.ctx.types,
+            &self.ctx,
+            app_type,
+        ) {
+            return None;
+        }
+        Some(base)
     }
 
     fn should_render_nested_application_property_mismatch(

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -289,6 +289,19 @@ pub(crate) fn is_generic_mapped_application<R: TypeResolver>(
     tsz_solver::type_queries::is_generic_mapped_application_db(db, resolver, type_id)
 }
 
+/// Check whether an application's *declared* alias body is a mapped type
+/// (e.g. `Partial<X>`, `Readonly<X>`, or `type F<T> = { [K in keyof T]... }`),
+/// even when the concrete instantiation is fully resolved. Diagnostic
+/// elaboration uses this to elaborate mapped-alias mismatches structurally
+/// rather than via type-argument variance, matching tsc.
+pub(crate) fn application_base_is_mapped_type<R: TypeResolver>(
+    db: &dyn QueryDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> bool {
+    tsz_solver::type_queries::application_base_is_mapped_type_db(db, resolver, type_id)
+}
+
 /// Check if a type contains type parameters that require instantiation,
 /// but correctly handles mapped types by only checking their constraint and
 /// `name_type` (not the template, which always contains the iteration variable).

--- a/crates/tsz-checker/tests/generic_property_mismatch_display_tests.rs
+++ b/crates/tsz-checker/tests/generic_property_mismatch_display_tests.rs
@@ -277,9 +277,16 @@ fn generic_primitive_property_mismatch_is_property_name_independent() {
 }
 
 #[test]
-fn generic_mapped_property_mismatch_surfaces_type_arg_directly() {
-    // Mapped type aliases are also generic applications; tsc skips the
-    // "Types of property" wrapper for same-generic type-argument mismatches.
+fn generic_mapped_property_mismatch_elaborates_structurally() {
+    // A homomorphic mapped-type alias (`Wrap<T> = { [K in keyof T]: T[K] }`) is
+    // NOT a nominal generic reference: even though it is spelled as a generic
+    // application, tsc elaborates the mismatch *structurally* — it keeps the
+    // `Types of property 'a' are incompatible.` wrapper and then the leaf —
+    // rather than collapsing to a single covariant type-argument line the way a
+    // class/interface reference (`Box<number>`) does. Verified against tsc:
+    //   Type 'Wrap<{ a: number; }>' is not assignable to type 'Wrap<{ a: string; }>'.
+    //     Types of property 'a' are incompatible.
+    //       Type 'number' is not assignable to type 'string'.
     let diagnostic = ts2322_diagnostic(
         r#"
 type Wrap<T> = { [K in keyof T]: T[K] };
@@ -292,15 +299,15 @@ target = source;
     );
 
     assert!(
-        !has_related(&diagnostic, "Types of property 'a' are incompatible."),
-        "same-generic mapped mismatch must NOT show property-path wrapper, got {diagnostic:#?}"
+        has_related(&diagnostic, "Types of property 'a' are incompatible."),
+        "mapped-alias mismatch must keep the structural property wrapper, got {diagnostic:#?}"
     );
     assert!(
         has_related(
             &diagnostic,
             "Type 'number' is not assignable to type 'string'."
         ),
-        "expected type-argument mismatch nested directly for mapped wrapper, got {diagnostic:#?}"
+        "expected the leaf relation beneath the property wrapper, got {diagnostic:#?}"
     );
 }
 

--- a/crates/tsz-checker/tests/property_chain_elaboration_collapse_tests.rs
+++ b/crates/tsz-checker/tests/property_chain_elaboration_collapse_tests.rs
@@ -158,3 +158,124 @@ fn generic_application_property_is_not_collapsed() {
         "application-typed property must not be folded into a dotted path: {related:?}"
     );
 }
+
+/// A homomorphic mapped-type alias application (`Id<{ p: number }>` vs
+/// `Id<{ p: string }>`) is NOT a nominal generic reference: `tsc` elaborates it
+/// structurally (`Types of property 'p' are incompatible.` + leaf) rather than
+/// collapsing to a single covariant type-argument line the way `Box<number>` vs
+/// `Box<string>` does. tsz previously treated the mapped application like a
+/// nominal generic and dropped the property header, leaving only the bare leaf.
+/// Property names vary so the rule is structural, not a spelling match.
+#[test]
+fn single_level_mapped_alias_application_keeps_property_header() {
+    for (prop, leaf) in [
+        ("value", "Type 'number' is not assignable to type 'string'"),
+        (
+            "payload",
+            "Type 'number' is not assignable to type 'string'",
+        ),
+    ] {
+        let source = format!(
+            "type Id<T> = {{ [K in keyof T]: Id<T[K]> }};\n\
+             type S = Id<{{ {prop}: number }}>;\n\
+             type D = Id<{{ {prop}: string }}>;\n\
+             declare const src: S;\n\
+             const t: D = src;\n"
+        );
+        let diag = single_ts2322(&source);
+        let related = &diag.related_information;
+        assert_eq!(related.len(), 2, "mapped chain for `{source}`: {related:?}");
+        assert!(
+            related[0]
+                .message_text
+                .contains(&format!("Types of property '{prop}'")),
+            "mapped-alias property header must be present: {}",
+            related[0].message_text
+        );
+        assert_eq!(related[0].depth, 0);
+        assert!(
+            related[1].message_text.contains(leaf),
+            "leaf: {}",
+            related[1].message_text
+        );
+        assert_eq!(related[1].depth, 1, "leaf one level under property header");
+    }
+}
+
+/// A nested homomorphic mapped-type alias collapses its property run into a
+/// single dotted path exactly like a plain nested object does — the mapped
+/// applications at each level must not stop the collapse. tsz previously
+/// truncated the chain at the first property (`Types of property 'a'`) with no
+/// leaf, losing the root mismatch. Names vary so the collapse is structural.
+#[test]
+fn nested_mapped_alias_application_collapses_to_dotted_path() {
+    for (a, b, c) in [("a", "b", "c"), ("one", "two", "three")] {
+        let source = format!(
+            "type Id<T> = {{ [K in keyof T]: Id<T[K]> }};\n\
+             type S = Id<{{ {a}: {{ {b}: {{ {c}: number }} }} }}>;\n\
+             type D = Id<{{ {a}: {{ {b}: {{ {c}: string }} }} }}>;\n\
+             declare const src: S;\n\
+             const t: D = src;\n"
+        );
+        let diag = single_ts2322(&source);
+        let related = &diag.related_information;
+        assert_eq!(
+            related.len(),
+            2,
+            "collapsed chain for `{source}`: {related:?}"
+        );
+        let dotted = format!("'{a}.{b}.{c}'");
+        assert!(
+            related[0].message_text.contains("The types of")
+                && related[0].message_text.contains(&dotted)
+                && related[0]
+                    .message_text
+                    .contains("are incompatible between these types"),
+            "collapsed header: {}",
+            related[0].message_text
+        );
+        assert_eq!(related[0].depth, 0);
+        assert!(
+            related[1]
+                .message_text
+                .contains("Type 'number' is not assignable to type 'string'"),
+            "leaf: {}",
+            related[1].message_text
+        );
+        assert_eq!(related[1].depth, 1, "leaf one level under collapsed header");
+    }
+}
+
+/// A non-recursive mapped alias with explicit modifiers (`+readonly`/`+?`) is
+/// also structural: a nested mismatch collapses into a dotted path. Guards that
+/// the fix keys on the mapped alias *body*, not a specific user-defined `Id`
+/// spelling, and that the modifier-bearing form still elaborates structurally.
+#[test]
+fn modifier_mapped_alias_collapses_to_dotted_path() {
+    let diag = single_ts2322(
+        "type RO<T> = { +readonly [K in keyof T]: RO<T[K]> };\n\
+         type S = RO<{ outer: { inner: number } }>;\n\
+         type D = RO<{ outer: { inner: string } }>;\n\
+         declare const src: S;\n\
+         const t: D = src;\n",
+    );
+    let related = &diag.related_information;
+    assert_eq!(related.len(), 2, "got: {related:?}");
+    assert!(
+        related[0].message_text.contains("'outer.inner'")
+            && related[0]
+                .message_text
+                .contains("are incompatible between these types"),
+        "collapsed header: {}",
+        related[0].message_text
+    );
+    assert_eq!(related[0].depth, 0);
+    assert!(
+        related[1]
+            .message_text
+            .contains("Type 'number' is not assignable to type 'string'"),
+        "leaf: {}",
+        related[1].message_text
+    );
+    assert_eq!(related[1].depth, 1);
+}

--- a/crates/tsz-solver/src/type_queries/shape_queries.rs
+++ b/crates/tsz-solver/src/type_queries/shape_queries.rs
@@ -187,6 +187,48 @@ pub fn is_generic_mapped_application_db<R: TypeResolver>(
     is_generic_mapped_type_db(db.as_type_database(), instantiated)
 }
 
+/// Returns `true` when `type_id` is a generic `Application` whose aliased body
+/// is a mapped type (e.g. `Partial<X>`, `Readonly<X>`, or a user
+/// `type F<T> = { [K in keyof T]... }`), regardless of whether the concrete
+/// instantiation still contains type parameters.
+///
+/// Unlike [`is_generic_mapped_application_db`], this inspects the *declared*
+/// alias body rather than the substituted result, so it stays `true` for fully
+/// concrete instantiations like `Partial<{ a: number }>`. Diagnostic
+/// elaboration uses it to decide that such applications must be compared
+/// structurally (drilling into `Types of property` / `The types of 'a.b'`
+/// chains) rather than via type-argument variance: tsc never reduces a mapped
+/// alias mismatch to a single covariant type-argument line because the type
+/// parameter does not occupy a plain argument position.
+pub fn application_base_is_mapped_type_db<R: TypeResolver>(
+    db: &dyn crate::construction::QueryDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> bool {
+    if type_id.is_intrinsic() {
+        return false;
+    }
+    let Some(TypeData::Application(app_id)) = db.lookup(type_id) else {
+        return false;
+    };
+    let app = db.type_application(app_id);
+    let Some(def_id) = super::classifiers::get_lazy_def_id(db, app.base) else {
+        return false;
+    };
+    let type_db = db.as_type_database();
+    let Some(mut body) = resolver.resolve_lazy(def_id, type_db) else {
+        return false;
+    };
+    // The alias body may itself be a thin `Lazy` re-export; follow one more hop
+    // so `type Id<T> = ...` chains resolve to the mapped body.
+    if let Some(inner_def) = super::classifiers::get_lazy_def_id(type_db, body)
+        && let Some(resolved) = resolver.resolve_lazy(inner_def, type_db)
+    {
+        body = resolved;
+    }
+    crate::visitors::visitor_predicates::is_mapped_type(type_db, body)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -211,6 +253,91 @@ mod tests {
             default: None,
             is_const: false,
         })
+    }
+
+    /// Minimal resolver that maps a single `DefId` to a pre-built alias body so
+    /// `application_base_is_mapped_type_db` can be exercised without the full
+    /// checker `TypeEnvironment`.
+    struct DefBodyResolver {
+        def_id: DefId,
+        body: TypeId,
+    }
+
+    impl TypeResolver for DefBodyResolver {
+        fn resolve_ref(
+            &self,
+            _symbol: crate::types::SymbolRef,
+            _interner: &dyn TypeDatabase,
+        ) -> Option<TypeId> {
+            None
+        }
+
+        fn resolve_lazy(&self, def_id: DefId, _interner: &dyn TypeDatabase) -> Option<TypeId> {
+            (def_id == self.def_id).then_some(self.body)
+        }
+    }
+
+    fn make_identity_mapped(interner: &TypeInterner) -> TypeId {
+        let param = TypeParamInfo {
+            name: interner.intern_string("K"),
+            constraint: None,
+            default: None,
+            is_const: false,
+        };
+        interner.mapped(MappedType {
+            type_param: param,
+            constraint: interner.keyof(make_type_param(interner, "T")),
+            name_type: None,
+            template: TypeId::STRING,
+            readonly_modifier: None,
+            optional_modifier: None,
+        })
+    }
+
+    #[test]
+    fn application_base_is_mapped_type_detects_mapped_alias() {
+        let interner = TypeInterner::new();
+        let def_id = DefId(7);
+        let body = make_identity_mapped(&interner);
+        let resolver = DefBodyResolver { def_id, body };
+        let app = interner.application(interner.lazy(def_id), vec![TypeId::STRING]);
+        assert!(application_base_is_mapped_type_db(
+            &interner, &resolver, app
+        ));
+    }
+
+    #[test]
+    fn application_base_is_mapped_type_rejects_non_mapped_alias() {
+        let interner = TypeInterner::new();
+        let def_id = DefId(7);
+        // Alias body is a plain object-ish type, not a mapped type.
+        let resolver = DefBodyResolver {
+            def_id,
+            body: TypeId::STRING,
+        };
+        let app = interner.application(interner.lazy(def_id), vec![TypeId::STRING]);
+        assert!(!application_base_is_mapped_type_db(
+            &interner, &resolver, app
+        ));
+    }
+
+    #[test]
+    fn application_base_is_mapped_type_rejects_non_application() {
+        let interner = TypeInterner::new();
+        let resolver = DefBodyResolver {
+            def_id: DefId(7),
+            body: make_identity_mapped(&interner),
+        };
+        assert!(!application_base_is_mapped_type_db(
+            &interner,
+            &resolver,
+            TypeId::STRING
+        ));
+        assert!(!application_base_is_mapped_type_db(
+            &interner,
+            &resolver,
+            make_identity_mapped(&interner)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
AgentName: Studio-B

## Track
Diagnostics / solver — mapped & conditional type relation elaboration (closes the elaboration half of #10871; mapped/keyof family tracked under #8432).

## Invariant
When a failed assignment is between two applications of a **mapped-type alias** — `Partial<X>`, `Readonly<X>`, `Pick`/`Record`, or a user/recursive `type Id<T> = { [K in keyof T]: Id<T[K]> }` — `tsc` elaborates the mismatch **structurally**: it keeps the `Types of property 'p' are incompatible.` wrapper and collapses a run of single-property links into `The types of 'a.b.c' are incompatible between these types.`, then renders the leaf relation. It does **not** collapse to a single covariant type-argument line the way a nominal generic reference (`Box<T>`, `Pair<A,B>`, a plain-object generic alias `Wrap<T> = { value: T }`) does.

Structural rule: `When source and target are applications whose declared alias body is a mapped type, tsc compares them structurally rather than via type-argument variance; tsz now does the same through the solver query boundary.`

## Scope
- `crates/tsz-solver/src/type_queries/shape_queries.rs`: new `application_base_is_mapped_type_db` — inspects the *declared* alias body (unlike `is_generic_mapped_application_db`, which inspects the substituted result and is therefore `false` for concrete instantiations like `Partial<{ a: number }>`).
- `crates/tsz-checker/src/query_boundaries/common.rs`: thin query-boundary wrapper `application_base_is_mapped_type`.
- `crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs`: `application_base_for_property_mismatch_display` now returns `None` for mapped-alias applications, centrally routing the four call sites that gate the type-argument fast path (`should_render_nested_application_property_mismatch`, `nested_reason_reuses_enclosing_application_source`, `is_typed_array_application_property_mismatch_display`, `peel_plain_property_chain`) into the structural property-chain elaboration.
- Tests: new structural-elaboration regressions (single-level, nested, recursive, modifier-bearing, name-varied) in `property_chain_elaboration_collapse_tests.rs`; solver unit tests for the new query; corrected `generic_property_mismatch_display_tests::generic_mapped_property_mismatch_*` which had encoded the prior tsc-divergent behavior.

### Anti-hardcoding
The distinction keys on the alias **body** being a mapped type via a solver structural query — no identifier/alias/file-name string checks, no reading rendered printer output. Tests vary property names and use custom (non-`Partial`/`Id`) aliases so the rule is structural, not a spelling match. Nominal generics and plain-object aliases retain the type-argument line.

## Project Corpus Impact
- Row: nextjs (issue witness)
- Bug family: mapped/conditional relation diagnostics
- This is a diagnostic-elaboration parity fix; the relation outcome (TS2322/TS2345 emitted-or-not) is unchanged, only the nested elaboration chain now matches tsc. No project-row pass/fail flips expected; the `deeplyNestedMappedTypes.ts` accepted-regression is strictly improved (its single-recursive `Id` case now matches tsc exactly).

### Out of scope (separate subsystems, left as-is)
- Deeply-nested recursive mapped types (`Id2<Id2<T[K]>>`) that *over-instantiate* at depth (`number` expanding to array/string methods) — the recursive-utility-expansion family tracked under #8432 / #10875.
- Union-leaf elaboration depth (`number | undefined` → `string | undefined` not drilling to `number`/`string`) — pre-existing and mapped-independent (reproduced on plain `{ v: number|undefined }`).

## Verification
- Cross-checked against real `tsc` 6.0.2 for: `Partial`/`Readonly`/`Pick`/`Record`, custom homomorphic + key-remapped mapped aliases, single- and multi-level recursive `Id<T>`, and the nominal `Box<T>`/`Pair<A,B>`/plain-object-alias negative cases — all match.
- `cargo test -p tsz-checker --test property_chain_elaboration_collapse_tests` — 7 passed.
- `cargo test -p tsz-checker --test generic_property_mismatch_display_tests` — 14 passed.
- `cargo test -p tsz-checker --test same_generic_application_assign_outcome_tests` — 7 passed; `union_source_structural_elaboration_tests` 17; `tuple_element_mismatch_tests`/`satisfies_elaboration_chain_tests` pass.
- `cargo test -p tsz-solver --lib application_base_is_mapped` — 3 passed; `--lib relations::` — 1347 passed.
- `cargo clippy -p tsz-solver -p tsz-checker` — clean.
- Pre-existing failures confirmed unrelated via `git stash` baseline (TS2327 `optional_property_required_elaboration_tests`, lib-dependent `generator_annotation_mismatch_display_tests`).
- Rebased onto latest `origin/main`; clean rebase, no conflicts.

## Coordination Notes
- Issue #10871 claimed with the `WIP` label for this slice.
- Quality reviewed via 3 `/simplify` passes (reuse, simplification, efficiency, altitude); converged clean — only an idiomatic `match`→`let-else` tweak applied. Layering verified: type semantics live in the solver query, the checker consumes it through the query boundary.

---
_Generated by [Claude Code](https://claude.ai/code/session_0151q42uwnZH3DpuX8ZQWz5u)_

