### PR TITLE
ci: run native merge queue checks on Cloud Run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,11 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ci-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
-  # A newer pull_request event means the old PR run can no longer satisfy
-  # strict required checks for the current head SHA. Cancel stale PR runs so
-  # exact-head CI does not sit queued behind obsolete ready-review work.
+  group: ci-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}-${{ github.event_name == 'pull_request' && github.event.action == 'edited' && 'metadata' || 'suite' }}
+  # A newer suite pull_request event means the old PR run can no longer
+  # satisfy strict required checks for the current head SHA. Body/title edits
+  # run only the metadata gates and use a separate group so repairing PR body
+  # metadata does not cancel the real suite run for the same SHA.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
@@ -60,14 +61,11 @@ jobs:
           compiler_checks_required=true
           unit_packages=""
           if [[ "${{ github.event_name }}" == "merge_group" ]]; then
-            # Native merge queue has already admitted a PR whose current head
-            # satisfied the required PR status checks. The queued commit is a
-            # GitHub-owned synthetic merge; keep the required CI Summary alive
-            # for branch protection without scheduling the self-hosted suite.
-            echo "Native merge queue group - validating queue admission without self-hosted CI."
-            should_run=false
-            full_run=false
-            compiler_checks_required=false
+            # Native merge queue validates a GitHub-owned synthetic merge
+            # commit. Run the same Cloud Run-backed compiler suite here so
+            # branch protection is checking the actual queued commit, not only
+            # the PR head that entered the queue.
+            echo "Native merge queue group - running full Cloud Run CI for the queued merge commit."
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             if [[ "${{ github.event.action }}" == "edited" ]]; then
               # Body/title edits can repair AgentName, project-corpus, or WIP


### PR DESCRIPTION
AgentName: Studio-manager

## Track
CI native merge queue / runner scheduling.

## Invariant
Native `merge_group` events must run the required CI suite without PR metadata edits canceling full PR-head validation, and normal PR checks must continue to use the intended runner/Cloud Build paths.

## Scope
- `.github/workflows/ci.yml`

## Project Corpus Impact
- Row: n/a
- Bug family: CI native merge queue / runner scheduling

## Verification
- `python3` CI workflow sanity check
- `actionlint .github/workflows/ci.yml` reports pre-existing ShellCheck/custom runner-label warnings unrelated to this change

## Coordination Notes
- Queue hygiene is owned by `Studio-manager`.
- This PR remains off native queue until exact-head required checks are complete and reviewed at the latest head.