### PR TITLE
fix(emit/dts): keep typeof class heritage nameable

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -1322,23 +1322,56 @@ impl<'a> DeclarationEmitter<'a> {
             }
 
             let &type_idx = heritage.types.nodes.first()?;
-            if self.is_entity_name_heritage(type_idx)
-                && (!self.js_entity_extends_needs_synthetic_alias(type_idx)
-                    || self.heritage_type_is_bare_array(type_idx))
-            {
-                return None;
-            }
-
             let expr_idx = self
                 .arena
                 .get(type_idx)
                 .and_then(|type_node| self.arena.get_expr_type_args(type_node))
                 .map(|eta| eta.expression)
                 .unwrap_or(type_idx);
+            if self.is_entity_name_heritage(type_idx)
+                && (!self.js_entity_extends_needs_synthetic_alias(type_idx)
+                    || self.heritage_type_is_bare_array(type_idx)
+                    || self.js_entity_extends_inferred_typeof_reference_is_nameable(
+                        type_idx, expr_idx,
+                    ))
+            {
+                return None;
+            }
+
             return Some((type_idx, expr_idx));
         }
 
         None
+    }
+
+    fn js_entity_extends_inferred_typeof_reference_is_nameable(
+        &self,
+        type_idx: NodeIndex,
+        expr_idx: NodeIndex,
+    ) -> bool {
+        if !self.source_is_js_file {
+            return false;
+        }
+        let Some(type_id) = self.get_node_type_or_names(&[expr_idx, type_idx]) else {
+            return false;
+        };
+        if type_id == tsz_solver::types::TypeId::ANY {
+            return false;
+        }
+        let type_text = self.print_type_id(type_id);
+        let Some(reference) = type_text.strip_prefix("typeof ") else {
+            return false;
+        };
+        reference.split('.').all(Self::is_plain_identifier_part)
+    }
+
+    fn is_plain_identifier_part(text: &str) -> bool {
+        let mut chars = text.chars();
+        let Some(first) = chars.next() else {
+            return false;
+        };
+        (first == '_' || first == '$' || first.is_ascii_alphabetic())
+            && chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
     }
 
     pub(in crate::declaration_emitter) fn js_entity_extends_needs_synthetic_alias(

--- a/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs
@@ -1382,6 +1382,50 @@ export class Outer extends Inner {
 }
 
 #[test]
+fn test_js_extends_imported_typeof_entity_heritage_stays_nameable() {
+    let source = r#"
+import { LitElement } from "lit";
+export class ElementB extends LitElement {
+}
+"#;
+    let mut parser = ParserState::new("index.js".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+
+    let class_idx = find_class_node(
+        &parser,
+        "ElementB",
+        tsz_parser::parser::syntax_kind_ext::CLASS_DECLARATION,
+    );
+    let extends_expr_idx = find_class_extends_expression(&parser, class_idx);
+    let lit_element_sym = binder
+        .file_locals
+        .get("LitElement")
+        .expect("missing imported LitElement symbol");
+    let interner = TypeInterner::new();
+    let mut type_cache = crate::type_cache_view::TypeCacheView::default();
+    let typeof_lit_element = interner.type_query(SymbolRef(lit_element_sym.0));
+    type_cache
+        .node_types
+        .insert(extends_expr_idx.0, typeof_lit_element);
+    let current_arena = Arc::new(parser.arena.clone());
+    let mut emitter =
+        DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    emitter.set_current_arena(current_arena, "index.js".to_string());
+    let output = emitter.emit(root);
+
+    assert!(
+        output.contains("export class ElementB extends LitElement {"),
+        "Expected imported `typeof` entity heritage to stay nameable: {output}"
+    );
+    assert!(
+        !output.contains("ElementB_base"),
+        "Did not expect a synthetic base alias for nameable `typeof` heritage: {output}"
+    );
+}
+
+#[test]
 fn test_js_extends_imported_namespace_without_class_member_is_not_class_constructor() {
     // Negative case: the imported namespace's self-named member is a *variable*,
     // not a class, so its value meaning is NOT a class constructor. The new


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit/DTS parity: declaration emit nameability for JS class heritage.

## Invariant
When a JS exported class extends an imported ES-module class constructor and the checked heritage type is already nameable as `typeof <entity>`, `tsc` emits the direct heritage name. This PR changes the declaration emitter synthetic-extends-alias decision so that nameable `typeof` entity heritage does not become a `_base` alias.

## Scope
- `crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs`
- `crates/tsz-emitter/src/declaration_emitter/tests/generics_and_ambient.rs`

## Project Corpus Impact
- Row: `jsDeclarationEmitExportedClassWithExtends` (DTS emit)
- Bug family: DTS nameability / synthetic class heritage aliases for JS imported class constructors.
- Evidence: focused DTS row passes with `scripts/emit/run.sh --filter=jsDeclarationEmitExportedClassWithExtends --dts-only --verbose --timeout=20000 --json-out=/tmp/tsz-dts-jsDeclarationEmitExportedClassWithExtends-rebased-12508.json`.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `python3 scripts/emit/audit-output-surgery.py`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter -E 'test(test_js_extends_imported_typeof_entity_heritage_stays_nameable)' --no-fail-fast`
- `scripts/emit/run.sh --filter=jsDeclarationEmitExportedClassWithExtends --dts-only --verbose --timeout=20000 --json-out=/tmp/tsz-dts-jsDeclarationEmitExportedClassWithExtends-rebased-12508.json`

## Coordination Notes
- Structural rule: when JS direct entity heritage already has a nameable `typeof <entity>` constructor surface, declaration emit should print the heritage itself; `_base` aliases remain for non-nameable expressions and `any`/mixin-style heritage.
- Owner layer: declaration emitter nameability / synthetic heritage decision; no checker or solver semantic validation, and no output surgery.
- Rebased onto `origin/main` after #12505 landed; output-surgery audit remains at zero findings.
- No roadmap update: narrow parity fix, no durable direction/metric/track change.
