### PR TITLE
perf(checker): instantiate only the needed param per overload argument

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -584,35 +584,11 @@ impl<'a> CheckerState<'a> {
                             );
                             let mut progressive_args = Vec::with_capacity(args.len());
                             for (i, &arg_idx) in args.iter().enumerate() {
-                                let contextual_params = sig
-                                    .params
-                                    .iter()
-                                    .map(|param| {
-                                        let mut instantiated_param = *param;
-                                        instantiated_param.type_id =
-                                            crate::query_boundaries::common::instantiate_type(
-                                                self.ctx.types,
-                                                param.type_id,
-                                                &progressive_sub,
-                                            );
-                                        instantiated_param
-                                    })
-                                    .collect::<Vec<_>>();
-                                let contextual_type = contextual_params
-                                    .get(i)
-                                    .map(|p| (p.type_id, p.rest))
-                                    .or_else(|| {
-                                        let last = contextual_params.last()?;
-                                        last.rest.then_some((last.type_id, true))
-                                    })
-                                    .map(|(param_type, rest)| {
-                                        let param_type = if rest {
-                                            self.rest_argument_element_type_with_env(param_type)
-                                        } else {
-                                            param_type
-                                        };
-                                        self.normalize_contextual_call_param_type(param_type)
-                                    });
+                                let contextual_type = self.instantiated_contextual_param_type_at(
+                                    &sig.params,
+                                    i,
+                                    &progressive_sub,
+                                );
                                 let arg_type = self.compute_single_call_argument_type(
                                     arg_idx,
                                     contextual_type,
@@ -1144,35 +1120,12 @@ impl<'a> CheckerState<'a> {
                         };
                         let mut progressive_args = Vec::with_capacity(args.len());
                         for (i, &arg_idx) in args.iter().enumerate() {
-                            let contextual_params = sig
-                                .params
-                                .iter()
-                                .map(|param| {
-                                    let mut instantiated_param = *param;
-                                    instantiated_param.type_id =
-                                        crate::query_boundaries::common::instantiate_type(
-                                            self.ctx.types,
-                                            param.type_id,
-                                            &progressive_sub,
-                                        );
-                                    instantiated_param
-                                })
-                                .collect::<Vec<_>>();
-                            let contextual_type = contextual_params
-                                .get(i)
-                                .map(|p| (p.type_id, p.rest))
-                                .or_else(|| {
-                                    let last = contextual_params.last()?;
-                                    last.rest.then_some((last.type_id, true))
-                                })
-                                .map(|(param_type, rest)| {
-                                    let param_type = if rest {
-                                        self.rest_argument_element_type_with_env(param_type)
-                                    } else {
-                                        param_type
-                                    };
-                                    self.normalize_contextual_call_param_type(param_type)
-                                })
+                            let contextual_type = self
+                                .instantiated_contextual_param_type_at(
+                                    &sig.params,
+                                    i,
+                                    &progressive_sub,
+                                )
                                 .or_else(|| candidate_param_types.get(i).copied().flatten());
                             let arg_type = self.compute_single_call_argument_type(
                                 arg_idx,

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution/contextual_retry.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution/contextual_retry.rs
@@ -158,31 +158,8 @@ impl<'a> CheckerState<'a> {
             let mut progressive_sub = retry_substitution.unwrap_or_else(TypeSubstitution::new);
             let mut progressive_args = Vec::with_capacity(args.len());
             for (i, &arg_idx) in args.iter().enumerate() {
-                let contextual_params = sig
-                    .params
-                    .iter()
-                    .map(|param| {
-                        let mut instantiated_param = *param;
-                        instantiated_param.type_id =
-                            instantiate_type(self.ctx.types, param.type_id, &progressive_sub);
-                        instantiated_param
-                    })
-                    .collect::<Vec<_>>();
-                let contextual_type = contextual_params
-                    .get(i)
-                    .map(|p| (p.type_id, p.rest))
-                    .or_else(|| {
-                        let last = contextual_params.last()?;
-                        last.rest.then_some((last.type_id, true))
-                    })
-                    .map(|(param_type, rest)| {
-                        let param_type = if rest {
-                            self.rest_argument_element_type_with_env(param_type)
-                        } else {
-                            param_type
-                        };
-                        self.normalize_contextual_call_param_type(param_type)
-                    });
+                let contextual_type =
+                    self.instantiated_contextual_param_type_at(&sig.params, i, &progressive_sub);
                 let arg_type = self.compute_single_call_argument_type(
                     arg_idx,
                     contextual_type,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1014,6 +1014,9 @@ mod object_spread_discriminant_narrowing_tests;
 #[path = "tests/object_spread_optional_merge_tests.rs"]
 mod object_spread_optional_merge_tests;
 #[cfg(test)]
+#[path = "tests/operator_chain_overload_resolution_tests.rs"]
+mod operator_chain_overload_resolution_tests;
+#[cfg(test)]
 #[path = "tests/optional_key_extraction_tests.rs"]
 mod optional_key_extraction_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/operator_chain_overload_resolution_tests.rs
+++ b/crates/tsz-checker/src/tests/operator_chain_overload_resolution_tests.rs
@@ -1,0 +1,154 @@
+//! Regression tests for issue #11337: long generic operator chains such as
+//! `of(1).pipe(map(...), filter(...), scan(...), take(...))`.
+//!
+//! Overload resolution for these chains used to instantiate every parameter of
+//! the matched overload once per argument, making the per-argument loop
+//! `O(args * params)` — quadratic for a `pipe(op1, ..., opN)` overload that
+//! carries one parameter per stage. The shared
+//! `instantiated_contextual_param_type_at` helper now instantiates only the
+//! parameter that actually supplies each argument's contextual type, so the
+//! loop is linear. These tests pin the *behavioral* contract that must survive
+//! that refactor: each stage's callback parameter is still typed under the
+//! correct contextual type, and the chain's result type is preserved.
+
+use crate::test_utils::check_source_code_messages;
+
+/// A small, self-contained RxJS-shaped prelude. `pipe` is overloaded with one
+/// `OperatorFunction` parameter per stage (the exact shape that produced the
+/// quadratic instantiation), and the operator factories are generic so each
+/// stage's inline callback requires contextual typing from the previous stage.
+const RXJS_PRELUDE: &str = r#"
+interface Observable<T> {
+    pipe<A>(op1: OperatorFunction<T, A>): Observable<A>;
+    pipe<A, B>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>): Observable<B>;
+    pipe<A, B, C>(
+        op1: OperatorFunction<T, A>,
+        op2: OperatorFunction<A, B>,
+        op3: OperatorFunction<B, C>,
+    ): Observable<C>;
+    pipe<A, B, C, D>(
+        op1: OperatorFunction<T, A>,
+        op2: OperatorFunction<A, B>,
+        op3: OperatorFunction<B, C>,
+        op4: OperatorFunction<C, D>,
+    ): Observable<D>;
+    pipe<A, B, C, D, E>(
+        op1: OperatorFunction<T, A>,
+        op2: OperatorFunction<A, B>,
+        op3: OperatorFunction<B, C>,
+        op4: OperatorFunction<C, D>,
+        op5: OperatorFunction<D, E>,
+    ): Observable<E>;
+}
+type OperatorFunction<T, R> = (source: Observable<T>) => Observable<R>;
+declare function of<T>(value: T): Observable<T>;
+declare function map<T, R>(project: (value: T) => R): OperatorFunction<T, R>;
+declare function filter<T>(predicate: (value: T) => boolean): OperatorFunction<T, T>;
+declare function scan<T, R>(accumulator: (acc: R, value: T) => R, seed: R): OperatorFunction<T, R>;
+declare function take<T>(count: number): OperatorFunction<T, T>;
+"#;
+
+fn check(body: &str) -> Vec<(u32, String)> {
+    check_source_code_messages(&format!("{RXJS_PRELUDE}\n{body}"))
+}
+
+fn codes(messages: &[(u32, String)]) -> Vec<u32> {
+    messages.iter().map(|(code, _)| *code).collect()
+}
+
+#[test]
+fn long_operator_chain_resolves_without_diagnostics() {
+    // The canonical issue #11337 repro. A four-stage chain with a contextual
+    // result annotation (which drives the return-context-substitution path that
+    // owns the per-argument instantiation loop) must type-check cleanly.
+    let messages = check(
+        r#"
+const result: Observable<number> = of(1).pipe(
+    map((x) => x + 1),
+    filter((x) => x > 0),
+    scan((a, b) => a + b, 0),
+    take(10),
+);
+"#,
+    );
+    assert!(
+        messages.is_empty(),
+        "expected clean long operator chain, got {messages:?}",
+    );
+}
+
+#[test]
+fn each_stage_callback_param_is_typed_from_previous_stage() {
+    // `map((x) => ...)` receives `x: number` from `of(1)`. If contextual typing
+    // of the per-stage callback parameter regressed to `any`, the `.length`
+    // access below would be silently accepted. Requiring TS2339 here proves the
+    // optimized helper still threads the correct contextual parameter type.
+    let messages = check(
+        r#"
+const bad: Observable<number> = of(1).pipe(
+    map((x) => x.length),
+);
+"#,
+    );
+    assert!(
+        codes(&messages).contains(&2339),
+        "expected TS2339 for `.length` on a number stage param, got {messages:?}",
+    );
+}
+
+#[test]
+fn five_stage_operator_chain_resolves_without_diagnostics() {
+    // Breadth guard: a five-stage chain exercises the `pipe<A, B, C, D, E>`
+    // overload (five parameters), which is where the quadratic instantiation was
+    // most pronounced. The whole chain — including the alternating
+    // number/string stage transitions — must still type-check cleanly under the
+    // linear per-argument instantiation.
+    let messages = check(
+        r#"
+const result: Observable<number> = of(1).pipe(
+    map((x) => x + 1),
+    map((x) => `${x}`),
+    filter((s) => s.length > 0),
+    map((s) => s.length),
+    scan((a, b) => a + b, 0),
+);
+"#,
+    );
+    assert!(
+        messages.is_empty(),
+        "expected clean five-stage operator chain, got {messages:?}",
+    );
+}
+
+#[test]
+fn stage_type_transformation_flows_through_chain() {
+    // `map((x: number) => `${x}`)` turns the stream into `Observable<string>`,
+    // so the following `filter` callback parameter must be `string`. Calling a
+    // string method there must succeed, while a numeric method must fail —
+    // confirming the per-stage contextual type advances across stages.
+    let ok = check(
+        r#"
+const out: Observable<string> = of(1).pipe(
+    map((x) => `${x}`),
+    filter((s) => s.length > 0),
+);
+"#,
+    );
+    assert!(
+        ok.is_empty(),
+        "expected string-stage chain to type-check, got {ok:?}",
+    );
+
+    let bad = check(
+        r#"
+const out: Observable<string> = of(1).pipe(
+    map((x) => `${x}`),
+    filter((s) => s.toFixed(2) !== ""),
+);
+"#,
+    );
+    assert!(
+        codes(&bad).contains(&2339),
+        "expected TS2339 for `.toFixed` on a string stage param, got {bad:?}",
+    );
+}

--- a/crates/tsz-checker/src/types/computation/call/inner_argument_collection.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner_argument_collection.rs
@@ -1318,25 +1318,11 @@
                             }
                             let refreshed_contextual_types: Vec<Option<TypeId>> = (0..args.len())
                                 .map(|i| {
-                                    let param =
-                                        shape.params.get(i).map(|p| (p.type_id, p.rest)).or_else(
-                                            || {
-                                                let last = shape.params.last()?;
-                                                last.rest.then_some((last.type_id, true))
-                                            },
-                                        )?;
-                                    let instantiated =
-                                        crate::query_boundaries::common::instantiate_type(
-                                            self.ctx.types,
-                                            param.0,
-                                            &return_context_substitution,
-                                        );
-                                    let param_type = if param.1 {
-                                        self.rest_argument_element_type_with_env(instantiated)
-                                    } else {
-                                        instantiated
-                                    };
-                                    Some(self.normalize_contextual_call_param_type(param_type))
+                                    self.instantiated_contextual_param_type_at(
+                                        &shape.params,
+                                        i,
+                                        &return_context_substitution,
+                                    )
                                 })
                                 .collect();
                             let mut refreshed_args = self.collect_call_argument_types_with_context(

--- a/crates/tsz-checker/src/types/computation/call_finalize.rs
+++ b/crates/tsz-checker/src/types/computation/call_finalize.rs
@@ -200,6 +200,43 @@ impl<'a> CheckerState<'a> {
         self.evaluate_type_with_env(param_type)
     }
 
+    /// Contextual type contributed by the parameter that supplies argument
+    /// `index`, instantiated under `substitution`.
+    ///
+    /// Argument collection only consumes the parameter at the argument's own
+    /// position — or the trailing rest parameter when the argument index runs
+    /// past the fixed parameters. Building the entire instantiated parameter
+    /// list once per argument made the per-argument loop `O(args * params)`,
+    /// i.e. quadratic for long generic call chains such as
+    /// `pipe(op1, ..., opN)` whose matched overload carries one parameter per
+    /// stage. Instantiating only the parameter that is actually read keeps the
+    /// loop linear while producing the identical contextual type.
+    ///
+    /// `instantiate_type` short-circuits on an empty/identity substitution and
+    /// otherwise routes through the cross-call instantiation cache, so the
+    /// per-argument cost stays `O(1)` amortized.
+    pub(crate) fn instantiated_contextual_param_type_at(
+        &mut self,
+        params: &[tsz_solver::ParamInfo],
+        index: usize,
+        substitution: &common::TypeSubstitution,
+    ) -> Option<TypeId> {
+        let (param_type, rest) = params
+            .get(index)
+            .map(|param| (param.type_id, param.rest))
+            .or_else(|| {
+                let last = params.last()?;
+                last.rest.then_some((last.type_id, true))
+            })?;
+        let param_type = common::instantiate_type(self.ctx.types, param_type, substitution);
+        let param_type = if rest {
+            self.rest_argument_element_type_with_env(param_type)
+        } else {
+            param_type
+        };
+        Some(self.normalize_contextual_call_param_type(param_type))
+    }
+
     pub(crate) fn finalize_generic_call_result(
         &mut self,
         ctx: GenericCallFinalizeCtx<'_>,


### PR DESCRIPTION
## Summary

Closes #11337.

Long generic call chains such as `of(1).pipe(map(...), filter(...), scan(...), take(...))` resolve against a `pipe<A, B, …>(op1, …, opN)` overload that carries **one parameter per stage**. The per-argument contextual-typing loops in overload resolution instantiated **every** parameter of the matched overload on **every** iteration, while only ever reading the parameter at the argument's own index (or the trailing rest parameter). For a chain of length `N` the matched overload has `N` parameters, so the loop did `N args × N params` instantiations — **O(N²)**, exactly the "quadratic flow on chained operator wrappers" the issue reports.

The discarded `N−1` per-argument instantiations were never read, so computing only the needed parameter yields the **identical** contextual type. This is a pure performance refactor: behavior is unchanged.

### Structural rule

When collecting a call argument's contextual type from a candidate signature under a substitution, `tsc` consults only the parameter at the argument's own position (or the trailing rest parameter). `tsz` now does the same through a single shared solver-backed helper, instead of instantiating the entire parameter list per argument.

### Change

- New shared helper `CheckerState::instantiated_contextual_param_type_at(params, index, substitution)` instantiates only the parameter that supplies argument `index` (or the trailing rest param), applies rest-element extraction and `normalize_contextual_call_param_type`, and returns the contextual type. Each per-argument loop is now **O(N)**.
- Routed **four** previously copy-pasted inlined sites through the helper:
  - `overload_resolution.rs` — first-pass return-context progressive loop
  - `overload_resolution.rs` — second-pass (signature-specific) progressive loop
  - `overload_resolution/contextual_retry.rs` — contextual-refresh retry loop
  - `types/computation/call/inner_argument_collection.rs` — generic-call return-context argument collection
- Homed the helper beside its dependencies (`normalize_contextual_call_param_type`, `rest_argument_element_type_with_env`) in `call_finalize.rs` and widened visibility to `pub(crate)` so both overload resolution and generic-call argument collection share one implementation. `instantiate_type` short-circuits on an empty/identity substitution and otherwise routes through the cross-call instantiation cache, so the per-argument cost is O(1) amortized.

AgentName: Studio-B

## Track
Performance (solver-backed checker hot path) — overloaded/generic call argument collection.

## Invariant
Behavior-preserving. The removed per-argument instantiations were never read; instantiating only the consumed parameter produces the same `TypeId`. Overload selection, inference, contextual callback typing, and diagnostics are unchanged.

## Scope
- `crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs`
- `crates/tsz-checker/src/checkers/call_checker/overload_resolution/contextual_retry.rs`
- `crates/tsz-checker/src/types/computation/call/inner_argument_collection.rs`
- `crates/tsz-checker/src/types/computation/call_finalize.rs` (shared helper)
- `crates/tsz-checker/src/lib.rs` (+ test module registration)
- `crates/tsz-checker/src/tests/operator_chain_overload_resolution_tests.rs` (new)

Net `+212 / −102`: ~150 lines are the new test; the fix removes four copies of an inlined loop in favor of one 24-line helper.

## Project Corpus Impact
- Row: rxjs-project
- Bug family: #11337 quadratic flow on chained operator wrappers
- Evidence: Targets the `rxjs-project` row's long operator-pipeline checks. Reduces the matched-overload argument-collection loop from O(N^2) to O(N) in chain length `N`; no required project row should change diagnostics (behavior-preserving). The benchmark/threshold rows are owned by ready-review CI and the project corpus harness, not run locally per repo policy.

## Verification
- `cargo check -p tsz-checker` — clean.
- New `operator_chain_overload_resolution_tests` (4 tests: clean long-chain resolution, per-stage contextual callback typing via TS2339, five-stage breadth, stage-to-stage type propagation) — all pass.
- **Full `tsz-checker` lib suite before/after**: failing-test set is **byte-identical** (68 pre-existing, environment/fixture-dependent failures); diff of failure sets shows **0 regressions introduced** and none of the new tests in the failure set.
- `/simplify` (reuse/simplification/efficiency/altitude review) applied: the helper extraction and the 4th-site unification came out of that pass.

## Coordination Notes
- `git push`-only; no force pushes. Branch `claude/lucid-hopper-9guVx`.
- The remaining `instantiated_params`-indexing sites (which read an already-instantiated parameter vector rather than instantiating per-argument) are intentionally **not** routed through the helper — they are a different shape handled by `contextual_param_types_from_instantiated_params`.
- The repo's pre-existing local test failures are unrelated to this change (verified via baseline diff) and appear fixture/lib-dependent in this environment.

https://claude.ai/code/session_011nZedRWSFqwerTWEpvBgAD

---
_Generated by [Claude Code](https://claude.ai/code/session_011nZedRWSFqwerTWEpvBgAD)_