### PR TITLE
perf(checker): defer ts-toolbelt alias validation work

### DIFF
--- a/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
+++ b/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
@@ -21,6 +21,42 @@ fn alias_body_explicit_type_refs_use_validator_only_path() {
 }
 
 #[test]
+fn composed_generic_alias_body_can_defer_semantic_construction() {
+    let checker_source =
+        std::fs::read_to_string("src/types/type_checking/type_alias_missing_name_coverage.rs")
+            .expect("read type alias missing-name coverage");
+    assert!(
+        checker_source.contains("type_ref.type_arguments.as_ref().is_none_or")
+            && checker_source.contains("syntax_kind_ext::TEMPLATE_LITERAL_TYPE")
+            && checker_source.contains("syntax_kind_ext::TYPE_OPERATOR"),
+        "generic alias bodies composed from type references, template literals, \
+         and type operators should be eligible for lazy semantic construction"
+    );
+
+    let diags = check_source_diagnostics(
+        r#"
+type ObjectOf<List> = { [Key in keyof List]: List[Key] };
+type PickObject<Obj, Key extends keyof Obj> = { [P in Key]: Obj[P] };
+type ListOf<Obj> = Obj[keyof Obj][];
+
+type PickList<List, Key extends string | number | symbol> =
+    ListOf<PickObject<ObjectOf<List>, `${Key & number}` | Key>>;
+"#,
+    );
+
+    let relevant: Vec<_> = diags
+        .iter()
+        .filter(|d| matches!(d.code, 2304 | 2314 | 2315 | 2344 | 2558))
+        .collect();
+    assert_eq!(
+        relevant.len(),
+        0,
+        "composed generic alias bodies must still validate names and explicit \
+         type arguments without eager semantic construction; got: {relevant:#?}"
+    );
+}
+
+#[test]
 fn type_parameter_predicate_skips_intrinsic_cache_lookup() {
     let checker_source =
         std::fs::read_to_string("src/types/queries/core.rs").expect("read type queries");
@@ -85,7 +121,7 @@ fn mapped_alias_body_keeps_conservative_missing_name_path() {
         std::fs::read_to_string("src/types/type_checking/type_alias_missing_name_coverage.rs")
             .expect("read type alias missing-name coverage");
     assert!(
-        checker_source.contains("type_alias_body_missing_names_syntax_covered_inner")
+        checker_source.contains("type_alias_body_missing_names_covered_inner")
             && checker_source.contains("syntax_kind_ext::MAPPED_TYPE")
             && checker_source.contains("_ => false"),
         "Mapped alias bodies must keep the resolving coverage path because \
@@ -116,6 +152,80 @@ fn type_node_validation_cache_only_records_clean_walks() {
             && checker_source.contains(".type_node_validation")
             && checker_source.contains(".insert(validation_cache_key)"),
         "type-node validation success caching must not record diagnostic-bearing walks"
+    );
+}
+
+#[test]
+fn direct_conditional_true_branch_validation_skips_check_type_resolution() {
+    let checker_source = std::fs::read_to_string("src/types/type_checking/type_alias_checking.rs")
+        .expect("read type alias checker");
+    let direct_branch = checker_source
+        .find("if true_needs_direct_type_ref_validation")
+        .expect("direct true-branch validation path");
+    let mapped_branch = checker_source[direct_branch..]
+        .find("} else if true_is_mapped")
+        .map(|offset| direct_branch + offset)
+        .expect("mapped true-branch validation path");
+    let direct_branch_source = &checker_source[direct_branch..mapped_branch];
+    assert!(
+        direct_branch_source.contains("push_infer_bindings_from_extends")
+            && direct_branch_source.contains("check_child_type_node_in_current_scope")
+            && !direct_branch_source.contains("get_type_from_type_node(cond.check_type)"),
+        "Direct conditional true-branch type-reference validation should only push \
+         infer bindings and validate the branch; resolving the check type eagerly \
+         evaluates recursive aliases such as ts-toolbelt Drop/Flatten."
+    );
+}
+
+#[test]
+fn boolean_dispatch_index_alias_uses_declared_key_subset() {
+    let diags = check_source_diagnostics(
+        r#"
+type Boolean = 0 | 1;
+type Or<B1 extends Boolean, B2 extends Boolean> = {
+    0: {
+        0: 0;
+        1: 1;
+    };
+    1: {
+        0: 1;
+        1: 1;
+    };
+}[B1][B2];
+type Dispatch<A extends Boolean, B extends Boolean> = {
+    0: string;
+    1: number;
+}[Or<A, B>];
+
+type Good = Dispatch<0, 1>;
+type BadBoolean = 0 | 2;
+type Bad = {
+    0: string;
+    1: number;
+}[BadBoolean];
+"#,
+    );
+
+    let indexed_access_errors: Vec<_> = diags.iter().filter(|d| d.code == 2536).collect();
+    assert_eq!(
+        indexed_access_errors.len(),
+        1,
+        "Boolean dispatch aliases should validate when their declared result \
+         is covered by the dispatch table, while uncovered literal aliases \
+         still report TS2536; got: {diags:#?}"
+    );
+
+    let checker_source = std::fs::read_to_string("src/types/type_checking/indexed_access.rs")
+        .expect("read indexed access checker");
+    let fast_path = checker_source
+        .find("type_literal_dispatch_index_is_declared_key_subset")
+        .expect("dispatch index fast path");
+    let index_resolution = checker_source
+        .find("let index_type = self.get_type_from_type_node(data.index_type);")
+        .expect("indexed access index resolution");
+    assert!(
+        fast_path < index_resolution,
+        "Dispatch-table index validation must run before resolving the index type"
     );
 }
 

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -498,6 +498,11 @@ impl<'a> CheckerState<'a> {
         ) {
             return;
         }
+        if self
+            .type_literal_dispatch_index_is_declared_key_subset(data.object_type, data.index_type)
+        {
+            return;
+        }
 
         let index_type = self.get_type_from_type_node(data.index_type);
         use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -480,6 +480,258 @@ impl<'a> CheckerState<'a> {
         })
     }
 
+    pub(super) fn type_literal_dispatch_index_is_declared_key_subset(
+        &self,
+        object_type_node: NodeIndex,
+        index_type_node: NodeIndex,
+    ) -> bool {
+        let Some(keys) = self.type_literal_declared_property_keys(object_type_node) else {
+            return false;
+        };
+        !keys.is_empty()
+            && self.type_node_declared_literal_subset(index_type_node, &keys, &mut Vec::new(), 0)
+    }
+
+    fn type_literal_declared_property_keys(&self, type_node_idx: NodeIndex) -> Option<Vec<String>> {
+        let obj_node = self.ctx.arena.get(type_node_idx)?;
+        if obj_node.kind != syntax_kind_ext::TYPE_LITERAL {
+            return None;
+        }
+        let type_lit = self.ctx.arena.get_type_literal(obj_node)?;
+        let mut keys = Vec::new();
+        for &member_idx in &type_lit.members.nodes {
+            let member_node = self.ctx.arena.get(member_idx)?;
+            if member_node.kind == syntax_kind_ext::INDEX_SIGNATURE {
+                return None;
+            }
+            let (name_idx, _type_annotation) =
+                self.type_literal_member_name_and_type(member_node)?;
+            let name = crate::types_domain::queries::core::get_literal_property_name(
+                self.ctx.arena,
+                name_idx,
+            )?;
+            keys.push(name);
+        }
+        Some(keys)
+    }
+
+    fn type_node_declared_literal_subset(
+        &self,
+        node_idx: NodeIndex,
+        allowed_keys: &[String],
+        visited_aliases: &mut Vec<tsz_binder::SymbolId>,
+        depth: usize,
+    ) -> bool {
+        if depth > 12 || node_idx == NodeIndex::NONE {
+            return false;
+        }
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return false;
+        };
+
+        if let Some(literal) = self.ctx.arena.get_literal(node) {
+            return allowed_keys.iter().any(|key| key == &literal.text);
+        }
+        if let Some(literal_type) = self.ctx.arena.get_literal_type(node) {
+            return self.type_node_declared_literal_subset(
+                literal_type.literal,
+                allowed_keys,
+                visited_aliases,
+                depth + 1,
+            );
+        }
+
+        match node.kind {
+            k if k == syntax_kind_ext::PARENTHESIZED_TYPE
+                || k == syntax_kind_ext::OPTIONAL_TYPE
+                || k == syntax_kind_ext::REST_TYPE =>
+            {
+                self.ctx
+                    .arena
+                    .get_wrapped_type(node)
+                    .is_some_and(|wrapped| {
+                        self.type_node_declared_literal_subset(
+                            wrapped.type_node,
+                            allowed_keys,
+                            visited_aliases,
+                            depth + 1,
+                        )
+                    })
+            }
+            k if k == syntax_kind_ext::UNION_TYPE => self
+                .ctx
+                .arena
+                .get_composite_type(node)
+                .is_some_and(|composite| {
+                    !composite.types.nodes.is_empty()
+                        && composite.types.nodes.iter().copied().all(|member_idx| {
+                            self.type_node_declared_literal_subset(
+                                member_idx,
+                                allowed_keys,
+                                visited_aliases,
+                                depth + 1,
+                            )
+                        })
+                }),
+            k if k == syntax_kind_ext::CONDITIONAL_TYPE => self
+                .ctx
+                .arena
+                .get_conditional_type(node)
+                .is_some_and(|conditional| {
+                    self.type_node_declared_literal_subset(
+                        conditional.true_type,
+                        allowed_keys,
+                        visited_aliases,
+                        depth + 1,
+                    ) && self.type_node_declared_literal_subset(
+                        conditional.false_type,
+                        allowed_keys,
+                        visited_aliases,
+                        depth + 1,
+                    )
+                }),
+            k if k == syntax_kind_ext::INDEXED_ACCESS_TYPE => self
+                .ctx
+                .arena
+                .get_indexed_access_type(node)
+                .is_some_and(|indexed| {
+                    self.indexed_access_declared_values_subset(
+                        indexed.object_type,
+                        allowed_keys,
+                        visited_aliases,
+                        depth + 1,
+                    )
+                }),
+            k if k == syntax_kind_ext::TYPE_REFERENCE => self
+                .ctx
+                .arena
+                .get_type_ref(node)
+                .and_then(|type_ref| {
+                    self.type_reference_alias_body(type_ref.type_name, visited_aliases)
+                })
+                .is_some_and(|body| {
+                    self.type_node_declared_literal_subset(
+                        body,
+                        allowed_keys,
+                        visited_aliases,
+                        depth + 1,
+                    )
+                }),
+            _ => false,
+        }
+    }
+
+    fn indexed_access_declared_values_subset(
+        &self,
+        object_type_node: NodeIndex,
+        allowed_keys: &[String],
+        visited_aliases: &mut Vec<tsz_binder::SymbolId>,
+        depth: usize,
+    ) -> bool {
+        let Some(type_literals) =
+            self.possible_type_literals_from_indexed_dispatch(object_type_node, depth)
+        else {
+            return false;
+        };
+        !type_literals.is_empty()
+            && type_literals.into_iter().all(|type_lit_idx| {
+                let Some(type_lit_node) = self.ctx.arena.get(type_lit_idx) else {
+                    return false;
+                };
+                let Some(type_lit) = self.ctx.arena.get_type_literal(type_lit_node) else {
+                    return false;
+                };
+                !type_lit.members.nodes.is_empty()
+                    && type_lit.members.nodes.iter().copied().all(|member_idx| {
+                        let Some(member_node) = self.ctx.arena.get(member_idx) else {
+                            return false;
+                        };
+                        let Some((_name_idx, type_annotation)) =
+                            self.type_literal_member_name_and_type(member_node)
+                        else {
+                            return false;
+                        };
+                        self.type_node_declared_literal_subset(
+                            type_annotation,
+                            allowed_keys,
+                            visited_aliases,
+                            depth + 1,
+                        )
+                    })
+            })
+    }
+
+    fn possible_type_literals_from_indexed_dispatch(
+        &self,
+        node_idx: NodeIndex,
+        depth: usize,
+    ) -> Option<Vec<NodeIndex>> {
+        if depth > 12 {
+            return None;
+        }
+        let node = self.ctx.arena.get(node_idx)?;
+        if node.kind == syntax_kind_ext::TYPE_LITERAL {
+            return Some(vec![node_idx]);
+        }
+        if node.kind == syntax_kind_ext::PARENTHESIZED_TYPE
+            && let Some(wrapped) = self.ctx.arena.get_wrapped_type(node)
+        {
+            return self.possible_type_literals_from_indexed_dispatch(wrapped.type_node, depth + 1);
+        }
+        let indexed = self.ctx.arena.get_indexed_access_type(node)?;
+        let inner_literals =
+            self.possible_type_literals_from_indexed_dispatch(indexed.object_type, depth + 1)?;
+        let mut values = Vec::new();
+        for type_lit_idx in inner_literals {
+            let type_lit_node = self.ctx.arena.get(type_lit_idx)?;
+            let type_lit = self.ctx.arena.get_type_literal(type_lit_node)?;
+            for &member_idx in &type_lit.members.nodes {
+                let member_node = self.ctx.arena.get(member_idx)?;
+                let (_name_idx, type_annotation) =
+                    self.type_literal_member_name_and_type(member_node)?;
+                let value_node = self.ctx.arena.get(type_annotation)?;
+                let value_idx = if value_node.kind == syntax_kind_ext::PARENTHESIZED_TYPE {
+                    self.ctx.arena.get_wrapped_type(value_node)?.type_node
+                } else {
+                    type_annotation
+                };
+                if self
+                    .ctx
+                    .arena
+                    .get(value_idx)
+                    .is_some_and(|value_node| value_node.kind == syntax_kind_ext::TYPE_LITERAL)
+                {
+                    values.push(value_idx);
+                } else {
+                    return None;
+                }
+            }
+        }
+        Some(values)
+    }
+
+    fn type_reference_alias_body(
+        &self,
+        type_name: NodeIndex,
+        visited_aliases: &mut Vec<tsz_binder::SymbolId>,
+    ) -> Option<NodeIndex> {
+        let raw_sym_id = self.resolve_type_symbol_for_lowering(type_name)?;
+        let sym_id = tsz_binder::SymbolId(raw_sym_id);
+        if visited_aliases.contains(&sym_id) {
+            return None;
+        }
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        if !symbol.has_any_flags(tsz_binder::symbol_flags::TYPE_ALIAS)
+            || symbol.declarations.len() != 1
+        {
+            return None;
+        }
+        let decl_node = self.ctx.arena.get(symbol.declarations[0])?;
+        let alias = self.ctx.arena.get_type_alias(decl_node)?;
+        visited_aliases.push(sym_id);
+        Some(alias.type_node)
+    }
+
     fn type_literal_member_name_and_type(
         &self,
         member_node: &tsz_parser::parser::node::Node,

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -1537,20 +1537,24 @@ impl<'a> CheckerState<'a> {
                         .is_some_and(|n| n.kind == syntax_kind_ext::MAPPED_TYPE);
                     let true_needs_direct_type_ref_validation =
                         self.conditional_branch_needs_direct_type_ref_validation(cond.true_type);
-                    if true_is_mapped || true_needs_direct_type_ref_validation {
+                    if true_needs_direct_type_ref_validation {
+                        let infer_pushes = self.push_infer_bindings_from_extends(cond.extends_type);
+                        check_child_type_node_in_current_scope!(self, cond.true_type);
+                        self.pop_infer_bindings(infer_pushes);
+                    } else if true_is_mapped {
                         // Check if the check type resolves to a type parameter.
                         // If so, mapped true branches benefit from narrowing and
                         // we skip them. Direct type-reference branches still need
                         // their generic constraints checked under the conditional
-                        // `infer` bindings; that validation is definition-time
-                        // syntax/diagnostic work, not eager alias body lowering.
+                        // `infer` bindings, but they do not need this potentially
+                        // expensive check-type resolution.
                         let check_type = self.get_type_from_type_node(cond.check_type);
                         let check_is_type_param =
                             crate::query_boundaries::common::is_type_parameter_like(
                                 self.ctx.types,
                                 check_type,
                             );
-                        if !check_is_type_param || true_needs_direct_type_ref_validation {
+                        if !check_is_type_param {
                             let infer_pushes =
                                 self.push_infer_bindings_from_extends(cond.extends_type);
                             check_child_type_node_in_current_scope!(self, cond.true_type);

--- a/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
@@ -28,7 +28,11 @@ impl<'a> CheckerState<'a> {
                 let Some(type_ref) = self.ctx.arena.get_type_ref(node) else {
                     return false;
                 };
-                type_ref.type_arguments.is_none()
+                type_ref.type_arguments.as_ref().is_none_or(|args| {
+                    args.nodes.iter().copied().all(|arg_idx| {
+                        self.type_alias_body_allows_lazy_generic_semantic_body_inner(arg_idx)
+                    })
+                })
             }
             k if k == syntax_kind_ext::UNION_TYPE || k == syntax_kind_ext::INTERSECTION_TYPE => {
                 let Some(composite) = self.ctx.arena.get_composite_type(node) else {
@@ -43,13 +47,60 @@ impl<'a> CheckerState<'a> {
                     self.type_alias_body_allows_lazy_generic_semantic_body_inner(array.element_type)
                 })
             }
-            k if k == syntax_kind_ext::PARENTHESIZED_TYPE => self
+            k if k == syntax_kind_ext::TUPLE_TYPE => {
+                let Some(tuple) = self.ctx.arena.get_tuple_type(node) else {
+                    return false;
+                };
+                tuple.elements.nodes.iter().copied().all(|element_idx| {
+                    self.type_alias_body_allows_lazy_generic_semantic_body_inner(element_idx)
+                })
+            }
+            k if k == syntax_kind_ext::NAMED_TUPLE_MEMBER => self
                 .ctx
                 .arena
-                .get_wrapped_type(node)
-                .is_some_and(|wrapped| {
-                    self.type_alias_body_allows_lazy_generic_semantic_body_inner(wrapped.type_node)
+                .get_named_tuple_member(node)
+                .is_some_and(|member| {
+                    self.type_alias_body_allows_lazy_generic_semantic_body_inner(member.type_node)
                 }),
+            k if k == syntax_kind_ext::OPTIONAL_TYPE
+                || k == syntax_kind_ext::REST_TYPE
+                || k == syntax_kind_ext::PARENTHESIZED_TYPE =>
+            {
+                self.ctx
+                    .arena
+                    .get_wrapped_type(node)
+                    .is_some_and(|wrapped| {
+                        self.type_alias_body_allows_lazy_generic_semantic_body_inner(
+                            wrapped.type_node,
+                        )
+                    })
+            }
+            k if k == syntax_kind_ext::TYPE_OPERATOR => {
+                self.ctx.arena.get_type_operator(node).is_some_and(|op| {
+                    self.type_alias_body_allows_lazy_generic_semantic_body_inner(op.type_node)
+                })
+            }
+            k if k == syntax_kind_ext::TEMPLATE_LITERAL_TYPE => {
+                let Some(template) = self.ctx.arena.get_template_literal_type(node) else {
+                    return false;
+                };
+                template
+                    .template_spans
+                    .nodes
+                    .iter()
+                    .copied()
+                    .all(|span_idx| {
+                        let Some(span_node) = self.ctx.arena.get(span_idx) else {
+                            return false;
+                        };
+                        let Some(span) = self.ctx.arena.get_template_span(span_node) else {
+                            return false;
+                        };
+                        self.type_alias_body_allows_lazy_generic_semantic_body_inner(
+                            span.expression,
+                        )
+                    })
+            }
             k if Self::primitive_or_literal_type_kind_is_covered(k) => true,
             _ => false,
         }


### PR DESCRIPTION
AgentName: Studio-B

## Summary
- defer semantic body construction for safe composed generic alias bodies
- avoid resolving conditional check types when only direct true-branch type-reference validation is needed
- add a declared-key subset fast path for literal dispatch-table indexed access aliases

## Project Corpus Impact
- Row: ts-toolbelt-project
- Bug family: runtime slowdown during project timing

## Perf
- Baseline: tsz 2.304s, tsgo 103.6ms, 22.25x slower
- After lazy alias body change: tsz 1.735s, 16.75x slower
- After direct conditional validation: tsz 1.538s, 15.23x slower
- Final after dispatch-index fast path: tsz 1.507s, tsgo 103.4ms, 14.57x slower

## Validation
- cargo fmt --check
- cargo check -p tsz-checker --lib
- cargo test -p tsz-checker --lib ref_type_params_cache_tests -- --nocapture
- BENCH_PGO=0 TSZ_BENCH_PROJECT_SLOWDOWN_FAILURE_FACTOR=0 scripts/bench/bench-vs-tsgo.sh --quick --filter ^ts-toolbelt-project --json-file artifacts/perf/ts-toolbelt-after-dispatch-index-20260605.json --rebuild

