### PR TITLE
perf(solver): dedupe boxed DefId registration

### DIFF
--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -124,7 +124,12 @@ impl TypeCache {
             .extend(other.well_known_symbol_names);
         self.boxed_types.extend(other.boxed_types);
         for (kind, def_ids) in other.boxed_def_ids {
-            self.boxed_def_ids.entry(kind).or_default().extend(def_ids);
+            let target = self.boxed_def_ids.entry(kind).or_default();
+            for def_id in def_ids {
+                if !target.contains(&def_id) {
+                    target.push(def_id);
+                }
+            }
         }
     }
 }
@@ -1762,6 +1767,27 @@ mod tests {
         assert_eq!(
             cache.def_to_name.get(&def_id).map(String::as_str),
             Some("ConcatArray")
+        );
+    }
+
+    #[test]
+    fn type_cache_merge_dedupes_boxed_def_ids() {
+        let mut lhs = empty_cache();
+        let mut rhs = empty_cache();
+        let def_id = tsz_solver::DefId(42);
+
+        lhs.boxed_def_ids
+            .insert(tsz_solver::IntrinsicKind::Function, vec![def_id]);
+        rhs.boxed_def_ids
+            .insert(tsz_solver::IntrinsicKind::Function, vec![def_id]);
+
+        lhs.merge(rhs);
+
+        assert_eq!(
+            lhs.boxed_def_ids
+                .get(&tsz_solver::IntrinsicKind::Function)
+                .map(Vec::as_slice),
+            Some(&[def_id][..])
         );
     }
 }

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -631,8 +631,11 @@ impl TypeEnvironment {
 
     /// Register a `DefId` as belonging to a boxed type.
     pub fn register_boxed_def_id(&mut self, kind: IntrinsicKind, def_id: DefId) {
-        self.boxed_def_ids.entry(kind).or_default().push(def_id);
-        self.bump_generation();
+        let def_ids = self.boxed_def_ids.entry(kind).or_default();
+        if !def_ids.contains(&def_id) {
+            def_ids.push(def_id);
+            self.bump_generation();
+        }
     }
 
     /// Check if a `DefId` corresponds to a boxed type of the given kind.
@@ -1382,6 +1385,28 @@ mod tests {
         assert!(
             env.resolver_generation() > gen_before_mutation,
             "store mutation must still be visible after idempotent reinstall"
+        );
+    }
+
+    #[test]
+    fn boxed_def_id_registration_is_idempotent() {
+        let mut env = TypeEnvironment::new();
+        let def_id = DefId(7);
+
+        env.register_boxed_def_id(IntrinsicKind::Function, def_id);
+        let gen_after_first = env.resolver_generation();
+        env.register_boxed_def_id(IntrinsicKind::Function, def_id);
+
+        assert_eq!(
+            env.resolver_generation(),
+            gen_after_first,
+            "re-registering the same boxed DefId must not invalidate env caches"
+        );
+        assert_eq!(
+            env.snapshot_boxed_def_ids()
+                .get(&IntrinsicKind::Function)
+                .map(Vec::as_slice),
+            Some(&[def_id][..])
         );
     }
 

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -727,7 +727,10 @@ impl TypeInterner {
 
     /// Register a DefId as belonging to a boxed type.
     pub fn register_boxed_def_id(&self, kind: IntrinsicKind, def_id: DefId) {
-        self.boxed_def_ids.entry(kind).or_default().push(def_id);
+        let mut def_ids = self.boxed_def_ids.entry(kind).or_default();
+        if !def_ids.contains(&def_id) {
+            def_ids.push(def_id);
+        }
     }
 
     /// Check if a DefId corresponds to a boxed type of the given kind.

--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -48,6 +48,24 @@ fn estimated_size_accounts_for_retained_predicate_caches() {
 }
 
 #[test]
+fn boxed_def_id_registration_is_idempotent() {
+    let interner = TypeInterner::new();
+    let def_id = DefId(7);
+
+    interner.register_boxed_def_id(IntrinsicKind::Function, def_id);
+    interner.register_boxed_def_id(IntrinsicKind::Function, def_id);
+
+    assert!(interner.is_boxed_def_id(def_id, IntrinsicKind::Function));
+    assert_eq!(
+        interner
+            .boxed_def_ids
+            .get(&IntrinsicKind::Function)
+            .map(|entry| entry.len()),
+        Some(1)
+    );
+}
+
+#[test]
 fn all_type_parameter_intersections_preserve_ordered_members() {
     let interner = TypeInterner::new();
     let alpha = interner.type_param(TypeParamInfo::simple(interner.intern_string("Alpha")));


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 / performance-residency slice for #12271.

## Invariant
When the same boxed `DefId` is registered repeatedly for the same intrinsic kind, the registration is idempotent. The checker/solver should retain a single boxed-def entry and avoid bumping resolver generation for a no-op re-registration.

## Scope
- `crates/tsz-checker/src/context/core.rs`
- `crates/tsz-solver/src/def/resolver.rs`
- `crates/tsz-solver/src/intern/core/interner.rs`
- `crates/tsz-solver/src/intern/core/interner_tests.rs`

## Project Corpus Impact
- Row: n/a, small cache/residency bookkeeping slice.
- Bug family: #12271 repeated real-project setup/cache pressure.
- Evidence: extracted from the broader #12516 performance draft so duplicate boxed-type registrations do not grow retained vectors or invalidate resolver-generation-dependent caches when nothing changed.

## Verification
- Remote CI on `5b0cf5177bf3c4af300314c486ff3f93ec749561`: `gate`, `project-row-drift`, `cargo-shear`, `cargo-deny`, `lint`, `unit`, `unit-cloudbuild`, `dist-binaries`, and `CI Light Summary` passed.
- Synced with `origin/main` `153d300634826ad420ec027f9f560f880205c7d5` before this verification.
- No local tests were run in this continuation.

## Coordination Notes
- Extracted from #12516 to keep the #12271 runway moving as smaller reviewable PRs.
- Ready for manager/queue-owner review; no merge-queue action taken by Studio-B.
