### PR TITLE
fix(checker): accept resolved index-signature key types like PropertyKey (TS1268)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -234,6 +234,9 @@ mod imported_generator_iterable_tests;
 #[path = "tests/index_sig_param_intersection_validity_tests.rs"]
 mod index_sig_param_intersection_validity_tests;
 #[cfg(test)]
+#[path = "tests/index_sig_param_resolved_key_type_tests.rs"]
+mod index_sig_param_resolved_key_type_tests;
+#[cfg(test)]
 #[path = "tests/instantiation_expression_inline_utility_modifier_tests.rs"]
 mod instantiation_expression_inline_utility_modifier_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/index_signature.rs
+++ b/crates/tsz-checker/src/query_boundaries/index_signature.rs
@@ -20,6 +20,53 @@ pub(crate) fn index_key_type_satisfies_index_signature(
         || tsz_solver::relations::subtype::is_subtype_of(db, index_type, signature_key_type)
 }
 
+/// Mirror tsc's `everyType(type, isValidIndexKeyType)` over a *resolved* index
+/// key `TypeId`.
+///
+/// tsc validates index-signature parameter types against the resolved type
+/// rather than its syntactic spelling: a union is a valid key iff every
+/// constituent is, an intersection iff some constituent is, and the leaf cases
+/// are `string`/`number`/`symbol` and template-literal (pattern) types. Crucially
+/// this is *not* an assignability test — `any` is assignable to
+/// `string | number | symbol` yet is rejected by tsc, so we inspect the type's
+/// shape directly.
+///
+/// Callers must resolve the top-level key type before invoking this (e.g. the
+/// lib global `PropertyKey` is a `Lazy(DefId)` alias for
+/// `string | number | symbol`); union/intersection members are expected to be
+/// resolved as a side effect of building the compound type. Spellings that
+/// can't be reached this way are still covered by the AST fallback at the call
+/// sites, so this only ever participates in *accepting* a key type.
+pub(crate) fn resolved_index_key_type_is_valid(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    // `everyType` distributes the predicate over union constituents.
+    if let Some(members) = tsz_solver::type_queries::get_union_members(db, type_id) {
+        return !members.is_empty()
+            && members
+                .iter()
+                .all(|&member| resolved_index_key_constituent_is_valid(db, member));
+    }
+    resolved_index_key_constituent_is_valid(db, type_id)
+}
+
+/// Validity of a single (non-union) resolved constituent. The generic
+/// intersection case (`T & string`) is steered to TS1337 by the AST pre-check
+/// at the call sites before validity is consulted, so this mirrors tsc's
+/// `some(types, isValidIndexKeyType)` for the intersection arm.
+fn resolved_index_key_constituent_is_valid(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    if matches!(type_id, TypeId::STRING | TypeId::NUMBER | TypeId::SYMBOL) {
+        return true;
+    }
+    if tsz_solver::type_queries::is_template_literal_type(db, type_id) {
+        return true;
+    }
+    if let Some(members) = tsz_solver::type_queries::get_intersection_members(db, type_id) {
+        return members
+            .iter()
+            .any(|&member| resolved_index_key_constituent_is_valid(db, member));
+    }
+    false
+}
+
 /// Structural AST check for index-signature parameter type validity.
 ///
 /// Accepts `string`/`number`/`symbol` keywords, template literal types, type

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks.rs
@@ -89,15 +89,15 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        let Some(type_node) = self.ctx.arena.get(param_data.type_annotation) else {
+        if self.ctx.arena.get(param_data.type_annotation).is_none() {
             return;
-        };
+        }
+        let type_annotation = param_data.type_annotation;
 
-        // Check if the type annotation is a valid index signature parameter type
-        // Valid types: string, number, symbol (keywords), template literal type,
-        // or type references to string/number/symbol (including type aliases)
-        let is_valid =
-            self.is_valid_index_sig_param_type(type_node.kind, param_data.type_annotation);
+        // Check if the type annotation is a valid index signature parameter type.
+        let key_type = self.get_type_from_type_node(type_annotation);
+        let (is_generic_or_literal, is_valid) =
+            self.classify_index_sig_param_type(key_type, type_annotation);
 
         tracing::trace!(
             is_valid,
@@ -110,8 +110,6 @@ impl<'a> CheckerState<'a> {
             has_grammar_error = true;
             // TS1337: when the type is a generic type parameter or literal type,
             // emit the more specific "cannot be a literal type or generic type" message.
-            let is_generic_or_literal = self
-                .is_type_param_or_literal_in_index_sig(type_node.kind, param_data.type_annotation);
             if is_generic_or_literal {
                 self.error_at_node(
                     param_idx,

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_validity.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_validity.rs
@@ -8,8 +8,63 @@
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    /// Mirror tsc's `everyType(type, isValidIndexKeyType)` over the *resolved*
+    /// index-signature key `TypeId`.
+    ///
+    /// tsc validates index-signature parameter types against the resolved type,
+    /// not the syntactic spelling: an alias whose constituents are all subsets
+    /// of `string | number | symbol` (or a template-literal/pattern type) is a
+    /// valid key. The AST helper [`Self::is_valid_index_sig_param_type`] can only
+    /// recurse alias bodies that live in the current file's arena, so it misses
+    /// cross-file aliases — most notably the lib global `PropertyKey`
+    /// (`string | number | symbol`). Resolving the key type first makes the
+    /// decision independent of which source file declares the alias.
+    ///
+    /// `everyType` distributes the predicate over union constituents; a single
+    /// constituent is valid when it is `string`/`number`/`symbol`, a
+    /// template-literal type, or an intersection with some valid member. `any`,
+    /// `unknown`, `boolean`, literals, and object types are not valid keys —
+    /// matching tsc, and notably *not* an assignability test (`any` is
+    /// assignable to `string | number | symbol` yet is still rejected).
+    pub(crate) fn index_key_type_is_valid(&mut self, key_type: TypeId) -> bool {
+        let resolved = self.evaluate_type_for_assignability(key_type);
+        crate::query_boundaries::index_signature::resolved_index_key_type_is_valid(
+            self.ctx.types.as_type_database(),
+            resolved,
+        )
+    }
+
+    /// Classify an index-signature parameter type against tsc's grammar rules,
+    /// returning `(is_generic_or_literal, is_valid)`.
+    ///
+    /// tsc applies the TS1337 (literal/generic) condition *before* the
+    /// `isValidIndexKeyType` (TS1268) check, so a generic key like `T & string`
+    /// is never treated as valid even though one member is. `is_valid` combines
+    /// the resolved-type structural check ([`Self::index_key_type_is_valid`],
+    /// which accepts cross-file aliases such as the lib global `PropertyKey`)
+    /// with the AST helper as a defensive fallback for local composite spellings.
+    /// This is the single decision point shared by every index-signature site.
+    pub(crate) fn classify_index_sig_param_type(
+        &mut self,
+        key_type: TypeId,
+        type_annotation_idx: NodeIndex,
+    ) -> (bool, bool) {
+        let type_node_kind = self
+            .ctx
+            .arena
+            .get(type_annotation_idx)
+            .map_or(0, |n| n.kind);
+        let is_generic_or_literal =
+            self.is_type_param_or_literal_in_index_sig(type_node_kind, type_annotation_idx);
+        let is_valid = !is_generic_or_literal
+            && (self.index_key_type_is_valid(key_type)
+                || self.is_valid_index_sig_param_type(type_node_kind, type_annotation_idx));
+        (is_generic_or_literal, is_valid)
+    }
+
     /// Check if a type node represents a valid index signature parameter type.
     /// Valid types: string, number, symbol keywords, template literal types,
     /// type aliases that resolve to these, unions whose members are all valid,

--- a/crates/tsz-checker/src/tests/index_sig_param_resolved_key_type_tests.rs
+++ b/crates/tsz-checker/src/tests/index_sig_param_resolved_key_type_tests.rs
@@ -1,0 +1,146 @@
+//! Regression coverage for tsc's `isValidIndexKeyType` over *resolved* types.
+//!
+//! The AST-only validity fallback can only recurse type-alias bodies that live
+//! in the current file's arena. A bare reference to the lib global `PropertyKey`
+//! (`type PropertyKey = string | number | symbol`, declared in `lib.es5.d.ts`)
+//! resolves to a symbol whose declaration node lives in a *different* arena, so
+//! the AST recursion bailed out and tsz emitted a TS1268 false positive that
+//! `tsc` never reports (issue #12371). The same gap affects any user alias
+//! declared in another module.
+//!
+//! The fix routes the primary determination through the resolved key `TypeId`
+//! (tsc's `everyType(type, isValidIndexKeyType)`), so a union/intersection of
+//! `string`/`number`/`symbol`/template-literal members is accepted regardless of
+//! which source file declares the alias.
+
+use crate::CheckerOptions;
+use crate::test_utils::{
+    check_multi_file_with_libs, check_source_with_libs, diagnostic_codes, load_default_lib_files,
+};
+
+fn codes_with_lib(source: &str) -> Vec<u32> {
+    diagnostic_codes(&check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions::default(),
+        &load_default_lib_files(),
+    ))
+}
+
+/// The reported witness: a `readonly [k: PropertyKey]` index signature in a
+/// type-literal alias must not emit TS1268. `PropertyKey` is the lib global
+/// `string | number | symbol`.
+#[test]
+fn property_key_index_signature_in_type_alias_is_valid() {
+    let codes =
+        codes_with_lib("export type UnknownProperties = { readonly [k: PropertyKey]: unknown };");
+    assert!(
+        !codes.contains(&1268),
+        "TS1268 must not fire for `[k: PropertyKey]` (lib union alias): {codes:?}"
+    );
+}
+
+/// The same `PropertyKey` key must be accepted in every index-signature
+/// context: interface, class, and inline type literal — not just type aliases.
+#[test]
+fn property_key_index_signature_across_containers_is_valid() {
+    let codes = codes_with_lib(
+        r#"
+interface IFace { [k: PropertyKey]: unknown }
+class Cls { [k: PropertyKey]: unknown }
+declare const inline: { [k: PropertyKey]: unknown };
+type Alias = { [k: PropertyKey]: unknown };
+"#,
+    );
+    assert!(
+        !codes.contains(&1268),
+        "TS1268 must not fire for `PropertyKey` keys in interface/class/inline/alias: {codes:?}"
+    );
+}
+
+/// An index value typed with `PropertyKey` is still usable: assigning numeric,
+/// string, and symbol keys is accepted (the signature really is established).
+#[test]
+fn property_key_index_signature_accepts_all_key_kinds() {
+    let codes = codes_with_lib(
+        r#"
+type UnknownProperties = { readonly [k: PropertyKey]: unknown };
+const x: UnknownProperties = { a: 1, 2: 2, [Symbol()]: 3 };
+"#,
+    );
+    assert!(!codes.contains(&1268), "TS1268 must not fire: {codes:?}");
+    assert!(
+        !codes.contains(&2322) && !codes.contains(&2353),
+        "string/number/symbol keys must be assignable to a PropertyKey index: {codes:?}"
+    );
+}
+
+/// A user-defined alias that resolves to a valid key union but is declared in a
+/// *different* module exercises the same cross-arena path as the lib global.
+#[test]
+fn cross_module_key_alias_is_valid() {
+    let codes = diagnostic_codes(&check_multi_file_with_libs(
+        &[
+            ("keys.ts", "export type Key = string | number | symbol;"),
+            (
+                "main.ts",
+                r#"
+import type { Key } from "./keys";
+export type Bag = { [k: Key]: unknown };
+"#,
+            ),
+        ],
+        "main.ts",
+        CheckerOptions::default(),
+        &load_default_lib_files(),
+    ));
+    assert!(
+        !codes.contains(&1268),
+        "TS1268 must not fire for a valid key alias imported from another module: {codes:?}"
+    );
+}
+
+/// Subsets of `string | number | symbol` via the lib alias chain stay valid.
+#[test]
+fn aliases_to_key_subsets_are_valid() {
+    let codes = codes_with_lib(
+        r#"
+type Sk = string | symbol;
+type Nk = number | symbol;
+type A = { [k: Sk]: unknown };
+type B = { [k: Nk]: unknown };
+"#,
+    );
+    assert!(
+        !codes.contains(&1268),
+        "TS1268 must not fire for `string | symbol` / `number | symbol` aliases: {codes:?}"
+    );
+}
+
+/// The fix must not over-accept: a union alias that includes a non-key member
+/// (`boolean`) still triggers TS1268, matching tsc.
+#[test]
+fn union_alias_with_invalid_member_still_emits_ts1268() {
+    let codes = codes_with_lib(
+        r#"
+type Bad = string | boolean;
+type T = { [k: Bad]: unknown };
+"#,
+    );
+    assert!(
+        codes.contains(&1268),
+        "TS1268 expected for `string | boolean` index key alias: {codes:?}"
+    );
+}
+
+/// `any` is not a valid index key type in tsc (TS1268), even though every type
+/// is assignable to/from `any`. This pins that the fix uses tsc's structural
+/// `isValidIndexKeyType` rather than an assignability test.
+#[test]
+fn any_index_key_still_emits_ts1268() {
+    let codes = codes_with_lib("type T = { [k: any]: unknown };");
+    assert!(
+        codes.contains(&1268),
+        "TS1268 expected for `[k: any]`: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -2,7 +2,6 @@
 
 use crate::context::TypingRequest;
 use crate::query_boundaries::class_type::{callable_shape_for_type, construct_signatures_for_type};
-use crate::query_boundaries::common::is_template_literal_type;
 use crate::query_boundaries::common::{TypeSubstitution, instantiate_type};
 use crate::state::{CheckerState, MemberAccessLevel};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1232,10 +1231,13 @@ impl<'a> CheckerState<'a> {
                     // Suppress when the parameter already has grammar errors (rest/optional) — matches tsc.
                     let has_param_grammar_error =
                         param_data.is_some_and(|p| p.dot_dot_dot_token || p.question_token);
-                    let is_valid_index_type = key_type == TypeId::STRING
-                        || key_type == TypeId::NUMBER
-                        || key_type == TypeId::SYMBOL
-                        || is_template_literal_type(self.ctx.types, key_type);
+                    // Accepts any alias reducing to a valid index key, including the
+                    // cross-file lib global `PropertyKey`. A generic/literal key
+                    // keeps falling through to TS1268 (this site has no TS1337
+                    // branch), preserving existing class behavior.
+                    let type_annotation = param_data.map_or(NodeIndex::NONE, |p| p.type_annotation);
+                    let (_is_generic_or_literal, is_valid_index_type) =
+                        self.classify_index_sig_param_type(key_type, type_annotation);
 
                     if !is_valid_index_type && !has_param_grammar_error {
                         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};

--- a/crates/tsz-checker/src/types/class_type/core.rs
+++ b/crates/tsz-checker/src/types/class_type/core.rs
@@ -6,7 +6,6 @@ use super::helpers::{
 };
 use crate::context::{EnclosingClassInfo, is_js_file_name};
 use crate::query_boundaries::class_type::{callable_shape_for_type, object_shape_for_type};
-use crate::query_boundaries::common::is_template_literal_type;
 use crate::query_boundaries::common::{ObjectFlags, TypeSubstitution, instantiate_type};
 use crate::state::CheckerState;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -789,10 +788,12 @@ impl<'a> CheckerState<'a> {
                     // TS1268: An index signature parameter type must be 'string', 'number', 'symbol', or a template literal type
                     // Suppress when the parameter already has grammar errors (rest/optional) — matches tsc.
                     let has_param_grammar_error = param.dot_dot_dot_token || param.question_token;
-                    let is_valid_index_type = key_type == TypeId::STRING
-                        || key_type == TypeId::NUMBER
-                        || key_type == TypeId::SYMBOL
-                        || is_template_literal_type(self.ctx.types, key_type);
+                    // Accepts any alias reducing to a valid index key, including the
+                    // cross-file lib global `PropertyKey`. A generic/literal key
+                    // keeps falling through to TS1268 (this site has no TS1337
+                    // branch), preserving existing class behavior.
+                    let (_is_generic_or_literal, is_valid_index_type) =
+                        self.classify_index_sig_param_type(key_type, param.type_annotation);
 
                     if !is_valid_index_type && !has_param_grammar_error {
                         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -9,7 +9,6 @@
 //! - Index signature handling
 //! - Type parameter instantiation for generic bases
 
-use crate::query_boundaries::common::is_template_literal_type;
 use crate::state::CheckerState;
 use crate::types_domain::type_node_helpers::type_node_includes_explicit_undefined;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -505,29 +504,10 @@ impl<'a> CheckerState<'a> {
                 // Suppress when the parameter already has grammar errors (rest/optional) — matches tsc.
                 let has_param_grammar_error =
                     param_data.dot_dot_dot_token || param_data.question_token;
-                let is_valid_index_type = key_type == TypeId::STRING
-                    || key_type == TypeId::NUMBER
-                    || key_type == TypeId::SYMBOL
-                    || is_template_literal_type(self.ctx.types, key_type);
-
-                // Also check syntactically for type aliases that resolve to valid types
-                let is_valid_via_alias = if let Some(type_node) =
-                    self.ctx.arena.get(param_data.type_annotation)
-                {
-                    self.is_valid_index_sig_param_type(type_node.kind, param_data.type_annotation)
-                } else {
-                    false
-                };
-
-                if !is_valid_index_type && !is_valid_via_alias && !has_param_grammar_error {
+                let (is_generic_or_literal, is_valid_index_type) =
+                    self.classify_index_sig_param_type(key_type, param_data.type_annotation);
+                if !is_valid_index_type && !has_param_grammar_error {
                     use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-                    // Check if this is a literal type or generic type (TS1337 vs TS1268)
-                    let type_node = self.ctx.arena.get(param_data.type_annotation);
-                    let type_node_kind = type_node.map(|n| n.kind).unwrap_or(0);
-                    let is_generic_or_literal = self.is_type_param_or_literal_in_index_sig(
-                        type_node_kind,
-                        param_data.type_annotation,
-                    );
                     if is_generic_or_literal {
                         self.error_at_node(
                             param_idx,
@@ -561,7 +541,7 @@ impl<'a> CheckerState<'a> {
                     readonly,
                     param_name,
                 };
-                if is_valid_index_type || is_valid_via_alias {
+                if is_valid_index_type {
                     if key_type == TypeId::NUMBER {
                         Self::merge_index_signature(&mut number_index, info);
                     } else {

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -4,7 +4,6 @@
 //! callable types with call/construct signatures.
 
 use super::type_node_helpers::type_node_includes_explicit_undefined;
-use crate::query_boundaries::common::is_template_literal_type;
 use crate::state::{CheckerState, ParamTypeResolutionMode};
 use crate::symbol_resolver::TypeSymbolResolution;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
@@ -1318,45 +1317,20 @@ impl<'a> CheckerState<'a> {
                 // Suppress when the parameter already has grammar errors (rest/optional) — matches tsc.
                 let has_param_grammar_error =
                     param_data.dot_dot_dot_token || param_data.question_token;
-                let mut is_valid_index_type = false;
-                let mut is_valid_via_ast = false;
-                if !has_param_grammar_error && param_data.type_annotation.is_some() {
-                    // Check the AST node kind first: type parameters and literal types
-                    // trigger TS1337 regardless of what their constraint resolves to
-                    // (e.g. `T extends string` resolves to STRING but is still invalid).
-                    let type_ann_kind = self
-                        .ctx
-                        .arena
-                        .get(param_data.type_annotation)
-                        .map_or(0, |n| n.kind);
-                    let is_generic_or_literal = self.is_type_param_or_literal_in_index_sig(
-                        type_ann_kind,
-                        param_data.type_annotation,
-                    );
-                    if is_generic_or_literal {
+                let is_valid_index_type = if !has_param_grammar_error
+                    && param_data.type_annotation.is_some()
+                {
+                    let (is_generic_or_literal, is_valid) =
+                        self.classify_index_sig_param_type(key_type, param_data.type_annotation);
+                    if !is_valid {
                         use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-                        self.error_at_node(
-                            param_idx,
-                            diagnostic_messages::AN_INDEX_SIGNATURE_PARAMETER_TYPE_CANNOT_BE_A_LITERAL_TYPE_OR_GENERIC_TYPE_CONSI,
-                            diagnostic_codes::AN_INDEX_SIGNATURE_PARAMETER_TYPE_CANNOT_BE_A_LITERAL_TYPE_OR_GENERIC_TYPE_CONSI,
-                        );
-                    } else {
-                        is_valid_index_type = key_type == TypeId::STRING
-                            || key_type == TypeId::NUMBER
-                            || key_type == TypeId::SYMBOL
-                            || is_template_literal_type(self.ctx.types, key_type);
-                        // AST fallback: unions of valid types and non-generic
-                        // intersections (`string | number`, `string & Tag`)
-                        // resolve to composite TypeIds that don't match the
-                        // primitive checks above.
-                        is_valid_via_ast = !is_valid_index_type
-                            && crate::query_boundaries::index_signature::is_valid_index_sig_param_type_ast(
-                                self.ctx.arena,
-                                self.ctx.binder,
-                                param_data.type_annotation,
+                        if is_generic_or_literal {
+                            self.error_at_node(
+                                param_idx,
+                                diagnostic_messages::AN_INDEX_SIGNATURE_PARAMETER_TYPE_CANNOT_BE_A_LITERAL_TYPE_OR_GENERIC_TYPE_CONSI,
+                                diagnostic_codes::AN_INDEX_SIGNATURE_PARAMETER_TYPE_CANNOT_BE_A_LITERAL_TYPE_OR_GENERIC_TYPE_CONSI,
                             );
-                        if !is_valid_index_type && !is_valid_via_ast {
-                            use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+                        } else {
                             self.error_at_node(
                                 param_idx,
                                 diagnostic_messages::AN_INDEX_SIGNATURE_PARAMETER_TYPE_MUST_BE_STRING_NUMBER_SYMBOL_OR_A_TEMPLATE_LIT,
@@ -1364,7 +1338,10 @@ impl<'a> CheckerState<'a> {
                             );
                         }
                     }
-                }
+                    is_valid
+                } else {
+                    false
+                };
 
                 // TS2693: Check if parameter name without type annotation
                 // refers to a type (e.g., `[K]: number` where `K` is a type alias).
@@ -1424,7 +1401,7 @@ impl<'a> CheckerState<'a> {
                     readonly,
                     param_name,
                 };
-                if is_valid_index_type || is_valid_via_ast {
+                if is_valid_index_type {
                     if key_type == TypeId::NUMBER {
                         if number_index.is_none() {
                             number_index = Some(info);

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -1277,17 +1277,27 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                             );
                         }
                     } else {
-                        is_valid_index_type = key_type == TypeId::STRING
-                            || key_type == TypeId::NUMBER
-                            || key_type == TypeId::SYMBOL
-                            || crate::query_boundaries::common::is_template_literal_type(
+                        // Primary check: tsc's `everyType(type, isValidIndexKeyType)`
+                        // over the resolved key type. Resolve any `Lazy(DefId)`
+                        // alias head first (e.g. the cross-file lib global
+                        // `PropertyKey` => `string | number | symbol`), then ask
+                        // structurally whether it is a valid key type.
+                        let resolved_key = {
+                            let env = self.ctx.type_environment.borrow();
+                            crate::query_boundaries::flow::resolve_lazy_def_with_env(
                                 self.ctx.types,
+                                Some(&env),
                                 key_type,
+                            )
+                        };
+                        is_valid_index_type =
+                            crate::query_boundaries::index_signature::resolved_index_key_type_is_valid(
+                                self.ctx.types.as_type_database(),
+                                resolved_key,
                             );
-                        // AST fallback: unions of valid types and non-generic
-                        // intersections (`string | number`, `string & Tag`)
-                        // resolve to composite TypeIds that don't match the
-                        // primitive checks above.
+                        // AST fallback: a defensive net for local composite spellings
+                        // the resolved-type check can't reach (e.g. a still-Lazy
+                        // member). Only ever adds acceptance, never removes it.
                         is_valid_via_ast = !is_valid_index_type
                             && crate::query_boundaries::index_signature::is_valid_index_sig_param_type_ast(
                                 self.ctx.arena,

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -564,6 +564,18 @@ FILE_LINE_LIMIT_CHECKS = [
         2006,
     ),
     (
+        "Emitter boundary: emitter/expressions/core/private_fields.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-emitter"
+        / "src"
+        / "emitter"
+        / "expressions"
+        / "core"
+        / "private_fields.rs",
+        2006,
+    ),
+    (
         "Checker boundary: types/property_access_type/resolve.rs size ratchet",
         ROOT
         / "crates"
@@ -686,7 +698,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "types"
         / "class_type"
         / "constructor.rs",
-        2688,
+        2690,
     ),
     (
         "Solver boundary: diagnostics/format/compound.rs size ratchet",
@@ -1210,7 +1222,13 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # boundary re-exports already used throughout the checker; the new
         # call site walks the `extends` chain and substitutes inherited
         # member types via `instantiate_type`. No new quarantine entry.
-        3237,
+        #
+        # Ratcheted down by 6 after the index-signature key-type validity
+        # check moved to `query_boundaries::index_signature` (PR #12371/
+        # #12468): `classify_index_sig_param_type` and the resolved-key
+        # `resolved_index_key_type_is_valid` query each use solver calls
+        # rather than direct `query_boundaries::common` access.
+        3231,
     ),
 ]
 


### PR DESCRIPTION
## Agent
AgentName: Studio-A
ContributorIdentity: ClaudeOpus-IndexKey-12371

## Track
Conformance (checker diagnostics: index-signature grammar) for #12371.

## Invariant
When an index-signature parameter type structurally resolves to a subset of `string | number | symbol`, or to a valid template-literal key type, `tsc` accepts it without TS1268 independent of alias spelling or declaring file. Literal and generic index key cases still take the existing literal/generic diagnostic path first.

## Scope
- Adds a solver-backed index-signature query boundary for resolved key-type validity.
- Routes index-signature diagnostic sites through a shared classifier instead of relying only on local AST spelling.
- Covers type literals, interfaces, classes, `static` index signatures, and the type-node path.
- Bumps `constructor.rs` ratchet 2688→2690 (2 net lines added by the classify call site).
- Ratchets `query_boundaries::common` direct-reference cap 3237→3231 (PR removes 6 direct references by routing through the new `query_boundaries::index_signature` module).
- Pins `private_fields.rs` at 2006 lines in `FILE_LINE_LIMIT_CHECKS` (file grew past 2000 in a prior main commit with no guard).

## Project Corpus Impact
- Row: `gvergnaud/ts-pattern`
- Bug family: TS1268 false positives for `PropertyKey` and equivalent resolved key aliases in index signatures.
- Evidence: expected to remove false positives in `src/internals/symbols.ts` and `src/types/Pattern.ts`; similar family may apply to `type-fest` and `ts-toolbelt`.

## Verification
- `index_sig_param_resolved_key_type_tests` regression suite.
- `index_sig_param_intersection_validity_tests`.
- `cargo test -p tsz-checker --lib` with no new failures versus the local `main` baseline reported by the author.
- `cargo clippy -p tsz-checker`.
- `cargo fmt`.
- 474 arch guard unit tests pass locally on current head `babab6edd92a1a86d692410fa2d29f684c10586a` (rebased onto `73259e9`).
- PR-head CI running on new head; broad queue validation remains repo-local merge-queue owned.

## Coordination Notes
- Generated by Claude Code as `ClaudeOpus-IndexKey-12371` and normalized under `AgentName: Studio-A`.
- #12448 was closed as superseded because it was conflicting, carried stale accepted-regression/arch-ratchet churn, and omitted interface/class/static index-signature coverage that this PR includes.
- Rebased onto `73259e9` (2026-06-04): clean rebase, no conflicts; arch ratchets updated in same push.
- GitHub auto-merge is disabled; repo-local `merge-queue` admission requires exact-head green PR checks and latest-head review.