### PR TITLE
perf(checker): skip bare alias type parameter validation

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/mod.rs
+++ b/crates/tsz-checker/src/types/type_checking/mod.rs
@@ -34,6 +34,7 @@ mod type_alias_checking;
 mod type_alias_depth_helpers;
 mod type_alias_missing_name_coverage;
 mod type_alias_recursion_patterns;
+mod type_alias_variance;
 mod unused;
 
 /// Release the type-alias resolution scratch pool owned by this module tree.

--- a/crates/tsz-checker/src/types/type_checking/type_alias_body_validation.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_body_validation.rs
@@ -2,9 +2,45 @@
 
 use crate::state::CheckerState;
 use crate::state_type_analysis::cross_file_direct::is_builtin_lib_declaration_arena;
+use std::hash::{Hash, Hasher};
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 
 impl<'a> CheckerState<'a> {
+    pub(crate) fn active_resolving_alias_set_key(&self) -> u64 {
+        if self.ctx.symbol_resolution_set.is_empty() {
+            return 0;
+        }
+        if self.ctx.symbol_resolution_set.len() == 1 {
+            let Some(&sym_id) = self.ctx.symbol_resolution_set.iter().next() else {
+                return 0;
+            };
+            return self
+                .ctx
+                .get_existing_def_id(sym_id)
+                .map_or(u64::from(sym_id.0), |def_id| {
+                    (1_u64 << 32) | u64::from(def_id.0)
+                });
+        }
+
+        let mut entries = self
+            .ctx
+            .symbol_resolution_set
+            .iter()
+            .map(|&sym_id| {
+                self.ctx
+                    .get_existing_def_id(sym_id)
+                    .map_or(u64::from(sym_id.0), |def_id| {
+                        (1_u64 << 32) | u64::from(def_id.0)
+                    })
+            })
+            .collect::<Vec<_>>();
+        entries.sort_unstable();
+
+        let mut hasher = rustc_hash::FxHasher::default();
+        entries.hash(&mut hasher);
+        hasher.finish()
+    }
+
     /// Validate the diagnostics not covered by type-literal construction and
     /// return whether the normal alias-body validation walk can be skipped.
     pub(crate) fn validate_signature_only_type_literal_alias_body(

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -1470,30 +1470,36 @@ impl<'a> CheckerState<'a> {
                 }
             }
             k if k == syntax_kind_ext::TYPE_REFERENCE => {
-                if let Some(type_ref) = self.ctx.arena.get_type_ref(node)
-                    && let Some(type_arguments) = &type_ref.type_arguments
-                {
-                    for &arg_idx in &type_arguments.nodes {
-                        check_child_type_node!(self, arg_idx);
+                if let Some(type_ref) = self.ctx.arena.get_type_ref(node) {
+                    let is_bare_scoped_type_parameter = self
+                        .type_ref_is_bare_scoped_type_parameter(
+                            type_ref.type_name,
+                            type_ref.type_arguments.as_ref(),
+                        );
+                    if !is_bare_scoped_type_parameter {
+                        if let Some(type_arguments) = &type_ref.type_arguments {
+                            for &arg_idx in &type_arguments.nodes {
+                                check_child_type_node!(self, arg_idx);
+                            }
+                        }
+                        if let Some(sym_id) = self
+                            .resolve_type_symbol_for_lowering(type_ref.type_name)
+                            .map(tsz_binder::SymbolId)
+                            && (self.ctx.symbol_resolution_set.contains(&sym_id)
+                                || self.type_alias_reaches_resolving_alias(sym_id))
+                        {
+                            return;
+                        }
+                        if !self.check_explicit_type_reference_for_alias_body_validation(node_idx) {
+                            let _ = if nested_in_type_literal {
+                                self.get_type_from_type_node_in_type_literal(node_idx)
+                            } else {
+                                self.get_type_from_type_node(node_idx)
+                            };
+                        }
+                        self.check_styled_component_inner_component_constraint(node_idx);
                     }
                 }
-                if let Some(type_ref) = self.ctx.arena.get_type_ref(node)
-                    && let Some(sym_id) = self
-                        .resolve_type_symbol_for_lowering(type_ref.type_name)
-                        .map(tsz_binder::SymbolId)
-                    && (self.ctx.symbol_resolution_set.contains(&sym_id)
-                        || self.type_alias_reaches_resolving_alias(sym_id))
-                {
-                    return;
-                }
-                if !self.check_explicit_type_reference_for_alias_body_validation(node_idx) {
-                    let _ = if nested_in_type_literal {
-                        self.get_type_from_type_node_in_type_literal(node_idx)
-                    } else {
-                        self.get_type_from_type_node(node_idx)
-                    };
-                }
-                self.check_styled_component_inner_component_constraint(node_idx);
             }
             k if k == syntax_kind_ext::TYPE_LITERAL => {
                 if let Some(type_lit) = self.ctx.arena.get_type_literal(node) {

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -12,11 +12,9 @@
 
 use super::alias_defid_visited_pool::with_alias_defid_visited;
 use crate::state::CheckerState;
-use std::hash::{Hash, Hasher};
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, NodeList};
-use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
 #[inline]
@@ -622,120 +620,6 @@ impl<'a> CheckerState<'a> {
         }
 
         None
-    }
-
-    fn check_variance_annotations_supported_for_type_alias(
-        &mut self,
-        alias: &tsz_parser::parser::node::TypeAliasData,
-    ) -> bool {
-        let Some(type_params) = &alias.type_parameters else {
-            return true;
-        };
-
-        let variance_supported = self.type_alias_body_supports_variance_annotations(alias);
-        if variance_supported {
-            return true;
-        }
-
-        let mut emitted_unsupported_variance_diagnostic = false;
-        for param_idx in type_params.nodes.iter().copied() {
-            let Some(param_node) = self.ctx.arena.get(param_idx) else {
-                continue;
-            };
-            let Some(param) = self.ctx.arena.get_type_parameter(param_node) else {
-                continue;
-            };
-            if self.node_contains_any_parse_error(param.name)
-                || self.type_parameter_name_is_variance_keyword(param.name)
-            {
-                continue;
-            }
-            let Some(modifiers) = param.modifiers.as_ref() else {
-                continue;
-            };
-            let Some(variance_modifier_idx) =
-                modifiers.nodes.iter().copied().find(|&modifier_idx| {
-                    self.ctx
-                        .arena
-                        .get(modifier_idx)
-                        .is_some_and(|modifier_node| {
-                            matches!(
-                                modifier_node.kind,
-                                k if k == SyntaxKind::InKeyword as u16
-                                    || k == SyntaxKind::OutKeyword as u16
-                            )
-                        })
-                })
-            else {
-                continue;
-            };
-
-            self.error_at_node(
-                variance_modifier_idx,
-                crate::diagnostics::diagnostic_messages::VARIANCE_ANNOTATIONS_ARE_ONLY_SUPPORTED_IN_TYPE_ALIASES_FOR_OBJECT_FUNCTION_CONS,
-                crate::diagnostics::diagnostic_codes::VARIANCE_ANNOTATIONS_ARE_ONLY_SUPPORTED_IN_TYPE_ALIASES_FOR_OBJECT_FUNCTION_CONS,
-            );
-            emitted_unsupported_variance_diagnostic = true;
-        }
-
-        !emitted_unsupported_variance_diagnostic
-    }
-
-    fn type_alias_has_variance_annotation_to_check(
-        &self,
-        type_parameters: Option<&tsz_parser::parser::base::NodeList>,
-    ) -> bool {
-        let Some(type_params) = type_parameters else {
-            return false;
-        };
-
-        type_params.nodes.iter().copied().any(|param_idx| {
-            let Some(param_node) = self.ctx.arena.get(param_idx) else {
-                return false;
-            };
-            let Some(param) = self.ctx.arena.get_type_parameter(param_node) else {
-                return false;
-            };
-            let Some(modifiers) = &param.modifiers else {
-                return false;
-            };
-
-            let mut declared_in = false;
-            let mut declared_out = false;
-            for modifier_idx in modifiers.nodes.iter().copied() {
-                let Some(modifier_node) = self.ctx.arena.get(modifier_idx) else {
-                    continue;
-                };
-                declared_in |= modifier_node.kind == SyntaxKind::InKeyword as u16;
-                declared_out |= modifier_node.kind == SyntaxKind::OutKeyword as u16;
-            }
-
-            declared_in != declared_out
-        })
-    }
-
-    fn type_alias_body_supports_variance_annotations(
-        &self,
-        alias: &tsz_parser::parser::node::TypeAliasData,
-    ) -> bool {
-        self.ctx.arena.kind_at(alias.type_node).is_some_and(|kind| {
-            kind == syntax_kind_ext::TYPE_LITERAL
-                || kind == syntax_kind_ext::FUNCTION_TYPE
-                || kind == syntax_kind_ext::CONSTRUCTOR_TYPE
-                || kind == syntax_kind_ext::MAPPED_TYPE
-        })
-    }
-
-    fn type_parameter_name_is_variance_keyword(&self, name_idx: NodeIndex) -> bool {
-        if matches!(
-            self.get_identifier_text_from_idx(name_idx).as_deref(),
-            Some("in" | "out")
-        ) {
-            return true;
-        }
-        self.ctx.arena.get(name_idx).is_some_and(|node| {
-            node.kind == SyntaxKind::InKeyword as u16 || node.kind == SyntaxKind::OutKeyword as u16
-        })
     }
 
     /// Walk the alias body AST and return the AST node of the last
@@ -1353,41 +1237,6 @@ impl<'a> CheckerState<'a> {
             scope_key,
             active_alias_key,
         );
-    }
-
-    fn active_resolving_alias_set_key(&self) -> u64 {
-        if self.ctx.symbol_resolution_set.is_empty() {
-            return 0;
-        }
-        if self.ctx.symbol_resolution_set.len() == 1 {
-            let Some(&sym_id) = self.ctx.symbol_resolution_set.iter().next() else {
-                return 0;
-            };
-            return self
-                .ctx
-                .get_existing_def_id(sym_id)
-                .map_or(u64::from(sym_id.0), |def_id| {
-                    (1_u64 << 32) | u64::from(def_id.0)
-                });
-        }
-
-        let mut entries = self
-            .ctx
-            .symbol_resolution_set
-            .iter()
-            .map(|&sym_id| {
-                self.ctx
-                    .get_existing_def_id(sym_id)
-                    .map_or(u64::from(sym_id.0), |def_id| {
-                        (1_u64 << 32) | u64::from(def_id.0)
-                    })
-            })
-            .collect::<Vec<_>>();
-        entries.sort_unstable();
-
-        let mut hasher = rustc_hash::FxHasher::default();
-        entries.hash(&mut hasher);
-        hasher.finish()
     }
 
     fn check_type_node_with_literal_context(

--- a/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
@@ -851,7 +851,7 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    fn type_ref_is_bare_scoped_type_parameter(
+    pub(crate) fn type_ref_is_bare_scoped_type_parameter(
         &self,
         type_name: NodeIndex,
         type_arguments: Option<&tsz_parser::parser::base::NodeList>,

--- a/crates/tsz-checker/src/types/type_checking/type_alias_variance.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_variance.rs
@@ -1,0 +1,121 @@
+//! Type-alias variance annotation validation.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
+use tsz_scanner::SyntaxKind;
+
+impl<'a> CheckerState<'a> {
+    pub(crate) fn check_variance_annotations_supported_for_type_alias(
+        &mut self,
+        alias: &tsz_parser::parser::node::TypeAliasData,
+    ) -> bool {
+        let Some(type_params) = &alias.type_parameters else {
+            return true;
+        };
+
+        let variance_supported = self.type_alias_body_supports_variance_annotations(alias);
+        if variance_supported {
+            return true;
+        }
+
+        let mut emitted_unsupported_variance_diagnostic = false;
+        for param_idx in type_params.nodes.iter().copied() {
+            let Some(param_node) = self.ctx.arena.get(param_idx) else {
+                continue;
+            };
+            let Some(param) = self.ctx.arena.get_type_parameter(param_node) else {
+                continue;
+            };
+            if self.node_contains_any_parse_error(param.name)
+                || self.type_parameter_name_is_variance_keyword(param.name)
+            {
+                continue;
+            }
+            let Some(modifiers) = param.modifiers.as_ref() else {
+                continue;
+            };
+            let Some(variance_modifier_idx) =
+                modifiers.nodes.iter().copied().find(|&modifier_idx| {
+                    self.ctx
+                        .arena
+                        .get(modifier_idx)
+                        .is_some_and(|modifier_node| {
+                            matches!(
+                                modifier_node.kind,
+                                k if k == SyntaxKind::InKeyword as u16
+                                    || k == SyntaxKind::OutKeyword as u16
+                            )
+                        })
+                })
+            else {
+                continue;
+            };
+
+            self.error_at_node(
+                variance_modifier_idx,
+                crate::diagnostics::diagnostic_messages::VARIANCE_ANNOTATIONS_ARE_ONLY_SUPPORTED_IN_TYPE_ALIASES_FOR_OBJECT_FUNCTION_CONS,
+                crate::diagnostics::diagnostic_codes::VARIANCE_ANNOTATIONS_ARE_ONLY_SUPPORTED_IN_TYPE_ALIASES_FOR_OBJECT_FUNCTION_CONS,
+            );
+            emitted_unsupported_variance_diagnostic = true;
+        }
+
+        !emitted_unsupported_variance_diagnostic
+    }
+
+    pub(crate) fn type_alias_has_variance_annotation_to_check(
+        &self,
+        type_parameters: Option<&tsz_parser::parser::base::NodeList>,
+    ) -> bool {
+        let Some(type_params) = type_parameters else {
+            return false;
+        };
+
+        type_params.nodes.iter().copied().any(|param_idx| {
+            let Some(param_node) = self.ctx.arena.get(param_idx) else {
+                return false;
+            };
+            let Some(param) = self.ctx.arena.get_type_parameter(param_node) else {
+                return false;
+            };
+            let Some(modifiers) = &param.modifiers else {
+                return false;
+            };
+
+            let mut declared_in = false;
+            let mut declared_out = false;
+            for modifier_idx in modifiers.nodes.iter().copied() {
+                let Some(modifier_node) = self.ctx.arena.get(modifier_idx) else {
+                    continue;
+                };
+                declared_in |= modifier_node.kind == SyntaxKind::InKeyword as u16;
+                declared_out |= modifier_node.kind == SyntaxKind::OutKeyword as u16;
+            }
+
+            declared_in != declared_out
+        })
+    }
+
+    fn type_alias_body_supports_variance_annotations(
+        &self,
+        alias: &tsz_parser::parser::node::TypeAliasData,
+    ) -> bool {
+        self.ctx.arena.kind_at(alias.type_node).is_some_and(|kind| {
+            kind == syntax_kind_ext::TYPE_LITERAL
+                || kind == syntax_kind_ext::FUNCTION_TYPE
+                || kind == syntax_kind_ext::CONSTRUCTOR_TYPE
+                || kind == syntax_kind_ext::MAPPED_TYPE
+        })
+    }
+
+    fn type_parameter_name_is_variance_keyword(&self, name_idx: NodeIndex) -> bool {
+        if matches!(
+            self.get_identifier_text_from_idx(name_idx).as_deref(),
+            Some("in" | "out")
+        ) {
+            return true;
+        }
+        self.ctx.arena.get(name_idx).is_some_and(|node| {
+            node.kind == SyntaxKind::InKeyword as u16 || node.kind == SyntaxKind::OutKeyword as u16
+        })
+    }
+}

--- a/crates/tsz-lowering/src/lower/advanced.rs
+++ b/crates/tsz-lowering/src/lower/advanced.rs
@@ -466,6 +466,14 @@ impl<'a> TypeLowering<'a> {
                 && let Some(ident) = self.arena.get_identifier(name_node)
             {
                 let name = ident.escaped_text.as_str();
+                if data
+                    .type_arguments
+                    .as_ref()
+                    .is_none_or(|args| args.nodes.is_empty())
+                    && let Some(type_param) = self.lookup_type_param(name)
+                {
+                    return type_param;
+                }
 
                 // Handle string manipulation intrinsic types.
                 // String intrinsics (Uppercase, Lowercase, Capitalize, Uncapitalize)


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 / performance benchmark blocker for the `ts-essentials-project` green-row 2x target gap.

## Invariant
A bare reference to an in-scope type parameter with no type arguments has no arity, constraint, missing-name, recursive-alias, styled-component inner-component, or application-construction work to perform. This PR skips only that structural case in alias-body `check_type_node` validation and in lowering `TypeReference` resolution. Generic references, references with type arguments, unresolved names, recursive alias references, non-identifier references, and out-of-scope references remain on the existing validation/lowering paths.

## Scope
- `crates/tsz-checker/src/types/type_checking/type_alias_checking.rs`
- `crates/tsz-checker/src/types/type_checking/type_alias_body_validation.rs`
- `crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs`
- `crates/tsz-checker/src/types/type_checking/type_alias_variance.rs`
- `crates/tsz-checker/src/types/type_checking/mod.rs`
- `crates/tsz-lowering/src/lower/advanced.rs`

## Project Corpus Impact
- Row: `ts-essentials-project`
- Bug family: utility-type mapped/conditional/key-space alias body validation/lowering work
- Baseline after #12630 context-key slice, attribution sidecar `artifacts/perf/studio-b-scope-key-reuse-ts-essentials-attribution-20260605.perf.json`: `XOR` alias `body_validation` 20.04ms; slow `XOR` statement 45.25ms; diagnostics 0.
- Checker-skip attribution sidecar `artifacts/perf/studio-b-bare-tparam-validation-a0d7a45-ts-essentials-attribution-20260605.perf.json`: diagnostics 0, Check 0.45s, Total 0.60s, Memory 108352K; `XOR` alias `body_validation` 4.45ms; slow `XOR` statement 29.57ms. Semantic counters stayed stable: delegation calls 144, compute_type_of_symbol calls 500, TypeInterner calls 18114.
- Lowering-skip attribution sidecar `artifacts/perf/studio-b-lowering-bare-tparam-b61e77c-ts-essentials-attribution-20260605.perf.json`: diagnostics 0, Check 0.45s, Total 0.60s, Memory 108992K; `XOR` alias `body` 9.60ms, `body_validation` 4.48ms; slow `XOR` statement 26.91ms. Semantic counters stayed stable: delegation calls 144, compute_type_of_symbol calls 500, TypeInterner calls 18114.
- One-row quick timing artifact `artifacts/perf/studio-b-lowering-bare-tparam-ts-essentials-quick-20260605.json`: `tsz` 65.91ms vs `tsgo` 79.33ms, `tsz` 1.20x faster. Companion `artifacts/perf/studio-b-lowering-bare-tparam-ts-essentials-quick-20260605.tsgo-winners.json` reports `two_x_target.rows_below_target = 1` and target gap factor 1.6617. The row remains diagnostic-green and below the Studio-B 2x target.
- Current head `be8e07c52f` adds a refactor-only helper split so `type_alias_checking.rs` is 1932 lines, below the 2000-line guardrail, without changing the bare-type-parameter skip behavior.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-lowering -p tsz-checker`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json artifacts/perf/studio-b-lowering-bare-tparam-b61e77c-ts-essentials-attribution-20260605.perf.json --noEmit -p .target-bench/external/ts-essentials/tsconfig.flat.json`
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials-project$' --json-file artifacts/perf/studio-b-lowering-bare-tparam-ts-essentials-quick-20260605.json`
- `node scripts/bench/tsgo-winner-report.mjs artifacts/perf/studio-b-lowering-bare-tparam-ts-essentials-quick-20260605.json artifacts/perf/studio-b-lowering-bare-tparam-ts-essentials-quick-20260605.tsgo-winners.json`
- Exact current head `be8e07c52f`: `cargo fmt -p tsz-checker`
- Exact current head `be8e07c52f`: `git diff --check`
- Exact current head `be8e07c52f`: `cargo fmt --check -p tsz-checker`
- Exact current head `be8e07c52f`: `scripts/safe-run.sh cargo check -p tsz-checker`
- Exact current head `be8e07c52f`: `scripts/safe-run.sh cargo nextest run -p tsz-checker --test type_alias_signature_body_validation_tests --no-fail-fast`
- Exact current head `be8e07c52f`: `python3 scripts/arch/arch_guard.py` still fails known baseline guard buckets (`property_access_type/identifier_resolution.rs` direct lookup, `type_display.rs` 2014 lines, direct `tsz_solver` imports 36/35, `query_boundaries::common` quarantine references, clippy suppressions 11/10); `type_alias_checking.rs` is no longer a line-cap failure.

## Coordination Notes
- Follow-up to merged #12630. The missing-name coverage and context-key slices are already on `main` through #12630.
- Disk hygiene this cycle: `scripts/setup/disk-worktree-guard.sh --auto-prune` pruned none; `scripts/setup/clean.sh --quiet` preserved caches but removed the local `.target-bench` link, restored as a symlink to `/Users/mohsen/code/tsz-studio-b-12516-tsess-gap-20260604/.target-bench` for fixture reuse.
- `cargo nextest run -p tsz-checker ref_type_params_cache_tests` and `cargo nextest list -p tsz-checker ref_type_params_cache_tests` both hung after build/discovery with no child test process earlier in this cycle; stopped those local invocations. CI should still run exact-head nextest checks.
- Ready for review/CI. Do not queue until exact-head required checks pass. The overall Studio-B mission remains active because `ts-essentials-project` is still below the 2x target.
- Label audit note: `scripts/agents/ensure-agent-labels.sh --audit` reports repo-level missing canonical labels `agent:M1-D` and `agent:M4-C`; no open PR had missing, multiple, or noncanonical agent labels.
