### PR TITLE
fix(checker): render keyof of anonymous object literals as the key union

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs
@@ -7,6 +7,18 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    /// True when a `keyof` operand has no user-visible name: it is an object type
+    /// (typically an inline object type literal) with no binder symbol *and* no
+    /// type-alias name for display. Such an operand cannot be written as
+    /// `keyof Name`, so tsc renders the reduced key set (`"a" | "b"`) instead of
+    /// the `keyof { ... }` spelling. A named interface / class / alias fails this
+    /// predicate and keeps its `keyof Name` form.
+    pub(in crate::error_reporter) fn keyof_operand_is_anonymous(&self, operand: TypeId) -> bool {
+        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, operand)
+            .is_some_and(|shape| shape.symbol.is_none())
+            && self.lookup_type_alias_name_for_display(operand).is_none()
+    }
+
     /// True when `ty` is a `keyof X` whose operand `X` resolves to a plain object
     /// type with no string/number index signature. Only that shape yields a
     /// finite unit-literal key set (`"a" | "b"`, `0 | 1`), which tsc treats as a

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -891,10 +891,21 @@ impl<'a> CheckerState<'a> {
                 // For plain `keyof SomeName`, the annotation text is already correct
                 // (tsc shows `keyof A`, not the expanded literal union). Only route
                 // through TypeFormatter when the operand contains a union/intersection.
+                //
+                // An *anonymous* operand — an inline object type literal
+                // (`keyof { a: 1 }`) — has no writable name, so tsc renders the
+                // evaluated key set (`"a"`), not the `keyof { ... }` spelling.
+                // Route those through the TypeFormatter, which reduces the
+                // operator. A named operand keeps the annotation text.
+                let operand_is_anonymous = crate::query_boundaries::common::keyof_inner_type(
+                    self.ctx.types,
+                    display_target,
+                )
+                .is_some_and(|operand| self.keyof_operand_is_anonymous(operand));
                 let operand_text = display.trim_start_matches("keyof ").trim();
                 let needs_distribution = operand_text.contains('|')
                     || (operand_text.contains('&') && operand_text.starts_with('('));
-                if needs_distribution {
+                if needs_distribution || operand_is_anonymous {
                     return self.format_type_for_assignability_message(display_target);
                 }
                 return self.format_annotation_like_type(&display);

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -330,6 +330,26 @@ impl<'a> CheckerState<'a> {
             {
                 return format!("keyof {}", symbol.escaped_name);
             }
+
+            // Anonymous object operand (an inline `keyof { ... }` type literal):
+            // the operand has no user-visible name, so tsc renders the evaluated
+            // key set (`"a" | "b"`) rather than the `keyof { ... }` spelling — an
+            // index type only prints `keyof X` when `X` is a named reference. The
+            // alias-name branch above already returned for a named alias and the
+            // symbol-name branch for a symbol-bearing operand, so here it is
+            // enough to confirm the operand is an object with no binder symbol.
+            if crate::query_boundaries::common::object_shape_for_type(self.ctx.types, keyof_inner)
+                .is_some_and(|shape| shape.symbol.is_none())
+            {
+                let evaluated = self.evaluate_type_with_env(ty);
+                if evaluated != ty
+                    && evaluated != TypeId::ERROR
+                    && crate::query_boundaries::common::keyof_inner_type(self.ctx.types, evaluated)
+                        .is_none()
+                {
+                    return self.format_type_for_assignability_message(evaluated);
+                }
+            }
         }
 
         if let Some(alias_name) = self.lookup_type_alias_name_for_display(ty) {

--- a/crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs
@@ -15,6 +15,7 @@ use tsz_common::perf_counters::{
 use tsz_parser::NodeIndex;
 use tsz_parser::parser::node::{NodeAccess, NodeArena, TypeAliasData};
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 use tsz_solver::construction::TypeDatabase;
 
@@ -118,6 +119,29 @@ pub(crate) fn alias_declaration_body_is_computed(
                 && !crate::query_boundaries::diagnostics::union_or_intersection_mentions_object(
                     db, result,
                 )
+        }
+        // `keyof { ... }` over an inline object *type literal* is a reducing
+        // operator like indexed access: it resolves away into the operand's key
+        // set (a literal/primitive union) and never carries the alias's
+        // `aliasSymbol`, so tsc renders the underlying union, not the alias name.
+        // Verified against tsc 6.0.2: `type K = keyof { a: 1; b: 2 }` elaborates
+        // as `"a" | "b"`, never `K`.
+        //
+        // The gate is the *syntactic* operand shape: `keyof <TypeLiteral>` is
+        // anonymous (no writable name), so the alias name is the only handle and
+        // tsc drops it. `keyof Foo` over a named type reference keeps the
+        // `keyof Foo` spelling, and a generic `keyof T` stays deferred — neither
+        // reaches this flag because their operand node is not a `TypeLiteral`.
+        // This mirrors the conditional / indexed-access arms above.
+        syntax_kind_ext::TYPE_OPERATOR
+            if arena.get_type_operator(body_node).is_some_and(|op| {
+                op.operator == SyntaxKind::KeyOfKeyword as u16
+                    && arena
+                        .get(op.type_node)
+                        .is_some_and(|operand| operand.kind == syntax_kind_ext::TYPE_LITERAL)
+            }) =>
+        {
+            true
         }
         _ => false,
     }

--- a/crates/tsz-checker/src/tests/type_alias_computed_display_tests.rs
+++ b/crates/tsz-checker/src/tests/type_alias_computed_display_tests.rs
@@ -135,3 +135,77 @@ const h: Holder = { v: 0 };
         "expected a directly-written tuple alias to keep its name, got: {msg}"
     );
 }
+
+// ── `keyof` reducing-operator family (issue #12179 / #10914) ──────────────
+//
+// `keyof <anonymous object type literal>` is a reducing operator like an
+// indexed access: it resolves to the operand's key set and tsc renders that
+// union, dropping any alias name and the `keyof { ... }` spelling. A `keyof`
+// over a *named* operand keeps the `keyof Name` form. Binder names vary across
+// cases so a hardcoded fix cannot satisfy them.
+
+// 7. A non-generic alias whose body is `keyof { ... }` renders the key union.
+#[test]
+fn keyof_anonymous_object_literal_alias_renders_key_union() {
+    let msg = ts2322_target(
+        r#"
+type KeyAlias = keyof { alpha: 1; beta: 2 };
+type Holder = { v: KeyAlias };
+const h: Holder = { v: 0 };
+"#,
+    );
+    assert!(
+        msg.contains("\"alpha\" | \"beta\"") && !msg.contains("KeyAlias"),
+        "expected `keyof {{ ... }}` alias to render as the key union, got: {msg}"
+    );
+}
+
+// 8. Renamed binder, three keys — proves the rule is structural, not keyed on
+//    a specific identifier or arity.
+#[test]
+fn keyof_anonymous_object_literal_alias_renamed_binder() {
+    let msg = ts2322_target(
+        r#"
+type ColumnNames = keyof { id: 1; name: 2; createdAt: 3 };
+type Wrapper = { field: ColumnNames };
+const w: Wrapper = { field: 0 };
+"#,
+    );
+    assert!(
+        msg.contains("\"id\" | \"name\" | \"createdAt\"") && !msg.contains("ColumnNames"),
+        "expected renamed `keyof {{ ... }}` alias to render as the key union, got: {msg}"
+    );
+}
+
+// 9. Inline (un-aliased) `keyof { ... }` annotation also renders the key union.
+#[test]
+fn keyof_anonymous_object_literal_inline_renders_key_union() {
+    let msg = ts2322_target(
+        r#"
+const x: keyof { zebra: 1; quartz: 2 } = 0;
+"#,
+    );
+    assert!(
+        msg.contains("\"zebra\" | \"quartz\"") && !msg.contains("keyof {"),
+        "expected inline `keyof {{ ... }}` to render as the key union, got: {msg}"
+    );
+}
+
+// 10. Negative case: `keyof NamedInterface` keeps the `keyof Name` spelling and
+//     is never expanded to the literal key union — a named operand is not
+//     anonymous, so the operator form is preserved (the TYPE_LITERAL gate does
+//     not fire for a named type reference).
+#[test]
+fn keyof_named_interface_keeps_keyof_spelling() {
+    let msg = ts2322_target(
+        r#"
+interface Registry { red: 1; green: 2 }
+type RegistryKeys = keyof Registry;
+const h: RegistryKeys = 0;
+"#,
+    );
+    assert!(
+        msg.contains("keyof Registry") && !msg.contains("\"red\""),
+        "expected `keyof NamedInterface` to keep its operator spelling, got: {msg}"
+    );
+}


### PR DESCRIPTION
AgentName: M1-A
ContributorIdentity: claude-keyof-anon-display

Track: diagnostics / type-display (refs #12179)

Invariant: `keyof X` displays as `keyof X` only when `X` is a named reference;
when `X` is an anonymous object type literal, the index type resolves to its key
set and `tsc` renders that union (`"a" | "b"`), independent of alias spelling.

## Structural rule

When a type alias body (or an inline annotation) is `keyof` over an anonymous
object type literal, `tsc` treats it as a reducing operator — like an indexed
access: the operator resolves *away* into the operand's key set and the result
carries no `aliasSymbol`, so the diagnostic shows the underlying union, not the
alias name and not the `keyof { ... }` spelling. A `keyof` over a *named* operand
(interface / class / alias / type parameter) keeps the `keyof Name` form.

Owner layer: checker diagnostic rendering (fed by solver key-set evaluation). No
semantic decision is driven from formatted strings; gating is structural
(syntactic operand node kind, or type-level object-shape / name queries).

## Observed vs tsc (TS 6.0.2)

```ts
type K = keyof { a: 1; b: 2 };
const k: K = 'c';
//    tsc:          ... is not assignable to type '"a" | "b"'.
//    tsz (before): ... is not assignable to type 'K'.   (kept the alias name)

const x: keyof { a: 1; b: 2 } = 'c';
//    tsc:          ... type '"a" | "b"'.
//    tsz (before): ... type 'keyof { a: 1; b: 2; }'.    (kept the operator spelling)
```

## Scope (three display sites)

- `alias_declaration_body_is_computed` (`state/type_analysis/source_alias_attribution.rs`):
  treat a non-generic alias whose body is `keyof` over a `TYPE_LITERAL` operand as
  a computed body so the alias name is dropped, mirroring the existing conditional
  / indexed-access arms. Gated on the *syntactic* operand node (`TYPE_LITERAL`) — a
  named type reference or generic `keyof T` does not reach it.
- `format_type_for_assignability_message` (`error_reporter/core_formatting.rs`):
  after the alias-name and symbol-name branches, reduce an anonymous-operand
  `keyof` to its key union and display that.
- assignment-target annotation display
  (`error_reporter/.../assignment_formatting.rs`): route an anonymous-operand
  `keyof` through the `TypeFormatter` (which reduces it) instead of echoing the
  verbatim annotation text.

A shared `keyof_operand_is_anonymous` predicate (object shape with no binder
symbol and no display alias name) gates the type-level sites; named operands keep
`keyof Name`.

## Adjacent-case matrix

- alias vs inline; renamed binder; 2- and 3-key tuples render the key union.
- `keyof NamedInterface` keeps `keyof Name` (negative test).
- generic `keyof T` and `keyof (A | B)` / `keyof (A & B)` distribution paths
  unchanged (operand is not a `TYPE_LITERAL` / not an anonymous object).

## Project Corpus Impact

- Row: n/a
- Bug family: diagnostics / type-display (#12179)

Display-only; advances the #12179 "stable display independent of alias spelling"
rule for the `keyof`-alias surface. No relation/assignability outcome changes —
the same diagnostics fire, only the rendered target string changes to match tsc.
No project-row diagnostic counts change (target-text only).

## Verification

- New unit tests in `type_alias_computed_display_tests.rs` (alias, renamed
  binder, inline, named-operand negative) — all pass.
- Reduced repros diffed against `tsc` 6.0.2: exact match for the keyof-object
  cases.
- `cargo test -p tsz-checker --lib`: full-suite failure set byte-identical to
  `main` (74 pre-existing failures, unrelated: arch-contract / async-return /
  instanceof / jsx / jsdoc); this branch passes 4 more tests (the new keyof
  cases). Zero net regressions.
- `cargo clippy -p tsz-checker --lib`: clean. Rebased onto latest `main`
  (relocated the alias arm into `source_alias_attribution`); rebuild clean.

## Coordination Notes

One sub-case of the #12179 diagnostics-display family (adjacent to the #10914
alias-display witness). The tracker stays open; this PR does not close it. A
separate pre-existing divergence — `keyof NamedInterface` over-resolving to its
key union in *nested* (source-side) display positions — is left out of scope.

https://claude.ai/code/session_0152DBsz4XZTLHUHVErauLcm