### PR TITLE
fix(config): match TS5107 migration URL chaining

### DIFF
--- a/crates/tsz-core/src/config/deprecation_helpers.rs
+++ b/crates/tsz-core/src/config/deprecation_helpers.rs
@@ -1,16 +1,15 @@
 use tsz_common::diagnostics::data::diagnostic_messages;
 
-/// Returns true when `tsc 6.0.3` appends the migration-URL note for `option_key`.
+/// Returns true when `tsc 6.0.3` appends the migration-URL note.
 ///
-/// `tsc` only chains "Visit https://aka.ms/ts6" when the deprecated option has an
-/// active migration target documented in the TS 6 migration guide (module-resolution
-/// overhaul, target upgrade). Options that are deprecated without a documented
-/// migration path (e.g. `allowSyntheticDefaultImports=false`, `esModuleInterop=false`)
-/// do not get the URL suffix.
-pub(super) fn option_has_migration_url(option_key: &str) -> bool {
+/// `tsc` only chains "Visit https://aka.ms/ts6" for the deprecated entries
+/// whose `createDeprecatedDiagnostic` call receives the TS5111 related message.
+/// Most TS 6 deprecations, including `allowSyntheticDefaultImports=false`,
+/// `alwaysStrict=false`, and `moduleResolution=classic`, do not get the suffix.
+pub(super) fn option_has_migration_url(option_key: &str, option_value: Option<&str>) -> bool {
     matches!(
-        option_key,
-        "moduleResolution" | "module" | "target" | "downlevelIteration"
+        (option_key, option_value),
+        ("baseUrl", None) | ("moduleResolution", Some("node10"))
     )
 }
 
@@ -25,9 +24,13 @@ pub(super) fn with_migration_url(base: String) -> String {
     )
 }
 
-/// Appends the migration URL only when `tsc 6.0.3` would do so for `option_key`.
-pub(super) fn maybe_with_migration_url(base: String, option_key: &str) -> String {
-    if option_has_migration_url(option_key) {
+/// Appends the migration URL only when `tsc 6.0.3` would do so.
+pub(super) fn maybe_with_migration_url(
+    base: String,
+    option_key: &str,
+    option_value: Option<&str>,
+) -> String {
+    if option_has_migration_url(option_key, option_value) {
         with_migration_url(base)
     } else {
         base

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -1627,6 +1627,7 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
                             &[key, display_value, "7.0", "6.0"],
                         ),
                         key,
+                        Some(display_value),
                     );
                     diagnostics.push(Diagnostic::error(
                         file_path,
@@ -1638,11 +1639,9 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
                 }
             }
 
-            // No-value deprecations (TS5101): "Option '{0}' is deprecated..."
             let key_deprecations = ["baseUrl", "outFile", "downlevelIteration"];
             for key in &key_deprecations {
-                // Suppress TS5101 when TS5024 already fired for the same option:
-                // tsc does not emit a deprecation warning for options with type errors.
+                // Suppress TS5101 when TS5024 already fired; tsc skips invalid options.
                 if ts5024_keys.iter().any(|k| k == key) {
                     continue;
                 }
@@ -1660,6 +1659,7 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
                             &[key, "7.0", "6.0"],
                         ),
                         key,
+                        None,
                     );
                     diagnostics.push(Diagnostic::error(
                         file_path,

--- a/crates/tsz-core/src/config/tests/strict_lib_extends.rs
+++ b/crates/tsz-core/src/config/tests/strict_lib_extends.rs
@@ -1162,16 +1162,16 @@ fn ts6046_silent_for_valid_watch_file_value() {
 // so `try-tsz` project comparisons match tsc output on (code, message) tuples.
 
 #[test]
-fn ts5107_message_equals_flattened_tsc_output() {
-    let source = r#"{"compilerOptions":{"alwaysStrict":false}}"#;
+fn ts5107_message_with_migration_url_equals_flattened_tsc_output() {
+    let source = r#"{"compilerOptions":{"moduleResolution":"node10"}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let diag = parsed
         .diagnostics
         .iter()
         .find(|d| d.code == 5107)
-        .expect("expected TS5107 for alwaysStrict=false");
+        .expect("expected TS5107 for moduleResolution=node10");
     let expected = concat!(
-        "Option 'alwaysStrict=false' is deprecated and will stop functioning in TypeScript 7.0.",
+        "Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0.",
         " Specify compilerOption '\"ignoreDeprecations\": \"6.0\"' to silence this error.",
         "\n  Visit https://aka.ms/ts6 for migration information.",
     );
@@ -1182,7 +1182,46 @@ fn ts5107_message_equals_flattened_tsc_output() {
 }
 
 #[test]
-fn ts5101_message_equals_flattened_tsc_output() {
+fn ts5107_message_without_migration_url_equals_flattened_tsc_output() {
+    let source = r#"{"compilerOptions":{"allowSyntheticDefaultImports":false}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let diag = parsed
+        .diagnostics
+        .iter()
+        .find(|d| d.code == 5107)
+        .expect("expected TS5107 for allowSyntheticDefaultImports=false");
+    let expected = concat!(
+        "Option 'allowSyntheticDefaultImports=false' is deprecated and will stop ",
+        "functioning in TypeScript 7.0. Specify compilerOption ",
+        "'\"ignoreDeprecations\": \"6.0\"' to silence this error.",
+    );
+    assert_eq!(
+        diag.message_text, expected,
+        "TS5107 message must omit the TS5111 URL when tsc has no related message"
+    );
+}
+
+#[test]
+fn ts5107_classic_module_resolution_omits_migration_url() {
+    let source = r#"{"compilerOptions":{"moduleResolution":"classic"}}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let diag = parsed
+        .diagnostics
+        .iter()
+        .find(|d| d.code == 5107)
+        .expect("expected TS5107 for moduleResolution=classic");
+    let expected = concat!(
+        "Option 'moduleResolution=classic' is deprecated and will stop functioning in TypeScript 7.0.",
+        " Specify compilerOption '\"ignoreDeprecations\": \"6.0\"' to silence this error.",
+    );
+    assert_eq!(
+        diag.message_text, expected,
+        "TS5107 must distinguish node10 from classic for the TS5111 URL"
+    );
+}
+
+#[test]
+fn ts5101_message_with_migration_url_equals_flattened_tsc_output() {
     let source = r#"{"compilerOptions":{"baseUrl":"."}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let diag = parsed


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 8 diagnostics / project-comparison parity bug fix.

## Invariant
When a TypeScript 6 deprecated compiler option diagnostic is emitted, `tsc` only chains the TS5111 migration URL for entries whose `createDeprecatedDiagnostic` call has the related migration message. This PR makes `tsz` emit that URL through the `tsz-core` config/deprecation helper only for `baseUrl` and `moduleResolution=node10`, while omitting it for deprecated entries such as `allowSyntheticDefaultImports=false`, `alwaysStrict=false`, and `moduleResolution=classic`.

## Scope
- `crates/tsz-core/src/config/deprecation_helpers.rs`: make the migration URL decision depend on option key plus value.
- `crates/tsz-core/src/config/mod.rs`: pass the deprecated value into the helper without growing the over-cap source shard.
- `crates/tsz-core/src/config/tests/strict_lib_extends.rs`: add exact flattened-message coverage for URL and no-URL TS5107/TS5101 cases.

## Project Corpus Impact
- Row: projects with deprecated compiler options no longer get false `(code, message)` mismatches in `try-tsz`/project comparison when `tsc` omits the TS5111 URL, including the `allowSyntheticDefaultImports=false` witness from #12457.
- Bug family: TS5107/TS5101 diagnostic message parity for TypeScript 6 deprecated compiler options.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-core config::tests::strict_lib_extends`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- `wc -l crates/tsz-core/src/config/mod.rs` = 4281, unchanged from `origin/main`

## Coordination Notes
#12468 has landed in `main`; no owned Studio-A PRs were left open before starting this issue work. This PR addresses #12457, the over-correction from #12292. After the stale ready-state conformance aggregate run, this branch was rebased onto `origin/main` d52a91cd2afed5b4f1ffe6ece73a7b6133a43ca6 and repushed at e5e1df0fd28d0cb6541430ed27c3617f41b6b518. Public benchmark artifact tracking remains active in #10649: the public artifact has advanced to run 26942358199 at 73259e9522f1637b049713fc4d9fdf80c9a5de86, and follow-up producer run 26945632499 is still in progress for 4e7b29433ce34d7ef1be3eebc91e8aad3de23924.

Closes #12457.
