### PR TITLE
test(checker): ratchet repeated contextual inference calls

### DIFF
--- a/crates/tsz-checker/src/tests/generic_callback_sibling_arg_inference_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_callback_sibling_arg_inference_tests.rs
@@ -113,6 +113,38 @@ const narrowed: 0 = r; // TS2322 — number not assignable to 0
     );
 }
 
+/// Repeated calls in one checker run must start independent inference
+/// transactions. The first call widens a numeric literal through its callback;
+/// the second call must recompute from the string seed/callback instead of
+/// reusing the earlier numeric candidate or contextual substitution.
+#[test]
+fn repeated_contextual_calls_do_not_leak_inference_state() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function f<U>(fn: (acc: U) => U, init: U): U;
+
+const numeric = f((acc) => acc + 1, 0);
+const textual = f((acc) => acc + "!", "");
+
+const numericOk: number = numeric;
+const textualOk: string = textual;
+const numericTooNarrow: 0 = numeric;   // TS2322
+const textualTooNarrow: "" = textual; // TS2322
+"#,
+    );
+
+    let ts2322 = diagnostics_with_code(&diags, 2322);
+    assert_eq!(
+        ts2322.len(),
+        2,
+        "expected independent number/string repeated-call inference, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
 /// Control: the callback return does not depend on `U` (`() => 5`), but the
 /// callback-return candidate (`5`) still combines with `init`'s `0` and widens
 /// to `number`.


### PR DESCRIPTION
## Agent
AgentName: M4-C

## Track
Track 3: Inference Sessions, Instantiation, And Cache Contracts; test-only semantic-session ratchet.

## Invariant
When the same checker run evaluates repeated contextual generic calls, each call starts an independent inference transaction. A numeric call must not leak its widened candidate or contextual substitution into a later string call, and both calls must preserve their own widened result types.

## Scope
- `crates/tsz-checker/src/tests/generic_callback_sibling_arg_inference_tests.rs`

## Project Corpus Impact
- Row: Kysely/rxjs contextual generic substrate, no direct row result claim.
- Bug family: repeated generic calls and callback contextual typing session isolation.
- Evidence: adds a focused same-source repeated-call test over the existing sibling-argument contextual inference harness.

## Verification
- `scripts/safe-run.sh --limit 75% -- cargo nextest run -p tsz-checker --lib --profile quick generic_callback_sibling_arg_inference_tests::repeated_contextual_calls_do_not_leak_inference_state --no-capture --no-fail-fast`
- `cargo fmt --all --check`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Retargeted to `main` after #12552 landed as #12552 / `fb501adbb3`; refreshed again onto current `origin/main` at `d707ca16f3` after shard-5 runner timeouts on the previous ready run.
- No overlap with Studio-B #12551/#12546 or M4-B variance/cache work; this is a narrow repeated-call contextual inference guard.
- Follow-up M4-C work should move from ratchets into one bounded session/cache invariant with cache-on/cache-off or order-independence evidence.
