### PR TITLE
fix(checker): route class override incompatibility through the assignability gateway

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -999,12 +999,10 @@ impl<'a> CheckerState<'a> {
                             ),
                             diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE,
                         );
-                        let member_type_str = self.format_type(member_type);
-                        let base_type_str = self.format_type(base_type);
-                        self.report_type_not_assignable_detail(
+                        self.report_type_override_incompatibility_detail(
                             member_name_idx,
-                            &member_type_str,
-                            &base_type_str,
+                            member_type,
+                            base_type,
                             diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE,
                         );
                         continue;
@@ -1214,12 +1212,22 @@ impl<'a> CheckerState<'a> {
             let resolved_base_type = self.resolve_type_query_type(base_type);
 
             // Check type compatibility through centralized mismatch policy.
-            // Methods always use bivariant relation checks.
-            // Static properties also use bivariant checks — tsc checks the static
+            //
+            // Static properties use bivariant checks — tsc checks the static
             // side structurally (typeof Derived vs typeof Base) with the normal
-            // assignability relation, which without strictFunctionTypes is bivariant.
-            // Only instance property overrides use strict assignability (TS2416).
-            let should_report_mismatch = if is_method || is_static {
+            // assignability relation, which without strictFunctionTypes is
+            // bivariant.
+            //
+            // Instance methods and instance property overrides both route
+            // through the no-erase member-mismatch relation. Method-parameter
+            // bivariance is still honored by the `is_method` flag inside that
+            // relation; crucially, it does NOT erase the base member's
+            // method-local generics to their constraints. A concrete override
+            // such as `m(x: string): string` is therefore correctly rejected
+            // (TS2416) against a generic base `m<T extends string>(x: T): T`,
+            // matching tsc and the `implements` heritage path, which already
+            // used this relation.
+            let should_report_mismatch = if is_static {
                 should_report_member_type_mismatch_bivariant(
                     self,
                     resolved_member_type,
@@ -1236,9 +1244,6 @@ impl<'a> CheckerState<'a> {
             };
 
             if should_report_mismatch {
-                let member_type_str = self.format_type(member_type);
-                let base_type_str = self.format_type(base_type);
-
                 // TS2417: Static members use different error message and code
                 // TS2416: Instance members use standard property incompatibility error
                 if is_static {
@@ -1261,10 +1266,10 @@ impl<'a> CheckerState<'a> {
                         ),
                         diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE,
                     );
-                    self.report_type_not_assignable_detail(
+                    self.report_type_override_incompatibility_detail(
                         member_name_idx,
-                        &member_type_str,
-                        &base_type_str,
+                        member_type,
+                        base_type,
                         diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE,
                     );
                 }
@@ -1413,8 +1418,6 @@ impl<'a> CheckerState<'a> {
             return true;
         }
 
-        let member_type_str = self.format_type(resolved_member_type);
-        let base_type_str = self.format_type(resolved_base_type);
         let display_name = format_property_name_for_diagnostic(member_name);
         let base_class_display_name = base_class_name_for_diagnostic(base_class_name);
         self.error_at_node(
@@ -1424,10 +1427,10 @@ impl<'a> CheckerState<'a> {
             ),
             diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE,
         );
-        self.report_type_not_assignable_detail(
+        self.report_type_override_incompatibility_detail(
             member_name_idx,
-            &member_type_str,
-            &base_type_str,
+            resolved_member_type,
+            resolved_base_type,
             diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE,
         );
         true
@@ -1615,12 +1618,10 @@ impl<'a> CheckerState<'a> {
                         ),
                         diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE,
                     );
-                    let member_type_str = self.format_type(info.type_id);
-                    let base_type_str = self.format_type(base_type);
-                    self.report_type_not_assignable_detail(
+                    self.report_type_override_incompatibility_detail(
                         info.name_idx,
-                        &member_type_str,
-                        &base_type_str,
+                        info.type_id,
+                        base_type,
                         diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE,
                     );
                     continue;

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -429,53 +429,131 @@ impl<'a> CheckerState<'a> {
         target_type: &str,
         code: u32,
     ) {
-        let Some((pos, end)) = self.get_node_span(node_idx) else {
+        let detail = format!("Type '{source_type}' is not assignable to type '{target_type}'.");
+        if self.attach_elaboration_frames_to_lead(
+            node_idx,
+            code,
+            std::iter::once((detail.clone(), 0u8)),
+        ) {
             return;
+        }
+        // Fallback: emit as a standalone diagnostic when no matching lead is
+        // present (e.g., the lead error was suppressed).
+        if let Some((pos, end)) = self.get_node_span(node_idx) {
+            self.error(pos, end.saturating_sub(pos), detail, code);
+        }
+    }
+
+    /// Attach the full structural elaboration under a property-override
+    /// incompatibility lead (TS2416 / TS2417), routed through the shared
+    /// `relation -> reason -> diagnostic` assignability gateway.
+    ///
+    /// The single-frame [`Self::report_type_not_assignable_detail`] only ever
+    /// renders the top `Type 'S' is not assignable to type 'T'.` line, which
+    /// truncates `tsc`'s multi-line override elaboration (parameter
+    /// incompatibility, missing/optional property, nested property path,
+    /// type-argument variance, return-type mismatch, ...). Routing override and
+    /// `implements` mismatches through the same reason machinery the
+    /// TS2322/TS2345 assignment paths use restores parity: the rendered reason's
+    /// own lead becomes the first elaboration frame and its nested frames are
+    /// re-parented one level deeper under the override lead.
+    pub(crate) fn report_type_override_incompatibility_detail(
+        &mut self,
+        node_idx: NodeIndex,
+        source_type: TypeId,
+        target_type: TypeId,
+        code: u32,
+    ) {
+        if source_type != target_type
+            && let Some(reason) = self
+                .analyze_assignability_failure(source_type, target_type)
+                .failure_reason
+        {
+            // `render_failure_reason` is consumed for its returned elaboration
+            // only. Its top-level (`depth == 0`) display branch is written for
+            // assignment *expression* anchors and can incidentally resolve a
+            // non-expression anchor (here the overridden member's name node) as
+            // a value identifier, emitting spurious name-resolution diagnostics.
+            // Snapshot the diagnostic buffer and restore it so only the
+            // re-parented elaboration frames survive.
+            let diagnostics_before = self.ctx.diagnostics.len();
+            let inner = self.render_failure_reason(&reason, source_type, target_type, node_idx, 0);
+            self.ctx.diagnostics.truncate(diagnostics_before);
+            // The rendered reason's own lead becomes the first elaboration frame
+            // (depth 0); its nested frames sit one level deeper (depth + 1).
+            let frames = std::iter::once((inner.message_text, 0u8)).chain(
+                inner
+                    .related_information
+                    .into_iter()
+                    .map(|child| (child.message_text, child.depth.saturating_add(1))),
+            );
+            if self.attach_elaboration_frames_to_lead(node_idx, code, frames) {
+                return;
+            }
+        }
+
+        // Fallback: no structured reason available (e.g. suppressed/opaque
+        // types). Preserve the single-frame elaboration so the lead still
+        // carries the canonical `Type 'S' is not assignable to type 'T'.` line.
+        let source_str = self.format_type(source_type);
+        let target_str = self.format_type(target_type);
+        self.report_type_not_assignable_detail(node_idx, &source_str, &target_str, code);
+    }
+
+    /// Attach `frames` (each an elaboration `(message, depth)`) as related
+    /// information to the most recent diagnostic with `code` whose start matches
+    /// the raw span of `node_idx`, de-duplicating by `(message, depth)`. Returns
+    /// `false` when no matching lead diagnostic is present so callers can fall
+    /// back to a standalone diagnostic.
+    ///
+    /// Matching by `(code, start)` rather than `(code, start, length)` is
+    /// deliberate: `error_at_node` normalizes the lead's span (e.g. trimming to
+    /// the leading identifier of a declaration) while `get_node_span` returns
+    /// the raw node span, so the lengths can legitimately differ. Producing the
+    /// elaboration as indented related-information (instead of separate
+    /// top-level diagnostics) is what the conformance fingerprinter expects.
+    fn attach_elaboration_frames_to_lead(
+        &mut self,
+        node_idx: NodeIndex,
+        code: u32,
+        frames: impl IntoIterator<Item = (String, u8)>,
+    ) -> bool {
+        let Some((pos, end)) = self.get_node_span(node_idx) else {
+            return false;
         };
         let length = end.saturating_sub(pos);
-        let detail = format!("Type '{source_type}' is not assignable to type '{target_type}'.");
-
-        // Attach to the most recent diagnostic at this position with this code
-        // (the lead "Property X is not assignable" message we just emitted).
-        // This produces tsc-style multi-line diagnostics where the elaboration is
-        // indented under the lead, instead of two top-level diagnostics that the
-        // conformance fingerprinter treats as distinct entries.
-        //
-        // Match by `(code, start)` rather than `(code, start, length)` because
-        // `error_at_node` normalizes the anchor span (e.g., trimming to the
-        // leading identifier of a declaration), while `get_node_span` here returns
-        // the raw node span.
-        if let Some(parent) = self
+        let Some(parent) = self
             .ctx
             .diagnostics
             .iter_mut()
             .rev()
             .find(|diag| diag.code == code && diag.start == pos)
-        {
-            // Avoid duplicate related-info text.
-            if !parent
+        else {
+            return false;
+        };
+
+        let file = parent.file.clone();
+        for (message_text, depth) in frames {
+            if parent
                 .related_information
                 .iter()
-                .any(|info| info.message_text == detail)
+                .any(|info| info.message_text == message_text && info.depth == depth)
             {
-                parent
-                    .related_information
-                    .push(crate::diagnostics::DiagnosticRelatedInformation {
-                        file: parent.file.clone(),
-                        start: pos,
-                        length,
-                        message_text: detail,
-                        category: crate::diagnostics::DiagnosticCategory::Message,
-                        code,
-                        depth: 0,
-                    });
+                continue;
             }
-            return;
+            parent
+                .related_information
+                .push(crate::diagnostics::DiagnosticRelatedInformation {
+                    file: file.clone(),
+                    start: pos,
+                    length,
+                    message_text,
+                    category: crate::diagnostics::DiagnosticCategory::Message,
+                    code,
+                    depth,
+                });
         }
-
-        // Fallback: emit as a standalone diagnostic when no matching parent is
-        // present (e.g., the lead error was suppressed).
-        self.error(pos, length, detail, code);
+        true
     }
 
     /// Check that non-abstract class implements all abstract members from base class (error 2654).
@@ -1067,7 +1145,7 @@ impl<'a> CheckerState<'a> {
 
                     // Check that all interface members are implemented with compatible types
                     let mut missing_members: Vec<String> = Vec::new();
-                    let mut incompatible_members: Vec<(NodeIndex, String, String, String)> =
+                    let mut incompatible_members: Vec<(NodeIndex, String, TypeId, TypeId)> =
                         Vec::new(); // (node_idx, name, expected_type, actual_type)
                     // Build type arguments vector from implements clause (e.g., A<boolean> -> [boolean])
                     let mut type_args = Vec::new();
@@ -1319,13 +1397,11 @@ impl<'a> CheckerState<'a> {
                                             class_member_idx,
                                         );
                                     if types_incompatible {
-                                        let expected_str = self.format_type(interface_member_type);
-                                        let actual_str = self.format_type(class_member_type);
                                         incompatible_members.push((
                                             class_member_idx,
                                             member_name.clone(),
-                                            expected_str,
-                                            actual_str,
+                                            interface_member_type,
+                                            class_member_type,
                                         ));
                                     } else {
                                         self.error_at_node(
@@ -1417,13 +1493,11 @@ impl<'a> CheckerState<'a> {
                                     class_member_idx,
                                 )
                             {
-                                let expected_str = self.format_type(interface_member_type);
-                                let actual_str = self.format_type(class_member_type);
                                 incompatible_members.push((
                                     class_member_idx,
                                     member_name.clone(),
-                                    expected_str,
-                                    actual_str,
+                                    interface_member_type,
+                                    class_member_type,
                                 ));
                             }
                         } else if let Some(&inherited_type) =
@@ -1442,13 +1516,11 @@ impl<'a> CheckerState<'a> {
                                     class_idx,
                                 )
                             {
-                                let expected_str = self.format_type(interface_member_type);
-                                let actual_str = self.format_type(inherited_type);
                                 incompatible_members.push((
                                     class_error_idx,
                                     member_name.clone(),
-                                    expected_str,
-                                    actual_str,
+                                    interface_member_type,
+                                    inherited_type,
                                 ));
                             }
                         } else if let Some(&visibility) =
@@ -1609,13 +1681,11 @@ impl<'a> CheckerState<'a> {
                                     .get(&member_name)
                                     .copied()
                                     .unwrap_or(class_error_idx);
-                                let expected_str = self.format_type(target_property_type);
-                                let actual_str = self.format_type(source_property_type);
                                 incompatible_members.push((
                                     class_member_idx,
                                     member_name,
-                                    expected_str,
-                                    actual_str,
+                                    target_property_type,
+                                    source_property_type,
                                 ));
                             } else if suppress_index_member_duplicate {
                                 // Class member compatibility with its own declared index
@@ -1715,7 +1785,7 @@ impl<'a> CheckerState<'a> {
                     // clause.  Emit per-property errors for both interfaces and
                     // classes.
                     {
-                        for (class_member_idx, member_name, expected, actual) in
+                        for (class_member_idx, member_name, expected_type, actual_type) in
                             incompatible_members
                         {
                             let error_node_idx =
@@ -1733,10 +1803,10 @@ impl<'a> CheckerState<'a> {
                                 ),
                                 diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE,
                             );
-                            self.report_type_not_assignable_detail(
+                            self.report_type_override_incompatibility_detail(
                                 error_node_idx,
-                                &actual,
-                                &expected,
+                                actual_type,
+                                expected_type,
                                 diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE,
                             );
                         }

--- a/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
@@ -1361,7 +1361,7 @@ impl<'a> CheckerState<'a> {
             };
 
             let mut missing_members: Vec<String> = Vec::new();
-            let mut incompatible_members: Vec<(String, String, String)> = Vec::new();
+            let mut incompatible_members: Vec<(String, TypeId, TypeId)> = Vec::new();
             let mut interface_has_index_signature = false;
 
             if let Some(shape) = crate::query_boundaries::common::object_shape_for_type(
@@ -1401,12 +1401,10 @@ impl<'a> CheckerState<'a> {
                                 class_idx,
                             )
                         {
-                            let expected_str = self.format_type(interface_member_type);
-                            let actual_str = self.format_type(class_member_type);
                             incompatible_members.push((
                                 member_name.clone(),
-                                expected_str,
-                                actual_str,
+                                interface_member_type,
+                                class_member_type,
                             ));
                         }
                     } else {
@@ -1482,7 +1480,7 @@ impl<'a> CheckerState<'a> {
             }
 
             // Report incompatible member types (TS2416)
-            for (member_name, expected, actual) in incompatible_members {
+            for (member_name, expected_type, actual_type) in incompatible_members {
                 // For JSDoc @implements, we don't have a specific member node to point to,
                 // so use the class name node for the error location.
                 // Find the class member node if possible for better error location
@@ -1513,10 +1511,10 @@ impl<'a> CheckerState<'a> {
                     ),
                     diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE,
                 );
-                self.report_type_not_assignable_detail(
+                self.report_type_override_incompatibility_detail(
                     error_node_idx,
-                    &actual,
-                    &expected,
+                    actual_type,
+                    expected_type,
                     diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE,
                 );
             }

--- a/crates/tsz-checker/src/classes/class_member_info.rs
+++ b/crates/tsz-checker/src/classes/class_member_info.rs
@@ -427,8 +427,6 @@ impl<'a> CheckerState<'a> {
                                     diagnostic_codes::CLASS_STATIC_SIDE_INCORRECTLY_EXTENDS_BASE_CLASS_STATIC_SIDE,
                                 );
                             } else {
-                                let member_type_str = self.format_type(member_type);
-                                let base_type_str = self.format_type(base_type);
                                 let display_name = format_property_name_for_diagnostic(&info.name);
                                 let base_class_display_name = self
                                     .array_or_tuple_alias_target_text_for_name(base_class_name)
@@ -443,10 +441,10 @@ impl<'a> CheckerState<'a> {
                                     ),
                                     diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE,
                                 );
-                                self.report_type_not_assignable_detail(
+                                self.report_type_override_incompatibility_detail(
                                     info.name_idx,
-                                    &member_type_str,
-                                    &base_type_str,
+                                    member_type,
+                                    base_type,
                                     diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE,
                                 );
                             }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -318,6 +318,9 @@ mod optional_property_target_undefined_display_tests;
 #[path = "../tests/overload_modifier_tests.rs"]
 mod overload_modifier_tests;
 #[cfg(test)]
+#[path = "tests/override_incompatibility_elaboration_tests.rs"]
+mod override_incompatibility_elaboration_tests;
+#[cfg(test)]
 #[path = "../tests/override_intersection_display_tests.rs"]
 mod override_intersection_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/override_incompatibility_elaboration_tests.rs
+++ b/crates/tsz-checker/src/tests/override_incompatibility_elaboration_tests.rs
@@ -1,0 +1,195 @@
+//! Regression tests for TS2416/TS2417 property-override incompatibility
+//! *elaboration*.
+//!
+//! Structural rule: when a derived member's type is not assignable to the base
+//! member's type, tsc renders the override lead
+//! (`Property 'p' in type 'D' is not assignable to the same property in base
+//! type 'B'.`) followed by the *same* structural elaboration chain it produces
+//! for the equivalent TS2322/TS2345 assignment — the contravariant parameter
+//! frame, the missing/optional-property frame, the nested property path, and so
+//! on. Previously the override paths emitted only the single
+//! `Type 'S' is not assignable to type 'T'.` frame (or, for a missing-property
+//! failure, the *wrong* wrapper frame) and dropped everything deeper.
+//!
+//! The fix routes every override/`implements`/JSDoc-`@implements` mismatch
+//! through the shared `relation -> reason -> diagnostic` assignability gateway,
+//! so the chain matches tsc regardless of the heritage form.
+//!
+//! The rule is structural (independent of identifier spelling), so the cases
+//! below vary binder names where a name appears in the rendered output.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_codes, check_with_options, strict_checker_options};
+
+/// Full elaboration text (primary message plus every related-information line)
+/// of the single diagnostic with `code` in `source`, checked under strict
+/// options.
+fn elaboration(source: &str, code: u32) -> String {
+    elaboration_with(source, code, strict_checker_options())
+}
+
+fn elaboration_with(source: &str, code: u32, options: CheckerOptions) -> String {
+    let diags = check_with_options(source, options);
+    let matching: Vec<_> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "Expected exactly one TS{code}. Got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+    let mut lines = vec![matching[0].message_text.clone()];
+    lines.extend(
+        matching[0]
+            .related_information
+            .iter()
+            .map(|info| info.message_text.clone()),
+    );
+    lines.join("\n")
+}
+
+/// A property-typed (non-method) function override that fails on parameter
+/// contravariance must descend into the `Types of parameters` frame and the
+/// contravariant leaf, instead of stopping at the bare signature line.
+#[test]
+fn extends_property_function_override_elaborates_parameter_chain() {
+    let text = elaboration(
+        r#"
+class Animal { kind: "animal" = "animal"; }
+class Dog extends Animal { bark(): void {} }
+class Base { handler: (value: Animal) => void = () => {}; }
+class Derived extends Base { handler: (value: Dog) => void = () => {}; }
+"#,
+        2416,
+    );
+    assert_eq!(
+        text,
+        "Property 'handler' in type 'Derived' is not assignable to the same property in base type 'Base'.\n\
+         Type '(value: Dog) => void' is not assignable to type '(value: Animal) => void'.\n\
+         Types of parameters 'value' and 'value' are incompatible.\n\
+         Property 'bark' is missing in type 'Animal' but required in type 'Dog'.",
+    );
+}
+
+/// A missing-property object override surfaces the `Property ... is missing`
+/// frame *directly* under the lead (no spurious `Type 'S' is not assignable to
+/// type 'T'.` wrapper), matching tsc.
+#[test]
+fn extends_object_override_missing_property_skips_wrapper_frame() {
+    let text = elaboration(
+        r#"
+class Base { shape: { width: number; height: number } = { width: 0, height: 0 }; }
+class Derived extends Base { shape: { width: number } = { width: 0 }; }
+"#,
+        2416,
+    );
+    assert_eq!(
+        text,
+        "Property 'shape' in type 'Derived' is not assignable to the same property in base type 'Base'.\n\
+         Property 'height' is missing in type '{ width: number; }' but required in type '{ width: number; height: number; }'.",
+    );
+}
+
+/// A nested object property mismatch surfaces the wrapper frame, the
+/// `The types of 'a.b' are incompatible` path frame, and the leaf relation.
+#[test]
+fn extends_object_override_nested_property_path_elaborates() {
+    let text = elaboration(
+        r#"
+class Base { box: { inner: { value: number } } = { inner: { value: 0 } }; }
+class Derived extends Base { box: { inner: { value: string } } = { inner: { value: "" } }; }
+"#,
+        2416,
+    );
+    assert_eq!(
+        text,
+        "Property 'box' in type 'Derived' is not assignable to the same property in base type 'Base'.\n\
+         Type '{ inner: { value: string; }; }' is not assignable to type '{ inner: { value: number; }; }'.\n\
+         The types of 'inner.value' are incompatible between these types.\n\
+         Type 'string' is not assignable to type 'number'.",
+    );
+}
+
+/// The `implements` heritage path produces the identical parameter-chain
+/// elaboration; a method member's parameter incompatibility descends past the
+/// signature line.
+#[test]
+fn implements_method_parameter_mismatch_elaborates_parameter_chain() {
+    let text = elaboration(
+        r#"
+interface Sink { absorb(quantity: number): void; }
+class Bucket implements Sink { absorb(quantity: string): void {} }
+"#,
+        2416,
+    );
+    assert_eq!(
+        text,
+        "Property 'absorb' in type 'Bucket' is not assignable to the same property in base type 'Sink'.\n\
+         Type '(quantity: string) => void' is not assignable to type '(quantity: number) => void'.\n\
+         Types of parameters 'quantity' and 'quantity' are incompatible.\n\
+         Type 'number' is not assignable to type 'string'.",
+    );
+}
+
+/// The elaboration is keyed on structure, not identifiers: renaming every
+/// binder yields the same chain shape with the new names.
+#[test]
+fn override_elaboration_is_structural_not_identifier_keyed() {
+    let text = elaboration(
+        r#"
+class CreatureKind { kind: "creature" = "creature"; }
+class HoundKind extends CreatureKind { howl(): void {} }
+class Origin { onPick: (subject: CreatureKind) => void = () => {}; }
+class Refined extends Origin { onPick: (subject: HoundKind) => void = () => {}; }
+"#,
+        2416,
+    );
+    assert_eq!(
+        text,
+        "Property 'onPick' in type 'Refined' is not assignable to the same property in base type 'Origin'.\n\
+         Type '(subject: HoundKind) => void' is not assignable to type '(subject: CreatureKind) => void'.\n\
+         Types of parameters 'subject' and 'subject' are incompatible.\n\
+         Property 'howl' is missing in type 'CreatureKind' but required in type 'HoundKind'.",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative guards: routing instance-method overrides through the no-erase
+// relation must not introduce TS2416 false positives. Method parameters stay
+// bivariant, and a faithful generic override is still accepted.
+// ---------------------------------------------------------------------------
+
+/// Method parameter bivariance is preserved: an override may *widen* a method
+/// parameter (tsc accepts this for method-declared members).
+#[test]
+fn method_parameter_widening_override_is_accepted() {
+    let codes = check_source_codes(
+        r#"
+class Animal { kind: "animal" = "animal"; }
+class Dog extends Animal { bark(): void {} }
+class Base { greet(value: Dog): void {} }
+class Derived extends Base { greet(value: Animal): void {} }
+"#,
+    );
+    assert!(
+        !codes.contains(&2416),
+        "unexpected TS2416 (method-parameter bivariance must be preserved). Got: {codes:?}"
+    );
+}
+
+/// A faithful generic method override that keeps the type parameter is accepted.
+#[test]
+fn faithful_generic_method_override_is_accepted() {
+    let codes = check_source_codes(
+        r#"
+class Base { wrap<T extends string>(value: T): T { return value; } }
+class Derived extends Base { wrap<T extends string>(value: T): T { return value; } }
+"#,
+    );
+    assert!(
+        !codes.contains(&2416),
+        "unexpected TS2416 (faithful generic override must be accepted). Got: {codes:?}"
+    );
+}


### PR DESCRIPTION
AgentName: M1-B
Track: Conformance — class override variance & TS2416/TS2417 diagnostic elaboration

(Implementing agent: remote Claude Code session on branch `claude/confident-hawking-CMaMV`; ownership normalized to the `agent:M1-B` checker/assignability-gateway lane per Studio-manager audit.)

## Summary
Class `extends`, `implements`, and JSDoc `@implements` member overrides had two parity gaps with `tsc`:

1. **Truncated elaboration.** Every override mismatch emitted only the top `Type 'S' is not assignable to type 'T'.` frame (or, for a missing-property failure, the *wrong* wrapper frame), dropping the structural reason chain `tsc` prints — parameter incompatibility, missing/optional property, nested property path, return-type mismatch, etc.
2. **Variance false-negative.** The `extends` **method** override path routed through `should_report_member_type_mismatch_bivariant`, whose relation erases the base member's method-local generics to their constraints. A concrete override `m(x: string): string` was therefore wrongly accepted against a generic base method `m` whose type parameter is `T extends string` with signature `(x: T) => T` (tsc reports TS2416).

## Invariant
`When a derived member's type is not assignable to the base member's type, tsc reports TS2416/TS2417 followed by the same structural elaboration it produces for the equivalent TS2322/TS2345 assignment; and a concrete override may not erase a base method's universally-quantified method-local generics.` This is the architecture contract: `TS2322/TS2345/TS2416` share the `relation -> reason -> diagnostic` assignability gateway.

## Owner layer / structural rule
- **Solver-backed gateway (checker orchestration).** Override/`implements`/JSDoc mismatches now compute the failure reason via `analyze_assignability_failure` and render it via `render_failure_reason`, re-parenting the rendered frames one level under the override lead. A new shared helper `attach_elaboration_frames_to_lead` de-duplicates the find-lead-and-attach logic previously copied in `report_type_not_assignable_detail`.
- **Relation unification.** Instance-method overrides now use the no-erase `should_report_member_type_mismatch` relation already used by the `implements` path. Method-parameter bivariance is preserved by the `is_method` flag inside that relation; only `static` members keep the bivariant-callbacks relation.

The fix is structural, not identifier/file-name keyed: it routes through existing solver boundaries and varies binder names in tests.

## Scope
- `crates/tsz-checker/src/classes/class_implements_checker/core.rs` — gateway-routed `report_type_override_incompatibility_detail` + shared `attach_elaboration_frames_to_lead`; thread `TypeId`s through `incompatible_members`.
- `crates/tsz-checker/src/classes/class_checker.rs` — instance-method overrides use the no-erase relation; call sites pass `TypeId`s.
- `crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs`, `class_member_info.rs` — same migration.
- `crates/tsz-checker/src/tests/override_incompatibility_elaboration_tests.rs` — new regression suite.

## Adjacent-case matrix
Positive (now emit the full chain): extends property-function parameter contravariance, extends object missing-property (no wrapper frame), extends nested property path, `implements` method-parameter mismatch, renamed binders. Negative guards (must stay accepted): method-parameter widening (bivariance), faithful generic method override. Generic-drop overrides (constrained, renamed, no-`override`-keyword, unconstrained, covariant array return) now correctly emit TS2416.

## Project Corpus Impact
- Row: rxjs-project, ts-essentials-project, type-fest-project
- Bug family: generic-method-override-variance

Targets the generic-method-override family across the bench rows above. The change only deepens existing override diagnostics and tightens a false-negative; it does not alter non-override assignment diagnostics. A pre-existing, orthogonal renderer gap (the TS5082 "could be instantiated with an arbitrary type" note is not rendered on nested leaves; affects TS2322 equally) is intentionally **out of scope**.

## Verification
- Full `tsz-checker` lib suite: **0 new failures** vs base (75 pre-existing to 70); the 5 pre-existing `keeps_2416_*` variance tests now **pass**.
- All TS2416 / override / `implements` integration binaries green; new `override_incompatibility_elaboration_tests` (7 cases) green.
- Standalone fixtures diffed against `tsc` 6.0.2 for extends/implements/jsdoc, missing-property, nested path, function param/return, and generic-drop overrides.
- `cargo clippy -p tsz-checker --all-targets` clean. Rebased on latest `main` (no file overlap with intervening commits).

## Coordination Notes
Fixes #12178. Addresses row witnesses #10804, #10796, #10812. No competing open PR touches this family or these files. Did not run full conformance/emit/fourslash locally (CI-owned); requesting ready-review CI to validate corpus rows.