### PR TITLE
ci: speed up dist binary builds on cloud run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
                   should_run=false
                 fi
                 compiler_paths=$(printf '%s\n' "$all_paths" \
-                  | grep -E '^(Cargo\.(lock|toml)|\.cargo/|rust-toolchain|crates/clippy\.toml|crates/(conformance|tsz-(binder|checker|cli|common|core|emitter|lowering|lsp|parser|scanner|solver|wasm))(/|$)|benches/|tests/|TypeScript/|scripts/(conformance|emit|fourslash|tsc|dts|snapshot)|scripts/ci/lib/[^/]+\.sh|scripts/ci/(gcp-full-ci|github-suite|gcp-cache|suite-metadata|build-dist|dist|wasm)[^/]*\.sh)' \
+                  | grep -E '^(Cargo\.(lock|toml)|\.cargo/|rust-toolchain|crates/clippy\.toml|crates/(conformance|tsz-(binder|checker|cli|common|core|emitter|lowering|lsp|parser|scanner|solver|wasm))(/|$)|benches/|tests/|TypeScript/|scripts/(conformance|emit|fourslash|tsc|dts|snapshot)|scripts/ci/lib/[^/]+\.sh|scripts/ci/(ci-resources|gcp-full-ci|github-suite|gcp-cache|suite-metadata|build-dist|dist|wasm)[^/]*\.sh)' \
                   || true)
                 if [[ -z "$compiler_paths" ]]; then
                   compiler_checks_required=false
@@ -399,7 +399,7 @@ jobs:
                     2>/dev/null || echo "0")
                   if [[ "${required_summary_passed}" -gt 0 ]]; then
                     compiler_paths_on_pr=$(printf '%s\n' "${pr_changed_paths:-}" \
-                      | grep -E '^(Cargo\.(lock|toml)|\.cargo/|rust-toolchain|crates/clippy\.toml|crates/(conformance|tsz-(binder|checker|cli|common|core|emitter|lowering|lsp|parser|scanner|solver|wasm))(/|$)|benches/|tests/|TypeScript/|scripts/(conformance|emit|fourslash|tsc|dts|snapshot)|scripts/ci/lib/[^/]+\.sh|scripts/ci/(gcp-full-ci|github-suite|gcp-cache|suite-metadata|build-dist|dist|wasm)[^/]*\.sh)' \
+                      | grep -E '^(Cargo\.(lock|toml)|\.cargo/|rust-toolchain|crates/clippy\.toml|crates/(conformance|tsz-(binder|checker|cli|common|core|emitter|lowering|lsp|parser|scanner|solver|wasm))(/|$)|benches/|tests/|TypeScript/|scripts/(conformance|emit|fourslash|tsc|dts|snapshot)|scripts/ci/lib/[^/]+\.sh|scripts/ci/(ci-resources|gcp-full-ci|github-suite|gcp-cache|suite-metadata|build-dist|dist|wasm)[^/]*\.sh)' \
                       || true)
                     if [[ -n "$compiler_paths_on_pr" ]]; then
                       heavy_checks_passed=$(gh api \

--- a/scripts/ci/ci-resources.sh
+++ b/scripts/ci/ci-resources.sh
@@ -75,11 +75,11 @@ default_cargo_build_jobs() {
       ;;
     dist-binaries)
       # sccache is disabled for dist-binaries (TSZ_CI_DISABLE_SCCACHE=1 in
-      # GitHub CI) so every codegen unit compiles from scratch. The observed
-      # peak RSS per cargo job is slightly higher than the sccache-assisted
-      # path; budget 8192 MiB/job instead of the default 7168 to keep total
-      # cargo RSS below ~87% of RAM before OS overhead.
-      mem_per_job_mb="${TSZ_CI_DIST_CARGO_MB_PER_JOB:-8192}"
+      # GitHub CI) so every codegen unit compiles from scratch. Keep the
+      # default 7168 MiB/job budget so the 8 vCPU x 32 GiB Cloud Run runner can
+      # build at -j4; -j3 has repeatedly finished cargo just after the runner's
+      # external cancellation window and before artifact upload.
+      mem_per_job_mb="${TSZ_CI_DIST_CARGO_MB_PER_JOB:-7168}"
       ;;
     *)
       mem_per_job_mb="${TSZ_CI_CARGO_MB_PER_JOB:-7168}"

--- a/scripts/ci/test-pr-ready-state.mjs
+++ b/scripts/ci/test-pr-ready-state.mjs
@@ -143,6 +143,12 @@ assert.match(
   "edited PR events should refresh body/ready-state gates without publishing protected CI Summary",
 );
 
+assert.match(
+  ciWorkflow,
+  /scripts\/ci\/\(ci-resources\|gcp-full-ci\|github-suite\|gcp-cache\|suite-metadata\|build-dist\|dist\|wasm\)/,
+  "ci-resources.sh changes must require compiler CI because they size dist/unit/wasm jobs",
+);
+
 assert.doesNotMatch(
   ciWorkflow,
   /CI run superseded[\s\S]+?sys\.exit\(0\)/,

--- a/scripts/ci/test_ci_resources.py
+++ b/scripts/ci/test_ci_resources.py
@@ -108,6 +108,37 @@ class DefaultCargoBuildJobsTests(unittest.TestCase):
         )
         self.assertEqual(result_int(r), 1)
 
+    def test_dist_suite_uses_separate_mb_knob(self):
+        # dist-binaries reads TSZ_CI_DIST_CARGO_MB_PER_JOB, not the generic knob.
+        r = call_function(
+            "default_cargo_build_jobs",
+            host_cpus=32,
+            env_overrides={
+                "TSZ_CI_SUITE": "dist-binaries",
+                "TSZ_CI_DIST_CARGO_MB_PER_JOB": "999999",
+                "TSZ_CI_CARGO_MB_PER_JOB": "1",
+            },
+        )
+        self.assertEqual(result_int(r), 1)
+
+    def test_dist_suite_cloud_run_shape_gets_four_jobs(self):
+        env = os.environ.copy()
+        env["HOST_CPUS"] = "8"
+        env["TSZ_CI_SUITE"] = "dist-binaries"
+        cmd = (
+            f"source {SCRIPT}; "
+            "host_memory_mb() { echo 32097; }; "
+            "default_cargo_build_jobs"
+        )
+        r = subprocess.run(
+            ["bash", "-c", cmd],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        self.assertEqual(result_int(r), 4)
+
     def test_does_not_exceed_host_cpus(self):
         r = call_function("default_cargo_build_jobs", host_cpus=4,
                           env_overrides={"TSZ_CI_CARGO_MB_PER_JOB": "1"})


### PR DESCRIPTION
AgentName: Studio-Opus

Track: CI infrastructure / merge-queue unblocker

Invariant: `dist-binaries` must finish cargo, pack `dist-fast-binaries.tar`, and upload the artifact before dependent CI jobs run. The worker budget should keep the Cloud Run dist build below the observed external cancellation window without changing compiler behavior, and CI resource-script changes must run the compiler CI path that owns dist artifacts.

Scope:
- Lowers the `dist-binaries` memory-per-cargo-job default from 8192 MiB to the general 7168 MiB budget.
- This changes the 8 vCPU x 32 GiB Cloud Run dist job from `CARGO_BUILD_JOBS=3` to `CARGO_BUILD_JOBS=4`.
- Adds resource-policy tests proving `dist-binaries` still uses its own override knob and that the observed Cloud Run shape selects four jobs.
- Extends CI path classification so `.github/workflows/ci.yml` treats `scripts/ci/ci-resources.sh` changes as compiler/runtime CI changes instead of skipping `dist-binaries`.
- Adds a ready-state test that keeps the `ci-resources.sh` classifier wired into the compiler path gate.
- No compiler, checker, solver, emit, or benchmark semantics changed.

## Project Corpus Impact
- Row: n/a
- Bug family: CI artifact infrastructure; ready PRs cannot reach project/conformance/emit jobs when `dist-binaries` cancels after cargo finishes but before artifact upload.
- Evidence: Studio-Opus PRs #12573, #12662, #12684, and #12692 all reached the same `dist-binaries` cancellation pattern. #12692 run `27013028084` built all five dist-fast binaries successfully in 7m52s, then GitHub cancelled the job before Pack/Upload, leaving dependent jobs blocked. The first #12706 run skipped `dist-binaries` because `ci-resources.sh` was not classified as a compiler/runtime CI path; this PR now fixes that gate too.

Verification:
- `python3 -m unittest scripts.ci.test_ci_resources` (28 tests, 1 skipped)
- `node scripts/ci/test-pr-ready-state.mjs`
- `bash -n scripts/ci/ci-resources.sh`
- `git diff --check`

Coordination Notes:
- Owned by Studio-Opus under `agent:Studio-Opus`.
- This is intentionally small because it unblocks the existing Studio-Opus PR runway rather than changing compiler behavior.
- If the dist job still cancels after this, next escalation is runner timeout/configuration rather than per-PR code triage.