### PR TITLE
bench: surface winner measurement profile metadata

### DIFF
--- a/scripts/bench/bench-readiness-banner.mjs
+++ b/scripts/bench/bench-readiness-banner.mjs
@@ -42,6 +42,13 @@ export function benchReadinessMessages(readiness, winnerReport = null) {
   }
 
   const target = winnerReport?.two_x_target;
+  const measurementWarning = winnerReport?.measurement_profile?.warning;
+  if (typeof measurementWarning === "string" && measurementWarning.length > 0) {
+    messages.push(
+      `Benchmark companion report measurement profile warning: ${measurementWarning}; 2x target evidence may not be comparable.`,
+    );
+  }
+
   const targetGaps = Number(target?.rows_below_target ?? 0);
   if (targetGaps > 0) {
     const eligibleRows = Number(target?.eligible_green_rows ?? 0);

--- a/scripts/bench/test-bench-readiness-banner.mjs
+++ b/scripts/bench/test-bench-readiness-banner.mjs
@@ -13,6 +13,20 @@ assert.deepEqual(benchReadinessMessages(null), []);
 
 assert.match(
   benchReadinessMessages(null, {
+    measurement_profile: {
+      warning: "release-pgo metadata missing profile fingerprint",
+    },
+    two_x_target: {
+      eligible_green_rows: 2,
+      rows_below_target: 0,
+      missing_attribution_rows: [],
+    },
+  }).join(" "),
+  /measurement profile warning: release-pgo metadata missing profile fingerprint/,
+);
+
+assert.match(
+  benchReadinessMessages(null, {
     two_x_target: {
       eligible_green_rows: 2,
       rows_below_target: 1,

--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -38,7 +38,17 @@ withTempDir((dir) => {
     filter: "project|single",
     measurement_profile: {
       mode: "release-pgo",
+      tsz_binary_source: "bench-dist",
       generated_at: "2026-05-20T00:00:00.000Z",
+      profile_guided_optimization: {
+        requested: true,
+        required: true,
+        optimized: true,
+        profile_fingerprint: "profile-abc123",
+        training_fingerprint: "training-def456",
+        training_input_count: 12,
+        training_failure_count: 0,
+      },
     },
     results: [
       {
@@ -197,6 +207,14 @@ withTempDir((dir) => {
   assert.deepEqual(report.measurement_profile, {
     present: true,
     mode: "release-pgo",
+    tsz_binary_source: "bench-dist",
+    pgo_requested: true,
+    pgo_required: true,
+    pgo_optimized: true,
+    profile_fingerprint: "profile-abc123",
+    training_fingerprint: "training-def456",
+    training_input_count: 12,
+    training_failure_count: 0,
     warning: null,
   });
   assert.deepEqual(report.duplicate_rows, []);
@@ -257,6 +275,38 @@ withTempDir((dir) => {
   const importedReport = createTsgoWinnerReport(JSON.parse(fs.readFileSync(input, "utf8")), input);
   assert.equal(importedReport.totals.green_tsgo_winners, 3);
   assert.equal(importedReport.worst.name, "ts-toolbelt-project");
+});
+
+withTempDir((dir) => {
+  const input = path.join(dir, "bench.json");
+  writeJson(input, {
+    benchmark_runner: "scripts/bench/bench-vs-tsgo.sh",
+    measurement_profile: {
+      mode: "release-pgo",
+      tsz_binary_source: "bench-dist",
+      profile_guided_optimization: {
+        requested: true,
+        required: true,
+        optimized: false,
+      },
+    },
+    results: [],
+  });
+
+  const report = createTsgoWinnerReport(JSON.parse(fs.readFileSync(input, "utf8")), input);
+  assert.deepEqual(report.measurement_profile, {
+    present: true,
+    mode: "release-pgo",
+    tsz_binary_source: "bench-dist",
+    pgo_requested: true,
+    pgo_required: true,
+    pgo_optimized: false,
+    profile_fingerprint: null,
+    training_fingerprint: null,
+    training_input_count: null,
+    training_failure_count: null,
+    warning: "release-pgo metadata missing pgo optimized flag, profile fingerprint, training fingerprint",
+  });
 });
 
 withTempDir((dir) => {
@@ -474,6 +524,14 @@ withTempDir((dir) => {
   assert.deepEqual(report.measurement_profile, {
     present: false,
     mode: null,
+    tsz_binary_source: null,
+    pgo_requested: null,
+    pgo_required: null,
+    pgo_optimized: null,
+    profile_fingerprint: null,
+    training_fingerprint: null,
+    training_input_count: null,
+    training_failure_count: null,
     warning: "measurement_profile missing",
   });
   // 6 rows excluded due to missing phase/exit metadata or artifact_missing

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -138,15 +138,45 @@ function measurementProfileStatus(input) {
     return {
       present: false,
       mode: null,
+      tsz_binary_source: null,
+      pgo_requested: null,
+      pgo_required: null,
+      pgo_optimized: null,
+      profile_fingerprint: null,
+      training_fingerprint: null,
+      training_input_count: null,
+      training_failure_count: null,
       warning: "measurement_profile missing",
     };
   }
 
   const mode = typeof profile.mode === "string" && profile.mode ? profile.mode : null;
+  const pgo = profile.profile_guided_optimization && typeof profile.profile_guided_optimization === "object"
+    ? profile.profile_guided_optimization
+    : {};
+  const warning = (() => {
+    if (!mode) return "measurement_profile.mode missing";
+    if (mode === "release-pgo") {
+      const missing = [];
+      if (pgo.optimized !== true) missing.push("pgo optimized flag");
+      if (!pgo.profile_fingerprint) missing.push("profile fingerprint");
+      if (!pgo.training_fingerprint) missing.push("training fingerprint");
+      if (missing.length > 0) return `release-pgo metadata missing ${missing.join(", ")}`;
+    }
+    return null;
+  })();
   return {
     present: true,
     mode,
-    warning: mode ? null : "measurement_profile.mode missing",
+    tsz_binary_source: profile.tsz_binary_source ?? null,
+    pgo_requested: pgo.requested ?? null,
+    pgo_required: pgo.required ?? null,
+    pgo_optimized: pgo.optimized ?? null,
+    profile_fingerprint: pgo.profile_fingerprint ?? null,
+    training_fingerprint: pgo.training_fingerprint ?? null,
+    training_input_count: pgo.training_input_count ?? null,
+    training_failure_count: pgo.training_failure_count ?? null,
+    warning,
   };
 }
 


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Studio-Opus infrastructure / benchmark artifact schema

## Invariant
When the benchmark companion report is used as the canonical 2x tsgo-target artifact, it must carry enough measurement-profile metadata to judge whether release-pgo timing evidence is comparable; this PR changes benchmark reporting and readiness messaging only.

## Scope
- Expand scripts/bench/tsgo-winner-report.mjs measurement_profile output with PGO metadata fields and release-pgo metadata warnings.
- Surface companion-report measurement_profile warnings in scripts/bench/bench-readiness-banner.mjs.
- Add focused script coverage for the report schema and banner warning.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark artifact schema / 2x target evidence readiness
- Evidence: no compiler behavior or project-row metadata changes; node scripts/bench/project-row-summary.mjs --markdown still reports all 19 rows consistent across surfaces.

## Verification
- node scripts/bench/test-tsgo-winner-report.mjs
- node scripts/bench/test-bench-readiness-banner.mjs
- node scripts/bench/test-check-artifact-readiness.mjs
- node scripts/bench/project-row-summary.mjs --markdown
- git diff --check origin/main...HEAD
- Draft CI Light Summary: pass (run 27047744177)

## Coordination Notes
- Ready for PR-head CI. No overlap with active Studio-B performance branches; this only ratchets the benchmark companion artifact contract that those branches cite.
