### PR TITLE
refactor(emitter): split ES5 spread array helpers

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -5,7 +5,6 @@
 //! tagged template support, and spread call lowering.
 
 use super::super::*;
-use super::helpers::ArraySegment;
 use super::helpers_class_expression_static::Es5StaticClassExpressionElement;
 use crate::emitter::core::PropertyNameEmit;
 use crate::emitter::declarations::class::replace_identifier;
@@ -13,6 +12,9 @@ use crate::transforms::emit_utils;
 use crate::transforms::ir::IRNode;
 use crate::transforms::ir_printer::IRPrinter;
 use std::sync::Arc;
+
+#[path = "helpers_async/spread.rs"]
+mod spread;
 
 impl<'a> Printer<'a> {
     fn next_arguments_capture_name(&mut self) -> String {
@@ -1909,132 +1911,6 @@ impl<'a> Printer<'a> {
         self.write(")");
     }
 
-    fn emit_spread_args_array(&mut self, args: &[NodeIndex]) {
-        // Build arguments array using __spreadArray for spread elements
-        if args.is_empty() {
-            self.write("[]");
-            return;
-        }
-
-        // Check if there are any spread elements
-        let has_spread = args
-            .iter()
-            .any(|&arg_idx| emit_utils::is_spread_element(self.arena, arg_idx));
-
-        if !has_spread {
-            // No spreads, just emit an array literal
-            self.write("[");
-            self.emit_comma_separated(args);
-            self.write("]");
-            return;
-        }
-
-        // Build segments by grouping consecutive non-spread and spread elements
-        let mut segments: Vec<ArraySegment> = Vec::new();
-        let mut current_start = 0;
-
-        for (i, &arg_idx) in args.iter().enumerate() {
-            if emit_utils::is_spread_element(self.arena, arg_idx) {
-                // Add non-spread segment before this spread
-                if current_start < i {
-                    segments.push(ArraySegment::Elements(&args[current_start..i]));
-                }
-                // Add the spread element
-                segments.push(ArraySegment::Spread(arg_idx));
-                current_start = i + 1;
-            }
-        }
-
-        // Add remaining elements after last spread
-        if current_start < args.len() {
-            segments.push(ArraySegment::Elements(&args[current_start..]));
-        }
-
-        // Emit using nested __spreadArray calls
-        self.emit_spread_segments(&segments);
-    }
-
-    fn emit_spread_segments(&mut self, segments: &[ArraySegment]) {
-        if segments.is_empty() {
-            self.write("[]");
-            return;
-        }
-
-        let wrap_spread_with_read = self.ctx.target_es5 && self.ctx.options.downlevel_iteration;
-
-        if segments.len() == 1 {
-            match &segments[0] {
-                ArraySegment::Spread(spread_idx) => {
-                    // Just a single spread with no other arguments:
-                    // TypeScript optimization - pass arrays directly unless
-                    // downlevelIteration requires __read for iterable inputs.
-                    if let Some(spread_node) = self.arena.get(*spread_idx) {
-                        if wrap_spread_with_read {
-                            self.write_helper("__spreadArray");
-                            self.write("([], ");
-                            self.emit_spread_expression_with_read(spread_node, true);
-                            self.write(", false)");
-                        } else {
-                            self.emit_spread_expression(spread_node);
-                        }
-                    }
-                }
-                ArraySegment::Elements(elems) => {
-                    // Just elements: [1, 2, 3]
-                    self.write("[");
-                    self.emit_comma_separated(elems);
-                    self.write("]");
-                }
-            }
-            return;
-        }
-
-        // Multiple segments: build nested __spreadArray calls
-        // Pattern: __spreadArray(__spreadArray(base, segment1, false), segment2, false)
-
-        // Open __spreadArray calls for all but the last segment
-        for _ in 0..segments.len() - 1 {
-            self.write_helper("__spreadArray");
-            self.write("(");
-        }
-
-        // Emit the first segment as a complete unit
-        match &segments[0] {
-            ArraySegment::Elements(elems) => {
-                self.write("[");
-                self.emit_comma_separated(elems);
-                self.write("]");
-            }
-            ArraySegment::Spread(spread_idx) => {
-                // First segment is spread: emit as __spreadArray([], spread, false)
-                self.write_helper("__spreadArray");
-                self.write("([], ");
-                if let Some(spread_node) = self.arena.get(*spread_idx) {
-                    self.emit_spread_expression_with_read(spread_node, wrap_spread_with_read);
-                }
-                self.write(", false)");
-            }
-        }
-
-        // Emit remaining segments - each closes one __spreadArray call
-        for segment in &segments[1..] {
-            match segment {
-                ArraySegment::Elements(elems) => {
-                    self.write(", [");
-                    self.emit_comma_separated(elems);
-                    self.write("], false)");
-                }
-                ArraySegment::Spread(spread_idx) => {
-                    self.write(", ");
-                    if let Some(spread_node) = self.arena.get(*spread_idx) {
-                        self.emit_spread_expression_with_read(spread_node, wrap_spread_with_read);
-                    }
-                    self.write(", false)");
-                }
-            }
-        }
-    }
-
     /// Emit a new expression with spread arguments, lowered for ES5.
     pub(in crate::emitter) fn emit_new_expression_es5_spread(&mut self, node: &Node) {
         let Some(new_expr) = self.arena.get_call_expr(node) else {
@@ -2074,79 +1950,5 @@ impl<'a> Printer<'a> {
         self.write(", ");
         self.emit_new_spread_args_array(&args.nodes);
         self.write("))()");
-    }
-
-    fn emit_new_spread_args_array(&mut self, args: &[NodeIndex]) {
-        let mut segments: Vec<ArraySegment> = Vec::new();
-        let mut current_start = 0;
-
-        for (i, &arg_idx) in args.iter().enumerate() {
-            if emit_utils::is_spread_element(self.arena, arg_idx) {
-                if current_start < i {
-                    segments.push(ArraySegment::Elements(&args[current_start..i]));
-                }
-                segments.push(ArraySegment::Spread(arg_idx));
-                current_start = i + 1;
-            }
-        }
-
-        if current_start < args.len() {
-            segments.push(ArraySegment::Elements(&args[current_start..]));
-        }
-
-        if segments.is_empty() {
-            self.write("[void 0]");
-            return;
-        }
-
-        if segments.len() == 1
-            && let ArraySegment::Spread(spread_idx) = &segments[0]
-        {
-            self.write_helper("__spreadArray");
-            self.write("([void 0], ");
-            if let Some(spread_node) = self.arena.get(*spread_idx) {
-                self.emit_spread_expression(spread_node);
-            }
-            self.write(", false)");
-            return;
-        }
-
-        for _ in 0..segments.len() - 1 {
-            self.write_helper("__spreadArray");
-            self.write("(");
-        }
-
-        match &segments[0] {
-            ArraySegment::Elements(elems) => {
-                self.write("[void 0, ");
-                self.emit_comma_separated(elems);
-                self.write("]");
-            }
-            ArraySegment::Spread(spread_idx) => {
-                self.write_helper("__spreadArray");
-                self.write("([void 0], ");
-                if let Some(spread_node) = self.arena.get(*spread_idx) {
-                    self.emit_spread_expression(spread_node);
-                }
-                self.write(", false)");
-            }
-        }
-
-        for segment in &segments[1..] {
-            match segment {
-                ArraySegment::Elements(elems) => {
-                    self.write(", [");
-                    self.emit_comma_separated(elems);
-                    self.write("], false)");
-                }
-                ArraySegment::Spread(spread_idx) => {
-                    self.write(", ");
-                    if let Some(spread_node) = self.arena.get(*spread_idx) {
-                        self.emit_spread_expression(spread_node);
-                    }
-                    self.write(", false)");
-                }
-            }
-        }
     }
 }

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async/spread.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async/spread.rs
@@ -1,0 +1,206 @@
+use super::super::super::*;
+use super::super::helpers::ArraySegment;
+use crate::transforms::emit_utils;
+use tsz_parser::parser::NodeIndex;
+
+impl<'a> Printer<'a> {
+    pub(super) fn emit_spread_args_array(&mut self, args: &[NodeIndex]) {
+        // Build arguments array using __spreadArray for spread elements
+        if args.is_empty() {
+            self.write("[]");
+            return;
+        }
+
+        // Check if there are any spread elements
+        let has_spread = args
+            .iter()
+            .any(|&arg_idx| emit_utils::is_spread_element(self.arena, arg_idx));
+
+        if !has_spread {
+            // No spreads, just emit an array literal
+            self.write("[");
+            self.emit_comma_separated(args);
+            self.write("]");
+            return;
+        }
+
+        // Build segments by grouping consecutive non-spread and spread elements
+        let mut segments: Vec<ArraySegment> = Vec::new();
+        let mut current_start = 0;
+
+        for (i, &arg_idx) in args.iter().enumerate() {
+            if emit_utils::is_spread_element(self.arena, arg_idx) {
+                // Add non-spread segment before this spread
+                if current_start < i {
+                    segments.push(ArraySegment::Elements(&args[current_start..i]));
+                }
+                // Add the spread element
+                segments.push(ArraySegment::Spread(arg_idx));
+                current_start = i + 1;
+            }
+        }
+
+        // Add remaining elements after last spread
+        if current_start < args.len() {
+            segments.push(ArraySegment::Elements(&args[current_start..]));
+        }
+
+        // Emit using nested __spreadArray calls
+        self.emit_spread_segments(&segments);
+    }
+
+    fn emit_spread_segments(&mut self, segments: &[ArraySegment]) {
+        if segments.is_empty() {
+            self.write("[]");
+            return;
+        }
+
+        let wrap_spread_with_read = self.ctx.target_es5 && self.ctx.options.downlevel_iteration;
+
+        if segments.len() == 1 {
+            match &segments[0] {
+                ArraySegment::Spread(spread_idx) => {
+                    // Just a single spread with no other arguments:
+                    // TypeScript optimization - pass arrays directly unless
+                    // downlevelIteration requires __read for iterable inputs.
+                    if let Some(spread_node) = self.arena.get(*spread_idx) {
+                        if wrap_spread_with_read {
+                            self.write_helper("__spreadArray");
+                            self.write("([], ");
+                            self.emit_spread_expression_with_read(spread_node, true);
+                            self.write(", false)");
+                        } else {
+                            self.emit_spread_expression(spread_node);
+                        }
+                    }
+                }
+                ArraySegment::Elements(elems) => {
+                    // Just elements: [1, 2, 3]
+                    self.write("[");
+                    self.emit_comma_separated(elems);
+                    self.write("]");
+                }
+            }
+            return;
+        }
+
+        // Multiple segments: build nested __spreadArray calls
+        // Pattern: __spreadArray(__spreadArray(base, segment1, false), segment2, false)
+
+        // Open __spreadArray calls for all but the last segment
+        for _ in 0..segments.len() - 1 {
+            self.write_helper("__spreadArray");
+            self.write("(");
+        }
+
+        // Emit the first segment as a complete unit
+        match &segments[0] {
+            ArraySegment::Elements(elems) => {
+                self.write("[");
+                self.emit_comma_separated(elems);
+                self.write("]");
+            }
+            ArraySegment::Spread(spread_idx) => {
+                // First segment is spread: emit as __spreadArray([], spread, false)
+                self.write_helper("__spreadArray");
+                self.write("([], ");
+                if let Some(spread_node) = self.arena.get(*spread_idx) {
+                    self.emit_spread_expression_with_read(spread_node, wrap_spread_with_read);
+                }
+                self.write(", false)");
+            }
+        }
+
+        // Emit remaining segments - each closes one __spreadArray call
+        for segment in &segments[1..] {
+            match segment {
+                ArraySegment::Elements(elems) => {
+                    self.write(", [");
+                    self.emit_comma_separated(elems);
+                    self.write("], false)");
+                }
+                ArraySegment::Spread(spread_idx) => {
+                    self.write(", ");
+                    if let Some(spread_node) = self.arena.get(*spread_idx) {
+                        self.emit_spread_expression_with_read(spread_node, wrap_spread_with_read);
+                    }
+                    self.write(", false)");
+                }
+            }
+        }
+    }
+
+    pub(super) fn emit_new_spread_args_array(&mut self, args: &[NodeIndex]) {
+        let mut segments: Vec<ArraySegment> = Vec::new();
+        let mut current_start = 0;
+
+        for (i, &arg_idx) in args.iter().enumerate() {
+            if emit_utils::is_spread_element(self.arena, arg_idx) {
+                if current_start < i {
+                    segments.push(ArraySegment::Elements(&args[current_start..i]));
+                }
+                segments.push(ArraySegment::Spread(arg_idx));
+                current_start = i + 1;
+            }
+        }
+
+        if current_start < args.len() {
+            segments.push(ArraySegment::Elements(&args[current_start..]));
+        }
+
+        if segments.is_empty() {
+            self.write("[void 0]");
+            return;
+        }
+
+        if segments.len() == 1
+            && let ArraySegment::Spread(spread_idx) = &segments[0]
+        {
+            self.write_helper("__spreadArray");
+            self.write("([void 0], ");
+            if let Some(spread_node) = self.arena.get(*spread_idx) {
+                self.emit_spread_expression(spread_node);
+            }
+            self.write(", false)");
+            return;
+        }
+
+        for _ in 0..segments.len() - 1 {
+            self.write_helper("__spreadArray");
+            self.write("(");
+        }
+
+        match &segments[0] {
+            ArraySegment::Elements(elems) => {
+                self.write("[void 0, ");
+                self.emit_comma_separated(elems);
+                self.write("]");
+            }
+            ArraySegment::Spread(spread_idx) => {
+                self.write_helper("__spreadArray");
+                self.write("([void 0], ");
+                if let Some(spread_node) = self.arena.get(*spread_idx) {
+                    self.emit_spread_expression(spread_node);
+                }
+                self.write(", false)");
+            }
+        }
+
+        for segment in &segments[1..] {
+            match segment {
+                ArraySegment::Elements(elems) => {
+                    self.write(", [");
+                    self.emit_comma_separated(elems);
+                    self.write("], false)");
+                }
+                ArraySegment::Spread(spread_idx) => {
+                    self.write(", ");
+                    if let Some(spread_node) = self.arena.get(*spread_idx) {
+                        self.emit_spread_expression(spread_node);
+                    }
+                    self.write(", false)");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
AgentName: M1-Opus

## AgentName
M1-Opus

## Track
tech-debt / file-size hygiene

## Invariant
Behavior unchanged; ES5 spread call and `new (...spread)` output remains owned by the emitter ES5 helper layer. This PR only moves spread-array segment rendering helpers to a sibling module.

## Scope
- Split spread-array construction helpers out of `crates/tsz-emitter/src/emitter/es5/helpers_async.rs`.
- Add `crates/tsz-emitter/src/emitter/es5/helpers_async/spread.rs`.
- Keep both hand-authored files below the 2000-line cap.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: emitter refactor only; refreshed head `37b9f91262c3ca255c81d278e96ff0f94776b809` passed focused local verification.

## Verification
- `cargo fmt`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-emitter`
- `wc -l crates/tsz-emitter/src/emitter/es5/helpers_async.rs crates/tsz-emitter/src/emitter/es5/helpers_async/spread.rs` -> `1954` / `206`

## Coordination Notes
Focused follow-up for the over-2000-line split campaign. Refreshed onto `origin/main` at `1659c4b614`; no conformance, emit baseline, fourslash, or project-corpus suites were run locally; ready-review CI owns broad coverage.
