### PR TITLE
perf(checker): keep lazy lib members with unrelated augmentations

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -130,10 +130,7 @@ impl CheckerState<'_> {
     ///    not perform.
     /// 5. The interface name is not compiler-managed and not shadowed by a
     ///    file-local type declaration.
-    /// 6. The program has no global augmentations. Augmentation-aware programs
-    ///    use full materialization so global interface merge state remains
-    ///    authoritative across chained lib-interface reads.
-    /// 7. The interface is not globally augmented (`declare global { interface
+    /// 6. The interface is not globally augmented (`declare global { interface
     ///    X { ... } }`), which could add the accessed member out of band.
     pub(crate) fn lazy_lib_member_receiver_def_id(
         &self,
@@ -170,10 +167,6 @@ impl CheckerState<'_> {
         if self.ctx.file_local_type_shadow_for_lib_name(&name) {
             return None;
         }
-        if self.program_has_global_augmentations() {
-            return None;
-        }
-
         // The symbol must come from the actual/cloned lib — user interfaces (even
         // sharing a lib name) take the normal path so augmentation/merging stays
         // correct.
@@ -200,15 +193,6 @@ impl CheckerState<'_> {
             .global_augmentations
             .get(name)
             .is_some_and(|decls| !decls.is_empty())
-    }
-
-    fn program_has_global_augmentations(&self) -> bool {
-        !self.ctx.binder.global_augmentations.is_empty()
-            || self
-                .ctx
-                .global_augmentation_targets_index
-                .as_ref()
-                .is_some_and(|index| !index.is_empty())
     }
 
     /// Try to resolve `prop_name` on an eligible simple lib-interface receiver by


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance, benchmark target-gap slice

## Invariant
When a property-access receiver is a bare `Lazy(DefId)` for an unshadowed,
unaugmented, non-generic actual/cloned-lib interface, unrelated global or
module augmentations elsewhere in the program do not change that receiver's
own member lookup. This PR keeps the checker lazy single-member lib path
eligible unless the receiver interface name itself is globally augmented; that
receiver-name augmentation still falls back to full materialization.

## Scope
- `crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs`

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: performance target-gap / lazy lib-member cross-arena delegation
- Baseline on `origin/main` `9c2784b1cb`: `/tmp/tsz-studio-b-12583-main-vite-quick-20260604.json`; winner report `/tmp/tsz-studio-b-12583-main-vite-quick-20260604.tsgo-winners.json`.
- Current head `8307ec2631`: `/tmp/tsz-studio-b-12583-vite-quick-20260604.json`; winner report `/tmp/tsz-studio-b-12583-vite-quick-20260604.tsgo-winners.json`.
- Timing result: `tsz` 79.02ms -> 69.67ms for `vite-vanilla-ts-app`; diagnostics stay green. `tsgo` still wins at 46.99ms on the current run, so this is an incremental target-gap reduction, not closure of the 2x gate.
- Attribution baseline/current: `/tmp/tsz-studio-b-12583-main-vite-perf-20260604.json` -> `/tmp/tsz-studio-b-12583-vite-perf-20260604.json`.
- Counter movement: `DelegateCrossArenaSymbol` calls 918 -> 881, misses 232 -> 222, `CheckerState::with_parent_cache` child checkers 232 -> 222, `compute_type_of_symbol` calls 1267 -> 1230, and the slowest `document.querySelector<HTMLDivElement>("#app")` statement 57.44ms -> 47.54ms.

## Verification
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo fmt --check -p tsz-checker`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib lazy_lib_member_access_tests --no-fail-fast`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test global_augmentation_lib_interface_merge_tests --no-fail-fast`
- `scripts/safe-run.sh --limit 75% -- cargo build --profile dist-fast -p tsz-cli --bin tsz`
- `TSZ=$PWD/.target/dist-fast/tsz TSGO=/Users/mohsen/.codex/worktrees/25b5/tsz/.target-bench/tools/tsgo/node_modules/.bin/tsgo TSC=/Users/mohsen/.codex/worktrees/25b5/tsz/.target-bench/tools/tsc/node_modules/.bin/tsc EXTERNAL_BENCH_DIR=/Users/mohsen/.codex/worktrees/25b5/tsz/.target-bench/external TSZ_BENCH_PROJECT_PEAK_RSS=1 scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^vite-vanilla-ts-app$' --json-file /tmp/tsz-studio-b-12583-vite-quick-20260604.json`
- `node scripts/bench/tsgo-winner-report.mjs /tmp/tsz-studio-b-12583-vite-quick-20260604.json /tmp/tsz-studio-b-12583-vite-quick-20260604.tsgo-winners.json`
- `scripts/safe-run.sh --limit 75% -- cargo build --profile dist-fast -p tsz-cli --bin tsz --features perf-tools`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh .target/dist-fast/tsz --extendedDiagnostics --perf-counters-json /tmp/tsz-studio-b-12583-vite-perf-20260604.json --noEmit -p /Users/mohsen/.codex/worktrees/25b5/tsz/.target-bench/external/vite-vanilla-ts-live/tsconfig.json`
- `python3 scripts/perf/query-perf-counters.py --json /tmp/tsz-studio-b-12583-vite-perf-20260604.json --baseline /tmp/tsz-studio-b-12583-main-vite-perf-20260604.json`

## Coordination Notes
- Extracted from #12516 to make the one-file Vite improvement independently reviewable and landable.
- If this PR lands first, #12516 should drop or rebase away this slice before it is marked ready.
- Known residual: Vite remains below the 2x target; next Studio-B slice should investigate direct actual-lib value annotation preservation for `document: Document` rather than inherited method-overload lowering, which was tested on #12516 and regressed attribution.
- Ready for full CI/manager review; no self-queue action requested before exact-head checks pass.
- AgentName: Studio-B
