### PR TITLE
fix(solver): gate application-eval cache writes on recursion-limit state (#10826)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -484,6 +484,26 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self.silent_depth_bailed
     }
 
+    /// Whether this run hit any recursion / depth / iteration limit.
+    ///
+    /// Single source of truth for the three flags that mark a result as a
+    /// *stack-context artifact* rather than a stable, key-determined answer:
+    ///
+    /// - `guard.is_exceeded()` — a genuine `MAX_DEF_DEPTH` / divergent-growth /
+    ///   mapped-key bail; while set, `evaluate` returns `ERROR` for every node.
+    /// - `silent_depth_bailed` — the structural stack-protection bail that
+    ///   `clear_exceeded`s the guard and leaves the type opaque (unexpanded).
+    /// - `deep_recursion_seen` — a cycle/iteration bail returned an opaque
+    ///   cycle-breaker, or a `DefId` crossed the real-instantiation threshold.
+    ///
+    /// A run in any of these states must not persist results to caches whose
+    /// key does not capture the ambient stack depth (`closed_eval_cache`,
+    /// `application_eval_cache`); see the respective limit gates.
+    #[inline]
+    const fn recursion_limit_hit(&self) -> bool {
+        self.guard.is_exceeded() || self.silent_depth_bailed || self.deep_recursion_seen
+    }
+
     /// Mark the guard as exceeded, causing subsequent evaluations to bail out.
     ///
     /// Used when an external condition (e.g. mapped key count or distribution
@@ -1353,7 +1373,30 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         })
     }
 
-    /// Insert into the application-eval cache iff `query_db` is connected.
+    /// Whether an application-eval result produced by this run may be persisted
+    /// to the cross-evaluator `application_eval_cache`.
+    ///
+    /// The cache key is `(DefId, expanded_args, no_unchecked)` — it is
+    /// *resolver-* and *substitution-independent*, but it is NOT independent of
+    /// the ambient stack depth at the use site. When a recursive alias bails
+    /// because the surrounding evaluation was already deep (see
+    /// [`recursion_limit_hit`](Self::recursion_limit_hit)), the result is a
+    /// stack-context artifact. Persisting it poisons every *other* use site of
+    /// the same alias application — the "alias fan-out regression": one deep use
+    /// contaminating all of its siblings, which would each converge on their own
+    /// shallower stack. Recomputing (a cache miss) always re-derives the
+    /// correct, stack-local answer, so skipping the write only ever costs work,
+    /// never correctness. Termination is owned by the recursion guards and fuel,
+    /// not by this cache, so a skipped write cannot reintroduce a hang. Mirrors
+    /// the limit gate the `closed_eval_cache` already enforces.
+    #[inline]
+    const fn application_eval_result_cacheable(&self) -> bool {
+        !self.recursion_limit_hit()
+    }
+
+    /// Insert into the application-eval cache iff `query_db` is connected and the
+    /// current run has not hit any recursion/depth limit.
+    ///
     /// Folds the two-line `if let Some(db) = self.query_db { … }` idiom
     /// repeated in every body-aware shortcut and finalize helper.
     ///
@@ -1361,7 +1404,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// context: a limited resolver could otherwise store an under-resolved
     /// result under the resolver-independent `(DefId, args)` key and poison
     /// sibling reads. Reads use the same explicit `query_db` gate for the same
-    /// reason.
+    /// reason. They are additionally gated on
+    /// [`application_eval_result_cacheable`](Self::application_eval_result_cacheable)
+    /// so a depth-bounded run never persists a stack-context artifact.
     fn insert_application_eval_cache_if_some(
         &self,
         def_id: DefId,
@@ -1369,6 +1414,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         no_unchecked_indexed_access: bool,
         evaluated: TypeId,
     ) {
+        if !self.application_eval_result_cacheable() {
+            return;
+        }
         if let Some(db) = self.query_db {
             db.insert_application_eval_cache(
                 def_id,

--- a/crates/tsz-solver/src/evaluation/evaluate/closed_eval.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/closed_eval.rs
@@ -67,9 +67,7 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
             && self.query_db.is_some()
             && self.guard.depth() == 0;
         if !is_top_level
-            || self.silent_depth_bailed
-            || self.guard.is_exceeded()
-            || self.deep_recursion_seen
+            || self.recursion_limit_hit()
             || (self.interner.is_union_too_complex() && !union_too_complex_before)
         {
             return;

--- a/crates/tsz-solver/tests/architecture_guards.rs
+++ b/crates/tsz-solver/tests/architecture_guards.rs
@@ -200,6 +200,8 @@ fn evaluation_engine_keeps_request_stage_boundary() {
     let request_rs = read_solver_source("evaluation/request.rs");
     let result_rs = read_solver_source("evaluation/result.rs");
     let evaluate_rs = read_solver_source("evaluation/evaluate.rs");
+    // The public staged entry points live in the `evaluate/api.rs` submodule
+    // after the engine split; the module boundary is still owned by `evaluate`.
     let evaluate_api_rs = read_solver_source("evaluation/evaluate/api.rs");
     let query_cache_rs = read_solver_source("caches/query_cache.rs");
 

--- a/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
@@ -285,3 +285,108 @@ fn evaluate_application_reads_cache_only_with_query_db() {
         }
     }
 }
+
+/// Phase 5 — application-eval cache WRITE happens for a converging alias.
+///
+/// A normal, terminating alias application (`Box<T> = { value: T }`) must
+/// populate the per-file `application_eval_cache` so repeat use sites reuse the
+/// memoized expansion. This is the positive control for the limit-gated write
+/// below: the gate must not suppress healthy memoization.
+#[test]
+fn evaluate_application_caches_converging_alias_result() {
+    use crate::caches::db::TypeApplicationEvalCache;
+    use crate::caches::query_cache::QueryCache;
+
+    // Vary the def id and the type-parameter spelling so the rule is pinned to
+    // the structural `(DefId, args)` identity, not a name.
+    for (def_raw, param_name) in [(611u32, "T"), (733u32, "Element")] {
+        let interner = TypeInterner::new();
+        let def_id = DefId(def_raw);
+        let t_param = unconstrained_param(&interner, param_name);
+        let t_type = interner.intern(TypeData::TypeParameter(t_param));
+        let value_name = interner.intern_string("value");
+        let body = interner.object(vec![PropertyInfo::new(value_name, t_type)]);
+
+        let mut env = TypeEnvironment::new();
+        let app = alias_application(
+            &interner,
+            &mut env,
+            def_id,
+            DefKind::TypeAlias,
+            body,
+            vec![t_param],
+            vec![TypeId::STRING],
+        );
+
+        let qc = QueryCache::new(&interner);
+        let mut evaluator = TypeEvaluator::with_resolver(&interner, &env).with_query_db(&qc);
+        let result = evaluator.evaluate(app);
+
+        let expected = interner.object(vec![PropertyInfo::new(value_name, TypeId::STRING)]);
+        assert_eq!(
+            result, expected,
+            "Box<string> must expand to {{ value: string }}"
+        );
+        assert_eq!(
+            qc.lookup_application_eval_cache(def_id, &[TypeId::STRING], false),
+            Some(expected),
+            "a converging alias application must populate the application-eval cache"
+        );
+    }
+}
+
+/// Phase 5 — a depth-bounded (divergent) alias application must NOT poison the
+/// per-file `application_eval_cache`.
+///
+/// `Rec<T> = Rec<T[]>` grows its argument on every step and never terminates,
+/// so evaluation bails out (TS2589-class depth/divergence) and leaves the
+/// recursion guard exceeded. The bail result is a function of the *ambient
+/// stack depth* at this use site, not of `(DefId, args)`. Persisting it would
+/// poison every other use of the alias — the "alias fan-out regression" the
+/// fix targets: a sibling `Rec<string>` evaluated on its own shallower stack
+/// would converge differently and must never read back a stale bail artifact.
+///
+/// Structural axis (CLAUDE.md §25/§26): the rule is keyed on recursion state,
+/// not a spelling, so the def id and the type-parameter name both vary.
+#[test]
+fn evaluate_application_divergent_alias_does_not_poison_cache() {
+    use crate::caches::db::TypeApplicationEvalCache;
+    use crate::caches::query_cache::QueryCache;
+
+    for (def_raw, param_name, arg) in [
+        (821u32, "T", TypeId::STRING),
+        (947u32, "Item", TypeId::NUMBER),
+    ] {
+        let interner = TypeInterner::new();
+        let def_id = DefId(def_raw);
+        let t_param = unconstrained_param(&interner, param_name);
+        let t_type = interner.intern(TypeData::TypeParameter(t_param));
+        // Body: `Rec<T[]>` — the alias re-applies itself to an ever-growing
+        // argument, so the recursion diverges and must bail.
+        let grown_arg = interner.array(t_type);
+        let body = interner.application(interner.lazy(def_id), vec![grown_arg]);
+
+        let mut env = TypeEnvironment::new();
+        let app = alias_application(
+            &interner,
+            &mut env,
+            def_id,
+            DefKind::TypeAlias,
+            body,
+            vec![t_param],
+            vec![arg],
+        );
+
+        let qc = QueryCache::new(&interner);
+        let mut evaluator = TypeEvaluator::with_resolver(&interner, &env).with_query_db(&qc);
+        // Evaluation must terminate (the guards bound it) rather than hang.
+        let _ = evaluator.evaluate(app);
+
+        assert_eq!(
+            qc.lookup_application_eval_cache(def_id, &[arg], false),
+            None,
+            "a depth-bounded alias bail must not be persisted under (DefId, args); \
+             caching it would poison every sibling use of the alias"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #10826.

## Agent
AgentName: Studio-B

## Track
Track 10 / solver recursive-utility correctness and performance-cache safety slice for #12271 and #10826.

## Invariant
When application evaluation hits recursion, depth, divergent-growth, cycle, or iteration limits, the produced `ERROR` or opaque fallback artifact depends on ambient stack/request state and must not be written to a cache keyed only by `(DefId, expanded_args, no_unchecked)`. Healthy converging alias applications remain cacheable through the same shared application-eval cache chokepoint.

When closed-eval and application-eval cache writes need to decide whether a result is safe to persist, they use the same solver-owned recursion-limit predicate so the cache invariant is enforced consistently without checker-side shortcuts or fixture-name special cases.

## Scope
- `crates/tsz-solver/src/evaluation/evaluate.rs`
- `crates/tsz-solver/src/evaluation/evaluate/closed_eval.rs`
- Solver evaluator regression tests for converging alias caching and divergent alias non-poisoning.
- Architecture guard refresh for the pre-existing `evaluate/api.rs` public-entry split.

## Project Corpus Impact
- Row: recursive-utility/alias-fan-out rows, especially `zod-project`; adjacent family includes `ts-toolbelt-project`, `kysely-project`, and `type-fest-project`.
- Bug family: #10826 / #12271 recursive alias application cache poisoning under recursion-limit state.
- Evidence: this is a root-cause cache-invariant fix. It prevents one deep/divergent alias application use from poisoning sibling uses that would converge at shallower stack depth. The PR does not claim a green-row 2x speedup; fresh Bench artifacts are still required before any #12271 timing closure claim.
- Fallback: skipped cache writes recompute under the current request and rely on existing recursion guards/fuel for termination. Failures and limit-dependent artifacts are not synthesized from cache.

## Verification
- Author-reported local verification on the PR body before this coordination edit: `cargo nextest run -p tsz-solver` passed 6539 tests with 1 skipped, including the new evaluator regression tests and `evaluation_engine_keeps_request_stage_boundary`.
- Author-reported local verification: `cargo clippy -p tsz-solver --tests` was clean.
- Author-reported targeted checker recursive/TS2589 lib tests passed; observed checker failures were reported as pre-existing on a clean tree.
- Remote CI on `33609f53094c46a6ed9da5414026b985b6be2b75`: `gate`, `project-row-drift`, `conformance-snapshot-gate`, `cargo-shear`, `cargo-deny`, `lint`, and `CI Light Summary` passed before this body-only edit; broader ready CI was still queued/in progress at the time of this update.
- No local tests were run by Studio-B during this body-only coordination update.

## Coordination Notes
- Issue #10826 remains the scoped tracking witness for this cache-invariant fix; this PR itself is ready/open and not intentionally parked.
- The fix is intentionally broad at the shared application-eval cache-write chokepoint rather than scoped to a single witness repro.
- This body update removes ambiguous parked-state wording and keeps the existing evidence for the `project-corpus-pr-body` gate; it does not change code.
- Ready for manager/queue-owner review; no merge-queue action taken by Studio-B.
- AgentName: Studio-B



### CI Metadata Refresh: 3d4d9b9c63

AgentName: Studio-B

No source files changed. Pushed empty commit `3d4d9b9c63` only to refresh exact-head ready CI after the current PR body already contained the required plain `AgentName: Studio-B` field but the older `project-corpus-pr-body` check was still reporting the pre-fix body state.

Verification:
- Remote body rechecked before the refresh: `AgentName: Studio-B` is present under `## Agent`.
- No local tests were run for this no-code CI refresh.

Coordination Notes:
- Ready for manager/queue-owner review after refreshed CI completes; no merge-queue action taken by Studio-B.
