### PR TITLE
fix(checker): bound diagnostic display normalization recursion (#12455)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/excess_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/excess_display.rs
@@ -288,6 +288,11 @@ impl<'a> CheckerState<'a> {
         &self,
         ty: TypeId,
     ) -> Option<TypeId> {
+        // Bound the recursion (shared with `normalize_excess_display_type`,
+        // which this mutually recurses with) so deeply self-expanding generic
+        // types cannot overflow the stack while displaying an excess-property
+        // diagnostic (issue #12455).
+        let _display_guard = super::type_display::DisplayRecursionGuard::enter()?;
         let shape = crate::query_boundaries::common::object_shape_for_type(self.ctx.types, ty)?;
         let mut normalized = shape.as_ref().clone();
         let mut changed = false;
@@ -508,6 +513,12 @@ impl<'a> CheckerState<'a> {
     }
 
     fn strip_readonly_deep_for_excess_display(&self, ty: TypeId) -> TypeId {
+        // Bound the recursion so deeply self-expanding generic types cannot
+        // overflow the stack while stripping `readonly` for display (issue
+        // #12455).
+        let Some(_display_guard) = super::type_display::DisplayRecursionGuard::enter() else {
+            return ty;
+        };
         let Some(shape) =
             crate::query_boundaries::common::object_shape_for_type(self.ctx.types, ty)
         else {
@@ -549,6 +560,10 @@ impl<'a> CheckerState<'a> {
         prop_name: Atom,
         ty: TypeId,
     ) -> Option<TypeId> {
+        // Bound the recursion so deeply self-expanding generic types cannot
+        // overflow the stack while narrowing an excess-property function
+        // parameter for display (issue #12455).
+        let _display_guard = super::type_display::DisplayRecursionGuard::enter()?;
         let key_type = self.ctx.types.literal_string_atom(prop_name);
         if let Some(app) = crate::query_boundaries::common::type_application(self.ctx.types, ty) {
             let mut changed = false;

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -7,6 +7,68 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
 
+/// Maximum nesting depth for the diagnostic display normalization passes.
+///
+/// Before a type is handed to the solver's diagnostic formatter, the checker
+/// runs cosmetic normalization passes over it (resolving `Lazy` references,
+/// widening fresh literals, re-applying display aliases, materializing finite
+/// mapped types, stripping excess-property wrappers). These passes recurse
+/// structurally through applications, unions, intersections, and object shapes,
+/// and re-enter on each resolved/evaluated `Lazy` reference. On deeply
+/// self-expanding generic types — e.g. the higher-kinded middleware-mutator
+/// chains in `zustand` / `jotai` / `arktype`, where `Mutate<S, [...]>` peels one
+/// tuple element and nests another `StoreMutators[...]` application per step —
+/// that recursion never reaches a non-lazy fixpoint and overflows the worker
+/// stack (issue #12455).
+///
+/// The downstream formatter already truncates nested type printing at depth 8
+/// (`max_depth`) and elides long property-receiver objects by depth 26, so any
+/// normalization performed below this bound is never observable in the rendered
+/// diagnostic. Capping the passes here therefore bottoms out the recursion
+/// without changing any displayed output: once the limit is reached the type is
+/// returned unchanged (the cosmetic normalization is simply skipped for the
+/// unreachable depths). The bound is chosen far above the formatter's visible
+/// depth so realistic diagnostics are unaffected, yet far below the thousands of
+/// frames required to exhaust the worker stack.
+const MAX_DIAGNOSTIC_DISPLAY_RECURSION_DEPTH: u32 = 100;
+
+thread_local! {
+    static DISPLAY_RECURSION_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+/// RAII guard that bounds the recursion depth of the diagnostic display
+/// normalization passes (see [`MAX_DIAGNOSTIC_DISPLAY_RECURSION_DEPTH`]).
+///
+/// A single shared thread-local counter spans every mutually-recursive display
+/// normalization function, so the total stack depth across them is bounded even
+/// when one pass re-enters another. The depth is decremented on `Drop`, so every
+/// return path — including early exits — is accounted for without threading a
+/// depth parameter through each call site.
+pub(in crate::error_reporter::core) struct DisplayRecursionGuard;
+
+impl DisplayRecursionGuard {
+    /// Enter one level of display-normalization recursion.
+    ///
+    /// Returns `None` once the depth cap is reached; the caller must then leave
+    /// the type unchanged (return `ty` / `None`) instead of recursing further.
+    pub(in crate::error_reporter::core) fn enter() -> Option<Self> {
+        DISPLAY_RECURSION_DEPTH.with(|depth| {
+            if depth.get() >= MAX_DIAGNOSTIC_DISPLAY_RECURSION_DEPTH {
+                None
+            } else {
+                depth.set(depth.get() + 1);
+                Some(Self)
+            }
+        })
+    }
+}
+
+impl Drop for DisplayRecursionGuard {
+    fn drop(&mut self) {
+        DISPLAY_RECURSION_DEPTH.with(|depth| depth.set(depth.get().saturating_sub(1)));
+    }
+}
+
 impl<'a> CheckerState<'a> {
     pub(in crate::error_reporter) fn sanitize_type_annotation_text_for_diagnostic(
         &self,
@@ -310,23 +372,14 @@ impl<'a> CheckerState<'a> {
         &mut self,
         ty: TypeId,
     ) -> TypeId {
-        let Some(app) = query::type_application(self.ctx.types, ty) else {
+        // Bound the structural / lazy-resolution recursion so deeply
+        // self-expanding generic types cannot overflow the stack while a
+        // diagnostic type is normalized for display (issue #12455). The
+        // downstream formatter truncates nested printing well below this depth,
+        // so leaving the type unchanged at the cap never alters rendered output.
+        let Some(_display_guard) = DisplayRecursionGuard::enter() else {
             return ty;
         };
-        let args: Vec<_> = app
-            .args
-            .iter()
-            .map(|&arg| self.normalize_property_receiver_application_display_arg(arg))
-            .collect();
-
-        if args == app.args {
-            ty
-        } else {
-            self.ctx.types.factory().application(app.base, args)
-        }
-    }
-
-    fn normalize_property_receiver_application_display_alias(&mut self, ty: TypeId) -> TypeId {
         let Some(app) = query::type_application(self.ctx.types, ty) else {
             return ty;
         };
@@ -344,6 +397,9 @@ impl<'a> CheckerState<'a> {
     }
 
     fn normalize_property_receiver_application_display_arg(&mut self, ty: TypeId) -> TypeId {
+        let Some(_display_guard) = DisplayRecursionGuard::enter() else {
+            return ty;
+        };
         // Only resolve `Lazy(DefId)` references via the type environment.
         // Calling `evaluate_type_with_env` on richer shapes (e.g. `keyof T`,
         // `T[K]`, conditional types) eagerly expands them to their evaluated
@@ -457,7 +513,7 @@ impl<'a> CheckerState<'a> {
             let new_ty = self.ctx.types.factory().object_with_index(normalized_shape);
             if let Some(alias_origin) = self.ctx.types.get_display_alias(ty) {
                 let alias_origin =
-                    self.normalize_property_receiver_application_display_alias(alias_origin);
+                    self.normalize_property_receiver_application_display_type(alias_origin);
                 if query::type_application(self.ctx.types, alias_origin).is_some() {
                     self.ctx
                         .types
@@ -503,6 +559,12 @@ impl<'a> CheckerState<'a> {
         &self,
         ty: TypeId,
     ) -> TypeId {
+        // Bound the recursion so deeply self-expanding generic types cannot
+        // overflow the stack while an excess-property diagnostic type is
+        // normalized for display (issue #12455).
+        let Some(_display_guard) = DisplayRecursionGuard::enter() else {
+            return ty;
+        };
         let ty = crate::query_boundaries::common::evaluate_type(self.ctx.types, ty);
         if let Some(app) = query::type_application(self.ctx.types, ty) {
             let args: Vec<_> = app
@@ -1197,6 +1259,10 @@ impl<'a> CheckerState<'a> {
     }
 
     fn materialize_finite_mapped_type_for_display(&mut self, ty: TypeId) -> Option<TypeId> {
+        // Bound the recursion so deeply self-expanding generic types cannot
+        // overflow the stack while materializing a finite mapped type for
+        // display (issue #12455).
+        let _display_guard = DisplayRecursionGuard::enter()?;
         if let Some((mapped_id, mapped)) = query::mapped_type(self.ctx.types, ty) {
             let names =
                 crate::query_boundaries::state::checking::collect_finite_mapped_property_names(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1050,6 +1050,9 @@ mod property_alias_display_tests;
 #[path = "tests/property_index_key_relation_routing_arch_tests.rs"]
 mod property_index_key_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/property_receiver_display_recursion_overflow_tests.rs"]
+mod property_receiver_display_recursion_overflow_tests;
+#[cfg(test)]
 #[path = "tests/property_receiver_relation_routing_arch_tests.rs"]
 mod property_receiver_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/property_receiver_display_recursion_overflow_tests.rs
+++ b/crates/tsz-checker/src/tests/property_receiver_display_recursion_overflow_tests.rs
@@ -1,0 +1,197 @@
+//! Regression tests for stack overflow in the property-receiver application
+//! display normalization pre-pass (`normalize_property_receiver_application_*`
+//! in `error_reporter::core::type_display`).
+//!
+//! Structural rule: when a diagnostic must render a property-receiver type, the
+//! checker runs a cosmetic normalization pre-pass that resolves `Lazy`
+//! references, widens fresh literals, and re-applies display aliases. That
+//! pre-pass recurses structurally through applications, unions, intersections,
+//! and object shapes, and re-enters on each resolved `Lazy` reference using a
+//! *fresh* evaluation budget. On deeply self-expanding generic types — e.g. the
+//! higher-kinded middleware-mutator chains in `zustand` / `jotai` / `arktype`,
+//! where evaluating one layer yields another anonymous layer that is still lazy
+//! — the recursion never reaches a non-lazy fixpoint and overflows the worker
+//! stack (`SIGABRT`, issue #12455).
+//!
+//! The downstream solver diagnostic formatter already bounds nested type
+//! printing (`max_depth = 8`, long-receiver elision by depth 26), so the
+//! pre-pass is capped at a depth far above any visible nesting: once the bound
+//! is reached the type is returned unchanged, which bottoms out the recursion
+//! without altering any rendered diagnostic.
+//!
+//! These tests exercise recursive / higher-kinded receiver shapes through the
+//! diagnostic display path and assert that they terminate and render their
+//! aliased form (matching `tsc`). Binder names are varied so no fixture-name or
+//! identifier string can drive the behavior.
+
+use crate::test_utils::check_source_diagnostics;
+
+/// Run the checker purely to confirm the display path terminates (no stack
+/// overflow / non-termination) on the given source.
+fn assert_terminates(source: &str) {
+    let _ = check_source_diagnostics(source);
+}
+
+fn message_for_code(source: &str, code: u32) -> String {
+    let diags = check_source_diagnostics(source);
+    diags
+        .iter()
+        .find(|d| d.code == code)
+        .map(|d| d.message_text.clone())
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a TS{code} diagnostic; got {:?}",
+                diags
+                    .iter()
+                    .map(|d| (d.code, &d.message_text))
+                    .collect::<Vec<_>>()
+            )
+        })
+}
+
+/// A self-referential object alias used as a property-receiver renders via its
+/// alias name and does not expand (or overflow) while reporting TS2339.
+#[test]
+fn recursive_object_alias_receiver_renders_via_alias() {
+    let source = r#"
+type Rec<T> = { next: Rec<T>; payload: T };
+declare const value: Rec<number>;
+value.missingProperty;
+"#;
+    let message = message_for_code(source, 2339);
+    assert!(
+        message.contains("Rec<number>"),
+        "receiver should display via its alias, got: {message}"
+    );
+    // The body must not be expanded into the rendered receiver.
+    assert!(
+        !message.contains("next:"),
+        "recursive body must not be eagerly expanded into the message, got: {message}"
+    );
+}
+
+/// A homomorphic-mapped (`Identity`) wrapper over a self-referential body still
+/// terminates and renders via its alias when a property is missing.
+#[test]
+fn mapped_wrapped_self_referential_receiver_terminates() {
+    let source = r#"
+type Identity<O> = { [K in keyof O]: O[K] };
+type Grow<T> = Identity<{ head: T; tail: Grow<T> }>;
+declare function build<T>(seed: T): Grow<T>;
+const out: { totallyDifferent: true } = build(123);
+"#;
+    let message = message_for_code(source, 2741);
+    assert!(
+        message.contains("Grow<number>"),
+        "receiver should display via its alias, got: {message}"
+    );
+}
+
+/// Faithful (reduced) model of the `zustand` higher-kinded mutator chain that
+/// triggered the original SIGABRT: a recursive conditional (`Mutate`) that peels
+/// a tuple tail and re-indexes a declaration-merged interface. Assigning an
+/// incompatible value forces the deep `Mutate<...>` receiver to be displayed.
+const MUTATOR_CHAIN_DEFS: &str = r#"
+interface StoreMutators<S, A> {}
+type StoreMutatorIdentifier = keyof StoreMutators<unknown, unknown>;
+
+type Mutate<S, Ms> = number extends Ms['length' & keyof Ms]
+  ? S
+  : Ms extends []
+    ? S
+    : Ms extends [[infer Mi, infer Ma], ...infer Mrs]
+      ? Mutate<StoreMutators<S, Ma>[Mi & StoreMutatorIdentifier], Mrs>
+      : never;
+
+interface StoreApi<T> {
+  setState: (partial: T) => void;
+  getState: () => T;
+}
+
+type StateCreator<
+  T,
+  Mis extends [StoreMutatorIdentifier, unknown][] = [],
+  Mos extends [StoreMutatorIdentifier, unknown][] = [],
+  U = T,
+> = (store: Mutate<StoreApi<T>, Mis>) => U;
+"#;
+
+/// Assigning a non-function to a `StateCreator<...>` (whose body embeds the
+/// recursive `Mutate<...>`) reports TS2322 and terminates.
+#[test]
+fn zustand_style_mutator_chain_mismatch_terminates() {
+    let source = format!(
+        r#"
+{MUTATOR_CHAIN_DEFS}
+const bad: StateCreator<{{ n: number }}, [['m/a', never], ['m/b', never]]> = 42;
+"#
+    );
+    let message = message_for_code(&source, 2322);
+    assert!(
+        message.contains("StateCreator"),
+        "target should display via its alias, got: {message}"
+    );
+}
+
+/// Same shape as above with every binder renamed: the behavior must not depend
+/// on any identifier string (anti-hardcoding).
+#[test]
+fn zustand_style_mutator_chain_renamed_binders_terminates() {
+    let source = r#"
+interface MergedKinds<St, Ar> {}
+type KindId = keyof MergedKinds<unknown, unknown>;
+
+type Fold<St, Ks> = number extends Ks['length' & keyof Ks]
+  ? St
+  : Ks extends []
+    ? St
+    : Ks extends [[infer Ki, infer Ka], ...infer Kr]
+      ? Fold<MergedKinds<St, Ka>[Ki & KindId], Kr>
+      : never;
+
+interface Handle<V> {
+  put: (next: V) => void;
+  peek: () => V;
+}
+
+type Builder<V, Ins extends [KindId, unknown][] = [], Out = V> =
+  (handle: Fold<Handle<V>, Ins>) => Out;
+
+const wrong: Builder<{ q: string }, [['k/x', never], ['k/y', never]]> = 7;
+"#;
+    let message = message_for_code(source, 2322);
+    assert!(
+        message.contains("Builder"),
+        "target should display via its alias, got: {message}"
+    );
+}
+
+/// A genuinely incompatible plain assignment must still report TS2322 — the
+/// display cap must not suppress real diagnostics.
+#[test]
+fn plain_mismatch_still_reports() {
+    let source = r#"
+const value: { id: number } = "not an object";
+"#;
+    assert!(
+        !check_source_diagnostics(source)
+            .iter()
+            .filter(|d| d.code == 2322)
+            .collect::<Vec<_>>()
+            .is_empty(),
+        "a genuine mismatch must still report TS2322"
+    );
+}
+
+/// Smoke check: the recursive shapes above must not crash even when no property
+/// name is missing — exercising the normalization on a clean recursive receiver.
+#[test]
+fn recursive_receivers_do_not_crash() {
+    assert_terminates(
+        r#"
+type Loop<T> = { self: Loop<T>; value: T };
+declare const a: Loop<string>;
+const b: number = a.self.self.value;
+"#,
+    );
+}


### PR DESCRIPTION
AgentName: M4-Opus
ContributorIdentity: claude-confident-hawking

Track: Conformance — checker diagnostic display (stack-overflow / panic family)

Closes #12455.

## Invariant
The checker's diagnostic display normalization passes are cosmetic and must
terminate on any type, including infinitely/deeply self-expanding generic types.
Bounding their recursion never changes a rendered diagnostic, because the
downstream solver formatter already truncates nested type printing at depth 8
(`max_depth`) and elides long property-receiver objects by depth 26 — so any
normalization below that bound is unobservable.

## Structural rule
> When a diagnostic type is normalized for display, tsc bounds the work and
> truncates deep nesting; tsz now bounds every mutually-recursive display
> normalization pass through a single shared depth guard
> (`DisplayRecursionGuard`, cap 100), returning the type unchanged at the cap
> instead of recursing into unreachable (un-printed) depths.

## Root cause
The witnessed `SIGABRT` (`thread 'main' has overflowed its stack`) on
`pmndrs/jotai` / `pmndrs/zustand` reproduces a 128 MB worker-stack overflow. A
gdb backtrace pins the recursion to
`tsz_checker::error_reporter::core::type_display::normalize_property_receiver_application_display_*`
— a cosmetic pre-pass that resolves `Lazy` references, widens fresh literals,
and re-applies display aliases. It re-enters on each resolved `Lazy` reference
with a **fresh** evaluation budget (so it is *not* bounded by the instantiation
depth cap), and on higher-kinded middleware-mutator chains
(`Mutate<S, [...]>` peeling one tuple element and nesting another
`StoreMutators[...]` application per step) it never reaches a non-lazy fixpoint.
The main evaluation path survives the same shapes because it grows its stack via
`stacker::maybe_grow`; the display pre-pass does not.

## Owner layer
`crates/tsz-checker/src/error_reporter/core/` (`type_display.rs`,
`excess_display.rs`). No solver/relation change — the relation results are
unchanged; only the cosmetic display pre-pass is bounded.

## Scope
- `type_display.rs` — adds a shared thread-local RAII `DisplayRecursionGuard`
  (cap 100) and applies it to `normalize_property_receiver_application_display_type`,
  `normalize_property_receiver_application_display_arg`,
  `normalize_excess_display_type`, and
  `materialize_finite_mapped_type_for_display`. Removes a duplicate
  `normalize_property_receiver_application_display_alias` (it was byte-identical
  to the `_type` entry; its one caller now uses `_type`).
- `excess_display.rs` — applies the same guard to the mutually-recursive
  `normalize_excess_display_object_type`, `strip_readonly_deep_for_excess_display`,
  and `narrow_excess_function_param_by_property_key`.
- `tests/property_receiver_display_recursion_overflow_tests.rs` (+ `lib.rs`
  registration) — new checker regression suite.

The guard lives at the display boundary (not the interner/solver) because the
overflow is in the checker's cosmetic display pre-pass; the solver formatter
already bounds its own printing recursion.

## Anti-hardcoding
The guard is a structural depth bound — no identifier, alias, or file-name
string drives it. The regression suite includes a renamed-binder variant of the
mutator-chain fixture, and a negative case (a genuine mismatch still reports
TS2322).

## Project Corpus Impact
- Row: n/a (no required project-row baseline change; the fix removes a crash and
  preserves byte-identical diagnostics for non-pathological code). Witnesses that
  previously SIGABRT'd — jotai, zustand, ky, trpc, arktype (#12455) — no longer
  overflow.
- Bug family: unbounded diagnostic-display recursion → worker stack overflow.
- Type-semantic behavior is unchanged; assignability outcomes and rendered
  diagnostics for non-pathological code are byte-identical (the cap is far above
  the formatter's visible depth).

## Verification
- `cargo fmt -p tsz-checker --check` — clean.
- `cargo clippy -p tsz-checker` — clean.
- New suite `property_receiver_display_recursion_overflow_tests` — 6 passed.
- End-to-end on `pmndrs/zustand@4e15c2e` (`src/ + tests/`): pre-fix
  `signal 6 (SIGABRT) … has overflowed its stack`; post-fix **no overflow**
  (the recursive display functions no longer appear on any sampled stack). The
  minimal `Rec<number>` / `Grow<number>` repros still emit the expected
  TS2339 / TS2741 with the alias-preserving display.
- Confirmed the 8 pre-existing `--lib` display/excess test failures
  (`recursive_alias_application_target_display_tests`,
  `ts2353_generic_constraint_tests`, mapped-enum / synthetic-atom display,
  `union_excess_unresolved_member_matching_uses_relation_outcome`) fail
  identically on the branch base — this change adds **zero** new failures.
- `/simplify` (3 passes): generalized the per-call-site depth threading into one
  shared RAII guard, removed the duplicate `_alias` function, and extended the
  guard to every mutually-recursive display-normalization function in the
  excess-display family.

## Coordination Notes
- The remaining slowness on zustand after this fix is the **separate** perf-hang
  issue #12462 (`evaluate_type_for_assignability` → `register_resolved_type` →
  `contains_generic_type_parameters`, on the stacker-backed main eval path) and
  is intentionally out of scope here. This PR resolves the panic (#12455), not
  that perf cliff.
- Rebased onto latest `origin/main`; merges cleanly (touched files unmodified on
  main since base).

https://claude.ai/code/session_01RGidHcJuatNyMiLZQ85Abo