### PR TITLE
refactor(solver): split interner thread-local cache

### DIFF
--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -17,7 +17,6 @@ use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHasher};
 use smallvec::SmallVec;
-use std::cell::Cell;
 use std::hash::{Hash, Hasher};
 use std::sync::{
     Arc, OnceLock, RwLock,
@@ -25,144 +24,7 @@ use std::sync::{
 };
 use tsz_common::interner::{Atom, ShardedInterner};
 
-// ---------------------------------------------------------------------------
-// Thread-local direct-mapped lookup cache
-// ---------------------------------------------------------------------------
-// On single-threaded workloads (all benchmarks, CLI), every `lookup()` call
-// goes through `RwLock::read()` which costs ~15-25 ns per call (atomic CAS on
-// the reader count, memory fence, deref, fence, atomic decrement). A 1024-entry
-// direct-mapped cache turns >90% of lookups into a single array index + compare
-// (~1-2 ns). The cache is keyed by `TypeId.0` with the tag stored alongside
-// the data, so collisions just evict (no correctness issue).
-
-const LOOKUP_CACHE_BITS: u32 = 10;
-const LOOKUP_CACHE_SIZE: usize = 1 << LOOKUP_CACHE_BITS; // 1024
-#[allow(dead_code)]
-const LOOKUP_CACHE_MASK: u32 = (LOOKUP_CACHE_SIZE as u32) - 1;
-
-/// A single cache entry: (tag = TypeId raw value, cached TypeData, owning
-/// interner `instance_id`).
-///
-/// `tag == 0` means empty (`TypeId::NONE` is never looked up for user types).
-/// `instance_id` scopes the cache entry to the interner that inserted it, so
-/// a stale entry from a previous `TypeInterner` on the same thread is
-/// detected and treated as a miss — even though the raw `tag` may collide
-/// with a different type in the new interner. Without this, the thread-local
-/// cache was disabled entirely, forcing every `lookup()` through a
-/// `RwLock::read()` (~15-25 ns per call).
-#[derive(Clone, Copy)]
-struct LookupCacheEntry {
-    tag: u32,
-    instance_id: u32,
-    data: TypeData,
-}
-
-// LookupCacheEntry is used by TypeInternerCache below.
-
-// ---------------------------------------------------------------------------
-// Thread-local combined cache for both lookup and intern
-// ---------------------------------------------------------------------------
-// Combines both caches into a single struct to reduce thread_local! accesses.
-// On macOS, each thread_local! access goes through __tls_get_addr (~10-15ns).
-// By combining into one TLS access, we halve the overhead.
-
-const INTERN_CACHE_BITS: u32 = 9;
-const INTERN_CACHE_SIZE: usize = 1 << INTERN_CACHE_BITS; // 512
-#[allow(dead_code)]
-const INTERN_CACHE_MASK: u64 = (INTERN_CACHE_SIZE as u64) - 1;
-
-#[derive(Clone, Copy)]
-struct InternCacheEntry {
-    /// `FxHash` of the TypeData, used as tag
-    hash: u64,
-    /// Owning interner `instance_id` for cross-interner safety.
-    instance_id: u32,
-    /// The TypeData that was interned
-    key: TypeData,
-    /// The resulting TypeId
-    result: TypeId,
-}
-
-/// Combined thread-local cache for both `lookup()` and `intern()` directions.
-///
-/// Uses per-slot `Cell<T>` values for interior mutability. Both cache entry
-/// types are `Copy`, so each probe/insert remains one direct slot `get`/`set`
-/// with no `unsafe` and no manual `Send`/`Sync` impls. The cache is reached
-/// only through `thread_local!`, which requires neither bound.
-struct TypeInternerCache {
-    lookup: [Cell<LookupCacheEntry>; LOOKUP_CACHE_SIZE],
-    intern: [Cell<InternCacheEntry>; INTERN_CACHE_SIZE],
-}
-
-const EMPTY_LOOKUP_ENTRY: LookupCacheEntry = LookupCacheEntry {
-    tag: 0,
-    instance_id: 0,
-    data: TypeData::Error,
-};
-
-const EMPTY_INTERN_ENTRY: InternCacheEntry = InternCacheEntry {
-    hash: 0,
-    instance_id: 0,
-    key: TypeData::Error,
-    result: TypeId::NONE,
-};
-
-#[allow(dead_code)]
-impl TypeInternerCache {
-    const fn new() -> Self {
-        Self {
-            lookup: [const { Cell::new(EMPTY_LOOKUP_ENTRY) }; LOOKUP_CACHE_SIZE],
-            intern: [const { Cell::new(EMPTY_INTERN_ENTRY) }; INTERN_CACHE_SIZE],
-        }
-    }
-
-    #[inline(always)]
-    const fn lookup_probe(&self, id: TypeId, instance_id: u32) -> Option<TypeData> {
-        let idx = (id.0 & LOOKUP_CACHE_MASK) as usize;
-        let entry = self.lookup[idx].get();
-        if entry.tag == id.0 && entry.instance_id == instance_id {
-            Some(entry.data)
-        } else {
-            None
-        }
-    }
-
-    #[inline(always)]
-    fn lookup_insert(&self, id: TypeId, instance_id: u32, data: TypeData) {
-        let idx = (id.0 & LOOKUP_CACHE_MASK) as usize;
-        self.lookup[idx].set(LookupCacheEntry {
-            tag: id.0,
-            instance_id,
-            data,
-        });
-    }
-
-    #[inline(always)]
-    fn intern_probe(&self, hash: u64, instance_id: u32, key: &TypeData) -> Option<TypeId> {
-        let idx = (hash & INTERN_CACHE_MASK) as usize;
-        let entry = self.intern[idx].get();
-        if entry.hash == hash && entry.instance_id == instance_id && &entry.key == key {
-            Some(entry.result)
-        } else {
-            None
-        }
-    }
-
-    #[inline(always)]
-    fn intern_insert(&self, hash: u64, instance_id: u32, key: TypeData, result: TypeId) {
-        let idx = (hash & INTERN_CACHE_MASK) as usize;
-        self.intern[idx].set(InternCacheEntry {
-            hash,
-            instance_id,
-            key,
-            result,
-        });
-    }
-}
-
-thread_local! {
-    static TL_CACHE: TypeInternerCache = const { TypeInternerCache::new() };
-}
+mod cache;
 
 /// Global counter for assigning unique `instance_id`s to `TypeInterner`
 /// instances. `0` is reserved as "empty/no-interner" so it will never match
@@ -177,14 +39,7 @@ static NEXT_INTERNER_INSTANCE_ID: AtomicU32 = AtomicU32::new(1);
 /// Without this, the lookup cache may return `TypeData` from a dropped interner,
 /// causing incorrect type resolution and panics.
 pub fn clear_thread_local_cache() {
-    TL_CACHE.with(|cache| {
-        for cell in &cache.lookup {
-            cell.set(EMPTY_LOOKUP_ENTRY);
-        }
-        for cell in &cache.intern {
-            cell.set(EMPTY_INTERN_ENTRY);
-        }
-    });
+    cache::clear_thread_local_cache();
 }
 
 pub(super) const SHARD_BITS: u32 = 6;
@@ -1182,7 +1037,7 @@ impl TypeInterner {
 
         // Fast path: thread-local cache hit scoped by this interner's
         // instance_id.
-        if let Some(id) = TL_CACHE.with(|c| c.intern_probe(hash, self.instance_id, &key)) {
+        if let Some(id) = cache::intern_probe(hash, self.instance_id, &key) {
             if let Some(c) = pc {
                 c.interner_intern_hits
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -1192,7 +1047,7 @@ impl TypeInterner {
 
         let result = self.intern_slow(key, hash, pc);
         if result != TypeId::ERROR {
-            TL_CACHE.with(|c| c.intern_insert(hash, self.instance_id, key, result));
+            cache::intern_insert(hash, self.instance_id, key, result);
         }
         result
     }
@@ -1365,12 +1220,12 @@ impl TypeInterner {
 
         // Fast path: thread-local cache hit scoped by this interner's
         // instance_id.
-        if let Some(data) = TL_CACHE.with(|c| c.lookup_probe(id, self.instance_id)) {
+        if let Some(data) = cache::lookup_probe(id, self.instance_id) {
             return Some(data);
         }
 
         let data = self.lookup_slow(id)?;
-        TL_CACHE.with(|c| c.lookup_insert(id, self.instance_id, data));
+        cache::lookup_insert(id, self.instance_id, data);
         Some(data)
     }
 

--- a/crates/tsz-solver/src/intern/core/interner/cache.rs
+++ b/crates/tsz-solver/src/intern/core/interner/cache.rs
@@ -1,0 +1,172 @@
+//! Thread-local direct-mapped caches for type interning and lookup.
+
+use crate::types::{TypeData, TypeId};
+use std::cell::Cell;
+
+// ---------------------------------------------------------------------------
+// Thread-local direct-mapped lookup cache
+// ---------------------------------------------------------------------------
+// On single-threaded workloads (all benchmarks, CLI), every `lookup()` call
+// goes through `RwLock::read()` which costs ~15-25 ns per call (atomic CAS on
+// the reader count, memory fence, deref, fence, atomic decrement). A 1024-entry
+// direct-mapped cache turns >90% of lookups into a single array index + compare
+// (~1-2 ns). The cache is keyed by `TypeId.0` with the tag stored alongside
+// the data, so collisions just evict (no correctness issue).
+
+const LOOKUP_CACHE_BITS: u32 = 10;
+const LOOKUP_CACHE_SIZE: usize = 1 << LOOKUP_CACHE_BITS; // 1024
+#[allow(dead_code)]
+const LOOKUP_CACHE_MASK: u32 = (LOOKUP_CACHE_SIZE as u32) - 1;
+
+/// A single cache entry: (tag = TypeId raw value, cached TypeData, owning
+/// interner `instance_id`).
+///
+/// `tag == 0` means empty (`TypeId::NONE` is never looked up for user types).
+/// `instance_id` scopes the cache entry to the interner that inserted it, so
+/// a stale entry from a previous `TypeInterner` on the same thread is
+/// detected and treated as a miss -- even though the raw `tag` may collide
+/// with a different type in the new interner. Without this, the thread-local
+/// cache was disabled entirely, forcing every `lookup()` through a
+/// `RwLock::read()` (~15-25 ns per call).
+#[derive(Clone, Copy)]
+struct LookupCacheEntry {
+    tag: u32,
+    instance_id: u32,
+    data: TypeData,
+}
+
+// ---------------------------------------------------------------------------
+// Thread-local combined cache for both lookup and intern
+// ---------------------------------------------------------------------------
+// Combines both caches into a single struct to reduce thread_local! accesses.
+// On macOS, each thread_local! access goes through __tls_get_addr (~10-15ns).
+// By combining into one TLS access, we halve the overhead.
+
+const INTERN_CACHE_BITS: u32 = 9;
+const INTERN_CACHE_SIZE: usize = 1 << INTERN_CACHE_BITS; // 512
+#[allow(dead_code)]
+const INTERN_CACHE_MASK: u64 = (INTERN_CACHE_SIZE as u64) - 1;
+
+#[derive(Clone, Copy)]
+struct InternCacheEntry {
+    /// `FxHash` of the TypeData, used as tag
+    hash: u64,
+    /// Owning interner `instance_id` for cross-interner safety.
+    instance_id: u32,
+    /// The TypeData that was interned
+    key: TypeData,
+    /// The resulting TypeId
+    result: TypeId,
+}
+
+/// Combined thread-local cache for both `lookup()` and `intern()` directions.
+///
+/// Uses per-slot `Cell<T>` values for interior mutability. Both cache entry
+/// types are `Copy`, so each probe/insert remains one direct slot `get`/`set`
+/// with no `unsafe` and no manual `Send`/`Sync` impls. The cache is reached
+/// only through `thread_local!`, which requires neither bound.
+struct TypeInternerCache {
+    lookup: [Cell<LookupCacheEntry>; LOOKUP_CACHE_SIZE],
+    intern: [Cell<InternCacheEntry>; INTERN_CACHE_SIZE],
+}
+
+const EMPTY_LOOKUP_ENTRY: LookupCacheEntry = LookupCacheEntry {
+    tag: 0,
+    instance_id: 0,
+    data: TypeData::Error,
+};
+
+const EMPTY_INTERN_ENTRY: InternCacheEntry = InternCacheEntry {
+    hash: 0,
+    instance_id: 0,
+    key: TypeData::Error,
+    result: TypeId::NONE,
+};
+
+#[allow(dead_code)]
+impl TypeInternerCache {
+    const fn new() -> Self {
+        Self {
+            lookup: [const { Cell::new(EMPTY_LOOKUP_ENTRY) }; LOOKUP_CACHE_SIZE],
+            intern: [const { Cell::new(EMPTY_INTERN_ENTRY) }; INTERN_CACHE_SIZE],
+        }
+    }
+
+    #[inline(always)]
+    const fn lookup_probe(&self, id: TypeId, instance_id: u32) -> Option<TypeData> {
+        let idx = (id.0 & LOOKUP_CACHE_MASK) as usize;
+        let entry = self.lookup[idx].get();
+        if entry.tag == id.0 && entry.instance_id == instance_id {
+            Some(entry.data)
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    fn lookup_insert(&self, id: TypeId, instance_id: u32, data: TypeData) {
+        let idx = (id.0 & LOOKUP_CACHE_MASK) as usize;
+        self.lookup[idx].set(LookupCacheEntry {
+            tag: id.0,
+            instance_id,
+            data,
+        });
+    }
+
+    #[inline(always)]
+    fn intern_probe(&self, hash: u64, instance_id: u32, key: &TypeData) -> Option<TypeId> {
+        let idx = (hash & INTERN_CACHE_MASK) as usize;
+        let entry = self.intern[idx].get();
+        if entry.hash == hash && entry.instance_id == instance_id && &entry.key == key {
+            Some(entry.result)
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    fn intern_insert(&self, hash: u64, instance_id: u32, key: TypeData, result: TypeId) {
+        let idx = (hash & INTERN_CACHE_MASK) as usize;
+        self.intern[idx].set(InternCacheEntry {
+            hash,
+            instance_id,
+            key,
+            result,
+        });
+    }
+}
+
+thread_local! {
+    static TL_CACHE: TypeInternerCache = const { TypeInternerCache::new() };
+}
+
+pub(super) fn clear_thread_local_cache() {
+    TL_CACHE.with(|cache| {
+        for cell in &cache.lookup {
+            cell.set(EMPTY_LOOKUP_ENTRY);
+        }
+        for cell in &cache.intern {
+            cell.set(EMPTY_INTERN_ENTRY);
+        }
+    });
+}
+
+#[inline(always)]
+pub(super) fn lookup_probe(id: TypeId, instance_id: u32) -> Option<TypeData> {
+    TL_CACHE.with(|cache| cache.lookup_probe(id, instance_id))
+}
+
+#[inline(always)]
+pub(super) fn lookup_insert(id: TypeId, instance_id: u32, data: TypeData) {
+    TL_CACHE.with(|cache| cache.lookup_insert(id, instance_id, data));
+}
+
+#[inline(always)]
+pub(super) fn intern_probe(hash: u64, instance_id: u32, key: &TypeData) -> Option<TypeId> {
+    TL_CACHE.with(|cache| cache.intern_probe(hash, instance_id, key))
+}
+
+#[inline(always)]
+pub(super) fn intern_insert(hash: u64, instance_id: u32, key: TypeData, result: TypeId) {
+    TL_CACHE.with(|cache| cache.intern_insert(hash, instance_id, key, result));
+}


### PR DESCRIPTION
AgentName: M1-Opus

## AgentName
M1-Opus

## Track
Line-cap refactor / solver intern core

## Invariant
When solver interning looks up or interns canonical `TypeId`s, tsz still uses the same thread-local lookup/intern caches owned by the solver interner. This PR only moves cache storage/probe/insert helpers into `interner::cache` and keeps parent call sites delegating to the same operations.

## Scope
- Split `crates/tsz-solver/src/intern/core/interner/cache.rs` out of `interner.rs`.
- Keep `interner.rs` as the `TypeInterner` implementation and facade for `clear_thread_local_cache`.
- Reduce `crates/tsz-solver/src/intern/core/interner.rs` from 2104 lines on current main to 1959 lines; new `interner/cache.rs` is 172 lines.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: module-only solver interner refactor; no project-row behavior targeted.

## Verification
- `cargo fmt`
- `wc -l crates/tsz-solver/src/intern/core/interner.rs crates/tsz-solver/src/intern/core/interner/cache.rs` -> 1959 / 172
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver interned_type_limit_fallback_poison_returns_error interned_type_limit_boundary_is_strictly_greater_than_limit estimated_size_accounts_for_retained_predicate_caches` -> 3 passed, 6535 skipped

## Coordination Notes
- Branch refreshed onto `origin/main` at `1659c4b614`; head `90d954be0e`.
- Focused split toward the 2000-line hand-authored file cap.
- Older PR-body filters for `intersection_builder_*` were stale after rebase; no tests with that prefix exist under `crates/tsz-solver` on this head.
- Architecture guards were checked during intake and still report existing baseline failures unrelated to this split; this PR does not add checker/solver/emitter boundary debt.