### PR TITLE
fix(checker): emit TS2364 for array/object literal compound assignment LHS

### DIFF
--- a/crates/tsz-checker/src/assignability/compound_assignment.rs
+++ b/crates/tsz-checker/src/assignability/compound_assignment.rs
@@ -4,6 +4,7 @@ use crate::context::TypingRequest;
 use crate::diagnostics::diagnostic_codes;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
@@ -31,7 +32,18 @@ impl<'a> CheckerState<'a> {
     ) -> TypeId {
         // TS2364: The left-hand side of an assignment expression must be a variable or a property access.
         // Suppress when near a parse error (same rationale as in check_assignment_expression).
-        if !self.is_valid_assignment_target(left_idx) && !self.node_has_nearby_parse_error(left_idx)
+        //
+        // Compound assignments (+=, -=, etc.) are more restrictive than simple assignment:
+        // array/object destructuring patterns ([a, b] = rhs) are valid LHS for simple
+        // assignment but NOT for compound assignment. `[a, b] += rhs` is always TS2364
+        // because compound operators require a single readable reference, not a pattern.
+        let lhs_unwrapped = self.ctx.arena.skip_parenthesized_and_assertions(left_idx);
+        let is_destructuring_literal_lhs = self.ctx.arena.get(lhs_unwrapped).is_some_and(|n| {
+            n.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION
+                || n.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION
+        });
+        if (!self.is_valid_assignment_target(left_idx) || is_destructuring_literal_lhs)
+            && !self.node_has_nearby_parse_error(left_idx)
         {
             self.error_at_node(
                 left_idx,

--- a/crates/tsz-checker/tests/ts2364_import_meta_assignment_tests.rs
+++ b/crates/tsz-checker/tests/ts2364_import_meta_assignment_tests.rs
@@ -1,8 +1,8 @@
 //! Tests for TS2364: The left-hand side of an assignment expression must be a
 //! variable or a property access.
 //!
-//! Specifically tests that `import.meta = ...` is rejected (TS2364) while
-//! `import.meta.prop = ...` is allowed (it's a real property access).
+//! Covers: `import.meta = ...` (TS2364), array/object literals as compound
+//! assignment LHS (TS2364), and valid assignment targets.
 
 use tsz_checker::test_utils::check_source_codes as get_error_codes;
 
@@ -92,4 +92,116 @@ class B extends A {
         !c.contains(&2364),
         "Must NOT have TS2364 for super += (parse error suppresses semantic check): {c:?}",
     );
+}
+
+// =========================================================================
+// Array/object literal as compound assignment LHS — must emit TS2364
+// =========================================================================
+//
+// Structural rule: for compound assignments (+=, -=, etc.), the LHS must be a
+// variable, property access, or element access. Array/object destructuring
+// patterns ([a, b] = rhs) are valid for simple assignment (`=`) but NOT for
+// compound assignments ([a, b] += rhs is always TS2364). tsc emits TS2364 for
+// compound-assignment destructuring; tsz must do the same.
+
+#[test]
+fn array_literal_compound_assignment_lhs_emits_ts2364() {
+    let source = r#"
+let a: number, b: number;
+[a, b] += [1, 2];
+"#;
+    assert!(
+        has_error_with_code(source, 2364),
+        "Array literal as compound assignment LHS should emit TS2364"
+    );
+}
+
+#[test]
+fn object_literal_compound_assignment_lhs_emits_ts2364() {
+    let source = r#"
+let a: number;
+({a} += {a: 1});
+"#;
+    assert!(
+        has_error_with_code(source, 2364),
+        "Object literal as compound assignment LHS should emit TS2364"
+    );
+}
+
+#[test]
+fn simple_array_destructuring_is_valid() {
+    // [a, b] = rhs is valid (simple destructuring, not compound)
+    let source = r#"
+let a: number, b: number;
+[a, b] = [1, 2];
+"#;
+    let codes = get_error_codes(source);
+    assert!(
+        !codes.contains(&2364),
+        "Array destructuring simple assignment must NOT emit TS2364; got: {codes:?}"
+    );
+}
+
+#[test]
+fn function_call_compound_assignment_lhs_emits_ts2364() {
+    let source = r#"
+declare function f(): number;
+f() += 1;
+"#;
+    assert!(
+        has_error_with_code(source, 2364),
+        "Function call result as compound assignment LHS should emit TS2364"
+    );
+}
+
+#[test]
+fn array_literal_exponentiation_compound_assignment_lhs_emits_ts2364() {
+    let source = r#"
+let x: number;
+[x] **= 2;
+"#;
+    assert!(
+        has_error_with_code(source, 2364),
+        "Array literal as **= LHS should emit TS2364"
+    );
+}
+
+#[test]
+fn simple_object_destructuring_assignment_is_valid() {
+    // ({a} = rhs) is valid (simple destructuring, not compound)
+    let source = r#"
+let a: number;
+({a} = {a: 1});
+"#;
+    let codes = get_error_codes(source);
+    assert!(
+        !codes.contains(&2364),
+        "Object destructuring simple assignment must NOT emit TS2364; got: {codes:?}"
+    );
+}
+
+#[test]
+fn parenthesized_array_literal_compound_assignment_lhs_emits_ts2364() {
+    // ([a, b]) += rhs — parenthesized array literal as LHS — is still invalid
+    let source = r#"
+let a: number, b: number;
+([a, b]) += 1;
+"#;
+    assert!(
+        has_error_with_code(source, 2364),
+        "Parenthesized array literal as compound assignment LHS should emit TS2364"
+    );
+}
+
+#[test]
+fn all_arithmetic_compound_operators_reject_array_literal_lhs() {
+    // All compound arithmetic operators should reject array literal LHS,
+    // not just +=. The rule is structural, not operator-specific.
+    for op in ["-=", "*=", "/=", "%=", "**="] {
+        let source = format!("let a: number, b: number;\n[a, b] {op} 1;\n",);
+        assert!(
+            has_error_with_code(&source, 2364),
+            "Array literal as {op} LHS should emit TS2364"
+        );
+    }
 }

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -49,7 +49,9 @@ TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
 TypeScript/tests/cases/compiler/strictModeReservedWord.ts
 TypeScript/tests/cases/compiler/unicodeEscapesInNames02.ts
 TypeScript/tests/cases/conformance/es2019/importMeta/importMeta.ts
+TypeScript/tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts
 TypeScript/tests/cases/conformance/es6/for-ofStatements/for-of51.ts
+TypeScript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts
 TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts
 TypeScript/tests/cases/conformance/jsdoc/importTag17.ts

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -49,9 +49,7 @@ TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
 TypeScript/tests/cases/compiler/strictModeReservedWord.ts
 TypeScript/tests/cases/compiler/unicodeEscapesInNames02.ts
 TypeScript/tests/cases/conformance/es2019/importMeta/importMeta.ts
-TypeScript/tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts
 TypeScript/tests/cases/conformance/es6/for-ofStatements/for-of51.ts
-TypeScript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts
 TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts
 TypeScript/tests/cases/conformance/jsdoc/importTag17.ts


### PR DESCRIPTION
## Summary

Array and object literals (`[a,b]`, `{a}`) are valid simple-assignment LHS (destructuring), but **not** valid for compound assignments (`+=`, `-=`, `*=`, etc.). tsc emits TS2364 for `[a, b] += rhs`; tsz was silently accepting it.

Adds TS2364 checker coverage for the compound-assignment LHS cases. The matching conformance rows remain accepted for now because a separate parser recovery mismatch still emits TS1109 where tsc expects TS1128:
- `compoundAssignmentLHSIsValue.ts`
- `compoundExponentiationAssignmentLHSIsValue.ts`

---

AgentName: Studio-B

**Track:** Track 8 — Diagnostics / conformance parity

**Invariant:** When the LHS of a compound assignment (`+=`, `-=`, `*=`, `/=`, `%=`, `**=`, etc.) is an array or object literal (even parenthesized), tsz must emit TS2364, matching tsc exactly.

**Scope:** `crates/tsz-checker/src/assignability/compound_assignment.rs` — the `check_compound_assignment_expression` function. No changes to solver, emitter, or parser.

**Structural Rule:**
> `is_valid_assignment_target` returns `true` for `ARRAY_LITERAL_EXPRESSION` and `OBJECT_LITERAL_EXPRESSION` to permit simple destructuring assignment (`[a,b] = rhs`). Compound assignment checking must additionally reject those nodes because compound operators require a *readable single reference*, not a pattern. The fix unwraps parentheses (mirroring the recursion in `is_valid_assignment_target`) then guards against array/object literals before the normal validity check.

**Adjacent case matrix:**
| Input | Expected | Result |
|---|---|---|
| `[a, b] += [1, 2]` | TS2364 ✓ | fixed |
| `{a} += {a: 1}` | TS2364 ✓ | fixed |
| `([a, b]) += 1` | TS2364 ✓ | fixed (parenthesized) |
| `[x] **= 2` | TS2364 ✓ | fixed |
| `f() += 1` | TS2364 ✓ | pre-existing, confirmed |
| `[a, b] = [1, 2]` | no error ✓ | not regressed |
| `({a} = {a: 1})` | no error ✓ | not regressed |
| `import.meta = foo` | TS2364 ✓ | pre-existing, confirmed |
| `import.meta.foo = 42` | no error ✓ | pre-existing, confirmed |

All arithmetic compound operators (`-=`, `*=`, `/=`, `%=`, `**=`) also tested.

## Project Corpus Impact
- Row: n/a
- Bug family: compound-assignment-lhs-validity
- No benchmark project rows are expected to regress — the fix adds diagnostics where tsz was previously silent (net improvement in conformance parity).
- Leaves the two compound-assignment conformance rows in `scripts/conformance/conformance-accepted-regressions.txt`; their remaining parser recovery mismatch is outside this checker PR.

**Verification:**
```
scripts/safe-run.sh cargo test --package tsz-checker --test ts2364_import_meta_assignment_tests
# test result: ok. 11 passed; 0 failed; 0 ignored
```

**Coordination Notes:** No open PR covers compound assignment LHS validity. Background agents are separately investigating JS emit `+3/-1` block-scope patterns and `genericRestParameters1` DTS failure — those are independent. This PR is self-contained and does not touch those paths.
