### PR TITLE
perf(solver): defer template literal string extraction

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/template_literal.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/template_literal.rs
@@ -7,6 +7,11 @@ use crate::types::{LiteralValue, TemplateLiteralId, TemplateSpan, TypeData, Type
 
 use super::super::evaluate::TypeEvaluator;
 
+struct TemplateSpanExpansion {
+    cardinality: Option<usize>,
+    strings: Vec<String>,
+}
+
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Evaluate a template literal type: `hello${T}world`
     ///
@@ -57,9 +62,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 TemplateSpan::Type(type_id) => {
                     let evaluated = self.evaluate(*type_id);
                     normalized_spans.push(TemplateSpan::Type(evaluated));
-                    let span_count = self.template_span_complexity_cardinality(evaluated);
+                    let expansion = self.template_span_expansion(evaluated);
 
-                    if let Some(span_count) = span_count {
+                    if let Some(span_count) = expansion.cardinality {
                         total_combinations = total_combinations.saturating_mul(span_count);
                         if total_combinations >= TEMPLATE_LITERAL_EXPANSION_LIMIT {
                             self.interner().mark_union_too_complex();
@@ -67,22 +72,22 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         }
                     }
 
-                    let strings = self.extract_literal_strings(evaluated);
-                    if span_count.is_none() && !strings.is_empty() {
-                        total_combinations = total_combinations.saturating_mul(strings.len());
+                    if expansion.cardinality.is_none() && !expansion.strings.is_empty() {
+                        total_combinations =
+                            total_combinations.saturating_mul(expansion.strings.len());
                         if total_combinations >= TEMPLATE_LITERAL_EXPANSION_LIMIT {
                             self.interner().mark_union_too_complex();
                             return TypeId::STRING;
                         }
                     }
 
-                    if strings.is_empty() {
+                    if expansion.strings.is_empty() {
                         // Contains non-literal types. Keep scanning the remaining
                         // spans first so mixed template unions can still trip TS2590.
                         can_fully_expand = false;
                         evaluated_strings.push(None);
                     } else {
-                        evaluated_strings.push(Some(strings));
+                        evaluated_strings.push(Some(expansion.strings));
                     }
                 }
             }
@@ -148,52 +153,97 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Maximum recursion depth for template literal evaluation to prevent stack overflow.
     const MAX_LITERAL_COUNT_DEPTH: u32 = 50;
 
-    fn extract_literal_strings(&self, type_id: TypeId) -> Vec<String> {
-        self.extract_literal_strings_impl(type_id, 0)
+    fn template_span_expansion(&self, type_id: TypeId) -> TemplateSpanExpansion {
+        self.template_span_expansion_impl(type_id, 0)
     }
 
-    fn template_span_complexity_cardinality(&self, type_id: TypeId) -> Option<usize> {
-        self.template_span_complexity_cardinality_impl(type_id, 0)
-    }
-
-    fn template_span_complexity_cardinality_impl(
-        &self,
-        type_id: TypeId,
-        depth: u32,
-    ) -> Option<usize> {
+    fn template_span_expansion_impl(&self, type_id: TypeId, depth: u32) -> TemplateSpanExpansion {
         if depth > Self::MAX_LITERAL_COUNT_DEPTH {
-            return None;
+            return TemplateSpanExpansion {
+                cardinality: None,
+                strings: Vec::new(),
+            };
         }
 
         if type_id == TypeId::BOOLEAN {
-            return Some(2);
+            return TemplateSpanExpansion {
+                cardinality: Some(2),
+                strings: Vec::new(),
+            };
         }
-        if type_id == TypeId::BOOLEAN_TRUE
-            || type_id == TypeId::BOOLEAN_FALSE
-            || type_id == TypeId::NULL
-            || type_id == TypeId::UNDEFINED
-            || type_id == TypeId::VOID
-        {
-            return Some(1);
+        if type_id == TypeId::BOOLEAN_TRUE {
+            return TemplateSpanExpansion {
+                cardinality: Some(1),
+                strings: vec!["true".to_string()],
+            };
+        }
+        if type_id == TypeId::BOOLEAN_FALSE {
+            return TemplateSpanExpansion {
+                cardinality: Some(1),
+                strings: vec!["false".to_string()],
+            };
+        }
+        if type_id == TypeId::NULL || type_id == TypeId::UNDEFINED || type_id == TypeId::VOID {
+            return TemplateSpanExpansion {
+                cardinality: Some(1),
+                strings: Vec::new(),
+            };
         }
         if type_id.is_intrinsic() {
-            return None;
+            return TemplateSpanExpansion {
+                cardinality: None,
+                strings: Vec::new(),
+            };
         }
 
         match self.interner().lookup(type_id) {
-            Some(TypeData::Literal(_)) | Some(TypeData::StringIntrinsic { .. }) => Some(1),
+            Some(TypeData::Literal(lit)) => TemplateSpanExpansion {
+                cardinality: Some(1),
+                strings: Self::literal_template_string(self, lit)
+                    .into_iter()
+                    .collect(),
+            },
+            Some(TypeData::StringIntrinsic { .. }) => TemplateSpanExpansion {
+                cardinality: Some(1),
+                strings: Vec::new(),
+            },
             Some(TypeData::Enum(_, structural_type)) => {
-                self.template_span_complexity_cardinality_impl(structural_type, depth + 1)
+                self.template_span_expansion_impl(structural_type, depth + 1)
             }
             Some(TypeData::Union(members_id)) => {
                 let members = self.interner().type_list(members_id);
                 let mut count = 0usize;
+                let mut count_known = true;
+                let mut strings = Vec::with_capacity(members.len());
+                let mut all_stringifiable = true;
+
                 for &member in members.iter() {
-                    count = count.checked_add(
-                        self.template_span_complexity_cardinality_impl(member, depth + 1)?,
-                    )?;
+                    let expansion = self.template_span_expansion_impl(member, depth + 1);
+                    if let Some(cardinality) = expansion.cardinality {
+                        if let Some(next_count) = count.checked_add(cardinality) {
+                            count = next_count;
+                        } else {
+                            count_known = false;
+                        }
+                    } else {
+                        count_known = false;
+                    }
+
+                    if expansion.strings.is_empty() {
+                        all_stringifiable = false;
+                    } else if all_stringifiable {
+                        strings.extend(expansion.strings);
+                    }
                 }
-                Some(count)
+
+                TemplateSpanExpansion {
+                    cardinality: count_known.then_some(count),
+                    strings: if all_stringifiable {
+                        strings
+                    } else {
+                        Vec::new()
+                    },
+                }
             }
             Some(TypeData::TemplateLiteral(spans_id)) => {
                 let spans = self.interner().template_list(spans_id);
@@ -202,99 +252,71 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     let span_count = match span {
                         TemplateSpan::Text(_) => 1,
                         TemplateSpan::Type(type_id) => self
-                            .template_span_complexity_cardinality_impl(*type_id, depth + 1)
+                            .template_span_expansion_impl(*type_id, depth + 1)
+                            .cardinality
                             .unwrap_or(1),
                     };
                     total = total.saturating_mul(span_count);
                 }
-                Some(total)
+                TemplateSpanExpansion {
+                    cardinality: Some(total),
+                    strings: Vec::new(),
+                }
             }
-            _ => None,
+            _ => TemplateSpanExpansion {
+                cardinality: None,
+                strings: Vec::new(),
+            },
         }
     }
 
-    /// Internal implementation with depth tracking.
-    fn extract_literal_strings_impl(&self, type_id: TypeId, depth: u32) -> Vec<String> {
-        // Prevent infinite recursion in deeply nested union types
-        if depth > Self::MAX_LITERAL_COUNT_DEPTH {
-            return Vec::new(); // Abort - too deep
-        }
+    fn literal_template_string(&self, lit: LiteralValue) -> Option<String> {
+        match lit {
+            LiteralValue::String(atom) => Some(self.interner().resolve_atom_ref(atom).to_string()),
+            LiteralValue::Number(n) => {
+                // Convert number to string matching JavaScript's Number::toString(10).
+                // ECMAScript spec: use scientific notation if |x| < 10^-6 or |x| >= 10^21.
+                let n_val = n.0;
+                let abs_val = n_val.abs();
 
-        if let Some(TypeData::Union(members)) = self.interner().lookup(type_id) {
-            let members = self.interner().type_list(members);
-            let mut result = Vec::with_capacity(members.len());
-            for &member in members.iter() {
-                let strings = self.extract_literal_strings_impl(member, depth + 1);
-                if strings.is_empty() {
-                    // Union contains a non-stringifiable type
-                    return Vec::new();
-                }
-                result.extend(strings);
-            }
-            result
-        } else if let Some(TypeData::Literal(lit)) = self.interner().lookup(type_id) {
-            match lit {
-                LiteralValue::String(atom) => {
-                    vec![self.interner().resolve_atom_ref(atom).to_string()]
-                }
-                LiteralValue::Number(n) => {
-                    // Convert number to string matching JavaScript's Number::toString(10)
-                    // ECMAScript spec: use scientific notation if |x| < 10^-6 or |x| >= 10^21
-                    let n_val = n.0;
-                    let abs_val = n_val.abs();
+                tracing::trace!(
+                    number = n_val,
+                    abs_val = abs_val,
+                    "extract_literal_strings: converting number to string"
+                );
 
-                    tracing::trace!(
-                        number = n_val,
-                        abs_val = abs_val,
-                        "extract_literal_strings: converting number to string"
-                    );
-
-                    if n_val == 0.0 {
-                        vec!["0".to_string()]
-                    } else if !(1e-6..1e21).contains(&abs_val) {
-                        // Use scientific notation (Rust adds sign for negative exponents, but not positive)
-                        let mut s = format!("{n_val:e}");
-                        // Rust outputs "1e-7" for 1e-7 (good) but "1e21" instead of "1e+21" for 1e21
-                        // We need to add "+" to positive exponents
-                        if s.contains("e") && !s.contains("e-") && !s.contains("e+") {
-                            let parts: Vec<&str> = s.split('e').collect();
-                            if parts.len() == 2 {
-                                s = format!("{}e+{}", parts[0], parts[1]);
-                            }
+                if n_val == 0.0 {
+                    Some("0".to_string())
+                } else if !(1e-6..1e21).contains(&abs_val) {
+                    // Use scientific notation (Rust adds sign for negative exponents, but not positive).
+                    let mut s = format!("{n_val:e}");
+                    // Rust outputs "1e-7" for 1e-7 (good) but "1e21" instead of "1e+21" for 1e21.
+                    // We need to add "+" to positive exponents.
+                    if s.contains("e") && !s.contains("e-") && !s.contains("e+") {
+                        let parts: Vec<&str> = s.split('e').collect();
+                        if parts.len() == 2 {
+                            s = format!("{}e+{}", parts[0], parts[1]);
                         }
-                        tracing::trace!(result = %s, "extract_literal_strings: scientific notation");
-                        vec![s]
-                    } else if n_val.fract() == 0.0 && abs_val < 1e15 {
-                        // Integer-like number - avoid scientific notation
-                        let s = (n_val as i64).to_string();
-                        tracing::trace!(result = %s, "extract_literal_strings: integer-like");
-                        vec![s]
-                    } else {
-                        // Fixed-point notation
-                        let s = format!("{n_val}");
-                        tracing::trace!(result = %s, "extract_literal_strings: fixed-point");
-                        vec![s]
                     }
-                }
-                LiteralValue::Boolean(b) => {
-                    vec![if b {
-                        "true".to_string()
-                    } else {
-                        "false".to_string()
-                    }]
-                }
-                LiteralValue::BigInt(atom) => {
-                    // BigInt literals are stored without the 'n' suffix
-                    vec![self.interner().resolve_atom_ref(atom).to_string()]
+                    tracing::trace!(result = %s, "extract_literal_strings: scientific notation");
+                    Some(s)
+                } else if n_val.fract() == 0.0 && abs_val < 1e15 {
+                    // Integer-like number - avoid scientific notation.
+                    let s = (n_val as i64).to_string();
+                    tracing::trace!(result = %s, "extract_literal_strings: integer-like");
+                    Some(s)
+                } else {
+                    // Fixed-point notation.
+                    let s = format!("{n_val}");
+                    tracing::trace!(result = %s, "extract_literal_strings: fixed-point");
+                    Some(s)
                 }
             }
-        } else if let Some(TypeData::Enum(_, structural_type)) = self.interner().lookup(type_id) {
-            // Enum member types wrap a literal (e.g., AnimalType.cat wraps "cat").
-            // Delegate to the structural type to extract the underlying literal string.
-            self.extract_literal_strings_impl(structural_type, depth + 1)
-        } else {
-            // Not a literal type - can't extract string
-            Vec::new()
+            LiteralValue::Boolean(b) => Some(if b { "true" } else { "false" }.to_string()),
+            LiteralValue::BigInt(atom) => {
+                // BigInt literals are stored without the 'n' suffix.
+                Some(self.interner().resolve_atom_ref(atom).to_string())
+            }
         }
     }
 }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/template_literal.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/template_literal.rs
@@ -57,13 +57,19 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 TemplateSpan::Type(type_id) => {
                     let evaluated = self.evaluate(*type_id);
                     normalized_spans.push(TemplateSpan::Type(evaluated));
-                    let strings = self.extract_literal_strings(evaluated);
-                    let span_count = self
-                        .template_span_complexity_cardinality(evaluated)
-                        .or_else(|| (!strings.is_empty()).then_some(strings.len()));
+                    let span_count = self.template_span_complexity_cardinality(evaluated);
 
                     if let Some(span_count) = span_count {
                         total_combinations = total_combinations.saturating_mul(span_count);
+                        if total_combinations >= TEMPLATE_LITERAL_EXPANSION_LIMIT {
+                            self.interner().mark_union_too_complex();
+                            return TypeId::STRING;
+                        }
+                    }
+
+                    let strings = self.extract_literal_strings(evaluated);
+                    if span_count.is_none() && !strings.is_empty() {
+                        total_combinations = total_combinations.saturating_mul(strings.len());
                         if total_combinations >= TEMPLATE_LITERAL_EXPANSION_LIMIT {
                             self.interner().mark_union_too_complex();
                             return TypeId::STRING;
@@ -125,8 +131,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
 
         let literal_types: Vec<TypeId> = combinations
-            .iter()
-            .map(|s| self.interner().literal_string(s))
+            .into_iter()
+            .map(|s| self.interner().literal_string(&s))
             .collect();
 
         if literal_types.len() == 1 {
@@ -216,7 +222,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         if let Some(TypeData::Union(members)) = self.interner().lookup(type_id) {
             let members = self.interner().type_list(members);
-            let mut result = Vec::new();
+            let mut result = Vec::with_capacity(members.len());
             for &member in members.iter() {
                 let strings = self.extract_literal_strings_impl(member, depth + 1);
                 if strings.is_empty() {


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Performance tuning for #12271 eligible green solver-stress row below the 2x `tsgo` target.

## Invariant
When a template literal interpolation has a finite structural cardinality, `tsz` should account for expansion complexity in the solver before materializing string alternatives. For literal-union spans that still need expansion, `tsz` should collect cardinality and string alternatives in one bounded solver traversal. Expansion limits, `TS2590` union-too-complex behavior, non-literal fallback to template-literal types, and template-literal semantics are unchanged.

## Scope
- `crates/tsz-solver/src/evaluation/evaluate_rules/template_literal.rs`: evaluates each interpolation once, fuses template-span cardinality with literal-string extraction for unions/enums/literals, avoids extracting strings when cardinality alone proves the expansion is too complex, consumes generated combinations while interning literals, and preserves boolean literal expansion in the fused helper.

## Project Corpus Impact
- Row: `Template literal N=45`
- Bug family: solver-stress template literal Cartesian-product pressure.
- Before evidence: Bench run `27003419354`, artifact `bench-results-merged` / `bench-results-tsgo-winners.json`, source `d707ca16f3823cc12822404c4ee1100e77210f95`; row is green with `tsz_ms=423.48`, `tsgo_ms=644.98`, winner `tsz`, factor `1.52x`, below the 2x target.
- Expected impact: avoid double-walking literal union spans for cardinality and extraction, and skip string allocation for spans that already prove `TEMPLATE_LITERAL_EXPANSION_LIMIT` will be hit.
- After evidence: not measured locally in this PR because the machine is below the TSZ disk floor (`7 GB` free vs `20 GB` minimum). Focused `Template literal N=45` timing is still needed before claiming row movement.

## Verification
- `scripts/setup/disk-worktree-guard.sh && scripts/agents/show-goal.sh Studio-B && git status --short --branch`
- `git fetch origin main`
- `scripts/setup/disk-worktree-guard.sh --auto-prune && scripts/setup/clean.sh --quiet && scripts/setup/disk-worktree-guard.sh`
- Bench artifact inspection only: `gh run list --repo tsz-org/tsz --workflow bench.yml --limit 10 --json ...`; `gh run download 27003419354 --repo tsz-org/tsz --name bench-results-merged --dir /tmp/...`; `jq` over `bench-results-tsgo-winners.json`.
- Pre-commit formatting hook completed during commit `d0b517b65e`.
- Branch synced with `origin/main` and pushed at `7df5e901b6`.
- Not run locally: Rust tests, local solver-stress benchmark, broad benchmark suites.

## Coordination Notes
- Ready for manager review / CI expansion with the timing caveat above; manager can decide whether to request focused `Template literal N=45` timing before merge.
- No merge queue action requested from this implementation lane.
- Overlap: complements #12686's large project scheduling slice and #12683's BCT synthetic slice; this PR is limited to solver template-literal evaluation ordering/allocation.
