### PR TITLE
fix(solver): hoist null/undefined to canonical tail through nested anonymous union origins

### DIFF
--- a/crates/tsz-solver/src/diagnostics/format/compound/union_display.rs
+++ b/crates/tsz-solver/src/diagnostics/format/compound/union_display.rs
@@ -6,13 +6,7 @@ impl<'a> TypeFormatter<'a> {
         let mut has_null = false;
         let mut has_undefined = false;
         for &m in members {
-            if m == TypeId::NULL {
-                has_null = true;
-            } else if m == TypeId::UNDEFINED {
-                has_undefined = true;
-            } else {
-                ordered.push(m);
-            }
+            self.collect_union_member_for_display(m, &mut ordered, &mut has_null, &mut has_undefined);
         }
         // Sort non-nullish members by source position to match tsc's display order.
         // The interner sorts Lazy types by DefId.0 (allocation order), which doesn't
@@ -83,6 +77,75 @@ impl<'a> TypeFormatter<'a> {
 
         self.format_ordered_union_members(ordered)
     }
+
+    /// Partition a single union member into the non-nullish display list plus
+    /// the trailing `null`/`undefined` flags that [`format_union`] appends at
+    /// the canonical tail.
+    ///
+    /// tsc flattens unions structurally, so `null`/`undefined` always render
+    /// last regardless of how the union was constructed. Our diagnostic
+    /// `union_origin` side-table can preserve a nested *anonymous* sub-union
+    /// (e.g. the `number | undefined` produced by `T[K]` inside a homomorphic
+    /// mapped template `{ [K in keyof T]: T[K] | null }`), and the resulting
+    /// origin `[number | undefined, null]` would otherwise leak the nested
+    /// `undefined` ahead of `null` — `number | undefined | null` instead of
+    /// tsc's `number | null | undefined`.
+    ///
+    /// To match tsc we descend into nested unions that carry no preserved
+    /// display name (no `display_alias`) and no `union_origin` of their own,
+    /// hoisting their `null`/`undefined` to the tail while keeping the
+    /// remaining members cohesive so non-nullish ordering is unchanged.
+    /// Unions that *do* carry a display name or origin are left intact so the
+    /// alias/source-order they were preserved for is not lost.
+    fn collect_union_member_for_display(
+        &self,
+        member: TypeId,
+        ordered: &mut Vec<TypeId>,
+        has_null: &mut bool,
+        has_undefined: &mut bool,
+    ) {
+        if member == TypeId::NULL {
+            *has_null = true;
+            return;
+        }
+        if member == TypeId::UNDEFINED {
+            *has_undefined = true;
+            return;
+        }
+        if let Some(TypeData::Union(list_id)) = self.interner.lookup(member)
+            && self.interner.get_display_alias(member).is_none()
+            && self.interner.get_union_origin(member).is_none()
+            && self
+                .def_store
+                .and_then(|ds| ds.find_def_for_type(member))
+                .is_none()
+        {
+            let inner = self.interner.type_list(list_id);
+            let has_nested_nullish = inner
+                .iter()
+                .any(|&m| m == TypeId::NULL || m == TypeId::UNDEFINED);
+            if has_nested_nullish {
+                let mut remaining: Vec<TypeId> = Vec::with_capacity(inner.len());
+                for &m in inner.iter() {
+                    if m == TypeId::NULL {
+                        *has_null = true;
+                    } else if m == TypeId::UNDEFINED {
+                        *has_undefined = true;
+                    } else {
+                        remaining.push(m);
+                    }
+                }
+                match remaining.len() {
+                    0 => {}
+                    1 => ordered.push(remaining[0]),
+                    _ => ordered.push(self.interner.union_preserve_members(remaining)),
+                }
+                return;
+            }
+        }
+        ordered.push(member);
+    }
+
     pub(super) fn format_union_preserving_member_order(&mut self, members: &[TypeId]) -> String {
         self.format_ordered_union_members(members.to_vec())
     }

--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
@@ -1410,6 +1410,42 @@ fn typeof_result_carve_out_does_not_apply_to_subset() {
     );
 }
 
+/// A union whose `union_origin` preserves a nested *anonymous* sub-union
+/// (e.g. the `number | undefined` produced by `T[K]` inside a homomorphic
+/// mapped template `{ [K in keyof T]: T[K] | null }`) must still render
+/// `null`/`undefined` at the canonical tail — `number | null | undefined`,
+/// matching tsc — not leak the nested `undefined` ahead of `null`.
+#[test]
+fn nested_anonymous_union_origin_hoists_nullish_to_tail() {
+    let db = TypeInterner::new();
+    let inner = db.union(vec![TypeId::NUMBER, TypeId::UNDEFINED]); // number | undefined
+    let outer = db.union(vec![TypeId::NUMBER, TypeId::UNDEFINED, TypeId::NULL]);
+    // Simulate the `T[K] | null` origin preserving the nested sub-union.
+    db.store_union_origin(outer, vec![inner, TypeId::NULL]);
+
+    let mut fmt = TypeFormatter::new(&db);
+    assert_eq!(fmt.format(outer), "number | null | undefined");
+}
+
+/// The hoist must keep the non-nullish remainder of a nested anonymous union
+/// cohesive: `(string | number | undefined) | null` renders as
+/// `string | number | null | undefined`.
+#[test]
+fn nested_anonymous_union_origin_keeps_remainder_cohesive() {
+    let db = TypeInterner::new();
+    let inner = db.union(vec![TypeId::STRING, TypeId::NUMBER, TypeId::UNDEFINED]);
+    let outer = db.union(vec![
+        TypeId::STRING,
+        TypeId::NUMBER,
+        TypeId::UNDEFINED,
+        TypeId::NULL,
+    ]);
+    db.store_union_origin(outer, vec![inner, TypeId::NULL]);
+
+    let mut fmt = TypeFormatter::new(&db);
+    assert_eq!(fmt.format(outer), "string | number | null | undefined");
+}
+
 // =================================================================
 // Cyclic source-position graph guard (issue #7574 — 4th overflow).
 //


### PR DESCRIPTION
AgentName: M4-A
Track: conformance / diagnostics (mapped-key modifier family)
Invariant: union diagnostic display matches `tsc` member ordering regardless of how the union was constructed.

## Summary
Closes the modifier-**display** facet of the mapped-key bug family tracked in #12174.

When an optional property's mapped template adds a nullish member — e.g. the homomorphic map `{ [K in keyof T]: T[K] | null }` over `{ b?: number }` — the apparent read type of `b` is `number | null | undefined` in `tsc`. `tsz` rendered it as `number | undefined | null`.

```ts
type S = { b?: number };
type Nullify<T> = { [K in keyof T]: T[K] | null };
declare const y: Nullify<S>;
const a: 0 = y.b;
```
- `tsc` 6.0.3: `Type 'number | null | undefined' is not assignable to type '0'.`
- `tsz` (before): `Type 'number | undefined | null' ...`
- `tsz` (after): `Type 'number | null | undefined' ...`  ✅

## Structural rule
When a union is displayed, `null`/`undefined` render last (null before undefined) regardless of how the union was constructed, because `tsc` flattens unions structurally.

`tsz`'s diagnostic `union_origin` side-table can preserve a nested **anonymous** sub-union (the `number | undefined` produced by `T[K]` on an optional source property), giving an origin `[number | undefined, null]`. `format_union` only hoisted *direct* `null`/`undefined` members to the tail, so the `undefined` buried in the nested sub-union leaked ahead of `null`.

`format_union` now descends into nested unions that carry **no preserved display name** (no `display_alias`, no `union_origin`, no backing `DefId`) and hoists their `null`/`undefined` to the tail, keeping the non-nullish remainder cohesive so non-nullish ordering is unchanged. Unions that *do* carry a name/origin (e.g. `type A = number | undefined` displayed as `A | null`) are left intact so alias display is preserved.

Owner layer: solver diagnostic `TypeFormatter` (`crates/tsz-solver/src/diagnostics/format/compound/union_display.rs`). No checker-side type logic added.

## Scope
- `crates/tsz-solver/src/diagnostics/format/compound/union_display.rs`: new `collect_union_member_for_display` helper feeding `format_union`.
- `crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs`: two regression unit tests.

Adjacent matrix verified vs `tsc` 6.0.3 (all primary displays now identical):
- mapped `+?`/`-?`/`+readonly`/`-readonly`, key-remap `as K`, template-literal remap, filtering remap — modifier semantics preserved.
- homomorphic non-identity templates (`T[K][]`, `T[K] | null`), `Partial`/`Required`/`Pick`/`Omit`/`Record`, `Nullable`/`Partialize` aliases.
- alias preservation: `type A = number | undefined` still renders `A | null` (not flattened).
- explicit unions, optional `+ null`, intersection/union sources.

Out of scope (separate pre-existing bugs, unchanged here): which union constituent the TS2322 secondary line elaborates (`Type 'undefined'` vs `Type 'number'`), and union alias-selection display (`A | null` vs `B | undefined`).

## Project Corpus Impact
- Row: nextjs, zod, kysely, rxjs-style mapped optional null diagnostics
- Bug family: mapped-key modifier diagnostic display (#12174)
Display-only change to union member ordering in diagnostics; no semantic/relation behavior changes. Improves parity for nextjs/zod/kysely/rxjs-style mapped+optional+null rows in the bug family. No fixture-name fast paths.

## Verification
- `cargo test -p tsz-solver --lib diagnostics::format` — 219 passed (incl. 2 new + alias-preservation guards).
- `cargo test -p tsz-checker --lib error_reporter` — 177 passed.
- `cargo clippy -p tsz-solver --lib` — clean.
- Manual `tsc` 6.0.3 vs `tsz` diff over the adjacent matrix above — all primary type displays identical.
- Pre-existing local-only failures unrelated to this change and present on `main`: `architecture_guards::evaluation_engine_keeps_request_stage_boundary`, `architecture_contract_tests_src::test_no_push_diagnostic_outside_error_reporter`, and a debug-build stack overflow in one zod recursion test.

## Coordination Notes
Claimed #12174 with `WIP` label. Semantic modifier preservation across the family was already correct; this PR fixes the remaining display-ordering divergence. Ready-review CI owns broad conformance/emit/fourslash suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NdsUVzwTwC14oMePi6CyF)_
