### PR TITLE
refactor(checker): route falsy condition narrowing through flow boundary

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -1,7 +1,8 @@
 use super::FlowAnalyzer;
 use crate::query_boundaries::flow as flow_boundary;
 use crate::query_boundaries::flow_analysis::{
-    empty_object_type, is_union_type, is_unit_type, is_unknown_narrowing_literal,
+    self as flow_query, empty_object_type, is_union_type, is_unit_type,
+    is_unknown_narrowing_literal,
 };
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use tsz_binder::{FlowNodeId, SymbolId, symbol_flags};
@@ -12,6 +13,11 @@ use tsz_solver::TypeId;
 use tsz_solver::narrowing::{GuardSense, NarrowingContext, TypeGuard, TypeofKind};
 
 impl<'a> FlowAnalyzer<'a> {
+    fn narrow_to_falsy_via_flow_boundary(&self, type_id: TypeId) -> TypeId {
+        let env_borrow = self.type_environment.as_ref().map(|env| env.borrow());
+        flow_query::narrow_to_falsy(self.interner, env_borrow.as_deref(), type_id)
+    }
+
     fn union_logical_condition_branches(&self, types: Vec<TypeId>) -> TypeId {
         let mut members = Vec::with_capacity(types.len());
         let mut saw_reachable = false;
@@ -917,7 +923,7 @@ impl<'a> FlowAnalyzer<'a> {
                         return flow_boundary::narrow_non_nullish(self.interner, type_id);
                     }
                     // False branch - keep only falsy types (use Solver for NaN handling)
-                    return narrowing.narrow_to_falsy(type_id);
+                    return self.narrow_to_falsy_via_flow_boundary(type_id);
                 }
             }
 
@@ -1712,19 +1718,12 @@ impl<'a> FlowAnalyzer<'a> {
             || operator == SyntaxKind::QuestionQuestionEqualsToken as u16)
             && self.is_matching_reference(bin.left, target)
         {
-            let env_borrow;
-            let narrowing = if let Some(env) = &self.type_environment {
-                env_borrow = env.borrow();
-                self.make_narrowing_context().with_resolver(&*env_borrow)
-            } else {
-                self.make_narrowing_context()
-            };
             if is_true_branch {
                 // x holds the truthy result → remove null/undefined
                 return Some(flow_boundary::narrow_non_nullish(self.interner, type_id));
             }
             // x holds the falsy result → keep only falsy types
-            return Some(narrowing.narrow_to_falsy(type_id));
+            return Some(self.narrow_to_falsy_via_flow_boundary(type_id));
         }
         // For non-matching references, fall through to || handling below
 

--- a/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
@@ -198,3 +198,32 @@ fn direct_source_file_optional_param_undefined_check_uses_query_boundary() {
         "direct source-file lowering should not call the solver narrowing predicate directly"
     );
 }
+
+#[test]
+fn condition_false_branch_falsy_narrowing_uses_flow_query_boundary() {
+    let condition_source = fs::read_to_string("src/flow/control_flow/condition_narrowing.rs")
+        .expect("failed to read condition narrowing source");
+    let boundary_source = fs::read_to_string("src/query_boundaries/flow_analysis.rs")
+        .expect("failed to read flow analysis boundary source");
+    let compact_condition: String = condition_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let compact_boundary: String = boundary_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+
+    assert!(
+        compact_boundary.contains("fnnarrow_to_falsy("),
+        "flow analysis boundary should expose solver-owned falsy narrowing"
+    );
+    assert!(
+        compact_condition.contains("flow_query::narrow_to_falsy("),
+        "condition false-branch truthiness narrowing should route through the flow query boundary"
+    );
+    assert!(
+        !compact_condition.contains(".narrow_to_falsy(type_id)"),
+        "condition narrowing should not call solver falsy narrowing directly"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
M1-D flow graph and solver-owned narrowing predicates; refactor-only boundary ratchet.

## Invariant
When checker condition flow recognizes a false truthiness branch, checker supplies the condition/target flow fact and asks `query_boundaries::flow_analysis`; the solver-owned narrowing operation computes the falsy constituents.

## Scope
- Route condition false-branch property/element truthiness narrowing through `flow_analysis::narrow_to_falsy`.
- Route `||=` / `??=` false-branch result narrowing through the same flow boundary.
- Add a focused source-structure regression covering the condition-narrowing boundary route while preserving the landed undefined-membership boundary guards.

## Project Corpus Impact
- Row: n/a
- Bug family: flow/narrowing boundary hygiene, no behavior change intended.
- Evidence: refactor-only wrapper route; no fixture-specific or project-row logic added.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh --limit 75% -- cargo nextest run -p tsz-checker --lib --profile quick flow_guard_boundary_tests::condition_false_branch_falsy_narrowing_uses_flow_query_boundary --no-capture --no-fail-fast`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- M1-D owns this PR; rebased onto current `origin/main` at `a65e67594a646e24c265a64f88f76f2ebd1d7452` after #12680 merged.
- No overlap with #12680: this PR covers condition false-branch falsy narrowing; #12680 covered undefined-membership predicate boundaries and is now merged.
- No overlap with M1-B call predicate narrowing; this PR only routes falsy condition narrowing through the flow query boundary.
- Ready for full PR-head CI; no WIP blocker remains.
