### PR TITLE
test(agents): relax owned-work subprocess timeout

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -29,7 +29,7 @@ impl<'a> CheckerState<'a> {
         // than collapsing to a single covariant type-argument line. Excluding
         // them here routes the four call sites that gate the type-argument fast
         // path into the structural property-chain elaboration instead.
-        if crate::query_boundaries::common::application_base_is_mapped_type(
+        if crate::query_boundaries::diagnostics::application_base_is_mapped_type(
             self.ctx.types,
             &self.ctx,
             app_type,

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -289,19 +289,6 @@ pub(crate) fn is_generic_mapped_application<R: TypeResolver>(
     tsz_solver::type_queries::is_generic_mapped_application_db(db, resolver, type_id)
 }
 
-/// Check whether an application's *declared* alias body is a mapped type
-/// (e.g. `Partial<X>`, `Readonly<X>`, or `type F<T> = { [K in keyof T]... }`),
-/// even when the concrete instantiation is fully resolved. Diagnostic
-/// elaboration uses this to elaborate mapped-alias mismatches structurally
-/// rather than via type-argument variance, matching tsc.
-pub(crate) fn application_base_is_mapped_type<R: TypeResolver>(
-    db: &dyn QueryDatabase,
-    resolver: &R,
-    type_id: TypeId,
-) -> bool {
-    tsz_solver::type_queries::application_base_is_mapped_type_db(db, resolver, type_id)
-}
-
 /// Check if a type contains type parameters that require instantiation,
 /// but correctly handles mapped types by only checking their constraint and
 /// `name_type` (not the template, which always contains the iteration variable).

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -1,5 +1,7 @@
 use super::state::checking as state_checking;
-use tsz_solver::{TypeId, construction::TypeDatabase};
+use tsz_solver::TypeId;
+use tsz_solver::construction::{QueryDatabase, TypeDatabase};
+use tsz_solver::relations::subtype::TypeResolver;
 
 pub(crate) use super::common::{
     PropertyAccessResult, application_info, array_element_type, callable_shape_for_type,
@@ -26,6 +28,19 @@ pub(crate) fn union_or_intersection_mentions_object(
     type_id: TypeId,
 ) -> bool {
     tsz_solver::type_queries::union_or_intersection_mentions_object(db, type_id)
+}
+
+/// Check whether an application's *declared* alias body is a mapped type
+/// (e.g. `Partial<X>`, `Readonly<X>`, or `type F<T> = { [K in keyof T]... }`),
+/// even when the concrete instantiation is fully resolved. Diagnostic
+/// elaboration uses this to elaborate mapped-alias mismatches structurally
+/// rather than via type-argument variance, matching tsc.
+pub(crate) fn application_base_is_mapped_type<R: TypeResolver>(
+    db: &dyn QueryDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> bool {
+    tsz_solver::type_queries::application_base_is_mapped_type_db(db, resolver, type_id)
 }
 
 pub(crate) fn is_typeof_result_union(db: &dyn TypeDatabase, type_id: TypeId) -> bool {

--- a/scripts/agents/test_list_owned_work.py
+++ b/scripts/agents/test_list_owned_work.py
@@ -32,7 +32,7 @@ exec "$@"
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            timeout=10,
+            timeout=30,
         )
 
     def test_clear_owned_work_prints_summary_counters(self):


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
M1-B release-gate lint unblock; agent coordination harness stability; #8225 query-boundary cleanup.

## Invariant
When the owned-work listing test runs under slower CI load, it should still verify the fake-`gh` subprocess output instead of failing on a brittle 10-second harness timeout. This PR changes only the test harness timeout, not `list-owned-work.sh` behavior.

When diagnostic display needs to know whether an application's declared alias body is a mapped type, the checker should ask through the diagnostic query boundary, not grow the broad `query_boundaries::common` quarantine. This preserves the #12451 mapped-alias structural elaboration behavior while keeping `common.rs` under the #8225 size ratchet.

## Scope
- `scripts/agents/test_list_owned_work.py`
- `crates/tsz-checker/src/query_boundaries/common.rs`
- `crates/tsz-checker/src/query_boundaries/diagnostics.rs`
- `crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: test-harness-only timeout change plus query-boundary relocation for existing diagnostic display behavior; no compiler semantic behavior change intended.

## Verification
- `python3 scripts/agents/test_list_owned_work.py`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/safe-run.sh --limit 75% -- cargo nextest run -p tsz-checker --test generic_property_mismatch_display_tests --test property_chain_elaboration_collapse_tests`

## Coordination Notes
- Follow-up after #12443 merged before the lint-harness timeout commit was included.
- Keeps the subprocess test bounded at 30 seconds while avoiding observed CI-load false negatives.
- Merged current `origin/main` after #12451 grew `query_boundaries/common.rs`; moved the mapped-alias diagnostic helper to `query_boundaries::diagnostics`, bringing `common.rs` back to 1915 lines locally and clearing the #8225 line-ratchet failure without bumping the cap.
