### PR TITLE
perf(solver,checker): cache closed-eval conditional gate and JSDoc typedef misses

### DIFF
--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -33,6 +33,7 @@ namespace_member_resolution_cache = { lifetime = "FileLocalReset", capability = 
 export_equals_named_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 nested_namespace_candidates_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 symbol_name_candidates_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
+jsdoc_global_typedef_lookup_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local project-run lookup cache and re-entrancy state; reset with checker file/session state" }
 nested_namespace_candidates_cache_complete = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 lowering_entity_name_resolution_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 namespace_exports_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -77,8 +77,10 @@ impl<'a> CheckerContext<'a> {
             export_equals_named_cache: RefCell::new(FxHashMap::default()),
             nested_namespace_candidates_cache: RefCell::new(FxHashMap::default()),
             symbol_name_candidates_cache: RefCell::new(FxHashMap::default()),
-            jsdoc_global_typedef_miss_cache: RefCell::new(FxHashSet::default()),
-            jsdoc_global_typedef_in_progress: RefCell::new(FxHashSet::default()),
+            jsdoc_global_typedef_lookup_cache: crate::context::JSDocGlobalTypedefLookupCache {
+                miss_cache: RefCell::new(FxHashSet::default()),
+                in_progress: RefCell::new(FxHashSet::default()),
+            },
             nested_namespace_candidates_cache_complete: Cell::new(false),
             lowering_entity_name_resolution_cache: RefCell::new(FxHashMap::default()),
             namespace_exports_cache: RefCell::new(FxHashMap::default()),

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -77,6 +77,8 @@ impl<'a> CheckerContext<'a> {
             export_equals_named_cache: RefCell::new(FxHashMap::default()),
             nested_namespace_candidates_cache: RefCell::new(FxHashMap::default()),
             symbol_name_candidates_cache: RefCell::new(FxHashMap::default()),
+            jsdoc_global_typedef_miss_cache: RefCell::new(FxHashSet::default()),
+            jsdoc_global_typedef_in_progress: RefCell::new(FxHashSet::default()),
             nested_namespace_candidates_cache_complete: Cell::new(false),
             lowering_entity_name_resolution_cache: RefCell::new(FxHashMap::default()),
             namespace_exports_cache: RefCell::new(FxHashMap::default()),

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -105,6 +105,12 @@ impl RelationOverflowFlags {
     }
 }
 
+/// Project-run cache for global JSDoc typedef lookup.
+pub struct JSDocGlobalTypedefLookupCache {
+    pub miss_cache: RefCell<FxHashSet<String>>,
+    pub in_progress: RefCell<FxHashSet<String>>,
+}
+
 /// Maximum depth for nested `get_type_of_symbol` calls before giving up.
 ///
 /// Prevents stack overflow when resolving deeply recursive or circular
@@ -445,20 +451,10 @@ pub struct CheckerContext<'a> {
     /// and all cross-file binders.
     pub symbol_name_candidates_cache: RefCell<FxHashMap<String, Vec<SymbolId>>>,
 
-    /// Per-checker negative cache for `resolve_global_jsdoc_typedef_info`: names
-    /// that resolved to no global JSDoc `@typedef`. The global typedef set is
-    /// fixed for the project run, so a miss is stable, and the miss path scans
-    /// every source file's text (including all of `@types/*`) with `str::contains`
-    /// — re-running it for every unresolved type reference is quadratic. Caching
-    /// misses (the side-effect-free path) collapses the repeat scans to O(1).
-    pub jsdoc_global_typedef_miss_cache: RefCell<FxHashSet<String>>,
-
-    /// Names whose global JSDoc `@typedef` lookup is currently on the stack.
-    /// A self-referential typedef re-enters the lookup; the inner call's `None`
-    /// is only a cycle break, so `jsdoc_global_typedef_miss_cache` must record a
-    /// miss only at the outermost (non-re-entrant) lookup. This set tracks that
-    /// re-entrancy.
-    pub jsdoc_global_typedef_in_progress: RefCell<FxHashSet<String>>,
+    /// Negative results and re-entrancy state for global JSDoc typedef lookup.
+    /// Misses are stable for the project run; the in-progress set prevents a
+    /// recursive typedef's cycle-break `None` from poisoning that miss cache.
+    pub jsdoc_global_typedef_lookup_cache: JSDocGlobalTypedefLookupCache,
 
     /// True once `nested_namespace_candidates_cache` has been populated for every
     /// nested namespace export name visible across all binders.

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -445,6 +445,21 @@ pub struct CheckerContext<'a> {
     /// and all cross-file binders.
     pub symbol_name_candidates_cache: RefCell<FxHashMap<String, Vec<SymbolId>>>,
 
+    /// Per-checker negative cache for `resolve_global_jsdoc_typedef_info`: names
+    /// that resolved to no global JSDoc `@typedef`. The global typedef set is
+    /// fixed for the project run, so a miss is stable, and the miss path scans
+    /// every source file's text (including all of `@types/*`) with `str::contains`
+    /// — re-running it for every unresolved type reference is quadratic. Caching
+    /// misses (the side-effect-free path) collapses the repeat scans to O(1).
+    pub jsdoc_global_typedef_miss_cache: RefCell<FxHashSet<String>>,
+
+    /// Names whose global JSDoc `@typedef` lookup is currently on the stack.
+    /// A self-referential typedef re-enters the lookup; the inner call's `None`
+    /// is only a cycle break, so `jsdoc_global_typedef_miss_cache` must record a
+    /// miss only at the outermost (non-re-entrant) lookup. This set tracks that
+    /// re-entrancy.
+    pub jsdoc_global_typedef_in_progress: RefCell<FxHashSet<String>>,
+
     /// True once `nested_namespace_candidates_cache` has been populated for every
     /// nested namespace export name visible across all binders.
     pub nested_namespace_candidates_cache_complete: Cell<bool>,

--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -280,7 +280,8 @@ impl<'a> CheckerState<'a> {
         // as `pino` + `@types/node`).
         if self
             .ctx
-            .jsdoc_global_typedef_miss_cache
+            .jsdoc_global_typedef_lookup_cache
+            .miss_cache
             .borrow()
             .contains(name)
         {
@@ -296,7 +297,8 @@ impl<'a> CheckerState<'a> {
         // records a miss.
         let is_outermost = self
             .ctx
-            .jsdoc_global_typedef_in_progress
+            .jsdoc_global_typedef_lookup_cache
+            .in_progress
             .borrow_mut()
             .insert(name.to_string());
 
@@ -304,12 +306,14 @@ impl<'a> CheckerState<'a> {
 
         if is_outermost {
             self.ctx
-                .jsdoc_global_typedef_in_progress
+                .jsdoc_global_typedef_lookup_cache
+                .in_progress
                 .borrow_mut()
                 .remove(name);
             if result.is_none() {
                 self.ctx
-                    .jsdoc_global_typedef_miss_cache
+                    .jsdoc_global_typedef_lookup_cache
+                    .miss_cache
                     .borrow_mut()
                     .insert(name.to_string());
             }

--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -273,6 +273,55 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
+        // Negative-result fast path. A name that resolves to no global JSDoc
+        // `@typedef` anywhere in the project stays unresolved for the whole run,
+        // so re-scanning every source file's text for it on each unresolved type
+        // reference is pure repeated work (quadratic on dense `.d.ts` graphs such
+        // as `pino` + `@types/node`).
+        if self
+            .ctx
+            .jsdoc_global_typedef_miss_cache
+            .borrow()
+            .contains(name)
+        {
+            return None;
+        }
+
+        // Re-entrancy guard. A recursive typedef whose body references itself
+        // (`@typedef T ... T ...`) re-enters this lookup; the inner call returns
+        // `None` only as a *cycle break*, while the outermost call still resolves
+        // `T` to its type. Caching that provisional inner `None` would poison
+        // every later resolution of `T`. So only the outermost (non-re-entrant)
+        // lookup — where `None` genuinely means "no such typedef in any file" —
+        // records a miss.
+        let is_outermost = self
+            .ctx
+            .jsdoc_global_typedef_in_progress
+            .borrow_mut()
+            .insert(name.to_string());
+
+        let result = self.resolve_global_jsdoc_typedef_info_uncached(name);
+
+        if is_outermost {
+            self.ctx
+                .jsdoc_global_typedef_in_progress
+                .borrow_mut()
+                .remove(name);
+            if result.is_none() {
+                self.ctx
+                    .jsdoc_global_typedef_miss_cache
+                    .borrow_mut()
+                    .insert(name.to_string());
+            }
+        }
+
+        result
+    }
+
+    fn resolve_global_jsdoc_typedef_info_uncached(
+        &mut self,
+        name: &str,
+    ) -> Option<(TypeId, Vec<tsz_solver::TypeParamInfo>)> {
         let current_file_name = self.ctx.file_name.clone();
         let current_file_idx = self.ctx.current_file_idx;
         let use_typedef_prescan = self

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -122,6 +122,16 @@ pub trait TypePredicateCache {
     /// Record the result of `is_resolver_dependent_type(type_id)` in the shared
     /// interner cache. Default impl is a no-op.
     fn set_contains_resolver_dependent_cache(&self, _type_id: TypeId, _result: bool) {}
+
+    /// Look up a cached alias-opaque `contains Conditional` walk result, used by
+    /// the `closed_eval_cache` eligibility gate. Default impl returns `None`.
+    fn contains_conditional_cached(&self, _type_id: TypeId) -> Option<bool> {
+        None
+    }
+
+    /// Record the result of the alias-opaque `contains Conditional` walk in the
+    /// shared interner cache. Default impl is a no-op.
+    fn set_contains_conditional_cache(&self, _type_id: TypeId, _result: bool) {}
 }
 
 /// Narrow signal for tuple-size overflow discovered during solver evaluation.
@@ -570,6 +580,14 @@ impl TypePredicateCache for TypeInterner {
     fn set_contains_resolver_dependent_cache(&self, type_id: TypeId, result: bool) {
         self.contains_resolver_dependent_cache
             .insert(type_id, result);
+    }
+
+    fn contains_conditional_cached(&self, type_id: TypeId) -> Option<bool> {
+        self.contains_conditional_cache.get(&type_id).map(|v| *v)
+    }
+
+    fn set_contains_conditional_cache(&self, type_id: TypeId, result: bool) {
+        self.contains_conditional_cache.insert(type_id, result);
     }
 }
 

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1075,6 +1075,15 @@ impl TypePredicateCache for QueryCache<'_> {
         self.interner
             .set_contains_resolver_dependent_cache(type_id, result);
     }
+
+    fn contains_conditional_cached(&self, type_id: TypeId) -> Option<bool> {
+        self.interner.contains_conditional_cached(type_id)
+    }
+
+    fn set_contains_conditional_cache(&self, type_id: TypeId, result: bool) {
+        self.interner
+            .set_contains_conditional_cache(type_id, result);
+    }
 }
 
 impl TypeTupleLimitSignal for QueryCache<'_> {

--- a/crates/tsz-solver/src/evaluation/evaluate/closed_eval.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/closed_eval.rs
@@ -157,9 +157,14 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
     ///   utilities like `Omit`/`Pick`/`ComponentPropsWithRef` are already
     ///   excluded earlier by the `IndexAccess`-body requirement.
     fn body_has_conditional(&self, type_id: TypeId) -> bool {
-        crate::visitors::visitor_predicates::contains_type_matching(self.interner, type_id, |k| {
-            matches!(k, TypeData::Conditional(_))
-        })
+        // Routed through the project-wide `contains_conditional_cache` (see
+        // `contains_conditional_type`) so the eligibility gate is amortized O(1)
+        // per node rather than an O(subtree) walk on every cache-miss
+        // evaluation. The cached walker enumerates children identically to the
+        // generic `contains_type_matching(.., Conditional)` walk — both treat
+        // `Lazy`/`Application` bases as opaque leaves — so the answer is
+        // unchanged.
+        crate::type_queries::contains_conditional_type(self.interner, type_id)
     }
 
     /// Whether the object operand of a cacheable `IndexAccess`/`KeyOf` is safe to

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -1588,6 +1588,8 @@ impl TypeInterner {
             * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
         size += self.contains_type_query_cache.len()
             * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
+        size += self.contains_conditional_cache.len()
+            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
         // alloc_order is now stored per-shard alongside index_to_key (4 bytes per type)
         size += type_count * 4;
         size += self.display_properties.len()

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -556,6 +556,14 @@ pub struct TypeInterner {
     pub(crate) contains_lazy_or_recursive_cache: DashMap<TypeId, bool, FxBuildHasher>,
     pub(crate) contains_unresolved_application_cache: DashMap<TypeId, bool, FxBuildHasher>,
     pub(crate) contains_resolver_dependent_cache: DashMap<TypeId, bool, FxBuildHasher>,
+    /// Cache for the alias-opaque `contains Conditional` walk that backs the
+    /// `closed_eval_cache` eligibility gate (`is_closed_cacheable_kind`). The
+    /// walk treats `Lazy`/`Application` bases as opaque leaves, so the answer is
+    /// immutable per `TypeId`. Memoizing it project-wide turns the gate from an
+    /// O(subtree) walk on every cache-miss evaluation into an O(1) lookup,
+    /// eliminating the O(n^2) blow-up on dense recursive mapped/conditional/
+    /// index-access expansions (e.g. `pino.d.ts`).
+    pub(crate) contains_conditional_cache: DashMap<TypeId, bool, FxBuildHasher>,
     /// The global Array base type (e.g., Array<T> from lib.d.ts).
     /// Uses `AtomicU32` (with `u32::MAX` as sentinel for `None`) instead of
     /// `RwLock` so file checkers can overwrite the prime checker's value without
@@ -700,6 +708,7 @@ impl TypeInterner {
             contains_lazy_or_recursive_cache: DashMap::with_hasher(FxBuildHasher),
             contains_unresolved_application_cache: DashMap::with_hasher(FxBuildHasher),
             contains_resolver_dependent_cache: DashMap::with_hasher(FxBuildHasher),
+            contains_conditional_cache: DashMap::with_hasher(FxBuildHasher),
             array_base_type: AtomicU32::new(u32::MAX),
             array_display_base_type: AtomicU32::new(u32::MAX),
             array_base_type_params: OnceLock::new(),

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -556,13 +556,9 @@ pub struct TypeInterner {
     pub(crate) contains_lazy_or_recursive_cache: DashMap<TypeId, bool, FxBuildHasher>,
     pub(crate) contains_unresolved_application_cache: DashMap<TypeId, bool, FxBuildHasher>,
     pub(crate) contains_resolver_dependent_cache: DashMap<TypeId, bool, FxBuildHasher>,
-    /// Cache for the alias-opaque `contains Conditional` walk that backs the
-    /// `closed_eval_cache` eligibility gate (`is_closed_cacheable_kind`). The
-    /// walk treats `Lazy`/`Application` bases as opaque leaves, so the answer is
-    /// immutable per `TypeId`. Memoizing it project-wide turns the gate from an
-    /// O(subtree) walk on every cache-miss evaluation into an O(1) lookup,
-    /// eliminating the O(n^2) blow-up on dense recursive mapped/conditional/
-    /// index-access expansions (e.g. `pino.d.ts`).
+    /// Alias-opaque `contains Conditional` cache for the closed-eval gate.
+    /// The answer is immutable per `TypeId` and avoids repeated subtree walks
+    /// on dense recursive mapped/conditional/index-access expansions.
     pub(crate) contains_conditional_cache: DashMap<TypeId, bool, FxBuildHasher>,
     /// The global Array base type (e.g., Array<T> from lib.d.ts).
     /// Uses `AtomicU32` (with `u32::MAX` as sentinel for `None`) instead of

--- a/crates/tsz-solver/src/type_queries/data/content_predicates.rs
+++ b/crates/tsz-solver/src/type_queries/data/content_predicates.rs
@@ -186,6 +186,32 @@ impl ContentPredicate for SubstitutionDependentPredicate {
     }
 }
 
+struct ConditionalPredicate;
+impl ContentPredicate for ConditionalPredicate {
+    fn matches_node(&self, _db: &dyn TypeDatabase, key: &TypeData) -> bool {
+        matches!(key, TypeData::Conditional(_))
+    }
+    fn cached(&self, db: &dyn TypeDatabase, type_id: TypeId) -> Option<bool> {
+        db.contains_conditional_cached(type_id)
+    }
+    fn set_cache(&self, db: &dyn TypeDatabase, type_id: TypeId, result: bool) {
+        db.set_contains_conditional_cache(type_id, result);
+    }
+}
+
+/// Whether the alias-opaque structure of `type_id` contains a `Conditional`.
+///
+/// Like the generic `contains_type_matching(.., Conditional)` walk, this treats
+/// nested `Lazy`/`Application` bases as opaque leaves (it never resolves
+/// aliases), so the result is immutable per `TypeId`. Routing it through
+/// `contains_content_cached` memoizes every visited node in the project-wide
+/// `contains_conditional_cache`, turning the `closed_eval_cache` eligibility
+/// gate (`is_closed_cacheable_kind`) from an O(subtree) walk on every
+/// cache-miss evaluation into an amortized O(1) lookup.
+pub fn contains_conditional_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    contains_content_cached(db, type_id, &ConditionalPredicate)
+}
+
 /// Whether evaluating `type_id` depends on the substitution environment.
 ///
 /// Returns `true` if the type (recursively) contains any `TypeParameter`/


### PR DESCRIPTION
AgentName: Studio-Opus
Track: Performance / project-corpus perf-cliff family
Invariant: no relation/inference/narrowing/emit behavior change; caches govern an optimization gate and a side-effect-free miss path only
Scope: solver closed-eval cacheability gate + checker global JSDoc typedef lookup

## Summary

Two project-wide memoizations that remove **two of the dominant cost layers** from the dense-`.d.ts` / recursive-instantiation performance-cliff family tracked by #12462 (`pinojs/pino`: 19 files / 2.2k LOC that `tsc` clears in ~3s while `tsz` exceeds the 120s budget).

Both hot paths were found by sampling the hung `tsz` worker/main threads on `pino` (gdb stack sampling of the release binary), then re-profiling after each fix to confirm the targeted hot path was gone.

### 1. Solver: closed-eval cacheability gate (`is_closed_cacheable_kind`)

`try_closed_eval_read` runs on **every cache-miss `evaluate()`** of an `IndexAccess`/`KeyOf`/`Application` node and calls `body_has_conditional`, which did an **uncached** deep `contains_type_matching` walk. During a recursive `mapped -> conditional -> application -> mapped ...` expansion, each intermediate node re-walks its entire subtree -> **O(n^2)** over the expansion. Sampling showed `ContainsTypeChecker::check`/`check_key` at ~22/30 innermost frames.

Fix: route `body_has_conditional` through the **existing** persistent `ContentPredicate` infrastructure via a new `contains_conditional_type`, backed by a per-node `contains_conditional_cache` on the interner — the same end-to-end pattern already used by `is_substitution_dependent_type` (`contains_resolver_dependent_cache`). The cached walker (`CachedContentWalker::collect_children`) enumerates children **identically** to the generic `ContainsTypeChecker::check_key` (both treat `Lazy`/`Application` bases as opaque leaves), so the gate's answer is unchanged and now amortized **O(1)** per node. Any divergence is strictly more conservative (more nodes treated as non-cacheable), which is always sound for a cache-eligibility gate. After this fix the `ContainsTypeChecker` frames disappeared from the profile.

### 2. Checker: global JSDoc typedef lookup (`resolve_global_jsdoc_typedef_info`)

For every unresolved type reference this re-scanned **every source file's text** (including all of `@types/*`) with `str::contains`, never caching the result -> **O(references x files x text)**. Sampling showed `resolve_global_jsdoc_typedef_info`/`source_file_has_jsdoc_typedef_named` at ~18/30 innermost frames.

Fix: a project-run-stable **negative-result cache** — a name with no global `@typedef` anywhere is recorded once and short-circuited thereafter (the miss path has no side effects, so this is observationally identical). A **re-entrancy guard** ensures only the outermost (non-re-entrant) lookup records a miss, so a self-referential typedef's provisional cycle-break `None` never poisons later resolutions. After this fix the JSDoc frames dropped to ~2/30.

## Structural rule

> When deciding closed-eval cache eligibility or resolving a global JSDoc typedef name, `tsc` answers each query in (amortized) constant time after the first; `tsz` re-derived the answer from scratch on every query. Both queries are pure functions of the immutable interned type graph / fixed project file set, so they are memoized per `TypeId` / per name — owned by the solver `ContentPredicate` cache and the checker `CheckerContext`, respectively.

## Owner layer

Solver (closed-eval cache gate, `ContentPredicate` infrastructure) and Checker (`CheckerContext` JSDoc lookup). No relation/inference/narrowing semantics change.

## Project Corpus Impact

- Row: pino (n/a — not currently a required/tracked corpus row; used here as the minimal witness for the perf cliff)
- Bug family: recursive-mapped/conditional instantiation + cross-file resolution perf cliff (shared with #7574, #12455)
- These two fixes eliminate two confirmed dominant layers of the `pino` cliff. A third, deeper layer remains — cross-arena `compute_type_of_symbol` / alias / `export =` resolution under `pino`'s merged `declare function pino` + `namespace pino` (`export = pino`) — so `pino` does not yet finish within budget; that layer is the checker's most delicate subsystem and warrants its own change with conformance validation. #12462 remains open for it.

## Verification

- `cargo test -p tsz-solver --lib` -> **6528 passed, 0 failed**.
- `cargo test -p tsz-checker --lib -- jsdoc` -> the recursive-typedef regression (`non_generic_recursive_typedef_still_resolves`) now **passes**; the 2 remaining JSDoc failures and the zod-suite failures/stack-overflow were verified **pre-existing on the base branch** (confirmed by stashing this change and re-running).
- Re-profiled `pino` after each fix: the targeted hot path is gone in each case.
- Rebased onto latest `main`; `cargo check -p tsz-checker` (and transitively `tsz-solver`) clean.
- Follow-up arch-ratchet fix on head `b4e5e5ddab87`: `cargo fmt --all --check`; `python3 scripts/arch/arch_guard.py`; `git diff --check`; `scripts/safe-run.sh cargo clippy -p tsz-solver -p tsz-checker --all-targets -- -D warnings`; `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(non_generic_recursive_typedef_still_resolves)'`.

## Coordination Notes

No roadmap change (routine perf work). The remaining cross-arena layer is shared with the broader instantiation/resolution-explosion family (#7574, #12455) and is left for a dedicated, conformance-validated follow-up. Closes none; advances #12462. Studio-Opus added the arch-ratchet fix directly on top of the PR head via the GitHub API because HTTPS Git transport is returning repo-disabled 403s; no force update was used.

