### PR TITLE
chore(release): bump try-tsz publish version to 0.1.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-binder"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-checker"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "dashmap",
  "globset",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-cli"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-common"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1551,7 +1551,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-core"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-emitter"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "memchr",
  "rustc-hash",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lowering"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "indexmap",
  "rustc-hash",
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-lsp"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "globset",
  "json5",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-parser"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-scanner"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "serde",
  "tsz-common",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-solver"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "bitflags 2.11.0",
  "dashmap",
@@ -1672,7 +1672,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-wasm"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1691,7 +1691,7 @@ dependencies = [
 
 [[package]]
 name = "tsz-website"
-version = "0.1.14"
+version = "0.1.15"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["crates/.target"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 repository = "https://github.com/mohsen1/tsz"
 homepage = "https://github.com/mohsen1/tsz"
@@ -16,16 +16,16 @@ readme = "README.md"
 
 [workspace.dependencies]
 # Internal workspace crates
-tsz = { path = "crates/tsz-core", version = "0.1.14", package = "tsz-core" }
-tsz-common = { path = "crates/tsz-common", version = "0.1.14" }
-tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.14" }
-tsz-parser = { path = "crates/tsz-parser", version = "0.1.14" }
-tsz-binder = { path = "crates/tsz-binder", version = "0.1.14" }
-tsz-solver = { path = "crates/tsz-solver", version = "0.1.14" }
-tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.14" }
-tsz-checker = { path = "crates/tsz-checker", version = "0.1.14" }
-tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.14", default-features = false }
-tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.14" }
+tsz = { path = "crates/tsz-core", version = "0.1.15", package = "tsz-core" }
+tsz-common = { path = "crates/tsz-common", version = "0.1.15" }
+tsz-scanner = { path = "crates/tsz-scanner", version = "0.1.15" }
+tsz-parser = { path = "crates/tsz-parser", version = "0.1.15" }
+tsz-binder = { path = "crates/tsz-binder", version = "0.1.15" }
+tsz-solver = { path = "crates/tsz-solver", version = "0.1.15" }
+tsz-lowering = { path = "crates/tsz-lowering", version = "0.1.15" }
+tsz-checker = { path = "crates/tsz-checker", version = "0.1.15" }
+tsz-emitter = { path = "crates/tsz-emitter", version = "0.1.15", default-features = false }
+tsz-lsp = { path = "crates/tsz-lsp", version = "0.1.15" }
 
 # External dependencies (shared versions)
 anyhow = "1.0"


### PR DESCRIPTION
AgentName: Studio-manager
ContributorIdentity: tsz-release-bot

## Track
Release

## Invariant
Daily automated release of `try-tsz` to npm. Bumps the workspace
version from `0.1.14` to `0.1.15` and lets the merge queue
land it. The follow-up `tag-on-merge` job in `daily-release.yml`
tags the merge commit and dispatches `release.yml` plus
`npm-publish.yml`.

Commits accumulated since `v0.1.14`: 9.

## Scope
Mechanical version bump only:
- `Cargo.toml`: `workspace.package.version` plus every `tsz-*`
  pin in `[workspace.dependencies]` move `0.1.14` → `0.1.15`.
- `Cargo.lock`: each `tsz-*` workspace crate's `version` line
  moves `0.1.14` → `0.1.15`. Replacements are structurally
  paired to the preceding `name = "tsz-*"` line; a paired-count
  mismatch fails the workflow.

No semantic, build, or script changes.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a

## Verification
- Cargo.toml occurrence count of `0.1.14` before vs. `0.1.15`
  after must match (enforced by the workflow).
- Cargo.lock replacements are paired with their `name = "tsz-*"`
  header (Python pairing script in the workflow).

## Coordination Notes
- On merge, `daily-release.yml`'s `tag-on-merge` job pushes
  `v0.1.15` and dispatches `release.yml` and `npm-publish.yml`.
- To skip a day's release, close this PR; the next scheduled run
  opens a new one with the next patch.
