### PR TITLE
chore(agents): quiet PR manager triage

### DIFF
--- a/docs/plan/agents/LAUNCH.md
+++ b/docs/plan/agents/LAUNCH.md
@@ -9,6 +9,13 @@ lane's `agent:*` label, finish them, enqueue them, document the blocker, close
 with evidence, or hand them off before new issue work. Agents should not park
 drafts and start fresh PRs; owned open PRs are the current work queue.
 
+Keep PR comments quiet. Routine state belongs in the PR body, GitHub check
+state, and `node scripts/ci/pr-ownership-report.mjs`; do not post heartbeat
+comments for unchanged waiting/running/checking state. Use signed PR comments
+only for state transitions, blockers, handoffs/takeovers, queue-failure root
+cause, closure/superseded evidence, readiness risk, or submitted review
+findings.
+
 Each prompt is intentionally a `/goal` landing loop. The agent keeps working
 until its scoped changes land on `main`, and then starts the next scoped item
 that advances all tests, all benchmarks, `2x` green-row performance over
@@ -68,5 +75,5 @@ it manages open PRs, keeps labels and readiness state clean, submits reviews,
 queues eligible PRs, and waits when there is no useful PR action.
 
 ```text
-/goal You are AgentName Studio-manager. At the start of each cycle, run `git fetch origin main` and `scripts/agents/show-goal.sh Studio-manager`, then run the remaining commands listed under Start Every Cycle in `docs/plan/agents/Studio-manager.md` and follow that goal file. Manage PRs and submit reviews: audit labels, inspect owned and unowned PRs, request or provide actionable reviews, keep WIP/draft/native-queue state accurate, enqueue only verified ready PRs, prevent duplicate work, and keep going until all release-gate changes land in main. If no PR needs action, wait and refresh instead of marking the goal complete.
+/goal You are AgentName Studio-manager. At the start of each cycle, run `git fetch origin main` and `scripts/agents/show-goal.sh Studio-manager`, then run the remaining commands listed under Start Every Cycle in `docs/plan/agents/Studio-manager.md` and follow that goal file. Manage PRs and submit reviews: audit labels, inspect owned and unowned PRs, follow `Manager Next Actions` from `node scripts/ci/pr-ownership-report.mjs`, request or provide actionable reviews, keep WIP/draft/native-queue state accurate, enqueue only verified ready PRs, prevent duplicate work, and keep going until all release-gate changes land in main. Keep PR comments quiet: update PR bodies for routine state, do not post heartbeat comments, and comment only for blockers, handoffs/takeovers, queue-failure root cause, closure evidence, readiness risk, or review findings. If no PR needs action, wait and refresh instead of marking the goal complete.
 ```

--- a/docs/plan/agents/README.md
+++ b/docs/plan/agents/README.md
@@ -66,6 +66,20 @@ Rules:
 9. If a session pauses or abandons work, leave a signed comment with findings,
    blocker or reason, verification already run, and next owner/action.
 
+Comment budget:
+
+- Use the PR body as the routine state surface: scope, current blocker,
+  verification, Project Corpus Impact, and Coordination Notes.
+- Do not leave heartbeat comments for "checking", "waiting", "still running",
+  or unchanged CI/queue state. The ownership report and GitHub checks already
+  carry that state.
+- Leave at most one signed PR conversation comment for a state transition:
+  draft/WIP change, blocker, handoff/takeover, closure/superseded evidence,
+  queue failure root cause, or readiness risk.
+- Prefer submitted review comments for code findings. Use a PR conversation
+  comment only for cross-file scope, metadata, queue, blocker, or handoff
+  decisions.
+
 ## Live Intake Rule
 
 Every lane starts with its live PRs. Owned PRs are the work queue; issues are
@@ -98,6 +112,11 @@ node scripts/ci/pr-ownership-report.mjs
 node scripts/ci/pr-ownership-report.mjs --json /tmp/tsz-pr-ownership.json
 gh issue list --repo tsz-org/tsz --state open --limit 200 --json number,title,labels,updatedAt,url
 ```
+
+The `Manager Next Actions` section from `node scripts/ci/pr-ownership-report.mjs`
+is the default triage queue. Follow it before posting new PR comments; when an
+entry says `comment: none`, act through queueing, CI inspection, rebasing, or
+PR-body updates instead.
 
 ## Source-Of-Truth Goal Loop
 

--- a/docs/plan/agents/Studio-manager.md
+++ b/docs/plan/agents/Studio-manager.md
@@ -34,13 +34,20 @@ gh pr list --state open --limit 100 --json number,title,isDraft,labels,updatedAt
 - PR families: ready-but-unqueued PRs, blocked ready PRs, conflicting main PRs,
   stale drafts, duplicate invariants, missing `AgentName`, missing or
   noncanonical labels, and PRs needing high-level review.
+- Comment noise budget: use PR bodies, check state, and
+  `Manager Next Actions` from `node scripts/ci/pr-ownership-report.mjs` for
+  routine status. Do not leave heartbeat comments. Comment only for state
+  transitions, blocker/root-cause evidence, handoff/takeover, closure, queue
+  failure, readiness risk, or submitted review findings.
 - Architecture cleanup metric: label audit findings, ownership report
   mismatches, duplicate active invariants, stale WIP markers, and unreviewed
   high-risk PRs should trend down.
 - First live command: run the label audit and PR ownership report, then triage
-  queue candidates and PRs needing review.
-- Next concrete step: submit a review, add/remove the right label, enqueue a
-  verified ready PR, or leave a signed blocker/handoff comment.
+  the report's `Manager Next Actions`.
+- Next concrete step: enqueue a verified ready PR, inspect failed/missing CI,
+  submit an actionable review, add/remove the right label, update a PR body, or
+  leave one signed blocker/handoff comment when the report calls for a state
+  transition.
 
 ## Existing Work To Inspect First
 
@@ -85,6 +92,11 @@ Suggested fix: <small concrete action>
 Prefer submitted PR reviews for file-specific findings and PR conversation
 comments for high-level scope, duplication, metric truth, queueing, or
 readiness concerns.
+
+Quiet PR-management rule: if no state changed, do not comment. Refresh the
+ownership report, wait for pending checks, or update the PR body when durable
+coordination text is stale. Batch owner-level draft parking or stale-WIP
+follow-up instead of posting one comment per PR.
 
 ## Non-Overlap Rules
 

--- a/scripts/ci/pr-ownership-report.mjs
+++ b/scripts/ci/pr-ownership-report.mjs
@@ -373,6 +373,152 @@ function requiredCheckSummary(pr) {
   };
 }
 
+function requiredCheckState(checks) {
+  if (checks.some((check) => check.bucket === "fail")) return "fail";
+  if (checks.some((check) => check.bucket === "pending")) return "pending";
+  if (checks.some((check) => check.bucket === "missing")) return "missing";
+  return "pass";
+}
+
+function makeManagerActions(report) {
+  const actions = [];
+  const conflictingMainNumbers = new Set(report.conflictingMainPrs.map((pr) => pr.number));
+  for (const pr of report.readyMainNotQueuedPrs) {
+    if (conflictingMainNumbers.has(pr.number)) {
+      continue;
+    }
+    if (pr.queueCandidate) {
+      actions.push({
+        priority: "P0",
+        kind: "queue",
+        number: pr.number,
+        owner: ownerOf(pr),
+        action: "queue verified ready PR",
+        commentPolicy: "none; queue and verify merge result",
+        reason: "PR-head required checks passed and branch is mergeable",
+      });
+      continue;
+    }
+
+    const state = requiredCheckState(pr.checks);
+    if (state === "fail") {
+      actions.push({
+        priority: "P0",
+        kind: "fix-ci",
+        number: pr.number,
+        owner: ownerOf(pr),
+        action: "route failed required check to owner",
+        commentPolicy: "comment only with root cause or handoff",
+        reason: pr.checkSummary,
+      });
+    } else if (state === "pending") {
+      actions.push({
+        priority: "P1",
+        kind: "wait-ci",
+        number: pr.number,
+        owner: ownerOf(pr),
+        action: "wait for active PR-head checks",
+        commentPolicy: "none",
+        reason: pr.checkSummary,
+      });
+    } else if (state === "missing") {
+      actions.push({
+        priority: "P1",
+        kind: "refresh-ci",
+        number: pr.number,
+        owner: ownerOf(pr),
+        action: "refresh or request PR-head CI evidence",
+        commentPolicy: "none unless rerun/fix is blocked",
+        reason: pr.checkSummary,
+      });
+    }
+  }
+
+  for (const pr of report.conflictingReadyMainPrs) {
+    actions.push({
+      priority: "P0",
+      kind: "rebase-ready",
+      number: pr.number,
+      owner: ownerOf(pr),
+      action: "rebase or hand off conflicting ready PR",
+      commentPolicy: "comment only if taking over or handing off",
+      reason: `${pr.mergeStateStatus}/${pr.mergeable}`,
+    });
+  }
+
+  for (const pr of report.conflictingMainPrs.filter((candidate) => candidate.draft)) {
+    actions.push({
+      priority: "P1",
+      kind: "rebase-draft",
+      number: pr.number,
+      owner: ownerOf(pr),
+      action: "refresh, supersede, or close conflicting draft",
+      commentPolicy: "prefer PR body; comment for handoff/closure evidence",
+      reason: `${pr.mergeStateStatus}/${pr.mergeable}`,
+    });
+  }
+
+  for (const pr of report.staleDraftPrs) {
+    if (conflictingMainNumbers.has(pr.number)) {
+      continue;
+    }
+    actions.push({
+      priority: "P1",
+      kind: "stale-draft",
+      number: pr.number,
+      owner: ownerOf(pr),
+      action: "refresh blocker, hand off, or close stale draft",
+      commentPolicy: "one signed blocker/handoff comment if state changes",
+      reason: `draft age ${pr.ageHours}h`,
+    });
+  }
+
+  for (const pr of report.staleWipPrs) {
+    actions.push({
+      priority: "P1",
+      kind: "stale-wip",
+      number: pr.number,
+      owner: ownerOf(pr),
+      action: "refresh WIP blocker or split durable follow-up issue",
+      commentPolicy: "one signed blocker/handoff comment if keeping WIP open",
+      reason: `WIP age ${pr.ageHours}h`,
+    });
+  }
+
+  for (const owner of report.draftParkingOwners.filter((entry) => entry.overBudget)) {
+    actions.push({
+      priority: "P2",
+      kind: "draft-budget",
+      number: null,
+      owner: owner.owner,
+      action: "reduce unstacked draft runway",
+      commentPolicy: "batch by owner; do not comment on every PR",
+      reason: `${owner.unstackedDraft} unstacked drafts`,
+    });
+  }
+
+  for (const duplicate of report.duplicateDraftCleanupTargets) {
+    actions.push({
+      priority: "P2",
+      kind: "duplicate-drafts",
+      number: null,
+      owner: "mixed",
+      action: "deduplicate draft PRs for one issue",
+      commentPolicy: "comment only on PRs closed or handed off",
+      reason: `issue #${duplicate.issue}: ${duplicate.prs.map((pr) => `#${pr}`).join(", ")}`,
+    });
+  }
+
+  return actions.sort((a, b) => {
+    const priority = a.priority.localeCompare(b.priority);
+    if (priority !== 0) return priority;
+    const left = a.number ?? Number.MAX_SAFE_INTEGER;
+    const right = b.number ?? Number.MAX_SAFE_INTEGER;
+    if (left !== right) return left - right;
+    return a.kind.localeCompare(b.kind);
+  });
+}
+
 function makeReport(pulls) {
   const now = reportNow();
   const staleDraftHours = Number.parseInt(
@@ -639,6 +785,21 @@ function makeReport(pulls) {
     .filter((pr) => pr.ageHours !== null && pr.ageHours >= staleDraftHours)
     .sort((a, b) => (a.agentName || "").localeCompare(b.agentName || "") || a.number - b.number);
 
+  const staleWipPrs = normalized
+    .filter((pr) => pr.draft && isWipPr(pr))
+    .map((pr) => ({
+      number: pr.number,
+      agentName: pr.agentName,
+      agentLabel: pr.agentLabels.length === 1 ? `agent:${pr.agentLabels[0]}` : null,
+      updatedAt: pr.updatedAt,
+      ageHours: ageHours(pr.updatedAt, now),
+      stackRole: pr.stackRole,
+      markers: wipMarkers(pr),
+      title: pr.title,
+    }))
+    .filter((pr) => pr.ageHours !== null && pr.ageHours >= staleDraftHours)
+    .sort((a, b) => (a.agentName || "").localeCompare(b.agentName || "") || a.number - b.number);
+
   const readyMainNotQueuedPrs = normalized
     .filter((pr) => (
       !pr.draft
@@ -665,7 +826,7 @@ function makeReport(pulls) {
     })
     .sort((a, b) => Number(b.queueCandidate) - Number(a.queueCandidate) || a.number - b.number);
 
-  return {
+  const report = {
     generatedAt: new Date().toISOString(),
     counts: {
       open: normalized.length,
@@ -679,6 +840,7 @@ function makeReport(pulls) {
       queueCandidates: readyMainNotQueuedPrs.filter((pr) => pr.queueCandidate).length,
       draftParkingOwners: draftParkingOwners.length,
       staleDraftPrs: staleDraftPrs.length,
+      staleWipPrs: staleWipPrs.length,
     },
     byBase: [...byBase.entries()]
       .map(([base, prs]) => ({ base, prs: prs.sort((a, b) => a - b) }))
@@ -687,6 +849,7 @@ function makeReport(pulls) {
     draftRunwayByOwner,
     draftParkingOwners,
     staleDraftPrs,
+    staleWipPrs,
     readyMainNotQueuedPrs,
     stacks,
     duplicateTitleScopes,
@@ -703,6 +866,8 @@ function makeReport(pulls) {
     agentLabelMismatches,
     prs: normalized.sort((a, b) => a.number - b.number),
   };
+  report.managerActions = makeManagerActions(report);
+  return report;
 }
 
 function printMarkdown(report) {
@@ -710,8 +875,20 @@ function printMarkdown(report) {
   console.log("# Open PR Ownership Report");
   console.log("");
   console.log(
-    `Open: ${report.counts.open}; draft: ${report.counts.draft}; ready: ${report.counts.ready}; native queued: ${report.counts.nativeQueued}; ready not queued: ${report.counts.readyNotQueued}; queue candidates: ${report.counts.queueCandidates}; draft parking owners: ${report.counts.draftParkingOwners}; stale drafts: ${report.counts.staleDraftPrs}; stacked children: ${report.counts.stacked}; missing AgentName: ${report.counts.missingAgentName}; AgentName/label mismatches: ${report.counts.agentLabelMismatches}`,
+    `Open: ${report.counts.open}; draft: ${report.counts.draft}; ready: ${report.counts.ready}; native queued: ${report.counts.nativeQueued}; ready not queued: ${report.counts.readyNotQueued}; queue candidates: ${report.counts.queueCandidates}; draft parking owners: ${report.counts.draftParkingOwners}; stale drafts: ${report.counts.staleDraftPrs}; stale WIP: ${report.counts.staleWipPrs}; stacked children: ${report.counts.stacked}; missing AgentName: ${report.counts.missingAgentName}; AgentName/label mismatches: ${report.counts.agentLabelMismatches}`,
   );
+  console.log("");
+  console.log("## Manager Next Actions");
+  if (report.managerActions.length === 0) {
+    console.log("- none; wait and refresh without commenting");
+  } else {
+    for (const action of report.managerActions) {
+      const target = action.number === null ? action.owner : `#${action.number}`;
+      console.log(
+        `- ${action.priority} ${action.kind} ${target}: ${action.action}; comment: ${action.commentPolicy}; reason: ${action.reason}`,
+      );
+    }
+  }
   console.log("");
   console.log("## Owner Summary");
   if (report.ownerSummaries.length === 0) {
@@ -748,7 +925,11 @@ function printMarkdown(report) {
   }
   console.log("");
   console.log("## Draft Parking Risks");
-  if (report.draftParkingOwners.length === 0 && report.staleDraftPrs.length === 0) {
+  if (
+    report.draftParkingOwners.length === 0
+    && report.staleDraftPrs.length === 0
+    && report.staleWipPrs.length === 0
+  ) {
     console.log("- none");
   } else {
     if (report.draftParkingOwners.length) {
@@ -769,6 +950,17 @@ function printMarkdown(report) {
         const stack = pr.stackRole ? `; ${pr.stackRole}` : "";
         console.log(
           `- #${pr.number}: ${owner}; updated ${shortDate(pr.updatedAt)}; age ${pr.ageHours}h${stack}; ${pr.title}`,
+        );
+      }
+    }
+    if (report.staleWipPrs.length) {
+      console.log("");
+      console.log("Stale WIP PRs:");
+      for (const pr of report.staleWipPrs) {
+        const owner = ownerOf(pr);
+        const stack = pr.stackRole ? `; ${pr.stackRole}` : "";
+        console.log(
+          `- #${pr.number}: ${owner}; updated ${shortDate(pr.updatedAt)}; age ${pr.ageHours}h; ${pr.markers.join("+")}${stack}; ${pr.title}`,
         );
       }
     }

--- a/scripts/ci/test-pr-ownership-report.mjs
+++ b/scripts/ci/test-pr-ownership-report.mjs
@@ -158,6 +158,10 @@ withTempDir((dir) => {
   assert.match(result.stdout, /queue candidates: 0/);
   assert.match(
     result.stdout,
+    /Manager Next Actions[\s\S]*P0 rebase-ready #18: rebase or hand off conflicting ready PR; comment: comment only if taking over or handing off; reason: DIRTY\/CONFLICTING[\s\S]*P1 rebase-draft #19: refresh, supersede, or close conflicting draft; comment: prefer PR body; comment for handoff\/closure evidence; reason: DIRTY\/CONFLICTING/,
+  );
+  assert.match(
+    result.stdout,
     /Owner Summary[\s\S]*\| agent:delta \| 2 \| 0 \| 2 \| 0 \| 0 \| 0 \| 0 \| 1 \| 0 \|[\s\S]*\| agent:zeta \| 2 \| 1 \| 1 \| 0 \| 0 \| 0 \| 1 \| 1 \| 0 \|[\s\S]*\| unowned \| 2 \| 0 \| 2 \| 0 \| 1 \| 0 \| 0 \| 0 \| 0 \|[\s\S]*\| delta \| 1 \| 0 \| 1 \| 0 \| 0 \| 0 \| 0 \| 0 \| 0 \|/,
   );
   assert.match(
@@ -215,6 +219,7 @@ withTempDir((dir) => {
     queueCandidates: 0,
     draftParkingOwners: 1,
     staleDraftPrs: 1,
+    staleWipPrs: 0,
   });
   assert.deepEqual(report.byBase, [
     { base: "agent/mapped-a", prs: [12] },
@@ -340,6 +345,7 @@ withTempDir((dir) => {
       title: "fix(checker): conflicting draft branch",
     },
   ]);
+  assert.deepEqual(report.staleWipPrs, []);
   assert.deepEqual(report.readyMainNotQueuedPrs, [
     {
       number: 18,
@@ -354,6 +360,35 @@ withTempDir((dir) => {
       checkSummary: "CI Summary=missing",
       queueCandidate: false,
       title: "fix(solver): conflicting ready branch",
+    },
+  ]);
+  assert.deepEqual(report.managerActions, [
+    {
+      priority: "P0",
+      kind: "rebase-ready",
+      number: 18,
+      owner: "agent:zeta",
+      action: "rebase or hand off conflicting ready PR",
+      commentPolicy: "comment only if taking over or handing off",
+      reason: "DIRTY/CONFLICTING",
+    },
+    {
+      priority: "P1",
+      kind: "rebase-draft",
+      number: 19,
+      owner: "agent:delta",
+      action: "refresh, supersede, or close conflicting draft",
+      commentPolicy: "prefer PR body; comment for handoff/closure evidence",
+      reason: "DIRTY/CONFLICTING",
+    },
+    {
+      priority: "P2",
+      kind: "duplicate-drafts",
+      number: null,
+      owner: "mixed",
+      action: "deduplicate draft PRs for one issue",
+      commentPolicy: "comment only on PRs closed or handed off",
+      reason: "issue #42: #10, #11",
     },
   ]);
   assert.deepEqual(report.stacks, [
@@ -479,4 +514,62 @@ withTempDir((dir) => {
   assert.equal(report.prs.find((pr) => pr.number === 10).stackRole, "stack root");
   assert.equal(report.prs.find((pr) => pr.number === 12).stackRole, "stack child");
   assert.equal(report.prs.find((pr) => pr.number === 11).stackRole, null);
+});
+
+withTempDir((dir) => {
+  const fixture = path.join(dir, "prs.json");
+  const output = path.join(dir, "report.json");
+  writeJson(fixture, [
+    {
+      number: 20,
+      title: "[WIP] fix(checker): preserve lib heritage",
+      isDraft: true,
+      updatedAt: "2026-05-24T08:00:00Z",
+      baseRefName: "main",
+      headRefName: "agent/stale-wip",
+      labels: ["WIP", "agent:omega"],
+      body: "AgentName: omega\n",
+    },
+  ]);
+
+  const result = spawnSync(process.execPath, [SCRIPT, "--fixture", fixture, "--json", output], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      TSZ_PR_OWNERSHIP_REPORT_NOW: "2026-05-26T11:15:00Z",
+    },
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stdout,
+    /Manager Next Actions[\s\S]*P1 stale-wip #20: refresh WIP blocker or split durable follow-up issue; comment: one signed blocker\/handoff comment if keeping WIP open; reason: WIP age 51h/,
+  );
+
+  const report = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.equal(report.counts.staleDraftPrs, 0);
+  assert.equal(report.counts.staleWipPrs, 1);
+  assert.deepEqual(report.staleWipPrs, [
+    {
+      number: 20,
+      agentName: "omega",
+      agentLabel: "agent:omega",
+      updatedAt: "2026-05-24T08:00:00Z",
+      ageHours: 51,
+      stackRole: null,
+      markers: ["label", "title"],
+      title: "[WIP] fix(checker): preserve lib heritage",
+    },
+  ]);
+  assert.deepEqual(report.managerActions, [
+    {
+      priority: "P1",
+      kind: "stale-wip",
+      number: 20,
+      owner: "agent:omega",
+      action: "refresh WIP blocker or split durable follow-up issue",
+      commentPolicy: "one signed blocker/handoff comment if keeping WIP open",
+      reason: "WIP age 51h",
+    },
+  ]);
 });


### PR DESCRIPTION
## Agent
AgentName: Studio-manager

## Track
PR queue, label, and review debt / process tooling

## Invariant
When autonomous PR management runs, routine unchanged status should stay in durable state surfaces; this PR changes the manager prompt and ownership report so comments are reserved for state transitions, blockers, handoffs, queue failures, closure evidence, readiness risk, or review findings.

## Scope
- Add `Manager Next Actions` to `scripts/ci/pr-ownership-report.mjs`.
- Surface stale WIP PRs separately from ordinary stale drafts.
- Update manager and launch prompts to prefer PR bodies/reports over heartbeat comments.
- Extend ownership-report tests for the new action queue and stale-WIP handling.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: process/reporting-only change; compiler behavior and project corpus rows are unchanged.

## Verification
- `node scripts/ci/test-pr-ownership-report.mjs`
- `node scripts/ci/pr-ownership-report.mjs --json /tmp/tsz-pr-ownership-process.json | sed -n '1,80p'`
- `git diff --check`
- `scripts/agents/llm-context-audit.py`

## Coordination Notes
- Responds to the observed stale PR/noisy-comment process issue: manager now gets a deterministic action list with per-action comment policy.
- No PR comments were posted as part of this change.
