### PR TITLE
fix(resolver): prefer @types declarations over untyped scoped JS packages

### DIFF
--- a/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
+++ b/crates/tsz-core/src/module_resolver/node_modules_resolution.rs
@@ -214,7 +214,17 @@ impl ModuleResolver {
             }
         }
 
-        // Walk up directory tree looking for node_modules
+        // Walk up directory tree looking for node_modules.
+        //
+        // A runtime package that only resolves to a JavaScript entry (no
+        // bundled declarations) is remembered here rather than returned
+        // eagerly: tsc still prefers a matching `@types/...` declaration
+        // package over an untyped JS entry — e.g. `@babel/core` is typed by
+        // `@types/babel__core`, `@storybook/react` by `@types/storybook__react`.
+        // We keep walking for a typed resolution (a runtime package that
+        // resolves to `.ts`/`.d.ts`, an `@types/...` package, or a type root)
+        // and only fall back to the closest JS entry when none exist.
+        let mut js_fallback: Option<ResolvedModule> = None;
         let mut current = containing_dir.to_path_buf();
         loop {
             let child_node_modules = current.join("node_modules");
@@ -259,15 +269,29 @@ impl ModuleResolver {
                         specifier_span,
                         &conditions,
                     ) {
-                        Ok(resolved) => return Ok(resolved),
+                        Ok(resolved) => {
+                            // Typed resolutions win immediately. A JS-only entry
+                            // is deferred (keeping the first/closest one) so a
+                            // matching `@types/...` package can take priority
+                            // (see the `js_fallback` note above).
+                            if resolved.extension.is_javascript() {
+                                js_fallback.get_or_insert(resolved);
+                            } else {
+                                return Ok(resolved);
+                            }
+                        }
                         Err(e @ ResolutionFailure::NotFound { .. }) => {
                             // In Node16/NodeNext/Bundler, exports field is authoritative —
-                            // don't continue searching parent node_modules.
+                            // don't continue searching parent node_modules. A closer
+                            // JS entry already found still wins over giving up.
                             if self.should_stop_on_exports_failure(
                                 &package_dir,
                                 subpath.as_deref(),
                                 &conditions,
                             ) {
+                                if let Some(js) = js_fallback.take() {
+                                    return Ok(js);
+                                }
                                 return Err(e);
                             }
                         }
@@ -282,14 +306,19 @@ impl ModuleResolver {
                     // files like `node_modules/foo.d.ts`. Bundler mode never uses
                     // Node16/NodeNext extension priorities, so package_type is irrelevant.
                     if let Some(resolved) = self.try_file_or_directory(&package_dir, None) {
-                        return Ok(ResolvedModule {
+                        let module = ResolvedModule {
                             resolved_path: resolved.clone(),
                             resolved_using_ts_extension: false,
                             is_external: true,
-                            package_name: Some(package_name),
+                            package_name: Some(package_name.clone()),
                             original_specifier: specifier.to_string(),
                             extension: ModuleExtension::from_path(&resolved),
-                        });
+                        };
+                        if module.extension.is_javascript() {
+                            js_fallback.get_or_insert(module);
+                        } else {
+                            return Ok(module);
+                        }
                     }
                 }
                 // Only probe `node_modules/@types/foo` when `node_modules` itself
@@ -338,6 +367,15 @@ impl ModuleResolver {
             {
                 return Ok(resolved);
             }
+        }
+
+        // No typed resolution was found anywhere. If the package itself resolved
+        // to an untyped JavaScript entry, return that (the import binds as `any`
+        // and the caller surfaces TS7016) — this only happens once every
+        // `@types/...` probe above has failed, so a present declaration package
+        // always wins.
+        if let Some(js) = js_fallback {
+            return Ok(js);
         }
 
         Err(ResolutionFailure::NotFound {

--- a/crates/tsz-core/src/module_resolver/tests/lookup_integration.rs
+++ b/crates/tsz-core/src/module_resolver/tests/lookup_integration.rs
@@ -1785,3 +1785,171 @@ fn test_lookup_bare_json_specifier_nonexistent_upgrades_to_ts2732() {
 
     let _ = fs::remove_dir_all(&dir);
 }
+
+#[test]
+fn test_lookup_scoped_runtime_js_prefers_at_types_declarations() {
+    // Regression for the `@babel/core` -> `@types/babel__core` shape: a scoped
+    // runtime package that only ships JavaScript must resolve to its matching
+    // `@types/scope__name` declaration package instead of reporting TS7016.
+    use super::fixtures::TempFixture;
+    let fx = TempFixture::new();
+    // Runtime, JS-only scoped package (no bundled declarations).
+    fx.write(
+        "node_modules/@scope/widget/package.json",
+        r#"{"name":"@scope/widget","version":"1.0.0","main":"index.js"}"#,
+    );
+    fx.write(
+        "node_modules/@scope/widget/index.js",
+        "module.exports = {};",
+    );
+    // Declarations supplied via the mangled `@types/scope__name` package.
+    fx.write(
+        "node_modules/@types/scope__widget/package.json",
+        r#"{"name":"@types/scope__widget","version":"1.0.0","types":"index.d.ts"}"#,
+    );
+    let types_entry = fx.write(
+        "node_modules/@types/scope__widget/index.d.ts",
+        "export declare const widget: number;",
+    );
+    let containing = fx.write(
+        "src/index.ts",
+        "import { widget } from '@scope/widget';\nwidget;\n",
+    );
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Bundler),
+        module_suffixes: vec![String::new()],
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+
+    let request = ModuleLookupRequest {
+        specifier: "@scope/widget",
+        containing_file: &containing,
+        specifier_span: Span::new(0, 0),
+        import_kind: ImportKind::EsmImport,
+        resolution_mode_override: None,
+        no_implicit_any: true,
+        implied_classic_resolution: false,
+    };
+    let result = resolver.lookup(&request, |_, _| None, |_| false, None);
+    let outcome = result.classify();
+
+    assert!(
+        outcome.error.is_none(),
+        "scoped runtime JS with @types declarations must not report TS7016: {:?}",
+        outcome.error
+    );
+    assert_eq!(
+        outcome.resolved_path.as_deref(),
+        Some(types_entry.as_path()),
+        "scoped runtime JS package must resolve to its @types declaration file"
+    );
+}
+
+#[test]
+fn test_lookup_scoped_runtime_js_without_at_types_still_reports_ts7016() {
+    // The declaration-priority fallback must not mask the genuine "untyped JS"
+    // case: a scoped runtime package with no matching @types package still
+    // resolves to its JS entry and surfaces TS7016 under noImplicitAny.
+    use super::fixtures::TempFixture;
+    let fx = TempFixture::new();
+    fx.write(
+        "node_modules/@scope/untyped/package.json",
+        r#"{"name":"@scope/untyped","version":"1.0.0","main":"index.js"}"#,
+    );
+    fx.write(
+        "node_modules/@scope/untyped/index.js",
+        "module.exports = {};",
+    );
+    let containing = fx.write("src/index.ts", "import x from '@scope/untyped';\nx;\n");
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Bundler),
+        module_suffixes: vec![String::new()],
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+
+    let request = ModuleLookupRequest {
+        specifier: "@scope/untyped",
+        containing_file: &containing,
+        specifier_span: Span::new(0, 0),
+        import_kind: ImportKind::EsmImport,
+        resolution_mode_override: None,
+        no_implicit_any: true,
+        implied_classic_resolution: false,
+    };
+    let result = resolver.lookup(&request, |_, _| None, |_| false, None);
+    let outcome = result.classify();
+
+    let error = outcome
+        .error
+        .expect("untyped scoped JS package must still report a diagnostic");
+    assert_eq!(
+        error.code, COULD_NOT_FIND_DECLARATION_FILE,
+        "expected TS7016 for untyped scoped JS package, got TS{}",
+        error.code
+    );
+}
+
+#[test]
+fn test_lookup_at_types_declarations_win_over_closer_runtime_js() {
+    // Declaration priority is global across the node_modules walk: a closer
+    // JS-only runtime package must not shadow a matching @types declaration
+    // package living in a parent node_modules directory.
+    use super::fixtures::TempFixture;
+    let fx = TempFixture::new();
+    // Closer runtime JS-only package under app/node_modules.
+    fx.write(
+        "app/node_modules/@scope/cross/package.json",
+        r#"{"name":"@scope/cross","version":"1.0.0","main":"index.js"}"#,
+    );
+    fx.write(
+        "app/node_modules/@scope/cross/index.js",
+        "module.exports = {};",
+    );
+    // Declarations in the parent node_modules/@types.
+    fx.write(
+        "node_modules/@types/scope__cross/package.json",
+        r#"{"name":"@types/scope__cross","version":"1.0.0","types":"index.d.ts"}"#,
+    );
+    let types_entry = fx.write(
+        "node_modules/@types/scope__cross/index.d.ts",
+        "export declare const cross: string;",
+    );
+    let containing = fx.write(
+        "app/src/index.ts",
+        "import { cross } from '@scope/cross';\ncross;\n",
+    );
+
+    let options = ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Bundler),
+        module_suffixes: vec![String::new()],
+        ..Default::default()
+    };
+    let mut resolver = ModuleResolver::new(&options);
+
+    let request = ModuleLookupRequest {
+        specifier: "@scope/cross",
+        containing_file: &containing,
+        specifier_span: Span::new(0, 0),
+        import_kind: ImportKind::EsmImport,
+        resolution_mode_override: None,
+        no_implicit_any: true,
+        implied_classic_resolution: false,
+    };
+    let result = resolver.lookup(&request, |_, _| None, |_| false, None);
+    let outcome = result.classify();
+
+    assert!(
+        outcome.error.is_none(),
+        "parent @types declarations must win over closer JS-only package: {:?}",
+        outcome.error
+    );
+    assert_eq!(
+        outcome.resolved_path.as_deref(),
+        Some(types_entry.as_path()),
+        "resolution must prefer the parent @types declaration file"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
fix(resolver) — module resolution / @types fallback

## Invariant
When a non-relative specifier resolves a runtime npm package to an untyped JavaScript entry, `tsc` still prefers a matching declaration package (`@types/scope__name` for `@scope/name`, `@types/name` for `name`) found anywhere along the resolution walk. tsz must apply the same global declaration-priority before surfacing TS7016.

## Scope
Closes #12461.

Root cause (verified empirically, not assumed): the issue's *reduced* repro — only `@types/foo__bar` present, no runtime `@foo/bar` — already passed; `types_package_name` and `parse_package_specifier` already mangle scoped names correctly, and the existing `@types` fallback covers the "no runtime package" case. The real defect is the `@babel/core` shape: when a scoped **runtime** package resolves to a `.js` entry, `resolve_bare_specifier` returned it immediately and never probed `@types/babel__core`, so `lookup` fired TS7016 and cascaded TS7006/TS7031 implicit-any diagnostics across the import's callers.

Change: `crates/tsz-core/src/module_resolver/node_modules_resolution.rs::resolve_bare_specifier` now defers a JS-only runtime resolution into a `js_fallback` and keeps walking `node_modules` (and the type roots) for a typed resolution — a runtime package resolving to `.ts`/`.d.ts`, an `@types/…` package, or a type root. The deferred JS entry is returned only once every typed probe has failed, so a present declaration package always wins. This matches `tsc`'s declaration priority both at the same `node_modules` level and across levels (a parent `@types/…` beats a closer JS-only package). The exports-authoritative early-return preserves the closer JS entry if one was already found.

## Structural Rule
> When a bare specifier resolves a runtime package to a JavaScript-only entry, tsc prefers a reachable declaration package (`@types/scope__name` / `@types/name`, or the runtime package's own `.d.ts`) over the untyped JS, falling back to the JS entry only when no declarations exist anywhere — owned by the solver-backed module resolver (`resolve_bare_specifier`), with TS7016 emission left to `lookup`/`classify`.

## Project Corpus Impact
- Row: jotai (the issue's real-world discovery); any project depending on a scoped package whose types live in DefinitelyTyped (`@babel/*` → `@types/babel__*`, `@storybook/*`, `@wordpress/*`, `@reach/*`).
- Bug family: module-resolution — `@types/scope__name` fallback for untyped scoped JS packages (declaration priority over untyped JS).
- Effect: removes false TS7016 on the scoped import plus its cascading TS7006/TS7031 implicit-any diagnostics on callback parameters.

## Verification
- Reproduced with the built `tsz` binary in both `--moduleResolution bundler` and `node16`:
  - runtime `@baz/core` JS + `@types/baz__core` → clean (was TS7016).
  - scoped runtime JS with **no** `@types` → still TS7016 (fallback does not mask genuine untyped JS).
  - package shipping its own `.d.ts` alongside a stale `@types` → own declarations win.
  - cross-level: parent `node_modules/@types/…` beats a closer JS-only package.
- Added 3 regression tests in `crates/tsz-core/src/module_resolver/tests/lookup_integration.rs` (reusing the module's `TempFixture` helper).
- `cargo test -p tsz-core --lib module_resolver::` → 234 passed; cross-file `module_resolution_tests::` → 88 passed; `cargo test -p tsz-cli --lib driver::resolution` → 74 passed. Clippy clean on the changed crate.

## Coordination Notes
- No anti-hardcoding concerns: the rule keys off resolved-file extension (`is_javascript`) and the existing structural `types_package_name` mangling — no user identifier, file-name, or rendered-string predicates.
- `/simplify` applied: switched the two `is_none()` guards to `Option::get_or_insert`; new tests use the existing `TempFixture` fixture helper.