### PR TITLE
perf(solver): cache mapped property template instantiation

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -9,7 +9,7 @@ mod keyof_constraint;
 use crate::construction::TypeDatabase;
 use crate::instantiation::instantiate::{
     TypeSubstitution, instantiate_type_cached, instantiate_type_preserving,
-    instantiate_type_preserving_with_declared,
+    instantiate_type_preserving_cached, instantiate_type_preserving_with_declared,
 };
 use crate::objects::PropertyCollectionResult;
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
@@ -655,7 +655,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         declared_type,
                     )
                 } else {
-                    instantiate_type_preserving(self.interner(), mapped.template, &subst)
+                    instantiate_type_preserving_cached(
+                        self.interner(),
+                        self.query_db(),
+                        mapped.template,
+                        &subst,
+                    )
                 };
                 let evaluated = self.evaluate(instantiated_template);
 
@@ -777,7 +782,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         declared_type,
                     )
                 } else {
-                    instantiate_type_preserving(self.interner(), mapped.template, &subst)
+                    instantiate_type_preserving_cached(
+                        self.interner(),
+                        self.query_db(),
+                        mapped.template,
+                        &subst,
+                    )
                 };
                 let evaluated = self.evaluate(instantiated);
                 if evaluated == TypeId::ERROR && self.is_depth_exceeded() {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/mapped_tests.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/mapped_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::caches::query_cache::QueryCache;
 use crate::construction::TypeInterner;
 use crate::recursion::RecursionResult;
 use crate::types::TypeParamInfo;
@@ -47,6 +48,65 @@ fn build_instantiated_homomorphic_mapped(
         readonly_modifier: None,
         optional_modifier: None,
     }
+}
+
+#[test]
+fn mapped_property_template_uses_preserving_instantiation_cache() {
+    let interner = TypeInterner::new();
+    let query_cache = QueryCache::new(&interner);
+
+    let key_atom = interner.intern_string("K");
+    let key_param = interner.type_param(TypeParamInfo::simple(key_atom));
+    let wrapped_prop = PropertyInfo {
+        name: interner.intern_string("value"),
+        type_id: key_param,
+        write_type: key_param,
+        is_string_named: true,
+        ..Default::default()
+    };
+    let template = interner.object(vec![wrapped_prop]);
+    let constraint = interner.literal_string("same");
+
+    let mapped = |readonly_modifier| MappedType {
+        type_param: TypeParamInfo {
+            name: key_atom,
+            constraint: Some(constraint),
+            default: None,
+            is_const: false,
+        },
+        constraint,
+        name_type: None,
+        template,
+        readonly_modifier,
+        optional_modifier: None,
+    };
+
+    let first = interner.mapped(mapped(None));
+    let second = interner.mapped(mapped(Some(MappedModifier::Add)));
+    assert_ne!(
+        first, second,
+        "distinct mapped types keep the evaluator cache from hiding instantiation reuse"
+    );
+
+    let before = query_cache.statistics();
+    let mut first_eval = TypeEvaluator::new(&interner).with_query_db(&query_cache);
+    let first_result = first_eval.evaluate(first);
+    let after_first = query_cache.statistics();
+
+    let mut second_eval = TypeEvaluator::new(&interner).with_query_db(&query_cache);
+    let second_result = second_eval.evaluate(second);
+    let after_second = query_cache.statistics();
+
+    assert_ne!(first_result, TypeId::ERROR);
+    assert_ne!(second_result, TypeId::ERROR);
+    assert!(
+        after_first.instantiation_cache_misses > before.instantiation_cache_misses,
+        "first mapped property template instantiation should populate the cache"
+    );
+    assert!(
+        after_second.instantiation_cache_hits > after_first.instantiation_cache_hits,
+        "second mapped property template instantiation should reuse the preserving cache slot"
+    );
 }
 
 /// tsc's `instantiateMappedType` reduces a generic homomorphic mapped


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 3 / Track 5 performance cache slice for #12462 pino timeout.

## Invariant
When mapped type property evaluation substitutes an equivalent template/key pair without the homomorphic declared-property override, `tsc` reuses the semantic instantiated shape; this PR makes tsz reuse the solver instantiation cache through `instantiate_type_preserving_cached`, keyed by template `TypeId`, canonical substitution, and preserving mode bits.

## Scope
- Route named and unique-symbol mapped property template instantiation through the cache-aware preserving helper when `TypeEvaluator` has a `QueryDatabase`.
- Leave `instantiate_type_preserving_with_declared` unchanged for `-?` optional-property removal because that path carries declared source-property state outside the ordinary cache key.
- Add a mapped evaluator test proving two distinct mapped types with the same property template/key hit the preserving instantiation cache rather than relying on evaluator exact-type caching.

## Project Corpus Impact
- Row: n/a (#12462 pino external timeout witness; not currently one of the 19 public project rows)
- Bug family: mapped/indexed-access instantiation performance
- Pino (#12462) still times out; this is the next mapped-property instantiation layer after #12692 reduced mapped index-signature/template work. No green-row `tsgo` timing claim is made. Expected impact is lower redundant mapped property template walks in attribution mode for pino-like mapped/indexed access workloads.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib -E 'test(mapped_property_template_uses_preserving_instantiation_cache) | test(instantiation_cache)'`

## Coordination Notes
- Follow-up to Studio-Opus pino slices #12684 and #12692.
- No overlap found with current Studio-B open cache PRs; this touches only mapped property template instantiation, not default substitution-map cloning or index-signature template instantiation.
- Cache contract: key fields are inherited from `InstantiationRequest` (`type_id`, canonical substitution, mode bits, `this_type`); reset boundary is `QueryCache::clear` / per-query cache lifetime; absent cache falls back to the same instantiator walk; depth-exceeded results are not cached by the shared helper.
