### PR TITLE
fix(emit): name binding default class expressions

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/helpers.rs
@@ -65,6 +65,13 @@ impl<'a> Printer<'a> {
                     }
                     return self.identifier_binding_name(param.name);
                 }
+                syntax_kind_ext::BINDING_ELEMENT => {
+                    let element = self.arena.get_binding_element(parent_node)?;
+                    if element.initializer != current {
+                        return None;
+                    }
+                    return self.identifier_binding_name(element.name);
+                }
                 syntax_kind_ext::PROPERTY_DECLARATION => {
                     let property = self.arena.get_property_decl(parent_node)?;
                     if property.initializer != current {

--- a/crates/tsz-emitter/src/emitter/source_file/class_expr_computed_static_method_naming_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/class_expr_computed_static_method_naming_tests.rs
@@ -177,3 +177,22 @@ fn file_level_static_field_class_expr_temps_reserve_in_source_order_es2015() {
         "Nested function temp scopes should skip file-level class-expression temps.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn binding_pattern_default_class_expr_uses_binding_name_es2015() {
+    let source = "let { slot = class { static x = 1; } } = {};\nlet [item = class { static x = 2; }] = [];\n";
+    let output = emit(source, ScriptTarget::ES2015, false);
+
+    assert!(
+        output.contains(
+            "let { slot = (_a = class {\n    },\n    __setFunctionName(_a, \"slot\"),\n    _a.x = 1,\n    _a) } = {};"
+        ),
+        "Object binding defaults should use the binding element name for explicit class naming.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "let [item = (_b = class {\n    },\n    __setFunctionName(_b, \"item\"),\n    _b.x = 2,\n    _b)] = [];"
+        ),
+        "Array binding defaults should use the binding element name for explicit class naming.\nOutput:\n{output}"
+    );
+}


### PR DESCRIPTION
AgentName: Studio-C

Track: emit/js

Invariant: Preserve tsc named-evaluation behavior for anonymous class expressions in binding-pattern defaults. Emit-only resolver change; no checker/solver behavior changes.

Scope:
- Extend class-expression binding-name resolution to `BindingElement` initializers.
- Add ES2015 unit coverage for object and array binding defaults that lower static fields through class-expression comma items.
- Rebased onto `main` after #12469 landed.

## Project Corpus Impact
- Row: emit/js `staticFieldWithInterfaceContext`
- Bug family: class/private/accessor/decorator named evaluation in binding patterns
- Evidence: `scripts/emit/run.sh --js-only --filter=staticFieldWithInterfaceContext --verbose --timeout=20000 --json-out=/tmp/studio-c-staticFieldWithInterfaceContext-binding-mainbased.json` passes 1/1 on the main-based branch.

Verification:
- `cargo fmt --check`
- `cargo clippy -p tsz-emitter --all-targets --all-features -- -D warnings`
- `cargo nextest run -p tsz-emitter binding_pattern_default_class_expr_uses_binding_name_es2015 file_level_static_field_class_expr_temps_reserve_in_source_order_es2015 class_expression_static_comma_temp_follows_computed_name_temps`
- `git diff --check origin/main..HEAD`
- `wc -l crates/tsz-emitter/src/emitter/declarations/class/helpers.rs crates/tsz-emitter/src/emitter/source_file/class_expr_computed_static_method_naming_tests.rs`
- `scripts/emit/run.sh --js-only --filter=staticFieldWithInterfaceContext --verbose --timeout=20000 --json-out=/tmp/studio-c-staticFieldWithInterfaceContext-binding-mainbased.json`

Coordination Notes:
- Base is now `main` after #12469 merged at 2026-06-04T06:54:39Z.
- Branch head after rebase: `e6d093dcb1`.
- Exact-head PR checks should be re-read before adding `merge-queue`.
