### PR TITLE
refactor(checker): route typeof flow narrowing through boundary

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -18,6 +18,38 @@ impl<'a> FlowAnalyzer<'a> {
         flow_query::narrow_to_falsy(self.interner, env_borrow.as_deref(), type_id)
     }
 
+    fn narrow_by_typeof_result_via_flow_boundary(
+        &self,
+        type_id: TypeId,
+        typeof_result: &str,
+        is_true_branch: bool,
+    ) -> TypeId {
+        let env_borrow = self.type_environment.as_ref().map(|env| env.borrow());
+        flow_query::narrow_by_typeof_result(
+            self.interner,
+            env_borrow.as_deref(),
+            type_id,
+            typeof_result,
+            is_true_branch,
+        )
+    }
+
+    fn narrow_with_guard_via_flow_boundary(
+        &self,
+        type_id: TypeId,
+        guard: &TypeGuard,
+        is_true_branch: bool,
+    ) -> TypeId {
+        let env_borrow = self.type_environment.as_ref().map(|env| env.borrow());
+        flow_query::narrow_with_guard(
+            self.interner,
+            env_borrow.as_deref(),
+            type_id,
+            guard,
+            is_true_branch,
+        )
+    }
+
     fn union_logical_condition_branches(&self, types: Vec<TypeId>) -> TypeId {
         let mut members = Vec::with_capacity(types.len());
         let mut saw_reachable = false;
@@ -213,7 +245,11 @@ impl<'a> FlowAnalyzer<'a> {
                     let Some(typeof_result) = self.literal_string_from_node(case_expr) else {
                         break;
                     };
-                    return narrowing.narrow_by_typeof(narrowed, typeof_result);
+                    return self.narrow_by_typeof_result_via_flow_boundary(
+                        narrowed,
+                        typeof_result,
+                        true,
+                    );
                 }
 
                 if clause.expression.is_none() {
@@ -224,7 +260,8 @@ impl<'a> FlowAnalyzer<'a> {
                     break;
                 };
 
-                narrowed = narrowing.narrow_by_typeof_negation(narrowed, typeof_result);
+                narrowed =
+                    self.narrow_by_typeof_result_via_flow_boundary(narrowed, typeof_result, false);
                 if narrowed == TypeId::NEVER {
                     return TypeId::NEVER;
                 }
@@ -460,7 +497,8 @@ impl<'a> FlowAnalyzer<'a> {
                 };
 
                 applied = true;
-                narrowed = narrowing.narrow_by_typeof_negation(narrowed, typeof_result);
+                narrowed =
+                    self.narrow_by_typeof_result_via_flow_boundary(narrowed, typeof_result, false);
                 if narrowed == TypeId::NEVER {
                     return TypeId::NEVER;
                 }
@@ -1274,10 +1312,10 @@ impl<'a> FlowAnalyzer<'a> {
                     .is_some_and(|sid| self.is_unknown_catch_variable_symbol(sid));
                 let typeof_base_type =
                     flow_boundary::catch_variable_typeof_base_from_flow(type_id, is_catch_var);
-                let narrowed = narrowing.narrow_type(
+                let narrowed = self.narrow_with_guard_via_flow_boundary(
                     typeof_base_type,
                     &TypeGuard::Typeof(typeof_kind),
-                    GuardSense::from(effective_truth),
+                    effective_truth,
                 );
                 if effective_truth
                     && typeof_kind == TypeofKind::Object
@@ -1301,9 +1339,9 @@ impl<'a> FlowAnalyzer<'a> {
                 );
             } else {
                 // Collect the primitive members from the source type
-                let s = narrowing.narrow_by_typeof(type_id, "string");
-                let n = narrowing.narrow_by_typeof(type_id, "number");
-                let b = narrowing.narrow_by_typeof(type_id, "boolean");
+                let s = self.narrow_by_typeof_result_via_flow_boundary(type_id, "string", true);
+                let n = self.narrow_by_typeof_result_via_flow_boundary(type_id, "number", true);
+                let b = self.narrow_by_typeof_result_via_flow_boundary(type_id, "boolean", true);
                 let mut parts = Vec::new();
                 if s != TypeId::NEVER {
                     parts.push(s);

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -269,6 +269,29 @@ pub(crate) fn narrow_with_guard(
     narrowing.narrow_type(type_id, guard, GuardSense::from(is_true_branch))
 }
 
+/// Apply a runtime `typeof` result to a flow type.
+///
+/// The checker owns recognizing `typeof x === "..."` or switch-case syntax and
+/// extracting the string result. This boundary owns the semantic narrowing for
+/// both positive and negative branches.
+pub(crate) fn narrow_by_typeof_result(
+    db: &dyn QueryDatabase,
+    env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
+    type_id: TypeId,
+    typeof_result: &str,
+    is_true_branch: bool,
+) -> TypeId {
+    let mut narrowing = tsz_solver::narrowing::NarrowingContext::new(db);
+    if let Some(environment) = env {
+        narrowing = narrowing.with_resolver(environment);
+    }
+    if is_true_branch {
+        narrowing.narrow_by_typeof(type_id, typeof_result)
+    } else {
+        narrowing.narrow_by_typeof_negation(type_id, typeof_result)
+    }
+}
+
 /// Apply a type predicate discovered from a call-expression condition.
 ///
 /// The checker owns matching the callee, call target, optional-chain shape, and
@@ -1126,6 +1149,24 @@ mod tests {
         assert_eq!(members.len(), 2);
         assert!(members.contains(&db.literal_string("string")));
         assert!(members.contains(&db.literal_string("number")));
+    }
+
+    #[test]
+    fn narrow_by_typeof_result_routes_positive_and_negative_branches() {
+        let db = TypeInterner::new();
+        let source = db.union(vec![TypeId::STRING, TypeId::NUMBER, TypeId::BOOLEAN]);
+
+        assert_eq!(
+            narrow_by_typeof_result(&db, None, source, "string", true),
+            TypeId::STRING
+        );
+
+        let negative = narrow_by_typeof_result(&db, None, source, "string", false);
+        let members =
+            union_members_for_type(&db, negative).unwrap_or_else(|| vec![negative].into());
+        assert_eq!(members.len(), 2);
+        assert!(members.contains(&TypeId::NUMBER));
+        assert!(members.contains(&TypeId::BOOLEAN));
     }
 
     #[test]

--- a/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
@@ -227,3 +227,33 @@ fn condition_false_branch_falsy_narrowing_uses_flow_query_boundary() {
         "condition narrowing should not call solver falsy narrowing directly"
     );
 }
+
+#[test]
+fn condition_typeof_narrowing_uses_flow_query_boundary() {
+    let condition_source = fs::read_to_string("src/flow/control_flow/condition_narrowing.rs")
+        .expect("failed to read condition narrowing source");
+    let boundary_source = fs::read_to_string("src/query_boundaries/flow_analysis.rs")
+        .expect("failed to read flow analysis boundary source");
+    let compact_condition: String = condition_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let compact_boundary: String = boundary_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+
+    assert!(
+        compact_boundary.contains("fnnarrow_by_typeof_result("),
+        "flow analysis boundary should expose solver-owned typeof result narrowing"
+    );
+    assert!(
+        compact_condition.contains("flow_query::narrow_by_typeof_result("),
+        "condition typeof narrowing should route through the flow query boundary"
+    );
+    assert!(
+        !compact_condition.contains(".narrow_by_typeof(")
+            && !compact_condition.contains(".narrow_by_typeof_negation("),
+        "condition narrowing should not call solver typeof narrowing directly"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
Track 6: Flow Graph And Solver-Owned Narrowing Predicates; refactor-only boundary ratchet.

## Invariant
When checker CFG/AST analysis recognizes a runtime `typeof` flow predicate, `tsc` narrows through semantic type facts; this PR makes tsz route the reusable `typeof` narrowing operation through `query_boundaries/flow_analysis` while checker code supplies only the observed syntax, target, and branch.

## Scope
- `crates/tsz-checker/src/query_boundaries/flow_analysis.rs`: add `narrow_by_typeof_result` and unit coverage for positive/negative branches.
- `crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs`: route switch/default/non-standard `typeof` paths through the flow boundary helpers.
- `crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs`: pin the checker-side contract so direct solver `typeof` calls do not drift back into condition narrowing.

## Project Corpus Impact
- Row: n/a
- Bug family: flow/narrowing boundary cleanup
- Evidence: refactor-only; no project-row behavior path intentionally changed, but it reduces checker-local semantic narrowing ownership for Track 6.

## Verification
- `cargo fmt`
- `cargo nextest run -p tsz-checker --lib flow_guard_boundary_tests`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Open M1-D and M4-C owned work was clear before claiming this slice.
- Overlap check: active open PRs are in M1-A/M1-B/M4-Opus/Studio lanes; this PR only touches the Track 6 flow boundary and checker condition narrowing call sites.
- Disk note: local package-wide `nextest` attempt was blocked by macOS `errno=28`; removed clean merged M4-C worktrees #12694/#12699 and reran the narrower `--lib` flow guard suite successfully.
- Ready for manager review; no WIP markers.