### PR TITLE
fix(conformance): accept keyof/indexed-access drift after #12523

### DIFF
--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -76,7 +76,12 @@ TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 # (HTMLElementTagNameMap) still fails — the full lib type hierarchy exercises a
 # different code path. Tracked in #12260.
 TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
+# PR #12509 exact head 4a1304578f after #12523 landed on main (CI run
+# 26949719321): all six conformance shards passed, aggregate strictness found
+# two newly unlisted mapped/keyof/indexed-access drift rows. Tracked by #8432.
+TypeScript/tests/cases/compiler/indexingTypesWithNever.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
+TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
 
 # Ready-review aggregate drift observed on PR #11890 exact head f0e9bca2a1
 # (CI run 26900032045): all six conformance shards passed, aggregate strictness


### PR DESCRIPTION
## Agent
AgentName: M1-Opus

## Track
Conformance accepted-regression ledger unblocker.

## Invariant
When `origin/main` introduces newly observed conformance drift that is already tracked by the mapped/keyof/indexed-access family, the accepted-regression ledger must match the observed failing set so `conformance-aggregate` remains a strict gate for unlisted regressions. This PR records only the two rows reported by #12509 exact-head aggregate after #12523 landed.

## Scope
- `scripts/conformance/conformance-accepted-regressions.txt`

## Project Corpus Impact
- Row: n/a
- Bug family: mapped/keyof/indexed-access conformance drift, tracked by #8432.
- Evidence: ledger-only change; no compiler implementation, project harness, or emitted output path changes.

## Verification
Refreshed head `f8c33963a7` merged to `origin/main` `f408cd94ad`:
- `python3 scripts/conformance/query-conformance.py --dashboard` -> `12585/12585`, accepted-regression gate `30`.
- `rg -n indexingTypesWithNever scripts/conformance/conformance-accepted-regressions.txt` and sibling checks for `keyofAndIndexedAccessErrors`, `4a1304578f`, and `26949719321`.
- `python3 scripts/arch/arch_guard.py`.
- `git diff --check origin/m1opus/ledger-keyof-never-regressions-20260604..HEAD`.

## Coordination Notes
- #12509 exact head `4a1304578f` on main `e8aa93c994` failed `conformance-aggregate` with two unlisted rows while all six conformance shards passed: `TypeScript/tests/cases/compiler/indexingTypesWithNever.ts` and `TypeScript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts`.
- Refreshed after #12498 landed on current main; diff remains ledger-only against `origin/main`.

---
_Authored by M1-Opus._