### PR TITLE
fix(parser): accept contextual keywords as mapped-type parameter names

### DIFF
--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -952,8 +952,9 @@ impl ParserState {
 
         self.next_token(); // skip [
 
-        // Skip identifier
-        if self.is_token(SyntaxKind::Identifier) {
+        // Skip the type parameter name: any non-reserved keyword is valid here
+        // (e.g. `[type in keyof T]` uses `type` as a contextual identifier).
+        if self.is_identifier() {
             self.next_token();
         }
 
@@ -975,8 +976,9 @@ impl ParserState {
         // vs `[identifier :` pattern (index signature)
         let is_mapped = if self.is_token(SyntaxKind::OpenBracketToken) {
             self.next_token(); // skip [
-            if self.is_token(SyntaxKind::Identifier) {
-                self.next_token(); // skip identifier
+            // Skip the type parameter name (any non-reserved keyword, e.g. `type`)
+            if self.is_identifier() {
+                self.next_token(); // skip identifier or contextual keyword
             }
             self.is_token(SyntaxKind::InKeyword)
         } else {

--- a/crates/tsz-parser/tests/parser_unit_tests_parts/part_02.rs
+++ b/crates/tsz-parser/tests/parser_unit_tests_parts/part_02.rs
@@ -388,3 +388,66 @@ class A {
         parser.get_diagnostics()
     );
 }
+
+// ─── Contextual-keyword type-parameter names in mapped types (#12484) ─────────
+
+#[test]
+fn mapped_type_with_type_keyword_as_parameter_name() {
+    // `[type in keyof T]` — `type` is a contextual keyword valid as a
+    // mapped-type type-parameter name. tsc accepts this; tsz must not reject it.
+    let source = "type R<T> = { [type in keyof T]: T[type] };";
+    let (parser, root) = parse_clean_source(source, "[type in keyof T] mapped type");
+    let arena = parser.get_arena();
+    let stmt_idx = get_first_statement(arena, root);
+    let stmt_node = arena.get(stmt_idx).expect("stmt");
+    let alias = arena.get_type_alias(stmt_node).expect("type alias");
+    let type_node = arena.get(alias.type_node).expect("type node");
+    assert_eq!(
+        type_node.kind,
+        syntax_kind_ext::MAPPED_TYPE,
+        "{{[type in keyof T]: ...}} should parse as a mapped type, not object literal"
+    );
+}
+
+#[test]
+fn mapped_type_readonly_with_type_keyword_as_parameter_name() {
+    // `readonly [type in keyof T]` — same as above but with readonly modifier.
+    let source = "type R<T> = { readonly [type in keyof T]: T[type] };";
+    let (parser, root) =
+        parse_clean_source(source, "readonly [type in keyof T] mapped type");
+    let arena = parser.get_arena();
+    let stmt_idx = get_first_statement(arena, root);
+    let stmt_node = arena.get(stmt_idx).expect("stmt");
+    let alias = arena.get_type_alias(stmt_node).expect("type alias");
+    let type_node = arena.get(alias.type_node).expect("type node");
+    assert_eq!(
+        type_node.kind,
+        syntax_kind_ext::MAPPED_TYPE,
+        "readonly {{[type in keyof T]: ...}} should parse as a mapped type"
+    );
+    let mapped = arena.get_mapped_type(type_node).expect("mapped data");
+    assert!(
+        mapped.readonly_token.is_some(),
+        "should have readonly token"
+    );
+}
+
+#[test]
+fn mapped_type_contextual_keyword_names_vary_binder() {
+    // Varying the parameter name to non-`type` contextual keywords confirms
+    // the fix is structural (any non-reserved keyword), not name-specific.
+    // `interface` is a contextual keyword that should also be valid here.
+    let source = "type R<T> = { [interface in keyof T]: T[interface] };";
+    let (parser, root) =
+        parse_clean_source(source, "[interface in keyof T] mapped type");
+    let arena = parser.get_arena();
+    let stmt_idx = get_first_statement(arena, root);
+    let stmt_node = arena.get(stmt_idx).expect("stmt");
+    let alias = arena.get_type_alias(stmt_node).expect("type alias");
+    let type_node = arena.get(alias.type_node).expect("type node");
+    assert_eq!(
+        type_node.kind,
+        syntax_kind_ext::MAPPED_TYPE,
+        "{{[interface in keyof T]: ...}} should parse as a mapped type"
+    );
+}


### PR DESCRIPTION
AgentName: Studio-manager

**Track**: Track 8 – Diagnostics, Display, Parser Options (parser correctness / conformance parity)

**Invariant**: `{ [type in keyof T]: T[type] }` and any other mapped type whose parameter name is a non-reserved contextual keyword must parse as a `MappedType` node, not an object literal or index signature.

## Scope

`crates/tsz-parser/src/parser/state_types_advanced.rs` – two lookahead helpers:
- `look_ahead_is_mapped_type_start` (line ~953)
- `look_ahead_is_mapped_type` (line ~976)

Both used `is_token(SyntaxKind::Identifier)` to skip the type-parameter name token inside `[…]`. The bare `Identifier` kind (80) does not cover non-reserved keywords such as `type` (TypeKeyword = 156), `interface`, `from`, `module`, etc. Those tokens fell through unskipped, the subsequent `is_token(InKeyword)` test failed, and the node was misclassified.

**Fix**: Replace both `is_token(SyntaxKind::Identifier)` calls with `is_identifier()`. `is_identifier()` returns `true` for the bare Identifier kind **and** every non-reserved keyword in the `(WithKeyword, DeferKeyword]` range (i.e. all contextual keywords), exactly matching what tsc accepts as a mapped-type parameter name at this position.

```rust
// before
if self.is_token(SyntaxKind::Identifier) {
    self.next_token();
}

// after
if self.is_identifier() {
    self.next_token(); // skip identifier or contextual keyword
}
```

## Project Corpus Impact

- Row: n/a (parser-only fix; no project-bench row required)
- Bug family: mapped-type parameter name mis-classification (contextual keyword used as binder name)

Pure parser classification fix. No type-system logic changed. Previously, source using contextual-keyword parameter names triggered a mis-parse that would cascade into binder/checker errors on perfectly valid TypeScript. Zero behaviour change for the common case where the parameter is a plain identifier.

## Verification

```
cargo test -p tsz-parser
# 1354 passed; 0 failed
```

Three new tests added to `part_02.rs`:
- `mapped_type_with_type_keyword_as_parameter_name` – `[type in keyof T]`
- `mapped_type_readonly_with_type_keyword_as_parameter_name` – `readonly [type in keyof T]`
- `mapped_type_contextual_keyword_names_vary_binder` – `[interface in keyof T]` (confirms fix is structural, not name-specific, per anti-hardcoding contract)

## Coordination Notes

Closes #12484. No overlap with open PRs; no shared files with any active branch. This is a narrow single-concern parser fix with no downstream API changes.

https://claude.ai/code/session_01AU87RYk38jC6PcHduHz2GF
