### PR TITLE
fix(checker): report variance mismatch for callables sharing outer type params (#10804)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -794,34 +794,18 @@ impl<'a> CheckerState<'a> {
                     evaluated_target_for_infer_suppression,
                 );
 
-        // Whether `source`/`target` are both callable and, with their shared/outer
-        // type parameters held opaque, are genuinely *not* related. This is computed
-        // here (before the immutable-borrowing closures below) so the callable
-        // type-parameter suppression can defer to the solver rather than hide a real
-        // mismatch. Guarded by cheap structural checks so the relation probe only runs
-        // for callable-vs-callable pairs that actually mention type parameters.
-        let callable_pair_genuinely_unrelated_opaque = {
-            let is_callable_shape = |type_id: TypeId| {
-                crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, type_id)
-                    .is_some()
-                    || crate::query_boundaries::common::function_shape_for_type(
-                        self.ctx.types,
-                        type_id,
-                    )
-                    .is_some()
-            };
-            if is_callable_shape(source)
-                && is_callable_shape(target)
-                && crate::query_boundaries::common::contains_type_parameters(self.ctx.types, source)
-                && crate::query_boundaries::common::contains_type_parameters(self.ctx.types, target)
-            {
+        let callable_pair_genuinely_unrelated_opaque =
+            if crate::query_boundaries::assignability::callable_pair_contains_type_parameters(
+                self.ctx.types,
+                source,
+                target,
+            ) {
                 !self
                     .no_erase_generics_relation_outcome(source, target)
                     .related
             } else {
                 false
-            }
-        };
+            };
 
         // Suppress TS2322 for callable types with generic type parameters from outer
         // context. Skip the suppression when both sides have their own signature-level

--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -794,15 +794,55 @@ impl<'a> CheckerState<'a> {
                     evaluated_target_for_infer_suppression,
                 );
 
-        let callable_pair_genuinely_unrelated_opaque =
+        let callable_pair_has_opaque_return_mismatch =
             if crate::query_boundaries::assignability::callable_pair_contains_type_parameters(
                 self.ctx.types,
                 source,
                 target,
             ) {
-                !self
-                    .no_erase_generics_relation_outcome(source, target)
-                    .related
+                let callable_return_type = |type_id: TypeId| -> Option<TypeId> {
+                    if let Some(shape) = crate::query_boundaries::common::function_shape_for_type(
+                        self.ctx.types,
+                        type_id,
+                    ) {
+                        return Some(shape.return_type);
+                    }
+                    if let Some(shape) = crate::query_boundaries::common::callable_shape_for_type(
+                        self.ctx.types,
+                        type_id,
+                    ) {
+                        return shape.call_signatures.last().map(|sig| sig.return_type);
+                    }
+                    if let Some(app) =
+                        crate::query_boundaries::common::type_application(self.ctx.types, type_id)
+                    {
+                        if let Some(shape) =
+                            crate::query_boundaries::common::function_shape_for_type(
+                                self.ctx.types,
+                                app.base,
+                            )
+                        {
+                            return Some(shape.return_type);
+                        }
+                        if let Some(shape) =
+                            crate::query_boundaries::common::callable_shape_for_type(
+                                self.ctx.types,
+                                app.base,
+                            )
+                        {
+                            return shape.call_signatures.last().map(|sig| sig.return_type);
+                        }
+                    }
+                    None
+                };
+                match (callable_return_type(source), callable_return_type(target)) {
+                    (Some(source_return), Some(target_return)) => {
+                        !self
+                            .no_erase_generics_relation_outcome(source_return, target_return)
+                            .related
+                    }
+                    _ => false,
+                }
             } else {
                 false
             };
@@ -1154,18 +1194,12 @@ impl<'a> CheckerState<'a> {
                 && is_callable_or_function(target)
                 && contains_type_parameters(source)
                 && !self.callable_types_have_disjoint_type_parameters(source, target)
-                // A genuine structural mismatch confirmed by the solver while holding
-                // the shared/outer type parameters opaque (no-erase-generics) must not
-                // be suppressed. `callable_types_have_disjoint_type_parameters` only
-                // recognises *bare* `T` parameter/return positions, so it misses
-                // mismatches where the type parameter is nested (e.g. `(x: T[]) => T`
-                // vs `(x: T[]) => number`) or where both signatures reference outer
-                // parameters that nonetheless do not relate (`(x: T) => U` vs
-                // `(x: U) => T`). The opaque relation is the same one the interface
-                // heritage (TS2430) path trusts, so deferring to it keeps real
-                // overrides/assignments reported while still suppressing the
-                // unresolved-inference shapes this branch was added for.
-                && !callable_pair_genuinely_unrelated_opaque
+                // A genuine return mismatch confirmed by the solver while holding
+                // shared/outer type parameters opaque (no-erase-generics) must not be
+                // suppressed. Keep this return-scoped: tsc still accepts generic rest
+                // parameter comparisons whose return types agree, even when an opaque
+                // whole-callable probe cannot relate the parameter tuples.
+                && !callable_pair_has_opaque_return_mismatch
                 && !(has_own_signature_type_params(source)
                     && has_own_signature_type_params(target))
                 && !(has_own_signature_type_params(source)

--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -794,6 +794,35 @@ impl<'a> CheckerState<'a> {
                     evaluated_target_for_infer_suppression,
                 );
 
+        // Whether `source`/`target` are both callable and, with their shared/outer
+        // type parameters held opaque, are genuinely *not* related. This is computed
+        // here (before the immutable-borrowing closures below) so the callable
+        // type-parameter suppression can defer to the solver rather than hide a real
+        // mismatch. Guarded by cheap structural checks so the relation probe only runs
+        // for callable-vs-callable pairs that actually mention type parameters.
+        let callable_pair_genuinely_unrelated_opaque = {
+            let is_callable_shape = |type_id: TypeId| {
+                crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, type_id)
+                    .is_some()
+                    || crate::query_boundaries::common::function_shape_for_type(
+                        self.ctx.types,
+                        type_id,
+                    )
+                    .is_some()
+            };
+            if is_callable_shape(source)
+                && is_callable_shape(target)
+                && crate::query_boundaries::common::contains_type_parameters(self.ctx.types, source)
+                && crate::query_boundaries::common::contains_type_parameters(self.ctx.types, target)
+            {
+                !self
+                    .no_erase_generics_relation_outcome(source, target)
+                    .related
+            } else {
+                false
+            }
+        };
+
         // Suppress TS2322 for callable types with generic type parameters from outer
         // context. Skip the suppression when both sides have their own signature-level
         // type params — the solver handles generic-to-generic comparison correctly.
@@ -1141,6 +1170,18 @@ impl<'a> CheckerState<'a> {
                 && is_callable_or_function(target)
                 && contains_type_parameters(source)
                 && !self.callable_types_have_disjoint_type_parameters(source, target)
+                // A genuine structural mismatch confirmed by the solver while holding
+                // the shared/outer type parameters opaque (no-erase-generics) must not
+                // be suppressed. `callable_types_have_disjoint_type_parameters` only
+                // recognises *bare* `T` parameter/return positions, so it misses
+                // mismatches where the type parameter is nested (e.g. `(x: T[]) => T`
+                // vs `(x: T[]) => number`) or where both signatures reference outer
+                // parameters that nonetheless do not relate (`(x: T) => U` vs
+                // `(x: U) => T`). The opaque relation is the same one the interface
+                // heritage (TS2430) path trusts, so deferring to it keeps real
+                // overrides/assignments reported while still suppressing the
+                // unresolved-inference shapes this branch was added for.
+                && !callable_pair_genuinely_unrelated_opaque
                 && !(has_own_signature_type_params(source)
                     && has_own_signature_type_params(target))
                 && !(has_own_signature_type_params(source)

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -210,6 +210,9 @@ mod generator_union_return_type_tests;
 #[path = "tests/generator_yield_identity_tests.rs"]
 mod generator_yield_identity_tests;
 #[cfg(test)]
+#[path = "tests/generic_callable_outer_type_param_mismatch_tests.rs"]
+mod generic_callable_outer_type_param_mismatch_tests;
+#[cfg(test)]
 #[path = "tests/generic_default_application_arg_preservation_tests.rs"]
 mod generic_default_application_arg_preservation_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -295,6 +295,22 @@ pub(crate) fn contextual_function_callable_union_members(
     callable_members
 }
 
+pub(crate) fn callable_pair_contains_type_parameters(
+    db: &dyn TypeDatabase,
+    source: TypeId,
+    target: TypeId,
+) -> bool {
+    fn is_callable_or_function(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+        super::common::callable_shape_for_type(db, type_id).is_some()
+            || super::common::function_shape_for_type(db, type_id).is_some()
+    }
+
+    is_callable_or_function(db, source)
+        && is_callable_or_function(db, target)
+        && super::common::contains_type_parameters(db, source)
+        && super::common::contains_type_parameters(db, target)
+}
+
 /// Return true when the source is an intersection that directly contains the
 /// target as one of its constituents.
 ///

--- a/crates/tsz-checker/src/tests/generic_callable_outer_type_param_mismatch_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_callable_outer_type_param_mismatch_tests.rs
@@ -185,3 +185,14 @@ fn no_false_2322_function_array_identical_signatures() {
         "function f<T>(a: (x: T[]) => T[], b: (x: T[]) => T[]) { a = b; }",
     );
 }
+
+#[test]
+fn no_false_2322_generic_rest_tuple_parameter_with_matching_return() {
+    assert_no(
+        2322,
+        "function f<A extends unknown[]>(
+           a: (...args: [x: string, ...rest: A | [number]]) => void,
+           b: (x: string, ...rest: A | [number]) => void
+         ) { a = b; }",
+    );
+}

--- a/crates/tsz-checker/src/tests/generic_callable_outer_type_param_mismatch_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_callable_outer_type_param_mismatch_tests.rs
@@ -1,0 +1,187 @@
+//! Regression tests for issue #10804 — generic method override / callable
+//! assignment variance with *outer* type parameters.
+//!
+//! When two callable types both reference a type parameter from an enclosing
+//! scope (a class type parameter for a method override, or an outer function's
+//! `<T>` for a function-typed value), tsc still compares them structurally and
+//! reports a genuine incompatibility. tsz previously *suppressed* TS2322/TS2416
+//! for any callable-to-callable comparison where the source mentioned an outer
+//! type parameter and the two signatures were not fully *disjoint* in their
+//! bare type-parameter positions. That heuristic hid real mismatches:
+//!
+//! ```ts
+//! class Base<T> { m(x: T[]): T[] { return []; } }
+//! class Child<T> extends Base<T> { m(x: T[]): number { return 0; } } // TS2416
+//! ```
+//!
+//! The disjoint-only discriminator could not see the type parameter nested
+//! inside `T[]`, so it suppressed the diagnostic even though `number` is not a
+//! valid override return for `T[]`. The fix defers to the solver's opaque
+//! (`no_erase_generics`) relation — the same one the interface-heritage
+//! (TS2430) path already trusts — so a structurally-confirmed mismatch is never
+//! suppressed while the unresolved-inference shapes the heuristic guarded stay
+//! suppressed.
+//!
+//! Issue: <https://github.com/mohsen1/tsz/issues/10804>
+
+use crate::test_utils::check_source_codes;
+
+fn assert_has(code: u32, src: &str) {
+    let codes = check_source_codes(src);
+    assert!(
+        codes.contains(&code),
+        "expected TS{code}, got none. Got: {codes:?}\nSource:\n{src}"
+    );
+}
+
+fn assert_no(code: u32, src: &str) {
+    let codes = check_source_codes(src);
+    assert!(
+        !codes.contains(&code),
+        "unexpected TS{code} (false positive). Got: {codes:?}\nSource:\n{src}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Class override (TS2416): generic `Child<T> extends Base<T>` whose method
+// rewrites the return type to an incompatible concrete type. The base method's
+// parameter references `T` in a *nested* position (`T[]`, `T | null`, callback,
+// rest), which the old disjoint-only heuristic could not see.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn keeps_2416_generic_child_array_param_return_to_number() {
+    assert_has(
+        2416,
+        "class Base<T> { m(x: T[]): T[] { return []; } }
+         class Child<T> extends Base<T> { m(x: T[]): number { return 0; } }",
+    );
+}
+
+// Renamed type parameters — the rule is structural, not identifier-keyed.
+#[test]
+fn keeps_2416_generic_child_array_param_return_to_number_renamed() {
+    assert_has(
+        2416,
+        "class Base<A> { m(x: A[]): A[] { return []; } }
+         class Child<B> extends Base<B> { m(x: B[]): number { return 0; } }",
+    );
+}
+
+#[test]
+fn keeps_2416_generic_child_union_param_return_to_number() {
+    assert_has(
+        2416,
+        "class Base<T> { m(x: T | null): T { return null as any; } }
+         class Child<T> extends Base<T> { m(x: T | null): number { return 0; } }",
+    );
+}
+
+#[test]
+fn keeps_2416_generic_child_callback_param_return_to_number() {
+    assert_has(
+        2416,
+        "class Base<T> { m(cb: (v: T) => void): T { return null as any; } }
+         class Child<T> extends Base<T> { m(cb: (v: T) => void): number { return 0; } }",
+    );
+}
+
+#[test]
+fn keeps_2416_generic_child_rest_param_return_to_number() {
+    assert_has(
+        2416,
+        "class Base<T> { m(...xs: T[]): T { return null as any; } }
+         class Child<T> extends Base<T> { m(...xs: T[]): number { return 0; } }",
+    );
+}
+
+// Multi-level generic chain: the offending override sits at the bottom and the
+// base method is inherited through an empty intermediate level.
+#[test]
+fn keeps_2416_multi_level_generic_chain_return_mismatch() {
+    assert_has(
+        2416,
+        "class A<T> { m(x: T[]): T[] { return []; } }
+         class B<T> extends A<T> {}
+         class C<T> extends B<T> { m(x: T[]): number { return 0; } }",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls (class): a structurally-valid override must NOT error.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_false_2416_generic_child_matching_array_signature() {
+    assert_no(
+        2416,
+        "class Base<T> { m(x: T[]): T[] { return []; } }
+         class Child<T> extends Base<T> { m(x: T[]): T[] { return x; } }",
+    );
+}
+
+#[test]
+fn no_false_2416_generic_child_covariant_array_return() {
+    // Returning `readonly T[]` for a base `T[]`? No — keep it simple: identical
+    // signature with a different but compatible parameter name.
+    assert_no(
+        2416,
+        "class Base<T> { m(first: T[]): T[] { return []; } }
+         class Child<T> extends Base<T> { m(second: T[]): T[] { return second; } }",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Direct function-type assignment (TS2322): both sides reference the enclosing
+// function's `<T>`. A concrete return must not be silently accepted for a
+// type-parameter return.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn keeps_2322_function_type_param_param_return_mismatch() {
+    assert_has(
+        2322,
+        "function f<T>(a: (x: T) => T, b: (x: T) => number) { a = b; }",
+    );
+}
+
+#[test]
+fn keeps_2322_function_array_param_return_mismatch() {
+    assert_has(
+        2322,
+        "function f<T>(a: (x: T[]) => T[], b: (x: T[]) => number) { a = b; }",
+    );
+}
+
+// Two outer type parameters swapped between parameter and return positions:
+// `(x: T) => U` is not assignable to `(x: U) => T`. The old heuristic treated
+// the overlapping `{T, U}` sets as "not disjoint" and suppressed the error.
+#[test]
+fn keeps_2322_swapped_outer_type_parameters() {
+    assert_has(
+        2322,
+        "function f<T, U>(a: (x: U) => T, b: (x: T) => U) { a = b; }",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative controls (assignment): genuinely compatible callables that both
+// reference outer type parameters must NOT be flagged — this is the
+// false-positive shape the original suppression guarded.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_false_2322_function_identical_type_param_signatures() {
+    assert_no(
+        2322,
+        "function f<T>(a: (x: T) => T, b: (x: T) => T) { a = b; }",
+    );
+}
+
+#[test]
+fn no_false_2322_function_array_identical_signatures() {
+    assert_no(
+        2322,
+        "function f<T>(a: (x: T[]) => T[], b: (x: T[]) => T[]) { a = b; }",
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -10,8 +10,6 @@
 //! - `check_type_node` — recursive type node validation (mapped types, conditionals, etc.)
 //! - `precompute_type_query_flow_types` — pre-computes `typeof` flow-narrowed types
 
-mod type_query_flow;
-
 use super::alias_defid_visited_pool::with_alias_defid_visited;
 use crate::state::CheckerState;
 use tsz_parser::parser::node::NodeAccess;

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -10,6 +10,8 @@
 //! - `check_type_node` — recursive type node validation (mapped types, conditionals, etc.)
 //! - `precompute_type_query_flow_types` — pre-computes `typeof` flow-narrowed types
 
+mod type_query_flow;
+
 use super::alias_defid_visited_pool::with_alias_defid_visited;
 use crate::state::CheckerState;
 use tsz_parser::parser::node::NodeAccess;

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -27,66 +27,40 @@
 # - PR #12649 run 27016857260 attempt 2 at synthetic merge 3d599062d3 found
 #   thirteen rows returned and no previous accepted rows resolved after the
 #   exact-head cancelled shard rerun.
+# - PR #12659 run 27032877016 at synthetic merge c42c6ba96f found one returned
+#   row and sixteen previous accepted rows resolved after exact-head aggregate.
 # Keep these visible as accepted-regression debt until their owning parity
 # fixes remove them from exact-head aggregate output.
 TypeScript/tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts
-TypeScript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum3.ts
 TypeScript/tests/cases/compiler/declarationEmitObjectAssignedDefaultExport.ts
 TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules1.ts
 TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
-TypeScript/tests/cases/compiler/declarationsIndirectGeneratedAliasReference.ts
-TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
-TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/inferFromNestedSameShapeTuple.ts
 TypeScript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
-TypeScript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts
 TypeScript/tests/cases/compiler/letInConstDeclarations_ES6.ts
 TypeScript/tests/cases/compiler/letInLetConstDeclOfForOfAndForIn_ES6.ts
 TypeScript/tests/cases/compiler/letInLetDeclarations_ES6.ts
 TypeScript/tests/cases/compiler/promisesWithConstraints.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
-TypeScript/tests/cases/compiler/strictModeReservedWord.ts
-TypeScript/tests/cases/compiler/unicodeEscapesInNames02.ts
-TypeScript/tests/cases/conformance/es2019/importMeta/importMeta.ts
 TypeScript/tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts
 TypeScript/tests/cases/conformance/es6/for-ofStatements/for-of51.ts
 TypeScript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts
-TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts
-TypeScript/tests/cases/conformance/jsdoc/importTag17.ts
-TypeScript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit6.ts
 TypeScript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit7.ts
-TypeScript/tests/cases/conformance/salsa/plainJSGrammarErrors.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes2.ts
-TypeScript/tests/cases/conformance/types/conditional/inferTypes1.ts
-TypeScript/tests/cases/conformance/types/mapped/mappedTypeErrors2.ts
+TypeScript/tests/cases/conformance/types/rest/genericRestParameters3.ts
 TypeScript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts
-TypeScript/tests/cases/conformance/types/tuple/variadicTuples1.ts
-TypeScript/tests/cases/conformance/types/tuple/variadicTuples2.ts
 # covariantCallbacks.ts: RESOLVED by PR #12482. tsz now detects nullable-union
 # callback method parameters the way tsc does (getSingleCallSignature(
 # getNonNullableType(t))), so lib `Promise<A>` -> `Promise<B>` reports its
 # covariant TS2322 again. Removed from this ledger; covered by
 # nullable_union_callback_variance_tests.
-# infiniteExpansionThroughInstantiation.ts: RESOLVED (#10867). The TS2322 source
-# display for a generic interface reference written with free type-parameter
-# arguments (`OwnerList<T>`) no longer over-instantiates the argument from the
-# instantiated heritage/members (`OwnerList<List<T>>`); tsz now preserves the
-# as-written reference like tsc. Covered by
-# generic_interface_source_display_preserves_as_written_type_argument and
-# generic_interface_heritage_source_display_is_not_over_instantiated.
-
-# Current-main aggregate drift after PR branches first made the duplicate
-# type-query-flow module compileable again. Exact evidence:
-# - PR #12606 run 26999340595 at bb6caa8011 aggregated 12552/12585 and
-#   listed exactly these seven unaccepted rows after all conformance shards
-#   themselves completed successfully.
-TypeScript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum3.ts
-TypeScript/tests/cases/conformance/es2019/importMeta/importMeta.ts
-TypeScript/tests/cases/conformance/salsa/plainJSGrammarErrors.ts
-TypeScript/tests/cases/conformance/types/conditional/inferTypes1.ts
-TypeScript/tests/cases/conformance/types/mapped/mappedTypeErrors2.ts
-TypeScript/tests/cases/conformance/types/tuple/variadicTuples1.ts
-TypeScript/tests/cases/conformance/types/tuple/variadicTuples2.ts
+# infiniteExpansionThroughInstantiation.ts: RESOLVED. The TS2322 source type
+# `OwnerList<T>` was over-instantiated to `OwnerList<List<T>>` because the
+# eagerly-evaluated generic interface instance dropped its Application display
+# provenance whenever an argument carried a free type parameter
+# (store_parametric_structural_back_reference). Provenance is now recorded for
+# those instances, so display matches tsc. Covered by
+# recursive_generic_interface_application_display_tests.


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Conformance / checker assignability for generic callable variance (#10804).

## Invariant
When callable-to-callable assignability compares signatures that reference outer type parameters, genuine structural mismatches must not be suppressed. The checker suppression path now defers to the solver-backed opaque generic relation and preserves suppression only for signatures that remain related with outer type parameters held opaque.

## Scope
- `crates/tsz-checker/src/assignability/assignability_checker.rs`
- `crates/tsz-checker/src/query_boundaries/assignability.rs`
- `crates/tsz-checker/src/tests/generic_callable_outer_type_param_mismatch_tests.rs`
- `crates/tsz-checker/src/lib.rs` test registration

## Project Corpus Impact
- Row: `rxjs-project`
- Bug family: generic method override variance in mixed inheritance chains.
- Evidence: this only adds diagnostics for solver-confirmed structural mismatches and preserves suppression for the unresolved-inference shapes the heuristic was designed for. No speed claim is made.

## Verification
- Rebased onto `origin/main` `153d300634` and pushed refreshed head `17c4326627`.
- Local rebase verification: `git diff --check origin/main...HEAD`; `git diff --stat origin/main...HEAD` scope review.
- Earlier focused verification retained from this PR: `scripts/arch/check-checker-boundaries.sh`; `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib generic_callable_outer_type_param_mismatch_tests --no-fail-fast`; `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-common -p tsz-scanner -p tsz-parser -p tsz-binder -p tsz-solver -p tsz-checker -p tsz-emitter -p tsz-lowering -p tsz-lsp --all-targets -- -D warnings`. The older body also recorded a broad `cargo test` experiment predating current local-command guidance; exact-head CI is authoritative for broad suites.
- Exact-head CI restarted after the rebase and remains the source of broad validation. Follow-up head restores the current-main nested `type_query_flow` module edge so wasm/checker builds resolve `precompute_type_query_flow_types`.

## Coordination Notes
- Structural rule: class override and function-type assignment paths should report TS2416/TS2322 when the opaque generic relation confirms a genuine callable mismatch, including arrays, unions, callbacks, rest parameters, renamed type parameters, and swapped outer `T`/`U` positions.
- Owner layer: checker assignability diagnostic suppression via the shared assignability query boundary; no raw solver internals are matched in checker.
- Fallback: identical callable signatures referencing outer type parameters remain suppressed; object-literal method shapes behind the separate complex-type suppression clause remain out of scope.
- Refreshed after the main-line conformance aggregate/duplicate-module unblock so exact-head CI can rerun on current base.
- Ready for manager/queue-owner review once exact-head CI is green; no merge-queue action taken by Studio-B.
- AgentName: Studio-B

## Studio-B Refresh: 402bb4029c
AgentName: Studio-B

Root cause: the previous opaque whole-callable probe treated a generic rest parameter tuple mismatch as a genuine TS2322 even when callable return types agreed. That regressed TypeScript/tests/cases/conformance/types/rest/genericRestParameters3.ts with an extra line 84 diagnostic.

Fix: keep the PR invariant that real outer-type-parameter callable return mismatches are not suppressed, but scope the opaque no-erase probe to callable return types. Generic rest parameter uncertainty with matching returns remains suppressed like tsc. Added a negative regression for the generic rest tuple shape.

Verification:
- cargo fmt -p tsz-checker --check
- git diff --check
- CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo nextest run -p tsz-checker --lib generic_callable_outer_type_param_mismatch_tests
- CARGO_INCREMENTAL=0 scripts/safe-run.sh scripts/conformance/conformance.sh run --filter genericRestParameters3.ts --max 1 --workers 1 --verbose
