### PR TITLE
fix(checker): merge module augmentations reached through export * barrels

### DIFF
--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -358,6 +358,19 @@ impl<'a> CheckerState<'a> {
                 };
 
             let all_binders = self.ctx.all_binders.as_ref();
+            // Forward `export *` barrel direction (computed once, loop-invariant):
+            // the module we are resolving the interface from (`source_idx`)
+            // re-exports `interface_name`, and the chain lands on its declaring
+            // file. When that declaring file is an augmentation target, the
+            // augmentation must merge even though it was reached through the
+            // barrel (e.g. `./c` does `export * from './a'` and the augmentation
+            // targets `./a`). `resolve_export_in_file` follows wildcard and named
+            // re-export chains transitively, so multi-hop barrels are covered.
+            let source_export_decl_file = {
+                let mut visited = rustc_hash::FxHashSet::default();
+                self.resolve_export_in_file(source_idx, interface_name, &mut visited)
+                    .map(|(_sym_id, decl_file_idx)| decl_file_idx)
+            };
             for (aug_key, indexed_augs) in &aug_entries {
                 if candidates.iter().any(|c| c == aug_key) {
                     continue;
@@ -423,8 +436,15 @@ impl<'a> CheckerState<'a> {
                                     ) == Some(source_idx)
                             })
                     });
+                // Forward `export *` barrel direction (see `source_export_decl_file`
+                // above): the interface reached through `source_idx` declares in the
+                // augmentation target. Excludes the self case (`source_idx ==
+                // aug_target_idx`), which the direct candidate path already handles.
+                let source_reexports_aug_target =
+                    source_idx != aug_target_idx && source_export_decl_file == Some(aug_target_idx);
                 let reexports_from_source = wildcard_reexports_from_source
                     || named_reexports_from_source
+                    || source_reexports_aug_target
                     || self
                         .resolve_cross_file_export_from_file(
                             aug_key,

--- a/crates/tsz-checker/tests/export_star_module_augmentation_tests.rs
+++ b/crates/tsz-checker/tests/export_star_module_augmentation_tests.rs
@@ -206,3 +206,166 @@ const s: string = f.extra;
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Interface-MERGE through `export *` (distinct from new-export reachability).
+//
+// When a `declare module 'M' { interface I { … } }` augmentation *merges* a
+// required member into an interface `I` that already exists in `M`, reaching
+// `I` through an `export *` barrel must surface the merged member: a literal
+// missing it is TS2741, and supplying it is *not* an excess-property TS2353.
+// tsz previously dropped the merged member across the `export *` edge (it only
+// applied augmentations when the interface was imported directly from `M`),
+// so it reported a spurious TS2353 on the well-formed literal and missed the
+// TS2741 on the under-specified one.
+// ---------------------------------------------------------------------------
+
+/// `a.ts` declares `interface Opts { a }`; `augment.ts` merges `{ b: string }`;
+/// `barrel.ts` re-exports `M` via `export *`. `use_body` is appended after the
+/// imports in `use.ts`.
+fn merged_interface_diags(import_line: &str, use_body: &str) -> Vec<(u32, String)> {
+    let use_source = format!("\n{import_line}\n{use_body}\n");
+    diagnostics(
+        &[
+            ("a.ts", "\nexport interface Opts { a: number; }\n"),
+            (
+                "augment.ts",
+                "\nimport {} from \"./a\";\ndeclare module \"./a\" {\n    interface Opts { b: string; }\n}\n",
+            ),
+            ("barrel.ts", "\nexport * from \"./a\";\n"),
+            ("use.ts", use_source.as_str()),
+        ],
+        "use.ts",
+    )
+}
+
+/// Named import through `export *`: a literal missing the merged member is
+/// TS2741.
+#[test]
+fn export_star_named_import_requires_merged_augmentation_member() {
+    let diags = merged_interface_diags(
+        "import { Opts } from \"./barrel\";",
+        "const bad: Opts = { a: 1 };",
+    );
+    assert_eq!(
+        count_code(&diags, 2741),
+        1,
+        "expected TS2741 for missing merged member; got {diags:#?}"
+    );
+}
+
+/// Named import through `export *`: supplying the merged member is well-formed —
+/// no spurious excess-property TS2353 and no TS2741.
+#[test]
+fn export_star_named_import_accepts_merged_augmentation_member() {
+    let diags = merged_interface_diags(
+        "import { Opts } from \"./barrel\";",
+        "const ok: Opts = { a: 1, b: \"x\" };",
+    );
+    for &code in &[2353, 2741] {
+        assert_eq!(
+            count_code(&diags, code),
+            0,
+            "unexpected TS{code} on well-formed merged literal; got {diags:#?}"
+        );
+    }
+}
+
+/// `import * as ns` then `ns.Opts` in type position must also carry the merged
+/// member across the `export *` edge.
+#[test]
+fn export_star_namespace_qualified_type_requires_merged_member() {
+    let diags = merged_interface_diags(
+        "import * as ns from \"./barrel\";",
+        "const bad: ns.Opts = { a: 1 };",
+    );
+    assert_eq!(
+        count_code(&diags, 2741),
+        1,
+        "expected TS2741 through namespace-qualified merged type; got {diags:#?}"
+    );
+}
+
+/// Multi-hop `export *` chain (`barrel` -> `mid` -> `a`) must still merge the
+/// augmentation member. `resolve_export_in_file` follows the chain transitively.
+#[test]
+fn export_star_multi_hop_requires_merged_augmentation_member() {
+    let diags = diagnostics(
+        &[
+            ("a.ts", "\nexport interface Widget { id: number; }\n"),
+            (
+                "augment.ts",
+                "\nimport {} from \"./a\";\ndeclare module \"./a\" {\n    interface Widget { label: string; }\n}\n",
+            ),
+            ("mid.ts", "\nexport * from \"./a\";\n"),
+            ("barrel.ts", "\nexport * from \"./mid\";\n"),
+            (
+                "use.ts",
+                "\nimport { Widget } from \"./barrel\";\nconst bad: Widget = { id: 1 };\n",
+            ),
+        ],
+        "use.ts",
+    );
+    assert_eq!(
+        count_code(&diags, 2741),
+        1,
+        "expected TS2741 through multi-hop merged interface; got {diags:#?}"
+    );
+}
+
+/// Anti-hardcoding: the rule is structural, not name-driven. Renaming every
+/// binder (module names, interface name, members) preserves the behavior.
+#[test]
+fn export_star_merged_member_rule_is_binder_name_independent() {
+    let diags = diagnostics(
+        &[
+            (
+                "origin.ts",
+                "\nexport interface Zephyr { alpha: number; }\n",
+            ),
+            (
+                "grow.ts",
+                "\nimport {} from \"./origin\";\ndeclare module \"./origin\" {\n    interface Zephyr { omega: boolean; }\n}\n",
+            ),
+            ("gate.ts", "\nexport * from \"./origin\";\n"),
+            (
+                "main.ts",
+                "\nimport * as port from \"./gate\";\nconst bad: port.Zephyr = { alpha: 1 };\n",
+            ),
+        ],
+        "main.ts",
+    );
+    assert_eq!(
+        count_code(&diags, 2741),
+        1,
+        "expected TS2741 with renamed binders; got {diags:#?}"
+    );
+}
+
+/// Negative control: with no augmentation present, reaching the interface
+/// through `export *` must not synthesize a phantom required member, and excess
+/// properties are still rejected (TS2353). Guards against over-merging.
+#[test]
+fn export_star_without_augmentation_keeps_plain_interface_surface() {
+    let diags = diagnostics(
+        &[
+            ("a.ts", "\nexport interface Plain { a: number; }\n"),
+            ("barrel.ts", "\nexport * from \"./a\";\n"),
+            (
+                "use.ts",
+                "\nimport { Plain } from \"./barrel\";\nconst ok: Plain = { a: 1 };\nconst excess: Plain = { a: 1, b: 2 };\n",
+            ),
+        ],
+        "use.ts",
+    );
+    assert_eq!(
+        count_code(&diags, 2741),
+        0,
+        "no phantom required member without augmentation; got {diags:#?}"
+    );
+    assert_eq!(
+        count_code(&diags, 2353),
+        1,
+        "excess property still rejected without augmentation; got {diags:#?}"
+    );
+}


### PR DESCRIPTION
AgentName: M4-Opus

## Track
Conformance / module augmentation and cross-module re-export parity

## Invariant
Module augmentation symbol merging must match `tsc` through binder/checker symbol resolution, including augmentations reached through `export *` barrels.

## Scope
- Fixes the module augmentation path covered by issue #11353.
- Keeps semantic ownership in binder/checker symbol resolution and does not add user-name or fixture-name predicates.
- Adds targeted coverage for augmentation visibility through re-export barrels.

## Project Corpus Impact
- Row: n/a
- Bug family: #11353 module augmentation through export-star barrels

Targeted conformance fix only; no project-corpus row impact expected beyond closing the reported parity gap.

## Verification
- CI is running on the PR head.
- Body/ownership metadata normalized by Studio-manager; rerun only stale metadata-gate failures after the current run completes.

## Coordination Notes
- Issue #11353 carries canonical ownership label `agent:M4-Opus`; this PR is assigned to M4-Opus accordingly.
- A prior runner nickname claim existed in the original body, but canonical PR ownership is M4-Opus.
- AgentName: Studio-manager normalized metadata only; no code changes were made by Studio-manager.


<!-- Studio-manager metadata CI refresh: required CI Summary mirror after #12769 -->
