### PR TITLE
refactor(checker): name interface heritage relation guards

### DIFF
--- a/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
+++ b/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
@@ -209,7 +209,7 @@ impl<'a> CheckerState<'a> {
         if crate::query_boundaries::class::generic_erasure_fallback_is_safe(self, derived, base) {
             return false;
         }
-        if !self.is_assignable_to_bivariant(derived, base) {
+        if !self.diagnostic_relation_boolean_guard_bivariant(derived, base) {
             return false;
         }
         let (Some(derived_return), Some(base_return)) = (
@@ -218,7 +218,7 @@ impl<'a> CheckerState<'a> {
         ) else {
             return false;
         };
-        self.is_assignable_to_no_erase_generics(derived_return, base_return)
+        self.diagnostic_relation_boolean_guard_no_erase_generics(derived_return, base_return)
     }
 
     /// Return type of a callable member that has exactly one call signature and
@@ -277,7 +277,7 @@ impl<'a> CheckerState<'a> {
         )
         .map(|p| p.type_id)
         .unwrap_or(raw_derived_member);
-        self.is_assignable_to_no_erase_generics(derived, base_member)
+        self.diagnostic_relation_boolean_guard_no_erase_generics(derived, base_member)
     }
 
     pub(super) fn type_base_def_id(&self, type_id: TypeId) -> Option<tsz_solver::def::DefId> {

--- a/crates/tsz-checker/src/tests/class_boundary_fallback_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/class_boundary_fallback_relation_routing_arch_tests.rs
@@ -87,6 +87,52 @@ fn class_boundary_no_erase_generic_probes_use_relation_outcome_boundary() {
 }
 
 #[test]
+fn interface_heritage_member_fallbacks_use_named_diagnostic_relation_guards() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/classes/interface_heritage_index_compat.rs"),
+    )
+    .expect("failed to read interface_heritage_index_compat.rs");
+
+    let nongeneric_override_helper = source
+        .split("pub(super) fn nongeneric_input_only_generic_override_is_valid")
+        .nth(1)
+        .and_then(|tail| tail.split("fn single_call_signature_return_type").next())
+        .expect("failed to isolate nongeneric override fallback helper");
+    assert!(
+        nongeneric_override_helper
+            .contains("diagnostic_relation_boolean_guard_bivariant(derived, base)"),
+        "non-generic override fallback should name the bivariant diagnostic boolean guard"
+    );
+    assert!(
+        nongeneric_override_helper.contains(
+            "diagnostic_relation_boolean_guard_no_erase_generics(derived_return, base_return)"
+        ),
+        "non-generic override fallback should name the no-erase return diagnostic boolean guard"
+    );
+    assert!(
+        !nongeneric_override_helper.contains("is_assignable_to_bivariant(")
+            && !nongeneric_override_helper.contains("is_assignable_to_no_erase_generics("),
+        "non-generic override fallback should not embed raw relation predicates"
+    );
+
+    let this_member_helper = source
+        .split("pub(super) fn this_member_override_is_polymorphic")
+        .nth(1)
+        .and_then(|tail| tail.split("pub(super) fn type_base_def_id").next())
+        .expect("failed to isolate polymorphic this fallback helper");
+    assert!(
+        this_member_helper
+            .contains("diagnostic_relation_boolean_guard_no_erase_generics(derived, base_member)"),
+        "polymorphic-this fallback should name the no-erase diagnostic boolean guard"
+    );
+    assert!(
+        !this_member_helper.contains("is_assignable_to_no_erase_generics("),
+        "polymorphic-this fallback should not embed a raw no-erase relation predicate"
+    );
+}
+
+#[test]
 fn class_coinductive_return_cycle_param_check_uses_relation_outcome_boundary() {
     let source = fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR")).join("src/query_boundaries/class.rs"),


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker architecture / relation diagnostic routing cleanup for #8227.

## Invariant
When interface-heritage fallback code performs bivariant or no-erase generic compatibility probes only to decide whether to report/suppress checker diagnostics, tsz preserves the existing solver relation policy while routing those probes through named diagnostic relation guards owned by checker orchestration.

## Scope
- Route `nongeneric_input_only_generic_override_is_valid` bivariant and no-erase return probes through the existing diagnostic relation guard helpers.
- Route `this_member_override_is_polymorphic` no-erase probe through the existing diagnostic relation guard helper.
- Add an architecture regression test that locks those interface-heritage fallback probes away from raw `is_assignable_to_*` predicates.

## Project Corpus Impact
- Row: n/a.
- Bug family: n/a.
- Evidence: behavior-preserving checker routing cleanup only; no diagnostic text, solver policy, relation flags, emit, parser, or project-row fixture behavior intentionally changed.

## Verification
- `git diff --check origin/main...HEAD` -> passed.
- `cargo fmt --check` -> passed.
- `scripts/safe-run.sh cargo nextest run -p tsz-checker class_boundary_fallback_relation_routing_arch_tests` -> 4 passed, 13483 skipped.
- `scripts/arch/check-checker-boundaries.sh` -> passed; checker field-lifetime inventory passed with 240 classified fields.

## Coordination Notes
- No live M1-B PRs were open before this slice.
- Avoids active M1-A diagnostic-display work and Studio object-literal/solver-performance PRs; this PR only names interface-heritage relation boolean probes.
- `relation_routing_residual_arch_tests` was tried as an exploratory broader ratchet and still fails on existing unrelated raw-call sites in JSX props resolution, assignment formatting, mapped object literals, and type-node helpers. This PR does not broaden into those active/adjacent paths.
- Ready for exact-head CI and repo merge-queue review after CI is green.
