### PR TITLE
refactor(cli): split tsz binary entrypoint into command and execution modules (#9406)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -4,12 +4,8 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use rustc_hash::FxHashMap;
-use std::ffi::OsString;
 use std::io::IsTerminal;
-use std::path::{Path, PathBuf};
 
-use tsz::checker::diagnostics::DiagnosticCategory;
 use tsz_cli::args::CliArgs;
 use tsz_cli::help::{self, TSC_VERSION};
 use tsz_cli::{driver, locale, reporter::Reporter, watch};
@@ -17,26 +13,13 @@ use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
 
 use arg_preprocess::{EarlyExit, PreprocessOutcome, preprocess_args};
 use clap_errors::handle_clap_error;
-use diagnostics_report::print_diagnostics;
 
-/// tsc exit status codes (matching TypeScript's `ExitStatus` enum)
-const EXIT_SUCCESS: i32 = 0;
-const EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED: i32 = 1;
-const EXIT_DIAGNOSTICS_OUTPUTS_GENERATED: i32 = 2;
+/// tsc exit status codes (matching TypeScript's `ExitStatus` enum). Shared with
+/// the `run` execution submodule, so they are crate-visible rather than private.
+pub(crate) const EXIT_SUCCESS: i32 = 0;
+pub(crate) const EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED: i32 = 1;
+pub(crate) const EXIT_DIAGNOSTICS_OUTPUTS_GENERATED: i32 = 2;
 const TS5112_COMMAND_LINE_FILES_MESSAGE: &str = "tsconfig.json is present but will not be loaded if files are specified on commandline. Use '--ignoreConfig' to skip this error.";
-
-/// Extensions tsc lists in TS6231 "could not resolve path" messages, in tsc's display order.
-const TS6231_EXTENSIONS: &str = "'.ts', '.tsx', '.d.ts', '.cts', '.d.cts', '.mts', '.d.mts'";
-
-/// Prints a root-file resolution failure in tsc's format and exits with the diagnostics
-/// status code. Keeps the "file is in the program because" context consistent across all
-/// root-file error codes.
-fn report_root_file_diagnostic(code: u32, message: &str) -> ! {
-    println!("error TS{code}: {message}");
-    println!("  The file is in the program because:");
-    println!("    Root file specified for compilation\n");
-    std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_GENERATED)
-}
 
 fn main() -> Result<()> {
     // Initialize tracing if TSZ_LOG or RUST_LOG is set (zero cost otherwise).
@@ -78,6 +61,33 @@ fn main() -> Result<()> {
 }
 
 fn actual_main(mut args: CliArgs, cwd: std::path::PathBuf) -> Result<()> {
+    validate_locale_or_exit(&args);
+
+    // Initialize locale for i18n message translation
+    locale::init_locale(args.locale.as_deref());
+
+    match select_command(&mut args, &cwd) {
+        Command::Batch => run_batch_mode(),
+        Command::Init => init::handle_init(&args, &cwd),
+        Command::ShowConfig => handle_show_config(&args, &cwd),
+        Command::ListFilesOnly => handle_list_files_only(&args, &cwd),
+        Command::Build => handle_build(&args, &cwd),
+        Command::Watch => watch::run(&args, &cwd),
+        Command::Compile => run::run_compile(&args, &cwd),
+    }
+}
+
+/// Print the version banner and full help text, then exit 1 — tsc's behavior
+/// when a command line resolves to no compilation input.
+fn print_no_input_help_and_exit() -> ! {
+    println!("Version {TSC_VERSION}");
+    println!("{}", help::colorize_help(&help::render_help(TSC_VERSION)));
+    std::process::exit(1);
+}
+
+/// Reject a malformed `--locale` value the way tsc does, before any locale
+/// initialization or command dispatch happens.
+fn validate_locale_or_exit(args: &CliArgs) {
     if let Some(locale_id) = args.locale.as_deref()
         && !locale::is_valid_locale_shape(locale_id)
     {
@@ -91,29 +101,48 @@ fn actual_main(mut args: CliArgs, cwd: std::path::PathBuf) -> Result<()> {
         );
         std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED);
     }
+}
 
-    // Initialize locale for i18n message translation
-    locale::init_locale(args.locale.as_deref());
+/// The top-level action chosen from parsed CLI arguments. Modeling the
+/// dispatch decision as a value keeps `actual_main` readable as orchestration
+/// and separates the (process-exiting) argument validation that runs while the
+/// command is selected from the code that executes it.
+enum Command {
+    Batch,
+    Init,
+    ShowConfig,
+    ListFilesOnly,
+    Build,
+    Watch,
+    Compile,
+}
 
+/// Resolve which command to run from the parsed arguments, performing the same
+/// ordered validation and normalization tsc does. Invalid argument
+/// combinations terminate the process here with tsc's exit codes; otherwise the
+/// returned `Command` names the action to execute. `args` may be normalized in
+/// place (promoting a lone directory positional to `--project`, merging
+/// output-only tsconfig options) before the compile command is returned.
+fn select_command(args: &mut CliArgs, cwd: &std::path::Path) -> Command {
     // Handle --batch: enter batch compilation mode
     if args.batch {
-        return run_batch_mode();
+        return Command::Batch;
     }
 
     // Handle --init: create tsconfig.json
     if args.init {
-        return handle_init(&args, &cwd);
+        return Command::Init;
     }
 
-    reject_tsconfig_only_cli_options(&args);
-    reject_build_only_cli_options(&args);
+    reject_tsconfig_only_cli_options(args);
+    reject_build_only_cli_options(args);
 
     // Handle --showConfig: print resolved configuration
     if args.show_config {
-        return handle_show_config(&args, &cwd);
+        return Command::ShowConfig;
     }
 
-    if should_report_ts5112_for_command_line_files(&args, &cwd) {
+    if should_report_ts5112_for_command_line_files(args, cwd) {
         println!("error TS5112: {TS5112_COMMAND_LINE_FILES_MESSAGE}");
         std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED);
     }
@@ -124,34 +153,30 @@ fn actual_main(mut args: CliArgs, cwd: std::path::PathBuf) -> Result<()> {
     if args.list_files_only
         && args.files.is_empty()
         && args.project.is_none()
-        && driver::find_tsconfig(&cwd).is_none()
+        && driver::find_tsconfig(cwd).is_none()
     {
-        println!("Version {TSC_VERSION}");
-        println!("{}", help::colorize_help(&help::render_help(TSC_VERSION)));
-        std::process::exit(1);
+        print_no_input_help_and_exit();
     }
 
     // Handle --listFilesOnly: print file list and exit
     if args.list_files_only {
-        return handle_list_files_only(&args, &cwd);
+        return Command::ListFilesOnly;
     }
 
     // Handle --build mode
     if args.build {
-        return handle_build(&args, &cwd);
+        return Command::Build;
     }
 
     if args.watch {
-        return watch::run(&args, &cwd);
+        return Command::Watch;
     }
 
     // No-input behavior: if no files given, no --project, and no tsconfig.json
     // can be discovered from cwd or an ancestor, print version + help and exit
     // 1 (matching tsc v6 behavior).
-    if args.files.is_empty() && args.project.is_none() && driver::find_tsconfig(&cwd).is_none() {
-        println!("Version {TSC_VERSION}");
-        println!("{}", help::colorize_help(&help::render_help(TSC_VERSION)));
-        std::process::exit(1);
+    if args.files.is_empty() && args.project.is_none() && driver::find_tsconfig(cwd).is_none() {
+        print_no_input_help_and_exit();
     }
 
     // `tsz <dir>` should behave like `tsz --project <dir>` when no
@@ -187,201 +212,9 @@ fn actual_main(mut args: CliArgs, cwd: std::path::PathBuf) -> Result<()> {
     // `extendedDiagnostics`, `traceResolution`) from tsconfig. tsz only
     // checked the CLI-flag side. OR the tsconfig-side values into `args`
     // before the CLI gates further down inspect them.
-    let mut args = args;
-    merge_output_only_options_from_tsconfig(&mut args, &cwd);
+    merge_output_only_options_from_tsconfig(args, cwd);
 
-    if let Some(profile_path) = args.generate_cpu_profile.as_ref() {
-        println!(
-            "error: --generateCpuProfile is not supported by tsz; requested profile '{}' was not created. Use --generateTrace for native trace output.",
-            profile_path.display()
-        );
-        std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED);
-    }
-
-    // Initialize tracer if --generateTrace is specified
-    let tracer = args.generate_trace.is_some().then(|| {
-        let mut t = tsz_cli::trace::Tracer::new();
-        // Add process metadata
-        let mut meta_args = FxHashMap::default();
-        meta_args.insert("name".to_string(), serde_json::json!("tsz"));
-        t.metadata("process_name", meta_args);
-        t
-    });
-
-    let start_time = std::time::Instant::now();
-    let result = match driver::compile(&args, &cwd) {
-        Ok(r) => r,
-        Err(e) => {
-            let msg = e.to_string();
-            if let Some(rest) = msg.strip_prefix("TS6053: ") {
-                report_root_file_diagnostic(6053, rest);
-            }
-            if let Some(path_str) = msg.strip_prefix("TS6231: ") {
-                report_root_file_diagnostic(
-                    6231,
-                    &format!(
-                        "Could not resolve the path '{path_str}' with the extensions: {TS6231_EXTENSIONS}."
-                    ),
-                );
-            }
-            return Err(e);
-        }
-    };
-    let elapsed = start_time.elapsed();
-
-    // Write trace file if requested
-    if let (Some(trace_path), Some(mut tracer)) = (args.generate_trace.as_ref(), tracer) {
-        use tsz_cli::trace::categories;
-
-        // Record compilation summary events
-        tracer.complete_with_args("Compile", categories::PROGRAM, start_time, elapsed, {
-            let mut args = FxHashMap::default();
-            args.insert(
-                "fileCount".to_string(),
-                serde_json::json!(result.files_read.len()),
-            );
-            args.insert(
-                "errorCount".to_string(),
-                serde_json::json!(result.diagnostics.len()),
-            );
-            args.insert(
-                "emittedCount".to_string(),
-                serde_json::json!(result.emitted_files.len()),
-            );
-            args
-        });
-
-        // Add per-file events for files read
-        for file in &result.files_read {
-            let mut args = FxHashMap::default();
-            args.insert(
-                "path".to_string(),
-                serde_json::json!(file.display().to_string()),
-            );
-            tracer.instant_with_args("FileProcessed", categories::IO, args);
-        }
-
-        // Write the trace file
-        let trace_file = if trace_path.is_dir() {
-            trace_path.join("trace.json")
-        } else {
-            trace_path.to_path_buf()
-        };
-
-        if let Err(e) = tracer.write_to_file(&trace_file) {
-            println!("Warning: Failed to write trace file: {e}");
-        } else {
-            println!("Trace written to: {}", trace_file.display());
-        }
-    }
-
-    // Handle --listFiles: print all files read during compilation
-    if args.list_files {
-        for file in &result.files_read {
-            println!("{}", file.display());
-        }
-    }
-
-    // Handle --listEmittedFiles: print emitted file list
-    if args.list_emitted_files && !result.emitted_files.is_empty() {
-        for file in &result.emitted_files {
-            println!("TSFILE: {}", file.display());
-        }
-    }
-
-    // Handle --explainFiles: print files with inclusion reasons
-    if args.explain_files {
-        for info in &result.file_infos {
-            println!("{}", info.path.display());
-            for reason in &info.reasons {
-                println!("  {reason}");
-            }
-        }
-    }
-
-    // Handle --traceDependencies: print dependency graph
-    if args.trace_dependencies {
-        // Note: Full dependency tracing would require access to the dependency map
-        // For now, just list all files that were read (which includes dependencies)
-        for file in &result.files_read {
-            println!("{}", file.display());
-        }
-    }
-
-    // Handle --diagnostics: print compilation performance info
-    if args.diagnostics || args.extended_diagnostics {
-        print_diagnostics(&result, elapsed, args.extended_diagnostics);
-    }
-
-    // Perf-tools-only: write the machine-readable diagnostics JSON report.
-    // The flag and call site both compile out of default release builds.
-    #[cfg(feature = "perf-tools")]
-    if let Some(path) = args.diagnostics_json.as_deref() {
-        let raw_args: Vec<std::ffi::OsString> = std::env::args_os().collect();
-        if let Err(err) = tsz_cli::perf_json::write_compilation_report(path, &result, &raw_args) {
-            tracing::warn!(
-                "failed to write diagnostics JSON to {}: {err}",
-                path.display()
-            );
-        }
-    }
-
-    // Perf-tools-only: write the perf-counter JSON snapshot. The flag and
-    // the call both compile out of default release builds.
-    #[cfg(feature = "perf-tools")]
-    if let Some(path) = args.perf_counters_json.as_deref()
-        && let Err(err) = tsz_common::perf_counters::PerfCounters::write_json_to(path)
-    {
-        tracing::warn!(
-            "failed to write perf-counter JSON to {}: {err}",
-            path.display()
-        );
-    }
-
-    if !result.diagnostics.is_empty() {
-        let pretty = args
-            .pretty
-            .unwrap_or_else(|| std::io::stdout().is_terminal());
-        // When --pretty true is explicitly passed, force ANSI colors even
-        // when piped (not a TTY), matching tsc v6 behavior.
-        if args.pretty == Some(true) {
-            Reporter::force_colors(true);
-        }
-        let mut reporter = Reporter::new(pretty);
-        let output = reporter.render(&result.diagnostics);
-        if !output.is_empty() {
-            // tsc writes all diagnostics to stdout
-            print!("{output}");
-        }
-    }
-
-    if args.sound_report_only {
-        std::process::exit(EXIT_SUCCESS);
-    }
-
-    let has_errors = result
-        .diagnostics
-        .iter()
-        .any(|diag| diag.category == DiagnosticCategory::Error);
-
-    if has_errors {
-        // Match tsc exit codes:
-        // Exit code 1 (DiagnosticsPresent_OutputsSkipped): emit was suppressed due to errors
-        //   (--noEmitOnError with errors means no outputs were generated).
-        // Exit code 2 (DiagnosticsPresent_OutputsGenerated): errors exist but outputs were
-        //   still generated (or --noEmit where there's nothing to emit regardless).
-        // `result.no_emit` reflects the resolved option (CLI + tsconfig.json),
-        // so a tsconfig-only `noEmit` selects exit 2 just like the CLI flag.
-        if args.no_emit_on_error {
-            std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED);
-        } else if result.no_emit || !result.emitted_files.is_empty() {
-            std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_GENERATED);
-        } else {
-            std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED);
-        }
-    }
-
-    std::process::exit(EXIT_SUCCESS);
+    Command::Compile
 }
 
 fn should_report_ts5112_for_command_line_files(args: &CliArgs, cwd: &std::path::Path) -> bool {
@@ -599,594 +432,6 @@ fn reject_build_only_cli_options(args: &CliArgs) {
     }
 }
 
-fn handle_init(args: &CliArgs, cwd: &std::path::Path) -> Result<()> {
-    let tsconfig_path = cwd.join("tsconfig.json");
-    if tsconfig_path.exists() {
-        println!(
-            "error TS5054: A 'tsconfig.json' file is already defined at: '{}'.",
-            tsconfig_path.display()
-        );
-        std::process::exit(0);
-    }
-
-    let raw_args: Vec<OsString> = std::env::args_os().skip(1).collect();
-    let overrides = collect_init_overrides(&raw_args, args);
-    let config = render_init_template(&overrides);
-
-    std::fs::write(&tsconfig_path, config).with_context(|| {
-        format!(
-            "failed to write tsconfig.json to {}",
-            tsconfig_path.display()
-        )
-    })?;
-
-    println!("\nCreated a new tsconfig.json\n\nYou can learn more at https://aka.ms/tsconfig");
-
-    Ok(())
-}
-
-/// Walk the original CLI args in order and collect (canonical option name,
-/// JSON-formatted value) pairs for every recognized compiler option the user
-/// passed. Later occurrences supersede earlier ones (matching tsc's
-/// last-write-wins behavior). Order is preserved so that options not in the
-/// fixed `--init` template are appended in the order they appear.
-fn collect_init_overrides(raw_args: &[OsString], args: &CliArgs) -> Vec<(&'static str, String)> {
-    let mut overrides: Vec<(&'static str, String)> = Vec::new();
-    let mut i = 0;
-    while i < raw_args.len() {
-        let arg = raw_args[i].to_string_lossy().to_string();
-        if !arg.starts_with("--") || arg == "--" {
-            i += 1;
-            continue;
-        }
-        let (flag, has_inline_value) = match arg.find('=') {
-            Some(eq) => (arg[..eq].to_string(), true),
-            None => (arg.clone(), false),
-        };
-        let canonical = canonicalize_init_option(&flag);
-        let takes_value = canonical.is_some_and(init_option_takes_value);
-        if let Some(name) = canonical
-            && let Some(value) = init_option_value(name, args)
-        {
-            if let Some(pos) = overrides.iter().position(|(k, _)| *k == name) {
-                overrides[pos] = (name, value);
-            } else {
-                overrides.push((name, value));
-            }
-        }
-        if takes_value && !has_inline_value {
-            i += 2;
-        } else {
-            i += 1;
-        }
-    }
-    overrides
-}
-
-/// Returns the canonical (camelCase) compiler-option name for a CLI flag.
-/// Matching is case-insensitive and ignores `-` characters so that
-/// `--rootDir`, `--rootdir`, and `--root-dir` all map to `"rootDir"`.
-fn canonicalize_init_option(flag: &str) -> Option<&'static str> {
-    let key: String = flag
-        .trim_start_matches('-')
-        .chars()
-        .filter(|c| *c != '-')
-        .flat_map(char::to_lowercase)
-        .collect();
-    INIT_OPTION_TABLE.iter().find_map(|(canonical, _)| {
-        let canonical_key: String = canonical
-            .chars()
-            .filter(|c| *c != '-')
-            .flat_map(char::to_lowercase)
-            .collect();
-        (canonical_key == key).then_some(*canonical)
-    })
-}
-
-#[derive(Clone, Copy)]
-enum InitOptionKind {
-    /// Boolean flag (`--strict`, `--strict false`, `--strict true`).
-    Bool,
-    /// Flag that requires a value (`--target esnext`, `--lib es2015,dom`).
-    Value,
-}
-
-fn init_option_takes_value(name: &str) -> bool {
-    INIT_OPTION_TABLE
-        .iter()
-        .find(|(n, _)| *n == name)
-        .is_some_and(|(_, k)| matches!(k, InitOptionKind::Value))
-}
-
-/// Recognized compiler options for the `--init` flow.
-///
-/// The set is intentionally small relative to the full CLI surface: it covers
-/// every option that has a slot in the default template plus the most common
-/// command-line options that tsc users pass alongside `--init`. Unrecognized
-/// options are silently ignored, matching `tsc`.
-const INIT_OPTION_TABLE: &[(&str, InitOptionKind)] = &[
-    // Language and environment
-    ("target", InitOptionKind::Value),
-    ("module", InitOptionKind::Value),
-    ("moduleResolution", InitOptionKind::Value),
-    ("moduleDetection", InitOptionKind::Value),
-    ("jsx", InitOptionKind::Value),
-    ("jsxFactory", InitOptionKind::Value),
-    ("jsxFragmentFactory", InitOptionKind::Value),
-    ("jsxImportSource", InitOptionKind::Value),
-    ("lib", InitOptionKind::Value),
-    ("types", InitOptionKind::Value),
-    ("typeRoots", InitOptionKind::Value),
-    ("rootDir", InitOptionKind::Value),
-    ("outDir", InitOptionKind::Value),
-    ("outFile", InitOptionKind::Value),
-    ("baseUrl", InitOptionKind::Value),
-    ("declarationDir", InitOptionKind::Value),
-    ("newLine", InitOptionKind::Value),
-    ("noLib", InitOptionKind::Bool),
-    // Emit / output
-    ("declaration", InitOptionKind::Bool),
-    ("declarationMap", InitOptionKind::Bool),
-    ("sourceMap", InitOptionKind::Bool),
-    ("inlineSourceMap", InitOptionKind::Bool),
-    ("inlineSources", InitOptionKind::Bool),
-    ("emitDeclarationOnly", InitOptionKind::Bool),
-    ("noEmit", InitOptionKind::Bool),
-    ("noEmitOnError", InitOptionKind::Bool),
-    ("noEmitHelpers", InitOptionKind::Bool),
-    ("importHelpers", InitOptionKind::Bool),
-    ("downlevelIteration", InitOptionKind::Bool),
-    ("removeComments", InitOptionKind::Bool),
-    ("preserveConstEnums", InitOptionKind::Bool),
-    ("emitBOM", InitOptionKind::Bool),
-    // Interop / modules
-    ("esModuleInterop", InitOptionKind::Bool),
-    ("allowSyntheticDefaultImports", InitOptionKind::Bool),
-    ("isolatedModules", InitOptionKind::Bool),
-    ("isolatedDeclarations", InitOptionKind::Bool),
-    ("verbatimModuleSyntax", InitOptionKind::Bool),
-    ("forceConsistentCasingInFileNames", InitOptionKind::Bool),
-    ("preserveSymlinks", InitOptionKind::Bool),
-    ("erasableSyntaxOnly", InitOptionKind::Bool),
-    ("resolveJsonModule", InitOptionKind::Bool),
-    ("noResolve", InitOptionKind::Bool),
-    ("allowUmdGlobalAccess", InitOptionKind::Bool),
-    ("noUncheckedSideEffectImports", InitOptionKind::Bool),
-    ("allowImportingTsExtensions", InitOptionKind::Bool),
-    ("rewriteRelativeImportExtensions", InitOptionKind::Bool),
-    ("allowArbitraryExtensions", InitOptionKind::Bool),
-    // JavaScript support
-    ("allowJs", InitOptionKind::Bool),
-    ("checkJs", InitOptionKind::Bool),
-    // Decorators
-    ("experimentalDecorators", InitOptionKind::Bool),
-    ("emitDecoratorMetadata", InitOptionKind::Bool),
-    // Type checking
-    ("strict", InitOptionKind::Bool),
-    ("noImplicitAny", InitOptionKind::Bool),
-    ("strictNullChecks", InitOptionKind::Bool),
-    ("strictFunctionTypes", InitOptionKind::Bool),
-    ("strictBindCallApply", InitOptionKind::Bool),
-    ("strictPropertyInitialization", InitOptionKind::Bool),
-    ("strictBuiltinIteratorReturn", InitOptionKind::Bool),
-    ("noImplicitThis", InitOptionKind::Bool),
-    ("useUnknownInCatchVariables", InitOptionKind::Bool),
-    ("alwaysStrict", InitOptionKind::Bool),
-    ("noUnusedLocals", InitOptionKind::Bool),
-    ("noUnusedParameters", InitOptionKind::Bool),
-    ("exactOptionalPropertyTypes", InitOptionKind::Bool),
-    ("noImplicitReturns", InitOptionKind::Bool),
-    ("noFallthroughCasesInSwitch", InitOptionKind::Bool),
-    ("noUncheckedIndexedAccess", InitOptionKind::Bool),
-    ("noImplicitOverride", InitOptionKind::Bool),
-    ("noPropertyAccessFromIndexSignature", InitOptionKind::Bool),
-    ("allowUnreachableCode", InitOptionKind::Bool),
-    ("allowUnusedLabels", InitOptionKind::Bool),
-    ("useDefineForClassFields", InitOptionKind::Bool),
-    // Completeness
-    ("skipDefaultLibCheck", InitOptionKind::Bool),
-    ("skipLibCheck", InitOptionKind::Bool),
-    // Projects
-    ("composite", InitOptionKind::Bool),
-    ("incremental", InitOptionKind::Bool),
-    // Diagnostics / output formatting
-    ("diagnostics", InitOptionKind::Bool),
-    ("extendedDiagnostics", InitOptionKind::Bool),
-    ("explainFiles", InitOptionKind::Bool),
-    ("listFiles", InitOptionKind::Bool),
-    ("listEmittedFiles", InitOptionKind::Bool),
-    ("traceResolution", InitOptionKind::Bool),
-    ("noCheck", InitOptionKind::Bool),
-    ("noErrorTruncation", InitOptionKind::Bool),
-    ("preserveWatchOutput", InitOptionKind::Bool),
-    ("pretty", InitOptionKind::Bool),
-];
-
-/// Format the user-supplied value for a recognized option as a JSON literal.
-/// Returns `None` if the option is recognized but the parsed `args` struct
-/// does not carry a meaningful value (e.g., a `bool` field is `false` because
-/// the option was never on the command line — but in that case the caller
-/// would not invoke this function).
-fn init_option_value(name: &'static str, args: &CliArgs) -> Option<String> {
-    match name {
-        "target" => args.target.map(|t| json_str(target_init_str(t))),
-        "module" => args.module.map(|m| json_str(module_init_str(m))),
-        "moduleResolution" => args
-            .module_resolution
-            .map(|m| json_str(module_resolution_init_str(m))),
-        "moduleDetection" => args
-            .module_detection
-            .map(|m| json_str(module_detection_init_str(m))),
-        "jsx" => args.jsx.map(|j| json_str(jsx_init_str(j))),
-        "jsxFactory" => args.jsx_factory.as_deref().map(json_str),
-        "jsxFragmentFactory" => args.jsx_fragment_factory.as_deref().map(json_str),
-        "jsxImportSource" => args.jsx_import_source.as_deref().map(json_str),
-        "newLine" => args.new_line.map(|n| json_str(new_line_init_str(n))),
-        "lib" => args.lib.as_ref().map(|v| json_str_array(v)),
-        "types" => args.types.as_ref().map(|v| json_str_array(v)),
-        "typeRoots" => args
-            .type_roots
-            .as_ref()
-            .map(|v| json_path_array(v.iter().map(PathBuf::as_path))),
-        "rootDir" => args.root_dir.as_deref().map(json_path),
-        "outDir" => args.out_dir.as_deref().map(json_path),
-        "outFile" => args.out_file.as_deref().map(json_path),
-        "baseUrl" => args.base_url.as_deref().map(json_path),
-        "declarationDir" => args.declaration_dir.as_deref().map(json_path),
-        // Plain bool flags. The preprocessor in `preprocess_args` strips
-        // `--flag false` pairs and either flips the field to `false` directly
-        // or records the flag name in `explicitly_disabled_bool_flags`. By
-        // the time we get here, `args.<field>` already reflects the user's
-        // intent.
-        "noLib" => Some(bool_str(args.no_lib)),
-        "declaration" => Some(bool_str(args.declaration)),
-        "declarationMap" => Some(bool_str(args.declaration_map)),
-        "sourceMap" => Some(bool_str(args.source_map)),
-        "inlineSourceMap" => Some(bool_str(args.inline_source_map)),
-        "inlineSources" => Some(bool_str(args.inline_sources)),
-        "emitDeclarationOnly" => Some(bool_str(args.emit_declaration_only)),
-        "noEmit" => Some(bool_str(args.no_emit)),
-        "noEmitOnError" => Some(bool_str(args.no_emit_on_error)),
-        "noEmitHelpers" => Some(bool_str(args.no_emit_helpers)),
-        "importHelpers" => Some(bool_str(args.import_helpers)),
-        "downlevelIteration" => Some(bool_str(args.downlevel_iteration)),
-        "removeComments" => Some(bool_str(args.remove_comments)),
-        "preserveConstEnums" => Some(bool_str(args.preserve_const_enums)),
-        "emitBOM" => Some(bool_str(args.emit_bom)),
-        "esModuleInterop" => Some(bool_str(args.es_module_interop)),
-        "isolatedModules" => Some(bool_str(args.isolated_modules)),
-        "isolatedDeclarations" => Some(bool_str(args.isolated_declarations)),
-        "verbatimModuleSyntax" => Some(bool_str(args.verbatim_module_syntax)),
-        "preserveSymlinks" => Some(bool_str(args.preserve_symlinks)),
-        "erasableSyntaxOnly" => Some(bool_str(args.erasable_syntax_only)),
-        "resolveJsonModule" => Some(bool_str(args.resolve_json_module)),
-        "noResolve" => Some(bool_str(args.no_resolve)),
-        "allowUmdGlobalAccess" => Some(bool_str(args.allow_umd_global_access)),
-        "noUncheckedSideEffectImports" => Some(bool_str(args.no_unchecked_side_effect_imports)),
-        "allowImportingTsExtensions" => Some(bool_str(args.allow_importing_ts_extensions)),
-        "rewriteRelativeImportExtensions" => {
-            Some(bool_str(args.rewrite_relative_import_extensions))
-        }
-        "allowArbitraryExtensions" => Some(bool_str(args.allow_arbitrary_extensions)),
-        "allowJs" => Some(bool_str(args.allow_js)),
-        "checkJs" => Some(bool_str(args.check_js)),
-        "experimentalDecorators" => Some(bool_str(args.experimental_decorators)),
-        "emitDecoratorMetadata" => Some(bool_str(args.emit_decorator_metadata)),
-        "strict" => Some(bool_str(args.strict)),
-        "noUnusedLocals" => Some(bool_str(args.no_unused_locals)),
-        "noUnusedParameters" => Some(bool_str(args.no_unused_parameters)),
-        "exactOptionalPropertyTypes" => Some(bool_str(args.exact_optional_property_types)),
-        "noImplicitReturns" => Some(bool_str(args.no_implicit_returns)),
-        "noFallthroughCasesInSwitch" => Some(bool_str(args.no_fallthrough_cases_in_switch)),
-        "noUncheckedIndexedAccess" => Some(bool_str(args.no_unchecked_indexed_access)),
-        "noImplicitOverride" => Some(bool_str(args.no_implicit_override)),
-        "noPropertyAccessFromIndexSignature" => {
-            Some(bool_str(args.no_property_access_from_index_signature))
-        }
-        "skipDefaultLibCheck" => Some(bool_str(args.skip_default_lib_check)),
-        "skipLibCheck" => Some(bool_str(args.skip_lib_check)),
-        "composite" => Some(bool_str(args.composite)),
-        "incremental" => Some(bool_str(args.incremental)),
-        "diagnostics" => Some(bool_str(args.diagnostics)),
-        "extendedDiagnostics" => Some(bool_str(args.extended_diagnostics)),
-        "explainFiles" => Some(bool_str(args.explain_files)),
-        "listFiles" => Some(bool_str(args.list_files)),
-        "listEmittedFiles" => Some(bool_str(args.list_emitted_files)),
-        "traceResolution" => Some(bool_str(args.trace_resolution)),
-        "noCheck" => Some(bool_str(args.no_check)),
-        "noErrorTruncation" => Some(bool_str(args.no_error_truncation)),
-        "preserveWatchOutput" => Some(bool_str(args.preserve_watch_output)),
-        // Tri-state Option<bool> flags.
-        "pretty" => args.pretty.map(bool_str),
-        "noImplicitAny" => args.no_implicit_any.map(bool_str),
-        "strictNullChecks" => args.strict_null_checks.map(bool_str),
-        "strictFunctionTypes" => args.strict_function_types.map(bool_str),
-        "strictBindCallApply" => args.strict_bind_call_apply.map(bool_str),
-        "strictPropertyInitialization" => args.strict_property_initialization.map(bool_str),
-        "strictBuiltinIteratorReturn" => args.strict_builtin_iterator_return.map(bool_str),
-        "noImplicitThis" => args.no_implicit_this.map(bool_str),
-        "useUnknownInCatchVariables" => args.use_unknown_in_catch_variables.map(bool_str),
-        "alwaysStrict" => args.always_strict.map(bool_str),
-        "allowSyntheticDefaultImports" => args.allow_synthetic_default_imports.map(bool_str),
-        "forceConsistentCasingInFileNames" => {
-            args.force_consistent_casing_in_file_names.map(bool_str)
-        }
-        "allowUnreachableCode" => args.allow_unreachable_code.map(bool_str),
-        "allowUnusedLabels" => args.allow_unused_labels.map(bool_str),
-        "useDefineForClassFields" => args.use_define_for_class_fields.map(bool_str),
-        _ => None,
-    }
-}
-
-fn bool_str(b: bool) -> String {
-    if b { "true".into() } else { "false".into() }
-}
-
-fn json_str(s: &str) -> String {
-    // Escape backslashes and double quotes; tsconfig is JSONC and our values
-    // are user-supplied strings or paths.
-    let mut escaped = String::with_capacity(s.len() + 2);
-    escaped.push('"');
-    for c in s.chars() {
-        match c {
-            '\\' => escaped.push_str("\\\\"),
-            '"' => escaped.push_str("\\\""),
-            _ => escaped.push(c),
-        }
-    }
-    escaped.push('"');
-    escaped
-}
-
-fn json_path(p: &Path) -> String {
-    // tsc emits paths with forward slashes; do the same so that snapshots are
-    // stable on Windows-style inputs and so that the path round-trips through
-    // tsconfig parsing.
-    json_str(&p.to_string_lossy().replace('\\', "/"))
-}
-
-fn json_str_array(values: &[String]) -> String {
-    if values.is_empty() {
-        return "[]".into();
-    }
-    let items: Vec<String> = values.iter().map(|v| json_str(v)).collect();
-    format!("[{}]", items.join(", "))
-}
-
-fn json_path_array<'a, I: Iterator<Item = &'a Path>>(paths: I) -> String {
-    let items: Vec<String> = paths.map(json_path).collect();
-    if items.is_empty() {
-        "[]".into()
-    } else {
-        format!("[{}]", items.join(", "))
-    }
-}
-
-const fn target_init_str(t: tsz_cli::args::Target) -> &'static str {
-    use tsz_cli::args::Target;
-    match t {
-        Target::Es3 => "es3",
-        Target::Es5 => "es5",
-        // tsc canonicalizes ES2015 to "es6".
-        Target::Es2015 => "es6",
-        Target::Es2016 => "es2016",
-        Target::Es2017 => "es2017",
-        Target::Es2018 => "es2018",
-        Target::Es2019 => "es2019",
-        Target::Es2020 => "es2020",
-        Target::Es2021 => "es2021",
-        Target::Es2022 => "es2022",
-        Target::Es2023 => "es2023",
-        Target::Es2024 => "es2024",
-        Target::Es2025 => "es2025",
-        Target::EsNext => "esnext",
-    }
-}
-
-const fn module_init_str(m: tsz_cli::args::Module) -> &'static str {
-    use tsz_cli::args::Module;
-    match m {
-        Module::None => "none",
-        Module::CommonJs => "commonjs",
-        Module::Amd => "amd",
-        Module::Umd => "umd",
-        Module::System => "system",
-        // tsc canonicalizes ES2015 to "es6" for module too.
-        Module::Es2015 => "es6",
-        Module::Es2020 => "es2020",
-        Module::Es2022 => "es2022",
-        Module::EsNext => "esnext",
-        Module::Node16 => "node16",
-        Module::Node18 => "node18",
-        Module::Node20 => "node20",
-        Module::NodeNext => "nodenext",
-        Module::Preserve => "preserve",
-    }
-}
-
-const fn module_resolution_init_str(m: tsz_cli::args::ModuleResolution) -> &'static str {
-    use tsz_cli::args::ModuleResolution;
-    match m {
-        ModuleResolution::Classic => "classic",
-        // tsc emits "node10" as the canonical name for Node10/node.
-        ModuleResolution::Node10 => "node10",
-        ModuleResolution::Node16 => "node16",
-        ModuleResolution::NodeNext => "nodenext",
-        ModuleResolution::Bundler => "bundler",
-    }
-}
-
-const fn module_detection_init_str(m: tsz_cli::args::ModuleDetection) -> &'static str {
-    use tsz_cli::args::ModuleDetection;
-    match m {
-        ModuleDetection::Auto => "auto",
-        ModuleDetection::Force => "force",
-        ModuleDetection::Legacy => "legacy",
-    }
-}
-
-const fn jsx_init_str(j: tsz_cli::args::JsxEmit) -> &'static str {
-    use tsz_cli::args::JsxEmit;
-    match j {
-        JsxEmit::Preserve => "preserve",
-        JsxEmit::React => "react",
-        JsxEmit::ReactJsx => "react-jsx",
-        JsxEmit::ReactJsxDev => "react-jsxdev",
-        JsxEmit::ReactNative => "react-native",
-    }
-}
-
-const fn new_line_init_str(n: tsz_cli::args::NewLine) -> &'static str {
-    use tsz_cli::args::NewLine;
-    match n {
-        NewLine::Crlf => "crlf",
-        NewLine::Lf => "lf",
-    }
-}
-
-fn emit_init_line(
-    out: &mut String,
-    map: &std::collections::HashMap<&'static str, &str>,
-    key: &'static str,
-    default_value: &str,
-    comment_default: bool,
-) {
-    if let Some(value) = map.get(key) {
-        out.push_str("    \"");
-        out.push_str(key);
-        out.push_str("\": ");
-        out.push_str(value);
-        out.push_str(",\n");
-    } else if comment_default {
-        out.push_str("    // \"");
-        out.push_str(key);
-        out.push_str("\": ");
-        out.push_str(default_value);
-        out.push_str(",\n");
-    } else {
-        out.push_str("    \"");
-        out.push_str(key);
-        out.push_str("\": ");
-        out.push_str(default_value);
-        out.push_str(",\n");
-    }
-}
-
-/// Render the `tsconfig.json` body using the JSONC template that tsc 6.x
-/// emits, with each templated option replaced by the user-provided value (if
-/// any). Options that the user passed but that don't have a slot in the
-/// template are appended after the template body in CLI order, matching tsc.
-fn render_init_template(overrides: &[(&'static str, String)]) -> String {
-    use std::collections::HashMap;
-    let map: HashMap<&'static str, &str> =
-        overrides.iter().map(|(k, v)| (*k, v.as_str())).collect();
-
-    let mut out = String::new();
-    out.push_str("{\n");
-    out.push_str("  // Visit https://aka.ms/tsconfig to read more about this file\n");
-    out.push_str("  \"compilerOptions\": {\n");
-
-    out.push_str("    // File Layout\n");
-    emit_init_line(&mut out, &map, "rootDir", "\"./src\"", true);
-    emit_init_line(&mut out, &map, "outDir", "\"./dist\"", true);
-    out.push('\n');
-    out.push_str("    // Environment Settings\n");
-    out.push_str("    // See also https://aka.ms/tsconfig/module\n");
-    emit_init_line(&mut out, &map, "module", "\"nodenext\"", false);
-    emit_init_line(&mut out, &map, "target", "\"esnext\"", false);
-    emit_init_line(&mut out, &map, "types", "[]", false);
-    out.push_str("    // For nodejs:\n");
-    out.push_str("    // \"lib\": [\"esnext\"],\n");
-    out.push_str("    // \"types\": [\"node\"],\n");
-    out.push_str("    // and npm install -D @types/node\n");
-    out.push('\n');
-    out.push_str("    // Other Outputs\n");
-    emit_init_line(&mut out, &map, "sourceMap", "true", false);
-    emit_init_line(&mut out, &map, "declaration", "true", false);
-    emit_init_line(&mut out, &map, "declarationMap", "true", false);
-    out.push('\n');
-    out.push_str("    // Stricter Typechecking Options\n");
-    emit_init_line(&mut out, &map, "noUncheckedIndexedAccess", "true", false);
-    emit_init_line(&mut out, &map, "exactOptionalPropertyTypes", "true", false);
-    out.push('\n');
-    out.push_str("    // Style Options\n");
-    emit_init_line(&mut out, &map, "noImplicitReturns", "true", true);
-    emit_init_line(&mut out, &map, "noImplicitOverride", "true", true);
-    emit_init_line(&mut out, &map, "noUnusedLocals", "true", true);
-    emit_init_line(&mut out, &map, "noUnusedParameters", "true", true);
-    emit_init_line(&mut out, &map, "noFallthroughCasesInSwitch", "true", true);
-    emit_init_line(
-        &mut out,
-        &map,
-        "noPropertyAccessFromIndexSignature",
-        "true",
-        true,
-    );
-    out.push('\n');
-    out.push_str("    // Recommended Options\n");
-    emit_init_line(&mut out, &map, "strict", "true", false);
-    emit_init_line(&mut out, &map, "jsx", "\"react-jsx\"", false);
-    emit_init_line(&mut out, &map, "verbatimModuleSyntax", "true", false);
-    emit_init_line(&mut out, &map, "isolatedModules", "true", false);
-    emit_init_line(
-        &mut out,
-        &map,
-        "noUncheckedSideEffectImports",
-        "true",
-        false,
-    );
-    emit_init_line(&mut out, &map, "moduleDetection", "\"force\"", false);
-    emit_init_line(&mut out, &map, "skipLibCheck", "true", false);
-
-    // Append any overrides that don't have a slot in the template, preserving
-    // the order they appeared on the command line. tsc emits these after a
-    // single blank line separating them from the recommended-options block.
-    let template_keys: &[&str] = &[
-        "rootDir",
-        "outDir",
-        "module",
-        "target",
-        "types",
-        "sourceMap",
-        "declaration",
-        "declarationMap",
-        "noUncheckedIndexedAccess",
-        "exactOptionalPropertyTypes",
-        "noImplicitReturns",
-        "noImplicitOverride",
-        "noUnusedLocals",
-        "noUnusedParameters",
-        "noFallthroughCasesInSwitch",
-        "noPropertyAccessFromIndexSignature",
-        "strict",
-        "jsx",
-        "verbatimModuleSyntax",
-        "isolatedModules",
-        "noUncheckedSideEffectImports",
-        "moduleDetection",
-        "skipLibCheck",
-    ];
-    let mut appended_any = false;
-    for (key, value) in overrides.iter() {
-        if template_keys.contains(key) {
-            continue;
-        }
-        if !appended_any {
-            out.push('\n');
-            appended_any = true;
-        }
-        out.push_str("    \"");
-        out.push_str(key);
-        out.push_str("\": ");
-        out.push_str(value);
-        out.push_str(",\n");
-    }
-
-    out.push_str("  }\n");
-    out.push_str("}\n");
-    out
-}
-
 fn handle_show_config(args: &CliArgs, cwd: &std::path::Path) -> Result<()> {
     use tsz::checker::diagnostics::diagnostic_codes;
     use tsz_cli::config::load_tsconfig_with_diagnostics;
@@ -1305,9 +550,7 @@ fn handle_list_files_only(args: &CliArgs, cwd: &std::path::Path) -> Result<()> {
     use tsz_cli::fs::{FileDiscoveryOptions, discover_ts_files};
 
     if args.ignore_config && args.files.is_empty() {
-        println!("Version {TSC_VERSION}");
-        println!("{}", help::colorize_help(&help::render_help(TSC_VERSION)));
-        std::process::exit(1);
+        print_no_input_help_and_exit();
     }
 
     let tsconfig_path = if args.ignore_config {
@@ -1770,8 +1013,17 @@ mod clap_errors;
 #[path = "tsz/diagnostics_report.rs"]
 mod diagnostics_report;
 
+#[path = "tsz/init.rs"]
+mod init;
+
+#[path = "tsz/run.rs"]
+mod run;
+
 #[cfg(test)]
 use arg_preprocess::split_response_line;
+
+#[cfg(test)]
+use init::{collect_init_overrides, render_init_template};
 
 #[cfg(test)]
 #[path = "tsz/tests.rs"]

--- a/crates/tsz-cli/src/bin/tsz/init.rs
+++ b/crates/tsz-cli/src/bin/tsz/init.rs
@@ -1,0 +1,603 @@
+//! `--init` command: render and write a `tsconfig.json` template.
+//!
+//! This module owns the entire `--init` surface — recognizing which compiler
+//! options the user passed, formatting their values as JSONC literals, and
+//! rendering the template tsc 6.x emits. It is pure aside from `handle_init`'s
+//! single file write, so it stays decoupled from the rest of the entrypoint.
+
+use anyhow::{Context, Result};
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use tsz_cli::args::CliArgs;
+
+pub(crate) fn handle_init(args: &CliArgs, cwd: &std::path::Path) -> Result<()> {
+    let tsconfig_path = cwd.join("tsconfig.json");
+    if tsconfig_path.exists() {
+        println!(
+            "error TS5054: A 'tsconfig.json' file is already defined at: '{}'.",
+            tsconfig_path.display()
+        );
+        std::process::exit(0);
+    }
+
+    let raw_args: Vec<OsString> = std::env::args_os().skip(1).collect();
+    let overrides = collect_init_overrides(&raw_args, args);
+    let config = render_init_template(&overrides);
+
+    std::fs::write(&tsconfig_path, config).with_context(|| {
+        format!(
+            "failed to write tsconfig.json to {}",
+            tsconfig_path.display()
+        )
+    })?;
+
+    println!("\nCreated a new tsconfig.json\n\nYou can learn more at https://aka.ms/tsconfig");
+
+    Ok(())
+}
+
+/// Walk the original CLI args in order and collect (canonical option name,
+/// JSON-formatted value) pairs for every recognized compiler option the user
+/// passed. Later occurrences supersede earlier ones (matching tsc's
+/// last-write-wins behavior). Order is preserved so that options not in the
+/// fixed `--init` template are appended in the order they appear.
+pub(crate) fn collect_init_overrides(
+    raw_args: &[OsString],
+    args: &CliArgs,
+) -> Vec<(&'static str, String)> {
+    let mut overrides: Vec<(&'static str, String)> = Vec::new();
+    let mut i = 0;
+    while i < raw_args.len() {
+        let arg = raw_args[i].to_string_lossy().to_string();
+        if !arg.starts_with("--") || arg == "--" {
+            i += 1;
+            continue;
+        }
+        let (flag, has_inline_value) = match arg.find('=') {
+            Some(eq) => (arg[..eq].to_string(), true),
+            None => (arg.clone(), false),
+        };
+        let canonical = canonicalize_init_option(&flag);
+        let takes_value = canonical.is_some_and(init_option_takes_value);
+        if let Some(name) = canonical
+            && let Some(value) = init_option_value(name, args)
+        {
+            if let Some(pos) = overrides.iter().position(|(k, _)| *k == name) {
+                overrides[pos] = (name, value);
+            } else {
+                overrides.push((name, value));
+            }
+        }
+        if takes_value && !has_inline_value {
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    overrides
+}
+
+/// Returns the canonical (camelCase) compiler-option name for a CLI flag.
+/// Matching is case-insensitive and ignores `-` characters so that
+/// `--rootDir`, `--rootdir`, and `--root-dir` all map to `"rootDir"`.
+fn canonicalize_init_option(flag: &str) -> Option<&'static str> {
+    let key: String = flag
+        .trim_start_matches('-')
+        .chars()
+        .filter(|c| *c != '-')
+        .flat_map(char::to_lowercase)
+        .collect();
+    INIT_OPTION_TABLE.iter().find_map(|(canonical, _)| {
+        let canonical_key: String = canonical
+            .chars()
+            .filter(|c| *c != '-')
+            .flat_map(char::to_lowercase)
+            .collect();
+        (canonical_key == key).then_some(*canonical)
+    })
+}
+
+#[derive(Clone, Copy)]
+enum InitOptionKind {
+    /// Boolean flag (`--strict`, `--strict false`, `--strict true`).
+    Bool,
+    /// Flag that requires a value (`--target esnext`, `--lib es2015,dom`).
+    Value,
+}
+
+fn init_option_takes_value(name: &str) -> bool {
+    INIT_OPTION_TABLE
+        .iter()
+        .find(|(n, _)| *n == name)
+        .is_some_and(|(_, k)| matches!(k, InitOptionKind::Value))
+}
+
+/// Recognized compiler options for the `--init` flow.
+///
+/// The set is intentionally small relative to the full CLI surface: it covers
+/// every option that has a slot in the default template plus the most common
+/// command-line options that tsc users pass alongside `--init`. Unrecognized
+/// options are silently ignored, matching `tsc`.
+const INIT_OPTION_TABLE: &[(&str, InitOptionKind)] = &[
+    // Language and environment
+    ("target", InitOptionKind::Value),
+    ("module", InitOptionKind::Value),
+    ("moduleResolution", InitOptionKind::Value),
+    ("moduleDetection", InitOptionKind::Value),
+    ("jsx", InitOptionKind::Value),
+    ("jsxFactory", InitOptionKind::Value),
+    ("jsxFragmentFactory", InitOptionKind::Value),
+    ("jsxImportSource", InitOptionKind::Value),
+    ("lib", InitOptionKind::Value),
+    ("types", InitOptionKind::Value),
+    ("typeRoots", InitOptionKind::Value),
+    ("rootDir", InitOptionKind::Value),
+    ("outDir", InitOptionKind::Value),
+    ("outFile", InitOptionKind::Value),
+    ("baseUrl", InitOptionKind::Value),
+    ("declarationDir", InitOptionKind::Value),
+    ("newLine", InitOptionKind::Value),
+    ("noLib", InitOptionKind::Bool),
+    // Emit / output
+    ("declaration", InitOptionKind::Bool),
+    ("declarationMap", InitOptionKind::Bool),
+    ("sourceMap", InitOptionKind::Bool),
+    ("inlineSourceMap", InitOptionKind::Bool),
+    ("inlineSources", InitOptionKind::Bool),
+    ("emitDeclarationOnly", InitOptionKind::Bool),
+    ("noEmit", InitOptionKind::Bool),
+    ("noEmitOnError", InitOptionKind::Bool),
+    ("noEmitHelpers", InitOptionKind::Bool),
+    ("importHelpers", InitOptionKind::Bool),
+    ("downlevelIteration", InitOptionKind::Bool),
+    ("removeComments", InitOptionKind::Bool),
+    ("preserveConstEnums", InitOptionKind::Bool),
+    ("emitBOM", InitOptionKind::Bool),
+    // Interop / modules
+    ("esModuleInterop", InitOptionKind::Bool),
+    ("allowSyntheticDefaultImports", InitOptionKind::Bool),
+    ("isolatedModules", InitOptionKind::Bool),
+    ("isolatedDeclarations", InitOptionKind::Bool),
+    ("verbatimModuleSyntax", InitOptionKind::Bool),
+    ("forceConsistentCasingInFileNames", InitOptionKind::Bool),
+    ("preserveSymlinks", InitOptionKind::Bool),
+    ("erasableSyntaxOnly", InitOptionKind::Bool),
+    ("resolveJsonModule", InitOptionKind::Bool),
+    ("noResolve", InitOptionKind::Bool),
+    ("allowUmdGlobalAccess", InitOptionKind::Bool),
+    ("noUncheckedSideEffectImports", InitOptionKind::Bool),
+    ("allowImportingTsExtensions", InitOptionKind::Bool),
+    ("rewriteRelativeImportExtensions", InitOptionKind::Bool),
+    ("allowArbitraryExtensions", InitOptionKind::Bool),
+    // JavaScript support
+    ("allowJs", InitOptionKind::Bool),
+    ("checkJs", InitOptionKind::Bool),
+    // Decorators
+    ("experimentalDecorators", InitOptionKind::Bool),
+    ("emitDecoratorMetadata", InitOptionKind::Bool),
+    // Type checking
+    ("strict", InitOptionKind::Bool),
+    ("noImplicitAny", InitOptionKind::Bool),
+    ("strictNullChecks", InitOptionKind::Bool),
+    ("strictFunctionTypes", InitOptionKind::Bool),
+    ("strictBindCallApply", InitOptionKind::Bool),
+    ("strictPropertyInitialization", InitOptionKind::Bool),
+    ("strictBuiltinIteratorReturn", InitOptionKind::Bool),
+    ("noImplicitThis", InitOptionKind::Bool),
+    ("useUnknownInCatchVariables", InitOptionKind::Bool),
+    ("alwaysStrict", InitOptionKind::Bool),
+    ("noUnusedLocals", InitOptionKind::Bool),
+    ("noUnusedParameters", InitOptionKind::Bool),
+    ("exactOptionalPropertyTypes", InitOptionKind::Bool),
+    ("noImplicitReturns", InitOptionKind::Bool),
+    ("noFallthroughCasesInSwitch", InitOptionKind::Bool),
+    ("noUncheckedIndexedAccess", InitOptionKind::Bool),
+    ("noImplicitOverride", InitOptionKind::Bool),
+    ("noPropertyAccessFromIndexSignature", InitOptionKind::Bool),
+    ("allowUnreachableCode", InitOptionKind::Bool),
+    ("allowUnusedLabels", InitOptionKind::Bool),
+    ("useDefineForClassFields", InitOptionKind::Bool),
+    // Completeness
+    ("skipDefaultLibCheck", InitOptionKind::Bool),
+    ("skipLibCheck", InitOptionKind::Bool),
+    // Projects
+    ("composite", InitOptionKind::Bool),
+    ("incremental", InitOptionKind::Bool),
+    // Diagnostics / output formatting
+    ("diagnostics", InitOptionKind::Bool),
+    ("extendedDiagnostics", InitOptionKind::Bool),
+    ("explainFiles", InitOptionKind::Bool),
+    ("listFiles", InitOptionKind::Bool),
+    ("listEmittedFiles", InitOptionKind::Bool),
+    ("traceResolution", InitOptionKind::Bool),
+    ("noCheck", InitOptionKind::Bool),
+    ("noErrorTruncation", InitOptionKind::Bool),
+    ("preserveWatchOutput", InitOptionKind::Bool),
+    ("pretty", InitOptionKind::Bool),
+];
+
+/// Format the user-supplied value for a recognized option as a JSON literal.
+/// Returns `None` if the option is recognized but the parsed `args` struct
+/// does not carry a meaningful value (e.g., a `bool` field is `false` because
+/// the option was never on the command line — but in that case the caller
+/// would not invoke this function).
+fn init_option_value(name: &'static str, args: &CliArgs) -> Option<String> {
+    match name {
+        "target" => args.target.map(|t| json_str(target_init_str(t))),
+        "module" => args.module.map(|m| json_str(module_init_str(m))),
+        "moduleResolution" => args
+            .module_resolution
+            .map(|m| json_str(module_resolution_init_str(m))),
+        "moduleDetection" => args
+            .module_detection
+            .map(|m| json_str(module_detection_init_str(m))),
+        "jsx" => args.jsx.map(|j| json_str(jsx_init_str(j))),
+        "jsxFactory" => args.jsx_factory.as_deref().map(json_str),
+        "jsxFragmentFactory" => args.jsx_fragment_factory.as_deref().map(json_str),
+        "jsxImportSource" => args.jsx_import_source.as_deref().map(json_str),
+        "newLine" => args.new_line.map(|n| json_str(new_line_init_str(n))),
+        "lib" => args.lib.as_ref().map(|v| json_str_array(v)),
+        "types" => args.types.as_ref().map(|v| json_str_array(v)),
+        "typeRoots" => args
+            .type_roots
+            .as_ref()
+            .map(|v| json_path_array(v.iter().map(PathBuf::as_path))),
+        "rootDir" => args.root_dir.as_deref().map(json_path),
+        "outDir" => args.out_dir.as_deref().map(json_path),
+        "outFile" => args.out_file.as_deref().map(json_path),
+        "baseUrl" => args.base_url.as_deref().map(json_path),
+        "declarationDir" => args.declaration_dir.as_deref().map(json_path),
+        // Plain bool flags. The preprocessor in `preprocess_args` strips
+        // `--flag false` pairs and either flips the field to `false` directly
+        // or records the flag name in `explicitly_disabled_bool_flags`. By
+        // the time we get here, `args.<field>` already reflects the user's
+        // intent.
+        "noLib" => Some(bool_str(args.no_lib)),
+        "declaration" => Some(bool_str(args.declaration)),
+        "declarationMap" => Some(bool_str(args.declaration_map)),
+        "sourceMap" => Some(bool_str(args.source_map)),
+        "inlineSourceMap" => Some(bool_str(args.inline_source_map)),
+        "inlineSources" => Some(bool_str(args.inline_sources)),
+        "emitDeclarationOnly" => Some(bool_str(args.emit_declaration_only)),
+        "noEmit" => Some(bool_str(args.no_emit)),
+        "noEmitOnError" => Some(bool_str(args.no_emit_on_error)),
+        "noEmitHelpers" => Some(bool_str(args.no_emit_helpers)),
+        "importHelpers" => Some(bool_str(args.import_helpers)),
+        "downlevelIteration" => Some(bool_str(args.downlevel_iteration)),
+        "removeComments" => Some(bool_str(args.remove_comments)),
+        "preserveConstEnums" => Some(bool_str(args.preserve_const_enums)),
+        "emitBOM" => Some(bool_str(args.emit_bom)),
+        "esModuleInterop" => Some(bool_str(args.es_module_interop)),
+        "isolatedModules" => Some(bool_str(args.isolated_modules)),
+        "isolatedDeclarations" => Some(bool_str(args.isolated_declarations)),
+        "verbatimModuleSyntax" => Some(bool_str(args.verbatim_module_syntax)),
+        "preserveSymlinks" => Some(bool_str(args.preserve_symlinks)),
+        "erasableSyntaxOnly" => Some(bool_str(args.erasable_syntax_only)),
+        "resolveJsonModule" => Some(bool_str(args.resolve_json_module)),
+        "noResolve" => Some(bool_str(args.no_resolve)),
+        "allowUmdGlobalAccess" => Some(bool_str(args.allow_umd_global_access)),
+        "noUncheckedSideEffectImports" => Some(bool_str(args.no_unchecked_side_effect_imports)),
+        "allowImportingTsExtensions" => Some(bool_str(args.allow_importing_ts_extensions)),
+        "rewriteRelativeImportExtensions" => {
+            Some(bool_str(args.rewrite_relative_import_extensions))
+        }
+        "allowArbitraryExtensions" => Some(bool_str(args.allow_arbitrary_extensions)),
+        "allowJs" => Some(bool_str(args.allow_js)),
+        "checkJs" => Some(bool_str(args.check_js)),
+        "experimentalDecorators" => Some(bool_str(args.experimental_decorators)),
+        "emitDecoratorMetadata" => Some(bool_str(args.emit_decorator_metadata)),
+        "strict" => Some(bool_str(args.strict)),
+        "noUnusedLocals" => Some(bool_str(args.no_unused_locals)),
+        "noUnusedParameters" => Some(bool_str(args.no_unused_parameters)),
+        "exactOptionalPropertyTypes" => Some(bool_str(args.exact_optional_property_types)),
+        "noImplicitReturns" => Some(bool_str(args.no_implicit_returns)),
+        "noFallthroughCasesInSwitch" => Some(bool_str(args.no_fallthrough_cases_in_switch)),
+        "noUncheckedIndexedAccess" => Some(bool_str(args.no_unchecked_indexed_access)),
+        "noImplicitOverride" => Some(bool_str(args.no_implicit_override)),
+        "noPropertyAccessFromIndexSignature" => {
+            Some(bool_str(args.no_property_access_from_index_signature))
+        }
+        "skipDefaultLibCheck" => Some(bool_str(args.skip_default_lib_check)),
+        "skipLibCheck" => Some(bool_str(args.skip_lib_check)),
+        "composite" => Some(bool_str(args.composite)),
+        "incremental" => Some(bool_str(args.incremental)),
+        "diagnostics" => Some(bool_str(args.diagnostics)),
+        "extendedDiagnostics" => Some(bool_str(args.extended_diagnostics)),
+        "explainFiles" => Some(bool_str(args.explain_files)),
+        "listFiles" => Some(bool_str(args.list_files)),
+        "listEmittedFiles" => Some(bool_str(args.list_emitted_files)),
+        "traceResolution" => Some(bool_str(args.trace_resolution)),
+        "noCheck" => Some(bool_str(args.no_check)),
+        "noErrorTruncation" => Some(bool_str(args.no_error_truncation)),
+        "preserveWatchOutput" => Some(bool_str(args.preserve_watch_output)),
+        // Tri-state Option<bool> flags.
+        "pretty" => args.pretty.map(bool_str),
+        "noImplicitAny" => args.no_implicit_any.map(bool_str),
+        "strictNullChecks" => args.strict_null_checks.map(bool_str),
+        "strictFunctionTypes" => args.strict_function_types.map(bool_str),
+        "strictBindCallApply" => args.strict_bind_call_apply.map(bool_str),
+        "strictPropertyInitialization" => args.strict_property_initialization.map(bool_str),
+        "strictBuiltinIteratorReturn" => args.strict_builtin_iterator_return.map(bool_str),
+        "noImplicitThis" => args.no_implicit_this.map(bool_str),
+        "useUnknownInCatchVariables" => args.use_unknown_in_catch_variables.map(bool_str),
+        "alwaysStrict" => args.always_strict.map(bool_str),
+        "allowSyntheticDefaultImports" => args.allow_synthetic_default_imports.map(bool_str),
+        "forceConsistentCasingInFileNames" => {
+            args.force_consistent_casing_in_file_names.map(bool_str)
+        }
+        "allowUnreachableCode" => args.allow_unreachable_code.map(bool_str),
+        "allowUnusedLabels" => args.allow_unused_labels.map(bool_str),
+        "useDefineForClassFields" => args.use_define_for_class_fields.map(bool_str),
+        _ => None,
+    }
+}
+
+fn bool_str(b: bool) -> String {
+    if b { "true".into() } else { "false".into() }
+}
+
+fn json_str(s: &str) -> String {
+    // Escape backslashes and double quotes; tsconfig is JSONC and our values
+    // are user-supplied strings or paths.
+    let mut escaped = String::with_capacity(s.len() + 2);
+    escaped.push('"');
+    for c in s.chars() {
+        match c {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            _ => escaped.push(c),
+        }
+    }
+    escaped.push('"');
+    escaped
+}
+
+fn json_path(p: &Path) -> String {
+    // tsc emits paths with forward slashes; do the same so that snapshots are
+    // stable on Windows-style inputs and so that the path round-trips through
+    // tsconfig parsing.
+    json_str(&p.to_string_lossy().replace('\\', "/"))
+}
+
+fn json_str_array(values: &[String]) -> String {
+    if values.is_empty() {
+        return "[]".into();
+    }
+    let items: Vec<String> = values.iter().map(|v| json_str(v)).collect();
+    format!("[{}]", items.join(", "))
+}
+
+fn json_path_array<'a, I: Iterator<Item = &'a Path>>(paths: I) -> String {
+    let items: Vec<String> = paths.map(json_path).collect();
+    if items.is_empty() {
+        "[]".into()
+    } else {
+        format!("[{}]", items.join(", "))
+    }
+}
+
+const fn target_init_str(t: tsz_cli::args::Target) -> &'static str {
+    use tsz_cli::args::Target;
+    match t {
+        Target::Es3 => "es3",
+        Target::Es5 => "es5",
+        // tsc canonicalizes ES2015 to "es6".
+        Target::Es2015 => "es6",
+        Target::Es2016 => "es2016",
+        Target::Es2017 => "es2017",
+        Target::Es2018 => "es2018",
+        Target::Es2019 => "es2019",
+        Target::Es2020 => "es2020",
+        Target::Es2021 => "es2021",
+        Target::Es2022 => "es2022",
+        Target::Es2023 => "es2023",
+        Target::Es2024 => "es2024",
+        Target::Es2025 => "es2025",
+        Target::EsNext => "esnext",
+    }
+}
+
+const fn module_init_str(m: tsz_cli::args::Module) -> &'static str {
+    use tsz_cli::args::Module;
+    match m {
+        Module::None => "none",
+        Module::CommonJs => "commonjs",
+        Module::Amd => "amd",
+        Module::Umd => "umd",
+        Module::System => "system",
+        // tsc canonicalizes ES2015 to "es6" for module too.
+        Module::Es2015 => "es6",
+        Module::Es2020 => "es2020",
+        Module::Es2022 => "es2022",
+        Module::EsNext => "esnext",
+        Module::Node16 => "node16",
+        Module::Node18 => "node18",
+        Module::Node20 => "node20",
+        Module::NodeNext => "nodenext",
+        Module::Preserve => "preserve",
+    }
+}
+
+const fn module_resolution_init_str(m: tsz_cli::args::ModuleResolution) -> &'static str {
+    use tsz_cli::args::ModuleResolution;
+    match m {
+        ModuleResolution::Classic => "classic",
+        // tsc emits "node10" as the canonical name for Node10/node.
+        ModuleResolution::Node10 => "node10",
+        ModuleResolution::Node16 => "node16",
+        ModuleResolution::NodeNext => "nodenext",
+        ModuleResolution::Bundler => "bundler",
+    }
+}
+
+const fn module_detection_init_str(m: tsz_cli::args::ModuleDetection) -> &'static str {
+    use tsz_cli::args::ModuleDetection;
+    match m {
+        ModuleDetection::Auto => "auto",
+        ModuleDetection::Force => "force",
+        ModuleDetection::Legacy => "legacy",
+    }
+}
+
+const fn jsx_init_str(j: tsz_cli::args::JsxEmit) -> &'static str {
+    use tsz_cli::args::JsxEmit;
+    match j {
+        JsxEmit::Preserve => "preserve",
+        JsxEmit::React => "react",
+        JsxEmit::ReactJsx => "react-jsx",
+        JsxEmit::ReactJsxDev => "react-jsxdev",
+        JsxEmit::ReactNative => "react-native",
+    }
+}
+
+const fn new_line_init_str(n: tsz_cli::args::NewLine) -> &'static str {
+    use tsz_cli::args::NewLine;
+    match n {
+        NewLine::Crlf => "crlf",
+        NewLine::Lf => "lf",
+    }
+}
+
+fn emit_init_line(
+    out: &mut String,
+    map: &std::collections::HashMap<&'static str, &str>,
+    key: &'static str,
+    default_value: &str,
+    comment_default: bool,
+) {
+    if let Some(value) = map.get(key) {
+        out.push_str("    \"");
+        out.push_str(key);
+        out.push_str("\": ");
+        out.push_str(value);
+        out.push_str(",\n");
+    } else if comment_default {
+        out.push_str("    // \"");
+        out.push_str(key);
+        out.push_str("\": ");
+        out.push_str(default_value);
+        out.push_str(",\n");
+    } else {
+        out.push_str("    \"");
+        out.push_str(key);
+        out.push_str("\": ");
+        out.push_str(default_value);
+        out.push_str(",\n");
+    }
+}
+
+/// Render the `tsconfig.json` body using the JSONC template that tsc 6.x
+/// emits, with each templated option replaced by the user-provided value (if
+/// any). Options that the user passed but that don't have a slot in the
+/// template are appended after the template body in CLI order, matching tsc.
+pub(crate) fn render_init_template(overrides: &[(&'static str, String)]) -> String {
+    use std::collections::HashMap;
+    let map: HashMap<&'static str, &str> =
+        overrides.iter().map(|(k, v)| (*k, v.as_str())).collect();
+
+    let mut out = String::new();
+    out.push_str("{\n");
+    out.push_str("  // Visit https://aka.ms/tsconfig to read more about this file\n");
+    out.push_str("  \"compilerOptions\": {\n");
+
+    out.push_str("    // File Layout\n");
+    emit_init_line(&mut out, &map, "rootDir", "\"./src\"", true);
+    emit_init_line(&mut out, &map, "outDir", "\"./dist\"", true);
+    out.push('\n');
+    out.push_str("    // Environment Settings\n");
+    out.push_str("    // See also https://aka.ms/tsconfig/module\n");
+    emit_init_line(&mut out, &map, "module", "\"nodenext\"", false);
+    emit_init_line(&mut out, &map, "target", "\"esnext\"", false);
+    emit_init_line(&mut out, &map, "types", "[]", false);
+    out.push_str("    // For nodejs:\n");
+    out.push_str("    // \"lib\": [\"esnext\"],\n");
+    out.push_str("    // \"types\": [\"node\"],\n");
+    out.push_str("    // and npm install -D @types/node\n");
+    out.push('\n');
+    out.push_str("    // Other Outputs\n");
+    emit_init_line(&mut out, &map, "sourceMap", "true", false);
+    emit_init_line(&mut out, &map, "declaration", "true", false);
+    emit_init_line(&mut out, &map, "declarationMap", "true", false);
+    out.push('\n');
+    out.push_str("    // Stricter Typechecking Options\n");
+    emit_init_line(&mut out, &map, "noUncheckedIndexedAccess", "true", false);
+    emit_init_line(&mut out, &map, "exactOptionalPropertyTypes", "true", false);
+    out.push('\n');
+    out.push_str("    // Style Options\n");
+    emit_init_line(&mut out, &map, "noImplicitReturns", "true", true);
+    emit_init_line(&mut out, &map, "noImplicitOverride", "true", true);
+    emit_init_line(&mut out, &map, "noUnusedLocals", "true", true);
+    emit_init_line(&mut out, &map, "noUnusedParameters", "true", true);
+    emit_init_line(&mut out, &map, "noFallthroughCasesInSwitch", "true", true);
+    emit_init_line(
+        &mut out,
+        &map,
+        "noPropertyAccessFromIndexSignature",
+        "true",
+        true,
+    );
+    out.push('\n');
+    out.push_str("    // Recommended Options\n");
+    emit_init_line(&mut out, &map, "strict", "true", false);
+    emit_init_line(&mut out, &map, "jsx", "\"react-jsx\"", false);
+    emit_init_line(&mut out, &map, "verbatimModuleSyntax", "true", false);
+    emit_init_line(&mut out, &map, "isolatedModules", "true", false);
+    emit_init_line(
+        &mut out,
+        &map,
+        "noUncheckedSideEffectImports",
+        "true",
+        false,
+    );
+    emit_init_line(&mut out, &map, "moduleDetection", "\"force\"", false);
+    emit_init_line(&mut out, &map, "skipLibCheck", "true", false);
+
+    // Append any overrides that don't have a slot in the template, preserving
+    // the order they appeared on the command line. tsc emits these after a
+    // single blank line separating them from the recommended-options block.
+    let template_keys: &[&str] = &[
+        "rootDir",
+        "outDir",
+        "module",
+        "target",
+        "types",
+        "sourceMap",
+        "declaration",
+        "declarationMap",
+        "noUncheckedIndexedAccess",
+        "exactOptionalPropertyTypes",
+        "noImplicitReturns",
+        "noImplicitOverride",
+        "noUnusedLocals",
+        "noUnusedParameters",
+        "noFallthroughCasesInSwitch",
+        "noPropertyAccessFromIndexSignature",
+        "strict",
+        "jsx",
+        "verbatimModuleSyntax",
+        "isolatedModules",
+        "noUncheckedSideEffectImports",
+        "moduleDetection",
+        "skipLibCheck",
+    ];
+    let mut appended_any = false;
+    for (key, value) in overrides.iter() {
+        if template_keys.contains(key) {
+            continue;
+        }
+        if !appended_any {
+            out.push('\n');
+            appended_any = true;
+        }
+        out.push_str("    \"");
+        out.push_str(key);
+        out.push_str("\": ");
+        out.push_str(value);
+        out.push_str(",\n");
+    }
+
+    out.push_str("  }\n");
+    out.push_str("}\n");
+    out
+}

--- a/crates/tsz-cli/src/bin/tsz/run.rs
+++ b/crates/tsz-cli/src/bin/tsz/run.rs
@@ -1,0 +1,229 @@
+//! Default compile command: run the driver, write optional trace/diagnostics
+//! output, render diagnostics, and exit with tsc's status code.
+//!
+//! This is the execution half of the entrypoint's parse → execute split. The
+//! arguments handed here are already validated and normalized by
+//! `select_command`, so this module only orchestrates the compile and its
+//! side effects.
+
+use anyhow::Result;
+use rustc_hash::FxHashMap;
+use std::io::IsTerminal;
+
+use tsz::checker::diagnostics::DiagnosticCategory;
+use tsz_cli::args::CliArgs;
+use tsz_cli::{driver, reporter::Reporter};
+
+use super::diagnostics_report::print_diagnostics;
+use super::{EXIT_DIAGNOSTICS_OUTPUTS_GENERATED, EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED, EXIT_SUCCESS};
+
+/// Extensions tsc lists in TS6231 "could not resolve path" messages, in tsc's display order.
+const TS6231_EXTENSIONS: &str = "'.ts', '.tsx', '.d.ts', '.cts', '.d.cts', '.mts', '.d.mts'";
+
+/// Prints a root-file resolution failure in tsc's format and exits with the diagnostics
+/// status code. Keeps the "file is in the program because" context consistent across all
+/// root-file error codes.
+fn report_root_file_diagnostic(code: u32, message: &str) -> ! {
+    println!("error TS{code}: {message}");
+    println!("  The file is in the program because:");
+    println!("    Root file specified for compilation\n");
+    std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_GENERATED)
+}
+
+/// Compile `args` rooted at `cwd` and emit all of tsc's post-compile output
+/// (trace file, file lists, diagnostics) before exiting with the matching
+/// status code.
+pub(crate) fn run_compile(args: &CliArgs, cwd: &std::path::Path) -> Result<()> {
+    if let Some(profile_path) = args.generate_cpu_profile.as_ref() {
+        println!(
+            "error: --generateCpuProfile is not supported by tsz; requested profile '{}' was not created. Use --generateTrace for native trace output.",
+            profile_path.display()
+        );
+        std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED);
+    }
+
+    // Initialize tracer if --generateTrace is specified
+    let tracer = args.generate_trace.is_some().then(|| {
+        let mut t = tsz_cli::trace::Tracer::new();
+        // Add process metadata
+        let mut meta_args = FxHashMap::default();
+        meta_args.insert("name".to_string(), serde_json::json!("tsz"));
+        t.metadata("process_name", meta_args);
+        t
+    });
+
+    let start_time = std::time::Instant::now();
+    let result = match driver::compile(args, cwd) {
+        Ok(r) => r,
+        Err(e) => {
+            let msg = e.to_string();
+            if let Some(rest) = msg.strip_prefix("TS6053: ") {
+                report_root_file_diagnostic(6053, rest);
+            }
+            if let Some(path_str) = msg.strip_prefix("TS6231: ") {
+                report_root_file_diagnostic(
+                    6231,
+                    &format!(
+                        "Could not resolve the path '{path_str}' with the extensions: {TS6231_EXTENSIONS}."
+                    ),
+                );
+            }
+            return Err(e);
+        }
+    };
+    let elapsed = start_time.elapsed();
+
+    // Write trace file if requested
+    if let (Some(trace_path), Some(mut tracer)) = (args.generate_trace.as_ref(), tracer) {
+        use tsz_cli::trace::categories;
+
+        // Record compilation summary events
+        tracer.complete_with_args("Compile", categories::PROGRAM, start_time, elapsed, {
+            let mut event_args = FxHashMap::default();
+            event_args.insert(
+                "fileCount".to_string(),
+                serde_json::json!(result.files_read.len()),
+            );
+            event_args.insert(
+                "errorCount".to_string(),
+                serde_json::json!(result.diagnostics.len()),
+            );
+            event_args.insert(
+                "emittedCount".to_string(),
+                serde_json::json!(result.emitted_files.len()),
+            );
+            event_args
+        });
+
+        // Add per-file events for files read
+        for file in &result.files_read {
+            let mut event_args = FxHashMap::default();
+            event_args.insert(
+                "path".to_string(),
+                serde_json::json!(file.display().to_string()),
+            );
+            tracer.instant_with_args("FileProcessed", categories::IO, event_args);
+        }
+
+        // Write the trace file
+        let trace_file = if trace_path.is_dir() {
+            trace_path.join("trace.json")
+        } else {
+            trace_path.to_path_buf()
+        };
+
+        if let Err(e) = tracer.write_to_file(&trace_file) {
+            println!("Warning: Failed to write trace file: {e}");
+        } else {
+            println!("Trace written to: {}", trace_file.display());
+        }
+    }
+
+    // Handle --listFiles: print all files read during compilation
+    if args.list_files {
+        for file in &result.files_read {
+            println!("{}", file.display());
+        }
+    }
+
+    // Handle --listEmittedFiles: print emitted file list
+    if args.list_emitted_files && !result.emitted_files.is_empty() {
+        for file in &result.emitted_files {
+            println!("TSFILE: {}", file.display());
+        }
+    }
+
+    // Handle --explainFiles: print files with inclusion reasons
+    if args.explain_files {
+        for info in &result.file_infos {
+            println!("{}", info.path.display());
+            for reason in &info.reasons {
+                println!("  {reason}");
+            }
+        }
+    }
+
+    // Handle --traceDependencies: print dependency graph
+    if args.trace_dependencies {
+        // Note: Full dependency tracing would require access to the dependency map
+        // For now, just list all files that were read (which includes dependencies)
+        for file in &result.files_read {
+            println!("{}", file.display());
+        }
+    }
+
+    // Handle --diagnostics: print compilation performance info
+    if args.diagnostics || args.extended_diagnostics {
+        print_diagnostics(&result, elapsed, args.extended_diagnostics);
+    }
+
+    // Perf-tools-only: write the machine-readable diagnostics JSON report.
+    // The flag and call site both compile out of default release builds.
+    #[cfg(feature = "perf-tools")]
+    if let Some(path) = args.diagnostics_json.as_deref() {
+        let raw_args: Vec<std::ffi::OsString> = std::env::args_os().collect();
+        if let Err(err) = tsz_cli::perf_json::write_compilation_report(path, &result, &raw_args) {
+            tracing::warn!(
+                "failed to write diagnostics JSON to {}: {err}",
+                path.display()
+            );
+        }
+    }
+
+    // Perf-tools-only: write the perf-counter JSON snapshot. The flag and
+    // the call both compile out of default release builds.
+    #[cfg(feature = "perf-tools")]
+    if let Some(path) = args.perf_counters_json.as_deref()
+        && let Err(err) = tsz_common::perf_counters::PerfCounters::write_json_to(path)
+    {
+        tracing::warn!(
+            "failed to write perf-counter JSON to {}: {err}",
+            path.display()
+        );
+    }
+
+    if !result.diagnostics.is_empty() {
+        let pretty = args
+            .pretty
+            .unwrap_or_else(|| std::io::stdout().is_terminal());
+        // When --pretty true is explicitly passed, force ANSI colors even
+        // when piped (not a TTY), matching tsc v6 behavior.
+        if args.pretty == Some(true) {
+            Reporter::force_colors(true);
+        }
+        let mut reporter = Reporter::new(pretty);
+        let output = reporter.render(&result.diagnostics);
+        if !output.is_empty() {
+            // tsc writes all diagnostics to stdout
+            print!("{output}");
+        }
+    }
+
+    if args.sound_report_only {
+        std::process::exit(EXIT_SUCCESS);
+    }
+
+    let has_errors = result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.category == DiagnosticCategory::Error);
+
+    if has_errors {
+        // Match tsc exit codes:
+        // Exit code 1 (DiagnosticsPresent_OutputsSkipped): emit was suppressed due to errors
+        //   (--noEmitOnError with errors means no outputs were generated).
+        // Exit code 2 (DiagnosticsPresent_OutputsGenerated): errors exist but outputs were
+        //   still generated (or --noEmit where there's nothing to emit regardless).
+        // `result.no_emit` reflects the resolved option (CLI + tsconfig.json),
+        // so a tsconfig-only `noEmit` selects exit 2 just like the CLI flag.
+        if args.no_emit_on_error {
+            std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED);
+        } else if result.no_emit || !result.emitted_files.is_empty() {
+            std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_GENERATED);
+        } else {
+            std::process::exit(EXIT_DIAGNOSTICS_OUTPUTS_SKIPPED);
+        }
+    }
+
+    std::process::exit(EXIT_SUCCESS);
+}

--- a/crates/tsz-cli/src/bin/tsz/tests.rs
+++ b/crates/tsz-cli/src/bin/tsz/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::ffi::OsString;
 
 fn preprocess_strs(args: &[&str]) -> Vec<String> {
     preprocess_args(args.iter().map(OsString::from).collect())


### PR DESCRIPTION
AgentName: Studio-manager

Fixes #9406.

**AgentName:** Studio-manager

**Track:** CLI / entrypoint tech-debt — separate command parsing from execution.

**Invariant:** Pure restructuring of `crates/tsz-cli/src/bin/tsz.rs`. Process exit codes, stdout/stderr ordering, and every diagnostic string are byte-for-byte unchanged; the moved blocks are verbatim. No checker/solver/emit semantics are touched.

**Scope:**
- `crates/tsz-cli/src/bin/tsz.rs`
  - `actual_main` previously interleaved argument validation, command dispatch, and execution side effects in one ~300-line path. It is now a thin orchestrator: `validate_locale_or_exit` → `locale::init_locale` → `match select_command(&mut args, &cwd)` → dispatch.
  - New `Command` enum (`Batch`, `Init`, `ShowConfig`, `ListFilesOnly`, `Build`, `Watch`, `Compile`) is the named parse→execute boundary.
  - `select_command(&mut CliArgs, &Path) -> Command` performs the same ordered validation/normalization tsc does (TS5112/TS5042/no-input help, lone-directory `--project` promotion, output-only tsconfig merge), exiting in place on invalid combinations, and returns the action to run.
  - Extracted `print_no_input_help_and_exit()`, de-duplicating three identical "version + help, exit 1" blocks.
- `crates/tsz-cli/src/bin/tsz/init.rs` (new): the entire `--init` tsconfig-template subsystem (`render_init_template`, `INIT_OPTION_TABLE`, the `*_init_str`/`json_*` helpers, `handle_init`).
- `crates/tsz-cli/src/bin/tsz/run.rs` (new): the compile execution path (tracer setup, `driver::compile`, `--listFiles`/`--listEmittedFiles`/`--explainFiles`/`--diagnostics` output, diagnostic rendering, exit-code computation, `report_root_file_diagnostic`).
- `crates/tsz-cli/src/bin/tsz/tests.rs`: imports `OsString` directly now that the bin root no longer re-exports it; the `--init` unit tests still reach the moved helpers via a `#[cfg(test)]` re-export.

`EXIT_*` status constants are now `pub(crate)` since they are shared with the new `run` submodule.

`bin/tsz.rs` drops from 1778 to ~1010 lines, back under the 2000-line ceiling, with the entrypoint's two largest cohesive concerns (`--init` rendering and compile execution) in their own files.

**Project Corpus Impact:** None. No diagnostic, emit, or inference behavior changes; no required project row is affected.

**Verification** (on the rebased head, against latest `main`):
- `cargo fmt -p tsz-cli` (clean)
- `cargo check -p tsz-cli --bin tsz` → ok
- `cargo clippy -p tsz-cli --bin tsz --tests -- -D warnings` → ok
- `cargo test -p tsz-cli --bin tsz` → `75 passed; 0 failed`
- Rebased onto latest `main` (`153d300`) with no conflicts; re-checked compile post-rebase.

**Coordination Notes:** Claimed the issue with the `WIP` label after confirming it was unowned (no `agent:*` owner, no open PR, only automated triage comments). During the work the `agent:Studio-manager` coordination label was added to the issue, but there is no competing branch or PR for #9406 and no recent PR touches the entrypoint, so this is the sole implementation. Behavior-preserving refactor PR per the repo's refactor-PR checklist (behavior unchanged, focused checks, future entrypoint campaigns enabled). Happy to coordinate with Studio-manager on review/landing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HkGGjhqYxiKo4JZE9yJ7Ca)_



## Project Corpus Impact
- Row: n/a
- Bug family: n/a; behavior-preserving CLI entrypoint refactor
