### PR TITLE
perf(tools): map generic-function hotspot closure

### DIFF
--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -304,7 +304,9 @@ withTempDir((dir) => {
     /TSZ_PERF_COUNTERS=1 .*<generated-200-classes>\.ts/,
   );
   assert.match(
-    byName.get("200 generic functions").loss_closure.attribution_command,
+    report.target_gaps
+      .find((row) => row.name === "200 generic functions")
+      .loss_closure.attribution_command,
     /TSZ_PERF_COUNTERS=1 .*<generated-200-generic-functions>\.ts/,
   );
   assert.deepEqual(report.totals.missing_attribution_rows, [

--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -313,7 +313,7 @@ withTempDir((dir) => {
   ]);
   assert.deepEqual(
     report.target_gaps.map((row) => row.name),
-    ["200 generic functions", "BCT candidates=200", "200 classes"],
+    ["BCT candidates=200", "200 classes", "200 generic functions"],
   );
   assert.equal(report.two_x_target.rows_below_target, 3);
   assert.equal(report.two_x_target.rows_with_attribution, 0);

--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -281,6 +281,15 @@ withTempDir((dir) => {
         winner: "tsgo",
         factor: 1.06,
       },
+      {
+        name: "200 generic functions",
+        lines: 4200,
+        kb: 120,
+        tsz_ms: 396.48,
+        tsgo_ms: 404.57,
+        winner: "tsz",
+        factor: 1.02,
+      },
     ],
   });
 
@@ -294,18 +303,23 @@ withTempDir((dir) => {
     byName.get("200 classes").loss_closure.attribution_command,
     /TSZ_PERF_COUNTERS=1 .*<generated-200-classes>\.ts/,
   );
+  assert.match(
+    byName.get("200 generic functions").loss_closure.attribution_command,
+    /TSZ_PERF_COUNTERS=1 .*<generated-200-generic-functions>\.ts/,
+  );
   assert.deepEqual(report.totals.missing_attribution_rows, [
     "200 classes",
     "BCT candidates=200",
   ]);
   assert.deepEqual(
     report.target_gaps.map((row) => row.name),
-    ["BCT candidates=200", "200 classes"],
+    ["200 generic functions", "BCT candidates=200", "200 classes"],
   );
-  assert.equal(report.two_x_target.rows_below_target, 2);
+  assert.equal(report.two_x_target.rows_below_target, 3);
   assert.equal(report.two_x_target.rows_with_attribution, 0);
   assert.deepEqual(report.two_x_target.missing_attribution_rows, [
     "200 classes",
+    "200 generic functions",
     "BCT candidates=200",
   ]);
 });

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -98,6 +98,20 @@ const LOSS_CLOSURE_BY_ROW = new Map([
       url: "https://github.com/tsz-org/tsz/issues/8858",
     },
   ],
+  [
+    "200 generic functions",
+    {
+      owner: "Track 10 generic function scaling guard",
+      operation:
+        "generic async function checking with recursive DeepPartial option types and Promise<Result<T>> return construction",
+      command:
+        "scripts/safe-run.sh ./scripts/bench/perf-hotspots.sh --filter '^200 generic functions$' --json-file <artifact>.json",
+      attribution_command:
+        "TSZ_PERF_COUNTERS=1 .target/release/tsz --extendedDiagnostics --perf-counters-json <artifact>.perf.json --noEmit <generated-200-generic-functions>.ts",
+      issue: 12271,
+      url: "https://github.com/tsz-org/tsz/issues/12271",
+    },
+  ],
 ]);
 
 function lossClosureForRow(row) {


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance / benchmark attribution tooling for #12271.

## Invariant
When a green benchmark row falls below the 2x target, the `tsgo-winner-report` should identify the owner family and attribution command needed to investigate the repeated operation. This PR changes benchmark reporting metadata only; it does not change compiler behavior or benchmark timings.

## Scope
- `scripts/bench/tsgo-winner-report.mjs`
- `scripts/bench/test-tsgo-winner-report.mjs`

## Project Corpus Impact
- Row: n/a
- Bug family: #12271 synthetic generic-function scaling attribution.
- Evidence: Bench run `27003419354` on `d707ca16f3823cc12822404c4ee1100e77210f95` published `bench-results-synthetic` where `200 generic functions` was green but only `1.02x` in favor of tsz (`396.48ms` vs `404.57ms`). The shard has `two_x_target: null`, so this is a scaling clue, not a completion/failure claim. This PR makes future target-gap reports point to the relevant hotspot command and perf-counter attribution command.

## Verification
- `git diff --check HEAD~1..HEAD`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`
- `node scripts/bench/test-tsgo-winner-report.mjs`
- GitHub PR checks on head `47ec62bf43`: `gate`, `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `CI Light Summary` passed; heavy compiler/project suites were skipped by path gating.
- Not run: compiler tests, conformance, project compile guard, or benchmarks; this is benchmark-report metadata and unit-fixture coverage only.

## Coordination Notes
- Ready for manager review on head `47ec62bf43`; the refreshed CI after the test-fixture correction is green.
- Related to #12678 only by #12271 attribution/observability; it does not overlap the solver `TypeInterner` residency slice.
- No merge-queue action by Studio-B.



### Current Head Update: 47ec62bf43

AgentName: Studio-B

Fixed the report test fixture so the `200 generic functions` metadata assertion checks `target_gaps`, where tsz-wins-below-2x rows are reported, instead of `rows`, which intentionally contains only green `tsgo` winners.

Verification:
- `git diff --check`
- `node scripts/bench/test-tsgo-winner-report.mjs`
- GitHub PR checks on head `47ec62bf43`: `gate`, `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `CI Light Summary` passed.

Coordination Notes:
- No compiler behavior or benchmark timing changed.
- No merge-queue action taken by Studio-B.
