### PR TITLE
chore(deps): migrate lib snapshots to bincode 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,11 +90,22 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -1571,6 +1582,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,6 +1598,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ clap = { version = "4.5", features = ["derive"] }
 colored = "3.1"
 console_error_panic_hook = "0.1"
 criterion = "0.5"
-bincode = "1.3"
+bincode = { version = "2.0.1", features = ["serde"] }
 dashmap = "6.1"
 ena = "0.14"
 fixedbitset = "0.5"

--- a/crates/tsz-core/src/parallel/lib_snapshot.rs
+++ b/crates/tsz-core/src/parallel/lib_snapshot.rs
@@ -43,6 +43,8 @@
 //! debugging, local bisects, or cache-behaviour comparisons.
 
 use anyhow::{Context, Result, anyhow};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -307,7 +309,7 @@ pub(super) fn try_store_many(keys: &[(&str, u64)], libs: &[Arc<LibFile>]) -> Res
 }
 
 fn encode_snapshot(snapshot: &LibSnapshot) -> Result<Vec<u8>> {
-    let payload = bincode::serialize(snapshot).context("bincode serialize lib snapshot")?;
+    let payload = encode_payload(snapshot).context("bincode serialize lib snapshot")?;
     let mut out = Vec::with_capacity(SNAPSHOT_MAGIC.len() + payload.len());
     out.extend_from_slice(SNAPSHOT_MAGIC);
     out.extend_from_slice(&payload);
@@ -315,7 +317,7 @@ fn encode_snapshot(snapshot: &LibSnapshot) -> Result<Vec<u8>> {
 }
 
 fn encode_snapshot_set(snapshot: &LibSnapshotSet) -> Result<Vec<u8>> {
-    let payload = bincode::serialize(snapshot).context("bincode serialize lib snapshot set")?;
+    let payload = encode_payload(snapshot).context("bincode serialize lib snapshot set")?;
     let mut out = Vec::with_capacity(SNAPSHOT_MAGIC.len() + payload.len());
     out.extend_from_slice(SNAPSHOT_MAGIC);
     out.extend_from_slice(&payload);
@@ -327,7 +329,7 @@ fn decode_snapshot(bytes: &[u8]) -> Result<LibSnapshot> {
         return Err(anyhow!("snapshot magic mismatch"));
     }
     let payload = &bytes[SNAPSHOT_MAGIC.len()..];
-    bincode::deserialize(payload).context("bincode deserialize lib snapshot")
+    decode_payload(payload).context("bincode deserialize lib snapshot")
 }
 
 fn decode_snapshot_set(bytes: &[u8]) -> Result<LibSnapshotSet> {
@@ -335,7 +337,24 @@ fn decode_snapshot_set(bytes: &[u8]) -> Result<LibSnapshotSet> {
         return Err(anyhow!("snapshot magic mismatch"));
     }
     let payload = &bytes[SNAPSHOT_MAGIC.len()..];
-    bincode::deserialize(payload).context("bincode deserialize lib snapshot set")
+    decode_payload(payload).context("bincode deserialize lib snapshot set")
+}
+
+fn encode_payload<T: Serialize>(value: &T) -> Result<Vec<u8>, bincode::error::EncodeError> {
+    bincode::serde::encode_to_vec(value, bincode::config::legacy())
+}
+
+fn decode_payload<T: DeserializeOwned>(payload: &[u8]) -> Result<T> {
+    let (value, consumed): (T, usize) =
+        bincode::serde::decode_from_slice(payload, bincode::config::legacy())
+            .context("decode bincode payload")?;
+    if consumed != payload.len() {
+        return Err(anyhow!(
+            "bincode payload had {} trailing byte(s)",
+            payload.len() - consumed
+        ));
+    }
+    Ok(value)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Agent
AgentName: Studio-manager

## Track
Dependency maintenance / performance-sensitive lib snapshot cache path.

## Invariant
When lib snapshots are encoded for the disk-backed parse+bind cache, the cache must preserve the existing legacy bincode wire shape and reject malformed/trailing payload bytes; this PR changes only the bincode API migration layer and dependency version.

## Scope
- `Cargo.toml` / `Cargo.lock`: upgrade `bincode` from 1.3.3 to 2.0.1 with the `serde` feature.
- `crates/tsz-core/src/parallel/lib_snapshot.rs`: migrate snapshot encode/decode helpers to `bincode::serde` using `bincode::config::legacy()`, preserving full-payload consumption.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: lib snapshot serialization dependency/API migration only; no checker/solver semantics, diagnostics, emit baselines, project corpus rows, or fixture metadata changed.

## Verification
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-core --locked`
- `scripts/safe-run.sh cargo nextest run -p tsz-core snapshot_round_trips_via_bincode --locked`

## Coordination Notes
- Rebased onto `main` after #12447 landed.
- No speedup is claimed from this PR without a before/after lib-cache measurement; the change keeps the performance-sensitive cache path on the maintained bincode 2 API.
- `bincode 3.0.0` is intentionally not used because that crate currently fails to compile via an intentional `compile_error!`.
