### PR TITLE
test(checker): ratchet rendered decision debt to zero

### DIFF
--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs
@@ -641,7 +641,7 @@ fn test_multiline_rendered_type_decision_patterns_do_not_grow() {
     // ceiling.
     const MULTILINE_DECISION_LINE_CEILING: usize = 0;
     assert!(
-        decisions.len() <= MULTILINE_DECISION_LINE_CEILING,
+        decisions.len() == MULTILINE_DECISION_LINE_CEILING,
         "Multi-line rendered-type decision sites grew to {} (ceiling: {}). \
          Per §25 the printer must not feed checker decisions. Route the new \
          site through a structural `query_boundaries`/`tsz_solver::type_queries` \

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs
@@ -639,7 +639,7 @@ fn test_multiline_rendered_type_decision_patterns_do_not_grow() {
     // Adding a new rendered-type decision raises this count and fails the
     // test; the fix is to use a structural query instead, not to bump the
     // ceiling.
-    const MULTILINE_DECISION_LINE_CEILING: usize = 1;
+    const MULTILINE_DECISION_LINE_CEILING: usize = 0;
     assert!(
         decisions.len() <= MULTILINE_DECISION_LINE_CEILING,
         "Multi-line rendered-type decision sites grew to {} (ceiling: {}). \


### PR DESCRIPTION
## Agent
AgentName: M1-A

## Track
Track 10 diagnostic hardcoding debt burn-down; refactor/architecture ratchet.

## Invariant
When checker diagnostic code has no remaining multi-line rendered-type semantic decisions, the architecture guard should encode zero allowed sites so future work cannot reintroduce formatted-type predicates.

## Scope
- `crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: diagnostic hardcoding / type-display decision debt (#8775)
- Evidence: architecture-test ratchet only; no checker behavior, solver policy, project corpus, or emit changes. The accepted-regression ledger and solver changes in this branch are inherited from merged `origin/main`, not this PR authored scope.

## Verification
Latest sync head `e9d6b6a09de5670a42dfa3363b4c90750639ba4c` after merging current `origin/main` `e0e26737611297877eee2fd17a291765aa68ab95`:
- `python3 scripts/arch/arch_guard.py` -> passed
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib test_multiline_rendered_type_decision_patterns_do_not_grow` -> passed: 1 test passed, 6058 skipped
- `python3 scripts/conformance/query-conformance.py --dashboard` -> `12585/12585 (100.0%)`, accepted-regression gate `30 listed tests`
- `git diff --check origin/main...HEAD` -> clean

Queue evidence:
- Earlier queue synthetic run `26948076283` failed in `lint` on `clippy::absurd_extreme_comparisons` for the zero ceiling comparison; this PR now keeps the zero rendered-decision ratchet clippy-clean by asserting equality with the zero ceiling.
- Earlier queue synthetic run `26949789695` on `automation/merge-queue/pr-12531` failed inherited solver architecture size guards from merged `origin/main`, not this checker ratchet:
  - `crates/tsz-solver/src/operations/generic_call/resolve.rs:3413 lines (limit 3359)`
  - `crates/tsz-solver/src/operations/call_args.rs:2097 lines (limit 2084)`
- The inherited solver architecture guard blocker was fixed by merged PR #12513 and follow-up issue #12536 is now closed.
- Fresh exact-head CI is pending for `e9d6b6a09de5670a42dfa3363b4c90750639ba4c`; `merge-queue` will be restored only after exact-head checks are green and the current queue slot clears.

## Coordination Notes
- AgentName: M1-A
- Follow-up to #12483, which removed the last detected multi-line rendered-type decision site; this PR lowers the historic ceiling from `1` to `0`.
- #12530, #12528, #12523, and #12513 have landed on `main`; this branch merged current `origin/main` after those landings.
- `merge-queue` is absent while PR #12537 owns the active queue slot.
- Ready for requeue after fresh exact-head CI passes and no other PR remains active in the repo-local merge queue.
