### PR TITLE
fix(solver): preserve variadic tuple tail arity in inference (#12176)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1206,6 +1206,9 @@ mod variadic_tuple_elaboration_tests;
 #[path = "../tests/variadic_tuple_readonly_relation_tests.rs"]
 mod variadic_tuple_readonly_relation_tests;
 #[cfg(test)]
+#[path = "../tests/variadic_tuple_tail_arity_inference_tests.rs"]
+mod variadic_tuple_tail_arity_inference_tests;
+#[cfg(test)]
 #[path = "../tests/void_param_optionality_tests.rs"]
 mod void_param_optionality_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/tests/variadic_tuple_tail_arity_inference_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_tail_arity_inference_tests.rs
@@ -1,0 +1,162 @@
+//! Regression tests for #12176 — variadic tuple tail inference must preserve
+//! rest length and element positions, matching `tsc`'s `inferFromTupleTypes`.
+//!
+//! Structural rule: when inferring through `[H, ...Tail]`, `[...Init, L]`,
+//! `[H, ...Mid, L]`, or `[...A, ...B]`, the arity of each variadic/rest segment
+//! is preserved. Two adjacent variadic type parameters are split only when an
+//! implied arity is available (a bare `...rest: T` rest parameter, or a fixed
+//! constraint); otherwise neither is inferred and both fall back to their
+//! constraints — exactly as `tsc` does.
+//!
+//! Each test pins behavior with an assignability witness: a correct target type
+//! must NOT produce `TS2322`, and a deliberately wrong target type (one extra or
+//! one missing element, or a dropped arity) MUST produce `TS2322`. The rule is
+//! structural, so binder spellings are varied to guard against name-keyed logic.
+
+use crate::test_utils::{check_source_diagnostics, diagnostics_with_code};
+
+fn ts2322_count(source: &str) -> usize {
+    diagnostics_with_code(&check_source_diagnostics(source), 2322).len()
+}
+
+/// Partial application (`bind`): the callback's parameter tuple `[...T, ...U]`
+/// is split by the implied arity of the bound `...args: T`, so the returned
+/// signature keeps the trailing parameters' arity (`U = [number, boolean]`).
+#[test]
+fn bind_preserves_tail_parameter_arity() {
+    let ok = r#"
+declare function bind<T extends unknown[], U extends unknown[], R>(
+    fn: (...a: [...T, ...U]) => R,
+    ...b: T
+): (...r: U) => R;
+declare const fn3: (a: string, b: number, c: boolean) => void;
+const partial = bind(fn3, "x");
+const ok: (b: number, c: boolean) => void = partial;
+"#;
+    assert_eq!(ts2322_count(ok), 0, "bind tail arity should match tsc");
+}
+
+/// A wrong-arity target for the same `bind` result must be rejected.
+#[test]
+fn bind_tail_arity_rejects_wrong_signature() {
+    let bad = r#"
+declare function bind<T extends unknown[], U extends unknown[], R>(
+    fn: (...a: [...T, ...U]) => R,
+    ...b: T
+): (...r: U) => R;
+declare const fn3: (a: string, b: number, c: boolean) => void;
+const partial = bind(fn3, "x");
+const bad: (b: boolean) => void = partial;
+"#;
+    assert_eq!(ts2322_count(bad), 1, "wrong tail arity must be a TS2322");
+}
+
+/// More bound arguments shift the split point: `bind(fn3, "x", 1)` leaves
+/// `U = [boolean]`, so a single-parameter target signature is correct.
+#[test]
+fn bind_split_point_follows_bound_argument_count() {
+    let ok = r#"
+declare function bind<T extends unknown[], U extends unknown[], R>(
+    fn: (...a: [...T, ...U]) => R,
+    ...b: T
+): (...r: U) => R;
+declare const fn3: (a: string, b: number, c: boolean) => void;
+const partial = bind(fn3, "x", 1);
+const ok: (c: boolean) => void = partial;
+"#;
+    assert_eq!(
+        ts2322_count(ok),
+        0,
+        "split point must follow bound arg count"
+    );
+}
+
+/// Two adjacent variadic type parameters in a tuple-typed rest parameter have
+/// no implied arity, so `tsc` infers nothing and both default to their
+/// constraint (`unknown[]`). tsz must not over-infer a concrete arity.
+#[test]
+fn two_adjacent_variadics_without_implied_arity_fall_back_to_constraint() {
+    let ok = r#"
+declare function split<A extends unknown[], B extends unknown[]>(
+    ...xs: [...A, ...B]
+): [A, B];
+const r = split(1, 2, 3);
+const ok: [unknown[], unknown[]] = r;
+"#;
+    assert_eq!(
+        ts2322_count(ok),
+        0,
+        "split must yield [unknown[], unknown[]]"
+    );
+}
+
+/// The flip side: tsz must not silently infer `A = [number, number, number]`.
+#[test]
+fn two_adjacent_variadics_do_not_over_infer_arity() {
+    let bad = r#"
+declare function split<A extends unknown[], B extends unknown[]>(
+    ...xs: [...A, ...B]
+): [A, B];
+const r = split(1, 2, 3);
+const bad: [[number, number, number], []] = r;
+"#;
+    assert_eq!(
+        ts2322_count(bad),
+        1,
+        "over-inferring a concrete arity for an unsplittable variadic is wrong"
+    );
+}
+
+/// Fixed prefix + single variadic middle + fixed suffix: the middle keeps its
+/// exact arity (`M = [boolean, {}]`).
+#[test]
+fn prefix_variadic_suffix_preserves_middle_arity() {
+    let ok = r#"
+declare function mid<M extends unknown[]>(...xs: [string, ...M, number]): M;
+const m = mid("s", true, {}, 3);
+const ok: [boolean, {}] = m;
+"#;
+    assert_eq!(ts2322_count(ok), 0, "middle arity must be a 2-tuple");
+}
+
+/// An off-by-one target for the middle slice must be rejected.
+#[test]
+fn prefix_variadic_suffix_rejects_wrong_middle_arity() {
+    let bad = r#"
+declare function mid<M extends unknown[]>(...xs: [string, ...M, number]): M;
+const m = mid("s", true, {}, 3);
+const bad: [boolean, {}, number] = m;
+"#;
+    assert_eq!(ts2322_count(bad), 1, "wrong middle arity must be a TS2322");
+}
+
+/// The fix is structural, not keyed to the spellings `T`/`U`/`R`. Renamed
+/// binders must behave identically to `bind_preserves_tail_parameter_arity`.
+#[test]
+fn renamed_binders_preserve_tail_arity() {
+    let ok = r#"
+declare function applyHead<Head extends unknown[], Tail extends unknown[], Ret>(
+    cb: (...p: [...Head, ...Tail]) => Ret,
+    ...pre: Head
+): (...post: Tail) => Ret;
+declare const handler: (a: string, b: number, c: boolean) => void;
+const partial = applyHead(handler, "x");
+const ok: (b: number, c: boolean) => void = partial;
+"#;
+    assert_eq!(ts2322_count(ok), 0, "behavior must be name-independent");
+}
+
+/// Leading variadic + fixed suffix (`[...Init, L]`): the head keeps its arity.
+#[test]
+fn leading_variadic_with_fixed_suffix_preserves_arity() {
+    let ok = r#"
+declare function init<I extends unknown[]>(...xs: [...I, () => void]): I;
+const r = init(1, "a", true, () => {});
+const ok: [number, string, boolean] = r;
+"#;
+    assert_eq!(
+        ts2322_count(ok),
+        0,
+        "leading variadic arity must be preserved"
+    );
+}

--- a/crates/tsz-solver/src/inference/infer.rs
+++ b/crates/tsz-solver/src/inference/infer.rs
@@ -337,6 +337,15 @@ pub(crate) struct InferenceContext<'a> {
     /// element literals of a readonly array/tuple, so `new Set([1, 2] as const)`
     /// infers `Set<1 | 2>` rather than `Set<number>`.
     pub(crate) in_readonly_source_context: bool,
+    /// Implied arity per inference variable, mirroring tsc's `InferenceInfo.impliedArity`.
+    ///
+    /// Set during call-argument inference when a signature's non-array rest type is
+    /// a bare type parameter (`function f<T>(...args: T)` or `...rest: T`). The
+    /// implied arity is the number of trailing arguments that fall into the rest
+    /// parameter, and it lets variadic tuple inference distribute the middle of a
+    /// `[...A, ...B]` target between two adjacent variadic elements. Keyed by the
+    /// root inference variable (see [`InferenceContext::set_implied_arity`]).
+    pub(crate) implied_arities: FxHashMap<InferenceVar, usize>,
 }
 
 impl<'a> InferenceContext<'a> {
@@ -371,6 +380,7 @@ impl<'a> InferenceContext<'a> {
             vars_with_substituted_candidates: FxHashSet::default(),
             in_array_element_context: false,
             in_readonly_source_context: false,
+            implied_arities: FxHashMap::default(),
         }
     }
 
@@ -397,6 +407,7 @@ impl<'a> InferenceContext<'a> {
             vars_with_substituted_candidates: FxHashSet::default(),
             in_array_element_context: false,
             in_readonly_source_context: false,
+            implied_arities: FxHashMap::default(),
         }
     }
 
@@ -447,6 +458,56 @@ impl<'a> InferenceContext<'a> {
             .iter()
             .find(|(n, _, _)| *n == name)
             .map(|(_, v, _)| *v)
+    }
+
+    /// Record the implied arity for an inference variable (tsc's
+    /// `InferenceInfo.impliedArity`). Keyed by the root variable so it survives
+    /// later unification.
+    pub(crate) fn set_implied_arity(&mut self, var: InferenceVar, arity: usize) {
+        let root = self.table.find(var);
+        self.implied_arities.insert(root, arity);
+    }
+
+    /// Resolve the root inference variable named by a `TypeParameter`/`Infer`
+    /// placeholder type, or `None` if the type does not name a tracked variable.
+    fn type_param_root_for_type(&mut self, ty: TypeId) -> Option<InferenceVar> {
+        let name = match self.interner.lookup(ty) {
+            Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => info.name,
+            _ => return None,
+        };
+        let var = self.find_type_param(name)?;
+        Some(self.table.find(var))
+    }
+
+    /// Look up the implied arity for a target type that names an inference
+    /// variable (a `TypeParameter`/`Infer` placeholder). Returns `None` when the
+    /// type is not an inference variable or has no recorded implied arity.
+    pub(crate) fn implied_arity_for_type(&mut self, ty: TypeId) -> Option<usize> {
+        let root = self.type_param_root_for_type(ty)?;
+        self.implied_arities.get(&root).copied()
+    }
+
+    /// Fixed arity implied by the declared constraint of the type parameter named
+    /// by `ty`. Mirrors tsc's use of `getBaseConstraintOfType(param)` in the
+    /// `(variadic, rest)` / `(rest, variadic)` middle cases: when the constraint
+    /// is a non-variadic tuple, its length is the implied arity.
+    pub(crate) fn constraint_fixed_arity_for_type(&mut self, ty: TypeId) -> Option<usize> {
+        let declared = match self.interner.lookup(ty) {
+            Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => info.constraint,
+            _ => return None,
+        };
+        let constraint = declared.or_else(|| {
+            let root = self.type_param_root_for_type(ty)?;
+            self.declared_constraints.get(&root).copied()
+        })?;
+        let TypeData::Tuple(list_id) = self.interner.lookup(constraint)? else {
+            return None;
+        };
+        let elements = self.interner.tuple_list(list_id);
+        if elements.iter().any(|element| element.rest) {
+            return None;
+        }
+        Some(elements.len())
     }
 
     pub(crate) fn fixed_tuple_candidate_len_for_type(&mut self, ty: TypeId) -> Option<usize> {

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -1040,6 +1040,23 @@ impl<'a> InferenceContext<'a> {
                     .next()
                     .expect("target_rest flag guarantees next element");
 
+                // A tuple-typed rest parameter (`...args: [...T, ...U]`,
+                // `[A, ...B]`, …) carries its own variadic structure; route the
+                // remaining source params through variadic tuple inference so
+                // adjacent-variadic arity is preserved (e.g. `bind`).
+                if matches!(
+                    self.interner.lookup(target_param.type_id),
+                    Some(TypeData::Tuple(_))
+                ) {
+                    let rest: Vec<ParamInfo> = source_params.by_ref().copied().collect();
+                    self.infer_source_params_against_rest_tuple(
+                        &rest,
+                        target_param.type_id,
+                        priority,
+                    )?;
+                    break;
+                }
+
                 // CRITICAL: Check if target rest param is a type parameter (like A extends any[])
                 // If so, we need to infer it as a TUPLE of all remaining source params,
                 // not as individual param types.

--- a/crates/tsz-solver/src/inference/infer_matching_tuples.rs
+++ b/crates/tsz-solver/src/inference/infer_matching_tuples.rs
@@ -1,212 +1,323 @@
 //! Variadic tuple inference for `InferenceContext`.
 //!
-//! tsc's `inferFromTupleTypes` aligns fixed elements from the front (prefix)
-//! and the back (suffix), then collects the remaining "middle" source elements
-//! into a tuple and infers it against the target rest parameter. This module
-//! implements that algorithm so `infer_tuples` handles all variadic cases:
+//! Faithful port of tsc's `inferFromTupleTypes` (checker.ts). tsc aligns the
+//! leading fixed elements (the "start"), the trailing fixed elements (the
+//! "end"), and then distributes the remaining "middle" source elements among
+//! the target's variadic/rest elements. This module reproduces that algorithm
+//! so `infer_tuples` preserves rest length and element positions the same way
+//! `tsc` does across aliases, conditional wrappers, and call signatures:
 //!
-//! - `[H, ...Tail]` — fixed prefix, trailing rest
-//! - `[...Init, L]` — leading rest, fixed suffix
-//! - `[H, ...Mid, L]` — fixed prefix, rest, fixed suffix
-//! - Both source and target contain rest elements
-//! - Concrete source tuple against concrete array-typed rest element
+//! - `[H, ...Tail]` — fixed prefix, trailing variadic/rest
+//! - `[...Init, L]` — leading variadic/rest, fixed suffix
+//! - `[H, ...Mid, L]` — fixed prefix, single variadic/rest, fixed suffix
+//! - `[...A, ...B]` — two adjacent variadic elements (distributed by the
+//!   implied arity of `A`, or `A`'s constraint when `B` is a plain rest array)
+//! - Concrete source tuple against a concrete array-typed rest element
+//!
+//! tsc distinguishes `Variadic` (`...T` for a generic/tuple `T`) from `Rest`
+//! (`...E[]`, an array spread). tsz collapses both into `TupleElement::rest`,
+//! so the distinction is recovered structurally: a `rest` element whose type is
+//! array-like is a `Rest`, anything else is a `Variadic`.
 
-use crate::types::{InferencePriority, TupleListId, TypeData, TypeId};
+use crate::types::{InferencePriority, TupleElement, TupleListId, TypeData, TypeId};
 
 use super::infer::{InferenceContext, InferenceError};
 
-impl<'a> InferenceContext<'a> {
+impl InferenceContext<'_> {
     /// Infer from tuple types, handling variadic (rest) elements.
-    ///
-    /// Structural rule: given source `[s₀,…,sₙ]` and target `[t₀…tₖ, ...R, tₘ…tₙ]`,
-    /// `R` is inferred from the tuple `[sₖ₊₁,…,sₙ₋ₘ]` (the middle slice).
     pub(super) fn infer_tuples(
         &mut self,
         source_elems: TupleListId,
         target_elems: TupleListId,
         priority: InferencePriority,
     ) -> Result<(), InferenceError> {
-        let source_list = self.interner.tuple_list(source_elems);
-        let target_list = self.interner.tuple_list(target_elems);
+        // Copy the elements (they are `Copy`) so we can call `&mut self` inference
+        // methods without holding a borrow of the interner's tuple storage.
+        let source: Vec<TupleElement> = self.interner.tuple_list(source_elems).to_vec();
+        let target: Vec<TupleElement> = self.interner.tuple_list(target_elems).to_vec();
 
-        // Find the first rest-element index in each side.
-        let source_rest_idx = source_list.iter().position(|e| e.rest);
-        let target_rest_idx = target_list.iter().position(|e| e.rest);
+        let source_arity = source.len();
+        let target_arity = target.len();
+        let target_has_rest = target.iter().any(|e| e.rest);
 
-        // Neither side has a rest element — simple pairwise zip.
-        if source_rest_idx.is_none() && target_rest_idx.is_none() {
-            for (s, t) in source_list.iter().zip(target_list.iter()) {
+        // Same structure (same arity and matching variable/fixed positions): infer
+        // element-wise. Mirrors tsc's `isTupleTypeStructureMatching` fast path.
+        if source_arity == target_arity
+            && source
+                .iter()
+                .zip(target.iter())
+                .all(|(s, t)| s.rest == t.rest)
+        {
+            for (s, t) in source.iter().zip(target.iter()) {
                 self.infer_from_types(s.type_id, t.type_id, priority)?;
             }
             return Ok(());
         }
 
-        // Fixed-element counts before/after the rest position.
-        let source_prefix = source_rest_idx.unwrap_or(source_list.len());
-        let target_prefix = target_rest_idx.unwrap_or(target_list.len());
+        // Leading fixed count (tsc `fixedLength`): elements before the first
+        // variadic/rest. Trailing fixed count (tsc `getEndElementCount(_, Fixed)`):
+        // elements after the last variadic/rest.
+        let source_fixed = source.iter().position(|e| e.rest).unwrap_or(source_arity);
+        let target_fixed = target.iter().position(|e| e.rest).unwrap_or(target_arity);
+        let start_length = source_fixed.min(target_fixed);
 
-        // How many fixed elements to align from the front.
-        let prefix_count = source_prefix.min(target_prefix);
+        let source_end_fixed = source.iter().rev().take_while(|e| !e.rest).count();
+        let target_end_fixed = target.iter().rev().take_while(|e| !e.rest).count();
+        let end_length = source_end_fixed.min(if target_has_rest { target_end_fixed } else { 0 });
 
-        // How many fixed elements to align from the back.
-        // Variadic rest segments after the first rest are still variable-length
-        // tuple parts; they must not be treated as one fixed suffix element.
-        let source_trailing_fixed = source_list.iter().rev().take_while(|e| !e.rest).count();
-        let target_trailing_fixed = target_list.iter().rev().take_while(|e| !e.rest).count();
+        // Infer between the leading fixed elements.
+        for i in 0..start_length {
+            self.infer_from_types(source[i].type_id, target[i].type_id, priority)?;
+        }
 
-        // When source has no rest, all elements not consumed by the prefix are
-        // available for target's suffix. When source has a rest, only the source
-        // fixed elements after the last rest position are available.
-        let available_for_suffix = if source_rest_idx.is_some() {
-            source_trailing_fixed
+        // When a single source `Rest` (array spread) covers the entire middle,
+        // spread its element type over every target middle element. A `Variadic`
+        // target element receives the element type wrapped back in an array.
+        let single_source_rest_inner = (source_arity - start_length - end_length == 1
+            && source[start_length].rest)
+            .then(|| self.tuple_rest_array_inner(source[start_length].type_id))
+            .flatten();
+
+        if let Some(rest_inner) = single_source_rest_inner {
+            for t in &target[start_length..target_arity - end_length] {
+                let inferred = if self.tuple_element_is_variadic(*t) {
+                    self.interner.array(rest_inner)
+                } else {
+                    rest_inner
+                };
+                self.infer_from_types(inferred, t.type_id, priority)?;
+            }
         } else {
-            source_list.len().saturating_sub(prefix_count)
-        };
-        let suffix_count = available_for_suffix.min(target_trailing_fixed);
-
-        if let Some(target_rest_pos) = target_rest_idx
-            && let Some(next_rest_offset) = target_list[target_rest_pos + 1..]
-                .iter()
-                .position(|elem| elem.rest)
-            && let Some(prefix_len) =
-                self.fixed_tuple_candidate_len_for_type(target_list[target_rest_pos].type_id)
-        {
-            let next_rest_pos = target_rest_pos + 1 + next_rest_offset;
-            let prefix_end = target_rest_pos.saturating_add(prefix_len);
-            if prefix_end <= source_list.len() {
-                for i in 0..target_rest_pos {
-                    self.infer_from_types(
-                        source_list[i].type_id,
-                        target_list[i].type_id,
-                        priority,
-                    )?;
-                }
-
-                let suffix_count = source_trailing_fixed.min(
-                    target_list[next_rest_pos + 1..]
-                        .iter()
-                        .rev()
-                        .take_while(|elem| !elem.rest)
-                        .count(),
-                );
-                let end_index = source_list.len().saturating_sub(suffix_count);
-                if prefix_end <= end_index {
-                    for (s, t) in source_list
-                        .iter()
-                        .rev()
-                        .zip(target_list.iter().rev())
-                        .take(suffix_count)
-                    {
-                        self.infer_from_types(s.type_id, t.type_id, priority)?;
-                    }
-
-                    let middle = &source_list[prefix_end..end_index];
-                    let next_rest_type = target_list[next_rest_pos].type_id;
-                    if middle.len() == 1 && middle[0].rest {
-                        self.infer_from_types(middle[0].type_id, next_rest_type, priority)?;
-                    } else {
-                        let middle_tuple = self.interner.tuple(middle.to_vec());
-                        self.infer_from_types(middle_tuple, next_rest_type, priority)?;
-                    }
-                    return Ok(());
-                }
+            let middle_length = target_arity - start_length - end_length;
+            if middle_length == 2 {
+                self.infer_tuple_middle_pair(
+                    &source,
+                    &target,
+                    start_length,
+                    end_length,
+                    target_end_fixed,
+                    priority,
+                )?;
+            } else if middle_length == 1 {
+                self.infer_tuple_middle_single(
+                    &source,
+                    &target,
+                    start_length,
+                    end_length,
+                    priority,
+                )?;
             }
         }
 
-        if let Some(target_rest_pos) = target_rest_idx
-            && target_list[target_rest_pos + 1..]
-                .iter()
-                .any(|elem| elem.rest)
-        {
-            return Ok(());
-        }
-
-        // Prefix inference.
-        for i in 0..prefix_count {
-            self.infer_from_types(source_list[i].type_id, target_list[i].type_id, priority)?;
-        }
-
-        // Suffix inference (working backwards from the end).
-        for (s, t) in source_list
-            .iter()
-            .rev()
-            .zip(target_list.iter().rev())
-            .take(suffix_count)
-        {
-            self.infer_from_types(s.type_id, t.type_id, priority)?;
-        }
-
-        // Handle the variadic middle portion.
-        if let Some(target_rest_pos) = target_rest_idx {
-            let target_rest_type = target_list[target_rest_pos].type_id;
-
-            let rest_start = prefix_count;
-            let rest_end = source_list.len().saturating_sub(suffix_count);
-            let middle = &source_list[rest_start..rest_end];
-
-            // Single source rest element maps directly to the target rest parameter.
-            if middle.len() == 1 && middle[0].rest {
-                self.infer_from_types(middle[0].type_id, target_rest_type, priority)?;
-                return Ok(());
-            }
-
-            let is_target_type_param = matches!(
-                self.interner.lookup(target_rest_type),
-                Some(TypeData::TypeParameter(_) | TypeData::Infer(_))
-            );
-
-            if is_target_type_param {
-                // Collect middle source elements into a tuple and infer it
-                // against the type parameter (empty tuple included — it proves
-                // zero-arity and prevents the parameter defaulting to its
-                // constraint, which would hide arity mismatches).
-                let middle_tuple = self.interner.tuple(middle.to_vec());
-                self.infer_from_types(middle_tuple, target_rest_type, priority)?;
-            } else {
-                // Target rest is a concrete array type (e.g. `Array<X>`).
-                // Extract the element type and infer each source middle element
-                // individually against it.
-                let inner = self.tuple_infer_rest_elem_inner(target_rest_type);
-                for elem in middle {
-                    self.infer_from_types(elem.type_id, inner, priority)?;
-                }
-            }
-        } else if source_rest_idx.is_some() {
-            // Source has a rest element but target does not.
-            // Infer the source rest's element type against each target fixed
-            // element position that was not covered by the prefix.
-            // source_prefix == source_rest_idx.unwrap() when source_rest_idx.is_some().
-            let source_rest_type = source_list[source_prefix].type_id;
-            let inner = self.tuple_infer_rest_elem_inner(source_rest_type);
-            for i in prefix_count..target_prefix {
-                self.infer_from_types(inner, target_list[i].type_id, priority)?;
-            }
+        // Infer between the trailing fixed elements.
+        for i in 0..end_length {
+            self.infer_from_types(
+                source[source_arity - i - 1].type_id,
+                target[target_arity - i - 1].type_id,
+                priority,
+            )?;
         }
 
         Ok(())
     }
 
-    /// Extract the array element type from an array-like rest element type.
+    /// Infer a function's remaining source parameters against a tuple-typed rest
+    /// parameter (`...args: [...T, ...U]`, `[H, ...T]`, …). The source params are
+    /// packed into a tuple and inferred in the normal direction so the type
+    /// parameters inside the target tuple receive candidates with correct arity.
+    pub(crate) fn infer_source_params_against_rest_tuple(
+        &mut self,
+        source_params: &[crate::types::ParamInfo],
+        target_tuple: TypeId,
+        priority: InferencePriority,
+    ) -> Result<(), InferenceError> {
+        let elements: Vec<TupleElement> = source_params
+            .iter()
+            .map(|p| TupleElement {
+                type_id: p.type_id,
+                name: p.name,
+                optional: p.optional,
+                rest: p.rest,
+            })
+            .collect();
+        let source_tuple = self.interner.tuple(elements);
+        self.infer_from_types(source_tuple, target_tuple, priority)
+    }
+
+    /// Single variadic/rest target element in the middle.
+    fn infer_tuple_middle_single(
+        &mut self,
+        source: &[TupleElement],
+        target: &[TupleElement],
+        start_length: usize,
+        end_length: usize,
+        priority: InferencePriority,
+    ) -> Result<(), InferenceError> {
+        let mid = target[start_length];
+        if !mid.rest {
+            return Ok(());
+        }
+        let end = source.len() - end_length;
+        let slice = &source[start_length..end];
+
+        if let Some(inner) = self.tuple_rest_array_inner(mid.type_id) {
+            // `...E[]`: infer the element type of the source middle slice against `E`.
+            if let Some(rest_type) = self.element_type_of_slice(slice) {
+                self.infer_from_types(rest_type, inner, priority)?;
+            }
+        } else if slice.len() == 1 && slice[0].rest {
+            // A single source rest element maps directly to the variadic target,
+            // avoiding a spurious `[...X]` wrapper (so `[...U]` infers `T = U`).
+            self.infer_from_types(slice[0].type_id, mid.type_id, priority)?;
+        } else {
+            // `...T`: infer the source middle slice (as a tuple) against `T`.
+            let slice_tuple = self.interner.tuple(slice.to_vec());
+            self.infer_from_types(slice_tuple, mid.type_id, priority)?;
+        }
+        Ok(())
+    }
+
+    /// Two adjacent variadic/rest target elements in the middle. The split point
+    /// is determined by an implied arity, mirroring tsc exactly:
+    /// - `(variadic, variadic)`: the first element's recorded implied arity.
+    /// - `(variadic, rest)`: the fixed arity of the first element's constraint.
+    /// - `(rest, variadic)`: the fixed arity of the second element's constraint.
     ///
-    /// For `T[]` / `Array<T>` returns `T`; for `readonly T[]` returns `T`;
-    /// for a single-arg generic application returns its argument; for anything
-    /// else returns the type itself so the caller falls back gracefully.
-    fn tuple_infer_rest_elem_inner(&self, rest_type: TypeId) -> TypeId {
+    /// When no implied arity is available, neither element is inferred (the type
+    /// parameters fall back to their constraints), matching tsc.
+    fn infer_tuple_middle_pair(
+        &mut self,
+        source: &[TupleElement],
+        target: &[TupleElement],
+        start_length: usize,
+        end_length: usize,
+        target_end_fixed: usize,
+        priority: InferencePriority,
+    ) -> Result<(), InferenceError> {
+        let source_arity = source.len();
+        let first = target[start_length];
+        let second = target[start_length + 1];
+        let first_variadic = self.tuple_element_is_variadic(first);
+        let second_variadic = self.tuple_element_is_variadic(second);
+        let first_rest = first.rest && !first_variadic;
+        let second_rest = second.rest && !second_variadic;
+
+        if first_variadic && second_variadic {
+            let Some(implied_arity) = self.implied_arity_for_type(first.type_id) else {
+                return Ok(());
+            };
+            // tsc: sliceTupleType(source, startLength, endLength + sourceArity - impliedArity)
+            let end_skip = end_length + source_arity.saturating_sub(implied_arity);
+            let first_slice = self.slice_tuple(source, start_length, end_skip);
+            self.infer_from_types(first_slice, first.type_id, priority)?;
+            let second_slice = self.slice_tuple(source, start_length + implied_arity, end_length);
+            self.infer_from_types(second_slice, second.type_id, priority)?;
+        } else if first_variadic && second_rest {
+            let Some(implied_arity) = self.constraint_fixed_arity_for_type(first.type_id) else {
+                return Ok(());
+            };
+            // tsc: sliceTupleType(source, startLength, sourceArity - (startLength + impliedArity))
+            let end_skip = source_arity.saturating_sub(start_length + implied_arity);
+            let first_slice = self.slice_tuple(source, start_length, end_skip);
+            self.infer_from_types(first_slice, first.type_id, priority)?;
+            let lo = start_length + implied_arity;
+            let hi = source_arity.saturating_sub(end_length);
+            self.infer_rest_array_from_slice(second.type_id, source, lo, hi, priority)?;
+        } else if first_rest && second_variadic {
+            let Some(implied_arity) = self.constraint_fixed_arity_for_type(second.type_id) else {
+                return Ok(());
+            };
+            let end_index = source_arity.saturating_sub(target_end_fixed);
+            let start_index = end_index.saturating_sub(implied_arity);
+            let hi = source_arity.saturating_sub(end_length + implied_arity);
+            self.infer_rest_array_from_slice(first.type_id, source, start_length, hi, priority)?;
+            if start_index <= end_index {
+                let trailing = self.interner.tuple(source[start_index..end_index].to_vec());
+                self.infer_from_types(trailing, second.type_id, priority)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// If `rest_elem` is an array-like `Rest` element (`...E[]`), infer the
+    /// element type of the source slice `source[lo..hi]` against its element type
+    /// `E`. A no-op when `rest_elem` is not array-like or the slice is empty.
+    fn infer_rest_array_from_slice(
+        &mut self,
+        rest_elem: TypeId,
+        source: &[TupleElement],
+        lo: usize,
+        hi: usize,
+        priority: InferencePriority,
+    ) -> Result<(), InferenceError> {
+        let hi = hi.min(source.len());
+        let lo = lo.min(hi);
+        if let Some(inner) = self.tuple_rest_array_inner(rest_elem)
+            && let Some(rest_type) = self.element_type_of_slice(&source[lo..hi])
+        {
+            self.infer_from_types(rest_type, inner, priority)?;
+        }
+        Ok(())
+    }
+
+    /// Build a tuple `TypeId` from `elements[index .. len - end_skip]`,
+    /// preserving each element's flags. Empty when the range is degenerate.
+    fn slice_tuple(&self, elements: &[TupleElement], index: usize, end_skip: usize) -> TypeId {
+        let len = elements.len();
+        let end = len.saturating_sub(end_skip);
+        let slice = if index < end {
+            &elements[index..end]
+        } else {
+            &[]
+        };
+        self.interner.tuple(slice.to_vec())
+    }
+
+    /// Union of the element types of a tuple slice (tsc
+    /// `getElementTypeOfSliceOfTupleType`). A `Variadic` element contributes its
+    /// number-indexed element type; a `Rest` (array spread) contributes the array
+    /// element type; a fixed element contributes its type. `None` for an empty
+    /// slice.
+    fn element_type_of_slice(&self, slice: &[TupleElement]) -> Option<TypeId> {
+        if slice.is_empty() {
+            return None;
+        }
+        let element_types: Vec<TypeId> = slice
+            .iter()
+            .map(|elem| {
+                if elem.rest {
+                    self.tuple_rest_array_inner(elem.type_id)
+                        .unwrap_or_else(|| self.interner.index_access(elem.type_id, TypeId::NUMBER))
+                } else {
+                    elem.type_id
+                }
+            })
+            .collect();
+        Some(self.interner.union(element_types))
+    }
+
+    /// A `Variadic` element (`...T`, where `T` is a generic/tuple): a rest
+    /// element whose type is not array-like. Array-like rest elements (`...E[]`)
+    /// are tsc's `Rest` flavor instead.
+    fn tuple_element_is_variadic(&self, elem: TupleElement) -> bool {
+        elem.rest && self.tuple_rest_array_inner(elem.type_id).is_none()
+    }
+
+    /// Element type of an array-like rest element type (`E[]`, `readonly E[]`, or
+    /// a single-argument generic application). `None` for non-array-like types,
+    /// which marks the element as a `Variadic` (`...T`) rather than a `Rest`.
+    fn tuple_rest_array_inner(&self, rest_type: TypeId) -> Option<TypeId> {
         match self.interner.lookup(rest_type) {
-            Some(TypeData::Array(elem)) => elem,
+            Some(TypeData::Array(elem)) => Some(elem),
             Some(TypeData::ReadonlyType(inner)) => match self.interner.lookup(inner) {
-                Some(TypeData::Array(elem)) => elem,
-                _ => rest_type,
+                Some(TypeData::Array(elem)) => Some(elem),
+                _ => None,
             },
             Some(TypeData::Application(app_id)) => {
                 let app = self.interner.type_application(app_id);
-                if app.args.len() == 1 {
-                    app.args[0]
-                } else {
-                    rest_type
-                }
+                (app.args.len() == 1).then(|| app.args[0])
             }
-            _ => rest_type,
+            _ => None,
         }
     }
 }

--- a/crates/tsz-solver/src/operations/call_args.rs
+++ b/crates/tsz-solver/src/operations/call_args.rs
@@ -930,7 +930,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         self.interner.tuple(elements)
     }
 
-    fn spread_argument_marker_inner(&self, type_id: TypeId) -> Option<TypeId> {
+    pub(crate) fn spread_argument_marker_inner(&self, type_id: TypeId) -> Option<TypeId> {
         let Some(TypeData::Tuple(elems_id)) = self.interner.lookup(type_id) else {
             return None;
         };
@@ -1525,6 +1525,19 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             }
             Some(TypeData::Tuple(elements)) => {
                 let elements = self.interner.tuple_list(elements);
+                // Two or more adjacent variadic type parameters (`...args: [...A, ...B]`)
+                // cannot be split without an implied arity, which a tuple-typed rest
+                // parameter never has (tsc's `getNonArrayRestType` returns `undefined`
+                // for it). tsc infers nothing here, leaving `A`/`B` to fall back to
+                // their constraints — so bail out of the single-variadic slicing below
+                // rather than mis-distributing the arguments.
+                let infer_var_rest_count = elements
+                    .iter()
+                    .filter(|elem| elem.rest && var_map.contains_key(&elem.type_id))
+                    .count();
+                if infer_var_rest_count >= 2 {
+                    return None;
+                }
                 elements.iter().enumerate().find_map(|(i, elem)| {
                     if !elem.rest {
                         return None;

--- a/crates/tsz-solver/src/operations/constraints/signatures.rs
+++ b/crates/tsz-solver/src/operations/constraints/signatures.rs
@@ -215,6 +215,34 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
     ) {
         use crate::type_queries::unpack_tuple_rest_parameter;
 
+        // A tuple-typed rest parameter that carries inference variables
+        // (`...args: [...T, ...U]`, `[H, ...T]`, …) must keep its variadic
+        // structure. Unpacking it into array-typed params (the path below)
+        // severs the link to the type variables, so adjacent-variadic arity is
+        // lost (partial application / `bind`). Pack the remaining source params
+        // into a tuple and run the faithful variadic tuple inference instead.
+        if let Some((fixed_count, rest_tuple_ty)) =
+            self.tuple_rest_param_with_infer_vars(target_params, var_map)
+            && source_params.iter().take(fixed_count).all(|p| !p.rest)
+            && source_params.len() >= fixed_count
+        {
+            for (s_p, t_p) in source_params
+                .iter()
+                .zip(target_params.iter())
+                .take(fixed_count)
+            {
+                self.constrain_parameter_types(ctx, var_map, s_p.type_id, t_p.type_id, priority);
+            }
+            // Best-effort: inference errors here are non-fatal (the final
+            // argument check reports genuine mismatches).
+            let _ = ctx.infer_source_params_against_rest_tuple(
+                &source_params[fixed_count..],
+                rest_tuple_ty,
+                priority,
+            );
+            return;
+        }
+
         let s_params: Vec<ParamInfo> = source_params
             .iter()
             .flat_map(|p| unpack_tuple_rest_parameter(self.interner, p))
@@ -259,6 +287,30 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 );
             }
         }
+    }
+
+    /// If `target_params` ends in a single rest parameter whose type is a tuple
+    /// that carries an inference variable in a rest position
+    /// (`...args: [...T, ...U]`, `[H, ...T]`, `[number, ...T, boolean]`, …),
+    /// return the count of fixed parameters before it and the tuple type itself.
+    fn tuple_rest_param_with_infer_vars(
+        &self,
+        target_params: &[ParamInfo],
+        var_map: &FxHashMap<TypeId, crate::inference::infer::InferenceVar>,
+    ) -> Option<(usize, TypeId)> {
+        let last = target_params.last()?;
+        if !last.rest {
+            return None;
+        }
+        let tuple_ty = self.unwrap_readonly(last.type_id);
+        let TypeData::Tuple(list_id) = self.interner.lookup(tuple_ty)? else {
+            return None;
+        };
+        let elements = self.interner.tuple_list(list_id);
+        let has_infer_rest = elements
+            .iter()
+            .any(|elem| elem.rest && var_map.contains_key(&elem.type_id));
+        has_infer_rest.then(|| (target_params.len() - 1, tuple_ty))
     }
 
     /// Shared body for `constrain_{function,call_signature}_to_{call_signature,function}`.

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -240,6 +240,52 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             .then_some(info.name)
     }
 
+    /// Mirror tsc's implied-arity assignment for a non-array rest type parameter.
+    ///
+    /// When a signature ends in `...rest: T` where `T` is a bare type parameter,
+    /// the trailing arguments that fall into the rest parameter fix `T`'s arity.
+    /// Variadic tuple inference reads this to split adjacent variadic elements of
+    /// a `[...A, ...B]` target. Skips (leaves the arity unset) when a spread
+    /// argument appears among the fixed parameters, matching tsc.
+    fn record_rest_param_implied_arity(
+        &mut self,
+        infer_ctx: &mut InferenceContext,
+        func: &FunctionShape,
+        arg_types: &[TypeId],
+        type_param_vars: &[crate::inference::infer::InferenceVar],
+    ) {
+        let Some(rest_param) = func.params.last().filter(|param| param.rest) else {
+            return;
+        };
+        let Some(rest_name) =
+            self.type_param_name_if_generic_rest_tuple_param(func, rest_param.type_id)
+        else {
+            return;
+        };
+        let Some(var) = func
+            .type_params
+            .iter()
+            .zip(type_param_vars.iter())
+            .find_map(|(tp, &var)| (tp.name == rest_name).then_some(var))
+        else {
+            return;
+        };
+
+        // Fixed parameters before the rest parameter.
+        let fixed_param_count = func.params.len().saturating_sub(1);
+        let arg_count = fixed_param_count.min(arg_types.len());
+
+        // A spread argument among the fixed arguments makes the arity unknown.
+        let spread_in_fixed = arg_types[..arg_count]
+            .iter()
+            .any(|&arg| self.spread_argument_marker_inner(arg).is_some());
+        if spread_in_fixed {
+            return;
+        }
+
+        infer_ctx.set_implied_arity(var, arg_types.len().saturating_sub(arg_count));
+    }
+
     fn generic_rest_tuple_callback_arity_mismatch(
         &mut self,
         func: &FunctionShape,
@@ -480,6 +526,14 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 infer_ctx.set_declared_constraint(var, inst_constraint);
             }
         }
+
+        // Record the implied arity for a non-array rest type parameter (tsc's
+        // `getNonArrayRestType` path). For a signature whose rest parameter is a
+        // bare type parameter (`...rest: T`), the number of trailing arguments
+        // that land in the rest parameter is the implied arity of `T`. Variadic
+        // tuple inference uses it to split a `[...A, ...B]` target so the tail
+        // type parameter keeps its arity (e.g. partial-application / `bind`).
+        self.record_rest_param_implied_arity(&mut infer_ctx, func, arg_types, &type_param_vars);
 
         // Seed inference from generic `this` parameter when present.
         // For calls like `obj.method<T>(...)`, `this: T` must constrain `T` from

--- a/crates/tsz-solver/src/tests/file_size_baselines.txt
+++ b/crates/tsz-solver/src/tests/file_size_baselines.txt
@@ -16,7 +16,7 @@
 
 solver_max_loc      3474
 solver_oversized    20
-solver_file_generic_call_resolve 3380
+solver_file_generic_call_resolve 3413
 solver_file_eval_conditional 3257
 solver_file_evaluate 3474
 solver_file_instantiate 2872
@@ -29,7 +29,7 @@ solver_file_constraints_walker 2348
 solver_file_diag_format_mod 2318
 solver_file_eval_mapped 1963
 solver_file_subtype_generics 2217
-solver_file_call_args 2084
+solver_file_call_args 2097
 solver_file_eval_index_access 2226
 solver_file_def_core 2244
 solver_file_visitor_predicates 2162


### PR DESCRIPTION
Closes #12176.

AgentName: M4-B
ContributorIdentity: claude-lucid-hopper

Track: Conformance — type inference / solver (variadic tuples)

Invariant: When inferring through `[H, ...Tail]`, `[...Init, L]`, `[H, ...Mid, L]`, or `[...A, ...B]`, tsz preserves each variadic/rest segment's arity and element positions exactly as `tsc`'s `inferFromTupleTypes` does — across aliases, conditional wrappers, and call signatures. Adjacent variadic type parameters are split only when an implied arity exists (a bare `...rest: T` rest parameter, or a non-variadic tuple constraint); otherwise neither is inferred and both fall back to their constraints.

Structural rule: When a target tuple has the shape `[fixed…, ...R1, …, ...R2, fixed…]`, tsc aligns the leading and trailing fixed elements, then distributes the middle source elements among the variadic/rest elements using an implied arity. tsz now does this through the solver inference layer (`crates/tsz-solver/src/inference`), not through ad-hoc per-path slicing.

## Scope

- `crates/tsz-solver/src/inference/infer_matching_tuples.rs` — rewrote `infer_tuples` as a faithful port of tsc's `inferFromTupleTypes` (start/end/middle alignment; `(variadic,variadic)`, `(variadic,rest)`, `(rest,variadic)` middle cases; `slice_tuple` / `element_type_of_slice` helpers). `Variadic` (`...T`) vs `Rest` (`...E[]`) is recovered structurally since `TupleElement` collapses both into one `rest` flag.
- `crates/tsz-solver/src/inference/infer.rs` — added `InferenceContext.implied_arities` (tsc's `InferenceInfo.impliedArity`) plus `implied_arity_for_type` / `constraint_fixed_arity_for_type` lookups.
- `crates/tsz-solver/src/operations/generic_call/resolve.rs` — `record_rest_param_implied_arity` sets the implied arity from a signature's non-array rest type parameter and the argument count (tsc's `getNonArrayRestType`).
- `crates/tsz-solver/src/operations/constraints/signatures.rs` + `crates/tsz-solver/src/inference/infer_matching.rs` — route tuple-typed rest parameters (`...args: [...T, ...U]`) through the faithful tuple inference instead of unpacking them into array-typed params (which severed the link to the type variables, breaking `bind`-style partial application).
- `crates/tsz-solver/src/operations/call_args.rs` — direct calls whose rest parameter is a tuple with two or more inference-variable rest elements now infer nothing (matching tsc) rather than mis-distributing arguments.

## Project Corpus Impact

- Row: n/a (no required project row changes; behavior only tightened toward tsc parity)
- Bug family: variadic-tuples (#12176)
- No required project rows are expected to regress; the change only makes variadic tuple inference more tsc-faithful (tightening over-inference and recovering previously-dropped tail arity). Witnessed across rxjs, kysely, zod, ts-toolbelt, nextjs, large-ts-repo, type-fest rows (#12176 sub-issues).

## Verification (vs real `tsc` 6.0.2)

- Reduced parity matrix (function-call inference) now matches `tsc` exactly, e.g. `bind(fn3, "x") → (b: number, c: boolean) => void`, `split(1,2,3) → [unknown[], unknown[]]` (was `[[number, number], unknown[]]`), `mid("s", true, {}, 3) → [boolean, {}]`, and `[...T, number]` / `[number, ...T]` / `[...T, ...T]` forms.
- New checker regression suite `variadic_tuple_tail_arity_inference_tests.rs` (9 tests, positive + negative witnesses, renamed binders) — all pass.
- `cargo test -p tsz-solver --lib` — 6528 passed, 0 failed.
- `cargo clippy -p tsz-solver` and `-p tsz-checker --tests` — clean.
- File-size ratchet updated for the two touched tracked files; no new oversized files.

## Coordination Notes

- The conditional-type *branch decision* for two-variadic / concrete-prefix patterns (`T extends [...infer A, ...infer B] ? …`) lives in the relations layer and is intentionally out of scope here; this PR fixes the inference (candidate extraction) side.
- Full unification of the remaining parallel tuple-inference path (`operations/constraints/walker.rs::constrain_tuple_types`) onto `infer_tuples` is deferred as a follow-up refactor; this PR routes the affected call paths through the faithful implementation without ripping out the load-bearing walker path.

