### PR TITLE
fix(solver): avoid recursive callback return inference

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -47,6 +47,10 @@ name = "inference_placeholder_determinism_tests"
 path = "tests/inference_placeholder_determinism_tests.rs"
 
 [[test]]
+name = "context_sensitive_callback_inference_tests"
+path = "tests/context_sensitive_callback_inference_tests.rs"
+
+[[test]]
 name = "type_only_import_reexport_tests"
 path = "tests/type_only_import_reexport_tests.rs"
 

--- a/crates/tsz-checker/tests/context_sensitive_callback_inference_tests.rs
+++ b/crates/tsz-checker/tests/context_sensitive_callback_inference_tests.rs
@@ -1,0 +1,73 @@
+use tsz_checker::test_utils::{check_source_diagnostics, diagnostic_code_message_refs};
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|diagnostic| diagnostic.code)
+        .collect()
+}
+
+fn assert_no_ts2322(source: &str, context: &str) {
+    let diagnostics = check_source_diagnostics(source);
+    assert!(
+        !diagnostics.iter().any(|diagnostic| diagnostic.code == 2322),
+        "{context}: expected no TS2322, got {:#?}",
+        diagnostic_code_message_refs(&diagnostics),
+    );
+}
+
+#[test]
+fn nullish_callback_return_does_not_self_infer_wrapped_result() {
+    assert_no_ts2322(
+        r#"
+interface PLike<T> {
+    then<R1 = T>(onfulfilled: (value: T) => R1 | PLike<R1>): PLike<R1>;
+}
+
+function fwd<A, B = A>(
+    p: PLike<A>,
+    onfulfilled: (value: A) => B | PLike<B>,
+): PLike<B> {
+    return p.then(either => onfulfilled(either) ?? (either as unknown as B));
+}
+"#,
+        "context-sensitive nullish callback should not infer R1 := PLike<R1>",
+    );
+}
+
+#[test]
+fn nullish_callback_return_occurs_check_is_name_independent() {
+    assert_no_ts2322(
+        r#"
+interface Task<Value> {
+    then<Out = Value>(callback: (value: Value) => Out | Task<Out>): Task<Out>;
+}
+
+function forward<Input, Output = Input>(
+    task: Task<Input>,
+    callback: (value: Input) => Output | Task<Output>,
+): Task<Output> {
+    return task.then(item => callback(item) ?? (item as unknown as Output));
+}
+"#,
+        "renamed generic callback should not infer Out := Task<Out>",
+    );
+}
+
+#[test]
+fn concrete_bad_callback_return_still_reports_assignment_error() {
+    let source = r#"
+interface PLike<T> {
+    then<R1 = T>(onfulfilled: (value: T) => R1 | PLike<R1>): PLike<R1>;
+}
+
+function bad(p: PLike<number>): PLike<number> {
+    return p.then(() => "bad");
+}
+"#;
+    let actual = codes(source);
+    assert!(
+        actual.contains(&2322),
+        "concrete incompatible callback return must still report TS2322, got {actual:?}",
+    );
+}

--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -19,6 +19,17 @@ use rustc_hash::FxHashSet;
 use tsz_common::interner::Atom;
 
 impl<'a> InferenceContext<'a> {
+    fn discard_self_referential_candidates(
+        &mut self,
+        root: InferenceVar,
+        candidates: Vec<InferenceCandidate>,
+    ) -> Vec<InferenceCandidate> {
+        candidates
+            .into_iter()
+            .filter(|candidate| !self.occurs_in(root, candidate.type_id))
+            .collect()
+    }
+
     /// Returns `true` when `type_id` is a bare named `TypeParameter` with no
     /// `extends` constraint — a name that carries no structural information
     /// that a covariant inference result could violate.
@@ -426,8 +437,9 @@ impl<'a> InferenceContext<'a> {
         let mut upper_bounds = Vec::new();
         let mut self_referential_bounds = Vec::new();
         let mut seen_upper_bounds = FxHashSet::default();
-        let mut candidates = info.candidates;
-        let contra_candidates = info.contra_candidates;
+        let mut candidates = self.discard_self_referential_candidates(root, info.candidates);
+        let contra_candidates =
+            self.discard_self_referential_candidates(root, info.contra_candidates);
         for bound in info.upper_bounds {
             if self.occurs_in(root, bound) {
                 self_referential_bounds.push(bound);
@@ -1718,7 +1730,8 @@ impl<'a> InferenceContext<'a> {
             let dc = self.declared_constraints.get(&root).copied();
             let dc_preserves_literals =
                 self.literal_preserving_declared_constraints.contains(&root);
-            let mut candidates = info.candidates.clone();
+            let mut candidates =
+                self.discard_self_referential_candidates(root, info.candidates.clone());
             if !info.upper_bounds.is_empty() {
                 let has_informative_upper_bound = info
                     .upper_bounds
@@ -1733,11 +1746,10 @@ impl<'a> InferenceContext<'a> {
                     _ => true,
                 });
             }
-            let mut concrete_contra_candidates: Vec<_> = info
-                .contra_candidates
-                .iter()
+            let mut concrete_contra_candidates: Vec<_> = self
+                .discard_self_referential_candidates(root, info.contra_candidates.clone())
+                .into_iter()
                 .filter(|c| self.is_concrete_contra_candidate(c.type_id))
-                .cloned()
                 .collect();
             // Mirror the priority filter from `compute_constraint_result`: when
             // both co- and contra-variant candidates exist, drop contra-candidates
@@ -1863,7 +1875,12 @@ impl<'a> InferenceContext<'a> {
                         "get_current_substitution: not resolved"
                     );
 
-                    if !info.candidates.is_empty() {
+                    let candidates =
+                        self.discard_self_referential_candidates(root, info.candidates.clone());
+                    let contra_candidates = self
+                        .discard_self_referential_candidates(root, info.contra_candidates.clone());
+
+                    if !candidates.is_empty() {
                         let is_const = self.is_var_const(root);
                         let dc = self.declared_constraints.get(&root).copied();
                         let dc_preserves_literals =
@@ -1871,33 +1888,32 @@ impl<'a> InferenceContext<'a> {
                         let skip_literal_widening =
                             self.top_level_in_return_type_unfixed.contains(&root);
                         let covariant_result = self.resolve_from_candidates(
-                            &info.candidates,
+                            &candidates,
                             is_const,
                             &info.upper_bounds,
                             dc,
                             dc_preserves_literals,
                             skip_literal_widening,
                         );
-                        if !info.contra_candidates.is_empty() {
+                        if !contra_candidates.is_empty() {
                             let covariant_is_uninformative = matches!(
                                 covariant_result,
                                 TypeId::NEVER | TypeId::UNKNOWN | TypeId::ANY
                             );
                             let covariant_ok = !covariant_is_uninformative
-                                && info
-                                    .contra_candidates
+                                && contra_candidates
                                     .iter()
                                     .any(|c| self.is_subtype(covariant_result, c.type_id));
                             if covariant_ok {
                                 covariant_result
                             } else {
-                                self.resolve_from_contra_candidates(&info.contra_candidates)
+                                self.resolve_from_contra_candidates(&contra_candidates)
                             }
                         } else {
                             covariant_result
                         }
-                    } else if !info.contra_candidates.is_empty() {
-                        self.resolve_from_contra_candidates(&info.contra_candidates)
+                    } else if !contra_candidates.is_empty() {
+                        self.resolve_from_contra_candidates(&contra_candidates)
                     } else if !info.upper_bounds.is_empty() {
                         // No candidates yet, but we have a constraint (upper bound).
                         // Use the constraint as contextual fallback so that mapped types

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -329,7 +329,19 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         lower_bounds: &[TypeId],
         inferred: TypeId,
     ) -> TypeId {
-        let mut concrete_bounds = lower_bounds
+        let pruned_bounds = self.prune_wrapped_return_type_param_candidates(lower_bounds);
+        if pruned_bounds.len() != lower_bounds.len()
+            && let Some(candidate) = self.single_bare_return_type_param_candidate(&pruned_bounds)
+        {
+            return candidate;
+        }
+        let effective_lower_bounds = if pruned_bounds.is_empty() {
+            lower_bounds
+        } else {
+            pruned_bounds.as_slice()
+        };
+
+        let mut concrete_bounds = effective_lower_bounds
             .iter()
             .copied()
             .filter(|ty| {
@@ -362,7 +374,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // Conformance: `subtypeRelationForNever.ts`.
         let drop_never_promotion = concrete_bounds.len() == 1
             && concrete_bounds[0] == TypeId::NEVER
-            && lower_bounds
+            && effective_lower_bounds
                 .iter()
                 .any(|&b| matches!(b, TypeId::ANY | TypeId::UNKNOWN));
         if !drop_never_promotion
@@ -375,7 +387,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             return concrete_bounds[0];
         }
 
-        if lower_bounds.len() <= 1 {
+        if effective_lower_bounds.len() <= 1 {
             return inferred;
         }
 
@@ -387,14 +399,74 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             return inferred;
         }
 
-        let all_structural = lower_bounds
+        let all_structural = effective_lower_bounds
             .iter()
             .all(|ty| self.is_structural_return_inference_candidate(*ty));
         if all_structural {
-            return lower_bounds[0];
+            return effective_lower_bounds[0];
         }
 
         inferred
+    }
+
+    fn prune_wrapped_return_type_param_candidates(&self, lower_bounds: &[TypeId]) -> Vec<TypeId> {
+        let Some(duplicated_name) = self.duplicated_bare_return_type_param_name(lower_bounds)
+        else {
+            return lower_bounds.to_vec();
+        };
+
+        lower_bounds
+            .iter()
+            .copied()
+            .filter(|&bound| {
+                self.bare_return_type_param_name(bound) == Some(duplicated_name)
+                    || !self.is_structural_return_inference_candidate(bound)
+            })
+            .collect()
+    }
+
+    fn duplicated_bare_return_type_param_name(
+        &self,
+        lower_bounds: &[TypeId],
+    ) -> Option<tsz_common::Atom> {
+        let mut seen = FxHashSet::default();
+        let mut duplicated = None;
+        for &bound in lower_bounds {
+            let Some(name) = self.bare_return_type_param_name(bound) else {
+                continue;
+            };
+            if !seen.insert(name) {
+                if duplicated.is_some_and(|existing| existing != name) {
+                    return None;
+                }
+                duplicated = Some(name);
+            }
+        }
+        duplicated
+    }
+
+    fn bare_return_type_param_name(&self, ty: TypeId) -> Option<tsz_common::Atom> {
+        match self.interner.lookup(ty) {
+            Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => Some(info.name),
+            _ => None,
+        }
+    }
+
+    fn single_bare_return_type_param_candidate(&self, lower_bounds: &[TypeId]) -> Option<TypeId> {
+        let mut first = None;
+        let mut first_name = None;
+        for &bound in lower_bounds {
+            let name = self.bare_return_type_param_name(bound)?;
+            if let Some(existing) = first_name {
+                if existing != name {
+                    return None;
+                }
+            } else {
+                first_name = Some(name);
+                first = Some(bound);
+            }
+        }
+        first
     }
 
     pub(super) fn constrain_return_context_structure(


### PR DESCRIPTION
## Agent
AgentName: M4-B

## Track
Track 3 semantic campaign / M4-B: inference sessions, contextual callback returns, and recursive generic return candidates.

## Invariant
When a context-sensitive generic callback return contributes both a bare inference variable and a structurally wrapped candidate for that same return variable, `tsc` does not resolve the variable to the recursive wrapped form. This PR makes tsz keep the bare return candidate through solver-owned generic-call inference and reject self-referential inference candidates during resolution.

## Scope
- `crates/tsz-solver/src/inference/infer_resolve.rs`
- `crates/tsz-solver/src/operations/generic_call/inference_helpers.rs`
- `crates/tsz-checker/tests/context_sensitive_callback_inference_tests.rs`
- `crates/tsz-checker/Cargo.toml`

## Structural Rule
For callback return inference against `R | Wrapper<R>`, if the lower-bound set contains duplicate bare candidates for the same return type parameter plus a structural wrapper candidate produced by the contextual return pass, prefer the bare candidate and discard the wrapper candidate for this return-position resolution. General inference resolution also drops candidates that structurally contain the inference variable itself.

## Owner Layer
Solver inference: candidate collection/resolution and generic-call return-position inference. Checker diagnostics are unchanged and only observe the corrected inferred return type.

## Adjacent-Case Matrix
- PLike/R1 repro from #12474 no longer emits false TS2322.
- Renamed Task/Out variant proves the case is structural, not user-name keyed.
- Concrete incompatible callback return still emits TS2322.
- Adjacent generic-call filters were compared against current `origin/main`; the same 3 pass / 6 inherited failure shape appears on both branch and main.

## Project Corpus Impact
- Row: Kysely-style contextual generic inference family; no full project row claimed in this PR.
- Bug family: Track 3 contextual generic callback return inference / recursive wrapped return candidate resolution.
- Conformance witness: `await_incorrectThisType` now passes the narrow conformance filter.
- Accepted-regression ledger: no accepted-regression entry is currently listed in `scripts/conformance/conformance-accepted-regressions.txt`.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh --limit 75% -- cargo nextest run -p tsz-checker --test context_sensitive_callback_inference_tests` -> 3 passed
- `git diff --check`
- `python3 scripts/arch/arch_guard.py` -> passed
- `scripts/safe-run.sh --limit 75% -- ./scripts/conformance/conformance.sh run --filter await_incorrectThisType --verbose` -> 1/1 passed
- Adjacent branch check: `scripts/safe-run.sh --limit 75% -- cargo nextest run -p tsz-checker --test generic_call_inference_tests contextual_nested_generator_return_inference_drops_stale_ts2345 generic_class_function_member_annotated_callback_keeps_outer_type_param_in_ts2345 noinfer_array_alias_widens_to_primitive contextual_generic_new_return_recovers_unresolved_constructor_type_params class_tag_contextual_generator_callback_does_not_force_stale_ts2345 pipe_contextual_return_flows_through_generic_function_chain pipe_contextual_return_flows_through_nested_generic_call_chain generic_rest_parameter_infers_literal_tuple_under_primitive_array_constraint contextual_kysely_select_array_preserves_aliased_expression_factory_param` -> 3 passed, 6 failed
- Adjacent current-main comparison in `/Users/mohsen/code/tsz-studio-c-dts-rest-20260604` with the same filter -> 3 passed, 6 failed with the same failing tests (`NoInfer`, `Generator`, contextual constructor/generic rest/Kysely inherited failures)

## Coordination Notes
- Closes #12474.
- #12474 was originally labelled `agent:M1-A`, but the issue root cause and this fix are solver inference. The canonical `agent:M4-B` label has been applied, so this PR now owns the Track 3/M4-B inference work directly.
- PR #12482 references #12474 as a separate inference bug; this PR handles that separate inference bug without changing nullable-union callback variance policy.
