### PR TITLE
refactor(solver): split evaluation API wrappers

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -11,6 +11,7 @@
 //! - Handles deferred evaluation when type parameters are unknown
 //! - Supports distributivity for naked type parameters in unions
 
+mod api;
 pub(in crate::evaluation) mod application_types;
 mod array_methods;
 
@@ -30,11 +31,15 @@ use crate::relations::subtype::{NoopResolver, TypeResolver};
 #[cfg(test)]
 use crate::types::*;
 use crate::types::{
-    ConditionalType, ConditionalTypeId, MappedType, MappedTypeId, StringIntrinsicKind,
-    TemplateLiteralId, TemplateSpan, TupleElement, TupleListId, TypeApplicationId, TypeData,
-    TypeId, TypeListId, TypeParamInfo,
+    ConditionalTypeId, MappedTypeId, StringIntrinsicKind, TemplateLiteralId, TemplateSpan,
+    TupleElement, TupleListId, TypeApplicationId, TypeData, TypeId, TypeListId, TypeParamInfo,
 };
 use crate::visitors::visitor_predicates::contains_type_matching;
+pub use api::{
+    evaluate_conditional, evaluate_index_access, evaluate_index_access_with_options,
+    evaluate_keyof, evaluate_mapped, evaluate_type, evaluate_type_with_request,
+    evaluate_type_with_resolver,
+};
 use application_types::{ApplicationEvalContext, ApplicationEvalOutcome, HomomorphicMappedArg};
 pub(crate) use array_methods::{
     ARRAY_METHODS_RETURN_ANY, ARRAY_METHODS_RETURN_BOOLEAN, ARRAY_METHODS_RETURN_NUMBER,
@@ -45,15 +50,6 @@ use tsz_common::interner::Atom;
 
 mod closed_eval;
 mod support;
-
-/// Controls which subtype direction makes a member redundant when simplifying
-/// a union or intersection.
-enum SubtypeDirection {
-    /// member[i] <: member[j] → member[i] is redundant (union semantics).
-    SourceSubsumedByOther,
-    /// member[j] <: member[i] → member[i] is redundant (intersection semantics).
-    OtherSubsumedBySource,
-}
 
 /// Type evaluator for meta-types.
 ///
@@ -1988,70 +1984,6 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     }
 
     // Additional evaluator support methods live in the nested support module.
-}
-
-/// Convenience function for evaluating conditional types
-pub fn evaluate_conditional(interner: &dyn TypeDatabase, cond: &ConditionalType) -> TypeId {
-    let mut evaluator = TypeEvaluator::new(interner);
-    evaluator.evaluate_conditional(cond)
-}
-
-/// Convenience function for evaluating index access types
-pub fn evaluate_index_access(
-    interner: &dyn TypeDatabase,
-    object_type: TypeId,
-    index_type: TypeId,
-) -> TypeId {
-    let mut evaluator = TypeEvaluator::new(interner);
-    evaluator.evaluate_index_access(object_type, index_type)
-}
-
-/// Convenience function for evaluating index access types with options.
-pub fn evaluate_index_access_with_options(
-    interner: &dyn TypeDatabase,
-    object_type: TypeId,
-    index_type: TypeId,
-    no_unchecked_indexed_access: bool,
-) -> TypeId {
-    let mut evaluator = TypeEvaluator::new(interner);
-    evaluator.set_no_unchecked_indexed_access(no_unchecked_indexed_access);
-    evaluator.evaluate_index_access(object_type, index_type)
-}
-
-/// Convenience function for full type evaluation
-pub fn evaluate_type(interner: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
-    evaluate_type_with_request(interner, EvaluationRequest::new(type_id))
-}
-
-/// Convenience function for full type evaluation with an explicit resolver.
-pub fn evaluate_type_with_resolver(
-    interner: &dyn TypeDatabase,
-    resolver: &impl TypeResolver,
-    type_id: TypeId,
-) -> TypeId {
-    let mut evaluator = TypeEvaluator::with_resolver(interner, resolver);
-    evaluator.evaluate(type_id)
-}
-
-/// Convenience function for full type evaluation with explicit request options.
-pub fn evaluate_type_with_request(
-    interner: &dyn TypeDatabase,
-    request: EvaluationRequest,
-) -> TypeId {
-    let mut evaluator = TypeEvaluator::new(interner);
-    evaluator.evaluate_request_result(request).into_type_id()
-}
-
-/// Convenience function for evaluating mapped types
-pub fn evaluate_mapped(interner: &dyn TypeDatabase, mapped: &MappedType) -> TypeId {
-    let mut evaluator = TypeEvaluator::new(interner);
-    evaluator.evaluate_mapped(mapped)
-}
-
-/// Convenience function for evaluating keyof types
-pub fn evaluate_keyof(interner: &dyn TypeDatabase, operand: TypeId) -> TypeId {
-    let mut evaluator = TypeEvaluator::new(interner);
-    evaluator.evaluate_keyof(operand)
 }
 
 // Re-enabled evaluate tests - verifying API compatibility

--- a/crates/tsz-solver/src/evaluation/evaluate/api.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/api.rs
@@ -1,0 +1,72 @@
+//! Public convenience wrappers for type evaluation entry points.
+
+use crate::construction::TypeDatabase;
+use crate::evaluation::request::EvaluationRequest;
+use crate::relations::subtype::TypeResolver;
+use crate::types::{ConditionalType, MappedType, TypeId};
+
+use super::TypeEvaluator;
+
+/// Convenience function for evaluating conditional types.
+pub fn evaluate_conditional(interner: &dyn TypeDatabase, cond: &ConditionalType) -> TypeId {
+    let mut evaluator = TypeEvaluator::new(interner);
+    evaluator.evaluate_conditional(cond)
+}
+
+/// Convenience function for evaluating index access types.
+pub fn evaluate_index_access(
+    interner: &dyn TypeDatabase,
+    object_type: TypeId,
+    index_type: TypeId,
+) -> TypeId {
+    let mut evaluator = TypeEvaluator::new(interner);
+    evaluator.evaluate_index_access(object_type, index_type)
+}
+
+/// Convenience function for evaluating index access types with options.
+pub fn evaluate_index_access_with_options(
+    interner: &dyn TypeDatabase,
+    object_type: TypeId,
+    index_type: TypeId,
+    no_unchecked_indexed_access: bool,
+) -> TypeId {
+    let mut evaluator = TypeEvaluator::new(interner);
+    evaluator.set_no_unchecked_indexed_access(no_unchecked_indexed_access);
+    evaluator.evaluate_index_access(object_type, index_type)
+}
+
+/// Convenience function for full type evaluation.
+pub fn evaluate_type(interner: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    evaluate_type_with_request(interner, EvaluationRequest::new(type_id))
+}
+
+/// Convenience function for full type evaluation with an explicit resolver.
+pub fn evaluate_type_with_resolver(
+    interner: &dyn TypeDatabase,
+    resolver: &impl TypeResolver,
+    type_id: TypeId,
+) -> TypeId {
+    let mut evaluator = TypeEvaluator::with_resolver(interner, resolver);
+    evaluator.evaluate(type_id)
+}
+
+/// Convenience function for full type evaluation with explicit request options.
+pub fn evaluate_type_with_request(
+    interner: &dyn TypeDatabase,
+    request: EvaluationRequest,
+) -> TypeId {
+    let mut evaluator = TypeEvaluator::new(interner);
+    evaluator.evaluate_request_result(request).into_type_id()
+}
+
+/// Convenience function for evaluating mapped types.
+pub fn evaluate_mapped(interner: &dyn TypeDatabase, mapped: &MappedType) -> TypeId {
+    let mut evaluator = TypeEvaluator::new(interner);
+    evaluator.evaluate_mapped(mapped)
+}
+
+/// Convenience function for evaluating keyof types.
+pub fn evaluate_keyof(interner: &dyn TypeDatabase, operand: TypeId) -> TypeId {
+    let mut evaluator = TypeEvaluator::new(interner);
+    evaluator.evaluate_keyof(operand)
+}

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -16,6 +16,15 @@ const MAX_LAZY_CHAIN_DEPTH: usize = 32;
 /// structurally subsumed member can be dropped.
 type MemberModifierMap = Option<FxHashMap<u32, (bool, bool)>>;
 
+/// Controls which subtype direction makes a member redundant when simplifying
+/// a union or intersection.
+enum SubtypeDirection {
+    /// member[i] <: member[j] -> member[i] is redundant (union semantics).
+    SourceSubsumedByOther,
+    /// member[j] <: member[i] -> member[i] is redundant (intersection semantics).
+    OtherSubsumedBySource,
+}
+
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     #[inline]
     pub(super) fn cached_generic_instantiation(


### PR DESCRIPTION
AgentName: M1-Opus

## AgentName
M1-Opus

## Track
Refactor / solver line-count hygiene

## Invariant
When callers need top-level type evaluation entry points, tsz continues to answer through the solver evaluation owner. This PR moves only the free-function API wrappers into an `evaluate::api` child module and re-exports them from `evaluate`, preserving behavior and call sites.

## Scope
- Split `crates/tsz-solver/src/evaluation/evaluate/api.rs` out of `evaluate.rs`.
- Keep `evaluate.rs` as the public facade for `evaluate_type`, `evaluate_keyof`, index access, mapped, conditional, and resolver/request wrapper functions.
- Move the private subtype-direction enum into `evaluate/support.rs`, where redundant union/intersection member simplification uses it.
- Reduce `evaluate.rs` from 2064 lines on current `main` to 1996 lines; new `evaluate/api.rs` is 72 lines.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: module-only solver refactor; API wrappers are re-exported unchanged and no project-row behavior is targeted.

## Verification
- `cargo fmt`
- `wc -l crates/tsz-solver/src/evaluation/evaluate.rs crates/tsz-solver/src/evaluation/evaluate/api.rs crates/tsz-solver/src/evaluation/evaluate/support.rs` -> 1996 / 72 / 1674
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver test_evaluate_type_non_meta` -> 1 passed, 6537 skipped

## Coordination Notes
- Branch refreshed onto `origin/main` at `1659c4b614`; head `5c95b1977d`.
- Focused split toward the 2000-line source-file cap.
- Structural owner: solver evaluation; no checker, binder, emitter, CLI, or LSP logic changed.