### PR TITLE
fix(parser): scope tagged-template escape suppression to its own literal spans

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions.rs
+++ b/crates/tsz-parser/src/parser/state_expressions.rs
@@ -1265,9 +1265,7 @@ impl ParserState {
                 }
                 // Tagged template literals: tag`template` or tag`head${expr}tail`
                 SyntaxKind::NoSubstitutionTemplateLiteral | SyntaxKind::TemplateHead => {
-                    self.in_tagged_template = true;
-                    let template = self.parse_template_literal();
-                    self.in_tagged_template = false;
+                    let template = self.parse_tagged_template_literal();
                     let end_pos = self.token_end();
 
                     expr = self.arena.add_tagged_template(
@@ -1315,9 +1313,7 @@ impl ParserState {
                         } else if self.is_token(SyntaxKind::NoSubstitutionTemplateLiteral)
                             || self.is_token(SyntaxKind::TemplateHead)
                         {
-                            self.in_tagged_template = true;
-                            let template = self.parse_template_literal();
-                            self.in_tagged_template = false;
+                            let template = self.parse_tagged_template_literal();
                             let end_pos = self.token_end();
 
                             expr = self.arena.add_tagged_template(
@@ -1405,9 +1401,7 @@ impl ParserState {
                             diagnostic_messages::TAGGED_TEMPLATE_EXPRESSIONS_ARE_NOT_PERMITTED_IN_AN_OPTIONAL_CHAIN,
                             diagnostic_codes::TAGGED_TEMPLATE_EXPRESSIONS_ARE_NOT_PERMITTED_IN_AN_OPTIONAL_CHAIN,
                         );
-                        self.in_tagged_template = true;
-                        let template = self.parse_template_literal();
-                        self.in_tagged_template = false;
+                        let template = self.parse_tagged_template_literal();
                         let end_pos = self.token_end();
                         expr = self.arena.add_tagged_template(
                             syntax_kind_ext::TAGGED_TEMPLATE_EXPRESSION,
@@ -1514,9 +1508,7 @@ impl ParserState {
                                 tsz_common::diagnostics::diagnostic_messages::SUPER_MUST_BE_FOLLOWED_BY_AN_ARGUMENT_LIST_OR_MEMBER_ACCESS,
                                 tsz_common::diagnostics::diagnostic_codes::SUPER_MUST_BE_FOLLOWED_BY_AN_ARGUMENT_LIST_OR_MEMBER_ACCESS,
                             );
-                            self.in_tagged_template = true;
-                            let template = self.parse_template_literal();
-                            self.in_tagged_template = false;
+                            let template = self.parse_tagged_template_literal();
                             let end_pos = self.token_end();
 
                             expr = self.arena.add_tagged_template(
@@ -1566,9 +1558,7 @@ impl ParserState {
                             || self.is_token(SyntaxKind::TemplateHead)
                         {
                             // Tagged template with type arguments: tag<T>`template`
-                            self.in_tagged_template = true;
-                            let template = self.parse_template_literal();
-                            self.in_tagged_template = false;
+                            let template = self.parse_tagged_template_literal();
                             let end_pos = self.token_end();
 
                             expr = self.arena.add_tagged_template(

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -1152,7 +1152,18 @@ impl ParserState {
     fn parse_template_expression_span(&mut self) -> (u32, NodeIndex, bool) {
         let saved_flags = self.context_flags;
         self.context_flags |= crate::parser::state::CONTEXT_FLAG_TEMPLATE_SPAN_EXPRESSION;
+        // A `${...}` substitution is an independent expression: any template
+        // literal it contains determines its own tagged status. The enclosing
+        // template's tagged status must not leak in, or a nested *untagged*
+        // template's invalid escapes would be wrongly suppressed. tsc parses the
+        // span expression via `allowInAnd(parseExpression)` and only re-applies
+        // `isTaggedTemplate` when re-scanning the middle/tail literal below, so we
+        // clear the flag for the duration of the substitution and restore it for
+        // the literal-span re-scan that follows.
+        let saved_in_tagged_template = self.in_tagged_template;
+        self.in_tagged_template = false;
         let expression = self.parse_expression();
+        self.in_tagged_template = saved_in_tagged_template;
         self.context_flags = saved_flags;
         if expression.is_none() {
             // Emit TS1109 "Expression expected." for empty template expressions.
@@ -1363,6 +1374,27 @@ impl ParserState {
         } else {
             self.parse_template_expression()
         }
+    }
+
+    /// Parse the template portion of a tagged template, marking the parser as
+    /// being inside a tagged template so the immediate head/middle/tail literals
+    /// suppress invalid-escape errors (TS1125), which tagged templates permit
+    /// since ES2018.
+    ///
+    /// The `in_tagged_template` flag is saved and restored rather than reset to
+    /// `false`, so this works correctly under nesting: a tagged template that
+    /// appears inside another tagged template's substitution must not clobber the
+    /// enclosing template's tagged status when it finishes (which would otherwise
+    /// make the enclosing template's middle/tail literals spuriously report
+    /// TS1125). Substitution expressions themselves are parsed with the flag
+    /// cleared in `parse_template_expression_span`, matching tsc, where
+    /// `isTaggedTemplate` is re-applied only when re-scanning the literal spans.
+    pub(crate) fn parse_tagged_template_literal(&mut self) -> NodeIndex {
+        let saved_in_tagged_template = self.in_tagged_template;
+        self.in_tagged_template = true;
+        let template = self.parse_template_literal();
+        self.in_tagged_template = saved_in_tagged_template;
+        template
     }
 
     /// Parse parenthesized expression
@@ -1796,9 +1828,7 @@ impl ParserState {
                 // `new f\`abc\`.member(...)` parses the tagged template as
                 // part of the member expression, not as `(new f)\`abc\`...`.
                 SyntaxKind::NoSubstitutionTemplateLiteral | SyntaxKind::TemplateHead => {
-                    self.in_tagged_template = true;
-                    let template = self.parse_template_literal();
-                    self.in_tagged_template = false;
+                    let template = self.parse_tagged_template_literal();
                     let end_pos = self.token_end();
 
                     expr = self.arena.add_tagged_template(

--- a/crates/tsz-parser/tests/parser_improvement_template_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_template_recovery_tests.rs
@@ -211,3 +211,103 @@ fn test_ts1125_untagged_template_emits_errors() {
         ts1125_diagnostics
     );
 }
+
+/// Count the TS1125 (invalid escape) diagnostics for `source`, reusing the
+/// shared `diagnostic_codes` collector above.
+fn ts1125_count(source: &str) -> usize {
+    diagnostic_codes(source)
+        .into_iter()
+        .filter(|&code| code == 1125)
+        .count()
+}
+
+/// Structural rule: the invalid-escape suppression of a tagged template applies
+/// only to the literal head/middle/tail spans of *that* template, not to the
+/// `${...}` substitution expressions. A nested **untagged** template inside a
+/// tagged template's substitution is an ordinary untagged template and must
+/// still report TS1125 for its invalid escapes.
+///
+/// Witness for the `in_tagged_template` flag leaking into substitution
+/// expressions: before the fix the outer tag's flag stayed set while the
+/// substitution was parsed, so the inner untagged template's escape was wrongly
+/// suppressed (0 errors instead of 1).
+#[test]
+fn tagged_template_does_not_suppress_escapes_in_nested_untagged_substitution() {
+    // Outer is tagged: its head `\xZ1` and tail `\xZ3` are suppressed.
+    // The inner untagged template `\xZ2` in the substitution must report once.
+    assert_eq!(
+        ts1125_count(r#"const a = tag`\xZ1 ${ `\xZ2` } \xZ3`;"#),
+        1,
+        "an untagged template inside a tagged template's substitution must \
+         still report its invalid escape"
+    );
+}
+
+/// Structural rule: a tagged template nested inside another tagged template's
+/// substitution must restore — not clear — the enclosing template's tagged
+/// status when it finishes. Otherwise the outer template's middle/tail literals
+/// would spuriously report TS1125 after the nested tag.
+///
+/// Witness for the `in_tagged_template = false` reset clobbering the enclosing
+/// flag: before the fix the outer tag's tail `\xZ3` was wrongly reported (1
+/// error instead of 0).
+#[test]
+fn nested_tagged_template_does_not_clobber_enclosing_tagged_status() {
+    assert_eq!(
+        ts1125_count(r#"const b = tag`\xZ1 ${ inner`\xZ2` } \xZ3`;"#),
+        0,
+        "a tagged template nested in a tagged substitution must not make the \
+         enclosing template's tail report TS1125"
+    );
+}
+
+/// Control: with no tagging anywhere, every span reports. The outer untagged
+/// template head `\xZ1` and tail `\xZ3` plus the inner untagged template `\xZ2`
+/// each report — three errors total.
+#[test]
+fn untagged_template_with_nested_untagged_substitution_reports_all_escapes() {
+    assert_eq!(ts1125_count(r#"const c = `\xZ1 ${ `\xZ2` } \xZ3`;"#), 3,);
+}
+
+/// Control: an untagged outer template still reports its own head/tail escapes
+/// even when its substitution holds a *tagged* template (whose escapes are
+/// suppressed). Proves the fix suppresses only the immediately-tagged literal
+/// and does not over-suppress the surrounding untagged spans.
+#[test]
+fn untagged_template_reports_own_escapes_around_nested_tagged_substitution() {
+    assert_eq!(
+        ts1125_count(r#"const d = `\xZ1 ${ inner`\xZ2` } \xZ3`;"#),
+        2,
+    );
+}
+
+/// The rule is structural, not keyed on the `tag`/`inner` spellings or on the
+/// `\x` escape form: vary the tag binder names and use `\u` escapes, and the
+/// same head/tail-suppressed, nested-untagged-reported counts must hold.
+#[test]
+fn tagged_template_escape_suppression_is_structural() {
+    // Distinct tag names, `\u` escapes. Outer tagged: head/tail suppressed,
+    // nested untagged reports once.
+    assert_eq!(
+        ts1125_count(r#"const e = render`\uZ1 ${ `\uZ2` } \uZ3`;"#),
+        1,
+    );
+    // Distinct names again, nested tagged: zero.
+    assert_eq!(
+        ts1125_count(r#"const f = html`\uZ1 ${ styled`\uZ2` } \uZ3`;"#),
+        0,
+    );
+}
+
+/// Deep nesting: a tagged template whose substitution is an *untagged* template
+/// that itself contains a tagged template substitution. Only the untagged
+/// template's own head/tail escapes report; both tagged levels are suppressed.
+#[test]
+fn deeply_nested_template_tagging_tracks_each_level_independently() {
+    // outer tagged (suppressed) -> untagged span (head `\uZ2` + tail `\uZ4`
+    // report) -> tagged span (`\uZ3` suppressed). Outer tail `\uZ5` suppressed.
+    assert_eq!(
+        ts1125_count(r#"const g = outer`\uZ1 ${ `\uZ2 ${ mid`\uZ3` } \uZ4` } \uZ5`;"#),
+        2,
+    );
+}


### PR DESCRIPTION
AgentName: M1-A

Track: parser context recovery (#12182 — parser context recovery drifts across JSX, generic, and mapped boundaries)

## Invariant
When `tsc` parses a tagged template, the invalid-escape (TS1125) suppression that tagged templates earn (ES2018+) applies **only** to that template's immediate head/middle/tail literal spans. Substitution expressions are parsed independently (`allowInAnd(parseExpression)`) and each template literal determines its own tagged status. tsz must restore the tagged-template parser flag at the same grammar boundaries and must not let it drift into substitution expressions or across nested templates.

## Structural rule
When a template literal's escape sequence is scanned, `tsc` reports TS1125 iff that specific template is **not** being parsed as a tagged template; tsz does the same through the parser's `in_tagged_template` flag, which is now scoped to the literal spans of the immediately-tagged template via `parse_tagged_template_literal` and cleared while parsing each `${...}` substitution in `parse_template_expression_span`.

## Scope
The `in_tagged_template` flag was set `true` around the *entire* tagged-template parse and then reset to a hardcoded `false`. That drifted across template boundaries in two directions:

- **False negative (leak into substitution):** a nested **untagged** template literal inside a tagged template's `${...}` had its invalid escapes wrongly suppressed, because the outer tag's flag was still set while the substitution was parsed.
- **False positive (clobber on nesting):** a tagged template nested inside another tagged template's substitution reset the flag to `false` on completion, clobbering the enclosing template's tagged status, so the outer template's middle/tail literals then spuriously reported TS1125.

Fix:
- Add `parse_tagged_template_literal`, which **saves and restores** `in_tagged_template` (instead of forcing `false`), and route all six tagged-template call sites through it. This both deduplicates six identical inline copies and makes nesting non-destructive.
- In `parse_template_expression_span`, clear `in_tagged_template` while parsing the substitution expression and restore it for the middle/tail re-scan, matching `tsc`'s `isTaggedTemplate` re-application boundary.

Owner layer: parser (`crates/tsz-parser`). No checker/solver/emitter changes; this only corrects which TS1125 diagnostics the parser emits.

## Adjacent-case matrix (new regression tests)
- Tagged outer + nested **untagged** substitution → reports the inner escape (was 0, now 1). *(witness)*
- Tagged outer + nested **tagged** substitution → no spurious outer-tail error (was 1, now 0). *(witness)*
- Untagged outer + nested untagged substitution → all spans report (control, 3).
- Untagged outer + nested tagged substitution → outer head/tail report, inner suppressed (control, 2).
- Structural variants: different tag binder names (`render`/`html`/`styled`), both `\x` and `\u` escape forms.
- Three-level nesting: tagged → untagged → tagged, only the untagged level reports (2).

Both witnesses were verified to **fail on the pre-fix parser** and pass after the fix; the two pre-existing TS1125 tagged/untagged tests are unchanged.

## Project Corpus Impact
Parser-only diagnostic correction in a rarely-exercised nested-template-escape surface; no project-row API or module-identity changes. Behavior moves strictly toward `tsc` parity (one false negative and one false positive removed). Broad conformance/project suites are owned by ready-review CI.

## Verification
- `cargo test -p tsz-parser --lib` → 1379 passed, 0 failed.
- `cargo clippy -p tsz-parser --lib` → clean.
- `cargo fmt -p tsz-parser` → clean.
- Witness check: reverted the two source files, the two nested-template tests (plus the structural variant) FAIL; restored, all pass.

## Coordination Notes
Claimed #12182 and applied the `WIP` label. #12182 is a parser-family tracker; per its triage note the children stay open as row witnesses — this PR lands a structural fix for the tagged-template-span boundary slice of that family rather than closing the tracker.

Refs #12182

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxY2ARos3si8THMkUhpxjE)_

## Project Corpus Impact
- Row: n/a
- Bug family: parser tagged-template invalid-escape boundary

## Refresh Verification
- Head `e0f2d6f24b`: merged `origin/main` to refresh stale conformance aggregate artifacts/accepted-regression ledger; parser diff against current main remains scoped to `state_expressions.rs`, `state_expressions_literals.rs`, and `parser_improvement_template_recovery_tests.rs`.
- `cargo fmt -p tsz-parser --check` -> passed.
- `git diff --check` -> clean.
- `scripts/safe-run.sh cargo nextest run -p tsz-parser parser_improvement_template_recovery_tests` -> 17 passed, 1362 skipped.
- `python3 scripts/conformance/query-conformance.py --dashboard` -> `12585/12585 (100.0%)`, accepted-regression gate `33 listed tests` on this refreshed branch.

## Refresh Verification
- AgentName: M1-A
- Head: `00f584336ff8cc199e4f41e4af27bca8743f59e4`
- Refreshed by merging current `origin/main`; diff remains scoped to parser tagged-template escape suppression and recovery tests.
- `cargo fmt -p tsz-parser --check` passed.
- `git diff --check` passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-parser parser_improvement_template_recovery_tests` passed: 17 passed, 1369 skipped.
- `python3 scripts/conformance/query-conformance.py --dashboard` passed: dashboard 12585/12585 (100.0%); accepted-regression gate 31 listed tests.

## Refresh Verification
- AgentName: M1-A
- Head: `5c03f73e05f79c436f7f930c4d45f859689e5d20`
- Refreshed by merging current `origin/main`; diff remains scoped to parser tagged-template escape suppression and recovery tests.
- `cargo fmt -p tsz-parser --check` passed.
- `git diff --check` passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-parser parser_improvement_template_recovery_tests` passed: 17 passed, 1369 skipped.
- `python3 scripts/conformance/query-conformance.py --dashboard` passed: dashboard 12585/12585 (100.0%); accepted-regression gate 31 listed tests.

## Refresh Verification
- AgentName: M1-A
- Head: `c550383765a66b1d6b1ac6351a1d273f44d72b2b`
- Refreshed by merging current `origin/main`; diff remains scoped to parser tagged-template escape suppression and recovery tests.
- `cargo fmt -p tsz-parser --check` passed.
- `git diff --check` passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-parser parser_improvement_template_recovery_tests` passed: 17 passed, 1369 skipped.
- `python3 scripts/conformance/query-conformance.py --dashboard` passed: dashboard 12585/12585 (100.0%); accepted-regression gate 31 listed tests.

## Refresh Verification
- AgentName: M1-A
- Head: `0a052d09a5c7bdf325b3850443fc83ddafe835c8`
- Refreshed by merging current `origin/main`; diff remains scoped to parser tagged-template escape suppression and recovery tests.
- `cargo fmt -p tsz-parser --check` passed.
- `git diff --check` passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-parser parser_improvement_template_recovery_tests` passed: 17 passed, 1369 skipped.
- `python3 scripts/conformance/query-conformance.py --dashboard` passed: dashboard 12585/12585 (100.0%); accepted-regression gate 38 listed tests.

## Refresh Verification
- AgentName: M1-A
- Head: `4fd5bf28fb0d169a7ccd7810d8cc1e569695ab5b`
- Refreshed by merging current `origin/main`; diff remains scoped to parser tagged-template escape suppression and recovery tests.
- `cargo fmt -p tsz-parser --check` passed.
- `git diff --check` passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-parser parser_improvement_template_recovery_tests` passed: 17 passed, 1369 skipped.
- `python3 scripts/conformance/query-conformance.py --dashboard` passed: dashboard 12585/12585 (100.0%); accepted-regression gate 38 listed tests.
