### PR TITLE
fix(emit): reserve static class expression temps

### DIFF
--- a/crates/tsz-emitter/src/emitter/class_temp_reservations.rs
+++ b/crates/tsz-emitter/src/emitter/class_temp_reservations.rs
@@ -155,9 +155,19 @@ impl<'a> Printer<'a> {
 
         let legacy_computed_temps =
             self.estimate_legacy_decorator_computed_prefix_temp_count(class_idx, class);
+        let needs_class_expression_static_comma_temp =
+            self.file_level_class_expression_needs_static_comma_temp(class_idx, class);
+        let static_comma_computed_temps =
+            if needs_class_expression_static_comma_temp && !self.ctx.options.legacy_decorators {
+                self.estimate_class_expression_static_comma_computed_temp_count(class)
+            } else {
+                0
+            };
         let static_initializer_nodes = self.class_static_initializer_nodes_for_temp_plan(class);
         if static_initializer_nodes.is_empty() {
-            return legacy_computed_temps;
+            return legacy_computed_temps
+                + usize::from(needs_class_expression_static_comma_temp)
+                + static_comma_computed_temps;
         }
 
         let externalized_static_initializers = self.ctx.options.legacy_decorators
@@ -174,8 +184,115 @@ impl<'a> Printer<'a> {
                 .any(|idx| contains_super_reference(self.arena, *idx));
 
         legacy_computed_temps
+            + usize::from(needs_class_expression_static_comma_temp)
+            + static_comma_computed_temps
             + usize::from(needs_class_reference)
             + usize::from(needs_super_reference)
+    }
+
+    fn file_level_class_expression_needs_static_comma_temp(
+        &self,
+        class_idx: NodeIndex,
+        class: &ClassData,
+    ) -> bool {
+        if self
+            .arena
+            .get(class_idx)
+            .is_none_or(|node| node.kind != super::syntax_kind_ext::CLASS_EXPRESSION)
+        {
+            return false;
+        }
+
+        let target_needs_field_lowering = (self.ctx.options.target as u32)
+            < (ScriptTarget::ES2022 as u32)
+            || !self.ctx.options.use_define_for_class_fields;
+        let target_needs_static_block_lowering =
+            (self.ctx.options.target as u32) < (ScriptTarget::ES2022 as u32);
+
+        let has_static_field_comma_expr =
+            target_needs_field_lowering && target_needs_static_block_lowering && {
+                class.members.nodes.iter().any(|&member_idx| {
+                    let Some(member) = self.arena.get(member_idx) else {
+                        return false;
+                    };
+                    if member.kind != super::syntax_kind_ext::PROPERTY_DECLARATION {
+                        return false;
+                    }
+                    let Some(prop) = self.arena.get_property_decl(member) else {
+                        return false;
+                    };
+                    if !self.arena.is_static(&prop.modifiers)
+                        || self
+                            .arena
+                            .has_modifier(&prop.modifiers, super::SyntaxKind::AbstractKeyword)
+                        || self
+                            .arena
+                            .has_modifier(&prop.modifiers, super::SyntaxKind::DeclareKeyword)
+                        || crate::transforms::private_fields_es5::is_private_identifier(
+                            self.arena, prop.name,
+                        )
+                    {
+                        return false;
+                    }
+                    crate::transforms::emit_utils::class_field_decl_has_runtime_state(
+                        self.arena, prop,
+                    )
+                })
+            };
+        let has_static_block_comma_expr = target_needs_static_block_lowering
+            && class.members.nodes.iter().any(|&member_idx| {
+                self.arena.get(member_idx).is_some_and(|member| {
+                    member.kind == super::syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION
+                })
+            });
+
+        has_static_field_comma_expr || has_static_block_comma_expr
+    }
+
+    fn estimate_class_expression_static_comma_computed_temp_count(
+        &self,
+        class: &ClassData,
+    ) -> usize {
+        let mut count = 0;
+        for &member_idx in &class.members.nodes {
+            let Some(member_node) = self.arena.get(member_idx) else {
+                continue;
+            };
+            if member_node.kind != super::syntax_kind_ext::PROPERTY_DECLARATION {
+                continue;
+            }
+            let Some(prop) = self.arena.get_property_decl(member_node) else {
+                continue;
+            };
+            if self
+                .arena
+                .has_modifier(&prop.modifiers, super::SyntaxKind::AbstractKeyword)
+                || self
+                    .arena
+                    .has_modifier(&prop.modifiers, super::SyntaxKind::DeclareKeyword)
+            {
+                continue;
+            }
+            let Some(computed_expr) = self.legacy_computed_name_expression_needing_temp(prop.name)
+            else {
+                continue;
+            };
+            let is_private = self
+                .arena
+                .get(prop.name)
+                .is_some_and(|name| name.kind == super::SyntaxKind::PrivateIdentifier as u16);
+            let has_accessor = self
+                .arena
+                .has_modifier(&prop.modifiers, super::SyntaxKind::AccessorKeyword);
+            let property_is_erased = prop.initializer.is_none()
+                && !is_private
+                && !has_accessor
+                && !self.no_init_property_is_runtime_materialized(prop);
+            if !property_is_erased || !self.is_computed_name_expr_side_effect_free(computed_expr) {
+                count += 1;
+            }
+        }
+        count
     }
 
     fn estimate_legacy_decorator_computed_prefix_temp_count(

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs
@@ -1078,6 +1078,43 @@ impl<'a> Printer<'a> {
         let emits_as_class_expression = is_class_expression || assignment_prefix.is_some();
         let needs_private_comma_expr = is_class_expression && has_any_private_lowering;
 
+        // For class expressions with static field initializers, we need to wrap
+        // in a comma expression: `(_a = class C {}, _a.a = 1, _a)`.
+        let has_static_field_comma_expr = self.class_has_static_field_comma_expr(
+            class,
+            target_needs_field_lowering,
+            target_needs_static_block_lowering,
+            needs_private_field_lowering,
+        );
+        let has_static_block_comma_expr =
+            self.class_has_static_block_comma_expr(class, target_needs_static_block_lowering);
+        // A computed-named *static method or accessor* is emitted inline in the
+        // class body, so it only requires the `(_tmp = class {...}, ..., _tmp)`
+        // comma wrapping when the binding *also* loses JS named evaluation --
+        // i.e. a `using`/`await using` declaration lowered to
+        // `__addDisposableResource`, which moves the class out of
+        // direct-assignment position. A plain `var X = class {...}` keeps named
+        // evaluation and needs no wrapping for inline computed method names.
+        let has_static_computed_method_or_accessor = self
+            .class_has_static_computed_method_or_accessor_comma_expr(
+                class,
+                _idx,
+                emits_as_class_expression,
+            );
+        let needs_static_comma_expr = emits_as_class_expression
+            && !emit_assignment_static_elements_as_statements
+            && (has_static_field_comma_expr
+                || has_static_block_comma_expr
+                || has_static_computed_method_or_accessor);
+        let preplanned_class_expr_temp = if needs_static_comma_expr
+            && private_class_alias.is_none()
+            && self.file_level_class_temp_reservations.contains_key(&_idx)
+        {
+            Some(self.make_class_static_temp_name_hoisted(_idx))
+        } else {
+            None
+        };
+
         // Computed property name hoisting for class fields that will be lowered.
         // tsc hoists non-constant computed property name expressions to temp variables
         // (e.g., `_a = n, _b = s + n`) so that the evaluation order is preserved and
@@ -1228,7 +1265,10 @@ impl<'a> Printer<'a> {
                     }
                 } else {
                     // Allocate a temp variable for this computed property name
-                    let temp = if self.ctx.options.legacy_decorators && !has_legacy_decorators {
+                    let use_class_static_temp = (preplanned_class_expr_temp.is_some()
+                        && self.file_level_class_temp_reservations.contains_key(&_idx))
+                        || (self.ctx.options.legacy_decorators && !has_legacy_decorators);
+                    let temp = if use_class_static_temp {
                         self.make_class_static_temp_name_hoisted(_idx)
                     } else {
                         self.make_unique_name_hoisted()
@@ -1244,93 +1284,6 @@ impl<'a> Printer<'a> {
             }
         }
 
-        // For class expressions with static field initializers, we need to wrap
-        // in a comma expression: `(_a = class C {}, _a.a = 1, _a)`.
-        // Allocate the class-expression temp after computed-name temps so the
-        // generated `_a`, `_b`, `_c` ordering matches tsc.
-        let has_static_field_comma_expr = target_needs_field_lowering
-            && target_needs_static_block_lowering
-            && class.members.nodes.iter().any(|&member_idx| {
-                let Some(member) = self.arena.get(member_idx) else {
-                    return false;
-                };
-                if member.kind != syntax_kind_ext::PROPERTY_DECLARATION {
-                    return false;
-                }
-                let Some(prop) = self.arena.get_property_decl(member) else {
-                    return false;
-                };
-                if !self.arena.is_static(&prop.modifiers) {
-                    return false;
-                }
-                if self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
-                {
-                    return false;
-                }
-                if self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
-                {
-                    return false;
-                }
-                if needs_private_field_lowering && is_private_identifier(self.arena, prop.name) {
-                    return false;
-                }
-                // A static field that lowers to no runtime statement (a bare type-only
-                // declaration) neither needs a comma-expr temp nor a `__setFunctionName`
-                // helper item. Fields with runtime state (initializer, auto-accessor, or
-                // decorator) still carry static state.
-                crate::transforms::emit_utils::class_field_decl_has_runtime_state(self.arena, prop)
-            });
-        let has_static_block_comma_expr = target_needs_static_block_lowering
-            && class.members.nodes.iter().any(|&member_idx| {
-                self.arena
-                    .get(member_idx)
-                    .is_some_and(|m| m.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION)
-            });
-        // A computed-named *static method or accessor* is emitted inline in the
-        // class body, so it only requires the `(_tmp = class {...}, ..., _tmp)`
-        // comma wrapping when the binding *also* loses JS named evaluation --
-        // i.e. a `using`/`await using` declaration lowered to
-        // `__addDisposableResource`, which moves the class out of
-        // direct-assignment position. A plain `var X = class {...}` keeps named
-        // evaluation and needs no wrapping for inline computed method names.
-        let has_static_computed_method_or_accessor = emits_as_class_expression
-            && class.name.is_none()
-            && self.resolve_class_expr_binding_name(_idx).is_some()
-            && self.class_expr_binding_loses_named_evaluation(_idx)
-            && class.members.nodes.iter().any(|&member_idx| {
-                self.arena
-                    .get(member_idx)
-                    .is_some_and(|member| match member.kind {
-                        k if k == syntax_kind_ext::METHOD_DECLARATION => {
-                            self.arena.get_method_decl(member).is_some_and(|method| {
-                                self.arena.is_static(&method.modifiers)
-                                    && self.arena.get(method.name).is_some_and(|name| {
-                                        name.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
-                                    })
-                            })
-                        }
-                        k if k == syntax_kind_ext::GET_ACCESSOR
-                            || k == syntax_kind_ext::SET_ACCESSOR =>
-                        {
-                            self.arena.get_accessor(member).is_some_and(|accessor| {
-                                self.arena.is_static(&accessor.modifiers)
-                                    && self.arena.get(accessor.name).is_some_and(|name| {
-                                        name.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
-                                    })
-                            })
-                        }
-                        _ => false,
-                    })
-            });
-        let needs_static_comma_expr = emits_as_class_expression
-            && !emit_assignment_static_elements_as_statements
-            && (has_static_field_comma_expr
-                || has_static_block_comma_expr
-                || has_static_computed_method_or_accessor);
         let mut computed_prop_entries_consumed_by_member_name: Vec<usize> = Vec::new();
         if needs_computed_prop_hoisting && !computed_prop_entries.is_empty() {
             let mut pending_computed_entries = Vec::new();
@@ -1492,6 +1445,8 @@ impl<'a> Printer<'a> {
         let class_expr_temp = if needs_class_expr_temp {
             let temp = if let Some(ref alias) = private_class_alias {
                 alias.clone()
+            } else if let Some(temp) = preplanned_class_expr_temp {
+                temp
             } else {
                 self.make_class_static_temp_name_hoisted(_idx)
             };

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_after_body.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_after_body.rs
@@ -423,12 +423,16 @@ impl<'a> Printer<'a> {
                         name_emit,
                         init_idx,
                         _member_pos,
-                        _leading_comments,
-                        _trailing_comments,
+                        leading_comments,
+                        trailing_comments,
                     )) => {
                         self.write(",");
                         self.write_line();
                         self.increase_indent();
+                        for (comment_text, source_pos) in leading_comments {
+                            self.write_comment_with_reindent(&comment_text, Some(source_pos));
+                            self.write_line();
+                        }
                         if self.ctx.options.use_define_for_class_fields {
                             let define_name = match &name_emit {
                                 PropertyNameEmit::Dot(s) => format!("\"{s}\""),
@@ -496,6 +500,10 @@ impl<'a> Printer<'a> {
                                     self.write(&replaced);
                                 }
                             }
+                        }
+                        for comment_text in trailing_comments {
+                            self.write_space();
+                            self.write_comment(&comment_text);
                         }
                         self.decrease_indent();
                     }

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_recovery.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_recovery.rs
@@ -19,7 +19,7 @@ impl<'a> Printer<'a> {
     /// runtime. It keys purely on structural facts (no initializer + define
     /// semantics enabled) and intentionally does not re-check abstract/declare/
     /// private/accessor — those are filtered independently at each call site.
-    pub(super) const fn no_init_property_is_runtime_materialized(
+    pub(in crate::emitter) const fn no_init_property_is_runtime_materialized(
         &self,
         prop: &tsz_parser::parser::node::PropertyDeclData,
     ) -> bool {

--- a/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
@@ -1,8 +1,8 @@
 use super::super::super::Printer;
 use super::AutoAccessorEmitOptions;
-use crate::transforms::private_fields_es5::get_private_field_name;
+use crate::transforms::private_fields_es5::{get_private_field_name, is_private_identifier};
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::node::Node;
+use tsz_parser::parser::node::{ClassData, Node};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
@@ -156,6 +156,91 @@ impl<'a> Printer<'a> {
             }
         }
         false
+    }
+
+    pub(super) fn class_has_static_field_comma_expr(
+        &self,
+        class: &ClassData,
+        target_needs_field_lowering: bool,
+        target_needs_static_block_lowering: bool,
+        needs_private_field_lowering: bool,
+    ) -> bool {
+        target_needs_field_lowering
+            && target_needs_static_block_lowering
+            && class.members.nodes.iter().any(|&member_idx| {
+                let Some(member) = self.arena.get(member_idx) else {
+                    return false;
+                };
+                if member.kind != syntax_kind_ext::PROPERTY_DECLARATION {
+                    return false;
+                }
+                let Some(prop) = self.arena.get_property_decl(member) else {
+                    return false;
+                };
+                if !self.arena.is_static(&prop.modifiers)
+                    || self
+                        .arena
+                        .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
+                    || self
+                        .arena
+                        .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
+                    || (needs_private_field_lowering
+                        && is_private_identifier(self.arena, prop.name))
+                {
+                    return false;
+                }
+                crate::transforms::emit_utils::class_field_decl_has_runtime_state(self.arena, prop)
+            })
+    }
+
+    pub(super) fn class_has_static_block_comma_expr(
+        &self,
+        class: &ClassData,
+        target_needs_static_block_lowering: bool,
+    ) -> bool {
+        target_needs_static_block_lowering
+            && class.members.nodes.iter().any(|&member_idx| {
+                self.arena.get(member_idx).is_some_and(|member| {
+                    member.kind == syntax_kind_ext::CLASS_STATIC_BLOCK_DECLARATION
+                })
+            })
+    }
+
+    pub(super) fn class_has_static_computed_method_or_accessor_comma_expr(
+        &self,
+        class: &ClassData,
+        class_idx: NodeIndex,
+        emits_as_class_expression: bool,
+    ) -> bool {
+        emits_as_class_expression
+            && class.name.is_none()
+            && self.resolve_class_expr_binding_name(class_idx).is_some()
+            && self.class_expr_binding_loses_named_evaluation(class_idx)
+            && class.members.nodes.iter().any(|&member_idx| {
+                self.arena
+                    .get(member_idx)
+                    .is_some_and(|member| match member.kind {
+                        k if k == syntax_kind_ext::METHOD_DECLARATION => {
+                            self.arena.get_method_decl(member).is_some_and(|method| {
+                                self.arena.is_static(&method.modifiers)
+                                    && self.arena.get(method.name).is_some_and(|name| {
+                                        name.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+                                    })
+                            })
+                        }
+                        k if k == syntax_kind_ext::GET_ACCESSOR
+                            || k == syntax_kind_ext::SET_ACCESSOR =>
+                        {
+                            self.arena.get_accessor(member).is_some_and(|accessor| {
+                                self.arena.is_static(&accessor.modifiers)
+                                    && self.arena.get(accessor.name).is_some_and(|name| {
+                                        name.kind == syntax_kind_ext::COMPUTED_PROPERTY_NAME
+                                    })
+                            })
+                        }
+                        _ => false,
+                    })
+            })
     }
 
     pub(in crate::emitter) fn class_expr_is_exported_variable_initializer(

--- a/crates/tsz-emitter/src/emitter/source_file/class_expr_computed_static_method_naming_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/class_expr_computed_static_method_naming_tests.rs
@@ -154,3 +154,26 @@ fn var_bound_anonymous_class_computed_static_field_still_wraps_es2015() {
         "A runtime computed static field must not be emitted as a plain inline class body.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn file_level_static_field_class_expr_temps_reserve_in_source_order_es2015() {
+    let source = "let First = class {\n    // keep with lowered static field\n    static x = 1;\n};\nconst key = 'k';\nlet Second = class { static [key] = 2; };\nfunction later(value = class { static x = 3; }) {}\n";
+    let output = emit(source, ScriptTarget::ES2015, false);
+
+    assert!(
+        output.contains(
+            "let First = (_a = class {\n    },\n    __setFunctionName(_a, \"First\"),\n    // keep with lowered static field\n    _a.x = 1,\n    _a);"
+        ),
+        "Leading comments on static fields should be replayed inside class-expression comma lowering.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "let Second = (_b = class {\n    },\n    _c = key,\n    __setFunctionName(_b, \"Second\"),\n    _b[_c] = 2,\n    _b);"
+        ),
+        "File-level class-expression result temps should be reserved before their computed-key temps.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("function later(value) {\n    var _d;"),
+        "Nested function temp scopes should skip file-level class-expression temps.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
AgentName: Studio-C

Track: emit/js

Invariant: Preserve tsc-compatible class-expression temp ordering while keeping emit as OUTPUT-only lowering. No checker/solver behavior changes.

Scope:
- Reserve file-level static class-expression comma temps ahead of nested function temp scopes.
- Consume reserved top-level class result temps before computed static field key temps when tsc does so for file-level class expressions.
- Replay stored leading/trailing static-field comments inside class-expression comma lowering.
- Move the static-comma classification predicate into class helpers to keep `emit_es6.rs` under the 2000-line limit.
- Add focused ES2015 unit coverage for class result temp -> computed key temp ordering, comment replay, and nested-scope reservation.

## Project Corpus Impact
- Row: emit/js `staticFieldWithInterfaceContext`
- Bug family: class/private/accessor/decorator temp ordering and comment replay
- Evidence: focused `scripts/emit/run.sh --js-only --filter=staticFieldWithInterfaceContext --verbose --timeout=20000 --json-out=/tmp/studio-c-staticFieldWithInterfaceContext-after-rebase.json` cleared the earlier missing comment, `_b`/`_c` inversion, and nested `_r` reservation pieces; the row still needed #12471 for binding-pattern `__setFunctionName`.

Verification:
- `cargo fmt --check`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- `cargo nextest run -p tsz-emitter file_level_static_field_class_expr_temps_reserve_in_source_order_es2015 class_expression_static_comma_temp_follows_computed_name_temps`
- `cargo check -p tsz-emitter`
- `git diff --check origin/main..HEAD`
- `wc -l crates/tsz-emitter/src/emitter/declarations/class/emit_es6.rs crates/tsz-emitter/src/emitter/declarations/class/helpers.rs crates/tsz-emitter/src/emitter/class_temp_reservations.rs` (`emit_es6.rs` = 1951)
- `scripts/emit/run.sh --js-only --filter=staticFieldWithInterfaceContext --verbose --timeout=20000 --json-out=/tmp/studio-c-staticFieldWithInterfaceContext-after-rebase.json` (expected residual failure before #12471, noted above)

Coordination Notes:
- Branch head after lint fix: `2b7158827e`.
- This is a deliberately narrow PR that preserves the existing function-scope computed-before-wrapper unit behavior.
- #12471 is stacked on this PR and completes `staticFieldWithInterfaceContext`.
