### PR TITLE
fix(solver): keep weak-type-sensitive relations out of the shared cache

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -39,6 +39,18 @@ thread_local! {
     // an undetermined type and must NOT be cached as definitive, or it poisons
     // every later structural check that shares the same member type.
     static LAZY_RESOLVE_FAILURES: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    // Monotonic counter bumped whenever a structural comparison hits the
+    // weak-type (TS2559) trigger: a non-empty, non-weak source compared against
+    // a weak-type target with no common property names. Such a pair yields
+    // DIFFERENT results depending on whether weak-type enforcement is active
+    // (`SubtypeChecker::enforce_weak_types` plus the `in_property_check` /
+    // `in_intersection_member_check` gating context). That enforcement state is
+    // operation-local and is NOT encoded in the flag-agnostic
+    // `RelationCacheKey`, so a result computed while this counter changed must
+    // NOT be memoized in the shared relation cache or it poisons a sibling
+    // check that runs under a different enforcement state. Mirrors the
+    // unresolved-`Lazy` snapshot mechanism above.
+    static WEAK_TYPE_SENSITIVITY: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
 }
 
 /// Record that a `Lazy(DefId)` failed to resolve during a relation check.
@@ -53,6 +65,23 @@ pub(crate) fn note_lazy_resolve_failure() {
 #[inline]
 pub(crate) fn lazy_resolve_failure_count() -> u64 {
     LAZY_RESOLVE_FAILURES.with(std::cell::Cell::get)
+}
+
+/// Record that a structural comparison reached the weak-type (TS2559) trigger,
+/// making the in-flight result sensitive to the active weak-type enforcement
+/// state. See [`WEAK_TYPE_SENSITIVITY`].
+#[inline]
+pub(crate) fn note_weak_type_sensitivity() {
+    WEAK_TYPE_SENSITIVITY.with(|c| c.set(c.get().wrapping_add(1)));
+}
+
+/// Current value of the weak-type-sensitivity counter; compare a snapshot taken
+/// before computing a result with the value after to detect whether the
+/// computation depended on weak-type enforcement state (which the relation
+/// cache key does not encode).
+#[inline]
+pub(crate) fn weak_type_sensitivity_count() -> u64 {
+    WEAK_TYPE_SENSITIVITY.with(std::cell::Cell::get)
 }
 
 /// Pack depth (low 32) and fuel (high 32) into a single u64.
@@ -79,6 +108,7 @@ const fn unpack_fuel(state: u64) -> u32 {
 pub fn reset_subtype_thread_local_state() {
     GLOBAL_SUBTYPE_STATE.with(|s| s.set(0));
     LAZY_RESOLVE_FAILURES.with(|c| c.set(0));
+    WEAK_TYPE_SENSITIVITY.with(|c| c.set(0));
 }
 
 // Maximum number of non-trivial subtype checks per top-level call chain.
@@ -388,6 +418,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // yet registered, so a `False` is undetermined and must not be cached.
         let lazy_failures_at_entry = lazy_resolve_failure_count();
 
+        // Snapshot the weak-type-sensitivity counter. If it changes while
+        // computing this pair's result, the result depended on weak-type
+        // enforcement state (TS2559), which the flag-agnostic `RelationCacheKey`
+        // does not encode. Caching it would let a result computed under one
+        // enforcement state be served to a sibling check under another.
+        let weak_sensitivity_at_entry = weak_type_sensitivity_count();
+
         // Helper macro to decrement global depth and optionally reset fuel on early returns.
         macro_rules! leave_global {
             () => {
@@ -408,16 +445,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // computation did not depend on a `Lazy` whose body was unresolved
         // (which would make the result undetermined and poison the cache).
         //
-        // This is best-effort and intentionally conservative: the snapshot is
-        // process-wide (thread-local), so *any* unresolved-`Lazy` event anywhere
-        // in this top-level call's subtree — even in a branch whose result did
-        // not feed the final answer — suppresses the write. That only ever skips
-        // a cache write (correctness-preserving: the result is recomputed later,
-        // when the body is registered), never produces a wrong answer. Captures
-        // `lazy_failures_at_entry` from the enclosing scope by name.
+        // This is best-effort and intentionally conservative: the snapshots are
+        // process-wide (thread-local), so *any* unresolved-`Lazy` event or
+        // weak-type-sensitivity event anywhere in this top-level call's subtree
+        // — even in a branch whose result did not feed the final answer —
+        // suppresses the write. That only ever skips a cache write
+        // (correctness-preserving: the result is recomputed later), never
+        // produces a wrong answer. Captures `lazy_failures_at_entry` and
+        // `weak_sensitivity_at_entry` from the enclosing scope by name.
         macro_rules! cache_definitive {
             ($db:expr, $key:expr, $result:expr) => {
-                if lazy_resolve_failure_count() == lazy_failures_at_entry {
+                if lazy_resolve_failure_count() == lazy_failures_at_entry
+                    && weak_type_sensitivity_count() == weak_sensitivity_at_entry
+                {
                     match $result {
                         SubtypeResult::True => $db.insert_subtype_cache($key, true),
                         SubtypeResult::False => $db.insert_subtype_cache($key, false),

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -224,15 +224,29 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         //   { x: { c: string } } <: { x: { a?: string } }
         // The inner `{ c: string } <: { a?: string }` must fail because `{ a?: string }`
         // is a weak type and `{ c: string }` has no common properties with it.
-        if self.enforce_weak_types
-            && (!self.in_intersection_member_check || self.in_property_check)
-            && !source.properties.is_empty()
+        //
+        // The structural trigger (non-empty non-weak source vs weak-type target
+        // with no common property names) is evaluated independently of the
+        // enforcement flags. Whenever it holds, the relation result is
+        // weak-enforcement-sensitive: a checker with weak checks active returns
+        // `False` here while one with weak checks suppressed continues and may
+        // return `True`. That enforcement state is operation-local and is NOT
+        // part of the `RelationCacheKey`, so we record the sensitivity to keep
+        // such results out of the shared relation cache (see
+        // `note_weak_type_sensitivity`), preventing one enforcement state from
+        // poisoning another via a stale cache entry.
+        if !source.properties.is_empty()
             && Self::is_weak_type_shape(target)
             && !Self::is_weak_type_shape(source)
             && !self.is_global_object_shape(source)
             && !crate::utils::has_common_property_name(&source.properties, &target.properties)
         {
-            return SubtypeResult::False;
+            crate::relations::subtype::cache::note_weak_type_sensitivity();
+            if self.enforce_weak_types
+                && (!self.in_intersection_member_check || self.in_property_check)
+            {
+                return SubtypeResult::False;
+            }
         }
 
         // Fast fail for private/protected members: check these first so unrelated

--- a/crates/tsz-solver/tests/subtype_cache_tests.rs
+++ b/crates/tsz-solver/tests/subtype_cache_tests.rs
@@ -764,6 +764,95 @@ fn strict_null_checks_flip_yields_fresh_answer_via_shared_cache() {
     );
 }
 
+// =============================================================================
+// Weak-type (TS2559) enforcement sensitivity.
+//
+// Weak-type enforcement changes the structural subtype answer for weak-type
+// targets but is operation-local state that is NOT encoded in the flag-agnostic
+// `RelationCacheKey`. A result computed while the weak-type trigger fired must
+// therefore stay out of the shared relation cache so a checker running under a
+// different enforcement state cannot observe a poisoned entry.
+// =============================================================================
+
+/// Build a `{ c: string }` source and a weak-type `{ a?: string }` target that
+/// share no property names — the exact shape that drives the TS2559 weak-type
+/// trigger.
+fn weak_type_pair(interner: &TypeInterner) -> (TypeId, TypeId) {
+    let c = interner.intern_string("c");
+    let a = interner.intern_string("a");
+    let source = interner.object(vec![PropertyInfo::new(c, TypeId::STRING)]);
+    let target = interner.object(vec![PropertyInfo::opt(a, TypeId::STRING)]);
+    (source, target)
+}
+
+#[test]
+fn weak_type_enforcement_result_is_not_shared_across_enforcement_states() {
+    // Structural rule: when a non-empty non-weak source is compared to a
+    // weak-type target with no common properties, the answer depends on whether
+    // weak-type enforcement is active. Two checkers that differ only in
+    // `enforce_weak_types` must observe their own answers, never a cached one
+    // from the other state.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let (source, target) = weak_type_pair(&interner);
+
+    // Enforcing checker: weak target with no common properties => not a subtype.
+    let mut enforcing = SubtypeChecker::new(&interner).with_query_db(&db);
+    enforcing.enforce_weak_types = true;
+    let enforced = enforcing.is_subtype_of(source, target);
+    assert!(
+        !enforced,
+        "weak-type enforcement must reject `{{ c: string }}` <: `{{ a?: string }}`"
+    );
+
+    // Non-enforcing checker (the SubtypeChecker default): structurally the
+    // source satisfies an all-optional target, so it IS a subtype. This must be
+    // computed fresh, not served from the enforcing checker's cached `false`.
+    let mut relaxed = SubtypeChecker::new(&interner).with_query_db(&db);
+    let relaxed_result = relaxed.is_subtype_of(source, target);
+    assert!(
+        relaxed_result,
+        "without weak-type enforcement the all-optional target must accept the source; \
+         a cached enforced `false` must not poison this lookup"
+    );
+
+    assert_ne!(
+        enforced, relaxed_result,
+        "the two enforcement states must observe different answers for the weak-type pair"
+    );
+
+    // Re-running each checker in its own mode stays stable (no contamination
+    // through the shared cache in either direction).
+    let mut enforcing_again = SubtypeChecker::new(&interner).with_query_db(&db);
+    enforcing_again.enforce_weak_types = true;
+    assert!(!enforcing_again.is_subtype_of(source, target));
+
+    let mut relaxed_again = SubtypeChecker::new(&interner).with_query_db(&db);
+    assert!(relaxed_again.is_subtype_of(source, target));
+}
+
+#[test]
+fn weak_type_sensitive_result_is_not_memoized() {
+    // The weak-type trigger marks the in-flight result as enforcement-sensitive,
+    // which keeps it out of the shared relation cache. Probing the cache after
+    // an enforcing check must therefore report a miss for that pair, even though
+    // an ordinary (non-weak) subtype check of the same shape would be cached.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let (source, target) = weak_type_pair(&interner);
+
+    let mut enforcing = SubtypeChecker::new(&interner).with_query_db(&db);
+    enforcing.enforce_weak_types = true;
+    assert!(!enforcing.is_subtype_of(source, target));
+
+    let key = enforcing.debug_cache_key_for(source, target);
+    assert_eq!(
+        db.lookup_subtype_cache(key),
+        None,
+        "a weak-enforcement-sensitive result must not be memoized in the shared relation cache"
+    );
+}
+
 #[test]
 fn flag_flip_does_not_reuse_stale_cache_entry() {
     // Pin the cache-keying contract end-to-end: insert a result under one


### PR DESCRIPTION
## Summary

Fixes a relation-cache poisoning hazard around TS2559 weak-type enforcement. Closes #10882.

The shared relation cache key (`RelationCacheKey`) encodes every behavior-affecting *policy* flag (strict-null, strict-function, `SKIP_WEAK_TYPE_CHECKS`, …) but **not** the `SubtypeChecker`'s operation-local weak-type enforcement state: `enforce_weak_types` together with the `in_property_check` / `in_intersection_member_check` gating context. The weak-type check in `check_object_subtype` changes the structural subtype answer for weak-type targets, so a result computed with weak enforcement **active** could be memoized under the flag-agnostic key and later served to a sibling check running with weak enforcement **suppressed** (or vice-versa). Two checker instances sharing a `QueryCache` could therefore observe each other's wrong answer for `{ c: string } <: { a?: string }`-shaped pairs.

This matched the issue's "weak relation caching" signal: the cache key was too weak to distinguish weak-enforcement-sensitive results.

## Structural rule

`When a non-empty, non-weak source is compared to a weak-type target with no common property names, tsc's result depends on whether weak-type enforcement is active; tsz now records that sensitivity through the solver's relation-cache write gateway.`

## Owner layer

Solver (`relations/subtype`). The fix evaluates the weak-type *structural trigger* independently of the enforcement flags and records weak-type sensitivity through a new thread-local counter (`WEAK_TYPE_SENSITIVITY`), mirroring the established unresolved-`Lazy` snapshot mechanism (`LAZY_RESOLVE_FAILURES`) in the same module. Any subtype result whose computation hit the trigger is excluded from the shared relation cache via the existing `cache_definitive!` gateway, so the two enforcement states never contaminate each other — while every non-weak-sensitive result keeps sharing the cache.

This is deliberately chosen over adding an `enforce_weak_types` bit to `RelationCacheKey`: a cache-key flag would split the *entire* `enforce_weak_types=true` population (every assignability-internal subtype check) from the `false` population, broadly reducing cross-context cache sharing. The sensitivity counter only skips caching for the rare pairs that actually hit the weak trigger, preserving sharing everywhere else.

## Adjacent-case matrix

- Enforcing checker vs. relaxed (default) checker on the same pair → each observes its own answer (False vs. True), no poisoning in either direction.
- Intersection-member context (`in_intersection_member_check`) suppresses the weak return but still marks sensitivity, so it cannot collide with the property-check context that re-activates it.
- Non-weak targets short-circuit before the expensive `is_global_object_shape` / `has_common_property_name` work, so the common path cost is unchanged.

## Cache/order plan

`cache_definitive!` now additionally requires `weak_type_sensitivity_count()` to be unchanged across the computation window, alongside the existing unresolved-`Lazy` guard. The counter is reset in `reset_subtype_thread_local_state()` between sessions.

## Project Corpus Impact

- Row: recursive utility-type rows
- Bug family: weak relation cache poisoning / TS2559 weak-type enforcement (#10882)
- Impact: Removes latent cross-instance cache poisoning for weak-type assignability vs. pure-subtype checks. No new diagnostics are introduced; weak-sensitive relation pairs are recomputed instead of shared across enforcement contexts, and no required project row is expected to regress.

## Verification

- `cargo test -p tsz-solver --lib subtype_cache` → 53 passed (incl. 2 new weak-type regression tests).
- `cargo test -p tsz-solver --lib relation_cache` / `weak` suites → all green.
- Full `cargo test -p tsz-solver --lib` → 6554 passed; the only failure is the pre-existing `mapped.rs` file-size ratchet drift from #12739, unrelated to this change.
- `cargo clippy -p tsz-solver` → clean.
- `/simplify` (3 passes) applied: reuse `PropertyInfo::opt` in the test helper; otherwise clean.

## Coordination Notes

AgentName: Studio-B
Track: bench/performance — solver relation caching
Invariant: relation-cache results must be partitioned by every behavior-affecting input; weak-type enforcement state is operation-local and excluded from caching rather than keyed.
Scope: `crates/tsz-solver/src/relations/subtype/{cache.rs,rules/objects.rs}` + `tests/subtype_cache_tests.rs`.

https://claude.ai/code/session_01QwqGFBXXe86r8p94Cvegaz

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwqGFBXXe86r8p94Cvegaz)_