### PR TITLE
fix(solver): preserve literal arms in contextual tuple/object union extraction

### DIFF
--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -1857,4 +1857,67 @@ const neighbors: GraphNode[] = g.edges;
             "Cross-file F-bounded (param K): inherited edges should resolve, got: {diagnostics:?}"
         );
     }
+
+    #[test]
+    fn union_of_differing_arity_tuples_preserves_literal_element() {
+        // Regression: a fresh literal array element typed against a union of
+        // tuples whose members have DIFFERENT arity must keep its literal type.
+        //
+        // The per-position contextual type for index 0 of
+        // `[number, boolean] | [2]` is `number | 2`. tsc derives this with
+        // `UnionReduction.None`, so the literal arm `2` survives alongside its
+        // base primitive `number`. Reducing to `number` (subtype/literal
+        // absorption) dropped the literal arm, widened the fresh `2` to
+        // `number`, and produced a spurious TS2322 because `[number]` matches
+        // neither `[number, boolean]` (arity) nor `[2]` (literal). Vary the
+        // literal kind and tuple shape so the fix is structural, not pinned to
+        // one element type.
+        let source = r#"
+const numPair: [number, boolean] | [2] = [2];
+const numPairSwapped: [2] | [number, boolean] = [2];
+const strCase: [string, string] | ["x"] = ["x"];
+const bigintCase: [bigint, bigint] | [2n] = [2n];
+const longerArmFirst: [number, number, number] | [number, 7] = [3, 7];
+"#;
+        let errors = check_strict_codes(source);
+        assert!(
+            !errors.contains(&2322),
+            "literal element typed against a union of differing-arity tuples must be preserved (no spurious TS2322), got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn union_of_differing_arity_tuples_via_conditional_preserves_literal() {
+        // The same rule must hold when the tuple union is produced by a
+        // distributive conditional (issue #10864 family). `Tail<T>` over
+        // `[string, number, boolean] | [1, 2]` yields `[number, boolean] | [2]`;
+        // assigning the literal `[2]` must match the `[2]` arm. Renamed infer
+        // binders guard against a fixture-name fast path.
+        let source = r#"
+type DropFirst<Items> = Items extends [unknown, ...infer Remainder] ? Remainder : never;
+type Mixed = [string, number, boolean] | [1, 2];
+const tail: DropFirst<Mixed> = [2];
+"#;
+        let errors = check_strict_codes(source);
+        assert!(
+            !errors.contains(&2322),
+            "literal element typed against a conditional-derived tuple union must be preserved, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn union_of_tuples_still_rejects_non_member_literal() {
+        // Control: preserving literal arms must not over-accept. `[3]` matches
+        // neither arm of `[number, boolean] | [2]` (arity 1 but value 3 != 2),
+        // so TS2322 is still expected — confirming the fix does not blanket the
+        // union into an array.
+        let source = r#"
+const bad: [number, boolean] | [2] = [3];
+"#;
+        let errors = check_strict_codes(source);
+        assert!(
+            errors.contains(&2322),
+            "a literal that matches no tuple arm must still be rejected, got: {errors:?}"
+        );
+    }
 }

--- a/crates/tsz-solver/src/contextual/core.rs
+++ b/crates/tsz-solver/src/contextual/core.rs
@@ -8,7 +8,8 @@ use crate::contextual::extractors::{
     PropertyExtractor, RestOrOptionalTailPositionExtractor, RestParameterExtractor,
     RestPositionCheckExtractor, ReturnTypeExtractor, ThisTypeExtractor, ThisTypeMarkerExtractor,
     TupleElementExtractor, collect_from_intersection, collect_single_or_union,
-    collect_single_or_union_no_reduce, extract_param_type_at_for_call,
+    collect_single_or_union_no_reduce, collect_single_or_union_preserve,
+    extract_param_type_at_for_call,
 };
 #[cfg(test)]
 use crate::types::*;
@@ -1087,7 +1088,9 @@ impl<'a> ContextualTypeContext<'a> {
     ) -> Option<TypeId> {
         let expected = self.expected?;
 
-        // Handle Union explicitly - collect tuple element types from all members
+        // Handle Union explicitly - collect tuple element types from all members,
+        // preserving literal arms (see `collect_single_or_union_preserve`) so a
+        // fresh literal element keyed by `number | 2` is not widened to `number`.
         if let Some(TypeData::Union(members)) = self.interner.lookup(expected) {
             let members = self.interner.type_list(members);
             let elem_types: Vec<TypeId> = members
@@ -1097,7 +1100,7 @@ impl<'a> ContextualTypeContext<'a> {
                     ctx.get_tuple_element_type_inner(index, element_count)
                 })
                 .collect();
-            return collect_single_or_union(self.interner, elem_types);
+            return collect_single_or_union_preserve(self.interner, elem_types);
         }
 
         // Handle Intersection explicitly - collect tuple element types from all members

--- a/crates/tsz-solver/src/contextual/extractors.rs
+++ b/crates/tsz-solver/src/contextual/extractors.rs
@@ -51,6 +51,30 @@ pub(crate) fn collect_single_or_union_no_reduce(
     }
 }
 
+/// Like [`collect_single_or_union`] but preserves every member without any
+/// reduction (neither subtype nor literal absorption).
+///
+/// This mirrors tsc's `getTypeOfPropertyOfContextualType` /
+/// `getContextualTypeForElementExpression`, which build the per-member
+/// contextual type with `mapType(..., /*noReductions*/ true)`
+/// (`UnionReduction.None`). Reduction here would fold a literal member into
+/// its base primitive (e.g. `number | 2` → `number`) and silently drop the
+/// contextual literal arm, so a fresh literal element/property like `[2]`
+/// against `[number, boolean] | [2]` would widen to `number` and fail to
+/// match the literal union arm. Keeping `number | 2` lets the downstream
+/// literal-preservation check (`contextual_type_allows_literal`) find the
+/// matching literal arm.
+pub(crate) fn collect_single_or_union_preserve(
+    db: &dyn TypeDatabase,
+    types: Vec<TypeId>,
+) -> Option<TypeId> {
+    match types.len() {
+        0 => None,
+        1 => Some(types[0]),
+        _ => Some(db.union_preserve_members(types)),
+    }
+}
+
 /// Merge contextual candidates gathered from intersection members.
 ///
 /// Intersections frequently mix a precise member with a broad index-signature or
@@ -535,7 +559,8 @@ impl<'a> TypeVisitor for TupleElementExtractor<'a> {
 
     fn visit_union(&mut self, list_id: u32) -> Self::Output {
         // For unions of tuple/array types, extract the element type from each member
-        // and create a union of the results.
+        // and union the results, preserving literal arms (see
+        // `collect_single_or_union_preserve`) so fresh literal elements survive.
         let members = self.db.type_list(TypeListId(list_id));
         let types: Vec<TypeId> = members
             .iter()
@@ -545,7 +570,7 @@ impl<'a> TypeVisitor for TupleElementExtractor<'a> {
                 extractor.extract(member)
             })
             .collect();
-        collect_single_or_union(self.db, types)
+        collect_single_or_union_preserve(self.db, types)
     }
 
     fn visit_intersection(&mut self, list_id: u32) -> Self::Output {
@@ -745,9 +770,10 @@ impl<'a> TypeVisitor for PropertyExtractor<'a> {
     }
 
     fn visit_union(&mut self, list_id: u32) -> Self::Output {
-        // For unions, extract the property from each member and combine as a union.
-        // e.g., for { foo: ... } with contextual type A | B,
-        // the contextual type of `foo` is A["foo"] | B["foo"].
+        // For unions, extract the property from each member and combine as a union
+        // (`{ foo: ... }` with contextual `A | B` gives `foo` type `A["foo"] |
+        // B["foo"]`), preserving literal arms (see `collect_single_or_union_preserve`)
+        // so fresh literal properties are not widened.
         let members = self.db.type_list(TypeListId(list_id));
         let types: Vec<TypeId> = members
             .iter()
@@ -761,7 +787,7 @@ impl<'a> TypeVisitor for PropertyExtractor<'a> {
                 extractor.extract(member)
             })
             .collect();
-        collect_single_or_union(self.db, types)
+        collect_single_or_union_preserve(self.db, types)
     }
 
     fn visit_intersection(&mut self, list_id: u32) -> Self::Output {

--- a/crates/tsz-solver/tests/contextual_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/contextual_tests_parts/part_01.rs
@@ -629,3 +629,55 @@ fn test_homomorphic_mapped_per_index_contextual_skips_finite_literal_keys() {
         "literal-key constraint should not trigger positional substitution"
     );
 }
+
+/// Per-position contextual type over a union of differing-arity tuples must
+/// keep every member without reduction (tsc's `UnionReduction.None`). For
+/// `[number, boolean] | [2]` at index 0 the contextual type is `number | 2`,
+/// NOT `number`: reducing the literal `2` into its base primitive drops the
+/// contextual literal arm and causes a fresh `[2]` element to widen and
+/// spuriously fail assignment to the `[2]` tuple arm.
+#[test]
+fn test_tuple_element_contextual_union_preserves_literal_member() {
+    let interner = TypeInterner::new();
+
+    let two_lit = interner.literal_number(2.0);
+    let long_arm = interner.tuple(vec![
+        TupleElement {
+            type_id: TypeId::NUMBER,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: TypeId::BOOLEAN,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+    let short_arm = interner.tuple(vec![TupleElement {
+        type_id: two_lit,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+    let union_ty = interner.union(vec![long_arm, short_arm]);
+
+    let ctx = ContextualTypeContext::with_expected(&interner, union_ty);
+    let elem0 = ctx
+        .get_tuple_element_type_with_count(0, 1)
+        .expect("position 0 contextual type missing");
+
+    // Expected: a union that still contains the literal `2`. Without the fix
+    // this reduced to plain `number`.
+    let expected = interner.union_preserve_members(vec![TypeId::NUMBER, two_lit]);
+    assert_eq!(
+        elem0, expected,
+        "contextual element type must preserve the literal arm (`number | 2`), got a reduced form"
+    );
+    assert_ne!(
+        elem0,
+        TypeId::NUMBER,
+        "literal arm `2` must not be absorbed into `number`"
+    );
+}


### PR DESCRIPTION
AgentName: M4-C

**Track:** conformance / solver contextual typing
**Fixes:** #10864 (distributive-conditional-over-tuple-union family; parent tracker #12175)

## Invariant
When deriving the per-position contextual type for an array/tuple-literal element (or object-literal property) from a **union**, preserve every union member without reduction — matching tsc's `getTypeOfPropertyOfContextualType` / `getContextualTypeForElementExpression`, which build the per-member contextual type with `mapType(..., /*noReductions*/ true)` (`UnionReduction.None`). A fresh literal must still see its literal arm in the contextual union.

## Structural rule
When an array/tuple/object literal is checked against a union whose members have **differing shape** (tuple arity / property sets), the per-position contextual type for index/property `p` is the *unreduced* union of each member's `p` type. For `[number, boolean] | [2]` at index 0 that is `number | 2`, **not** `number`.

tsz previously built that union with full subtype reduction (`db.union`), folding `number | 2 → number` and dropping the contextual literal arm *before* the literal-preservation check (`contextual_type_allows_literal`) could find it. The fresh literal `2` then widened to `number`, producing `[number]`, which matches neither `[number, boolean]` (arity) nor `[2]` (literal) → spurious **TS2322**.

Witness (verified against tsc 6.0.2, the pinned target):
```ts
const a: [number, boolean] | [2] = [2];                   // tsc: OK   tsz(before): TS2322
const f: { k: number; j: boolean } | { k: 2 } = { k: 2 }; // object analogue (tracked separately, see Scope)
```
The distributive conditional itself already evaluated correctly (`Tail<[string,number,boolean] | [1,2]>` ⇒ `[number, boolean] | [2]`); the divergence was one layer down in contextual literal preservation, so the fix is independent of any conditional wrapper, fixture name, or binder name.

## Scope (owner layer: solver contextual extraction)
`crates/tsz-solver/src/contextual` — switch the contextual element/property union merge from `collect_single_or_union` (reduces) to a new `collect_single_or_union_preserve` (`union_preserve_members`), at:
- `TupleElementExtractor::visit_union`
- `ContextualTypeContext::get_tuple_element_type_inner` (Union branch)
- `PropertyExtractor::visit_union`

The object-literal property *value* path (`contextual_object_literal_property_type` env-property fallback in the checker) flows through a different mechanism and is **out of scope** here; tracked as a follow-up. Parameter/this/return/yield contextual extraction is intentionally left reducing (contravariant / non-literal surfaces; no tsc-verified divergence).

## Project Corpus Impact
- Row: nextjs (also large-ts-repo, kysely-project, zod-project, ts-toolbelt-project — tuple-union witnesses)
- Bug family: distributive-conditional-over-tuple-union contextual literal preservation (#12175)

Targets the tuple-union family witnesses (#10872/#10823/#10815/#10834/#10875 share this contextual surface). No required project row should regress; the change only *adds* members to internal contextual unions (never displayed) and is efficiency-neutral-to-positive (`union_preserve_members` skips the O(N²) subtype-reduction pass).

## Verification
- New regression tests (all green):
  - checker `array_literal_context_tests`: `union_of_differing_arity_tuples_preserves_literal_element` (number/string/bigint/swapped/longer-arm), `…_via_conditional_preserves_literal` (renamed infer binders), and a control `union_of_tuples_still_rejects_non_member_literal` (ensures no over-acceptance).
  - solver `test_tuple_element_contextual_union_preserves_literal_member` (asserts `number | 2`, not `number`).
- Full `cargo test -p tsz-solver --lib` and `cargo test -p tsz-checker --lib` (RUST_MIN_STACK bumped past a pre-existing zod stack-overflow): **diffed failing-test sets against clean `main` — identical (zero new failures, zero fixed-by-accident)**. The 71 shared failures are pre-existing environment/lib-dependent guards (architecture contracts, cross-file lib-name detection, async/Promise unwrap, zod) unrelated to this change.
- Differential checks against tsc 6.0.2 for the witnesses above.

## Coordination Notes
Issue #10864 claimed with `WIP` (AgentName: M4-C). No open PR covered this contextual surface (the related `confident-hawking` tuple-diagnostics PRs touch the *diagnostic rendering* path, not contextual literal preservation). `/simplify` applied (helper is the consistent third sibling alongside `collect_single_or_union` / `_no_reduce`; call-site comments condensed). Object-property-value widening filed as out-of-scope follow-up.