### PR TITLE
perf(checker): fast-path literal switch coverage

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -1,3 +1,4 @@
+use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 use tsz_solver::TypeId;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
@@ -204,11 +205,49 @@ pub(crate) fn cases_exhaust_type(
         return false;
     }
 
+    if case_types_exactly_cover_switch_domain(db.as_type_database(), switch_type, case_types) {
+        return true;
+    }
+
     let mut narrowing = tsz_solver::narrowing::NarrowingContext::new(db);
     if let Some(environment) = env {
         narrowing = narrowing.with_resolver(environment);
     }
     narrowing.narrow_excluding_types(switch_type, case_types) == TypeId::NEVER
+}
+
+fn case_type_domain(db: &dyn TypeDatabase, case_type: TypeId) -> TypeId {
+    enum_member_domain(db, case_type)
+}
+
+fn case_types_exactly_cover_switch_domain(
+    db: &dyn TypeDatabase,
+    switch_type: TypeId,
+    case_types: &[TypeId],
+) -> bool {
+    let Some(members) = union_members_for_type(db, switch_type) else {
+        return case_types
+            .iter()
+            .any(|&case_type| case_type_domain(db, case_type) == switch_type);
+    };
+
+    let mut remaining: FxHashSet<TypeId> = FxHashSet::default();
+    remaining.reserve(members.len());
+    remaining.extend(
+        members
+            .iter()
+            .copied()
+            .map(|member| enum_member_domain(db, member)),
+    );
+
+    for &case_type in case_types {
+        remaining.remove(&case_type_domain(db, case_type));
+        if remaining.is_empty() {
+            return true;
+        }
+    }
+
+    false
 }
 
 /// Apply a solver-owned type guard to a flow type.
@@ -1087,6 +1126,23 @@ mod tests {
         assert_eq!(members.len(), 2);
         assert!(members.contains(&db.literal_string("string")));
         assert!(members.contains(&db.literal_string("number")));
+    }
+
+    #[test]
+    fn cases_exhaust_type_uses_exact_literal_union_coverage() {
+        let db = TypeInterner::new();
+        let first = db.literal_string("first");
+        let second = db.literal_string("second");
+        let third = db.literal_string("third");
+        let switch_type = db.union(vec![first, second, third]);
+
+        assert!(cases_exhaust_type(
+            &db,
+            None,
+            switch_type,
+            &[second, first, third],
+        ));
+        assert!(!cases_exhaust_type(&db, None, switch_type, &[first, third]));
     }
 
     #[test]


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Performance tuning for #12271 eligible green solver-stress CFA rows below the 2x `tsgo` target.

## Invariant
When switch exhaustiveness is checked against a literal union and the case list exactly covers every union member by type identity, the checker query boundary can prove coverage without constructing a `NarrowingContext` or running relation-backed exclusion. This PR adds that exact-coverage fast path only; partial, complex, lazy, or non-identity cases keep the existing `narrow_excluding_types` fallback.

## Scope
- `crates/tsz-checker/src/query_boundaries/flow_analysis.rs`: adds exact literal-union switch coverage before the existing narrowing fallback, plus adjacent query-boundary coverage.

## Project Corpus Impact
- Row: `CFA branches=100`, `CFA branches=150`
- Bug family: solver-stress control-flow/switch exhaustiveness pressure
- Before evidence: Bench run `27003419354`, artifact `bench-results-solver-stress`, source `d707ca16f3823cc12822404c4ee1100e77210f95`.
- `CFA branches=100`: green with `tsz_ms=523.75`, `tsgo_ms=697.04`, winner `tsz`, factor `1.33x`, below the 2x target.
- `CFA branches=150`: green with `tsz_ms=960.37`, `tsgo_ms=1220.15`, winner `tsz`, factor `1.27x`, below the 2x target.
- Expected impact: large no-default discriminant switches whose case labels exactly cover the switch literal union avoid relation-backed exclusion work during reachability/fall-through analysis.
- After evidence: not yet measured in this PR; draft pending CI and focused timing if requested.

## Verification
- `scripts/setup/disk-worktree-guard.sh && git worktree list && scripts/agents/show-goal.sh Studio-B`
- `git fetch origin main`
- `scripts/agents/list-owned-work.sh Studio-B`
- `git diff --check origin/main...HEAD`
- `scripts/agents/ensure-agent-labels.sh --audit`
- Pre-commit formatting hook completed during commit.
- Not run locally: Rust tests, local solver-stress benchmark, broad benchmark suites.
- GitHub PR checks on head `baa1a62251`: `gate`, `project-row-drift`, `cargo-shear`, `cargo-deny`, and `lint` passed; `unit`, `unit-cloudbuild`, and `dist-binaries` were still pending at Studio-B ready handoff.
- Ready handoff note: focused CFA timing is still needed before claiming row movement.

## Coordination Notes
- Ready for manager review/CI expansion; reviewer/manager should decide whether to run focused `CFA branches=100` / `CFA branches=150` timing before merge.
- No merge queue action requested from this implementation lane.
- Overlap: complements #12687's template-literal solver-stress slice and #12686's large-project scheduling slice; this PR is limited to switch coverage proving in the checker query boundary.