### PR TITLE
refactor(emitter): split commonjs binding collectors

### DIFF
--- a/crates/tsz-emitter/src/transforms/mod.rs
+++ b/crates/tsz-emitter/src/transforms/mod.rs
@@ -63,6 +63,7 @@ pub mod helpers;
 pub mod ir;
 pub mod ir_printer;
 pub mod module_commonjs;
+mod module_commonjs_bindings;
 pub mod module_commonjs_ir;
 pub mod namespace_es5;
 pub mod namespace_es5_ir;

--- a/crates/tsz-emitter/src/transforms/module_commonjs.rs
+++ b/crates/tsz-emitter/src/transforms/module_commonjs.rs
@@ -19,6 +19,7 @@
 //! exports.default = myFunc;
 //! ```
 
+use super::module_commonjs_bindings::collect_declaration_names;
 use crate::transforms::emit_utils::{
     identifier_text as get_identifier_text, is_valid_identifier_name, specifier_name_text,
 };
@@ -1891,79 +1892,6 @@ pub fn emit_reexport_property(export_name: &str, module_var: &str, import_name: 
     format!(
         "Object.defineProperty(exports, \"{export_name}\", {{ enumerable: true, get: function () {{ return {module_var}.{import_name}; }} }});"
     )
-}
-
-/// Collect exported names from a variable declaration (identifier or binding pattern).
-fn collect_declaration_names(arena: &NodeArena, decl_idx: NodeIndex, exports: &mut Vec<String>) {
-    let Some(decl_node) = arena.get(decl_idx) else {
-        return;
-    };
-
-    if decl_node.kind == syntax_kind_ext::VARIABLE_DECLARATION_LIST {
-        if let Some(decl_list) = arena.get_variable(decl_node) {
-            for &inner_decl_idx in &decl_list.declarations.nodes {
-                collect_declaration_names(arena, inner_decl_idx, exports);
-            }
-        }
-        return;
-    }
-
-    if let Some(decl) = arena.get_variable_declaration(decl_node) {
-        collect_binding_names(arena, decl.name, exports);
-    }
-}
-
-fn collect_binding_names(arena: &NodeArena, name_idx: NodeIndex, exports: &mut Vec<String>) {
-    if name_idx.is_none() {
-        return;
-    }
-
-    let Some(node) = arena.get(name_idx) else {
-        return;
-    };
-
-    if node.kind == SyntaxKind::Identifier as u16 {
-        if let Some(id) = arena.get_identifier(node) {
-            exports.push(id.escaped_text.clone());
-        }
-        return;
-    }
-
-    match node.kind {
-        k if k == syntax_kind_ext::OBJECT_BINDING_PATTERN
-            || k == syntax_kind_ext::ARRAY_BINDING_PATTERN =>
-        {
-            if let Some(pattern) = arena.get_binding_pattern(node) {
-                for &elem_idx in &pattern.elements.nodes {
-                    collect_binding_names_from_element(arena, elem_idx, exports);
-                }
-            }
-        }
-        k if k == syntax_kind_ext::BINDING_ELEMENT => {
-            if let Some(elem) = arena.get_binding_element(node) {
-                collect_binding_names(arena, elem.name, exports);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn collect_binding_names_from_element(
-    arena: &NodeArena,
-    elem_idx: NodeIndex,
-    exports: &mut Vec<String>,
-) {
-    if elem_idx.is_none() {
-        return;
-    }
-
-    let Some(elem_node) = arena.get(elem_idx) else {
-        return;
-    };
-
-    if let Some(elem) = arena.get_binding_element(elem_node) {
-        collect_binding_names(arena, elem.name, exports);
-    }
 }
 
 #[cfg(test)]

--- a/crates/tsz-emitter/src/transforms/module_commonjs_bindings.rs
+++ b/crates/tsz-emitter/src/transforms/module_commonjs_bindings.rs
@@ -1,0 +1,83 @@
+//! Binding-name collectors for the `CommonJS` module transform.
+
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeArena;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+/// Collect exported names from a variable declaration, including binding patterns.
+pub(crate) fn collect_declaration_names(
+    arena: &NodeArena,
+    decl_idx: NodeIndex,
+    exports: &mut Vec<String>,
+) {
+    let Some(decl_node) = arena.get(decl_idx) else {
+        return;
+    };
+
+    if decl_node.kind == syntax_kind_ext::VARIABLE_DECLARATION_LIST {
+        if let Some(decl_list) = arena.get_variable(decl_node) {
+            for &inner_decl_idx in &decl_list.declarations.nodes {
+                collect_declaration_names(arena, inner_decl_idx, exports);
+            }
+        }
+        return;
+    }
+
+    if let Some(decl) = arena.get_variable_declaration(decl_node) {
+        collect_binding_names(arena, decl.name, exports);
+    }
+}
+
+fn collect_binding_names(arena: &NodeArena, name_idx: NodeIndex, exports: &mut Vec<String>) {
+    if name_idx.is_none() {
+        return;
+    }
+
+    let Some(node) = arena.get(name_idx) else {
+        return;
+    };
+
+    if node.kind == SyntaxKind::Identifier as u16 {
+        if let Some(id) = arena.get_identifier(node) {
+            exports.push(id.escaped_text.clone());
+        }
+        return;
+    }
+
+    match node.kind {
+        k if k == syntax_kind_ext::OBJECT_BINDING_PATTERN
+            || k == syntax_kind_ext::ARRAY_BINDING_PATTERN =>
+        {
+            if let Some(pattern) = arena.get_binding_pattern(node) {
+                for &elem_idx in &pattern.elements.nodes {
+                    collect_binding_names_from_element(arena, elem_idx, exports);
+                }
+            }
+        }
+        k if k == syntax_kind_ext::BINDING_ELEMENT => {
+            if let Some(elem) = arena.get_binding_element(node) {
+                collect_binding_names(arena, elem.name, exports);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_binding_names_from_element(
+    arena: &NodeArena,
+    elem_idx: NodeIndex,
+    exports: &mut Vec<String>,
+) {
+    if elem_idx.is_none() {
+        return;
+    }
+
+    let Some(elem_node) = arena.get(elem_idx) else {
+        return;
+    };
+
+    if let Some(elem) = arena.get_binding_element(elem_node) {
+        collect_binding_names(arena, elem.name, exports);
+    }
+}


### PR DESCRIPTION
AgentName: M1-Opus

## AgentName
M1-Opus

## Track
Tech debt / source file line-cap split

## Invariant
When the CommonJS transform scans binding patterns for exported runtime names, tsz owns that syntactic emit planning in the emitter transform layer. This PR only moves the binding-name collector helpers into a sibling emitter transform module; it does not change module/export scheduling, helper emission, target policy, semantic validation, or emitted output text surgery.

## Scope
- Split `crates/tsz-emitter/src/transforms/module_commonjs_bindings.rs` out of `module_commonjs.rs`.
- Import the existing `collect_declaration_names` helper back into the CommonJS transform.
- Keep `module_commonjs.rs` below the 2000-line cap; new binding helper module is small and focused.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: mechanical emitter-internal helper split; refreshed head `cf36b08bdf1c8cf3c7b50bdf17ee235f83b82cd6` passed focused local verification.

## Verification
- `cargo fmt`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-emitter`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter module_commonjs` -> 42 passed, 4126 skipped
- `wc -l crates/tsz-emitter/src/transforms/mod.rs crates/tsz-emitter/src/transforms/module_commonjs.rs crates/tsz-emitter/src/transforms/module_commonjs_bindings.rs` -> `91` / `1944` / `83`

## Coordination Notes
Focused line-cap split refreshed onto `origin/main` at `1659c4b614`. No full emit/conformance/fourslash run locally, per repo contract. Adjacent matrix: CommonJS unit coverage for export collection/import binding remains green; transform ownership stays in emitter; no semantic validation or output-string patching added.
