### PR TITLE
perf(counters): attribute lib bootstrap work

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -260,7 +260,16 @@ fn should_apply_duplicate_package_redirect(importing_file: &Path) -> bool {
 /// Build a fresh checker-facing lib set from the already-loaded lib sources so program
 /// binding and checker lib resolution stay isolated without requiring disk reloads.
 pub(super) fn load_checker_libs(lib_files: &[Arc<LibFile>]) -> CheckerLibSet {
-    let files = parallel::clone_lib_files_for_checker(lib_files, lib_files.len() > 1);
+    let should_clone_libs_in_parallel = lib_files.len() > 1;
+    let clone_start = tsz_common::perf_counters::enabled_fast().then(std::time::Instant::now);
+    let files = parallel::clone_lib_files_for_checker(lib_files, should_clone_libs_in_parallel);
+    if let Some(start) = clone_start {
+        tsz_common::perf_counters::record_checker_lib_clone(
+            lib_files.len() as u64,
+            should_clone_libs_in_parallel,
+            start.elapsed().as_nanos() as u64,
+        );
+    }
     let contexts = files
         .iter()
         .map(|lib| LibContext {

--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -144,6 +144,7 @@ impl PerfCounters {
             + &Self::dump_delegate_source_file_miss_residues(
                 &snap.delegate_source_file_miss_residues,
             )
+            + &Self::dump_lib_bootstrap(&snap)
             + &Self::dump_source_file_symbol_arena_cache_eligibility_outcomes()
             + &Self::dump_slow_check_timings(&snap)
             + &Self::dump_by_reason()
@@ -740,6 +741,37 @@ impl PerfCounters {
             if count > 0 {
                 out.push_str(&format!("  {name:<32} {count:>12}\n"));
             }
+        }
+        out
+    }
+
+    fn dump_lib_bootstrap(snap: &PerfCounterSnapshot) -> String {
+        let counters = snap.lib_bootstrap;
+        if counters.snapshot_set_load_attempts == 0 && counters.checker_lib_clone_calls == 0 {
+            return String::new();
+        }
+
+        let mut out = String::from("\nLib bootstrap attribution:\n");
+        if counters.snapshot_set_load_attempts > 0 {
+            out.push_str(&format!(
+                "  snapshot set load  attempts={} hits={} misses={} files={} total_ms={:.2} max_ms={:.2}\n",
+                counters.snapshot_set_load_attempts,
+                counters.snapshot_set_load_hits,
+                counters.snapshot_set_load_misses,
+                counters.snapshot_set_load_files_total,
+                counters.snapshot_set_load_elapsed_ms_total,
+                counters.snapshot_set_load_elapsed_ms_max,
+            ));
+        }
+        if counters.checker_lib_clone_calls > 0 {
+            out.push_str(&format!(
+                "  checker lib clone  calls={} parallel_calls={} files={} total_ms={:.2} max_ms={:.2}\n",
+                counters.checker_lib_clone_calls,
+                counters.checker_lib_clone_parallel_calls,
+                counters.checker_lib_clone_files_total,
+                counters.checker_lib_clone_elapsed_ms_total,
+                counters.checker_lib_clone_elapsed_ms_max,
+            ));
         }
         out
     }

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -71,6 +71,19 @@ pub struct PerfCounters {
     pub source_file_symbol_arena_cache_eligibility_outcome:
         [AtomicU64; SOURCE_FILE_SYMBOL_ARENA_CACHE_ELIGIBILITY_OUTCOME_COUNT],
 
+    // --- lib bootstrap ----------------------------------------------------
+    pub lib_snapshot_set_load_attempts: AtomicU64,
+    pub lib_snapshot_set_load_hits: AtomicU64,
+    pub lib_snapshot_set_load_misses: AtomicU64,
+    pub lib_snapshot_set_load_files_total: AtomicU64,
+    pub lib_snapshot_set_load_elapsed_ns_total: AtomicU64,
+    pub lib_snapshot_set_load_elapsed_ns_max: AtomicU64,
+    pub checker_lib_clone_calls: AtomicU64,
+    pub checker_lib_clone_parallel_calls: AtomicU64,
+    pub checker_lib_clone_files_total: AtomicU64,
+    pub checker_lib_clone_elapsed_ns_total: AtomicU64,
+    pub checker_lib_clone_elapsed_ns_max: AtomicU64,
+
     // ─── checker construction ────────────────────────────────────────────
     pub checker_state_constructed: AtomicU64,
     pub checker_state_with_parent_cache_constructed: AtomicU64,
@@ -212,6 +225,17 @@ impl PerfCounters {
                 CROSS_FILE_CACHE_MISS_CAUSE_COUNT],
             source_file_symbol_arena_cache_eligibility_outcome: [const { AtomicU64::new(0) };
                 SOURCE_FILE_SYMBOL_ARENA_CACHE_ELIGIBILITY_OUTCOME_COUNT],
+            lib_snapshot_set_load_attempts: AtomicU64::new(0),
+            lib_snapshot_set_load_hits: AtomicU64::new(0),
+            lib_snapshot_set_load_misses: AtomicU64::new(0),
+            lib_snapshot_set_load_files_total: AtomicU64::new(0),
+            lib_snapshot_set_load_elapsed_ns_total: AtomicU64::new(0),
+            lib_snapshot_set_load_elapsed_ns_max: AtomicU64::new(0),
+            checker_lib_clone_calls: AtomicU64::new(0),
+            checker_lib_clone_parallel_calls: AtomicU64::new(0),
+            checker_lib_clone_files_total: AtomicU64::new(0),
+            checker_lib_clone_elapsed_ns_total: AtomicU64::new(0),
+            checker_lib_clone_elapsed_ns_max: AtomicU64::new(0),
             checker_state_constructed: AtomicU64::new(0),
             checker_state_with_parent_cache_constructed: AtomicU64::new(0),
             with_parent_cache_by_reason: [const { AtomicU64::new(0) };
@@ -325,6 +349,44 @@ pub fn record_max(counter: &AtomicU64, value: u64) {
             Err(observed) => current = observed,
         }
     }
+}
+
+pub fn record_lib_snapshot_set_load(file_count: u64, hit: bool, elapsed_ns: u64) {
+    if !enabled_fast() {
+        return;
+    }
+    let c = counters();
+    c.lib_snapshot_set_load_attempts
+        .fetch_add(1, Ordering::Relaxed);
+    if hit {
+        c.lib_snapshot_set_load_hits
+            .fetch_add(1, Ordering::Relaxed);
+    } else {
+        c.lib_snapshot_set_load_misses
+            .fetch_add(1, Ordering::Relaxed);
+    }
+    c.lib_snapshot_set_load_files_total
+        .fetch_add(file_count, Ordering::Relaxed);
+    c.lib_snapshot_set_load_elapsed_ns_total
+        .fetch_add(elapsed_ns, Ordering::Relaxed);
+    record_max(&c.lib_snapshot_set_load_elapsed_ns_max, elapsed_ns);
+}
+
+pub fn record_checker_lib_clone(file_count: u64, parallel: bool, elapsed_ns: u64) {
+    if !enabled_fast() {
+        return;
+    }
+    let c = counters();
+    c.checker_lib_clone_calls.fetch_add(1, Ordering::Relaxed);
+    if parallel {
+        c.checker_lib_clone_parallel_calls
+            .fetch_add(1, Ordering::Relaxed);
+    }
+    c.checker_lib_clone_files_total
+        .fetch_add(file_count, Ordering::Relaxed);
+    c.checker_lib_clone_elapsed_ns_total
+        .fetch_add(elapsed_ns, Ordering::Relaxed);
+    record_max(&c.checker_lib_clone_elapsed_ns_max, elapsed_ns);
 }
 
 /// RAII guard that tracks recursion depth into

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -1,6 +1,6 @@
 /// Stable schema version for `PerfCounterSnapshot`. Bump when the JSON
 /// shape changes in a way the bench harness must adapt to.
-pub const PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION: u32 = 6;
+pub const PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION: u32 = 7;
 
 /// Frozen value-object view of the counter state. Built by
 /// [`PerfCounters::snapshot`]; serializable to JSON via serde.
@@ -26,6 +26,7 @@ pub struct PerfCounterSnapshot {
     pub delegate: DelegateCounters,
     pub checker: CheckerCounters,
     pub identity: IdentityCounters,
+    pub lib_bootstrap: LibBootstrapCounters,
     pub overlay: OverlayCounters,
     pub resolver: ResolverCounters,
     pub interner: InternerCounters,
@@ -330,6 +331,25 @@ pub struct IdentityCounters {
     pub type_environment_raw_symbol_lazy_fallbacks: u64,
 }
 
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct LibBootstrapCounters {
+    pub snapshot_set_load_attempts: u64,
+    pub snapshot_set_load_hits: u64,
+    pub snapshot_set_load_misses: u64,
+    pub snapshot_set_load_files_total: u64,
+    pub snapshot_set_load_elapsed_ms_total: f64,
+    pub snapshot_set_load_elapsed_ms_max: f64,
+    pub checker_lib_clone_calls: u64,
+    pub checker_lib_clone_parallel_calls: u64,
+    pub checker_lib_clone_files_total: u64,
+    pub checker_lib_clone_elapsed_ms_total: f64,
+    pub checker_lib_clone_elapsed_ms_max: f64,
+}
+
+fn ns_to_ms(ns: u64) -> f64 {
+    ns as f64 / 1_000_000.0
+}
+
 /// One `(name, count)` row in a named-counter JSON array.
 ///
 /// Used for the `alias_shortcut_outcomes`,
@@ -514,6 +534,27 @@ impl PerfCounters {
                 type_environment_raw_symbol_lazy_fallbacks: load(
                     &c.type_environment_raw_symbol_lazy_fallbacks,
                 ),
+            },
+            lib_bootstrap: LibBootstrapCounters {
+                snapshot_set_load_attempts: load(&c.lib_snapshot_set_load_attempts),
+                snapshot_set_load_hits: load(&c.lib_snapshot_set_load_hits),
+                snapshot_set_load_misses: load(&c.lib_snapshot_set_load_misses),
+                snapshot_set_load_files_total: load(&c.lib_snapshot_set_load_files_total),
+                snapshot_set_load_elapsed_ms_total: ns_to_ms(load(
+                    &c.lib_snapshot_set_load_elapsed_ns_total,
+                )),
+                snapshot_set_load_elapsed_ms_max: ns_to_ms(load(
+                    &c.lib_snapshot_set_load_elapsed_ns_max,
+                )),
+                checker_lib_clone_calls: load(&c.checker_lib_clone_calls),
+                checker_lib_clone_parallel_calls: load(&c.checker_lib_clone_parallel_calls),
+                checker_lib_clone_files_total: load(&c.checker_lib_clone_files_total),
+                checker_lib_clone_elapsed_ms_total: ns_to_ms(load(
+                    &c.checker_lib_clone_elapsed_ns_total,
+                )),
+                checker_lib_clone_elapsed_ms_max: ns_to_ms(load(
+                    &c.checker_lib_clone_elapsed_ns_max,
+                )),
             },
             overlay: OverlayCounters {
                 copy_calls: load(&c.copy_symbol_file_targets_calls),

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -2,10 +2,10 @@ mod json_tests {
     use super::*;
 
     #[test]
-    fn schema_version_is_six() {
+    fn schema_version_is_seven() {
         // Bumping schema_version is a breaking change for the bench harness;
         // make the intent explicit.
-        assert_eq!(PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION, 6);
+        assert_eq!(PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION, 7);
     }
 
     #[test]
@@ -20,6 +20,7 @@ mod json_tests {
             "delegate",
             "checker",
             "identity",
+            "lib_bootstrap",
             "overlay",
             "resolver",
             "interner",
@@ -56,7 +57,7 @@ mod json_tests {
         ] {
             assert!(json.get(key).is_some(), "missing top-level key: {key}");
         }
-        assert_eq!(json["schema_version"], 6);
+        assert_eq!(json["schema_version"], 7);
     }
 
     #[test]

--- a/crates/tsz-core/src/parallel/lib_snapshot.rs
+++ b/crates/tsz-core/src/parallel/lib_snapshot.rs
@@ -204,21 +204,55 @@ pub(super) fn try_load(file_name: &str, source_text: &str) -> Option<Arc<LibFile
 /// The key contains each lib file's name and content hash in final load order,
 /// so a hit is valid only for the exact same lib graph and physical contents.
 pub(super) fn try_load_many(keys: &[(&str, u64)]) -> Option<Vec<Arc<LibFile>>> {
-    if keys.is_empty() || !is_enabled() {
+    if keys.is_empty() {
         return None;
     }
-    let dir = cache_dir()?;
+    let timing_start = tsz_common::perf_counters::enabled_fast().then(std::time::Instant::now);
+    let record = |hit: bool| {
+        if let Some(start) = timing_start {
+            tsz_common::perf_counters::record_lib_snapshot_set_load(
+                keys.len() as u64,
+                hit,
+                start.elapsed().as_nanos() as u64,
+            );
+        }
+    };
+    if !is_enabled() {
+        record(false);
+        return None;
+    }
+    let dir = match cache_dir() {
+        Some(dir) => dir,
+        None => {
+            record(false);
+            return None;
+        }
+    };
     let set_hash = lib_set_hash(keys);
     let path = snapshot_set_path(&dir, set_hash);
-    let bytes = fs::read(&path).ok()?;
-    let snapshot = decode_snapshot_set(&bytes).ok()?;
+    let bytes = match fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            record(false);
+            return None;
+        }
+    };
+    let snapshot = match decode_snapshot_set(&bytes) {
+        Ok(snapshot) => snapshot,
+        Err(_) => {
+            record(false);
+            return None;
+        }
+    };
     if snapshot.set_hash != set_hash || snapshot.files.len() != keys.len() {
+        record(false);
         return None;
     }
 
     let mut files = Vec::with_capacity(snapshot.files.len());
     for (snapshot, (expected_name, expected_hash)) in snapshot.files.into_iter().zip(keys) {
         if snapshot.content_hash != *expected_hash || snapshot.file_name != *expected_name {
+            record(false);
             return None;
         }
         files.push(Arc::new(LibFile::new(
@@ -228,6 +262,7 @@ pub(super) fn try_load_many(keys: &[(&str, u64)]) -> Option<Vec<Arc<LibFile>>> {
             snapshot.root_index,
         )));
     }
+    record(true);
     Some(files)
 }
 


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 / performance-counter attribution slice for #12271.

## Invariant
When a project check spends time in lib snapshot/bootstrap work, perf counters should attribute that work separately from recursive semantic evaluation. The counter surface records lib snapshot-set load attempts, hits, misses, files, and time plus checker lib clone calls, files, and time without changing compiler semantics.

## Scope
- `crates/tsz-cli/src/driver/check.rs`
- `crates/tsz-common/src/perf_counters/dump.rs`
- `crates/tsz-common/src/perf_counters/runtime.rs`
- `crates/tsz-common/src/perf_counters/snapshot.rs`
- `crates/tsz-common/src/perf_counters/tests.rs`
- `crates/tsz-core/src/parallel/lib_snapshot.rs`

## Project Corpus Impact
- Row: n/a, attribution/counter visibility only.
- Bug family: #12271 lib bootstrap/setup attribution for real-project performance triage.
- Evidence: extracted from #12516 so later benchmark/perf-counter artifacts can separate lib bootstrap overhead from recursive type evaluation pressure before making timing claims.

## Verification
- Remote CI on `671cd2211dbb337f45963b5ec87ee9b8251c3181`: `gate`, `project-row-drift`, `cargo-shear`, `cargo-deny`, `lint`, `unit`, `unit-cloudbuild`, `dist-binaries`, and `CI Light Summary` passed.
- Synced with `origin/main` `153d300634826ad420ec027f9f560f880205c7d5` before this verification.
- No local tests were run in this continuation.

## Coordination Notes
- Extracted from #12516 to keep the #12271 runway moving as smaller reviewable PRs.
- Ready for manager/queue-owner review; no merge-queue action taken by Studio-B.
