### PR TITLE
fix(solver): inherit modifiers for self-indexed mapped types `{ [Q in P]: T[P] }`

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -35,6 +35,10 @@ name = "nested_discriminant_narrowing_tests"
 path = "tests/nested_discriminant_narrowing_tests.rs"
 
 [[test]]
+name = "homomorphic_self_indexed_mapped_modifier_tests"
+path = "tests/homomorphic_self_indexed_mapped_modifier_tests.rs"
+
+[[test]]
 name = "inference_placeholder_determinism_tests"
 path = "tests/inference_placeholder_determinism_tests.rs"
 

--- a/crates/tsz-checker/tests/homomorphic_self_indexed_mapped_modifier_tests.rs
+++ b/crates/tsz-checker/tests/homomorphic_self_indexed_mapped_modifier_tests.rs
@@ -1,0 +1,202 @@
+//! Homomorphic modifier inheritance for self-indexed mapped types
+//! `{ [Q in P]: T[P] }`.
+//!
+//! Structural rule: tsc derives a mapped type's modifier source from its
+//! iteration constraint's type parameter (`getModifiersTypeFromMappedType`
+//! follows `P`'s `keyof T` constraint to `T`). When such a mapped type's
+//! constraint parameter `P` is substituted by a single property key `k`, the
+//! template `T[P]` denotes `T[k]` = `T[Q]` (the sole iterated key), so the
+//! result must inherit `T`'s `readonly`/optional modifier for `k`. tsz
+//! previously preserved this only when the template indexed by the iteration
+//! variable (`T[Q]`); the source-key form (`T[P]`) dropped the `readonly`
+//! modifier, which silently broke the ts-essentials `ReadonlyKeys` /
+//! `WritableKeys` / `MarkWritable` family (the `IfEquals` identity trick
+//! compares `{ [Q in P]: T[P] }` against `{ -readonly [Q in P]: T[P] }`).
+//!
+//! Binder names are varied across cases so the rule is structural, not keyed to
+//! any particular alias/property/type-parameter spelling (anti-hardcoding).
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_codes(source)
+        .into_iter()
+        // 2318 = "Cannot find global type" noise in minimal-lib harness runs.
+        .filter(|&code| code != 2318)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Positive: `T[P]` over a readonly named property keeps it readonly (TS2540).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn self_indexed_mapped_preserves_readonly_named_property_emits_2540() {
+    let source = r#"
+type Obj = { readonly a: number; b: string };
+type Probe<T, P extends keyof T> = { [Q in P]: T[P] };
+type Picked = Probe<Obj, "a">;
+declare const picked: Picked;
+picked.a = 1;
+"#;
+    let codes = codes(source);
+    assert!(
+        codes.contains(&2540),
+        "self-indexed mapped `T[P]` over readonly property must keep readonly (TS2540). Got: {codes:?}"
+    );
+}
+
+/// Same rule, completely different binder names — proves it is structural.
+#[test]
+fn self_indexed_mapped_preserves_readonly_named_property_emits_2540_renamed() {
+    let source = r#"
+type Record = { readonly handle: number; label: string };
+type Lift<Src, Key extends keyof Src> = { [Member in Key]: Src[Key] };
+type Held = Lift<Record, "handle">;
+declare const held: Held;
+held.handle = 42;
+"#;
+    let codes = codes(source);
+    assert!(
+        codes.contains(&2540),
+        "renamed self-indexed mapped `Src[Key]` over readonly property must keep readonly (TS2540). Got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative: a writable source property stays writable (no TS2540).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn self_indexed_mapped_writable_property_stays_writable_no_2540() {
+    let source = r#"
+type Obj = { readonly a: number; b: string };
+type Probe<T, P extends keyof T> = { [Q in P]: T[P] };
+type Picked = Probe<Obj, "b">;
+declare const picked: Picked;
+picked.b = "x";
+"#;
+    let codes = codes(source);
+    assert!(
+        !codes.contains(&2540),
+        "writable source property must not become readonly. Got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Positive: `T[P]` over a readonly array property keeps the readonly index
+// signature, so an element write reports TS2542.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn self_indexed_mapped_preserves_readonly_array_emits_2542() {
+    let source = r#"
+type Obj = { readonly items: readonly number[] };
+type Probe<T, P extends keyof T> = { [Q in P]: T[P] };
+type Picked = Probe<Obj, "items">;
+declare const picked: Picked;
+picked.items[0] = 1;
+"#;
+    let codes = codes(source);
+    assert!(
+        codes.contains(&2542),
+        "self-indexed mapped over a readonly array property must keep the readonly index signature (TS2542). Got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative: an explicit `-readonly` modifier still removes readonly even on the
+// self-indexed `T[P]` form.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn self_indexed_mapped_minus_readonly_removes_readonly_no_2540() {
+    let source = r#"
+type Obj = { readonly a: number };
+type Unlock<T, P extends keyof T> = { -readonly [Q in P]: T[P] };
+type Opened = Unlock<Obj, "a">;
+declare const opened: Opened;
+opened.a = 5;
+"#;
+    let codes = codes(source);
+    assert!(
+        !codes.contains(&2540),
+        "`-readonly` must remove readonly even for the self-indexed template. Got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative (single-key guard): a multi-key constraint must NOT collapse to a
+// per-key homomorphic form — `{ [Q in P]: T[P] }` with `P = "a" | "b"` gives
+// each property the union `T["a" | "b"]`, so reading a property as the union
+// type is accepted (no TS2322).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn self_indexed_mapped_multi_key_keeps_union_value_no_2322() {
+    let source = r#"
+type Obj = { a: number; b: string };
+type Probe<T, P extends keyof T> = { [Q in P]: T[P] };
+type Both = Probe<Obj, "a" | "b">;
+declare const both: Both;
+const a: number | string = both.a;
+const b: number | string = both.b;
+"#;
+    let codes = codes(source);
+    assert!(
+        !codes.contains(&2322),
+        "multi-key self-indexed mapped must keep the union value type. Got: {codes:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: the ts-essentials `ReadonlyKeys` / `WritableKeys` trick now
+// distinguishes readonly from writable keys.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn readonly_keys_writable_keys_trick_distinguishes_mutability() {
+    let source = r#"
+type IfEquals<X, Y, A, B> =
+  (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? A : B;
+type ReadonlyKeys<T> = {
+  [P in keyof T]-?: IfEquals<{ [Q in P]: T[P] }, { -readonly [Q in P]: T[P] }, never, P>
+}[keyof T];
+type WritableKeys<T> = {
+  [P in keyof T]-?: IfEquals<{ [Q in P]: T[P] }, { -readonly [Q in P]: T[P] }, P, never>
+}[keyof T];
+type Obj = { readonly a: number; b: string; readonly c: boolean };
+const ra: ReadonlyKeys<Obj> = "a";
+const rc: ReadonlyKeys<Obj> = "c";
+const wb: WritableKeys<Obj> = "b";
+"#;
+    let codes = codes(source);
+    assert!(
+        !codes.contains(&2322),
+        "ReadonlyKeys/WritableKeys must accept the correct readonly/writable keys. Got: {codes:?}"
+    );
+}
+
+/// Negative side of the trick: a writable key is not a `ReadonlyKeys` member and
+/// a readonly key is not a `WritableKeys` member — both assignments must error.
+#[test]
+fn readonly_keys_writable_keys_trick_rejects_wrong_keys() {
+    let source = r#"
+type IfEquals<X, Y, A, B> =
+  (<T>() => T extends X ? 1 : 2) extends (<T>() => T extends Y ? 1 : 2) ? A : B;
+type ReadonlyKeys<T> = {
+  [P in keyof T]-?: IfEquals<{ [Q in P]: T[P] }, { -readonly [Q in P]: T[P] }, never, P>
+}[keyof T];
+type WritableKeys<T> = {
+  [P in keyof T]-?: IfEquals<{ [Q in P]: T[P] }, { -readonly [Q in P]: T[P] }, P, never>
+}[keyof T];
+type Obj = { readonly a: number; b: string; readonly c: boolean };
+const wrongReadonly: ReadonlyKeys<Obj> = "b";
+const wrongWritable: WritableKeys<Obj> = "a";
+"#;
+    let codes = codes(source);
+    assert!(
+        codes.iter().filter(|&&c| c == 2322).count() >= 2,
+        "ReadonlyKeys/WritableKeys must reject the wrong-mutability keys (two TS2322). Got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -289,6 +289,65 @@ impl<'a> TypeInstantiator<'a> {
         self.shadowed.contains(&name)
     }
 
+    /// Restore the homomorphic modifier source of a self-indexed mapped type
+    /// `{ [Q in P]: T[P] }` when its constraint parameter `P` is substituted by a
+    /// single property key.
+    ///
+    /// tsc derives a mapped type's modifier source from its iteration
+    /// constraint's type parameter (`getModifiersTypeFromMappedType` follows
+    /// `P`'s `keyof T` constraint to `T`). Bare substitution of `P := "k"`
+    /// rewrites the template `T[P]` to `T["k"]`, erasing that link, so the
+    /// inherited `readonly`/optional modifiers of `T`'s key are dropped. This is
+    /// the substrate of ts-essentials' `ReadonlyKeys` / `WritableKeys` /
+    /// `MarkWritable`, where the `IfEquals` identity trick compares
+    /// `{ [Q in P]: T[P] }` against `{ -readonly [Q in P]: T[P] }`.
+    ///
+    /// Because the sole iterated key `Q` equals `P` here, `T[P]` denotes `T[Q]`.
+    /// Rewriting the template index from the constraint parameter `P` to the
+    /// iteration variable `Q` restores the homomorphic form so the evaluator
+    /// inherits `T`'s per-key modifiers, matching tsc — without changing the
+    /// property's value type. The single-key guard is essential: for a union of
+    /// keys `T[P]` is the union of all key values, which `T[Q]` (per-key) would
+    /// not preserve.
+    fn rewrite_single_key_self_indexed_template(&self, mapped: &MappedType) -> Option<TypeId> {
+        // Constraint must be a bare type parameter `P` (the homomorphic
+        // iteration variable), distinct from this mapped type's own iteration
+        // variable `Q`, neither shadowed nor still free. This gate rejects the
+        // common `{ [K in keyof T]: ... }` form (constraint is `KeyOf`) up front.
+        let TypeData::TypeParameter(constraint_param) = self.interner.lookup(mapped.constraint)?
+        else {
+            return None;
+        };
+        let p_name = constraint_param.name;
+        if p_name == mapped.type_param.name || self.is_shadowed(p_name) {
+            return None;
+        }
+        // Template must be the self-index `T[P]` (index is the constraint
+        // parameter, not already the iteration variable `Q`). Checked before the
+        // potentially-expensive evaluation below so non-matching templates exit
+        // cheaply.
+        let TypeData::IndexAccess(source, index) = self.interner.lookup(mapped.template)? else {
+            return None;
+        };
+        let TypeData::TypeParameter(index_param) = self.interner.lookup(index)? else {
+            return None;
+        };
+        if index_param.name != p_name {
+            return None;
+        }
+        // `P` must be substituted with a single property key. A union of keys
+        // would change `T[P]` (the union of all key values) into a per-key
+        // `T[Q]`, so it is intentionally excluded.
+        let substituted = self.substitution.get(p_name)?;
+        let resolved = crate::evaluation::evaluate::evaluate_type(self.interner, substituted);
+        if !crate::type_queries::is_type_usable_as_property_name(self.interner, resolved) {
+            return None;
+        }
+        // Rewrite `T[P]` to `T[Q]` (Q = this mapped type's iteration variable).
+        let iter_var = self.interner.type_param(mapped.type_param);
+        Some(self.interner.index_access(source, iter_var))
+    }
+
     /// Whether the unmapped-TypeParameter constraint-fallback at
     /// `instantiate_inner` is safe to apply for `name`.
     ///
@@ -1287,9 +1346,21 @@ impl<'a> TypeInstantiator<'a> {
 
             // Mapped: instantiate constraint and template
             TypeData::Mapped(mapped_id) => {
-                let mapped = self.interner.get_mapped(*mapped_id);
+                let mut mapped = self.interner.get_mapped(*mapped_id);
                 let tp_slice = std::slice::from_ref(&mapped.type_param);
                 let (shadowed_len, saved_visiting) = self.enter_shadowing_scope(tp_slice);
+
+                // Restore homomorphic modifier inheritance for a self-indexed
+                // mapped type `{ [Q in P]: T[P] }` whose constraint parameter is
+                // substituted by a single key (ts-essentials `ReadonlyKeys` /
+                // `WritableKeys` substrate). Done before the constraint/template
+                // substitution below collapses `T[P]` to `T["k"]`.
+                if let Some(rewritten) = self.rewrite_single_key_self_indexed_template(&mapped) {
+                    mapped = MappedType {
+                        template: rewritten,
+                        ..mapped
+                    };
+                }
 
                 // Homomorphic array/tuple handling must run before standard
                 // instantiation collapses `keyof T` to a flat union.


### PR DESCRIPTION
AgentName: Studio-B
ContributorIdentity: confident-hawking

## Track
Solver mapped-type instantiation / homomorphic modifier inheritance for the ts-essentials `ReadonlyKeys` / `WritableKeys` substrate. Advances #10792 and the mapped/keyof family tracked in #8432.

## Invariant
When a homomorphic mapped type `{ [Q in P]: T[P] }` has its constraint type parameter `P` substituted by a single property key, `tsc` keeps the source `readonly`/optional modifier because the mapped type still follows `P`'s `keyof T` constraint back to `T`. `tsz` should preserve that modifier instead of severing the homomorphic link during substitution.

## Scope
- Solver mapped instantiation: `crates/tsz-solver/src/instantiation/instantiate.rs`.
- Rewrites the template index `P` to the iteration variable `Q` before substitution collapses `T[P]` to `T["k"]`.
- Adds checker regressions for the readonly/writable key utility surface.

## Project Corpus Impact
- Row: n/a in sandbox; advances `ts-essentials-project` recursive-utility substrate from #10792.
- Bug family: homomorphic mapped-type modifier inheritance under instantiation.

## Verification
- `cargo fmt --check -p tsz-solver -p tsz-checker`.
- `cargo clippy -p tsz-solver -p tsz-checker --release --tests`.
- `homomorphic_self_indexed_mapped_modifier_tests.rs` regression suite, 8/8 passing.
- Full `tsz-solver` suite, reported 6525 passed / 0 failed.
- `tsz-checker` mapped/readonly/homomorphic filters, with reported pre-existing #8432 mapped/keyof failures only.
- Differential check against `tsc` 6.0.2 across ts-essentials utility battery.

## Coordination Notes
- Generated by Claude Code as `confident-hawking`.
- #10792 is canonically owned by `agent:Studio-B`; this PR is normalized to Studio-B.
- Potential overlap/coordination risk: #10792 was just cleaned up to keep Studio-B focused on #12473 before reclaiming another bug. Do not queue this PR until Studio-B resolves whether #12477 should remain active alongside #12473.
- GitHub auto-merge is disabled; repo-local queue admission requires exact-head green checks and manager review.
