### PR TITLE
perf(checker): cache default constraint validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1260,8 +1260,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_SHA: ${{ github.sha }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
           python3 - <<'PY'
@@ -1307,11 +1307,10 @@ jobs:
           def mirror_previous_required_summary():
               repository = os.environ["GITHUB_REPOSITORY"]
               current_run_id = int(os.environ["GITHUB_RUN_ID"])
-              head_sha = os.environ["GITHUB_SHA"]
+              head_sha = os.environ["CI_HEAD_SHA"]
               query = urllib.parse.urlencode({
                   "head_sha": head_sha,
                   "event": "pull_request",
-                  "status": "completed",
                   "per_page": "20",
               })
               runs = github_json(f"/repos/{repository}/actions/workflows/ci.yml/runs?{query}").get("workflow_runs", [])

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       bench_shell_only: ${{ steps.gate.outputs.bench_shell_only }}
       perf_tool_only: ${{ steps.gate.outputs.perf_tool_only }}
       arch_tool_only: ${{ steps.gate.outputs.arch_tool_only }}
+      metadata_only_skip: ${{ steps.gate.outputs.metadata_only_skip }}
       compiler_checks_required: ${{ steps.gate.outputs.compiler_checks_required }}
       unit_packages: ${{ steps.gate.outputs.unit_packages }}
     steps:
@@ -71,13 +72,14 @@ jobs:
               # Body/title edits can repair AgentName, project-corpus, or WIP
               # metadata without changing the PR head SHA. Refresh only the
               # metadata gates so stale failed PR-body checks can clear without
-              # asking agents to push a no-op code commit. Keep this off the
-              # protected "CI Summary" context: it did not run heavy CI and
-              # must not satisfy branch protection for the head SHA.
+              # asking agents to push a no-op code commit. The summary job
+              # mirrors the previous real CI Summary for this exact head SHA so
+              # native merge queue still sees the protected context without a
+              # light run masking a failed full run.
               echo "PR metadata edited — refreshing body/ready-state checks without heavy CI."
               should_run=false
               full_run=false
-              required_summary=false
+              metadata_only_skip=true
               compiler_checks_required=false
             fi
             # The `labeled` event triggers on every label add. We only care
@@ -297,9 +299,6 @@ jobs:
                 required_summary=false
               fi
             fi
-            if [[ "$metadata_only_skip" == "true" ]]; then
-              required_summary=false
-            fi
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
             # Skip redundant main CI when the push is a PR merge already validated by PR CI.
             # Saves ~40+ runner-minutes per merge (32 conformance + lint + unit + wasm + emit shards).
@@ -435,6 +434,7 @@ jobs:
           echo "bench_shell_only=${bench_shell_only}" >> "$GITHUB_OUTPUT"
           echo "perf_tool_only=${perf_tool_only}" >> "$GITHUB_OUTPUT"
           echo "arch_tool_only=${arch_tool_only}" >> "$GITHUB_OUTPUT"
+          echo "metadata_only_skip=${metadata_only_skip}" >> "$GITHUB_OUTPUT"
           echo "compiler_checks_required=${compiler_checks_required}" >> "$GITHUB_OUTPUT"
           echo "unit_packages=${unit_packages}" >> "$GITHUB_OUTPUT"
 
@@ -1258,12 +1258,18 @@ jobs:
     steps:
       - name: Verify required CI jobs
         env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
           python3 - <<'PY'
           import json
           import os
           import sys
+          import urllib.parse
+          import urllib.request
 
           needs = json.loads(os.environ["NEEDS_JSON"])
           gate = needs["gate"]
@@ -1272,6 +1278,7 @@ jobs:
           bench_shell_only = gate.get("outputs", {}).get("bench_shell_only") == "true"
           perf_tool_only = gate.get("outputs", {}).get("perf_tool_only") == "true"
           arch_tool_only = gate.get("outputs", {}).get("arch_tool_only") == "true"
+          metadata_only_skip = gate.get("outputs", {}).get("metadata_only_skip") == "true"
           compiler_checks_required = gate.get("outputs", {}).get("compiler_checks_required") != "false"
 
           gate_result = gate.get("result")
@@ -1284,7 +1291,52 @@ jobs:
               print(f"project-corpus-pr-body did not pass: {pr_body.get('result')}")
               sys.exit(1)
 
+          def github_json(path):
+              token = os.environ["GH_TOKEN"]
+              request = urllib.request.Request(
+                  f"https://api.github.com{path}",
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urllib.request.urlopen(request, timeout=20) as response:
+                  return json.loads(response.read().decode("utf-8"))
+
+          def mirror_previous_required_summary():
+              repository = os.environ["GITHUB_REPOSITORY"]
+              current_run_id = int(os.environ["GITHUB_RUN_ID"])
+              head_sha = os.environ["GITHUB_SHA"]
+              query = urllib.parse.urlencode({
+                  "head_sha": head_sha,
+                  "event": "pull_request",
+                  "status": "completed",
+                  "per_page": "20",
+              })
+              runs = github_json(f"/repos/{repository}/actions/workflows/ci.yml/runs?{query}").get("workflow_runs", [])
+              runs = [run for run in runs if int(run.get("id", 0)) != current_run_id]
+              runs.sort(key=lambda run: run.get("created_at", ""), reverse=True)
+              for run in runs:
+                  jobs = github_json(f"/repos/{repository}/actions/runs/{run['id']}/jobs?per_page=100").get("jobs", [])
+                  summaries = [job for job in jobs if job.get("name") == "CI Summary"]
+                  if not summaries:
+                      continue
+                  summary = summaries[-1]
+                  conclusion = summary.get("conclusion")
+                  url = summary.get("html_url") or run.get("html_url")
+                  if conclusion == "success":
+                      print(f"Metadata-only CI mirrors successful CI Summary from run {run['id']}: {url}")
+                      return
+                  print(f"Previous CI Summary for this head was {conclusion or 'missing'} in run {run['id']}: {url}")
+                  sys.exit(1)
+              print(f"Metadata-only CI could not find a previous required CI Summary for head {head_sha}.")
+              sys.exit(1)
+
           if not should_run:
+              if metadata_only_skip:
+                  mirror_previous_required_summary()
+                  sys.exit(0)
               if bench_shell_only:
                   bench_smoke = needs.get("bench-script-smoke", {})
                   if bench_smoke.get("result") != "success":

--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -51,6 +51,9 @@ pub struct TypeReferenceValidationCaches {
     /// underneath `conditional_branch_constraint` because different conditional
     /// aliases can expose the same mapped-object branch/value constraint pair.
     pub indexed_object_map_branch_constraint: FxHashMap<(TypeId, TypeId), bool>,
+    /// Type-parameter default/constraint validations that completed without
+    /// diagnostics for the active checker file.
+    pub type_param_default_constraint: FxHashSet<(u32, TypeId, TypeId)>,
     /// Synthetic type-node surfaces cached for the active checker file.
     pub type_node_surface: TypeNodeSurfaceCaches,
 }

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -281,6 +281,9 @@ impl<'a> CheckerContext<'a> {
             .indexed_object_map_branch_constraint
             .clear();
         self.type_reference_validation_caches
+            .type_param_default_constraint
+            .clear();
+        self.type_reference_validation_caches
             .type_node_surface
             .clear();
         self.in_conditional_extends_depth = 0;

--- a/crates/tsz-checker/src/state/type_analysis/type_param_defaults.rs
+++ b/crates/tsz-checker/src/state/type_analysis/type_param_defaults.rs
@@ -22,6 +22,24 @@ impl<'a> CheckerState<'a> {
             let Some(constraint_type) = param.constraint else {
                 continue;
             };
+            let validation_cache_key = (param_idx.0, default_type, constraint_type);
+            if self
+                .ctx
+                .type_reference_validation_caches
+                .type_param_default_constraint
+                .contains(&validation_cache_key)
+            {
+                continue;
+            }
+            let diagnostics_before = self.ctx.diagnostics.len();
+            macro_rules! cache_default_constraint_success {
+                () => {{
+                    self.ctx
+                        .type_reference_validation_caches
+                        .type_param_default_constraint
+                        .insert(validation_cache_key);
+                }};
+            }
             let constraint_has_type_params =
                 generic_query::contains_type_parameters(self.ctx.types, constraint_type);
             let default_has_type_params =
@@ -35,12 +53,14 @@ impl<'a> CheckerState<'a> {
                 if !is_other_bare_type_parameter(default_type)
                     && !is_other_bare_type_parameter(constraint_type)
                 {
+                    cache_default_constraint_success!();
                     continue;
                 }
             }
             if self
                 .empty_type_literal_satisfies_optional_mapped_constraint(param_idx, constraint_type)
             {
+                cache_default_constraint_success!();
                 continue;
             }
             // A default that is syntactically one branch of its constraint union
@@ -48,6 +68,7 @@ impl<'a> CheckerState<'a> {
             // validation from depending on an early semantic copy of the same
             // branch that may not have all lazy aliases stabilized yet.
             if self.type_parameter_default_syntactically_satisfies_constraint(param_idx) {
+                cache_default_constraint_success!();
                 continue;
             }
             let mut default_satisfies = self
@@ -123,6 +144,7 @@ impl<'a> CheckerState<'a> {
                         );
                 }
                 if default_satisfies {
+                    cache_default_constraint_success!();
                     continue;
                 }
                 let type_str = self.format_type(default_type);
@@ -132,6 +154,9 @@ impl<'a> CheckerState<'a> {
                     crate::diagnostics::diagnostic_codes::TYPE_DOES_NOT_SATISFY_THE_CONSTRAINT,
                     &[&type_str, &constraint_str],
                 );
+            }
+            if self.ctx.diagnostics.len() == diagnostics_before {
+                cache_default_constraint_success!();
             }
         }
     }

--- a/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
+++ b/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
@@ -1,7 +1,7 @@
 use crate::context::CheckerOptions;
 use crate::test_utils::{
     check_computed_type_argument_resolution_counts, check_multi_file_with_global_index,
-    check_source_diagnostics,
+    check_source_diagnostics, diagnostic_count,
 };
 
 /// When multiple type references in the same alias body refer to the same
@@ -174,6 +174,50 @@ fn direct_conditional_true_branch_validation_skips_check_type_resolution() {
         "Direct conditional true-branch type-reference validation should only push \
          infer bindings and validate the branch; resolving the check type eagerly \
          evaluates recursive aliases such as ts-toolbelt Drop/Flatten."
+    );
+}
+
+#[test]
+fn recursive_alias_type_args_are_not_validated_before_cycle_guard() {
+    let checker_source = std::fs::read_to_string("src/types/type_checking/type_alias_checking.rs")
+        .expect("read type alias checker");
+    let type_reference_branch = checker_source
+        .find("k if k == syntax_kind_ext::TYPE_REFERENCE =>")
+        .expect("type-reference validation branch");
+    let branch_source = &checker_source[type_reference_branch..];
+    let recursive_guard = branch_source
+        .find("type_alias_reaches_resolving_alias")
+        .expect("recursive alias guard");
+    let argument_walk = branch_source
+        .find("for &arg_idx in &type_arguments.nodes")
+        .expect("type argument validation walk");
+    assert!(
+        recursive_guard < argument_walk,
+        "Recursive alias references should short-circuit before declaration-time \
+         type-argument validation; ts-toolbelt dispatch aliases recursively refer \
+         to themselves with expensive intermediate arguments."
+    );
+}
+
+#[test]
+fn recursive_alias_type_arg_skip_preserves_missing_name_diagnostics() {
+    let diags = check_source_diagnostics(
+        r#"
+type A<T extends string> = {0: A<number>}[0];
+type C<T> = {0: C<Missing>}[0];
+"#,
+    );
+
+    assert_eq!(
+        diagnostic_count(&diags, 2304),
+        1,
+        "Recursive alias type arguments should still report unresolved names; got: {diags:#?}"
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2344),
+        0,
+        "Recursive alias type arguments should not be constraint-validated during \
+         cycle detection; got: {diags:#?}"
     );
 }
 

--- a/crates/tsz-checker/src/tests/type_param_default_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/type_param_default_relation_routing_arch_tests.rs
@@ -53,3 +53,27 @@ fn type_parameter_default_relation_outcome_uses_default_request() {
         "type-parameter default diagnostics should have a request-shaped RelationKind::TypeParameterDefault helper"
     );
 }
+
+#[test]
+fn clean_type_parameter_default_validation_is_cached_per_checker_file() {
+    let source = fs::read_to_string("src/state/type_analysis/type_param_defaults.rs")
+        .expect("failed to read type_param_defaults.rs");
+    let caches = fs::read_to_string("src/context/caches.rs").expect("failed to read caches.rs");
+    let reset =
+        fs::read_to_string("src/context/file_session_reset.rs").expect("failed to read reset.rs");
+
+    assert!(
+        source.contains("type_param_default_constraint")
+            && source.contains("let diagnostics_before = self.ctx.diagnostics.len();")
+            && source.contains("diagnostics.len() == diagnostics_before"),
+        "successful default/constraint validations should be cached only after a clean diagnostic pass"
+    );
+    assert!(
+        caches.contains("pub type_param_default_constraint: FxHashSet<(u32, TypeId, TypeId)>"),
+        "default/constraint validation cache should be keyed by declaration and resolved types"
+    );
+    assert!(
+        reset.contains(".type_param_default_constraint") && reset.contains(".clear()"),
+        "default/constraint validation cache should reset between checker file sessions"
+    );
+}

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -1372,11 +1372,6 @@ impl<'a> CheckerState<'a> {
                             type_ref.type_arguments.as_ref(),
                         );
                     if !is_bare_scoped_type_parameter {
-                        if let Some(type_arguments) = &type_ref.type_arguments {
-                            for &arg_idx in &type_arguments.nodes {
-                                check_child_type_node!(self, arg_idx);
-                            }
-                        }
                         if let Some(sym_id) = self
                             .resolve_type_symbol_for_lowering(type_ref.type_name)
                             .map(tsz_binder::SymbolId)
@@ -1384,6 +1379,11 @@ impl<'a> CheckerState<'a> {
                                 || self.type_alias_reaches_resolving_alias(sym_id))
                         {
                             return;
+                        }
+                        if let Some(type_arguments) = &type_ref.type_arguments {
+                            for &arg_idx in &type_arguments.nodes {
+                                check_child_type_node!(self, arg_idx);
+                            }
                         }
                         if !self.check_explicit_type_reference_for_alias_body_validation(node_idx) {
                             let _ = if nested_in_type_literal {


### PR DESCRIPTION
AgentName: Studio-B
Track: performance
Invariant: Cache successful type-parameter default/constraint validation only within the active checker file; reset with existing type-reference validation caches so diagnostics, relation routing, and missing-name behavior stay unchanged. Metadata-only CI runs must mirror a prior successful full CI Summary for the exact head SHA instead of replacing the protected check with a light summary.
Scope: checker default/constraint validation cache for the ts-toolbelt slowdown row, plus native merge queue CI summary handling.

## Summary
- cache successful type-parameter default/constraint validations for the active checker file
- reset the cache with the other type-reference validation caches between file sessions
- short-circuit recursive alias references before walking declaration-time type arguments, while preserving missing-name diagnostics
- keep metadata-only PR edits on lightweight CI while publishing the protected CI Summary only by mirroring a prior successful full run for the same head SHA

## Project Corpus Impact
- Row: ts-toolbelt-project
- Bug family: runtime slowdown during project timing
- Baseline: tsz 1.491s +/- 0.015s, tsgo 101.9ms +/- 1.8ms, tsgo 14.64x +/- 0.30 faster
- After: tsz 1.437s +/- 0.028s, tsgo 100.8ms +/- 1.2ms, tsgo 14.26x +/- 0.33 faster
- Direct confirmation with benchmark env: tsz 1.406s +/- 0.006s, tsgo 96.6ms +/- 1.3ms, tsgo 14.56x +/- 0.20 faster

## Verification
- cargo fmt --check
- cargo test -p tsz-checker --lib ref_type_params_cache_tests -- --nocapture
- cargo test -p tsz-checker --lib type_param_default_relation_routing_arch_tests -- --nocapture
- cargo check -p tsz-checker --lib
- cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'
- embedded CI summary Python compile check
- local metadata-only CI summary replay against prior full run 27040429648
- node scripts/ci/test-cloudbuild-config-paths.mjs
- BENCH_PGO=0 TSZ_BENCH_PROJECT_SLOWDOWN_FAILURE_FACTOR=0 scripts/bench/bench-vs-tsgo.sh --quick --filter ^ts-toolbelt-project$ --json-file artifacts/perf/ts-toolbelt-default-cache-20260605.json

## Coordination Notes
- Metadata normalized by Studio-manager so the ready PR carries the required release-gate sections before queue admission.
- The CI workflow keeps normal compiler suites on the Cloud Run runner fleet, keeps the required unit suite on the Cloud Build private pool, and does not move additional work to Cloud Build.
- Queue admission depends on exact-head required checks and native merge queue state.
