### PR TITLE
fix(core): stop parsing .json inputs as TypeScript on the no-check path

### DIFF
--- a/crates/tsz-core/src/parallel/core/parse_and_libs.rs
+++ b/crates/tsz-core/src/parallel/core/parse_and_libs.rs
@@ -229,7 +229,19 @@ fn validate_json_syntax(source: &str) -> Vec<ParseDiagnostic> {
     diagnostics
 }
 
-fn synthesize_json_bind_result(file_name: String, source_text: String) -> BindResult {
+/// Build the empty source-file skeleton tsz uses to represent a `.json` file.
+///
+/// `.json` inputs are never run through the TypeScript grammar (that is what
+/// produces spurious TS1005/TS1128 on a perfectly valid `package.json`). Instead
+/// every parse/bind entry point routes `.json` through this single helper so the
+/// program holds a statement-free source file plus the strict-JSON validation
+/// diagnostics, matching tsc's dedicated JSON parse path. Returning the parts
+/// (rather than a `BindResult`) lets both the bind paths and the parse-only
+/// no-check path share one definition of "how a JSON file enters the program".
+fn synthesize_json_source_file(
+    file_name: &str,
+    source_text: String,
+) -> (NodeArena, NodeIndex, Vec<ParseDiagnostic>) {
     let parse_diagnostics = validate_json_syntax(&source_text);
 
     let mut arena = NodeArena::new();
@@ -241,7 +253,7 @@ fn synthesize_json_bind_result(file_name: String, source_text: String) -> BindRe
         SourceFileData {
             statements: NodeList::default(),
             end_of_file_token: eof_token,
-            file_name: file_name.clone(),
+            file_name: file_name.to_string(),
             text: Arc::<str>::from(source_text),
             language_version: 99,
             language_variant: 0,
@@ -255,6 +267,27 @@ fn synthesize_json_bind_result(file_name: String, source_text: String) -> BindRe
             transform_flags: 0,
         },
     );
+
+    (arena, source_file, parse_diagnostics)
+}
+
+/// Build a parse-only [`ParseResult`] for a `.json` file without invoking the
+/// TypeScript parser. Used by the no-check / parse-only driver paths, mirroring
+/// the `.json` skip in the bind paths.
+fn synthesize_json_parse_result(file_name: String, source_text: String) -> ParseResult {
+    let (arena, source_file, parse_diagnostics) =
+        synthesize_json_source_file(&file_name, source_text);
+    ParseResult {
+        file_name,
+        source_file,
+        arena,
+        parse_diagnostics,
+    }
+}
+
+fn synthesize_json_bind_result(file_name: String, source_text: String) -> BindResult {
+    let (arena, source_file, parse_diagnostics) =
+        synthesize_json_source_file(&file_name, source_text);
 
     let mut binder = BinderState::new();
     binder.set_debug_file(&file_name);
@@ -450,6 +483,15 @@ pub fn parse_files_parallel(files: Vec<(String, String)>) -> Vec<ParseResult> {
 
     maybe_parallel_into!(files)
         .map(|(file_name, source_text)| {
+            // Skip parsing .json files - they should not be parsed as TypeScript.
+            // A `.json` input is a JSON module, not a TS source; running it
+            // through the TS grammar emits spurious TS1005/TS1128 on valid JSON
+            // (e.g. `package.json`). The bind paths already route `.json` here;
+            // the parse-only no-check path must do the same.
+            if file_name.ends_with(".json") {
+                return synthesize_json_parse_result(file_name, source_text);
+            }
+
             let mut parser = ParserState::new(file_name.clone(), source_text);
             let source_file = parser.parse_source_file();
 
@@ -468,6 +510,11 @@ pub fn parse_files_parallel(files: Vec<(String, String)>) -> Vec<ParseResult> {
 
 /// Parse a single file (for comparison/testing)
 pub fn parse_file_single(file_name: String, source_text: String) -> ParseResult {
+    // Mirror the `.json` skip used by every other parse/bind entry point.
+    if file_name.ends_with(".json") {
+        return synthesize_json_parse_result(file_name, source_text);
+    }
+
     let mut parser = ParserState::new(file_name.clone(), source_text);
     let source_file = parser.parse_source_file();
 

--- a/crates/tsz-core/tests/parallel_tests_parts/part_00.rs
+++ b/crates/tsz-core/tests/parallel_tests_parts/part_00.rs
@@ -308,6 +308,76 @@ fn test_parse_and_bind_single_json_keyword_root_is_valid() {
     assert!(result.parse_diagnostics.is_empty());
 }
 
+/// Regression for #12485: the parse-only (no-check) path must skip the TS
+/// grammar for `.json` inputs just like the bind paths. A realistic
+/// `package.json` is valid JSON; running it through the TS parser produced ~200
+/// spurious TS1005/TS1128 grammar errors.
+#[test]
+fn test_parse_file_single_json_is_not_parsed_as_typescript() {
+    let package_json = r#"{
+  "name": "drizzle-orm",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": { "build": "tsc", "test": "vitest" },
+  "keywords": ["orm", "sql", "typescript"],
+  "exports": { ".": "./index.js", "./package.json": "./package.json" }
+}"#;
+
+    let result = parse_file_single("package.json".to_string(), package_json.to_string());
+
+    assert_eq!(result.file_name, "package.json");
+    assert!(result.source_file.is_some());
+    assert!(
+        result.parse_diagnostics.is_empty(),
+        "valid package.json must not emit grammar diagnostics, got: {:?}",
+        result.parse_diagnostics
+    );
+}
+
+#[test]
+fn test_parse_files_parallel_json_is_not_parsed_as_typescript() {
+    let files = vec![
+        ("a.ts".to_string(), "export const a = 1;".to_string()),
+        (
+            "package.json".to_string(),
+            r#"{ "name": "pkg", "version": "1.0.0", "dependencies": {} }"#.to_string(),
+        ),
+        (
+            "tsconfig.json".to_string(),
+            r#"{ "compilerOptions": { "strict": true }, "include": ["**/*"] }"#.to_string(),
+        ),
+    ];
+
+    let results = parse_files_parallel(files);
+
+    assert_eq!(results.len(), 3);
+    for result in &results {
+        assert!(result.source_file.is_some());
+        assert!(
+            result.parse_diagnostics.is_empty(),
+            "{} should parse cleanly, got: {:?}",
+            result.file_name,
+            result.parse_diagnostics
+        );
+    }
+}
+
+/// The parse-only path still surfaces strict-JSON violations (unquoted property
+/// names) as TS1327 rather than TS-grammar noise, matching the bind path.
+#[test]
+fn test_parse_file_single_json_reports_strict_json_violation() {
+    let result =
+        parse_file_single("settings.json".to_string(), "{ name: \"x\" }".to_string());
+
+    let codes: Vec<u32> = result.parse_diagnostics.iter().map(|d| d.code).collect();
+    assert_eq!(
+        codes,
+        vec![1327],
+        "expected TS1327 for unquoted JSON property name, got: {:?}",
+        result.parse_diagnostics
+    );
+}
+
 // =========================================================================
 // Parallel Binding Tests
 // =========================================================================


### PR DESCRIPTION
AgentName: Studio-B
Track: core / file routing (parse pipeline)

## Summary

Closes #12485.

A `.json` input is a JSON module, not a TypeScript source. Running it through the TypeScript grammar emits spurious `TS1005`/`TS1128` on perfectly valid JSON — e.g. a `package.json` becomes a ~200-error "syntax disaster".

Every **bind** path already guarded against this and routed `.json` through `synthesize_json_bind_result`:
- `parse_and_bind_parallel`
- `parse_and_bind_single`
- `bind_file_with_libs_with_language_version`

But the two **parse-only** entry points did not, and ran every file through `ParserState`/`parse_source_file`:
- `parse_files_parallel`
- `parse_file_single`

`parse_files_parallel` is exactly what the driver uses on the no-check / parse-only path (`--noCheck --noEmit`, and the skip-lib-check declaration path) at `crates/tsz-cli/src/driver/core.rs`. So on those paths a valid `package.json` was scanned as TS and produced the witness diagnostics verbatim:

```
package.json(1,9): error TS1005: ';' expected.
```

## Structural rule

> When a program input has the `.json` extension, tsc never routes it through the TypeScript grammar; it is parsed by the dedicated JSON path (statement-free source file + strict-JSON validation). tsz must do the same at **every** parse/bind entry point, not just the bind paths.

## Owner layer & fix

`crates/tsz-core/src/parallel/core/parse_and_libs.rs`:
- Factored the JSON source-file skeleton out of `synthesize_json_bind_result` into a single `synthesize_json_source_file(file_name, source_text) -> (NodeArena, NodeIndex, Vec<ParseDiagnostic>)`. This is now the one definition of "how a JSON file enters the program".
- Added `synthesize_json_parse_result` (the `ParseResult` analogue of the bind variant) and routed `.json` through it from `parse_files_parallel` and `parse_file_single`, mirroring the existing bind-path guard.

Strict-JSON violations are unchanged: an unquoted key still yields `TS1327` on the parse-only path, same as the bind path. Only the TS-grammar noise is removed. The bind-path behavior is byte-identical (same skeleton, same `script_kind`).

## Adjacent-case matrix

- Valid `package.json` (realistic: nested objects, arrays, `exports` map) on the no-check path — no diagnostics ✅
- Mixed `.ts` + `package.json` + `tsconfig.json` batch through `parse_files_parallel` — `.ts` parses, `.json` clean ✅
- Single-file `parse_file_single` with `package.json` — clean ✅
- Strict-JSON violation (`{ name: "x" }`, unquoted key) on the parse path — still `TS1327` ✅
- Bind paths (full-check) — unchanged (already guarded; refactor is behavior-preserving) ✅

## Project Corpus Impact

- Row: drizzle-orm style projects (`allowJs`+`checkJs` with a root `package.json`) and any project compiled on a no-check/parse-only path.
- Bug family: file routing — `.json` mis-parsed as TS on the no-check path.

Removes ~200 spurious `TS1005`/`TS1128` per project from `package.json`/`tsconfig.json`/`.json` config files. No new diagnostics introduced; strict-JSON validation (`TS1327`) preserved. No emit/runtime change.

## Verification

- New regression tests in `crates/tsz-core/tests/parallel_tests_parts/part_00.rs`:
  - `test_parse_file_single_json_is_not_parsed_as_typescript`
  - `test_parse_files_parallel_json_is_not_parsed_as_typescript`
  - `test_parse_file_single_json_reports_strict_json_violation`
- `cargo test -p tsz-core --lib json`: 49 passed, 0 failed.
- `cargo test -p tsz-core --lib parallel::core::tests`: 222 passed, 0 failed.
- `cargo clippy -p tsz-core`: no findings in the changed file (one pre-existing `collapsible_if` in the untouched `config/lib_resolution.rs`, surfaced only by the container's newer clippy).
- Manual repro with `.target/debug/tsz -p tsconfig.json --noCheck`: a valid `package.json` went from 5× `TS1005` to 0; an invalid `{ name: "x" }` still reports `TS1327`.

## Coordination Notes

Scope is the parse pipeline only. Module resolution and discovery already exclude `.json` correctly (discovery filters to ts/js; resolution gates `.json` behind `resolveJsonModule` with `TS2732`), so this is purely the missing parse-only guard. Rebased on latest `main` (`047f5ac`); no overlap with that commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01981W6tDet1iWpsgzWytsUo)_
