### PR TITLE
ci: require full checks for workflow changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
                   should_run=false
                 fi
                 compiler_paths=$(printf '%s\n' "$all_paths" \
-                  | grep -E '^(Cargo\.(lock|toml)|\.cargo/|rust-toolchain|crates/clippy\.toml|crates/(conformance|tsz-(binder|checker|cli|common|core|emitter|lowering|lsp|parser|scanner|solver|wasm))(/|$)|benches/|tests/|TypeScript/|scripts/(conformance|emit|fourslash|tsc|dts|snapshot)|scripts/ci/lib/[^/]+\.sh|scripts/ci/(ci-resources|gcp-full-ci|github-suite|gcp-cache|suite-metadata|build-dist|dist|wasm)[^/]*\.sh)' \
+                  | grep -E '^(Cargo\.(lock|toml)|\.cargo/|rust-toolchain|\.github/workflows/(ci|bench)\.yml|crates/clippy\.toml|crates/(conformance|tsz-(binder|checker|cli|common|core|emitter|lowering|lsp|parser|scanner|solver|wasm))(/|$)|benches/|tests/|TypeScript/|scripts/(conformance|emit|fourslash|tsc|dts|snapshot)|scripts/ci/lib/[^/]+\.sh|scripts/ci/(ci-resources|gcp-full-ci|github-suite|gcp-cache|suite-metadata|build-dist|dist|wasm)[^/]*\.sh)' \
                   || true)
                 if [[ -z "$compiler_paths" ]]; then
                   compiler_checks_required=false
@@ -399,7 +399,7 @@ jobs:
                     2>/dev/null || echo "0")
                   if [[ "${required_summary_passed}" -gt 0 ]]; then
                     compiler_paths_on_pr=$(printf '%s\n' "${pr_changed_paths:-}" \
-                      | grep -E '^(Cargo\.(lock|toml)|\.cargo/|rust-toolchain|crates/clippy\.toml|crates/(conformance|tsz-(binder|checker|cli|common|core|emitter|lowering|lsp|parser|scanner|solver|wasm))(/|$)|benches/|tests/|TypeScript/|scripts/(conformance|emit|fourslash|tsc|dts|snapshot)|scripts/ci/lib/[^/]+\.sh|scripts/ci/(ci-resources|gcp-full-ci|github-suite|gcp-cache|suite-metadata|build-dist|dist|wasm)[^/]*\.sh)' \
+                      | grep -E '^(Cargo\.(lock|toml)|\.cargo/|rust-toolchain|\.github/workflows/(ci|bench)\.yml|crates/clippy\.toml|crates/(conformance|tsz-(binder|checker|cli|common|core|emitter|lowering|lsp|parser|scanner|solver|wasm))(/|$)|benches/|tests/|TypeScript/|scripts/(conformance|emit|fourslash|tsc|dts|snapshot)|scripts/ci/lib/[^/]+\.sh|scripts/ci/(ci-resources|gcp-full-ci|github-suite|gcp-cache|suite-metadata|build-dist|dist|wasm)[^/]*\.sh)' \
                       || true)
                     if [[ -n "$compiler_paths_on_pr" ]]; then
                       heavy_checks_passed=$(gh api \
@@ -905,10 +905,10 @@ jobs:
           compression-level: 1
 
   unit:
-    # Required unit context. Run on the Cloud Build private pool instead of
-    # the 8-vCPU self-hosted runner: the old local path repeatedly hit
-    # linker/process kills while the same suite passed through Cloud Build.
-    # Keep the status name as `unit` so branch protection remains stable.
+    # Required unit context. Keep this on the Cloud Build private pool: direct
+    # Cloud Run unit still OOMs while linking checker integration test targets
+    # even with one test thread and single-threaded lld. The remaining compiler
+    # shards run on the Cloud Run runner fleet.
     name: unit
     needs: gate
     if: needs.gate.outputs.should_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true'
@@ -935,19 +935,27 @@ jobs:
 
   unit-cloudbuild:
     # Compatibility status for dashboards and branch-protection rules that may
-    # still look for the experimental Cloud Build context. The Cloud Build unit
-    # suite is now executed by the required `unit` job above.
+    # still look for the old experimental Cloud Build context. The required
+    # Cloud Build unit suite is enforced by the `unit` job above.
     name: unit-cloudbuild
-    needs: gate
-    if: needs.gate.outputs.should_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true'
-    runs-on: [self-hosted, tsz-cloud-run]
+    needs: [gate, unit]
+    if: always() && needs.gate.outputs.should_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true'
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
       - name: Report promoted unit path
-        run: echo "Cloud Build unit suite is enforced by the required unit job."
+        env:
+          UNIT_RESULT: ${{ needs.unit.result }}
+        run: |
+          set -euo pipefail
+          if [[ "$UNIT_RESULT" != "success" ]]; then
+            echo "Required Cloud Build unit job did not pass: ${UNIT_RESULT}"
+            exit 1
+          fi
+          echo "Cloud Build unit suite is enforced by the required unit job."
 
   conformance:
     # Conformance shards consume the dist-fast binaries artifact and run the

--- a/scripts/bench/test-project-file-stats.mjs
+++ b/scripts/bench/test-project-file-stats.mjs
@@ -561,10 +561,16 @@ sum_ts_stats '${srcDir.replace(/'/g, "'\\''")}'
 
 {
   const extract = awkExtractFunction("bench_project_file_stats_cache_dir");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-cache-dir-resolver-"));
+  const functionFile = path.join(dir, "bench-cache-dir.sh");
+  const extractResult = spawnSync("bash", ["-c", `${extract} > '${functionFile.replace(/'/g, "'\\''")}'`], {
+    encoding: "utf8",
+  });
+  assert.equal(extractResult.status, 0, extractResult.stderr);
 
   const runResolver = (envLine) => {
     const script = `set -euo pipefail
-source <(${extract})
+source '${functionFile.replace(/'/g, "'\\''")}'
 ${envLine}
 bench_project_file_stats_cache_dir
 `;
@@ -575,40 +581,44 @@ bench_project_file_stats_cache_dir
     return result.stdout.trim();
   };
 
-  // With a persistent BENCH_TARGET_DIR available, the default must live under
-  // it — NOT under the ephemeral per-run TEMP_DIR, even when TEMP_DIR is set.
-  const persistent = runResolver(
-    'BENCH_TARGET_DIR=/persist/.target-bench; TEMP_DIR=/tmp/run-XXXX; TMPDIR=/tmp; unset TSZ_PROJECT_FILE_STATS_CACHE_DIR',
-  );
-  assert.equal(
-    persistent,
-    "/persist/.target-bench/project-file-stats-cache",
-    "default cache dir is anchored to the run-surviving BENCH_TARGET_DIR",
-  );
-  assert.ok(
-    !persistent.includes("/run-XXXX"),
-    "default cache dir must not live under the per-run TEMP_DIR that is deleted on exit",
-  );
+  try {
+    // With a persistent BENCH_TARGET_DIR available, the default must live under
+    // it — NOT under the ephemeral per-run TEMP_DIR, even when TEMP_DIR is set.
+    const persistent = runResolver(
+      'BENCH_TARGET_DIR=/persist/.target-bench; TEMP_DIR=/tmp/run-XXXX; TMPDIR=/tmp; unset TSZ_PROJECT_FILE_STATS_CACHE_DIR',
+    );
+    assert.equal(
+      persistent,
+      "/persist/.target-bench/project-file-stats-cache",
+      "default cache dir is anchored to the run-surviving BENCH_TARGET_DIR",
+    );
+    assert.ok(
+      !persistent.includes("/run-XXXX"),
+      "default cache dir must not live under the per-run TEMP_DIR that is deleted on exit",
+    );
 
-  // An explicit override always wins over the computed default.
-  const overridden = runResolver(
-    'BENCH_TARGET_DIR=/persist/.target-bench; TSZ_PROJECT_FILE_STATS_CACHE_DIR=/custom/cache',
-  );
-  assert.equal(
-    overridden,
-    "/custom/cache",
-    "an explicit TSZ_PROJECT_FILE_STATS_CACHE_DIR overrides the default",
-  );
+    // An explicit override always wins over the computed default.
+    const overridden = runResolver(
+      'BENCH_TARGET_DIR=/persist/.target-bench; TSZ_PROJECT_FILE_STATS_CACHE_DIR=/custom/cache',
+    );
+    assert.equal(
+      overridden,
+      "/custom/cache",
+      "an explicit TSZ_PROJECT_FILE_STATS_CACHE_DIR overrides the default",
+    );
 
-  // With no persistent target known, fall back to TMPDIR rather than crashing.
-  const tmpFallback = runResolver(
-    'unset BENCH_TARGET_DIR; TMPDIR=/tmp/fallback; unset TSZ_PROJECT_FILE_STATS_CACHE_DIR',
-  );
-  assert.equal(
-    tmpFallback,
-    "/tmp/fallback/project-file-stats-cache",
-    "without BENCH_TARGET_DIR the resolver falls back to TMPDIR",
-  );
+    // With no persistent target known, fall back to TMPDIR rather than crashing.
+    const tmpFallback = runResolver(
+      'unset BENCH_TARGET_DIR; TMPDIR=/tmp/fallback; unset TSZ_PROJECT_FILE_STATS_CACHE_DIR',
+    );
+    assert.equal(
+      tmpFallback,
+      "/tmp/fallback/project-file-stats-cache",
+      "without BENCH_TARGET_DIR the resolver falls back to TMPDIR",
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 console.log("project-file-stats tests passed");

--- a/scripts/ci/test-pr-ready-state.mjs
+++ b/scripts/ci/test-pr-ready-state.mjs
@@ -149,6 +149,12 @@ assert.match(
   "ci-resources.sh changes must require compiler CI because they size dist/unit/wasm jobs",
 );
 
+assert.match(
+  ciWorkflow,
+  /\\.github\/workflows\/\(ci\|bench\)\\.yml/,
+  "CI workflow changes must require compiler CI because they route native merge queue and Cloud Run jobs",
+);
+
 assert.doesNotMatch(
   ciWorkflow,
   /CI run superseded[\s\S]+?sys\.exit\(0\)/,
@@ -168,3 +174,21 @@ for (const job of ["lint", "cargo-shear", "cargo-deny"]) {
     `${job} should run on hosted Ubuntu so cheap gates are not blocked by the self-hosted pool`,
   );
 }
+
+assert.match(
+  ciWorkflow,
+  /\n\s{2}unit:\n[\s\S]+?runs-on: \[self-hosted, tsz-cloud-run\][\s\S]+?Submit required unit suite to Cloud Build pool[\s\S]+?gcloud builds submit[\s\S]+?--config=scripts\/cloudbuild\/cloudbuild-unit\.yaml/,
+  "unit should submit the heavy checker-linking unit suite to Cloud Build",
+);
+
+assert.doesNotMatch(
+  ciWorkflow,
+  /\n\s{2}unit:\n[\s\S]+?Run unit suite on Cloud Run runner/,
+  "unit should not run the checker-linking unit suite directly on 32 GiB Cloud Run workers",
+);
+
+assert.match(
+  ciWorkflow,
+  /\n\s{2}unit-cloudbuild:\n[\s\S]+?needs: \[gate, unit\][\s\S]+?UNIT_RESULT: \$\{\{ needs\.unit\.result \}\}[\s\S]+?Required Cloud Build unit job did not pass/,
+  "legacy unit-cloudbuild context should mirror the required Cloud Build unit job",
+);


### PR DESCRIPTION
## Summary
- classify `.github/workflows/ci.yml` and `bench.yml` as compiler-affecting paths so workflow changes run the full compiler suite on PR and merge-queue validation
- keep the heavy required `unit` suite on the Cloud Build private pool after direct Cloud Run validation still hit checker-linker SIGKILLs
- keep the legacy `unit-cloudbuild` context, but make it mirror the real `unit` result on hosted Ubuntu
- fix the benchmark cache-dir test to avoid brittle process-substitution sourcing

## Validation
- `node scripts/ci/test-pr-ready-state.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `node scripts/bench/test-project-file-stats.mjs`
- `git diff --check`
- `TSZ_CI_SKIP_HOST_APT=1 TSZ_CI_DISABLE_SCCACHE=1 scripts/ci/gcp-full-ci.sh lint` with local `remote.origin.url` temporarily set to `https://github.com/tsz-org/tsz.git` so the workspace metadata guard matches the moved repo
- PR CI attempted direct Cloud Run unit twice; both failed from checker integration/linker SIGKILL, so unit remains on Cloud Build as the heavy exception

## Project Corpus Impact
- Row: n/a
- Bug family: CI runner routing / native merge queue gcloud infra

AgentName: Studio-manager
