### PR TITLE
perf(checker): cache indexed object branch constraint proofs

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -107,6 +107,30 @@ impl<'a> CheckerState<'a> {
         branch: TypeId,
         constraint: TypeId,
     ) -> bool {
+        let cache_key = (branch, constraint);
+        if let Some(&cached) = self
+            .ctx
+            .type_reference_validation_caches
+            .indexed_object_map_branch_constraint
+            .get(&cache_key)
+        {
+            return cached;
+        }
+
+        let result =
+            self.indexed_object_map_branch_satisfies_constraint_uncached(branch, constraint);
+        self.ctx
+            .type_reference_validation_caches
+            .indexed_object_map_branch_constraint
+            .insert(cache_key, result);
+        result
+    }
+
+    fn indexed_object_map_branch_satisfies_constraint_uncached(
+        &mut self,
+        branch: TypeId,
+        constraint: TypeId,
+    ) -> bool {
         let Some((object_type, _index_type)) =
             query::index_access_components(self.ctx.types.as_type_database(), branch)
         else {

--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -25,6 +25,10 @@ pub struct TypeReferenceValidationCaches {
     /// reached repeatedly while extracting generic parameter lists from aliases
     /// imported or re-exported through several files.
     pub conditional_branch_constraint: FxHashMap<(TypeId, TypeId), bool>,
+    /// Results for indexed-object-map branch constraint proofs. This memo sits
+    /// underneath `conditional_branch_constraint` because different conditional
+    /// aliases can expose the same mapped-object branch/value constraint pair.
+    pub indexed_object_map_branch_constraint: FxHashMap<(TypeId, TypeId), bool>,
 }
 
 /// Sparse cache for node-index-keyed `TypeId` lookups.

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -277,6 +277,9 @@ impl<'a> CheckerContext<'a> {
         self.type_reference_validation_caches
             .conditional_branch_constraint
             .clear();
+        self.type_reference_validation_caches
+            .indexed_object_map_branch_constraint
+            .clear();
         self.in_conditional_extends_depth = 0;
         self.typeof_param_scope.clear();
         self.type_param_constraint_excluded_params.clear();


### PR DESCRIPTION
## Summary
- memoize indexed-object-map branch constraint proofs in the existing per-file type-reference validation cache
- clear the memo with the other validation caches between source-file sessions

## Project Corpus Impact
- Row: ts-toolbelt-project
- Bug family: type-reference constraint proof perf for conditional/mapped indexed-object branches

## Perf
- ts-toolbelt quick baseline: tsz `2.166 s ± 0.018`, tsgo `102.0 ms ± 1.2`, tsgo `21.24x` faster
- after: tsz `2.136 s ± 0.019`, tsgo `101.7 ms ± 1.1`, tsgo `21.00x` faster
- perf counters: Check `2.30s` -> `2.24s`; `_Pick` body `398.56ms` -> `385.28ms`

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p tsz-checker`
- manual equivalent of `conditional_constraint_relation_routing_arch_tests` string assertions
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh .target-bench/dist-fast/tsz --extendedDiagnostics --perf-counters-json artifacts/perf/ts-toolbelt-next-indexed-branch-cache.perf.json --noEmit -p .target-bench/external/ts-toolbelt/tsconfig.flat.json`
- `scripts/safe-run.sh ./scripts/bench/perf-hotspots.sh --quick --filter '^ts-toolbelt-project$' --json-file artifacts/perf/ts-toolbelt-next-indexed-branch-cache.json`

Note: a focused `cargo test -p tsz-checker conditional_constraint_relation_routing_arch_tests -- --nocapture` could not link locally because `ld` failed with `errno=28` (no space left on device) while building multiple checker test binaries.

AgentName: Codex