### PR TITLE
fix(dts): collapse conditional alias declared call returns

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
@@ -777,7 +777,9 @@ impl<'a> DeclarationEmitter<'a> {
                 .get(initializer)
                 .is_some_and(|node| node.kind == syntax_kind_ext::CALL_EXPRESSION)
         {
-            if let Some(type_text) = self.preferred_expression_type_text(initializer) {
+            if !self.call_expression_declared_return_has_source_conditional_alias(initializer)
+                && let Some(type_text) = self.preferred_expression_type_text(initializer)
+            {
                 let type_text = Self::strip_synthetic_anonymous_object_members(&type_text);
                 let type_text = self
                     .expand_portable_mapped_object_text_in_current_context(&type_text)
@@ -1001,6 +1003,8 @@ impl<'a> DeclarationEmitter<'a> {
         let call = self.arena.get_call_expr(expr_node)?;
         let binder = self.binder?;
         let explicit_type_args = self.type_argument_list_source_text(call.type_arguments.as_ref());
+        let receiver_type_param_substitutions =
+            self.call_receiver_declared_type_param_substitutions(call.expression, binder);
         let Some((sym_id, imported_module)) =
             self.resolve_declared_call_callee_symbol(call.expression, binder)
         else {
@@ -1057,6 +1061,12 @@ impl<'a> DeclarationEmitter<'a> {
                 .trim_end_matches(';')
                 .trim_end()
                 .to_string();
+            if !receiver_type_param_substitutions.is_empty() {
+                type_text = Self::replace_whole_words_in_text(
+                    &type_text,
+                    &receiver_type_param_substitutions,
+                );
+            }
 
             let mut type_param_names = Vec::new();
             let mut type_param_substitutions = Vec::new();
@@ -1089,9 +1099,17 @@ impl<'a> DeclarationEmitter<'a> {
                                     self.source_slice_from_arena(source_arena, param.constraint)
                                 })
                         {
+                            let constraint = Self::replace_whole_words_in_text(
+                                &constraint,
+                                &receiver_type_param_substitutions,
+                            );
                             type_param_constraints.push((name_text.clone(), constraint));
                         }
                         if let Some(fallback) = fallback {
+                            let fallback = Self::replace_whole_words_in_text(
+                                &fallback,
+                                &receiver_type_param_substitutions,
+                            );
                             type_param_fallbacks.push((name_text.clone(), fallback));
                         }
                         type_param_names.push(name_text);
@@ -1114,6 +1132,14 @@ impl<'a> DeclarationEmitter<'a> {
                             &type_param_constraints,
                         ),
                     );
+                    if !receiver_type_param_substitutions.is_empty() {
+                        for (_, arg_text) in &mut type_param_substitutions {
+                            *arg_text = Self::replace_whole_words_in_text(
+                                arg_text,
+                                &receiver_type_param_substitutions,
+                            );
+                        }
+                    }
                     self.clear_conflicting_literal_substitution(
                         source_arena,
                         decl_idx,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_declared_call.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_declared_call.rs
@@ -2,6 +2,7 @@ use super::super::DeclarationEmitter;
 use super::type_inference::CallableDeclParts;
 use tsz_binder::{BinderState, SymbolId};
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::base::NodeList;
 use tsz_parser::parser::node::{CallExprData, Node, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
@@ -274,6 +275,8 @@ impl<'a> DeclarationEmitter<'a> {
             .resolve_portability_import_alias(type_sym, binder)
             .unwrap_or(type_sym);
         let type_sym = self.resolve_portability_declaration_symbol(type_sym, binder);
+        let receiver_type_param_substitutions =
+            self.receiver_declared_type_param_substitutions(base_sym, type_sym, binder);
 
         self.with_symbol_declarations(type_sym, |source_arena, decl_idx| {
             let member_idx =
@@ -300,6 +303,12 @@ impl<'a> DeclarationEmitter<'a> {
                 .trim_end_matches(';')
                 .trim_end()
                 .to_string();
+            if !receiver_type_param_substitutions.is_empty() {
+                type_text = Self::replace_whole_words_in_text(
+                    &type_text,
+                    &receiver_type_param_substitutions,
+                );
+            }
 
             let mut type_param_names = Vec::new();
             let mut type_param_substitutions = Vec::new();
@@ -332,9 +341,17 @@ impl<'a> DeclarationEmitter<'a> {
                                     self.source_slice_from_arena(source_arena, param.constraint)
                                 })
                         {
+                            let constraint = Self::replace_whole_words_in_text(
+                                &constraint,
+                                &receiver_type_param_substitutions,
+                            );
                             type_param_constraints.push((name_text.clone(), constraint));
                         }
                         if let Some(fallback) = fallback {
+                            let fallback = Self::replace_whole_words_in_text(
+                                &fallback,
+                                &receiver_type_param_substitutions,
+                            );
                             type_param_fallbacks.push((name_text.clone(), fallback));
                         }
                         type_param_names.push(name_text);
@@ -357,6 +374,14 @@ impl<'a> DeclarationEmitter<'a> {
                             &type_param_constraints,
                         ),
                     );
+                    if !receiver_type_param_substitutions.is_empty() {
+                        for (_, arg_text) in &mut type_param_substitutions {
+                            *arg_text = Self::replace_whole_words_in_text(
+                                arg_text,
+                                &receiver_type_param_substitutions,
+                            );
+                        }
+                    }
                     self.clear_conflicting_literal_substitution(
                         source_arena,
                         member_idx,
@@ -456,6 +481,226 @@ impl<'a> DeclarationEmitter<'a> {
                 self.expand_rest_tuple_parameters_in_function_type_text(expr_idx, &formatted)
                     .unwrap_or(formatted),
             )
+        })
+    }
+
+    pub(in crate::declaration_emitter) fn call_expression_declared_return_has_source_conditional_alias(
+        &self,
+        expr_idx: NodeIndex,
+    ) -> bool {
+        let Some(expr_node) = self.arena.get(expr_idx) else {
+            return false;
+        };
+        if expr_node.kind != syntax_kind_ext::CALL_EXPRESSION {
+            return false;
+        }
+        let Some(call) = self.arena.get_call_expr(expr_node) else {
+            return false;
+        };
+        let Some(binder) = self.binder else {
+            return false;
+        };
+
+        if let Some((sym_id, _)) = self.resolve_declared_call_callee_symbol(call.expression, binder)
+        {
+            return self
+                .with_symbol_declarations(sym_id, |source_arena, decl_idx| {
+                    let decl_node = source_arena.get(decl_idx)?;
+                    let callable = Self::callable_decl_parts_from_node(source_arena, decl_node)?;
+                    callable.type_annotation.is_some().then(|| {
+                        self.source_type_contains_conditional_alias_application(
+                            source_arena,
+                            callable.type_annotation,
+                            0,
+                        )
+                    })
+                })
+                .unwrap_or(false);
+        }
+
+        self.property_access_declared_return_has_source_conditional_alias(call.expression, binder)
+    }
+
+    fn property_access_declared_return_has_source_conditional_alias(
+        &self,
+        callee_expr: NodeIndex,
+        binder: &BinderState,
+    ) -> bool {
+        let Some(callee_node) = self.arena.get(callee_expr) else {
+            return false;
+        };
+        if callee_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return false;
+        }
+        let Some(access) = self.arena.get_access_expr(callee_node) else {
+            return false;
+        };
+        let Some(member_name) = self.get_identifier_text(access.name_or_argument) else {
+            return false;
+        };
+        let Some(base_sym) = self.value_reference_symbol(access.expression) else {
+            return false;
+        };
+        let Some(type_sym) = self.declared_type_symbol_for_symbol(base_sym) else {
+            return false;
+        };
+        let type_sym = self
+            .resolve_portability_import_alias(type_sym, binder)
+            .unwrap_or(type_sym);
+        let type_sym = self.resolve_portability_declaration_symbol(type_sym, binder);
+
+        self.with_symbol_declarations(type_sym, |source_arena, decl_idx| {
+            let member_idx =
+                self.type_member_decl_from_decl(source_arena, decl_idx, &member_name)?;
+            let decl_node = source_arena.get(member_idx)?;
+            let callable =
+                Self::callable_type_member_decl_parts_from_node(source_arena, decl_node)?;
+            callable.type_annotation.is_some().then(|| {
+                self.source_type_contains_conditional_alias_application(
+                    source_arena,
+                    callable.type_annotation,
+                    0,
+                )
+            })
+        })
+        .unwrap_or(false)
+    }
+
+    pub(in crate::declaration_emitter) fn call_receiver_declared_type_param_substitutions(
+        &self,
+        callee_expr: NodeIndex,
+        binder: &BinderState,
+    ) -> Vec<(String, String)> {
+        let Some(callee_node) = self.arena.get(callee_expr) else {
+            return Vec::new();
+        };
+        if callee_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return Vec::new();
+        }
+        let Some(access) = self.arena.get_access_expr(callee_node) else {
+            return Vec::new();
+        };
+        let Some(base_sym) = self.value_reference_symbol(access.expression) else {
+            return Vec::new();
+        };
+        let Some(type_sym) = self.declared_type_symbol_for_symbol(base_sym) else {
+            return Vec::new();
+        };
+        let type_sym = self
+            .resolve_portability_import_alias(type_sym, binder)
+            .unwrap_or(type_sym);
+        let type_sym = self.resolve_portability_declaration_symbol(type_sym, binder);
+        self.receiver_declared_type_param_substitutions(base_sym, type_sym, binder)
+    }
+
+    fn receiver_declared_type_param_substitutions(
+        &self,
+        value_sym: SymbolId,
+        type_sym: SymbolId,
+        binder: &BinderState,
+    ) -> Vec<(String, String)> {
+        let type_param_names = self
+            .declared_type_parameter_names_for_symbol(type_sym)
+            .unwrap_or_default();
+        if type_param_names.is_empty() {
+            return Vec::new();
+        }
+
+        let annotation_args = self
+            .with_declared_type_annotation_for_symbol(value_sym, |annotation_arena, type_idx| {
+                let type_node =
+                    annotation_arena.get(annotation_arena.skip_parenthesized(type_idx))?;
+                if type_node.kind != syntax_kind_ext::TYPE_REFERENCE {
+                    return None;
+                }
+                let annotation_type_sym = self
+                    .declaration_type_symbol_from_type_node(annotation_arena, type_idx)
+                    .map(|sym_id| self.resolve_portability_declaration_symbol(sym_id, binder))?;
+                if annotation_type_sym != type_sym {
+                    return None;
+                }
+                let type_ref = annotation_arena.get_type_ref(type_node)?;
+                let type_args = type_ref.type_arguments.as_ref()?;
+                Some(self.type_argument_texts_from_arena(annotation_arena, type_args))
+            })
+            .unwrap_or_default();
+
+        type_param_names
+            .into_iter()
+            .zip(annotation_args)
+            .filter(|(name, text)| !name.is_empty() && !text.is_empty())
+            .collect()
+    }
+
+    fn declared_type_parameter_names_for_symbol(&self, type_sym: SymbolId) -> Option<Vec<String>> {
+        self.with_symbol_declarations(type_sym, |source_arena, decl_idx| {
+            let decl_node = source_arena.get(decl_idx)?;
+            let type_params = source_arena
+                .get_interface(decl_node)
+                .and_then(|decl| decl.type_parameters.as_ref())
+                .or_else(|| {
+                    source_arena
+                        .get_class(decl_node)
+                        .and_then(|decl| decl.type_parameters.as_ref())
+                })
+                .or_else(|| {
+                    source_arena
+                        .get_type_alias(decl_node)
+                        .and_then(|decl| decl.type_parameters.as_ref())
+                })?;
+            Some(self.type_parameter_names_from_arena(source_arena, type_params))
+        })
+    }
+
+    fn type_parameter_names_from_arena(
+        &self,
+        source_arena: &NodeArena,
+        type_params: &NodeList,
+    ) -> Vec<String> {
+        type_params
+            .nodes
+            .iter()
+            .filter_map(|&param_idx| {
+                source_arena
+                    .get(param_idx)
+                    .and_then(|node| source_arena.get_type_parameter(node))
+                    .and_then(|param| self.identifier_text_from_arena(source_arena, param.name))
+            })
+            .collect()
+    }
+
+    fn type_argument_texts_from_arena(
+        &self,
+        source_arena: &NodeArena,
+        type_args: &NodeList,
+    ) -> Vec<String> {
+        type_args
+            .nodes
+            .iter()
+            .filter_map(|&arg_idx| {
+                if let Some(text) = self.emit_type_node_text_from_arena(source_arena, arg_idx) {
+                    return Some(text.trim().to_string());
+                }
+                self.source_slice_from_arena(source_arena, arg_idx)
+                    .map(|text| Self::trim_type_argument_text(&text))
+            })
+            .collect()
+    }
+
+    fn trim_type_argument_text(text: &str) -> String {
+        let mut trimmed = text.trim().trim_end_matches(',').trim().to_string();
+        while trimmed.ends_with('>') && Self::angle_depth(&trimmed) < 0 {
+            trimmed.pop();
+            trimmed = trimmed.trim_end().to_string();
+        }
+        trimmed
+    }
+
+    fn angle_depth(text: &str) -> i32 {
+        text.chars().fold(0, |depth, ch| match ch {
+            '<' => depth + 1,
+            '>' => depth - 1,
+            _ => depth,
         })
     }
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
@@ -991,7 +991,11 @@ impl<'a> DeclarationEmitter<'a> {
                 if let Some(text) = self.mixin_call_intersection_source_text(expr_idx) {
                     return Some(text);
                 }
-                let reused_type_text = self.call_expression_reused_type_text(expr_idx);
+                let suppress_declared_conditional_alias_surface =
+                    self.call_expression_declared_return_has_source_conditional_alias(expr_idx);
+                let reused_type_text = (!suppress_declared_conditional_alias_surface)
+                    .then(|| self.call_expression_reused_type_text(expr_idx))
+                    .flatten();
                 let reused_type_uses_function_local_alias =
                     reused_type_text.as_deref().is_some_and(|type_text| {
                         self.type_text_starts_with_function_local_type_alias(type_text)
@@ -1061,8 +1065,16 @@ impl<'a> DeclarationEmitter<'a> {
                     })
                     .filter(|type_text| !type_text.is_empty() && type_text != "any");
                 reused_type_text
-                    .or_else(|| self.call_expression_source_return_type_text(expr_idx))
-                    .or_else(|| self.call_expression_declared_return_type_text(expr_idx))
+                    .or_else(|| {
+                        (!suppress_declared_conditional_alias_surface)
+                            .then(|| self.call_expression_source_return_type_text(expr_idx))
+                            .flatten()
+                    })
+                    .or_else(|| {
+                        (!suppress_declared_conditional_alias_surface)
+                            .then(|| self.call_expression_declared_return_type_text(expr_idx))
+                            .flatten()
+                    })
             }
             k if k == syntax_kind_ext::TAGGED_TEMPLATE_EXPRESSION => {
                 self.tagged_template_declared_return_type_text(expr_idx)

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_surface.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_surface.rs
@@ -2,7 +2,9 @@
 
 use super::super::DeclarationEmitter;
 use tsz_parser::parser::NodeIndex;
-use tsz_parser::parser::node::NodeArena;
+use tsz_parser::parser::node::{NodeAccess, NodeArena};
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
 
 impl<'a> DeclarationEmitter<'a> {
     pub(in crate::declaration_emitter) fn call_expression_declared_return_surface_text(
@@ -20,6 +22,16 @@ impl<'a> DeclarationEmitter<'a> {
         {
             return Some(self.print_type_id_expanded_for_inferred_declaration(type_id));
         }
+        if let Some(type_id) = self.get_node_type_or_names(&[expr_idx])
+            && self.type_contains_conditional_alias_application_for_inferred_emit(type_id, 0)
+        {
+            return Some(self.print_type_id_for_inferred_declaration(type_id));
+        }
+        if self.source_type_contains_conditional_alias_application(source_arena, type_annotation, 0)
+            && let Some(type_id) = self.get_node_type_or_names(&[expr_idx])
+        {
+            return Some(self.print_type_id_expanded_for_inferred_declaration(type_id));
+        }
         if explicit_type_args.is_empty()
             && !has_call_site_type_param_substitutions
             && std::ptr::eq(source_arena, self.arena)
@@ -29,5 +41,157 @@ impl<'a> DeclarationEmitter<'a> {
             return Some(self.print_type_id_for_inferred_declaration(surface));
         }
         None
+    }
+
+    pub(in crate::declaration_emitter) fn source_type_contains_conditional_alias_application(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        depth: u8,
+    ) -> bool {
+        if depth > 32 {
+            return false;
+        }
+        let Some(type_node) = source_arena.get(type_idx) else {
+            return false;
+        };
+        if type_node.kind == syntax_kind_ext::TYPE_REFERENCE
+            && let Some(type_ref) = source_arena.get_type_ref(type_node)
+            && let Some(alias_name) =
+                self.return_surface_type_reference_name_text(source_arena, type_ref.type_name)
+            && (self
+                .find_type_alias_type_node_in_arena(source_arena, &alias_name)
+                .is_some_and(|alias_type| {
+                    self.type_node_is_conditional_after_parens(source_arena, alias_type, depth + 1)
+                })
+                || self.type_reference_resolves_to_conditional_alias(
+                    source_arena,
+                    type_idx,
+                    depth + 1,
+                ))
+        {
+            return true;
+        }
+        source_arena
+            .get_children(type_idx)
+            .into_iter()
+            .any(|child_idx| {
+                self.source_type_contains_conditional_alias_application(
+                    source_arena,
+                    child_idx,
+                    depth + 1,
+                )
+            })
+    }
+
+    fn type_node_is_conditional_after_parens(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        depth: u8,
+    ) -> bool {
+        if depth > 32 {
+            return false;
+        }
+        let Some(type_node) = source_arena.get(type_idx) else {
+            return false;
+        };
+        if type_node.kind == syntax_kind_ext::CONDITIONAL_TYPE {
+            return true;
+        }
+        if type_node.kind == syntax_kind_ext::PARENTHESIZED_TYPE
+            && let Some(wrapped) = source_arena.get_wrapped_type(type_node)
+        {
+            return self.type_node_is_conditional_after_parens(
+                source_arena,
+                wrapped.type_node,
+                depth + 1,
+            );
+        }
+        false
+    }
+
+    fn type_reference_resolves_to_conditional_alias(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+        depth: u8,
+    ) -> bool {
+        if depth > 32 {
+            return false;
+        }
+        let Some(sym_id) = self.declaration_type_symbol_from_type_node(source_arena, type_idx)
+        else {
+            return false;
+        };
+        self.with_symbol_declarations(sym_id, |alias_arena, decl_idx| {
+            let decl_node = alias_arena.get(decl_idx)?;
+            let alias = alias_arena.get_type_alias(decl_node)?;
+            Some(self.type_node_is_conditional_after_parens(
+                alias_arena,
+                alias.type_node,
+                depth + 1,
+            ))
+        })
+        .unwrap_or(false)
+    }
+
+    fn return_surface_type_reference_name_text(
+        &self,
+        source_arena: &NodeArena,
+        name_idx: NodeIndex,
+    ) -> Option<String> {
+        let name_node = source_arena.get(name_idx)?;
+        if name_node.kind == SyntaxKind::Identifier as u16 {
+            return self.identifier_text_from_arena(source_arena, name_idx);
+        }
+        if name_node.kind == syntax_kind_ext::QUALIFIED_NAME {
+            let qualified = source_arena.get_qualified_name(name_node)?;
+            return self.identifier_text_from_arena(source_arena, qualified.right);
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsz_parser::parser::ParserState;
+
+    #[test]
+    fn source_type_detects_nested_conditional_alias_application() {
+        let mut parser = ParserState::new(
+            "return-surface.ts".to_string(),
+            r#"
+type Next<T, Fn> = Fn extends (value: T) => unknown ? (value: T) => ReturnType<Fn> : never;
+interface Box<T> {
+    pipe<Fn extends (value: T) => unknown>(fn: Fn): Box<Next<T, Fn>>;
+}
+"#
+            .to_string(),
+        );
+        parser.parse_source_file();
+        let emitter = DeclarationEmitter::new(&parser.arena);
+        let return_type = parser
+            .arena
+            .nodes
+            .iter()
+            .enumerate()
+            .find_map(|(idx, node)| {
+                (node.kind == syntax_kind_ext::TYPE_REFERENCE)
+                    .then_some(NodeIndex(idx as u32))
+                    .filter(|&idx| {
+                        emitter
+                            .source_slice_from_arena(&parser.arena, idx)
+                            .is_some_and(|text| text.trim() == "Box<Next<T, Fn>>")
+                    })
+            })
+            .expect("method return type");
+
+        assert!(emitter.source_type_contains_conditional_alias_application(
+            &parser.arena,
+            return_type,
+            0
+        ));
     }
 }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
@@ -870,6 +870,78 @@ let z = ImportedWidget.make({ label: "ok" });
 }
 
 #[test]
+fn declared_call_return_substitutes_receiver_type_parameters_before_member_type_parameters() {
+    let source = r#"
+type InferPipe<State, Fn> =
+    Fn extends (value: State) => unknown ? (value: State) => ReturnType<Fn> : never;
+interface PipeBox<State> {
+    pipe<Fn extends (value: State) => unknown>(fn: Fn): PipeBox<InferPipe<State, Fn>>;
+}
+declare const source: PipeBox<string>;
+declare const parseValue: (value: string) => number;
+let out = source.pipe(parseValue);
+"#;
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+    let interner = TypeInterner::new();
+    let type_cache = crate::type_cache_view::TypeCacheView::default();
+    let emitter = DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    let call_idx = parser
+        .arena
+        .nodes
+        .iter()
+        .enumerate()
+        .find_map(|(idx, node)| {
+            (node.kind == syntax_kind_ext::CALL_EXPRESSION).then_some(NodeIndex(idx as u32))
+        })
+        .expect("missing call expression");
+
+    assert!(emitter.call_expression_declared_return_has_source_conditional_alias(call_idx));
+    assert_eq!(
+        emitter.call_expression_declared_return_type_text(call_idx),
+        Some("PipeBox<InferPipe<string, (value: string) => number>>".to_string())
+    );
+}
+
+#[test]
+fn declared_call_return_substitutes_receiver_type_parameters_with_renamed_binders() {
+    let source = r#"
+type Next<Input, Handler> =
+    Handler extends (item: Input) => unknown ? (item: Input) => ReturnType<Handler> : never;
+interface Chain<Input> {
+    map<Handler extends (item: Input) => unknown>(handler: Handler): Chain<Next<Input, Handler>>;
+}
+declare const chain: Chain<number>;
+declare const handler: (item: number) => string;
+let out = chain.map(handler);
+"#;
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+    let interner = TypeInterner::new();
+    let type_cache = crate::type_cache_view::TypeCacheView::default();
+    let emitter = DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+    let call_idx = parser
+        .arena
+        .nodes
+        .iter()
+        .enumerate()
+        .find_map(|(idx, node)| {
+            (node.kind == syntax_kind_ext::CALL_EXPRESSION).then_some(NodeIndex(idx as u32))
+        })
+        .expect("missing call expression");
+
+    assert!(emitter.call_expression_declared_return_has_source_conditional_alias(call_idx));
+    assert_eq!(
+        emitter.call_expression_declared_return_type_text(call_idx),
+        Some("Chain<Next<number, (item: number) => string>>".to_string())
+    );
+}
+
+#[test]
 fn instantiation_expression_source_surface_detects_unresolved_declaration_text() {
     assert!(
         !DeclarationEmitter::instantiated_source_type_needs_semantic_surface(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
@@ -246,7 +246,7 @@ impl<'a> DeclarationEmitter<'a> {
             .is_some_and(|text| matches!(text.trim(), "null" | "undefined"))
     }
 
-    fn with_declared_type_annotation_for_symbol<T>(
+    pub(in crate::declaration_emitter) fn with_declared_type_annotation_for_symbol<T>(
         &self,
         sym_id: SymbolId,
         mut f: impl FnMut(&NodeArena, NodeIndex) -> Option<T>,

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -537,6 +537,7 @@ impl<'a> DeclarationEmitter<'a> {
                     .arena
                     .get(initializer)
                     .is_some_and(|node| node.kind == syntax_kind_ext::CALL_EXPRESSION)
+                && !self.call_expression_declared_return_has_source_conditional_alias(initializer)
                 && let Some(type_text) =
                     self.call_expression_reused_type_text(initializer)
                         .filter(|text| {
@@ -552,6 +553,7 @@ impl<'a> DeclarationEmitter<'a> {
                     .arena
                     .get(initializer)
                     .is_some_and(|node| node.kind == syntax_kind_ext::CALL_EXPRESSION)
+                && !self.call_expression_declared_return_has_source_conditional_alias(initializer)
                 && let Some(type_text) = self.preferred_expression_type_text(initializer)
             {
                 let reused_type_text = self.call_expression_reused_type_text(initializer);


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit/DTS parity follow-up for the remaining declaration emit tail after #12676.

## Invariant
When a declared receiver-member call has a source return annotation that applies a conditional type alias, declaration emit should not preserve the intermediate source alias surface after call-site substitution if tsc emits the canonical resolved declaration surface. This PR keeps the detection in declaration-emitter source/AST helpers and uses the checked inferred declaration type for that conditional-alias call surface, without output string surgery or checker/solver semantic validation in the emitter.

## Scope
- crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
- crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_declared_call.rs
- crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_fallback_types.rs
- crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_surface.rs
- crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_tests.rs
- crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
- crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs

## Project Corpus Impact
- Row: n/a
- Bug family: DTS inferred return surface for declared receiver-member calls involving conditional alias applications.
- Evidence: targeted DTS baseline filter inferredReturnTypeIncorrectReuse1 now passes locally; no project corpus row was run for this narrow declaration emit baseline fix.

## Verification
- cargo fmt
- git diff --check origin/main..HEAD
- cargo nextest run -p tsz-emitter -E 'test(declared_call_return_substitutes_receiver_type_parameters) or test(source_type_detects_nested_conditional_alias_application)'
- ./scripts/emit/run.sh --filter=inferredReturnTypeIncorrectReuse1 --dts-only --verbose --json-out=/tmp/tsz-12728-dts-inferredReturnTypeIncorrectReuse1.json

## Coordination Notes
- AgentName: Studio-C
- #12676 merged while this follow-up was being prepared; this PR is a fresh one-commit branch on current origin/main.
- CI artifact for #12676 showed DTS at 1668/1669 with inferredReturnTypeIncorrectReuse1 as the remaining DTS failure; this PR targets that row directly.
- Existing Studio-C PR #12702 is ready but not queueable yet because exact-head heavy checks are still running/queued; a blocker note was posted there before opening this follow-up.
- No output surgery was added. The source conditional-alias check is structural over parsed type nodes and binder-backed alias declarations.
- Do not add merge-queue until exact-head PR checks, including CI Summary and GitGuardian Security Checks, pass on this head.