### PR TITLE
fix(resolver): resolve @types/* triple-slash siblings via realpath through pnpm symlinks

### DIFF
--- a/crates/tsz-cli/src/driver/resolution/type_packages.rs
+++ b/crates/tsz-cli/src/driver/resolution/type_packages.rs
@@ -67,12 +67,76 @@ pub(crate) fn resolve_type_reference_from_node_modules_with_cache(
         .and_then(|(package_name, subpath)| subpath.map(|subpath| (package_name, subpath)));
     let conditions = export_conditions(options);
 
-    let mut current = from_file.parent().unwrap_or(base_dir);
+    // Primary walk: from the importing file's literal (possibly symlinked)
+    // directory up to the project base directory.
+    if let Some(resolved) = probe_type_reference_in_node_modules_chain(
+        from_file.parent().unwrap_or(base_dir),
+        base_dir,
+        &candidates,
+        package_subpath.as_ref(),
+        &conditions,
+        &effective_mode,
+        options,
+        resolution_cache,
+    ) {
+        return Some(resolved);
+    }
+
+    // Secondary walk for symlinked layouts (pnpm `.pnpm` sandboxes, yarn/npm
+    // linked deps). When symlinks are honored (`preserveSymlinks: false`, the
+    // default), `tsc` resolves sibling `@types/*` packages relative to the
+    // *real* (`realpath`) location of the importing `.d.ts`, not the symlink
+    // path. In a pnpm tree `node_modules/@types/foo` is a symlink into
+    // `node_modules/.pnpm/@types+foo@V/node_modules/@types/foo`, and the
+    // siblings it references (e.g. `@types/express-serve-static-core`) live
+    // next to the symlink *target*. The literal walk above only sees the
+    // symlink-relative tree and misses them; re-walk from the real path to
+    // recover the siblings, matching `tsc`.
+    if !options.preserve_symlinks {
+        let real_from_file = canonicalize_or_owned(from_file);
+        if real_from_file.as_path() != from_file {
+            let real_base = canonicalize_or_owned(base_dir);
+            if let Some(resolved) = probe_type_reference_in_node_modules_chain(
+                real_from_file.parent().unwrap_or(real_base.as_path()),
+                real_base.as_path(),
+                &candidates,
+                package_subpath.as_ref(),
+                &conditions,
+                &effective_mode,
+                options,
+                resolution_cache,
+            ) {
+                return Some(resolved);
+            }
+        }
+    }
+
+    None
+}
+
+/// Walk `node_modules` directories from `start_dir` up to (and including)
+/// `stop_dir`, probing each for the triple-slash type reference described by
+/// `candidates`/`package_subpath`. Returns the first declaration file found.
+///
+/// This is the shared engine for both the literal (symlink-relative) walk and
+/// the `realpath` walk used to recover siblings in pnpm/symlinked layouts.
+#[allow(clippy::too_many_arguments)]
+fn probe_type_reference_in_node_modules_chain(
+    start_dir: &Path,
+    stop_dir: &Path,
+    candidates: &[String],
+    package_subpath: Option<&(String, String)>,
+    conditions: &[&str],
+    effective_mode: &str,
+    options: &ResolvedCompilerOptions,
+    resolution_cache: &mut ModuleResolutionCache,
+) -> Option<PathBuf> {
+    let mut current = start_dir;
 
     loop {
         let node_modules = current.join("node_modules");
         if resolution_cache.node_modules_dir_exists(&node_modules) {
-            if let Some((package_name, subpath)) = package_subpath.as_ref() {
+            if let Some((package_name, subpath)) = package_subpath {
                 let package_root = node_modules.join(package_name);
                 if resolution_cache.package_root_dir_exists(&package_root) {
                     let package_json =
@@ -81,7 +145,7 @@ pub(crate) fn resolve_type_reference_from_node_modules_with_cache(
                         &package_root,
                         Some(subpath),
                         package_json.as_ref(),
-                        &conditions,
+                        conditions,
                         options,
                         resolution_cache,
                     );
@@ -91,12 +155,12 @@ pub(crate) fn resolve_type_reference_from_node_modules_with_cache(
                 }
             }
 
-            for candidate in &candidates {
+            for candidate in candidates {
                 let package_root = node_modules.join(candidate);
                 if resolution_cache.package_root_dir_exists(&package_root) {
                     let resolved = resolve_type_package_entry_with_mode_and_cache(
                         &package_root,
-                        &effective_mode,
+                        effective_mode,
                         options,
                         resolution_cache,
                     );
@@ -116,7 +180,7 @@ pub(crate) fn resolve_type_reference_from_node_modules_with_cache(
             }
         }
 
-        if current == base_dir {
+        if current == stop_dir {
             break;
         }
         let Some(parent) = current.parent() else {
@@ -444,6 +508,10 @@ pub(crate) fn resolve_type_package_entry_with_mode_and_cache(
 
     None
 }
+
+#[cfg(test)]
+#[path = "type_packages_symlink_tests.rs"]
+mod type_packages_symlink_tests;
 
 pub(crate) fn default_type_roots(base_dir: &Path) -> Vec<PathBuf> {
     let mut roots = Vec::new();

--- a/crates/tsz-cli/src/driver/resolution/type_packages_symlink_tests.rs
+++ b/crates/tsz-cli/src/driver/resolution/type_packages_symlink_tests.rs
@@ -1,0 +1,163 @@
+//! Regression coverage for triple-slash `@types/*` resolution through pnpm
+//! (and other) symlink layouts.
+//!
+//! When `node_modules/@types/<pkg>` is a symlink into a pnpm `.pnpm` sandbox,
+//! the sibling `@types/*` packages it references via
+//! `/// <reference types="..." />` live next to the symlink *target*, not next
+//! to the symlink. With `preserveSymlinks: false` (the default), `tsc`
+//! resolves them by walking the real (`realpath`) location of the importing
+//! `.d.ts`. These tests pin that behavior.
+//!
+//! Package names are intentionally synthetic (`foo`, `foo-core`, `foo-bar`)
+//! rather than the real `express` triple to prove the fix is structural and
+//! not keyed on any particular package name.
+
+use super::*;
+use crate::config::ModuleResolutionKind;
+use std::fs;
+use std::os::unix::fs::symlink;
+
+fn node16_options() -> ResolvedCompilerOptions {
+    ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        preserve_symlinks: false,
+        module_suffixes: vec![String::new()],
+        ..Default::default()
+    }
+}
+
+/// Create an `@types/<pkg>` package (a `package.json` pointing at
+/// `index.d.ts`, plus the `index.d.ts` body) under `at_types`.
+fn write_types_package(at_types: &Path, pkg: &str, index_dts: &str) {
+    let dir = at_types.join(pkg);
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("package.json"),
+        r#"{"name":"@types/PKG","version":"1.0.0","types":"index.d.ts"}"#.replace("PKG", pkg),
+    )
+    .unwrap();
+    fs::write(dir.join("index.d.ts"), index_dts).unwrap();
+}
+
+/// Build a pnpm-style layout where `@types/foo` is hoisted to the top-level
+/// `node_modules/@types` via a symlink into the `.pnpm` sandbox, and the
+/// sibling `@types/foo-core` / `@types/foo-bar` packages it references only
+/// exist inside that sandbox.
+///
+/// Returns `(canonical_root, symlinked_foo_index_dts)`.
+fn build_pnpm_layout(root: &Path) -> (PathBuf, PathBuf) {
+    let pnpm_pkg = root.join("node_modules/.pnpm/@types+foo@1.0.0/node_modules/@types");
+
+    // foo references its two siblings via triple-slash type references; the
+    // siblings only exist inside this .pnpm sandbox.
+    write_types_package(
+        &pnpm_pkg,
+        "foo",
+        "/// <reference types=\"foo-core\" />\n\
+         /// <reference types=\"foo-bar\" />\n\
+         export {};\n",
+    );
+    write_types_package(&pnpm_pkg, "foo-core", "export interface Core {}\n");
+    write_types_package(&pnpm_pkg, "foo-bar", "export interface Bar {}\n");
+
+    // Only `@types/foo` is hoisted to the top-level node_modules, as a symlink
+    // pointing into the .pnpm sandbox (the transitive siblings are NOT hoisted).
+    let top_at_types = root.join("node_modules/@types");
+    fs::create_dir_all(&top_at_types).unwrap();
+    symlink(pnpm_pkg.join("foo"), top_at_types.join("foo")).unwrap();
+
+    let canonical_root = canonicalize_or_owned(root);
+    let symlinked_foo_index = root.join("node_modules/@types/foo/index.d.ts");
+    (canonical_root, symlinked_foo_index)
+}
+
+#[test]
+fn triple_slash_at_types_sibling_resolved_through_pnpm_symlink() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let (base_dir, symlinked_foo_index) = build_pnpm_layout(dir.path());
+
+    let options = node16_options();
+
+    for sibling in ["foo-core", "foo-bar"] {
+        let mut cache = ModuleResolutionCache::default();
+        let resolved = resolve_type_reference_from_node_modules_with_cache(
+            sibling,
+            &symlinked_foo_index,
+            &base_dir,
+            None,
+            &options,
+            &mut cache,
+        );
+
+        let expected = canonicalize_or_owned(
+            &base_dir
+                .join("node_modules/.pnpm/@types+foo@1.0.0/node_modules/@types")
+                .join(sibling)
+                .join("index.d.ts"),
+        );
+
+        assert_eq!(
+            resolved,
+            Some(expected),
+            "sibling `{sibling}` must resolve through the pnpm symlink realpath"
+        );
+    }
+}
+
+#[test]
+fn triple_slash_at_types_sibling_not_resolved_with_preserve_symlinks() {
+    // With `preserveSymlinks: true`, `tsc` keeps the symlink-relative identity
+    // and does NOT reach into the `.pnpm` sandbox, so the sibling is unresolved
+    // (it would report TS2688). Parity requires the same here.
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let (base_dir, symlinked_foo_index) = build_pnpm_layout(dir.path());
+
+    let options = ResolvedCompilerOptions {
+        preserve_symlinks: true,
+        ..node16_options()
+    };
+
+    let mut cache = ModuleResolutionCache::default();
+    let resolved = resolve_type_reference_from_node_modules_with_cache(
+        "foo-core",
+        &symlinked_foo_index,
+        &base_dir,
+        None,
+        &options,
+        &mut cache,
+    );
+
+    assert_eq!(
+        resolved, None,
+        "preserveSymlinks must not walk into the symlink target's sandbox"
+    );
+}
+
+#[test]
+fn top_level_at_types_sibling_still_resolves_without_symlink_walk() {
+    // A non-symlinked layout (sibling hoisted next to the importer) must keep
+    // resolving via the literal walk — the realpath fallback must not regress
+    // the common case.
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let root = dir.path();
+    let at_types = root.join("node_modules/@types");
+
+    write_types_package(
+        &at_types,
+        "foo",
+        "/// <reference types=\"foo-core\" />\nexport {};\n",
+    );
+    write_types_package(&at_types, "foo-core", "export interface Core {}\n");
+
+    let base_dir = canonicalize_or_owned(root);
+    let from_file = root.join("node_modules/@types/foo/index.d.ts");
+
+    let options = node16_options();
+    let mut cache = ModuleResolutionCache::default();
+    let resolved = resolve_type_reference_from_node_modules_with_cache(
+        "foo-core", &from_file, &base_dir, None, &options, &mut cache,
+    );
+
+    let expected = canonicalize_or_owned(&base_dir.join("node_modules/@types/foo-core/index.d.ts"));
+    assert_eq!(resolved, Some(expected));
+}


### PR DESCRIPTION
AgentName: Studio-B

Fixes #12459.

## Track
module-resolution / `@types/*` triple-slash type reference resolution.

## Invariant
When resolving a `/// <reference types="X" />` directive from a `.d.ts` whose `@types` package was reached via a symlink (pnpm `.pnpm` sandbox, or yarn/npm `link`) and `preserveSymlinks` is `false` (the default), `tsc` resolves sibling `@types/*` packages from the **realpath** of the importing file. `tsz` now does the same via the triple-slash `node_modules` fallback. With `preserveSymlinks: true`, the symlink-relative identity is preserved (no sandbox walk), matching `tsc`.

## Structural rule
When a triple-slash type reference is resolved from a file inside a symlinked `node_modules/@types/<pkg>/...`, `tsc` walks adjacent `node_modules/@types/<sibling>` directories using the real (`realpath`) location of the containing file. In a pnpm tree, `node_modules/@types/foo` is a symlink into `node_modules/.pnpm/@types+foo@V/node_modules/@types/foo`, and the siblings it references (`@types/express-serve-static-core`, `@types/serve-static`, …) live next to the symlink **target**, not the symlink. The previous literal (symlink-relative) walk could not see them → spurious `TS2688`.

## Scope
- `crates/tsz-cli/src/driver/resolution/type_packages.rs`
  - Extracted the per-`node_modules` probe loop into `probe_type_reference_in_node_modules_chain` (shared engine).
  - `resolve_type_reference_from_node_modules_with_cache` now performs the existing literal walk first, then — only when it fails and `!preserveSymlinks` and the file's realpath differs — a second walk from `canonicalize(from_file)`, bounded by `canonicalize(base_dir)`. Literal-first preserves existing ordering and avoids regressing the common case.
- `crates/tsz-cli/src/driver/resolution/type_packages_symlink_tests.rs` (new): focused regression coverage.
- No checker/solver/emitter changes. No `@types`/file-name/identifier string hardcoding; the fix is purely structural (realpath of the containing file). File identity for the symlinked package is unchanged (still the symlink path, matching `tsc`); only sibling lookup uses realpath.

## Project Corpus Impact
- Row: pnpm projects with `@types/*` fan-out via triple-slash references.
- Bug family: transitive `@types/*` resolution in pnpm/symlinked trees (witness: `mswjs/msw` — `@types/express` → `express-serve-static-core`, `serve-static`, two `TS2688`s eliminated).
- Broadly affects pnpm apps pulling `@types/express`, `@types/koa`, `@types/react-redux`, etc.

## Verification
- `cargo test -p tsz-cli --lib type_packages_symlink` — 3 passed (pnpm symlink resolves; `preserveSymlinks` negative; non-symlink common case).
- `cargo check -p tsz-cli` clean; changed files clippy-clean.
- Rebased on latest `main`; no conflicts.

## Coordination Notes
- #12459 was explicitly released by Studio-B (their active WIP is #10814/#12473); claimed here as unowned.
- Related: #12372 (bare-identifier transitive `@types`) — different surface (bare specifier vs triple-slash), not addressed in this PR.
- Tests use synthetic package names (`foo`/`foo-core`/`foo-bar`) to prove the fix is structural, not keyed on any real package name.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46gbfEXgVhvev7fdGqPpi)_