### PR TITLE
fix(checker): emit TS2454 definite-assignment for locally-declared vars with cross-file-type annotations

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -35,6 +35,10 @@ name = "assertion_source_literal_display_tests"
 path = "tests/assertion_source_literal_display_tests.rs"
 
 [[test]]
+name = "export_default_interface_type_import_tests"
+path = "tests/export_default_interface_type_import_tests.rs"
+
+[[test]]
 name = "nested_discriminant_narrowing_tests"
 path = "tests/nested_discriminant_narrowing_tests.rs"
 

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -1043,13 +1043,9 @@ impl<'a> CheckerState<'a> {
                 return (TypeId::ERROR, Vec::new());
             }
 
-            // Synthetic `export default interface A {}` / `export default type A = ...`
-            // aliases are type-only: the binder gives them no `value_declaration`,
-            // only a declaration that points at the inline INTERFACE/TYPE_ALIAS node.
-            // That same node also declares a local type symbol (`A`) in scope. Resolve
-            // to the local symbol's type so a cross-file default import
-            // (`import A from './a'; let x: A`) sees the interface/alias type instead
-            // of falling through to the generic alias-`any` path.
+            // Type-only inline default exports have no `value_declaration`; resolve
+            // their inline interface/type alias declaration to the local type symbol
+            // so default imports see that type instead of generic alias `any`.
             if import_module.is_none()
                 && value_decl.is_none()
                 && let Some(target_type) =
@@ -2000,90 +1996,5 @@ impl<'a> CheckerState<'a> {
         // Fallback: return ANY for unresolved symbols to prevent cascading errors
         // The actual "cannot find" error should already be emitted elsewhere
         (TypeId::ANY, Vec::new())
-    }
-
-    /// Resolve the type of a synthetic `export default interface A {}` /
-    /// `export default type A = ...` alias.
-    ///
-    /// The binder models the inline default export of a pure type as an
-    /// `ALIAS`-only `"default"` symbol whose declaration is the
-    /// `INTERFACE_DECLARATION` / `TYPE_ALIAS_DECLARATION` node, but it carries no
-    /// `value_declaration` (it is type-only). The same node also declares a local
-    /// type symbol (`A`) in its file scope. We resolve the alias to that local
-    /// symbol's type so a cross-file default import of the type
-    /// (`import A from './a'; let x: A`) sees the interface/alias type rather than
-    /// the generic alias-`any` fallback.
-    ///
-    /// The match is purely structural (binder symbol flags + declaration node
-    /// kind); no identifier/file-name string is used as a decision predicate.
-    fn inline_default_export_type_only_target_type(
-        &mut self,
-        alias_sym_id: tsz_binder::SymbolId,
-        declarations: &[NodeIndex],
-    ) -> Option<TypeId> {
-        // Resolve the local interface/type-alias symbol first, holding only
-        // immutable borrows of the declaring file's arena/binder. Drop those
-        // borrows before calling `get_type_of_symbol` (which needs `&mut self`).
-        let local_sym_id = {
-            // The alias's declarations live in its declaring file's arena/binder,
-            // not necessarily the current one (cross-file default import).
-            let file_idx = self
-                .ctx
-                .resolve_symbol_declaring_file_index(alias_sym_id)
-                .or_else(|| self.ctx.resolve_symbol_file_index(alias_sym_id));
-            let arena = match file_idx {
-                Some(idx) => self.ctx.get_arena_for_file(idx as u32),
-                None => self.ctx.arena,
-            };
-            let binder = file_idx
-                .and_then(|idx| self.ctx.get_binder_for_file(idx))
-                .unwrap_or(self.ctx.binder);
-
-            let mut found = None;
-            for &decl_idx in declarations {
-                let Some(decl_node) = arena.get(decl_idx) else {
-                    continue;
-                };
-                // Only the synthetic default export carries an inline
-                // interface/type declaration node as one of its declarations.
-                let name_idx = if decl_node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
-                    arena.get_interface(decl_node).map(|iface| iface.name)
-                } else if decl_node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION {
-                    arena.get_type_alias(decl_node).map(|alias| alias.name)
-                } else {
-                    None
-                };
-                let Some(name_idx) = name_idx else {
-                    continue;
-                };
-                let Some(name) = arena
-                    .get(name_idx)
-                    .and_then(|n| arena.get_identifier(n))
-                    .map(|ident| ident.escaped_text.as_str())
-                else {
-                    continue;
-                };
-
-                // Find the local TYPE symbol the binder declared for this inline
-                // declaration's name. It must be a real interface/type-alias
-                // symbol, distinct from the `ALIAS`-only default-export symbol.
-                let Some(candidate) = binder.file_locals.get(name) else {
-                    continue;
-                };
-                if candidate == alias_sym_id {
-                    continue;
-                }
-                if binder.get_symbol(candidate).is_some_and(|local| {
-                    local.has_any_flags(symbol_flags::INTERFACE | symbol_flags::TYPE_ALIAS)
-                }) {
-                    found = Some(candidate);
-                    break;
-                }
-            }
-            found?
-        };
-
-        let target_type = self.get_type_of_symbol(local_sym_id);
-        (target_type != TypeId::ERROR && target_type != TypeId::ANY).then_some(target_type)
     }
 }

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -1043,6 +1043,21 @@ impl<'a> CheckerState<'a> {
                 return (TypeId::ERROR, Vec::new());
             }
 
+            // Synthetic `export default interface A {}` / `export default type A = ...`
+            // aliases are type-only: the binder gives them no `value_declaration`,
+            // only a declaration that points at the inline INTERFACE/TYPE_ALIAS node.
+            // That same node also declares a local type symbol (`A`) in scope. Resolve
+            // to the local symbol's type so a cross-file default import
+            // (`import A from './a'; let x: A`) sees the interface/alias type instead
+            // of falling through to the generic alias-`any` path.
+            if import_module.is_none()
+                && value_decl.is_none()
+                && let Some(target_type) =
+                    self.inline_default_export_type_only_target_type(sym_id, declarations)
+            {
+                return (target_type, Vec::new());
+            }
+
             // Synthetic `export default ...` aliases point directly at the exported
             // declaration node (often an anonymous class/function). They are real
             // value symbols, not unresolved imports, so compute the declaration type
@@ -1985,5 +2000,90 @@ impl<'a> CheckerState<'a> {
         // Fallback: return ANY for unresolved symbols to prevent cascading errors
         // The actual "cannot find" error should already be emitted elsewhere
         (TypeId::ANY, Vec::new())
+    }
+
+    /// Resolve the type of a synthetic `export default interface A {}` /
+    /// `export default type A = ...` alias.
+    ///
+    /// The binder models the inline default export of a pure type as an
+    /// `ALIAS`-only `"default"` symbol whose declaration is the
+    /// `INTERFACE_DECLARATION` / `TYPE_ALIAS_DECLARATION` node, but it carries no
+    /// `value_declaration` (it is type-only). The same node also declares a local
+    /// type symbol (`A`) in its file scope. We resolve the alias to that local
+    /// symbol's type so a cross-file default import of the type
+    /// (`import A from './a'; let x: A`) sees the interface/alias type rather than
+    /// the generic alias-`any` fallback.
+    ///
+    /// The match is purely structural (binder symbol flags + declaration node
+    /// kind); no identifier/file-name string is used as a decision predicate.
+    fn inline_default_export_type_only_target_type(
+        &mut self,
+        alias_sym_id: tsz_binder::SymbolId,
+        declarations: &[NodeIndex],
+    ) -> Option<TypeId> {
+        // Resolve the local interface/type-alias symbol first, holding only
+        // immutable borrows of the declaring file's arena/binder. Drop those
+        // borrows before calling `get_type_of_symbol` (which needs `&mut self`).
+        let local_sym_id = {
+            // The alias's declarations live in its declaring file's arena/binder,
+            // not necessarily the current one (cross-file default import).
+            let file_idx = self
+                .ctx
+                .resolve_symbol_declaring_file_index(alias_sym_id)
+                .or_else(|| self.ctx.resolve_symbol_file_index(alias_sym_id));
+            let arena = match file_idx {
+                Some(idx) => self.ctx.get_arena_for_file(idx as u32),
+                None => self.ctx.arena,
+            };
+            let binder = file_idx
+                .and_then(|idx| self.ctx.get_binder_for_file(idx))
+                .unwrap_or(self.ctx.binder);
+
+            let mut found = None;
+            for &decl_idx in declarations {
+                let Some(decl_node) = arena.get(decl_idx) else {
+                    continue;
+                };
+                // Only the synthetic default export carries an inline
+                // interface/type declaration node as one of its declarations.
+                let name_idx = if decl_node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
+                    arena.get_interface(decl_node).map(|iface| iface.name)
+                } else if decl_node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION {
+                    arena.get_type_alias(decl_node).map(|alias| alias.name)
+                } else {
+                    None
+                };
+                let Some(name_idx) = name_idx else {
+                    continue;
+                };
+                let Some(name) = arena
+                    .get(name_idx)
+                    .and_then(|n| arena.get_identifier(n))
+                    .map(|ident| ident.escaped_text.as_str())
+                else {
+                    continue;
+                };
+
+                // Find the local TYPE symbol the binder declared for this inline
+                // declaration's name. It must be a real interface/type-alias
+                // symbol, distinct from the `ALIAS`-only default-export symbol.
+                let Some(candidate) = binder.file_locals.get(name) else {
+                    continue;
+                };
+                if candidate == alias_sym_id {
+                    continue;
+                }
+                if binder.get_symbol(candidate).is_some_and(|local| {
+                    local.has_any_flags(symbol_flags::INTERFACE | symbol_flags::TYPE_ALIAS)
+                }) {
+                    found = Some(candidate);
+                    break;
+                }
+            }
+            found?
+        };
+
+        let target_type = self.get_type_of_symbol(local_sym_id);
+        (target_type != TypeId::ERROR && target_type != TypeId::ANY).then_some(target_type)
     }
 }

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias_helpers.rs
@@ -1,4 +1,89 @@
 impl<'a> CheckerState<'a> {
+    /// Resolve the type of a synthetic `export default interface A {}` /
+    /// `export default type A = ...` alias.
+    ///
+    /// The binder models the inline default export of a pure type as an
+    /// `ALIAS`-only `"default"` symbol whose declaration is the
+    /// `INTERFACE_DECLARATION` / `TYPE_ALIAS_DECLARATION` node, but it carries no
+    /// `value_declaration` (it is type-only). The same node also declares a local
+    /// type symbol (`A`) in its file scope. We resolve the alias to that local
+    /// symbol's type so a cross-file default import of the type
+    /// (`import A from './a'; let x: A`) sees the interface/alias type rather than
+    /// the generic alias-`any` fallback.
+    ///
+    /// The match is purely structural (binder symbol flags + declaration node
+    /// kind); no identifier/file-name string is used as a decision predicate.
+    fn inline_default_export_type_only_target_type(
+        &mut self,
+        alias_sym_id: tsz_binder::SymbolId,
+        declarations: &[NodeIndex],
+    ) -> Option<TypeId> {
+        // Resolve the local interface/type-alias symbol first, holding only
+        // immutable borrows of the declaring file's arena/binder. Drop those
+        // borrows before calling `get_type_of_symbol` (which needs `&mut self`).
+        let local_sym_id = {
+            // The alias's declarations live in its declaring file's arena/binder,
+            // not necessarily the current one (cross-file default import).
+            let file_idx = self
+                .ctx
+                .resolve_symbol_declaring_file_index(alias_sym_id)
+                .or_else(|| self.ctx.resolve_symbol_file_index(alias_sym_id));
+            let arena = match file_idx {
+                Some(idx) => self.ctx.get_arena_for_file(idx as u32),
+                None => self.ctx.arena,
+            };
+            let binder = file_idx
+                .and_then(|idx| self.ctx.get_binder_for_file(idx))
+                .unwrap_or(self.ctx.binder);
+
+            let mut found = None;
+            for &decl_idx in declarations {
+                let Some(decl_node) = arena.get(decl_idx) else {
+                    continue;
+                };
+                // Only the synthetic default export carries an inline
+                // interface/type declaration node as one of its declarations.
+                let name_idx = if decl_node.kind == syntax_kind_ext::INTERFACE_DECLARATION {
+                    arena.get_interface(decl_node).map(|iface| iface.name)
+                } else if decl_node.kind == syntax_kind_ext::TYPE_ALIAS_DECLARATION {
+                    arena.get_type_alias(decl_node).map(|alias| alias.name)
+                } else {
+                    None
+                };
+                let Some(name_idx) = name_idx else {
+                    continue;
+                };
+                let Some(name) = arena
+                    .get(name_idx)
+                    .and_then(|n| arena.get_identifier(n))
+                    .map(|ident| ident.escaped_text.as_str())
+                else {
+                    continue;
+                };
+
+                // Find the local TYPE symbol the binder declared for this inline
+                // declaration's name. It must be a real interface/type-alias
+                // symbol, distinct from the `ALIAS`-only default-export symbol.
+                let Some(candidate) = binder.file_locals.get(name) else {
+                    continue;
+                };
+                if candidate == alias_sym_id {
+                    continue;
+                }
+                if binder.get_symbol(candidate).is_some_and(|local| {
+                    local.has_any_flags(symbol_flags::INTERFACE | symbol_flags::TYPE_ALIAS)
+                }) {
+                    found = Some(candidate);
+                    break;
+                }
+            }
+            found?
+        };
+
+        let target_type = self.get_type_of_symbol(local_sym_id);
+        (target_type != TypeId::ERROR && target_type != TypeId::ANY).then_some(target_type)
+    }
+
     fn type_node_contains_kind(&self, root: NodeIndex, kind: u16) -> bool {
         let mut stack = vec![root];
         while let Some(idx) = stack.pop() {

--- a/crates/tsz-checker/tests/export_default_interface_type_import_tests.rs
+++ b/crates/tsz-checker/tests/export_default_interface_type_import_tests.rs
@@ -1,0 +1,125 @@
+//! Regression tests: a default-imported inline `export default interface`
+//! must resolve to the interface type in the importing file.
+//!
+//! Structural rule: the binder models `export default interface A { ... }` as a
+//! type-only `"default"` ALIAS symbol whose declaration is the inline
+//! `INTERFACE_DECLARATION` node, with no `value_declaration`. The same node also
+//! declares a local interface symbol in scope. When the alias has no
+//! `import_module`, no `value_declaration`, and one of its declarations is an
+//! inline interface/type-alias node, the checker resolves to that local type
+//! symbol's type (owner: `compute_type_of_symbol` alias path in the checker).
+//! Before the fix, the alias fell through to the generic alias-`any` path, so a
+//! default-imported interface annotation widened to `any` — silently dropping
+//! both definite-assignment (TS2454) and assignability (TS2322) diagnostics in
+//! the consuming file. The TS2454 facet is covered end-to-end by the
+//! `exportDefaultInterface` conformance fixture; these unit tests cover the
+//! type-resolution facet (TS2322) that the no-lib multi-file harness supports.
+//!
+//! Cases vary the interface name, the imported binding name, and the import
+//! shape (`import`, `import type`) to prove the rule is structural and not keyed
+//! to any single spelling.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file_with_global_index;
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+/// Return the error codes emitted for the entry file of a multi-file project.
+fn codes(files: &[(&str, &str)], entry: &str) -> Vec<u32> {
+    check_multi_file_with_global_index(files, entry, opts())
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn default_imported_inline_interface_resolves_type_for_ts2322() {
+    // The imported interface type must be live for assignability: assigning its
+    // `number` property to a `string` is TS2322. If the annotation widened to
+    // `any` (the bug), no TS2322 would fire.
+    let codes = codes(
+        &[
+            ("a.ts", "export default interface A { value: number; }\n"),
+            (
+                "b.ts",
+                "import A from './a';\nvar a: A;\nconst bad: string = a.value;\n",
+            ),
+        ],
+        "b.ts",
+    );
+    assert!(
+        codes.contains(&2322),
+        "default-imported inline interface property type must be live (TS2322), got: {codes:?}"
+    );
+}
+
+#[test]
+fn renamed_default_import_of_inline_interface_resolves_type() {
+    // Vary both binder names: the interface is `Widget`, the import binding is
+    // `Gadget`. The rule must not depend on the names matching.
+    let codes = codes(
+        &[
+            (
+                "widget.ts",
+                "export default interface Widget { size: number; }\n",
+            ),
+            (
+                "use.ts",
+                "import Gadget from './widget';\ndeclare const g: Gadget;\nconst bad: string = g.size;\n",
+            ),
+        ],
+        "use.ts",
+    );
+    assert!(
+        codes.contains(&2322),
+        "renamed default import of inline interface must resolve type (TS2322), got: {codes:?}"
+    );
+}
+
+#[test]
+fn import_type_default_of_inline_interface_resolves_type() {
+    // `import type` default of an inline interface must also resolve the type.
+    let codes = codes(
+        &[
+            ("m.ts", "export default interface Conf { level: number; }\n"),
+            (
+                "u.ts",
+                "import type C from './m';\ndeclare const c: C;\nconst bad: string = c.level;\n",
+            ),
+        ],
+        "u.ts",
+    );
+    assert!(
+        codes.contains(&2322),
+        "import type default of inline interface must resolve type (TS2322), got: {codes:?}"
+    );
+}
+
+#[test]
+fn default_imported_inline_interface_is_not_widened_to_any() {
+    // Negative facet: a property that does NOT exist on the imported interface
+    // must surface TS2339. If the annotation widened to `any` (the bug), the
+    // missing-property access would be silently accepted.
+    let codes = codes(
+        &[
+            (
+                "model.ts",
+                "export default interface Model { name: string; }\n",
+            ),
+            (
+                "view.ts",
+                "import Model from './model';\ndeclare const m: Model;\nconst missing = m.doesNotExist;\n",
+            ),
+        ],
+        "view.ts",
+    );
+    assert!(
+        codes.contains(&2339),
+        "default-imported inline interface must not widen to `any` (expect TS2339), got: {codes:?}"
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -22,7 +22,6 @@ TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules
 TypeScript/tests/cases/compiler/declarationsIndirectGeneratedAliasReference.ts
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
-TypeScript/tests/cases/compiler/exportDefaultInterface.ts
 TypeScript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
 TypeScript/tests/cases/compiler/inferFromNestedSameShapeTuple.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts


### PR DESCRIPTION
## Agent
AgentName: M1-Opus

## Track
Conformance / checker semantic fix.

## Invariant
When a locally-declared variable's type annotation references a cross-file type that is a default-imported inline `export default interface A {}`, `tsc` resolves the annotation to the interface type and still runs definite-assignment (`TS2454`) and assignability (`TS2322`) on the consuming file. This PR makes tsz do that through checker alias type resolution (`compute_type_of_symbol`) without binder, solver, or emitter changes.

## Structural Rule
The binder models `export default interface A {}` as a type-only `"default"` alias symbol whose declaration is the inline `INTERFACE_DECLARATION` node, with no `value_declaration`. When an alias has no `import_module`, no `value_declaration`, and one of its declarations is an inline `INTERFACE_DECLARATION` / `TYPE_ALIAS_DECLARATION`, the checker resolves to the local interface/type-alias symbol the binder declared for that node's name and requests that symbol's type. The match is structural: binder symbol flags plus declaration node kind, with no identifier or file-name string driving the decision.

## Scope
- `crates/tsz-checker` alias type resolution (`compute_type_of_symbol` helper path).
- `crates/tsz-checker/tests/export_default_interface_type_import_tests.rs`.
- `scripts/conformance/conformance-accepted-regressions.txt` removes the fixed `exportDefaultInterface.ts` entry.

## Project Corpus Impact
- Row: none expected.
- Bug family: cross-file alias type resolution / definite-assignment false negative.
- Evidence: checker-only diagnostic fix for a niche default-export type shape; no project harness or emitted output path changes.

## Verification
Refreshed remote head `950671f52d` on `origin/main` `8ed5000182`:
- `cargo fmt --check`.
- `git diff --check`.
- `python3 scripts/arch/arch_guard.py`.
- `python3 scripts/conformance/query-conformance.py --dashboard` -> `12585/12585`, accepted-regression gate `26`.
- `! rg -n 'exportDefaultInterface\.ts' scripts/conformance/conformance-accepted-regressions.txt`.
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test export_default_interface_type_import_tests` -> 4 passed.
- `scripts/safe-run.sh scripts/conformance/conformance.sh run --filter exportDefaultInterface` -> 6/6 passed, including `TypeScript/tests/cases/compiler/exportDefaultInterface.ts`.
- PR-head CI on `950671f52d`: `CI Summary=SUCCESS` (run `26958934093`), `gate=SUCCESS`, `project-corpus-pr-body=SUCCESS`, GitGuardian green.

## Coordination Notes
- Refreshed after current `main` advanced through #12432; the PR is no longer conflicting and the current-main architecture guard passes.
- Remote branch `origin/m1opus/ts2454-cross-file-type-annotation` is source of truth at `950671f52d`. A local refresh merge commit was created in `/Users/mohsen/code/tsz-ts2454-cross-file-refresh-20260604` but not pushed because the remote branch had already been refreshed equivalently.

---
_Authored by M1-Opus._
