### PR TITLE
fix(solver/checker): render computed-bodied alias object/mapped results structurally

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1241,16 +1241,6 @@ pub(crate) fn is_tuple_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::is_tuple_type(db, type_id)
 }
 
-/// `true` when `type_id` is a *union or intersection* that contains an
-/// anonymous object — i.e. it mentions an object but is not itself a bare
-/// object/mapped shape. Computed-alias structural display keeps these deferred
-/// (a union/intersection that mixes objects elaborates through a separate path)
-/// while still letting a bare object or mapped result render structurally.
-pub(crate) fn union_or_intersection_with_object(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    tsz_solver::type_queries::union_or_intersection_mentions_object(db, type_id)
-        && !tsz_solver::type_queries::is_object_type(db, type_id)
-}
-
 pub(crate) fn is_intersection_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::is_intersection_type(db, type_id)
 }

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1241,6 +1241,16 @@ pub(crate) fn is_tuple_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::is_tuple_type(db, type_id)
 }
 
+/// `true` when `type_id` is a *union or intersection* that contains an
+/// anonymous object — i.e. it mentions an object but is not itself a bare
+/// object/mapped shape. Computed-alias structural display keeps these deferred
+/// (a union/intersection that mixes objects elaborates through a separate path)
+/// while still letting a bare object or mapped result render structurally.
+pub(crate) fn union_or_intersection_with_object(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    tsz_solver::type_queries::union_or_intersection_mentions_object(db, type_id)
+        && !tsz_solver::type_queries::is_object_type(db, type_id)
+}
+
 pub(crate) fn is_intersection_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::is_intersection_type(db, type_id)
 }

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -37,6 +37,11 @@ pub(crate) fn union_or_intersection_mentions_object(
     tsz_solver::type_queries::union_or_intersection_mentions_object(db, type_id)
 }
 
+pub(crate) fn union_or_intersection_with_object(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    union_or_intersection_mentions_object(db, type_id)
+        && !tsz_solver::type_queries::is_object_type(db, type_id)
+}
+
 /// Check whether an application's *declared* alias body is a mapped type
 /// (e.g. `Partial<X>`, `Readonly<X>`, or `type F<T> = { [K in keyof T]... }`),
 /// even when the concrete instantiation is fully resolved. Diagnostic

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1528,19 +1528,17 @@ impl<'a> CheckerState<'a> {
                     .register_type_to_def(result, def_id);
                 self.ctx.definition_store.set_body(def_id, result);
 
-                // Mark the body as "computed" when the declared alias body is a
-                // non-generic reducing operator whose result tsc renders without
-                // an `aliasSymbol`. `find_type_alias_by_body` and the diagnostic
-                // formatters then show the underlying structural type rather than
-                // the alias name. Generic aliases keep their name since the
-                // operator is part of the definition, not a simplification.
-                let body_is_computed = self
+                // Record the body's display provenance (see
+                // `record_alias_body_provenance`). Only a non-generic alias is a
+                // candidate: a generic alias keeps its name because the operator
+                // is part of the definition, not a simplification.
+                let alias_is_non_generic = self
                     .ctx
                     .definition_store
                     .get(def_id)
-                    .filter(|d| d.type_params.is_empty())
-                    .and_then(|_| self.ctx.binder.get_symbol(sym_id))
-                    .is_some_and(|symbol| {
+                    .is_some_and(|d| d.type_params.is_empty());
+                let body_is_computed = alias_is_non_generic
+                    && self.ctx.binder.get_symbol(sym_id).is_some_and(|symbol| {
                         symbol.declarations.iter().any(|&decl_idx| {
                             super::source_alias_attribution::alias_declaration_body_is_computed(
                                 self.ctx.arena,
@@ -1550,9 +1548,7 @@ impl<'a> CheckerState<'a> {
                             )
                         })
                     });
-                if body_is_computed {
-                    self.ctx.definition_store.mark_body_as_computed(result);
-                }
+                self.record_alias_body_provenance(result, body_is_computed, alias_is_non_generic);
                 // Also register the evaluated form of the type.
                 // Type aliases with union/intersection bodies often contain Lazy
                 // members (e.g., `type Exotic = CatDog | ManBearPig`). When these
@@ -1574,15 +1570,34 @@ impl<'a> CheckerState<'a> {
                         // otherwise the reverse lookup repaints the alias name onto
                         // the shared structural result (e.g. a conditional that
                         // reduces to `{ a: 1; }`).
-                        if body_is_computed {
-                            self.ctx.definition_store.mark_body_as_computed(evaluated);
-                        }
+                        self.record_alias_body_provenance(
+                            evaluated,
+                            body_is_computed,
+                            alias_is_non_generic,
+                        );
                     }
                 }
             }
         }
 
         result
+    }
+
+    /// Record the display provenance of an alias body `TypeId`: a reducing
+    /// result is "computed" (rendered structurally), while a constructive
+    /// non-generic alias body is "directly named" so it keeps its name even if a
+    /// computed alias resolves to the same interned shape ("direct wins").
+    fn record_alias_body_provenance(
+        &self,
+        body: TypeId,
+        is_computed: bool,
+        alias_is_non_generic: bool,
+    ) {
+        if is_computed {
+            self.ctx.definition_store.mark_body_as_computed(body);
+        } else if alias_is_non_generic {
+            self.ctx.definition_store.mark_body_as_directly_named(body);
+        }
     }
 
     /// Resolve a `typeof X` type query with flow-sensitive narrowing.

--- a/crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs
@@ -117,7 +117,9 @@ pub(crate) fn alias_declaration_body_is_computed(
         syntax_kind_ext::CONDITIONAL_TYPE | syntax_kind_ext::INDEXED_ACCESS_TYPE => {
             !crate::query_boundaries::common::is_conditional_type(db, result)
                 && !crate::query_boundaries::common::is_index_access_type(db, result)
-                && !crate::query_boundaries::common::union_or_intersection_with_object(db, result)
+                && !crate::query_boundaries::diagnostics::union_or_intersection_with_object(
+                    db, result,
+                )
         }
         // `keyof { ... }` over an inline object *type literal* is a reducing
         // operator like indexed access: it resolves away into the operand's key

--- a/crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs
@@ -93,9 +93,10 @@ pub(crate) fn record_source_alias_rejection_kinds(
 ///   `"a"|"b"`); a distribution into object-typed members keeps the name.
 /// - A **conditional** or **indexed access** resolves away into its branch /
 ///   element type and never carries the alias's `aliasSymbol`, so tsc renders
-///   the evaluated underlying type. Object results are excluded because a
-///   shared object shape is painted through the reverse `find_def_for_type`
-///   lookup, where marking it would mis-route the alias name.
+///   the evaluated underlying type, including bare object and mapped shapes.
+///   Unions/intersections that mix in objects stay deferred to the separate
+///   elaboration path; directly-written aliases sharing a bare object shape are
+///   protected by the def store's "direct wins" provenance.
 pub(crate) fn alias_declaration_body_is_computed(
     arena: &NodeArena,
     db: &dyn TypeDatabase,
@@ -116,9 +117,7 @@ pub(crate) fn alias_declaration_body_is_computed(
         syntax_kind_ext::CONDITIONAL_TYPE | syntax_kind_ext::INDEXED_ACCESS_TYPE => {
             !crate::query_boundaries::common::is_conditional_type(db, result)
                 && !crate::query_boundaries::common::is_index_access_type(db, result)
-                && !crate::query_boundaries::diagnostics::union_or_intersection_mentions_object(
-                    db, result,
-                )
+                && !crate::query_boundaries::common::union_or_intersection_with_object(db, result)
         }
         // `keyof { ... }` over an inline object *type literal* is a reducing
         // operator like indexed access: it resolves away into the operand's key

--- a/crates/tsz-checker/src/tests/type_alias_computed_display_tests.rs
+++ b/crates/tsz-checker/src/tests/type_alias_computed_display_tests.rs
@@ -119,6 +119,65 @@ const h: Holder = { v: 0 };
     );
 }
 
+// 5b. A conditional reducing to a bare *object* renders the object structurally
+//     (issue #10914 / #10799 follow-up; tsc shows `{ a: 1; }`, never the alias
+//     name). The shared-shape repaint that previously forced object results to
+//     keep the alias name is prevented by the def store's "direct wins" guard.
+#[test]
+fn conditional_alias_to_object_renders_underlying_object() {
+    let msg = ts2322_target(
+        r#"
+type Boxed = true extends true ? { a: 1 } : never;
+type Holder = { v: Boxed };
+const h: Holder = { v: 0 };
+"#,
+    );
+    assert!(
+        msg.contains("{ a: 1; }") && !msg.contains("Boxed"),
+        "expected conditional object alias to render as `{{ a: 1; }}`, got: {msg}"
+    );
+}
+
+// 5c. Renamed binder, indexed-access reducing to an object — proves the object
+//     rule is structural, not keyed on an identifier.
+#[test]
+fn indexed_access_alias_to_object_renders_underlying_object() {
+    let msg = ts2322_target(
+        r#"
+type Picked = { p: { a: 1 } }["p"];
+type Wrapper = { field: Picked };
+const w: Wrapper = { field: 0 };
+"#,
+    );
+    assert!(
+        msg.contains("{ a: 1; }") && !msg.contains("Picked"),
+        "expected indexed-access object alias to render as `{{ a: 1; }}`, got: {msg}"
+    );
+}
+
+// 5d. Collision guard: when a directly-written alias and a computed alias
+//     resolve to the *same* interned object shape, the directly-written alias
+//     keeps its name. Without the "direct wins" guard, marking the shared shape
+//     computed would strip `Direct`'s name too (the prior `C_uobj` regression).
+#[test]
+fn computed_object_shape_shared_with_direct_alias_keeps_direct_name() {
+    let diags = check_source_diagnostics(
+        r#"
+type Direct = { a: 1 };
+type Computed = true extends true ? { a: 1 } : never;
+type Holder = { d: Direct };
+const h: Holder = { d: 0 };
+"#,
+    );
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        ts2322.iter().any(|d| d.message_text.contains("Direct")),
+        "expected the directly-written alias to keep its name despite a computed \
+         alias sharing the shape, got: {:?}",
+        ts2322.iter().map(|d| &d.message_text).collect::<Vec<_>>()
+    );
+}
+
 // 6. Negative case: a directly-written tuple alias KEEPS its name (it is a
 //    freshly-constructed structural type with an alias symbol).
 #[test]

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -324,6 +324,15 @@ pub struct DefinitionStore {
     /// `"a"|"b"` but tsc shows the expanded union, not `T2`).
     computed_alias_bodies: DefDashSet<TypeId>,
 
+    /// Set of body `TypeId`s that are the constructive body of at least one
+    /// *non-computed* type alias (`type Direct = { a: 1 }`), so they must keep
+    /// their alias name even when an unrelated *computed* alias resolves to the
+    /// same interned shape. Because structurally-identical types share one
+    /// `TypeId`, marking that shape computed (for the computed alias) would
+    /// otherwise strip the name from the directly-written alias too. "Direct
+    /// wins": a shape recorded here is never reported as a computed body.
+    directly_named_alias_bodies: DefDashSet<TypeId>,
+
     /// Set of type-alias `DefId`s whose instantiation is unconditionally
     /// infinite (e.g. `type A<T> = T extends infer X ? A<X & B> : never`).
     /// The checker records these when it emits TS2589 at the alias definition;
@@ -589,6 +598,7 @@ impl DefinitionStore {
             symbol_mappings_snapshot: Mutex::new(None),
             body_to_alias: DefDashMap::default(),
             computed_alias_bodies: DefDashSet::default(),
+            directly_named_alias_bodies: DefDashSet::default(),
             depth_poisoned_defs: DefDashSet::default(),
             shape_to_def: DefDashMap::default(),
             file_to_defs: DefDashMap::with_capacity_and_hasher(file_capacity, Default::default()),
@@ -1027,6 +1037,7 @@ impl DefinitionStore {
         self.symbol_only_index.clear();
         self.body_to_alias.clear();
         self.computed_alias_bodies.clear();
+        self.directly_named_alias_bodies.clear();
         self.shape_to_def.clear();
         self.file_to_defs.clear();
         self.class_to_constructor.clear();
@@ -1307,8 +1318,10 @@ impl DefinitionStore {
     pub fn find_type_alias_by_body(&self, type_id: TypeId) -> Option<DefId> {
         // Skip bodies that were marked as "computed" (produced by intersection
         // reduction, conditional evaluation, etc.). tsc does not preserve alias
-        // names for such types.
-        if self.computed_alias_bodies.contains(&type_id) {
+        // names for such types. A shape that is also the constructive body of a
+        // directly-written alias keeps its name ("direct wins"), so it is not
+        // skipped here.
+        if self.is_computed_body(type_id) {
             return None;
         }
         self.body_to_alias.get(&type_id).map(|r| *r)
@@ -1322,9 +1335,23 @@ impl DefinitionStore {
         self.bump_generation();
     }
 
-    /// Check if a body `TypeId` was marked as "computed".
+    /// Record `body` as the constructive body of a non-computed type alias, so
+    /// it keeps its alias name even if a computed alias resolves to the same
+    /// interned shape ("direct wins"). See [`Self::directly_named_alias_bodies`].
+    pub fn mark_body_as_directly_named(&self, body: TypeId) {
+        self.directly_named_alias_bodies.insert(body);
+        self.bump_generation();
+    }
+
+    /// Check if a body `TypeId` should be displayed structurally because it was
+    /// produced by a reducing operator (conditional/indexed-access/intersection)
+    /// that carries no `aliasSymbol` in tsc. A shape that is also the body of a
+    /// directly-written alias is excluded ("direct wins"): that alias must keep
+    /// its name, and because tsz interns structurally-identical types to one
+    /// `TypeId`, the shared shape cannot be reported as computed.
     pub fn is_computed_body(&self, body: TypeId) -> bool {
         self.computed_alias_bodies.contains(&body)
+            && !self.directly_named_alias_bodies.contains(&body)
     }
 
     /// Find all `DefId`s registered under the given name.

--- a/crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/def_symbol_names.rs
@@ -130,7 +130,15 @@ impl<'a> TypeFormatter<'a> {
                 && (def.kind == DefKind::TypeAlias
                     || (matches!(def.kind, DefKind::Interface | DefKind::Class)
                         && !def.type_params.is_empty()));
-            if !skip_for_empty_alias {
+            // A type alias whose body was produced by a reducing operator (a
+            // conditional / indexed access that resolved into this object shape)
+            // carries no `aliasSymbol` in tsc, so render the shape structurally
+            // instead of repainting it with the alias name. The def store's
+            // "direct wins" guard keeps the name for a directly-written alias
+            // that happens to share the same interned shape.
+            let skip_for_computed_alias = def.kind == DefKind::TypeAlias
+                && def.body.is_some_and(|b| def_store.is_computed_body(b));
+            if !skip_for_empty_alias && !skip_for_computed_alias {
                 return Some(self.format_def_name(&def));
             }
         }

--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -813,11 +813,14 @@ impl<'a> TypeFormatter<'a> {
     /// type alias whose body resolves to a primitive `Intrinsic` or a `Literal`
     /// is rendered as the underlying type, not by the alias name.
     ///
-    /// Returns the resolved primitive/literal `TypeId` to format in place of the
-    /// alias name, or `None` when the alias should keep its name (generic alias,
-    /// or a body that is a union/intersection/object/array/tuple/function/…).
-    /// Alias chains are followed (`type A = B; type B = string` → `string`); a
-    /// bounded visited set guards against cyclic alias definitions.
+    /// Returns the resolved structural `TypeId` to format in place of the alias
+    /// name, or `None` when the alias should keep its name (generic alias, or a
+    /// constructive body that carries tsc's `aliasSymbol`). A body flagged as a
+    /// computed reducing result — including a bare object or mapped shape — is
+    /// rendered structurally; the def store's "direct wins" guard keeps the name
+    /// for a directly-written alias that shares the same interned shape. Alias
+    /// chains are followed (`type A = B; type B = string` → `string`); a bounded
+    /// visited set guards against cyclic alias definitions.
     fn type_alias_body_displayed_as_underlying(&self, def_id: crate::def::DefId) -> Option<TypeId> {
         use crate::def::DefKind;
 
@@ -847,14 +850,13 @@ impl<'a> TypeFormatter<'a> {
             // structural type — `[string, number]`, `number[]`, `() => void`, … —
             // rather than the alias name, matching the checker-side display.
             //
-            // Object-mentioning bodies (a bare object, or a union/intersection
-            // containing one) are excluded: re-formatting such a shared shape
-            // re-enters the reverse `find_def_for_type` lookup, which can repaint
-            // it with an unrelated alias name. Those keep the existing display
-            // path. This mirrors the checker's `computed body` marking gate.
-            if def_store.is_computed_body(body)
-                && !crate::type_queries::union_or_intersection_mentions_object(self.interner, body)
-            {
+            // Object-mentioning bodies are included: when such a shared shape is
+            // re-formatted, the reverse `find_def_by_shape` lookup consults the
+            // same `is_computed_body` flag and so does not repaint it with the
+            // computed alias's own name. A shape that is *also* the body of a
+            // directly-written alias is excluded from `is_computed_body` by the
+            // def store's "direct wins" guard, so that alias keeps its name.
+            if def_store.is_computed_body(body) {
                 return Some(body);
             }
             match self.interner.lookup(body) {


### PR DESCRIPTION
AgentName: Studio-B
ContributorIdentity: confident-hawking

Track: 1 (conformance / diagnostic parity)

## Invariant
When a non-generic type alias's declared body is a **conditional** or **indexed access** that resolves to a **bare object / mapped shape**, `tsc` attaches no `aliasSymbol` to the reduced result and renders the underlying structural type; tsz now does the same instead of printing the alias name. Display-only — no relation, inference, narrowing, or emit behavior changes.

```ts
type Boxed = true extends true ? { a: 1 } : never;
type Holder = { v: Boxed };
const h: Holder = { v: 0 };
// tsc & tsz now: Type 'number' is not assignable to type '{ a: 1; }'.   (was: '...type 'Boxed'.')
```

## Structural rule
PR #12425 extended computed-bodied-alias structural display to the tuple-like family (tuple / array / function / primitive union) but **excluded object/mapped results**, because a structurally-identical object shape is interned to a single `TypeId`: marking that shape "computed" for one alias would strip the name from an unrelated *directly-written* alias resolving to the same shape (the `C_uobj` regression).

This lifts the exclusion for a **bare object / mapped** result and makes it collision-safe:

- The def store records the constructive bodies of non-computed aliases in `directly_named_alias_bodies`. `is_computed_body(t)` now reports `t` as computed only when no directly-written alias also owns it — **"direct wins"**.
- The object-name repaint path `resolve_object_shape_name` → `find_def_by_shape` (which tuples never hit, hence they already worked) now consults the same `is_computed_body` flag.
- A conditional/indexed result that is a **union / intersection mixing in an object** stays deferred (its interleaved elaboration is owned by a separate path); only bare object/mapped results are newly included, via the single-sourced `union_or_intersection_with_object` predicate.

So `type Computed = true extends true ? { a: 1 } : never` renders `{ a: 1; }`, while `type Direct = { a: 1 }` sharing the same interned shape keeps its name.

## Owner layer
- **Solver `def` store** owns provenance: `directly_named_alias_bodies` + the "direct wins" guard folded into `is_computed_body` / `find_type_alias_by_body` (single source of truth consulted by all display sites).
- **Solver `diagnostics::format`** (`type_alias_body_displayed_as_underlying`, `resolve_object_shape_name`) renders structurally off that flag; the old per-site object exclusion is removed.
- **Checker `state/type_analysis`** decides whether a body is computed (`source_alias_attribution::alias_declaration_body_is_computed`, narrowed via `union_or_intersection_with_object`) and records constructive non-generic bodies as directly-named (`record_alias_body_provenance`). No checker-side printer-string matching.

## Scope
- `crates/tsz-solver/src/def/core.rs`: `directly_named_alias_bodies`, `mark_body_as_directly_named`, guarded `is_computed_body` / `find_type_alias_by_body`.
- `crates/tsz-solver/src/diagnostics/format/{key.rs,compound/def_symbol_names.rs}`: render computed object bodies structurally; collision-safe shape-name repaint.
- `crates/tsz-checker/src/state/type_analysis/{core.rs,source_alias_attribution.rs}`: narrow the computed-body gate to allow bare object/mapped results; record directly-named bodies.
- `crates/tsz-checker/src/query_boundaries/diagnostics.rs`: `union_or_intersection_with_object` predicate.
- Tests: 3 new end-to-end cases in `type_alias_computed_display_tests.rs` (conditional→object, indexed-access→object with renamed binders, and the direct-vs-computed collision guard).

## Project Corpus Impact
- Row: rxjs-project / utility-types-project (diagnostic display family).
- Bug family: conditional-types / type-display (#10799, #10914 object-result witnesses; follow-up to #12425).
- Display-only: no project compiles differently — only the rendered target type in `TS2322`/elaboration messages moves toward tsc parity. No required project-corpus row should regress.

## Verification
- `cargo test -p tsz-checker --lib type_alias_computed_display_tests::` → 9 passed (3 new + 6 existing).
- `cargo test -p tsz-solver --lib` → 6525 passed, 0 failed.
- `cargo test -p tsz-checker --lib` → green except 4 failures that are **pre-existing on `main`** (verified by stashing this change): `cross_file_direct_alias_chain_globals_tests::direct_source_file_type_alias_lowers_imported_typeof_marker_leaf`, two `zod_type_query_regression_tests`, one `yield_star_return_type_tests`. Unrelated to this change.
- `cargo clippy -p tsz-solver -p tsz-checker --lib` → clean.
- Rebased onto current `main` (resolved against #12425's `source_alias_attribution` refactor).

## Coordination Notes
- Completes the **object/mapped-result** half of the computed-bodied-alias display campaign (#12399 scalar → #12425 tuple-like → this). Remaining follow-ups, unchanged here: union/intersection-of-objects results, template-literal bodies, and full reduction of nested recursive utility applications (e.g. `DeepReadonly<…>` inner layers).
- Issue #10914 marked `WIP` and owned via `agent:M1-A` (diagnostic/type-display lane); this is the object-display slice.
- `scripts/arch/arch_guard.py` reports a pre-existing size-ratchet overage on `state/type_analysis/core.rs` (already over on `main`); this change adds a small helper and does not bump the ratchet.

https://claude.ai/code/session_01EbmfLtKNhUT6EPjPxEyCnw

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbmfLtKNhUT6EPjPxEyCnw)_