### PR TITLE
refactor(emitter): split IR printer predicates

### DIFF
--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -30,6 +30,8 @@ mod ir_printer_generator_state;
 mod ir_printer_helpers;
 #[path = "ir_printer_namespace.rs"]
 mod ir_printer_namespace;
+#[path = "ir_printer/node_predicates.rs"]
+mod ir_printer_node_predicates;
 #[path = "ir_printer_recovery.rs"]
 mod ir_printer_recovery;
 use ir_printer_namespace::NamespaceIifeContext;
@@ -95,43 +97,6 @@ pub struct IRPrinter<'a> {
 }
 
 impl<'a> IRPrinter<'a> {
-    /// Check if a generator switch case should stay on the `case N:` line.
-    fn is_generator_inline_case_statement(node: &IRNode) -> bool {
-        match node {
-            IRNode::ThrowStatement(expr) => Self::is_generator_inline_throw_expression(expr),
-            IRNode::ReturnStatement(Some(expr)) => {
-                matches!(expr.as_ref(), IRNode::GeneratorOp { .. })
-            }
-            _ => false,
-        }
-    }
-
-    fn is_generator_break_return(node: &IRNode) -> bool {
-        matches!(
-            node,
-            IRNode::ReturnStatement(Some(expr))
-                if matches!(expr.as_ref(), IRNode::GeneratorOp { opcode: 3, .. })
-        )
-    }
-
-    fn is_generator_sent_assignment(node: &IRNode) -> bool {
-        matches!(
-            node,
-            IRNode::ExpressionStatement(expr)
-                if matches!(
-                    expr.as_ref(),
-                    IRNode::BinaryExpr { right, .. } if matches!(right.as_ref(), IRNode::GeneratorSent)
-                )
-        )
-    }
-
-    const fn is_generator_inline_throw_expression(expr: &IRNode) -> bool {
-        matches!(
-            expr,
-            IRNode::Identifier(_) | IRNode::CallExpr { .. } | IRNode::GeneratorSent
-        )
-    }
-
     pub(crate) fn emit_es5_class_expression(
         &mut self,
         name: &str,
@@ -236,16 +201,6 @@ impl<'a> IRPrinter<'a> {
         )
     }
 
-    fn should_indent_sequence_child(node: &IRNode) -> bool {
-        match node {
-            IRNode::NamespaceIIFE {
-                skip_sequence_indent,
-                ..
-            } => !skip_sequence_indent,
-            _ => true,
-        }
-    }
-
     fn generator_state_name_for_function_body(body: &[IRNode]) -> Option<&'static str> {
         if !body
             .iter()
@@ -271,15 +226,6 @@ impl<'a> IRPrinter<'a> {
         }
 
         (!hoisted_vars.is_empty()).then(|| Self::generator_state_name_for_hoisted(&hoisted_vars))
-    }
-
-    fn is_noop_statement(node: &IRNode) -> bool {
-        match node {
-            IRNode::Sequence(nodes) if nodes.is_empty() => true,
-            IRNode::EmptyStatement => true,
-            IRNode::Raw(text) => text.trim().is_empty(),
-            _ => false,
-        }
     }
 
     fn write_embedded_output(&mut self, output: &str) {

--- a/crates/tsz-emitter/src/transforms/ir_printer/node_predicates.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer/node_predicates.rs
@@ -1,0 +1,59 @@
+use super::{IRNode, IRPrinter};
+
+impl IRPrinter<'_> {
+    /// Check if a generator switch case should stay on the `case N:` line.
+    pub(super) fn is_generator_inline_case_statement(node: &IRNode) -> bool {
+        match node {
+            IRNode::ThrowStatement(expr) => Self::is_generator_inline_throw_expression(expr),
+            IRNode::ReturnStatement(Some(expr)) => {
+                matches!(expr.as_ref(), IRNode::GeneratorOp { .. })
+            }
+            _ => false,
+        }
+    }
+
+    pub(super) fn is_generator_break_return(node: &IRNode) -> bool {
+        matches!(
+            node,
+            IRNode::ReturnStatement(Some(expr))
+                if matches!(expr.as_ref(), IRNode::GeneratorOp { opcode: 3, .. })
+        )
+    }
+
+    pub(super) fn is_generator_sent_assignment(node: &IRNode) -> bool {
+        matches!(
+            node,
+            IRNode::ExpressionStatement(expr)
+                if matches!(
+                    expr.as_ref(),
+                    IRNode::BinaryExpr { right, .. } if matches!(right.as_ref(), IRNode::GeneratorSent)
+                )
+        )
+    }
+
+    const fn is_generator_inline_throw_expression(expr: &IRNode) -> bool {
+        matches!(
+            expr,
+            IRNode::Identifier(_) | IRNode::CallExpr { .. } | IRNode::GeneratorSent
+        )
+    }
+
+    pub(super) fn should_indent_sequence_child(node: &IRNode) -> bool {
+        match node {
+            IRNode::NamespaceIIFE {
+                skip_sequence_indent,
+                ..
+            } => !skip_sequence_indent,
+            _ => true,
+        }
+    }
+
+    pub(super) fn is_noop_statement(node: &IRNode) -> bool {
+        match node {
+            IRNode::Sequence(nodes) if nodes.is_empty() => true,
+            IRNode::EmptyStatement => true,
+            IRNode::Raw(text) => text.trim().is_empty(),
+            _ => false,
+        }
+    }
+}


### PR DESCRIPTION
AgentName: M1-Opus

## Track
tech-debt / file-size hygiene

## Invariant
Behavior unchanged: IR string emission stays owned by the emitter IR printer; this PR only moves small IR-node classification predicates into a sibling helper module.

## Scope
- Split generator/sequence/no-op predicate helpers out of `crates/tsz-emitter/src/transforms/ir_printer.rs`.
- Add `crates/tsz-emitter/src/transforms/ir_printer/node_predicates.rs` with the moved `IRPrinter` helper methods.
- Keep both resulting emitter files below the 2000-line shard limit.

## Project Corpus Impact
- Row: none
- Bug family: none
- Evidence: emitter refactor only; refreshed head `fdedf401d48f095209d7cf727e09f474f669bc71` passed focused local verification.

## Verification
- `cargo fmt`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-emitter`
- `wc -l crates/tsz-emitter/src/transforms/ir_printer.rs crates/tsz-emitter/src/transforms/ir_printer/node_predicates.rs` -> `1949` / `59`

## Coordination Notes
Focused follow-up for the >2k-line split campaign. Refreshed onto `origin/main` at `1659c4b614`. No conformance, emit baseline, fourslash, or project-corpus suites run locally per repo guidance; ready-review CI owns broad coverage.
