### PR TITLE
fix(checker): collapse duplicate TS7039 mapped-type emission to one owner

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -841,6 +841,9 @@ path = "tests/ts2344_any_key_mapped_constraint_tests.rs"
 name = "mapped_type_errors_conformance_tests"
 path = "tests/mapped_type_errors_conformance_tests.rs"
 [[test]]
+name = "mapped_type_missing_template_single_ts7039_tests"
+path = "tests/mapped_type_missing_template_single_ts7039_tests.rs"
+[[test]]
 name = "mapped_type_interface_tests"
 path = "tests/mapped_type_interface_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/context/diagnostic_push.rs
+++ b/crates/tsz-checker/src/context/diagnostic_push.rs
@@ -5,7 +5,7 @@
 //! and contain no cross-method dependencies beyond what `self` provides.
 
 use crate::context::CheckerContext;
-use crate::diagnostics::{Diagnostic, diagnostic_codes};
+use crate::diagnostics::{Diagnostic, diagnostic_codes, diagnostic_messages};
 
 /// Decide whether a freshly produced diagnostic should replace an already
 /// emitted one that collides with it on the dedup key.
@@ -211,6 +211,33 @@ impl<'a> CheckerContext<'a> {
             message,
             code,
         ));
+    }
+
+    /// Emit TS7039 ("Mapped object type implicitly has an 'any' template
+    /// type.") for a mapped-type node that omits its template type under
+    /// `noImplicitAny`.
+    ///
+    /// Single source of truth for the diagnostic: the type-lowering path
+    /// (`get_type_from_mapped_type`) and the type-alias / member missing-name
+    /// validation walks all route through here, so the message, code, and span
+    /// have one owner and the same mapped-type node cannot emit the diagnostic
+    /// more than once for structural reasons. Previously each walk emitted it
+    /// twice and only the `(start, code)` dedup collapsed the redundant pair —
+    /// a fragile masking that depended on both emissions resolving to the same
+    /// span. Anchors on the mapped-type node, matching the span `tsc` reports.
+    pub(crate) fn report_mapped_type_missing_template(
+        &mut self,
+        mapped_idx: tsz_parser::parser::NodeIndex,
+    ) {
+        let Some((start, end)) = self.get_node_span(mapped_idx) else {
+            return;
+        };
+        self.error(
+            start,
+            end.saturating_sub(start),
+            diagnostic_messages::MAPPED_OBJECT_TYPE_IMPLICITLY_HAS_AN_ANY_TEMPLATE_TYPE.to_string(),
+            diagnostic_codes::MAPPED_OBJECT_TYPE_IMPLICITLY_HAS_AN_ANY_TEMPLATE_TYPE,
+        );
     }
 
     /// Push a diagnostic with deduplication.

--- a/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/member_declaration_checks.rs
@@ -609,17 +609,6 @@ impl<'a> CheckerState<'a> {
             }
             k if k == syntax_kind_ext::MAPPED_TYPE => {
                 if let Some(mapped) = self.ctx.arena.get_mapped_type(node) {
-                    // TS7039: Mapped object type implicitly has an 'any' template type.
-                    if self.ctx.no_implicit_any() && mapped.type_node.is_none() {
-                        let pos = node.pos;
-                        let len = node.end.saturating_sub(node.pos);
-                        self.ctx.error(
-                            pos,
-                            len,
-                            "Mapped object type implicitly has an 'any' template type.".to_string(),
-                            7039,
-                        );
-                    }
                     let param_binding =
                         self.push_mapped_type_param_provisional(mapped.type_parameter);
                     let is_direct_self_constraint = param_binding
@@ -656,13 +645,7 @@ impl<'a> CheckerState<'a> {
                     if mapped.type_node.is_some() {
                         self.check_type_for_missing_names(mapped.type_node);
                     } else if self.ctx.no_implicit_any() {
-                        // TS7039: Mapped object type implicitly has an 'any' template type
-                        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-                        self.error_at_node(
-                            type_idx,
-                            diagnostic_messages::MAPPED_OBJECT_TYPE_IMPLICITLY_HAS_AN_ANY_TEMPLATE_TYPE,
-                            diagnostic_codes::MAPPED_OBJECT_TYPE_IMPLICITLY_HAS_AN_ANY_TEMPLATE_TYPE,
-                        );
+                        self.ctx.report_mapped_type_missing_template(type_idx);
                     }
                     if let Some(ref members) = mapped.members {
                         for &member_idx in &members.nodes {

--- a/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
@@ -690,14 +690,6 @@ impl<'a> CheckerState<'a> {
             }
             k if k == syntax_kind_ext::MAPPED_TYPE => {
                 if let Some(mapped) = self.ctx.arena.get_mapped_type(node) {
-                    if self.ctx.no_implicit_any() && mapped.type_node.is_none() {
-                        self.ctx.error(
-                            node.pos,
-                            node.end.saturating_sub(node.pos),
-                            "Mapped object type implicitly has an 'any' template type.".to_string(),
-                            7039,
-                        );
-                    }
                     let param_binding =
                         self.push_mapped_type_param_provisional(mapped.type_parameter);
                     self.check_type_parameter_node_for_missing_names(mapped.type_parameter);
@@ -711,12 +703,7 @@ impl<'a> CheckerState<'a> {
                             mapped.type_node,
                         );
                     } else if self.ctx.no_implicit_any() {
-                        use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
-                        self.error_at_node(
-                            type_idx,
-                            diagnostic_messages::MAPPED_OBJECT_TYPE_IMPLICITLY_HAS_AN_ANY_TEMPLATE_TYPE,
-                            diagnostic_codes::MAPPED_OBJECT_TYPE_IMPLICITLY_HAS_AN_ANY_TEMPLATE_TYPE,
-                        );
+                        self.ctx.report_mapped_type_missing_template(type_idx);
                     }
                     if let Some(ref members) = mapped.members {
                         let member_nodes = members.nodes.clone();

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -1303,9 +1303,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         // This error occurs when the type expression after the colon is missing.
         // Example: type Foo = {[P in "bar"]};  // Missing ": T" after "bar"]
         if data.type_node == ParserNodeIndex::NONE {
-            let message = "Mapped object type implicitly has an 'any' template type.";
-            self.ctx
-                .error(node.pos, node.end - node.pos, message.to_string(), 7039);
+            self.ctx.report_mapped_type_missing_template(idx);
             return TypeId::ANY;
         }
 

--- a/crates/tsz-checker/tests/mapped_type_missing_template_single_ts7039_tests.rs
+++ b/crates/tsz-checker/tests/mapped_type_missing_template_single_ts7039_tests.rs
@@ -1,0 +1,119 @@
+//! Regression coverage for TS7039 ("Mapped object type implicitly has an
+//! 'any' template type.") cardinality.
+//!
+//! A mapped type that omits its template type under `noImplicitAny` must emit
+//! exactly one TS7039, anchored on the mapped-type node, regardless of the
+//! syntactic position the mapped type appears in (top-level alias body,
+//! object/interface member, conditional-nested, or with an `as` name clause).
+//!
+//! Previously the type-alias missing-name post-walk and the member missing-name
+//! walk each contained two emission sites for this diagnostic, and only the
+//! `(start, code)` diagnostic dedup collapsed the redundant pair at runtime.
+//! That masking was span-coincidence-dependent and fragile. The emission is now
+//! owned by a single helper (`report_mapped_type_missing_template`), so exactly
+//! one diagnostic is produced for structural reasons rather than by dedup. This
+//! test pins the cardinality and span so the collapse cannot silently regress.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_with_options;
+
+fn no_implicit_any_options() -> CheckerOptions {
+    CheckerOptions {
+        no_implicit_any: true,
+        ..CheckerOptions::default()
+    }
+}
+
+fn ts7039(source: &str) -> Vec<Diagnostic> {
+    check_with_options(source, no_implicit_any_options())
+        .into_iter()
+        .filter(|diag| diag.code == 7039)
+        .collect()
+}
+
+/// The mapped-type node text the diagnostic should anchor on, so a span
+/// regression is caught alongside the cardinality regression.
+fn anchor_text<'a>(source: &'a str, diagnostic: &Diagnostic) -> &'a str {
+    let start = diagnostic.start as usize;
+    let end = start.saturating_add(diagnostic.length as usize);
+    source
+        .get(start..end)
+        .expect("TS7039 span must land on char boundaries within the source")
+}
+
+#[test]
+fn top_level_alias_mapped_type_without_template_emits_single_ts7039() {
+    // Binder names deliberately non-canonical (`Container`/`Slot`) so the rule
+    // is structural and not keyed to any identifier text.
+    let source = "type Container<Slot> = { [Member in keyof Slot] };";
+    let diags = ts7039(source);
+    assert_eq!(
+        diags.len(),
+        1,
+        "expected exactly one TS7039 for a bare mapped-type alias body, got: {diags:#?}",
+    );
+    assert!(
+        anchor_text(source, &diags[0]).starts_with('{'),
+        "TS7039 should anchor on the mapped-type node, got {:?}",
+        anchor_text(source, &diags[0]),
+    );
+}
+
+#[test]
+fn interface_member_mapped_type_without_template_emits_single_ts7039() {
+    let source = "\
+interface Wrapper<Payload> {
+    field: { [Slot in keyof Payload] };
+}";
+    let diags = ts7039(source);
+    assert_eq!(
+        diags.len(),
+        1,
+        "expected exactly one TS7039 for a mapped type in interface-member position, got: {diags:#?}",
+    );
+}
+
+#[test]
+fn type_literal_member_mapped_type_without_template_emits_single_ts7039() {
+    let source = "type Holder<Source> = { inner: { [Element in keyof Source] } };";
+    let diags = ts7039(source);
+    assert_eq!(
+        diags.len(),
+        1,
+        "expected exactly one TS7039 for a mapped type nested in a type-literal member, got: {diags:#?}",
+    );
+}
+
+#[test]
+fn conditional_nested_mapped_type_without_template_emits_single_ts7039() {
+    let source = "type Branch<Input> = Input extends object ? { [Field in keyof Input] } : never;";
+    let diags = ts7039(source);
+    assert_eq!(
+        diags.len(),
+        1,
+        "expected exactly one TS7039 for a mapped type nested in a conditional branch, got: {diags:#?}",
+    );
+}
+
+#[test]
+fn as_clause_mapped_type_without_template_emits_single_ts7039() {
+    let source = "type Renamed<Original> = { [Key in keyof Original as `p${string & Key}`] };";
+    let diags = ts7039(source);
+    assert_eq!(
+        diags.len(),
+        1,
+        "expected exactly one TS7039 for a remapped (`as`-clause) mapped type without a template, got: {diags:#?}",
+    );
+}
+
+#[test]
+fn mapped_type_with_template_emits_no_ts7039() {
+    // Negative control: a fully-formed mapped type must not trip the diagnostic.
+    let source = "type Identity<Source> = { [Key in keyof Source]: Source[Key] };";
+    let diags = ts7039(source);
+    assert!(
+        diags.is_empty(),
+        "a mapped type with a template type must not emit TS7039, got: {diags:#?}",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: confident-hawking

## Track
fix(checker)

Closes #11870.

## Invariant
When a mapped type omits its template type under `noImplicitAny`, `tsc` emits exactly one TS7039 ("Mapped object type implicitly has an 'any' template type."), anchored on the mapped-type node. tsz now produces exactly one such diagnostic for structural reasons (a single emission owner), not as a side effect of diagnostic deduplication.

## Scope
TS7039 for a template-less mapped type was emitted from three places, two of which double-emitted within a single walk:

- `types/type_node_advanced.rs` `get_type_from_mapped_type` — the canonical type-lowering path; emitted once, but via a hardcoded message string + raw `7039`.
- `types/type_checking/type_alias_missing_name_coverage.rs` (MAPPED_TYPE arm) — the optimized type-alias missing-name post-walk; emitted **twice** (once hardcoded at `node.pos`, once through the `else if no_implicit_any()` branch).
- `state/state_checking_members/member_declaration_checks.rs` (MAPPED_TYPE arm) — the member missing-name walk; **same double-emit** (broader than the originally reported witness).

The redundant second emission in each walk was masked at runtime only because both calls resolved to the same `(start = node.pos, code = 7039)` dedup key. That masking is fragile — it silently breaks the moment mapped-type anchoring (`normalized_anchor_span`) diverges from the raw node span — and the message string was hardcoded at every site.

This PR introduces a single owner, `CheckerContext::report_mapped_type_missing_template(node_idx)`, which anchors on the mapped-type node and emits through the shared `MAPPED_OBJECT_TYPE_IMPLICITLY_HAS_AN_ANY_TEMPLATE_TYPE` message/code constants. The lowering path and both missing-name walks route through it. `CheckerContext` is the lowest layer common to all three callers (the lowering path runs on `TypeNodeChecker`, which is not a `CheckerState` but reaches the context via `self.ctx`). The redundant inline blocks and hardcoded strings are removed, so the diagnostic has one source of truth and the same node cannot emit it more than once.

The missing-name walks deliberately avoid re-lowering alias bodies, so they must still emit the diagnostic themselves to preserve parity — they now do so through the shared owner rather than ad hoc, which is why collapsing (rather than deleting the walk emission) is the correct depth.

No semantic/observable change: span and message are preserved.

## Project Corpus Impact
- Row: none expected to move. This is a diagnostic-cardinality/DRY hardening with byte-identical output.
- Bug family: duplicate/cardinality diagnostics in mapped-type `noImplicitAny` validation.
- Anti-hardcoding: removes the hardcoded `"Mapped object type implicitly has an 'any' template type."` string from three sites in favor of the generated `diagnostic_messages`/`diagnostic_codes` constants; the rule is keyed on mapped-type structure, not identifier text (regression test varies binder names).

## Verification
- New regression suite `mapped_type_missing_template_single_ts7039_tests` (6 tests) — asserts exactly one TS7039 across top-level alias, interface-member, type-literal-member, conditional-nested, and `as`-clause positions (binder names varied), plus a negative control for a fully-formed mapped type. Passes (`6 passed`).
- Differential check against `tsc` 6.0.2 for all four positions: tsz emits one TS7039 at the identical span before and after this change — e.g. `type M<T> = { [K in keyof T] };` → `(1,13)`; interface member → `(2,11)`; conditional branch → `(1,35)`; `as`-clause → `(1,20)`.
- Adjacent suites run green: `mapped_type_errors_conformance_tests`, `mapped_type_interface_tests`, `missing_name_type_parameter_reference_tests`, `ts7053_template_mapped_tests`, `ts2344_any_key_mapped_constraint_tests`.
- Note: `mapped_type_diagnostic_display_tests::identity_mapped_optional_ts2327_source_type_shows_question_mark` fails, but it fails identically on pristine `origin/main` (verified by swapping in main's sources) — a pre-existing failure unrelated to this change.

## Coordination Notes
- #11870 was previously referenced by PR #12147, which is **closed and unmerged** and never touched the TS7039 path; the defect was still present on `main`. Claimed #11870 with the `WIP` label before starting.
- `cargo nextest` is unavailable in this environment; local verification used `cargo test`. Ready-review/merge-queue CI owns the broad suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GMCasrDETb9Vu6BP4PCk48)_