### PR TITLE
fix(solver): fall back to keyof O for deferred O[K] index bound (#12450)

### DIFF
--- a/crates/tsz-checker/tests/deferred_keyof_index_access_assignability_tests.rs
+++ b/crates/tsz-checker/tests/deferred_keyof_index_access_assignability_tests.rs
@@ -597,3 +597,93 @@ class Holder<K1 extends keyof Things, K2 extends keyof Things> {
             .collect::<Vec<_>>()
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #12450 — index parameter whose constraint is UNAVAILABLE at the
+// indexed-access relation site.
+//
+// `errorInfoForRelatedIndexTypesNoConstraintElaboration.ts` assigns `{}` to
+// `JSX.IntrinsicElements[T1]` (T1 bound by `keyof JSX.IntrinsicElements`).
+// tsc accepts it — every intrinsic element's prop type is all-optional, so
+// `{}` is assignable for any `T1`. tsz emitted a false TS2322 because the
+// indexed-access subtype fallback (`check_generic_index_access_subtype`) bailed
+// to `false` whenever the index type parameter reached it without its
+// constraint attached. The fix falls back to `keyof O` as the effective index
+// bound (an index into `O` ranges over `keyof O`) and runs the existing
+// all-keys-must-pass distribution. A genuinely unconstrained index parameter
+// reproduces the same `constraint == None` branch in a self-contained way (no
+// react16/JSX corpus needed).
+//
+// Structural rule: when `S` is assigned into a deferred `O[K]` whose index
+// bound is unavailable, `S` is accepted iff it is assignable to `O[k]` for
+// EVERY `k` in `keyof O`. The fallback only widens which keys are checked; it
+// never widens source acceptance, so required-property and distinct-key
+// mismatches keep their TS2322.
+
+/// `{}` assigned into `O[K]` where `K`'s constraint is unavailable and every
+/// value type of `O` is all-optional must NOT emit the false `'{}' is not
+/// assignable` TS2322. Two parameter spellings keep the rule structural
+/// (anti-hardcoding directive §25).
+#[test]
+fn empty_object_into_unavailable_constraint_index_all_optional_accepts_two_names() {
+    for (p1, p2) in [("T1", "T2"), ("Tag", "Other")] {
+        let source = format!(
+            r#"
+interface Things {{
+    a: {{ id?: string }};
+    b: {{ name?: number }};
+}}
+class Holder<{p1}, {p2}> {{
+    M() {{
+        let c1: Things[{p1}] = {{}};
+    }}
+}}
+"#
+        );
+        let diags = check_source_diagnostics(&source);
+        assert!(
+            !diags.iter().any(|d| {
+                d.code == 2322 && d.message_text.contains("Type '{}' is not assignable")
+            }),
+            "{{}} -> Things[{p1}] (unavailable-constraint index, all-optional values) must \
+             NOT emit the false '{{}} not assignable' TS2322; got: {:?}",
+            diags
+                .iter()
+                .map(|d| (d.code, d.message_text.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
+}
+
+/// Over-acceptance guard: the same unavailable-constraint index must STILL
+/// reject `{}` when at least one value type of `O` carries a required member,
+/// because the universally-quantified `K` could select that key.
+#[test]
+fn empty_object_into_unavailable_constraint_index_required_prop_rejects_two_names() {
+    for p1 in ["T1", "Tag"] {
+        let source = format!(
+            r#"
+interface Things {{
+    a: {{ id?: string }};
+    b: {{ req: string }};
+}}
+class Holder<{p1}, Other> {{
+    M() {{
+        let c1: Things[{p1}] = {{}};
+    }}
+}}
+"#
+        );
+        let diags = check_source_diagnostics(&source);
+        let assignability_errors = count(&diags, 2322) + count(&diags, 2741);
+        assert!(
+            assignability_errors >= 1,
+            "{{}} -> Things[{p1}] (unavailable-constraint index, one required-prop value) must \
+             still emit an assignability error; got: {:?}",
+            diags
+                .iter()
+                .map(|d| (d.code, d.message_text.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -386,9 +386,24 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Check if source is a subtype of an `IndexAccess` target where the index is generic.
     ///
     /// If `Target` is `Obj[K]` where `K` is generic, we check if `Source <: Obj[C]`
-    /// where `C` is the constraint of `K`.
+    /// where `C` is the **effective index bound** of `K`.
     /// Specifically, if `C` is a union of string literals `"a" | "b"`, we verify
-    /// `Source <: Obj["a"]` AND `Source <: Obj["b"]`.
+    /// `Source <: Obj["a"]` AND `Source <: Obj["b"]` (every key must accept the
+    /// source, since `K` is universally quantified over its bound).
+    ///
+    /// ## Effective index bound
+    /// The bound is `K`'s declared constraint when it is attached to the
+    /// type-parameter node. When it is *not* attached at this relation site
+    /// (`constraint == None`), the bound falls back to `keyof Obj`: for the
+    /// deferred access `Obj[K]` to be well-formed at all, `K` must range over
+    /// `keyof Obj`, so `keyof Obj` is the soundest upper bound to distribute
+    /// over. Bailing to `false` here instead would fabricate a spurious
+    /// `TS2322` — most visibly `{}` assigned to `JSX.IntrinsicElements[T]`,
+    /// where every element's prop type is all-optional so `{}` is in fact
+    /// assignable for any `T` (issue #12450). This fallback only widens *which*
+    /// keys are checked; the all-keys-must-pass loop below still rejects a
+    /// source that fails against any single value type, so required-property
+    /// and distinct-key mismatches keep their correct `TS2322`.
     pub(crate) fn check_generic_index_access_subtype(
         &mut self,
         source: TypeId,
@@ -414,9 +429,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return false;
         };
 
-        let Some(constraint) = t_param.constraint else {
-            return false;
-        };
+        // Use the declared constraint when present; otherwise fall back to
+        // `keyof Obj` as the effective bound (see the doc comment). `Obj[K]`
+        // only type-checks when `K extends keyof Obj`, so this is sound and
+        // never widens the source acceptance — only the set of keys checked.
+        let constraint = t_param
+            .constraint
+            .unwrap_or_else(|| self.interner.keyof(t_obj));
 
         // Evaluate the constraint to resolve any type aliases/applications
         let constraint = self.evaluate_type(constraint);


### PR DESCRIPTION
AgentName: M4-B

Refs #12450 — addresses the root-caused false-positive mechanism (verified locally). The issue is intentionally left **open** (not auto-closed): the react16 `errorInfoForRelatedIndexTypesNoConstraintElaboration.ts` conformance witness can't be reproduced in a web session (TypeScript submodule not initialized), so the witness flip is deferred to the maintainer's full-conformance run. See the CI status note at the bottom.

## Track
Conformance / solver relation policy — indexed-access (`O[K]`) subtype fallback.

## Invariant
Parity with `tsc`: no false-positive diagnostics. When `S` is assigned into a deferred indexed-access target `O[K]` whose index parameter `K` is universally quantified, `S` is assignable iff it is assignable to `O[k]` for **every** `k` in the effective bound of `K`. The relation must derive that bound rather than fabricating a `TS2322` when the bound is not inlined on the type-parameter node.

## Structural rule
`When the target is a deferred O[K] and K's declared constraint is unavailable at the relation site, tsc still relates S against the value types reachable through K's bound; tsz now uses keyof O as that effective index bound through the solver's check_generic_index_access_subtype, instead of bailing to false.`

An index into `O` can only range over `keyof O` (otherwise `O[K]` is ill-formed and reported elsewhere as `TS2536`), so `keyof O` is the soundest upper bound to distribute over. The fallback only widens **which keys are checked**, never source acceptance: the existing all-keys-must-pass loop still rejects a source that fails against any single value type.

## Root cause (verified empirically)
`crates/tsz-solver/src/relations/subtype/helpers.rs::check_generic_index_access_subtype` is the deferred-target fallback in the subtype relation (invoked from `core_dispatch.rs` only after a prior structural check returned `False`). It is reached when `O[K]` was **not** eagerly resolved to its value-type union — e.g. for objects above `LARGE_OBJECT_DEFERRAL_THRESHOLD` (60) in `evaluation/evaluate_rules/index_access.rs`. There the index parameter can arrive with `constraint == None`, and the old `let Some(constraint) = … else { return false }` fabricated `Type '{}' is not assignable to type 'O[T1]'` even though every value type is all-optional (so `{}` is assignable for any `T1`). Reproduced the exact shape and its removal with a self-contained harness.

## Owner layer
Solver (`tsz-solver`) relation — type semantics stay in the solver; no checker changes.

## Scope
- `crates/tsz-solver/src/relations/subtype/helpers.rs` — in `check_generic_index_access_subtype`, fall back to `self.interner.keyof(t_obj)` when the index type parameter's constraint is `None`; the existing constraint-evaluation + per-key distribution is unchanged.
- `crates/tsz-checker/tests/deferred_keyof_index_access_assignability_tests.rs` — two name-varied regressions: all-optional value types accept `{}` (no false `TS2322`); a value type with a required member still rejects `{}` (over-acceptance guard).

### Anti-hardcoding
The fallback is a structural `keyof` of the object being indexed — no identifier/alias/file-name string checks, no reading rendered printer output. Tests vary the type-parameter spelling (`T1`/`Tag`) so the rule is structural, not a name match.

## Project Corpus Impact
- Row: nextjs
- Bug family: false-positive-indexed-access-assignability

Strictly removes a false `TS2322` on the constraint-unavailable indexed-access path; no previously-clean assignment is affected.

## Verification
- `cargo test -p tsz-checker --test deferred_keyof_index_access_assignability_tests` — 17 passed (15 existing + 2 new).
- `cargo test -p tsz-solver --lib` — 6525 passed, 0 failed.
- Spot-checked related checker suites — all green. The 3 failures in `enum_indexed_access_tests` are pre-existing on `origin/main` (confirmed by `git stash`).
- `cargo clippy -p tsz-solver --lib` — clean; `cargo fmt` applied.
- 3 `/simplify` passes (reuse, simplification, efficiency, altitude); converged — only a `match` → `unwrap_or_else` idiom tweak applied.
- Rebased onto latest `origin/main`; clean rebase, no conflicts.

## CI status
- All checks that validate this change are green on this head: `unit`, `emit`, every `conformance-*` shard, every `fourslash-*` + `fourslash-aggregate`, `dist-binaries` (full rebuild), `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `project-compile-guard`, `lsp-e2e`, `wasm`/`wasm-web`, `conformance-snapshot-gate`.
- `conformance-aggregate` (and downstream `CI Summary`) is red **identically on `main` at this PR's base `6737e8839b`** (job 79467592902) — a pre-existing, repo-wide state from the emptied accepted-regressions ledger (#12436). This PR's conformance delta vs base is **0 new failures**.

## Coordination Notes
- #12450 carries the `WIP` label and a signed root-cause comment; left open pending full-conformance confirmation of the witness.
- No open PR touches `check_generic_index_access_subtype`; verified before starting.