### PR TITLE
fix(resolution): deterministic canonical module identity keys

### DIFF
--- a/crates/tsz-cli/src/driver/emit.rs
+++ b/crates/tsz-cli/src/driver/emit.rs
@@ -189,7 +189,7 @@ pub(crate) fn emit_outputs(
     let root_file_paths: FxHashSet<String> = context
         .root_file_paths
         .iter()
-        .map(|path| std::fs::canonicalize(path).unwrap_or_else(|_| path.clone()))
+        .map(|path| canonicalize_or_owned(path.as_path()))
         .map(|path| path.to_string_lossy().replace('\\', "/"))
         .collect();
     let file_lookup = build_program_file_lookup(context.program);

--- a/crates/tsz-cli/src/driver/resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution.rs
@@ -11,6 +11,7 @@ mod discovery;
 mod exports_imports;
 mod package_resolution;
 mod path_resolution;
+mod probe_counts;
 mod program_file_index;
 mod type_packages;
 
@@ -27,6 +28,7 @@ pub(crate) use path_resolution::{
     build_duplicate_package_redirects, normalize_path, normalize_resolved_path,
     resolve_module_specifier,
 };
+use probe_counts::*;
 pub(crate) use program_file_index::ProgramFileIndex;
 pub(crate) use type_packages::{
     collect_type_packages_from_root, default_type_roots, resolve_type_package_entry_with_cache,
@@ -62,63 +64,6 @@ pub(crate) enum AmbientModuleDeclarationSpecifierPolicy {
     Check {
         is_external_module: bool,
     },
-}
-
-// ─────────────────────────────────────────────────────────────────────────
-// Counting filesystem probes (`PERFORMANCE_PLAN.md` §4.T0.3 follow-up)
-//
-// The plan calls for `resolver.is_file/is_dir/read_dir` counters so the
-// 2026-05-10 attribution decision matrix can prove (or refute) that the
-// resolver is on the hot path. Rather than sprinkle inline `inc()` calls
-// before every `Path::is_file()`, we wrap the three probe primitives in
-// thin counting helpers and route resolver code through them. Call sites
-// in this file now use `count_is_file(p)` instead of `p.is_file()`, which
-// keeps the diff one token per call and makes future swaps to a real
-// `CountingFs` trait (the eventual T2.0 wrapper) a one-place change.
-//
-// The counter bumps themselves now live in `tsz_common::perf_counters`
-// as `record_resolver_*` helpers (sibling to the cross-arena / interner
-// helpers consolidated in #5097 / #5103 / #5112 / #5115 / #5118). Each
-// wrapper here keeps its file-local identity because it bundles the
-// counter with the underlying syscall — that's intentional grouping —
-// while the gate-and-deref pattern lives in one place.
-#[inline]
-pub(super) fn count_is_file(path: &Path) -> bool {
-    tsz_common::perf_counters::record_resolver_is_file();
-    path.is_file()
-}
-
-#[inline]
-pub(super) fn count_is_dir(path: &Path) -> bool {
-    tsz_common::perf_counters::record_resolver_is_dir();
-    path.is_dir()
-}
-
-#[inline]
-pub(super) fn count_read_dir(path: &Path) -> std::io::Result<std::fs::ReadDir> {
-    tsz_common::perf_counters::record_resolver_read_dir();
-    std::fs::read_dir(path)
-}
-
-/// Bump `resolver_candidate_paths_total` once per invocation. The
-/// `tsz_common::perf_counters::record_resolver_candidate_path` helper
-/// gates and dereferences once; this wrapper preserves the file-local
-/// `count_candidate_path` name so the two emit sites
-/// (path-mapping virtual roots and suffix-extension expansion) stay
-/// stable.
-#[inline]
-pub(super) fn count_candidate_path() {
-    tsz_common::perf_counters::record_resolver_candidate_path();
-}
-
-/// Bump `resolver_read_package_json_calls` once per uncached read.
-/// Sits inside `read_package_json_uncached`, which `large-ts-repo`
-/// profiles flag as the dominant resolver work — keeping the gate
-/// cheap matters even though the surrounding `read_to_string` is
-/// several orders of magnitude more expensive.
-#[inline]
-pub(super) fn count_read_package_json() {
-    tsz_common::perf_counters::record_resolver_read_package_json();
 }
 
 #[derive(Default)]

--- a/crates/tsz-cli/src/driver/resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution.rs
@@ -283,8 +283,17 @@ pub(crate) fn canonicalize_with_missing_tail(path: &Path) -> PathBuf {
     canonical
 }
 
+/// Canonicalize to a real on-disk path, falling back to the *lexically
+/// normalized* path when the file cannot be canonicalized (missing or
+/// transiently unreadable file, relative anchor).
+///
+/// The fallback is normalized rather than the raw input so callers that key
+/// identity on the result — program-file caches, dedup sets, redirect maps —
+/// stay deterministic: `./a/b.ts`, `a/b.ts`, and `a/b.ts/` collapse to one key
+/// instead of three. Display-only callers are unaffected, as a normalized path
+/// renders identically to (and more cleanly than) the raw input.
 pub(crate) fn canonicalize_or_owned(path: &Path) -> PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    std::fs::canonicalize(path).unwrap_or_else(|_| normalize_path(path))
 }
 
 pub(crate) fn env_flag(name: &str) -> bool {

--- a/crates/tsz-cli/src/driver/resolution/canonical_id_tests.rs
+++ b/crates/tsz-cli/src/driver/resolution/canonical_id_tests.rs
@@ -1,0 +1,142 @@
+//! Tests for deterministic canonical module-identity keys.
+//!
+//! Structural rule: when `preserveSymlinks` is off and a resolved path cannot
+//! be canonicalized, module identity must key on the deterministic
+//! lexically-normalized path — never the raw textual input — and lexical
+//! normalization must clamp `..` at the filesystem root the way `tsc`/Node do.
+//! The same logical file must therefore mint the same canonical ID regardless
+//! of how the specifier was spelled.
+//!
+//! Coverage matrix:
+//! - `.` / `..` collapse in lexical normalization
+//! - `..` clamps at the filesystem root (no escape past root)
+//! - leading `..` preserved on relative paths
+//! - equivalent spellings of a *missing* file collapse to one canonical ID
+//! - `preserveSymlinks` keeps the verbatim (lexically-normalized) path
+//! - real on-disk files still canonicalize to their absolute real path
+use super::{normalize_path, normalize_resolved_path};
+use crate::config::{ModuleResolutionKind, ResolvedCompilerOptions};
+use crate::driver::resolution::canonicalize_or_owned;
+use std::path::{Path, PathBuf};
+
+fn opts(preserve_symlinks: bool) -> ResolvedCompilerOptions {
+    ResolvedCompilerOptions {
+        module_resolution: Some(ModuleResolutionKind::Node16),
+        preserve_symlinks,
+        module_suffixes: vec![String::new()],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn normalize_path_collapses_cur_and_parent_segments() {
+    assert_eq!(
+        normalize_path(Path::new("/a/./b/c")),
+        PathBuf::from("/a/b/c")
+    );
+    assert_eq!(
+        normalize_path(Path::new("/a/b/../c")),
+        PathBuf::from("/a/c")
+    );
+    assert_eq!(
+        normalize_path(Path::new("/a/b/../../c/./d")),
+        PathBuf::from("/c/d")
+    );
+}
+
+#[test]
+fn normalize_path_clamps_parent_dir_at_root() {
+    // `..` must never pop past the filesystem root; an absolute path stays
+    // absolute. The naive `PathBuf::pop` loop dropped the root component here,
+    // degrading `/a/../../b` into a *relative* `b` and splitting identity.
+    assert_eq!(normalize_path(Path::new("/a/../../b")), PathBuf::from("/b"));
+    assert_eq!(normalize_path(Path::new("/../../x")), PathBuf::from("/x"));
+    assert_eq!(normalize_path(Path::new("/..")), PathBuf::from("/"));
+}
+
+#[test]
+fn normalize_path_preserves_leading_parent_on_relative_paths() {
+    // Relative paths have no root to clamp against, so leading `..` is real
+    // and must survive normalization rather than being silently dropped.
+    assert_eq!(normalize_path(Path::new("../foo")), PathBuf::from("../foo"));
+    assert_eq!(
+        normalize_path(Path::new("../../a/b")),
+        PathBuf::from("../../a/b")
+    );
+    assert_eq!(
+        normalize_path(Path::new("a/../../b")),
+        PathBuf::from("../b")
+    );
+}
+
+#[test]
+fn missing_file_equivalent_spellings_share_one_canonical_id() {
+    // A path that cannot be canonicalized must fall back to the lexically
+    // normalized form, so every equivalent spelling of one (missing) file
+    // produces a single identity key. Use a path guaranteed not to exist.
+    let base = "/tsz-nonexistent-canonical-id-probe/pkg";
+    let options = opts(false);
+    let expected = PathBuf::from(format!("{base}/a/b.ts"));
+
+    let id_of = |spelling: &str| normalize_resolved_path(Path::new(spelling), &options);
+    assert_eq!(id_of(&format!("{base}/a/b.ts")), expected);
+    assert_eq!(
+        id_of(&format!("{base}/a/./b.ts")),
+        expected,
+        "`./` spelling must not split identity"
+    );
+    assert_eq!(
+        id_of(&format!("{base}/a/x/../b.ts")),
+        expected,
+        "`..` spelling must not split identity"
+    );
+}
+
+#[test]
+fn preserve_symlinks_keeps_verbatim_normalized_path() {
+    let options = opts(true);
+    let p = Path::new("/tsz-nonexistent-canonical-id-probe/a/./b/../c.ts");
+    assert_eq!(
+        normalize_resolved_path(p, &options),
+        PathBuf::from("/tsz-nonexistent-canonical-id-probe/a/c.ts")
+    );
+}
+
+#[test]
+fn canonicalize_or_owned_falls_back_to_lexically_normalized_path() {
+    // The shared helper that feeds program-file caches, dedup sets, and
+    // redirect maps must also collapse equivalent spellings of a missing file
+    // to one key — not echo the raw input — so identity stays deterministic.
+    let base = "/tsz-nonexistent-canonical-id-probe/lib";
+    let expected = PathBuf::from(format!("{base}/x/y.ts"));
+    assert_eq!(
+        canonicalize_or_owned(Path::new(&format!("{base}/x/y.ts"))),
+        expected
+    );
+    assert_eq!(
+        canonicalize_or_owned(Path::new(&format!("{base}/x/./y.ts"))),
+        expected
+    );
+    assert_eq!(
+        canonicalize_or_owned(Path::new(&format!("{base}/x/z/../y.ts"))),
+        expected
+    );
+}
+
+#[test]
+fn existing_file_canonicalizes_to_absolute_real_path() {
+    use std::fs;
+
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let root = dir.path();
+    fs::create_dir_all(root.join("sub")).unwrap();
+    fs::write(root.join("sub/mod.ts"), "export {};").unwrap();
+
+    let options = opts(false);
+    // A `.`-laden spelling of a real file resolves to its canonical real path,
+    // which is itself absolute and free of `.`/`..` segments.
+    let spelled = root.join("sub/./mod.ts");
+    let canonical = normalize_resolved_path(&spelled, &options);
+    let expected = fs::canonicalize(root.join("sub/mod.ts")).unwrap();
+    assert_eq!(canonical, expected);
+}

--- a/crates/tsz-cli/src/driver/resolution/path_resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution/path_resolution.rs
@@ -531,19 +531,49 @@ pub(crate) const fn extension_candidates_for_resolution(
     }
 }
 
+/// Lexically normalize a path: collapse `.`, resolve `..` against the
+/// preceding *named* segment, and leave the path otherwise untouched. This is
+/// purely textual — it never touches the filesystem — so it is the stable
+/// identity key for files that cannot be canonicalized.
+///
+/// Two corrections over a naive `PathBuf::pop` loop, both of which otherwise
+/// let one logical file mint several distinct identity keys:
+/// - `..` clamps at the filesystem root / drive prefix (matching `tsc`/Node)
+///   instead of popping past it, so an absolute `/a/../../b` stays absolute
+///   (`/b`) rather than degrading to a relative `b`.
+/// - leading `..` on a relative path is preserved (`../foo` stays `../foo`)
+///   instead of being silently dropped.
 pub(crate) fn normalize_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+
     let mut normalized = PathBuf::new();
+    // Count of poppable `Normal` segments currently sitting above any root or
+    // leading `..` run. Tracking it lets `..` resolve in a single pass without
+    // re-parsing `normalized` on every parent segment.
+    let mut poppable = 0usize;
+    let mut rooted = false;
 
     for component in path.components() {
         match component {
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                normalized.pop();
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if poppable > 0 {
+                    normalized.pop();
+                    poppable -= 1;
+                } else if !rooted {
+                    // Relative path with nothing to pop: keep the leading `..`.
+                    normalized.push("..");
+                }
+                // Otherwise `..` is at the filesystem root or a drive prefix,
+                // where `tsc`/Node clamp instead of escaping root: a no-op.
             }
-            std::path::Component::RootDir
-            | std::path::Component::Normal(_)
-            | std::path::Component::Prefix(_) => {
+            Component::RootDir | Component::Prefix(_) => {
+                rooted = true;
                 normalized.push(component.as_os_str());
+            }
+            Component::Normal(segment) => {
+                normalized.push(segment);
+                poppable += 1;
             }
         }
     }
@@ -554,16 +584,24 @@ pub(crate) fn normalize_path(path: &Path) -> PathBuf {
 pub(crate) fn normalize_resolved_path(path: &Path, options: &ResolvedCompilerOptions) -> PathBuf {
     let normalized = normalize_path(path);
     if options.preserve_symlinks {
+        return normalized;
+    }
+    // When the path cannot be canonicalized (missing or transiently
+    // unreadable file, relative anchor), the lexically-normalized path is the
+    // only deterministic identity key. Falling back to the *raw* input — as a
+    // bare `canonicalize_or_owned` would — lets `./a/b.ts`, `a/b.ts`, and
+    // `a/b.ts/` resolve to three distinct IDs for one file, which is precisely
+    // the "unstable canonical IDs" symptom. The real-path branch only matters
+    // when canonicalization actually succeeds.
+    let Ok(canonical) = std::fs::canonicalize(path) else {
+        return normalized;
+    };
+    let preserve_package_link_identity = path_has_symlinked_package_ancestor(path)
+        || (!has_node_modules_component(path) && has_node_modules_component(&canonical));
+    if preserve_package_link_identity {
         normalized
     } else {
-        let canonical = canonicalize_or_owned(path);
-        let preserve_package_link_identity = path_has_symlinked_package_ancestor(path)
-            || (!has_node_modules_component(path) && has_node_modules_component(&canonical));
-        if preserve_package_link_identity {
-            normalized
-        } else {
-            canonical
-        }
+        canonical
     }
 }
 
@@ -836,3 +874,7 @@ pub(crate) const NODE16_COMMONJS_EXTENSION_CANDIDATES: [&str; 7] =
 #[cfg(test)]
 #[path = "paths_imports_tests.rs"]
 mod paths_imports_tests;
+
+#[cfg(test)]
+#[path = "canonical_id_tests.rs"]
+mod canonical_id_tests;

--- a/crates/tsz-cli/src/driver/resolution/probe_counts.rs
+++ b/crates/tsz-cli/src/driver/resolution/probe_counts.rs
@@ -1,0 +1,32 @@
+use std::path::Path;
+
+// Counting filesystem probes (`PERFORMANCE_PLAN.md` §4.T0.3 follow-up).
+// Keep the counter bump and underlying syscall bundled so resolver call sites
+// stay one token away from a future `CountingFs` trait.
+#[inline]
+pub(super) fn count_is_file(path: &Path) -> bool {
+    tsz_common::perf_counters::record_resolver_is_file();
+    path.is_file()
+}
+
+#[inline]
+pub(super) fn count_is_dir(path: &Path) -> bool {
+    tsz_common::perf_counters::record_resolver_is_dir();
+    path.is_dir()
+}
+
+#[inline]
+pub(super) fn count_read_dir(path: &Path) -> std::io::Result<std::fs::ReadDir> {
+    tsz_common::perf_counters::record_resolver_read_dir();
+    std::fs::read_dir(path)
+}
+
+#[inline]
+pub(super) fn count_candidate_path() {
+    tsz_common::perf_counters::record_resolver_candidate_path();
+}
+
+#[inline]
+pub(super) fn count_read_package_json() {
+    tsz_common::perf_counters::record_resolver_read_package_json();
+}


### PR DESCRIPTION
Closes #11634

AgentName: Studio-Opus
**Track:** module-resolution / canonical module identity
**Invariant:** one logical file ⇒ one canonical identity key, regardless of how the specifier was spelled or whether the file canonicalizes.

## Scope

The `vite-vanilla-ts-app` bench row (case `module-resolution-14-20`) and its consolidated symlinked-fixture family describe *"unstable canonical IDs."* The row is currently green, so the literal synthetic case shows no diagnostic delta today — but the symptom names two genuine determinism defects in the canonical-ID producer that this PR fixes broadly (every row's identity path) rather than papering over one fixture.

## Structural rule

> When `preserveSymlinks` is off and a resolved path cannot be canonicalized, module identity must key on the deterministic lexically-normalized path — never the raw textual input — and lexical normalization must clamp `..` at the filesystem root the way `tsc`/Node do.

Owner layer: CLI driver resolution (`crates/tsz-cli/src/driver/resolution`), which owns realpath/identity keying (`normalize_resolved_path`, `canonicalize_or_owned`, `ProgramFileIndex`).

## What was wrong

1. **Raw fallback on `canonicalize` failure.** `normalize_resolved_path` computed a lexically-normalized path but, when `std::fs::canonicalize` failed (missing/transient file, relative anchor), fell through `canonicalize_or_owned` to the **raw** input. That let `./a/b.ts`, `a/b.ts`, and `a/b.ts/` mint three distinct identity keys for one file.
2. **`normalize_path` over-popped `..` past the filesystem root** and dropped leading `..` on relative paths, so an absolute `/a/../../b` degraded into a relative `b`, splitting identity.

## Fix (right altitude, broad but regression-safe)

- `normalize_path` rewritten as a single pass that clamps `..` at the root/drive prefix and preserves leading `..` (matching `tsc`/Node `path.normalize`). No intermediate allocation.
- `normalize_resolved_path` early-returns the lexically-normalized path when `canonicalize` fails; the real-path branch only runs on success.
- The **shared** `canonicalize_or_owned` helper now uses the same lexical fallback, so every identity-keying caller — program-file caches, dedup sets, redirect maps — is deterministic. The declaration-emit portability path (`emit.rs`) reuses the helper instead of reimplementing `canonicalize, else raw` inline.

Behavior on the success path (file exists) is unchanged; only the failure/pathological branches change, all toward determinism.

## Adjacent-case matrix (new `canonical_id_tests.rs`, 7 tests)

- `.` / `..` collapse in lexical normalization
- `..` clamps at the filesystem root (no escape past root)
- leading `..` preserved on relative paths
- equivalent spellings (`./`, `..`) of a missing file collapse to one canonical ID
- `preserveSymlinks` keeps the verbatim normalized path
- `canonicalize_or_owned` failure fallback is lexically normalized
- a real on-disk file still canonicalizes to its absolute real path

## Project Corpus Impact

- Row: `vite-vanilla-ts-app` (`module-resolution-14-20`)
- Bug family: canonical module identity determinism for module resolution (#11634).
- Evidence: identity keying only; no relation/inference/emit semantics change. Existing symlink identity tests (`program_file_index::tests::symlinked_and_real_paths_resolve_to_same_idx`, `preserve_symlinks_disables_real_path_fallback`, `first_write_wins_keeps_idx_deterministic`) and the `paths_imports_tests` suite continue to pass.

## Verification

- `cargo test -p tsz-cli --lib` → **1274 passed**; the 15 failures are **pre-existing and environment-driven** (confirmed identical on a clean tree): local Node-bundled `tsc` version skew vs the pinned TS 6.0.3 (`tsc_parity_*`, several `declaration_emit_*` baselines) and root-user filesystem quirks (`...tsbuildinfo_is_not_writable`). My change adds **+7 passing tests and zero new failures**.
- New `canonical_id_tests`: 7/7 pass (post-rebase onto latest `main`).
- `cargo clippy -p tsz-cli` clean for all changed files. fmt applied.
- Rebased onto latest `main`; merges cleanly (no conflicts).

## Coordination Notes

`tsz-core`'s `normalize_path_segments` is intentionally **not** reused: it is `pub(crate)` (unreachable from `tsz-cli`) and carries the same root-clamp defect. Fixing/exporting it would push behavior changes into the core module-resolver hot path that can't be validated without a full conformance run (forbidden locally), so it's deferred to a core-owned follow-up.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvjeP4iiZoh4L4X5UP52q9)_