### PR TITLE
perf(solver): skip disjoint object BCT tournament

### DIFF
--- a/crates/tsz-solver/src/operations/expression_ops.rs
+++ b/crates/tsz-solver/src/operations/expression_ops.rs
@@ -904,6 +904,15 @@ pub fn compute_best_common_type_cached<R: TypeResolver>(
         return interner.union(widened);
     }
 
+    // If every object candidate has a required primitive field name that no
+    // sibling has, no candidate can be a supertype of all siblings: every other
+    // sibling is missing that required field. The fallback subtype-reduction
+    // pass would keep the same list, so skip both the tournament and the
+    // fallback pairwise walk for wide disjoint object candidate sets.
+    if bct_candidates_proven_pairwise_incomparable_by_unique_required_fields(interner, &widened) {
+        return interner.union(widened);
+    }
+
     // Step 2: Find the best common type from the candidate types
     // TypeScript rule: The best common type must be one of the input types
     // For example: [Dog, Cat] -> Dog | Cat (NOT Animal, even if both extend Animal)
@@ -1025,7 +1034,7 @@ fn remove_subtypes_for_bct<R: TypeResolver>(
         return hit;
     }
 
-    if subtype_reduction_proven_noop_by_unique_required_fields(interner, types) {
+    if bct_candidates_proven_pairwise_incomparable_by_unique_required_fields(interner, types) {
         let result: Arc<[TypeId]> = Arc::from(types.to_vec());
         if let (Some(db), Some(key)) = (query_db, cache_key) {
             db.insert_subtype_reduction_cache(key, result.clone());
@@ -1092,7 +1101,7 @@ fn remove_subtypes_for_bct<R: TypeResolver>(
     result
 }
 
-fn subtype_reduction_proven_noop_by_unique_required_fields(
+fn bct_candidates_proven_pairwise_incomparable_by_unique_required_fields(
     interner: &dyn TypeDatabase,
     types: &[TypeId],
 ) -> bool {

--- a/crates/tsz-solver/src/operations/expression_ops.rs
+++ b/crates/tsz-solver/src/operations/expression_ops.rs
@@ -910,6 +910,10 @@ pub fn compute_best_common_type_cached<R: TypeResolver>(
     // pass would keep the same list, so skip both the tournament and the
     // fallback pairwise walk for wide disjoint object candidate sets.
     if bct_candidates_proven_pairwise_incomparable_by_unique_required_fields(interner, &widened) {
+        if resolver.is_some() {
+            let reduced = remove_subtypes_for_bct(interner, query_db, &widened, resolver);
+            return interner.union(reduced.to_vec());
+        }
         return interner.union(widened);
     }
 

--- a/crates/tsz-solver/tests/expression_ops_tests.rs
+++ b/crates/tsz-solver/tests/expression_ops_tests.rs
@@ -879,6 +879,55 @@ fn test_bct_cache_no_query_db_disables_cache() {
 }
 
 #[test]
+fn test_bct_unique_required_fields_skip_subtype_reduction_cache_probe() {
+    // Wide object candidate lists whose members each have a distinct required
+    // primitive field are pairwise incomparable: no sibling can be a subtype of
+    // another sibling that requires a field it does not have. BCT may therefore
+    // go straight to the fallback union without probing the subtype-reduction
+    // cache.
+    use crate::caches::query_cache::QueryCache;
+    use crate::types::PropertyInfo;
+
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let prop_alpha = interner.intern_string("alpha");
+    let prop_beta = interner.intern_string("beta");
+    let prop_gamma = interner.intern_string("gamma");
+
+    let alpha = interner.object(vec![PropertyInfo::new(prop_alpha, TypeId::NUMBER)]);
+    let beta = interner.object(vec![PropertyInfo::new(prop_beta, TypeId::STRING)]);
+    let gamma = interner.object(vec![PropertyInfo::new(prop_gamma, TypeId::BOOLEAN)]);
+
+    let stats0 = db.statistics();
+    let result = crate::operations::expression_ops::compute_best_common_type_cached::<NoopResolver>(
+        &interner,
+        Some(&db),
+        &[alpha, beta, gamma],
+        None,
+    );
+    let stats1 = db.statistics();
+
+    assert_eq!(
+        stats1.subtype_reduction_cache_entries, stats0.subtype_reduction_cache_entries,
+        "unique required-field proof should skip subtype-reduction cache population"
+    );
+    assert_eq!(
+        stats1.subtype_reduction_cache_misses, stats0.subtype_reduction_cache_misses,
+        "unique required-field proof should skip subtype-reduction cache lookup"
+    );
+
+    let Some(crate::types::TypeData::Union(list_id)) = interner.lookup(result) else {
+        panic!("expected BCT fallback to produce a union");
+    };
+    let members = interner.type_list(list_id);
+    assert_eq!(members.len(), 3);
+    assert!(members.contains(&alpha));
+    assert!(members.contains(&beta));
+    assert!(members.contains(&gamma));
+}
+
+#[test]
 fn test_bct_cache_resolver_present_distinct_from_absent() {
     // Same input TypeIds, but `resolver = Some(_)` vs `None` must occupy
     // distinct cache slots — a no-resolver answer cached and served back

--- a/crates/tsz-solver/tests/expression_ops_tests.rs
+++ b/crates/tsz-solver/tests/expression_ops_tests.rs
@@ -598,7 +598,10 @@ fn test_bct_unique_required_fields_prove_subtype_reduction_noop() {
     });
 
     assert!(
-        subtype_reduction_proven_noop_by_unique_required_fields(&interner, &[a, b, c]),
+        bct_candidates_proven_pairwise_incomparable_by_unique_required_fields(
+            &interner,
+            &[a, b, c]
+        ),
         "unique required public fields should prove that no object candidate is a subtype"
     );
 
@@ -622,7 +625,7 @@ fn test_bct_unique_required_fields_noop_proof_rejects_optional_and_indexed_shape
     let optional_a = interner.object(vec![PropertyInfo::opt(name_a, TypeId::NUMBER)]);
     let required_b = interner.object(vec![PropertyInfo::new(name_b, TypeId::NUMBER)]);
     assert!(
-        !subtype_reduction_proven_noop_by_unique_required_fields(
+        !bct_candidates_proven_pairwise_incomparable_by_unique_required_fields(
             &interner,
             &[optional_a, required_b]
         ),
@@ -640,7 +643,7 @@ fn test_bct_unique_required_fields_noop_proof_rejects_optional_and_indexed_shape
         ..ObjectShape::default()
     });
     assert!(
-        !subtype_reduction_proven_noop_by_unique_required_fields(
+        !bct_candidates_proven_pairwise_incomparable_by_unique_required_fields(
             &interner,
             &[indexed_a, required_b]
         ),


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance / best-common-type scale guard for #12271.

## Invariant
When every object BCT candidate has a public required primitive property name that no sibling has, no sibling can be a subtype of another candidate requiring that missing property. This PR lets the solver use that structural proof before the BCT tournament and fallback subtype-reduction walk, preserving the same fallback union result through the solver layer.

## Scope
- `crates/tsz-solver/src/operations/expression_ops.rs`
- `crates/tsz-solver/tests/expression_ops_tests.rs`

## Project Corpus Impact
- Row: `BCT candidates=200`
- Bug family: #12271 best-common-type fallback candidate subtype reduction.
- Before evidence: Bench run `27003419354` on `d707ca16f3823cc12822404c4ee1100e77210f95` published `bench-results-algorithmic-bct` where `BCT candidates=200` was green but a `tsgo` winner at `1.05x` (`tsz_ms=548.07`, `tsgo_ms=522.09`). The same run's generated report showed `2x target gaps: 1/4` for the BCT shard. This is before evidence only; no after timing is claimed yet.

## Verification
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`
- Pre-commit formatting hook ran during both commits.
- GitHub PR checks on head `4ab8540fed`: `gate` and `CI Light Summary` passed on the current draft-mode run; earlier exact-head checks had `project-row-drift`, `cargo-shear`, `cargo-deny`, `lint`, and `unit-cloudbuild` passing. Draft-mode broad jobs are skipped until ready.
- Ready handoff note: focused BCT timing is still needed before claiming row movement.
- Not run locally: Rust tests, conformance, project compile guard, or benchmarks. CI/targeted reviewer verification should cover the added BCT unit test and, if useful, a narrow `BCT candidates=200` benchmark after build artifacts are available.

## Coordination Notes
- Ready for manager review/CI expansion; reviewer/manager should decide whether to run focused `BCT candidates=200` timing before merge.
- Overlap checked against current Studio-B PRs; this is a solver BCT structural fast path, distinct from #12681 report metadata and #12678 TypeInterner predicate-cache residency observability.
- No merge-queue action by Studio-B.

