### PR TITLE
perf(checker): preserve lazy lib value annotations

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs
@@ -340,6 +340,71 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|ident| ident.escaped_text == name)
     }
 
+    fn direct_actual_lib_value_annotation_symbol_type(
+        &mut self,
+        sym_id: SymbolId,
+        symbol: &tsz_binder::Symbol,
+        delegate_arena: &NodeArena,
+    ) -> Option<(TypeId, Vec<TypeParamInfo>)> {
+        if !symbol.has_any_flags(symbol_flags::VARIABLE)
+            || symbol.has_any_flags(symbol_flags::TYPE | symbol_flags::MODULE | symbol_flags::ALIAS)
+            || symbol.declarations.len() != 1
+        {
+            return None;
+        }
+
+        let decl_idx = symbol.declarations[0];
+        let mut builtin_lib_arena = None;
+        if let Some(declaration_arenas) = self.ctx.binder.declaration_arenas.get(&(sym_id, decl_idx))
+        {
+            for arena in declaration_arenas.iter().map(AsRef::as_ref) {
+                if !is_builtin_lib_declaration_arena(arena) {
+                    continue;
+                }
+                if builtin_lib_arena.replace(arena).is_some() {
+                    return None;
+                }
+            }
+        }
+        if builtin_lib_arena.is_none() && is_builtin_lib_declaration_arena(delegate_arena) {
+            builtin_lib_arena = Some(delegate_arena);
+        }
+
+        let arena = builtin_lib_arena?;
+        let declaration = arena
+            .get(decl_idx)
+            .and_then(|node| arena.get_variable_declaration(node))?;
+        let annotation = declaration.type_annotation.into_option()?;
+        let type_ref = arena
+            .get(annotation)
+            .filter(|node| node.kind == syntax_kind_ext::TYPE_REFERENCE)
+            .and_then(|node| arena.get_type_ref(node))?;
+        if type_ref
+            .type_arguments
+            .as_ref()
+            .is_some_and(|args| !args.nodes.is_empty())
+        {
+            return None;
+        }
+        let name = arena
+            .get(type_ref.type_name)
+            .and_then(|name_node| arena.get_identifier(name_node))
+            .map(|ident| ident.escaped_text.as_str())?;
+        if common::is_compiler_managed_type(name) || self.ctx.file_local_type_shadow_for_lib_name(name)
+        {
+            return None;
+        }
+
+        let def_id = self.resolve_actual_lib_name_to_def_id_for_lowering(name)?;
+        let lazy_type = self.ctx.types.lazy(def_id);
+        self.lazy_lib_member_receiver_def_id(lazy_type)?;
+        self.ctx.symbol_types.insert(sym_id, lazy_type);
+        self.ctx
+            .lib_delegation_cache
+            .insert_symbol_type(sym_id, (lazy_type, Vec::new()));
+        Some((lazy_type, Vec::new()))
+    }
+
     fn direct_actual_lib_type_alias_body(
         &mut self,
         sym_id: SymbolId,
@@ -497,17 +562,24 @@ impl<'a> CheckerState<'a> {
             return Some(result);
         }
 
+        let delegate_arena = delegate_arena?;
         if needs_cross_file_delegation
             || delegate_arena_source != CrossArenaSymbolMissSource::SymbolArena
-            || !delegate_arena.is_some_and(is_direct_actual_lib_declaration_arena)
             || !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
         {
             return None;
         }
 
-        let delegate_arena = delegate_arena?;
         let symbol = self.get_cross_file_symbol(sym_id)?.clone();
         let name = symbol.escaped_name.clone();
+        if let Some(result) =
+            self.direct_actual_lib_value_annotation_symbol_type(sym_id, &symbol, delegate_arena)
+        {
+            return Some(result);
+        }
+        if !is_direct_actual_lib_declaration_arena(delegate_arena) {
+            return None;
+        }
         let intl_namespace_export =
             self.symbol_is_actual_lib_namespace_export("Intl", &name, sym_id);
         if !symbol.has_any_flags(symbol_flags::TYPE) {

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
@@ -547,6 +547,52 @@ fn direct_value_merged_builtin_dom_interface_symbol_type_returns_type_position_l
         "value-merged DOM interfaces with non-void method returns should stay on the existing child/interface path",
     );
 
+    let document_value_sym_id = state
+        .ctx
+        .binder
+        .file_locals
+        .get("document")
+        .expect("document should resolve to a lib value symbol");
+    let document_value_arena = state
+        .ctx
+        .binder
+        .symbol_arenas
+        .get(&document_value_sym_id)
+        .map(std::convert::AsRef::as_ref);
+    let (document_value, document_value_params) = state
+        .direct_actual_lib_symbol_type(
+            document_value_sym_id,
+            CrossArenaSymbolMissSource::SymbolArena,
+            document_value_arena,
+            false,
+        )
+        .expect("document should lower to its annotated lazy lib interface");
+    assert!(
+        document_value_params.is_empty(),
+        "document should not expose type parameters",
+    );
+    let document_def = state
+        .resolve_actual_lib_name_to_def_id_for_lowering("Document")
+        .expect("Document should resolve to a lib definition");
+    assert_eq!(
+        crate::query_boundaries::common::lazy_def_id(state.ctx.types, document_value),
+        Some(document_def),
+        "document should preserve its Document annotation as a Lazy interface",
+    );
+    assert!(
+        state
+            .lazy_lib_member_receiver_def_id(document_value)
+            .is_some(),
+        "the returned lazy interface should remain eligible for lazy member lookup",
+    );
+    let (cached_document_value, cached_document_value_params) = state
+        .ctx
+        .lib_delegation_cache
+        .symbol_type(document_value_sym_id)
+        .expect("direct annotation path should populate the delegation cache");
+    assert_eq!(cached_document_value, document_value);
+    assert!(cached_document_value_params.is_empty());
+
     let error_sym_id = state
         .ctx
         .binder


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance / benchmark blocker micro-slice

## Invariant
When an actual/cloned builtin-lib value symbol has exactly one builtin-lib variable declaration whose annotation is a bare type reference to an unshadowed, unaugmented, non-generic lib interface, tsz may preserve the annotation as `Lazy(DefId)` through the checker cross-file direct actual-lib value path. Values with multiple declarations, missing/non-bare annotations, type arguments, compiler-managed targets, local type shadows, or lazy-member-ineligible receivers fall back to the existing materialization path.

## Scope
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs`
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs`

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: performance; DOM lib global value/member access
- Evidence: focused Vite quick timing improved from the post-#12583 baseline `tsz 69.67ms / tsgo 46.99ms` to exact rebased head `tsz 67.31ms / tsgo 46.93ms`; row remains a `tsgo` winner. Attribution counters move `DelegateCrossArenaSymbol` misses `222 -> 221`, `CheckerState::with_parent_cache` child checkers `222 -> 221`, and `compute_type_of_symbol` calls `1230 -> 1220`.

## Verification
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo fmt --check -p tsz-checker`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib direct_value_merged_builtin_dom_interface_symbol_type_returns_type_position_lazy_ref --no-fail-fast`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib direct_actual_lib_symbol_type_handles_selected_value_interfaces --no-fail-fast`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib direct_cross_file_interface_lowering_handles_simple_builtin_dom_interfaces --no-fail-fast`
- `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli --bin tsz`
- `TSZ=$PWD/.target/dist-fast/tsz TSGO=/Users/mohsen/.codex/worktrees/25b5/tsz/.target-bench/tools/tsgo/node_modules/.bin/tsgo TSC=/Users/mohsen/.codex/worktrees/25b5/tsz/.target-bench/tools/tsc/node_modules/.bin/tsc EXTERNAL_BENCH_DIR=/Users/mohsen/.codex/worktrees/25b5/tsz/.target-bench/external TSZ_BENCH_PROJECT_PEAK_RSS=1 scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^vite-vanilla-ts-app$' --json-file /tmp/tsz-studio-b-lib-value-lazy-vite-quick-rebased-20260604.json`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json /tmp/tsz-studio-b-lib-value-lazy-vite-perf-rebased-20260604.json --noEmit -p /Users/mohsen/.codex/worktrees/25b5/tsz/.target-bench/external/vite-vanilla-ts-live/tsconfig.json`
- `python3 scripts/perf/query-perf-counters.py --json /tmp/tsz-studio-b-lib-value-lazy-vite-perf-rebased-20260604.json --baseline /tmp/tsz-studio-b-12583-vite-perf-20260604.json`

## Coordination Notes
- Ready for manager review; not queued by Studio-B.
- Rebased onto current `origin/main` at head `080b3507f8` after #12587. This intentionally leaves `document.querySelector<HTMLDivElement>("#app")` method-overload work for a follow-up because `querySelector` has multiple generic overloads and should not be handled by a brittle method shortcut.
- #12516 remains draft and should still rebase/drop the #12583 slice independently before readiness.
