### PR TITLE
ci: preserve manual website redeploys

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,8 +29,10 @@ permissions:
 
 concurrency:
   # Never cancel an in-flight deploy — the check job skips if one is already
-  # running so we don't queue up stale work.
-  group: pages-${{ github.ref }}
+  # running so we don't queue up stale work. Manual redeploys are kept out of
+  # the workflow_run pending slot so fresh benchmark publishes cannot be
+  # cancelled by unrelated CI completion churn before their jobs start.
+  group: ${{ github.event_name == 'workflow_dispatch' && format('pages-manual-{0}', github.ref) || format('pages-{0}', github.ref) }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
AgentName: Studio-A

Track: release metric truth / website benchmark artifact propagation

Invariant: a successful benchmark publish must be able to force a website redeploy even while unrelated CI workflow_run events are completing. Manual gh-pages redeploys must not be cancelled before their jobs start by automatic workflow_run churn.

Scope: updates `.github/workflows/gh-pages.yml` concurrency grouping so `workflow_dispatch` redeploys use a separate pending slot from automatic `workflow_run` deploy checks. No compiler, benchmark, emit, conformance, or website build logic changes.

Project Corpus Impact: protects public benchmark/project-row artifact freshness. This does not change benchmark row definitions or benchmark measurements; it keeps the public `benchmark-data/latest.json` surface from staying stale after `bench-publish` writes fresh GCS artifacts.

Verification:
- Local: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/gh-pages.yml"); puts "ok"'`
- PR-head CI: verify the latest head run before queueing; expected path-gated checks are `CI Summary`, `gate`, `lint`, `project-row-drift`, `project-corpus-pr-body`, `cargo-deny`, and `cargo-shear`, with broad suites skipped by the workflow gate for this workflow-only change.
- Observed run 27003419354 publish `bench-runs/latest.json` successfully, while workflow_dispatch gh-pages runs 27010582247 and 27011387546 were cancelled before jobs amid workflow_run churn.

Coordination Notes: #10649 has the live artifact trail. Run 27003419354 (`d707ca16f3823cc12822404c4ee1100e77210f95`) published to GCS successfully, and the public endpoint later advanced to workflow_run_id `27003419354`. This PR isolates forced redeploys so future benchmark publishes/manual redeploys can refresh the public endpoint without being cancelled by unrelated workflow_run churn.