### PR TITLE
perf(solver): expose type predicate cache residency

### DIFF
--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -1588,6 +1588,14 @@ impl TypeInterner {
             * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
         size += self.contains_type_query_cache.len()
             * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
+        size += self.contains_type_params_cache.len()
+            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
+        size += self.contains_lazy_or_recursive_cache.len()
+            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
+        size += self.contains_unresolved_application_cache.len()
+            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
+        size += self.contains_resolver_dependent_cache.len()
+            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
         size += self.contains_conditional_cache.len()
             * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
         // alloc_order is now stored per-shard alongside index_to_key (4 bytes per type)

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -521,6 +521,24 @@ pub struct TypeInterner {
     pub(super) instance_id: u32,
 }
 
+/// Entry-count snapshot for retained `TypeInterner` predicate caches.
+///
+/// These caches memoize immutable per-`TypeId` content predicates. The snapshot
+/// is observability-only: it does not change cache keys, invalidation, fuel, or
+/// predicate answers.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TypePredicateCacheStatistics {
+    pub identity_comparable_cache_entries: usize,
+    pub contains_this_cache_entries: usize,
+    pub contains_infer_cache_entries: usize,
+    pub contains_type_query_cache_entries: usize,
+    pub contains_type_params_cache_entries: usize,
+    pub contains_lazy_or_recursive_cache_entries: usize,
+    pub contains_unresolved_application_cache_entries: usize,
+    pub contains_resolver_dependent_cache_entries: usize,
+    pub contains_conditional_cache_entries: usize,
+}
+
 impl std::fmt::Debug for TypeInterner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TypeInterner")
@@ -530,6 +548,24 @@ impl std::fmt::Debug for TypeInterner {
 }
 
 impl TypeInterner {
+    /// Capture retained predicate-cache entry counts for perf attribution.
+    #[must_use]
+    pub fn type_predicate_cache_statistics(&self) -> TypePredicateCacheStatistics {
+        TypePredicateCacheStatistics {
+            identity_comparable_cache_entries: self.identity_comparable_cache.len(),
+            contains_this_cache_entries: self.contains_this_cache.len(),
+            contains_infer_cache_entries: self.contains_infer_cache.len(),
+            contains_type_query_cache_entries: self.contains_type_query_cache.len(),
+            contains_type_params_cache_entries: self.contains_type_params_cache.len(),
+            contains_lazy_or_recursive_cache_entries: self.contains_lazy_or_recursive_cache.len(),
+            contains_unresolved_application_cache_entries: self
+                .contains_unresolved_application_cache
+                .len(),
+            contains_resolver_dependent_cache_entries: self.contains_resolver_dependent_cache.len(),
+            contains_conditional_cache_entries: self.contains_conditional_cache.len(),
+        }
+    }
+
     /// Create a new type interner with pre-registered intrinsics.
     ///
     /// Uses lazy initialization for all `DashMap` structures to minimize

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -528,14 +528,23 @@ pub struct TypeInterner {
 /// predicate answers.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct TypePredicateCacheStatistics {
+    /// Number of memoized identity-comparability predicate results.
     pub identity_comparable_cache_entries: usize,
+    /// Number of memoized `ThisType` containment predicate results.
     pub contains_this_cache_entries: usize,
+    /// Number of memoized `infer` containment predicate results.
     pub contains_infer_cache_entries: usize,
+    /// Number of memoized `typeof` query containment predicate results.
     pub contains_type_query_cache_entries: usize,
+    /// Number of memoized type-parameter containment predicate results.
     pub contains_type_params_cache_entries: usize,
+    /// Number of memoized lazy-or-recursive containment predicate results.
     pub contains_lazy_or_recursive_cache_entries: usize,
+    /// Number of memoized unresolved-application containment predicate results.
     pub contains_unresolved_application_cache_entries: usize,
+    /// Number of memoized resolver-dependent containment predicate results.
     pub contains_resolver_dependent_cache_entries: usize,
+    /// Number of memoized conditional-type containment predicate results.
     pub contains_conditional_cache_entries: usize,
 }
 


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance / tooling-guardrail observability for #12271.

## Invariant
When retained `TypeInterner` predicate caches memoize immutable per-`TypeId` content predicates, tsz should expose their entry counts and include them in retained-size accounting without changing cache keys, invalidation, request scope, fuel behavior, or predicate answers. This PR changes solver interner observability only.

## Scope
- `crates/tsz-solver/src/intern/core/interner.rs`
- `crates/tsz-solver/src/intern/core/constructors.rs`

## Project Corpus Impact
- Row: n/a
- Bug family: #12271 performance attribution / cache residency visibility.
- Evidence: `python3 scripts/perf/cache-visibility-report.py --json` on current main flagged `contains_type_params_cache`, `contains_lazy_or_recursive_cache`, `contains_unresolved_application_cache`, and `contains_resolver_dependent_cache` as retained `TypeInterner` caches without size/stat signals. This PR adds same-file entry-count statistics and retained-size accounting for those caches. It does not claim a project-row timing improvement.

## Verification
- `git diff --check HEAD~1..HEAD` on the initial implementation commit before the docs follow-up.
- Pre-commit formatting hook ran for both commits.
- Not run locally: compiler tests, conformance, project compile guard, or benchmarks.
- PR-head CI on `d8addb6842`: `gate`, `project-row-drift`, `lint`, `cargo-shear`, `cargo-deny`, `unit`, `unit-cloudbuild`, `dist-binaries`, and `CI Light Summary` passed.

## Coordination Notes
- Ready for manager review: PR-head CI is green for this #12271 observability slice.
- Overlap checked against open `agent:Studio-B` PRs. This does not duplicate #12667 split-evaluator cache stats or #12669 lib-bootstrap counters; it covers retained `TypeInterner` predicate-cache residency that the current cache-visibility report still flags.
- No merge-queue action by Studio-B.

