### PR TITLE
arch: fix two failing guard tests and ratchet stale caps

### DIFF
--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -238,7 +238,7 @@ LINE_LIMIT_CHECKS = [
             # delete it from this set in the same diff and the
             # `test_excluded_files_actually_exceed_limit` test will catch
             # any regression.
-            "crates/tsz-checker/src/state/type_resolution/module.rs",
+            # (empty — all files are now under the 2000-line limit)
         },
     ),
     (
@@ -262,7 +262,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "src"
         / "query_boundaries"
         / "common.rs",
-        1924,
+        1901,
     ),
     (
         "Emitter transform boundary: class_es5_ir.rs must not grow",
@@ -734,7 +734,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "state"
         / "type_resolution"
         / "module.rs",
-        2596,
+        1953,
     ),
     (
         "Parser boundary: parser/state_statements_class_members.rs size ratchet",
@@ -1234,7 +1234,8 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # rather than direct `query_boundaries::common` access.
         #
         # Ratcheted down after arch-smoke caught current stacked-branch slack.
-        3211,
+        # Ratcheted 3211→3208 after guard tests caught slack in the live count.
+        3208,
     ),
 ]
 

--- a/scripts/arch/test_arch_guard.py
+++ b/scripts/arch/test_arch_guard.py
@@ -528,7 +528,7 @@ class ArchGuardQueryBoundaryCommonSizeTests(unittest.TestCase):
 
     def test_rule_exists_with_current_limit(self):
         path, limit = self._query_common_size_check()
-        self.assertEqual(limit, 1924)
+        self.assertEqual(limit, 1901)
         self.assertTrue(
             str(path).endswith("crates/tsz-checker/src/query_boundaries/common.rs")
         )


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Architecture / guardrail hygiene

## Invariant
When architecture guard ratchets track live repository counts, stale caps and stale file-line exclusions must fail locally instead of leaving slack. This PR updates the arch guard script/test data only; it does not change compiler behavior.

## Scope
- `scripts/arch/arch_guard_shared.py`
- `scripts/arch/test_arch_guard.py`

## Summary
- Removes `crates/tsz-checker/src/state/type_resolution/module.rs` from the over-2000-line exclusion set because the file is now under the cap.
- Ratchets `QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS` from 3211 to the live 3208 count.
- Ratchets file-line caps for `state/type_resolution/module.rs` and `query_boundaries/common.rs`, including the matching assertion in `test_arch_guard.py`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: arch guard script/test data only; no compiler, checker, solver, emitter, CLI, or project corpus behavior path changes.

## Verification
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/test_arch_guard.py` (228 tests, OK) on rebased head `65ec18976006d84a8244c52b5e0d459c11e79ca0`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- AgentName: Studio-C
- Refreshed over current `origin/main` and force-pushed with lease from `afdada121baa20c90c4fa1b28ed52f4368be267e` to `65ec18976006d84a8244c52b5e0d459c11e79ca0`.
- Draft/WIP state was documented in a signed comment before ready handoff.
- No overlap with current ready Studio-C emit/tooling PR files.