### PR TITLE
fix(emit): recover orphan case class fields

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class_members.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class_members.rs
@@ -359,6 +359,14 @@ impl<'a> Printer<'a> {
         }
         self.write(")");
 
+        if self.recovered_if_class_member_has_invalid_header(node, method.body) {
+            self.write(" { }");
+            if let Some(body_node) = self.arena.get(method.body) {
+                self.skip_comments_for_erased_node(body_node);
+            }
+            return;
+        }
+
         // Skip return type for JavaScript emit — skip comments inside erased return type
         if !self.ctx.flags.in_declaration_emit
             && method.type_annotation.is_some()
@@ -449,6 +457,39 @@ impl<'a> Printer<'a> {
             self.pending_lowered_async_arrow_super_capture =
                 prev_pending_lowered_async_arrow_super_capture;
         }
+    }
+
+    fn recovered_if_class_member_has_invalid_header(&self, node: &Node, body: NodeIndex) -> bool {
+        if self.class_member_emit_depth == 0 {
+            return false;
+        }
+        let Some(text) = self.source_text else {
+            return false;
+        };
+        let Some(method) = self.arena.get_method_decl(node) else {
+            return false;
+        };
+        let Some(name_node) = self.arena.get(method.name) else {
+            return false;
+        };
+        let is_if_keyword_name = name_node.kind == SyntaxKind::IfKeyword as u16
+            || self
+                .arena
+                .get_identifier(name_node)
+                .is_some_and(|ident| ident.escaped_text == "if");
+        if !is_if_keyword_name {
+            return false;
+        }
+        let Some(body_node) = self.arena.get(body) else {
+            return false;
+        };
+        let start = (name_node.end as usize).min(text.len());
+        let end = (body_node.pos as usize).min(text.len());
+        if start >= end {
+            return false;
+        }
+        let header = &text[start..end];
+        header.contains("!=") || header.contains("==")
     }
 
     pub(in crate::emitter) fn emit_recovered_object_method_without_body(&mut self, node: &Node) {

--- a/crates/tsz-emitter/src/emitter/expressions/core/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/helpers.rs
@@ -779,8 +779,15 @@ impl<'a> Printer<'a> {
                 self.write(" ?");
                 self.write_line();
                 self.increase_indent();
-                self.emit(cond.when_true);
-                if newline_before_colon {
+                if self.arena.is_missing_recovery_identifier(cond.when_false) {
+                    if !self.arena.is_missing_recovery_identifier(cond.when_true) {
+                        self.emit(cond.when_true);
+                        self.write_line();
+                    }
+                    self.write(":");
+                    self.write_line();
+                } else if newline_before_colon {
+                    self.emit(cond.when_true);
                     let colon_on_true_line =
                         self.colon_on_true_line(cond.when_true, cond.when_false);
                     if colon_on_true_line {
@@ -795,6 +802,7 @@ impl<'a> Printer<'a> {
                         self.emit(cond.when_false);
                     }
                 } else {
+                    self.emit(cond.when_true);
                     self.write(" : ");
                     self.emit(cond.when_false);
                 }

--- a/crates/tsz-emitter/src/emitter/expressions/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/mod.rs
@@ -880,6 +880,23 @@ mod tests {
         );
     }
 
+    #[test]
+    fn conditional_case_a_missing_false_branch_breaks_before_semicolon() {
+        let source = "function f() {\n    return true ?\n        : ;\n}\n";
+
+        let (parser, root) = parse_test_source(source);
+
+        let mut printer = Printer::new(&parser.arena, PrintOptions::default());
+        printer.set_source_text(source);
+        printer.print(root);
+        let output = printer.finish().code;
+
+        assert!(
+            output.contains("return true ?\n        :\n    ;"),
+            "Missing false branch should keep `:` and the return semicolon on separate lines.\nOutput:\n{output}"
+        );
+    }
+
     /// Case B with nested ternaries: `a\n  ? b ? d : e\n  : c ? f : g`
     #[test]
     fn conditional_case_b_nested_ternaries() {

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -1177,6 +1177,15 @@ impl<'a> Printer<'a> {
         self.ctx.flags.optional_chain_needs_parens = prev_optional;
         self.ctx.flags.nullish_coalescing_needs_parens = prev_nullish;
 
+        if binary.operator_token == SyntaxKind::ColonToken as u16
+            && self.arena.is_missing_recovery_identifier(binary.left)
+        {
+            self.write(": ");
+            self.emit(binary.right);
+            self.ctx.flags.in_binary_operand = prev_in_binary;
+            return;
+        }
+
         // Check if there's a line break between left operand and operator,
         // and between operator and right operand. TypeScript preserves these
         // line breaks and places the operator at the START of the continuation

--- a/crates/tsz-emitter/src/emitter/expressions/literals.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/literals.rs
@@ -472,11 +472,6 @@ impl<'a> Printer<'a> {
             return;
         }
 
-        if let Some(recovered) = self.recovered_return_object_literal_text(node) {
-            self.write(&recovered);
-            return;
-        }
-
         let emitted_properties: Vec<NodeIndex> = obj
             .elements
             .nodes
@@ -1486,30 +1481,6 @@ impl<'a> Printer<'a> {
     fn node_text_contains_newline(&self, start: usize, end: usize) -> bool {
         self.source_text
             .is_some_and(|text| start < end && end <= text.len() && text[start..end].contains('\n'))
-    }
-
-    fn recovered_return_object_literal_text(&self, node: &Node) -> Option<String> {
-        let text = self.source_text?;
-        let open = self.find_block_opening_brace_pos(node)? as usize;
-        let close_end = self.find_block_closing_brace_end(node) as usize;
-        if close_end <= open + 1 || close_end > text.len() {
-            return None;
-        }
-
-        let inner = text[open + 1..close_end - 1].trim();
-        if inner.contains(':') {
-            return None;
-        }
-        let rest = inner.strip_prefix("return")?;
-        if !rest.starts_with(char::is_whitespace) {
-            return None;
-        }
-        let value = rest.trim().trim_end_matches(';').trim();
-        if value.is_empty() {
-            return None;
-        }
-
-        Some(format!("{{ return: {value} }}"))
     }
 
     /// Emit object literal with spread elements as `Object.assign()` for pre-ES2018 targets.

--- a/crates/tsz-emitter/tests/class_member_recovery_tests.rs
+++ b/crates/tsz-emitter/tests/class_member_recovery_tests.rs
@@ -480,3 +480,125 @@ fn duplicate_static_field_modifier_lowers_as_instance_field() {
         "Duplicate static field recovery must not emit a static field assignment.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn orphan_case_after_malformed_if_recovers_as_class_field() {
+    let source = r#"class Program {
+    static Main() {
+        try {
+            if (retValue != 0 ^= {
+                return 1;
+            }
+            case = bfs.STATEMENTS(4);
+            if (retValue != 0) {
+                return 1;
+            ^
+            retValue = bfs.TYPES();
+            if (retValue != 0) {
+                return 1 &&
+            }
+        }
+        catch (e) {
+            console.log(e);
+        }
+        finally {
+        }
+    }
+}
+"#;
+
+    let output = print_with_printer_options(
+        source,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            use_define_for_class_fields: false,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        output.contains(
+            "if (retValue != 0)\n                 ^= {\n                    return: 1\n                };"
+        ),
+        "Malformed assignment after a binary if-condition should remain in the body.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("constructor() {\n        this.case = bfs.STATEMENTS(4);\n    }"),
+        "Recovered orphan `case` assignment should become a class field initializer.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("if(retValue) { }"),
+        "Recovered control-keyword class member with an invalid header should emit an empty body.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("}\ntry {\n}\ncatch (e)"),
+        "Recovered orphan catch should be emitted after the class body, not as a class member.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("}\n != 0;\n{"),
+        "Recovered comparison tail should be emitted after the class body.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("bfs.TYPES();") && !output.contains(" = bfs.TYPES();"),
+        "Recovered leading assignment should emit the right-hand call without the synthetic `=`.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("        catch(e)"),
+        "Recovered orphan catch must not remain indented inside the class body.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn malformed_while_colon_tail_preserves_tsc_recovery_shape() {
+    let source = "public Overloads( while : string, ...rest: string[]) {  &\npublic DefaultValue(value?: string = \"Hello\") { }\n";
+    let output = print_with_printer_options(
+        source,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            use_define_for_class_fields: false,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        output.contains("while ()\n    : string, ;\nrest: string[];"),
+        "Recovered `while : string, ...rest` tail should preserve tsc-compatible layout.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn malformed_catch_question_tail_does_not_emit_extra_semicolon() {
+    let source = r#"function f() {
+    try {
+        throw null;
+    }
+    catch (Exception)  ?
+    }
+    finally {
+        try { }
+        catch (Exception) { }
+    }
+}
+"#;
+    let output = print_with_printer_options(
+        source,
+        PrinterOptions {
+            target: ScriptTarget::ES2015,
+            use_define_for_class_fields: false,
+            ..Default::default()
+        },
+    );
+
+    assert!(
+        output.contains("catch (Exception) { }"),
+        "Recovered dangling `?` after catch should still emit the catch clause.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("catch (Exception) { }\n    ;"),
+        "Recovered dangling `?` after catch must not emit an extra semicolon.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("?"),
+        "Recovered dangling `?` after catch must not survive in output.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/tests/statements.rs
+++ b/crates/tsz-emitter/tests/statements.rs
@@ -70,6 +70,21 @@ fn parse_and_emit_nodenext_cjs_es2015(source: &str, file_name: &str) -> String {
 }
 
 #[test]
+fn recovered_catch_dangling_question_does_not_emit_extra_semicolon() {
+    let source = "for (var x in { x: 0 }) {\n    !\n    try { throw null; }\n    catch (Exception) ?\n}\nfinally { try { } catch (Exception) { } }\n";
+    let output = parse_and_print(source);
+
+    assert!(
+        output.contains("catch (Exception) { }\n}"),
+        "Recovered catch should close the for body without an extra semicolon.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("catch (Exception) { }\n    ;"),
+        "Dangling `?` after a missing catch block must not emit as a separate semicolon.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn recovered_top_level_accessor_modifier_comes_from_parser_fact() {
     let output = parse_and_emit_strict_target(
         "accessor /* recovered */ function F() {}\n",

--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -45,6 +45,7 @@ mod state_recovery_helpers;
 mod state_statements;
 mod state_statements_class;
 mod state_statements_class_declarations;
+mod state_statements_class_member_properties;
 mod state_statements_class_members;
 mod state_statements_class_recovery;
 mod state_statements_keywords;

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -86,6 +86,10 @@ pub const CONTEXT_FLAG_TEMPLATE_SPAN_EXPRESSION: u32 = 262144;
 pub const CONTEXT_FLAG_PARAMETER_BINDING_PATTERN: u32 = 524288;
 /// Context flag: parsing a function-like body.
 pub const CONTEXT_FLAG_FUNCTION_BODY: u32 = 1048576;
+/// Context flag: parsing an `if` condition header.
+pub const CONTEXT_FLAG_IF_CONDITION: u32 = 2097152;
+/// Context flag: parsing parameters of a recovered class member named `if`.
+pub const CONTEXT_FLAG_RECOVERED_IF_CLASS_MEMBER_PARAMETERS: u32 = 4194304;
 
 // =============================================================================
 // Parse Diagnostic
@@ -1071,6 +1075,31 @@ impl ParserState {
     #[inline]
     pub(crate) const fn in_parenthesized_expression_context(&self) -> bool {
         (self.context_flags & CONTEXT_FLAG_IN_PARENTHESIZED_EXPRESSION) != 0
+    }
+
+    #[inline]
+    pub(crate) const fn in_if_condition_context(&self) -> bool {
+        (self.context_flags & CONTEXT_FLAG_IF_CONDITION) != 0
+    }
+
+    #[inline]
+    pub(crate) const fn in_recovered_if_class_member_parameters(&self) -> bool {
+        (self.context_flags & CONTEXT_FLAG_RECOVERED_IF_CLASS_MEMBER_PARAMETERS) != 0
+    }
+
+    #[inline]
+    pub(crate) const fn current_token_is_comparison_tail(&self) -> bool {
+        matches!(
+            self.current_token,
+            SyntaxKind::ExclamationEqualsToken
+                | SyntaxKind::ExclamationEqualsEqualsToken
+                | SyntaxKind::EqualsEqualsToken
+                | SyntaxKind::EqualsEqualsEqualsToken
+                | SyntaxKind::LessThanToken
+                | SyntaxKind::LessThanEqualsToken
+                | SyntaxKind::GreaterThanToken
+                | SyntaxKind::GreaterThanEqualsToken
+        )
     }
 
     /// Check if the current token is an illegal binding identifier in the current context

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -745,7 +745,8 @@ impl ParserState {
         self.parse_expected(SyntaxKind::OpenParenToken);
 
         let saved_context_flags = self.context_flags;
-        self.context_flags |= crate::parser::state::CONTEXT_FLAG_IN_PARENTHESIZED_EXPRESSION;
+        self.context_flags |= crate::parser::state::CONTEXT_FLAG_IN_PARENTHESIZED_EXPRESSION
+            | crate::parser::state::CONTEXT_FLAG_IF_CONDITION;
         let expression = self.parse_expression();
         self.context_flags = saved_context_flags;
 
@@ -866,40 +867,20 @@ impl ParserState {
         self.parse_expected(SyntaxKind::WhileKeyword);
         let has_open_paren = self.parse_expected(SyntaxKind::OpenParenToken);
         let missing_open_paren_before_colon =
-            !has_open_paren && self.parse_optional(SyntaxKind::ColonToken);
+            !has_open_paren && self.is_token(SyntaxKind::ColonToken);
 
-        let condition = self.parse_expression();
+        let condition = if missing_open_paren_before_colon {
+            NodeIndex::NONE
+        } else {
+            self.parse_expression()
+        };
 
         // Check for missing while condition: while () { }
-        if condition == NodeIndex::NONE {
+        if condition == NodeIndex::NONE && !missing_open_paren_before_colon {
             self.error_expression_expected();
         }
 
         if missing_open_paren_before_colon {
-            if self.is_token(SyntaxKind::DotDotDotToken) {
-                self.error_expression_expected();
-                self.next_token();
-                let _ = self.parse_expression();
-            }
-            if self.is_token(SyntaxKind::ColonToken) {
-                self.next_token();
-                let _ = self.parse_expression();
-            }
-            while !matches!(
-                self.token(),
-                SyntaxKind::CloseParenToken
-                    | SyntaxKind::OpenBraceToken
-                    | SyntaxKind::CloseBraceToken
-                    | SyntaxKind::EndOfFileToken
-            ) {
-                if self.is_token(SyntaxKind::CloseBracketToken) {
-                    self.parse_error_at_current_token(
-                        tsz_common::diagnostics::diagnostic_messages::AN_ELEMENT_ACCESS_EXPRESSION_SHOULD_TAKE_AN_ARGUMENT,
-                        diagnostic_codes::AN_ELEMENT_ACCESS_EXPRESSION_SHOULD_TAKE_AN_ARGUMENT,
-                    );
-                }
-                self.next_token();
-            }
             if self.is_token(SyntaxKind::CloseParenToken) {
                 self.parse_error_at_current_token("';' expected.", diagnostic_codes::EXPECTED);
                 self.next_token();
@@ -913,7 +894,11 @@ impl ParserState {
             self.parse_expected(SyntaxKind::CloseParenToken);
         }
 
-        let statement = self.parse_statement();
+        let statement = if missing_open_paren_before_colon {
+            self.parse_recovered_leading_colon_expression_statement()
+        } else {
+            self.parse_statement()
+        };
         self.check_using_outside_block(statement);
 
         let end_pos = self.token_end();

--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -220,6 +220,21 @@ impl ParserState {
                 return left;
             }
 
+            if self.in_if_condition_context()
+                && self
+                    .arena
+                    .get(left)
+                    .is_some_and(|node| node.kind == syntax_kind_ext::BINARY_EXPRESSION)
+            {
+                if deferred_failed_async_arrow_colon_recovery
+                    && !self.is_token(SyntaxKind::ColonToken)
+                {
+                    self.pending_failed_async_arrow_colon_recovery =
+                        saved_pending_failed_async_arrow_colon_recovery;
+                }
+                return left;
+            }
+
             if self.in_parenthesized_expression_context()
                 && self
                     .arena

--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -562,6 +562,16 @@ impl ParserState {
                 continue;
             }
 
+            if previous_statement_was_block
+                && self.orphan_case_assignment_starts_recovered_class_member()
+            {
+                self.parse_error_at_current_token(
+                    "Declaration or statement expected.",
+                    diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
+                );
+                break;
+            }
+
             if self.recover_orphan_case_assignment_before_if() {
                 previous_statement_was_block = false;
                 continue;
@@ -687,6 +697,28 @@ impl ParserState {
     }
 
     fn recover_orphan_case_assignment_before_if(&mut self) -> bool {
+        if !self.current_token_starts_case_assignment() {
+            return false;
+        }
+
+        self.parse_error_at_current_token(
+            "Declaration or statement expected.",
+            diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
+        );
+        self.skip_orphan_case_assignment();
+        if self.is_token(SyntaxKind::IfKeyword) {
+            self.report_orphan_case_following_if_header_recovery();
+        }
+        true
+    }
+
+    fn orphan_case_assignment_starts_recovered_class_member(&mut self) -> bool {
+        self.in_block_context()
+            && self.in_class_body()
+            && self.current_token_starts_case_assignment()
+    }
+
+    fn current_token_starts_case_assignment(&mut self) -> bool {
         if !self.is_token(SyntaxKind::CaseKeyword) {
             return false;
         }
@@ -698,14 +730,10 @@ impl ParserState {
             !self.scanner.has_preceding_line_break() && self.is_token(SyntaxKind::EqualsToken);
         self.scanner.restore_state(snapshot);
         self.current_token = current;
-        if !has_same_line_equals {
-            return false;
-        }
+        has_same_line_equals
+    }
 
-        self.parse_error_at_current_token(
-            "Declaration or statement expected.",
-            diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
-        );
+    fn skip_orphan_case_assignment(&mut self) {
         while !self.is_token(SyntaxKind::SemicolonToken)
             && !self.is_token(SyntaxKind::CloseBraceToken)
             && !self.is_token(SyntaxKind::EndOfFileToken)
@@ -718,10 +746,6 @@ impl ParserState {
         if self.is_token(SyntaxKind::SemicolonToken) {
             self.next_token();
         }
-        if self.is_token(SyntaxKind::IfKeyword) {
-            self.report_orphan_case_following_if_header_recovery();
-        }
-        true
     }
 
     fn report_orphan_case_following_if_header_recovery(&mut self) {

--- a/crates/tsz-parser/src/parser/state_statements_class.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class.rs
@@ -487,6 +487,13 @@ impl ParserState {
                 if !self.is_token(SyntaxKind::CloseParenToken)
                     && !self.is_token(SyntaxKind::EndOfFileToken)
                 {
+                    if self.in_recovered_if_class_member_parameters()
+                        && self.current_token_is_comparison_tail()
+                    {
+                        self.error_comma_expected();
+                        self.suppress_next_missing_close_paren_error_once = true;
+                        break;
+                    }
                     if recover_tail_from_definite_assignment_colon
                         && matches!(
                             self.token(),

--- a/crates/tsz-parser/src/parser/state_statements_class_member_properties.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_member_properties.rs
@@ -1,0 +1,624 @@
+//! Parser state - class member property parsing and recovery helpers.
+
+use super::state::{
+    CONTEXT_FLAG_ASYNC, CONTEXT_FLAG_GENERATOR, CONTEXT_FLAG_STATIC_BLOCK, ParserState,
+};
+use super::state_statements_class_members::ClassMemberModifierSet;
+use crate::parser::{NodeIndex, syntax_kind_ext};
+use tsz_common::diagnostics::diagnostic_codes;
+use tsz_scanner::SyntaxKind;
+
+impl ParserState {
+    /// Construct the body of a property class member: parse type annotation,
+    /// optional/definite tokens, and initializer expression.
+    pub(crate) fn construct_class_member_property(
+        &mut self,
+        start_pos: u32,
+        mods: ClassMemberModifierSet,
+        name: NodeIndex,
+        question_token: bool,
+        exclamation_token: bool,
+        late_property_name_decorator: bool,
+        method_saved_flags: u32,
+    ) -> NodeIndex {
+        use tsz_common::diagnostics::diagnostic_codes;
+
+        // Property - parse optional type and initializer
+        self.context_flags = method_saved_flags;
+        let type_annotation = if self.parse_optional(SyntaxKind::ColonToken) {
+            self.parse_type()
+        } else {
+            NodeIndex::NONE
+        };
+
+        let init_saved_flags = self.context_flags;
+        self.context_flags &=
+            !(CONTEXT_FLAG_ASYNC | CONTEXT_FLAG_GENERATOR | CONTEXT_FLAG_STATIC_BLOCK);
+        self.context_flags |= crate::parser::state::CONTEXT_FLAG_CLASS_FIELD_INITIALIZER;
+
+        let has_equals_initializer = self.parse_optional(SyntaxKind::EqualsToken);
+        let initializer = if has_equals_initializer {
+            self.parse_assignment_expression()
+        } else if type_annotation != NodeIndex::NONE
+            && !self.is_token(SyntaxKind::SemicolonToken)
+            && !self.is_token(SyntaxKind::CloseBraceToken)
+            && !self.is_token(SyntaxKind::EndOfFileToken)
+            && (((self.is_token(SyntaxKind::StringLiteral)
+                || self.is_token(SyntaxKind::NumericLiteral)
+                || self.is_token(SyntaxKind::BigIntLiteral))
+                // A literal that looks like the next member's property name (followed by
+                // `:` or `?`) starts the next member, not an initializer for this one.
+                && !self.look_ahead_is_next_class_member_property_name())
+                || self.is_token(SyntaxKind::DotToken))
+        {
+            self.parse_error_at_current_token(
+                "Expected '=' for property initializer.",
+                diagnostic_codes::EXPECTED_FOR_PROPERTY_INITIALIZER,
+            );
+            self.parse_assignment_expression()
+        } else {
+            NodeIndex::NONE
+        };
+
+        self.context_flags = init_saved_flags;
+
+        if has_equals_initializer
+            && self.is_token(SyntaxKind::CommaToken)
+            && !self.scanner.has_preceding_line_break()
+        {
+            self.parse_error_at_current_token("';' expected.", diagnostic_codes::EXPECTED);
+        }
+
+        // When a property with an initializer is followed by a line break and
+        // a continuation token (`[`, `(`, `.`), report a missing semicolon.
+        // Exception: if the property has a computed name, no type annotation,
+        // and the next line starts with `[`, treat `[` as a new computed
+        // property (ASI), not element access on the initializer.
+        // tsc only treats `[` as a continuation when there IS a type
+        // annotation (e.g., `[e]: number = 0\n[e2]` → TS1005), but not
+        // when there's only an initializer (e.g., `[e] = "A"\n[e2] = "B"`).
+        let is_computed_name = self
+            .arena
+            .get(name)
+            .is_some_and(|n| n.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME);
+        if initializer != NodeIndex::NONE
+            && !self.is_token(SyntaxKind::SemicolonToken)
+            && self.scanner.has_preceding_line_break()
+            && self.class_member_initializer_continues_on_next_line()
+            && !(is_computed_name
+                && type_annotation == NodeIndex::NONE
+                && self.is_token(SyntaxKind::OpenBracketToken)
+                && !self.look_ahead_is_invalid_class_member_method_like_continuation())
+        {
+            self.report_missing_semicolon_after_class_field_initializer();
+            self.recover_invalid_class_member_initializer_continuation();
+        }
+
+        // TS1442: when a property has a type annotation but no initializer
+        // and the next token cannot end the declaration (not `;`, `}`, EOF,
+        // and no preceding line break), emit "Expected '=' for property
+        // initializer." — matching tsc's parseSemicolonAfterPropertyName.
+        if type_annotation != NodeIndex::NONE
+            && initializer == NodeIndex::NONE
+            && !late_property_name_decorator
+            && !self.can_parse_semicolon()
+        {
+            let (message, code) = if self.is_token(SyntaxKind::OpenParenToken) {
+                (
+                    "Cannot start a function call in a type annotation.",
+                    diagnostic_codes::CANNOT_START_A_FUNCTION_CALL_IN_A_TYPE_ANNOTATION,
+                )
+            } else {
+                (
+                    "Expected '=' for property initializer.",
+                    diagnostic_codes::EXPECTED_FOR_PROPERTY_INITIALIZER,
+                )
+            };
+            self.parse_error_at_current_token(message, code);
+        }
+
+        // Match tsc's parseSemicolonAfterPropertyName: when a property has
+        // no type annotation and no initializer and no semicolon follows,
+        // use keyword-aware semicolon error (TS1434/TS1435) instead of
+        // the generic "';' expected". This produces "Unexpected keyword or
+        // identifier" for bare identifiers like `NoMove` in class bodies.
+        if !mods.has_var_let
+            && type_annotation == NodeIndex::NONE
+            && initializer == NodeIndex::NONE
+            && !late_property_name_decorator
+            && !self.is_token(SyntaxKind::SemicolonToken)
+            && !self.can_parse_semicolon()
+        {
+            let name_is_identifier = self
+                .arena
+                .get(name)
+                .is_some_and(|node| node.kind == SyntaxKind::Identifier as u16);
+            if !name_is_identifier
+                && matches!(
+                    self.token(),
+                    SyntaxKind::CommaToken
+                        | SyntaxKind::CloseBracketToken
+                        | SyntaxKind::CloseParenToken
+                )
+            {
+                self.parse_error_at_current_token("';' expected.", diagnostic_codes::EXPECTED);
+            } else {
+                self.parse_error_for_missing_semicolon_after(name);
+            }
+        }
+
+        let end_pos = self.token_end();
+        self.arena.add_property_decl(
+            syntax_kind_ext::PROPERTY_DECLARATION,
+            start_pos,
+            end_pos,
+            crate::parser::node::PropertyDeclData {
+                modifiers: mods.modifiers,
+                name,
+                question_token,
+                exclamation_token,
+                type_annotation,
+                initializer,
+            },
+        )
+    }
+
+    pub(crate) fn look_ahead_is_class_body_variable_statement(&mut self) -> bool {
+        if !matches!(
+            self.token(),
+            SyntaxKind::VarKeyword | SyntaxKind::LetKeyword
+        ) {
+            return false;
+        }
+
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+
+        self.next_token();
+        let is_match = if self.scanner.has_preceding_line_break() {
+            false
+        } else if matches!(
+            self.token(),
+            SyntaxKind::OpenBraceToken | SyntaxKind::OpenBracketToken
+        ) {
+            true
+        } else if self.is_identifier_or_keyword() || self.is_token(SyntaxKind::PrivateIdentifier) {
+            self.next_token();
+            !self.scanner.has_preceding_line_break() && !self.is_token(SyntaxKind::OpenParenToken)
+        } else {
+            false
+        };
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        is_match
+    }
+
+    pub(crate) fn look_ahead_is_class_body_function_statement(&mut self) -> bool {
+        if !self.is_token(SyntaxKind::FunctionKeyword) {
+            return false;
+        }
+
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+        self.next_token();
+        let is_match = self.is_identifier_or_keyword() && !self.scanner.has_preceding_line_break();
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        is_match
+    }
+
+    pub(crate) fn look_ahead_is_property_name_same_line(&mut self) -> bool {
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+
+        self.next_token();
+        let is_match = self.is_property_name() && !self.scanner.has_preceding_line_break();
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        is_match
+    }
+
+    pub(crate) fn recover_invalid_class_body_variable_statement(&mut self) {
+        self.parse_error_at_current_token(
+            "Unexpected token. A constructor, method, accessor, or property was expected.",
+            diagnostic_codes::UNEXPECTED_TOKEN_A_CONSTRUCTOR_METHOD_ACCESSOR_OR_PROPERTY_WAS_EXPECTED,
+        );
+
+        while !self.is_token(SyntaxKind::SemicolonToken)
+            && !self.is_token(SyntaxKind::CloseBraceToken)
+            && !self.is_token(SyntaxKind::EndOfFileToken)
+        {
+            self.next_token();
+        }
+
+        if self.is_token(SyntaxKind::SemicolonToken) {
+            self.next_token();
+        }
+
+        if self.is_token(SyntaxKind::CloseBraceToken) {
+            self.parse_error_at_current_token(
+                "Declaration or statement expected.",
+                diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
+            );
+        }
+    }
+
+    pub(crate) fn recover_invalid_class_body_function_statement(&mut self) {
+        self.parse_error_at_current_token(
+            "Unexpected token. A constructor, method, accessor, or property was expected.",
+            diagnostic_codes::UNEXPECTED_TOKEN_A_CONSTRUCTOR_METHOD_ACCESSOR_OR_PROPERTY_WAS_EXPECTED,
+        );
+
+        // Skip the invalid `function ...` statement body on the same line.
+        // Unlike module-like recovery, don't emit an intermediate TS1005
+        // ("';' expected.") here — tsc reports only TS1068 + trailing TS1128.
+        self.next_token();
+        while !self.is_token(SyntaxKind::EndOfFileToken) && !self.scanner.has_preceding_line_break()
+        {
+            self.next_token();
+        }
+
+        // If we're at the class closing brace, report the follow-up statement-level
+        // recovery diagnostic.
+        if self.is_token(SyntaxKind::CloseBraceToken) {
+            self.parse_error_at_current_token(
+                "Declaration or statement expected.",
+                diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
+            );
+        }
+    }
+
+    pub(crate) fn class_member_is_recovered_invalid_if_method(&self, member: NodeIndex) -> bool {
+        let text = self.get_source_text();
+        let Some(member_node) = self.arena.get(member) else {
+            return false;
+        };
+        let Some(method) = self.arena.get_method_decl(member_node) else {
+            return false;
+        };
+        let Some(name_node) = self.arena.get(method.name) else {
+            return false;
+        };
+        let is_if_name = name_node.kind == SyntaxKind::IfKeyword as u16
+            || self
+                .arena
+                .get_identifier(name_node)
+                .is_some_and(|ident| ident.escaped_text == "if");
+        if !is_if_name {
+            return false;
+        }
+        if let Some(body_node) = self.arena.get(method.body) {
+            if body_node.pos == body_node.end && self.current_token_is_comparison_tail() {
+                return true;
+            }
+            let start = (name_node.end as usize).min(text.len());
+            let end = (body_node.pos as usize).min(text.len());
+            return start < end && text[start..end].contains("!=");
+        }
+
+        self.current_token_is_comparison_tail()
+    }
+
+    const fn class_member_initializer_continues_on_next_line(&self) -> bool {
+        matches!(
+            self.token(),
+            SyntaxKind::OpenParenToken
+                | SyntaxKind::OpenBracketToken
+                | SyntaxKind::DotToken
+                | SyntaxKind::QuestionDotToken
+                | SyntaxKind::NoSubstitutionTemplateLiteral
+                | SyntaxKind::TemplateHead
+        )
+    }
+
+    fn report_missing_semicolon_after_class_field_initializer(&mut self) {
+        if let Some((pos, len)) = self.class_field_initializer_continuation_anchor() {
+            self.parse_error_at(pos, len, "';' expected.", diagnostic_codes::EXPECTED);
+        } else {
+            self.error_token_expected(";");
+        }
+    }
+
+    fn class_field_initializer_continuation_anchor(&mut self) -> Option<(u32, u32)> {
+        let (open, close) = match self.token() {
+            SyntaxKind::OpenBracketToken => {
+                (SyntaxKind::OpenBracketToken, SyntaxKind::CloseBracketToken)
+            }
+            SyntaxKind::OpenParenToken => (SyntaxKind::OpenParenToken, SyntaxKind::CloseParenToken),
+            _ => return None,
+        };
+
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+        let mut depth = 0u32;
+        let mut anchor = None;
+
+        while !self.is_token(SyntaxKind::EndOfFileToken) {
+            if self.is_token(open) {
+                depth += 1;
+            } else if self.is_token(close) {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    let pos = self.token_end();
+                    anchor = Some((pos, 1));
+
+                    if open == SyntaxKind::OpenBracketToken {
+                        self.next_token();
+                        if self.is_token(SyntaxKind::OpenParenToken) {
+                            let mut paren_depth = 0u32;
+                            while !self.is_token(SyntaxKind::EndOfFileToken) {
+                                if self.is_token(SyntaxKind::OpenParenToken) {
+                                    paren_depth += 1;
+                                } else if self.is_token(SyntaxKind::CloseParenToken) {
+                                    paren_depth = paren_depth.saturating_sub(1);
+                                    if paren_depth == 0 {
+                                        self.next_token();
+                                        if self.is_token(SyntaxKind::OpenBraceToken) {
+                                            anchor = Some((self.token_pos(), 1));
+                                        }
+                                        break;
+                                    }
+                                }
+                                self.next_token();
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+            self.next_token();
+        }
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        anchor
+    }
+
+    fn recover_invalid_class_member_initializer_continuation(&mut self) {
+        if !self.look_ahead_is_invalid_class_member_method_like_continuation() {
+            return;
+        }
+
+        if self.is_token(SyntaxKind::OpenBracketToken) {
+            let mut bracket_depth = 0u32;
+            while !self.is_token(SyntaxKind::EndOfFileToken) {
+                if self.is_token(SyntaxKind::OpenBracketToken) {
+                    bracket_depth += 1;
+                } else if self.is_token(SyntaxKind::CloseBracketToken) {
+                    bracket_depth = bracket_depth.saturating_sub(1);
+                    if bracket_depth == 0 {
+                        self.next_token();
+                        break;
+                    }
+                }
+                self.next_token();
+            }
+        }
+
+        if !self.is_token(SyntaxKind::OpenParenToken) {
+            return;
+        }
+        self.suppress_next_missing_class_close_brace_error_once = true;
+
+        let mut paren_depth = 0u32;
+        while !self.is_token(SyntaxKind::EndOfFileToken) {
+            if self.is_token(SyntaxKind::OpenParenToken) {
+                paren_depth += 1;
+            } else if self.is_token(SyntaxKind::CloseParenToken) {
+                paren_depth = paren_depth.saturating_sub(1);
+                if paren_depth == 0 {
+                    self.next_token();
+                    break;
+                }
+            }
+            self.next_token();
+        }
+    }
+
+    fn look_ahead_is_invalid_class_member_method_like_continuation(&mut self) -> bool {
+        if !self.is_token(SyntaxKind::OpenBracketToken)
+            && !self.is_token(SyntaxKind::OpenParenToken)
+        {
+            return false;
+        }
+
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+
+        let mut is_match = false;
+
+        if self.is_token(SyntaxKind::OpenBracketToken) {
+            let mut bracket_depth = 0u32;
+            while !self.is_token(SyntaxKind::EndOfFileToken) {
+                if self.is_token(SyntaxKind::OpenBracketToken) {
+                    bracket_depth += 1;
+                } else if self.is_token(SyntaxKind::CloseBracketToken) {
+                    bracket_depth = bracket_depth.saturating_sub(1);
+                    if bracket_depth == 0 {
+                        self.next_token();
+                        break;
+                    }
+                }
+                self.next_token();
+            }
+        }
+
+        if self.is_token(SyntaxKind::OpenParenToken) {
+            let mut paren_depth = 0u32;
+            while !self.is_token(SyntaxKind::EndOfFileToken) {
+                if self.is_token(SyntaxKind::OpenParenToken) {
+                    paren_depth += 1;
+                } else if self.is_token(SyntaxKind::CloseParenToken) {
+                    paren_depth = paren_depth.saturating_sub(1);
+                    if paren_depth == 0 {
+                        self.next_token();
+                        is_match = self.is_token(SyntaxKind::OpenBraceToken);
+                        break;
+                    }
+                }
+                self.next_token();
+            }
+        }
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        is_match
+    }
+
+    /// Look ahead to check if the current string/numeric literal token is actually
+    /// the property name of the next class member (followed by `:` or `?`).
+    /// This prevents false TS1442 when two string-literal-named properties appear
+    /// in sequence, e.g., `"d": string; "e": number;`.
+    fn look_ahead_is_next_class_member_property_name(&mut self) -> bool {
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+
+        self.next_token(); // skip the string/numeric literal
+
+        let is_property_name = matches!(
+            self.token(),
+            SyntaxKind::ColonToken       // "d": type
+            | SyntaxKind::QuestionToken // "d"?: type
+        );
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        is_property_name
+    }
+
+    /// Look ahead to see if we have an accessor (get/set followed by property name and ()
+    pub(crate) fn look_ahead_is_accessor(&mut self) -> bool {
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+
+        // Skip 'get' or 'set'
+        self.next_token();
+
+        // Note: line breaks after get/set do NOT prevent accessor parsing.
+        // The ECMAScript grammar has no [no LineTerminator here] restriction
+        // for get/set in class method definitions.
+
+        // Check the token AFTER 'get' or 'set' to determine what we have:
+        // - `:`, `=`, `;`, `}`, `?` → property named 'get'/'set' (e.g., `get: number`)
+        // - `(` → method named 'get'/'set' (e.g., `get() {}`)
+        // - identifier/string/etc → accessor (e.g., `get foo() {}`)
+        let next_token = self.token();
+        let is_accessor = !matches!(
+            next_token,
+            SyntaxKind::ColonToken          // `get: number` - property
+                | SyntaxKind::EqualsToken     // `get = 1` - property
+                | SyntaxKind::SemicolonToken  // `get;` - property
+                | SyntaxKind::CloseBraceToken // `get }` - property
+                | SyntaxKind::OpenParenToken  // `get()` - method
+                | SyntaxKind::QuestionToken // `get?` - property
+        ) && self.is_property_name(); // Also ensure there's a valid property name
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        is_accessor
+    }
+
+    /// Look ahead to see if we have a static block: static { ... }
+    pub(crate) fn look_ahead_is_static_block(&mut self) -> bool {
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+
+        // Skip 'static'
+        self.next_token();
+        // Check for '{'
+        let is_block = self.is_token(SyntaxKind::OpenBraceToken);
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        is_block
+    }
+
+    /// Parse static block: static { ... }
+    pub(crate) fn parse_static_block(&mut self) -> NodeIndex {
+        let start_pos = self.token_pos();
+
+        // Consume 'static'
+        self.parse_expected(SyntaxKind::StaticKeyword);
+
+        // Parse the block body with static block context (where 'await' is reserved)
+        // IMPORTANT: Static blocks create a fresh execution context - they do NOT inherit
+        // async/generator context from enclosing functions. Clear those flags.
+        self.parse_expected(SyntaxKind::OpenBraceToken);
+        let saved_flags = self.context_flags;
+        // Clear async/generator flags and set static block flag
+        self.context_flags &= !(CONTEXT_FLAG_ASYNC | CONTEXT_FLAG_GENERATOR);
+        self.context_flags |= CONTEXT_FLAG_STATIC_BLOCK;
+        let statements = self.parse_statements();
+        self.context_flags = saved_flags;
+        self.parse_expected(SyntaxKind::CloseBraceToken);
+
+        let end_pos = self.token_end();
+
+        self.arena.add_block(
+            syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION,
+            start_pos,
+            end_pos,
+            crate::parser::node::BlockData {
+                statements,
+                multi_line: true,
+            },
+        )
+    }
+
+    /// Look ahead to see if this is an index signature: [key: Type]: `ValueType`
+    /// vs a computed property: [expr]: Type or [computed]()
+    ///
+    /// Matches tsc's `isUnambiguouslyIndexSignature`. Recognizes:
+    ///   [id:    [id,    [id?:    [id?,    [id?]    [...    [modifier id
+    pub(crate) fn look_ahead_is_index_signature(&mut self) -> bool {
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+
+        // Skip '['
+        self.next_token();
+
+        let is_index_sig = if self.is_token(SyntaxKind::DotDotDotToken) {
+            true
+        } else if self.is_parameter_modifier() {
+            self.next_token();
+            self.is_identifier_or_keyword()
+        } else if !self.is_identifier_or_keyword() {
+            false
+        } else {
+            self.next_token();
+            if self.is_token(SyntaxKind::ColonToken) || self.is_token(SyntaxKind::CommaToken) {
+                // `[id:` or `[id,`
+                true
+            } else if self.is_token(SyntaxKind::QuestionToken) {
+                // `[id?` — check what follows: `:`, `,`, or `]` means index signature
+                self.next_token();
+                self.is_token(SyntaxKind::ColonToken)
+                    || self.is_token(SyntaxKind::CommaToken)
+                    || self.is_token(SyntaxKind::CloseBracketToken)
+            } else {
+                false
+            }
+        };
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        is_index_sig
+    }
+
+    /// Check if this is `[]` — an empty index signature (malformed, no parameters).
+    /// Used in type member contexts where `[]` should be an empty index signature,
+    /// NOT in type suffix contexts where `[]` is an array type.
+    pub(crate) fn look_ahead_is_empty_index_signature(&mut self) -> bool {
+        let snapshot = self.scanner.save_state();
+        let current = self.current_token;
+
+        self.next_token(); // skip `[`
+        let is_empty = self.is_token(SyntaxKind::CloseBracketToken);
+
+        self.scanner.restore_state(snapshot);
+        self.current_token = current;
+        is_empty
+    }
+}

--- a/crates/tsz-parser/src/parser/state_statements_class_members.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_members.rs
@@ -1165,6 +1165,8 @@ impl ParserState {
 
             let member = self.parse_class_member();
             if member.is_some() {
+                let recovered_invalid_if_member =
+                    self.class_member_is_recovered_invalid_if_method(member);
                 // Don't consume trailing semicolon if the member itself is a
                 // SemicolonClassElement — that would eat the next standalone `;`.
                 let is_semi_element = self
@@ -1175,6 +1177,32 @@ impl ParserState {
                     self.parse_optional(SyntaxKind::SemicolonToken);
                 }
                 members.push(member);
+
+                if recovered_invalid_if_member
+                    && matches!(
+                        self.token(),
+                        SyntaxKind::CatchKeyword | SyntaxKind::FinallyKeyword
+                    )
+                {
+                    break;
+                }
+
+                if recovered_invalid_if_member
+                    && matches!(
+                        self.token(),
+                        SyntaxKind::ExclamationEqualsToken
+                            | SyntaxKind::ExclamationEqualsEqualsToken
+                            | SyntaxKind::EqualsEqualsToken
+                            | SyntaxKind::EqualsEqualsEqualsToken
+                            | SyntaxKind::LessThanToken
+                            | SyntaxKind::LessThanEqualsToken
+                            | SyntaxKind::GreaterThanToken
+                            | SyntaxKind::GreaterThanEqualsToken
+                    )
+                {
+                    self.suppress_next_missing_class_close_brace_error_once = true;
+                    break;
+                }
 
                 if self.is_token(SyntaxKind::OpenBraceToken)
                     && !self.scanner.has_preceding_line_break()
@@ -1914,7 +1942,13 @@ impl ParserState {
         let has_open_paren = self.parse_optional(SyntaxKind::OpenParenToken);
         let mut body_already_consumed_by_recovery = false;
         let parameters = if has_open_paren {
+            let saved_flags = self.context_flags;
+            if self.class_member_name_is_if_keyword(name) {
+                self.context_flags |=
+                    crate::parser::state::CONTEXT_FLAG_RECOVERED_IF_CLASS_MEMBER_PARAMETERS;
+            }
             let parameters = self.parse_parameter_list();
+            self.context_flags = saved_flags;
             self.parse_expected(SyntaxKind::CloseParenToken);
             parameters
         } else if asterisk_token {
@@ -1936,10 +1970,22 @@ impl ParserState {
         } else {
             NodeIndex::NONE
         };
+        let recovered_if_comparison_tail =
+            self.class_member_name_is_if_keyword(name) && self.current_token_is_comparison_tail();
 
         self.push_label_scope();
         let body = if body_already_consumed_by_recovery {
             NodeIndex::NONE
+        } else if recovered_if_comparison_tail {
+            self.arena.add_block(
+                syntax_kind_ext::BLOCK,
+                self.token_pos(),
+                self.token_pos(),
+                crate::parser::node::BlockData {
+                    statements: self.make_node_list(Vec::new()),
+                    multi_line: false,
+                },
+            )
         } else if self.is_token(SyntaxKind::OpenBraceToken) {
             self.parse_block()
         } else {
@@ -1979,585 +2025,14 @@ impl ParserState {
         )
     }
 
-    /// Construct the body of a property class member: parse type annotation,
-    /// optional/definite tokens, and initializer expression.
-    fn construct_class_member_property(
-        &mut self,
-        start_pos: u32,
-        mods: ClassMemberModifierSet,
-        name: NodeIndex,
-        question_token: bool,
-        exclamation_token: bool,
-        late_property_name_decorator: bool,
-        method_saved_flags: u32,
-    ) -> NodeIndex {
-        use tsz_common::diagnostics::diagnostic_codes;
-
-        // Property - parse optional type and initializer
-        self.context_flags = method_saved_flags;
-        let type_annotation = if self.parse_optional(SyntaxKind::ColonToken) {
-            self.parse_type()
-        } else {
-            NodeIndex::NONE
+    fn class_member_name_is_if_keyword(&self, name: NodeIndex) -> bool {
+        let Some(name_node) = self.arena.get(name) else {
+            return false;
         };
-
-        let init_saved_flags = self.context_flags;
-        self.context_flags &=
-            !(CONTEXT_FLAG_ASYNC | CONTEXT_FLAG_GENERATOR | CONTEXT_FLAG_STATIC_BLOCK);
-        self.context_flags |= crate::parser::state::CONTEXT_FLAG_CLASS_FIELD_INITIALIZER;
-
-        let has_equals_initializer = self.parse_optional(SyntaxKind::EqualsToken);
-        let initializer = if has_equals_initializer {
-            self.parse_assignment_expression()
-        } else if type_annotation != NodeIndex::NONE
-            && !self.is_token(SyntaxKind::SemicolonToken)
-            && !self.is_token(SyntaxKind::CloseBraceToken)
-            && !self.is_token(SyntaxKind::EndOfFileToken)
-            && (((self.is_token(SyntaxKind::StringLiteral)
-                || self.is_token(SyntaxKind::NumericLiteral)
-                || self.is_token(SyntaxKind::BigIntLiteral))
-                // A literal that looks like the next member's property name (followed by
-                // `:` or `?`) starts the next member, not an initializer for this one.
-                && !self.look_ahead_is_next_class_member_property_name())
-                || self.is_token(SyntaxKind::DotToken))
-        {
-            self.parse_error_at_current_token(
-                "Expected '=' for property initializer.",
-                diagnostic_codes::EXPECTED_FOR_PROPERTY_INITIALIZER,
-            );
-            self.parse_assignment_expression()
-        } else {
-            NodeIndex::NONE
-        };
-
-        self.context_flags = init_saved_flags;
-
-        if has_equals_initializer
-            && self.is_token(SyntaxKind::CommaToken)
-            && !self.scanner.has_preceding_line_break()
-        {
-            self.parse_error_at_current_token("';' expected.", diagnostic_codes::EXPECTED);
-        }
-
-        // When a property with an initializer is followed by a line break and
-        // a continuation token (`[`, `(`, `.`), report a missing semicolon.
-        // Exception: if the property has a computed name, no type annotation,
-        // and the next line starts with `[`, treat `[` as a new computed
-        // property (ASI), not element access on the initializer.
-        // tsc only treats `[` as a continuation when there IS a type
-        // annotation (e.g., `[e]: number = 0\n[e2]` → TS1005), but not
-        // when there's only an initializer (e.g., `[e] = "A"\n[e2] = "B"`).
-        let is_computed_name = self
-            .arena
-            .get(name)
-            .is_some_and(|n| n.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME);
-        if initializer != NodeIndex::NONE
-            && !self.is_token(SyntaxKind::SemicolonToken)
-            && self.scanner.has_preceding_line_break()
-            && self.class_member_initializer_continues_on_next_line()
-            && !(is_computed_name
-                && type_annotation == NodeIndex::NONE
-                && self.is_token(SyntaxKind::OpenBracketToken)
-                && !self.look_ahead_is_invalid_class_member_method_like_continuation())
-        {
-            self.report_missing_semicolon_after_class_field_initializer();
-            self.recover_invalid_class_member_initializer_continuation();
-        }
-
-        // TS1442: when a property has a type annotation but no initializer
-        // and the next token cannot end the declaration (not `;`, `}`, EOF,
-        // and no preceding line break), emit "Expected '=' for property
-        // initializer." — matching tsc's parseSemicolonAfterPropertyName.
-        if type_annotation != NodeIndex::NONE
-            && initializer == NodeIndex::NONE
-            && !late_property_name_decorator
-            && !self.can_parse_semicolon()
-        {
-            let (message, code) = if self.is_token(SyntaxKind::OpenParenToken) {
-                (
-                    "Cannot start a function call in a type annotation.",
-                    diagnostic_codes::CANNOT_START_A_FUNCTION_CALL_IN_A_TYPE_ANNOTATION,
-                )
-            } else {
-                (
-                    "Expected '=' for property initializer.",
-                    diagnostic_codes::EXPECTED_FOR_PROPERTY_INITIALIZER,
-                )
-            };
-            self.parse_error_at_current_token(message, code);
-        }
-
-        // Match tsc's parseSemicolonAfterPropertyName: when a property has
-        // no type annotation and no initializer and no semicolon follows,
-        // use keyword-aware semicolon error (TS1434/TS1435) instead of
-        // the generic "';' expected". This produces "Unexpected keyword or
-        // identifier" for bare identifiers like `NoMove` in class bodies.
-        if !mods.has_var_let
-            && type_annotation == NodeIndex::NONE
-            && initializer == NodeIndex::NONE
-            && !late_property_name_decorator
-            && !self.is_token(SyntaxKind::SemicolonToken)
-            && !self.can_parse_semicolon()
-        {
-            let name_is_identifier = self
+        name_node.kind == SyntaxKind::IfKeyword as u16
+            || self
                 .arena
-                .get(name)
-                .is_some_and(|node| node.kind == SyntaxKind::Identifier as u16);
-            if !name_is_identifier
-                && matches!(
-                    self.token(),
-                    SyntaxKind::CommaToken
-                        | SyntaxKind::CloseBracketToken
-                        | SyntaxKind::CloseParenToken
-                )
-            {
-                self.parse_error_at_current_token("';' expected.", diagnostic_codes::EXPECTED);
-            } else {
-                self.parse_error_for_missing_semicolon_after(name);
-            }
-        }
-
-        let end_pos = self.token_end();
-        self.arena.add_property_decl(
-            syntax_kind_ext::PROPERTY_DECLARATION,
-            start_pos,
-            end_pos,
-            crate::parser::node::PropertyDeclData {
-                modifiers: mods.modifiers,
-                name,
-                question_token,
-                exclamation_token,
-                type_annotation,
-                initializer,
-            },
-        )
-    }
-
-    fn look_ahead_is_class_body_variable_statement(&mut self) -> bool {
-        if !matches!(
-            self.token(),
-            SyntaxKind::VarKeyword | SyntaxKind::LetKeyword
-        ) {
-            return false;
-        }
-
-        let snapshot = self.scanner.save_state();
-        let current = self.current_token;
-
-        self.next_token();
-        let is_match = if self.scanner.has_preceding_line_break() {
-            false
-        } else if matches!(
-            self.token(),
-            SyntaxKind::OpenBraceToken | SyntaxKind::OpenBracketToken
-        ) {
-            true
-        } else if self.is_identifier_or_keyword() || self.is_token(SyntaxKind::PrivateIdentifier) {
-            self.next_token();
-            !self.scanner.has_preceding_line_break() && !self.is_token(SyntaxKind::OpenParenToken)
-        } else {
-            false
-        };
-
-        self.scanner.restore_state(snapshot);
-        self.current_token = current;
-        is_match
-    }
-
-    fn look_ahead_is_class_body_function_statement(&mut self) -> bool {
-        if !self.is_token(SyntaxKind::FunctionKeyword) {
-            return false;
-        }
-
-        let snapshot = self.scanner.save_state();
-        let current = self.current_token;
-        self.next_token();
-        let is_match = self.is_identifier_or_keyword() && !self.scanner.has_preceding_line_break();
-        self.scanner.restore_state(snapshot);
-        self.current_token = current;
-        is_match
-    }
-
-    fn look_ahead_is_property_name_same_line(&mut self) -> bool {
-        let snapshot = self.scanner.save_state();
-        let current = self.current_token;
-
-        self.next_token();
-        let is_match = self.is_property_name() && !self.scanner.has_preceding_line_break();
-
-        self.scanner.restore_state(snapshot);
-        self.current_token = current;
-        is_match
-    }
-
-    fn recover_invalid_class_body_variable_statement(&mut self) {
-        self.parse_error_at_current_token(
-            "Unexpected token. A constructor, method, accessor, or property was expected.",
-            diagnostic_codes::UNEXPECTED_TOKEN_A_CONSTRUCTOR_METHOD_ACCESSOR_OR_PROPERTY_WAS_EXPECTED,
-        );
-
-        while !self.is_token(SyntaxKind::SemicolonToken)
-            && !self.is_token(SyntaxKind::CloseBraceToken)
-            && !self.is_token(SyntaxKind::EndOfFileToken)
-        {
-            self.next_token();
-        }
-
-        if self.is_token(SyntaxKind::SemicolonToken) {
-            self.next_token();
-        }
-
-        if self.is_token(SyntaxKind::CloseBraceToken) {
-            self.parse_error_at_current_token(
-                "Declaration or statement expected.",
-                diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
-            );
-        }
-    }
-
-    fn recover_invalid_class_body_function_statement(&mut self) {
-        self.parse_error_at_current_token(
-            "Unexpected token. A constructor, method, accessor, or property was expected.",
-            diagnostic_codes::UNEXPECTED_TOKEN_A_CONSTRUCTOR_METHOD_ACCESSOR_OR_PROPERTY_WAS_EXPECTED,
-        );
-
-        // Skip the invalid `function ...` statement body on the same line.
-        // Unlike module-like recovery, don't emit an intermediate TS1005
-        // ("';' expected.") here — tsc reports only TS1068 + trailing TS1128.
-        self.next_token();
-        while !self.is_token(SyntaxKind::EndOfFileToken) && !self.scanner.has_preceding_line_break()
-        {
-            self.next_token();
-        }
-
-        // If we're at the class closing brace, report the follow-up statement-level
-        // recovery diagnostic.
-        if self.is_token(SyntaxKind::CloseBraceToken) {
-            self.parse_error_at_current_token(
-                "Declaration or statement expected.",
-                diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
-            );
-        }
-    }
-
-    const fn class_member_initializer_continues_on_next_line(&self) -> bool {
-        matches!(
-            self.token(),
-            SyntaxKind::OpenParenToken
-                | SyntaxKind::OpenBracketToken
-                | SyntaxKind::DotToken
-                | SyntaxKind::QuestionDotToken
-                | SyntaxKind::NoSubstitutionTemplateLiteral
-                | SyntaxKind::TemplateHead
-        )
-    }
-
-    fn report_missing_semicolon_after_class_field_initializer(&mut self) {
-        if let Some((pos, len)) = self.class_field_initializer_continuation_anchor() {
-            self.parse_error_at(pos, len, "';' expected.", diagnostic_codes::EXPECTED);
-        } else {
-            self.error_token_expected(";");
-        }
-    }
-
-    fn class_field_initializer_continuation_anchor(&mut self) -> Option<(u32, u32)> {
-        let (open, close) = match self.token() {
-            SyntaxKind::OpenBracketToken => {
-                (SyntaxKind::OpenBracketToken, SyntaxKind::CloseBracketToken)
-            }
-            SyntaxKind::OpenParenToken => (SyntaxKind::OpenParenToken, SyntaxKind::CloseParenToken),
-            _ => return None,
-        };
-
-        let snapshot = self.scanner.save_state();
-        let current = self.current_token;
-        let mut depth = 0u32;
-        let mut anchor = None;
-
-        while !self.is_token(SyntaxKind::EndOfFileToken) {
-            if self.is_token(open) {
-                depth += 1;
-            } else if self.is_token(close) {
-                depth = depth.saturating_sub(1);
-                if depth == 0 {
-                    let pos = self.token_end();
-                    anchor = Some((pos, 1));
-
-                    if open == SyntaxKind::OpenBracketToken {
-                        self.next_token();
-                        if self.is_token(SyntaxKind::OpenParenToken) {
-                            let mut paren_depth = 0u32;
-                            while !self.is_token(SyntaxKind::EndOfFileToken) {
-                                if self.is_token(SyntaxKind::OpenParenToken) {
-                                    paren_depth += 1;
-                                } else if self.is_token(SyntaxKind::CloseParenToken) {
-                                    paren_depth = paren_depth.saturating_sub(1);
-                                    if paren_depth == 0 {
-                                        self.next_token();
-                                        if self.is_token(SyntaxKind::OpenBraceToken) {
-                                            anchor = Some((self.token_pos(), 1));
-                                        }
-                                        break;
-                                    }
-                                }
-                                self.next_token();
-                            }
-                        }
-                    }
-                    break;
-                }
-            }
-            self.next_token();
-        }
-
-        self.scanner.restore_state(snapshot);
-        self.current_token = current;
-        anchor
-    }
-
-    fn recover_invalid_class_member_initializer_continuation(&mut self) {
-        if !self.look_ahead_is_invalid_class_member_method_like_continuation() {
-            return;
-        }
-
-        if self.is_token(SyntaxKind::OpenBracketToken) {
-            let mut bracket_depth = 0u32;
-            while !self.is_token(SyntaxKind::EndOfFileToken) {
-                if self.is_token(SyntaxKind::OpenBracketToken) {
-                    bracket_depth += 1;
-                } else if self.is_token(SyntaxKind::CloseBracketToken) {
-                    bracket_depth = bracket_depth.saturating_sub(1);
-                    if bracket_depth == 0 {
-                        self.next_token();
-                        break;
-                    }
-                }
-                self.next_token();
-            }
-        }
-
-        if !self.is_token(SyntaxKind::OpenParenToken) {
-            return;
-        }
-        self.suppress_next_missing_class_close_brace_error_once = true;
-
-        let mut paren_depth = 0u32;
-        while !self.is_token(SyntaxKind::EndOfFileToken) {
-            if self.is_token(SyntaxKind::OpenParenToken) {
-                paren_depth += 1;
-            } else if self.is_token(SyntaxKind::CloseParenToken) {
-                paren_depth = paren_depth.saturating_sub(1);
-                if paren_depth == 0 {
-                    self.next_token();
-                    break;
-                }
-            }
-            self.next_token();
-        }
-    }
-
-    fn look_ahead_is_invalid_class_member_method_like_continuation(&mut self) -> bool {
-        if !self.is_token(SyntaxKind::OpenBracketToken)
-            && !self.is_token(SyntaxKind::OpenParenToken)
-        {
-            return false;
-        }
-
-        let snapshot = self.scanner.save_state();
-        let current = self.current_token;
-
-        let mut is_match = false;
-
-        if self.is_token(SyntaxKind::OpenBracketToken) {
-            let mut bracket_depth = 0u32;
-            while !self.is_token(SyntaxKind::EndOfFileToken) {
-                if self.is_token(SyntaxKind::OpenBracketToken) {
-                    bracket_depth += 1;
-                } else if self.is_token(SyntaxKind::CloseBracketToken) {
-                    bracket_depth = bracket_depth.saturating_sub(1);
-                    if bracket_depth == 0 {
-                        self.next_token();
-                        break;
-                    }
-                }
-                self.next_token();
-            }
-        }
-
-        if self.is_token(SyntaxKind::OpenParenToken) {
-            let mut paren_depth = 0u32;
-            while !self.is_token(SyntaxKind::EndOfFileToken) {
-                if self.is_token(SyntaxKind::OpenParenToken) {
-                    paren_depth += 1;
-                } else if self.is_token(SyntaxKind::CloseParenToken) {
-                    paren_depth = paren_depth.saturating_sub(1);
-                    if paren_depth == 0 {
-                        self.next_token();
-                        is_match = self.is_token(SyntaxKind::OpenBraceToken);
-                        break;
-                    }
-                }
-                self.next_token();
-            }
-        }
-
-        self.scanner.restore_state(snapshot);
-        self.current_token = current;
-        is_match
-    }
-
-    /// Look ahead to check if the current string/numeric literal token is actually
-    /// the property name of the next class member (followed by `:` or `?`).
-    /// This prevents false TS1442 when two string-literal-named properties appear
-    /// in sequence, e.g., `"d": string; "e": number;`.
-    fn look_ahead_is_next_class_member_property_name(&mut self) -> bool {
-        let snapshot = self.scanner.save_state();
-        let current = self.current_token;
-
-        self.next_token(); // skip the string/numeric literal
-
-        let is_property_name = matches!(
-            self.token(),
-            SyntaxKind::ColonToken       // "d": type
-            | SyntaxKind::QuestionToken // "d"?: type
-        );
-
-        self.scanner.restore_state(snapshot);
-        self.current_token = current;
-        is_property_name
-    }
-
-    /// Look ahead to see if we have an accessor (get/set followed by property name and ()
-    pub(crate) fn look_ahead_is_accessor(&mut self) -> bool {
-        let snapshot = self.scanner.save_state();
-        let current = self.current_token;
-
-        // Skip 'get' or 'set'
-        self.next_token();
-
-        // Note: line breaks after get/set do NOT prevent accessor parsing.
-        // The ECMAScript grammar has no [no LineTerminator here] restriction
-        // for get/set in class method definitions.
-
-        // Check the token AFTER 'get' or 'set' to determine what we have:
-        // - `:`, `=`, `;`, `}`, `?` → property named 'get'/'set' (e.g., `get: number`)
-        // - `(` → method named 'get'/'set' (e.g., `get() {}`)
-        // - identifier/string/etc → accessor (e.g., `get foo() {}`)
-        let next_token = self.token();
-        let is_accessor = !matches!(
-            next_token,
-            SyntaxKind::ColonToken          // `get: number` - property
-                | SyntaxKind::EqualsToken     // `get = 1` - property
-                | SyntaxKind::SemicolonToken  // `get;` - property
-                | SyntaxKind::CloseBraceToken // `get }` - property
-                | SyntaxKind::OpenParenToken  // `get()` - method
-                | SyntaxKind::QuestionToken // `get?` - property
-        ) && self.is_property_name(); // Also ensure there's a valid property name
-
-        self.scanner.restore_state(snapshot);
-        self.current_token = current;
-        is_accessor
-    }
-
-    /// Look ahead to see if we have a static block: static { ... }
-    pub(crate) fn look_ahead_is_static_block(&mut self) -> bool {
-        let snapshot = self.scanner.save_state();
-        let current = self.current_token;
-
-        // Skip 'static'
-        self.next_token();
-        // Check for '{'
-        let is_block = self.is_token(SyntaxKind::OpenBraceToken);
-
-        self.scanner.restore_state(snapshot);
-        self.current_token = current;
-        is_block
-    }
-
-    /// Parse static block: static { ... }
-    pub(crate) fn parse_static_block(&mut self) -> NodeIndex {
-        let start_pos = self.token_pos();
-
-        // Consume 'static'
-        self.parse_expected(SyntaxKind::StaticKeyword);
-
-        // Parse the block body with static block context (where 'await' is reserved)
-        // IMPORTANT: Static blocks create a fresh execution context - they do NOT inherit
-        // async/generator context from enclosing functions. Clear those flags.
-        self.parse_expected(SyntaxKind::OpenBraceToken);
-        let saved_flags = self.context_flags;
-        // Clear async/generator flags and set static block flag
-        self.context_flags &= !(CONTEXT_FLAG_ASYNC | CONTEXT_FLAG_GENERATOR);
-        self.context_flags |= CONTEXT_FLAG_STATIC_BLOCK;
-        let statements = self.parse_statements();
-        self.context_flags = saved_flags;
-        self.parse_expected(SyntaxKind::CloseBraceToken);
-
-        let end_pos = self.token_end();
-
-        self.arena.add_block(
-            syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION,
-            start_pos,
-            end_pos,
-            crate::parser::node::BlockData {
-                statements,
-                multi_line: true,
-            },
-        )
-    }
-
-    /// Look ahead to see if this is an index signature: [key: Type]: `ValueType`
-    /// vs a computed property: [expr]: Type or [computed]()
-    ///
-    /// Matches tsc's `isUnambiguouslyIndexSignature`. Recognizes:
-    ///   [id:    [id,    [id?:    [id?,    [id?]    [...    [modifier id
-    pub(crate) fn look_ahead_is_index_signature(&mut self) -> bool {
-        let snapshot = self.scanner.save_state();
-        let current = self.current_token;
-
-        // Skip '['
-        self.next_token();
-
-        let is_index_sig = if self.is_token(SyntaxKind::DotDotDotToken) {
-            true
-        } else if self.is_parameter_modifier() {
-            self.next_token();
-            self.is_identifier_or_keyword()
-        } else if !self.is_identifier_or_keyword() {
-            false
-        } else {
-            self.next_token();
-            if self.is_token(SyntaxKind::ColonToken) || self.is_token(SyntaxKind::CommaToken) {
-                // `[id:` or `[id,`
-                true
-            } else if self.is_token(SyntaxKind::QuestionToken) {
-                // `[id?` — check what follows: `:`, `,`, or `]` means index signature
-                self.next_token();
-                self.is_token(SyntaxKind::ColonToken)
-                    || self.is_token(SyntaxKind::CommaToken)
-                    || self.is_token(SyntaxKind::CloseBracketToken)
-            } else {
-                false
-            }
-        };
-
-        self.scanner.restore_state(snapshot);
-        self.current_token = current;
-        is_index_sig
-    }
-
-    /// Check if this is `[]` — an empty index signature (malformed, no parameters).
-    /// Used in type member contexts where `[]` should be an empty index signature,
-    /// NOT in type suffix contexts where `[]` is an array type.
-    pub(crate) fn look_ahead_is_empty_index_signature(&mut self) -> bool {
-        let snapshot = self.scanner.save_state();
-        let current = self.current_token;
-
-        self.next_token(); // skip `[`
-        let is_empty = self.is_token(SyntaxKind::CloseBracketToken);
-
-        self.scanner.restore_state(snapshot);
-        self.current_token = current;
-        is_empty
+                .get_identifier(name_node)
+                .is_some_and(|ident| ident.escaped_text == "if")
     }
 }

--- a/crates/tsz-parser/src/parser/state_switch_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_switch_recovery.rs
@@ -6,6 +6,63 @@ use tsz_scanner::SyntaxKind;
 use tsz_scanner::scanner_impl::TokenFlags;
 
 impl ParserState {
+    pub(crate) fn parse_recovered_leading_colon_expression_statement(&mut self) -> NodeIndex {
+        let start_pos = self.token_pos();
+        let missing_left = self.create_missing_expression();
+        let operator_token = SyntaxKind::ColonToken as u16;
+        self.parse_expected(SyntaxKind::ColonToken);
+
+        let right = if self.is_expression_start() {
+            self.parse_assignment_expression()
+        } else {
+            self.error_expression_expected();
+            self.create_missing_expression()
+        };
+
+        let mut expression = self.arena.add_binary_expr(
+            syntax_kind_ext::BINARY_EXPRESSION,
+            start_pos,
+            self.token_end(),
+            BinaryExprData {
+                left: missing_left,
+                operator_token,
+                right,
+            },
+        );
+
+        if self.parse_optional(SyntaxKind::CommaToken) {
+            if self.is_token(SyntaxKind::DotDotDotToken) {
+                self.error_expression_expected();
+                self.next_token();
+            }
+
+            let missing_right = self.create_missing_expression();
+            expression = self.arena.add_binary_expr(
+                syntax_kind_ext::BINARY_EXPRESSION,
+                start_pos,
+                self.token_end(),
+                BinaryExprData {
+                    left: expression,
+                    operator_token: SyntaxKind::CommaToken as u16,
+                    right: missing_right,
+                },
+            );
+        }
+
+        if !self.can_parse_semicolon() {
+            self.parse_error_for_missing_semicolon_after(expression);
+        } else if self.is_token(SyntaxKind::SemicolonToken) {
+            self.next_token();
+        }
+
+        self.arena.add_expr_statement(
+            syntax_kind_ext::EXPRESSION_STATEMENT,
+            start_pos,
+            self.token_end(),
+            ExprStatementData { expression },
+        )
+    }
+
     pub(crate) fn parse_switch_case_clauses(&mut self) -> Vec<NodeIndex> {
         let mut clauses = Vec::new();
         let mut seen_default = false;
@@ -164,6 +221,10 @@ impl ParserState {
             };
 
             let catch_block = self.parse_block();
+            if self.catch_missing_block_has_dangling_question_recovery(catch_block) {
+                self.error_expression_expected();
+                self.next_token();
+            }
             let catch_end = self.token_end();
 
             self.arena.add_catch_clause(
@@ -216,6 +277,32 @@ impl ParserState {
                 finally_block,
             },
         )
+    }
+
+    fn catch_missing_block_has_dangling_question_recovery(
+        &mut self,
+        catch_block: NodeIndex,
+    ) -> bool {
+        if !self.is_token(SyntaxKind::QuestionToken) {
+            return false;
+        }
+        let Some(block_node) = self.arena.get(catch_block) else {
+            return false;
+        };
+        if block_node.pos != self.token_pos() {
+            return false;
+        }
+
+        let saved_token = self.current_token;
+        let saved_state = self.scanner.save_state();
+        self.next_token();
+        let is_recovery_boundary = matches!(
+            self.token(),
+            SyntaxKind::CloseBraceToken | SyntaxKind::FinallyKeyword | SyntaxKind::EndOfFileToken
+        );
+        self.scanner.restore_state(saved_state);
+        self.current_token = saved_token;
+        is_recovery_boundary
     }
 
     // Parse with statement
@@ -284,6 +371,8 @@ impl ParserState {
         self.jsx_missing_brace_semicolon_window_start = Some(start_pos);
 
         let started_with_binary_operator = !self.is_expression_start() && self.is_binary_operator();
+        let started_with_assignment_operator =
+            !self.is_expression_start() && self.is_assignment_operator(self.token());
         // A statement that begins with a purely-binary operator (e.g. `|| a`,
         // `!= b`, `&& c`; not `+`/`-`/`*`/`/`, which are unary/JSX/regex at
         // statement start and stay on their existing paths) is recovered by tsc
@@ -303,41 +392,64 @@ impl ParserState {
                 self.token(),
                 SyntaxKind::CommaToken | SyntaxKind::QuestionToken
             );
-        let mut expression =
-            if started_with_binary_operator && !started_with_binary_operator_skip_path {
+        let mut expression = if started_with_assignment_operator {
+            self.error_expression_expected();
+            let operator_token = self.token() as u16;
+            self.next_token();
+            let mut right = self.parse_assignment_expression();
+            if right.is_none() {
                 self.error_expression_expected();
-                let start_pos = self.token_pos();
-                let missing_left = self.create_missing_expression();
-                self.parse_binary_expression_chain_seeded(2, start_pos, Some(missing_left))
-            } else if started_with_binary_operator {
-                self.error_expression_expected();
-                self.next_token();
-                let right = if self.is_expression_start() {
-                    self.parse_binary_expression(2)
-                } else {
-                    NodeIndex::NONE
-                };
-                if right.is_none() {
-                    self.create_missing_expression()
-                } else {
-                    right
-                }
+                right = self.create_missing_expression();
+            }
+            if operator_token == SyntaxKind::EqualsToken as u16 {
+                right
             } else {
-                // Early rejection: If the current token cannot start an expression, fail immediately
-                // This prevents TS1109 from being emitted for tokens that are obviously not expressions
-                // (e.g., }, ], ), etc.) when we fall through to parse_expression_statement() from
-                // parse_statement()'s wildcard match.
-                let recoverable_bare_hash_expression = self.is_token(SyntaxKind::HashToken)
-                    && self.bare_hash_is_followed_by_statement_boundary();
-                if !self.is_expression_start() && !recoverable_bare_hash_expression {
-                    // Don't emit error here - let the statement-level error handling deal with it
-                    // Just return NONE to indicate failure
-                    self.jsx_missing_brace_semicolon_window_start = None;
-                    return NodeIndex::NONE;
-                }
-
-                self.parse_expression()
+                let missing_left = self.create_missing_expression();
+                self.arena.add_binary_expr(
+                    syntax_kind_ext::BINARY_EXPRESSION,
+                    start_pos,
+                    self.token_end(),
+                    BinaryExprData {
+                        left: missing_left,
+                        operator_token,
+                        right,
+                    },
+                )
+            }
+        } else if started_with_binary_operator && !started_with_binary_operator_skip_path {
+            self.error_expression_expected();
+            let start_pos = self.token_pos();
+            let missing_left = self.create_missing_expression();
+            self.parse_binary_expression_chain_seeded(2, start_pos, Some(missing_left))
+        } else if started_with_binary_operator {
+            self.error_expression_expected();
+            self.next_token();
+            let right = if self.is_expression_start() {
+                self.parse_binary_expression(2)
+            } else {
+                NodeIndex::NONE
             };
+            if right.is_none() {
+                self.create_missing_expression()
+            } else {
+                right
+            }
+        } else {
+            // Early rejection: If the current token cannot start an expression, fail immediately
+            // This prevents TS1109 from being emitted for tokens that are obviously not expressions
+            // (e.g., }, ], ), etc.) when we fall through to parse_expression_statement() from
+            // parse_statement()'s wildcard match.
+            let recoverable_bare_hash_expression = self.is_token(SyntaxKind::HashToken)
+                && self.bare_hash_is_followed_by_statement_boundary();
+            if !self.is_expression_start() && !recoverable_bare_hash_expression {
+                // Don't emit error here - let the statement-level error handling deal with it
+                // Just return NONE to indicate failure
+                self.jsx_missing_brace_semicolon_window_start = None;
+                return NodeIndex::NONE;
+            }
+
+            self.parse_expression()
+        };
 
         // If expression parsing failed completely, resync to recover
         if expression.is_none() {

--- a/crates/tsz-parser/tests/parser_improvement_expression_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_expression_recovery_tests.rs
@@ -191,6 +191,34 @@ fn test_statement_starting_with_binary_operator_varies_with_operator_and_names()
 }
 
 #[test]
+fn test_statement_starting_with_assignment_operator_keeps_missing_left_binary() {
+    let cases = [
+        ("^= replacement;\n", SyntaxKind::CaretEqualsToken),
+        ("&&= fallback;\n", SyntaxKind::AmpersandAmpersandEqualsToken),
+        (
+            "??= defaultValue;\n",
+            SyntaxKind::QuestionQuestionEqualsToken,
+        ),
+    ];
+    for (source, op) in cases {
+        let ops = binary_ops_with_missing_left(source);
+        assert!(
+            ops.contains(&op),
+            "expected `<missing> {op:?} rhs` recovery for source {source:?}, got {ops:?}"
+        );
+    }
+}
+
+#[test]
+fn test_statement_starting_with_equals_recovers_to_rhs_expression() {
+    let ops = binary_ops_with_missing_left("= replacement;\n");
+    assert!(
+        !ops.contains(&SyntaxKind::EqualsToken),
+        "plain `=` statement recovery should resume at the RHS expression, got {ops:?}"
+    );
+}
+
+#[test]
 fn test_statement_starting_with_binary_operator_does_not_drop_operator() {
     // Regression guard: previously the parser skipped a leading binary operator
     // and produced just the right operand (`|| b` became `b`). Confirm the

--- a/crates/tsz-parser/tests/state_declaration_tests.rs
+++ b/crates/tsz-parser/tests/state_declaration_tests.rs
@@ -1483,6 +1483,31 @@ fn while_missing_open_paren_before_colon_recovers_rest_tail() {
             .any(|(_, _, _, message)| message == "')' expected."),
         "while colon recovery should not report a spurious missing `)`, got {fingerprints:?}"
     );
+
+    let (parser, root) = parse_source(source);
+    let arena = parser.get_arena();
+    let sf = arena.get_source_file_at(root).unwrap();
+    let while_node = arena
+        .get(sf.statements.nodes[1])
+        .expect("expected recovered while statement");
+    assert_eq!(while_node.kind, syntax_kind_ext::WHILE_STATEMENT);
+    let while_data = arena.get_loop(while_node).expect("expected loop data");
+    assert_eq!(
+        while_data.condition,
+        NodeIndex::NONE,
+        "`while :` recovery should keep the condition missing"
+    );
+    assert_eq!(
+        arena.get(while_data.statement).unwrap().kind,
+        syntax_kind_ext::EXPRESSION_STATEMENT,
+        "the leading colon tail should become the while body"
+    );
+    assert!(
+        sf.statements.nodes.iter().skip(2).any(|&idx| arena
+            .get(idx)
+            .is_some_and(|node| node.kind == syntax_kind_ext::LABELED_STATEMENT)),
+        "`rest: string[]` should survive as a following labeled statement"
+    );
 }
 
 #[test]

--- a/crates/tsz-parser/tests/state_statement_tests.rs
+++ b/crates/tsz-parser/tests/state_statement_tests.rs
@@ -30,5 +30,29 @@ fn assert_function_body_recovery_uses_statement_errors(source: &str) {
     );
 }
 
+#[test]
+fn catch_missing_block_dangling_question_is_not_a_following_statement() {
+    let source = "for (var x in { x: 0 }) {\n    !\n    try { throw null; }\n    catch (Exception) ?\n}\nfinally { }\n";
+    let (parser, root) = parse_source(source);
+    let arena = parser.get_arena();
+    let sf = arena.get_source_file_at(root).unwrap();
+    let for_node = arena
+        .get(sf.statements.nodes[0])
+        .expect("expected recovered for statement");
+    let for_data = arena.get_for_in_of(for_node).expect("expected for-in data");
+    let body_node = arena.get(for_data.statement).expect("expected for body");
+    let body = arena.get_block(body_node).expect("expected block body");
+
+    assert_eq!(
+        body.statements.nodes.len(),
+        2,
+        "dangling `?` after a missing catch block should be consumed by catch recovery"
+    );
+    assert_eq!(
+        arena.get(body.statements.nodes[1]).unwrap().kind,
+        syntax_kind_ext::TRY_STATEMENT
+    );
+}
+
 include!("state_statement_tests_parts/part_00.rs");
 include!("state_statement_tests_parts/part_01.rs");


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit/DTS parity: parser-recovery JS emit slice for `constructorWithIncompleteTypeAnnotation`.

## Invariant
When malformed class-body recovery sees an orphan `case = ...` assignment and then a recovered invalid `if` member before `catch`/`finally`, `tsc` keeps the assignment as a class field and resumes the following `catch`/`finally` outside the class body. Malformed `while : T, ...rest`, missing-false ternaries, and dangling `?` after a missing catch block must recover structurally so the emitter prints the tsc baseline without output surgery.

## Scope
- Split class-member property construction/recovery helpers out of the over-ceiling parser class-member shard.
- Recover orphan `case = ...` assignments as class fields while preserving ordinary statement-list recovery.
- Stop recovered invalid `if` class members at following `catch`/`finally` or comparison-tail boundaries.
- Stop binary-expression `if` conditions before a following assignment operator.
- Recover statement-start plain `=` to the RHS expression while preserving compound-assignment missing-left recovery.
- Recover malformed `while : string, ...rest` with an empty condition, leading-colon body, and following `rest:` label.
- Format missing-false-branch ternaries so `:` and the enclosing return semicolon stay on separate lines.
- Consume dangling `?` after a synthesized missing catch block when the next token is a recovery boundary.
- Remove the recovered-return object-literal text helper so structured object-literal emission preserves multiline layout.
- Add focused parser and emitter regression coverage for these recovery shapes.

## Project Corpus Impact
- Row: `constructorWithIncompleteTypeAnnotation` JS emit
- Bug family: JavaScript emit parser/recovery for malformed class members, control-flow tails, missing ternary branches, and catch recovery.
- Evidence: `scripts/emit/run.sh --filter=constructorWithIncompleteTypeAnnotation --js-only --verbose --timeout=20000 --json-out=/tmp/tsz-12467-rebased-constructor.json` passed 1/1 on rebased head `99bdc61664`.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -p tsz-parser -p tsz-emitter --all-targets --all-features -- -D warnings` (pre-rebase head `b08360c93f`; code replayed cleanly)
- `python3 scripts/emit/audit-output-surgery.py --json-report /tmp/tsz-12467-output-surgery-audit.json` (pre-rebase head `b08360c93f`; passed, unallowlisted=0, existing allowlist exhausted)
- `cargo nextest run -p tsz-parser while_missing_open_paren_before_colon_recovers_rest_tail catch_missing_block_dangling_question_is_not_a_following_statement --no-fail-fast` (pre-rebase head `b08360c93f`)
- `cargo nextest run -p tsz-emitter malformed_while_colon_tail_preserves_tsc_recovery_shape orphan_case_after_malformed_if_recovers_as_class_field conditional_case_a_missing_false_branch_breaks_before_semicolon recovered_catch_dangling_question_does_not_emit_extra_semicolon --no-fail-fast` (pre-rebase head `b08360c93f`)
- `scripts/emit/run.sh --filter=constructorWithIncompleteTypeAnnotation --js-only --verbose --timeout=20000 --json-out=/tmp/tsz-12467-rebased-constructor.json` (rebased head `99bdc61664`)

## Coordination Notes
- Rebased onto `origin/main` at `52e55706f4`; local focused JS row remains closed.
- Ready for CI/heavy emit verification on head `99bdc61664`.
- No new output surgery and no checker/solver semantic validation.
- The class-member shard is under the 2000-line ceiling after moving property helpers to `state_statements_class_member_properties.rs`.
