### PR TITLE
refactor(checker): name no-erase diagnostic relation guard

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -510,7 +510,7 @@ impl<'a> CheckerState<'a> {
         target: TypeId,
     ) -> crate::query_boundaries::assignability::RelationOutcome {
         crate::query_boundaries::assignability::RelationOutcome {
-            related: self.is_assignable_to_no_erase_generics(source, target),
+            related: self.diagnostic_relation_boolean_guard_no_erase_generics(source, target),
             depth_exceeded: false,
             iteration_exceeded: false,
             failure: None,
@@ -590,16 +590,20 @@ impl<'a> CheckerState<'a> {
         self.is_assignable_to_bivariant(source, target)
     }
 
-    /// Strict-function-types boolean relation guard for diagnostic code paths.
-    ///
-    /// Use this only when the caller intentionally needs the legacy strict
-    /// function relation rather than the default assignability relation.
     pub(crate) fn diagnostic_relation_boolean_guard_strict(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> bool {
         self.is_assignable_to_strict(source, target)
+    }
+
+    pub(crate) fn diagnostic_relation_boolean_guard_no_erase_generics(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        self.is_assignable_to_no_erase_generics(source, target)
     }
 
     /// No-weak-checks boolean relation guard for diagnostic code paths.


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker architecture / relation diagnostic routing refactor.

## Invariant
When a class or heritage diagnostic probe intentionally needs no-generic-erasure compatibility only, tsz records that relation role through a named diagnostic boolean guard while preserving the same relation behavior and leaving solver policy untouched.

## Scope
- Add `diagnostic_relation_boolean_guard_no_erase_generics` beside the existing default, bivariant, strict, and no-weak diagnostic boolean guards.
- Route `no_erase_generics_relation_outcome` through the no-erasure guard instead of embedding the raw no-erasure relation call directly.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-boundary refactor / diagnostic routing
- Evidence: behavior-preserving helper routing only; no fixture-specific or project-row logic added.

## Verification
- `git diff --check origin/main...HEAD` passed.
- `scripts/arch/check-checker-boundaries.sh` passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-checker class_boundary_fallback_relation_routing_arch_tests` passed: 3 tests run, 3 passed, 13442 skipped.

## Coordination Notes
- Refs #8227.
- Avoids active object-literal/EPC, diagnostic display, and solver-policy PRs in neighboring lanes.
- Ready for queue-owner review after remote body and `agent:M1-B` label verification.
