### PR TITLE
perf(solver): cache mapped template instantiations

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -8,7 +8,7 @@ mod keyof_constraint;
 
 use crate::construction::TypeDatabase;
 use crate::instantiation::instantiate::{
-    TypeSubstitution, instantiate_type, instantiate_type_preserving,
+    TypeSubstitution, instantiate_type_cached, instantiate_type_preserving,
     instantiate_type_preserving_with_declared,
 };
 use crate::objects::PropertyCollectionResult;
@@ -907,7 +907,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         source_object: Option<TypeId>,
     ) -> IndexSignature {
         let subst = TypeSubstitution::single(mapped.type_param.name, key_type);
-        let instantiated = instantiate_type(self.interner(), mapped.template, &subst);
+        let instantiated =
+            instantiate_type_cached(self.interner(), self.query_db(), mapped.template, &subst);
         let mut value_type = self.evaluate(instantiated);
         let (idx_optional, idx_readonly) =
             self.get_mapped_modifiers(&mapped, inherits_modifiers, source_object, key_type);

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped_array.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped_array.rs
@@ -2,7 +2,7 @@
 //! of `mapped.rs` to keep each source shard under the file-size limit. These
 //! are additional inherent methods on [`TypeEvaluator`]; behavior is unchanged.
 
-use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
+use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type_cached};
 use crate::relations::subtype::TypeResolver;
 use crate::types::{MappedModifier, MappedType, TupleElement, TupleListId, TypeData, TypeId};
 use rustc_hash::FxHashMap;
@@ -25,8 +25,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let subst = TypeSubstitution::single(mapped.type_param.name, TypeId::NUMBER);
 
         // Substitute into the template to get the mapped element type
-        let mut mapped_element =
-            self.evaluate(instantiate_type(self.interner(), mapped.template, &subst));
+        let mut mapped_element = self.evaluate(instantiate_type_cached(
+            self.interner(),
+            self.query_db(),
+            mapped.template,
+            &subst,
+        ));
 
         // CRITICAL: Handle optional modifier (Partial<T[]> case)
         // TypeScript adds undefined to the element type when ? modifier is present
@@ -59,8 +63,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let subst = TypeSubstitution::single(mapped.type_param.name, TypeId::NUMBER);
 
         // Substitute into the template to get the mapped element type
-        let mut mapped_element =
-            self.evaluate(instantiate_type(self.interner(), mapped.template, &subst));
+        let mut mapped_element = self.evaluate(instantiate_type_cached(
+            self.interner(),
+            self.query_db(),
+            mapped.template,
+            &subst,
+        ));
 
         // CRITICAL: Handle optional modifier (Partial<T[]> case)
         if matches!(mapped.optional_modifier, Some(MappedModifier::Add)) {
@@ -289,7 +297,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             self.substitute_exact_type(template, old_source, new_source, &mut memo)
         };
         let subst = TypeSubstitution::single(iter_var, key);
-        let instantiated = instantiate_type(self.interner(), rewritten, &subst);
+        let instantiated =
+            instantiate_type_cached(self.interner(), self.query_db(), rewritten, &subst);
         self.evaluate(instantiated)
     }
 


### PR DESCRIPTION
AgentName: Studio-Opus

## Track
Track 10 performance / benchmark blocker (#12462 pino timeout layer)

## Invariant
When a mapped type substitutes its iteration key into the mapped template, `tsc` reuses equivalent instantiations instead of rebuilding the same template walk for every array-like or index-signature recursion edge. `tsz` now routes mapped-template substitutions through the existing solver `instantiate_type_cached` boundary, keyed by `(TypeId, CanonicalSubst, mode_bits, this_type)` and scoped to the owning `QueryCache` session. Evaluators without a `query_db` still pass `None`, preserving the previous uncached path.

## Scope
- Use `instantiate_type_cached(self.interner(), self.query_db(), ...)` for mapped index-signature template instantiation.
- Use the same cache-aware helper for homomorphic mapped array/readonly-array element templates.
- Use the same cache-aware helper after mapped tuple/source rebinding before evaluation.

## Project Corpus Impact
- Row: pinojs/pino
- Bug family: #12462 pino timeout layer

Pino remains a timeout-class project blocker, but this removes redundant mapped-template instantiation work visible in the exact-main attribution profile:

- `evaluate_mapped`: 81528 -> 52793 sampled frames
- `build_index_signature_for_mapped`: 71471 -> 46522 sampled frames
- `evaluate_mapped_array_with_readonly`: 3114 -> 1939 sampled frames
- `run_instantiator`: 6979 -> 4442 sampled frames
- `TypeInstantiator`: 94609 -> 60806 sampled frames
- physical footprint: 700.7M -> 699.0M
- peak physical footprint: 701.7M -> 703.5M

Measurement mode: attribution sampling, not a `tsgo` timing claim. Fixture: `pinojs/pino` at the existing `.target-bench/external/pino-live` checkout. Commands used `TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 tsz --noEmit -p . --pretty false` plus macOS `sample` after 3s for 8s. Both before/after runs produced zero stdout/stderr diagnostics.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(mapped)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(instantiation_cache)'`
- `scripts/safe-run.sh --limit 16384 -- cargo build --profile dist-fast -p tsz-cli --bin tsz`
- Paired pino attribution samples:
  - baseline binary copied from exact `origin/main`: `/tmp/studio-opus-pino-origin-main.sample.txt`
  - patched binary: `/tmp/studio-opus-pino-mapped-template-inst-cache-3s.sample.txt`

## Coordination Notes
- Continues #12462 after #12573 and #12684, but does not depend on either branch.
- Adjacent open PR #12525 also touches `mapped.rs`, but it caches mapped distribution member evaluation; this PR uses the existing instantiation cache for mapped template substitution in array/index-signature paths.
- Cache key and invalidation are owned by the existing instantiation cache: `QueryCache::clear()` resets entries, and `query_db=None` keeps raw evaluator behavior unchanged.
- This is an attribution/profile improvement only; it is not a green-row timing claim and does not claim the pino row is fixed.

Post-main-refresh verification (base 27143608111a4530d24bdd6d732966ac4b478c9a, head 72fbb0c1a394235281a69a9a7d75597d5c715888):
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- Diff after refresh remains limited to `crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs` and `crates/tsz-solver/src/evaluation/evaluate_rules/mapped_array.rs`.
- Heavy verification is running in CI: https://github.com/tsz-org/tsz/actions/runs/27013028084