### PR TITLE
fix(checker): preserve generic lib constraint arguments (#12546)

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -111,14 +111,14 @@ impl<'a> CheckerState<'a> {
                     if constraint_resolved == TypeId::ANY {
                         continue;
                     }
-                    let required_constraint = self.instantiate_constraint_with_type_args(
-                        constraint_resolved,
+                    let inst_constraint = self.instantiate_constraint_with_type_args(
+                        constraint,
                         type_params,
                         &type_args,
                     );
                     if self.required_mapped_constraint_source_is_required_and_arg_satisfies(
                         type_arg,
-                        required_constraint,
+                        inst_constraint,
                         &type_arg_substitutions,
                     ) {
                         continue;
@@ -973,23 +973,12 @@ impl<'a> CheckerState<'a> {
                                     continue;
                                 }
                             }
-                            let constraint_resolved = self.resolve_lazy_type(constraint);
-                            let mut subst =
-                                crate::query_boundaries::common::TypeSubstitution::new();
-                            for (j, p) in type_params.iter().enumerate() {
-                                if let Some(&arg) = type_args.get(j) {
-                                    subst.insert(p.name, arg);
-                                }
-                            }
-                            let inst_constraint = if subst.is_empty() {
-                                constraint_resolved
-                            } else {
-                                crate::query_boundaries::common::instantiate_type(
-                                    self.ctx.types,
-                                    constraint_resolved,
-                                    &subst,
-                                )
-                            };
+                            let inst_constraint = self.instantiate_constraint_with_type_args(
+                                constraint,
+                                type_params,
+                                &type_args,
+                            );
+                            let inst_constraint = self.resolve_lazy_type(inst_constraint);
                             if query::contains_free_type_parameters(self.ctx.types, inst_constraint)
                             {
                                 continue;
@@ -1560,22 +1549,12 @@ impl<'a> CheckerState<'a> {
                         {
                             continue;
                         }
-                        // Instantiate the constraint with all provided type arguments
-                        let mut subst = crate::query_boundaries::common::TypeSubstitution::new();
-                        for (j, p) in type_params.iter().enumerate() {
-                            if let Some(&arg) = type_args.get(j) {
-                                subst.insert(p.name, arg);
-                            }
-                        }
-                        let inst_constraint = if subst.is_empty() {
-                            constraint_resolved
-                        } else {
-                            crate::query_boundaries::common::instantiate_type(
-                                self.ctx.types,
-                                constraint_resolved,
-                                &subst,
-                            )
-                        };
+                        let inst_constraint = self.instantiate_constraint_with_type_args(
+                            constraint,
+                            type_params,
+                            &type_args,
+                        );
+                        let inst_constraint = self.resolve_lazy_type(inst_constraint);
                         if query::contains_type_parameters(self.ctx.types, inst_constraint) {
                             continue;
                         }
@@ -1686,7 +1665,10 @@ impl<'a> CheckerState<'a> {
                     }
                 }
 
-                // Resolve the constraint in case it's a Lazy type
+                // Instantiate before resolving so dependent constraints like
+                // `Required<Options>` keep the earlier type-argument binding.
+                let constraint =
+                    self.instantiate_constraint_with_type_args(constraint, type_params, &type_args);
                 let constraint = self.resolve_lazy_type(constraint);
                 let constraint = self
                     .resolve_well_known_lib_constraint_type(constraint)

--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -21,6 +21,18 @@ pub(crate) struct CallTypeArgumentValidation {
 
 impl<'a> CheckerState<'a> {
     fn resolve_well_known_lib_constraint_type(&mut self, constraint: TypeId) -> Option<TypeId> {
+        let generic_app = query_common::get_application_lazy_def_id(self.ctx.types, constraint)
+            .is_some()
+            || self
+                .ctx
+                .types
+                .get_display_alias(constraint)
+                .is_some_and(|alias| {
+                    query_common::get_application_lazy_def_id(self.ctx.types, alias).is_some()
+                });
+        if generic_app {
+            return None;
+        }
         let name = self.well_known_lib_constraint_type_name(constraint)?;
         self.resolve_lib_type_by_name(&name)
     }

--- a/crates/tsz-checker/tests/homomorphic_indexed_access_tests.rs
+++ b/crates/tsz-checker/tests/homomorphic_indexed_access_tests.rs
@@ -30,6 +30,10 @@ fn ts2536(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
     diags.iter().filter(|d| d.code == 2536).collect()
 }
 
+fn ts2344(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
+    diags.iter().filter(|d| d.code == 2344).collect()
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Standard lib utilities
 // ──────────────────────────────────────────────────────────────────────────
@@ -396,5 +400,105 @@ type Test<T> = {
     assert!(
         !ts2536(&diags).is_empty(),
         "B[P] where P extends keyof A but B ≠ A must still emit TS2536: {diags:?}"
+    );
+}
+
+#[test]
+fn create_type_options_satisfies_required_options_constraint() {
+    let diags = check_es5(
+        r#"
+type CreateTypeOptions<
+  Options extends Required<Options>,
+  OverrideOptions extends Partial<Options>,
+  DefaultOptions extends Required<Options>,
+> = {
+  [Key in keyof Options]: OverrideOptions[Key] extends Options[Key] ? OverrideOptions[Key] : DefaultOptions[Key];
+};
+
+type DefaultPathsOptions = {
+  depth: 7;
+  anyArrayIndexAccessor: `${number}`;
+};
+
+type PathsOptions = {
+  depth: number;
+  anyArrayIndexAccessor: string;
+};
+
+type UnsafePaths<Type, Options extends Required<PathsOptions>> = Type;
+
+type Paths<Type, OverridePathOptions extends Partial<PathsOptions> = {}> = UnsafePaths<
+  Type,
+  CreateTypeOptions<PathsOptions, OverridePathOptions, DefaultPathsOptions>
+>;
+
+type Ok = Paths<{ value: string }>;
+"#,
+    );
+    assert!(
+        ts2344(&diags).is_empty(),
+        "CreateTypeOptions must not emit TS2344: {diags:?}"
+    );
+}
+
+#[test]
+fn renamed_create_type_options_binders_satisfy_required_constraint() {
+    let diags = check_es5(
+        r#"
+type MergeOptions<
+  Bag extends Required<Bag>,
+  Patch extends Partial<Bag>,
+  Fallback extends Required<Bag>,
+> = {
+  [Name in keyof Bag]: Patch[Name] extends Bag[Name] ? Patch[Name] : Fallback[Name];
+};
+
+interface Shape {
+  mode: "deep";
+  count: number;
+}
+
+interface ShapeDefaults {
+  mode: "deep";
+  count: 1;
+}
+
+type UseShape<Value, Config extends Required<Shape>> = Value;
+type Ok = UseShape<string, MergeOptions<Shape, {}, ShapeDefaults>>;
+"#,
+    );
+    assert!(
+        ts2344(&diags).is_empty(),
+        "renamed option binders must not affect TS2344: {diags:?}"
+    );
+}
+
+#[test]
+fn incompatible_create_type_options_defaults_still_emit_ts2344() {
+    let diags = check_es5(
+        r#"
+type CreateTypeOptions<
+  Options extends Required<Options>,
+  OverrideOptions extends Partial<Options>,
+  DefaultOptions extends Required<Options>,
+> = {
+  [Key in keyof Options]: OverrideOptions[Key] extends Options[Key] ? OverrideOptions[Key] : DefaultOptions[Key];
+};
+
+interface PathBag {
+  depth: number;
+}
+
+interface BadDefaults {
+  depth: string;
+}
+
+type UsePaths<Type, Options extends Required<PathBag>> = Type;
+type Bad = UsePaths<unknown, CreateTypeOptions<PathBag, {}, BadDefaults>>;
+"#,
+    );
+    assert!(
+        !ts2344(&diags).is_empty(),
+        "incompatible defaults must still emit TS2344"
     );
 }

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_00.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_00.rs
@@ -1086,6 +1086,57 @@ fn run_tsc_with_exit_code(cwd: &Path, args: &[&str]) -> Option<(i32, String)> {
     Some((code, normalize_output(&combined)))
 }
 
+#[test]
+fn create_type_options_required_constraint_cli_no_ts2344() {
+    let temp = TempDir::new("create_type_options_required_constraint").expect("temp dir");
+    write_file(
+        &temp.path.join("repro.ts"),
+        r#"type CreateTypeOptions<
+  Options extends Required<Options>,
+  OverrideOptions extends Partial<Options>,
+  DefaultOptions extends Required<Options>,
+> = {
+  [Key in keyof Options]: OverrideOptions[Key] extends Options[Key] ? OverrideOptions[Key] : DefaultOptions[Key];
+};
+
+type DefaultPathsOptions = {
+  depth: 7;
+  anyArrayIndexAccessor: `${number}`;
+};
+
+type PathsOptions = {
+  depth: number;
+  anyArrayIndexAccessor: string;
+};
+
+type UnsafePaths<Type, Options extends Required<PathsOptions>> = Type;
+
+type Paths<Type, OverridePathOptions extends Partial<PathsOptions> = {}> = UnsafePaths<
+  Type,
+  CreateTypeOptions<PathsOptions, OverridePathOptions, DefaultPathsOptions>
+>;
+
+type Ok = Paths<{ value: string }>;
+"#,
+    );
+    let args = ["--noEmit", "--pretty", "false", "--strict", "repro.ts"];
+    let Some((tsc_code, tsc_output)) = run_tsc_with_exit_code(&temp.path, &args) else {
+        println!("skipping: tsc not found");
+        return;
+    };
+    let Some((tsz_code, tsz_output)) = run_tsz_with_exit_code(&temp.path, &args) else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+
+    assert_eq!(tsc_code, 0, "tsc should accept repro:\n{tsc_output}");
+    assert_eq!(tsz_code, 0, "tsz should accept repro:\n{tsz_output}");
+    assert!(
+        !tsz_output.contains("TS2344"),
+        "dependent Required<T> constraints must not emit TS2344:\n{tsz_output}"
+    );
+}
+
 /// Run both tsc and tsz and assert their outputs match exactly.
 /// Returns the common output on success.
 fn assert_tsc_tsz_match(cwd: &Path, args: &[&str], label: &str) -> String {
@@ -1793,4 +1844,3 @@ fn tsc_command() -> Option<Command> {
 // ===========================================================================
 // Integration tests: exact match (where checker positions agree)
 // ===========================================================================
-


### PR DESCRIPTION
AgentName: Studio-B

## Track
Conformance / checker generic constraint validation.

## Invariant
When generic type-argument validation checks a constraint that depends on earlier type parameters through a generic lib utility application such as `Required<Options>`, the checker instantiates that constraint with the visible type arguments before resolving well-known lib aliases. Generic lib applications and their display aliases must not collapse to a bare lib type by name, because doing so drops arguments like `PathsOptions` and creates false `Required<T>` TS2344 targets.

## Scope
- `crates/tsz-checker` generic constraint validation.
- Focused checker and CLI regression tests.
- No solver, emitter, resolver, or performance-cache behavior is changed.

## Project Corpus Impact
- Row: `ts-essentials-project`
- Bug family: generic lib utility constraint instantiation / false TS2344 over dependent `Required<Options>` constraints.
- Fixes #12546. Restores the required compile-guard row by making `CreateTypeOptions<PathsOptions, OverridePathOptions, DefaultPathsOptions>` validate like `tsc`; this unblocks semantic PRs currently failing `project-compile-guard` with the two false TS2344 diagnostics in `lib/paths/index.ts`.

## Verification
- `scripts/safe-run.sh cargo fmt --check -p tsz-checker -p tsz-cli`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test homomorphic_indexed_access_tests create_type_options_satisfies_required_options_constraint renamed_create_type_options_binders_satisfy_required_constraint incompatible_create_type_options_defaults_still_emit_ts2344`
- `scripts/safe-run.sh cargo nextest run -p tsz-cli --test tsc_compat_tests create_type_options_required_constraint_cli_no_ts2344`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- Touched source/test files remain under 2000 physical lines.
- Attempted `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli --bin tsz`, but local disk was exhausted at 145-176 MB free after repo-prescribed cleanup, so project-compile verification is delegated to CI artifacts.

## Coordination Notes
- Split from draft performance PR #12516 so the #12546 release-gate fix can land independently of WIP performance/residency work.
- #12540, #12541, and #12473 remain unqueued until exact-head CI confirms this blocker is gone.
- AgentName: Studio-B
