### PR TITLE
refactor(checker): route enum flow identity through boundary

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -594,11 +594,10 @@ impl<'a> FlowAnalyzer<'a> {
                                     // the declared enum so cross-enum assignments still report
                                     // TS2322.
                                     if self.is_const_variable_declaration(flow.node)
-                                        && crate::query_boundaries::common::enum_components(
-                                            self.interner,
+                                        && query::has_enum_components(
+                                            self.interner.as_type_database(),
                                             narrowing_base,
                                         )
-                                        .is_some()
                                         && self.flow_assignability_related(
                                             assigned_type,
                                             narrowing_base,

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -80,6 +80,14 @@ pub(crate) fn enum_member_domain(db: &dyn TypeDatabase, type_id: TypeId) -> Type
         .unwrap_or(type_id)
 }
 
+/// Return whether a type carries enum component identity.
+///
+/// The checker owns deciding which flow assignments get enum-specific
+/// reduction. This boundary owns the reusable semantic enum-domain query.
+pub(crate) fn has_enum_components(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    tsz_solver::visitor::enum_components(db, type_id).is_some()
+}
+
 pub(crate) fn enum_member_union_domain(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
     let Some(members) = union_members_for_type(db, type_id) else {
         return enum_member_domain(db, type_id);
@@ -1103,6 +1111,17 @@ mod tests {
         assert!(members.contains(&literal));
         assert!(members.contains(&TypeId::NUMBER));
         assert!(!members.contains(&enum_member));
+    }
+
+    #[test]
+    fn has_enum_components_tracks_enum_identity() {
+        let db = TypeInterner::new();
+        let literal = db.literal_string("ready");
+        let enum_member = db.enum_type(tsz_solver::def::DefId(702), literal);
+
+        assert!(has_enum_components(&db, enum_member));
+        assert!(!has_enum_components(&db, literal));
+        assert!(!has_enum_components(&db, TypeId::NUMBER));
     }
 
     #[test]


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker architecture / query-boundary cleanup refactor.

## Invariant
When checker flow traversal needs to know whether an assignment base carries enum component identity, checker owns CFG/source assignment selection; `query_boundaries::flow_analysis` owns the semantic enum-domain query.

## Scope
- Add `flow_analysis::has_enum_components` as the narrow flow/query-boundary helper.
- Route const-flow enum identity preservation through the flow boundary instead of the broad common boundary.
- Add a unit test covering enum identity versus literal/non-enum types.

## Project Corpus Impact
- Row: n/a
- Bug family: checker flow/query-boundary refactor
- Evidence: behavior-preserving routing cleanup; no project-row, fixture-specific, or solver-policy logic added.

## Verification
- `cargo fmt --check` passed.
- `scripts/arch/check-checker-boundaries.sh` passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -- query_boundaries::flow_analysis::tests::has_enum_components_tracks_enum_identity --exact` passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test enum_nominality_tests -- test_const_with_numeric_literal_initializer_preserves_cross_enum_check --exact` passed.
- Draft exact-head CI run `27021760477` passed.

## Coordination Notes
- Refs #8225 and #8227.
- No solver policy, variance, inference, cache-key, or diagnostic wording changes.
- Ready for full exact-head CI and queue review.