### PR TITLE
fix(checker): resolve generic lib constraints structurally

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -1683,11 +1683,8 @@ impl<'a> CheckerState<'a> {
 
                 // Resolve the constraint in case it's a Lazy type
                 let constraint = self.resolve_lazy_type(constraint);
-                let constraint_name = self.format_type_diagnostic(constraint);
                 let constraint = self
-                    .is_well_known_lib_type_name(&constraint_name)
-                    .then(|| self.resolve_lib_type_by_name(&constraint_name))
-                    .flatten()
+                    .resolve_well_known_lib_constraint_type(constraint)
                     .unwrap_or(constraint);
                 if let Some(&arg_idx) = type_args_list.nodes.get(i)
                     && self
@@ -1726,7 +1723,7 @@ impl<'a> CheckerState<'a> {
                 };
                 let primitive_fails_nominal_lib_object =
                     query::is_primitive_type(self.ctx.types.as_type_database(), type_arg)
-                        && self.is_nominal_lib_object_type_name(&constraint_name);
+                        && self.is_nominal_lib_object_constraint_type(constraint);
                 if primitive_fails_nominal_lib_object {
                     if let Some(&arg_idx) = type_args_list.nodes.get(i) {
                         self.error_type_constraint_not_satisfied(

--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -20,6 +20,50 @@ pub(crate) struct CallTypeArgumentValidation {
 // =============================================================================
 
 impl<'a> CheckerState<'a> {
+    fn resolve_well_known_lib_constraint_type(&mut self, constraint: TypeId) -> Option<TypeId> {
+        let name = self.well_known_lib_constraint_type_name(constraint)?;
+        self.resolve_lib_type_by_name(&name)
+    }
+
+    fn is_nominal_lib_object_constraint_type(&self, constraint: TypeId) -> bool {
+        self.well_known_lib_constraint_type_name(constraint)
+            .is_some_and(|name| self.is_nominal_lib_object_type_name(&name))
+    }
+
+    fn well_known_lib_constraint_type_name(&self, type_id: TypeId) -> Option<String> {
+        if let Some(def_id) = query_common::lazy_def_id(self.ctx.types, type_id)
+            && let Some(name) = self.well_known_lib_constraint_def_name(def_id)
+        {
+            return Some(name);
+        }
+
+        if let Some(def_id) = query_common::get_application_lazy_def_id(self.ctx.types, type_id)
+            && let Some(name) = self.well_known_lib_constraint_def_name(def_id)
+        {
+            return Some(name);
+        }
+
+        if let Some(def_id) = self.ctx.definition_store.find_def_for_type(type_id)
+            && let Some(name) = self.well_known_lib_constraint_def_name(def_id)
+        {
+            return Some(name);
+        }
+
+        if let Some(alias) = self.ctx.types.get_display_alias(type_id)
+            && alias != type_id
+        {
+            return self.well_known_lib_constraint_type_name(alias);
+        }
+
+        None
+    }
+
+    fn well_known_lib_constraint_def_name(&self, def_id: tsz_solver::DefId) -> Option<String> {
+        let name = self.ctx.definition_store.get_name(def_id)?;
+        let name = self.ctx.types.resolve_atom_ref(name).to_string();
+        self.is_well_known_lib_type_name(&name).then_some(name)
+    }
+
     fn type_reference_arg_validation_scope_key(&self) -> u64 {
         let mut entries = self
             .ctx
@@ -1082,11 +1126,8 @@ impl<'a> CheckerState<'a> {
             // like `WeakKeyTypes[keyof WeakKeyTypes]` (indexed access types) need
             // to be reduced to their concrete form (e.g., `object | symbol`) for
             // the assignability check to work correctly.
-            let constraint_name = self.format_type_diagnostic(constraint);
             let resolved_constraint = self
-                .is_well_known_lib_type_name(&constraint_name)
-                .then(|| self.resolve_lib_type_by_name(&constraint_name))
-                .flatten()
+                .resolve_well_known_lib_constraint_type(constraint)
                 .unwrap_or(constraint);
             let evaluated_constraint = self.evaluate_type_for_assignability(resolved_constraint);
             let constraint_for_check =

--- a/crates/tsz-checker/tests/rendered_decision_debt_tests.rs
+++ b/crates/tsz-checker/tests/rendered_decision_debt_tests.rs
@@ -445,3 +445,42 @@ fn mapped_declared_source_display_uses_finite_property_surface() {
         "finite mapped display classification should live in the diagnostic query boundary"
     );
 }
+
+#[test]
+fn generic_constraint_lib_resolution_uses_structural_names() {
+    let sources = [
+        std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/checkers/generic_checker/mod.rs"
+        ))
+        .expect("generic checker source should be readable"),
+        std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/checkers/generic_checker/constraint_validation.rs"
+        ))
+        .expect("generic constraint validation source should be readable"),
+    ];
+
+    for source in sources {
+        assert!(
+            !source.contains("let constraint_name = self.format_type_diagnostic(constraint);"),
+            "generic constraint lib fallback must not derive a semantic decision from rendered constraint text"
+        );
+        assert!(
+            !source.contains("is_well_known_lib_type_name(&constraint_name)"),
+            "generic constraint lib fallback should prove lib identity structurally"
+        );
+    }
+
+    let generic_checker = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/checkers/generic_checker/mod.rs"
+    ))
+    .expect("generic checker source should be readable");
+    assert!(
+        generic_checker.contains("resolve_well_known_lib_constraint_type")
+            && generic_checker.contains("query_common::lazy_def_id")
+            && generic_checker.contains("query_common::get_application_lazy_def_id"),
+        "generic constraint lib fallback should inspect Lazy/Application DefIds"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track 10 diagnostic hardcoding debt burn-down; checker diagnostic refactor for #8775.

## Invariant
When generic constraint checking needs the concrete fallback for a well-known lib constraint, tsz proves the lib identity from Lazy/Application DefId, reverse definition mapping, or display-alias metadata. It must not derive the semantic decision from `format_type_diagnostic(constraint)` output.

## Scope
- `crates/tsz-checker/src/checkers/generic_checker/mod.rs`
- `crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs`
- `crates/tsz-checker/tests/rendered_decision_debt_tests.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: diagnostic hardcoding debt (#8775), not a project-corpus compatibility row.
- Evidence: checker-only decision-path cleanup with no accepted-regression ledger changes; conformance dashboard remains 12585/12585 with 24 accepted-regression entries after rebasing onto current `origin/main`.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test rendered_decision_debt_tests generic_constraint_lib_resolution_uses_structural_names`
- `git diff --check`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- Rebased onto `origin/main` at `70e0b5607568a9612e74d3210118f283ac63f437` and reran the local verification above.

## Coordination Notes
- Ready for review/CI at head `1672abcc267ad8cf8d748365084afe061ed289a9`.
- No owned M1-A PRs were open at cycle start.
- Overlap: checker generic constraint diagnostics only; no solver policy, emitter, or accepted-regression artifact changes.
- Repo-wide label audit has one unrelated finding on #12529 (`AgentName=Codex` missing canonical agent label); left untouched by this PR.