### PR TITLE
perf(checker): cache clean type-node validation walks

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -74,7 +74,7 @@ impl<'a> CheckerState<'a> {
         self.is_well_known_lib_type_name(&name).then_some(name)
     }
 
-    fn type_reference_arg_validation_scope_key(&self) -> u64 {
+    pub(crate) fn type_reference_arg_validation_scope_key(&self) -> u64 {
         let mut entries = self
             .ctx
             .type_parameter_scope

--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -9,6 +9,10 @@ pub struct TypeReferenceValidationCaches {
     /// Type-reference argument validations that completed without diagnostics
     /// in the current lexical type-parameter scope.
     pub arg_validation: FxHashSet<(u32, u32, u64)>,
+    /// Type-node validations that completed without diagnostics in the
+    /// current lexical type-parameter scope and active alias-resolution
+    /// context.
+    pub type_node_validation: FxHashSet<(u32, bool, u64, u64)>,
     /// Syntax-guided type-reference argument instantiations in the current
     /// lexical type-parameter scope, including misses.
     pub syntax_instantiation: FxHashMap<(usize, u32, TypeId, u64), Option<TypeId>>,

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -266,6 +266,9 @@ impl<'a> CheckerContext<'a> {
         self.type_parameter_scope.clear();
         self.type_reference_validation_caches.arg_validation.clear();
         self.type_reference_validation_caches
+            .type_node_validation
+            .clear();
+        self.type_reference_validation_caches
             .syntax_instantiation
             .clear();
         self.type_reference_validation_caches

--- a/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
+++ b/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
@@ -62,6 +62,32 @@ fn tuple_alias_body_missing_names_covered_by_validation() {
 }
 
 #[test]
+fn type_node_validation_cache_is_context_keyed() {
+    let checker_source = std::fs::read_to_string("src/types/type_checking/type_alias_checking.rs")
+        .expect("read type alias checker");
+    assert!(
+        checker_source.contains("active_resolving_alias_set_key")
+            && checker_source.contains("type_reference_arg_validation_scope_key")
+            && checker_source.contains("type_node_validation"),
+        "type-node validation success caching must be keyed by lexical scope \
+         and active alias-resolution context"
+    );
+}
+
+#[test]
+fn type_node_validation_cache_only_records_clean_walks() {
+    let checker_source = std::fs::read_to_string("src/types/type_checking/type_alias_checking.rs")
+        .expect("read type alias checker");
+    assert!(
+        checker_source.contains("let diagnostics_before = self.ctx.diagnostics.len();")
+            && checker_source.contains("if self.ctx.diagnostics.len() == diagnostics_before")
+            && checker_source.contains(".type_node_validation")
+            && checker_source.contains(".insert(validation_cache_key)"),
+        "type-node validation success caching must not record diagnostic-bearing walks"
+    );
+}
+
+#[test]
 fn renamed_tuple_dispatch_alias_still_validates_annotations() {
     let diags = check_source_diagnostics(
         r#"

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -12,6 +12,7 @@
 
 use super::alias_defid_visited_pool::with_alias_defid_visited;
 use crate::state::CheckerState;
+use std::hash::{Hash, Hasher};
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
@@ -1347,6 +1348,30 @@ impl<'a> CheckerState<'a> {
         self.check_type_node_with_literal_context(node_idx, nested_in_type_literal);
     }
 
+    fn active_resolving_alias_set_key(&self) -> u64 {
+        if self.ctx.symbol_resolution_set.is_empty() {
+            return 0;
+        }
+
+        let mut entries = self
+            .ctx
+            .symbol_resolution_set
+            .iter()
+            .map(|&sym_id| {
+                self.ctx
+                    .get_existing_def_id(sym_id)
+                    .map_or(u64::from(sym_id.0), |def_id| {
+                        (1_u64 << 32) | u64::from(def_id.0)
+                    })
+            })
+            .collect::<Vec<_>>();
+        entries.sort_unstable();
+
+        let mut hasher = rustc_hash::FxHasher::default();
+        entries.hash(&mut hasher);
+        hasher.finish()
+    }
+
     fn check_type_node_with_literal_context(
         &mut self,
         node_idx: NodeIndex,
@@ -1358,6 +1383,21 @@ impl<'a> CheckerState<'a> {
         let Some(node) = self.ctx.arena.get(node_idx) else {
             return;
         };
+        let validation_cache_key = (
+            node_idx.0,
+            nested_in_type_literal,
+            self.type_reference_arg_validation_scope_key(),
+            self.active_resolving_alias_set_key(),
+        );
+        if self
+            .ctx
+            .type_reference_validation_caches
+            .type_node_validation
+            .contains(&validation_cache_key)
+        {
+            return;
+        }
+        let diagnostics_before = self.ctx.diagnostics.len();
         let child_nested_in_type_literal =
             nested_in_type_literal || node.kind == syntax_kind_ext::TYPE_LITERAL;
         macro_rules! check_child_type_node {
@@ -1701,6 +1741,13 @@ impl<'a> CheckerState<'a> {
                 }
             }
             _ => {}
+        }
+
+        if self.ctx.diagnostics.len() == diagnostics_before {
+            self.ctx
+                .type_reference_validation_caches
+                .type_node_validation
+                .insert(validation_cache_key);
         }
     }
 


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Performance / checker type-alias validation cache slice.

## Invariant
When a type-node validation walk completes without adding diagnostics, the same AST subtree may skip a later validation request only under the same lexical type-parameter scope, same type-literal context, and same active alias-resolution context; this PR changes checker validation caching only.

## Scope
- Adds a file-session success cache for clean `check_type_node_with_literal_context` walks.
- Keys the cache by node id, type-literal context, lexical type-parameter/conditional-extends scope, and active resolving-alias set.
- Clears the cache with sibling type-reference validation caches on file-session reset.
- Adds focused cache invariant tests in `ref_type_params_cache_tests`.

## Project Corpus Impact
- Row: `ts-essentials-project`.
- Bug family: green-row timing target gap, type-alias `body_validation` repeated subtree work.
- Evidence: exact rebased-head quick row `/tmp/studio-b-type-node-validation-cache-main-ts-essentials-quick.json` reports `tsz` 74.89 ms vs `tsgo` 46.95 ms (`tsgo` 1.59x faster). Earlier fresh pre-patch local run in this session reported `tsz` 267.30 ms vs `tsgo` 109.16 ms. Final attribution `/tmp/studio-b-type-node-validation-cache-main-ts-essentials.perf.json` remains diagnostic-green with 0 errors and keeps the remaining hot family in alias `body_validation`.

## Verification
- `cargo fmt --all --check`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib ref_type_params_cache_tests`
- `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli --bin tsz`
- `TSZ=$PWD/.target/dist-fast/tsz TSGO=/Users/mohsen/code/tsz/.target-bench/tools/tsgo/node_modules/.bin/tsgo TSC=/Users/mohsen/code/tsz/.target-bench/tools/tsc/node_modules/.bin/tsc EXTERNAL_BENCH_DIR=/Users/mohsen/code/tsz/.target-bench/external TSZ_BENCH_PROJECT_PEAK_RSS=1 scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials-project$' --json-file /tmp/studio-b-type-node-validation-cache-main-ts-essentials-quick.json`
- `node scripts/bench/tsgo-winner-report.mjs /tmp/studio-b-type-node-validation-cache-main-ts-essentials-quick.json /tmp/studio-b-type-node-validation-cache-main-ts-essentials-quick.tsgo-winners.json`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json /tmp/studio-b-type-node-validation-cache-main-ts-essentials.perf.json --noEmit -p /Users/mohsen/code/tsz/.target-bench/external/ts-essentials/tsconfig.flat.json`
- `git diff --check HEAD~1..HEAD`

## Coordination Notes
- Standalone off `main`; does not depend on the Vite stack #12603/#12614/#12616.
- Potential conceptual overlap with draft #12516 (`cache recursive validation work`); this PR is a smaller measured subset: successful type-node validation only, scoped by active alias-resolution context, with no diagnostic-bearing walk caching.
- The ts-essentials row is still below the 2x target after this slice (`tsgo` remains 1.59x faster), so follow-up work should continue from the remaining alias `body_validation` timings rather than broadening this cache without new evidence.
