### PR TITLE
perf(checker): cache JSDoc typedef prescan

### DIFF
--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -80,6 +80,7 @@ impl<'a> CheckerContext<'a> {
             jsdoc_global_typedef_lookup_cache: crate::context::JSDocGlobalTypedefLookupCache {
                 miss_cache: RefCell::new(FxHashSet::default()),
                 in_progress: RefCell::new(FxHashSet::default()),
+                typedef_presence_by_file: Arc::new(dashmap::DashMap::new()),
             },
             nested_namespace_candidates_cache_complete: Cell::new(false),
             lowering_entity_name_resolution_cache: RefCell::new(FxHashMap::default()),
@@ -678,6 +679,12 @@ impl<'a> CheckerContext<'a> {
                 *ctx.lowering_entity_name_resolution_cache.borrow_mut() = parent_cache.clone();
             }
         }
+        ctx.jsdoc_global_typedef_lookup_cache
+            .typedef_presence_by_file = Arc::clone(
+            &parent
+                .jsdoc_global_typedef_lookup_cache
+                .typedef_presence_by_file,
+        );
         ctx.skip_lib_type_resolution = parent.skip_lib_type_resolution;
 
         // CRITICAL: Propagate in-progress set from parent to prevent re-entrant

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -110,6 +110,7 @@ impl RelationOverflowFlags {
 pub struct JSDocGlobalTypedefLookupCache {
     pub miss_cache: RefCell<FxHashSet<String>>,
     pub in_progress: RefCell<FxHashSet<String>>,
+    pub typedef_presence_by_file: Arc<dashmap::DashMap<(u32, u32, String), bool>>,
 }
 
 /// Maximum depth for nested `get_type_of_symbol` calls before giving up.

--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -131,6 +131,32 @@ impl<'a> CheckerState<'a> {
         })
     }
 
+    fn source_file_has_jsdoc_typedef_named_cached(
+        &self,
+        file_idx: usize,
+        source_file_idx: usize,
+        source_file: &SourceFileData,
+        name: &str,
+    ) -> bool {
+        let key = (file_idx as u32, source_file_idx as u32, name.to_string());
+        if let Some(result) = self
+            .ctx
+            .jsdoc_global_typedef_lookup_cache
+            .typedef_presence_by_file
+            .get(&key)
+            .map(|entry| *entry.value())
+        {
+            return result;
+        }
+
+        let result = Self::source_file_has_jsdoc_typedef_named(source_file, name);
+        self.ctx
+            .jsdoc_global_typedef_lookup_cache
+            .typedef_presence_by_file
+            .insert(key, result);
+        result
+    }
+
     pub(crate) fn source_file_has_jsdoc_typedef_namespace_root(
         source_file: &SourceFileData,
         name: &str,
@@ -339,8 +365,19 @@ impl<'a> CheckerState<'a> {
             .source_files
             .iter()
             .enumerate()
-            .filter(|(_, source_file)| {
-                !use_typedef_prescan || Self::source_file_has_jsdoc_typedef_named(source_file, name)
+            .filter(|(source_file_idx, source_file)| {
+                if !use_typedef_prescan {
+                    return true;
+                }
+                let file_idx = self
+                    .global_source_file_idx_for_name(&source_file.file_name)
+                    .unwrap_or(current_file_idx);
+                self.source_file_has_jsdoc_typedef_named_cached(
+                    file_idx,
+                    *source_file_idx,
+                    source_file,
+                    name,
+                )
             })
             .map(|(source_file_idx, source_file)| {
                 (
@@ -386,7 +423,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            for source_file in &arena.source_files {
+            for (source_file_idx, source_file) in arena.source_files.iter().enumerate() {
                 if Self::jsdoc_source_file_is_external_module(
                     &self.ctx,
                     file_idx,
@@ -397,7 +434,12 @@ impl<'a> CheckerState<'a> {
                     continue;
                 }
                 if use_typedef_prescan
-                    && !Self::source_file_has_jsdoc_typedef_named(source_file, name)
+                    && !self.source_file_has_jsdoc_typedef_named_cached(
+                        file_idx,
+                        source_file_idx,
+                        source_file,
+                        name,
+                    )
                 {
                     continue;
                 }
@@ -1685,6 +1727,62 @@ new C().x;
         assert_eq!(
             direct.map(|ty| checker.format_type(ty)),
             Some("number".to_string())
+        );
+    }
+
+    #[test]
+    fn jsdoc_typedef_prescan_cache_keys_by_file_and_name() {
+        let source = r#"
+/** @typedef {{ value: number }} Payload */
+let value;
+"#;
+        let mut parser = ParserState::new("test.js".to_string(), source.to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(parser.get_arena(), root);
+        let types = TypeInterner::new();
+        let checker = CheckerState::new(
+            parser.get_arena(),
+            &binder,
+            &types,
+            "test.js".to_string(),
+            crate::context::CheckerOptions {
+                allow_js: true,
+                check_js: true,
+                ..crate::context::CheckerOptions::default()
+            },
+        );
+        let source_file = parser
+            .get_arena()
+            .source_files
+            .first()
+            .expect("source file should be available after parse");
+
+        assert!(checker.source_file_has_jsdoc_typedef_named_cached(7, 0, source_file, "Payload"));
+        assert!(checker.source_file_has_jsdoc_typedef_named_cached(7, 0, source_file, "Payload"));
+        assert_eq!(
+            checker
+                .ctx
+                .jsdoc_global_typedef_lookup_cache
+                .typedef_presence_by_file
+                .len(),
+            1
+        );
+
+        assert!(!checker.source_file_has_jsdoc_typedef_named_cached(
+            7,
+            0,
+            source_file,
+            "MissingPayload"
+        ));
+        assert!(checker.source_file_has_jsdoc_typedef_named_cached(8, 0, source_file, "Payload"));
+        assert_eq!(
+            checker
+                .ctx
+                .jsdoc_global_typedef_lookup_cache
+                .typedef_presence_by_file
+                .len(),
+            3
         );
     }
 }


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 10 performance / project-corpus blocker: pino attribution-layer reduction.

## Invariant
When project-wide JSDoc global typedef lookup pre-scans a source file for a typedef name, the answer depends only on the project file identity, source-file ordinal, and requested typedef name for the current compilation. This PR caches that pure pre-scan result in the checker JSDoc lookup cache and shares it with child checkers; semantic typedef resolution, recursive typedef cycle handling, and miss-cache behavior stay unchanged.

## Scope
- Add a shared per-run JSDoc typedef presence cache keyed by `(file_idx, source_file_idx, typedef_name)`.
- Route global JSDoc typedef pre-scan filters through the cache for current and cross-file arenas.
- Keep global lookup miss/in-progress logic unchanged.
- Add a focused cache key/positive-negative unit test.

## Project Corpus Impact
- Row: n/a (pino #12462 fixture; not a formal project row)
- Bug family: pino timeout / repeated JSDoc global typedef pre-scan

Pino remains a red timeout witness; this is not a green-row or `tsgo` timing claim.

Fixture: `/Users/mohsen/code/pino-live` at `ff0dc5c6cd5f18611e8d588e3c528ce703792fea`; `npx tsc --noEmit -p . --pretty false` passes.

Current-main witness before this PR: `TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 .target/dist-fast/tsz --noEmit -p . --pretty false` timed out at 60s with zero stdout/stderr. Attribution sample `/tmp/pino-post12732-sample.txt` showed:
- `source_file_has_jsdoc_typedef_named`: 864 sampled frames
- `resolve_global_jsdoc_typedef_info`: 419 sampled frames
- `TwoWaySearcher`: 870 sampled frames
- physical footprint: 688.0M; peak: 693.9M

After this PR, same fixture/env/sample window, zero stdout/stderr:
- `source_file_has_jsdoc_typedef_named`: 70 sampled frames
- `resolve_global_jsdoc_typedef_info`: 51 sampled frames
- `TwoWaySearcher`: 88 sampled frames
- physical footprint: 695.1M; peak: 699.1M

The next visible layer is mapped/conditional instantiation again (`TypeInstantiator`, `evaluate_mapped`, `build_index_signature_for_mapped`, `evaluate_conditional`).

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/safe-run.sh --limit 16384 -- cargo nextest run -p tsz-checker --lib -E 'test(jsdoc_typedef_prescan_cache_keys_by_file_and_name)'`
- `scripts/safe-run.sh --limit 16384 -- cargo check -p tsz-checker`
- `scripts/safe-run.sh --limit 24576 -- cargo build --profile dist-fast -p tsz-cli --bin tsz`
- Pino `npx tsc --noEmit -p . --pretty false`
- Pino 60s bounded `tsz --noEmit -p . --pretty false` before/after timeout witnesses, both zero stdout/stderr
- Pino 10s macOS `sample` before/after attribution counts above

## Coordination Notes
- This follows #12727 and keeps #12462 open.
- Does not overlap active Studio-B ts-toolbelt/Vite performance PRs or Studio-C emit work.
- Cache key fields: project file index, source-file ordinal, typedef name.
- Invalidation/reset boundary: one checker/project compilation run; child checkers share the same `DashMap` handle for cross-file lookup reuse.
- Behavior without cache is unchanged because misses/hits fall back to the existing `source_file_has_jsdoc_typedef_named` parser-backed pre-scan.