### PR TITLE
fix(solver): preserve readonly array shape through homomorphic mapped types (#10855)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -505,12 +505,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         .evaluate_mapped_tuple_with_readonly(mapped, tuple_id, source, false);
                 }
 
-                // `readonly [a, b]`: map each element and preserve readonly
-                // unless the modifier strips it (`-readonly`).
+                // `readonly` tuple/array source, delegated (`None` => object path).
                 Some(TypeData::ReadonlyType(inner)) => {
-                    if let Some(TypeData::Tuple(tuple_id)) = self.interner().lookup(inner) {
-                        return self
-                            .evaluate_mapped_tuple_with_readonly(mapped, tuple_id, source, true);
+                    if let Some(result) =
+                        self.evaluate_mapped_over_readonly_source(mapped, source, inner)
+                    {
+                        return result;
                     }
                 }
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/tests.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::construction::TypeInterner;
 use crate::recursion::RecursionResult;
-use crate::types::{PropertyInfo, TupleElement, TypeParamInfo};
+use crate::types::{MappedModifier, PropertyInfo, TupleElement, TypeParamInfo};
 
 #[test]
 fn evaluate_keyof_or_constraint_preserves_reentrant_constraint() {
@@ -982,4 +982,80 @@ fn distributed_mapped_over_intersection_is_idempotent() {
         first, second,
         "re-evaluating the same distributed mapped id must be stable (cached)"
     );
+}
+
+/// Build the identity homomorphic mapped `{ [K in keyof T]: T[K] }` over
+/// `source`, optionally adding an identity `as K` remap and a readonly modifier.
+/// Reuses [`build_identity_homomorphic_mapped`] for the shared base shape.
+fn build_homomorphic_mapped_over(
+    interner: &TypeInterner,
+    iter_name: &str,
+    source: TypeId,
+    as_clause: bool,
+    readonly_modifier: Option<MappedModifier>,
+) -> MappedType {
+    let mut mapped = build_identity_homomorphic_mapped(interner, iter_name, source);
+    if as_clause {
+        let iter_atom = interner.intern_string(iter_name);
+        mapped.name_type = Some(interner.type_param(TypeParamInfo::simple(iter_atom)));
+    }
+    mapped.readonly_modifier = readonly_modifier;
+    mapped
+}
+
+/// A homomorphic mapped type over `readonly T[]` / `ReadonlyArray<T>` must
+/// preserve the readonly array shape rather than collapsing to a plain object
+/// (which dropped the `readonly` modifier and synthesized mutable-array methods
+/// like `push`). Readonly is kept for a plain `{ [K in keyof T]: T[K] }`, an
+/// identity `as K` remap, and an explicit `+readonly`; a no-`as` `-readonly`
+/// yields a mutable array, matching tsc's `instantiateMappedArrayType`.
+#[test]
+fn homomorphic_mapped_over_readonly_array_preserves_readonly() {
+    let interner = TypeInterner::new();
+    // source: readonly number[]
+    let source = interner.readonly_type(interner.array(TypeId::NUMBER));
+
+    // (as_clause, readonly_modifier, expect_readonly_result, label)
+    let cases = [
+        (false, None, true, "plain identity"),
+        (true, None, true, "identity as K"),
+        (false, Some(MappedModifier::Add), true, "+readonly"),
+        (
+            false,
+            Some(MappedModifier::Remove),
+            false,
+            "-readonly (no as)",
+        ),
+    ];
+
+    for iter_name in ["K", "P", "Item"] {
+        for &(as_clause, readonly_modifier, expect_readonly, label) in &cases {
+            let mapped = build_homomorphic_mapped_over(
+                &interner,
+                iter_name,
+                source,
+                as_clause,
+                readonly_modifier,
+            );
+            let mut evaluator = TypeEvaluator::new(&interner);
+            let result = evaluator.evaluate_mapped(&mapped);
+            let inner = match interner.lookup(result) {
+                Some(TypeData::ReadonlyType(inner)) if expect_readonly => inner,
+                Some(TypeData::Array(_)) if !expect_readonly => result,
+                other => panic!(
+                    "iter `{iter_name}`: {label}: expected a {} array, got {other:?}",
+                    if expect_readonly {
+                        "readonly"
+                    } else {
+                        "mutable"
+                    }
+                ),
+            };
+            assert!(
+                matches!(interner.lookup(inner), Some(TypeData::Array(_))),
+                "iter `{iter_name}`: {label}: result must wrap an Array, inner was {:?}",
+                interner.lookup(inner)
+            );
+        }
+    }
 }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped_array.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped_array.rs
@@ -49,12 +49,36 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
     /// Evaluate a homomorphic mapped type over an Array type with explicit readonly flag.
     ///
-    /// Used for `ReadonlyArray`<T> to preserve readonly semantics.
+    /// Used for `ReadonlyArray`<T> to preserve readonly semantics. The mapped
+    /// type's `readonly` modifier is resolved homomorphically against the
+    /// source's readonly-ness (`+readonly` => readonly, `-readonly` => mutable,
+    /// none => copy `source_readonly`).
     pub(crate) fn evaluate_mapped_array_with_readonly(
         &mut self,
         mapped: &MappedType,
+        element_type: TypeId,
+        source_readonly: bool,
+    ) -> TypeId {
+        let final_readonly = mapped.resolve_readonly(source_readonly);
+        self.evaluate_mapped_array_with_explicit_readonly(mapped, element_type, final_readonly)
+    }
+
+    /// Evaluate a homomorphic mapped type over an Array type, wrapping the result
+    /// as readonly exactly when `final_readonly` is set.
+    ///
+    /// Unlike [`Self::evaluate_mapped_array_with_readonly`], the caller decides
+    /// the final readonly-ness rather than having the mapped modifier resolved
+    /// here. This is required for `as`-clause maps: tsc only applies the
+    /// `+readonly`/`-readonly` modifier to an array's surface for a no-`as`
+    /// homomorphic map (`instantiateMappedArrayType` under
+    /// `if (!type.declaration.nameType)`); with an `as` clause the array's
+    /// readonly-ness mirrors the source instead, so a readonly array stays
+    /// readonly even under `-readonly`.
+    pub(crate) fn evaluate_mapped_array_with_explicit_readonly(
+        &mut self,
+        mapped: &MappedType,
         _element_type: TypeId,
-        is_readonly: bool,
+        final_readonly: bool,
     ) -> TypeId {
         let subst = TypeSubstitution::single(mapped.type_param.name, TypeId::NUMBER);
 
@@ -67,13 +91,73 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             mapped_element = self.interner().union2(mapped_element, TypeId::UNDEFINED);
         }
 
-        // Apply readonly modifier (homomorphic: copy source readonly when absent)
-        if mapped.resolve_readonly(is_readonly) {
+        if final_readonly {
             // Wrap the array type in ReadonlyType to get readonly semantics
             let array_type = self.interner().array(mapped_element);
             self.interner().readonly_type(array_type)
         } else {
             self.interner().array(mapped_element)
+        }
+    }
+
+    /// Map a homomorphic identity mapped type over a syntax-level `readonly`
+    /// source — `readonly [..]` (a `ReadonlyType(Tuple)`) or `readonly T[]`
+    /// (a `ReadonlyType(Array(..))`, which `ReadonlyArray<T>` also interns to).
+    /// The lib-interface `ReadonlyArray<T>` form that resolves to an
+    /// `ObjectWithIndex` is detected separately by the caller's match block,
+    /// which needs structural array-marker checks this helper does not perform.
+    ///
+    /// Returns `None` (so the caller falls through to the generic object path)
+    /// when `inner` is neither tuple- nor array-shaped, and for the one array
+    /// shape we cannot model: `-readonly` under an `as` clause.
+    ///
+    /// Without the array arm here a homomorphic mapped type — `{ [K in keyof T]:
+    /// T[K] }`, an identity `as K`, or a key-filtering `as` clause — fell through
+    /// to the generic property-building path, reshaping the readonly array into a
+    /// plain object and dropping its `readonly` modifier.
+    ///
+    /// The mapped `readonly` modifier only rewrites the array surface for a
+    /// no-`as` homomorphic map (tsc's `instantiateMappedArrayType`, gated by
+    /// `if (!type.declaration.nameType)`). With an `as` clause tsc routes through
+    /// the object path, where the modifier never adds or removes a readonly
+    /// array's methods (`push`/`pop`/...): the surface mirrors the source. We
+    /// reproduce that by keeping the array readonly when an `as` clause is present
+    /// and only resolving `+readonly`/`-readonly` for the no-`as` case.
+    ///
+    /// `-readonly` under an `as` clause is the shape we cannot represent as an
+    /// array: tsc yields a hybrid object with a *writable* index but still no
+    /// mutable-array methods (a readonly array minus its readonly index). A
+    /// mutable array would invent `push`; a readonly array would reject valid
+    /// element writes. That case returns `None` and keeps its pre-existing
+    /// object-path approximation rather than emitting a false positive.
+    pub(crate) fn evaluate_mapped_over_readonly_source(
+        &mut self,
+        mapped: &MappedType,
+        source: TypeId,
+        inner: TypeId,
+    ) -> Option<TypeId> {
+        match self.interner().lookup(inner) {
+            Some(TypeData::Tuple(tuple_id)) => {
+                Some(self.evaluate_mapped_tuple_with_readonly(mapped, tuple_id, source, true))
+            }
+            Some(TypeData::Array(element_type)) => {
+                if mapped.name_type.is_some()
+                    && matches!(mapped.readonly_modifier, Some(MappedModifier::Remove))
+                {
+                    return None;
+                }
+                let final_readonly = if mapped.name_type.is_none() {
+                    mapped.resolve_readonly(true)
+                } else {
+                    true
+                };
+                Some(self.evaluate_mapped_array_with_explicit_readonly(
+                    mapped,
+                    element_type,
+                    final_readonly,
+                ))
+            }
+            _ => None,
         }
     }
 


### PR DESCRIPTION
## Agent
AgentName: Studio-B

Fixes #10855 (family #12174: mapped key operations lose optional/readonly intent).

## Track
Conformance / solver mapped-type evaluation. Relevant bench rows: `nextjs-fresh-app` and the #12174 family.

## Invariant
When a homomorphic mapped type is applied to a readonly array (`readonly T[]` / `ReadonlyArray<T>`), `tsc` preserves the readonly array shape; tsz now does the same through the solver's `evaluate_mapped` readonly-source path. The mapped readonly modifier only rewrites the array surface for a no-`as` map (`tsc` gates `instantiateMappedArrayType` on `!nameType`); with an `as` clause the surface mirrors the source.

## Scope
- `crates/tsz-solver/.../mapped.rs`: route `ReadonlyType(inner)` through a new helper for tuple and array sources.
- `crates/tsz-solver/.../mapped_array.rs`: add `evaluate_mapped_over_readonly_source` and `evaluate_mapped_array_with_explicit_readonly`; `evaluate_mapped_array_with_readonly` now delegates.
- Adjacent matrix: plain identity, identity `as K`, key-filtering `as`, `+readonly`, `-readonly`, `Partial<readonly T[]>`, readonly tuples unchanged, mutable arrays/tuples unchanged, and varied iteration-variable names.
- The one unrepresentable shape, `-readonly` under an `as` clause (writable index but no mutable-array methods), returns `None` and keeps its pre-existing object-path approximation rather than emitting a false positive.

## Project Corpus Impact
- Row: `nextjs-fresh-app` and related #12174 family witnesses.
- Bug family: homomorphic mapped key operations losing readonly/optional intent (#10855/#12174).
- Outcome impact: pure shape preservation in mapped evaluation; no new builtin/global ids.
- Compatibility impact: affects only homomorphic maps over readonly arrays, improving the previous divergence where readonly array shape was lost and `push` was allowed.
- Performance impact: no performance-motivated change claimed.

## Verification
- `MapArr<readonly number[]>.push` -> `TS2339` against `tsc` 6.0.2 (was: no error).
- `IdPlain<readonly number[]>`, `IdRemap<readonly number[]>`, and `ReadonlyArray<number>`: `push` rejected and assignability to `number[]` rejected.
- `Partial<readonly number[]>`: element becomes `number | undefined` and remains readonly.
- `-readonly` without `as` over readonly array becomes mutable array.
- `cargo test -p tsz-solver --lib mapped`: 388 passed, 0 failed, including `homomorphic_mapped_over_readonly_array_preserves_readonly`.
- `cargo test -p tsz-solver --lib`: 6528 passed; the one failure (`architecture_guards::evaluation_engine_keeps_request_stage_boundary`) is pre-existing on the clean tree and touches files this PR does not modify.
- `cargo clippy -p tsz-solver --lib`: clean.
- File-size ratchet green: `mapped.rs` 1962 <= 1963 baseline.

## Coordination Notes
- Anti-hardcoding: no identifier, file-name, or printer-string checks; the decision is keyed on structural `TypeData` shapes and `name_type`/modifier presence. Regression tests vary iteration-variable names (`K`/`P`/`Item`) to prove the rule is structural.
- Stays out of the contested alias-display-provenance work (#12647/#12502/#12661) and the recursive over-instantiation family; this is readonly-array shape preservation only.
- Residual divergences observed during investigation (literal `false` -> `boolean` widening in TS2741 source display; identity-mapped alias name collapse in display) are pre-existing, general, and out of scope.
- Body normalized by Studio-manager to satisfy the TSZ PR contract; no code changes.

Generated by Claude Code: https://claude.ai/code/session_01Qa1DVhtESvSozesqosRRrR
