### PR TITLE
refactor(emitter): split commonjs transform tests

### DIFF
--- a/crates/tsz-emitter/src/transforms/module_commonjs.rs
+++ b/crates/tsz-emitter/src/transforms/module_commonjs.rs
@@ -1967,50 +1967,5 @@ fn collect_binding_names_from_element(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::collect_export_names;
-    use tsz_parser::ParserState;
-
-    /// When a module has two `export namespace N {}` blocks (merged declarations),
-    /// `collect_export_names` must return `N` only once, matching tsc's behavior
-    /// for the `exports.N = void 0` initialization line.
-    #[test]
-    fn collect_export_names_deduplicates_merged_namespaces() {
-        let source = "export namespace N { export const a = 1; }\nexport namespace N { export const b = 2; }\n";
-
-        let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-        let root = parser.parse_source_file();
-
-        let sf_node = parser.arena.get(root).unwrap();
-        let stmts = parser.arena.get_source_file(sf_node).unwrap();
-        let names = collect_export_names(&parser.arena, &stmts.statements.nodes);
-
-        let n_count = names.iter().filter(|n| n.as_str() == "N").count();
-        assert_eq!(
-            n_count, 1,
-            "Merged namespace declarations should produce exactly one export name, got: {names:?}"
-        );
-    }
-
-    /// When exports are unique, deduplication should not remove anything.
-    #[test]
-    fn collect_export_names_preserves_unique_names() {
-        let source = "export const a = 1;\nexport const b = 2;\nexport function c() {}\n";
-
-        let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
-        let root = parser.parse_source_file();
-
-        let sf_node = parser.arena.get(root).unwrap();
-        let stmts = parser.arena.get_source_file(sf_node).unwrap();
-        let names = collect_export_names(&parser.arena, &stmts.statements.nodes);
-
-        assert_eq!(
-            names.len(),
-            3,
-            "All unique names should be preserved: {names:?}"
-        );
-        assert!(names.contains(&"a".to_string()));
-        assert!(names.contains(&"b".to_string()));
-        assert!(names.contains(&"c".to_string()));
-    }
-}
+#[path = "module_commonjs/tests.rs"]
+mod tests;

--- a/crates/tsz-emitter/src/transforms/module_commonjs/tests.rs
+++ b/crates/tsz-emitter/src/transforms/module_commonjs/tests.rs
@@ -1,0 +1,46 @@
+use super::collect_export_names;
+use tsz_parser::ParserState;
+
+/// When a module has two `export namespace N {}` blocks (merged declarations),
+/// `collect_export_names` must return `N` only once, matching tsc's behavior
+/// for the `exports.N = void 0` initialization line.
+#[test]
+fn collect_export_names_deduplicates_merged_namespaces() {
+    let source =
+        "export namespace N { export const a = 1; }\nexport namespace N { export const b = 2; }\n";
+
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let sf_node = parser.arena.get(root).unwrap();
+    let stmts = parser.arena.get_source_file(sf_node).unwrap();
+    let names = collect_export_names(&parser.arena, &stmts.statements.nodes);
+
+    let n_count = names.iter().filter(|n| n.as_str() == "N").count();
+    assert_eq!(
+        n_count, 1,
+        "Merged namespace declarations should produce exactly one export name, got: {names:?}"
+    );
+}
+
+/// When exports are unique, deduplication should not remove anything.
+#[test]
+fn collect_export_names_preserves_unique_names() {
+    let source = "export const a = 1;\nexport const b = 2;\nexport function c() {}\n";
+
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let sf_node = parser.arena.get(root).unwrap();
+    let stmts = parser.arena.get_source_file(sf_node).unwrap();
+    let names = collect_export_names(&parser.arena, &stmts.statements.nodes);
+
+    assert_eq!(
+        names.len(),
+        3,
+        "All unique names should be preserved: {names:?}"
+    );
+    assert!(names.contains(&"a".to_string()));
+    assert!(names.contains(&"b".to_string()));
+    assert!(names.contains(&"c".to_string()));
+}


### PR DESCRIPTION
AgentName: M1-Opus

## AgentName
M1-Opus

## Track
tech-debt / file-size hygiene

## Invariant
Behavior unchanged: CommonJS module/export transform behavior stays owned by the emitter transform; this PR only moves the existing transform unit tests into a sibling test module.

## Scope
- Split the `#[cfg(test)]` CommonJS transform tests out of `crates/tsz-emitter/src/transforms/module_commonjs.rs`.
- Add `crates/tsz-emitter/src/transforms/module_commonjs/tests.rs` with the moved tests.
- Keep both resulting emitter files below the 2000-line shard limit.

## Project Corpus Impact
- Row: none
- Bug family: none
- Evidence: test-only emitter refactor; refreshed head `0e57616e140287ffe1166b2be60b4ef5a0fedecf` passed focused local verification.

## Verification
- `cargo fmt`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-emitter`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter module_commonjs` -> 42 passed, 4126 skipped
- `wc -l crates/tsz-emitter/src/transforms/module_commonjs.rs crates/tsz-emitter/src/transforms/module_commonjs/tests.rs` -> `1971` / `46`

## Coordination Notes
Focused follow-up for the >2k-line split campaign. Refreshed onto `origin/main` at `1659c4b614`. No conformance, emit baseline, fourslash, or project-corpus suites run locally per repo guidance; ready-review CI owns broad coverage.
