### PR TITLE
fix(config): chain TS5111 migration URL only where tsc 6.0.3 does

### DIFF
--- a/crates/tsz-core/src/config/deprecation_helpers.rs
+++ b/crates/tsz-core/src/config/deprecation_helpers.rs
@@ -1,16 +1,33 @@
 use tsz_common::diagnostics::data::diagnostic_messages;
 
-/// Returns true when `tsc 6.0.3` appends the migration-URL note for `option_key`.
+/// Returns true when `tsc 6.0.3` chains the TS5111 migration-URL note
+/// (Visit <https://aka.ms/ts6> for migration information.) onto the TS5107/TS5101
+/// message for the given deprecated `(option_key, display_value)` pair.
 ///
-/// `tsc` only chains "Visit https://aka.ms/ts6" when the deprecated option has an
-/// active migration target documented in the TS 6 migration guide (module-resolution
-/// overhaul, target upgrade). Options that are deprecated without a documented
-/// migration path (e.g. `allowSyntheticDefaultImports=false`, `esModuleInterop=false`)
-/// do not get the URL suffix.
-pub(super) fn option_has_migration_url(option_key: &str) -> bool {
+/// `tsc` decides this per deprecation, not per option name: it passes the URL as the
+/// `related` chain argument in only two of the 6.0-wave deprecations. This mirrors
+/// `checkDeprecations("6.0", "7.0", ...)` inside `verifyDeprecatedCompilerOptions`
+/// (TypeScript 6.0.3 `commandLineParser`/`program`). The full wave and its URL state:
+///
+/// | deprecation                       | TS code | migration URL |
+/// |-----------------------------------|---------|---------------|
+/// | `moduleResolution=node10`         | TS5107  | yes           |
+/// | `baseUrl`                         | TS5101  | yes           |
+/// | `moduleResolution=classic`        | TS5107  | no            |
+/// | `target=ES5`                      | TS5107  | no            |
+/// | `module=None`/`AMD`/`UMD`/`System`| TS5107  | no            |
+/// | `alwaysStrict=false`              | TS5107  | no            |
+/// | `esModuleInterop=false`           | TS5107  | no            |
+/// | `allowSyntheticDefaultImports=false` | TS5107 | no          |
+/// | `outFile`                         | TS5101  | no            |
+/// | `downlevelIteration`              | TS5101  | no            |
+///
+/// `display_value` is the rendered option value for TS5107 (e.g. `"node10"`,
+/// `"classic"`) and `None` for the key-only TS5101 deprecations.
+pub(super) fn option_has_migration_url(option_key: &str, display_value: Option<&str>) -> bool {
     matches!(
-        option_key,
-        "moduleResolution" | "module" | "target" | "downlevelIteration"
+        (option_key, display_value),
+        ("moduleResolution", Some("node10")) | ("baseUrl", None)
     )
 }
 
@@ -25,11 +42,63 @@ pub(super) fn with_migration_url(base: String) -> String {
     )
 }
 
-/// Appends the migration URL only when `tsc 6.0.3` would do so for `option_key`.
-pub(super) fn maybe_with_migration_url(base: String, option_key: &str) -> String {
-    if option_has_migration_url(option_key) {
+/// Appends the migration URL only when `tsc 6.0.3` would do so for the
+/// `(option_key, display_value)` deprecation.
+pub(super) fn maybe_with_migration_url(
+    base: String,
+    option_key: &str,
+    display_value: Option<&str>,
+) -> String {
+    if option_has_migration_url(option_key, display_value) {
         with_migration_url(base)
     } else {
         base
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact TS6-wave table from `tsc 6.0.3`. Each row is
+    /// `(option_key, display_value, expects_url)` and mirrors a
+    /// `createDeprecatedDiagnostic(...)` call in `checkDeprecations("6.0", "7.0")`.
+    const TS6_DEPRECATION_URL_MATRIX: &[(&str, Option<&str>, bool)] = &[
+        // The only two deprecations tsc chains the migration URL onto.
+        ("moduleResolution", Some("node10"), true),
+        ("baseUrl", None, true),
+        // Everything else in the 6.0 wave is deprecated without the URL.
+        ("moduleResolution", Some("classic"), false),
+        ("target", Some("ES5"), false),
+        ("module", Some("None"), false),
+        ("module", Some("AMD"), false),
+        ("module", Some("UMD"), false),
+        ("module", Some("System"), false),
+        ("alwaysStrict", Some("false"), false),
+        ("esModuleInterop", Some("false"), false),
+        ("allowSyntheticDefaultImports", Some("false"), false),
+        ("outFile", None, false),
+        ("downlevelIteration", None, false),
+    ];
+
+    #[test]
+    fn migration_url_matches_tsc_6_0_3_table() {
+        for &(key, value, expected) in TS6_DEPRECATION_URL_MATRIX {
+            assert_eq!(
+                option_has_migration_url(key, value),
+                expected,
+                "migration URL decision for ({key}, {value:?}) must match tsc 6.0.3"
+            );
+        }
+    }
+
+    #[test]
+    fn maybe_with_migration_url_appends_only_when_expected() {
+        let base = "Option 'x' is deprecated.".to_string();
+        assert!(
+            maybe_with_migration_url(base.clone(), "moduleResolution", Some("node10"))
+                .contains("aka.ms/ts6")
+        );
+        assert!(!maybe_with_migration_url(base, "target", Some("ES5")).contains("aka.ms/ts6"));
     }
 }

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -1627,6 +1627,7 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
                             &[key, display_value, "7.0", "6.0"],
                         ),
                         key,
+                        Some(display_value),
                     );
                     diagnostics.push(Diagnostic::error(
                         file_path,
@@ -1660,6 +1661,7 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
                             &[key, "7.0", "6.0"],
                         ),
                         key,
+                        None,
                     );
                     diagnostics.push(Diagnostic::error(
                         file_path,

--- a/crates/tsz-core/src/config/tests/strict_lib_extends.rs
+++ b/crates/tsz-core/src/config/tests/strict_lib_extends.rs
@@ -1160,9 +1160,12 @@ fn ts6046_silent_for_valid_watch_file_value() {
 // TS5107 and TS5101 must produce the same combined message as tsc's
 // `flattenDiagnosticMessageText` ("\n  " separator before the TS5111 URL)
 // so `try-tsz` project comparisons match tsc output on (code, message) tuples.
+// tsc 6.0.3 chains the TS5111 migration URL onto only two deprecations:
+// `moduleResolution=node10` and `baseUrl` (see `option_has_migration_url`).
 
 #[test]
 fn ts5107_message_equals_flattened_tsc_output() {
+    // `alwaysStrict=false` is deprecated WITHOUT the migration URL in tsc 6.0.3.
     let source = r#"{"compilerOptions":{"alwaysStrict":false}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let diag = parsed
@@ -1173,16 +1176,16 @@ fn ts5107_message_equals_flattened_tsc_output() {
     let expected = concat!(
         "Option 'alwaysStrict=false' is deprecated and will stop functioning in TypeScript 7.0.",
         " Specify compilerOption '\"ignoreDeprecations\": \"6.0\"' to silence this error.",
-        "\n  Visit https://aka.ms/ts6 for migration information.",
     );
     assert_eq!(
         diag.message_text, expected,
-        "TS5107 message must exactly match tsc flattenDiagnosticMessageText output"
+        "TS5107 for alwaysStrict=false must match tsc flattenDiagnosticMessageText output (no URL)"
     );
 }
 
 #[test]
 fn ts5101_message_equals_flattened_tsc_output() {
+    // `baseUrl` IS one of the two deprecations tsc chains the migration URL onto.
     let source = r#"{"compilerOptions":{"baseUrl":"."}}"#;
     let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
     let diag = parsed
@@ -1199,4 +1202,45 @@ fn ts5101_message_equals_flattened_tsc_output() {
         diag.message_text, expected,
         "TS5101 message must exactly match tsc flattenDiagnosticMessageText output"
     );
+}
+
+/// Full TS6-wave parity matrix: for every deprecated option, the TS5107/TS5101
+/// message must carry the TS5111 migration URL only when tsc 6.0.3 does. The
+/// expected URL state was captured from the `typescript@6.0.3` oracle.
+#[test]
+fn ts6_deprecation_migration_url_matches_tsc_oracle() {
+    // (compilerOptions JSON, expected TS code, expects_url)
+    let cases: &[(&str, u32, bool)] = &[
+        (r#"{"moduleResolution":"node10"}"#, 5107, true),
+        (r#"{"moduleResolution":"node"}"#, 5107, true),
+        (r#"{"baseUrl":"."}"#, 5101, true),
+        (r#"{"moduleResolution":"classic"}"#, 5107, false),
+        (r#"{"target":"ES5"}"#, 5107, false),
+        (r#"{"module":"amd"}"#, 5107, false),
+        (r#"{"module":"umd"}"#, 5107, false),
+        (r#"{"module":"system"}"#, 5107, false),
+        (r#"{"module":"none"}"#, 5107, false),
+        (r#"{"alwaysStrict":false}"#, 5107, false),
+        (r#"{"esModuleInterop":false}"#, 5107, false),
+        (r#"{"allowSyntheticDefaultImports":false}"#, 5107, false),
+        (r#"{"outFile":"out.js"}"#, 5101, false),
+        (r#"{"downlevelIteration":true}"#, 5101, false),
+    ];
+    for (opts, code, expects_url) in cases {
+        let source = format!(r#"{{"compilerOptions":{opts}}}"#);
+        let parsed = parse_tsconfig_with_diagnostics(&source, "tsconfig.json").unwrap();
+        let diag = parsed
+            .diagnostics
+            .iter()
+            .find(|d| d.code == *code)
+            .unwrap_or_else(|| panic!("expected TS{code} for {opts}"));
+        let has_url = diag.message_text.contains(
+            tsz_common::diagnostics::data::diagnostic_messages::VISIT_HTTPS_AKA_MS_TS6_FOR_MIGRATION_INFORMATION,
+        );
+        assert_eq!(
+            has_url, *expects_url,
+            "TS{code} migration-URL state for {opts} must match tsc 6.0.3 (got message: {:?})",
+            diag.message_text
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #12457.

`tsc 6.0.3` chains the TS5111 note *"Visit https://aka.ms/ts6 for migration information."* onto only **two** of its 6.0-wave deprecated options. After #12292/#12493, tsz decided this on the option **name** (`moduleResolution | module | target | downlevelIteration`), which both over-applied the URL and missed it on `baseUrl`. This re-keys the decision on the exact `(option, value)` table tsc uses.

## Structural Rule
When a 6.0-wave option is deprecated, `tsc 6.0.3` chains the TS5111 migration URL **iff** the deprecation is `moduleResolution=node10` or `baseUrl`; every other deprecation (`moduleResolution=classic`, `target=ES5`, `module=None/AMD/UMD/System`, `alwaysStrict=false`, `esModuleInterop=false`, `allowSyntheticDefaultImports=false`, `outFile`, `downlevelIteration`) omits it. tsz now does the same through `tsz_core::config::deprecation_helpers::option_has_migration_url`, keyed on the `(option_key, display_value)` pair — mirroring `checkDeprecations("6.0", "7.0", …)` in TypeScript's `verifyDeprecatedCompilerOptions`, where the URL is the per-deprecation `related` chain argument (not an option-name attribute). The decision is value-sensitive: `moduleResolution=node10` chains the URL, `moduleResolution=classic` does not, so an option-name allowlist is structurally insufficient.

## Owner Layer
Checker / config boundary — `crates/tsz-core/src/config` (`deprecation_helpers.rs` owns the table; `mod.rs` threads the rendered value through the two emission sites). The diagnostic message is computed in exactly one place; the `try-tsz` worker path reuses it.

## Ground Truth
The full table was captured from the `typescript@6.0.3` oracle, both by reading `verifyDeprecatedCompilerOptions` and by running `tsc -p` on each option:

| deprecation | code | URL |
|---|---|---|
| `moduleResolution=node10` (and `node`) | TS5107 | yes |
| `baseUrl` | TS5101 | yes |
| `moduleResolution=classic` | TS5107 | no |
| `target=ES5` | TS5107 | no |
| `module=None/AMD/UMD/System` | TS5107 | no |
| `alwaysStrict=false` | TS5107 | no |
| `esModuleInterop=false` | TS5107 | no |
| `allowSyntheticDefaultImports=false` | TS5107 | no |
| `outFile` | TS5101 | no |
| `downlevelIteration` | TS5101 | no |

## Scope
Broad over the whole 6.0 deprecation wave, not just the issue's two witnesses (`allowSyntheticDefaultImports=false`, `moduleResolution=node10`). Adds the previously-missing URL to `baseUrl` and removes the wrongly-applied URL from `module`, `target`, `downlevelIteration`, and `moduleResolution=classic`. Two pre-existing golden-message tests that asserted the over-applied URL (`ts5107_message_equals_flattened_tsc_output` for `alwaysStrict`, `ts5101_message_equals_flattened_tsc_output` for `baseUrl` — both failing on `main`) are corrected.

## Adjacent-case Matrix
- value-sensitive same-option: `moduleResolution=node10` (URL) vs `moduleResolution=classic` (no URL)
- key-based (TS5101) positive `baseUrl` vs negatives `outFile`/`downlevelIteration`
- value-based (TS5107) negatives across `module` synonyms, `target`, boolean toggles
- `node` alias normalizes to `node10` display and keeps the URL

## Project Corpus Impact
- Row: n/a (diagnostic-message parity fix; not a benchmark-row change)
- Bug family: config-deprecation-message-parity (TS5107/TS5101 + TS5111 chain)
- Affects the (code, message) tuple for TS5107/TS5101 on any project setting these deprecated options. Corrects parity for the issue's real-world witnesses (msw `allowSyntheticDefaultImports:false`; comlink `moduleResolution:node10`) and restores the URL on `baseUrl`-using projects.

## Verification
- `cargo nextest run -p tsz-core config::deprecation_helpers config::tests::strict_lib_extends` — 71 passed (incl. new `migration_url_matches_tsc_6_0_3_table` and `ts6_deprecation_migration_url_matches_tsc_oracle`).
- `cargo nextest run -p tsz-cli test_ts5107_module_resolution_node10_has_migration_url test_ts5107_allow_synthetic_default_imports_false_no_migration_url config_deprecation_diagnostics_ignore_location` — 5 passed.
- Each row of the parity matrix was confirmed against the real `typescript@6.0.3` CLI oracle.
- `cargo fmt` clean; `cargo clippy -p tsz-core --lib` clean for the changed code.

## Coordination Notes
- No anti-hardcoding concerns: the table encodes built-in compiler-option/value pairs from tsc's own deprecation list — no user identifiers, file names, or printer-output string matching. Checker stays thin; the structural decision lives in the config/solver-adjacent helper.
- No roadmap change (routine parity fix).

AgentName: Studio-A
Track: conformance / config parity
Invariant: TS5107/TS5101 (code, message) tuples match `tsc 6.0.3` per (option, value).
