### PR TITLE
perf(checker): cache export-equals named misses by alias chain

### DIFF
--- a/crates/tsz-checker/src/context/aliases.rs
+++ b/crates/tsz-checker/src/context/aliases.rs
@@ -69,9 +69,10 @@ pub(crate) fn namespace_exports_cache_estimated_size_bytes(cache: &NamespaceExpo
     size
 }
 
-/// Per-checker positive cache for named exports reached through `export=`.
-/// Keyed by `(current_file_idx, module_specifier, export_name)`.
-pub type ExportEqualsNamedCache = FxHashMap<(usize, String, String), Option<SymbolId>>;
+/// Per-checker cache for named exports reached through `export=`.
+/// Keyed by `(current_file_idx, module_specifier, export_name, visited_aliases)`.
+pub type ExportEqualsNamedCache =
+    FxHashMap<(usize, String, String, Vec<SymbolId>), Option<SymbolId>>;
 
 #[must_use]
 pub(crate) fn export_equals_named_cache_entries(cache: &ExportEqualsNamedCache) -> usize {
@@ -83,11 +84,12 @@ pub(crate) fn export_equals_named_cache_estimated_size_bytes(
     cache: &ExportEqualsNamedCache,
 ) -> usize {
     let mut size = cache.capacity()
-        * (std::mem::size_of::<(usize, String, String)>()
+        * (std::mem::size_of::<(usize, String, String, Vec<SymbolId>)>()
             + std::mem::size_of::<Option<SymbolId>>()
             + 8);
-    for (_, specifier, export_name) in cache.keys() {
+    for (_, specifier, export_name, visited_aliases) in cache.keys() {
         size += specifier.capacity() + export_name.capacity();
+        size += visited_aliases.capacity() * std::mem::size_of::<SymbolId>();
     }
     size
 }
@@ -219,13 +221,19 @@ mod tests {
         assert_eq!(export_equals_named_cache_entries(&cache), 0);
         assert_eq!(export_equals_named_cache_estimated_size_bytes(&cache), 0);
 
-        cache.insert((1, "pkg".to_string(), "foo".to_string()), Some(SymbolId(3)));
-        cache.insert((1, "pkg".to_string(), "bar".to_string()), None);
+        cache.insert(
+            (1, "pkg".to_string(), "foo".to_string(), vec![]),
+            Some(SymbolId(3)),
+        );
+        cache.insert(
+            (1, "pkg".to_string(), "bar".to_string(), vec![SymbolId(7)]),
+            None,
+        );
 
         assert_eq!(export_equals_named_cache_entries(&cache), 2);
         assert!(
             export_equals_named_cache_estimated_size_bytes(&cache)
-                >= 2 * (std::mem::size_of::<(usize, String, String)>()
+                >= 2 * (std::mem::size_of::<(usize, String, String, Vec<SymbolId>)>()
                     + std::mem::size_of::<Option<SymbolId>>())
         );
     }

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -2062,19 +2062,20 @@ impl<'a> CheckerState<'a> {
         export_name: &str,
         visited_aliases: &mut AliasCycleTracker,
     ) -> Option<tsz_binder::SymbolId> {
+        let mut visited_key: Vec<_> = visited_aliases.iter().collect();
+        visited_key.sort_by_key(|sym_id| sym_id.0);
         let cache_key = (
             self.ctx.current_file_idx,
             module_specifier.to_string(),
             export_name.to_string(),
+            visited_key,
         );
-        let cache_miss = visited_aliases.len() == 0;
         if let Some(cached) = self
             .ctx
             .export_equals_named_cache
             .borrow()
             .get(&cache_key)
             .copied()
-            && (cached.is_some() || cache_miss)
         {
             return cached;
         }
@@ -2086,12 +2087,10 @@ impl<'a> CheckerState<'a> {
                 visited_aliases,
             )
         });
-        if resolved.is_some() || cache_miss {
-            self.ctx
-                .export_equals_named_cache
-                .borrow_mut()
-                .insert(cache_key, resolved);
-        }
+        self.ctx
+            .export_equals_named_cache
+            .borrow_mut()
+            .insert(cache_key, resolved);
         resolved
     }
 


### PR DESCRIPTION
AgentName: Studio-Opus

Track: Performance / project corpus pino blocker (#12462)

Invariant: When an `export =` named-export lookup is evaluated under a particular alias-cycle visited set, tsz must reuse only results computed with the same current file, module specifier, export name, and visited alias set. Cycle-break misses from one alias chain must not poison top-level or different-chain lookups.

Scope:
- Changes `ExportEqualsNamedCache` from `(current_file_idx, module_specifier, export_name)` to `(current_file_idx, module_specifier, export_name, visited_aliases)`.
- Caches both hits and misses for non-empty alias-cycle paths by isolating the visited-alias membership in the key.
- Updates cache residency accounting for the visited-alias vector and the adjacent unit fixture.

## Project Corpus Impact
- Row: pino (#12462)
- Bug family: checker/solver performance; `export =` alias-chain named export resolution
- Target blocker: pino at `ff0dc5c6cd5f18611e8d588e3c528ce703792fea` from #12462.
- Before this patch on the #12557 head, a 10s macOS sample of the 60s timed-out pino run showed `resolve_named_export_via_export_equals_tracked_uncached` in the top collapsed stack (118 samples), under repeated `compute_type_of_symbol` / alias / `export =` resolution.
- After this patch, the same bounded pino run still times out at 60s, but the export-equals uncached function drops out of the top collapsed stack; the next visible layer is string/module lookup and cross-file/global resolution. This is a layer-removal PR, not a claim that pino is fixed.
- Residency remains file-local; the added key component is bounded by the alias-cycle tracker membership for the lookup.

Verification:
- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(export_equals_named_cache_statistics_report_entries_and_size) | test(resolve_named_export_via_export_equals_handles_qualified_and_alias_targets)'`
- `scripts/safe-run.sh cargo clippy -p tsz-checker --all-targets -- -D warnings`
- pino witness: `.target/dist-fast/tsz --noEmit -p . --pretty false` with `TSZ_USE_EMBEDDED_LIBS=1`, `RUST_MIN_STACK=536870912`, 60s bound; still timed out, with samples captured before/after to identify the removed layer.

Coordination Notes:
- Owned PR runway was empty before opening this draft.
- This PR follows merged #12557 and narrows the remaining pino `export =` alias-resolution layer.
- Next follow-up for #12462 should inspect repeated string/module lookup and cross-file/global resolution after this cache lands.
