### PR TITLE
perf(checker): prune object type args before keyof expansion

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/constructors/callable_type_arguments.rs
+++ b/crates/tsz-checker/src/state/type_resolution/constructors/callable_type_arguments.rs
@@ -321,26 +321,34 @@ impl<'a> CheckerState<'a> {
             if query::contains_type_parameters(self.ctx.types.as_type_database(), constraint) {
                 continue;
             }
-            let constraint = self.evaluate_type_for_assignability(constraint);
             let db = self.ctx.types.as_type_database();
-            if !common_query::is_literal_or_primitive_or_compound_of_those(db, constraint) {
-                continue;
-            }
-
             if common_query::contains_type_parameters(db, type_arg)
                 || common_query::enum_def_id(db, type_arg).is_some()
             {
                 continue;
             }
 
-            if !common_query::is_literal_or_primitive_or_compound_of_those(db, type_arg) {
-                if query::lazy_def_id(db, type_arg).is_some_and(|def_id| {
+            let object_like_type_arg = common_query::is_object_like_type(db, type_arg)
+                || query::lazy_def_id(db, type_arg).is_some_and(|def_id| {
                     matches!(
                         self.ctx.definition_store.get_kind(def_id),
                         Some(DefKind::Class | DefKind::Interface)
                     )
-                }) || common_query::is_object_like_type(db, type_arg)
-                {
+                });
+            if (common_query::is_keyof_type(db, constraint)
+                || common_query::contains_keyof_type(db, constraint))
+                && object_like_type_arg
+            {
+                return true;
+            }
+
+            let constraint = self.evaluate_type_for_assignability(constraint);
+            if !common_query::is_literal_or_primitive_or_compound_of_those(db, constraint) {
+                continue;
+            }
+
+            if !common_query::is_literal_or_primitive_or_compound_of_those(db, type_arg) {
+                if object_like_type_arg {
                     return true;
                 }
                 continue;

--- a/crates/tsz-checker/src/tests/explicit_type_arg_overload_pruning_tests.rs
+++ b/crates/tsz-checker/src/tests/explicit_type_arg_overload_pruning_tests.rs
@@ -60,3 +60,49 @@ const selected: "specific" = choose<"a">(0);
         "multiple viable overloads should keep declaration order, got {diagnostics:?}",
     );
 }
+
+#[test]
+fn explicit_object_type_arg_prunes_keyof_constraint_before_key_expansion() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+interface FirstRegistry {
+  alpha: string;
+  beta: string;
+}
+
+declare function choose<K extends keyof FirstRegistry>(value: unknown): "registry";
+declare function choose<ElementType extends object>(value: unknown): "object";
+
+const selected: "object" = choose<object>("alpha");
+"#,
+    );
+
+    let codes = diagnostic_codes(&diagnostics);
+    assert!(
+        !codes.contains(&2322),
+        "object type arguments should prune keyof-constrained overloads, got {diagnostics:?}",
+    );
+}
+
+#[test]
+fn explicit_object_type_arg_keyof_pruning_varies_binder_names() {
+    let diagnostics = check_source_diagnostics(
+        r#"
+interface SecondRegistry {
+  gamma: number;
+  delta: number;
+}
+
+declare function select<NameKey extends keyof SecondRegistry>(value: unknown): "key";
+declare function select<NodeShape extends object>(value: unknown): "shape";
+
+const selected: "shape" = select<object>("gamma");
+"#,
+    );
+
+    let codes = diagnostic_codes(&diagnostics);
+    assert!(
+        !codes.contains(&2322),
+        "renamed object type arguments should prune keyof-constrained overloads, got {diagnostics:?}",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Performance / Vite green-row 2x target-gap slice.

## Invariant
When an explicit call type argument is already known to be object-like and a candidate overload constrains that type parameter through `keyof`, the candidate is not viable for that object type argument. The checker can reject it before evaluating the keyspace, preserving existing fallback behavior for type parameters, enums, unknown/error/any, non-key constraints, and unresolved local object type arguments.

## Scope
- `crates/tsz-checker/src/state/type_resolution/constructors/callable_type_arguments.rs`
- `crates/tsz-checker/src/tests/explicit_type_arg_overload_pruning_tests.rs`

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: performance/explicit type-argument overload materialization after merged lazy DOM method-member slice #12600.
- Status: diagnostic-green before and after; `tsz` wins the quick row but remains below the Studio-B 2x target.
- Current timing artifact: `artifacts/perf/studio-b-12600-keyof-object-vite-quick-20260604.json`, `tsz` 66.22ms vs `tsgo` 76.57ms, `tsz` 1.16x faster.
- Current winner report: `artifacts/perf/studio-b-12600-keyof-object-vite-quick-20260604.tsgo-winners.json`, 0 green `tsgo` winners, 1/1 row still below 2x, target gap factor 1.7297.
- Current attribution artifact: `artifacts/perf/studio-b-12600-keyof-object-vite-distfast-perf-20260604.json`.
- Local pre-keyof quick anchor on the #12600 branch: `artifacts/perf/studio-b-12600-current-vite-quick-20260604.json`, `tsz` 79.44ms vs `tsgo` 87.59ms, `tsz` 1.10x faster, target gap factor 1.8139.
- Counter movement from local pre-keyof attribution to current: interned types 7310 -> 7099, intern misses 7200 -> 6989, slowest `document.querySelector<HTMLDivElement>("#app")` statement 47.27ms -> 39.56ms. `DelegateCrossArenaSymbol` misses remain 210 and `with_parent_cache` remains 211, so the remaining target is still cross-arena DOM materialization rather than this keyspace-pruning slice.

## Verification
- `cargo fmt --all`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib explicit_type_arg_overload_pruning_tests`
- `scripts/safe-run.sh scripts/bench/bench-vs-tsgo.sh --quick --filter '^vite-vanilla-ts-app$' --json-file artifacts/perf/studio-b-12600-keyof-object-vite-quick-20260604.json`
- `node scripts/bench/tsgo-winner-report.mjs artifacts/perf/studio-b-12600-keyof-object-vite-quick-20260604.json artifacts/perf/studio-b-12600-keyof-object-vite-quick-20260604.tsgo-winners.json`
- `scripts/safe-run.sh --limit 75% -- cargo build --profile dist-fast -p tsz-cli --bin tsz --features perf-tools && TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh .target/dist-fast/tsz --extendedDiagnostics --perf-counters-json artifacts/perf/studio-b-12600-keyof-object-vite-distfast-perf-20260604.json --noEmit -p .target-bench/external/vite-vanilla-ts-live/tsconfig.json`
- `python3 scripts/perf/query-perf-counters.py --json artifacts/perf/studio-b-12600-keyof-object-vite-distfast-perf-20260604.json`

## Coordination Notes
- Opened as a draft follow-up because #12600 merged before this commit was pushed. Branch head: `c9a3301553`.
- This is an incremental performance shrink, not a completed Studio-B 2x gate. Do not claim Vite as 2x complete from this PR.
- Boundary note: explicit type-argument pruning stays in the callable type-argument constructor and uses solver query helpers for `keyof`, object-like, enum, and type-parameter shape checks.
- Touched files are below the 2000-line cap.


## Follow-up Composition Check
- Local temporary branch: `codex/studio-b-vite-combined-check-20260604` = #12603 head `afc71e2e43` plus this PR's commit cherry-picked as `9609908beb`.
- Compatibility check: `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib explicit_type_arg_overload_pruning_tests` passed on the combined branch.
- Combined timing artifact: `artifacts/perf/studio-b-12603-plus-12607-vite-quick-20260604.json`, `tsz` 65.79ms vs `tsgo` 77.16ms, `tsz` 1.17x faster.
- Combined winner report: `artifacts/perf/studio-b-12603-plus-12607-vite-quick-20260604.tsgo-winners.json`, 0 green `tsgo` winners, 1/1 row still below 2x.
- Combined attribution artifact: `artifacts/perf/studio-b-12603-plus-12607-vite-distfast-perf-20260604.json`; `DelegateCrossArenaSymbol` misses 86, `with_parent_cache` 87, interned types 6432, hot `querySelector` statement 39.53ms. This confirms #12603's child-checker reduction composes with this keyspace-pruning slice, but the remaining 2x gap is still dominated by cross-arena DOM alias/interface materialization.
