### PR TITLE
fix(solver): infer fixed prefix/suffix of variadic tuple rest params

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -247,6 +247,10 @@ name = "variadic_tuple_recursive_zip_tests"
 path = "tests/variadic_tuple_recursive_zip_tests.rs"
 
 [[test]]
+name = "variadic_tuple_rest_param_suffix_inference_tests"
+path = "tests/variadic_tuple_rest_param_suffix_inference_tests.rs"
+
+[[test]]
 name = "recursive_conditional_alias_index_tests"
 path = "tests/recursive_conditional_alias_index_tests.rs"
 

--- a/crates/tsz-checker/tests/variadic_tuple_rest_param_suffix_inference_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_rest_param_suffix_inference_tests.rs
@@ -1,0 +1,228 @@
+//! Regression coverage for variadic tuple inference through a tuple-typed rest
+//! parameter that has fixed elements on *both* sides of the variadic part.
+//!
+//! Structural rule: a tuple-typed rest parameter is, to `tsc`, just a tuple
+//! parameter. When a call's trailing arguments are matched against
+//! `...args: [pre…, ...Mid, post…]`, `tsc` packs every trailing argument into a
+//! single source tuple and runs `inferFromTupleTypes`, so the fixed prefix, the
+//! single variadic middle, *and* the fixed suffix each receive candidates with
+//! the correct arity and element positions.
+//!
+//! Before the fix, tsz only inferred the middle variadic slice: a fixed suffix
+//! type parameter (`L` in `[H, ...M, L]`) was never inferred and fell back to
+//! `unknown`, and a fixed prefix type parameter (`H`) was dropped whenever a
+//! fixed suffix was present. Each case below pins behavior with an assignability
+//! witness — the exact type `tsc` produces must NOT raise `TS2322`, and a
+//! deliberately wrong target type MUST raise exactly one `TS2322`. Binder
+//! spellings are varied so the behavior is structural, not name-keyed.
+
+use tsz_checker::test_utils::check_source_codes;
+
+fn assert_no_errors(source: &str, label: &str) {
+    let codes = check_source_codes(source);
+    assert!(
+        codes.is_empty(),
+        "{label}: expected no diagnostics, got {codes:?}"
+    );
+}
+
+fn assert_only_one_2322(source: &str, label: &str) {
+    let codes = check_source_codes(source);
+    assert_eq!(
+        codes,
+        vec![2322],
+        "{label}: expected exactly one TS2322, got {codes:?}"
+    );
+}
+
+// =============================================================================
+// Fixed prefix + variadic middle + fixed suffix: [H, ...M, L]
+// =============================================================================
+
+#[test]
+fn prefix_middle_suffix_type_params_all_inferred() {
+    assert_no_errors(
+        r#"
+declare function f<H, M extends unknown[], L>(...args: [H, ...M, L]): [H, M, L];
+const r = f("a", 1, true);
+const ok: [string, [number], boolean] = r;
+"#,
+        "[H, ...M, L]: H=string, M=[number], L=boolean",
+    );
+}
+
+#[test]
+fn prefix_middle_suffix_rejects_wrong_suffix_type() {
+    // The suffix `L` must actually be inferred (regression: it used to be
+    // `unknown`, which silently accepted any target).
+    assert_only_one_2322(
+        r#"
+declare function f<H, M extends unknown[], L>(...args: [H, ...M, L]): [H, M, L];
+const r = f("a", 1, true);
+const bad: [string, [number], string] = r;
+"#,
+        "wrong suffix element type must be a TS2322",
+    );
+}
+
+#[test]
+fn prefix_middle_suffix_rejects_wrong_prefix_type() {
+    assert_only_one_2322(
+        r#"
+declare function f<H, M extends unknown[], L>(...args: [H, ...M, L]): [H, M, L];
+const r = f("a", 1, true);
+const bad: [number, [number], boolean] = r;
+"#,
+        "wrong prefix element type must be a TS2322",
+    );
+}
+
+#[test]
+fn prefix_middle_suffix_longer_middle_keeps_arity() {
+    assert_no_errors(
+        r#"
+declare function f<H, M extends unknown[], L>(...args: [H, ...M, L]): [H, M, L];
+const r = f("a", 1, 2, 3, true);
+const ok: [string, [number, number, number], boolean] = r;
+"#,
+        "longer middle: M=[number, number, number]",
+    );
+}
+
+#[test]
+fn prefix_middle_suffix_empty_middle_is_empty_tuple() {
+    assert_no_errors(
+        r#"
+declare function f<H, M extends unknown[], L>(...args: [H, ...M, L]): [H, M, L];
+const r = f("a", true);
+const ok: [string, [], boolean] = r;
+"#,
+        "no middle arguments: M=[]",
+    );
+}
+
+#[test]
+fn prefix_middle_suffix_renamed_binders() {
+    // Proves the fix is structural, not keyed to the spellings H/M/L.
+    assert_no_errors(
+        r#"
+declare function combine<Head, Mid extends unknown[], Tail>(
+    ...xs: [Head, ...Mid, Tail]
+): [Head, Mid, Tail];
+const r = combine("h", 1, 2, "t");
+const ok: [string, [number, number], string] = r;
+"#,
+        "renamed binders behave identically",
+    );
+}
+
+// =============================================================================
+// Leading variadic + fixed suffix type parameter(s): [...I, L]
+// =============================================================================
+
+#[test]
+fn leading_variadic_with_suffix_type_param_inferred() {
+    assert_no_errors(
+        r#"
+declare function f<I extends unknown[], L>(...args: [...I, L]): [I, L];
+const r = f("a", 1, true);
+const ok: [[string, number], boolean] = r;
+"#,
+        "[...I, L]: I=[string, number], L=boolean",
+    );
+}
+
+#[test]
+fn leading_variadic_with_suffix_rejects_wrong_suffix() {
+    assert_only_one_2322(
+        r#"
+declare function f<I extends unknown[], L>(...args: [...I, L]): [I, L];
+const r = f("a", 1, true);
+const bad: [[string, number], string] = r;
+"#,
+        "wrong suffix element type must be a TS2322",
+    );
+}
+
+#[test]
+fn leading_variadic_with_two_fixed_suffix_params() {
+    assert_no_errors(
+        r#"
+declare function f<I extends unknown[], P, Q>(...args: [...I, P, Q]): [I, P, Q];
+const r = f(1, 2, "x", true);
+const ok: [[number, number], string, boolean] = r;
+"#,
+        "[...I, P, Q]: I=[number, number], P=string, Q=boolean",
+    );
+}
+
+// =============================================================================
+// Multiple fixed prefix elements before the variadic: [A, B, ...M, L]
+// =============================================================================
+
+#[test]
+fn two_prefix_elements_with_middle_and_suffix() {
+    assert_no_errors(
+        r#"
+declare function f<A, B, M extends unknown[], L>(...args: [A, B, ...M, L]): [A, B, M, L];
+const r = f("a", 1, true, false, {}, 9);
+const ok: [string, number, [boolean, boolean, {}], number] = r;
+"#,
+        "[A, B, ...M, L]: prefix, middle, and suffix all inferred",
+    );
+}
+
+// =============================================================================
+// Guard: two adjacent variadic type parameters still fall back to constraints
+// =============================================================================
+//
+// `[...A, ...B]` has no implied arity to split on, so `tsc` infers nothing and
+// both `A` and `B` default to their constraint (`unknown[]`). The broad fix must
+// preserve this: it must NOT over-infer a concrete arity by greedily packing the
+// arguments into the first variadic.
+
+#[test]
+fn two_adjacent_variadics_fall_back_to_constraint() {
+    assert_no_errors(
+        r#"
+declare function split<A extends unknown[], B extends unknown[]>(
+    ...xs: [...A, ...B]
+): [A, B];
+const r = split("a", 1, true);
+const ok: [unknown[], unknown[]] = r;
+"#,
+        "two adjacent variadics: A=B=unknown[]",
+    );
+}
+
+#[test]
+fn two_adjacent_variadics_do_not_over_infer() {
+    assert_only_one_2322(
+        r#"
+declare function split<A extends unknown[], B extends unknown[]>(
+    ...xs: [...A, ...B]
+): [A, B];
+const r = split("a", 1, true);
+const bad: [[string, number, boolean], []] = r;
+"#,
+        "over-inferring a concrete arity for an unsplittable variadic is wrong",
+    );
+}
+
+// =============================================================================
+// Fixed prefix params before the rest parameter stay positional
+// =============================================================================
+
+#[test]
+fn fixed_param_before_variadic_rest_tuple() {
+    // A normal fixed parameter ahead of the rest parameter must still be
+    // inferred positionally while the rest tuple distributes the trailing args.
+    assert_no_errors(
+        r#"
+declare function f<F, M extends unknown[], L>(first: F, ...rest: [...M, L]): [F, M, L];
+const r = f("first", 1, 2, true);
+const ok: [string, [number, number], boolean] = r;
+"#,
+        "fixed leading param + [...M, L] rest tuple",
+    );
+}

--- a/crates/tsz-solver/src/operations/call_args.rs
+++ b/crates/tsz-solver/src/operations/call_args.rs
@@ -1262,47 +1262,34 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             }
             Some(TypeData::Tuple(elements)) => {
                 let elements = self.interner.tuple_list(elements);
-                // Two or more adjacent variadic type parameters (`...args: [...A, ...B]`)
-                // cannot be split without an implied arity, which a tuple-typed rest
-                // parameter never has (tsc's `getNonArrayRestType` returns `undefined`
-                // for it). tsc infers nothing here, leaving `A`/`B` to fall back to
-                // their constraints — so bail out of the single-variadic slicing below
-                // rather than mis-distributing the arguments.
+                // A tuple-typed rest parameter is, to tsc, just a tuple parameter:
+                // its fixed prefix, single variadic middle, and fixed suffix are all
+                // inferred together by `inferFromTupleTypes`. We mirror that by packing
+                // EVERY trailing argument into one source tuple and inferring it against
+                // the whole rest tuple type, so `constrain_tuple_types` can recover every
+                // element position — including the fixed prefix/suffix type parameters
+                // (`H` and `L` in `...args: [H, ...M, L]`) that a middle-only slice drops.
+                //
+                // This is correct precisely when the tuple has exactly one variadic
+                // element that is an inference variable:
+                //   * 0 such elements — nothing variadic to distribute; a fully fixed
+                //     tuple rest param (`...args: [T, number]`) is inferred positionally
+                //     by the normal argument loop, and a concrete-only spread
+                //     (`...args: [string, ...number[]]`) carries no inference variable.
+                //   * 2+ such elements (`...args: [...A, ...B]`) cannot be split without
+                //     an implied arity, which a tuple-typed rest parameter never has
+                //     (tsc's `getNonArrayRestType` returns `undefined`); tsc infers
+                //     nothing and both fall back to their constraints, so we bail and let
+                //     Round 1's positional loop leave them unconstrained.
                 let infer_var_rest_count = elements
                     .iter()
                     .filter(|elem| elem.rest && var_map.contains_key(&elem.type_id))
                     .count();
-                if infer_var_rest_count >= 2 {
+                if infer_var_rest_count != 1 {
                     return None;
                 }
-                elements.iter().enumerate().find_map(|(i, elem)| {
-                    if !elem.rest {
-                        return None;
-                    }
-                    if !var_map.contains_key(&elem.type_id) {
-                        return None;
-                    }
-
-                    // Count trailing elements after the variadic part, but allow optional
-                    // tail elements to be omitted when they don't match.
-                    let tail = &elements[i + 1..];
-                    let min_index = rest_start + i;
-                    let mut trailing_count = 0usize;
-                    let mut arg_index = arg_types.len();
-                    for tail_elem in tail.iter().rev() {
-                        if arg_index <= min_index {
-                            break;
-                        }
-                        let arg_type = arg_types[arg_index - 1];
-                        let assignable = self.checker.is_assignable_to(arg_type, tail_elem.type_id);
-                        if tail_elem.optional && !assignable {
-                            break;
-                        }
-                        trailing_count += 1;
-                        arg_index -= 1;
-                    }
-                    Some((rest_start + i, elem.type_id, trailing_count))
-                })
+                let source_tuple = self.build_rest_argument_source_tuple(arg_types, rest_start);
+                return Some((rest_start, rest_param_type, source_tuple));
             }
             // Application rest param: e.g., `...args: TupleMapper<Tuple>` where Tuple
             // is an inference variable and TupleMapper is a mapped type alias.
@@ -1346,39 +1333,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // The variadic arguments start at start_index and end before trailing elements.
         let end_index = arg_types.len().saturating_sub(trailing_count);
         let tuple_elements: Vec<TupleElement> = if start_index < end_index {
-            arg_types[start_index..end_index]
-                .iter()
-                .flat_map(|&ty| {
-                    if let Some(inner) = self.spread_argument_marker_inner(ty) {
-                        return vec![TupleElement {
-                            type_id: inner,
-                            name: None,
-                            optional: false,
-                            rest: true,
-                        }];
-                    }
-                    // Recognize spread marker tuples [...T] from the checker.
-                    // Only match markers whose inner type is a TypeParameter.
-                    if let Some(TypeData::Tuple(elems_id)) = self.interner.lookup(ty) {
-                        let elems = self.interner.tuple_list(elems_id);
-                        if elems.len() == 1
-                            && elems[0].rest
-                            && matches!(
-                                self.interner.lookup(elems[0].type_id),
-                                Some(TypeData::TypeParameter(_))
-                            )
-                        {
-                            return elems.to_vec();
-                        }
-                    }
-                    vec![TupleElement {
-                        type_id: ty,
-                        name: None,
-                        optional: false,
-                        rest: false,
-                    }]
-                })
-                .collect()
+            self.rest_argument_tuple_elements(&arg_types[start_index..end_index])
         } else {
             Vec::new()
         };
@@ -1394,6 +1349,58 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             target_type,
             self.interner.tuple(tuple_elements),
         ))
+    }
+
+    /// Convert a slice of call-argument types into tuple elements for variadic
+    /// tuple inference. A spread-argument marker (`f(...xs)`) and a checker
+    /// `[...T]` marker tuple whose inner type is a bare type parameter both
+    /// become `rest` elements so the resulting source tuple keeps the same
+    /// variadic structure tsc sees; every other argument becomes a fixed
+    /// element.
+    fn rest_argument_tuple_elements(&self, args: &[TypeId]) -> Vec<TupleElement> {
+        args.iter()
+            .flat_map(|&ty| {
+                if let Some(inner) = self.spread_argument_marker_inner(ty) {
+                    return vec![TupleElement {
+                        type_id: inner,
+                        name: None,
+                        optional: false,
+                        rest: true,
+                    }];
+                }
+                // Recognize spread marker tuples [...T] from the checker.
+                // Only match markers whose inner type is a TypeParameter.
+                if let Some(TypeData::Tuple(elems_id)) = self.interner.lookup(ty) {
+                    let elems = self.interner.tuple_list(elems_id);
+                    if elems.len() == 1
+                        && elems[0].rest
+                        && matches!(
+                            self.interner.lookup(elems[0].type_id),
+                            Some(TypeData::TypeParameter(_))
+                        )
+                    {
+                        return elems.to_vec();
+                    }
+                }
+                vec![TupleElement {
+                    type_id: ty,
+                    name: None,
+                    optional: false,
+                    rest: false,
+                }]
+            })
+            .collect()
+    }
+
+    /// Pack every trailing argument (`arg_types[rest_start..]`) into one source
+    /// tuple so it can be inferred against a tuple-typed rest parameter as a
+    /// whole. tsc treats a tuple-typed rest parameter exactly like a tuple
+    /// parameter, so the entire argument list — fixed prefix, variadic middle,
+    /// and fixed suffix — is distributed in a single `inferFromTupleTypes` pass.
+    fn build_rest_argument_source_tuple(&self, arg_types: &[TypeId], rest_start: usize) -> TypeId {
+        let elements =
+            self.rest_argument_tuple_elements(arg_types.get(rest_start..).unwrap_or(&[]));
+        self.interner.tuple(elements)
     }
 
     /// Check if a type evaluates to or contains a function type.


### PR DESCRIPTION
AgentName: Studio-B
Track: Track 1 — conformance / inference parity
Invariant: tsz call-site inference matches tsc for tuple-typed rest parameters (`inferFromTupleTypes`).
Scope: solver call-resolution (`rest_tuple_inference_target`) + regression tests. No checker/emit/public-API surface change.

## Summary

Fixes a verified parity bug in the variadic-tuple-tail family for issue #10801. Call-site inference for a tuple-typed rest parameter with a single variadic element and **fixed elements around it** only inferred the middle variadic slice. The fixed *suffix* type parameter (`L` in `...args: [H, ...M, L]`) was never inferred (fell back to `unknown`), and the fixed *prefix* (`H`) was also dropped whenever a suffix was present — the prefix argument was skipped as an "aggregate rest" argument.

Verified against `tsc` 6.0:

| signature + call | tsc | tsz (before) | tsz (after) |
|---|---|---|---|
| `(...a:[H,...M,L]) f("a",1,true)` | `[string,[number],boolean]` | `[unknown,[number],unknown]` | `[string,[number],boolean]` |
| `(...a:[...I,L]) f("a",1,true)` | `[[string,number],boolean]` | `[[string,number],unknown]` | `[[string,number],boolean]` |
| `(...a:[A,B,...M,L]) f("a",1,true,false,{},9)` | `[string,number,[boolean,boolean,{}],number]` | dropped prefix+suffix | matches |

## Structural rule

When a generic call's trailing arguments match a tuple-typed rest parameter with a single inference-variable variadic element, tsc treats the rest parameter as a tuple parameter and distributes the whole argument list (fixed prefix, variadic middle, fixed suffix) in one `inferFromTupleTypes` pass; tsz now does the same through the solver's `rest_tuple_inference_target` → `constrain_tuple_types` path.

Instead of computing a middle-only slice in `rest_tuple_inference_target` (`crates/tsz-solver/src/operations/call_args.rs`), pack **all** trailing arguments into one source tuple and infer it against the whole rest-tuple type. The existing `constrain_tuple_types` already recovers every element position (prefix/middle/suffix), so no special-casing is added — the fix routes a new call site through the existing general algorithm.

Routed only when the rest tuple has **exactly one** inference-variable variadic element. The two-adjacent-variadic case (`...args: [...A, ...B]`) still bails to constraints (`A = B = unknown[]`), matching tsc, since it has no implied arity to split on.

## Owner layer

Solver (`tsz-solver`). Checker orchestration unchanged; the inference decision stays inside the solver's call-resolution boundary.

## Adjacent-case matrix

`prefix+middle+suffix`, `leading-variadic+suffix`, two fixed-suffix params, multi-prefix, renamed binders (structural, not name-keyed), empty middle, longer middle, fixed param before the rest tuple, plus the two-adjacent-variadic guard (positive + negative witnesses).

## Verification

- New `crates/tsz-checker/tests/variadic_tuple_rest_param_suffix_inference_tests.rs` — 13 tests, all green; each pinned against `tsc` 6.0.
- Full `tsz-solver` lib suite: 6528 passed, 0 failed.
- `variadic_tuple_arity_inference_tests`, `variadic_tuple_recursive_zip_tests`, `rest_tuple_conditional_arg_tests`, `spread_rest_tests`, `contextual_tuple_tests`, `call_resolution_regression_tests`, `generic_call_inference_tests`: no new failures (pre-existing baseline failures confirmed pre-existing via stash).
- `cargo fmt` + `cargo clippy -p tsz-solver --lib` clean.

## Project Corpus Impact

- Row: rxjs-project
- Bug family: variadic-tuples (tuple-typed rest-parameter tail/suffix inference)
- Impact: targets the `rxjs-project` benchmark family (variadic callback signatures / tuple-heavy operator typing). No required project row regressed; the change is structural and name-independent.

## Coordination Notes

Closes the call-inference side of #10801. The `/simplify` pass collapsed the routing guard to `infer_var_rest_count != 1` and extracted a shared `rest_argument_tuple_elements` helper (DRY with the existing bare-type-param/Application packing).

https://claude.ai/code/session_01Y96DbLY5yvtc3boRVUg11F