### PR TITLE
docs(site): remove benchmark warning from compatibility

### DIFF
--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -8,7 +8,6 @@ import {
   PROJECT_ROWS_BY_NAME,
   REQUIRED_PROJECT_ROWS,
 } from "../../../../scripts/bench/project-rows.mjs";
-import { benchReadinessMessages } from "../../../../scripts/bench/bench-readiness-banner.mjs";
 import { selectLatestBenchmarkArtifact } from "../../../../scripts/bench/benchmark-artifact-selection.mjs";
 import { subsystemForCode } from "../../../../scripts/ci/diagnostic-subsystems.mjs";
 import { fmt } from "./loc.js";
@@ -809,17 +808,6 @@ function readJsonIfExists(p) {
   }
 }
 
-function benchReadinessBanner(readiness, winnerReport) {
-  const messages = benchReadinessMessages(readiness, winnerReport);
-  if (messages.length === 0) return "";
-  return `<p class="bench-readiness-warning">⚠️ ${escapeHtml(messages.join(" "))}</p>`;
-}
-
-let _benchReadinessStatus;
-let _benchmarkSourceKind = null;
-let _benchmarkArtifactPath = null;
-let _benchWinnerReport;
-
 function benchmarkArtifactFiles() {
   const artifactsDir = path.join(ROOT, "artifacts");
   const ciLatest = [
@@ -841,27 +829,6 @@ function benchmarkArtifactFiles() {
   }
 }
 
-function loadBenchReadinessStatus() {
-  if (_benchReadinessStatus === undefined) {
-    _benchReadinessStatus = readJsonIfExists(path.join(ROOT, "artifacts", "bench-readiness-status.json")) ?? null;
-  }
-  if (_benchReadinessStatus) return _benchReadinessStatus;
-  if (_benchmarkSourceKind === "snapshot") return { artifact_absent: true };
-  return null;
-}
-
-function loadBenchWinnerReport() {
-  if (_benchWinnerReport !== undefined) return _benchWinnerReport;
-  if (!_benchmarkArtifactPath) {
-    _benchWinnerReport = null;
-    return _benchWinnerReport;
-  }
-
-  const winnerPath = _benchmarkArtifactPath.replace(/\.json$/, ".tsgo-winners.json");
-  _benchWinnerReport = readJsonIfExists(winnerPath) ?? null;
-  return _benchWinnerReport;
-}
-
 function sanitizeLegacyBenchmarkData(data) {
   if (data?.validation?.hyperfine_exit_codes_required === true) {
     return data;
@@ -880,8 +847,6 @@ function loadBenchmarks() {
   if (overrideArtifact) {
     const data = readJsonIfExists(overrideArtifact);
     if (data?.results) {
-      _benchmarkSourceKind = "override";
-      _benchmarkArtifactPath = overrideArtifact;
       return sanitizeLegacyBenchmarkData(data);
     }
   }
@@ -892,13 +857,9 @@ function loadBenchmarks() {
     snapshotPath,
   ]);
   if (selectedArtifact) {
-    _benchmarkSourceKind = selectedArtifact.file === snapshotPath ? "snapshot" : "artifact";
-    _benchmarkArtifactPath = selectedArtifact.file;
     return sanitizeLegacyBenchmarkData(selectedArtifact.data);
   }
 
-  _benchmarkSourceKind = null;
-  _benchmarkArtifactPath = null;
   return null;
 }
 
@@ -1742,13 +1703,9 @@ export function getProjectCompatibilityDashboard() {
 })();
 </script>`;
 
-  const readiness = loadBenchReadinessStatus();
-  const artifactBanner = benchReadinessBanner(readiness, loadBenchWinnerReport());
-
   return `<section class="compat-dashboard">
   <h2>Project compatibility</h2>
-  ${artifactBanner}
-  <p class="compat-dashboard-intro">These rows track real project fixtures that <code>tsc</code> accepts. A green row means <code>tsz</code> completed the same project check; red or yellow rows identify the current blocker before timing claims are treated as release evidence.</p>
+  <p class="compat-dashboard-intro">These rows track real project fixtures that <code>tsc</code> accepts. A green row means <code>tsz</code> completed the same project check; red or yellow rows identify the current compatibility blocker.</p>
   <div class="compat-table-wrap">
     <table class="compat-table" data-compat-sortable>
       <thead>

--- a/docs/site/compatibility.md
+++ b/docs/site/compatibility.md
@@ -7,7 +7,7 @@ permalink: /compatibility/index.html
 
 # Compatibility
 
-`tsz` is close to `tsc` compatibility across diagnostics, emit, and editor behavior. The remaining work is concentrated in real-project compile readiness, project timing completeness, and the last release-gate gaps tracked below.
+`tsz` is close to `tsc` compatibility across diagnostics, emit, and editor behavior. The remaining work is concentrated in real-project compile readiness and the last release-gate gaps tracked below.
 
 Currently tracking **TypeScript `{{ metrics.ts_version }}`**.
 

--- a/scripts/bench/test-bench-readiness-banner.mjs
+++ b/scripts/bench/test-bench-readiness-banner.mjs
@@ -103,13 +103,18 @@ const websiteBenchmarkData = fs.readFileSync(
 );
 assert.match(
   websiteBenchmarkData,
-  /benchReadinessBanner\(readiness, loadBenchWinnerReport\(\)\)/,
-  "website compatibility dashboard should pass the tsgo winner companion report into the readiness banner",
+  /current compatibility blocker/,
+  "website compatibility dashboard should frame project rows as compatibility blockers",
 );
-assert.match(
+assert.doesNotMatch(
   websiteBenchmarkData,
-  /replace\(\/\\\.json\$\/, "\.tsgo-winners\.json"\)/,
-  "website compatibility dashboard should load the selected artifact's tsgo winner companion report",
+  /benchReadinessBanner|loadBenchReadinessStatus|loadBenchWinnerReport|bench-readiness-warning/,
+  "website compatibility dashboard should not render benchmark readiness warnings",
+);
+assert.doesNotMatch(
+  websiteBenchmarkData,
+  /current release truth|public speed claims|2x target gap/,
+  "website compatibility dashboard should not include benchmark launch messaging",
 );
 
 console.log("bench readiness banner tests passed");


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Website / release-metric presentation PR.

## Invariant
When the compatibility page presents real-project compile readiness, it should explain compatibility blockers without benchmark artifact freshness warnings or speed-target launch messaging. This PR changes the public website/docs surface only.

## Scope
- Remove the benchmark-readiness banner from the project compatibility dashboard.
- Drop now-unused website benchmark-readiness loader plumbing from the dashboard data module.
- Update compatibility page copy to avoid benchmark/timing framing.
- Update the bench-readiness website assertion to check that compatibility stays free of benchmark launch warnings.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: website presentation change only; project-corpus rows, benchmark artifacts, and compiler behavior are unchanged.

## Verification
- `node scripts/bench/test-bench-readiness-banner.mjs`
- `npm run build` in `crates/tsz-website`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`
- Browser DOM check against `http://localhost:8080/compatibility/` verified the stale artifact, companion-report, public-speed-claim, and `bench-readiness-warning` text/class are absent.
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `python3 scripts/emit/query-emit.py --families`
- `node scripts/bench/project-row-summary.mjs --markdown`

## Coordination Notes
- Separate from active Studio-A compiler PRs #12448 and #12468.
- Branch created from current `origin/main` after intake.
