### PR TITLE
fix(solver): align recursive-growth divergence ceiling with tsc tail limit (#10875)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1080,6 +1080,9 @@ mod property_receiver_display_recursion_overflow_tests;
 #[path = "tests/property_receiver_relation_routing_arch_tests.rs"]
 mod property_receiver_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/recursive_accumulator_depth_tests.rs"]
+mod recursive_accumulator_depth_tests;
+#[cfg(test)]
 #[path = "../tests/recursive_alias_application_target_display_tests.rs"]
 mod recursive_alias_application_target_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/recursive_accumulator_depth_tests.rs
+++ b/crates/tsz-checker/src/tests/recursive_accumulator_depth_tests.rs
@@ -1,0 +1,156 @@
+//! Regression tests for spurious `TS2589` on *terminating* recursive
+//! accumulator type aliases (issue #10875).
+//!
+//! Structural rule: a tail-recursive conditional alias that grows an
+//! accumulator by a bounded amount per step and stops at a concrete bound —
+//! e.g.
+//! `type BuildTuple<L extends number, T extends any[] = []> =
+//!    T['length'] extends L ? T : BuildTuple<L, [...T, any]>` — terminates and
+//! must not be flagged as excessively deep. `tsc` evaluates such an alias up to
+//! its tail-recursion limit (1000 instantiations): `BuildTuple<999>` is clean,
+//! `BuildTuple<1000>` reports TS2589. The divergent-growth detector that powers
+//! tsz's use-site TS2589 probe must use that same 1000-step ceiling rather than
+//! firing on the first couple dozen growth steps, so terminating accumulators
+//! evaluate fully while genuinely unbounded growth is still reported at the
+//! boundary `tsc` uses.
+//!
+//! Anti-hardcoding: the rule is exercised with renamed binders, a different
+//! per-step growth increment, and a non-tuple (numeric counter) accumulator so
+//! the fix cannot be satisfied by matching a specific identifier or body shape.
+
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+const TS2589: u32 = 2589;
+
+const BUILD_TUPLE: &str = r#"
+type BuildTuple<L extends number, T extends any[] = []> =
+  T['length'] extends L ? T : BuildTuple<L, [...T, any]>;
+"#;
+
+/// Core repro: a terminating accumulator that needs far more than a couple
+/// dozen steps (40) must not emit TS2589 — `tsc` accepts it.
+#[test]
+fn terminating_build_tuple_deep_is_not_excessively_deep() {
+    let source = format!(
+        r#"
+{BUILD_TUPLE}
+type R = BuildTuple<40>;
+declare const r: R;
+const n: number = r.length;
+"#
+    );
+    let codes = strict_codes(&source);
+    assert!(
+        !codes.contains(&TS2589),
+        "BuildTuple<40> terminates; TS2589 is a false positive. Got: {codes:?}"
+    );
+}
+
+/// Just under tsc's tail-recursion limit: still clean.
+#[test]
+fn terminating_build_tuple_at_999_is_clean() {
+    let source = format!(
+        r#"
+{BUILD_TUPLE}
+type R = BuildTuple<999>;
+declare const r: R;
+const n: number = r.length;
+"#
+    );
+    let codes = strict_codes(&source);
+    assert!(
+        codes.is_empty(),
+        "BuildTuple<999> matches tsc (clean). Got: {codes:?}"
+    );
+}
+
+/// At/over the 1000-iteration limit, divergence detection must still fire —
+/// matching tsc, which reports TS2589 for `BuildTuple<1000>`.
+#[test]
+fn build_tuple_at_limit_still_reports_ts2589() {
+    let source = format!(
+        r#"
+{BUILD_TUPLE}
+type R = BuildTuple<1000>;
+declare const r: R;
+"#
+    );
+    let codes = strict_codes(&source);
+    assert!(
+        codes.contains(&TS2589),
+        "BuildTuple<1000> reaches the tail-recursion limit; TS2589 expected. Got: {codes:?}"
+    );
+}
+
+/// A genuinely non-terminating accumulator (the length check can never match
+/// because the accumulator grows two elements per step against an odd bound)
+/// must still report TS2589.
+#[test]
+fn non_terminating_accumulator_reports_ts2589() {
+    let codes = strict_codes(
+        r#"
+type Never<L extends number, T extends any[] = []> =
+  T['length'] extends L ? T : Never<L, [...T, any, any]>;
+type R = Never<3>;
+declare const r: R;
+"#,
+    );
+    assert!(
+        codes.contains(&TS2589),
+        "Never<3> never converges; TS2589 expected. Got: {codes:?}"
+    );
+}
+
+/// Anti-hardcoding: renamed binders (`L`/`T` -> `Len`/`Acc`) must behave
+/// identically.
+#[test]
+fn renamed_binders_terminating_accumulator_is_clean() {
+    let codes = strict_codes(
+        r#"
+type Build<Len extends number, Acc extends any[] = []> =
+  Acc['length'] extends Len ? Acc : Build<Len, [...Acc, any]>;
+type R = Build<60>;
+declare const r: R;
+const n: number = r.length;
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2589),
+        "Renamed terminating accumulator must not emit TS2589. Got: {codes:?}"
+    );
+}
+
+/// Anti-hardcoding: a non-tuple accumulator (numeric-string length counter via
+/// a recursive defaulted alias) that terminates must also be accepted.
+#[test]
+fn terminating_string_accumulator_is_clean() {
+    let codes = strict_codes(
+        r#"
+type Repeat<N extends number, S extends string = "", C extends any[] = []> =
+  C['length'] extends N ? S : Repeat<N, `${S}x`, [...C, 1]>;
+type R = Repeat<50>;
+const r: R = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+"#,
+    );
+    assert!(
+        !codes.contains(&TS2589),
+        "Terminating string accumulator must not emit TS2589. Got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/recursive_growth.rs
+++ b/crates/tsz-solver/src/evaluation/recursive_growth.rs
@@ -28,12 +28,24 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
     const MAX_RECURSIVE_GROWTH_STEP: u64 = 100_000;
 
     /// New maximum argument weights an alias may reach during the TS2589
-    /// detection pass before its self-recursion is treated as divergent. The
-    /// detection pass is depth-bounded (`MAX_DEF_DEPTH`) and runs in a single
-    /// evaluator, so this only needs to be below that ceiling to fire promptly;
-    /// it never sees a *terminating* recursion, which defers under free type
-    /// parameters instead of recursing.
-    const MAX_DETECTION_GROWTH_STEPS: u32 = 25;
+    /// detection pass before its self-recursion is treated as divergent.
+    ///
+    /// The detection pass is normally driven with *free* type parameters, where
+    /// a terminating alias defers under its condition and never reaches this
+    /// tracker. But the use-site TS2589 probe (`state/type_resolution`) also runs
+    /// this pass for *concrete*-argument applications of accumulator aliases that
+    /// omit a defaulted counter (e.g. `BuildTuple<40>` for
+    /// `type BuildTuple<L extends number, T extends any[] = []> =
+    ///   T['length'] extends L ? T : BuildTuple<L, [...T, any]>`). Such an alias
+    /// legitimately grows its accumulator by one element per step and *does*
+    /// terminate, reaching a new maximum weight on every step. The ceiling must
+    /// therefore match the tail-recursion iteration limit the conditional
+    /// evaluator already honours (`conditional::MAX_TAIL_RECURSION_DEPTH` =
+    /// 1000, itself tsc's tail-recursion / `instantiationCount` bound). At 1000
+    /// the detector flags genuinely unbounded linear growth at the same boundary
+    /// `tsc` reports TS2589, while exponential growth is still caught far sooner
+    /// by the per-step `MAX_RECURSIVE_GROWTH_STEP` weight ceiling.
+    const MAX_DETECTION_GROWTH_STEPS: u32 = 1000;
 
     /// Cheap structural-weight estimate for the divergent-growth detector.
     ///


### PR DESCRIPTION
Fixes #10875

AgentName: M4-A
Track: Track 1 — conformance / diagnostics parity

## Summary
Terminating tail-recursive accumulator aliases (the canonical tuple/counter `BuildTuple` + `DeepObject` patterns) emitted a spurious `TS2589` ("Type instantiation is excessively deep and possibly infinite") once the recursion ran for more than ~25 steps, even though they converge. `tsc` accepts them.

## Structural rule
A tail-recursive conditional alias that grows an accumulator by a bounded amount per step and stops at a concrete bound — the `BuildTuple` shape: `length extends L ? T : BuildTuple<L, [...T, any]>` — terminates. `tsc` evaluates it up to its tail-recursion limit of 1000 instantiations: `BuildTuple` at 999 is clean, at 1000 it reports `TS2589`. tsz must do the same through the solver's divergent-growth detector.

## Root cause / owner layer
Owner: **solver** (`crates/tsz-solver/src/evaluation/recursive_growth.rs`). `detect_recursive_growth` has three divergence signals; signal 2 (`MAX_DETECTION_GROWTH_STEPS`) flags an alias as divergent after a sustained run of *new maximum* argument weights during the TS2589 detection pass. The ceiling was 25.

The detection pass is normally driven with *free* type parameters, where a terminating alias defers under its condition and never reaches the tracker. But the use-site TS2589 probe (`crates/tsz-checker/src/state/type_resolution/core.rs`) also runs that pass for **concrete-argument** applications of accumulator aliases that omit a defaulted counter (`BuildTuple` at 40). Such an alias reaches a new maximum weight on *every* step yet still terminates, so it tripped the 25-step ceiling far before convergence.

The conditional evaluator already honours tsc's tail-recursion bound (`conditional::MAX_TAIL_RECURSION_DEPTH = 1000`); the growth detector was the sole component capping legitimate linear growth earlier. The fix raises `MAX_DETECTION_GROWTH_STEPS` to 1000 so the divergence boundary matches tsc exactly. Exponential growth is still caught promptly by the per-step `MAX_RECURSIVE_GROWTH_STEP` weight ceiling (100k), and genuinely unbounded linear growth still reports `TS2589` at the 1000-step boundary.

## Invariant
tsz reports `TS2589` for a recursive type instantiation iff `tsc` does, at the same depth boundary. Terminating accumulator recursion below 1000 steps evaluates to its converged type; recursion that reaches 1000 steps (or exhibits exponential per-step growth) reports `TS2589`.

## Scope
One-line constant change plus its rationale comment in `recursive_growth.rs`; new regression-test module wired into `tsz-checker`. No change to evaluation results, narrowing, emit, or any other diagnostic.

## Adjacent-case matrix (verified vs `tsc` 6.0.2)
| Case | `tsc` | tsz before | tsz after |
| --- | --- | --- | --- |
| `BuildTuple` at 40 (terminating) | clean | TS2589 | clean |
| `BuildTuple` at 999 | clean | TS2589 | clean |
| `BuildTuple` at 1000 | TS2589 | TS2589 | TS2589 |
| renamed binders, +1 growth, `Repeat` string-builder | clean | TS2589 | clean |
| `Never` at 3 (2-per-step vs odd bound, non-terminating) | TS2589 | TS2589 | TS2589 |
| `TrimLeft` deep string recursion | clean | clean | clean |

## Project Corpus Impact
- Row: n/a
- Bug family: recursive-types divergence (spurious TS2589)

No required project row is expected to regress. The change only removes spurious `TS2589` on deep-but-finite recursive utilities (common in type-level libraries such as type-challenges / ts-toolbelt) and preserves the existing divergence boundary; it cannot turn a previously-clean row red because it only *relaxes* an over-eager bail to tsc's boundary. `BuildTuple` at 999 evaluates in ~0.75s (no perf cliff).

## Verification
- `cargo test -p tsz-checker --lib recursive_accumulator_depth` — 6/6 pass (new regression module).
- `cargo test -p tsz-checker --test recursive_alias_counter_convergence_ts2589_tests` — 6/6 pass (existing TS2589 convergence + divergence suite, unchanged).
- `cargo clippy -p tsz-solver --lib` — clean.
- Manual boundary check of `tsz` vs `tsc` 6.0.2 for `BuildTuple` at N in {25,40,100,500,999,1000,1001}: exact parity.

## Coordination Notes
Issue #10875 is labelled `WIP` for the duration of this PR. The repro shape matches the existing `build_tuple_guarded_recursion_no_ts2589` test (which used a bound of 6, below the old ceiling, so it never caught the deep case). No overlap with other open recursive-types PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqTtqTWLKcXnH82eFa2HQn)_
