### PR TITLE
perf(checker): decouple source option-bag lowering from cache eligibility

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -2,6 +2,7 @@
 //! delegating type resolution to child checkers, tracking cross-file targets,
 //! and cross-file interface declaration merging.
 use crate::state::CheckerState;
+use crate::state_type_analysis::cross_file_direct::is_direct_lowering_source_file_arena;
 use crate::symbols_domain::name_text::expression_name_text_in_arena;
 use crate::types_domain::queries::lib_resolution::keyword_syntax_to_type_id;
 use tsz_binder::{SymbolId, symbol_flags};
@@ -709,7 +710,8 @@ impl<'a> CheckerState<'a> {
                         delegate_binder,
                         symbol_arena,
                         false,
-                        symbol_type_cache_from_symbol_arena,
+                        symbol_type_cache_from_symbol_arena
+                            || is_direct_lowering_source_file_arena(symbol_arena),
                     )
             {
                 self.ctx.symbol_types.insert(sym_id, direct_type);

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct.rs
@@ -58,7 +58,7 @@ fn is_direct_lowering_declaration_arena(arena: &NodeArena) -> bool {
     })
 }
 
-pub(super) fn is_direct_lowering_source_file_arena(arena: &NodeArena) -> bool {
+pub(crate) fn is_direct_lowering_source_file_arena(arena: &NodeArena) -> bool {
     arena
         .source_files
         .first()
@@ -77,3 +77,7 @@ mod actual_lib_tests;
 #[cfg(test)]
 #[path = "cross_file_direct_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "cross_file_direct_source_option_bag_tests.rs"]
+mod source_option_bag_tests;

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_source_option_bag_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_source_option_bag_tests.rs
@@ -1,0 +1,440 @@
+//! Tests for decoupling source-file option-bag direct lowering from
+//! shared symbol-arena cache eligibility (issue #7531).
+//!
+//! Structural rule: when a cross-file source-file interface is an unmerged
+//! option-bag shape (only property signatures with scope-independent or
+//! direct-lowerable-sibling annotations), tsz can lower it directly via
+//! `delegate_cross_arena_symbol_resolution` without constructing a child
+//! checker, even when the shared symbol-arena cache is ineligible.
+//!
+//! Cache ineligibility happens on two hot project-row paths: the cross-file
+//! delegation path (`needs_cross_file_delegation = true`), where
+//! `symbol_type_cache_from_symbol_arena` is `false` by definition; and
+//! programs with any module augmentation, where the shared-cache gate is
+//! disabled program-wide.
+//!
+//! The structural option-bag guard inside `direct_cross_file_interface_lowering`
+//! remains the safety gate, so heritage/computed/complex shapes still fall back
+//! to the child-checker path.
+
+use crate::context::{CheckerContext, CheckerOptions};
+use crate::query_boundaries::common::TypeInterner;
+use crate::state::CheckerState;
+use std::sync::Arc;
+use tsz_binder::{BinderState, ModuleAugmentation};
+use tsz_common::perf_counters::{DirectCrossFileInterfaceLoweringOutcome, PerfCounters};
+use tsz_parser::NodeIndex;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeId;
+use tsz_solver::def::DefinitionStore;
+
+fn parse_bound_source_with_name(
+    file_name: &str,
+    source: &str,
+) -> (
+    Arc<tsz_parser::parser::node::NodeArena>,
+    Arc<BinderState>,
+    TypeInterner,
+) {
+    let mut parser = ParserState::new(file_name.to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    (
+        Arc::new(parser.get_arena().clone()),
+        Arc::new(binder),
+        TypeInterner::new(),
+    )
+}
+
+/// Build a checker whose `requester` arena has no local declaration of
+/// `symbol_name`, with `symbol_name` owned by the `target` file through the
+/// cross-file symbol-file index. This forces `needs_cross_file_delegation`,
+/// the path where `symbol_type_cache_from_symbol_arena` is always `false`.
+fn setup_cross_file_index_state<'a>(
+    symbol_name: &str,
+    types: &'a TypeInterner,
+    requester_arena: &'a Arc<tsz_parser::parser::node::NodeArena>,
+    requester_binder: &'a Arc<BinderState>,
+    target_arena: &Arc<tsz_parser::parser::node::NodeArena>,
+    target_binder: &Arc<BinderState>,
+) -> (CheckerState<'a>, tsz_binder::SymbolId) {
+    let sym = target_binder
+        .file_locals
+        .get(symbol_name)
+        .unwrap_or_else(|| panic!("{symbol_name} symbol not found in target binder"));
+
+    let requester_file_name = requester_arena
+        .source_files
+        .first()
+        .expect("requester arena has source file")
+        .file_name
+        .clone();
+    let mut ctx = CheckerContext::new_with_shared_def_store(
+        requester_arena.as_ref(),
+        requester_binder.as_ref(),
+        types,
+        requester_file_name,
+        CheckerOptions::default(),
+        Arc::new(DefinitionStore::new()),
+    );
+    ctx.share_owner_symbol_type_results = true;
+    ctx.set_all_arenas(Arc::new(vec![
+        Arc::clone(requester_arena),
+        Arc::clone(target_arena),
+    ]));
+    ctx.set_all_binders(Arc::new(vec![
+        Arc::clone(requester_binder),
+        Arc::clone(target_binder),
+    ]));
+    let state = CheckerState { ctx };
+
+    let target_file_idx = state
+        .ctx
+        .get_file_idx_for_arena(target_arena.as_ref())
+        .expect("target arena should be indexed");
+    state.ctx.register_symbol_file_index(sym, target_file_idx);
+    (state, sym)
+}
+
+fn enable_perf_counters_for_direct_lowering_test() {
+    #[cfg(any(test, debug_assertions))]
+    tsz_common::perf_counters::force_enable_perf_counters_for_tests();
+    assert!(
+        tsz_common::perf_counters::enabled_fast(),
+        "direct-lowering branch tests need perf counters enabled"
+    );
+}
+
+fn direct_interface_lowering_count(outcome: DirectCrossFileInterfaceLoweringOutcome) -> u64 {
+    PerfCounters::snapshot().direct_interface_lowering_outcomes[outcome.as_index()].count
+}
+
+fn with_parent_cache_constructed_count() -> u64 {
+    PerfCounters::snapshot()
+        .checker
+        .with_parent_cache_constructed
+}
+
+/// Root cause #1: the cross-file delegation path always sees
+/// `symbol_type_cache_from_symbol_arena == false`, so the option-bag fast path
+/// was never eligible. After decoupling, a scope-independent option-bag
+/// interface lowers directly without a child checker.
+#[test]
+fn delegate_cross_arena_source_option_bag_lowers_directly_via_cross_file_index() {
+    let (target_arena, target_binder, types) = parse_bound_source_with_name(
+        "config.ts",
+        r#"
+                export interface PluginConfig {
+                    enabled: boolean;
+                    timeout: number;
+                    tag: "fast" | "slow";
+                }
+            "#,
+    );
+    let (requester_arena, requester_binder, _) =
+        parse_bound_source_with_name("app.ts", "// imports PluginConfig from config");
+
+    let (mut state, plugin_sym) = setup_cross_file_index_state(
+        "PluginConfig",
+        &types,
+        &requester_arena,
+        &requester_binder,
+        &target_arena,
+        &target_binder,
+    );
+
+    enable_perf_counters_for_direct_lowering_test();
+    let success_before =
+        direct_interface_lowering_count(DirectCrossFileInterfaceLoweringOutcome::Success);
+    let child_checkers_before = with_parent_cache_constructed_count();
+    let (ty, params) = state
+        .delegate_cross_arena_symbol_resolution(plugin_sym)
+        .expect("cross-file source-file option-bag interface should delegate successfully");
+    let success_after =
+        direct_interface_lowering_count(DirectCrossFileInterfaceLoweringOutcome::Success);
+    let child_checkers_after = with_parent_cache_constructed_count();
+
+    assert_eq!(
+        success_after - success_before,
+        1,
+        "PluginConfig should hit direct cross-file interface lowering"
+    );
+    assert_eq!(
+        child_checkers_after, child_checkers_before,
+        "direct source-file option-bag lowering must not construct a delegated child checker"
+    );
+
+    assert_ne!(
+        ty,
+        TypeId::UNKNOWN,
+        "PluginConfig must not lower to UNKNOWN"
+    );
+    assert_ne!(ty, TypeId::ERROR, "PluginConfig must not lower to ERROR");
+    assert!(params.is_empty(), "PluginConfig should be non-generic");
+    let enabled = state.ctx.types.intern_string("enabled");
+    assert!(
+        crate::query_boundaries::common::raw_property_type(
+            state.ctx.types.as_type_database(),
+            ty,
+            enabled,
+        )
+        .is_some(),
+        "directly lowered PluginConfig should retain 'enabled' property",
+    );
+}
+
+/// Same cross-file delegation path, but the option-bag references a same-file
+/// sibling alias. The sibling must resolve through the delegate binder's lazy
+/// `DefId`, still without a child checker.
+#[test]
+fn delegate_cross_arena_source_option_bag_with_sibling_alias_lowers_directly_via_cross_file_index()
+{
+    let (target_arena, target_binder, types) = parse_bound_source_with_name(
+        "task.ts",
+        r#"
+                type Priority = "high" | "low" | "none";
+                export interface WorkItem {
+                    priority: Priority;
+                    retries: number;
+                }
+            "#,
+    );
+    let (requester_arena, requester_binder, _) =
+        parse_bound_source_with_name("runner.ts", "// imports WorkItem from task");
+
+    let (mut state, work_item_sym) = setup_cross_file_index_state(
+        "WorkItem",
+        &types,
+        &requester_arena,
+        &requester_binder,
+        &target_arena,
+        &target_binder,
+    );
+
+    enable_perf_counters_for_direct_lowering_test();
+    let success_before =
+        direct_interface_lowering_count(DirectCrossFileInterfaceLoweringOutcome::Success);
+    let child_checkers_before = with_parent_cache_constructed_count();
+    let (ty, params) = state
+        .delegate_cross_arena_symbol_resolution(work_item_sym)
+        .expect("cross-file option-bag with sibling alias should delegate successfully");
+    let success_after =
+        direct_interface_lowering_count(DirectCrossFileInterfaceLoweringOutcome::Success);
+    let child_checkers_after = with_parent_cache_constructed_count();
+
+    assert_eq!(
+        success_after - success_before,
+        1,
+        "WorkItem should hit direct cross-file interface lowering"
+    );
+    assert_eq!(
+        child_checkers_after, child_checkers_before,
+        "direct option-bag lowering with sibling aliases must not construct a delegated child checker"
+    );
+
+    assert_ne!(ty, TypeId::UNKNOWN);
+    assert_ne!(ty, TypeId::ERROR);
+    assert!(params.is_empty(), "WorkItem should be non-generic");
+    let priority = state.ctx.types.intern_string("priority");
+    let priority_type = crate::query_boundaries::common::raw_property_type(
+        state.ctx.types.as_type_database(),
+        ty,
+        priority,
+    )
+    .expect("directly lowered WorkItem should retain 'priority' property");
+    // The sibling annotation must resolve through the delegate file's binder,
+    // i.e. its lazy DefId points at the target file's `Priority`, not at a
+    // same-spelled symbol in the requester file.
+    let target_priority_sym = target_binder
+        .file_locals
+        .get("Priority")
+        .expect("Priority sibling symbol in delegate file");
+    let target_priority_def = state.ctx.get_or_create_def_id(target_priority_sym);
+    assert_eq!(
+        crate::query_boundaries::common::lazy_def_id(
+            state.ctx.types.as_type_database(),
+            priority_type,
+        ),
+        Some(target_priority_def),
+        "the 'priority' annotation should resolve to the delegate file's Priority sibling",
+    );
+}
+
+/// Root cause #2: when the program has any module augmentation, the shared
+/// symbol-arena cache gate is disabled program-wide, so
+/// `symbol_type_cache_from_symbol_arena` is `false` even on the symbol-arena
+/// delegation path. The option-bag interface must still lower directly.
+#[test]
+fn delegate_cross_arena_source_option_bag_resolves_in_program_with_module_augmentations() {
+    let (target_arena, target_binder, types) = parse_bound_source_with_name(
+        "options.ts",
+        r#"
+                export interface BuildOptions {
+                    minify: boolean;
+                    sourcemap: boolean;
+                }
+            "#,
+    );
+    let (requester_arena, mut requester_binder, _) =
+        parse_bound_source_with_name("build.ts", "// imports BuildOptions from options");
+    let build_opts_sym = target_binder
+        .file_locals
+        .get("BuildOptions")
+        .expect("BuildOptions symbol");
+    let build_opts_decl = target_binder
+        .get_symbol(build_opts_sym)
+        .expect("BuildOptions symbol data")
+        .declarations[0];
+    {
+        let rb = Arc::make_mut(&mut requester_binder);
+        Arc::make_mut(&mut rb.symbol_arenas).insert(build_opts_sym, Arc::clone(&target_arena));
+        Arc::make_mut(&mut rb.declaration_arenas)
+            .entry((build_opts_sym, build_opts_decl))
+            .or_default()
+            .push(Arc::clone(&target_arena));
+        Arc::make_mut(&mut rb.module_augmentations).insert(
+            "./other-module".to_string(),
+            vec![ModuleAugmentation::new("x".to_string(), NodeIndex::NONE)],
+        );
+    }
+
+    let mut ctx = CheckerContext::new_with_shared_def_store(
+        requester_arena.as_ref(),
+        requester_binder.as_ref(),
+        &types,
+        "build.ts".to_string(),
+        CheckerOptions::default(),
+        Arc::new(DefinitionStore::new()),
+    );
+    ctx.share_owner_symbol_type_results = true;
+    ctx.set_all_arenas(Arc::new(vec![
+        Arc::clone(&requester_arena),
+        Arc::clone(&target_arena),
+    ]));
+    ctx.set_all_binders(Arc::new(vec![
+        Arc::clone(&requester_binder),
+        Arc::clone(&target_binder),
+    ]));
+    let mut state = CheckerState { ctx };
+    assert!(
+        state.ctx.program_has_module_augmentations(),
+        "fixture should make the source-file symbol-arena cache ineligible"
+    );
+
+    enable_perf_counters_for_direct_lowering_test();
+    let success_before =
+        direct_interface_lowering_count(DirectCrossFileInterfaceLoweringOutcome::Success);
+    let child_checkers_before = with_parent_cache_constructed_count();
+    let (ty, params) = state
+        .delegate_cross_arena_symbol_resolution(build_opts_sym)
+        .expect(
+            "source-file option-bag should delegate even when the program has module augmentations",
+        );
+    let success_after =
+        direct_interface_lowering_count(DirectCrossFileInterfaceLoweringOutcome::Success);
+    let child_checkers_after = with_parent_cache_constructed_count();
+
+    assert_eq!(
+        success_after - success_before,
+        1,
+        "BuildOptions should hit direct lowering even when module augmentations disable shared source-file symbol caching"
+    );
+    assert_eq!(
+        child_checkers_after, child_checkers_before,
+        "module-augmentation source-file option-bag lowering must not construct a delegated child checker"
+    );
+
+    assert_ne!(
+        ty,
+        TypeId::UNKNOWN,
+        "BuildOptions must not lower to UNKNOWN"
+    );
+    assert_ne!(ty, TypeId::ERROR, "BuildOptions must not lower to ERROR");
+    assert!(params.is_empty(), "BuildOptions should be non-generic");
+    let minify = state.ctx.types.intern_string("minify");
+    assert!(
+        crate::query_boundaries::common::raw_property_type(
+            state.ctx.types.as_type_database(),
+            ty,
+            minify,
+        )
+        .is_some(),
+        "BuildOptions should retain 'minify' property even with program-level augmentations present",
+    );
+}
+
+/// Safety gate: a source-file interface with heritage is not an option-bag
+/// shape, so the structural guard rejects it and it still falls back to the
+/// child-checker path. Decoupling must not broaden the admitted shape.
+#[test]
+fn delegate_cross_arena_source_interface_with_heritage_still_falls_back() {
+    let (target_arena, target_binder, types) = parse_bound_source_with_name(
+        "complex.ts",
+        r#"
+                export interface BaseOptions {
+                    enabled: boolean;
+                }
+                export interface ComplexOptions extends BaseOptions {
+                    timeout: number;
+                }
+            "#,
+    );
+    let (requester_arena, requester_binder, _) =
+        parse_bound_source_with_name("consumer.ts", "// imports ComplexOptions from complex");
+
+    let (mut state, complex_sym) = setup_cross_file_index_state(
+        "ComplexOptions",
+        &types,
+        &requester_arena,
+        &requester_binder,
+        &target_arena,
+        &target_binder,
+    );
+
+    enable_perf_counters_for_direct_lowering_test();
+    let success_before =
+        direct_interface_lowering_count(DirectCrossFileInterfaceLoweringOutcome::Success);
+    let complex_before = direct_interface_lowering_count(
+        DirectCrossFileInterfaceLoweringOutcome::ComplexDeclaration,
+    );
+    let child_checkers_before = with_parent_cache_constructed_count();
+    let (ty, params) = state
+        .delegate_cross_arena_symbol_resolution(complex_sym)
+        .expect("complex source-file interface should still delegate through fallback");
+    let success_after =
+        direct_interface_lowering_count(DirectCrossFileInterfaceLoweringOutcome::Success);
+    let complex_after = direct_interface_lowering_count(
+        DirectCrossFileInterfaceLoweringOutcome::ComplexDeclaration,
+    );
+    let child_checkers_after = with_parent_cache_constructed_count();
+
+    assert_eq!(
+        success_after, success_before,
+        "heritage-bearing source-file interfaces must not be admitted to direct lowering"
+    );
+    assert_eq!(
+        complex_after - complex_before,
+        1,
+        "heritage-bearing source-file interfaces should be rejected by the structural direct-lowering guard"
+    );
+    assert_eq!(
+        child_checkers_after - child_checkers_before,
+        1,
+        "complex source-file interfaces should fall back to delegated child-checker resolution"
+    );
+
+    assert_ne!(ty, TypeId::UNKNOWN);
+    assert_ne!(ty, TypeId::ERROR);
+    assert!(params.is_empty(), "ComplexOptions should be non-generic");
+    let timeout = state.ctx.types.intern_string("timeout");
+    assert!(
+        crate::query_boundaries::common::raw_property_type(
+            state.ctx.types.as_type_database(),
+            ty,
+            timeout,
+        )
+        .is_some(),
+        "fallback-lowered ComplexOptions should retain its own property",
+    );
+}

--- a/crates/tsz-common/src/perf_counters/definitions.rs
+++ b/crates/tsz-common/src/perf_counters/definitions.rs
@@ -34,12 +34,31 @@ impl PaddedAtomicU64 {
 /// numbers we're trying to collect.
 static ENABLED_FAST: OnceLock<bool> = OnceLock::new();
 
+/// Test-only override so unit tests that assert on counter deltas can opt
+/// into counting without depending on the `TSZ_PERF_COUNTERS` env var (and
+/// without being defeated by the `ENABLED_FAST` `OnceLock` having already
+/// latched `false`). Only compiled in test/debug builds; production builds
+/// keep the single env-gated `OnceLock` read.
+#[cfg(any(test, debug_assertions))]
+static FORCE_ENABLED_FOR_TESTS: AtomicBool = AtomicBool::new(false);
+
 /// Cheap O(1) gate readable from any hot path. Reads a `OnceLock<bool>`
 /// (one branch + one load) instead of going through `counters().enabled`
 /// (deref-via-OnceLock + load).
 #[inline(always)]
 pub fn enabled_fast() -> bool {
+    #[cfg(any(test, debug_assertions))]
+    if FORCE_ENABLED_FOR_TESTS.load(Ordering::Relaxed) {
+        return true;
+    }
     *ENABLED_FAST.get_or_init(|| std::env::var_os("TSZ_PERF_COUNTERS").is_some())
+}
+
+/// Force the perf-counter gate on for the current process. Test-only; lets a
+/// unit test observe `fetch_add` deltas regardless of env or `OnceLock` state.
+#[cfg(any(test, debug_assertions))]
+pub fn force_enable_perf_counters_for_tests() {
+    FORCE_ENABLED_FOR_TESTS.store(true, Ordering::Relaxed);
 }
 
 // Declarative manifest for enum-backed counter families. Each entry owns the


### PR DESCRIPTION
## Agent
AgentName: M4-Opus

## Track
Track 7 / Track 10: project-row cross-arena delegation performance (issue #7531).

## Summary
Lands the decoupling described in the issue body: source-file option-bag
interfaces can now be lowered directly (without constructing a child
`CheckerState`) even when the shared symbol-arena type cache is ineligible.
This is the residual fix after #7701 landed the option-bag *lowering* machinery
itself; #8177 carried this decoupling but was closed dirty/unmerged.

## Invariant
When a cross-file source-file interface is an unmerged option-bag shape (only
property signatures with scope-independent or direct-lowerable-sibling
annotations), tsz lowers it without a child checker regardless of shared-cache
eligibility. Heritage/computed/complex shapes continue to use the existing
child-checker fallback.

## Structural Rule
`direct_cross_file_interface_lowering`'s `allow_source_file_arena` gate was
fed `symbol_type_cache_from_symbol_arena`, which is `false` on the two hottest
project-row delegation paths:

1. **Cross-file delegation** (`needs_cross_file_delegation = true`):
   `symbol_type_cache_from_symbol_arena = symbol_type_cache_file_idx.is_some() && !needs_cross_file_delegation`,
   so it is `false` by definition here.
2. **Programs with any module augmentation**:
   `symbol_arena_symbol_type_cache_file_idx` returns `None` when
   `program_has_module_augmentations()` is true, disabling the gate
   program-wide (e.g. vite/nextjs projects).

On both paths a trivial property-only interface fell back to child-checker
construction even though it is safe to lower directly.

Fix: OR `is_direct_lowering_source_file_arena(symbol_arena)` into the
`allow_source_file_arena` argument at the single delegation call site. The
`||` short-circuits when the shared cache is already eligible (common path
unchanged). The structural option-bag guard inside
`direct_cross_file_interface_lowering` (heritage / computed names /
non-direct-lowerable members / sibling cycles / generics) remains the safety
gate. Results that miss shared-cache eligibility still land in the
per-checker `lib_delegation_cache` / cross-file cache exactly as before — only
the decision to *attempt* direct lowering changes.

## Owner Layer
Checker cross-file direct lowering owns the decision of whether a cross-file
query needs a child checker. Type construction stays in `TypeLowering`;
relation/evaluation semantics remain solver-owned. No new
user-name/file-name literals, no printer-output predicates.

## Scope
- `crates/tsz-checker/src/state/type_analysis/cross_file.rs` — import + OR-in
  the predicate at the `direct_cross_file_interface_lowering` call site.
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct.rs` —
  `is_direct_lowering_source_file_arena` `pub(super)` → `pub(crate)`; wire the
  new test module.
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_source_option_bag_tests.rs`
  — new; 4 focused tests.
- `crates/tsz-common/src/perf_counters/definitions.rs` — test/debug-only
  `force_enable_perf_counters_for_tests()` so the unit tests can observe
  counter deltas without the `TSZ_PERF_COUNTERS` env var. Zero production
  impact (the extra branch is `#[cfg(any(test, debug_assertions))]`).

## Adjacent Cases
- Scope-independent option bag via cross-file index (root cause #1) → direct,
  no child checker.
- Option bag with same-file sibling alias via cross-file index → direct; the
  sibling's lazy `DefId` resolves to the **delegate** file's symbol.
- Option bag in a program with module augmentations (root cause #2) → direct,
  no child checker.
- Interface with heritage → rejected by the structural guard, still falls back
  to the child checker (negative case).

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`, `nextjs-fresh-app`, `ts-essentials-project`
  (the cross-arena delegation / module-augmentation rows tracked in #7531).
- Bug family: O(N×M) child-checker construction for option-bag source-file
  interfaces on cache-ineligible delegation paths.
- Behavior is identical to the child-checker result for admitted shapes (the
  same `TypeLowering` produces the interface type); this removes the child
  `CheckerState` construction on the hot path.

## Verification
Local (`cargo nextest` is not installed in this environment; used `cargo test`
with `--test-threads=1` for the counter-delta tests):

```
cargo fmt --check -p tsz-checker -p tsz-common                      # clean
cargo clippy -p tsz-checker -p tsz-common --lib --tests -- -D warnings  # clean
cargo test -p tsz-checker --lib delegate_cross_arena_source -- --test-threads=1
    # 4 passed (the new tests)
```

Regression sweep (`cargo test -p tsz-checker --lib cross_file -- --test-threads=1`):
baseline `main` = 239 passed / 7 failed; this branch = 243 passed (+4 new) /
**same 7** failed. The 7 pre-existing failures (and 13 pre-existing
`architecture_contract` failures) reproduce identically on clean `main` in this
environment — they need the full lib `.d.ts` fixtures that aren't checked out
here. **This change introduces zero regressions.**

**Not run here:** project-row timing / perf counters
(`with_parent_cache_constructed`, `DelegateCrossArenaSymbol`, overlay copies).
This worktree has no `.target-bench` project fixtures, so a perf-capable runner
should confirm the row-level child-checker reduction and timing before this is
treated as closing the timing gate. The unit tests assert the mechanism
directly: each admitted shape records one `DirectCrossFileInterfaceLoweringOutcome::Success`
and **zero** `with_parent_cache_constructed` deltas.

## Coordination Notes
- Builds on #7701 (option-bag lowering machinery) and #7183/#7320/#7634.
- Supersedes the unmerged decoupling in #8177 (closed dirty); re-applied
  against current `main` as the narrow residual change only.
- Does not repeat the rejected broad external `.d.ts` cache or broad
  source-alias relaxation from #7531's discussion.
- Per the open-issue discussion (https://github.com/mohsen1/tsz/issues/7531#issuecomment-4504036853),
  maintainer may prefer to keep #7531 open until a perf runner verifies the
  remaining cross-arena delegation residue; `Fixes #7531` reflects that this PR
  implements the exact fix the issue body specifies, but the close decision can
  be revisited if broader residue work remains.

---
_Generated by [Claude Code](https://claude.ai/code/session_014a7UMRMew7HcVCoqgvzNeP)_
