### PR TITLE
refactor(checker): name strict diagnostic relation guard

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -527,7 +527,7 @@ impl<'a> CheckerState<'a> {
         target: TypeId,
     ) -> crate::query_boundaries::assignability::RelationOutcome {
         crate::query_boundaries::assignability::RelationOutcome {
-            related: self.is_assignable_to_strict(source, target),
+            related: self.diagnostic_relation_boolean_guard_strict(source, target),
             depth_exceeded: false,
             iteration_exceeded: false,
             failure: None,
@@ -588,6 +588,18 @@ impl<'a> CheckerState<'a> {
         target: TypeId,
     ) -> bool {
         self.is_assignable_to_bivariant(source, target)
+    }
+
+    /// Strict-function-types boolean relation guard for diagnostic code paths.
+    ///
+    /// Use this only when the caller intentionally needs the legacy strict
+    /// function relation rather than the default assignability relation.
+    pub(crate) fn diagnostic_relation_boolean_guard_strict(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        self.is_assignable_to_strict(source, target)
     }
 
     /// No-weak-checks boolean relation guard for diagnostic code paths.


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker architecture / relation diagnostic routing refactor.

## Invariant
When a diagnostic probe intentionally needs strict-function-types compatibility only, tsz records that intent through a named diagnostic boolean guard; relation behavior remains unchanged and solver policy is not modified.

## Scope
- Add `diagnostic_relation_boolean_guard_strict` beside the existing default, bivariant, and no-weak diagnostic boolean guards.
- Route `strict_relation_outcome` through the strict guard instead of embedding the raw strict relation call directly.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-boundary refactor / diagnostic routing
- Evidence: behavior-preserving helper routing only; no fixture-specific or project-row logic added.

## Verification
- `git diff --check origin/main...HEAD` passed.
- `scripts/arch/check-checker-boundaries.sh` passed.
- `cargo nextest run -p tsz-checker call_checker_diagnostic_relation_routing_arch_tests` passed: 4 tests run, 4 passed, 13378 skipped.

## Coordination Notes
- Refs #8227.
- Avoids active object-literal/EPC and diagnostic display PRs in M1-A / Studio-B lanes.
- Refreshed onto latest `origin/main`; exact-head CI owns broad validation.
