### PR TITLE
perf(solver): cache inference generic expansion

### DIFF
--- a/crates/tsz-solver/src/inference/infer.rs
+++ b/crates/tsz-solver/src/inference/infer.rs
@@ -10,7 +10,7 @@
 //! - Best common type calculation
 //! - Efficient unification with path compression
 
-use crate::construction::TypeDatabase;
+use crate::construction::{QueryDatabase, TypeDatabase};
 #[cfg(test)]
 use crate::types::*;
 use crate::types::{InferencePriority, TemplateSpan, TypeData, TypeId};
@@ -261,6 +261,8 @@ pub(crate) struct InferenceContext<'a> {
     pub(crate) interner: &'a dyn TypeDatabase,
     /// Type resolver for semantic lookups (e.g., base class queries)
     pub(crate) resolver: Option<&'a dyn crate::relations::subtype::TypeResolver>,
+    // Shared query database for cache-aware inference-time instantiation.
+    pub(crate) query_db: Option<&'a dyn QueryDatabase>,
     /// Memoized subtype checks used by BCT and bound validation.
     pub(crate) subtype_cache: RefCell<FxHashMap<(TypeId, TypeId), bool>>,
     /// Active subtype checks used for coinductive cycle breaking in the
@@ -364,6 +366,7 @@ impl<'a> InferenceContext<'a> {
         InferenceContext {
             interner,
             resolver: None,
+            query_db: None,
             subtype_cache: RefCell::new(FxHashMap::default()),
             active_subtype_checks: RefCell::new(FxHashSet::default()),
             table: InPlaceUnificationTable::new(),
@@ -391,6 +394,32 @@ impl<'a> InferenceContext<'a> {
         InferenceContext {
             interner,
             resolver: Some(resolver),
+            query_db: None,
+            subtype_cache: RefCell::new(FxHashMap::default()),
+            active_subtype_checks: RefCell::new(FxHashSet::default()),
+            table: InPlaceUnificationTable::new(),
+            type_params: Vec::new(),
+            declared_constraints: FxHashMap::default(),
+            literal_preserving_declared_constraints: FxHashSet::default(),
+            app_expansion_depth: 0,
+            in_contra_mode: false,
+            reverse_mapped_properties: FxHashMap::default(),
+            source_is_type_annotation: false,
+            infer_depth: 0,
+            infer_visited: FxHashSet::default(),
+            top_level_in_return_type_unfixed: FxHashSet::default(),
+            vars_with_substituted_candidates: FxHashSet::default(),
+            in_array_element_context: false,
+            in_readonly_source_context: false,
+            implied_arities: FxHashMap::default(),
+        }
+    }
+
+    pub fn with_query_db(query_db: &'a dyn QueryDatabase) -> Self {
+        InferenceContext {
+            interner: query_db.as_type_database(),
+            resolver: Some(query_db),
+            query_db: Some(query_db),
             subtype_cache: RefCell::new(FxHashMap::default()),
             active_subtype_checks: RefCell::new(FxHashSet::default()),
             table: InPlaceUnificationTable::new(),

--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -9,7 +9,9 @@
 //! lower/upper bound candidates for each inference variable.
 
 use crate::def::DefId;
-use crate::instantiation::instantiate::{TypeSubstitution, instantiate_generic, instantiate_type};
+use crate::instantiation::instantiate::{
+    TypeSubstitution, instantiate_generic_cached, instantiate_type,
+};
 use crate::relations::variance::compute_type_param_variances_with_resolver;
 use crate::types::{
     CallSignature, CallableShapeId, FunctionShape, FunctionShapeId, InferencePriority,
@@ -928,7 +930,8 @@ impl<'a> InferenceContext<'a> {
         let body = resolver.resolve_lazy(def_id, self.interner)?;
 
         // Instantiate the body with the application's type arguments
-        let instantiated = instantiate_generic(self.interner, body, &type_params, &app.args);
+        let instantiated =
+            instantiate_generic_cached(self.interner, self.query_db, body, &type_params, &app.args);
 
         // Restore depth after expansion
         self.app_expansion_depth = depth;

--- a/crates/tsz-solver/src/inference/mod.rs
+++ b/crates/tsz-solver/src/inference/mod.rs
@@ -38,7 +38,7 @@ pub fn infer_type_arguments_from_param_args(
         return Vec::new();
     }
 
-    let mut ctx = InferenceContext::with_resolver(db.as_type_database(), db);
+    let mut ctx = InferenceContext::with_query_db(db);
     let mut vars = Vec::with_capacity(type_params.len());
     for tp in type_params {
         let var = ctx.fresh_type_param(tp.name, tp.is_const);

--- a/crates/tsz-solver/src/operations/generic_call/normalization.rs
+++ b/crates/tsz-solver/src/operations/generic_call/normalization.rs
@@ -566,10 +566,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         // Save state to prevent pollution if evaluator is reused
         let previous_defaulted = std::mem::take(&mut self.defaulted_placeholders);
 
-        let mut infer_ctx = InferenceContext::with_resolver(
-            self.interner.as_type_database(),
-            self.interner.as_type_resolver(),
-        );
+        let mut infer_ctx = InferenceContext::with_query_db(self.interner);
         let mut substitution = TypeSubstitution::new();
         let mut var_map: FxHashMap<TypeId, crate::inference::infer::InferenceVar> =
             FxHashMap::default();

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -261,10 +261,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             return result;
         }
 
-        let mut infer_ctx = InferenceContext::with_resolver(
-            self.interner.as_type_database(),
-            self.interner.as_type_resolver(),
-        );
+        let mut infer_ctx = InferenceContext::with_query_db(self.interner);
         let mut substitution = TypeSubstitution::new();
         let mut var_map: FxHashMap<TypeId, crate::inference::infer::InferenceVar> =
             FxHashMap::default();


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 benchmark blocker / solver cache-residency follow-up for #12271 and #12021.

## Invariant
When inference expands a generic alias/application body under a live `QueryDatabase`, solver should route that `(body, canonical_subst, mode_bits=0, this_type=None)` request through the shared instantiation cache instead of rebuilding the same substituted body per inference traversal. Inference contexts without a query database keep the old uncached fallback.

## Scope
- `crates/tsz-solver/src/inference/infer.rs`: add an optional `QueryDatabase` handle to `InferenceContext` and a `with_query_db` constructor.
- `crates/tsz-solver/src/inference/infer_matching.rs`: use `instantiate_generic_cached` for inference-time `TypeApplication` expansion when a query database is available.
- `crates/tsz-solver/src/inference/mod.rs`: construct the shared type-predicate inference context with the query database.
- `crates/tsz-solver/src/operations/generic_call/resolve.rs`: construct call inference with the cache-aware inference context.
- `crates/tsz-solver/src/operations/generic_call/normalization.rs`: construct normalized call inference with the cache-aware inference context.

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`, `utility-types-project`.
- Bug family: recursive utility expansion fan-out / generic inference application expansion that missed the cross-call instantiation cache after #12019.
- Before evidence: latest full bench artifact `27003419354` reports `vite-vanilla-ts-app` green but `tsgo` winner (`tsz_ms=166.25`, `tsgo_ms=115.21`, factor `1.44`) and `utility-types-project` green TSZ winner but below target (`tsz_ms=77.27`, `tsgo_ms=112.8`, factor `1.46`). Issue #12021 specifically tracks the follow-up from #12019 for measuring and tuning recursive utility expansion fan-out.
- Timing claim: not made locally; this PR is a solver cache-wiring slice and waits for CI/focused benchmark artifact evidence.

## Verification
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`
- Pre-commit formatting hook during commit
- PR-head checks on `83fc051e274e80a6bfd90b860e663f6112f80f28`: `gate`, `project-row-drift`, `cargo-shear`, `cargo-deny`, and `lint` passed.
- Pending at ready handoff: `unit`, `unit-cloudbuild`, and `dist-binaries`.
- Not run locally: targeted tests or benchmarks, per current no-local-validation instruction.

## Coordination Notes
- Ready for manager review / CI expansion with the timing caveat above; manager can decide whether to request focused `vite-vanilla-ts-app` / `utility-types-project` timing before merge.
- No merge queue action requested from this implementation lane.
- Overlap checked against open performance PRs; avoided mapped-template caching owned by #12692 and benchmark harness file-stat caching owned by #12690.
- This intentionally continues the #12019 follow-up path without broadening diagnostics formatting or contextual-type callers in the same PR.
