### PR TITLE
fix(parser): only absorb definite assignment '!' after a plain identifier

### DIFF
--- a/crates/tsz-parser/src/parser/mod.rs
+++ b/crates/tsz-parser/src/parser/mod.rs
@@ -68,6 +68,9 @@ pub(crate) mod test_fixture;
 // without grepping a single monolithic file. Each shard imports only the
 // `test_fixture` helpers it actually uses; tests share no per-shard helpers.
 #[cfg(test)]
+#[path = "../../tests/definite_assignment_assertion_tests.rs"]
+mod definite_assignment_assertion_tests;
+#[cfg(test)]
 #[path = "../../tests/parser_async_arrow_context_tests.rs"]
 mod parser_async_arrow_context_tests;
 #[cfg(test)]

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -1307,8 +1307,19 @@ impl ParserState {
             self.parse_identifier()
         };
 
-        // Parse definite assignment assertion (!)
-        let exclamation_token = self.parse_optional(SyntaxKind::ExclamationToken);
+        // Inside a `for` initializer tsc clears `allowExclamation`, so a `!`
+        // here is never a definite assignment assertion.
+        let exclamation_token = false;
+
+        // A stray `!` directly after the binding name is a definite assignment
+        // assertion that is not allowed in a `for` initializer. tsc's
+        // `parseDelimitedList` recovery reports it as a missing comma between
+        // declarators (TS1005 `',' expected`) rather than a `';' expected`, so
+        // emit that and consume the `!` to keep the header parse aligned.
+        if self.is_token(SyntaxKind::ExclamationToken) {
+            self.error_comma_expected();
+            self.next_token();
+        }
 
         // Optional type annotation
         let type_annotation = if self.parse_optional(SyntaxKind::ColonToken) {

--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -1842,7 +1842,10 @@ impl ParserState {
         self.recovered_template_literal_property_in_object = false;
 
         let name = self.parse_variable_declaration_name();
-        let exclamation_token = self.parse_optional(SyntaxKind::ExclamationToken);
+        // tsc only treats a postfix `!` as a definite assignment assertion when
+        // the binding name is a plain identifier and no line break precedes it.
+        // Outside `for` initializers `allowExclamation` is true.
+        let exclamation_token = self.parse_definite_assignment_assertion(name, true);
         let type_annotation = if self.parse_optional(SyntaxKind::ColonToken) {
             self.parse_type()
         } else {

--- a/crates/tsz-parser/src/parser/state_variable_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_variable_declarations.rs
@@ -112,6 +112,48 @@ impl ParserState {
         }
     }
 
+    /// Parse an optional definite assignment assertion `!` after a variable
+    /// declaration name.
+    ///
+    /// Mirrors tsc's `parseVariableDeclaration` (`src/compiler/parser.ts`):
+    ///
+    /// ```ignore
+    /// if (allowExclamation && name.kind === SyntaxKind.Identifier &&
+    ///     token() === SyntaxKind.ExclamationToken && !scanner.hasPrecedingLineBreak()) {
+    ///     exclamationToken = parseTokenNode<...>();
+    /// }
+    /// ```
+    ///
+    /// The `!` is only consumed when all three structural conditions hold:
+    /// - `allow_exclamation` is set. tsc clears it inside `for` initializers
+    ///   (`allowExclamation = !inForStatementInitializer`), so a `!` there is
+    ///   left for list-recovery rather than absorbed as a definite assignment.
+    /// - the binding `name` is a plain `Identifier`, never an object/array
+    ///   binding pattern or an error/missing node.
+    /// - there is no preceding line break, so ASI does not split the statement
+    ///   (`let x` / `!expr` on the next line is two statements, not one).
+    ///
+    /// Returns `true` when a `!` was consumed.
+    pub(crate) fn parse_definite_assignment_assertion(
+        &mut self,
+        name: NodeIndex,
+        allow_exclamation: bool,
+    ) -> bool {
+        if allow_exclamation
+            && self.is_token(SyntaxKind::ExclamationToken)
+            && !self.scanner.has_preceding_line_break()
+            && self
+                .arena
+                .get(name)
+                .is_some_and(crate::parser::node::Node::is_identifier)
+        {
+            self.next_token();
+            true
+        } else {
+            false
+        }
+    }
+
     pub(crate) fn parse_variable_declaration_initializer(&mut self) -> NodeIndex {
         if self.pending_array_binding_tail_recovery {
             return NodeIndex::NONE;
@@ -180,8 +222,17 @@ impl ParserState {
             }
             return;
         }
+        // A binding pattern followed by a stray *same-line* `!` is a definite
+        // assignment assertion the parser refused to absorb (tsc only allows `!`
+        // after a plain identifier). tsc recovers that as a missing-comma cascade
+        // and does not also report TS1182, so suppress it. A `!` after a line
+        // break is a separate expression statement via ASI and must NOT suppress
+        // TS1182 — `const {x}\n!foo;` still reports the missing initializer.
+        let stray_same_line_definite_assignment =
+            self.is_token(SyntaxKind::ExclamationToken) && !self.scanner.has_preceding_line_break();
         if !is_catch_clause
             && initializer.is_none()
+            && !stray_same_line_definite_assignment
             && !self.in_ambient_context()
             && let Some(name_node) = self.arena.get(name)
             && name_node.is_binding_pattern()

--- a/crates/tsz-parser/tests/definite_assignment_assertion_tests.rs
+++ b/crates/tsz-parser/tests/definite_assignment_assertion_tests.rs
@@ -1,0 +1,307 @@
+//! Tests for the definite assignment assertion `!` in variable declarations.
+//!
+//! Structural rule (mirrors tsc's `parseVariableDeclaration`): a postfix `!`
+//! after a variable binding is only absorbed as a definite assignment assertion
+//! when **all three** hold:
+//!   1. `allowExclamation` is set — tsc clears it inside `for` initializers
+//!      (`allowExclamation = !inForStatementInitializer`);
+//!   2. the binding `name` is a plain `Identifier`, never an object/array
+//!      binding pattern;
+//!   3. there is no preceding line break (so ASI does not split the statement).
+//!
+//! When any condition fails tsc leaves the `!` for declaration-list recovery
+//! (it does not become a definite assignment assertion, and the wrong-context
+//! grammar errors TS1263/TS1264 must not fire). Before the fix tsz consumed the
+//! `!` unconditionally, mis-reporting TS1263/TS2483 instead of the structural
+//! comma/expression recovery tsc emits.
+//!
+//! Tests vary the binder name (`x`, `value`, `count`, …) to prove the behavior
+//! is structural and not keyed to a specific identifier spelling.
+
+use crate::parser::test_fixture::parse_source;
+use crate::parser::{NodeIndex, syntax_kind_ext};
+use tsz_common::diagnostics::diagnostic_codes;
+use tsz_scanner::SyntaxKind;
+
+/// Find the first `VARIABLE_DECLARATION` node and return whether it recorded a
+/// definite assignment assertion (`exclamation_token`).
+fn first_decl_has_exclamation(parser: &crate::parser::ParserState) -> Option<bool> {
+    let arena = parser.get_arena();
+    arena
+        .nodes
+        .iter()
+        .enumerate()
+        .find(|(_, n)| n.kind == syntax_kind_ext::VARIABLE_DECLARATION)
+        .and_then(|(idx, _)| arena.get_variable_declaration_at(NodeIndex(idx as u32)))
+        .map(|decl| decl.exclamation_token)
+}
+
+fn codes(parser: &crate::parser::ParserState) -> Vec<u32> {
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases: a plain identifier on one line DOES take the assertion.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn identifier_with_type_annotation_takes_assertion() {
+    for (source, ident) in [
+        ("let x!: number;", "x"),
+        ("let value!: string;", "value"),
+        ("var counter!: bigint;", "counter"),
+        ("const ready!: boolean = true as boolean;", "ready"),
+    ] {
+        let (parser, _) = parse_source(source);
+        assert_eq!(
+            first_decl_has_exclamation(&parser),
+            Some(true),
+            "`{ident}` definite assignment must be absorbed for {source:?}"
+        );
+    }
+}
+
+#[test]
+fn definite_assignment_does_not_emit_wrong_context_errors() {
+    // A well-formed `let x!: number;` is valid TypeScript — no TS1263/TS1264.
+    let (parser, _) = parse_source("let x!: number;");
+    assert!(
+        parser.get_diagnostics().is_empty(),
+        "valid definite assignment must not emit diagnostics, got {:?}",
+        parser.get_diagnostics()
+    );
+}
+
+#[test]
+fn multiple_declarators_each_take_their_own_assertion() {
+    let source = "let a!: number, b!: string, c!: boolean;";
+    let (parser, _) = parse_source(source);
+    assert!(
+        parser.get_diagnostics().is_empty(),
+        "multi-declarator definite assignments must parse cleanly, got {:?}",
+        parser.get_diagnostics()
+    );
+    let arena = parser.get_arena();
+    let with_excl = arena
+        .nodes
+        .iter()
+        .filter(|n| n.kind == syntax_kind_ext::VARIABLE_DECLARATION)
+        .count();
+    assert_eq!(with_excl, 3, "expected three declarators in {source:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Binding patterns never take the assertion (tsc: `name.kind === Identifier`).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn array_binding_pattern_does_not_take_assertion() {
+    // tsc recovers `const [a]!: T = ...` as a missing-comma cascade and never
+    // reports TS1263 (initializer + assertion) nor TS1182 (destructuring needs
+    // an initializer) — the `!` is simply not a definite assignment here.
+    let (parser, _) = parse_source("const [a]!: number[] = [1];");
+    assert_eq!(
+        first_decl_has_exclamation(&parser),
+        Some(false),
+        "array binding pattern must not absorb `!`"
+    );
+    let found = codes(&parser);
+    assert!(
+        !found.contains(
+            &diagnostic_codes::DECLARATIONS_WITH_INITIALIZERS_CANNOT_ALSO_HAVE_DEFINITE_ASSIGNMENT_ASSERTIONS
+        ),
+        "TS1263 must not fire for a binding pattern, got {found:?}"
+    );
+    assert!(
+        !found.contains(&diagnostic_codes::A_DESTRUCTURING_DECLARATION_MUST_HAVE_AN_INITIALIZER),
+        "TS1182 must be suppressed when a stray `!` follows the pattern, got {found:?}"
+    );
+    assert!(
+        found.contains(&diagnostic_codes::EXPECTED),
+        "tsc emits TS1005 ',' expected at the stray `!`, got {found:?}"
+    );
+}
+
+#[test]
+fn object_binding_pattern_does_not_take_assertion() {
+    let (parser, _) = parse_source("const { value }!: any = {};");
+    assert_eq!(
+        first_decl_has_exclamation(&parser),
+        Some(false),
+        "object binding pattern must not absorb `!`"
+    );
+    let found = codes(&parser);
+    assert!(
+        !found.contains(
+            &diagnostic_codes::DECLARATIONS_WITH_INITIALIZERS_CANNOT_ALSO_HAVE_DEFINITE_ASSIGNMENT_ASSERTIONS
+        ),
+        "TS1263 must not fire for a binding pattern, got {found:?}"
+    );
+    assert!(
+        found.contains(&diagnostic_codes::EXPECTED),
+        "tsc emits TS1005 ',' expected at the stray `!`, got {found:?}"
+    );
+}
+
+#[test]
+fn plain_binding_pattern_without_assertion_still_requires_initializer() {
+    // The TS1182 suppression must be *gated on a stray `!`* — an ordinary
+    // initializer-less destructuring declaration must still report TS1182.
+    for source in ["const [a];", "let { value };"] {
+        let found = codes(&parse_source(source).0);
+        assert!(
+            found.contains(&diagnostic_codes::A_DESTRUCTURING_DECLARATION_MUST_HAVE_AN_INITIALIZER),
+            "TS1182 must still fire for {source:?}, got {found:?}"
+        );
+    }
+}
+
+#[test]
+fn line_break_before_bang_on_binding_pattern_keeps_ts1182() {
+    // A `!` after a line break is a separate expression statement (ASI), not a
+    // stray definite assignment — so the initializer-less binding pattern must
+    // STILL report TS1182. The suppression is gated on a *same-line* `!`.
+    for source in ["const {x}\n!foo;", "const [a]\n!bar;"] {
+        let found = codes(&parse_source(source).0);
+        assert!(
+            found.contains(&diagnostic_codes::A_DESTRUCTURING_DECLARATION_MUST_HAVE_AN_INITIALIZER),
+            "TS1182 must still fire across a line break for {source:?}, got {found:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ASI: a line break before `!` splits the statement, so `!` is never absorbed.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn line_break_before_bang_splits_into_two_statements() {
+    // `let x` is complete; `!foo;` on the next line is a separate expression
+    // statement. The declaration must NOT record a definite assignment.
+    for (source, ident) in [
+        ("let x\n!foo;", "x"),
+        ("let value\n!ready();", "value"),
+        ("var flag\n!flag;", "flag"),
+    ] {
+        let (parser, root) = parse_source(source);
+        assert_eq!(
+            first_decl_has_exclamation(&parser),
+            Some(false),
+            "ASI must prevent `!` absorption for {source:?} (binder `{ident}`)"
+        );
+        let arena = parser.get_arena();
+        let sf = arena.get_source_file_at(root).unwrap();
+        assert_eq!(
+            sf.statements.nodes.len(),
+            2,
+            "ASI must yield two statements for {source:?}"
+        );
+        // No wrong-context definite-assignment grammar error.
+        let found = codes(&parser);
+        assert!(
+            !found.contains(
+                &diagnostic_codes::DECLARATIONS_WITH_INITIALIZERS_CANNOT_ALSO_HAVE_DEFINITE_ASSIGNMENT_ASSERTIONS
+            ),
+            "TS1263 must not fire across the line break for {source:?}, got {found:?}"
+        );
+    }
+}
+
+#[test]
+fn same_line_bang_after_identifier_is_still_absorbed() {
+    // Guard the line-break rule against over-reach: a same-line `!` after a
+    // plain identifier is still a definite assignment assertion.
+    let (parser, _) = parse_source("let x!: number;");
+    assert_eq!(first_decl_has_exclamation(&parser), Some(true));
+}
+
+// ---------------------------------------------------------------------------
+// `for` initializers clear `allowExclamation`: `!` is never a definite
+// assignment assertion there (regardless of binder spelling).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn for_of_initializer_does_not_take_assertion() {
+    for (source, _ident) in [
+        ("for (const x!: number of []) {}", "x"),
+        ("for (const item!: string of []) {}", "item"),
+    ] {
+        let (parser, _) = parse_source(source);
+        assert_eq!(
+            first_decl_has_exclamation(&parser),
+            Some(false),
+            "for-of initializer must not absorb `!` for {source:?}"
+        );
+        let found = codes(&parser);
+        assert!(
+            found.contains(&diagnostic_codes::EXPECTED),
+            "tsc emits TS1005 ',' expected for {source:?}, got {found:?}"
+        );
+    }
+}
+
+#[test]
+fn for_in_initializer_does_not_take_assertion() {
+    let (parser, _) = parse_source("for (const key!: string in {}) {}");
+    assert_eq!(
+        first_decl_has_exclamation(&parser),
+        Some(false),
+        "for-in initializer must not absorb `!`"
+    );
+}
+
+#[test]
+fn plain_for_initializer_does_not_take_assertion() {
+    let (parser, _) = parse_source("for (let i!: number = 0; i < 3; i++) {}");
+    assert_eq!(
+        first_decl_has_exclamation(&parser),
+        Some(false),
+        "C-style for initializer must not absorb `!`"
+    );
+    let found = codes(&parser);
+    assert!(
+        found.contains(&diagnostic_codes::EXPECTED),
+        "tsc emits TS1005 ',' expected at the stray `!`, got {found:?}"
+    );
+}
+
+#[test]
+fn valid_for_loops_are_unaffected() {
+    // The fix must not perturb ordinary `for` headers without a stray `!`.
+    for source in [
+        "for (let i = 0; i < 3; i++) {}",
+        "for (const x of [1]) { x; }",
+        "for (const k in {}) { k; }",
+        "for (let a = 0, b = 1; a < b; a++) {}",
+    ] {
+        let (parser, _) = parse_source(source);
+        assert!(
+            parser.get_diagnostics().is_empty(),
+            "valid for-loop {source:?} must parse cleanly, got {:?}",
+            parser.get_diagnostics()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The stray `!` is recovered as a separate token, not silently dropped: the
+// node stream still contains the `for` body, etc. (smoke test for no panic).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stray_bang_recovery_does_not_panic_and_keeps_for_body() {
+    let (parser, root) = parse_source("for (let i!: number = 0; i < 3; i++) { i; }");
+    let arena = parser.get_arena();
+    let sf = arena.get_source_file_at(root).unwrap();
+    assert_eq!(sf.statements.nodes.len(), 1, "the `for` statement survives");
+    assert_eq!(
+        arena.get(sf.statements.nodes[0]).unwrap().kind,
+        syntax_kind_ext::FOR_STATEMENT
+    );
+    // Sanity: there is no leftover lone `!` swallowing the loop body.
+    assert!(
+        !parser.get_diagnostics().is_empty(),
+        "the stray `!` is reported, not ignored"
+    );
+    let _ = SyntaxKind::ExclamationToken;
+}


### PR DESCRIPTION
## Summary

Fixes #10929 (ts-essentials-project: assertion handling at declaration boundaries). The reported witness was the parser mixing type/definite-assignment assertions with declaration boundaries, mis-tokenizing the following statement. The underlying wrong operation is **definite assignment assertion (`!`) parsing in variable declarations**, fixed broadly rather than for the single repro.

AgentName: M4-Opus
Track: Parser / grammar edge handling (declaration boundaries)
Invariant: Parser node shape and diagnostics for variable declarations match `tsc` exactly; valid `!`-annotated declarations are byte-identical to before.

## Structural rule

> When a postfix `!` follows a variable binding, `tsc` absorbs it as a definite
> assignment assertion **only** when (1) the declaration is not a `for`
> initializer (`allowExclamation = !inForStatementInitializer`), (2) the binding
> `name` is a plain `Identifier` — never an object/array binding pattern, and
> (3) no line break precedes the `!` (ASI). tsz previously consumed the `!`
> unconditionally via `parse_optional(ExclamationToken)`, so it reported
> wrong-context grammar errors (`TS1263`/`TS1264`/`TS2483`) instead of tsc's
> structural comma/expression recovery.

Owner layer: parser (`tsz-parser`). This is syntax-only; no checker/solver changes.

## Scope

- New shared helper `parse_definite_assignment_assertion(name, allow_exclamation)` in `state_variable_declarations.rs` encoding the three structural conditions, mirroring tsc's `parseVariableDeclaration`.
- Normal declarator path (`state_statements.rs`) routes through it with `allow_exclamation = true`.
- `for`-initializer declarator path (`state_declarations_exports.rs`) never absorbs `!`; a stray `!` is recovered as a missing comma (`TS1005 ',' expected`), matching tsc's leading `parseDelimitedList` diagnostic.
- `TS1182` (destructuring needs an initializer) is suppressed only for a **same-line** stray `!`; a line-break `!` is a separate statement and still reports `TS1182`.

## Adjacent-case matrix (differential vs `tsc` 6.0.2)

| Case | Before | After / tsc |
|---|---|---|
| `let x!: number;` (valid, identifier) | absorbed | absorbed (unchanged) |
| `let a!: number, b!: string;` | ok | ok |
| `class C { x!: number; }` | ok | ok (unchanged path) |
| `const [a]!: number[] = [1];` | `TS1263` (wrong) | `TS1005`/`TS1109`/`TS1011` |
| `const {a}!: any = {};` | `TS1263` (wrong) | `TS1005`/`TS1109` |
| `let x\n!foo;` (ASI) | `TS1264` + cascade | `TS2304` only |
| `const {x}\n!foo;` (ASI, pattern) | dropped `TS1182` | `TS1182` retained |
| `const [a];` (plain, no init) | `TS1182` | `TS1182` (still fires) |
| `for (const x!: number of [])` | `TS2483` (wrong) | leading `TS1005 ','` |
| `for (let i!: number = 0; ...)` | `TS1263` (wrong) | leading `TS1005 ','` |
| valid `for`/destructuring/non-null chains | ok | ok (unaffected) |

Binder names are varied (`x`, `value`, `count`, `item`, `key`, ...) across the tests to prove the behavior is structural, not keyed to an identifier spelling.

## Fallback

The two pathological `for (... ! ...)` inputs (definite assignment in a `for` header — invalid TS that essentially never appears) now emit the correct **leading** diagnostic and recover gracefully; every diagnostic tsz emits is a subset of tsc's cascade at matching positions. Previously these emitted a semantically wrong single diagnostic. No valid `for` header is affected.

## Project Corpus Impact

- Row: ts-essentials-project (and any row containing definite-assignment declarations) — no behavior change for valid code, so no row drift expected.
- Bug family: parser / definite-assignment-assertion declaration-boundary handling.

Parser-only change; no type-evaluation, cache-key, or residency surface touched. Valid declarations produce identical AST/diagnostics, so required project rows are not regressed.

## Verification

- `cargo test -p tsz-parser` — 1368 passed, 0 failed (13 new regression tests in `definite_assignment_assertion_tests.rs` + 8 pre-existing definite-assignment tests green).
- `cargo clippy -p tsz-parser --tests` — clean.
- Differential vs `tsc` 6.0.2 over the matrix above: all realistic cases now match exactly; the two residual `for`-header diffs emit only correct (subset) diagnostics.
- `cargo build -p tsz-checker` — compiles (no API change); end-to-end `tsz` binary runs over the matrix confirm valid semantics (strictPropertyInitialization suppression, destructuring) match tsc.

## Coordination Notes

Self-reviewed via `/simplify` (4 cleanup agents): collapsed an always-false helper call in the `for` path to a direct `false`, and tightened the `TS1182` suppression to a same-line check after the altitude review surfaced that a line-break `!` must not suppress the missing-initializer diagnostic (added a dedicated regression test). Branch rebased onto latest `main`; no conflicts.
