### PR TITLE
fix(resolver): prefer @types declarations over untyped JS package resolution (#12461)

### DIFF
--- a/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
+++ b/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
@@ -183,6 +183,42 @@ impl ModuleResolver {
         })
     }
 
+    /// Probe `<base>/@types/<mangled-scope>` for a bare specifier's typings.
+    ///
+    /// `base` is either a `node_modules` directory or a configured `typeRoots`
+    /// entry. For a scoped specifier `@scope/name`, `types_package_name`
+    /// collapses the `/` to `__` (`@types/scope__name`) — the `DefinitelyTyped`
+    /// naming convention tsc has used since 3.x. `@types/*` specifiers never
+    /// re-derive a nested `@types/@types/...` lookup.
+    fn resolve_types_fallback(
+        &self,
+        base: &Path,
+        package_name: &str,
+        subpath: Option<&str>,
+        specifier: &str,
+        containing_file: &str,
+        specifier_span: Span,
+        conditions: &[String],
+    ) -> Option<ResolvedModule> {
+        if package_name.starts_with("@types/") {
+            return None;
+        }
+        let types_dir = base.join(types_package_name(package_name));
+        if cached_is_dir(&types_dir)
+            && let Ok(resolved) = self.resolve_package(
+                &types_dir,
+                subpath,
+                specifier,
+                containing_file,
+                specifier_span,
+                conditions,
+            )
+        {
+            return Some(resolved);
+        }
+        None
+    }
+
     /// Resolve a bare specifier (npm package)
     pub(super) fn resolve_bare_specifier(
         &self,
@@ -213,6 +249,23 @@ impl ModuleResolver {
                 // Fall through to node_modules resolution.
             }
         }
+
+        // A runtime package that resolves to an untyped JavaScript file, or an
+        // `exports`-authoritative failure, does not end the search: tsc still
+        // probes `@types/<mangled-scope>` and prefers that declaration over the
+        // untyped JS. We defer the untyped resolution until the `@types`
+        // fallback (node_modules + typeRoots) has had its chance, then fall back
+        // to it so `allowJs` keeps working and the checker can still emit TS7016.
+        let mut deferred_untyped_js: Option<ResolvedModule> = None;
+        // A deferred `exports`-authoritative failure to surface if no typed
+        // resolution is found anywhere.
+        let mut exports_failed: Option<ResolutionFailure> = None;
+        // Node resolution stops at the *nearest* `node_modules` that contains
+        // the package: a hoisted ancestor copy must not win once the nearest
+        // package has resolved (to JS) or authoritatively failed its `exports`.
+        // The `@types` fallback uses a different package name, so it keeps
+        // searching ancestors and `typeRoots` even after this is set.
+        let mut package_search_stopped = false;
 
         // Walk up directory tree looking for node_modules
         let mut current = containing_dir.to_path_buf();
@@ -250,46 +303,68 @@ impl ModuleResolver {
             for node_modules in node_modules_roots {
                 let package_dir = node_modules.join(&package_name);
 
-                if cached_is_dir(&package_dir) {
-                    match self.resolve_package(
-                        &package_dir,
-                        subpath.as_deref(),
-                        specifier,
-                        containing_file,
-                        specifier_span,
-                        &conditions,
-                    ) {
-                        Ok(resolved) => return Ok(resolved),
-                        Err(e @ ResolutionFailure::NotFound { .. }) => {
-                            // In Node16/NodeNext/Bundler, exports field is authoritative —
-                            // don't continue searching parent node_modules.
-                            if self.should_stop_on_exports_failure(
-                                &package_dir,
-                                subpath.as_deref(),
-                                &conditions,
-                            ) {
-                                return Err(e);
+                // The nearest `node_modules` containing the package wins; once it
+                // has resolved (to JS) or authoritatively failed, `package_search_stopped`
+                // skips the package probe in every ancestor (only the `@types`
+                // fallback below keeps walking).
+                if !package_search_stopped {
+                    if cached_is_dir(&package_dir) {
+                        match self.resolve_package(
+                            &package_dir,
+                            subpath.as_deref(),
+                            specifier,
+                            containing_file,
+                            specifier_span,
+                            &conditions,
+                        ) {
+                            // A package that ships its own TS/declaration entry
+                            // wins outright. An untyped JS resolution is deferred
+                            // so an `@types/<mangled>` declaration (if any) can
+                            // take precedence, matching tsc — but the nearest
+                            // package is now found, so stop the package walk.
+                            Ok(resolved)
+                                if resolved.extension.is_javascript()
+                                    && !package_name.starts_with("@types/") =>
+                            {
+                                if deferred_untyped_js.is_none() {
+                                    deferred_untyped_js = Some(resolved);
+                                }
+                                package_search_stopped = true;
+                            }
+                            Ok(resolved) => return Ok(resolved),
+                            Err(e @ ResolutionFailure::NotFound { .. }) => {
+                                // In Node16/NodeNext/Bundler, exports field is
+                                // authoritative — don't search parent node_modules
+                                // for the package, but still run the `@types` fallback.
+                                if self.should_stop_on_exports_failure(
+                                    &package_dir,
+                                    subpath.as_deref(),
+                                    &conditions,
+                                ) {
+                                    exports_failed = Some(e);
+                                    package_search_stopped = true;
+                                }
+                            }
+                            Err(_) => {
+                                // Continue searching in parent directories
                             }
                         }
-                        Err(_) => {
-                            // Continue searching in parent directories
+                    } else if matches!(self.resolution_kind, ModuleResolutionKind::Bundler)
+                        && subpath.is_none()
+                    {
+                        // In bundler mode, package specifiers may resolve directly to
+                        // files like `node_modules/foo.d.ts`. Bundler mode never uses
+                        // Node16/NodeNext extension priorities, so package_type is irrelevant.
+                        if let Some(resolved) = self.try_file_or_directory(&package_dir, None) {
+                            return Ok(ResolvedModule {
+                                resolved_path: resolved.clone(),
+                                resolved_using_ts_extension: false,
+                                is_external: true,
+                                package_name: Some(package_name),
+                                original_specifier: specifier.to_string(),
+                                extension: ModuleExtension::from_path(&resolved),
+                            });
                         }
-                    }
-                } else if matches!(self.resolution_kind, ModuleResolutionKind::Bundler)
-                    && subpath.is_none()
-                {
-                    // In bundler mode, package specifiers may resolve directly to
-                    // files like `node_modules/foo.d.ts`. Bundler mode never uses
-                    // Node16/NodeNext extension priorities, so package_type is irrelevant.
-                    if let Some(resolved) = self.try_file_or_directory(&package_dir, None) {
-                        return Ok(ResolvedModule {
-                            resolved_path: resolved.clone(),
-                            resolved_using_ts_extension: false,
-                            is_external: true,
-                            package_name: Some(package_name),
-                            original_specifier: specifier.to_string(),
-                            extension: ModuleExtension::from_path(&resolved),
-                        });
                     }
                 }
                 // Only probe `node_modules/@types/foo` when `node_modules` itself
@@ -297,21 +372,15 @@ impl ModuleResolver {
                 // absent if its parent is. Gating by discovered node_modules roots
                 // skips the `is_dir` syscall on every ancestor that has no
                 // `node_modules` (the common case for ancestors above the project root).
-                if package_name.starts_with("@types/") {
-                    continue;
-                }
-                let types_package = types_package_name(&package_name);
-                let types_dir = node_modules.join(&types_package);
-                if cached_is_dir(&types_dir)
-                    && let Ok(resolved) = self.resolve_package(
-                        &types_dir,
-                        subpath.as_deref(),
-                        specifier,
-                        containing_file,
-                        specifier_span,
-                        &conditions,
-                    )
-                {
+                if let Some(resolved) = self.resolve_types_fallback(
+                    &node_modules,
+                    &package_name,
+                    subpath.as_deref(),
+                    specifier,
+                    containing_file,
+                    specifier_span,
+                    &conditions,
+                ) {
                     return Ok(resolved);
                 }
             }
@@ -325,19 +394,27 @@ impl ModuleResolver {
 
         // Try type roots (for @types packages)
         for type_root in &self.type_roots {
-            let types_package = type_root.join(types_package_name(&package_name));
-            if cached_is_dir(&types_package)
-                && let Ok(resolved) = self.resolve_package(
-                    &types_package,
-                    subpath.as_deref(),
-                    specifier,
-                    containing_file,
-                    specifier_span,
-                    &conditions,
-                )
-            {
+            if let Some(resolved) = self.resolve_types_fallback(
+                type_root,
+                &package_name,
+                subpath.as_deref(),
+                specifier,
+                containing_file,
+                specifier_span,
+                &conditions,
+            ) {
                 return Ok(resolved);
             }
+        }
+
+        // No `@types` declaration anywhere: fall back to the deferred untyped JS
+        // resolution (kept for `allowJs`/TS7016), then to a deferred
+        // exports-authoritative failure, then to a generic not-found.
+        if let Some(resolved) = deferred_untyped_js {
+            return Ok(resolved);
+        }
+        if let Some(e) = exports_failed {
+            return Err(e);
         }
 
         Err(ResolutionFailure::NotFound {

--- a/crates/tsz-core/src/module_resolver/tests.rs
+++ b/crates/tsz-core/src/module_resolver/tests.rs
@@ -23,5 +23,6 @@ mod path_mapping;
 mod pattern_matching;
 mod resolution_failure;
 mod resolver_integration;
+mod scoped_types_fallback;
 mod specifier_parsing;
 mod target_package_type;

--- a/crates/tsz-core/src/module_resolver/tests/scoped_types_fallback.rs
+++ b/crates/tsz-core/src/module_resolver/tests/scoped_types_fallback.rs
@@ -1,0 +1,235 @@
+//! `@types/<mangled>` fallback for runtime packages that ship no declarations.
+//!
+//! TypeScript's `DefinitelyTyped` convention: typings for `@scope/name` live in
+//! `@types/scope__name` (the `/` collapses to `__`), and typings for a plain
+//! `name` live in `@types/name`. tsc probes the `@types` package whenever the
+//! runtime package itself yields no declaration — whether because the package
+//! resolves to an untyped JavaScript file or because its `exports` map has no
+//! typed entry. An `@types` declaration is preferred over the untyped JS, but a
+//! package's *own* declarations always win over `@types`.
+//!
+//! Regression coverage for the scoped-`@types` name-mangling bug where a runtime
+//! `@scope/name` package (e.g. `@babel/core`) hid the installed
+//! `@types/scope__name` declarations and surfaced a false TS7016.
+
+use super::super::*;
+use super::fixtures::TempFixture;
+
+fn bundler_resolver() -> ModuleResolver {
+    ModuleResolver::new(&ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Bundler),
+        resolve_package_json_exports: true,
+        module_suffixes: vec![String::new()],
+        ..Default::default()
+    })
+}
+
+/// A scoped runtime package whose `exports` map points only at JavaScript must
+/// still pick up its `@types/scope__name` declarations.
+#[test]
+fn scoped_runtime_js_package_falls_back_to_mangled_types() {
+    let fx = TempFixture::new();
+    fx.write(
+        "node_modules/@acme/widget/package.json",
+        r#"{"name":"@acme/widget","version":"1.0.0","exports":{".":"./lib/index.js"}}"#,
+    );
+    fx.write(
+        "node_modules/@acme/widget/lib/index.js",
+        "module.exports = {};",
+    );
+    fx.write(
+        "node_modules/@types/acme__widget/package.json",
+        r#"{"name":"@types/acme__widget","version":"0.0.0","types":"index.d.ts"}"#,
+    );
+    let dts = fx.write(
+        "node_modules/@types/acme__widget/index.d.ts",
+        "export declare function widget(): string;",
+    );
+    let importer = fx.write("src/app.ts", "import { widget } from '@acme/widget';");
+
+    let mut resolver = bundler_resolver();
+    let resolved = resolver
+        .resolve("@acme/widget", &importer, Span::new(0, 12))
+        .expect("@acme/widget should resolve to @types/acme__widget declarations");
+    assert_eq!(resolved.resolved_path, dts);
+    assert_eq!(resolved.extension, ModuleExtension::Dts);
+}
+
+/// The same fallback must apply to a plain (non-scoped) runtime package.
+#[test]
+fn plain_runtime_js_package_falls_back_to_types() {
+    let fx = TempFixture::new();
+    fx.write(
+        "node_modules/leftpadish/package.json",
+        r#"{"name":"leftpadish","version":"1.0.0","exports":{".":"./dist/index.js"}}"#,
+    );
+    fx.write(
+        "node_modules/leftpadish/dist/index.js",
+        "module.exports = {};",
+    );
+    fx.write(
+        "node_modules/@types/leftpadish/package.json",
+        r#"{"name":"@types/leftpadish","version":"0.0.0","types":"index.d.ts"}"#,
+    );
+    let dts = fx.write(
+        "node_modules/@types/leftpadish/index.d.ts",
+        "export declare function pad(): string;",
+    );
+    let importer = fx.write("src/app.ts", "import { pad } from 'leftpadish';");
+
+    let mut resolver = bundler_resolver();
+    let resolved = resolver
+        .resolve("leftpadish", &importer, Span::new(0, 10))
+        .expect("leftpadish should resolve to @types/leftpadish declarations");
+    assert_eq!(resolved.resolved_path, dts);
+    assert_eq!(resolved.extension, ModuleExtension::Dts);
+}
+
+/// A runtime package that ships its *own* declarations must keep them; the
+/// `@types` package is only a fallback and must not override real typings.
+#[test]
+fn own_declarations_win_over_types_package() {
+    let fx = TempFixture::new();
+    fx.write(
+        "node_modules/@acme/gadget/package.json",
+        r#"{"name":"@acme/gadget","version":"1.0.0","types":"index.d.ts","main":"lib/index.js"}"#,
+    );
+    let own_dts = fx.write(
+        "node_modules/@acme/gadget/index.d.ts",
+        "export declare function gadget(): number;",
+    );
+    fx.write(
+        "node_modules/@acme/gadget/lib/index.js",
+        "module.exports = {};",
+    );
+    fx.write(
+        "node_modules/@types/acme__gadget/package.json",
+        r#"{"name":"@types/acme__gadget","version":"0.0.0","types":"index.d.ts"}"#,
+    );
+    fx.write(
+        "node_modules/@types/acme__gadget/index.d.ts",
+        "export declare function gadget(): string;",
+    );
+    let importer = fx.write("src/app.ts", "import { gadget } from '@acme/gadget';");
+
+    let mut resolver = bundler_resolver();
+    let resolved = resolver
+        .resolve("@acme/gadget", &importer, Span::new(0, 12))
+        .expect("@acme/gadget should resolve to its own declarations");
+    assert_eq!(resolved.resolved_path, own_dts);
+    assert_eq!(resolved.extension, ModuleExtension::Dts);
+}
+
+/// With no `@types` package present, a runtime JS package still resolves to the
+/// JavaScript file (preserving `allowJs`/TS7016 behavior in the checker).
+#[test]
+fn js_only_package_without_types_keeps_javascript() {
+    let fx = TempFixture::new();
+    fx.write(
+        "node_modules/@acme/plain/package.json",
+        r#"{"name":"@acme/plain","version":"1.0.0","exports":{".":"./lib/index.js"}}"#,
+    );
+    let js = fx.write(
+        "node_modules/@acme/plain/lib/index.js",
+        "module.exports = {};",
+    );
+    let importer = fx.write("src/app.ts", "import '@acme/plain';");
+
+    let mut resolver = bundler_resolver();
+    let resolved = resolver
+        .resolve("@acme/plain", &importer, Span::new(0, 11))
+        .expect("@acme/plain should still resolve to its JavaScript file");
+    assert_eq!(resolved.resolved_path, js);
+    assert_eq!(resolved.extension, ModuleExtension::Js);
+}
+
+/// The `@types` fallback keeps walking ancestor `node_modules` even when the
+/// nearest runtime copy resolved to untyped JavaScript: a nested JS-only
+/// package picks up `@types` declarations hoisted to an ancestor.
+#[test]
+fn types_fallback_reaches_ancestor_when_nearest_is_js_only() {
+    let fx = TempFixture::new();
+    // Nearest copy: untyped JS only, nested beside the importer.
+    fx.write(
+        "app/node_modules/leftpadish/package.json",
+        r#"{"name":"leftpadish","version":"1.0.0","exports":{".":"./index.js"}}"#,
+    );
+    fx.write(
+        "app/node_modules/leftpadish/index.js",
+        "module.exports = {};",
+    );
+    // Declarations hoisted to the workspace-root `@types`.
+    fx.write(
+        "node_modules/@types/leftpadish/package.json",
+        r#"{"name":"@types/leftpadish","version":"0.0.0","types":"index.d.ts"}"#,
+    );
+    let dts = fx.write(
+        "node_modules/@types/leftpadish/index.d.ts",
+        "export declare function pad(): string;",
+    );
+    let importer = fx.write("app/src/app.ts", "import { pad } from 'leftpadish';");
+
+    let mut resolver = bundler_resolver();
+    let resolved = resolver
+        .resolve("leftpadish", &importer, Span::new(0, 10))
+        .expect("ancestor @types/leftpadish should type the nested JS-only copy");
+    assert_eq!(resolved.resolved_path, dts);
+    assert_eq!(resolved.extension, ModuleExtension::Dts);
+}
+
+/// Node resolution stops at the nearest package: a nested untyped-JS copy is
+/// kept even when a *same-named* typed copy exists in an ancestor
+/// `node_modules` (the ancestor package must not win).
+#[test]
+fn nearest_js_package_is_not_overridden_by_ancestor_same_named_package() {
+    let fx = TempFixture::new();
+    // Nearest copy: untyped JS only.
+    fx.write(
+        "app/node_modules/widgetlib/package.json",
+        r#"{"name":"widgetlib","version":"1.0.0","exports":{".":"./index.js"}}"#,
+    );
+    let nested_js = fx.write(
+        "app/node_modules/widgetlib/index.js",
+        "module.exports = {};",
+    );
+    // Ancestor copy of the SAME package, this one with declarations.
+    fx.write(
+        "node_modules/widgetlib/package.json",
+        r#"{"name":"widgetlib","version":"1.0.0","types":"index.d.ts"}"#,
+    );
+    fx.write(
+        "node_modules/widgetlib/index.d.ts",
+        "export declare function w(): string;",
+    );
+    let importer = fx.write("app/src/app.ts", "import 'widgetlib';");
+
+    let mut resolver = bundler_resolver();
+    let resolved = resolver
+        .resolve("widgetlib", &importer, Span::new(0, 9))
+        .expect("nearest widgetlib should resolve (to its JS), not the ancestor copy");
+    assert_eq!(resolved.resolved_path, nested_js);
+    assert_eq!(resolved.extension, ModuleExtension::Js);
+}
+
+/// A scoped `@types` package is reachable even when no runtime package is
+/// installed under the original scoped name.
+#[test]
+fn scoped_types_resolves_without_runtime_package() {
+    let fx = TempFixture::new();
+    fx.write(
+        "node_modules/@types/acme__only/package.json",
+        r#"{"name":"@types/acme__only","version":"0.0.0","types":"index.d.ts"}"#,
+    );
+    let dts = fx.write(
+        "node_modules/@types/acme__only/index.d.ts",
+        "export declare function only(): string;",
+    );
+    let importer = fx.write("src/app.ts", "import { only } from '@acme/only';");
+
+    let mut resolver = bundler_resolver();
+    let resolved = resolver
+        .resolve("@acme/only", &importer, Span::new(0, 11))
+        .expect("@acme/only should resolve to @types/acme__only declarations");
+    assert_eq!(resolved.resolved_path, dts);
+    assert_eq!(resolved.extension, ModuleExtension::Dts);
+}


### PR DESCRIPTION
AgentName: Studio-B
Track: Module resolver — `@types` fallback / node_modules resolution

## Invariant
When a bare specifier's runtime package resolves to an **untyped JavaScript**
file, or its `exports` map fails authoritatively to yield a typed entry, the
resolver still probes `@types/<mangled-scope>` and prefers that declaration
over the untyped JS. A package's own declarations still win over `@types`, and
Node's "nearest package wins" rule is preserved.

## Structural rule
`When a runtime package resolves to untyped JavaScript (or its exports map has
no typed entry), tsc still probes @types/<mangled> and prefers that declaration
over the untyped JS; tsz now does the same by deferring the untyped resolution
through the resolve_bare_specifier @types fallback (node_modules + typeRoots)
before falling back to it.`

## Summary
Fixes #12461. The reported witness was scoped-`@types` name mangling
(`@babel/core` → `@types/babel__core` on `pmndrs/jotai`), but the mangling
itself (`types_package_name`, `parse_package_specifier`) already worked. The
real root cause is broader: when the **real** runtime package is installed
(e.g. `@babel/core`, whose `exports` map points only at JavaScript and ships
no declarations), `resolve_bare_specifier` returned the JS — or the
exports-authoritative `NotFound` — immediately and never reached the `@types`
fallback, surfacing a false **TS7016** (`Could not find a declaration file for
module '…'`) plus cascading implicit-`any` diagnostics.

The fix defers an untyped-JS resolution (and any exports-authoritative failure)
until the `@types` fallback across `node_modules` and `typeRoots` has had its
chance, then falls back to the deferred JS so `allowJs`/TS7016 still behave.
Once the **nearest** copy of the package resolves to JS or fails its exports,
the package walk stops for ancestors (a hoisted same-named copy must not win),
while the `@types` fallback — a different package name — keeps searching.

## Owner layer
`crates/tsz-core/src/module_resolver/node_modules_resolution.rs`
(`resolve_bare_specifier`; new shared `resolve_types_fallback` helper that
dedupes the `node_modules` and `typeRoots` `@types` probes). No checker/solver
change — purely module resolution.

## Adjacent-case matrix
- Scoped runtime JS package + `@types/scope__name` → resolves to `@types` `.d.ts` ✅
- Plain (non-scoped) runtime JS package + `@types/name` → resolves to `@types` `.d.ts` ✅
- Package ships its **own** `.d.ts` while `@types` also present → own types win ✅
- JS-only package, no `@types` → still resolves to JS (preserves `allowJs`/TS7016) ✅
- Scoped `@types` with no runtime package installed → still resolves ✅
- Nearest copy JS-only + `@types` hoisted to ancestor → ancestor `@types` types it ✅
- Nearest copy JS-only + **same-named** typed copy in ancestor → nearest JS kept (ancestor not used) ✅
- Verified live across `moduleResolution` `bundler`/`node16`/`nodenext`/`node10` ✅
- Genuinely missing module → still TS2307 ✅
- Anti-hardcoding: tests use varied binder/package names (`@acme/widget`, `leftpadish`, `widgetlib`), no file-name/identifier literals drive logic.

## Project Corpus Impact
- Row: jotai (and any project depending on a scoped or plain npm package whose
  declarations live in a `@types/*` DefinitelyTyped package while the runtime
  package itself ships no types — `@babel/*`, `@reach/*`, `@storybook/*`,
  `@wordpress/*`, etc.).
- Bug family: runtime JS package shadows installed `@types` declarations →
  false TS7016 + cascading implicit-any. Removes false positives; introduces no
  new diagnostics (own-types and genuine-missing cases unchanged).

## Verification
- New suite `crates/tsz-core/src/module_resolver/tests/scoped_types_fallback.rs`
  (7 tests) — pass. Confirmed the positive cases reproduce the false TS7016
  without the fix and resolve to the `@types` `.d.ts` with it.
- `cargo test -p tsz-core --lib module_resolver` — 238 pass, 0 fail.
- `cargo test -p tsz-cli --lib resolution` — 117 pass, 0 fail.
- `cargo clippy -p tsz-core` — clean for the changed files (pre-existing
  `config/*` lints from a newer local toolchain are unrelated).
- Manual CLI oracle on the reduced repros (scoped + non-scoped, real-pkg-JS +
  `@types`) across bundler/node16/nodenext/node10: only the deliberate TS2322
  remains; the false TS7016 is gone. Negative repros still emit TS2307 / TS7016.
- `/simplify` run (3 passes): extracted the shared `resolve_types_fallback`
  helper, collapsed the duplicated `cached_is_dir` package/bundler guards under
  a single `!package_search_stopped` check. Reuse/simplification/efficiency
  agents reported clean; the two altitude findings (Classic-mode path and
  `should_skip_fallback_on_not_found`) were assessed as not-applicable —
  Classic resolution never resolves a runtime JS package from `node_modules`,
  and the skip-decision uses a structurally different operation.
- Rebased onto current `origin/main` (`c04074d`); no conflicts (the 3 newer
  commits touch checker/solver only).

## Coordination Notes
Claimed #12461 with a `WIP` label + claim comment before coding. The
scoped-name mangling helpers are left untouched; the new gate is a structural
"untyped resolution must not beat an available declaration" rule, not a
name-based special case.

https://claude.ai/code/session_01ECQ2nn33iwUE7kv643L1Ec

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECQ2nn33iwUE7kv643L1Ec)_