### PR TITLE
refactor(checker): route undefined predicates through boundaries

### DIFF
--- a/crates/tsz-checker/src/flow/flow_analysis/usage.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/usage.rs
@@ -530,7 +530,6 @@ impl<'a> CheckerState<'a> {
     /// without strict null checks all types implicitly include `undefined`.
     pub(crate) fn skip_definite_assignment_for_type(&self, declared_type: TypeId) -> bool {
         use tsz_solver::TypeId;
-        use tsz_solver::narrowing::type_contains_undefined;
 
         // tsc gates TS2454 on strictNullChecks. Without it, every type implicitly
         // includes undefined/null, so an uninitialized variable is always valid.
@@ -547,7 +546,10 @@ impl<'a> CheckerState<'a> {
         }
 
         // Skip if the type includes undefined or void (uninitialized variables are undefined)
-        type_contains_undefined(self.ctx.types, declared_type)
+        crate::query_boundaries::flow_analysis::type_contains_undefined(
+            self.ctx.types,
+            declared_type,
+        )
     }
 
     /// - Not in ambient contexts

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -15,7 +15,7 @@ pub(crate) use super::common::{
     contains_type_parameters, function_shape_for_type, is_keyof_type,
     is_literal_type_through_type_constraints, is_narrowing_literal, is_type_parameter_like,
     is_union_type, is_unit_type, is_unknown_narrowing_literal, object_shape_for_type,
-    stringify_literal_type, tuple_elements as tuple_elements_for_type,
+    stringify_literal_type, tuple_elements as tuple_elements_for_type, type_contains_undefined,
     union_members as union_members_for_type,
 };
 

--- a/crates/tsz-checker/src/query_boundaries/type_predicates.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_predicates.rs
@@ -15,6 +15,10 @@ pub(crate) fn is_top_level_error_or_error_union_member(
         })
 }
 
+pub(crate) fn type_contains_undefined(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    tsz_solver::narrowing::type_contains_undefined(db, type_id)
+}
+
 pub(crate) fn contains_conditional_with_application_extends(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_functions.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_functions.rs
@@ -361,7 +361,10 @@ impl<'a> CheckerState<'a> {
             if param.question_token
                 && type_id != TypeId::ANY
                 && type_id != TypeId::ERROR
-                && !tsz_solver::narrowing::type_contains_undefined(self.ctx.types, type_id)
+                && !crate::query_boundaries::type_predicates::type_contains_undefined(
+                    self.ctx.types,
+                    type_id,
+                )
             {
                 type_id = self.ctx.types.factory().union2(type_id, TypeId::UNDEFINED);
             }

--- a/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
@@ -153,3 +153,48 @@ fn in_condition_narrowing_routes_through_flow_query_boundary() {
         "checker `in` narrowing should not construct and apply `InProperty` guards locally"
     );
 }
+
+#[test]
+fn definite_assignment_undefined_skip_uses_flow_query_boundary() {
+    let usage_source = fs::read_to_string("src/flow/flow_analysis/usage.rs")
+        .expect("failed to read flow usage source");
+    let boundary_source = fs::read_to_string("src/query_boundaries/flow_analysis.rs")
+        .expect("failed to read flow analysis boundary source");
+    let compact_usage: String = usage_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let compact_boundary: String = boundary_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+
+    assert!(
+        compact_boundary.contains("type_contains_undefined,"),
+        "flow analysis boundary should expose the solver-owned undefined predicate"
+    );
+    assert!(
+        compact_usage.contains("query_boundaries::flow_analysis::type_contains_undefined("),
+        "TS2454 flow usage should ask the flow query boundary for undefined membership"
+    );
+    assert!(
+        !compact_usage.contains("tsz_solver::narrowing::type_contains_undefined"),
+        "flow usage should not import the solver narrowing predicate directly"
+    );
+}
+
+#[test]
+fn direct_source_file_optional_param_undefined_check_uses_query_boundary() {
+    let source = fs::read_to_string("src/state/type_analysis/cross_file_direct_functions.rs")
+        .expect("failed to read direct source-file function lowering source");
+    let compact_source: String = source.chars().filter(|c| !c.is_whitespace()).collect();
+
+    assert!(
+        compact_source.contains("query_boundaries::type_predicates::type_contains_undefined("),
+        "direct source-file optional parameter lowering should ask a query boundary for undefined membership"
+    );
+    assert!(
+        !compact_source.contains("tsz_solver::narrowing::type_contains_undefined"),
+        "direct source-file lowering should not call the solver narrowing predicate directly"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
M1-D flow graph and solver-owned narrowing predicates; refactor-only boundary ratchet.

## Invariant
When checker code needs to know whether a flow/lowered type includes `undefined`, checker supplies the source/control-flow context and asks a query boundary; the solver-owned narrowing predicate computes the semantic membership answer.

## Scope
- Re-export the solver-owned `type_contains_undefined` predicate through `query_boundaries::flow_analysis` for flow usage.
- Route `flow_analysis/usage.rs` TS2454 skip logic through that flow boundary instead of importing `tsz_solver::narrowing` directly.
- Route direct source-file optional-parameter lowering through `query_boundaries::type_predicates::type_contains_undefined` instead of calling the solver predicate directly or adding new `query_boundaries::common` debt.
- Add focused source-structure tests to prevent direct solver predicate calls from returning in those checker paths.

## Project Corpus Impact
- Row: n/a
- Bug family: flow/narrowing boundary hygiene, no behavior change intended.
- Evidence: refactor-only wrapper routes; no fixture-specific or project-row logic added.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- Attempted focused `scripts/safe-run.sh cargo nextest run -p tsz-checker -E 'test(definite_assignment_undefined_skip_uses_flow_query_boundary) | test(direct_source_file_optional_param_undefined_check_uses_query_boundary)'`; local link failed with `ENOSPC` after compiling, so PR-head CI owns the compiled test signal.
- PR-head CI must be green before native queue admission; a body edit after the previous green run made GitHub expect a fresh protected `CI Summary`, so this body is intentionally head-neutral before the final synchronize run.

## Coordination Notes
- M1-D owns #12680; branch is rebased onto current `origin/main` and contains only the undefined-membership boundary route.
- #12555 is M4-C-owned and already native-queued separately.
- No overlap with M1-B #12648: this PR only routes undefined-membership predicates through query boundaries.
