### PR TITLE
perf(checker): prune explicit type-arg overloads cheaply

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -705,6 +705,9 @@ mod excess_prop_object_union_display_tests;
 #[path = "tests/explicit_alias_constraint_relation_routing_arch_tests.rs"]
 mod explicit_alias_constraint_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/explicit_type_arg_overload_pruning_tests.rs"]
+mod explicit_type_arg_overload_pruning_tests;
+#[cfg(test)]
 #[path = "../tests/file_session_switch_to_file_tests.rs"]
 mod file_session_switch_to_file_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_resolution/constructors/callable_type_arguments.rs
+++ b/crates/tsz-checker/src/state/type_resolution/constructors/callable_type_arguments.rs
@@ -1,8 +1,10 @@
+use crate::query_boundaries::common as common_query;
 use crate::query_boundaries::state::type_resolution as query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeList;
 use tsz_solver::computation::TypeSubstitution;
-use tsz_solver::{CallableShape, TypeId};
+use tsz_solver::def::DefKind;
+use tsz_solver::{CallSignature, CallableShape, TypeId};
 
 impl<'a> CheckerState<'a> {
     /// Apply explicit type arguments to a callable type for function calls.
@@ -66,23 +68,17 @@ impl<'a> CheckerState<'a> {
             }
             query::SignatureTypeKind::Callable(shape_id) => {
                 let shape = self.ctx.types.callable_shape(shape_id);
+                let call_signatures = shape.call_signatures.clone();
+                let construct_signatures = shape.construct_signatures.clone();
 
                 // Find signatures that can accept the supplied explicit type
                 // arguments. Exact arity for instantiation expressions is
                 // checked before this path; ordinary calls may supply a prefix
                 // when remaining type parameters have defaults or can infer.
-                let matching_calls: Vec<tsz_solver::CallSignature> = shape
-                    .call_signatures
-                    .iter()
-                    .filter(|&sig| sig.type_params.len() >= type_args.len())
-                    .cloned()
-                    .collect();
-                let matching_constructs: Vec<tsz_solver::CallSignature> = shape
-                    .construct_signatures
-                    .iter()
-                    .filter(|&sig| sig.type_params.len() >= type_args.len())
-                    .cloned()
-                    .collect();
+                let matching_calls =
+                    self.signatures_matching_explicit_type_args(&call_signatures, &type_args);
+                let matching_constructs =
+                    self.signatures_matching_explicit_type_args(&construct_signatures, &type_args);
 
                 if matching_calls.is_empty() && matching_constructs.is_empty() {
                     return callee_type;
@@ -274,5 +270,87 @@ impl<'a> CheckerState<'a> {
         } else {
             self.instantiate_signature(sig, &args)
         }
+    }
+
+    fn signatures_matching_explicit_type_args(
+        &mut self,
+        signatures: &[CallSignature],
+        type_args: &[TypeId],
+    ) -> Vec<CallSignature> {
+        let arity_matches: Vec<CallSignature> = signatures
+            .iter()
+            .filter(|sig| sig.type_params.len() >= type_args.len())
+            .cloned()
+            .collect();
+        let constraint_matches: Vec<CallSignature> = arity_matches
+            .iter()
+            .filter(|sig| {
+                !self.explicit_type_args_definitely_violate_signature_constraints(sig, type_args)
+            })
+            .cloned()
+            .collect();
+
+        if constraint_matches.is_empty() {
+            arity_matches
+        } else {
+            constraint_matches
+        }
+    }
+
+    fn explicit_type_args_definitely_violate_signature_constraints(
+        &mut self,
+        sig: &CallSignature,
+        type_args: &[TypeId],
+    ) -> bool {
+        for (param, &type_arg) in sig.type_params.iter().zip(type_args.iter()) {
+            let Some(constraint) = param.constraint else {
+                continue;
+            };
+            if matches!(type_arg, TypeId::ANY | TypeId::UNKNOWN | TypeId::ERROR) {
+                continue;
+            }
+
+            let substitution =
+                TypeSubstitution::from_args(self.ctx.types, &sig.type_params, type_args);
+            let constraint = crate::query_boundaries::common::instantiate_type_preserving_meta(
+                self.ctx.types,
+                constraint,
+                &substitution,
+            );
+            let constraint = self.resolve_lazy_type(constraint);
+            if query::contains_type_parameters(self.ctx.types.as_type_database(), constraint) {
+                continue;
+            }
+            let constraint = self.evaluate_type_for_assignability(constraint);
+            let db = self.ctx.types.as_type_database();
+            if !common_query::is_literal_or_primitive_or_compound_of_those(db, constraint) {
+                continue;
+            }
+
+            if common_query::contains_type_parameters(db, type_arg)
+                || common_query::enum_def_id(db, type_arg).is_some()
+            {
+                continue;
+            }
+
+            if !common_query::is_literal_or_primitive_or_compound_of_those(db, type_arg) {
+                if query::lazy_def_id(db, type_arg).is_some_and(|def_id| {
+                    matches!(
+                        self.ctx.definition_store.get_kind(def_id),
+                        Some(DefKind::Class | DefKind::Interface)
+                    )
+                }) || common_query::is_object_like_type(db, type_arg)
+                {
+                    return true;
+                }
+                continue;
+            }
+
+            let outcome = self.type_arg_constraint_no_weak_relation_outcome(type_arg, constraint);
+            if !outcome.related && !outcome.depth_exceeded && !outcome.iteration_exceeded {
+                return true;
+            }
+        }
+        false
     }
 }

--- a/crates/tsz-checker/src/tests/explicit_type_arg_overload_pruning_tests.rs
+++ b/crates/tsz-checker/src/tests/explicit_type_arg_overload_pruning_tests.rs
@@ -1,0 +1,62 @@
+//! Regression tests for explicit type-argument overload pruning.
+//!
+//! Structural rule: when a call supplies explicit type arguments, overloads
+//! whose type-parameter constraints cannot accept those arguments are not viable
+//! candidates for the instantiated call signature set. Ambiguous or diagnostic
+//! cases still fall back to the full overload family.
+
+use crate::test_utils::{check_source_diagnostics, diagnostic_codes};
+
+#[test]
+fn explicit_type_arg_constraint_prunes_wrongly_ordered_overload() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+declare function choose<TValue extends number>(value: unknown): "number";
+declare function choose<TItem extends string>(value: unknown): "string";
+
+const selected: "string" = choose<"literal">(0);
+"#,
+    );
+
+    let codes = diagnostic_codes(&diagnostics);
+    assert!(
+        !codes.contains(&2322),
+        "explicit string type argument should prune the number-constrained overload, got {diagnostics:?}",
+    );
+}
+
+#[test]
+fn explicit_type_arg_constraint_pruning_varies_binder_names() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+declare function choose<TNumber extends number>(value: unknown): "number";
+declare function choose<TText extends string>(value: unknown): "string";
+
+const selected: "number" = choose<7>("value");
+"#,
+    );
+
+    let codes = diagnostic_codes(&diagnostics);
+    assert!(
+        !codes.contains(&2322),
+        "explicit number type argument should prune the string-constrained overload, got {diagnostics:?}",
+    );
+}
+
+#[test]
+fn explicit_type_arg_pruning_keeps_multiple_viable_overloads_ordered() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+declare function choose<TSpecific extends "a" | "b">(value: unknown): "specific";
+declare function choose<TGeneral extends string>(value: unknown): "general";
+
+const selected: "specific" = choose<"a">(0);
+"#,
+    );
+
+    let codes = diagnostic_codes(&diagnostics);
+    assert!(
+        !codes.contains(&2322),
+        "multiple viable overloads should keep declaration order, got {diagnostics:?}",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Performance benchmark blocker; checker/type-resolution candidate pruning.

## Invariant
When a call supplies explicit type arguments and an overload candidate's type-parameter constraint is a concrete primitive/literal key space that the explicit argument cannot satisfy, tsz may skip instantiating that overload candidate. This PR changes the checker type-resolution owner for explicit callable type-argument application, using solver-backed/common query boundaries and falling back to the full overload family when the result is ambiguous, non-terminal, generic, enum-shaped, or would require a diagnostic-bearing relation.

## Scope
- `crates/tsz-checker/src/state/type_resolution/constructors/callable_type_arguments.rs`
- `crates/tsz-checker/src/tests/explicit_type_arg_overload_pruning_tests.rs`
- `crates/tsz-checker/src/lib.rs` test registration

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: explicit type-argument overload candidate over-instantiation on DOM-like overload sets.
- Evidence: quick row remains diagnostic-clean and avoids the first naive relation-probe regression; `tsz` quick mean `67.04ms` vs `tsgo` `45.86ms` in `/tmp/tsz-studio-b-explicit-typearg-prune-cheap-vite-quick-20260604.json`.
- 2x target report: `/tmp/tsz-studio-b-explicit-typearg-prune-cheap-vite-quick-20260604.tsgo-winners.json` has `rows_below_target: 1`, `target_gaps[0].name: vite-vanilla-ts-app`, and `target_gap_factor: 2.923680767553424`; this PR shrinks/protects the measured path but does not close the full 2x target gap.
- Attribution: `/tmp/tsz-studio-b-explicit-typearg-prune-cheap-vite-perf-20260604.json` keeps `DelegateCrossArenaSymbol` misses at `221`, `with_parent_cache` at `221`, and `compute_type_of_symbol` at `1220`, matching the post-#12589 baseline while avoiding the abandoned naive probe's `230`/`1261` regression.

## Verification
- `scripts/safe-run.sh cargo fmt --check -p tsz-checker`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib explicit_type_arg --no-fail-fast`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib generic_overloaded_call_with_explicit_type_args --no-fail-fast`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib dom_fuel_exhaustion_ts2322_tests --no-fail-fast`
- `git diff --check`
- `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli --bin tsz`
- `TSZ=$PWD/.target/dist-fast/tsz TSGO=/Users/mohsen/.codex/worktrees/25b5/tsz/.target-bench/tools/tsgo/node_modules/.bin/tsgo TSC=/Users/mohsen/.codex/worktrees/25b5/tsz/.target-bench/tools/tsc/node_modules/.bin/tsc EXTERNAL_BENCH_DIR=/Users/mohsen/.codex/worktrees/25b5/tsz/.target-bench/external TSZ_BENCH_PROJECT_PEAK_RSS=1 scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^vite-vanilla-ts-app$' --json-file /tmp/tsz-studio-b-explicit-typearg-prune-cheap-vite-quick-20260604.json`
- `node scripts/bench/tsgo-winner-report.mjs /tmp/tsz-studio-b-explicit-typearg-prune-cheap-vite-quick-20260604.json /tmp/tsz-studio-b-explicit-typearg-prune-cheap-vite-quick-20260604.tsgo-winners.json`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json /tmp/tsz-studio-b-explicit-typearg-prune-cheap-vite-perf-20260604.json --noEmit -p /Users/mohsen/.codex/worktrees/25b5/tsz/.target-bench/external/vite-vanilla-ts-live/tsconfig.json`

## Coordination Notes
- Ready for manager/queue-owner review; not queued by this implementation agent.
- Overlap check: no open PR on this branch; scoped to explicit call type-argument candidate construction and a new focused test module.
- `scripts/agents/ensure-agent-labels.sh --audit` currently fails only because canonical labels `agent:M1-D` and `agent:M4-C` are missing globally; it reports no open PR label problems and no noncanonical agent labels.
- Follow-up: this is a small safe slice, not the full path to beating `tsgo` on the Vite row; next likely work remains reducing DOM interface materialization in the `document.querySelector<HTMLDivElement>` main-statement path.