### PR TITLE
fix(checker): accept input-only generic method drops in interface extends (#10804)

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker_compat.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat.rs
@@ -790,6 +790,9 @@ impl<'a> CheckerState<'a> {
                                 ) && !self.generic_method_override_is_valid_specialization(
                                     derived_prop_type,
                                     base_prop_type,
+                                ) && !self.nongeneric_input_only_generic_override_is_valid(
+                                    derived_prop_type,
+                                    base_prop_type,
                                 ) && !this_poly_ok;
                             self.ctx.skip_callable_type_param_suppression.set(false);
                             mismatch
@@ -1457,6 +1460,9 @@ impl<'a> CheckerState<'a> {
                                 ) && !self.generic_method_override_is_valid_specialization(
                                     generic_override_source,
                                     base_prop_type_id,
+                                ) && !self.nongeneric_input_only_generic_override_is_valid(
+                                    generic_override_source,
+                                    base_prop_type_id,
                                 ) {
                                     let diagnostic_base_name = self
                                         .array_or_tuple_alias_target_text_for_name(&base_name)
@@ -1716,6 +1722,9 @@ impl<'a> CheckerState<'a> {
                                 base_method_type,
                                 *derived_member_idx,
                             ) && !self.generic_method_override_is_valid_specialization(
+                                derived_method_type,
+                                base_method_type,
+                            ) && !self.nongeneric_input_only_generic_override_is_valid(
                                 derived_method_type,
                                 base_method_type,
                             ) && !this_poly_ok

--- a/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
+++ b/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
@@ -160,6 +160,85 @@ impl<'a> CheckerState<'a> {
             .related
     }
 
+    /// True when a *non-generic* derived method validly overrides a *generic*
+    /// base method by dropping the base's method-local type parameter(s) to
+    /// their constraints.
+    ///
+    /// tsc's `compareSignaturesRelated` accepts dropping a method-local generic
+    /// that appears only in **input** (contravariant) positions — the override's
+    /// wider concrete parameter accepts every instantiation of the parameter —
+    /// and rejects one used in a **covariant** (return/output) position, where a
+    /// caller relies on getting a specific instantiation back. For example,
+    /// `with(k: string): Sub` is a valid override of
+    /// `with<K extends string>(k: K): Base` (input-only `K`), while
+    /// `m(): string` is **not** a valid override of `m<T>(): T` (covariant `T`).
+    ///
+    /// The strict no-erase relation used by `should_report_member_type_mismatch`
+    /// rejects *both*, producing a false `TS2430` on the sound input-only case.
+    /// The decision is keyed on the structural shape of the signatures (whether
+    /// the base carries method-local type parameters the override does not), not
+    /// on any identifier, so renaming the method or its type parameter does not
+    /// change the outcome.
+    ///
+    /// Restricted to the regime the strict relation over-reports — the base
+    /// method is generic and the override is not — via
+    /// `generic_erasure_fallback_is_safe` so ordinary non-generic and
+    /// matching-generic overrides keep the strict relation's decision. In that
+    /// regime, dropping the base's method-local generic(s) to their
+    /// constraint(s) is sound iff BOTH hold:
+    /// 1. The override is assignable to the base after erasing those generics to
+    ///    their constraints (method parameters bivariant). This accepts an
+    ///    input-only parameter — the override's wider concrete parameter admits
+    ///    every instantiation — while still rejecting a genuine parameter or
+    ///    callback-position mismatch (`each(f: () => string)` is not assignable
+    ///    to the erased `each(f: () => unknown)`).
+    /// 2. The override's return type is assignable to the base's return type with
+    ///    the generics kept OPAQUE (no-erase). A method-local generic used
+    ///    covariantly in the return (`m(): string` vs `m<T>(): T`) fails this —
+    ///    a concrete type is not assignable to the opaque `T` — while a generic
+    ///    used only in inputs leaves a concrete (or `this`-family) return that
+    ///    relates normally.
+    ///
+    /// Together these reproduce tsc's `compareSignaturesRelated` decision for the
+    /// non-generic-override-of-generic-base shape without re-deriving variance.
+    pub(super) fn nongeneric_input_only_generic_override_is_valid(
+        &mut self,
+        derived: TypeId,
+        base: TypeId,
+    ) -> bool {
+        if crate::query_boundaries::class::generic_erasure_fallback_is_safe(self, derived, base) {
+            return false;
+        }
+        if !self.is_assignable_to_bivariant(derived, base) {
+            return false;
+        }
+        let (Some(derived_return), Some(base_return)) = (
+            self.single_call_signature_return_type(derived),
+            self.single_call_signature_return_type(base),
+        ) else {
+            return false;
+        };
+        self.is_assignable_to_no_erase_generics(derived_return, base_return)
+    }
+
+    /// Return type of a callable member that has exactly one call signature and
+    /// no construct signatures — the single-method-override shape. Returns `None`
+    /// for overloaded members, constructors, or non-callable types, so the
+    /// caller defers to the strict relation in those shapes.
+    fn single_call_signature_return_type(&self, type_id: TypeId) -> Option<TypeId> {
+        if let Some(shape) =
+            crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
+        {
+            return Some(shape.return_type);
+        }
+        let shape =
+            crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, type_id)?;
+        if shape.call_signatures.len() == 1 && shape.construct_signatures.is_empty() {
+            return Some(shape.call_signatures[0].return_type);
+        }
+        None
+    }
+
     /// True when a derived interface member that mentions the polymorphic `this`
     /// type is a valid override of the base member under tsc's `this`-type
     /// relation.

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -243,6 +243,9 @@ mod instantiation_expression_inline_utility_modifier_tests;
 #[path = "tests/instantiation_expression_lib_display_tests.rs"]
 mod instantiation_expression_lib_display_tests;
 #[cfg(test)]
+#[path = "tests/interface_extends_generic_override_variance_tests.rs"]
+mod interface_extends_generic_override_variance_tests;
+#[cfg(test)]
 #[path = "tests/interface_heritage_index_relation_routing_arch_tests.rs"]
 mod interface_heritage_index_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/interface_extends_generic_override_variance_tests.rs
+++ b/crates/tsz-checker/src/tests/interface_extends_generic_override_variance_tests.rs
@@ -1,0 +1,205 @@
+//! Regression tests for issue #10804 — generic method override variance in
+//! interface `extends` chains (TS2430).
+//!
+//! When an interface `extends` a base whose method is *generic* and the
+//! override drops the method-local type parameter to a concrete type, the
+//! override is a valid specialization **only** when the dropped type parameter
+//! appears solely in input (contravariant) positions: the override's wider
+//! concrete parameter accepts every instantiation of the base's type parameter.
+//! `with(k: string): Sub` is therefore a valid override of
+//! `with<K extends string>(k: K): Base` — tsc accepts it. By contrast, a
+//! method-local generic used in a covariant (return/output) position cannot be
+//! dropped: `m(): string` is not a valid override of `m<T>(): T`, because a
+//! caller could instantiate `T` with a subtype and expect it back. tsc reports
+//! TS2430 for those.
+//!
+//! The strict no-erase relation used by the interface-extends member check
+//! rejected *both* shapes, producing a false TS2430 on the sound input-only
+//! case. The `class extends` (TS2416) and `implements` paths already accept the
+//! input-only specialization through their generic-aware relations; this routes
+//! the interface-extends path through the same discriminator so all three
+//! heritage forms make identical variance decisions (matching tsc's
+//! `compareSignaturesRelated`). Verified against tsc 6.0.2.
+
+use crate::test_utils::check_source_codes;
+
+fn assert_has_2430(src: &str) {
+    let codes = check_source_codes(src);
+    assert!(
+        codes.contains(&2430),
+        "expected TS2430, got none. Got: {codes:?}\nSource:\n{src}"
+    );
+}
+
+fn assert_no_2430(src: &str) {
+    let codes = check_source_codes(src);
+    assert!(
+        !codes.contains(&2430),
+        "unexpected TS2430 (false positive). Got: {codes:?}\nSource:\n{src}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Input-only method-local generic dropped to its constraint: tsc ACCEPTS
+// (the override's wider concrete parameter accepts every instantiation).
+// These were the false positives fixed by #10804.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_false_2430_input_only_constrained_generic_covariant_return() {
+    assert_no_2430(
+        "interface Builder { with<K extends string>(k: K): Builder; }
+         interface SubBuilder extends Builder { with(k: string): SubBuilder; }
+         declare const d: SubBuilder;",
+    );
+}
+
+// Renamed method, interface, and type parameter — proves the rule is
+// structural, not keyed to any identifier spelling.
+#[test]
+fn no_false_2430_input_only_constrained_generic_renamed() {
+    assert_no_2430(
+        "interface Bldr { put<Z extends string>(z: Z): Bldr; }
+         interface SubB extends Bldr { put(z: string): SubB; }
+         declare const d: SubB;",
+    );
+}
+
+// Same (non-narrowed) return type — still input-only, still accepted.
+#[test]
+fn no_false_2430_input_only_constrained_generic_same_return() {
+    assert_no_2430(
+        "interface Builder { with<K extends string>(k: K): Builder; }
+         interface Sub extends Builder { with(k: string): Builder; }
+         declare const d: Sub;",
+    );
+}
+
+// Unconstrained method-local generic in input-only position: the constraint is
+// `unknown`, and `(k: unknown) => Sub` accepts every `(k: K) => Base`.
+#[test]
+fn no_false_2430_input_only_unconstrained_generic() {
+    assert_no_2430(
+        "interface Base { with<K>(k: K): Base; }
+         interface Sub extends Base { with(k: unknown): Sub; }
+         declare const d: Sub;",
+    );
+}
+
+// Generic base interface plus an input-only method-local generic, with a
+// covariant return narrowing of the self type.
+#[test]
+fn no_false_2430_generic_base_interface_input_only_method_generic() {
+    assert_no_2430(
+        "interface Base<T> { with<K extends string>(k: K, t: T): Base<T>; }
+         interface Sub<T> extends Base<T> { with(k: string, t: T): Sub<T>; }
+         declare const d: Sub<number>;",
+    );
+}
+
+// Override re-declares the same method-local generic (already accepted before
+// the fix; kept as a guard so the new fallback does not perturb it).
+#[test]
+fn no_false_2430_matching_generic_method_redeclared() {
+    assert_no_2430(
+        "interface Base { m<T extends string>(x: T): T; }
+         interface Der extends Base { m<U extends string>(x: U): U; }
+         declare const d: Der;",
+    );
+}
+
+// Method-parameter bivariance must be preserved: narrowing a method parameter
+// is accepted by tsc (unsound but intentional), and the fix must not regress it.
+#[test]
+fn no_false_2430_method_param_narrowing_stays_bivariant() {
+    assert_no_2430(
+        "interface Animal {}
+         interface Dog extends Animal {}
+         interface Base { handle(x: Animal): void; }
+         interface Der extends Base { handle(x: Dog): void; }
+         declare const d: Der;",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Method-local generic used in a covariant (return/output) position: tsc
+// REJECTS (TS2430). Dropping it is unsound, so the fix must NOT over-suppress.
+// ---------------------------------------------------------------------------
+
+// Bare method-local generic in return position.
+#[test]
+fn keeps_2430_bare_generic_return_dropped() {
+    assert_has_2430(
+        "interface Base { m<T>(): T; }
+         interface Der extends Base { m(): string; }
+         declare const d: Der;",
+    );
+}
+
+// Constrained method-local generic used in both parameter AND return position.
+#[test]
+fn keeps_2430_constrained_generic_param_and_return_dropped() {
+    assert_has_2430(
+        "interface Base { m<T extends string>(x: T): T; }
+         interface Der extends Base { m(x: string): string; }
+         declare const d: Der;",
+    );
+}
+
+// Renamed variant of the param+return case.
+#[test]
+fn keeps_2430_constrained_generic_param_and_return_dropped_renamed() {
+    assert_has_2430(
+        "interface Base { m<K extends string>(x: K): K; }
+         interface Der extends Base { m(x: string): string; }
+         declare const d: Der;",
+    );
+}
+
+// Method-local generic in a callback *return* position (`f: () => U`): the
+// override only accepts callbacks returning `string`, so dropping `U` is
+// unsound even though `U` is nested inside a parameter.
+#[test]
+fn keeps_2430_callback_return_generic_dropped() {
+    assert_has_2430(
+        "interface Base { each<U>(f: () => U): void; }
+         interface Der extends Base { each(f: () => string): void; }
+         declare const d: Der;",
+    );
+}
+
+// Method-local generic in a covariant position reached through the method's own
+// return (`map<U>(f: () => U): U`).
+#[test]
+fn keeps_2430_method_return_via_callback_generic_dropped() {
+    assert_has_2430(
+        "interface Base { map<U>(f: () => U): U; }
+         interface Der extends Base { map(f: () => string): string; }
+         declare const d: Der;",
+    );
+}
+
+// Two method-local generics: one input-only (`I`), one used in return (`O`).
+// `O`'s covariant use makes the whole drop unsound. tsc reports.
+#[test]
+fn keeps_2430_mixed_input_output_generics_dropped() {
+    assert_has_2430(
+        "interface Base { f<I extends string, O>(i: I, o: O): O; }
+         interface Der extends Base { f(i: string, o: number): number; }
+         declare const d: Der;",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Genuine non-generic member mismatch must still report (the fallback must not
+// rescue real incompatibilities).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn keeps_2430_genuine_return_type_mismatch() {
+    assert_has_2430(
+        "interface Base { m(x: string): number; }
+         interface Der extends Base { m(x: string): string; }
+         declare const d: Der;",
+    );
+}


### PR DESCRIPTION
AgentName: Studio-manager
ContributorIdentity: confident-hawking

Track: 1 — conformance / checker false-positive (generic method override variance)

## Invariant
When an interface `extends` a base whose method is generic and the override
drops the base's method-local type parameter to a concrete type, the override is
a valid specialization **iff** the dropped parameter appears only in **input**
(contravariant) positions. tsz now accepts that shape (matching tsc) instead of
emitting a false **TS2430**, while still reporting the unsound covariant case.

```ts
interface Builder { with<K extends string>(k: K): Builder; }
interface SubBuilder extends Builder { with(k: string): SubBuilder; }
// tsc 6.0.2 & tsz now: OK (was: TS2430 "incorrectly extends")

interface Base { m<T>(): T; }
interface Der extends Base { m(): string; }
// tsc & tsz: still TS2430 — T is used covariantly in the return.
```

## Structural rule
> When a non-generic method overrides a generic base method through interface
> `extends`, `tsc`'s `compareSignaturesRelated` accepts dropping a method-local
> type parameter that occurs only in input positions (the override's wider
> concrete parameter admits every instantiation) and rejects one used in a
> covariant return/output position (a caller relies on getting a specific
> instantiation back). tsz now makes the same decision through the
> interface-extends member-compatibility boundary.

The interface-extends member check routed methods through the strict no-erase
relation (`should_report_member_type_mismatch`), which rejects **both** the
sound input-only drop and the unsound covariant-return drop — a false TS2430 on
the former. The class-extends (TS2416) and `implements` paths already accept the
input-only specialization; this brings the third heritage form into line so all
three make identical variance decisions.

## Owner layer
- **Checker** — `CheckerState::nongeneric_input_only_generic_override_is_valid`
  (`classes/interface_heritage_index_compat.rs`), wired as a suppression term at
  the three interface-extends member-comparison sites in
  `classes/class_checker_compat.rs`. No solver/relation change.
- The decision composes two existing relation entrypoints — no new solver
  policy, no printer-output inspection, no identifier/file-name literals:
  1. `is_assignable_to_bivariant` (erase generics to constraints, method
     parameters bivariant) — accepts an input-only parameter, rejects a genuine
     parameter or callback-position mismatch.
  2. `is_assignable_to_no_erase_generics` on the **return types** (generics kept
     opaque) — rejects a method-local generic used covariantly in the return.
- Gated to the over-report regime (base method generic, override not) via the
  existing `generic_erasure_fallback_is_safe` predicate, so ordinary non-generic
  and matching-generic overrides keep the strict relation's decision.

## Scope
- `crates/tsz-checker/src/classes/interface_heritage_index_compat.rs`: new
  `nongeneric_input_only_generic_override_is_valid` + `single_call_signature_return_type` helper.
- `crates/tsz-checker/src/classes/class_checker_compat.rs`: add the suppression
  term at the three interface-extends member sites (single-base, multi-base /
  overload-combined, and the `this`-aware method path).
- `crates/tsz-checker/src/tests/interface_extends_generic_override_variance_tests.rs`:
  new regression suite (14 cases) + module registration in `lib.rs`.

## Adjacent-case matrix (verified against tsc 6.0.2)
- Input-only generic dropped to constraint, covariant / same / narrowed return — **accepted** ✅
- Renamed method + interface + type parameter (anti-hardcoding) — accepted ✅
- Unconstrained input-only generic (`with<K>(k: K)` → `with(k: unknown)`) — accepted ✅
- Generic base interface + input-only method generic — accepted ✅
- Two input-only generics; diamond multi-base; 3-level chain — accepted ✅
- Method-local generic in **return** (`m<T>(): T` → `m(): string`) — **TS2430** ✅
- Generic in param **and** return (`m<T extends string>(x: T): T`) — TS2430 ✅
- Generic in callback return (`map<U>(f: () => U): U`, `each<U>(f: () => U): void`) — TS2430 ✅
- Two generics, one input one output — TS2430 ✅
- Genuine non-generic member mismatch — TS2430 ✅
- Method-parameter bivariance (narrowing / widening) — preserved ✅
- Overloaded-derived override — defers to the strict relation (matches tsc) ✅

## Project Corpus Impact
- Row: rxjs-project (`#10804` witness; the broader generic-method-override
  variance family also covers `#10796`/`#10812`/`#10828`/`#12178`).
- Bug family: generic method override variance through interface `extends`.
- Display/relation correctness only — the change **only removes false positives**
  (suppresses a spurious TS2430); it never introduces a new diagnostic, so no
  required project-corpus row should regress.

## Verification
- New suite `interface_extends_generic_override_variance_tests` → **14 passed, 0 failed**.
- Full `cargo test -p tsz-checker --lib` → failing set **identical to `main`**
  (75 pre-existing failures, **0 new, 0 fixed-by-side-effect**), confirmed by
  stashing the change and diffing the failure sets before/after.
- CLI oracle vs `tsc 6.0.2` on the full matrix above (`--strict`): every case
  matches, including the previously-divergent input-only shapes.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib` clean.
- Rebased onto current `origin/main`; no conflicts.

## Coordination Notes
- Claims `#10804` (was deliberately unclaimed for implementation under
  `agent:Studio-manager` triage custody). Adding `WIP` + a claim comment.
- Scope is intentionally the interface-extends **false-positive** direction
  (removes errors, conformance-safe). The symmetric class-extends
  **false-negatives** (`keeps_2416_*` in `class_extends_generic_override_variance_tests`,
  pre-existing on `main` after the no-erase-first revert) add errors and risk the
  prior 24-case conformance drift, so they are left out of this PR.
- Anti-hardcoding gate: structural relation decisions only; tests vary binder,
  method, and type-parameter names.

https://claude.ai/code/session_01MARj7gFvbqv4CoRnzM7Gey

---
_Generated by [Claude Code](https://claude.ai/code/session_01MARj7gFvbqv4CoRnzM7Gey)_
