### PR TITLE
fix(solver): detect nullable-union callbacks in method parameter variance

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -975,6 +975,9 @@ mod new_typeof_property_tests;
 #[path = "tests/nonunique_symbol_property_access_tests.rs"]
 mod nonunique_symbol_property_access_tests;
 #[cfg(test)]
+#[path = "tests/nullable_union_callback_variance_tests.rs"]
+mod nullable_union_callback_variance_tests;
+#[cfg(test)]
 #[path = "tests/nullish_target_relation_routing_arch_tests.rs"]
 mod nullish_target_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/nullable_union_callback_variance_tests.rs
+++ b/crates/tsz-checker/src/tests/nullable_union_callback_variance_tests.rs
@@ -1,0 +1,124 @@
+//! Regression tests for method parameters typed as a nullable union of a
+//! callback (the exact shape of `Promise.then`'s `onfulfilled`).
+//!
+//! tsc detects callback parameters with `getSingleCallSignature(getNonNullableType(t))`,
+//! i.e. it strips `null`/`undefined` before deciding whether a method parameter is a
+//! callback. A method parameter typed `((value: T) => R) | undefined` must therefore be
+//! compared with strict callback variance, not relaxed method bivariance — otherwise a
+//! covariant container like `Promise<T>` is wrongly accepted in both directions.
+//!
+//! Before the fix, `((value: T) => R) | undefined` method parameters fell out of callback
+//! detection (the union is not itself callable), so the comparison silently relaxed to
+//! method bivariance and dropped the expected TS2322. Plain (non-union) callback
+//! parameters were already handled, so these tests vary both the union wrapper and the
+//! binder names to keep the fix structural rather than name- or shape-specific.
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2322_count(src: &str) -> usize {
+    check_source_diagnostics(src)
+        .iter()
+        .filter(|d| d.code == 2322)
+        .count()
+}
+
+/// A `Promise.then`-shaped interface (`then(cb: ((v: T) => U) | undefined): Self<U>`)
+/// is covariant in `T`. Assigning the wider instantiation to the narrower one must
+/// report TS2322; the reverse assignment is sound and must stay clean.
+#[test]
+fn nullable_union_callback_method_is_covariant() {
+    let diags = check_source_diagnostics(
+        r#"
+interface Wide { a: string }
+interface Narrow extends Wide { b: string }
+interface Thenable<T> {
+    chain<U>(cb: ((value: T) => Thenable<U>) | undefined | null): Thenable<U>;
+}
+declare let wide: Thenable<Wide>;
+declare let narrow: Thenable<Narrow>;
+narrow = wide;  // error: Thenable<Wide> not assignable to Thenable<Narrow>
+wide = narrow;  // ok
+"#,
+    );
+    let errors: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected exactly one TS2322 on the widening assignment, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The same structural rule with different binder names and `| undefined` only,
+/// to prove the fix keys off type structure, not specific identifiers.
+#[test]
+fn nullable_union_callback_method_is_covariant_renamed() {
+    assert_eq!(
+        ts2322_count(
+            r#"
+interface Base { id: number }
+interface Derived extends Base { extra: number }
+interface Box<Elem> {
+    map<Out>(transform: ((item: Elem) => Box<Out>) | undefined): Box<Out>;
+}
+declare let loose: Box<Base>;
+declare let tight: Box<Derived>;
+tight = loose;  // error
+loose = tight;  // ok
+"#,
+        ),
+        1,
+        "renamed binders must still report the covariant mismatch exactly once",
+    );
+}
+
+/// A plain (non-union) callback method parameter was already strict; this guards
+/// that the fix did not change that established behavior.
+#[test]
+fn plain_callback_method_remains_covariant() {
+    assert_eq!(
+        ts2322_count(
+            r#"
+interface Wide { a: string }
+interface Narrow extends Wide { b: string }
+interface Thenable<T> {
+    chain<U>(cb: (value: T) => Thenable<U>): Thenable<U>;
+}
+declare let wide: Thenable<Wide>;
+declare let narrow: Thenable<Narrow>;
+narrow = wide;  // error
+wide = narrow;  // ok
+"#,
+        ),
+        1,
+        "plain callback method parameters must keep strict callback variance",
+    );
+}
+
+/// When the nullability facts differ between the two sides (one side cannot be
+/// `undefined`), tsc does not treat the parameters as matching callbacks. The
+/// optional/required parameter mismatch is the dominant signal here; this test
+/// only pins that the comparison stays sound (no spurious extra TS2322 beyond the
+/// genuine widening one).
+#[test]
+fn nullable_union_callback_covariant_when_both_optional() {
+    assert_eq!(
+        ts2322_count(
+            r#"
+interface Wide { a: string }
+interface Narrow extends Wide { b: string }
+interface Thenable<T> {
+    chain<U>(cb?: (value: T) => Thenable<U>): Thenable<U>;
+}
+declare let wide: Thenable<Wide>;
+declare let narrow: Thenable<Narrow>;
+narrow = wide;  // error
+wide = narrow;  // ok
+"#,
+        ),
+        1,
+        "optional callback method parameters must keep strict callback variance",
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
@@ -445,12 +445,41 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // (`value: T` in `Bivar<T>`); those keep ordinary method bivariance.
         let callback_originated_from_instantiated_generic =
             self.callback_param_originated_from_instantiated_generic(source_type, target_type);
-        let inner_signature_is_method_like = self.callable_first_signature_is_method(source_type)
-            || self.callable_first_signature_is_method(target_type);
-        let entering_callback_check = s_has_call
-            && t_has_call
+        // tsc detects callback parameters with `getSingleCallSignature(getNonNullableType(t))`,
+        // i.e. it strips `null`/`undefined` before deciding whether a parameter is a
+        // callback. A method parameter typed `((value: T) => R) | undefined` (the exact
+        // shape of `Promise.then`'s `onfulfilled`) is therefore still a callback and must
+        // be compared with strict callback variance, not relaxed method bivariance. The
+        // strictness only applies when both sides agree on nullability — tsc additionally
+        // gates on `getTypeFacts(IsUndefinedOrNull)` matching across source and target.
+        let s_nonnull = crate::narrowing::utils::remove_nullish(self.interner, source_type);
+        let t_nonnull = crate::narrowing::utils::remove_nullish(self.interner, target_type);
+        let s_is_nullable = s_nonnull != source_type;
+        let t_is_nullable = t_nonnull != target_type;
+        // Reuse the raw modality flags computed above when no nullish member was
+        // stripped (the common path); only re-query callability on the stripped
+        // form when the parameter actually was a nullish union, keeping the hot
+        // non-nullable path free of extra `evaluate_type` walks.
+        let s_call_for_callback = if s_is_nullable {
+            self.callable_modality_flags_for_type(s_nonnull).0
+        } else {
+            s_has_call
+        };
+        let t_call_for_callback = if t_is_nullable {
+            self.callable_modality_flags_for_type(t_nonnull).0
+        } else {
+            t_has_call
+        };
+        // `inner_signature_is_method_like` probes call `evaluate_type`; keep them
+        // behind the cheaper predicates and the `method_should_be_bivariant`
+        // short-circuit so they only run for non-method callback slots.
+        let entering_callback_check = s_call_for_callback
+            && t_call_for_callback
+            && s_is_nullable == t_is_nullable
             && !callback_originated_from_instantiated_generic
-            && (method_should_be_bivariant || inner_signature_is_method_like);
+            && (method_should_be_bivariant
+                || self.callable_first_signature_is_method(s_nonnull)
+                || self.callable_first_signature_is_method(t_nonnull));
         let entering_bivariant_callback_return =
             entering_callback_check && method_should_be_bivariant;
         let saved_in_callback = self.in_callback_param_check;

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -90,7 +90,11 @@ TypeScript/tests/cases/compiler/promisesWithConstraints.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes2.ts
 TypeScript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts
-TypeScript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/covariantCallbacks.ts
+# covariantCallbacks.ts: RESOLVED by this PR — tsz now detects nullable-union
+# callback method parameters the way tsc does (getSingleCallSignature(
+# getNonNullableType(t))), so lib `Promise<A>` -> `Promise<B>` reports its
+# covariant TS2322 again. Removed from this ledger; covered by
+# nullable_union_callback_variance_tests.
 TypeScript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughInstantiation.ts
 
 # PR #12491 exact-head aggregate run 26937439181 (job 79473172800) still


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
M4-B / user-requested M4-C scope: solver relation policy for inference/session-adjacent callback variance.

## Invariant
When method parameters are nullable unions whose non-nullish member is a callback, `tsc` detects the callback via `getSingleCallSignature(getNonNullableType(t))` and compares matching callbacks under strict callback variance. This PR makes `tsz` do that in the solver relation path, so covariant containers such as `Promise<T>` reject the widening direction while preserving the safe direction.

## Structural Rule
`tsz` previously tested callability on the raw method parameter type. A union such as `((value: T) => R) | undefined` is not itself callable, so callback detection failed and comparison fell back to method bivariance. The solver branch strips nullish with the existing narrowing helper before detecting callback parameters, then gates the strict callback path on matching nullability.

## Owner Layer
Solver: `crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs`, inside the shared `are_parameters_compatible_impl` assignability path.

## Scope
- `crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs`
- `crates/tsz-checker/src/tests/nullable_union_callback_variance_tests.rs`
- `crates/tsz-checker/src/lib.rs`
- `scripts/conformance/conformance-accepted-regressions.txt`

## Adjacent-case Matrix
- Nullish-union callback method parameter rejects the widening direction and accepts the safe reverse direction.
- Binder-renamed forms (`Base`/`Derived`, `Box<Elem>`) behave the same way, keeping the rule structural.
- Plain non-union callback method parameters remain covered by the existing strict callback path.
- Optional callback parameters remain covariant when both sides agree on nullability.

## Project Corpus Impact
- Row: n/a
- Bug family: conformance relation-policy false negative for nullable-union callback method parameters.
- Evidence: targeted solver relation branch; no benchmark project row is claimed or required for this PR.

## Verification
- `cargo fmt --check` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `python3 scripts/arch/arch_guard.py` -> passed
- `scripts/safe-run.sh --limit 75% -- cargo nextest run -p tsz-checker --lib nullable_union_callback` -> 4 passed
- `scripts/safe-run.sh --limit 75% -- ./scripts/conformance/conformance.sh run --filter covariantCallbacks --filter await_incorrectThisType --verbose` -> passed
- `scripts/safe-run.sh --limit 75% -- ./scripts/conformance/conformance.sh run --filter constructorWithIncompleteTypeAnnotation --filter unicodeEscapesInNames02 --filter compoundExponentiationAssignmentLHSIsValue --filter compoundAssignmentLHSIsValue --verbose` -> passed after rebase
- `python3 scripts/conformance/query-conformance.py --dashboard` -> `12585/12585 (100.0%)`, accepted-regression gate `24 listed tests`

## Coordination Notes
- Rebased on current `origin/main` after #12506 landed; the previously accepted `await_incorrectThisType.ts` regression is now removed from this PR's ledger change.
- Earlier exact-head CI failures were stale against the pre-#12506 base and current-main arch ratchets; local rebased evidence above is clean.
- Exact-head CI for `912453ed0d` is pending after force-push.

Refs #8432. Tracks #12474.