### PR TITLE
fix(solver): re-generalize higher-order generic composition (TS 3.4 HOFI)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -228,6 +228,9 @@ mod heritage_constraint_structural_name_lookup_arch_tests;
 #[path = "../tests/heritage_type_only_tests.rs"]
 mod heritage_type_only_tests;
 #[cfg(test)]
+#[path = "tests/higher_order_regeneralization_tests.rs"]
+mod higher_order_regeneralization_tests;
+#[cfg(test)]
 #[path = "tests/homomorphic_mapped_member_override_tests.rs"]
 mod homomorphic_mapped_member_override_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/higher_order_regeneralization_tests.rs
+++ b/crates/tsz-checker/src/tests/higher_order_regeneralization_tests.rs
@@ -1,0 +1,138 @@
+//! Regression tests for higher-order function type inference (TypeScript 3.4)
+//! re-generalization through generic wrappers — issue #10792.
+//!
+//! When a generic function flows into a contextual function-typed parameter of
+//! an outer generic call, the free type parameters of the argument must be
+//! propagated into the call result and re-generalized into a fresh generic
+//! signature, displayed with their original source names. Previously `tsz`
+//! widened them to `unknown` (severing the parameter/return link) or leaked the
+//! internal `__infer_src_*` placeholder into the result.
+//!
+//! Each repro is tsc-clean (or matches tsc's exact diagnostic) and varies
+//! binder names so the fix stays structural rather than tied to identifier
+//! spellings.
+use crate::test_utils::check_source_diagnostics;
+
+fn inference_diags(diags: &[crate::diagnostics::Diagnostic]) -> Vec<(u32, String)> {
+    diags
+        .iter()
+        .filter(|d| d.code == 2322 || d.code == 2345 || d.code == 18046)
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+/// `lift(box)` must re-generalize to `<T>(a: T) => { v: T }`. Calling it with a
+/// number and assigning the result to `{ v: number }` is tsc-clean; a result
+/// widened to `(a: unknown) => unknown` would reject the assignment (TS2322).
+#[test]
+fn naked_single_wrapper_regeneralizes_parameter_and_return() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function box<T>(x: T): { v: T };
+declare function lift<A, B>(f: (a: A) => B): (a: A) => B;
+const l = lift(box);
+const ok: { v: number } = l(5);
+"#,
+    );
+    let unexpected = inference_diags(&diags);
+    assert!(
+        unexpected.is_empty(),
+        "expected tsc-clean higher-order wrapper, got: {unexpected:?}"
+    );
+}
+
+/// Same structural shape with entirely different binder names, locking the fix
+/// to structure rather than the `T`/`A`/`B` spellings.
+#[test]
+fn naked_single_wrapper_regeneralizes_with_varied_names() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function wrapValue<Elem>(x: Elem): { boxed: Elem };
+declare function through<In, Out>(f: (a: In) => Out): (a: In) => Out;
+const t = through(wrapValue);
+const ok: { boxed: string } = t("hi");
+"#,
+    );
+    let unexpected = inference_diags(&diags);
+    assert!(
+        unexpected.is_empty(),
+        "expected tsc-clean higher-order wrapper, got: {unexpected:?}"
+    );
+}
+
+/// A generic function argument whose type parameter is *non-naked* (wrapped in
+/// `Box<W>`) must also re-generalize, displaying the source name `W`. This is
+/// the existing source-placeholder path; the regression guards its display.
+#[test]
+fn non_naked_single_wrapper_regeneralizes() {
+    let diags = check_source_diagnostics(
+        r#"
+interface Box<W> { value: W }
+declare function unwrap<W>(b: Box<W>): W;
+declare function adapt<A, B>(f: (a: A) => B): (a: A) => B;
+const u = adapt(unwrap);
+const ok: number = u({ value: 1 });
+"#,
+    );
+    let unexpected = inference_diags(&diags);
+    assert!(
+        unexpected.is_empty(),
+        "expected tsc-clean non-naked higher-order wrapper, got: {unexpected:?}"
+    );
+}
+
+/// The re-generalized signature must display with the source type-parameter
+/// name (`T`), never the internal `__infer_src_*` placeholder and never a
+/// widened `unknown`. `makeGetter(box)` is `<T>() => { v: T }`; assigning it to
+/// `number` reproduces tsc's exact message.
+#[test]
+fn regeneralized_signature_uses_source_name_not_placeholder() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function box<T>(x: T): { v: T };
+declare function makeGetter<A, B>(f: (a: A) => B): () => B;
+const g = makeGetter(box);
+const bad: number = g;
+"#,
+    );
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322, got: {:?}",
+        inference_diags(&diags)
+    );
+    let message = &ts2322[0].message_text;
+    assert!(
+        message.contains("() => { v: T; }"),
+        "re-generalized type should display the source name, got: {message:?}"
+    );
+    assert!(
+        !message.contains("__infer"),
+        "internal inference placeholder leaked into diagnostic: {message:?}"
+    );
+    assert!(
+        !message.contains("unknown"),
+        "higher-order free type parameter was widened to unknown: {message:?}"
+    );
+}
+
+/// When the wrapper pins the type parameter through a second argument (the
+/// `compose`-style shared placeholder), re-generalization is suppressed and the
+/// type parameter is determined concretely. `applyTo(pair, 7)` is tsc-clean.
+#[test]
+fn shared_placeholder_argument_still_infers_concretely() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function pair<A>(x: A): [A, A];
+declare function applyTo<X, Y>(f: (a: X) => Y, x: X): Y;
+const r = applyTo(pair, 7);
+const ok: [number, number] = r;
+"#,
+    );
+    let unexpected = inference_diags(&diags);
+    assert!(
+        unexpected.is_empty(),
+        "shared-placeholder argument must infer concretely, got: {unexpected:?}"
+    );
+}

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -1088,9 +1088,11 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     for tp in &s_fn.type_params {
                         let var = ctx.fresh_var();
                         let placeholder_id = self.checker.next_inference_placeholder_id();
+                        let origin_name = self.interner.resolve_atom_ref(tp.name);
                         crate::operations::generic_call::write_src_placeholder_name(
                             &mut src_placeholder_buf,
                             placeholder_id,
+                            &origin_name,
                         );
                         let placeholder_atom = self.interner.intern_string(&src_placeholder_buf);
                         ctx.register_type_param(placeholder_atom, var, tp.is_const);

--- a/crates/tsz-solver/src/operations/core/call_evaluator.rs
+++ b/crates/tsz-solver/src/operations/core/call_evaluator.rs
@@ -237,6 +237,20 @@ pub struct CallEvaluator<'a, C: AssignabilityChecker> {
     /// base instead: re-entering Case 2's fallback for the same `(alias_base, source)`
     /// indicates a coinductive fixed point, and we converge to the source.
     pub(crate) reverse_alias_expansion_visited: RefCell<FxHashSet<(TypeId, TypeId)>>,
+    /// Inference-placeholder name atoms (`__infer_*`) allocated for the type
+    /// parameters of the generic call currently being resolved. Used to gate
+    /// higher-order (TypeScript 3.4) re-generalization: a re-generalization is
+    /// only safe when the argument's contextual placeholders belong to *this*
+    /// call, so the gate fails closed (falls back to instantiation) for nested
+    /// or stale state.
+    pub(crate) current_call_inference_placeholders: FxHashSet<tsz_common::Atom>,
+    /// Subset of [`Self::current_call_inference_placeholders`] that appears in
+    /// more than one parameter of the callee signature. When an argument's
+    /// contextual target uses a shared placeholder (e.g. the middle type `B` in
+    /// `compose(f: (a: A) => B, g: (b: B) => C)`), the argument's free type
+    /// parameters must instead chain through the shared inference variable, so
+    /// higher-order re-generalization of that argument is suppressed.
+    pub(crate) shared_inference_placeholders: FxHashSet<tsz_common::Atom>,
 }
 
 /// Operation-local cache statistics for [`CallEvaluator`].
@@ -311,6 +325,8 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             reverse_mapped_depth: Cell::new(0),
             reverse_mapped_visited: RefCell::new(FxHashSet::default()),
             reverse_alias_expansion_visited: RefCell::new(FxHashSet::default()),
+            current_call_inference_placeholders: FxHashSet::default(),
+            shared_inference_placeholders: FxHashSet::default(),
         }
     }
 

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -1717,6 +1717,56 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             };
             return self.interner.function(erased);
         }
+
+        // Case 1b: naked source type params against a pure higher-order
+        // inference target. TypeScript 3.4 higher-order function type inference
+        // propagates the free type parameters of a generic function argument
+        // through the wrapper instead of collapsing them. When the contextual
+        // target is built entirely from outer inference placeholders (the
+        // `pipe`/`compose`/`makeGetter` family), instantiating the naked source
+        // param against that placeholder unifies the source type parameter with
+        // an outer placeholder that no concrete argument can pin, so it later
+        // resolves to `unknown` and the return-flow link is lost.
+        //
+        // Routing such arguments through the constraint walker's generic source
+        // branch (`return source_ty`) instead creates fresh `__infer_src_*`
+        // placeholders for the source type parameters. Those survive into the
+        // call result and are re-generalized by
+        // `hoist_source_placeholders_into_return_type`, reproducing tsc's
+        // `<T>(a: T) => { value: T[] }` shape. When an outer argument *does*
+        // pin the parameter, the source placeholder simply unifies with the
+        // concrete evidence and resolves normally, so this path stays correct
+        // for the determined case as well.
+        if source_type_params_are_naked
+            && target_params_need_hofi
+            && target_fn.type_params.is_empty()
+        {
+            // Every contextual placeholder of this argument (its parameters and
+            // its return) must be a bare outer inference placeholder for the
+            // pure higher-order shape to hold; `collect` into an `Option` so a
+            // single non-placeholder position short-circuits to `None`.
+            let placeholder_atoms: Option<Vec<_>> = target_param_types
+                .iter()
+                .chain(std::iter::once(&target_fn.return_type))
+                .map(|&pt| self.outer_inference_placeholder_atom(pt))
+                .collect();
+            // Fail closed: only re-generalize when the placeholders belong to the
+            // call currently being resolved (guards against nested/stale state)
+            // and none of them is shared across multiple callee parameters (which
+            // would chain this argument's type parameters through a shared
+            // inference variable, e.g. `compose`'s middle type `B`).
+            let safe_to_regeneralize = placeholder_atoms.as_ref().is_some_and(|atoms| {
+                !atoms.is_empty()
+                    && atoms.iter().all(|atom| {
+                        self.current_call_inference_placeholders.contains(atom)
+                            && !self.shared_inference_placeholders.contains(atom)
+                    })
+            });
+            if safe_to_regeneralize {
+                return source_ty;
+            }
+        }
+
         // Case 1: naked type params — fall through to instantiation
 
         let prev_contextual_type = self.contextual_type;
@@ -1798,6 +1848,25 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         }
 
         result
+    }
+
+    /// Returns the placeholder name atom when `ty` is a bare inference
+    /// placeholder (`__infer_*`) introduced by an enclosing generic call.
+    /// Used to detect pure higher-order inference targets where a generic
+    /// function argument's free type parameters must be propagated rather than
+    /// instantiated against the placeholder.
+    fn outer_inference_placeholder_atom(&self, ty: TypeId) -> Option<tsz_common::Atom> {
+        match self.interner.lookup(ty) {
+            Some(TypeData::TypeParameter(info))
+                if self
+                    .interner
+                    .resolve_atom_ref(info.name)
+                    .starts_with("__infer_") =>
+            {
+                Some(info.name)
+            }
+            _ => None,
+        }
     }
 
     pub(super) fn single_concrete_upper_bound(

--- a/crates/tsz-solver/src/operations/generic_call/mod.rs
+++ b/crates/tsz-solver/src/operations/generic_call/mod.rs
@@ -47,14 +47,34 @@ pub(crate) fn write_placeholder_name(buf: &mut String, id: u64) {
     write!(buf, "__infer_{id}").expect("write to String is infallible");
 }
 
-/// Write the higher-order source placeholder name `__infer_src_{id}` into `buf`.
+/// Write the higher-order source placeholder name into `buf`.
+///
+/// The name is `__infer_src_{id}#{origin}`. The `{id}` keeps the placeholder
+/// program-unique; the `#{origin}` suffix records the *original* type parameter
+/// name of the generic function argument so that, when a higher-order inference
+/// result is re-generalized (see
+/// [`super::CallEvaluator::hoist_source_placeholders_into_return_type`]), the
+/// re-generalized type parameters display with their source names — matching
+/// tsc's `<T>(a: T) => ...` output instead of the internal placeholder name.
+///
+/// `#` is not a valid identifier character, so it is an unambiguous delimiter:
+/// every `starts_with("__infer_src_")` check elsewhere keeps matching, and the
+/// origin can be recovered with [`decode_src_placeholder_origin`].
 ///
 /// `buf` is cleared first so callers can reuse a single allocation across
 /// type parameters.
-pub(crate) fn write_src_placeholder_name(buf: &mut String, id: u64) {
+pub(crate) fn write_src_placeholder_name(buf: &mut String, id: u64, origin: &str) {
     use std::fmt::Write;
     buf.clear();
-    write!(buf, "__infer_src_{id}").expect("write to String is infallible");
+    write!(buf, "__infer_src_{id}#{origin}").expect("write to String is infallible");
+}
+
+/// Recover the original source type-parameter name encoded by
+/// [`write_src_placeholder_name`], or `None` when `name` is not an origin-tagged
+/// source placeholder (e.g. legacy `__infer_src_ctx_*` names).
+pub(crate) fn decode_src_placeholder_origin(name: &str) -> Option<&str> {
+    let origin = name.strip_prefix("__infer_src_")?.split_once('#')?.1;
+    (!origin.is_empty()).then_some(origin)
 }
 
 /// Check if a type constraint is a primitive type (string, number, boolean, bigint, symbol)

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -375,6 +375,59 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             }
         }
 
+        // Record this call's inference placeholders and the subset shared across
+        // more than one parameter. Higher-order (TS 3.4) re-generalization of a
+        // generic function argument is only safe when the argument's contextual
+        // placeholders are not chained through a shared inference variable (the
+        // `B` of `compose(f: (a: A) => B, g: (b: B) => C)`). See
+        // `instantiate_generic_function_argument_against_target`.
+        //
+        // This metadata is only consulted when an argument is itself a generic
+        // function (the sole trigger for re-generalization), so the whole
+        // computation — including the per-parameter `collect_referenced_types`
+        // walk, which is expensive for large generic signatures — is skipped
+        // when no argument is a generic function. The two sets are still cleared
+        // so a later read cannot observe a previous call's state.
+        self.current_call_inference_placeholders.clear();
+        self.shared_inference_placeholders.clear();
+        let any_arg_is_generic_function = arg_types.iter().any(|&arg_type| {
+            Self::get_contextual_signature_cached(self.interner, arg_type)
+                .is_some_and(|shape| !shape.type_params.is_empty())
+        });
+        if any_arg_is_generic_function {
+            self.current_call_inference_placeholders
+                .extend(type_param_placeholder_atoms.iter().copied());
+            if func.params.len() > 1 {
+                let mut param_reference_counts: FxHashMap<tsz_common::Atom, u32> =
+                    FxHashMap::default();
+                let mut seen_in_param: FxHashSet<tsz_common::Atom> = FxHashSet::default();
+                for param in &func.params {
+                    seen_in_param.clear();
+                    for referenced in crate::visitor::collect_referenced_types(
+                        self.interner.as_type_database(),
+                        param.type_id,
+                    ) {
+                        if let Some(info) =
+                            crate::type_param_info(self.interner.as_type_database(), referenced)
+                            && local_type_param_names.contains(&info.name)
+                            && seen_in_param.insert(info.name)
+                        {
+                            *param_reference_counts.entry(info.name).or_insert(0) += 1;
+                        }
+                    }
+                }
+                for (tp, &placeholder_atom) in func
+                    .type_params
+                    .iter()
+                    .zip(type_param_placeholder_atoms.iter())
+                {
+                    if param_reference_counts.get(&tp.name).copied().unwrap_or(0) > 1 {
+                        self.shared_inference_placeholders.insert(placeholder_atom);
+                    }
+                }
+            }
+        }
+
         // Re-set declared constraints using the full substitution now that all
         // placeholders exist. When type parameter order is `<T extends ..U.., U extends P>`,
         // the initial pass above sets T's constraint before U's placeholder exists, so

--- a/crates/tsz-solver/src/operations/generic_call/return_context.rs
+++ b/crates/tsz-solver/src/operations/generic_call/return_context.rs
@@ -2,9 +2,9 @@
 
 use crate::inference::infer::InferenceContext;
 use crate::inference::infer::InferenceVar;
-use crate::instantiation::instantiate::TypeSubstitution;
+use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
 use crate::operations::{AssignabilityChecker, CallEvaluator};
-use crate::types::{FunctionShape, TupleElement, TypeData, TypeId, TypeParamInfo};
+use crate::types::{FunctionShape, ParamInfo, TupleElement, TypeData, TypeId, TypeParamInfo};
 
 use super::{GenericCallRequest, GenericCallResult};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -87,6 +87,16 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         self.interner.function(shape)
     }
 
+    /// Re-generalize a higher-order inference result.
+    ///
+    /// When a generic function argument's free type parameters survive into the
+    /// call result as `__infer_src_*` placeholders (TypeScript 3.4 higher-order
+    /// function type inference), turn them back into proper type parameters of
+    /// the resulting function signature. Each surviving placeholder is renamed
+    /// to its original source type-parameter name (recorded in the placeholder
+    /// atom), so the result displays as tsc's `<T>(a: T) => { value: T[] }`
+    /// rather than leaking the internal `__infer_src_*` name. Collisions are
+    /// disambiguated with a numeric suffix.
     pub(super) fn hoist_source_placeholders_into_return_type(&self, return_type: TypeId) -> TypeId {
         let Some(TypeData::Function(shape_id)) = self.interner.lookup(return_type) else {
             return return_type;
@@ -97,7 +107,7 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             return return_type;
         }
 
-        let mut hoisted = Vec::new();
+        let mut placeholders: Vec<TypeParamInfo> = Vec::new();
         let mut seen = FxHashSet::default();
         for referenced in
             crate::visitor::collect_all_types(self.interner.as_type_database(), return_type)
@@ -107,22 +117,63 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             };
             if !self
                 .interner
-                .resolve_atom(info.name)
-                .as_str()
+                .resolve_atom_ref(info.name)
                 .starts_with("__infer_src_")
             {
                 continue;
             }
             if seen.insert(info.name) {
-                hoisted.push(info);
+                placeholders.push(info);
             }
         }
-        sort_type_params_by_name(&mut hoisted);
 
-        if hoisted.is_empty() {
+        if placeholders.is_empty() {
             return return_type;
         }
+        // Deterministic ordering: placeholder atoms are allocated in source
+        // order, so sorting by name keeps the re-generalized parameter list
+        // stable across runs.
+        sort_type_params_by_name(&mut placeholders);
 
+        let mut rename = TypeSubstitution::new();
+        let mut hoisted = Vec::with_capacity(placeholders.len());
+        let mut used_names: FxHashSet<tsz_common::Atom> = FxHashSet::default();
+        for info in &placeholders {
+            let raw = self.interner.resolve_atom_ref(info.name);
+            let origin = super::decode_src_placeholder_origin(&raw).unwrap_or("T");
+            let mut display_atom = self.interner.intern_string(origin);
+            let mut suffix = 1u32;
+            while !used_names.insert(display_atom) {
+                let candidate = format!("{origin}_{suffix}");
+                display_atom = self.interner.intern_string(&candidate);
+                suffix += 1;
+            }
+            let renamed = TypeParamInfo {
+                name: display_atom,
+                ..*info
+            };
+            let renamed_id = self.interner.type_param(renamed);
+            rename.insert(info.name, renamed_id);
+            hoisted.push(renamed);
+        }
+
+        // Rewrite the body so the placeholders read as their renamed
+        // parameters. The signature itself was non-generic until now, so there
+        // are no bound parameters that could shadow the rename.
+        shape.params = shape
+            .params
+            .iter()
+            .map(|param| ParamInfo {
+                name: param.name,
+                type_id: instantiate_type(self.interner, param.type_id, &rename),
+                optional: param.optional,
+                rest: param.rest,
+            })
+            .collect();
+        shape.return_type = instantiate_type(self.interner, shape.return_type, &rename);
+        shape.this_type = shape
+            .this_type
+            .map(|this_type| instantiate_type(self.interner, this_type, &rename));
         shape.type_params = hoisted;
         self.interner.function(shape)
     }


### PR DESCRIPTION
Fixes #10792.

AgentName: Studio-B
Track: Conformance / generic inference (solver)

Invariant: Match `tsc` exactly for higher-order function type inference (TypeScript 3.4) — a generic function flowing through a generic wrapper keeps its free type parameters and re-generalizes the result, displayed with the source type-parameter names.

## Structural rule

When a generic function argument's type parameters are **naked** (e.g. `box` whose parameter is `x: T` and result is `{ v: T }`) and the contextual target is a pure higher-order inference placeholder, `tsc` propagates the source type parameters as fresh source placeholders and re-generalizes the call result into a generic signature displayed with the original source names. `tsz` previously instantiated the naked source parameter against an outer inference placeholder that no concrete argument could pin, so it collapsed to `unknown` and the parameter/return link was lost. Non-naked source placeholders survived inference but were displayed with their internal `__infer_src_*` name.

`tsz` now does the same through the solver generic-call source-placeholder branch (owner: `tsz-solver` `operations/generic_call`).

### Witness (`tsc` 6.0.x oracle)

For `declare function box(x: T): { v: T }` and `declare function makeGetter(f: (a: A) => B): () => B`, `const g = makeGetter(box)`:

- tsc / after: `g` is the generic `() => { v: T }` over a fresh `T`
- before: `g` was the non-generic `() => { v: unknown }`

## Scope

- `instantiate_generic_function_argument_against_target` (`inference_helpers.rs`): new **Case 1b** routes naked-type-param generic function arguments through the constraint walker's generic-source branch in pure higher-order scenarios. Gated, **fail-closed**, by whether the target placeholders belong to the call currently being resolved and are **not shared** across multiple callee parameters (the middle type of a `compose`-style callee). Chained multi-argument composition keeps its existing behavior — no regression.
- `mod.rs` / `return_context.rs`: the original source type-parameter name is encoded into the placeholder atom (`__infer_src_{id}#{origin}`; `#` is not a valid identifier char, so every `starts_with("__infer_src_")` check keeps matching) and `hoist_source_placeholders_into_return_type` re-generalizes the result, renaming surviving placeholders to their source names. This **also fixes the display** of the pre-existing non-naked source-placeholder path (it previously leaked `__infer_src_*`).
- `resolve.rs` / `call_evaluator.rs`: the per-call placeholder/shared sets are computed only when an argument is itself a generic function, so the per-parameter `collect_referenced_types` walk is skipped on the common path.

### Adjacent-case matrix (all match `tsc` 6.0.2 exactly)

| case | shape | now matches tsc |
| --- | --- | --- |
| `makeGetter(box)` | naked, return-only | yes |
| `makeSetter(box)` | naked, param-only | yes |
| `lift(box)` | naked, param+return | yes |
| `adapt(unwrap)` | non-naked source param | yes |
| curried wrapper | nested return | yes |
| varied names (`Elem`, `In`/`Out`) | naked | uses source names |
| `applyTo(pair, 7)` | shared placeholder, pinned | infers concretely (gated out) |

## Anti-hardcoding

No user-name/file-name literals drive logic; the only string predicate is the existing `__infer_*` placeholder-naming convention. Tests vary binder names (`T`, `Elem`, `In`, `Out`, `W`) to keep the fix structural.

## Project Corpus Impact

- Row: ts-essentials-project
- Bug family: generic-inference

Targets generic composition / `ReturnType` through wrappers. No new failures expected; chained composition is explicitly gated to baseline behavior.

## Verification

- New regression tests: `crates/tsz-checker/src/tests/higher_order_regeneralization_tests.rs` (5 tests, name-varied) — all pass.
- `cargo nextest run -p tsz-solver --lib`: 6527/6528 pass; the single failure (`architecture_guards::evaluation_engine_keeps_request_stage_boundary`) is **pre-existing** drift from refactor #12598 (the guard expects `evaluate_type_with_request` in `evaluate.rs`; it moved) and touches no file in this PR.
- `cargo nextest run -p tsz-checker --lib`: failure set is identical to base `main` (verified by stash/diff). The only delta was 2 `typebox` tests that **time out on pristine `main` too** under local load — environmental, not a regression.
- `cargo clippy -p tsz-solver --lib` and `-p tsz-checker --lib --tests`: clean.
- Oracle diff vs `tsc` 6.0.2 on the full adjacent-case matrix above: exact match.

## Coordination Notes

Chained multi-generic-argument composition (`compose`, `pipe` of two generic functions) still partially widens/leaks the *return* free parameter — a pre-existing cross-argument source-placeholder unification gap that this PR deliberately gates out rather than half-fix. Tracked as follow-up on #10792.

https://claude.ai/code/session_014kiXjB6c5YFGhPGH6kTVcY
