### PR TITLE
refactor(solver): split constraint predicate helpers

### DIFF
--- a/crates/tsz-solver/src/visitors/visitor_predicates.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates.rs
@@ -12,12 +12,18 @@
 //!   Variants that unwrap through `ReadonlyType`, `NoInfer`, and `TypeParameter` constraints.
 //! - **Object classification**: `ObjectTypeKind` enum and `classify_object_type`.
 
+mod constraint_unwrap;
 mod identity_comparable;
 mod predicate_pool;
 
 use crate::construction::TypeDatabase;
-use crate::types::{IntrinsicKind, ObjectShapeId};
+use crate::types::IntrinsicKind;
 use crate::{TypeData, TypeId};
+pub use constraint_unwrap::{
+    ObjectTypeKind, classify_object_type, is_empty_object_type_through_type_constraints,
+    is_function_type_through_type_constraints, is_literal_type_through_type_constraints,
+    is_object_like_type_through_type_constraints,
+};
 pub use identity_comparable::is_identity_comparable_type;
 use predicate_pool::with_predicate_buffers;
 use rustc_hash::FxHashMap;
@@ -1858,206 +1864,6 @@ impl<'a> ShallowContainsTypeChecker<'a> {
             }
             TypeData::StringIntrinsic { type_arg, .. } => self.check(*type_arg),
             TypeData::Enum(_def_id, member_type) => self.check(*member_type),
-        }
-    }
-}
-
-// =============================================================================
-// TypeDatabase-based convenience functions with constraint unwrapping
-// =============================================================================
-
-/// Check if a type is a literal type (`TypeDatabase` version).
-pub fn is_literal_type_through_type_constraints(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    LiteralTypeChecker::check(types, type_id)
-}
-
-/// Check if a type is a function type (`TypeDatabase` version).
-pub fn is_function_type_through_type_constraints(
-    types: &dyn TypeDatabase,
-    type_id: TypeId,
-) -> bool {
-    FunctionTypeChecker::check(types, type_id)
-}
-
-/// Check if a type is object-like (`TypeDatabase` version).
-pub fn is_object_like_type_through_type_constraints(
-    types: &dyn TypeDatabase,
-    type_id: TypeId,
-) -> bool {
-    ObjectTypeChecker::check(types, type_id)
-}
-
-/// Check if a type is an empty object type (`TypeDatabase` version).
-pub fn is_empty_object_type_through_type_constraints(
-    types: &dyn TypeDatabase,
-    type_id: TypeId,
-) -> bool {
-    let checker = EmptyObjectChecker::new(types);
-    checker.check(type_id)
-}
-
-// =============================================================================
-// Object Type Classification
-// =============================================================================
-
-/// Classification of object types for freshness tracking.
-pub enum ObjectTypeKind {
-    /// A regular object type (no index signatures).
-    Object(ObjectShapeId),
-    /// An object type with index signatures.
-    ObjectWithIndex(ObjectShapeId),
-    /// Not an object type.
-    NotObject,
-}
-
-/// Classify a type as an object type kind.
-///
-/// This is used by the freshness tracking system to determine if a type
-/// is a fresh object literal that needs special handling.
-pub fn classify_object_type(types: &dyn TypeDatabase, type_id: TypeId) -> ObjectTypeKind {
-    if type_id.is_intrinsic() {
-        return ObjectTypeKind::NotObject;
-    }
-    match types.lookup(type_id) {
-        Some(TypeData::Object(shape_id)) => ObjectTypeKind::Object(shape_id),
-        Some(TypeData::ObjectWithIndex(shape_id)) => ObjectTypeKind::ObjectWithIndex(shape_id),
-        _ => ObjectTypeKind::NotObject,
-    }
-}
-
-// =============================================================================
-// Visitor Pattern Implementations for Helper Functions
-// =============================================================================
-
-/// Visitor to check if a type is a literal type.
-struct LiteralTypeChecker;
-
-impl LiteralTypeChecker {
-    fn check(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
-        // Fast path: intrinsic types are never literal types EXCEPT for
-        // `BOOLEAN_TRUE` (14) and `BOOLEAN_FALSE` (15) which are reserved
-        // intrinsic IDs for the `true` / `false` literal types. All other
-        // intrinsic IDs match no arm and fall through to `_ => false`.
-        // `is_intrinsic()` is a free `TypeId`-range check; the explicit
-        // exception preserves slow-path behaviour without `TypeData`
-        // lookup. Same family as #2001 / #2005 / #2008 / #2009 / #2014
-        // / #2019 / #2025.
-        if type_id.is_intrinsic() {
-            return type_id == TypeId::BOOLEAN_TRUE || type_id == TypeId::BOOLEAN_FALSE;
-        }
-        match types.lookup(type_id) {
-            Some(TypeData::Literal(_)) => true,
-            Some(TypeData::Enum(_, structural_type)) => Self::check(types, structural_type),
-            Some(TypeData::ReadonlyType(inner) | TypeData::NoInfer(inner)) => {
-                Self::check(types, inner)
-            }
-            Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => {
-                info.constraint.is_some_and(|c| Self::check(types, c))
-            }
-            _ => false,
-        }
-    }
-}
-
-/// Visitor to check if a type is a function type.
-struct FunctionTypeChecker;
-
-impl FunctionTypeChecker {
-    fn check(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
-        // Fast path: intrinsic types match no arm. Skip lookup + dispatch.
-        // Same family as #2001 / #2005 / #2008 / #2009 / #2014 / #2019 / #2025 / #2032.
-        if type_id.is_intrinsic() {
-            return false;
-        }
-        match types.lookup(type_id) {
-            Some(TypeData::Function(_) | TypeData::Callable(_)) => true,
-            Some(TypeData::Intersection(members)) => {
-                let members = types.type_list(members);
-                members.iter().any(|&member| Self::check(types, member))
-            }
-            Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => {
-                info.constraint.is_some_and(|c| Self::check(types, c))
-            }
-            // The global `Function` interface is typeof "function" at runtime.
-            // Check if this Lazy type is the known boxed Function type.
-            Some(TypeData::Lazy(def_id)) => {
-                types.is_boxed_def_id(def_id, crate::types::IntrinsicKind::Function)
-            }
-            _ => false,
-        }
-    }
-}
-
-/// Visitor to check if a type is object-like.
-struct ObjectTypeChecker;
-
-impl ObjectTypeChecker {
-    fn check(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
-        // Fast path: intrinsic types match no arm. Skip lookup + dispatch.
-        if type_id.is_intrinsic() {
-            return false;
-        }
-        match types.lookup(type_id) {
-            Some(
-                TypeData::Object(_)
-                | TypeData::ObjectWithIndex(_)
-                | TypeData::Array(_)
-                | TypeData::Tuple(_)
-                | TypeData::Mapped(_)
-                | TypeData::Application(_),
-            ) => true,
-            Some(TypeData::ReadonlyType(inner) | TypeData::NoInfer(inner)) => {
-                Self::check(types, inner)
-            }
-            Some(TypeData::Intersection(members)) => {
-                let members = types.type_list(members);
-                members.iter().all(|&member| Self::check(types, member))
-            }
-            Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => info
-                .constraint
-                .is_some_and(|constraint| Self::check(types, constraint)),
-            // Lazy types represent unresolved type references (interfaces, classes).
-            // Most are object-like at runtime (interfaces/classes), but the global
-            // `Function` interface is typeof "function". Check if this Lazy type
-            // is the known boxed Function — if so, it's NOT object-like.
-            Some(TypeData::Lazy(def_id)) => {
-                !types.is_boxed_def_id(def_id, crate::types::IntrinsicKind::Function)
-            }
-            _ => false,
-        }
-    }
-}
-
-/// Visitor to check if a type is an empty object type.
-struct EmptyObjectChecker<'a> {
-    db: &'a dyn TypeDatabase,
-}
-
-impl<'a> EmptyObjectChecker<'a> {
-    fn new(db: &'a dyn TypeDatabase) -> Self {
-        Self { db }
-    }
-
-    fn check(&self, type_id: TypeId) -> bool {
-        if type_id.is_intrinsic() {
-            return false;
-        }
-        match self.db.lookup(type_id) {
-            Some(TypeData::Object(shape_id)) => {
-                let shape = self.db.object_shape(shape_id);
-                shape.properties.is_empty()
-            }
-            Some(TypeData::ObjectWithIndex(shape_id)) => {
-                let shape = self.db.object_shape(shape_id);
-                shape.properties.is_empty()
-                    && shape.string_index.is_none()
-                    && shape.number_index.is_none()
-            }
-            Some(TypeData::ReadonlyType(inner) | TypeData::NoInfer(inner)) => self.check(inner),
-            Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => {
-                info.constraint.is_some_and(|c| self.check(c))
-            }
-            _ => false,
         }
     }
 }

--- a/crates/tsz-solver/src/visitors/visitor_predicates/constraint_unwrap.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates/constraint_unwrap.rs
@@ -1,0 +1,193 @@
+//! Constraint-unwrapping type predicate helpers.
+
+use crate::construction::TypeDatabase;
+use crate::types::ObjectShapeId;
+use crate::{TypeData, TypeId};
+
+/// Check if a type is a literal type (`TypeDatabase` version).
+pub fn is_literal_type_through_type_constraints(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    LiteralTypeChecker::check(types, type_id)
+}
+
+/// Check if a type is a function type (`TypeDatabase` version).
+pub fn is_function_type_through_type_constraints(
+    types: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> bool {
+    FunctionTypeChecker::check(types, type_id)
+}
+
+/// Check if a type is object-like (`TypeDatabase` version).
+pub fn is_object_like_type_through_type_constraints(
+    types: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> bool {
+    ObjectTypeChecker::check(types, type_id)
+}
+
+/// Check if a type is an empty object type (`TypeDatabase` version).
+pub fn is_empty_object_type_through_type_constraints(
+    types: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> bool {
+    let checker = EmptyObjectChecker::new(types);
+    checker.check(type_id)
+}
+
+/// Classification of object types for freshness tracking.
+pub enum ObjectTypeKind {
+    /// A regular object type (no index signatures).
+    Object(ObjectShapeId),
+    /// An object type with index signatures.
+    ObjectWithIndex(ObjectShapeId),
+    /// Not an object type.
+    NotObject,
+}
+
+/// Classify a type as an object type kind.
+///
+/// This is used by the freshness tracking system to determine if a type
+/// is a fresh object literal that needs special handling.
+pub fn classify_object_type(types: &dyn TypeDatabase, type_id: TypeId) -> ObjectTypeKind {
+    if type_id.is_intrinsic() {
+        return ObjectTypeKind::NotObject;
+    }
+    match types.lookup(type_id) {
+        Some(TypeData::Object(shape_id)) => ObjectTypeKind::Object(shape_id),
+        Some(TypeData::ObjectWithIndex(shape_id)) => ObjectTypeKind::ObjectWithIndex(shape_id),
+        _ => ObjectTypeKind::NotObject,
+    }
+}
+
+/// Visitor to check if a type is a literal type.
+struct LiteralTypeChecker;
+
+impl LiteralTypeChecker {
+    fn check(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
+        // Fast path: intrinsic types are never literal types EXCEPT for
+        // `BOOLEAN_TRUE` (14) and `BOOLEAN_FALSE` (15) which are reserved
+        // intrinsic IDs for the `true` / `false` literal types. All other
+        // intrinsic IDs match no arm and fall through to `_ => false`.
+        // `is_intrinsic()` is a free `TypeId`-range check; the explicit
+        // exception preserves slow-path behaviour without `TypeData`
+        // lookup. Same family as #2001 / #2005 / #2008 / #2009 / #2014
+        // / #2019 / #2025.
+        if type_id.is_intrinsic() {
+            return type_id == TypeId::BOOLEAN_TRUE || type_id == TypeId::BOOLEAN_FALSE;
+        }
+        match types.lookup(type_id) {
+            Some(TypeData::Literal(_)) => true,
+            Some(TypeData::Enum(_, structural_type)) => Self::check(types, structural_type),
+            Some(TypeData::ReadonlyType(inner) | TypeData::NoInfer(inner)) => {
+                Self::check(types, inner)
+            }
+            Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => {
+                info.constraint.is_some_and(|c| Self::check(types, c))
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Visitor to check if a type is a function type.
+struct FunctionTypeChecker;
+
+impl FunctionTypeChecker {
+    fn check(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
+        // Fast path: intrinsic types match no arm. Skip lookup + dispatch.
+        // Same family as #2001 / #2005 / #2008 / #2009 / #2014 / #2019 / #2025 / #2032.
+        if type_id.is_intrinsic() {
+            return false;
+        }
+        match types.lookup(type_id) {
+            Some(TypeData::Function(_) | TypeData::Callable(_)) => true,
+            Some(TypeData::Intersection(members)) => {
+                let members = types.type_list(members);
+                members.iter().any(|&member| Self::check(types, member))
+            }
+            Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => {
+                info.constraint.is_some_and(|c| Self::check(types, c))
+            }
+            // The global `Function` interface is typeof "function" at runtime.
+            // Check if this Lazy type is the known boxed Function type.
+            Some(TypeData::Lazy(def_id)) => {
+                types.is_boxed_def_id(def_id, crate::types::IntrinsicKind::Function)
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Visitor to check if a type is object-like.
+struct ObjectTypeChecker;
+
+impl ObjectTypeChecker {
+    fn check(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
+        // Fast path: intrinsic types match no arm. Skip lookup + dispatch.
+        if type_id.is_intrinsic() {
+            return false;
+        }
+        match types.lookup(type_id) {
+            Some(
+                TypeData::Object(_)
+                | TypeData::ObjectWithIndex(_)
+                | TypeData::Array(_)
+                | TypeData::Tuple(_)
+                | TypeData::Mapped(_)
+                | TypeData::Application(_),
+            ) => true,
+            Some(TypeData::ReadonlyType(inner) | TypeData::NoInfer(inner)) => {
+                Self::check(types, inner)
+            }
+            Some(TypeData::Intersection(members)) => {
+                let members = types.type_list(members);
+                members.iter().all(|&member| Self::check(types, member))
+            }
+            Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => info
+                .constraint
+                .is_some_and(|constraint| Self::check(types, constraint)),
+            // Lazy types represent unresolved type references (interfaces, classes).
+            // Most are object-like at runtime (interfaces/classes), but the global
+            // `Function` interface is typeof "function". Check if this Lazy type
+            // is the known boxed Function -- if so, it's NOT object-like.
+            Some(TypeData::Lazy(def_id)) => {
+                !types.is_boxed_def_id(def_id, crate::types::IntrinsicKind::Function)
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Visitor to check if a type is an empty object type.
+struct EmptyObjectChecker<'a> {
+    db: &'a dyn TypeDatabase,
+}
+
+impl<'a> EmptyObjectChecker<'a> {
+    fn new(db: &'a dyn TypeDatabase) -> Self {
+        Self { db }
+    }
+
+    fn check(&self, type_id: TypeId) -> bool {
+        if type_id.is_intrinsic() {
+            return false;
+        }
+        match self.db.lookup(type_id) {
+            Some(TypeData::Object(shape_id)) => {
+                let shape = self.db.object_shape(shape_id);
+                shape.properties.is_empty()
+            }
+            Some(TypeData::ObjectWithIndex(shape_id)) => {
+                let shape = self.db.object_shape(shape_id);
+                shape.properties.is_empty()
+                    && shape.string_index.is_none()
+                    && shape.number_index.is_none()
+            }
+            Some(TypeData::ReadonlyType(inner) | TypeData::NoInfer(inner)) => self.check(inner),
+            Some(TypeData::TypeParameter(info) | TypeData::Infer(info)) => {
+                info.constraint.is_some_and(|c| self.check(c))
+            }
+            _ => false,
+        }
+    }
+}


### PR DESCRIPTION
AgentName: M1-Opus

## AgentName
M1-Opus

## Track
Refactor / solver line-count hygiene

## Invariant
When solver callers need constraint-unwrapped type classification or object-kind classification, tsz answers through the solver visitor predicate owner. This PR moves that existing helper family into a child module and re-exports the same public functions/types from `visitor_predicates`, preserving behavior and call sites.

## Scope
- Split `crates/tsz-solver/src/visitors/visitor_predicates/constraint_unwrap.rs` out of `visitor_predicates.rs`.
- Keep the parent module as the public facade for `is_*_through_type_constraints`, `classify_object_type`, and `ObjectTypeKind`.
- Reduce `visitor_predicates.rs` from 2120 lines on current `main` to 1926 lines; new `constraint_unwrap.rs` is 193 lines.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: module-only solver refactor; public symbols are re-exported unchanged and no project-row behavior is targeted.

## Verification
- `cargo fmt`
- `wc -l crates/tsz-solver/src/visitors/visitor_predicates.rs crates/tsz-solver/src/visitors/visitor_predicates/constraint_unwrap.rs` -> 1926 / 193
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver predicate_checker_memo_entry_counts_are_observable` -> 1 passed, 6537 skipped

## Coordination Notes
- Branch refreshed onto `origin/main` at `1659c4b614`; head `22d13f0350`.
- Focused split toward the 2000-line source-file cap.
- Structural owner: solver visitor predicates; no checker, binder, emitter, CLI, or LSP logic changed.
- Intake guard status: conformance dashboard remains exact (`12585/12585`) with 26 accepted-regression entries; `scripts/arch/check-checker-boundaries.sh` and `python3 scripts/arch/arch_guard.py` still report existing baseline failures unrelated to this solver module split.