### PR TITLE
fix(resolver): anchor node_modules walk-ups at realpath for pnpm symlinks (#12459)

### DIFF
--- a/crates/tsz-cli/src/driver/resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution.rs
@@ -132,6 +132,11 @@ pub(crate) struct ModuleResolutionCache {
     file_exists_by_path: FxHashMap<PathBuf, bool>,
     node_modules_dir_by_path: FxHashMap<PathBuf, bool>,
     package_root_dir_by_path: FxHashMap<PathBuf, bool>,
+    // Realpath of a directory, memoized. Anchoring `node_modules` walk-ups at
+    // the realpath of the containing file (tsc's `preserveSymlinks: false`
+    // default) means we `canonicalize` the same package directories repeatedly;
+    // a file with many imports shares one parent directory.
+    canonical_dir_by_path: FxHashMap<PathBuf, PathBuf>,
     // Per-compiler-options cache. A compile uses one resolved `paths` table, so
     // the specifier alone is enough to memoize the best matching mapping.
     path_mapping_by_specifier: FxHashMap<String, Option<(usize, String)>>,
@@ -192,6 +197,19 @@ impl ModuleResolutionCache {
         self.package_root_dir_by_path
             .insert(path.to_path_buf(), exists);
         exists
+    }
+
+    /// Realpath of a directory (falling back to the input when it cannot be
+    /// canonicalized), memoized for the lifetime of the resolution.
+    pub(crate) fn canonical_dir(&mut self, dir: &Path) -> PathBuf {
+        if let Some(cached) = self.canonical_dir_by_path.get(dir) {
+            return cached.clone();
+        }
+
+        let canonical = canonicalize_or_owned(dir);
+        self.canonical_dir_by_path
+            .insert(dir.to_path_buf(), canonical.clone());
+        canonical
     }
 
     fn select_path_mapping<'a>(

--- a/crates/tsz-cli/src/driver/resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution.rs
@@ -9,6 +9,7 @@ use tsz::parser::NodeIndex;
 
 mod discovery;
 mod exports_imports;
+mod fs_helpers;
 mod package_resolution;
 mod path_resolution;
 mod program_file_index;
@@ -23,6 +24,9 @@ pub(crate) use discovery::{
     collect_module_specifiers_for_check, collect_module_specifiers_from_text,
     collect_star_export_specifiers, json_type_attribute_enables_json_module,
     module_specifier_has_type_json_import_attribute,
+};
+pub(crate) use fs_helpers::{
+    canonicalize_or_owned, canonicalize_with_missing_tail, env_flag, is_declaration_file,
 };
 pub(crate) use path_resolution::{
     build_duplicate_package_redirects, normalize_path, normalize_resolved_path,
@@ -269,49 +273,6 @@ impl ModuleResolutionCache {
             current = parent;
         }
     }
-}
-
-pub(crate) fn is_declaration_file(path: &Path) -> bool {
-    tsz::module_resolver::ModuleExtension::from_path(path).is_declaration()
-}
-
-pub(crate) fn canonicalize_with_missing_tail(path: &Path) -> PathBuf {
-    if let Ok(canonical) = std::fs::canonicalize(path) {
-        return canonical;
-    }
-
-    let mut tail = Vec::new();
-    let mut current = path;
-    while !current.exists() {
-        let Some(name) = current.file_name() else {
-            return path.to_path_buf();
-        };
-        tail.push(name.to_os_string());
-        let Some(parent) = current.parent() else {
-            return path.to_path_buf();
-        };
-        current = parent;
-    }
-
-    let Ok(mut canonical) = std::fs::canonicalize(current) else {
-        return path.to_path_buf();
-    };
-    for component in tail.iter().rev() {
-        canonical.push(component);
-    }
-    canonical
-}
-
-pub(crate) fn canonicalize_or_owned(path: &Path) -> PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
-}
-
-pub(crate) fn env_flag(name: &str) -> bool {
-    let Ok(value) = std::env::var(name) else {
-        return false;
-    };
-    let normalized = value.trim().to_ascii_lowercase();
-    matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
 }
 
 #[cfg(test)]

--- a/crates/tsz-cli/src/driver/resolution/fs_helpers.rs
+++ b/crates/tsz-cli/src/driver/resolution/fs_helpers.rs
@@ -1,0 +1,48 @@
+//! Small filesystem and environment helpers shared across the resolution
+//! submodules. Kept in their own module so `resolution.rs` stays within its
+//! architecture size ratchet.
+
+use std::path::{Path, PathBuf};
+
+pub(crate) fn is_declaration_file(path: &Path) -> bool {
+    tsz::module_resolver::ModuleExtension::from_path(path).is_declaration()
+}
+
+pub(crate) fn canonicalize_with_missing_tail(path: &Path) -> PathBuf {
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        return canonical;
+    }
+
+    let mut tail = Vec::new();
+    let mut current = path;
+    while !current.exists() {
+        let Some(name) = current.file_name() else {
+            return path.to_path_buf();
+        };
+        tail.push(name.to_os_string());
+        let Some(parent) = current.parent() else {
+            return path.to_path_buf();
+        };
+        current = parent;
+    }
+
+    let Ok(mut canonical) = std::fs::canonicalize(current) else {
+        return path.to_path_buf();
+    };
+    for component in tail.iter().rev() {
+        canonical.push(component);
+    }
+    canonical
+}
+
+pub(crate) fn canonicalize_or_owned(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+pub(crate) fn env_flag(name: &str) -> bool {
+    let Ok(value) = std::env::var(name) else {
+        return false;
+    };
+    let normalized = value.trim().to_ascii_lowercase();
+    matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
+}

--- a/crates/tsz-cli/src/driver/resolution/package_resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution/package_resolution.rs
@@ -173,6 +173,11 @@ pub(crate) fn resolve_node_module_specifier(
     // Self-reference: check if any ancestor package.json has a "name" matching
     // the import specifier. Node.js supports importing your own package by name
     // using the "exports" field in package.json.
+    //
+    // This walk targets the containing package's own root (the first named
+    // package.json), reachable through the symlink, so it needs no realpath
+    // anchoring — unlike the `node_modules` walk below, which looks for sibling
+    // packages that live next to the symlink target in a pnpm sandbox.
     {
         let mut dir = from_file.parent().unwrap_or(base_dir);
         loop {
@@ -233,7 +238,10 @@ pub(crate) fn resolve_node_module_specifier(
         }
     }
 
-    let mut current = from_file.parent().unwrap_or(base_dir);
+    // Anchor the walk-up at the realpath of the containing file so a package's
+    // own dependencies inside a pnpm `.pnpm` sandbox resolve (matches tsc).
+    let (origin, stop_dir) = module_walk_bounds(from_file, base_dir, options, resolution_cache);
+    let mut current = origin.as_path();
 
     loop {
         // 1. Look for the package itself in node_modules
@@ -306,7 +314,7 @@ pub(crate) fn resolve_node_module_specifier(
             }
         }
 
-        if current == base_dir {
+        if current == stop_dir.as_path() {
             break;
         }
         let Some(parent) = current.parent() else {
@@ -346,6 +354,9 @@ pub(crate) fn resolve_package_imports_specifier(
 ) -> Option<PathBuf> {
     let conditions = export_conditions(options);
     let compiler_version = types_versions_compiler_version(options);
+    // `#imports` resolve targets *within* the containing package, reached
+    // through the symlink, so this walk needs no realpath anchoring (only the
+    // `node_modules` sibling walk does — see `module_walk_bounds`).
     let mut current = from_file.parent().unwrap_or(base_dir);
 
     loop {

--- a/crates/tsz-cli/src/driver/resolution/path_resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution/path_resolution.rs
@@ -551,6 +551,51 @@ pub(crate) fn normalize_path(path: &Path) -> PathBuf {
     normalized
 }
 
+/// Anchor `dir` for a `node_modules` walk: the real (symlink-resolved) path
+/// when `preserveSymlinks` is false (tsc's default), else `dir` unchanged.
+fn anchor_walk_dir(
+    dir: &Path,
+    options: &ResolvedCompilerOptions,
+    resolution_cache: &mut ModuleResolutionCache,
+) -> PathBuf {
+    if options.preserve_symlinks {
+        dir.to_path_buf()
+    } else {
+        resolution_cache.canonical_dir(dir)
+    }
+}
+
+/// Origin and stop boundary for a `node_modules` walk-up from `from_file`.
+///
+/// tsc resolves module specifiers and `/// <reference types="..." />`
+/// directives relative to the *real* (`realpath`) location of the containing
+/// file when `preserveSymlinks` is false (the default). Under pnpm, packages
+/// are symlinked from `node_modules/<pkg>` into a `.pnpm` sandbox, so a
+/// package's own dependencies and the sibling `@types/*` packages it references
+/// live next to the symlink *target*, not next to the symlink. Walking up from
+/// the symlink path only sees the hoisted `node_modules/@types` entry and
+/// misses those siblings; walking up from the realpath finds them, matching
+/// tsc. When the containing file is not behind a symlink this is a no-op.
+///
+/// The returned `stop` boundary is the realpath of `base_dir`: because the
+/// origin is realpath-anchored its ancestor chain passes through the real
+/// `base_dir`, so the stop comparison must use the same realpath or the loop
+/// would never match and would walk to the filesystem root.
+pub(crate) fn module_walk_bounds(
+    from_file: &Path,
+    base_dir: &Path,
+    options: &ResolvedCompilerOptions,
+    resolution_cache: &mut ModuleResolutionCache,
+) -> (PathBuf, PathBuf) {
+    let origin = anchor_walk_dir(
+        from_file.parent().unwrap_or(base_dir),
+        options,
+        resolution_cache,
+    );
+    let stop = anchor_walk_dir(base_dir, options, resolution_cache);
+    (origin, stop)
+}
+
 pub(crate) fn normalize_resolved_path(path: &Path, options: &ResolvedCompilerOptions) -> PathBuf {
     let normalized = normalize_path(path);
     if options.preserve_symlinks {

--- a/crates/tsz-cli/src/driver/resolution/type_packages.rs
+++ b/crates/tsz-cli/src/driver/resolution/type_packages.rs
@@ -67,7 +67,10 @@ pub(crate) fn resolve_type_reference_from_node_modules_with_cache(
         .and_then(|(package_name, subpath)| subpath.map(|subpath| (package_name, subpath)));
     let conditions = export_conditions(options);
 
-    let mut current = from_file.parent().unwrap_or(base_dir);
+    // Anchor the walk-up at the realpath of the containing file so sibling
+    // `@types/*` packages inside a pnpm `.pnpm` sandbox resolve (matches tsc).
+    let (origin, stop_dir) = module_walk_bounds(from_file, base_dir, options, resolution_cache);
+    let mut current = origin.as_path();
 
     loop {
         let node_modules = current.join("node_modules");
@@ -116,7 +119,7 @@ pub(crate) fn resolve_type_reference_from_node_modules_with_cache(
             }
         }
 
-        if current == base_dir {
+        if current == stop_dir.as_path() {
             break;
         }
         let Some(parent) = current.parent() else {

--- a/crates/tsz-cli/src/driver/resolution_tests.rs
+++ b/crates/tsz-cli/src/driver/resolution_tests.rs
@@ -101,6 +101,100 @@ fn test_preserve_symlinks_keeps_symlink_path_identity() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+/// A `/// <reference types="..." />` directive in a `.d.ts` reached through a
+/// pnpm symlink must resolve its sibling `@types/*` packages from the realpath
+/// of the symlink target, matching tsc's `preserveSymlinks: false` default.
+///
+/// Layout mirrors pnpm: `node_modules/@types/a` is a symlink into the `.pnpm`
+/// sandbox where the sibling `@types/b` lives next to the target. Walking up
+/// from the symlink path only sees the hoisted `node_modules/@types` entry and
+/// misses `b`; walking from the realpath finds it.
+#[test]
+#[cfg(unix)]
+fn test_triple_slash_types_resolves_sibling_through_pnpm_symlink() {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    let dir = std::env::temp_dir().join("tsz_driver_resolution_pnpm_triple_slash");
+    let _ = fs::remove_dir_all(&dir);
+
+    let sandbox = dir.join("node_modules/.pnpm/@types+a@1.0.0/node_modules/@types");
+    fs::create_dir_all(sandbox.join("a")).unwrap();
+    fs::create_dir_all(sandbox.join("b")).unwrap();
+    fs::write(
+        sandbox.join("a/index.d.ts"),
+        "/// <reference types=\"b\" />\nexport interface A {}",
+    )
+    .unwrap();
+    fs::write(
+        sandbox.join("a/package.json"),
+        "{\"name\":\"@types/a\",\"version\":\"1.0.0\",\"types\":\"index.d.ts\"}",
+    )
+    .unwrap();
+    fs::write(sandbox.join("b/index.d.ts"), "export interface B {}").unwrap();
+    fs::write(
+        sandbox.join("b/package.json"),
+        "{\"name\":\"@types/b\",\"version\":\"1.0.0\",\"types\":\"index.d.ts\"}",
+    )
+    .unwrap();
+
+    // Hoist `@types/a` into `node_modules/@types/a` via a pnpm-style symlink.
+    fs::create_dir_all(dir.join("node_modules/@types")).unwrap();
+    symlink(
+        dir.join("node_modules/.pnpm/@types+a@1.0.0/node_modules/@types/a"),
+        dir.join("node_modules/@types/a"),
+    )
+    .unwrap();
+
+    let from_file = dir.join("node_modules/@types/a/index.d.ts");
+    let real_b = canonicalize_or_owned(&sandbox.join("b/index.d.ts"));
+
+    let make_options = |preserve_symlinks: bool| ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        preserve_symlinks,
+        module_suffixes: vec![String::new()],
+        printer: tsz::emitter::PrinterOptions {
+            module: ModuleKind::Node16,
+            ..Default::default()
+        },
+        checker: tsz::checker::context::CheckerOptions {
+            module: ModuleKind::Node16,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    // Default (preserveSymlinks: false) walks the realpath and finds the sibling.
+    let options = make_options(false);
+    let mut cache = ModuleResolutionCache::default();
+    let resolved = resolve_type_reference_from_node_modules_with_cache(
+        "b", &from_file, &dir, None, &options, &mut cache,
+    );
+    assert_eq!(
+        resolved,
+        Some(real_b),
+        "sibling @types/b should resolve from the realpath of the pnpm symlink target"
+    );
+
+    // preserveSymlinks: true keeps the symlink path, where the sibling is absent.
+    let preserve_options = make_options(true);
+    let mut preserve_cache = ModuleResolutionCache::default();
+    let preserved = resolve_type_reference_from_node_modules_with_cache(
+        "b",
+        &from_file,
+        &dir,
+        None,
+        &preserve_options,
+        &mut preserve_cache,
+    );
+    assert_eq!(
+        preserved, None,
+        "preserveSymlinks keeps the symlink path, where no sibling @types/b exists"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn test_normalize_resolved_path_preserves_symlink_ancestor_identity() {
     use std::fs;

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -356,12 +356,13 @@ FILE_LINE_LIMIT_CHECKS = [
         ROOT / "crates" / "tsz-scanner" / "src" / "scanner_impl.rs",
         1463,
     ),
-    # CLI driver resolution: split into discovery/exports_imports/package_resolution/
-    # path_resolution/type_packages submodules; ratchet holds the orchestrator at 301.
+    # CLI driver resolution: split into discovery/exports_imports/fs_helpers/
+    # package_resolution/path_resolution/type_packages submodules; ratchet holds
+    # the orchestrator at 280 after extracting the fs/env helpers into fs_helpers.
     (
         "CLI boundary: driver/resolution monolith size ratchet",
         ROOT / "crates" / "tsz-cli" / "src" / "driver" / "resolution.rs",
-        301,
+        280,
     ),
     # Emitter class declarations: split by emit feature family per §19.
     (


### PR DESCRIPTION
AgentName: Studio-B
ContributorIdentity: ClaudeOpus-Resolver-20260604

## Track
Module Resolution / pnpm compatibility

## Invariant
When `preserveSymlinks` is false (tsc's default), module specifiers and
`/// <reference types="..." />` directives resolve relative to the **real**
(`realpath`) location of the containing file. Under pnpm, packages are hoisted
from `node_modules/<pkg>` as symlinks into a `.pnpm` sandbox, so a package's
own dependencies and the sibling `@types/*` packages it references live next to
the symlink *target*, not next to the symlink.

**Structural rule:** When a `.d.ts` reached through a pnpm symlink references a
sibling `@types/*` package (or imports its own dependency), tsc walks
`node_modules` up from the realpath of the containing file. tsz now does the
same through the resolver's `node_modules` walk-up loops.

## Scope
Fixes #12459. tsz previously walked `node_modules` up from the **symlink**
path, so it only saw the hoisted `node_modules/@types` entry and missed the
siblings in the `.pnpm` sandbox — producing false `TS2688` ("Cannot find type
definition file for ...") for e.g. `@types/express`'s
`/// <reference types="express-serve-static-core" />` and
`/// <reference types="serve-static" />`, and failing bare imports of a
symlinked package's own dependencies.

Changes (all in `crates/tsz-cli/src/driver/resolution/`):
- New shared helper `module_walk_bounds` (+ private `anchor_walk_dir`) in
  `path_resolution.rs` returns the realpath-anchored walk **origin** and the
  realpath-anchored **stop** boundary (`base_dir`), gated on
  `!preserve_symlinks` (a no-op when the containing file is not behind a
  symlink).
- `ModuleResolutionCache::canonical_dir` memoizes the `realpath` per directory,
  so the extra `canonicalize` is paid at most once per distinct directory.
- Both `node_modules`-walking loops now use it: triple-slash type references
  (`type_packages.rs`) and bare-import package resolution
  (`package_resolution.rs`).
- File identity is unchanged — resolved candidates still flow through
  `normalize_resolved_path`, preserving the existing symlinked-package identity
  behavior (`preserve_package_link_identity`). The fix cleanly separates
  *search origin* (realpath) from *result identity* (symlink-preserving).
- The self-reference and `#imports` walks target the containing package itself
  (reachable through the symlink) and are deliberately left symlink-relative;
  comments now document why, to prevent a future false-consistency edit.

## Project Corpus Impact
- Row: msw-project (the canary added in #12465 cites this exact bug at
  `node_modules/@types/express/index.d.ts:8-9`).
- Bug family: pnpm `.pnpm`-sandbox `@types/*` sibling and dependency resolution.
  Broadly affects any pnpm project pulling `@types/express`, `@types/koa`,
  `@types/react-redux`, etc. that fan out via triple-slash references.

## Verification
- `cargo test -p tsz-cli --lib driver::resolution::resolution_tests` → 57
  passed, including the new
  `test_triple_slash_types_resolves_sibling_through_pnpm_symlink` (asserts both
  `preserveSymlinks: false` resolves the sibling via realpath and
  `preserveSymlinks: true` keeps the symlink path with no sibling).
- Full `cargo test -p tsz-cli --lib`: failing-test set is **identical** with and
  without this change (124 pre-existing, binary-dependent env failures; **0 new,
  0 regressed**).
- `cargo fmt -p tsz-cli --check` clean; `cargo clippy -p tsz-cli` clean for the
  changed crate.
- Three `/simplify` passes: first consolidated two near-identical helpers into
  `module_walk_bounds`; passes two and three confirmed the diff is clean.

## Coordination Notes
- Issue #12459 carries `agent:Studio-B`; this PR is labelled to match that lane.
- Verified no competing open PR references #12459 before and after the work.
- Not WIP/draft — ready for the merge queue.

Fixes #12459

https://claude.ai/code/session_01SATCZCUdDFNHYdREw7EUR5

