### PR TITLE
perf(checker): cache globalThis type query surface

### DIFF
--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -1,7 +1,29 @@
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::cell::Cell;
 use std::sync::Arc;
 use tsz_binder::SymbolId;
 use tsz_solver::{TypeId, TypeParamInfo};
+
+/// File-local synthetic type-node surface caches.
+#[derive(Debug, Default)]
+pub struct TypeNodeSurfaceCaches {
+    /// Cached synthetic `typeof globalThis` surface for this checker file.
+    ///
+    /// The surface is derived from current-file and lib value globals, so it is
+    /// checker-local rather than `ProgramContext`-shared. The in-progress bit
+    /// breaks nested `typeof globalThis` annotations while the surface itself is
+    /// being built; those recursive self-edges use `unknown`, matching the
+    /// explicit `globalThis` self-property fallback.
+    pub global_this_type: Cell<Option<TypeId>>,
+    pub global_this_type_in_progress: Cell<bool>,
+}
+
+impl TypeNodeSurfaceCaches {
+    pub fn clear(&self) {
+        self.global_this_type.set(None);
+        self.global_this_type_in_progress.set(false);
+    }
+}
 
 /// Checker-local memos for type-reference argument validation.
 #[derive(Debug, Default)]
@@ -29,6 +51,8 @@ pub struct TypeReferenceValidationCaches {
     /// underneath `conditional_branch_constraint` because different conditional
     /// aliases can expose the same mapped-object branch/value constraint pair.
     pub indexed_object_map_branch_constraint: FxHashMap<(TypeId, TypeId), bool>,
+    /// Synthetic type-node surfaces cached for the active checker file.
+    pub type_node_surface: TypeNodeSurfaceCaches,
 }
 
 /// Sparse cache for node-index-keyed `TypeId` lookups.

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -280,6 +280,9 @@ impl<'a> CheckerContext<'a> {
         self.type_reference_validation_caches
             .indexed_object_map_branch_constraint
             .clear();
+        self.type_reference_validation_caches
+            .type_node_surface
+            .clear();
         self.in_conditional_extends_depth = 0;
         self.typeof_param_scope.clear();
         self.type_param_constraint_excluded_params.clear();

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -11,7 +11,8 @@ mod cross_file_delegation_cache;
 mod cross_file_type_params_cache;
 pub use cache_statistics::CheckerContextCacheStatistics;
 pub use caches::{
-    NarrowableIdentifierCache, NodeTypeCache, SymbolTypeCache, TypeReferenceValidationCaches,
+    NarrowableIdentifierCache, NodeTypeCache, SymbolTypeCache, TypeNodeSurfaceCaches,
+    TypeReferenceValidationCaches,
 };
 pub(crate) use compiler_options::is_declaration_file_name;
 pub(crate) use compiler_options::is_js_file_name;

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -1141,6 +1141,30 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     }
 
     fn get_global_this_type(&mut self, _error_node: NodeIndex) -> TypeId {
+        if let Some(cached) = self
+            .ctx
+            .type_reference_validation_caches
+            .type_node_surface
+            .global_this_type
+            .get()
+        {
+            return cached;
+        }
+        if self
+            .ctx
+            .type_reference_validation_caches
+            .type_node_surface
+            .global_this_type_in_progress
+            .get()
+        {
+            return TypeId::UNKNOWN;
+        }
+        self.ctx
+            .type_reference_validation_caches
+            .type_node_surface
+            .global_this_type_in_progress
+            .set(true);
+
         let mut names = rustc_hash::FxHashSet::default();
         for (name, _) in self.ctx.binder.file_locals.iter() {
             names.insert(name.clone());
@@ -1183,10 +1207,21 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             properties.push(prop);
         }
 
-        self.ctx.types.factory().object_with_index(ObjectShape {
+        let global_this_type = self.ctx.types.factory().object_with_index(ObjectShape {
             properties,
             ..ObjectShape::default()
-        })
+        });
+        self.ctx
+            .type_reference_validation_caches
+            .type_node_surface
+            .global_this_type
+            .set(Some(global_this_type));
+        self.ctx
+            .type_reference_validation_caches
+            .type_node_surface
+            .global_this_type_in_progress
+            .set(false);
+        global_this_type
     }
 
     fn global_this_surface_symbol(&self, name: &str) -> Option<tsz_binder::SymbolId> {


### PR DESCRIPTION
AgentName: Studio-Opus

## Track
Track 10 performance / benchmark blocker (#12462 pino timeout layer)

## Invariant
When synthesizing `typeof globalThis`, `tsc` exposes the current file plus lib value-global surface without recursively rebuilding that surface for nested `typeof globalThis` annotations. This PR makes tsz build the checker-local global surface once per file through the checker type-node cache bucket; nested self-edges while the surface is in progress resolve to `unknown`, matching the existing explicit `globalThis` self-property fallback.

## Scope
- Add a file-local `TypeNodeSurfaceCaches` bucket under the existing `TypeReferenceValidationCaches` field, avoiding a new `CheckerContext` field.
- Cache the synthetic `typeof globalThis` object for the active checker file.
- Reset the cache at the file-session boundary with the other type-node validation caches.

## Project Corpus Impact
- Row: pinojs/pino
- Bug family: #12462 pino timeout layer

Pino remains a timeout-class project blocker, but this removes the visible repeated `typeof globalThis` layer called out in #12462 and reduces sampled pino work in an exact-main paired profile:

- `get_global_this_type`: 2412 -> 1 sampled frames
- `global_this_surface_symbol`: 53 -> 0 sampled frames
- `declared_annotation_type_for_type_query_symbol`: 2330 -> 1 sampled frames
- `evaluate_mapped`: 13886 -> 13146 sampled frames
- `build_index_signature`: 13542 -> 12824 sampled frames
- physical footprint: 700.7M -> 695.0M
- peak physical footprint: 701.7M -> 699.9M

Measurement mode: attribution sampling, not a `tsgo` timing claim. Fixture: `pinojs/pino` at the existing `.target-bench/external/pino-live` checkout. Commands used `TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 tsz --noEmit -p . --pretty false` plus macOS `sample` after 3s for 8s. Both before/after runs produced zero stdout/stderr diagnostics.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test global_this_property_access_diagnostics_tests`
- `scripts/safe-run.sh --limit 16384 -- cargo build --profile dist-fast -p tsz-cli --bin tsz`
- Paired pino attribution samples:
  - baseline binary copied from exact `origin/main`: `/tmp/studio-opus-pino-origin-main.sample.txt`
  - patched binary: `/tmp/studio-opus-pino-global-this-2.sample.txt`

## Coordination Notes
- Continues #12462 after #12573’s filename-index layer; does not overlap ordinary Studio-B solver mapped-type PRs.
- Cache key: active checker file/session, because the surface depends on current-file globals plus lib globals.
- Reset boundary: `CheckerContext::reset_for_next_file()` clears `type_node_surface` with the other type-reference/type-node caches.
- Behavior when cache is absent: the existing builder runs and produces the same `ObjectShape`; the cache only reuses that result within the same checker file.
- Known noise: attribution samples are not wall-time claims and should not be compared against timing-mode `tsgo` artifacts.

Post-main-refresh verification (base 27143608111a4530d24bdd6d732966ac4b478c9a, head e682883a8bc87206bc55673140a34c39e7cabfae):
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- Diff after refresh remains limited to checker cache/type-query files: `crates/tsz-checker/src/context/caches.rs`, `crates/tsz-checker/src/context/file_session_reset.rs`, `crates/tsz-checker/src/context/mod.rs`, and `crates/tsz-checker/src/types/type_node_advanced.rs`.