### PR TITLE
fix(parser): accept keyword/reserved-word labels in named tuple members

### DIFF
--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -276,8 +276,11 @@ impl ParserState {
         // Check for ... prefix (rest parameter)
         let dot_dot_dot_token = self.parse_optional(SyntaxKind::DotDotDotToken);
 
-        // Parse name
-        let name = self.parse_identifier();
+        // Parse name. A named tuple member label is an *identifier name*, so any
+        // keyword or reserved word is a legal label (tsc parses it with
+        // `parseIdentifierName`). Using `parse_identifier` here would wrongly
+        // reject `[in: T]`, `[function: T]`, `[...new: T[]]`, etc. with TS1359.
+        let name = self.parse_identifier_name();
 
         // Check for optional marker
         let question_token = self.parse_optional(SyntaxKind::QuestionToken);

--- a/crates/tsz-parser/tests/parser_improvement_tuple_type_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_tuple_type_recovery_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for parser improvements to reduce TS1005 and TS2300 false positives — tuple type recovery.
 
-use crate::parser::test_fixture::parse_source;
+use crate::parser::test_fixture::{assert_span, parse_source};
 use tsz_common::diagnostics::diagnostic_codes;
 
 #[test]
@@ -215,6 +215,60 @@ fn tuple_with_double_bar_token_reports_comma_expected_without_cascade() {
             && d.code != diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED),
         "expected no `]`/TS1128 cascade, got {diagnostics:?}",
     );
+}
+
+/// A named tuple member label is an *identifier name*: tsc parses it with
+/// `parseIdentifierName`, so every keyword and reserved word is a legal label.
+/// Before the fix, `parse_named_tuple_member` used `parse_identifier`, which
+/// rejected reserved words with a spurious TS1359
+/// ("'<word>' is a reserved word that cannot be used here").
+///
+/// The matrix below varies the label across reserved words (`in`, `function`,
+/// `new`, `delete`, `for`, `if`, `typeof`, `void`, `return`), the contextual
+/// keyword `readonly`, and a plain identifier so a fix that special-cases a
+/// single spelling — or only the contextual-keyword case that already worked —
+/// fails. Each shape covers the plain, optional, and labeled-rest forms.
+const KEYWORD_TUPLE_LABELS: &[&str] = &[
+    "in", "function", "new", "delete", "for", "if", "typeof", "void", "return", "readonly",
+    "yield", "await", "label",
+];
+
+#[test]
+fn named_tuple_member_keyword_labels_do_not_emit_ts1359() {
+    for label in KEYWORD_TUPLE_LABELS {
+        for source in [
+            format!("type T = [{label}: string];"),
+            format!("type T = [{label}?: string];"),
+            format!("type T = [...{label}: string[]];"),
+            format!("type T = [head: number, {label}: string];"),
+        ] {
+            let (parser, _root) = parse_source(&source);
+            let diagnostics = parser.get_diagnostics();
+            // A clean parse is the strongest guarantee — it subsumes the absence
+            // of the TS1359 ("reserved word that cannot be used here") that the
+            // pre-fix `parse_identifier` raised for keyword labels.
+            assert!(
+                diagnostics.is_empty(),
+                "named tuple label {label:?} should parse cleanly (no TS1359) in {source:?}, got {diagnostics:?}",
+            );
+        }
+    }
+}
+
+#[test]
+fn named_tuple_member_keyword_label_span_covers_member_text() {
+    use crate::parser::syntax_kind_ext;
+    // The named-tuple-member node must span exactly `label: Type` (not overshoot
+    // into the surrounding `[]`/`;`), regardless of whether the label is a
+    // keyword or a plain identifier.
+    for (source, member_text) in [
+        ("type T = [in: string];", "in: string"),
+        ("type T = [function: number];", "function: number"),
+        ("type T = [...new: string[]];", "...new: string[]"),
+        ("type T = [plain: string];", "plain: string"),
+    ] {
+        assert_span(source, syntax_kind_ext::NAMED_TUPLE_MEMBER, member_text);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #10937 (parser tuple recovery family).

`parse_named_tuple_member` parsed the member label with `parse_identifier`, which rejects reserved words with **TS1359** ("'<word>' is a reserved word that cannot be used here"). A named tuple member label is an identifier *name*, so `tsc` parses it with `parseIdentifierName` and accepts **any** keyword or reserved word as a label. tsz therefore emitted a spurious TS1359 for valid tuple types such as `[in: T]`, `[function: T]`, `[...new: T[]]`, and `[for?: T]`; only contextual keywords (`type`, `readonly`) happened to work because they aren't in the reserved-word range.

The fix switches the label to `parse_identifier_name`, the existing general primitive that mirrors tsc's `parseIdentifierName` (already used for JSX attribute names, class member names, and the tuple-member *type* path). This is a one-for-one structural swap — no name/string special-casing.

AgentName: M4-Opus

**Track:** parser / diagnostics conformance

**Invariant:** `When a tuple element is a named member (`name:`/`name?:`/`...name:`), tsc parses the label as an identifier-name (`parseIdentifierName`) and accepts any keyword or reserved word; tsz now does the same through `ParserState::parse_identifier_name` instead of `parse_identifier`.`

**Scope:**
- `crates/tsz-parser/src/parser/state_types_advanced.rs` — `parse_named_tuple_member` uses `parse_identifier_name`. The labeled-rest form `[...name: T]` routes through the same function, so it is covered too. Upstream detection lookaheads already gate on `is_identifier_or_keyword` followed by `:`, so non-label types are unaffected.
- `crates/tsz-parser/tests/parser_improvement_tuple_type_recovery_tests.rs` — regression tests.

**Adjacent-case matrix (tests):** label varied across reserved words (`in`, `function`, `new`, `delete`, `for`, `if`, `typeof`, `void`, `return`, `yield`, `await`), the contextual keyword `readonly`, and a plain identifier; each across the plain (`[x: T]`), optional (`[x?: T]`), labeled-rest (`[...x: T[]]`), and second-position (`[head: number, x: T]`) forms. Plus a span test asserting the `NamedTupleMember` node spans exactly `label: Type` (no overshoot) for keyword, rest, and plain labels. Negative/fallback case is unchanged: a bare keyword with no following `:` still falls through to regular type parsing.

## Project Corpus Impact

- Row: n/a
- Bug family: parser tuple recovery / keyword named tuple member labels
- Impact: Removes false-positive TS1359 parse diagnostics on tuple types using keyword labels (a common pattern, e.g. `[in: string, out: number]`). End-to-end checker run on keyword-labeled tuples (incl. rest spreads and function rest params) produces zero diagnostics, matching tsc. No required project row is expected to regress; ready-review CI owns the broad corpus.

**Verification:**
- `cargo test -p tsz-parser --lib parser_improvement_tuple_type_recovery_tests` → 12 passed.
- `cargo test -p tsz-parser --lib` → 1391 passed, 0 failed.
- `cargo clippy -p tsz-parser --all-targets` → clean.
- Manual checker-pipeline check (`check_source_strict`) on `[in: string, out: number]`, `[first: string, ...rest: number[]]`, function rest param `...args: [name: string, age: number]`, and `[new: string]` → zero diagnostics.

**Coordination Notes:** Claimed #10937 and added the `WIP` label while in progress. No roadmap change (routine conformance fix). Rebased on latest `main`; no conflicts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzjL1SgweLPP53yHwZmXkW)_
