### PR TITLE
refactor(checker): name assign outcome fast-path guard

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -222,7 +222,7 @@ impl<'a> CheckerState<'a> {
         source: TypeId,
         target: TypeId,
     ) -> crate::query_boundaries::assignability::RelationOutcome {
-        let related = self.is_assignable_to(source, target);
+        let related = self.diagnostic_relation_boolean_guard(source, target);
         if related {
             return crate::query_boundaries::assignability::RelationOutcome {
                 related: true,

--- a/crates/tsz-checker/src/tests/relation_routing_residual_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/relation_routing_residual_arch_tests.rs
@@ -61,6 +61,36 @@ fn inline_arch_test_relation_assertion(relative_path: &str, line: &str) -> bool 
             || line.contains(".assign_relation_outcome_with_env("))
 }
 
+fn function_body_between<'a>(source: &'a str, start_marker: &str, end_marker: &str) -> &'a str {
+    let start = source
+        .find(start_marker)
+        .expect("missing function start marker");
+    let rest = &source[start..];
+    let end = rest.find(end_marker).expect("missing function end marker");
+    &rest[..end]
+}
+
+#[test]
+fn assign_relation_outcome_fast_path_uses_named_diagnostic_guard() {
+    let source = fs::read_to_string("src/assignability/assignability_relation.rs")
+        .expect("failed to read assignability relation source");
+    let body = function_body_between(
+        &source,
+        "pub(crate) fn assign_relation_outcome(",
+        "pub(crate) fn variance_accepted_relation_outcome(",
+    );
+    let compact: String = body.chars().filter(|ch| !ch.is_whitespace()).collect();
+
+    assert!(
+        compact.contains("self.diagnostic_relation_boolean_guard(source,target)"),
+        "assign_relation_outcome should name its boolean fast path as a diagnostic guard"
+    );
+    assert!(
+        !compact.contains("self.is_assignable_to(source,target)"),
+        "assign_relation_outcome should not embed a raw assignability fast path"
+    );
+}
+
 #[test]
 fn production_checker_relation_truth_uses_outcome_boundaries() {
     let mut violations = Vec::new();


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker architecture / relation diagnostic routing refactor.

## Invariant
When a diagnostic relation outcome fast-path only needs a boolean accept/reject answer, tsz routes that predicate through a named diagnostic boolean guard before falling back to `RelationRequest` / `RelationOutcome` failure analysis; this PR changes checker orchestration only and leaves solver relation policy untouched.

## Scope
- Route `assign_relation_outcome`'s initial success fast-path through `diagnostic_relation_boolean_guard` instead of embedding a raw `is_assignable_to` call.
- Add an architecture regression test that pins the named guard requirement for that diagnostic outcome helper.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation-boundary refactor / diagnostic routing
- Evidence: behavior-preserving helper routing only; no fixture-specific or project-row logic added.

## Verification
- `git diff --check origin/main...HEAD` passed.
- `scripts/arch/check-checker-boundaries.sh` passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-checker assign_relation_outcome_fast_path_uses_named_diagnostic_guard` passed: 1 test run, 1 passed, 13458 skipped.

## Coordination Notes
- Refs #8227.
- Avoids active object-literal/EPC, diagnostic display, flow/narrowing, and solver-policy lanes.
- Ready for queue-owner review after remote body and `agent:M1-B` label verification.
