### PR TITLE
perf(cli): keep large fresh checks parallel

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -224,6 +224,16 @@ fn parallel_file_session_reuse_requested() -> bool {
     )
 }
 
+const fn should_use_sequential_fresh_checking(
+    work_item_count: usize,
+    has_large_wildcard_barrel: bool,
+    has_parallel_order_sensitive_global_lib: bool,
+) -> bool {
+    work_item_count <= FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES
+        || has_large_wildcard_barrel
+        || has_parallel_order_sensitive_global_lib
+}
+
 const fn needs_separate_boxed_prime_checker(
     no_emit: bool,
     emit_declarations: bool,
@@ -1266,23 +1276,18 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
             let parallel_reuse_requested = parallel_file_session_reuse_requested();
             let has_parallel_order_sensitive_global_lib =
                 has_parallel_order_sensitive_global_lib(checker_libs);
-            let use_sequential_checking = work_items.len() <= 32
-                || has_large_wildcard_barrel(WildcardBarrelAnalysisInput {
+            let has_large_wildcard_barrel =
+                has_large_wildcard_barrel(WildcardBarrelAnalysisInput {
                     files: &program.files,
                     wildcard_reexports: &program.wildcard_reexports,
                     work_items: &work_items,
                     large_export_threshold: LARGE_WILDCARD_BARREL_EXPORTS,
-                })
-                // DOM-style global declarations are order-sensitive with
-                // multiple concurrent checker contexts. Keep those projects
-                // on the deterministic single-worker path until global
-                // lookup state is fully parallel-stable.
-                || has_parallel_order_sensitive_global_lib
-                // Fresh per-file checkers can observe project-level lib/global
-                // state in scheduler order when run concurrently. If the
-                // session-reuse path is explicitly disabled, keep the fallback
-                // deterministic by using fresh checkers sequentially.
-                || !reuse_requested;
+                });
+            let use_sequential_checking = should_use_sequential_fresh_checking(
+                work_items.len(),
+                has_large_wildcard_barrel,
+                has_parallel_order_sensitive_global_lib,
+            );
             // T2.1.B (`PERFORMANCE_PLAN.md` §6 PR table): the sequential
             // no-emit path *can* construct one `CheckerState` and re-target
             // it across files via `CheckerContext::switch_to_file` instead

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
@@ -685,6 +685,28 @@ const checked: boolean = Op.is(made);
         );
     }
 
+#[test]
+fn large_reuse_off_batches_keep_fresh_parallel_eligible() {
+    let large_project = FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES + 1;
+
+    assert!(
+        !should_use_sequential_fresh_checking(large_project, false, false),
+        "large fresh-checker batches should stay parallel-eligible even when session reuse is off"
+    );
+    assert!(
+        should_use_sequential_fresh_checking(10, false, false),
+        "tiny batches stay sequential for deterministic cross-file behavior"
+    );
+    assert!(
+        should_use_sequential_fresh_checking(large_project, true, false),
+        "large wildcard barrels stay on the deterministic sequential fallback"
+    );
+    assert!(
+        should_use_sequential_fresh_checking(large_project, false, true),
+        "order-sensitive global libraries stay on the deterministic sequential fallback"
+    );
+}
+
     #[test]
     fn tiny_no_emit_reuse_path_covers_boxed_prime_checker() {
         assert!(


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Performance/runtime blocker for #12271 large project benchmark triage.

## Invariant
When a large no-emit project is not in an explicit deterministic-sequential fallback family, disabling file-session reuse must not also disable fresh-checker parallelism. This PR changes the CLI driver scheduling policy only: file-session reuse remains opt-in, while the existing fresh-checker parallel branch stays eligible for large safe workloads.

## Scope
- `crates/tsz-cli/src/driver/check.rs`: separates sequential fallback selection from file-session reuse opt-in.
- `crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs`: ratchets the policy so large reuse-off batches remain fresh-parallel eligible while tiny batches, large wildcard barrels, and order-sensitive global libs remain sequential.

## Project Corpus Impact
- Row: `large-ts-repo`
- Bug family: runtime timeout / project graph stress
- Before evidence: Bench run `27003419354`, artifact `bench-results-large-ts-repo`, source `d707ca16f3823cc12822404c4ee1100e77210f95`; `large-ts-repo` reached 6061 project files and reported `tsz exit codes 124`, with `tsz` at `1500.376 s` vs `tsgo` at `62.266 s`.
- Expected impact: default no-emit large projects can use existing fresh-checker parallelism instead of falling into sequential fresh-checker dispatch solely because `TSZ_FILE_SESSION_REUSE` is unset.
- After evidence: not yet measured in this PR; focused large-repo timing is still needed before claiming row movement.

## Verification
- `scripts/setup/disk-worktree-guard.sh && git worktree list && scripts/agents/show-goal.sh Studio-B`
- `git fetch origin main`
- `scripts/agents/list-owned-work.sh Studio-B`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`
- Pre-commit formatting hook completed during commit.
- PR-head checks on `1d585a2cdb41207d33637a5c40832b53938681fe`: `gate`, `project-row-drift`, `cargo-shear`, `cargo-deny`, and `lint` passed.
- Pending at ready handoff: `unit`, `unit-cloudbuild`, and `dist-binaries`.
- Not run locally: Rust tests, local large-repo benchmark, or broad benchmark suites.

## Coordination Notes
- Ready for manager review / CI expansion with the timing caveat above; manager can decide whether to request focused large-repo timing before merge.
- No merge queue action requested from this implementation lane.
- Overlap: complements #12683's BCT synthetic-row slice and #12678's residency visibility slice; this PR is limited to CLI project-file dispatch policy.
