### PR TITLE
fix(resolver): anchor node_modules walk-up at realpath inside symlinked packages

### DIFF
--- a/crates/tsz-cli/src/driver/resolution/package_resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution/package_resolution.rs
@@ -233,7 +233,11 @@ pub(crate) fn resolve_node_module_specifier(
         }
     }
 
-    let mut current = from_file.parent().unwrap_or(base_dir);
+    // Anchor the walk-up at the containing file's real path so bare imports
+    // from inside a symlinked package (pnpm's `.pnpm` sandbox) can reach the
+    // package's private/transitive dependencies. See `node_modules_walkup_dir`.
+    let start_dir = node_modules_walkup_dir(from_file, base_dir, options);
+    let mut current = start_dir.as_path();
 
     loop {
         // 1. Look for the package itself in node_modules

--- a/crates/tsz-cli/src/driver/resolution/path_resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution/path_resolution.rs
@@ -628,6 +628,54 @@ pub(crate) fn has_node_modules_component(path: &Path) -> bool {
     })
 }
 
+/// Directory from which a `node_modules` walk-up should begin for resolutions
+/// originating in `from_file`.
+///
+/// `tsc` performs module resolution relative to the *real* on-disk location of
+/// a file (`preserveSymlinks: false`, the default). When a package is installed
+/// through a symlink — pnpm hoists `node_modules/<pkg>` to a symlink whose
+/// target lives in an isolated `.pnpm/<pkg>@<version>/node_modules` sandbox —
+/// that sandbox holds the package's private (transitive) dependencies. Walking
+/// up from the *symlink* path only reaches the top-level `node_modules`, so
+/// transitive `@types/*` siblings referenced via `/// <reference types="..." />`
+/// or bare `import`/`require` from inside the package are missed, producing
+/// spurious `TS2688`/`TS2307`.
+///
+/// Resolving the real path of the containing directory restores parity: the
+/// walk-up then traverses the sandbox and finds the siblings. The file's
+/// program identity (its symlink-relative display path) is untouched — only the
+/// lookup anchor changes, mirroring how `tsc` separates module identity from
+/// the realpath used for resolution.
+///
+/// The probe is gated so ordinary project files never pay a `realpath` syscall:
+/// `preserveSymlinks` disables it (matching `tsc`), and the `realpath` is only
+/// taken when the file actually lives inside a symlinked `node_modules` package.
+///
+/// Use this only for *cross-package* walk-ups — resolving a different package
+/// (a bare specifier or a `/// <reference types>` sibling). Walk-ups that stay
+/// *inside* the containing package (package.json `imports`, self-reference,
+/// nearest-`package.json` mode detection) must keep the symlink-relative anchor
+/// so intra-package files retain their symlink identity (see
+/// `normalize_resolved_path`); those paths are fully reachable through the
+/// symlink and have no sandbox blind spot.
+pub(crate) fn node_modules_walkup_dir(
+    from_file: &Path,
+    base_dir: &Path,
+    options: &ResolvedCompilerOptions,
+) -> PathBuf {
+    let dir = from_file.parent().unwrap_or(base_dir);
+    // The cheap `node_modules` path scan short-circuits the per-ancestor
+    // symlink probe for ordinary project files.
+    let needs_realpath = !options.preserve_symlinks
+        && has_node_modules_component(from_file)
+        && path_has_symlinked_package_ancestor(from_file);
+    if needs_realpath {
+        canonicalize_or_owned(dir)
+    } else {
+        dir.to_path_buf()
+    }
+}
+
 pub(crate) fn is_root_alias_symlink(dir: &Path) -> bool {
     if !dir.is_absolute() {
         return false;

--- a/crates/tsz-cli/src/driver/resolution/type_packages.rs
+++ b/crates/tsz-cli/src/driver/resolution/type_packages.rs
@@ -67,7 +67,12 @@ pub(crate) fn resolve_type_reference_from_node_modules_with_cache(
         .and_then(|(package_name, subpath)| subpath.map(|subpath| (package_name, subpath)));
     let conditions = export_conditions(options);
 
-    let mut current = from_file.parent().unwrap_or(base_dir);
+    // Anchor the walk-up at the containing file's real path so triple-slash
+    // references from inside a symlinked package (pnpm's `.pnpm` sandbox) can
+    // reach the package's private/transitive `@types/*` siblings. See
+    // `node_modules_walkup_dir`.
+    let start_dir = node_modules_walkup_dir(from_file, base_dir, options);
+    let mut current = start_dir.as_path();
 
     loop {
         let node_modules = current.join("node_modules");

--- a/crates/tsz-cli/src/driver/resolution_tests.rs
+++ b/crates/tsz-cli/src/driver/resolution_tests.rs
@@ -198,6 +198,169 @@ fn test_resolve_module_specifier_from_node_modules_package_finds_sibling_package
     let _ = fs::remove_dir_all(&dir);
 }
 
+/// Build the shared options used by the pnpm-symlink resolution tests.
+#[cfg(test)]
+fn pnpm_symlink_test_options(preserve_symlinks: bool) -> ResolvedCompilerOptions {
+    ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        preserve_symlinks,
+        module_suffixes: vec![String::new()],
+        printer: tsz::emitter::PrinterOptions {
+            module: ModuleKind::Node16,
+            ..Default::default()
+        },
+        checker: tsz::checker::context::CheckerOptions {
+            module: ModuleKind::Node16,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Build a pnpm sandbox where the top-level `@types/express` is a symlink into
+/// the `.pnpm` store and `@types/express-serve-static-core` exists *only* as its
+/// transitive (un-hoisted) sibling inside that store. Returns `(project_dir,
+/// sandbox_types_dir)`; `express/index.d.ts` is written with `express_content`.
+#[cfg(test)]
+fn setup_pnpm_express_sandbox(dir_name: &str, express_content: &str) -> (PathBuf, PathBuf) {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    let dir = std::env::temp_dir().join(dir_name);
+    let _ = fs::remove_dir_all(&dir);
+    let sandbox = dir.join("node_modules/.pnpm/@types+express@5.0.6/node_modules/@types");
+    fs::create_dir_all(sandbox.join("express")).unwrap();
+    fs::create_dir_all(sandbox.join("express-serve-static-core")).unwrap();
+    fs::write(sandbox.join("express/index.d.ts"), express_content).unwrap();
+    fs::write(
+        sandbox.join("express-serve-static-core/index.d.ts"),
+        "export type Core = number;",
+    )
+    .unwrap();
+    fs::create_dir_all(dir.join("node_modules/@types")).unwrap();
+    symlink(
+        sandbox.join("express"),
+        dir.join("node_modules/@types/express"),
+    )
+    .unwrap();
+    (dir, sandbox)
+}
+
+/// `/// <reference types="..." />` from inside a pnpm-symlinked `@types/*`
+/// package must reach the package's *transitive* `@types/*` sibling, which
+/// lives only inside the realpath `.pnpm/<pkg>@<ver>/node_modules` sandbox and
+/// is never hoisted to the top-level `node_modules/@types`.
+#[test]
+fn test_type_reference_resolves_transitive_sibling_in_pnpm_symlink_sandbox() {
+    let (dir, sandbox) = setup_pnpm_express_sandbox(
+        "tsz_driver_resolution_pnpm_triple_slash",
+        "/// <reference types=\"express-serve-static-core\" />\nexport {};",
+    );
+
+    let options = pnpm_symlink_test_options(false);
+    let mut cache = ModuleResolutionCache::default();
+
+    // Resolve from the *symlink* path, exactly as file discovery records it.
+    let from_file = dir.join("node_modules/@types/express/index.d.ts");
+    let resolved = resolve_type_reference_from_node_modules_with_cache(
+        "express-serve-static-core",
+        &from_file,
+        &dir,
+        None,
+        &options,
+        &mut cache,
+    );
+
+    let expected = canonicalize_or_owned(&sandbox.join("express-serve-static-core/index.d.ts"));
+    assert_eq!(resolved.map(|p| canonicalize_or_owned(&p)), Some(expected));
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// `preserveSymlinks` keeps `tsc`'s symlink-path resolution: the transitive
+/// sibling is *not* visible from the top-level symlink path, so the reference
+/// stays unresolved. This pins the gate so the realpath anchor only applies
+/// when symlinks are followed.
+#[test]
+fn test_type_reference_preserve_symlinks_does_not_reach_sandbox_sibling() {
+    let (dir, _sandbox) = setup_pnpm_express_sandbox(
+        "tsz_driver_resolution_pnpm_triple_slash_preserve",
+        "export {};",
+    );
+
+    let options = pnpm_symlink_test_options(true);
+    let mut cache = ModuleResolutionCache::default();
+    let from_file = dir.join("node_modules/@types/express/index.d.ts");
+    let resolved = resolve_type_reference_from_node_modules_with_cache(
+        "express-serve-static-core",
+        &from_file,
+        &dir,
+        None,
+        &options,
+        &mut cache,
+    );
+
+    assert_eq!(resolved, None);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A bare `import`/`require` from inside a pnpm-symlinked package must reach the
+/// package's transitive dependency in the realpath sandbox — the same root
+/// cause as the triple-slash case, exercised through the bare-specifier
+/// walk-up.
+#[test]
+fn test_bare_import_resolves_transitive_dependency_in_pnpm_symlink_sandbox() {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+
+    let dir = std::env::temp_dir().join("tsz_driver_resolution_pnpm_bare_import");
+    let _ = fs::remove_dir_all(&dir);
+    let sandbox = dir.join("node_modules/.pnpm/@types+react@19.0.0/node_modules");
+    fs::create_dir_all(sandbox.join("@types/react")).unwrap();
+    fs::create_dir_all(sandbox.join("csstype")).unwrap();
+    fs::write(
+        sandbox.join("@types/react/index.d.ts"),
+        "import type { Properties } from \"csstype\";\nexport type R = Properties;",
+    )
+    .unwrap();
+    fs::write(
+        sandbox.join("csstype/package.json"),
+        "{\"name\":\"csstype\",\"version\":\"3.0.0\",\"types\":\"index.d.ts\"}",
+    )
+    .unwrap();
+    fs::write(
+        sandbox.join("csstype/index.d.ts"),
+        "export interface Properties {}",
+    )
+    .unwrap();
+    fs::create_dir_all(dir.join("node_modules/@types")).unwrap();
+    symlink(
+        sandbox.join("@types/react"),
+        dir.join("node_modules/@types/react"),
+    )
+    .unwrap();
+
+    let options = pnpm_symlink_test_options(false);
+    let mut cache = ModuleResolutionCache::default();
+    let known_files: FxHashSet<PathBuf> = FxHashSet::default();
+
+    let from_file = dir.join("node_modules/@types/react/index.d.ts");
+    let resolved = resolve_module_specifier(
+        &from_file,
+        "csstype",
+        &options,
+        &dir,
+        &mut cache,
+        &known_files,
+    );
+
+    let expected = canonicalize_or_owned(&sandbox.join("csstype/index.d.ts"));
+    assert_eq!(resolved.map(|p| canonicalize_or_owned(&p)), Some(expected));
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn test_normalize_resolved_path_collapses_segments_for_symlinked_package_identity() {
     use std::fs;


### PR DESCRIPTION
Fixes #12459

AgentName: Studio-B
Track: module-resolution / resolver
Invariant: `tsc` resolves modules relative to a file's *real* on-disk location (`preserveSymlinks: false`, the default). A file's program identity (its symlink-relative display path) is independent of the realpath used to anchor further resolution.

## Structural Rule
When a file lives inside a symlinked `node_modules` package and `preserveSymlinks` is off, `tsc` performs the `node_modules` walk-up from the file's **realpath**, so it can reach the package's private/transitive dependencies; `tsz` was anchoring the walk-up at the **symlink** path and missing them.

## Scope
pnpm hoists `node_modules/<pkg>` to a symlink whose target lives in an isolated `node_modules/.pnpm/<pkg>@<ver>/node_modules` sandbox. That sandbox holds the package's *transitive* dependencies, which are **not** hoisted to the top-level `node_modules`. Because `tsz` anchored the `node_modules` walk-up at the symlink path, `/// <reference types="..." />` directives and bare `import`/`require` statements from inside such a package could not see their sibling packages, producing spurious `TS2688` / `TS2307`. Witnessed by `mswjs/msw` (two `TS2688` in `@types/express/index.d.ts` for `express-serve-static-core` and `serve-static`), but the family covers any pnpm project pulling in fan-out `@types/*`.

The fix is a single shared helper, `node_modules_walkup_dir` (`crates/tsz-cli/src/driver/resolution/path_resolution.rs`), that re-anchors the walk-up at the containing file's realpath when — and only when — the file lives inside a symlinked `node_modules` package and `preserveSymlinks` is off. It is applied at the two **cross-package** walk-ups:
- `resolve_type_reference_from_node_modules_with_cache` (triple-slash type references)
- `resolve_node_module_specifier` (bare `import`/`require`)

Deliberately **not** applied to intra-package walk-ups (`package.json` `imports`, self-reference, nearest-`package.json` mode detection): those resolve content that is fully reachable through the symlink, and keeping the symlink anchor preserves each file's symlink identity (see `normalize_resolved_path` / `preserve_package_link_identity`). The helper's doc states this boundary so future cross-package walk-ups apply it and intra-package ones don't.

Owner layer: CLI driver resolver (`tsz-cli`). No checker/solver/emitter changes.

No hardcoding: no fixture-name, package-name, or path-string special cases — the gate is purely structural (`!preserveSymlinks && has_node_modules_component && path_has_symlinked_package_ancestor`). The cheap `node_modules` path scan short-circuits the per-ancestor symlink probe so ordinary project files never pay a `realpath` syscall, and the helper is computed once per resolution (outside the walk-up loop).

## Project Corpus Impact
- Row: n/a (no project-bench row added or rescored; removes false TS2688/TS2307 on pnpm projects with transitive `@types/*` such as msw)
- Bug family: module-resolution (pnpm symlink sandbox / transitive `@types` identity)

No change for npm-flat layouts or `preserveSymlinks: true` (gated out). File program identity is unchanged, so no module-specifier/display drift.

## Verification
- `cargo test -p tsz-cli --lib resolution::resolution_tests` → **59 passed / 0 failed**, including 3 new pnpm tests:
  - `test_type_reference_resolves_transitive_sibling_in_pnpm_symlink_sandbox` (positive)
  - `test_type_reference_preserve_symlinks_does_not_reach_sandbox_sibling` (gate: `preserveSymlinks` keeps `tsc` behavior → unresolved)
  - `test_bare_import_resolves_transitive_dependency_in_pnpm_symlink_sandbox` (bare-import surface of the same root cause)
- `cargo test -p tsz-cli --test tsc_compat_tests` → passed.
- `cargo fmt` clean.

## Coordination Notes
Studio-B explicitly released #12459 (2026-06-04T09:21:59Z, "leave this issue open but unclaimed"); no open PR targeted it. Sibling agent `claude-confident-hawking/qrRGV` is on the separate SIGABRT family (#12455) — no overlap.

---
_Generated by [Claude Code](https://claude.ai/code)_