### PR TITLE
fix(parser): stop losing token boundaries in template-literal-type recovery

### DIFF
--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -819,16 +819,44 @@ impl ParserState {
         loop {
             let type_node = self.parse_type();
 
-            // Now we need to rescan for the template continuation
-            // The scanner needs to be told to rescan as template
-            self.scanner.re_scan_template_token(false);
-            self.current_token = self.scanner.get_token();
-
+            // tsc's `parseLiteralOfTemplateSpan`: only when the `${...}` substitution
+            // actually closes with `}` do we re-scan the brace as a template
+            // middle/tail. If a syntax error left the scanner parked on some other
+            // token, re-scanning a template token from that non-`}` position would
+            // reinterpret unrelated source as template text and lose token
+            // boundaries during recovery. In that case tsc emits `'}' expected` and
+            // synthesizes a missing `TemplateTail` without consuming the token, so
+            // the surrounding statement context recovers from the real position.
+            // `re_scan_template_token` only rewinds `pos` to the token start, so the
+            // span start is the same whether or not we re-scan; read it once.
             let span_start = self.token_pos();
-            let is_tail = self.is_token(SyntaxKind::TemplateTail);
+            let (literal, is_tail) = if self.is_token(SyntaxKind::CloseBraceToken) {
+                // Tell the scanner to rescan the `}` as a template continuation.
+                self.scanner.re_scan_template_token(false);
+                self.current_token = self.scanner.get_token();
 
-            // Parse the template middle/tail literal
-            let literal = self.parse_template_literal_span();
+                let is_tail = self.is_token(SyntaxKind::TemplateTail);
+
+                // Parse the template middle/tail literal.
+                let literal = self.parse_template_literal_span();
+                (literal, is_tail)
+            } else {
+                use tsz_common::diagnostics::diagnostic_codes;
+                let literal_end = self.token_end();
+                self.parse_error_at_current_token("'}' expected.", diagnostic_codes::EXPECTED);
+                let literal = self.arena.add_literal(
+                    SyntaxKind::TemplateTail as u16,
+                    span_start,
+                    literal_end,
+                    node::LiteralData {
+                        text: String::new(),
+                        raw_text: None,
+                        value: None,
+                        has_invalid_escape: false,
+                    },
+                );
+                (literal, true)
+            };
             let span_end = self.token_full_start();
 
             // Create a template span node

--- a/crates/tsz-parser/tests/parser_improvement_template_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_template_recovery_tests.rs
@@ -3,6 +3,92 @@
 use crate::parser::syntax_kind_ext;
 use crate::parser::test_fixture::parse_source;
 
+/// Collect the diagnostic codes for `source` in emission order.
+fn diagnostic_codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    parser.get_diagnostics().iter().map(|d| d.code).collect()
+}
+
+/// Structural rule: inside a template-literal *type*, each `${...}` substitution
+/// is a full type expression terminated by `}`. tsc's `parseLiteralOfTemplateSpan`
+/// only re-scans the brace as a template middle/tail when the substitution
+/// actually closes with `}`. If a syntax error leaves the parser parked on some
+/// other token, tsc emits `'}' expected` (TS1005) and synthesizes a *missing*
+/// `TemplateTail` without consuming the token — so the rest of the source is
+/// recovered from its real position. tsz must not blindly re-scan a template
+/// token from a non-`}` position, which would reinterpret unrelated source as
+/// template text and lose token boundaries during recovery.
+///
+/// `type R = ` + "`${A B}`" closes the substitution after `A`; the stray `B`
+/// must trigger the `TS1005` / `TS1128` / `TS1160` recovery cascade exactly as
+/// tsc produces, rather than being silently absorbed as template text.
+#[test]
+fn template_type_substitution_unterminated_by_stray_token_recovers_like_tsc() {
+    assert_eq!(
+        diagnostic_codes("type R = `${A B}`;"),
+        vec![1005, 1128, 1160],
+        "stray token after a template-type substitution type must emit the \
+         '}}' expected / declaration-expected / unterminated-template cascade"
+    );
+}
+
+/// The same rule must hold regardless of the binder spelling and across a
+/// statement-terminator stray token, proving the recovery is structural and not
+/// keyed on a particular identifier or token.
+#[test]
+fn template_type_substitution_stray_token_recovery_is_structural() {
+    // A different binder name and a `;` (instead of an identifier) as the stray
+    // token: still `'}' expected` + declaration-expected + unterminated.
+    assert_eq!(
+        diagnostic_codes("type Mapped = `${Outer;}`;"),
+        vec![1005, 1128, 1160],
+    );
+}
+
+/// A failed type parse inside the substitution (no valid type at all) reports
+/// `Type expected` (TS1110) at the offending token; tsc's same-position
+/// deduplication then suppresses the redundant `'}' expected`, leaving the
+/// declaration-expected / unterminated cascade. The previous tsz behavior
+/// swallowed everything after the bogus substitution into a phantom tail and
+/// emitted only the single TS1110.
+#[test]
+fn template_type_substitution_empty_or_invalid_recovers_like_tsc() {
+    assert_eq!(diagnostic_codes("type X = `${,}`;"), vec![1110, 1128, 1160]);
+    // A bare, well-formed empty substitution `${}` reports only `Type expected`,
+    // since the `}` legitimately closes the (empty) substitution.
+    assert_eq!(diagnostic_codes("type Y = `${}`;"), vec![1110]);
+}
+
+/// Multi-span template types must recover at the first broken span and not
+/// cascade phantom tails through the remaining spans.
+#[test]
+fn template_type_multi_span_recovers_at_first_broken_span() {
+    assert_eq!(
+        diagnostic_codes("type Q = `pre${A}mid${,}post`;"),
+        vec![1110, 1128, 1160],
+    );
+}
+
+/// Regression guard: a *valid* constrained-`infer` template-literal type in a
+/// conditional `extends` branch — the exact surface family in the originating
+/// benchmark row — must still parse with zero diagnostics. The fix only changes
+/// the error-recovery branch, so the well-formed grammar stays untouched.
+#[test]
+fn template_type_constrained_infer_extends_branch_parses_clean() {
+    for source in [
+        "type Foo<T> = T extends `${infer A extends string}` ? A : never;",
+        "type Split<S> = S extends `${infer H extends string}${infer R}` ? H : never;",
+        "type Joined = `a${string}b${number}c`;",
+        "type Nested<T> = T extends `x${T extends string ? `${infer A}` : never}y` ? A : never;",
+    ] {
+        assert!(
+            diagnostic_codes(source).is_empty(),
+            "expected no parse errors for {source:?}, got {:?}",
+            diagnostic_codes(source),
+        );
+    }
+}
+
 /// Structural rule: when a template literal appears where an object-literal
 /// property name is expected, tsc closes the object literal at the template,
 /// recovers the template as a tagged-template tail on the object expression,


### PR DESCRIPTION
Fixes #10925.

AgentName: M4-Opus
Track: parser / grammar edge handling
Invariant: template-literal-type span parsing matches `tsc`'s `parseLiteralOfTemplateSpan` recovery, including same-position diagnostic dedup.

## Structural rule
When a template-literal **type** `` `...${T}...` `` has a `${...}` substitution whose
type parse stops on a token other than `}` (an error-recovery situation), `tsc`
emits `'}' expected` and synthesizes a missing tail; tsz now does the same
through the parser's `parse_template_literal_type`.

Concretely, `tsc`'s `parseLiteralOfTemplateSpan` only re-scans the brace as a
template middle/tail **when the current token is actually `}`**. Otherwise it
emits `TS1005 '}' expected`, synthesizes a *missing* `TemplateTail` without
consuming the token, and lets the surrounding statement context recover from the
real position. tsz previously re-scanned a template token **unconditionally**, so
after an error it reinterpreted unrelated source as template text and silently
swallowed the rest of the statement — dropping the diagnostics `tsc` produces.

## Owner layer
Parser (`crates/tsz-parser/src/parser/state_types_advanced.rs`,
`parse_template_literal_type`). No checker/solver/emitter involvement. The
type-side template-span parser is brought in line with the already-correct
expression-side path (`state_expressions_literals.rs`); tsz's existing
same-position diagnostic dedup (`parse_error_at`) reproduces `tsc`'s exact
cascades.

## Adjacent-case matrix (verified at exact `tsc` parity)
- Stray token closes substitution early: `` `${A B}` `` -> `TS1005 / TS1128 / TS1160`
  (previously **no diagnostic** — the core bug).
- Empty / invalid substitution: `` `${,}` ``, `` `${)}` `` -> `TS1110 / TS1128 / TS1160`
  (the redundant `'}' expected` is suppressed by same-position dedup, matching `tsc`).
- Well-formed empty `` `${}` `` -> `TS1110` only.
- Statement-terminator stray token `` `${A;}` `` -> `TS1005 / TS1128 / TS1160`.
- Multi-span recovery `` `pre${A}mid${,}post` `` -> recovers at the first broken span.
- Binder spelling varied across tests (anti-hardcoding gate) — recovery is structural.

## Fallback / negative cases
Valid constrained-`infer` template types in conditional `extends` branches — the
exact surface family from the originating row — still parse with **zero**
diagnostics (`` T extends `${infer A extends string}` ? A : never ``, multi-`infer`
splits, nested conditional templates). The change only touches the error branch;
the well-formed grammar is untouched. The two remaining template-substitution
divergences vs `tsc` (trailing `|` union operand, unterminated tuple element) are
**pre-existing** in separate recovery subsystems and are unchanged by this PR.

## Scope
`crates/tsz-parser/src/parser/state_types_advanced.rs` (fix) +
`crates/tsz-parser/tests/parser_improvement_template_recovery_tests.rs`
(5 new regression tests). 2 files, +122/-8.

## Project Corpus Impact
- Row: ts-essentials-project
- Bug family: parser template-literal-type recovery (parser/grammar edge handling)
- Effect: parser-only diagnostic recovery for malformed template-literal types;
  well-formed code (the conformance/corpus compile surface) is unaffected, so no
  project-row compile output changes are expected.

## Verification
- `cargo test -p tsz-parser --lib` -> 1373 passed / 0 failed.
- `cargo clippy -p tsz-parser --lib` -> clean.
- 25+ snippet differential vs the bundled `tsc` confirms exact
  diagnostic-code-and-position parity on the recovery matrix above.
- `/simplify` run 3x.

## Coordination Notes
No solver/checker/emitter changes; no API changes; clean fast-forward over
`main` (no conflict). Tracking issue #10925 is labeled WIP while this PR is in
flight.