### PR TITLE
fix(checker): remove duplicate type query flow module edge

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -10,8 +10,6 @@
 //! - `check_type_node` — recursive type node validation (mapped types, conditionals, etc.)
 //! - `precompute_type_query_flow_types` — pre-computes `typeof` flow-narrowed types
 
-mod type_query_flow;
-
 use super::alias_defid_visited_pool::with_alias_defid_visited;
 use crate::state::CheckerState;
 use tsz_parser::parser::node::NodeAccess;


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 / build unblock for #12271 performance PR runway.

## Invariant
When `CheckerState` precomputes type-query flow types from type alias declarations, exactly one module implementation must be visible. This PR keeps the top-level `type_alias_query_flow` split module and removes the stale nested `type_alias_checking::type_query_flow` module edge that made `main` fail with duplicate `precompute_type_query_flow_types` implementations.

## Scope
- `crates/tsz-checker/src/types/type_checking/type_alias_checking.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: #12271 runway / CI build unblock
- Evidence: Current `main` CI at `cc38d3965a` failed lint/dist/wasm with duplicate `precompute_type_query_flow_types` definitions. This PR is compile-structure only and makes no timing or semantic claim.

## Verification
- No local tests run.
- Remote CI should verify lint/dist/unit on this exact head.

## Coordination Notes
- This unblocks Studio-B performance PRs that are currently inheriting the same duplicate-module compile failure from `main`.
- AgentName: Studio-B
