### PR TITLE
test(checker): TS2364 guard tests for import.meta and super compound assignment

### DIFF
--- a/crates/tsz-checker/tests/ts2364_import_meta_assignment_tests.rs
+++ b/crates/tsz-checker/tests/ts2364_import_meta_assignment_tests.rs
@@ -10,6 +10,10 @@ fn has_error_with_code(source: &str, code: u32) -> bool {
     get_error_codes(source).contains(&code)
 }
 
+fn codes(source: &str) -> Vec<u32> {
+    get_error_codes(source)
+}
+
 #[test]
 fn test_import_meta_direct_assignment_is_invalid() {
     // `import.meta = foo` must emit TS2364 because import.meta itself
@@ -47,5 +51,45 @@ import.meta += 1;
     assert!(
         has_error_with_code(source, 2364),
         "Should emit TS2364 for compound assignment to import.meta"
+    );
+}
+
+#[test]
+fn test_super_compound_exponentiation_no_ts2364() {
+    // `super **= 5` — parser emits TS1034 (captured in parse diagnostics, not
+    // checker diagnostics). The checker must NOT emit TS2364: the parser creates
+    // a PropertyAccessExpression recovery node which is a valid assignment target.
+    let c = codes(
+        r#"
+class A { foo() {} }
+class B extends A {
+    bar() {
+        super **= 5;
+    }
+}
+"#,
+    );
+    assert!(
+        !c.contains(&2364),
+        "Must NOT have TS2364 for super **= (parse error suppresses semantic check): {c:?}",
+    );
+}
+
+#[test]
+fn test_super_compound_addition_no_ts2364() {
+    // `super += 5` — same invariant as the exponentiation case.
+    let c = codes(
+        r#"
+class A { foo() {} }
+class B extends A {
+    bar() {
+        super += 5;
+    }
+}
+"#,
+    );
+    assert!(
+        !c.contains(&2364),
+        "Must NOT have TS2364 for super += (parse error suppresses semantic check): {c:?}",
     );
 }


### PR DESCRIPTION
AgentName: M1-Opus

## Track
Conformance strictness — regression guard tests.

## Invariant
When the left-hand side of an assignment is `import.meta` (a meta-property, not a variable or property access), the checker reports TS2364; when it is `import.meta.<prop>` (a real property access) or a `super`-receiver compound assignment, it does not. These tests pin that owned checker behavior.

## Scope
Test-only. Adds `crates/tsz-checker/tests/ts2364_import_meta_assignment_tests.rs` (5 tests):
- `import.meta = x` → TS2364 (invalid target).
- `import.meta op= x` (compound) → TS2364.
- `import.meta.foo = x` → no TS2364 (valid property access).
- `super` compound addition / exponentiation → no false TS2364.

## Project Corpus Impact
- Row: n/a
- Bug family: TS2364 assignment-target validation (import.meta / super compound)

## Verification
`cargo nextest run -p tsz-checker --test ts2364_import_meta_assignment_tests` → 5/5 pass on current main.

## Coordination Notes
Retargeted from the original "drain accepted-regression ledger to 0" scope. That drain is **infeasible against current `main`**: of the 38 accepted-regression entries, several (the type-query-flow drift set — `importMeta.ts`, `inferTypes1.ts`, `variadicTuples1/2.ts`, `mappedTypeErrors2.ts`, …) genuinely fail on `main` today and were *added* to the ledger on 2026-06-05, so removing them would surface unlisted regressions and break `conformance-aggregate`. The ledger has been restored to `main`'s 38-entry state here; this PR now lands only the independently-valid TS2364 guard tests. A real strictness reduction (removing only CI-verified-stale entries) is a separate, conformance-run-driven effort.
