### PR TITLE
refactor(checker): route no-weak diagnostic outcome through guard

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -610,7 +610,7 @@ impl<'a> CheckerState<'a> {
         target: TypeId,
     ) -> crate::query_boundaries::assignability::RelationOutcome {
         crate::query_boundaries::assignability::RelationOutcome {
-            related: self.is_assignable_to_no_weak_checks(source, target),
+            related: self.diagnostic_relation_boolean_guard_no_weak_checks(source, target),
             depth_exceeded: false,
             iteration_exceeded: false,
             failure: None,


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker architecture / relation diagnostic routing refactor.

## Invariant
When a diagnostic probe intentionally uses the no-weak assignability relation, tsz records that intent through the diagnostic boolean guard; relation behavior remains unchanged and solver policy is not modified.

## Scope
- Route `no_weak_relation_outcome` through `diagnostic_relation_boolean_guard_no_weak_checks` instead of calling the raw no-weak relation directly.
- Keep the existing `RelationOutcome` shape and no-weak relation semantics unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-boundary refactor / diagnostic routing
- Evidence: behavior-preserving one-line guard routing; no fixture-specific or project-row logic added.

## Verification
- `git diff --check` passed.
- `scripts/arch/check-checker-boundaries.sh` passed.

## Coordination Notes
- Refs #8227.
- Opened as draft while exact-head CI runs.
- Avoids active object-literal/EPC diagnostic work such as #12710 and display/elaboration PRs in neighboring lanes.
