### PR TITLE
perf(solver): cache mapped helper instantiations

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -8,8 +8,8 @@ mod keyof_constraint;
 
 use crate::construction::TypeDatabase;
 use crate::instantiation::instantiate::{
-    TypeSubstitution, instantiate_type_cached, instantiate_type_preserving,
-    instantiate_type_preserving_cached, instantiate_type_preserving_with_declared,
+    TypeSubstitution, instantiate_type_cached, instantiate_type_preserving_cached,
+    instantiate_type_preserving_with_declared,
 };
 use crate::objects::PropertyCollectionResult;
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
@@ -72,7 +72,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         );
 
         let subst = TypeSubstitution::single(mapped.type_param.name, key_type);
-        let remapped = instantiate_type_preserving(self.interner(), name_type, &subst);
+        let remapped =
+            instantiate_type_preserving_cached(self.interner(), self.query_db(), name_type, &subst);
 
         tracing::trace!(
             remapped_before_eval = remapped.0,
@@ -997,8 +998,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             subst.insert(mapped.type_param.name, member);
 
             // Evaluate the `as` clause to get the remapped key
-            let remapped_key = self.evaluate(instantiate_type_preserving(
+            let remapped_key = self.evaluate(instantiate_type_preserving_cached(
                 self.interner(),
+                self.query_db(),
                 name_type,
                 &subst,
             ));
@@ -1028,8 +1030,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             };
 
             // Evaluate the template with the substitution
-            let instantiated_template =
-                instantiate_type_preserving(self.interner(), mapped.template, &subst);
+            let instantiated_template = instantiate_type_preserving_cached(
+                self.interner(),
+                self.query_db(),
+                mapped.template,
+                &subst,
+            );
             let property_type = self.evaluate(instantiated_template);
 
             if property_type == TypeId::ERROR && self.is_depth_exceeded() {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/mapped_tests.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/mapped_tests.rs
@@ -109,6 +109,119 @@ fn mapped_property_template_uses_preserving_instantiation_cache() {
     );
 }
 
+#[test]
+fn remapped_key_type_uses_preserving_instantiation_cache() {
+    let interner = TypeInterner::new();
+    let query_cache = QueryCache::new(&interner);
+
+    let key_atom = interner.intern_string("K");
+    let key_param = interner.type_param(TypeParamInfo::simple(key_atom));
+    let name_type = interner.object(vec![PropertyInfo {
+        name: interner.intern_string("key"),
+        type_id: key_param,
+        write_type: key_param,
+        is_string_named: true,
+        ..Default::default()
+    }]);
+    let constraint = interner.literal_string("same");
+
+    let mapped = MappedType {
+        type_param: TypeParamInfo {
+            name: key_atom,
+            constraint: Some(constraint),
+            default: None,
+            is_const: false,
+        },
+        constraint,
+        name_type: Some(name_type),
+        template: TypeId::BOOLEAN,
+        readonly_modifier: None,
+        optional_modifier: None,
+    };
+
+    let before = query_cache.statistics();
+    let mut first_eval = TypeEvaluator::new(&interner).with_query_db(&query_cache);
+    let first_result = first_eval.remap_key_type_for_mapped(&mapped, constraint);
+    let after_first = query_cache.statistics();
+
+    let mut second_eval = TypeEvaluator::new(&interner).with_query_db(&query_cache);
+    let second_result = second_eval.remap_key_type_for_mapped(&mapped, constraint);
+    let after_second = query_cache.statistics();
+
+    assert!(first_result.is_ok());
+    assert!(second_result.is_ok());
+    assert!(
+        after_first.instantiation_cache_misses > before.instantiation_cache_misses,
+        "first remapped-key instantiation should populate the preserving cache"
+    );
+    assert!(
+        after_second.instantiation_cache_hits > after_first.instantiation_cache_hits,
+        "second remapped-key instantiation should reuse the preserving cache slot"
+    );
+}
+
+#[test]
+fn mapped_index_template_uses_instantiation_cache_per_concrete_key() {
+    let interner = TypeInterner::new();
+    let query_cache = QueryCache::new(&interner);
+
+    let key_atom = interner.intern_string("K");
+    let key_param = interner.type_param(TypeParamInfo::simple(key_atom));
+    let wrapped_prop = PropertyInfo {
+        name: interner.intern_string("value"),
+        type_id: key_param,
+        write_type: key_param,
+        is_string_named: true,
+        ..Default::default()
+    };
+    let template = interner.object(vec![wrapped_prop]);
+    let constraint = interner.union(vec![
+        interner.literal_string("first"),
+        interner.literal_string("second"),
+    ]);
+
+    let mapped = |readonly_modifier| MappedType {
+        type_param: TypeParamInfo {
+            name: key_atom,
+            constraint: Some(constraint),
+            default: None,
+            is_const: false,
+        },
+        constraint,
+        name_type: None,
+        template,
+        readonly_modifier,
+        optional_modifier: None,
+    };
+
+    let first = interner.mapped(mapped(None));
+    let second = interner.mapped(mapped(Some(MappedModifier::Add)));
+    assert_ne!(
+        first, second,
+        "distinct mapped types keep the evaluator cache from hiding per-key instantiation reuse"
+    );
+
+    let before = query_cache.statistics();
+    let mut first_eval = TypeEvaluator::new(&interner).with_query_db(&query_cache);
+    let first_result = first_eval.evaluate(interner.index_access(first, constraint));
+    let after_first = query_cache.statistics();
+
+    let mut second_eval = TypeEvaluator::new(&interner).with_query_db(&query_cache);
+    let second_result = second_eval.evaluate(interner.index_access(second, constraint));
+    let after_second = query_cache.statistics();
+
+    assert_ne!(first_result, TypeId::ERROR);
+    assert_ne!(second_result, TypeId::ERROR);
+    assert!(
+        after_first.instantiation_cache_misses > before.instantiation_cache_misses,
+        "first mapped[index] per-key template instantiation should populate the cache"
+    );
+    assert!(
+        after_second.instantiation_cache_hits > after_first.instantiation_cache_hits,
+        "second mapped[index] per-key template instantiation should reuse cached template instantiations"
+    );
+}
+
 /// tsc's `instantiateMappedType` reduces a generic homomorphic mapped
 /// type to its source whenever the source resolves to a primitive,
 /// literal, `never`, unique symbol, or enum. This proves the rule is

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped_template_index.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped_template_index.rs
@@ -2,7 +2,7 @@
 
 use super::mapped::MappedKeys;
 use crate::evaluation::evaluate::TypeEvaluator;
-use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
+use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type_cached};
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
 use crate::types::{MappedModifier, MappedType, TypeData, TypeId};
 use smallvec::SmallVec;
@@ -31,7 +31,12 @@ pub(super) fn try_evaluate_mapped_template_per_concrete_key<R: TypeResolver>(
         .iter()
         .filter_map(|mapped_key| {
             let subst = TypeSubstitution::single(mapped.type_param.name, mapped_key.key_literal);
-            let instantiated = instantiate_type(evaluator.interner(), mapped.template, &subst);
+            let instantiated = instantiate_type_cached(
+                evaluator.interner(),
+                evaluator.query_db(),
+                mapped.template,
+                &subst,
+            );
             let evaluated = evaluator.evaluate(instantiated);
             (evaluated != TypeId::NEVER).then_some(evaluated)
         })
@@ -88,7 +93,12 @@ pub(super) fn try_evaluate_remapped_mapped_template_for_index<R: TypeResolver>(
         }
 
         let subst = TypeSubstitution::single(mapped.type_param.name, mapped_key.key_literal);
-        let instantiated = instantiate_type(evaluator.interner(), mapped.template, &subst);
+        let instantiated = instantiate_type_cached(
+            evaluator.interner(),
+            evaluator.query_db(),
+            mapped.template,
+            &subst,
+        );
         let mut evaluated = evaluator.evaluate(instantiated);
         if matches!(mapped.optional_modifier, Some(MappedModifier::Add)) {
             evaluated = evaluator.interner().union2(evaluated, TypeId::UNDEFINED);


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Performance / solver cache coverage

## Invariant
When mapped-type helper paths repeat the same structural substitution for remapped keys or finite mapped-index templates, `tsc` preserves mapped semantics without recomputing unrelated type construction; this PR makes tsz preserve those semantics through solver evaluation while routing the substitutions through the shared `QueryCache` instantiation cache.

## Scope
- Route mapped `as`-clause remapping through `instantiate_type_preserving_cached` when a query cache is available.
- Route finite mapped-template indexed-access helpers through `instantiate_type_cached`.
- Add cache-stat tests that prove repeated remapped-key and per-concrete-key mapped-index substitutions populate and then hit the instantiation cache without evaluator-cache masking.

## Project Corpus Impact
- Row: n/a
- Bug family: pino mapped/instantiation timeout layer (#12462)
- Evidence: This is a cache-coverage slice from the pino timeout investigation. The targeted pino sample did not show a material end-to-end improvement, so this PR does not claim to close #12462; it removes uncached mapped helper work exposed by that investigation and keeps the proof local to cache counters.

## Verification
- `cargo fmt --all --check`
- `scripts/safe-run.sh --limit 16384 -- cargo check -p tsz-solver`
- `scripts/safe-run.sh --limit 16384 -- cargo nextest run -p tsz-solver --lib -E 'test(remapped_key_type_uses_preserving_instantiation_cache) | test(mapped_index_template_uses_instantiation_cache_per_concrete_key) | test(mapped_property_template_uses_preserving_instantiation_cache)'`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- PR-head CI draft run 27046087066 passed: gate, project-row-drift, unit, cargo-shear, cargo-deny, dist-binaries, lint, unit-cloudbuild, CI Light Summary.
- Pino attribution sample before/after: no material movement; stdout/stderr empty in both samples.

## Coordination Notes
- Owned by Studio-Opus.
- Related to #12462 but intentionally scoped to mapped-helper cache coverage; Studio-B's broader pino/default/type-layer PRs remain separate.
