### PR TITLE
bench: share measurement profile status helper

### DIFF
--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -32,6 +32,7 @@ import {
   hasCompletePhaseMetadata,
   isGreen,
 } from "./row-utils.mjs";
+import { measurementProfileStatus } from "./measurement-profile.mjs";
 
 const args = process.argv.slice(2);
 
@@ -122,57 +123,6 @@ function rowState(row, duplicate = false) {
 }
 
 const STATE_ICON = { green: "✅", yellow: "⚠️", red: "❌", gray: "⬜", missing: "🚫" };
-
-function analyzeMeasurementProfile(artifact) {
-  const profile = artifact?.measurement_profile;
-  if (!profile || typeof profile !== "object") {
-    return {
-      present: false,
-      mode: null,
-      tsz_binary_source: null,
-      pgo_requested: null,
-      pgo_required: null,
-      pgo_optimized: null,
-      profile_fingerprint: null,
-      training_fingerprint: null,
-      training_input_count: null,
-      training_failure_count: null,
-      warning: "measurement_profile missing",
-    };
-  }
-
-  const pgo = profile.profile_guided_optimization && typeof profile.profile_guided_optimization === "object"
-    ? profile.profile_guided_optimization
-    : {};
-  const mode = typeof profile.mode === "string" && profile.mode.trim()
-    ? profile.mode.trim()
-    : null;
-  const warning = (() => {
-    if (!mode) return "measurement_profile.mode missing";
-    if (mode === "release-pgo") {
-      const missing = [];
-      if (pgo.optimized !== true) missing.push("pgo optimized flag");
-      if (!pgo.profile_fingerprint) missing.push("profile fingerprint");
-      if (!pgo.training_fingerprint) missing.push("training fingerprint");
-      if (missing.length) return `release-pgo metadata missing ${missing.join(", ")}`;
-    }
-    return null;
-  })();
-
-  return {
-    present: true,
-    mode,
-    tsz_binary_source: profile.tsz_binary_source ?? null,
-    pgo_requested: pgo.requested ?? null,
-    pgo_required: pgo.required ?? null,
-    pgo_optimized: pgo.optimized ?? null,
-    profile_fingerprint: pgo.profile_fingerprint ?? null,
-    training_fingerprint: pgo.training_fingerprint ?? null,
-    training_input_count: pgo.training_input_count ?? null,
-    training_failure_count: pgo.training_failure_count ?? null,
-    warning,
-  };
-}
 
 function cleanValidationWarnings(warnings) {
   if (!Array.isArray(warnings)) return [];
@@ -304,7 +254,7 @@ function analyzeArtifact(artifact, expectedCommit) {
   });
 
   return {
-    measurementProfile: analyzeMeasurementProfile(artifact),
+    measurementProfile: measurementProfileStatus(artifact),
     validationWarnings: analyzeValidationWarnings(artifact),
     sourceFreshness: analyzeSourceFreshness(artifact, expectedCommit),
     rows,
@@ -471,7 +421,7 @@ function buildReport({ artifact, measurementProfile, validationWarnings, sourceF
   const sourceCommit = artifact?.source_commit?.slice(0, 10) ?? "unknown";
   const generatedAt = artifact?.generated_at ?? null;
   const workflowUrl = artifact?.workflow_run_url ?? null;
-  const profile = measurementProfile ?? analyzeMeasurementProfile(artifact);
+  const profile = measurementProfile ?? measurementProfileStatus(artifact);
   const profileLabel = profile.present
     ? `${profile.mode ?? "unknown"}${profile.warning ? ` (${profile.warning})` : ""}`
     : profile.warning;

--- a/scripts/bench/measurement-profile.mjs
+++ b/scripts/bench/measurement-profile.mjs
@@ -1,0 +1,50 @@
+export function measurementProfileStatus(artifact) {
+  const profile = artifact?.measurement_profile;
+  if (!profile || typeof profile !== "object") {
+    return {
+      present: false,
+      mode: null,
+      tsz_binary_source: null,
+      pgo_requested: null,
+      pgo_required: null,
+      pgo_optimized: null,
+      profile_fingerprint: null,
+      training_fingerprint: null,
+      training_input_count: null,
+      training_failure_count: null,
+      warning: "measurement_profile missing",
+    };
+  }
+
+  const mode = typeof profile.mode === "string" && profile.mode.trim()
+    ? profile.mode.trim()
+    : null;
+  const pgo = profile.profile_guided_optimization && typeof profile.profile_guided_optimization === "object"
+    ? profile.profile_guided_optimization
+    : {};
+  const warning = (() => {
+    if (!mode) return "measurement_profile.mode missing";
+    if (mode === "release-pgo") {
+      const missing = [];
+      if (pgo.optimized !== true) missing.push("pgo optimized flag");
+      if (!pgo.profile_fingerprint) missing.push("profile fingerprint");
+      if (!pgo.training_fingerprint) missing.push("training fingerprint");
+      if (missing.length > 0) return `release-pgo metadata missing ${missing.join(", ")}`;
+    }
+    return null;
+  })();
+
+  return {
+    present: true,
+    mode,
+    tsz_binary_source: profile.tsz_binary_source ?? null,
+    pgo_requested: pgo.requested ?? null,
+    pgo_required: pgo.required ?? null,
+    pgo_optimized: pgo.optimized ?? null,
+    profile_fingerprint: pgo.profile_fingerprint ?? null,
+    training_fingerprint: pgo.training_fingerprint ?? null,
+    training_input_count: pgo.training_input_count ?? null,
+    training_failure_count: pgo.training_failure_count ?? null,
+    warning,
+  };
+}

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { measurementProfileStatus } from "./measurement-profile.mjs";
 import { PROJECT_ROWS_BY_NAME } from "./project-rows.mjs";
 import { isGreen, isIncompleteCompat } from "./row-utils.mjs";
 
@@ -130,54 +131,6 @@ function tszSpeedupVsTsgo(row) {
   if (row?.winner === "tsz") return factor;
   if (row?.winner === "tsgo") return 1 / factor;
   return null;
-}
-
-function measurementProfileStatus(input) {
-  const profile = input?.measurement_profile;
-  if (!profile || typeof profile !== "object") {
-    return {
-      present: false,
-      mode: null,
-      tsz_binary_source: null,
-      pgo_requested: null,
-      pgo_required: null,
-      pgo_optimized: null,
-      profile_fingerprint: null,
-      training_fingerprint: null,
-      training_input_count: null,
-      training_failure_count: null,
-      warning: "measurement_profile missing",
-    };
-  }
-
-  const mode = typeof profile.mode === "string" && profile.mode ? profile.mode : null;
-  const pgo = profile.profile_guided_optimization && typeof profile.profile_guided_optimization === "object"
-    ? profile.profile_guided_optimization
-    : {};
-  const warning = (() => {
-    if (!mode) return "measurement_profile.mode missing";
-    if (mode === "release-pgo") {
-      const missing = [];
-      if (pgo.optimized !== true) missing.push("pgo optimized flag");
-      if (!pgo.profile_fingerprint) missing.push("profile fingerprint");
-      if (!pgo.training_fingerprint) missing.push("training fingerprint");
-      if (missing.length > 0) return `release-pgo metadata missing ${missing.join(", ")}`;
-    }
-    return null;
-  })();
-  return {
-    present: true,
-    mode,
-    tsz_binary_source: profile.tsz_binary_source ?? null,
-    pgo_requested: pgo.requested ?? null,
-    pgo_required: pgo.required ?? null,
-    pgo_optimized: pgo.optimized ?? null,
-    profile_fingerprint: pgo.profile_fingerprint ?? null,
-    training_fingerprint: pgo.training_fingerprint ?? null,
-    training_input_count: pgo.training_input_count ?? null,
-    training_failure_count: pgo.training_failure_count ?? null,
-    warning,
-  };
 }
 
 function inferDominantSubsystemFromPerfSnapshot(snapshot) {


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Studio-Opus infrastructure / benchmark artifact schema

## Invariant
When benchmark readiness and winner-report tooling evaluate a measurement_profile, both surfaces must apply the same structural release-PGO metadata rule through one benchmark helper; this PR changes script organization only and preserves the emitted status shape.

## Scope
- Add scripts/bench/measurement-profile.mjs as the shared measurement_profile status helper.
- Route scripts/bench/check-artifact-readiness.mjs through the helper.
- Route scripts/bench/tsgo-winner-report.mjs through the helper.

## Project Corpus Impact
- Row: n/a
- Bug family: benchmark artifact schema / 2x target evidence readiness
- Evidence: no compiler behavior or project-row metadata changes; node scripts/bench/project-row-summary.mjs --markdown still reports all 19 rows consistent across surfaces.

## Verification
- node scripts/bench/test-tsgo-winner-report.mjs
- node scripts/bench/test-check-artifact-readiness.mjs
- node scripts/bench/test-bench-readiness-banner.mjs
- node scripts/bench/project-row-summary.mjs --markdown
- git diff --check
- Draft CI Light Summary: pass (run 27048581731)
- PR-head CI Summary: pass (run 27048719829)

## Coordination Notes
- Ready for merge queue. No overlap with active Studio-B performance branches or Studio-C emit branches; this only removes duplicated benchmark measurement-profile status logic after #12741 landed.
