### PR TITLE
chore(emit): make emit-detail freshness wording truthful

### DIFF
--- a/scripts/emit/query-emit.py
+++ b/scripts/emit/query-emit.py
@@ -247,7 +247,7 @@ def emit_freshness_status(detail_summary, public_summary):
         return {"state": "stale", **status}
     if status["jsPassDelta"] < 0 or status["dtsPassDelta"] < 0:
         return {"state": "detail-ahead", **status}
-    return {"state": "current", **status}
+    return {"state": "aggregate-match", **status}
 
 
 def emit_freshness_report(detail_summary, public_summary):
@@ -280,8 +280,12 @@ def emit_freshness_status_line_from_status(status):
             f"(README/public ahead by JS +{status['jsPassDelta']:,} pass, "
             f"DTS +{status['dtsPassDelta']:,} pass over matching totals)."
         )
-    if state == "current":
-        return "Emit detail freshness: current (README/public aggregate matches checked detail)."
+    if state == "aggregate-match":
+        return (
+            "Emit detail freshness: aggregate-match "
+            "(README/public aggregate matches checked detail; "
+            "per-row freshness is not proven)."
+        )
     if state == "detail-ahead":
         return (
             "Emit detail freshness: detail-ahead "
@@ -298,7 +302,7 @@ def emit_freshness_status_line_from_status(status):
 
 
 def emit_detail_is_current(freshness_status):
-    return freshness_status.get("state") == "current"
+    return freshness_status.get("state") == "aggregate-match"
 
 
 def emit_pass_rate(summary, prefix):

--- a/scripts/emit/test_query_emit_families.py
+++ b/scripts/emit/test_query_emit_families.py
@@ -196,7 +196,7 @@ after
         self.assertEqual(status["state"], "different-domain")
         self.assertEqual(status["jsTotalDelta"], 470)
 
-    def test_freshness_status_reports_current_detail(self):
+    def test_freshness_status_reports_aggregate_match_detail(self):
         summary = {
             "jsPass": 13459,
             "jsTotal": 13530,
@@ -204,11 +204,27 @@ after
             "dtsTotal": 1669,
         }
         status = self.mod.emit_freshness_status(summary, dict(summary))
-        self.assertEqual(status["state"], "current")
+        self.assertEqual(status["state"], "aggregate-match")
+
+    def test_freshness_status_line_does_not_overstate_row_freshness(self):
+        line = self.mod.emit_freshness_status_line_from_status(
+            {
+                "state": "aggregate-match",
+                "jsPassDelta": 0,
+                "dtsPassDelta": 0,
+                "jsTotalDelta": 0,
+                "dtsTotalDelta": 0,
+            }
+        )
+
+        self.assertIn("aggregate-match", line)
+        self.assertIn("per-row freshness is not proven", line)
+        self.assertNotIn("current", line)
 
     def test_current_detail_requirement_requires_matching_aggregates(self):
-        self.assertTrue(self.mod.emit_detail_is_current({"state": "current"}))
+        self.assertTrue(self.mod.emit_detail_is_current({"state": "aggregate-match"}))
         for state in (
+            "current",
             "stale",
             "detail-ahead",
             "different-domain",
@@ -237,7 +253,7 @@ after
         status = self.mod.emit_freshness_status(detail_summary, public_summary)
         self.assertIn(
             status["state"],
-            ("current", "detail-ahead"),
+            ("aggregate-match", "detail-ahead"),
             "committed scripts/emit/emit-detail.json is "
             f"'{status['state']}' relative to the README emit aggregate "
             f"({status}); refresh emit-detail.json + emit-snapshot.json from "


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit/DTS parity tooling: emit detail freshness and failure-family triage accuracy.

## Invariant
When checked `scripts/emit/emit-detail.json` aggregate totals match the README/public aggregate, `query-emit.py` should describe that as aggregate agreement only; it must not imply per-row failure-family detail is proven current. This PR changes emit tooling/reporting, not emitter semantics.

## Scope
- `scripts/emit/query-emit.py`
- `scripts/emit/test_query_emit_families.py`

## Project Corpus Impact
- Row: n/a
- Bug family: emit tooling / stale checked-detail triage guard.
- Evidence: live focused emit filters on current `origin/main` passed rows still listed in checked detail, including `declarationEmitDestructuringArrayPattern2`, full `destructuring` subset, `downlevelLetConst14`, `letDeclarations-scopes-duplicates`, `constructorWithIncompleteTypeAnnotation`, `arrayLiterals2ES5`, `contextualTypeWithTuple`, `privateWriteOnlyAccessorRead`, and `jsxParsingError1`.

## Verification
- `git diff --check origin/main..HEAD`
- `python3 -m unittest scripts.emit.test_query_emit_families`
- `python3 scripts/emit/query-emit.py --freshness`
- `python3 scripts/emit/query-emit.py --freshness-json`

## Coordination Notes
- Structural rule: aggregate equality is a metric consistency check, not a per-test freshness proof.
- Owner layer: emit scripts/reporting; no checker/solver/emitter output behavior changes and no output surgery.
- Scope note: PR range changes only `scripts/emit/query-emit.py` and `scripts/emit/test_query_emit_families.py`; unrelated local JSX edits in this worktree were left unstaged and are not part of the branch.
- No roadmap update: narrow tooling truthfulness fix for agent triage, not a durable metric change.
