### PR TITLE
fix(emit): remove final top-level using output surgery

### DIFF
--- a/crates/tsz-emitter/src/emitter/source_file/top_level_using.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/top_level_using.rs
@@ -1655,6 +1655,16 @@ impl<'a> Printer<'a> {
         Some(rewritten)
     }
 
+    fn top_level_using_assignment_rhs<'b>(emitted: &'b str, binding_name: &str) -> Option<&'b str> {
+        Some(
+            emitted
+                .strip_prefix(binding_name)?
+                .trim_start()
+                .strip_prefix('=')?
+                .trim_start(),
+        )
+    }
+
     fn mark_top_level_using_inline_cjs_export(
         &mut self,
         export_name: Option<&String>,
@@ -2381,9 +2391,25 @@ impl<'a> Printer<'a> {
                 return true;
             }
         }
+        let use_default_tc39_display_name = self.in_system_execute_body
+            && export_name.as_deref() == Some("default")
+            && !self.ctx.options.target.supports_es2025()
+            && class.name.is_none()
+            && has_decorators
+            && !self.ctx.options.legacy_decorators;
+        let prev_pending_tc39_name = if use_default_tc39_display_name {
+            self.pending_tc39_class_expression_name
+                .replace(("default".to_string(), false))
+        } else {
+            None
+        };
+
         let before_len = self.writer.len();
         self.emit(idx);
         let after_len = self.writer.len();
+        if use_default_tc39_display_name {
+            self.pending_tc39_class_expression_name = prev_pending_tc39_name;
+        }
         if let Some(prev) = prev_anon_default_name {
             self.anonymous_default_export_name = prev;
         }
@@ -2505,20 +2531,13 @@ impl<'a> Printer<'a> {
                     .strip_suffix(';')
                     .unwrap_or(&rewritten)
                     .trim_start();
-                let inline_expr = if let Some(eq_idx) = trimmed.find(" = (() => {") {
-                    let iife = trimmed[eq_idx + 3..].replace("class_1", "default_1");
-                    iife.replace(
-                        "__setFunctionName(_classThis, \"default_1\");",
-                        "__setFunctionName(_classThis, \"default\");",
-                    )
-                } else {
-                    trimmed.to_string()
-                };
+                let inline_expr =
+                    Self::top_level_using_assignment_rhs(trimmed, &binding_name).unwrap_or(trimmed);
                 self.write_export_binding_start(export_name);
                 if self.in_top_level_using_scope {
                     self.write("_default = ");
                 }
-                self.write(&inline_expr);
+                self.write(inline_expr);
                 self.write_export_binding_end();
             } else if self.in_system_execute_body
                 && (has_explicit_export_modifier

--- a/crates/tsz-emitter/src/emitter/transform_dispatch.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch.rs
@@ -1011,7 +1011,14 @@ impl<'a> Printer<'a> {
                 && class.name.is_none()
                 && !self.collect_class_decorators(&class.modifiers).is_empty()
             {
-                emitter.set_anonymous_class_name(self.next_tc39_anonymous_class_name());
+                let default_export_class_name = self
+                    .pending_tc39_class_expression_name
+                    .as_ref()
+                    .filter(|(name, is_expression)| !*is_expression && name == "default")
+                    .and_then(|_| self.anonymous_default_export_name.clone());
+                let class_name = default_export_class_name
+                    .unwrap_or_else(|| self.next_tc39_anonymous_class_name());
+                emitter.set_anonymous_class_name(class_name);
             }
         }
         if let Some(text) = self.source_text_for_map() {

--- a/crates/tsz-emitter/tests/system_using_es_decorator_default_tests.rs
+++ b/crates/tsz-emitter/tests/system_using_es_decorator_default_tests.rs
@@ -50,4 +50,14 @@ fn system_using_es5_threads_default_tracker_for_tc39_decorated_anonymous_default
          `_default` so live-binding re-exports observe the post-decorator value.\n\
          Output:\n{output}"
     );
+    assert!(
+        !output.contains("class_1"),
+        "System top-level using default export should request the default_1 binding instead \
+         of leaking the fallback class_1 name.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("__setFunctionName(_classThis, \"default\")"),
+        "System top-level using default export should keep the runtime function name as \
+         `default`.\nOutput:\n{output}"
+    );
 }

--- a/scripts/emit/output-surgery-allowlist.txt
+++ b/scripts/emit/output-surgery-allowlist.txt
@@ -2,4 +2,3 @@
 # Current semantic rewrites over already-emitted JS/DTS. This file is a ratchet:
 # counts may go down as plan/IR/declaration-summary work removes debt; new or
 # increased counts require an explicit category and removal reason.
-crates/tsz-emitter/src/emitter/source_file/top_level_using.rs|resource-region-output-surgery|1|top-level using region rewrites emitted strings; migrate to disposable-region plan


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit/DTS parity tech-debt: resource-management output-surgery burn-down.

## Invariant
When a downlevel System top-level `using` region contains an anonymous default TC39-decorated class export, `tsc` chooses the synthesized default class binding before printing; this PR makes tsz route that name through the TC39 class/top-level using output owner instead of rewriting emitted class text.

## Scope
- Route `default` display name plus `default_1` runtime binding through the TC39 class-expression emitter for System top-level `using` default exports.
- Emit the default export RHS from the printed assignment boundary without class-name text replacement.
- Remove the final resource-region output-surgery allowlist entry.
- Add focused System top-level using anonymous default TC39 decorator coverage.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit resource-management lowering / output-surgery debt.
- Evidence: output-only emit architecture slice; no checker/project-corpus behavior expected to change.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/emit/audit-output-surgery.py`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter system_using_block_threads_default_tracker_for_anonymous_decorated_default_class system_using_es5_threads_default_tracker_for_tc39_decorated_anonymous_default_class --no-fail-fast`
- `scripts/emit/run.sh --filter=UsingDeclarationsTopLevelOfModule --js-only --verbose --json-out=/tmp/tsz-studio-c-resource-default-emit.json`

## Coordination Notes
- Linked umbrella: #9339.
- Builds directly on #12500 now merged.
- No checker semantic validation and no new output surgery.
- Output-surgery audit now reports `total_findings=0` and `warning_status=clear`.