### PR TITLE
perf(solver): cache-aware keyof/mapped/conditional/index eval entry points (#12021)

### DIFF
--- a/crates/tsz-solver/src/caches/instantiation_cache_test.rs
+++ b/crates/tsz-solver/src/caches/instantiation_cache_test.rs
@@ -695,3 +695,75 @@ fn cache_clear_drops_all_instantiation_entries() {
     db.clear();
     assert_eq!(db.statistics().instantiation_cache_entries, 0);
 }
+
+#[test]
+fn query_database_evaluate_entry_points_preserve_results() {
+    // #12021: `QueryCache` overrides `evaluate_conditional` / `evaluate_keyof` /
+    // `evaluate_mapped` / `evaluate_index_access_with_options` to thread `self`
+    // as the `query_db` so recursive utility expansion through those entry
+    // points reaches the cross-call instantiation cache (instead of the
+    // trait-default `query_db = None` evaluator built by the free functions).
+    // The override must change ONLY caching behavior — never the computed type.
+    use crate::caches::db::QueryDatabase;
+    use crate::types::{ConditionalType, MappedType};
+
+    let interner = TypeInterner::new();
+    let qc = QueryCache::new(&interner);
+
+    // keyof { a: string; b: number }
+    let source = object_with_pair(&interner, TypeId::STRING, TypeId::NUMBER);
+    let keyof_src = interner.keyof(source);
+    assert_eq!(
+        QueryDatabase::evaluate_keyof(&qc, source),
+        crate::evaluation::evaluate::evaluate_keyof(&interner, source),
+        "evaluate_keyof override must match the uncached result",
+    );
+
+    // { a: string; b: number }["a"]
+    let key_a = interner.literal_string("a");
+    assert_eq!(
+        QueryDatabase::evaluate_index_access_with_options(&qc, source, key_a, false),
+        crate::evaluation::evaluate::evaluate_index_access_with_options(
+            &interner, source, key_a, false,
+        ),
+        "evaluate_index_access override must match the uncached result",
+    );
+
+    // string extends string ? number : boolean
+    let cond = ConditionalType {
+        check_type: TypeId::STRING,
+        extends_type: TypeId::STRING,
+        true_type: TypeId::NUMBER,
+        false_type: TypeId::BOOLEAN,
+        is_distributive: false,
+    };
+    assert_eq!(
+        QueryDatabase::evaluate_conditional(&qc, &cond),
+        crate::evaluation::evaluate::evaluate_conditional(&interner, &cond),
+        "evaluate_conditional override must match the uncached result",
+    );
+
+    // Homomorphic `{ [P in keyof T]: T[P] }` instantiated with T = source.
+    let iter_atom = interner.intern_string("P");
+    let outer_t = interner.type_param(param_info(interner.intern_string("T")));
+    let iter_param = interner.type_param(param_info(iter_atom));
+    let template = interner.index_access(source, iter_param);
+    let mapped = MappedType {
+        type_param: TypeParamInfo {
+            name: iter_atom,
+            constraint: Some(interner.keyof(outer_t)),
+            default: None,
+            is_const: false,
+        },
+        constraint: keyof_src,
+        name_type: None,
+        template,
+        readonly_modifier: None,
+        optional_modifier: None,
+    };
+    assert_eq!(
+        QueryDatabase::evaluate_mapped(&qc, &mapped),
+        crate::evaluation::evaluate::evaluate_mapped(&interner, &mapped),
+        "evaluate_mapped override must match the uncached result",
+    );
+}

--- a/crates/tsz-solver/src/caches/mod.rs
+++ b/crates/tsz-solver/src/caches/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod db;
 pub(crate) mod instantiation_cache;
 pub(crate) mod query_cache;
+mod query_cache_evaluation;
 pub(crate) mod query_trace;
 pub(crate) mod subtype_reduction_cache;

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -427,12 +427,6 @@ pub struct QueryCache<'a> {
     shared: Option<&'a SharedQueryCache>,
 }
 
-/// A `query_db`-backed evaluator: a `TypeEvaluator` with the `NoopResolver`
-/// (matching `evaluate_type_with_options`) whose cross-call caches are wired to
-/// a `QueryCache`. See [`QueryCache::query_backed_evaluator`].
-type QueryBackedEvaluator<'a> =
-    crate::evaluation::evaluate::TypeEvaluator<'a, crate::def::resolver::NoopResolver>;
-
 impl<'a> QueryCache<'a> {
     pub fn new(interner: &'a TypeInterner) -> Self {
         Self::with_optional_shared(interner, None)
@@ -445,23 +439,6 @@ impl<'a> QueryCache<'a> {
     /// to both local and shared caches for cross-file benefit.
     pub fn new_with_shared(interner: &'a TypeInterner, shared: &'a SharedQueryCache) -> Self {
         Self::with_optional_shared(interner, Some(shared))
-    }
-
-    /// Build a `TypeEvaluator` wired to this cache's cross-call instantiation
-    /// and application-eval caches.
-    ///
-    /// The sub-evaluation entry points (`evaluate_conditional`, `evaluate_keyof`,
-    /// `evaluate_mapped`, `evaluate_index_access_with_options`) otherwise fall
-    /// through to the `QueryDatabase` trait defaults, which construct a fresh
-    /// `TypeEvaluator` with `query_db = None`. That strips the cross-call
-    /// instantiation cache (`#12019`) at the entry boundary, so recursive
-    /// utility expansion re-walks the same `(body, substitution)` pairs on every
-    /// call. Threading `self` as the `query_db` lets those entry points share the
-    /// same memoized walks the top-level `evaluate_type_with_options` path
-    /// already uses. The resolver stays `Noop` to match that path exactly; only
-    /// caching behavior changes, never the computed result.
-    fn query_backed_evaluator(&self) -> QueryBackedEvaluator<'_> {
-        crate::evaluation::evaluate::TypeEvaluator::new(self.as_type_database()).with_query_db(self)
     }
 
     fn with_optional_shared(

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -427,6 +427,12 @@ pub struct QueryCache<'a> {
     shared: Option<&'a SharedQueryCache>,
 }
 
+/// A `query_db`-backed evaluator: a `TypeEvaluator` with the `NoopResolver`
+/// (matching `evaluate_type_with_options`) whose cross-call caches are wired to
+/// a `QueryCache`. See [`QueryCache::query_backed_evaluator`].
+type QueryBackedEvaluator<'a> =
+    crate::evaluation::evaluate::TypeEvaluator<'a, crate::def::resolver::NoopResolver>;
+
 impl<'a> QueryCache<'a> {
     pub fn new(interner: &'a TypeInterner) -> Self {
         Self::with_optional_shared(interner, None)
@@ -439,6 +445,23 @@ impl<'a> QueryCache<'a> {
     /// to both local and shared caches for cross-file benefit.
     pub fn new_with_shared(interner: &'a TypeInterner, shared: &'a SharedQueryCache) -> Self {
         Self::with_optional_shared(interner, Some(shared))
+    }
+
+    /// Build a `TypeEvaluator` wired to this cache's cross-call instantiation
+    /// and application-eval caches.
+    ///
+    /// The sub-evaluation entry points (`evaluate_conditional`, `evaluate_keyof`,
+    /// `evaluate_mapped`, `evaluate_index_access_with_options`) otherwise fall
+    /// through to the `QueryDatabase` trait defaults, which construct a fresh
+    /// `TypeEvaluator` with `query_db = None`. That strips the cross-call
+    /// instantiation cache (`#12019`) at the entry boundary, so recursive
+    /// utility expansion re-walks the same `(body, substitution)` pairs on every
+    /// call. Threading `self` as the `query_db` lets those entry points share the
+    /// same memoized walks the top-level `evaluate_type_with_options` path
+    /// already uses. The resolver stays `Noop` to match that path exactly; only
+    /// caching behavior changes, never the computed result.
+    fn query_backed_evaluator(&self) -> QueryBackedEvaluator<'_> {
+        crate::evaluation::evaluate::TypeEvaluator::new(self.as_type_database()).with_query_db(self)
     }
 
     fn with_optional_shared(
@@ -1666,9 +1689,7 @@ impl QueryDatabase for QueryCache<'_> {
             query_id
         });
 
-        let mut evaluator =
-            crate::evaluation::evaluate::TypeEvaluator::new(self.as_type_database());
-        evaluator = evaluator.with_query_db(self);
+        let mut evaluator = self.query_backed_evaluator();
         let result = evaluator.evaluate_request_result(request).into_type_id();
 
         // PERF: Persist intermediate evaluation results from this session into
@@ -1699,6 +1720,31 @@ impl QueryDatabase for QueryCache<'_> {
             query_trace::unary_end(query_id, "evaluate_type_with_options", result, false);
         }
         result
+    }
+
+    /// Cache-aware override of the `QueryDatabase` default, which would build a
+    /// `query_db = None` evaluator and bypass the cross-call instantiation cache.
+    fn evaluate_conditional(&self, cond: &ConditionalType) -> TypeId {
+        self.query_backed_evaluator().evaluate_conditional(cond)
+    }
+
+    fn evaluate_index_access_with_options(
+        &self,
+        object_type: TypeId,
+        index_type: TypeId,
+        no_unchecked_indexed_access: bool,
+    ) -> TypeId {
+        let mut evaluator = self.query_backed_evaluator();
+        evaluator.set_no_unchecked_indexed_access(no_unchecked_indexed_access);
+        evaluator.evaluate_index_access(object_type, index_type)
+    }
+
+    fn evaluate_keyof(&self, operand: TypeId) -> TypeId {
+        self.query_backed_evaluator().evaluate_keyof(operand)
+    }
+
+    fn evaluate_mapped(&self, mapped: &MappedType) -> TypeId {
+        self.query_backed_evaluator().evaluate_mapped(mapped)
     }
 
     /// Look up a cross-call `instantiate_type` result.

--- a/crates/tsz-solver/src/caches/query_cache_evaluation.rs
+++ b/crates/tsz-solver/src/caches/query_cache_evaluation.rs
@@ -1,0 +1,30 @@
+//! Cache-aware evaluation helpers for `QueryCache`.
+
+use crate::caches::db::TypeDatabase;
+use crate::caches::query_cache::QueryCache;
+use crate::def::resolver::NoopResolver;
+use crate::evaluation::evaluate::TypeEvaluator;
+
+/// A `query_db`-backed evaluator: a `TypeEvaluator` with the `NoopResolver`
+/// (matching `evaluate_type_with_options`) whose cross-call caches are wired to
+/// a `QueryCache`. See [`QueryCache::query_backed_evaluator`].
+pub(crate) type QueryBackedEvaluator<'a> = TypeEvaluator<'a, NoopResolver>;
+
+impl<'a> QueryCache<'a> {
+    /// Build a `TypeEvaluator` wired to this cache's cross-call instantiation
+    /// and application-eval caches.
+    ///
+    /// The sub-evaluation entry points (`evaluate_conditional`, `evaluate_keyof`,
+    /// `evaluate_mapped`, `evaluate_index_access_with_options`) otherwise fall
+    /// through to the `QueryDatabase` trait defaults, which construct a fresh
+    /// `TypeEvaluator` with `query_db = None`. That strips the cross-call
+    /// instantiation cache (`#12019`) at the entry boundary, so recursive
+    /// utility expansion re-walks the same `(body, substitution)` pairs on every
+    /// call. Threading `self` as the `query_db` lets those entry points share the
+    /// same memoized walks the top-level `evaluate_type_with_options` path
+    /// already uses. The resolver stays `Noop` to match that path exactly; only
+    /// caching behavior changes, never the computed result.
+    pub(crate) fn query_backed_evaluator(&self) -> QueryBackedEvaluator<'_> {
+        TypeEvaluator::new(self as &dyn TypeDatabase).with_query_db(self)
+    }
+}


### PR DESCRIPTION
AgentName: Studio-B
Track: Performance / recursive utility expansion (`agent:Studio-B`)
Invariant: Cache wiring is semantically transparent — results must match the uncached path exactly; only memoization changes.

## Scope

Follow-up to #12021 / #12019. PR #12019 routed `instantiate_generic` through the
cross-call `InstantiationCache`, but the wiring was being stripped at four
evaluation entry points.

The `QueryDatabase` default implementations of `evaluate_conditional`,
`evaluate_keyof`, `evaluate_mapped`, and `evaluate_index_access_with_options`
delegate to the `evaluate/api.rs` free functions, which build a fresh
`TypeEvaluator` with `query_db = None`. That `None` disables the cross-call
instantiation cache (and the application-eval cache) for any recursive utility
expansion reached through those entry points, so the same `(body, substitution)`
walks are recomputed on every call.

`QueryCache` already overrides `evaluate_type_with_options` to pass
`with_query_db(self)`; these four sub-evaluation entry points were missed. This
PR overrides them on `QueryCache` through a shared `query_backed_evaluator`
helper, mirroring the existing `evaluate_type_with_options` wiring exactly.

**Structural rule:** When a `QueryCache`-backed `QueryDatabase` evaluates a
`keyof` / mapped / conditional / indexed-access type, tsz must thread the same
`query_db` it uses for top-level `evaluate_type`, so internal
`instantiate_*_cached` calls hit the cross-call `InstantiationCache` instead of
silently bypassing it.

**Owner layer:** Solver caches (`crates/tsz-solver/src/caches/query_cache.rs`).
This is the correct altitude: a trait-default fix in `db.rs` can't coerce
`&self` (`&dyn QueryDatabase`) into the `&dyn QueryDatabase` that
`with_query_db` needs without a `Self: Sized` bound that would break
dyn-dispatch, and `TypeInterner` (the only other impl) has a no-op cache, so
the concrete `QueryCache` override is the only impl that benefits.

## Why this is safe (not a result change)

`QueryCache` only ever uses the `NoopResolver` — the same resolver
`evaluate_type_with_options` already passes alongside `query_db = self`. So no
"stronger-resolver vs. weaker-resolver" cache-poisoning regime is introduced;
the four entry points simply join the regime the dominant `evaluate_type`
traffic already runs under. The only `query_db`-gated branches in the evaluator
are cache probes/inserts (verified in `evaluate.rs`), and `closed_eval_cache`
writes remain gated behind `with_closed_eval_writes` (not set here).

## Project Corpus Impact

- Row: vite-vanilla-ts-app, type-fest-project, utility-types-project
- Bug family: recursive utility expansion fan-out / instantiation-cache coverage (#12021, #12019)
- Impact: No diagnostic/emit behavior change expected (semantically transparent caching). This removes the cache-stripping boundary so the #12019 instantiation cache reaches the keyof/mapped/conditional/index entry points; row timings remain CI/bench-owned.

## Verification

- `cargo build -p tsz-solver`, `cargo clippy -p tsz-solver` — clean.
- `cargo test -p tsz-solver --lib` — 6551 passed; the only failure is the
  pre-existing, unrelated `solver_file_eval_mapped` file-size ratchet (present
  on `origin/main` itself, where #12738 merged after the drift, proving the
  merge queue does not gate on it).
- New test `query_database_evaluate_entry_points_preserve_results` asserts each
  of the four entry points returns the same type as the uncached
  `evaluate/api.rs` free function.
- `cargo test -p tsz-checker` for `class_field_mapped_type_indexed_access_tests`
  and `awaited_generic_application_fold_tests` — pass (exercise mapped / generic
  application / indexed-access through `QueryCache`).
- `/simplify` applied: `evaluate_type_with_options` now reuses the new helper;
  added a `QueryBackedEvaluator` type alias; trimmed redundant docs.

## Coordination Notes

Converts the #12019 enabling slice into broader cache coverage and partially
addresses #12021 step 3 (audit remaining non-cache callers). The three
remaining non-cache `instantiate_generic` callers (`DefaultJudge`,
`ContextualTypeContext`, diagnostics formatter) lack a reachable `QueryDatabase`
and would need deeper structural threading — left for a follow-up.


---
_Generated by [Claude Code](https://claude.ai/code/session_018GjGD37QpgQazmWTN6jsu3)_
