### PR TITLE
refactor(emitter): split private-field new helpers

### DIFF
--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs
@@ -3,6 +3,9 @@ use crate::transforms::private_fields_es5::get_private_field_name;
 use tsz_parser::parser::{NodeIndex, NodeList, node::Node, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 
+#[path = "private_fields/invalid_new.rs"]
+mod invalid_new;
+
 /// Result of extracting a private field access from a (possibly parenthesized) node.
 #[derive(Clone)]
 struct PrivateFieldAccess {
@@ -1908,99 +1911,5 @@ impl<'a> Printer<'a> {
         if self.new_expression_has_explicit_parens(node, call.expression) {
             self.write("()");
         }
-    }
-
-    fn emit_invalid_new_optional_chain(
-        &mut self,
-        callee: NodeIndex,
-        args: Option<&NodeList>,
-    ) -> bool {
-        let mut tail = Vec::new();
-        let Some((access_kind, base, name_or_argument)) =
-            self.collect_invalid_new_optional_access(callee, &mut tail)
-        else {
-            return false;
-        };
-
-        let needs_parens = self.ctx.flags.optional_chain_needs_parens;
-        if needs_parens {
-            self.open_paren();
-            self.ctx.flags.optional_chain_needs_parens = false;
-        }
-        let temp = self.make_unique_name_hoisted();
-        self.open_paren();
-        self.write(&temp);
-        self.write(" = new ");
-        let prev_new = self.paren_in_new_callee;
-        self.paren_in_new_callee = true;
-        self.emit(base);
-        self.paren_in_new_callee = prev_new;
-        self.close_paren();
-        self.write(" === null || ");
-        self.write(&temp);
-        self.write(" === void 0 ? void 0 : ");
-        self.write(&temp);
-        self.emit_optional_access_segment(access_kind, name_or_argument);
-        self.emit_optional_chain_tail(&tail);
-        if let Some(args) = args {
-            self.open_paren();
-            let valid_args: Vec<_> = args.nodes.iter().copied().filter(|n| n.is_some()).collect();
-            self.emit_comma_separated(&valid_args);
-            self.close_paren();
-        }
-        if needs_parens {
-            self.close_paren();
-        }
-        true
-    }
-
-    fn collect_invalid_new_optional_access(
-        &self,
-        idx: NodeIndex,
-        tail: &mut Vec<OptionalChainSegment>,
-    ) -> Option<(u16, NodeIndex, NodeIndex)> {
-        let node = self.arena.get(idx)?;
-
-        if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
-            && let Some(paren) = self.arena.get_parenthesized(node)
-        {
-            return self.collect_invalid_new_optional_access(paren.expression, tail);
-        }
-
-        if (node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-            || node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
-            && let Some(access) = self.arena.get_access_expr(node)
-        {
-            if access.question_dot_token {
-                return Some((node.kind, access.expression, access.name_or_argument));
-            }
-
-            if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-                tail.push(OptionalChainSegment::Property(access.name_or_argument));
-            } else {
-                tail.push(OptionalChainSegment::Element(access.name_or_argument));
-            }
-            return self.collect_invalid_new_optional_access(access.expression, tail);
-        }
-
-        None
-    }
-
-    fn emit_invalid_new_type_assertion_callee(&mut self, expression: NodeIndex) -> bool {
-        let Some(expr_node) = self.arena.get(expression) else {
-            return false;
-        };
-        if expr_node.kind != syntax_kind_ext::TYPE_ASSERTION {
-            return false;
-        }
-        let Some(assertion) = self.arena.get_type_assertion(expr_node) else {
-            return false;
-        };
-
-        self.write(" < ");
-        self.emit(assertion.type_node);
-        self.write(" > ");
-        self.emit(assertion.expression);
-        true
     }
 }

--- a/crates/tsz-emitter/src/emitter/expressions/core/private_fields/invalid_new.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/core/private_fields/invalid_new.rs
@@ -1,0 +1,97 @@
+use super::{NodeIndex, NodeList, OptionalChainSegment, Printer, syntax_kind_ext};
+
+impl<'a> Printer<'a> {
+    pub(super) fn emit_invalid_new_optional_chain(
+        &mut self,
+        callee: NodeIndex,
+        args: Option<&NodeList>,
+    ) -> bool {
+        let mut tail = Vec::new();
+        let Some((access_kind, base, name_or_argument)) =
+            self.collect_invalid_new_optional_access(callee, &mut tail)
+        else {
+            return false;
+        };
+
+        let needs_parens = self.ctx.flags.optional_chain_needs_parens;
+        if needs_parens {
+            self.open_paren();
+            self.ctx.flags.optional_chain_needs_parens = false;
+        }
+        let temp = self.make_unique_name_hoisted();
+        self.open_paren();
+        self.write(&temp);
+        self.write(" = new ");
+        let prev_new = self.paren_in_new_callee;
+        self.paren_in_new_callee = true;
+        self.emit(base);
+        self.paren_in_new_callee = prev_new;
+        self.close_paren();
+        self.write(" === null || ");
+        self.write(&temp);
+        self.write(" === void 0 ? void 0 : ");
+        self.write(&temp);
+        self.emit_optional_access_segment(access_kind, name_or_argument);
+        self.emit_optional_chain_tail(&tail);
+        if let Some(args) = args {
+            self.open_paren();
+            let valid_args: Vec<_> = args.nodes.iter().copied().filter(|n| n.is_some()).collect();
+            self.emit_comma_separated(&valid_args);
+            self.close_paren();
+        }
+        if needs_parens {
+            self.close_paren();
+        }
+        true
+    }
+
+    fn collect_invalid_new_optional_access(
+        &self,
+        idx: NodeIndex,
+        tail: &mut Vec<OptionalChainSegment>,
+    ) -> Option<(u16, NodeIndex, NodeIndex)> {
+        let node = self.arena.get(idx)?;
+
+        if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION
+            && let Some(paren) = self.arena.get_parenthesized(node)
+        {
+            return self.collect_invalid_new_optional_access(paren.expression, tail);
+        }
+
+        if (node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            || node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
+            && let Some(access) = self.arena.get_access_expr(node)
+        {
+            if access.question_dot_token {
+                return Some((node.kind, access.expression, access.name_or_argument));
+            }
+
+            if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+                tail.push(OptionalChainSegment::Property(access.name_or_argument));
+            } else {
+                tail.push(OptionalChainSegment::Element(access.name_or_argument));
+            }
+            return self.collect_invalid_new_optional_access(access.expression, tail);
+        }
+
+        None
+    }
+
+    pub(super) fn emit_invalid_new_type_assertion_callee(&mut self, expression: NodeIndex) -> bool {
+        let Some(expr_node) = self.arena.get(expression) else {
+            return false;
+        };
+        if expr_node.kind != syntax_kind_ext::TYPE_ASSERTION {
+            return false;
+        }
+        let Some(assertion) = self.arena.get_type_assertion(expr_node) else {
+            return false;
+        };
+
+        self.write(" < ");
+        self.emit(assertion.type_node);
+        self.write(" > ");
+        self.emit(assertion.expression);
+        true
+    }
+}


### PR DESCRIPTION
AgentName: M1-Opus

## AgentName
M1-Opus

## Track
tech-debt / file-size hygiene

## Invariant
Behavior unchanged; private-field `new` expression recovery remains owned by the emitter expression/private-fields layer. This PR only moves invalid `new` optional-chain and type-assertion callee helpers to a sibling module.

## Scope
- Split invalid `new` optional-chain/type-assertion helper methods out of `crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs`.
- Add `crates/tsz-emitter/src/emitter/expressions/core/private_fields/invalid_new.rs`.
- Keep both hand-authored files below the 2000-line cap.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: emitter refactor only; refreshed head `e2eead33fb886d2614188b02021f8ce5fcf9198e` passed focused local verification.

## Verification
- `cargo fmt`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-emitter`
- `wc -l crates/tsz-emitter/src/emitter/expressions/core/private_fields.rs crates/tsz-emitter/src/emitter/expressions/core/private_fields/invalid_new.rs` -> `1915` / `97`

## Coordination Notes
Focused follow-up for the over-2000-line split campaign. Refreshed onto `origin/main` at `1659c4b614`; no conformance, emit baseline, fourslash, or project-corpus suites were run locally; ready-review CI owns broad coverage.
