### PR TITLE
fix(checker): keep user interfaces out of lib heritage override (#12464)

### DIFF
--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -324,6 +324,25 @@ impl<'a> CheckerContext<'a> {
             if kind != tsz_solver::def::DefKind::Interface {
                 return None;
             }
+            // Skip the override for an interface that definitively comes from a
+            // user source file (a real file id, not the `u32::MAX` lib sentinel).
+            // The override exists to upgrade a standard-library interface to its
+            // late heritage-merged body. A user interface only lands in
+            // `lib_type_resolution_cache` because its name was resolved through
+            // the lib path during generic-reference prewarming; substituting
+            // that cached "lib" body yields a structurally divergent `TypeId`
+            // from the same alias resolved through its ordinary path. When the
+            // divergent body sits in a contravariant position — a hybrid
+            // callable's parameter reached through a homomorphic mapped type —
+            // the two forms of one alias fail to relate and tsz reports a
+            // spurious "Type 'X' is not assignable to type 'X'".
+            if self
+                .definition_store
+                .get_file_id(def_id)
+                .is_some_and(|file_id| file_id != u32::MAX)
+            {
+                return None;
+            }
             let name_atom = self.definition_store.get_name(def_id)?;
             let name = self.types.resolve_atom(name_atom);
             if name == "Atomics" {

--- a/crates/tsz-cli/tests/driver_tests_parts/part_12.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_12.rs
@@ -980,3 +980,134 @@ fn invalid_config_es_module_interop_keeps_cli_file_emit_classic_unless_cli_enabl
         "explicit --esModuleInterop must still enable the interop helper, got:\n{a_js}"
     );
 }
+
+/// The (code, message) pairs of any "Type 'X' is not assignable to type 'X'"
+/// self-assignment diagnostics (TS2322/TS2719) in a result, for the #12464
+/// regression guards below.
+fn self_assign_diagnostics(diagnostics: &[tsz_common::diagnostics::Diagnostic]) -> Vec<(u32, String)> {
+    diagnostics
+        .iter()
+        .filter(|d| d.code == 2322 || d.code == 2719)
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+/// Issue #12464: a cross-file generic interface used as the call-signature
+/// parameter of a hybrid callable, assigned back through a homomorphic mapped
+/// type, must not produce a spurious "Type 'X' is not assignable to type 'X'".
+///
+/// This needs the full driver (real lib load + project-wide symbol resolution):
+/// the consuming file routes the imported generic interface through the lib
+/// resolution path during generic-reference prewarming, so it lands in
+/// `lib_type_resolution_cache`. Before the fix, `lib_heritage_cache_override`
+/// substituted that cached body for the *user* interface, yielding a divergent
+/// `TypeId` from the same alias resolved normally, and the two forms failed to
+/// relate. The check is name-agnostic — `tsz` (and `tsc`) accept this program.
+#[test]
+fn cross_file_generic_callable_param_through_mapped_type_no_false_self_assign() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+
+    write_file(
+        &base.join("atom.ts"),
+        "export interface Atom<Value> {\n  read: (get: <V>(a: Atom<V>) => V) => Value\n}\n",
+    );
+    write_file(
+        &base.join("main.ts"),
+        r#"import type { Atom } from "./atom";
+type AnyAtom = Atom<unknown>;
+type Hook = {
+  (atom: AnyAtom): void;
+  add(atom: AnyAtom, cb: () => void): () => void;
+};
+type Hooks = { readonly m?: Hook };
+declare const v: Hook;
+function init(hooks: Hooks): void {
+  type Mut = { -readonly [P in keyof Hooks]: Hooks[P] };
+  (hooks as Mut).m = v;
+}
+"#,
+    );
+
+    let args = parse_args(&["tsz", "--noEmit", "--strict", "atom.ts", "main.ts"]);
+    let result = compile(&args, base).expect("compile should succeed");
+    let self_assign = self_assign_diagnostics(&result.diagnostics);
+    assert!(
+        self_assign.is_empty(),
+        "cross-file generic callable param through mapped type must not report \
+         a self-assignment TS2322/TS2719, got: {self_assign:?}"
+    );
+}
+
+/// Same rule, every binder name changed (interface / alias / property), to keep
+/// the guard structural rather than tied to the jotai spellings.
+#[test]
+fn cross_file_generic_callable_param_through_mapped_type_renamed_no_false_self_assign() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+
+    write_file(
+        &base.join("cell.ts"),
+        "export interface Cell<T> {\n  peek: (get: <U>(c: Cell<U>) => U) => T\n}\n",
+    );
+    write_file(
+        &base.join("main.ts"),
+        r#"import type { Cell } from "./cell";
+type AnyCell = Cell<unknown>;
+type Listener = {
+  (cell: AnyCell): void;
+  attach(cell: AnyCell, cb: () => void): () => void;
+};
+type Listeners = { readonly slot?: Listener };
+declare const listener: Listener;
+function setup(ls: Listeners): void {
+  type Mutable = { -readonly [P in keyof Listeners]: Listeners[P] };
+  (ls as Mutable).slot = listener;
+}
+"#,
+    );
+
+    let args = parse_args(&["tsz", "--noEmit", "--strict", "cell.ts", "main.ts"]);
+    let result = compile(&args, base).expect("compile should succeed");
+    let self_assign = self_assign_diagnostics(&result.diagnostics);
+    assert!(
+        self_assign.is_empty(),
+        "renamed cross-file generic callable param must not report a \
+         self-assignment TS2322/TS2719, got: {self_assign:?}"
+    );
+}
+
+/// Negative guard: a genuine member mismatch through the same mapped-type path
+/// must still be reported as TS2322, so the fix does not silence real errors.
+#[test]
+fn cross_file_generic_callable_param_genuine_mismatch_still_reports_ts2322() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = temp.path.as_path();
+
+    write_file(
+        &base.join("atom.ts"),
+        "export interface Atom<Value> {\n  read: (get: <V>(a: Atom<V>) => V) => Value\n}\n",
+    );
+    write_file(
+        &base.join("main.ts"),
+        r#"import type { Atom } from "./atom";
+type AnyAtom = Atom<unknown>;
+type Hook = { (atom: AnyAtom): void; a: number };
+type Hooks = { readonly m?: Hook };
+declare const wrong: { (atom: AnyAtom): void; a: string };
+function init(hooks: Hooks): void {
+  type Mut = { -readonly [P in keyof Hooks]: Hooks[P] };
+  (hooks as Mut).m = wrong;
+}
+"#,
+    );
+
+    let args = parse_args(&["tsz", "--noEmit", "--strict", "atom.ts", "main.ts"]);
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&2322),
+        "genuine member mismatch (a: string vs a: number) must still report \
+         TS2322; got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -1164,6 +1164,15 @@ impl DefinitionStore {
         self.definitions.get(&id).map(|r| r.name)
     }
 
+    /// The declaring file id of a definition, if known.
+    ///
+    /// Reads the single field directly rather than cloning the whole
+    /// `DefinitionInfo` (as `get` does), matching `get_kind`/`get_name`. Lib
+    /// definitions use the `u32::MAX` sentinel.
+    pub fn get_file_id(&self, id: DefId) -> Option<u32> {
+        self.definitions.get(&id).and_then(|r| r.file_id)
+    }
+
     /// Add an export to an existing definition.
     pub fn add_export(&self, id: DefId, name: Atom, export_def: DefId) {
         if let Some(mut entry) = self.definitions.get_mut(&id) {


### PR DESCRIPTION
AgentName: Studio-B

## Summary

Fixes #12464 — a spurious `Type 'X' is not assignable to type 'X'` (TS2322/TS2719) on `pmndrs/jotai`'s `src/vanilla/internals.ts`, where `tsc 6.0.3` reports nothing.

**Track:** Conformance — checker false-positive (named-alias identity).

## Structural rule

> When a named alias `A = G<X>` (with `G` a generic interface declared in another file) is used in a contravariant position — a hybrid callable's call-signature parameter reached through a homomorphic mapped type `{ [P in keyof T]: T[P] }` — both sides of the assignment must resolve to one canonical type. `tsz` was producing two structurally divergent `TypeId`s for the one alias.

Root cause: a **user-defined** generic interface lands in `lib_type_resolution_cache` because its name is resolved through the lib path during generic-reference prewarming. `lib_heritage_cache_override` (whose only job is to upgrade a *standard-library* interface to its late heritage-merged body) then substituted that cached "lib" body for the user interface. The substituted body differs from the same alias resolved through its ordinary path; in a contravariant parameter position the two forms fail to relate, producing the false positive.

## Owner layer

Checker — `CheckerContext::lib_heritage_cache_override` (`crates/tsz-checker/src/context/resolver.rs`). The override now returns `None` for interfaces whose def comes from a user source file (a real file id, not the `u32::MAX` lib sentinel — the discriminator already used at `state/type_environment/lazy.rs` and `context/def_mapping.rs`). User interfaces keep their single, canonical resolution; lib types are unaffected.

A cheap `DefinitionStore::get_file_id` accessor (single-field read, matching `get_kind`/`get_name`) avoids cloning the whole `DefinitionInfo` on this resolution path.

## Scope

- `crates/tsz-solver/src/def/core.rs` — add `get_file_id`.
- `crates/tsz-checker/src/context/resolver.rs` — guard the override on lib-origin.
- `crates/tsz-cli/tests/driver_tests_parts/part_12.rs` — driver-level regression tests.

## Adjacent-case matrix

- Positive (jotai shape): hybrid callable param `Atom<unknown>` through a `-readonly` mapped type — accepted.
- Renamed binders (interface/alias/property all changed) — same rule, proves the fix is structural, not keyed to the jotai spellings.
- Negative: a genuine member mismatch (`a: string` vs `a: number`) through the same mapped-type path still reports TS2322.

## Project Corpus Impact

- Row: n/a (no required project-corpus row depends on this path; jotai `src/vanilla/internals.ts` is the discovery witness, not a benchmark row)
- Bug family: lib-heritage-override named-alias identity false positive (TS2322/TS2719)

The change only *narrows* an override that was firing on user types; lib-type resolution, display, and elaboration paths are untouched. Verified the full `tsz-checker --lib` suite (75 pre-existing failures, identical set before/after — zero new) and `tsz-cli` `driver_tests` (9 pre-existing failures, identical set; the 2 new positive guards move from fail→pass).

## Verification

- New driver tests: fail on baseline with the exact issue diagnostic (`Type 'Hook' is not assignable to type 'Hook'`), pass with the fix.
- Real jotai `src/vanilla/internals.ts` at the issue's commit: 5 spurious diagnostics → 0.
- `cargo clippy -p tsz-solver -p tsz-checker`: clean.
- Failure-set diff before/after the change on both `tsz-checker --lib` and `tsz-cli driver_tests`: no newly failing tests.

## Coordination Notes

Claims #12464 (label set to `WIP`). Rebased onto latest `origin/main` (no conflicts). The anti-hardcoding gate is satisfied: the discriminator is the structural `file_id` lib sentinel, no user-name/file-name string checks, and the regression matrix varies binder names.

https://claude.ai/code/session_0188NmBMQa6ayEsBQYHsU7NE