### PR TITLE
fix(checker): follow import aliases in cross-arena type alias lowering

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
@@ -128,14 +128,14 @@ impl<'a> CheckerState<'a> {
             // `file_locals.get(name)` returns ALIAS sym_ids for imported names;
             // ALIAS is not part of `symbol_flags::TYPE`, so downstream resolvers
             // would reject it. Follow the alias chain to the declaring sym_id.
-            if let Some(file_idx) = decl_file_idx {
-                if let Some(alias_target) = self.source_file_import_alias_target_for_lowering(
+            if let Some(file_idx) = decl_file_idx
+                && let Some(alias_target) = self.source_file_import_alias_target_for_lowering(
                     file_idx,
                     decl_binder,
                     current_sym,
-                ) {
-                    current_sym = alias_target.sym_id;
-                }
+                )
+            {
+                current_sym = alias_target.sym_id;
             }
 
             Some(current_sym)

--- a/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
@@ -95,6 +95,7 @@ impl<'a> CheckerState<'a> {
             .get_binder_for_arena(decl_arena)
             .unwrap_or(self.ctx.binder);
         let namespace_prefix = self.type_alias_namespace_prefix(decl_arena, decl_idx);
+        let decl_file_idx = self.ctx.get_file_idx_for_arena(decl_arena);
         let resolve_symbol_in_decl_binder = |name: &str| -> Option<SymbolId> {
             let mut segments = name.split('.');
             let root_name = segments.next()?;
@@ -122,6 +123,19 @@ impl<'a> CheckerState<'a> {
                             .as_ref()
                             .and_then(|members| members.get(segment))
                     })?;
+            }
+
+            // `file_locals.get(name)` returns ALIAS sym_ids for imported names;
+            // ALIAS is not part of `symbol_flags::TYPE`, so downstream resolvers
+            // would reject it. Follow the alias chain to the declaring sym_id.
+            if let Some(file_idx) = decl_file_idx {
+                if let Some(alias_target) = self.source_file_import_alias_target_for_lowering(
+                    file_idx,
+                    decl_binder,
+                    current_sym,
+                ) {
+                    current_sym = alias_target.sym_id;
+                }
             }
 
             Some(current_sym)

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -344,12 +344,33 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     ) -> Option<(NodeIndex, &NodeArena)> {
         use tsz_parser::parser::syntax_kind_ext;
 
+        // When `sym_id` is a cross-file symbol (authoritative file ≠ current file),
+        // resolve the binder for that file so its declaration_arenas are searched first.
+        // Without this, `self.ctx.binder` (the current file's binder) never holds
+        // declarations for types defined in other files, and the arena falls back to
+        // `self.ctx.arena` which produces NodeIndex collisions.
+        let auth_binder: Option<&tsz_binder::BinderState> = self
+            .ctx
+            .resolve_symbol_file_index(sym_id)
+            .filter(|&f| f != self.ctx.current_file_idx)
+            .and_then(|f| self.ctx.get_binder_for_file(f));
+
         for decl_idx in symbol.all_declarations() {
             if decl_idx.is_none() {
                 continue;
             }
 
             let mut candidate_arenas: Vec<&NodeArena> = Vec::new();
+            // Prefer the authoritative (cross-file) binder's arenas to avoid
+            // NodeIndex collisions with the current file's binder.
+            if let Some(auth) = auth_binder {
+                if let Some(arenas) = auth.declaration_arenas.get(&(sym_id, decl_idx)) {
+                    candidate_arenas.extend(arenas.iter().map(std::convert::AsRef::as_ref));
+                }
+                if let Some(symbol_arena) = auth.symbol_arenas.get(&sym_id) {
+                    candidate_arenas.push(symbol_arena.as_ref());
+                }
+            }
             if let Some(arenas) = self.ctx.binder.declaration_arenas.get(&(sym_id, decl_idx)) {
                 candidate_arenas.extend(arenas.iter().map(std::convert::AsRef::as_ref));
             }

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -95,6 +95,68 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         Some(target_sym_id)
     }
 
+    /// Like [`resolve_import_alias_type_target_symbol`] but looks up the symbol
+    /// from `decl_binder` rather than `self.ctx.binder`, and derives the source
+    /// file index from `decl_arena` rather than falling back to
+    /// `self.ctx.current_file_idx`.
+    ///
+    /// Used when lowering cross-file type alias bodies: the `name_resolver` and
+    /// `def_id_resolver` closures inside `ensure_type_alias_resolved_inner`
+    /// receive raw `SymbolId`s from `decl_binder` (the declaring file). Without
+    /// this, import aliases in a cross-file declaring binder are invisible to
+    /// `resolve_import_alias_type_target_symbol` (which only checks
+    /// `self.ctx.binder`), so the alias's `DefId` never gets a body registered
+    /// and `resolve_lazy` falls back to the raw-number index — potentially
+    /// resolving to a same-named type from an unrelated file.
+    fn resolve_import_alias_in_decl_binder(
+        &self,
+        decl_binder: &tsz_binder::BinderState,
+        decl_arena: &NodeArena,
+        sym_id: tsz_binder::SymbolId,
+    ) -> Option<tsz_binder::SymbolId> {
+        let symbol = decl_binder.get_symbol(sym_id)?;
+        if !symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS) {
+            return None;
+        }
+        if !symbol.is_type_only {
+            return None;
+        }
+        let module_name = symbol.import_module.as_ref()?;
+        let import_name = symbol.import_name.as_deref()?;
+        if import_name == "*" {
+            return None;
+        }
+
+        let source_file_idx = self
+            .ctx
+            .get_file_idx_for_arena(decl_arena)
+            .unwrap_or(self.ctx.current_file_idx);
+        let target_file_idx = self
+            .ctx
+            .resolve_import_target_from_file(source_file_idx, module_name)?;
+        let target_binder = self.ctx.get_binder_for_file(target_file_idx)?;
+        let target_arena = self.ctx.get_arena_for_file(target_file_idx as u32);
+        let target_file_name = target_arena.source_files.first()?.file_name.as_str();
+
+        let target_sym_id = self
+            .ctx
+            .module_exports_for_module(target_binder, target_file_name)
+            .and_then(|exports| exports.get(import_name))
+            .or_else(|| {
+                self.ctx
+                    .module_exports_for_module(target_binder, module_name)
+                    .and_then(|exports| exports.get(import_name))
+            })
+            .or_else(|| target_binder.file_locals.get(import_name))?;
+        let target_symbol = target_binder.get_symbol(target_sym_id)?;
+        if !target_symbol.has_any_flags(tsz_binder::symbol_flags::TYPE) {
+            return None;
+        }
+        self.ctx
+            .register_symbol_file_target(target_sym_id, target_file_idx);
+        Some(target_sym_id)
+    }
+
     pub(super) fn entity_name_text(&self, idx: NodeIndex) -> Option<String> {
         entity_name_text_in_arena(self.ctx.arena, idx)
     }
@@ -706,13 +768,32 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         &self,
         sym_id: tsz_binder::SymbolId,
     ) -> Option<&tsz_binder::Symbol> {
+        // Raw `SymbolId` values are per-binder-local: different binders in the
+        // same compilation can assign the same `u32` to unrelated symbols.
+        // When `resolve_symbol_file_index` has recorded an authoritative file for
+        // `sym_id` that differs from the current checker file, return THAT file's
+        // symbol rather than the current binder's colliding symbol.
+        //
+        // Without this, cross-file type aliases passed to `ensure_type_alias_resolved`
+        // or `ensure_declared_type_params_cached` could receive the wrong symbol
+        // from the current binder (e.g. a type-parameter instead of the
+        // target interface), causing the TYPE_ALIAS / INTERFACE flag check to
+        // fail silently and leaving DefId bodies unregistered.
+        let auth_file = self.ctx.resolve_symbol_file_index(sym_id);
+        if let Some(file_idx) = auth_file
+            && file_idx != self.ctx.current_file_idx
+            && let Some(binder) = self.ctx.get_binder_for_file(file_idx)
+            && let Some(sym) = binder.get_symbol(sym_id)
+        {
+            return Some(sym);
+        }
+
         self.ctx
             .binder
             .get_symbol(sym_id)
             .or_else(|| {
-                // O(1) fast-path via resolve_symbol_file_index
-                let file_idx = self.ctx.resolve_symbol_file_index(sym_id);
-                if let Some(file_idx) = file_idx
+                // O(1) fast-path via resolve_symbol_file_index (same-file case handled above)
+                if let Some(file_idx) = auth_file
                     && let Some(binder) = self.ctx.get_binder_for_file(file_idx)
                     && let Some(sym) = binder.get_symbol(sym_id)
                 {
@@ -770,9 +851,24 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             return;
         }
 
+        // When `sym_id` belongs to a different file (cross-file symbol), use that
+        // file's binder to look up declaration arenas. The current binder only has
+        // arenas for symbols declared in its own file.
+        let auth_binder: &tsz_binder::BinderState = self
+            .ctx
+            .resolve_symbol_file_index(sym_id)
+            .filter(|&f| f != self.ctx.current_file_idx)
+            .and_then(|f| self.ctx.get_binder_for_file(f))
+            .unwrap_or(self.ctx.binder);
         let mut decls_with_arenas = Vec::new();
         for &decl_idx in &symbol.declarations {
-            if let Some(arenas) = self.ctx.binder.declaration_arenas.get(&(sym_id, decl_idx)) {
+            if let Some(arenas) = auth_binder.declaration_arenas.get(&(sym_id, decl_idx)) {
+                decls_with_arenas.extend(arenas.iter().map(|arena| (decl_idx, arena.as_ref())));
+            } else if let Some(arena) = auth_binder.symbol_arenas.get(&sym_id) {
+                decls_with_arenas.push((decl_idx, arena.as_ref()));
+            } else if let Some(arenas) = self.ctx.binder.declaration_arenas.get(&(sym_id, decl_idx))
+            {
+                // Fallback: also check the current binder for merged declarations.
                 decls_with_arenas.extend(arenas.iter().map(|arena| (decl_idx, arena.as_ref())));
             } else if let Some(arena) = self.ctx.binder.symbol_arenas.get(&sym_id) {
                 decls_with_arenas.push((decl_idx, arena.as_ref()));
@@ -999,6 +1095,25 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         self.ctx.get_or_create_def_id(referenced_sym_id)
                     }
                 };
+            // When `decl_binder` differs from the current-file binder (cross-file
+            // type-alias body lowering), symbol IDs returned by `resolve_text_symbol`
+            // belong to the declaring binder and may be import-alias symbols. Those
+            // aliases must be followed to their target so the correct `DefId` (and
+            // thus the correct type body) is obtained.  Without this step, the raw
+            // import-alias `SymbolId` is used as the key into `DefinitionStore`, and
+            // `TypeEnvironment::resolve_lazy` falls back to the file-agnostic
+            // `find_def_by_symbol` path, which returns the first-registered `DefId`
+            // for that raw numeric value — potentially a colliding symbol from an
+            // unrelated file.
+            let follow_decl_binder_alias =
+                |alias_sym_id: tsz_binder::SymbolId| -> Option<tsz_binder::SymbolId> {
+                    // The same-arena path uses `resolve_type_symbol` which already
+                    // resolves aliases; only apply this to cross-file arenas.
+                    if std::ptr::eq(decl_arena, self.ctx.arena) {
+                        return None;
+                    }
+                    self.resolve_import_alias_in_decl_binder(decl_binder, decl_arena, alias_sym_id)
+                };
             let def_id_resolver = |n: NodeIndex| -> Option<tsz_solver::def::DefId> {
                 let (referenced_sym_id, referenced_name) =
                     if std::ptr::eq(decl_arena, self.ctx.arena) {
@@ -1011,7 +1126,10 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         if is_compiler_managed_type(ident_name) {
                             return None;
                         }
-                        (resolve_text_symbol(ident_name)?, ident_name.to_string())
+                        let raw_sym_id = resolve_text_symbol(ident_name)?;
+                        let effective_sym_id =
+                            follow_decl_binder_alias(raw_sym_id).unwrap_or(raw_sym_id);
+                        (effective_sym_id, ident_name.to_string())
                     };
                 let resolved_def_id = def_id_for_symbol(referenced_sym_id, &referenced_name);
                 self.ensure_declared_type_params_cached(referenced_sym_id, resolved_def_id);
@@ -1054,7 +1172,9 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     scoped.push_str(prefix);
                     scoped.push('.');
                     scoped.push_str(name);
-                    if let Some(referenced_sym_id) = resolve_text_symbol(&scoped) {
+                    if let Some(raw_sym_id) = resolve_text_symbol(&scoped) {
+                        let referenced_sym_id =
+                            follow_decl_binder_alias(raw_sym_id).unwrap_or(raw_sym_id);
                         let resolved = def_id_for_symbol(referenced_sym_id, &scoped);
                         self.ensure_declared_type_params_cached(referenced_sym_id, resolved);
                         if referenced_sym_id != sym_id && resolved != def_id {
@@ -1063,7 +1183,8 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         return Some(resolved);
                     }
                 }
-                let referenced_sym_id = resolve_text_symbol(name)?;
+                let raw_sym_id = resolve_text_symbol(name)?;
+                let referenced_sym_id = follow_decl_binder_alias(raw_sym_id).unwrap_or(raw_sym_id);
                 let resolved = def_id_for_symbol(referenced_sym_id, name);
                 self.ensure_declared_type_params_cached(referenced_sym_id, resolved);
                 if referenced_sym_id != sym_id && resolved != def_id {


### PR DESCRIPTION
## Agent
AgentName: M4-C

## Track
M4-C inference sessions, contextual typing, overloads, constructors, and instantiation-state bugs; cross-file contextual generic alias fix.

## Invariant
When cross-arena type alias lowering resolves an imported type name from the declaring file, tsz follows the declaring binder's import alias to the target `SymbolId` before using it for `DefId` registration or type-node resolution. The checker lowering path preserves the declaring file's symbol ownership instead of treating binder-local raw `SymbolId` numbers as globally unique.

## Scope
- `crates/tsz-checker/src/state/type_analysis/computed_alias.rs`
- `crates/tsz-checker/src/types/type_node_resolution.rs`
- Structural rule: imported bare names in cross-file alias bodies resolve to the declaring target symbol, not the local import ALIAS symbol.
- Adjacent matrix: duplicate helper names across files, non-ALIAS symbols, namespace traversal, same-arena alias lowering, and cross-file declaration arena lookup.

## Project Corpus Impact
- Row: Kysely-style contextual generic callback patterns.
- Bug family: cross-file contextual typing / conditional generic alias lowering.
- Evidence: prior draft-head CI passed `unit`; the PR's focused reduction covers `reader.call<number>(1)` staying typed when `SelectFrom<Parser>` imports `ResultBuilder` from another file with duplicate helper names present.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/agents/ensure-agent-labels.sh --audit`
- Prior draft CI on pre-rebase head passed `unit`, `unit-cloudbuild`, `lint`, `cargo-deny`, `cargo-shear`, and `project-row-drift`.
- Focused compiled tests were not rerun locally after the clean rebase because this new worktree has a cold Cargo cache and the machine is below the repo disk comfort line; exact-head ready CI must provide the compiled signal before queueing.

## Coordination Notes
- M4-C owns this PR; rebased onto current `origin/main` at `a9684a3e28cdae1433b34b80f7d7526b9c8a2508`.
- Independent of M4-A mapped/conditional evaluation and M4-B relation/cache keying; this PR only follows declaring-file import aliases before cross-file type alias lowering uses symbol IDs as semantic keys.
- If dotted-path import alias cases appear later, extend the root-segment alias-following path with the same declaring-binder ownership rule.
- Ready for exact-head PR CI; do not queue until `CI Summary` is green on this head.
