### PR TITLE
fix(emit): infer yield* delegated element type in generator DTS yield inference

### DIFF
--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -103,6 +103,10 @@ path = "tests/inferred_object_index_signature_dts_emit_tests.rs"
 name = "generic_call_bare_type_param_dts_emit_tests"
 path = "tests/generic_call_bare_type_param_dts_emit_tests.rs"
 
+[[test]]
+name = "generator_yield_star_dts_emit_tests"
+path = "tests/generator_yield_star_dts_emit_tests.rs"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/crates/tsz-cli/tests/generator_yield_star_dts_emit_tests.rs
+++ b/crates/tsz-cli/tests/generator_yield_star_dts_emit_tests.rs
@@ -1,0 +1,219 @@
+//! DTS emit for `yield*` (delegating yield) in unannotated generators.
+//!
+//! tsc infers an unannotated generator's yield type from the values it yields,
+//! including the *element* type of any iterable delegated to with `yield*`:
+//! `function* g() { yield* [1, 2]; }` emits `Generator<number, void, unknown>`.
+//!
+//! tsz's declaration emitter previously bailed out the moment its body-driven
+//! yield-type inference saw a `yield*` expression and fell back to
+//! `Generator<any, void, unknown>`.  The fix routes the delegated operand
+//! through the solver's iterator protocol so the element type participates in
+//! that inference.  Resolution covers operands whose iterator info is available
+//! structurally (arrays and tuples); other operands keep the conservative `any`
+//! fallback rather than emitting a wrong type.
+//!
+//! These tests exercise the body-driven inference path — generator methods and
+//! locally-declared generators surfaced through a re-export.  (Directly-exported
+//! top-level `export function*` declarations are emitted through a separate path
+//! that does not yet run body-driven yield inference even for plain `yield`; that
+//! pre-existing gap is tracked separately.)
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_yield_star_dts_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+fn emit_dts(name: &str, source: &str) -> Option<String> {
+    let tsz_bin = find_tsz_binary()?;
+    let temp = TempDir::new(name).expect("temp dir");
+    let src_path = temp.path.join("repro.ts");
+    std::fs::write(&src_path, source).expect("write repro file");
+
+    let output = Command::new(tsz_bin)
+        .args([
+            "repro.ts",
+            "--declaration",
+            "--emitDeclarationOnly",
+            "--target",
+            "es2015",
+            "--lib",
+            "es6",
+            "--pretty",
+            "false",
+        ])
+        .current_dir(&temp.path)
+        .output()
+        .expect("run tsz declaration emit");
+
+    let dts = std::fs::read_to_string(temp.path.join("repro.d.ts")).unwrap_or_else(|_| {
+        panic!(
+            "expected repro.d.ts to be emitted.\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+    Some(dts)
+}
+
+/// Primary repro: delegating to an array literal contributes the array element
+/// type, not `any`.  Adjacent case: a differently-named generator proves the
+/// rule is not binder-name dependent.
+#[test]
+fn yield_star_array_delegation_infers_element_type() {
+    let Some(dts) = emit_dts(
+        "array",
+        r#"
+function* numbers() { yield* [1, 2]; }
+function* renamed() { yield* [10, 20, 30]; }
+export { numbers, renamed };
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("numbers(): Generator<number, void, unknown>"),
+        "yield* array element type should drive the inferred yield type:\n{dts}"
+    );
+    assert!(
+        dts.contains("renamed(): Generator<number, void, unknown>"),
+        "yield* inference must not depend on the generator name:\n{dts}"
+    );
+    assert!(
+        !dts.contains("Generator<any"),
+        "yield* delegation must not fall back to Generator<any>:\n{dts}"
+    );
+}
+
+/// A plain `yield` and a `yield*` producing the same element type collapse to
+/// that single yield type, matching tsc.
+#[test]
+fn yield_star_mixed_with_plain_yield_unifies_to_shared_type() {
+    let Some(dts) = emit_dts(
+        "mixed",
+        "function* gen() { yield 1; yield* [2, 3]; }\nexport { gen };\n",
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("gen(): Generator<number, void, unknown>"),
+        "mixed yield / yield* with matching element types should infer number:\n{dts}"
+    );
+}
+
+/// Delegating to a tuple yields the union of its element types.
+#[test]
+fn yield_star_tuple_delegation_unions_element_types() {
+    let Some(dts) = emit_dts(
+        "tuple",
+        "function* gen() { yield* [1, \"x\"] as [number, string]; }\nexport { gen };\n",
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("gen(): Generator<string | number, void, unknown>")
+            || dts.contains("gen(): Generator<number | string, void, unknown>"),
+        "yield* over a tuple should union element types:\n{dts}"
+    );
+}
+
+/// Async generators delegating to an array infer `AsyncGenerator<element>`.
+#[test]
+fn async_yield_star_array_delegation_infers_element_type() {
+    let Some(dts) = emit_dts(
+        "async",
+        "async function* gen() { yield* [1, 2]; }\nexport { gen };\n",
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("gen(): AsyncGenerator<number, void, unknown>"),
+        "async yield* array element type should drive the inferred yield type:\n{dts}"
+    );
+}
+
+/// Generator *method* declarations (here on an exported class) share the same
+/// body-driven inference path.
+#[test]
+fn yield_star_array_delegation_in_method_infers_element_type() {
+    let Some(dts) = emit_dts(
+        "method",
+        r#"
+export class C {
+    *gen() { yield* [1, 2]; }
+}
+"#,
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert!(
+        dts.contains("gen(): Generator<number, void, unknown>"),
+        "generator method yield* delegation should infer the element type:\n{dts}"
+    );
+}
+
+/// Regression guard: a `yield*` whose element type is not structurally
+/// resolvable keeps the conservative `Generator<any, …>` fallback rather than
+/// emitting a wrong type or dropping the generator return type entirely.
+#[test]
+fn yield_star_unresolvable_operand_keeps_any_fallback() {
+    let Some(dts) = emit_dts(
+        "fallback",
+        "function* gen(x: Iterable<unknown>) { yield* x; }\nexport { gen };\n",
+    ) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    // The exact element type is not resolved structurally here; the emitter must
+    // still produce a Generator return type (conservatively `any`), never panic
+    // or drop the annotation.
+    assert!(
+        dts.contains("gen(x: Iterable<unknown>): Generator<"),
+        "unresolvable yield* should still emit a Generator return type:\n{dts}"
+    );
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs
@@ -425,7 +425,7 @@ impl<'a> DeclarationEmitter<'a> {
         body_idx: NodeIndex,
     ) -> Option<String> {
         let mut yield_type = None;
-        if !self.collect_unique_yield_type_text_from_node(body_idx, &mut yield_type, 0) {
+        if !self.collect_unique_yield_type_text_from_node(body_idx, is_async, &mut yield_type, 0) {
             return None;
         }
         let yield_type = yield_type.unwrap_or_else(|| "undefined".to_string());
@@ -440,6 +440,7 @@ impl<'a> DeclarationEmitter<'a> {
     fn collect_unique_yield_type_text_from_node(
         &self,
         node_idx: NodeIndex,
+        is_async: bool,
         preferred: &mut Option<String>,
         depth: usize,
     ) -> bool {
@@ -456,7 +457,18 @@ impl<'a> DeclarationEmitter<'a> {
                     return false;
                 };
                 if yield_expr.asterisk_token {
-                    return false;
+                    // `yield* <iterable>` contributes the *element* type of the
+                    // delegated iterable to the enclosing generator's inferred
+                    // yield type (e.g. `yield* [1, 2]` yields `number`). Resolve
+                    // that element type through the solver's iterator protocol so
+                    // delegated yields participate in declaration inference instead
+                    // of forcing the conservative `any` fallback.
+                    let Some(type_text) =
+                        self.yield_star_delegated_yield_type_text(yield_expr.expression, is_async)
+                    else {
+                        return false;
+                    };
+                    return self.merge_unique_type_text(preferred, type_text);
                 }
                 let type_text = if yield_expr.expression.is_none() {
                     "undefined".to_string()
@@ -496,9 +508,48 @@ impl<'a> DeclarationEmitter<'a> {
                 .get_children(node_idx)
                 .into_iter()
                 .all(|child_idx| {
-                    self.collect_unique_yield_type_text_from_node(child_idx, preferred, depth + 1)
+                    self.collect_unique_yield_type_text_from_node(
+                        child_idx,
+                        is_async,
+                        preferred,
+                        depth + 1,
+                    )
                 }),
         }
+    }
+
+    /// Resolve the declaration-emit text for the element type delegated by a
+    /// `yield* <iterable>` expression.
+    ///
+    /// The element type is the iterable's iteration (`yield`) type, e.g. `number`
+    /// for `yield* [1, 2]`. Resolution goes through the solver's iterator
+    /// protocol (`get_iterator_info`), which covers array and tuple operands
+    /// structurally; async generators consult the async iterator protocol first
+    /// and fall back to the sync one (mirroring how `yield*` is checked). Returns
+    /// `None` whenever the element type cannot be resolved (or widens to `any`),
+    /// so the caller keeps its conservative `Generator<any, …>` fallback rather
+    /// than emitting a wrong type.
+    fn yield_star_delegated_yield_type_text(
+        &self,
+        expression: NodeIndex,
+        is_async: bool,
+    ) -> Option<String> {
+        let interner = self.type_interner?;
+        let iterable_type = self.get_node_type_or_names(&[expression])?;
+        let element = if is_async {
+            // `get_async_iterable_element_type` tries the async iterator protocol,
+            // then the sync protocol, and returns `any` when neither resolves.
+            tsz_solver::operations::get_async_iterable_element_type(interner, iterable_type)
+        } else {
+            tsz_solver::operations::get_iterator_info(interner, iterable_type, false)
+                .map(|info| info.yield_type)?
+        };
+        let element = self.widen_unique_symbol_value_type_for_dts(element, 0);
+        let type_text = self.print_type_id_for_inferred_declaration(element);
+        if type_text.is_empty() || type_text == "any" {
+            return None;
+        }
+        Some(type_text)
     }
 
     fn merge_unique_type_text(&self, preferred: &mut Option<String>, type_text: String) -> bool {


### PR DESCRIPTION
Fixes #12476

AgentName: Studio-C
ContributorIdentity: ClaudeOpus-EmitYieldStar

## Track
Emit / DTS parity.

## Invariant
When an unannotated generator's body delegates with `yield*`, the delegated
iterable's iteration (element) type participates in the generator's inferred
yield type — exactly like a plain `yield` contributes its value type. tsz
previously bailed out (`return false`) on the first `yield*` expression in the
declaration emitter's body-driven yield collector and fell back to an `any`
yield type:

```ts
function* gen() { yield* [1, 2]; }
// tsc infers the yield type as number (Generator of number).
// tsz, before this fix, inferred any (Generator of any).
```

## Failure family
Declaration emit (`.d.ts`) yield-type inference for delegating yields.

## Output owner
Emitter only —
`crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_normalization.rs`.
No semantic validation is added to emit; the element type is obtained from the
solver's iterator protocol (`get_iterator_info` /
`get_async_iterable_element_type`), keeping type semantics in the solver. No
emitted output is patched after the fact.

## Scope
- `collect_unique_yield_type_text_from_node` threads `is_async` and, in the
  `yield*` arm, resolves the delegated element type via the new
  `yield_star_delegated_yield_type_text` helper instead of bailing to `any`.
- The element type is merged through the existing `merge_unique_type_text`
  path, symmetric with the regular-`yield` arm.
- Unresolvable operands keep the conservative `any` fallback, so the change is
  a strict improvement (never emits a wrong type).

## Adjacent-case matrix
- delegating to an array literal -> element type (sync)
- plain `yield` mixed with a same-element `yield*` -> single yield type
- delegating to a tuple -> union of element types
- async generator delegating to an array -> async generator of the element
- generator **method** declarations (incl. in exported classes)
- unresolvable operand (e.g. `yield*` of an `Iterable` parameter) -> `any`
  fallback preserved

## Known remaining gap (pre-existing, out of scope)
Directly-exported top-level `export function* g() { ... }` declarations are
emitted through a separate path that does not run body-driven yield inference
at all — even `export function* g() { yield 1; }` already emits an `any` yield
type. That path needs its own fix; this PR covers the body-driven inference
path (generator methods and locally-declared generators surfaced via
re-export). Tracked in #12476.

## Project Corpus Impact
- Row: n/a
- Bug family: declaration-emit generator yield inference
- Evidence: emitter-local change to body-driven yield-type text; no project-row
  semantics or benchmark fixture configuration changed.

## Verification
- `cargo fmt -p tsz-emitter -p tsz-cli -- --check` (clean)
- `scripts/safe-run.sh cargo clippy -p tsz-emitter --profile dev-fast` (clean)
- `scripts/safe-run.sh cargo test -p tsz-cli --profile dev-fast --test generator_yield_star_dts_emit_tests` (6 passed)
- `scripts/safe-run.sh cargo test -p tsz-emitter --profile dev-fast --lib` — only
  the pre-existing unrelated failure
  `test_js_extends_imported_namespace_without_class_member_is_not_class_constructor`
  (verified failing on base via `git stash`); generator/yield/iterable subsets all green.
- Oracle parity confirmed against tsc 6.0.2: array/tuple/mixed/async/method
  cases emit identical `.d.ts` return types.

## Coordination Notes
New CLI integration test `generator_yield_star_dts_emit_tests` registered in
`crates/tsz-cli/Cargo.toml`. The exported-top-level-generator gap is documented
in #12476 as a separate follow-up. Ownership normalized to Studio-C per
Studio-manager; original contributor identity recorded above.