### PR TITLE
fix(ci): stabilize project-compile-guard no-op fast path for generated rows

### DIFF
--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -412,6 +412,8 @@ run_lint() {
     node --check "$script" || return $?
   done
   node scripts/ci/test-project-compile-guard-readiness-artifacts.mjs || return $?
+  node scripts/ci/test-project-compile-guard-fingerprint.mjs || return $?
+  node scripts/ci/test-project-compile-guard-rss-sentinel.mjs || return $?
   node scripts/ci/test-pr-ownership-report.mjs || return $?
   node scripts/ci/test-type-challenges-semantic-families.mjs || return $?
   node scripts/ci/test-pr-ready-state.mjs || return $?

--- a/scripts/ci/lib/project-compile-fingerprint.sh
+++ b/scripts/ci/lib/project-compile-fingerprint.sh
@@ -1,0 +1,124 @@
+# shellcheck shell=bash
+# Result-cache fingerprint helpers for scripts/ci/project-compile-guard.sh.
+#
+# This file is sourced (never executed) by the compile guard and by
+# scripts/ci/test-project-compile-guard-fingerprint.mjs so the no-op fast-path
+# key has a single, unit-tested definition.
+#
+# The compile guard skips recompiling a project row when its fingerprint
+# matches a prior run. For that fast path to be *stable* (no spurious misses
+# that burn compile budget on unchanged rows) and *correct* (no stale hits),
+# the fingerprint must track exactly the inputs that determine the result:
+#   - the tsz binary (callers expose its hash as $_TSZ_BINARY_HASH),
+#   - the tsconfig content,
+#   - the compiled source tree's identity.
+#
+# Callers must set $_TSZ_BINARY_HASH before invoking compute_compile_fingerprint.
+
+# Source globs that participate in a project's compiled-source identity. Kept in
+# sync with count_ts_files plus the project tsconfigs (which also pull in JSON).
+TSZ_COMPILE_FINGERPRINT_SOURCE_GLOBS=('*.ts' '*.tsx' '*.mts' '*.cts' '*.json')
+
+# Stable sha256 of a file (Linux sha256sum / macOS shasum).
+sha256_of_file() {
+  sha256sum "$1" 2>/dev/null | awk '{print $1}' \
+    || shasum -a 256 "$1" 2>/dev/null | awk '{print $1}' || true
+}
+
+# Stable sha256 of stdin. Same fallback chain as sha256_of_file; an empty input
+# still yields a fixed digest, which keeps a clean/empty source identity stable.
+sha256_of_stdin() {
+  sha256sum 2>/dev/null | awk '{print $1}' \
+    || shasum -a 256 2>/dev/null | awk '{print $1}' || true
+}
+
+# Echo the resolved physical path of $1 (handling a missing leaf) or fail.
+tsz_fingerprint_resolve_physical() {
+  local p="$1"
+  if [[ -d "$p" ]]; then
+    (cd "$p" 2>/dev/null && pwd -P)
+    return
+  fi
+  local parent base parent_phys
+  parent="$(dirname "$p")"
+  base="$(basename "$p")"
+  parent_phys="$(cd "$parent" 2>/dev/null && pwd -P)" || return 1
+  printf '%s/%s\n' "$parent_phys" "$base"
+}
+
+# Content fingerprint of the compiled source tree under $1. Stable across
+# regenerations because it hashes file *content* and the relative path, never
+# mtime, so a regenerated-but-identical fixture keeps hitting the fast path.
+# Prunes node_modules/.next like count_ts_files. Echoes "absent" when the tree
+# is missing so a still-missing tree stays a stable key rather than an error.
+hash_source_tree() {
+  local dir="$1"
+  [[ -d "$dir" ]] || {
+    printf 'absent'
+    return 0
+  }
+
+  local find_name=() glob first=1
+  for glob in "${TSZ_COMPILE_FINGERPRINT_SOURCE_GLOBS[@]}"; do
+    if [[ "$first" == "1" ]]; then
+      find_name+=(-name "$glob")
+      first=0
+    else
+      find_name+=(-o -name "$glob")
+    fi
+  done
+
+  {
+    find "$dir" \
+      \( -path '*/node_modules/*' -o -path '*/.next/*' \) -prune -o \
+      -type f \( "${find_name[@]}" \) -print 2>/dev/null || true
+  } \
+    | LC_ALL=C sort \
+    | while IFS= read -r f; do
+        printf '%s  %s\n' "$(sha256_of_file "$f")" "${f#"$dir"/}"
+      done \
+    | sha256_of_stdin
+}
+
+# Fingerprint for a check_project invocation:
+#   <name>|<tsz binary hash>|<tsconfig hash>|<source identity>
+# Returns empty on failure so callers treat caching as unavailable.
+#
+# Source identity:
+#   - When the fixture directory is itself the toplevel of a git repository, use
+#     HEAD plus a content-sensitive dirty marker (git diff against HEAD). A clean
+#     tree yields an empty, stable marker; uncommitted edits change it, so a
+#     stale tree cannot falsely hit.
+#   - Otherwise fall back to a content hash of the compiled source tree. This is
+#     the case for generated-app rows, which have no per-fixture .git and live
+#     inside the tsz checkout: a bare `git rev-parse HEAD` there walks up into
+#     the tsz repository and reports the tsz toplevel/HEAD, which both ignores
+#     the generated sources and changes on every tsz commit -- so the no-op fast
+#     path would never be stable for those rows. Comparing the fixture directory
+#     against the repo toplevel rejects that inherited-repo case directly.
+compute_compile_fingerprint() {
+  local name="$1" tsconfig="$2" src_dir="${3:-}"
+
+  [[ -z "${_TSZ_BINARY_HASH:-}" ]] && return
+  local tsconfig_hash=""
+  [[ -f "$tsconfig" ]] && tsconfig_hash="$(sha256_of_file "$tsconfig")"
+  [[ -f "$tsconfig" && -z "$tsconfig_hash" ]] && return
+
+  local fixture_dir fixture_phys
+  fixture_dir="$(dirname "$tsconfig")"
+  [[ -n "$src_dir" ]] || src_dir="$fixture_dir"
+  fixture_phys="$(tsz_fingerprint_resolve_physical "$fixture_dir" 2>/dev/null || true)"
+
+  local source_id="" toplevel=""
+  toplevel="$(git -C "$fixture_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$toplevel" && -n "$fixture_phys" && "$toplevel" == "$fixture_phys" ]]; then
+    local git_ref="" dirty_marker=""
+    git_ref="$(git -C "$fixture_dir" rev-parse HEAD 2>/dev/null || true)"
+    dirty_marker="$(git -C "$fixture_dir" diff HEAD 2>/dev/null | sha256_of_stdin)"
+    source_id="git:${git_ref}:${dirty_marker}"
+  else
+    source_id="tree:$(hash_source_tree "$src_dir")"
+  fi
+
+  printf '%s' "${name}|${_TSZ_BINARY_HASH}|${tsconfig_hash}|${source_id}"
+}

--- a/scripts/ci/lib/project-compile-fingerprint.sh
+++ b/scripts/ci/lib/project-compile-fingerprint.sh
@@ -86,9 +86,10 @@ hash_source_tree() {
 #
 # Source identity:
 #   - When the fixture directory is itself the toplevel of a git repository, use
-#     HEAD plus a content-sensitive dirty marker (git diff against HEAD). A clean
-#     tree yields an empty, stable marker; uncommitted edits change it, so a
-#     stale tree cannot falsely hit.
+#     HEAD plus a content-sensitive dirty marker (git diff against HEAD) and the
+#     compiled source-tree content hash. A clean tree yields an empty, stable
+#     marker; uncommitted tracked edits and untracked compiled source files
+#     change the key, so a stale tree cannot falsely hit.
 #   - Otherwise fall back to a content hash of the compiled source tree. This is
 #     the case for generated-app rows, which have no per-fixture .git and live
 #     inside the tsz checkout: a bare `git rev-parse HEAD` there walks up into
@@ -112,10 +113,11 @@ compute_compile_fingerprint() {
   local source_id="" toplevel=""
   toplevel="$(git -C "$fixture_dir" rev-parse --show-toplevel 2>/dev/null || true)"
   if [[ -n "$toplevel" && -n "$fixture_phys" && "$toplevel" == "$fixture_phys" ]]; then
-    local git_ref="" dirty_marker=""
+    local git_ref="" dirty_marker="" source_tree_marker=""
     git_ref="$(git -C "$fixture_dir" rev-parse HEAD 2>/dev/null || true)"
     dirty_marker="$(git -C "$fixture_dir" diff HEAD 2>/dev/null | sha256_of_stdin)"
-    source_id="git:${git_ref}:${dirty_marker}"
+    source_tree_marker="$(hash_source_tree "$src_dir")"
+    source_id="git:${git_ref}:${dirty_marker}:tree:${source_tree_marker}"
   else
     source_id="tree:$(hash_source_tree "$src_dir")"
   fi

--- a/scripts/ci/project-compile-guard.sh
+++ b/scripts/ci/project-compile-guard.sh
@@ -78,11 +78,10 @@ if [[ ! -x "$TSZ_BIN" ]]; then
   exit 1
 fi
 
-# Stable sha256 hash of a file (Linux sha256sum / macOS shasum).
-sha256_of_file() {
-  sha256sum "$1" 2>/dev/null | awk '{print $1}' \
-    || shasum -a 256 "$1" 2>/dev/null | awk '{print $1}' || true
-}
+# Result-cache fingerprint helpers (sha256_of_file, compute_compile_fingerprint,
+# hash_source_tree). Sourced so the no-op fast-path key has one tested home.
+# shellcheck source=scripts/ci/lib/project-compile-fingerprint.sh
+source "$ROOT_DIR/scripts/ci/lib/project-compile-fingerprint.sh"
 
 # Compute tsz binary hash once at startup for all per-project fingerprints.
 _TSZ_BINARY_HASH="$(sha256_of_file "$TSZ_BIN")"
@@ -498,24 +497,6 @@ write_compile_cache() {
     && mv "${_cf}.tmp" "$_cf" 2>/dev/null || true
 }
 
-# Fingerprint for a check_project invocation.
-# Key: tsz binary hash (computed once at startup) + tsconfig content + fixture git HEAD.
-# Returns empty on failure — callers treat empty as "caching unavailable".
-compute_compile_fingerprint() {
-  local name="$1" tsconfig="$2"
-  # The key is composed of fixed-length hashes — no need to hash it again.
-  # Return empty if critical components are missing so callers disable caching.
-  [[ -z "$_TSZ_BINARY_HASH" ]] && return
-  local tsconfig_hash=""
-  [[ -f "$tsconfig" ]] && tsconfig_hash="$(sha256_of_file "$tsconfig")"
-  [[ -f "$tsconfig" && -z "$tsconfig_hash" ]] && return
-  # git -C already performs the upward .git search, handles worktrees (.git files),
-  # and returns empty (non-zero exit suppressed) when outside any repo.
-  local git_ref=""
-  git_ref="$(git -C "$(dirname "$tsconfig")" rev-parse HEAD 2>/dev/null || true)"
-  printf '%s' "${name}|${_TSZ_BINARY_HASH}|${tsconfig_hash}|${git_ref}"
-}
-
 check_project() {
   local name="$1"
   local tsconfig="$2"
@@ -523,13 +504,14 @@ check_project() {
   local tsc_exit_codes="${4:-}"
   local log="$FIXTURE_ROOT/${name}.log"
 
-  # Result cache: skip recompilation when tsz binary, tsconfig content, and
-  # fixture git HEAD are all unchanged from a prior run. The cache file is named
+  # Result cache: skip recompilation when the tsz binary, tsconfig content, and
+  # compiled-source identity are all unchanged from a prior run (see
+  # scripts/ci/lib/project-compile-fingerprint.sh). The cache file is named
   # per-project; the stored fingerprint is validated on read so stale entries are
   # overwritten rather than accumulated. Disable with TSZ_PROJECT_COMPILE_RESULT_CACHE=0.
   local _fp="" _cache_file=""
   if [[ "${TSZ_PROJECT_COMPILE_RESULT_CACHE:-1}" == "1" ]]; then
-    _fp="$(compute_compile_fingerprint "$name" "$tsconfig" 2>/dev/null || true)"
+    _fp="$(compute_compile_fingerprint "$name" "$tsconfig" "$src_dir" 2>/dev/null || true)"
     [[ -n "$_fp" ]] && _cache_file="$RESULT_CACHE_DIR/${name}"
   fi
 

--- a/scripts/ci/test-project-compile-guard-fingerprint.mjs
+++ b/scripts/ci/test-project-compile-guard-fingerprint.mjs
@@ -89,6 +89,11 @@ git_quiet -C "$OUTER" add -A
 git_quiet -C "$OUTER" commit -m "outer v3"
 emit B_AFTER_OUTER_COMMIT "$(compute_compile_fingerprint git-fixture "$FIX/tsconfig.json" "$FIX/src")"
 
+# Add an untracked compiled source file. The git diff marker omits this case, so
+# the git-fixture identity must also include the compiled source-tree hash.
+printf 'export const z: number = 1;\n' > "$FIX/src/untracked.ts"
+emit B_UNTRACKED "$(compute_compile_fingerprint git-fixture "$FIX/tsconfig.json" "$FIX/src")"
+
 # Dirty the tracked tree (no commit). The content-sensitive dirty marker must
 # move the key so a stale tree cannot falsely hit.
 printf 'export const y: number = 99;\n' > "$FIX/src/lib.ts"
@@ -123,6 +128,7 @@ for (const key of [
   "OUTER_HEAD",
   "B_FIRST",
   "B_AFTER_OUTER_COMMIT",
+  "B_UNTRACKED",
   "B_DIRTY",
   "B_AFTER_COMMIT",
 ]) {
@@ -159,6 +165,11 @@ assert.equal(
   kv.B_FIRST,
   kv.B_AFTER_OUTER_COMMIT,
   "git-fixture fingerprint must be stable across outer (tsz) commits",
+);
+assert.notEqual(
+  kv.B_FIRST,
+  kv.B_UNTRACKED,
+  "git-fixture fingerprint must change when an untracked compiled source file is added",
 );
 assert.notEqual(
   kv.B_FIRST,

--- a/scripts/ci/test-project-compile-guard-fingerprint.mjs
+++ b/scripts/ci/test-project-compile-guard-fingerprint.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// Regression: the project-compile-guard result-cache fingerprint must give
+// unchanged rows a *stable* no-op fast path while staying correct.
+//
+// The defect this guards against: generated-app rows (vite/next) have no
+// per-fixture .git and live under $FIXTURE_ROOT inside the tsz checkout, so the
+// old `git -C "$(dirname tsconfig)" rev-parse HEAD` walked UP into the tsz
+// repository and folded the *tsz* HEAD into the fingerprint. That made the
+// fingerprint (a) change on every tsz commit -- so the row never hit the fast
+// path and burned compile budget -- and (b) ignore the generated sources that
+// actually determine the result.
+//
+// We exercise the real, sourced library (scripts/ci/lib/project-compile-
+// fingerprint.sh) against throwaway git repos so the contract is tested, not a
+// mirror of it.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
+const LIB = path.join(ROOT, "scripts", "ci", "lib", "project-compile-fingerprint.sh");
+
+assert.ok(fs.existsSync(LIB), `fingerprint library missing: ${LIB}`);
+
+// Drive the sourced library from bash. Emits `KEY=value` lines we parse below.
+// `fp <label> <tsconfig> <src_dir>` prints the fingerprint for one invocation.
+const harness = String.raw`
+set -Eeuo pipefail
+source "$LIB_PATH"
+
+# A fixed stand-in for the tsz binary hash; the real guard derives this from the
+# built binary. Holding it constant isolates the source-identity behaviour.
+export _TSZ_BINARY_HASH="deadbeef"
+
+git_quiet() { git -c init.defaultBranch=main -c user.email=t@t -c user.name=t -c commit.gpgsign=false "$@" >/dev/null 2>&1; }
+
+emit() { printf '%s=%s\n' "$1" "$2"; }
+
+# --- Build an OUTER repo that stands in for the tsz checkout. ---------------
+OUTER="$(mktemp -d)"
+trap 'rm -rf "$OUTER"' EXIT
+git_quiet -C "$OUTER" init
+echo "outer-v1" > "$OUTER/README.md"
+git_quiet -C "$OUTER" add -A
+git_quiet -C "$OUTER" commit -m "outer v1"
+
+# FIXTURE_ROOT lives inside the outer repo, exactly like .target/... does.
+export FIXTURE_ROOT="$OUTER/.target/project-compile-guard"
+mkdir -p "$FIXTURE_ROOT"
+
+# === Case A: generated-app row (NO per-fixture .git, nested in outer repo) ===
+GEN="$FIXTURE_ROOT/gen-app"
+mkdir -p "$GEN/src"
+printf '{"compilerOptions":{"noEmit":true}}\n' > "$GEN/tsconfig.json"
+printf 'export const x: number = 1;\n' > "$GEN/src/main.ts"
+emit A_FIRST  "$(compute_compile_fingerprint gen-app "$GEN/tsconfig.json" "$GEN/src")"
+
+# Move the OUTER repo HEAD. A stable fast path must NOT notice this.
+echo "outer-v2" > "$OUTER/README.md"
+git_quiet -C "$OUTER" add -A
+git_quiet -C "$OUTER" commit -m "outer v2"
+emit A_AFTER_OUTER_COMMIT "$(compute_compile_fingerprint gen-app "$GEN/tsconfig.json" "$GEN/src")"
+
+# Change the generated source. The fingerprint MUST change.
+printf 'export const x: number = 2;\n' > "$GEN/src/main.ts"
+emit A_AFTER_SRC_EDIT "$(compute_compile_fingerprint gen-app "$GEN/tsconfig.json" "$GEN/src")"
+
+# Capture the outer HEAD so the test can assert it never leaks into the key.
+emit OUTER_HEAD "$(git -C "$OUTER" rev-parse HEAD)"
+
+# === Case B: git-backed fixture (its OWN repo under FIXTURE_ROOT) ============
+FIX="$FIXTURE_ROOT/git-fixture"
+mkdir -p "$FIX/src"
+git_quiet -C "$FIX" init
+printf 'export const y: number = 1;\n' > "$FIX/src/lib.ts"
+git_quiet -C "$FIX" add -A
+git_quiet -C "$FIX" commit -m "fixture v1"
+printf '{"compilerOptions":{"noEmit":true}}\n' > "$FIX/tsconfig.json"
+emit B_FIRST "$(compute_compile_fingerprint git-fixture "$FIX/tsconfig.json" "$FIX/src")"
+
+# Another outer commit must not move a git-fixture key either.
+echo "outer-v3" > "$OUTER/README.md"
+git_quiet -C "$OUTER" add -A
+git_quiet -C "$OUTER" commit -m "outer v3"
+emit B_AFTER_OUTER_COMMIT "$(compute_compile_fingerprint git-fixture "$FIX/tsconfig.json" "$FIX/src")"
+
+# Dirty the tracked tree (no commit). The content-sensitive dirty marker must
+# move the key so a stale tree cannot falsely hit.
+printf 'export const y: number = 99;\n' > "$FIX/src/lib.ts"
+emit B_DIRTY "$(compute_compile_fingerprint git-fixture "$FIX/tsconfig.json" "$FIX/src")"
+
+# Commit it: HEAD changes, and the tree is clean again.
+git_quiet -C "$FIX" add -A
+git_quiet -C "$FIX" commit -m "fixture v2"
+emit B_AFTER_COMMIT "$(compute_compile_fingerprint git-fixture "$FIX/tsconfig.json" "$FIX/src")"
+`;
+
+const result = spawnSync("bash", ["-c", harness], {
+  encoding: "utf8",
+  env: { ...process.env, LIB_PATH: LIB },
+});
+assert.equal(result.status, 0, `harness failed: ${result.stderr}`);
+
+const kv = Object.fromEntries(
+  result.stdout
+    .split(/\r?\n/)
+    .filter((l) => l.includes("="))
+    .map((l) => {
+      const i = l.indexOf("=");
+      return [l.slice(0, i), l.slice(i + 1)];
+    }),
+);
+
+for (const key of [
+  "A_FIRST",
+  "A_AFTER_OUTER_COMMIT",
+  "A_AFTER_SRC_EDIT",
+  "OUTER_HEAD",
+  "B_FIRST",
+  "B_AFTER_OUTER_COMMIT",
+  "B_DIRTY",
+  "B_AFTER_COMMIT",
+]) {
+  assert.ok(kv[key], `missing harness output: ${key}\n${result.stdout}`);
+}
+
+// --- Case A: generated-app stability + content sensitivity ------------------
+assert.equal(
+  kv.A_FIRST,
+  kv.A_AFTER_OUTER_COMMIT,
+  "generated-app fingerprint must be stable across outer (tsz) commits",
+);
+assert.notEqual(
+  kv.A_FIRST,
+  kv.A_AFTER_SRC_EDIT,
+  "generated-app fingerprint must change when a compiled source file changes",
+);
+assert.ok(
+  kv.A_FIRST.includes("|tree:"),
+  `generated-app row should use a content-tree identity, got: ${kv.A_FIRST}`,
+);
+// The outer (tsz) HEAD must never leak into a generated-app fingerprint.
+assert.ok(
+  !kv.A_FIRST.includes(kv.OUTER_HEAD),
+  "outer repo HEAD must not appear in the generated-app fingerprint",
+);
+
+// --- Case B: git-fixture HEAD + dirty marker --------------------------------
+assert.ok(
+  kv.B_FIRST.includes("|git:"),
+  `git-fixture row should use a git identity, got: ${kv.B_FIRST}`,
+);
+assert.equal(
+  kv.B_FIRST,
+  kv.B_AFTER_OUTER_COMMIT,
+  "git-fixture fingerprint must be stable across outer (tsz) commits",
+);
+assert.notEqual(
+  kv.B_FIRST,
+  kv.B_DIRTY,
+  "git-fixture fingerprint must change when the tracked tree is dirtied",
+);
+assert.notEqual(
+  kv.B_FIRST,
+  kv.B_AFTER_COMMIT,
+  "git-fixture fingerprint must change when HEAD advances",
+);
+assert.notEqual(
+  kv.B_DIRTY,
+  kv.B_AFTER_COMMIT,
+  "committing a dirty edit must not collide with the dirty-tree fingerprint",
+);
+
+console.log("project-compile-guard fingerprint: ok");


### PR DESCRIPTION
## Agent
AgentName: Studio-B

Closes #10924.

## Track
Project compatibility harness / perf stability.

## Invariant
An unchanged project row must take the result-cache no-op fast path on every rerun (stable: no spurious misses), and a changed row must never take it (correct: no stale hits). The fingerprint must depend only on the inputs that determine the compile result: the tsz binary, the tsconfig content, and the compiled-source identity. It must never depend on the enclosing tsz checkout.

Structural rule: When a project row's fixture directory is itself the toplevel of a git repository, `tsc`-equivalent guard caching keys on that repo's `HEAD` plus a content-sensitive dirty marker; otherwise (generated-app rows, which have no per-fixture `.git`) it keys on a content hash of the compiled source tree. tsz now does this through `scripts/ci/lib/project-compile-fingerprint.sh`.

## Scope
- `scripts/ci/lib/project-compile-fingerprint.sh`: single home for the project compile result-cache key.
- `scripts/ci/project-compile-guard.sh`: thread `src_dir` into the fingerprint so the hashed tree matches the compiled tree.
- `scripts/ci/test-project-compile-guard-fingerprint.mjs`: regression coverage for generated-app and git-backed fixture keys.
- `scripts/ci/test-project-compile-guard-rss-sentinel.mjs`: wire previously orphaned RSS sentinel coverage into lint.
- `scripts/ci/gcp-full-ci.sh`: run the new focused harness tests from the lint suite.

## Project Corpus Impact
- Row: generated project rows, especially `vite-vanilla-ts-app` and `nextjs-fresh-app`.
- Bug family: project-compile-guard fingerprint/result-cache stability.
- Outcome impact: no change to any row's compile pass/fail result, diagnostics, or emit behavior.
- Performance/stability impact: generated-app rows now reuse cached compile-guard results across tsz commits when generated sources and the binary are unchanged, avoiding redundant recompiles and reducing timing variance.
- Evidence: row coverage surfaces remain unchanged; `project-row-summary.mjs` and `test-project-row-summary.mjs` were reported clean in the PR verification.

## Problem
`compute_compile_fingerprint` computed source identity via `git -C "$(dirname tsconfig)" rev-parse HEAD`. Generated-app rows (`vite-vanilla-ts-app`, `nextjs-fresh-app`) have no per-fixture `.git` and are generated under `$FIXTURE_ROOT` inside the tsz checkout, so `git rev-parse` walked up and reported the tsz repo `HEAD`.

Consequences:
- Instability: the fingerprint changed on every tsz commit, so the row never hit the no-op fast path and re-ran a full compile, inflating timing variance.
- Wrong key: the generated sources that actually determine the result were not part of the fingerprint at all.

## Fix
- Extract the fingerprint logic into sourced, unit-tested library `scripts/ci/lib/project-compile-fingerprint.sh`.
- Trust a git ref only when the fixture directory's resolved physical path equals `git rev-parse --show-toplevel`; this rejects the inherited-tsz-repo case and is decoupled from `$FIXTURE_ROOT`.
- For non-git fixtures, hash the compiled source tree by content plus relative path, never mtime, so a regenerated-but-identical fixture stays a stable key while real source changes invalidate it.
- Git-backed fixtures gain a content-sensitive dirty marker (`git diff HEAD`) so uncommitted edits can no longer falsely hit a clean-HEAD cache entry.
- Thread `src_dir` into the fingerprint so the hashed tree matches the compiled tree.

## Adjacent-case Matrix
Regression test `test-project-compile-guard-fingerprint.mjs` exercises the real sourced library against throwaway git repos:
- generated-app row: stable across outer tsz commits; changes when a source file changes; uses `tree:` identity; outer HEAD never leaks into the key.
- git-backed fixture: stable across outer commits; uses `git:` identity; changes on a dirty tracked tree; changes on a new commit; dirty-edit key does not collide with the committed key.

The test fails against the prior implementation and passes against the fix.

## Verification
- `node scripts/ci/test-project-compile-guard-fingerprint.mjs` — passes on fix, fails on prior code.
- `node scripts/ci/test-project-compile-guard-rss-sentinel.mjs` — green and now wired into CI lint.
- `node scripts/bench/project-row-summary.mjs` and `test-project-row-summary.mjs` — clean.
- `bash -n` on the guard and the new library.
- `node --check` on the new test.
- Both new tests wired into `run_lint` in `scripts/ci/gcp-full-ci.sh`.

## Coordination Notes
- Pure CI/harness change; no checker, solver, or emitter semantics touched.
- Branch rebased onto latest `origin/main`; no file overlap with intervening commits.
- Body normalized by Studio-B to satisfy `project-corpus-pr-body`; no code changes in this metadata update.