### PR TITLE
perf(checker): lower lazy lib method members

### DIFF
--- a/crates/tsz-checker/src/types/queries/lib_resolution_member.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution_member.rs
@@ -10,11 +10,13 @@
 //!
 //! Scope (intentionally narrow for soundness — anything else returns `None` and
 //! falls back to the full-materialization path):
-//! - Plain property signatures only (`prop: T` / `prop?: T`). Methods,
-//!   accessors, index signatures, call/construct signatures, readonly writes,
-//!   and computed/symbol-named members take the full path.
-//! - A single own declaration of the member. Members declared more than once
-//!   (overloads / split declarations) take the full path.
+//! - Plain property signatures (`prop: T` / `prop?: T`) and unambiguous method
+//!   signature groups. Accessors, index signatures, call/construct signatures,
+//!   readonly writes, optional methods, and computed/symbol-named members take
+//!   the full path.
+//! - A single own property declaration, or one method overload group in one
+//!   arena. Split declarations and mixed property/method members take the full
+//!   path.
 //! - Heritage-inherited members can be resolved when the inherited annotation
 //!   does not reference the base interface's type parameters. Parameter-dependent
 //!   inherited members fall back to full materialization for substitution.
@@ -23,7 +25,7 @@
 
 use tsz_lowering::TypeLowering;
 use tsz_parser::parser::node::NodeAccess;
-use tsz_parser::parser::syntax_kind_ext::{self, PROPERTY_SIGNATURE};
+use tsz_parser::parser::syntax_kind_ext::{self, METHOD_SIGNATURE, PROPERTY_SIGNATURE};
 use tsz_parser::parser::{NodeArena, NodeIndex};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
@@ -39,9 +41,9 @@ use std::sync::Arc;
 use tsz_binder::{BinderState, SymbolId, symbol_flags};
 
 impl CheckerState<'_> {
-    /// Resolve a single plain property `prop_name` of the simple lib interface
-    /// named `name`, returning its lowered member type without materializing the
-    /// rest of the interface.
+    /// Resolve a single plain property or unambiguous method group `prop_name`
+    /// of the simple lib interface named `name`, returning its lowered member
+    /// type without materializing the rest of the interface.
     ///
     /// Returns `None` (caller falls back to full materialization) when:
     /// - the interface symbol cannot be selected,
@@ -108,7 +110,11 @@ impl CheckerState<'_> {
         // Find the single own plain-property-signature declaration of `prop_name`
         // across the interface's declarations. Bail (None) on any ambiguity so
         // overloads/split declarations keep their full-path semantics.
-        let mut member: Option<(NodeIndex, &NodeArena, Vec<SymbolId>)> = None;
+        enum MemberMatch<'arena> {
+            Property(NodeIndex, &'arena NodeArena, Vec<SymbolId>),
+            Methods(Vec<NodeIndex>, &'arena NodeArena, Vec<SymbolId>),
+        }
+        let mut member: Option<MemberMatch<'_>> = None;
         for &(decl_idx, arena) in &decls_with_arenas {
             let Some(node) = arena.get(decl_idx) else {
                 continue;
@@ -136,7 +142,7 @@ impl CheckerState<'_> {
                 let Some(member_node) = arena.get(member_idx) else {
                     continue;
                 };
-                if member_node.kind != PROPERTY_SIGNATURE {
+                if member_node.kind != PROPERTY_SIGNATURE && member_node.kind != METHOD_SIGNATURE {
                     continue;
                 }
                 let Some(sig) = arena.get_signature(member_node) else {
@@ -151,15 +157,42 @@ impl CheckerState<'_> {
                 if member_name != prop_name {
                     continue;
                 }
-                if member.is_some() {
-                    // Declared more than once — ambiguous, fall back.
-                    return None;
+                match (&mut member, member_node.kind) {
+                    (None, k) if k == PROPERTY_SIGNATURE => {
+                        member = Some(MemberMatch::Property(
+                            member_idx,
+                            arena,
+                            type_param_symbols.clone(),
+                        ));
+                    }
+                    (None, k) if k == METHOD_SIGNATURE => {
+                        if sig.question_token {
+                            return None;
+                        }
+                        member = Some(MemberMatch::Methods(
+                            vec![member_idx],
+                            arena,
+                            type_param_symbols.clone(),
+                        ));
+                    }
+                    (Some(MemberMatch::Methods(methods, existing_arena, _)), k)
+                        if k == METHOD_SIGNATURE && std::ptr::eq(*existing_arena, arena) =>
+                    {
+                        if sig.question_token {
+                            return None;
+                        }
+                        methods.push(member_idx);
+                    }
+                    _ => {
+                        // Mixed property/method declarations, duplicate properties, or
+                        // overloads split across arenas are ambiguous; fall back.
+                        return None;
+                    }
                 }
-                member = Some((member_idx, arena, type_param_symbols.clone()));
             }
         }
 
-        let (member_idx, member_arena, type_param_symbols) = if let Some(member) = member {
+        let member = if let Some(member) = member {
             member
         } else {
             let mut heritage_bases = Vec::new();
@@ -220,6 +253,21 @@ impl CheckerState<'_> {
                 }
             }
             return inherited_member;
+        };
+        let (member_idx, member_arena, type_param_symbols) = match member {
+            MemberMatch::Property(member_idx, member_arena, type_param_symbols) => {
+                (member_idx, member_arena, type_param_symbols)
+            }
+            MemberMatch::Methods(methods, member_arena, type_param_symbols) => {
+                return self.lower_simple_lib_interface_method_group(
+                    member_arena,
+                    &methods,
+                    &type_param_symbols,
+                    selected_binder,
+                    &decls_with_arenas,
+                    fallback_arena,
+                );
+            }
         };
         let member_node = member_arena.get(member_idx)?;
         let sig = member_arena.get_signature(member_node)?;
@@ -303,6 +351,60 @@ impl CheckerState<'_> {
             return None;
         }
         Some(member_type)
+    }
+
+    fn lower_simple_lib_interface_method_group(
+        &mut self,
+        member_arena: &NodeArena,
+        methods: &[NodeIndex],
+        type_param_symbols: &[SymbolId],
+        selected_binder: &BinderState,
+        decls_with_arenas: &[(NodeIndex, &NodeArena)],
+        fallback_arena: &NodeArena,
+    ) -> Option<TypeId> {
+        if methods.is_empty() || !type_param_symbols.is_empty() {
+            return None;
+        }
+
+        let resolver = |node_idx: NodeIndex| -> Option<u32> {
+            resolve_lib_node_in_arenas(selected_binder, node_idx, decls_with_arenas, fallback_arena)
+                .map(|sym_id| sym_id.0)
+        };
+        let def_id_resolver = |node_idx: NodeIndex| -> Option<tsz_solver::DefId> {
+            lib_def_id_from_node(
+                &self.ctx,
+                selected_binder,
+                node_idx,
+                decls_with_arenas,
+                fallback_arena,
+            )
+        };
+        let name_resolver = |type_name: &str| -> Option<tsz_solver::DefId> {
+            self.resolve_actual_lib_name_to_def_id_for_lowering(type_name)
+                .or_else(|| self.resolve_entity_name_text_to_def_id_for_lowering(type_name))
+        };
+        let lazy_type_params_resolver =
+            |def_id: tsz_solver::def::DefId| self.ctx.get_def_type_params(def_id);
+
+        let lowering = TypeLowering::with_hybrid_resolver(
+            fallback_arena,
+            self.ctx.types,
+            &resolver,
+            &def_id_resolver,
+            &resolver,
+        )
+        .with_builtin_iterator_return_type(self.builtin_iterator_return_intrinsic_type())
+        .with_lazy_type_params_resolver(&lazy_type_params_resolver)
+        .with_name_def_id_resolver(&name_resolver);
+        let lowering =
+            if self.ctx.all_binders.is_some() || self.ctx.global_file_locals_index.is_some() {
+                lowering.prefer_name_def_id_resolution()
+            } else {
+                lowering
+            };
+        lowering
+            .with_arena(member_arena)
+            .lower_method_signature_group(methods)
     }
 
     fn type_annotation_is_lib_interface_reference(

--- a/crates/tsz-lowering/src/lower/core/signature_members.rs
+++ b/crates/tsz-lowering/src/lower/core/signature_members.rs
@@ -443,6 +443,50 @@ impl<'a> TypeLowering<'a> {
         }
     }
 
+    pub fn lower_method_signature_group(&self, methods: &[NodeIndex]) -> Option<TypeId> {
+        if methods.is_empty() {
+            return None;
+        }
+
+        let mut signatures = Vec::with_capacity(methods.len());
+        for &method_idx in methods {
+            let member = self.arena.get(method_idx)?;
+            if member.kind != syntax_kind_ext::METHOD_SIGNATURE {
+                return None;
+            }
+            let sig = self.arena.get_signature(member)?;
+            if sig.question_token {
+                return None;
+            }
+            let mut lowered = self.lower_call_signature(sig);
+            lowered.is_method = true;
+            signatures.push(lowered);
+        }
+
+        if signatures.len() == 1 {
+            let sig = signatures.pop()?;
+            return Some(self.interner.function(FunctionShape {
+                type_params: sig.type_params,
+                params: sig.params,
+                this_type: sig.this_type,
+                return_type: sig.return_type,
+                type_predicate: sig.type_predicate,
+                is_constructor: false,
+                is_method: true,
+            }));
+        }
+
+        Some(self.interner.callable(CallableShape {
+            call_signatures: signatures,
+            construct_signatures: Vec::new(),
+            properties: Vec::new(),
+            string_index: None,
+            number_index: None,
+            symbol: None,
+            is_abstract: false,
+        }))
+    }
+
     pub(super) fn lower_method_signature(&self, sig: &SignatureData) -> TypeId {
         let (type_params, (params, this_type, return_type, type_predicate)) = self
             .with_type_params(&sig.type_parameters, || {


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Performance / Vite green-row 2x target-gap slice.

## Invariant
When a lazy single-member lib-interface receiver asks for an unambiguous plain method signature group in one actual/cloned lib arena, `tsz` lowers just that method group through the existing `TypeLowering` signature path and returns the same function/callable member shape the full interface path would create.

When an explicit call type argument is already known to be object-like and a candidate overload constrains that type parameter through `keyof`, the candidate is not viable for that object type argument. The checker can reject it before evaluating the keyspace, preserving existing fallback behavior for type parameters, enums, unknown/error/any, non-key constraints, and unresolved local object type arguments.

## Scope
- `crates/tsz-checker/src/types/queries/lib_resolution_member.rs`
- `crates/tsz-lowering/src/lower/core/signature_members.rs`
- `crates/tsz-checker/src/state/type_resolution/constructors/callable_type_arguments.rs`
- `crates/tsz-checker/src/tests/explicit_type_arg_overload_pruning_tests.rs`

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: performance/lazy DOM lib method and explicit type-argument overload materialization.
- Status: diagnostic-green before and after; `tsz` now wins the quick row but remains below the Studio-B 2x target.
- Current timing artifact: `artifacts/perf/studio-b-12600-keyof-object-vite-quick-20260604.json`, `tsz` 66.22ms vs `tsgo` 76.57ms, `tsz` 1.16x faster.
- Current winner report: `artifacts/perf/studio-b-12600-keyof-object-vite-quick-20260604.tsgo-winners.json`, 0 green `tsgo` winners, 1/1 row still below 2x, target gap factor 1.7297.
- Current attribution artifact: `artifacts/perf/studio-b-12600-keyof-object-vite-distfast-perf-20260604.json`.
- Local pre-keyof quick anchor on this branch: `artifacts/perf/studio-b-12600-current-vite-quick-20260604.json`, `tsz` 79.44ms vs `tsgo` 87.59ms, `tsz` 1.10x faster, target gap factor 1.8139.
- Counter movement from local pre-keyof attribution to current: interned types 7310 -> 7099, intern misses 7200 -> 6989, slowest `document.querySelector<HTMLDivElement>("#app")` statement 47.27ms -> 39.56ms. `DelegateCrossArenaSymbol` misses remain 210 and `with_parent_cache` remains 211, so the remaining target is still cross-arena DOM materialization rather than this keyspace-pruning slice.

## Verification
- `cargo fmt --all`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib explicit_type_arg_overload_pruning_tests`
- `scripts/safe-run.sh scripts/bench/bench-vs-tsgo.sh --quick --filter '^vite-vanilla-ts-app$' --json-file artifacts/perf/studio-b-12600-keyof-object-vite-quick-20260604.json`
- `node scripts/bench/tsgo-winner-report.mjs artifacts/perf/studio-b-12600-keyof-object-vite-quick-20260604.json artifacts/perf/studio-b-12600-keyof-object-vite-quick-20260604.tsgo-winners.json`
- `scripts/safe-run.sh --limit 75% -- cargo build --profile dist-fast -p tsz-cli --bin tsz --features perf-tools && TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh .target/dist-fast/tsz --extendedDiagnostics --perf-counters-json artifacts/perf/studio-b-12600-keyof-object-vite-distfast-perf-20260604.json --noEmit -p .target-bench/external/vite-vanilla-ts-live/tsconfig.json`
- `python3 scripts/perf/query-perf-counters.py --json artifacts/perf/studio-b-12600-keyof-object-vite-distfast-perf-20260604.json`

Earlier method-group slice verification retained from the first commit:
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib lazy_lib_member_access_tests --no-fail-fast`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib value_merged_builtin_dom_interface_type_argument_keeps_inherited_members direct_value_merged_builtin_dom_interface_symbol_type_returns_type_position_lazy_ref inherited_simple_lib_member_falls_back_on_duplicate_renamed_bases --no-fail-fast`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test global_augmentation_lib_interface_merge_tests --no-fail-fast`
- `scripts/safe-run.sh cargo fmt --check -p tsz-checker -p tsz-lowering`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-checker -p tsz-lowering`

## Coordination Notes
- Branch head pushed: `df6486747e` (`perf(checker): prune object type args before keyof expansion`).
- This is an incremental performance shrink, not a completed Studio-B 2x gate. Do not claim Vite as 2x complete from this PR.
- Boundary note: method-member lowering stays on the checker/query-boundary plus `TypeLowering` path; explicit type-argument pruning stays in the callable type-argument constructor and uses solver query helpers for `keyof`, object-like, enum, and type-parameter shape checks.
- Architecture guard audit from the first slice: `scripts/safe-run.sh scripts/arch/check-checker-boundaries.sh` failed on pre-existing `origin/main` debt in `crates/tsz-checker/src/error_reporter/core/type_display.rs` at 2014 lines. Touched files remain below the 2000-line cap.
