### PR TITLE
fix(checker): preserve literal types of `as T` assertion sources in assignability diagnostics

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -31,6 +31,10 @@ web-time = { workspace = true }
 stacker = "0.1.23"
 
 [[test]]
+name = "assertion_source_literal_display_tests"
+path = "tests/assertion_source_literal_display_tests.rs"
+
+[[test]]
 name = "nested_discriminant_narrowing_tests"
 path = "tests/nested_discriminant_narrowing_tests.rs"
 

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1138,6 +1138,16 @@ impl<'a> CheckerState<'a> {
         let (source_str, mut target_str) =
             self.finalize_pair_display_for_diagnostic(source, target, source_str, target_str);
         let mut source_str = source_str;
+        // Preserve the literal surface of a plain `as T` / `<T>` assertion
+        // source. This `_at` path is distinct from the `AssignmentSource` role
+        // path, so both funnel through the shared
+        // `assertion_source_literal_display`.
+        if !source_from_annotation
+            && !source_from_array_literal_tuple
+            && let Some(display) = self.assertion_source_literal_display(anchor_idx, source, target)
+        {
+            source_str = display;
+        }
         if !source_from_annotation && !source_from_array_literal_tuple {
             source_str = self.apply_ts2739_nonliteral(source, source_str);
         }

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -1831,6 +1831,18 @@ impl<'a> CheckerState<'a> {
         param_type: TypeId,
         arg_idx: NodeIndex,
     ) -> String {
+        // A plain `expr as T` / `<T>expr` assertion argument yields the asserted
+        // type `T` as written. `tsc` reports it with its literal element /
+        // property types intact (a regular, non-fresh type) rather than widening
+        // them as for a fresh array/object literal argument. Detect the assertion
+        // before the `skip_parenthesized_and_assertions` below peels it away to
+        // the inner literal (which would otherwise route the operand through the
+        // fresh-literal widening). `format_type_diagnostic` renders the asserted
+        // type with literals preserved. `as const` and `satisfies` are excluded.
+        if self.expression_is_plain_type_assertion(arg_idx) {
+            return self.format_type_diagnostic(arg_type);
+        }
+
         let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(arg_idx);
         let is_array_literal_arg = self
             .ctx

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -104,6 +104,36 @@ impl<'a> CheckerState<'a> {
         saw_number_literal.then_some(non_numeric_parts)
     }
 
+    /// When the diagnostic source expression at `anchor_idx` is a plain
+    /// `expr as T` / `<T>expr` assertion (not `as const`, not `satisfies`),
+    /// return the asserted type formatted with its literal element / property
+    /// types preserved.
+    ///
+    /// The value of such an assertion is the asserted type `T` exactly as
+    /// written, which `tsc` treats as a *regular* (non-fresh) type. The general
+    /// source-display fallbacks reach the inner literal expression node (the
+    /// widening machinery peels assertions via `skip_parenthesized_and_assertions`)
+    /// and re-widen its element/property literals as though they came from a
+    /// fresh literal expression, collapsing `[1, 2, 3] as [1, 2, 3]` to
+    /// `[number, number, number]`. Intercepting before that peel keeps the
+    /// literals, matching `tsc`. Returns `None` for non-assertion sources so the
+    /// caller proceeds with its normal display path (fresh literal expressions
+    /// still widen). Shared by the two parallel TS2322 source-display pipelines
+    /// (`format_assignment_source_type_for_diagnostic` and
+    /// `format_top_level_assignability_message_types_at`) so they cannot diverge.
+    pub(in crate::error_reporter) fn assertion_source_literal_display(
+        &mut self,
+        anchor_idx: NodeIndex,
+        source: TypeId,
+        target: TypeId,
+    ) -> Option<String> {
+        let expr_idx = self
+            .direct_diagnostic_source_expression(anchor_idx)
+            .or_else(|| self.assignment_source_expression(anchor_idx))?;
+        self.expression_is_plain_type_assertion(expr_idx)
+            .then(|| self.format_assignability_type_for_message(source, target))
+    }
+
     pub(in crate::error_reporter) fn format_assignment_source_type_for_diagnostic(
         &mut self,
         source: TypeId,
@@ -139,6 +169,13 @@ impl<'a> CheckerState<'a> {
         }
 
         if let Some(display) = self.tuple_structural_source_display(source, target) {
+            return display;
+        }
+
+        // Preserve the literal surface of a plain `as T` / `<T>` assertion source
+        // before the widening fallbacks below; see
+        // `assertion_source_literal_display`.
+        if let Some(display) = self.assertion_source_literal_display(anchor_idx, source, target) {
             return display;
         }
 

--- a/crates/tsz-checker/src/types/computation/object_literal_widening.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_widening.rs
@@ -23,6 +23,41 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|assertion| self.is_const_assertion_type_node(assertion.type_node))
     }
 
+    /// Returns `true` when `expr_idx` (after skipping parentheses) is a plain
+    /// `expr as T` / `<T>expr` type assertion — an `as`/angle-bracket assertion
+    /// that is **not** `as const` and **not** a `satisfies` expression.
+    ///
+    /// The value of such an assertion is the asserted type `T` exactly as
+    /// written, which `tsc` treats as a *regular* (non-fresh) type: the literal
+    /// element/property types of `T` are preserved verbatim in assignability
+    /// diagnostics rather than widened the way a fresh object/array literal
+    /// expression is. Diagnostic source-display paths consult this to suppress
+    /// the fresh-literal widening for assertion operands, so
+    /// `[1, 2, 3] as [1, 2, 3]` renders as `[1, 2, 3]` (matching `tsc`) instead
+    /// of `[number, number, number]`. `satisfies` is excluded (it is a distinct
+    /// node kind whose value is the operand's own type), and `as const` is
+    /// excluded because it already preserves a `readonly` literal surface
+    /// through its own path.
+    pub(crate) fn expression_is_plain_type_assertion(&self, expr_idx: NodeIndex) -> bool {
+        let expr_idx = self.ctx.arena.skip_parenthesized(expr_idx);
+        let Some(node) = self.ctx.arena.get(expr_idx) else {
+            return false;
+        };
+        // `AS_EXPRESSION` / `TYPE_ASSERTION` only — `SATISFIES_EXPRESSION` is a
+        // distinct kind and is excluded inherently. Read the node once and
+        // exclude `as const` via the shared `ConstKeyword` type-node primitive
+        // so there is a single const-assertion check.
+        if node.kind != syntax_kind_ext::AS_EXPRESSION
+            && node.kind != syntax_kind_ext::TYPE_ASSERTION
+        {
+            return false;
+        }
+        self.ctx
+            .arena
+            .get_type_assertion(node)
+            .is_none_or(|assertion| !self.is_const_assertion_type_node(assertion.type_node))
+    }
+
     pub(crate) fn widen_mutable_object_literal_property_types(&self, type_id: TypeId) -> TypeId {
         crate::query_boundaries::type_computation::core::widen_mutable_object_literal_property_types(
             self.ctx.types,

--- a/crates/tsz-checker/tests/assertion_source_literal_display_tests.rs
+++ b/crates/tsz-checker/tests/assertion_source_literal_display_tests.rs
@@ -1,0 +1,142 @@
+//! A plain `expr as T` / `<T>expr` type assertion yields the asserted type `T`
+//! as written. `tsc` treats that result as a *regular* (non-fresh) type and
+//! preserves its literal element/property types in assignability diagnostics —
+//! it does NOT widen them the way a fresh object/array literal expression is
+//! widened.
+//!
+//! Before the fix, tsz routed assertion operands through the same fresh-literal
+//! widening as bare literal expressions, so `[1, 2, 3] as [1, 2, 3]` rendered
+//! as `[number, number, number]` and `{ a: 1 } as { a: 1 }` as `{ a: number; }`
+//! in TS2322/TS2345 messages. Declared references and `as const` were already
+//! preserved; only the assertion operand diverged.
+//!
+//! Negative controls confirm the gate is scoped to assertion operands: a fresh
+//! array literal still widens to `number[]`, and `as const` still renders a
+//! `readonly` literal surface. Binder names, literal values, and target types
+//! are varied across cases so the behavior is proven structural, not keyed on a
+//! fixture identifier.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_common::diagnostics::Diagnostic;
+
+fn check_strict(source: &str) -> Vec<Diagnostic> {
+    let options = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..Default::default()
+    };
+    tsz_checker::test_utils::check_source(source, "test.ts", options)
+}
+
+fn message_for(diags: &[Diagnostic], code: u32) -> String {
+    let matches: Vec<&Diagnostic> = diags.iter().filter(|d| d.code == code).collect();
+    assert!(
+        !matches.is_empty(),
+        "expected a TS{code} diagnostic, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    matches[0].message_text.clone()
+}
+
+/// `expr as [literal tuple]` assigned to a scalar preserves the tuple's literal
+/// element types in the TS2322 source display.
+#[test]
+fn tuple_assertion_source_preserves_literals_against_scalar_target() {
+    let diags = check_strict("const first: 0 = ([1, 2, 3] as [1, 2, 3]);\n");
+    let msg = message_for(&diags, 2322);
+    assert!(
+        msg.contains("Type '[1, 2, 3]' is not assignable to type '0'"),
+        "assertion tuple source must preserve literals; got: {msg}"
+    );
+    assert!(
+        !msg.contains("[number, number, number]"),
+        "assertion tuple source must not widen literal elements; got: {msg}"
+    );
+}
+
+/// `<[literal tuple]>expr` (angle-bracket form) behaves the same.
+#[test]
+fn angle_bracket_tuple_assertion_source_preserves_literals() {
+    let diags = check_strict("const seq: 7 = (<[8, 9]>(null as any));\n");
+    let msg = message_for(&diags, 2322);
+    assert!(
+        msg.contains("Type '[8, 9]' is not assignable to type '7'"),
+        "angle-bracket assertion must preserve literals; got: {msg}"
+    );
+}
+
+/// `expr as { ...literal props }` preserves literal property types.
+#[test]
+fn object_assertion_source_preserves_literal_properties() {
+    let diags = check_strict("const box: 0 = ({ width: 4 } as { width: 4 });\n");
+    let msg = message_for(&diags, 2322);
+    assert!(
+        msg.contains("width: 4"),
+        "assertion object source must preserve the literal property type; got: {msg}"
+    );
+    assert!(
+        !msg.contains("width: number"),
+        "assertion object source must not widen the literal property; got: {msg}"
+    );
+}
+
+/// Assertion argument operands preserve literals in TS2345 just like the
+/// assignment path.
+#[test]
+fn tuple_assertion_argument_preserves_literals() {
+    let diags = check_strict(
+        "declare function take(value: 0): void;\n\
+         take([5, 6] as [5, 6]);\n",
+    );
+    let msg = message_for(&diags, 2345);
+    assert!(
+        msg.contains("Argument of type '[5, 6]'"),
+        "assertion argument must preserve literals; got: {msg}"
+    );
+    assert!(
+        !msg.contains("[number, number]"),
+        "assertion argument must not widen literal elements; got: {msg}"
+    );
+}
+
+/// Negative control: a fresh array literal (no assertion) still widens to its
+/// inferred array type, matching `tsc`.
+#[test]
+fn fresh_array_literal_source_still_widens() {
+    let diags = check_strict("const items: 0 = [1, 2, 3];\n");
+    let msg = message_for(&diags, 2322);
+    assert!(
+        msg.contains("number[]"),
+        "fresh array literal must still widen to number[]; got: {msg}"
+    );
+}
+
+/// Negative control: `as const` keeps its `readonly` literal surface (its own
+/// path), unaffected by the plain-assertion gate.
+#[test]
+fn const_assertion_source_keeps_readonly_literal_surface() {
+    let diags = check_strict("const pair: 0 = ([10, 11] as const);\n");
+    let msg = message_for(&diags, 2322);
+    assert!(
+        msg.contains("readonly [10, 11]"),
+        "as const must keep its readonly literal surface; got: {msg}"
+    );
+}
+
+/// Negative control: a declared reference of a literal tuple type was already
+/// preserved and must stay preserved.
+#[test]
+fn declared_reference_source_preserves_literals() {
+    let diags = check_strict(
+        "declare const triple: [1, 2, 3];\n\
+         const out: 0 = triple;\n",
+    );
+    let msg = message_for(&diags, 2322);
+    assert!(
+        msg.contains("Type '[1, 2, 3]' is not assignable to type '0'"),
+        "declared literal-tuple reference must preserve literals; got: {msg}"
+    );
+}


### PR DESCRIPTION
AgentName: Studio-B

Track: 1 (bug fix — conformance/diagnostic parity)

Invariant: assignability diagnostics show the source type `tsc` would show; an `as T` / `<T>` assertion result is a regular (non-fresh) type whose literals are preserved.

Fixes #10817.

## Structural rule
When the source of an assignability diagnostic (TS2322/TS2345) is a plain `expr as T` / `<T>expr` type assertion (not `as const`, not `satisfies`), `tsc` reports the asserted type `T` with its literal element/property types preserved — `as T` yields a **regular (non-fresh)** type. tsz instead reached the inner literal expression node (the display machinery peels assertions via `skip_parenthesized_and_assertions`) and re-widened its literals as if they came from a fresh literal expression, so `[1, 2, 3] as [1, 2, 3]` rendered as `[number, number, number]` and `{ a: 1 } as { a: 1 }` as `{ a: number; }`. tsz now preserves them through the diagnostic source-display gateway.

## Owner layer
Checker diagnostics: `error_reporter` source-display paths + one small AST predicate. **No solver / type-system change** — the asserted `TypeId` was already the regular type; the divergence was display-only (a four-angle altitude review confirmed the display layer is the correct depth and a deeper `AS_EXPRESSION` change would be misdirected and risk excess-property/narrowing regressions).

## Context: issue #10817 (variadic tuple spread inference / arity)
Investigation showed the **solver is already correct** for variadic-tuple composition: `Zip`, `Reverse`, `Concat`, `Last`/`Init`/`Tail`, `Flatten`, and prefix/suffix/middle rest inference all evaluate to the right types (verified via `Expect<Equal<…>>` and indexed probes; the existing `variadic_tuple_recursive_zip_tests` already locks this in). The reproducible `tsc` divergence remaining in this family is that variadic-tuple-composed types (and any literal-bearing tuple/object) **lost their exact element types in diagnostics** when the source was an `as`/`<T>` assertion — i.e. "exact tuple lengths and positions" were not shown. This PR restores that fidelity.

## Adjacent-case matrix
- Tuple assertion vs scalar target: `[1,2,3] as [1,2,3]` → `[1, 2, 3]` (was `[number, number, number]`).
- Angle-bracket form `<[8,9]>x`.
- Object assertion: `{ a: 1 } as { a: 1 }` → `{ a: 1; }` (was `{ a: number; }`).
- Call-argument assertion (TS2345).
- Negative controls (unchanged): fresh array literal still widens to `number[]`; `as const` keeps `readonly [..]`; declared reference preserves literals.

## Scope
`crates/tsz-checker` only: `expression_is_plain_type_assertion` predicate + shared `assertion_source_literal_display` helper, wired into the two TS2322 source-display paths (`AssignmentSource` role + top-level `_at`) and the call-argument path. +1 registered test file.

## Project Corpus Impact
- Row: n/a (diagnostic-display-only change; no project-corpus row gating logic touched)
- Bug family: variadic-tuples / diagnostics (assignment-source literal display for `as`/`<T>` assertion operands)

Diagnostic-display only; improves message fidelity for assertion sources (ts-toolbelt and other tuple-heavy rows). No semantic/assignability change, so no row flips related↔unrelated.

## Verification
- New `assertion_source_literal_display_tests` (7 cases incl. negative controls) — all pass.
- Behaviour-preserving refactor confirmed green against nearby display suites: `readonly_tuple_source_display`, `tuple_element_mismatch`, `conditional_alias_source_display`, `destructuring_spread_rest_tuple_source_display`, `union_tuple_source_display`, `tuple_type_assertion_inference`, `variadic_tuple_recursive_zip`, `variadic_tuple_arity_inference`, `generic_call_primitive_widening_display`, `object_literal_getter_widening`, `tuple_arity_elaboration`, `generic_conflicting_argument_type_display`, and more.
- Anti-hardcoding: predicate keys on AST node kind / `ConstKeyword` type-node, never on identifier or rendered text; tests vary binder names and literal values.

## Coordination Notes
Rebased on latest `main`. `/simplify` (4-angle review) applied: extracted the shared helper so the two parallel TS2322 source-display pipelines cannot diverge, reused the existing const-assertion primitive (single const check, one arena read), trimmed duplicated rationale comments.

https://claude.ai/code/session_01M7BjDABPFT5BkAqvBqbEeh