### PR TITLE
fix(config): normalize inherited tsconfig selectors so extends-anchored globs match

### DIFF
--- a/crates/tsz-cli/src/driver/tests.rs
+++ b/crates/tsz-cli/src/driver/tests.rs
@@ -1385,6 +1385,59 @@ fn test_compile_emits_ts18003_in_batch_style_project_mode() {
 }
 
 #[test]
+fn test_no_ts18003_when_inherited_include_has_dot_prefix() {
+    // Regression for the selector-normalization half of issue #12460 (the
+    // `mswjs/msw` shape): a root that inherits `"include": ["./global.d.ts"]`
+    // from a base config via `extends`. Anchoring the inherited selector onto
+    // the base dir must collapse the leading `./`, otherwise the glob
+    // `<dir>/./global.d.ts` matches nothing and discovery raises a false
+    // TS18003.
+    //
+    // Deliberately no `references` here: the references-only suppression (added
+    // separately in #12493) would otherwise mask a broken selector fix, so this
+    // test would no longer exercise the normalization. With an empty discovery
+    // and no `files`/`references`, a regressed selector would re-raise TS18003.
+    let dir = tempfile::tempdir().expect("temp dir");
+    let root = dir.path();
+    fs::write(
+        root.join("tsconfig.base.json"),
+        r#"{
+      "compilerOptions": { "strict": true },
+      "include": ["./global.d.ts"],
+      "exclude": ["node_modules"]
+    }"#,
+    )
+    .expect("write base tsconfig");
+    fs::write(
+        root.join("tsconfig.json"),
+        r#"{ "extends": "./tsconfig.base.json" }"#,
+    )
+    .expect("write root tsconfig");
+    fs::write(
+        root.join("global.d.ts"),
+        "declare module 'virtual-mod' { export const x: number; }\n",
+    )
+    .expect("write global.d.ts");
+
+    let project = root.to_string_lossy().to_string();
+    let args = CliArgs::try_parse_from([
+        "tsz",
+        "--project",
+        project.as_str(),
+        "--noEmit",
+        "--pretty",
+        "false",
+    ])
+    .expect("args");
+    let result = compile(&args, root).expect("compile succeeds");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(&18003),
+        "inherited ./global.d.ts must be discovered; got: {codes:?}"
+    );
+}
+
+#[test]
 fn test_batch_style_project_mode_keeps_ts7005_for_imported_dts_export() {
     let dir = tempfile::tempdir().expect("temp dir");
     fs::write(

--- a/crates/tsz-core/src/config/extends.rs
+++ b/crates/tsz-core/src/config/extends.rs
@@ -355,7 +355,54 @@ fn anchor_relative_selector(selector: &mut String, base_dir: &Path) {
     if candidate.is_absolute() {
         return;
     }
-    *selector = base_dir.join(candidate).to_string_lossy().into_owned();
+    let joined = base_dir.join(candidate);
+    *selector = lexically_normalize_selector(&joined)
+        .to_string_lossy()
+        .into_owned();
+}
+
+/// Lexically collapse `.` and `..` components in an anchored selector path
+/// without touching the filesystem.
+///
+/// Anchoring a relative `include`/`exclude`/`files` selector onto its
+/// declaring config's directory via [`Path::join`] preserves any leading
+/// `./` (or embedded `..`) the selector carried — e.g. a base config's
+/// `"./global.d.ts"` becomes `<dir>/./global.d.ts`. That is a valid
+/// filesystem path but an *unmatchable glob*: during glob matching the `.`
+/// is a literal path component, so the pattern never matches the real
+/// `<dir>/global.d.ts` and discovery reports zero inputs (a false `TS18003`).
+///
+/// This rebuilds the path from [`Path::components`], which preserves glob
+/// metacharacters such as `**`/`*.ts` (unlike [`std::fs::canonicalize`], which
+/// hits the filesystem) and removes the `.`/`..` segments. The sibling
+/// `resolution::helpers::normalize_path_segments` is deliberately *not* reused
+/// here: it short-circuits to the original string when `components()` surfaces
+/// no `.`/`..`, but `components()` silently drops *embedded* `.` segments, so a
+/// joined `<dir>/./glob` would be returned with its `/./` intact.
+fn lexically_normalize_selector(path: &Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                // Resolve `..` against a preceding concrete component only.
+                // Never pop a root/prefix, and keep `..` when there is nothing
+                // ordinary to cancel (it would otherwise change the meaning).
+                if matches!(
+                    normalized.components().next_back(),
+                    Some(Component::Normal(_))
+                ) {
+                    normalized.pop();
+                } else {
+                    normalized.push("..");
+                }
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
 }
 
 pub(super) fn merge_configs(base: TsConfig, mut child: TsConfig) -> TsConfig {
@@ -614,6 +661,66 @@ mod tests {
         );
         let files = config.files.as_ref().unwrap();
         assert_eq!(files[0], parent_abs.join("entry.ts").to_string_lossy());
+    }
+
+    #[test]
+    fn anchor_inherited_root_selectors_normalizes_dot_segments() {
+        // Regression for the false TS18003 on a references-only root that
+        // inherits `"include": ["./global.d.ts"]` from a base config (the
+        // `mswjs/msw` shape). `Path::join` keeps the leading `./`, producing
+        // an unmatchable glob `<dir>/./global.d.ts`; anchoring must collapse
+        // `.`/`..` while leaving glob metacharacters intact.
+        let temp = tempdir().unwrap();
+        let config_dir = temp.path().join("project");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        let config_path = config_dir.join("tsconfig.base.json");
+
+        let mut config = TsConfig {
+            include: Some(vec![
+                "./global.d.ts".to_string(),
+                "./src/**/*.ts".to_string(),
+            ]),
+            exclude: Some(vec!["./node_modules".to_string()]),
+            files: Some(vec!["../shared/entry.ts".to_string()]),
+            ..Default::default()
+        };
+
+        anchor_inherited_root_selectors(&mut config, &config_path);
+        let parent_abs = std::fs::canonicalize(&config_dir).unwrap_or_else(|_| config_dir.clone());
+
+        let include = config.include.as_ref().unwrap();
+        assert_eq!(
+            include[0],
+            parent_abs.join("global.d.ts").to_string_lossy(),
+            "leading ./ must be collapsed so the glob matches the real file"
+        );
+        assert_eq!(
+            include[1],
+            parent_abs.join("src/**/*.ts").to_string_lossy(),
+            "glob metacharacters must survive normalization"
+        );
+        let exclude = config.exclude.as_ref().unwrap();
+        assert_eq!(
+            exclude[0],
+            parent_abs.join("node_modules").to_string_lossy()
+        );
+        let files = config.files.as_ref().unwrap();
+        assert_eq!(
+            files[0],
+            parent_abs
+                .parent()
+                .unwrap()
+                .join("shared/entry.ts")
+                .to_string_lossy(),
+            ".. must resolve against the declaring config's directory"
+        );
+
+        for selector in include.iter().chain(exclude).chain(files) {
+            assert!(
+                !selector.contains("/./") && !selector.contains("/../"),
+                "anchored selector must not retain dot segments: {selector}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Agent
AgentName: Studio-A
ContributorIdentity: confident-hawking

Closes #12460 (selector-normalization half). The complementary references-only `TS18003` suppression for the same issue landed separately in #12493; this PR was rebased on current `main` and trimmed to the **non-duplicated** selector fix.

## Track
CLI config validation / input-file discovery — `extends`-inherited selector anchoring.

## Invariant
When an `include`/`exclude`/`files` selector is inherited through tsconfig `extends`, anchoring it onto the declaring config's directory must produce a pattern that still matches the same files `tsc` would match — `.`/`..` segments are collapsed while glob metacharacters survive.

## Scope
**Root cause (the witness):** `mswjs/msw@8a19d54` emitted a false `TS18003` while `tsc 6.0.3` is clean. The msw root tsconfig inherits `"include": ["./global.d.ts"]` from `tsconfig.base.json`. Anchoring that inherited selector to the base dir does `Path::join("./global.d.ts")`, which **preserves the literal `./`**, yielding the glob `/abs/msw/./global.d.ts`. That is a valid filesystem path but an *unmatchable glob* — during glob matching the `.` is a literal component — so discovery finds zero inputs and (absent the references suppression) reports a false `TS18003`. The sibling concrete-path anchor uses `std::fs::canonicalize` to normalize, but selectors can't: globs are not real paths.

**Structural rule:** When a config inherits a relative selector via `extends`, `tsc` resolves it relative to the declaring config's directory and the resulting pattern still matches the real file; tsz now does the same through `tsz_core::config::extends::lexically_normalize_selector`.

Change (owner layer = config loading; no checker/solver type semantics):
- `crates/tsz-core/src/config/extends.rs` — anchored selectors are lexically normalized (rebuilt from `Path::components`, which drops `.`/`..` while keeping `**`/`*.ts`). Fixes the true origin, so it covers **every** project that places `include`/`exclude` in an extended base config, not just msw. Documents why the existing `resolution::helpers::normalize_path_segments` can't be reused (it short-circuits to the original string when `components()` surfaces no dot segment, but `components()` silently hides *embedded* `.`).

No user-name/file-name literals drive logic; no formatted-diagnostic string is used as a predicate; tests vary identifiers and paths.

## Project Corpus Impact
- Row: any project whose root/base tsconfig uses `extends` + relative `include`/`exclude` selectors (e.g. `mswjs/msw`).
- Bug family: false `TS18003` from malformed inherited-selector globs.
- No fixture configuration or benchmark wiring changed.

## Verification
- Built `tsz` against a real `mswjs/msw@8a19d5485adad2b8a816e04a937f4c76169cd5b9` checkout: `tsz -p . --noEmit` previously emitted `TS18003`; now emits 0 (remaining `TS5107` is a separate, pre-existing `allowSyntheticDefaultImports` deprecation, out of scope).
- Unit test `anchor_inherited_root_selectors_normalizes_dot_segments` — `.`/`..` collapsed, glob metacharacters preserved, no `/./` or `/../` retained.
- Driver regression `test_no_ts18003_when_inherited_include_has_dot_prefix` — the inherited `./global.d.ts` extends shape, deliberately **without** `references` so it isolates the selector fix rather than relying on #12493's suppression.
- Existing `test_compile_emits_ts18003_*`, `project::fs::tests`, and `config::extends` suites pass.
- Rebased on current `origin/main` (after #12493); `core.rs` resolved to main's version (its references gate kept), duplicated reference tests dropped. No conflicts.

## Coordination Notes
- AgentName: confident-hawking (ContributorIdentity per Studio-manager normalization).
- Rebased + trimmed per @mohsen1 / Studio-manager review: removed the duplicated references-only suppression (now in #12493), keeping only the selector-normalization fix.
- The issue's hand-written reduced repro doesn't reproduce; the real trigger is the `extends`-inherited selector, confirmed against the actual msw config.

https://claude.ai/code/session_012QFHTu4TNiS127cpqTCWyN