### PR TITLE
fix(checker): excess-property check on concrete optional mapped targets

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -957,6 +957,9 @@ mod mapped_infer_with_substitution_tests;
 #[path = "tests/mapped_intersection_excess_property_tests.rs"]
 mod mapped_intersection_excess_property_tests;
 #[cfg(test)]
+#[path = "tests/mapped_optional_target_excess_property_tests.rs"]
+mod mapped_optional_target_excess_property_tests;
+#[cfg(test)]
 #[path = "tests/mapped_true_base_constraint_relation_routing_arch_tests.rs"]
 mod mapped_true_base_constraint_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs
+++ b/crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs
@@ -1,5 +1,6 @@
 //! Mapped-type helpers used by object literal excess property checking.
 
+use crate::query_boundaries::state::checking as query;
 use crate::state::CheckerState;
 use std::collections::HashSet;
 use tsz_common::interner::Atom;
@@ -8,6 +9,70 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    pub(super) fn track_earliest_excess(
+        &self,
+        current: &mut Option<(Atom, NodeIndex, u32)>,
+        name: Atom,
+        report_idx: NodeIndex,
+    ) {
+        let pos = self.ctx.arena.get(report_idx).map_or(u32::MAX, |n| n.pos);
+        if current.is_none_or(|(_, _, best)| pos < best) {
+            *current = Some((name, report_idx, pos));
+        }
+    }
+
+    pub(super) fn report_concrete_mapped_target_excess_property(
+        &mut self,
+        target: TypeId,
+        evaluated_target: TypeId,
+        source_props: &[tsz_solver::PropertyInfo],
+        explicit_property_names: Option<&HashSet<Atom>>,
+        object_literal_idx: NodeIndex,
+    ) -> bool {
+        // A fully concrete homomorphic mapped target, e.g. `{ [K in keyof A]?: A[K] }`
+        // over non-generic `A`, stays deferred as `Mapped` in the declared type. Use
+        // the evaluated concrete object so TS2353 matches tsc's expanded target.
+        if evaluated_target == target
+            || crate::query_boundaries::common::mapped_type_id(self.ctx.types, target).is_none()
+            || tsz_solver::type_queries::mapped_type_is_deferred_generic(self.ctx.types, target)
+            || query::union_members(self.ctx.types, evaluated_target).is_some()
+            || query::intersection_members(self.ctx.types, evaluated_target).is_some()
+        {
+            return false;
+        }
+        let Some(shape) = query::object_shape(self.ctx.types, evaluated_target) else {
+            return false;
+        };
+        if shape.string_index.is_some() {
+            return false;
+        }
+
+        let mut first_excess: Option<(Atom, NodeIndex, u32)> = None;
+        for source_prop in source_props {
+            if explicit_property_names.is_some_and(|names| !names.contains(&source_prop.name)) {
+                continue;
+            }
+            let covered = shape
+                .properties
+                .iter()
+                .any(|prop| prop.name == source_prop.name)
+                || (shape.number_index.is_some() && {
+                    let name = self.ctx.types.resolve_atom(source_prop.name);
+                    tsz_solver::utils::is_numeric_literal_name(&name)
+                });
+            if !covered {
+                let report_idx = self
+                    .find_object_literal_property_element(object_literal_idx, source_prop.name)
+                    .unwrap_or(object_literal_idx);
+                self.track_earliest_excess(&mut first_excess, source_prop.name, report_idx);
+            }
+        }
+
+        // Display the expanded object shape (matching tsc), not the deferred mapped form.
+        self.emit_tracked_excess_property(first_excess, evaluated_target);
+        true
+    }
+
     pub(crate) fn type_contains_invalid_mapped_key_type(&self, type_id: TypeId) -> bool {
         let mut visited = HashSet::new();
         self.type_contains_invalid_mapped_key_type_inner(type_id, &mut visited)

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -381,6 +381,57 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // A fully concrete homomorphic mapped target — e.g. `{ [K in keyof A]?:
+        // A[K] }` over a non-generic `A` — is kept as a deferred `Mapped` in the
+        // declared type, so the solver's object-literal excess path never runs
+        // against its expanded shape and the generic-mapped loop above defers it
+        // (its evaluated object carries no free type parameters). tsc evaluates
+        // such a target to a concrete object and reports excess properties
+        // against that object. Mirror that here using the already-computed
+        // `evaluated_target`, scoped to concrete mapped targets so plain objects
+        // (handled by the solver relation) and generic/deferred mapped targets
+        // (where the property set is not knowable) are untouched.
+        if evaluated_target != target
+            && crate::query_boundaries::common::mapped_type_id(self.ctx.types, target).is_some()
+            && !tsz_solver::type_queries::mapped_type_is_deferred_generic(self.ctx.types, target)
+            // A homomorphic mapped type over a union source distributes to a
+            // union (and an intersection target keeps an intersection shape), so
+            // leave those to the union/intersection paths below.
+            && query::union_members(self.ctx.types, evaluated_target).is_none()
+            && query::intersection_members(self.ctx.types, evaluated_target).is_none()
+            && let Some(shape) = query::object_shape(self.ctx.types, evaluated_target)
+            && shape.string_index.is_none()
+        {
+            let mut first_excess: Option<(Atom, NodeIndex, u32)> = None;
+            for source_prop in source_props {
+                if explicit_property_names.is_some()
+                    && !explicit_property_names
+                        .as_ref()
+                        .is_some_and(|names| names.contains(&source_prop.name))
+                {
+                    continue;
+                }
+                let covered = shape
+                    .properties
+                    .iter()
+                    .any(|prop| prop.name == source_prop.name)
+                    || (shape.number_index.is_some() && {
+                        let name = self.ctx.types.resolve_atom(source_prop.name);
+                        tsz_solver::utils::is_numeric_literal_name(&name)
+                    });
+                if !covered {
+                    let report_idx = self
+                        .find_object_literal_property_element(object_literal_idx, source_prop.name)
+                        .unwrap_or(object_literal_idx);
+                    self.track_earliest_excess(&mut first_excess, source_prop.name, report_idx);
+                }
+            }
+            // Display the expanded object shape (matching tsc), not the deferred
+            // mapped form.
+            self.emit_tracked_excess_property(first_excess, evaluated_target);
+            return;
+        }
+
         if let Some(members) = query::intersection_members(self.ctx.types, union_check_target) {
             let mut first_excess: Option<(Atom, NodeIndex, u32)> = None;
             for source_prop in source_props {

--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -163,19 +163,7 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    fn track_earliest_excess(
-        &self,
-        current: &mut Option<(Atom, NodeIndex, u32)>,
-        name: Atom,
-        report_idx: NodeIndex,
-    ) {
-        let pos = self.ctx.arena.get(report_idx).map_or(u32::MAX, |n| n.pos);
-        if current.is_none_or(|(_, _, best)| pos < best) {
-            *current = Some((name, report_idx, pos));
-        }
-    }
-
-    fn emit_tracked_excess_property(
+    pub(super) fn emit_tracked_excess_property(
         &mut self,
         tracked: Option<(Atom, NodeIndex, u32)>,
         target: TypeId,
@@ -381,54 +369,13 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        // A fully concrete homomorphic mapped target — e.g. `{ [K in keyof A]?:
-        // A[K] }` over a non-generic `A` — is kept as a deferred `Mapped` in the
-        // declared type, so the solver's object-literal excess path never runs
-        // against its expanded shape and the generic-mapped loop above defers it
-        // (its evaluated object carries no free type parameters). tsc evaluates
-        // such a target to a concrete object and reports excess properties
-        // against that object. Mirror that here using the already-computed
-        // `evaluated_target`, scoped to concrete mapped targets so plain objects
-        // (handled by the solver relation) and generic/deferred mapped targets
-        // (where the property set is not knowable) are untouched.
-        if evaluated_target != target
-            && crate::query_boundaries::common::mapped_type_id(self.ctx.types, target).is_some()
-            && !tsz_solver::type_queries::mapped_type_is_deferred_generic(self.ctx.types, target)
-            // A homomorphic mapped type over a union source distributes to a
-            // union (and an intersection target keeps an intersection shape), so
-            // leave those to the union/intersection paths below.
-            && query::union_members(self.ctx.types, evaluated_target).is_none()
-            && query::intersection_members(self.ctx.types, evaluated_target).is_none()
-            && let Some(shape) = query::object_shape(self.ctx.types, evaluated_target)
-            && shape.string_index.is_none()
-        {
-            let mut first_excess: Option<(Atom, NodeIndex, u32)> = None;
-            for source_prop in source_props {
-                if explicit_property_names.is_some()
-                    && !explicit_property_names
-                        .as_ref()
-                        .is_some_and(|names| names.contains(&source_prop.name))
-                {
-                    continue;
-                }
-                let covered = shape
-                    .properties
-                    .iter()
-                    .any(|prop| prop.name == source_prop.name)
-                    || (shape.number_index.is_some() && {
-                        let name = self.ctx.types.resolve_atom(source_prop.name);
-                        tsz_solver::utils::is_numeric_literal_name(&name)
-                    });
-                if !covered {
-                    let report_idx = self
-                        .find_object_literal_property_element(object_literal_idx, source_prop.name)
-                        .unwrap_or(object_literal_idx);
-                    self.track_earliest_excess(&mut first_excess, source_prop.name, report_idx);
-                }
-            }
-            // Display the expanded object shape (matching tsc), not the deferred
-            // mapped form.
-            self.emit_tracked_excess_property(first_excess, evaluated_target);
+        if self.report_concrete_mapped_target_excess_property(
+            target,
+            evaluated_target,
+            source_props,
+            explicit_property_names.as_ref(),
+            object_literal_idx,
+        ) {
             return;
         }
 

--- a/crates/tsz-checker/src/tests/mapped_optional_target_excess_property_tests.rs
+++ b/crates/tsz-checker/src/tests/mapped_optional_target_excess_property_tests.rs
@@ -1,0 +1,139 @@
+//! Excess-property (TS2353) checking against a *concrete* homomorphic mapped
+//! target that adds the optional modifier (`?` / `+?`).
+//!
+//! Structural rule: when a homomorphic mapped type over a non-generic source —
+//! `{ [K in keyof A]?: A[K] }`, with or without an identity/renaming `as`
+//! clause — is used as a contextual type, tsc evaluates it to a concrete object
+//! and applies normal excess-property checking against the expanded shape. The
+//! optional modifier turns the result into a "weak" object, but a fresh object
+//! literal that specifies a key outside the source key set is still TS2353.
+//!
+//! tsz before fix: such a target was kept as a deferred `Mapped` in the declared
+//! type, so the solver's object-literal excess path never ran against the
+//! expanded shape and the checker's generic-mapped excess loop deferred it (the
+//! evaluated object carries no free type parameters). The excess key was
+//! silently accepted. A *generic* `Partial<T>`-style target must stay deferred,
+//! since its key set is unknown until `T` is instantiated.
+//!
+//! Binder names are varied across cases so the fix is structural, not spelling
+//! specific.
+
+use crate::test_utils::check_source_strict_messages_without_missing_libs;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_strict_messages_without_missing_libs(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+/// Plain `?` optional homomorphic mapped target flags an excess key.
+#[test]
+fn plain_optional_mapped_target_flags_excess_property() {
+    let diags = check_source_strict_messages_without_missing_libs(
+        "type Src = { a: string; b: number };\n\
+         const v: { [K in keyof Src]?: Src[K] } = { a: \"\", b: 1, zzz: 9 };",
+    );
+    let cs: Vec<u32> = diags.iter().map(|(c, _)| *c).collect();
+    assert!(
+        cs.contains(&2353),
+        "excess key on optional mapped target must be TS2353; got {diags:?}"
+    );
+    // The display must show the expanded object, not the deferred mapped form.
+    let msg = diags
+        .iter()
+        .find(|(c, _)| *c == 2353)
+        .map(|(_, m)| m.clone())
+        .unwrap_or_default();
+    assert!(
+        msg.contains("a?:") && msg.contains("b?:") && !msg.contains("in keyof"),
+        "TS2353 must render the expanded object shape, got: {msg}"
+    );
+}
+
+/// Explicit `+?` optional modifier behaves the same as `?`.
+#[test]
+fn plus_optional_mapped_target_flags_excess_property() {
+    let cs = codes(
+        "type Box = { x: string; y: number };\n\
+         const v: { [P in keyof Box]+?: Box[P] } = { x: \"\", y: 1, extra: true };",
+    );
+    assert!(
+        cs.contains(&2353),
+        "excess key on `+?` mapped target must be TS2353; got {cs:?}"
+    );
+}
+
+/// An identity-renaming `as K` clause is still homomorphic, so excess checking
+/// applies against the (unchanged) key set.
+#[test]
+fn identity_rename_optional_mapped_target_flags_excess_property() {
+    let cs = codes(
+        "type Rec = { one: string; two: number };\n\
+         const v: { [K in keyof Rec as K]?: Rec[K] } = { one: \"\", two: 1, three: 3 };",
+    );
+    assert!(
+        cs.contains(&2353),
+        "excess key on `as K` optional mapped target must be TS2353; got {cs:?}"
+    );
+}
+
+/// A fresh object literal that stays within the source key set is clean — the
+/// fix must not introduce false positives.
+#[test]
+fn optional_mapped_target_without_excess_is_clean() {
+    let cs = codes(
+        "type Src = { a: string; b: number };\n\
+         const v: { [K in keyof Src]?: Src[K] } = { a: \"\", b: 1 };",
+    );
+    assert!(
+        cs.is_empty(),
+        "in-bounds object literal against optional mapped target must be clean; got {cs:?}"
+    );
+}
+
+/// The empty object literal satisfies an all-optional mapped target.
+#[test]
+fn empty_literal_satisfies_optional_mapped_target() {
+    let cs = codes(
+        "type Src = { a: string; b: number };\n\
+         const v: { [K in keyof Src]?: Src[K] } = {};",
+    );
+    assert!(
+        cs.is_empty(),
+        "empty literal against all-optional mapped target must be clean; got {cs:?}"
+    );
+}
+
+/// A generic `Partial<T>`-style optional mapped target keeps its key set
+/// deferred; an object literal with an unknown-at-definition key must NOT be
+/// reported as excess (tsc accepts it until `T` is instantiated).
+#[test]
+fn generic_optional_mapped_target_does_not_flag_excess() {
+    let cs = codes(
+        "type Part<T> = { [K in keyof T]?: T[K] };\n\
+         function f<T>(): void {\n\
+           const v: Part<T> = { anything: 1 } as Part<T>;\n\
+           void v;\n\
+         }",
+    );
+    assert!(
+        !cs.contains(&2353),
+        "generic deferred mapped target must not flag excess; got {cs:?}"
+    );
+}
+
+/// `-?` (required) optional-removal mapped targets are not weak; excess on a
+/// required-shaped target is still flagged (regression guard for the shared
+/// path).
+#[test]
+fn required_mapped_target_still_flags_excess_property() {
+    let cs = codes(
+        "type Src = { a?: string; b?: number };\n\
+         const v: { [K in keyof Src]-?: Src[K] } = { a: \"\", b: 1, gone: 0 };",
+    );
+    assert!(
+        cs.contains(&2353),
+        "excess key on `-?` mapped target must be TS2353; got {cs:?}"
+    );
+}

--- a/crates/tsz-solver/src/type_queries/mapped.rs
+++ b/crates/tsz-solver/src/type_queries/mapped.rs
@@ -34,6 +34,28 @@ pub fn optional_mapped_type_adds_implicit_undefined(
     !template_covers_optional_undefined_display(db, mapped.template)
 }
 
+/// Whether a mapped type is still *deferred/generic* — its key source,
+/// template, or `as` clause references a free type parameter beyond its bound
+/// iteration variable, so the relation cannot expand it to concrete properties.
+///
+/// A fully concrete homomorphic mapped target such as `{ [K in keyof A]?: A[K] }`
+/// over a non-generic `A` is wholly expandable, so callers that special-case
+/// deferred mapped surfaces (e.g. the implicit `| undefined` ambiguity that an
+/// optional-add mapped target would otherwise display) must not treat it as
+/// deferred: tsc evaluates it to a concrete object and reports precise
+/// structural diagnostics (excess properties, exact member display) against the
+/// expanded shape.
+pub fn mapped_type_is_deferred_generic(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    let Some(mapped) = super::data::get_mapped_type(db, type_id) else {
+        return false;
+    };
+    crate::visitors::visitor_predicates::contains_free_type_parameters_except_name(
+        db,
+        type_id,
+        mapped.type_param.name,
+    )
+}
+
 fn template_covers_optional_undefined_display(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     if matches!(type_id, TypeId::UNDEFINED | TypeId::ANY | TypeId::UNKNOWN) {
         return true;

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -27,66 +27,40 @@
 # - PR #12649 run 27016857260 attempt 2 at synthetic merge 3d599062d3 found
 #   thirteen rows returned and no previous accepted rows resolved after the
 #   exact-head cancelled shard rerun.
+# - PR #12659 run 27032877016 at synthetic merge c42c6ba96f found one returned
+#   row and sixteen previous accepted rows resolved after exact-head aggregate.
 # Keep these visible as accepted-regression debt until their owning parity
 # fixes remove them from exact-head aggregate output.
 TypeScript/tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts
-TypeScript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum3.ts
 TypeScript/tests/cases/compiler/declarationEmitObjectAssignedDefaultExport.ts
 TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules1.ts
 TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
-TypeScript/tests/cases/compiler/declarationsIndirectGeneratedAliasReference.ts
-TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
-TypeScript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 TypeScript/tests/cases/compiler/inferFromNestedSameShapeTuple.ts
 TypeScript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
-TypeScript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts
 TypeScript/tests/cases/compiler/letInConstDeclarations_ES6.ts
 TypeScript/tests/cases/compiler/letInLetConstDeclOfForOfAndForIn_ES6.ts
 TypeScript/tests/cases/compiler/letInLetDeclarations_ES6.ts
 TypeScript/tests/cases/compiler/promisesWithConstraints.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
-TypeScript/tests/cases/compiler/strictModeReservedWord.ts
-TypeScript/tests/cases/compiler/unicodeEscapesInNames02.ts
-TypeScript/tests/cases/conformance/es2019/importMeta/importMeta.ts
 TypeScript/tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts
 TypeScript/tests/cases/conformance/es6/for-ofStatements/for-of51.ts
 TypeScript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts
-TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts
-TypeScript/tests/cases/conformance/jsdoc/importTag17.ts
-TypeScript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit6.ts
 TypeScript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit7.ts
-TypeScript/tests/cases/conformance/salsa/plainJSGrammarErrors.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes2.ts
-TypeScript/tests/cases/conformance/types/conditional/inferTypes1.ts
-TypeScript/tests/cases/conformance/types/mapped/mappedTypeErrors2.ts
+TypeScript/tests/cases/conformance/types/rest/genericRestParameters3.ts
 TypeScript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts
-TypeScript/tests/cases/conformance/types/tuple/variadicTuples1.ts
-TypeScript/tests/cases/conformance/types/tuple/variadicTuples2.ts
 # covariantCallbacks.ts: RESOLVED by PR #12482. tsz now detects nullable-union
 # callback method parameters the way tsc does (getSingleCallSignature(
 # getNonNullableType(t))), so lib `Promise<A>` -> `Promise<B>` reports its
 # covariant TS2322 again. Removed from this ledger; covered by
 # nullable_union_callback_variance_tests.
-# infiniteExpansionThroughInstantiation.ts: RESOLVED (#10867). The TS2322 source
-# display for a generic interface reference written with free type-parameter
-# arguments (`OwnerList<T>`) no longer over-instantiates the argument from the
-# instantiated heritage/members (`OwnerList<List<T>>`); tsz now preserves the
-# as-written reference like tsc. Covered by
-# generic_interface_source_display_preserves_as_written_type_argument and
-# generic_interface_heritage_source_display_is_not_over_instantiated.
-
-# Current-main aggregate drift after PR branches first made the duplicate
-# type-query-flow module compileable again. Exact evidence:
-# - PR #12606 run 26999340595 at bb6caa8011 aggregated 12552/12585 and
-#   listed exactly these seven unaccepted rows after all conformance shards
-#   themselves completed successfully.
-TypeScript/tests/cases/compiler/declarationEmitComputedPropertyNameEnum3.ts
-TypeScript/tests/cases/conformance/es2019/importMeta/importMeta.ts
-TypeScript/tests/cases/conformance/salsa/plainJSGrammarErrors.ts
-TypeScript/tests/cases/conformance/types/conditional/inferTypes1.ts
-TypeScript/tests/cases/conformance/types/mapped/mappedTypeErrors2.ts
-TypeScript/tests/cases/conformance/types/tuple/variadicTuples1.ts
-TypeScript/tests/cases/conformance/types/tuple/variadicTuples2.ts
+# infiniteExpansionThroughInstantiation.ts: RESOLVED. The TS2322 source type
+# `OwnerList<T>` was over-instantiated to `OwnerList<List<T>>` because the
+# eagerly-evaluated generic interface instance dropped its Application display
+# provenance whenever an argument carried a free type parameter
+# (store_parametric_structural_back_reference). Provenance is now recorded for
+# those instances, so display matches tsc. Covered by
+# recursive_generic_interface_application_display_tests.

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -29,28 +29,35 @@
 #   exact-head cancelled shard rerun.
 # - PR #12659 run 27032877016 at synthetic merge c42c6ba96f found one returned
 #   row and sixteen previous accepted rows resolved after exact-head aggregate.
+# - PR #12660 run 27037607717 at synthetic merge 854e089920 found seven rows
+#   returned and two previous accepted rows resolved after exact-head aggregate.
 # Keep these visible as accepted-regression debt until their owning parity
 # fixes remove them from exact-head aggregate output.
 TypeScript/tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts
 TypeScript/tests/cases/compiler/declarationEmitObjectAssignedDefaultExport.ts
 TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules1.ts
 TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
+TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
+TypeScript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
 TypeScript/tests/cases/compiler/inferFromNestedSameShapeTuple.ts
 TypeScript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
+TypeScript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts
 TypeScript/tests/cases/compiler/letInConstDeclarations_ES6.ts
 TypeScript/tests/cases/compiler/letInLetConstDeclOfForOfAndForIn_ES6.ts
 TypeScript/tests/cases/compiler/letInLetDeclarations_ES6.ts
 TypeScript/tests/cases/compiler/promisesWithConstraints.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
+TypeScript/tests/cases/compiler/strictModeReservedWord.ts
+TypeScript/tests/cases/compiler/unicodeEscapesInNames02.ts
 TypeScript/tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts
 TypeScript/tests/cases/conformance/es6/for-ofStatements/for-of51.ts
 TypeScript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts
+TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts
-TypeScript/tests/cases/conformance/node/nodeModulesTripleSlashReferenceModeDeclarationEmit7.ts
+TypeScript/tests/cases/conformance/jsdoc/importTag17.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes2.ts
-TypeScript/tests/cases/conformance/types/rest/genericRestParameters3.ts
 TypeScript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts
 # covariantCallbacks.ts: RESOLVED by PR #12482. tsz now detects nullable-union
 # callback method parameters the way tsc does (getSingleCallSignature(


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Conformance / checker excess-property diagnostics for concrete mapped targets.

## Invariant
When a homomorphic mapped type over a non-generic source evaluates to a concrete object target, `tsc` applies normal excess-property checking to fresh object literals. `tsz` now does this in the checker object-literal excess path using a solver structural query to distinguish genuinely deferred generic mapped targets.

## Scope
- `crates/tsz-checker/src/state/state_checking/property.rs`
- `crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs`
- `crates/tsz-solver/src/type_queries/mapped.rs`
- `crates/tsz-checker/src/tests/mapped_optional_target_excess_property_tests.rs`
- `crates/tsz-checker/src/lib.rs` test registration
- `scripts/conformance/conformance-accepted-regressions.txt` ledger sync from exact-head aggregate evidence

## Project Corpus Impact
- Row: n/a.
- Bug family: TS2353 excess-property checking for concrete optional homomorphic mapped targets.
- Evidence: diagnostic-only tightening for fresh object literals against concrete mapped target key sets. Generic `Partial<T>`-style targets remain deferred and are covered as negative controls; no project-row timing claim is made.

## Verification
- Refreshed onto `origin/main` `e172ee4f2e` and pushed head `45ac65dd48`.
- Exact-head CI run `27037607717` on prior head `d8400bd3` passed all non-aggregate jobs; conformance aggregate on synthetic merge `854e089920878850ebad7e52c59a8f396cdd0b17` reported seven returned accepted rows and two resolved rows.
- Ledger refresh verification on `45ac65dd48`: `python3 scripts/conformance/query-conformance.py --dashboard` -> `12585/12585`, accepted-regression gate `26` listed tests.
- Ledger integrity on `45ac65dd48`: `active=26`, `unique=26`, duplicates `0`.
- Delta hygiene: `git diff --check origin/claude/brave-volta-p3yUk..HEAD` passed before push.
- Earlier focused verification retained from this PR: `cargo fmt --all --check`; `git diff --check`; `scripts/arch/check-checker-boundaries.sh`; `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib mapped_optional_target_excess_property_tests --no-fail-fast`; `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-common -p tsz-scanner -p tsz-parser -p tsz-binder -p tsz-solver -p tsz-checker -p tsz-emitter -p tsz-lowering -p tsz-lsp --all-targets -- -D warnings`.
- Fresh exact-head CI is running as `27038888735` for `45ac65dd48`.

## Coordination Notes
- Structural rule: concrete homomorphic mapped targets such as `{ [K in keyof A]?: A[K] }`, `+?`, identity `as K`, and `-?` forms use the evaluated target key set for fresh-literal excess checks; genuinely generic/deferred mapped targets do not.
- Owner layer: checker object-literal excess-property path with solver-backed structural query; no fixture-name fast path.
- Refreshed after main-line movement and conformance aggregate drift so exact-head CI can rerun on current base.
- Ready for manager/queue-owner review once exact-head CI is green; no merge-queue action taken by Studio-B.
- AgentName: Studio-B
