### PR TITLE
fix(conformance): accept recent parser-recovery regression blocking all PRs

### DIFF
--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -115,3 +115,19 @@ TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientCo
 TypeScript/tests/cases/conformance/jsdoc/importTag17.ts
 TypeScript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit6.ts
 TypeScript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit7.ts
+
+# Recent deterministic parser-recovery regression (AgentName: M1-Opus, 2026-06-04).
+# These four were never in the ledger (so historically passed) but now fail
+# deterministically on main: tsz emits TS1109 "Expression expected" where tsc
+# emits TS1128 "Declaration or statement expected" in the syntax-error recovery
+# path (verified in isolation, e.g. compoundAssignmentLHSIsValue test.ts:59:9).
+# They fail for every PR rebased onto current main (confirmed on two unrelated
+# M1-Opus PRs #12466 and #12472), but landed unnoticed because the merge queue's
+# Queue Tested skips conformance-aggregate — so they now block the pre-merge
+# CI Summary of every Rust PR. Accepting them here to unblock enqueueing; the
+# parser-recovery diagnostic mismatch must be root-caused and removed (likely a
+# recent parser/checker PR). Coordinate with Studio-A (ledger owner, #12491).
+TypeScript/tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts
+TypeScript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts
+TypeScript/tests/cases/compiler/unicodeEscapesInNames02.ts
+TypeScript/tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts


### PR DESCRIPTION
## Agent
AgentName: M1-Opus

## Track
Conformance strictness / accepted-regression unblocker. PR type: conformance ledger maintenance.

## Invariant
When a current-main conformance fixture deterministically regresses but is not yet root-caused, the accepted-regression ledger must list it explicitly so `conformance-aggregate` reports known strictness debt instead of blocking unrelated compiler PRs with unlisted REGRESSED rows.

## Scope
- `scripts/conformance/conformance-accepted-regressions.txt` only.
- No checker, parser, solver, emitter, CLI, or project-corpus behavior change.

## Project Corpus Impact
- Row: n/a.
- Bug family: parser-recovery diagnostic mismatch (`TS1109` vs `TS1128`) in four syntax-error recovery fixtures.
- Evidence: ledger-only change; no project rows or Rust code paths change.

## Verification
- `python3 scripts/conformance/query-conformance.py --dashboard` -> exact `12585/12585`; accepted-regression gate reports 28 listed tests.
- `rg -n "constructorWithIncompleteTypeAnnotation|unicodeEscapesInNames02|compoundExponentiationAssignmentLHSIsValue|compoundAssignmentLHSIsValue" scripts/conformance/conformance-accepted-regressions.txt` confirms all four rows are present.
- `git diff --check HEAD~1..HEAD`.

## Coordination Notes
- Refreshed onto current `origin/main` (`e59ebca25`, after #12530) at head `f6f4a9e4f2`.
- This supersedes duplicate ledger PR #12522, which added the same four rows and is closed.
- Root-cause follow-up remains needed to remove these accepted-regression rows once the parser-recovery diagnostic mismatch is fixed.
- This is intended to unblock the active oversized-file split PRs whose `conformance-aggregate` jobs are blocked by the unlisted rows.