### PR TITLE
chore(setup): surface low-disk cache pressure

### DIFF
--- a/scripts/setup/disk-worktree-guard.sh
+++ b/scripts/setup/disk-worktree-guard.sh
@@ -91,6 +91,7 @@ pruned=""
 disk_free_gb_after=""
 disk_free_mb_after=""
 disk_shortfall_mb_after=""
+cache_pressure_candidates=""
 
 prune_incremental() {
   local pruned=0
@@ -182,8 +183,64 @@ else
   echo "  none"
 fi
 
+emit_cache_candidate() {
+  local scope="$1"
+  local wt="$2"
+  local branch="$3"
+  local cache_name
+  local tdir
+  local size_kb
+  local size_mb
+
+  for cache_name in target .target .target-bench; do
+    tdir="$wt/$cache_name"
+    [[ -d "$tdir" ]] || continue
+    size_kb="$(du -sk "$tdir" 2>/dev/null | awk 'NR==1 {print $1}')"
+    [[ -n "$size_kb" ]] || continue
+    (( size_kb > 0 )) || continue
+    size_mb=$(( (size_kb + 1023) / 1024 ))
+    printf '%012d\tsize_mb=%s path=%s cache=%s scope=%s branch=%s\n' \
+      "$size_kb" "$size_mb" "$tdir" "$cache_name" "$scope" "${branch:-unknown}"
+  done
+}
+
+if [[ "$disk_status" == "low" ]]; then
+  echo "cache_pressure_candidates:"
+  cache_pressure_candidates="$(
+    {
+      current_branch="$(
+        git -C "$REPO_ROOT" symbolic-ref --short -q HEAD \
+          || git -C "$REPO_ROOT" rev-parse --short=12 HEAD
+      )"
+      emit_cache_candidate current "$REPO_ROOT" "$current_branch"
+
+      if [[ -n "$reuse_candidates" ]]; then
+        while IFS= read -r line; do
+          line="${line#  }"
+          [[ -n "$line" ]] || continue
+          [[ "$line" != "none" ]] || continue
+          wt="${line%% branch=*}"
+          rest="${line#* branch=}"
+          branch="${rest%% inactive_hours>=*}"
+          [[ -n "$wt" && "$wt" != "$line" ]] || continue
+          emit_cache_candidate inactive-clean "$wt" "$branch"
+        done <<< "$reuse_candidates"
+      fi
+    } | sort -rn | head -8 | cut -f2-
+  )"
+
+  if [[ -n "$cache_pressure_candidates" ]]; then
+    while IFS= read -r line; do
+      printf '  %s\n' "$line"
+    done <<< "$cache_pressure_candidates"
+  else
+    echo "  none"
+  fi
+fi
+
 if [[ -n "$JSON_REPORT" ]]; then
   REUSE_CANDIDATES="$reuse_candidates" \
+  CACHE_PRESSURE_CANDIDATES="$cache_pressure_candidates" \
   JSON_REPORT="$JSON_REPORT" \
   WORKTREE_PARENT="$WORKTREE_PARENT" \
   REPO_ROOT="$REPO_ROOT" \
@@ -222,6 +279,22 @@ const candidates = (process.env.REUSE_CANDIDATES ?? "")
     };
   });
 
+const cachePressureCandidates = (process.env.CACHE_PRESSURE_CANDIDATES ?? "")
+  .split(/\n/)
+  .map((line) => line.trim())
+  .filter(Boolean)
+  .map((line) => {
+    const match = /^size_mb=(\d+) path=(.*?) cache=(\S+) scope=(\S+) branch=(.*)$/.exec(line);
+    if (!match) return { raw: line };
+    return {
+      size_mb: Number(match[1]),
+      path: match[2],
+      cache: match[3],
+      scope: match[4],
+      branch: match[5],
+    };
+  });
+
 const report = {
   ok: process.env.DISK_STATUS === "ok",
   status: process.env.DISK_STATUS,
@@ -244,6 +317,8 @@ const report = {
     : null,
   reuse_candidate_count: candidates.length,
   reuse_candidates: candidates,
+  cache_pressure_candidate_count: cachePressureCandidates.length,
+  cache_pressure_candidates: cachePressureCandidates,
 };
 
 fs.mkdirSync(path.dirname(process.env.JSON_REPORT), { recursive: true });

--- a/scripts/setup/test_disk_worktree_guard.py
+++ b/scripts/setup/test_disk_worktree_guard.py
@@ -41,7 +41,8 @@ class DiskWorktreeGuardTests(unittest.TestCase):
         self.run_git(["config", "user.name", "Studio F"], fake_repo)
         self.run_git(["config", "commit.gpgsign", "false"], fake_repo)
         (fake_repo / "README.md").write_text("# fake repo\n", encoding="utf-8")
-        self.run_git(["add", "README.md"], fake_repo)
+        (fake_repo / ".gitignore").write_text(".target/\ntarget/\n", encoding="utf-8")
+        self.run_git(["add", ".gitignore", "README.md"], fake_repo)
         self.run_git(["commit", "-m", "initial"], fake_repo)
         return fake_repo, fake_script
 
@@ -117,6 +118,32 @@ class DiskWorktreeGuardTests(unittest.TestCase):
             self.assertIn("disk_status=low", result.stdout)
             self.assertRegex(result.stdout, r"disk_shortfall_mb=\d+")
 
+    def test_low_disk_reports_cache_pressure_for_clean_inactive_worktrees(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = pathlib.Path(temp_dir).resolve()
+            fake_repo, fake_script = self.make_fake_repo(temp_root)
+            clean_worktree, dirty_worktree = self.add_clean_and_dirty_worktrees(
+                fake_repo, temp_root
+            )
+            (clean_worktree / ".target").mkdir()
+            (clean_worktree / ".target" / "cache.bin").write_bytes(b"x" * 1024)
+            (dirty_worktree / ".target").mkdir()
+            (dirty_worktree / ".target" / "cache.bin").write_bytes(b"x" * 1024)
+            old_timestamp = time.time() - 7200
+            self.age_worktree_files(clean_worktree, old_timestamp)
+            self.age_worktree_files(dirty_worktree, old_timestamp)
+
+            result = self.run_guard(
+                fake_repo,
+                fake_script,
+                env_overrides={"TSZ_DISK_MIN_FREE_GB": "9999999"},
+            )
+
+            self.assertIn("cache_pressure_candidates:", result.stdout)
+            self.assertIn(f"path={clean_worktree / '.target'}", result.stdout)
+            self.assertIn("scope=inactive-clean", result.stdout)
+            self.assertNotIn(f"path={dirty_worktree / '.target'}", result.stdout)
+
     def test_json_report_records_disk_status_and_reuse_candidates(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_root = pathlib.Path(temp_dir).resolve()
@@ -141,6 +168,8 @@ class DiskWorktreeGuardTests(unittest.TestCase):
             self.assertIsNone(report["pruned"])
             self.assertIsNone(report["disk_after_auto_prune"])
             self.assertEqual(1, report["reuse_candidate_count"])
+            self.assertIsInstance(report["cache_pressure_candidate_count"], int)
+            self.assertIsInstance(report["cache_pressure_candidates"], list)
             self.assertEqual(
                 {
                     "path": str(clean_worktree),


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Studio-Opus infrastructure / disk-cache hygiene blocker.

## Invariant
When disk is below the guard threshold, agents need compact, actionable cache ownership hints without broad recursive `du` output; this PR makes `disk-worktree-guard.sh` report only current-checkout and clean inactive worktree cache candidates, preserving source worktrees and avoiding dirty worktrees.

## Scope
- Add a low-disk `cache_pressure_candidates` section to `scripts/setup/disk-worktree-guard.sh`.
- Include matching `cache_pressure_candidates` / count fields in the JSON report.
- Cover clean inactive cache reporting, dirty worktree exclusion, JSON schema, and disk-preflight parser compatibility in focused tests.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a (setup/disk hygiene infrastructure)
- No compiler, emit, conformance, or project-row behavior changes. This reduces Studio-side downtime when cache pressure blocks project/performance sampling.

## Verification
- `python3 -m unittest scripts.setup.test_disk_worktree_guard scripts.agents.test_disk_preflight`
- `git diff --check HEAD~1..HEAD`
- `python3 scripts/arch/arch_guard.py`
- Live smoke: `TSZ_DISK_MIN_FREE_GB=20 scripts/setup/disk-worktree-guard.sh | sed -n '1,90p'`

## Coordination Notes
- Triggered by the post-#12727 pino sampling attempt: a current-main dist-fast build hit `ENOSPC` while the guard only reported reusable worktrees, not cache pressure. This PR makes the next cleanup decision visible without deleting source or active dirty worktrees.
- The output remains compact and low-disk-only; no startup hook prints broad file trees or roadmap-sized context.
