### PR TITLE
fix(checker): aggregate inherited overloaded members in implements checks

### DIFF
--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -888,17 +888,11 @@ impl<'a> CheckerState<'a> {
             rustc_hash::FxHashMap::default();
         if !overloaded_methods.is_empty() {
             let class_instance_type = self.get_class_instance_type(class_idx, class_data);
-            if let Some(shape) = crate::query_boundaries::common::object_shape_for_type(
+            overloaded_member_types = crate::query_boundaries::class::instance_member_types_by_name(
                 self.ctx.types,
                 class_instance_type,
-            ) {
-                for prop in &shape.properties {
-                    let name = self.ctx.types.resolve_atom(prop.name);
-                    if overloaded_methods.contains(&name) {
-                        overloaded_member_types.insert(name, prop.type_id);
-                    }
-                }
-            }
+            );
+            overloaded_member_types.retain(|name, _| overloaded_methods.contains(name));
         }
 
         // Build a map of inherited PUBLIC instance members from the base class chain.

--- a/crates/tsz-checker/src/classes/class_implements_helpers.rs
+++ b/crates/tsz-checker/src/classes/class_implements_helpers.rs
@@ -484,6 +484,40 @@ impl<'a> CheckerState<'a> {
                     ));
                 }
 
+                // Member names with more than one declaration in this base
+                // (method overloads or a get/set accessor pair). For those, any
+                // single declaration's type is incomplete: collecting only the
+                // first overload signature drops the rest, which produces a false
+                // TS2416/TS2420 when the implemented interface relies on a later
+                // overload. The base class's instance-type shape already
+                // aggregates the full overload set (and hides the implementation
+                // signature) exactly as the own-class overloaded path does, so
+                // pull the merged member type from there for these names.
+                let overloaded_member_names: rustc_hash::FxHashSet<String> = {
+                    let mut counts: rustc_hash::FxHashMap<String, u32> =
+                        rustc_hash::FxHashMap::default();
+                    for &member_idx in &base_class.members.nodes {
+                        if let Some(name) = self.get_member_name(member_idx) {
+                            *counts.entry(name).or_default() += 1;
+                        }
+                    }
+                    counts
+                        .into_iter()
+                        .filter_map(|(name, count)| (count >= 2).then_some(name))
+                        .collect()
+                };
+                let base_aggregated_member_types: rustc_hash::FxHashMap<String, TypeId> =
+                    if overloaded_member_names.is_empty() {
+                        rustc_hash::FxHashMap::default()
+                    } else {
+                        let base_instance_type =
+                            self.get_class_instance_type(base_decl, base_class);
+                        crate::query_boundaries::class::instance_member_types_by_name(
+                            self.ctx.types,
+                            base_instance_type,
+                        )
+                    };
+
                 // Collect public members from the base class
                 for &member_idx in &base_class.members.nodes {
                     if let Some(name) = self.get_member_name(member_idx)
@@ -500,7 +534,14 @@ impl<'a> CheckerState<'a> {
                         let visibility_mask =
                             tsz_binder::symbol_flags::PRIVATE | tsz_binder::symbol_flags::PROTECTED;
                         if sym_flags & visibility_mask == 0 {
-                            let member_type = self.get_type_of_class_member(member_idx);
+                            let member_type = if overloaded_member_names.contains(&name) {
+                                base_aggregated_member_types
+                                    .get(&name)
+                                    .copied()
+                                    .unwrap_or_else(|| self.get_type_of_class_member(member_idx))
+                            } else {
+                                self.get_type_of_class_member(member_idx)
+                            };
                             result.insert(
                                 name,
                                 self.apply_inherited_member_substitutions(

--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -20,6 +20,29 @@ pub(crate) fn maybe_substitute_this_type(
     }
 }
 
+/// Build a `name -> member type` map from a class/interface instance type's
+/// object shape.
+///
+/// The instance-type shape already merges method overloads into a single
+/// callable (and hides the implementation signature), so it is the canonical
+/// source for an externally-visible member type. Both the own-class and the
+/// inherited-member `implements` paths use this so they aggregate overloads
+/// identically. Returns an empty map when the type has no object shape.
+pub(crate) fn instance_member_types_by_name(
+    db: &dyn QueryDatabase,
+    instance_type: TypeId,
+) -> rustc_hash::FxHashMap<String, TypeId> {
+    crate::query_boundaries::common::object_shape_for_type(db.as_type_database(), instance_type)
+        .map(|shape| {
+            shape
+                .properties
+                .iter()
+                .map(|prop| (db.resolve_atom(prop.name), prop.type_id))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Collect a type's call signatures, handling both `CallableShape`
 /// (overloaded / object-with-call-sigs) and the single-signature `FunctionShape`
 /// that an interface method declaration lowers to. `get_call_signatures` alone

--- a/crates/tsz-checker/src/tests/generic_mixed_inheritance_chain_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_mixed_inheritance_chain_tests.rs
@@ -259,3 +259,155 @@ fn keeps_2430_three_level_chain_intermediate_breaks_variance() {
         "expected TS2430 when intermediate level changes return type; got: {codes:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Case 7: Overloaded method INHERITED from a base class, checked against an
+// interface in a `class S extends Base implements I` mixed chain. (Issue
+// #10828.) Collecting only the first overload signature of the inherited
+// member drops the rest, producing a false TS2416/TS2420 when the interface's
+// overload set relies on a later signature. The inherited member's *full*
+// overload set must be compared against the interface member, mirroring the
+// own-class overloaded path. tsc accepts these (no diagnostic).
+// ---------------------------------------------------------------------------
+
+fn assert_no_2416_or_2420(src: &str) {
+    let codes = check_source_codes(src);
+    assert!(
+        !codes.contains(&2416) && !codes.contains(&2420),
+        "unexpected TS2416/TS2420 (false positive). Got: {codes:?}\nSource:\n{src}"
+    );
+}
+
+// Non-generic overloaded method inherited from the base satisfies the
+// interface's identical overload set.
+#[test]
+fn no_false_2416_inherited_overloaded_method_matches_interface_overloads() {
+    assert_no_2416_or_2420(
+        "interface Schema {
+           refine(check: string): number
+           refine(check: boolean): number
+         }
+         class Base {
+           refine(check: string): number
+           refine(check: boolean): number
+           refine(check: any): any { return 0 }
+         }
+         class S extends Base implements Schema {}",
+    );
+}
+
+// Same shape with a renamed method so the rule is not keyed on an identifier.
+#[test]
+fn no_false_2416_inherited_overloaded_method_matches_interface_overloads_renamed() {
+    assert_no_2416_or_2420(
+        "interface Spec {
+           validate(input: string): number
+           validate(input: boolean): number
+         }
+         class Core {
+           validate(input: string): number
+           validate(input: boolean): number
+           validate(input: any): any { return 0 }
+         }
+         class Impl extends Core implements Spec {}",
+    );
+}
+
+// Generic builder shape (the reported zod-style repro): the inherited generic
+// overload set (a type-guard overload plus a predicate overload, returning the
+// builder) satisfies the interface's matching overload set through the
+// `extends Base<O> implements Schema<O>` chain.
+#[test]
+fn no_false_2416_inherited_generic_overloaded_builder_through_mixed_chain() {
+    assert_no_2416_or_2420(
+        "interface Schema<O> {
+           refine<R extends O>(check: (v: O) => v is R): Schema<R>
+           refine(check: (v: O) => boolean): Schema<O>
+         }
+         class Base<O> {
+           refine<R extends O>(check: (v: O) => v is R): Base<R>
+           refine(check: (v: O) => boolean): Base<O>
+           refine(check: any): any { return this }
+         }
+         class S<O> extends Base<O> implements Schema<O> {}",
+    );
+}
+
+// Renamed generic builder shape — structural, not identifier-keyed.
+#[test]
+fn no_false_2416_inherited_generic_overloaded_builder_through_mixed_chain_renamed() {
+    assert_no_2416_or_2420(
+        "interface Validator<V> {
+           narrow<N extends V>(guard: (value: V) => value is N): Validator<N>
+           narrow(guard: (value: V) => boolean): Validator<V>
+         }
+         class BaseValidator<V> {
+           narrow<N extends V>(guard: (value: V) => value is N): BaseValidator<N>
+           narrow(guard: (value: V) => boolean): BaseValidator<V>
+           narrow(guard: any): any { return this }
+         }
+         class Concrete<V> extends BaseValidator<V> implements Validator<V> {}",
+    );
+}
+
+// The interface requires the SECOND overload specifically; collecting only the
+// first inherited signature would (incorrectly) reject this. tsc accepts.
+#[test]
+fn no_false_2416_inherited_overloaded_method_interface_needs_second_overload() {
+    assert_no_2416_or_2420(
+        "interface I { f(x: number): number }
+         class Base {
+           f(x: string): string
+           f(x: number): number
+           f(x: any): any { return x }
+         }
+         class S extends Base implements I {}",
+    );
+}
+
+// Negative control: the inherited overload set is genuinely incompatible with
+// the interface (first overload returns `boolean` where the interface requires
+// `string`), so a diagnostic must still fire. The combined-overload comparison
+// must not silently accept a real mismatch.
+#[test]
+fn keeps_diagnostic_for_inherited_overloaded_method_genuine_mismatch() {
+    let codes = check_source_codes(
+        "interface I {
+           f(x: string): boolean
+           f(x: number): number
+         }
+         class Base {
+           f(x: string): string
+           f(x: number): number
+           f(x: any): any { return x }
+         }
+         class S extends Base implements I {}",
+    );
+    assert!(
+        codes.contains(&2416) || codes.contains(&2420),
+        "expected TS2416/TS2420 for genuinely incompatible inherited overload set; got {codes:?}"
+    );
+}
+
+// Negative control: the interface requires an overload (`boolean` parameter)
+// that the inherited overload set cannot service at all. tsc reports.
+#[test]
+fn keeps_diagnostic_when_inherited_overloads_miss_required_interface_overload() {
+    let codes = check_source_codes(
+        "interface I {
+           f(x: string): string
+           f(x: number): number
+           f(x: boolean): boolean
+         }
+         class Base {
+           f(x: string): string
+           f(x: number): number
+           f(x: any): any { return x }
+         }
+         class S extends Base implements I {}",
+    );
+    assert!(
+        codes.contains(&2416) || codes.contains(&2420),
+        "expected TS2416/TS2420 when inherited overloads miss a required interface overload; got {codes:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Bug-family: generic method override variance in mixed inheritance chains (issue #10828, zod-project row; shared with #10796/#10804/#10812/#12178).

## Invariant
When an inherited class member with multiple declarations (method overloads or a get/set accessor pair) is checked against an interface member, the comparison uses the member's **full externally-visible type** — overloads merged, implementation signature hidden — matching tsc's `compareSignaturesRelated`.

## Scope
**Inherited overloaded members lost their overload set.** In `class S extends Base implements I {}`, when the relevant method is *inherited* from `Base`, `collect_inherited_public_members` captured only the **first** declaration's signature for that name, dropping the remaining overloads. Comparing that single signature against the interface's full overload set produced a false TS2416/TS2420 whenever the interface relied on a later overload (the reported zod builder shape).

The inherited member now pulls its aggregated type from the base class instance-type shape — which already merges the full overload set and hides the implementation signature — exactly as the own-class `implements` path does. Both paths now build their aggregated `name -> member type` map through one shared `query_boundaries::class::instance_member_types_by_name` helper (DRY cleanup).

Owner layer: solver-backed query boundary (`query_boundaries/class`) plus checker orchestration (`class_implements_helpers`, `class_implements_checker/core`). No raw printer-output predicates, no identifier/file-name literals.

## Project Corpus Impact
- Row: zod-project (and the shared variance family).
- Bug family: overloaded inherited members through `extends`+`implements`.
- No fixture configuration or benchmark wiring changed.

## Verification
- Current head: `a88d23b39f835066e3878e4aeecf8170b82c6b86`.
- New regression tests (7) in `generic_mixed_inheritance_chain_tests.rs`: inherited overloaded method satisfies interface overloads (non-generic + renamed), generic builder shape through the mixed chain (+ renamed), interface needs the second overload, plus two negative controls (genuine mismatch / missing required overload).
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib generic_mixed_inheritance_chain assignability_type_comparability_relation_routing` -> 25 passed, 6010 skipped.
- Integration (prior head): `class_implements_overloaded_method_ts2416_tests`, `abstract_method_overload_ts2416_tests`, `accessor_pair_override_ts2416_tests`, `generic_method_override_constraint_ts2416_tests`, `class_implements_index_signature_tests`, `class_implements_predicate_inference_tests`, `ts2430_tests` -> 105 passed.
- CLI validated against tsc: #10828 repro clean; non-generic/generic inherited overload sets through `implements` clean; negative controls still report.
- Draft light CI on exact head `a88d23b39f835066e3878e4aeecf8170b82c6b86`: `gate`, `CI Light Summary`, and GitGuardian passed; full CI pending after clearing WIP/draft.

## Coordination Notes
- AgentName: Studio-B
- Closes #10828.
- The prior head (`ca49a21`) also restored a `NO_ERASE_GENERICS`-first bivariant override relation in `should_report_assignability_mismatch_bivariant`. Exact-head `conformance-aggregate` showed that change caused 24 unlisted regressions (`covariantCallbacks`, `conditionalTypes1/2`, `varianceAnnotations`, `infiniteExpansionThroughInstantiation`, declaration-emit cases, ...), so that behavior change was reverted as real drift.
- This PR is now scoped to inherited-overload aggregation only and does not touch the bivariant override relation.
- Rebased on latest `origin/main` (`156d9a0`); no conflicts.

https://claude.ai/code/session_015phZPNLkxDs982tXqfh9g4
