### PR TITLE
bench: prove emit detail row freshness

### DIFF
--- a/docs/development/TOOLING.md
+++ b/docs/development/TOOLING.md
@@ -171,10 +171,12 @@ family rows are suppressed by default. Pass `--include-stale-detail` only when
 the report is explicitly framed as historical checked-detail triage rather than
 the current public remaining set.
 
-When checked detail and README/public aggregates match, the named rows are still
-aggregate-only evidence. `--freshness-json` reports
-`rowFreshnessProven: false` until the detail artifact carries row-level source
-metadata.
+When checked detail and README/public aggregates match,
+`scripts/emit/emit-snapshot.json` can prove the named rows too. It does so by
+storing the checked-detail row fingerprint and result count beside the public
+summary. `--freshness-json` reports `rowFreshnessProven: true` only when the
+README aggregate, snapshot summary, detail summary, recomputed detail rows, and
+snapshot fingerprint all agree.
 
 ### Mutation Testing
 

--- a/scripts/emit/emit-snapshot.json
+++ b/scripts/emit/emit-snapshot.json
@@ -1,4 +1,6 @@
 {
+  "detailFingerprint": "sha256:ae915601e209085f2b623861b2958c2ad662e48802127c28bc065a4ba0422ed0",
+  "detailResultCount": 13531,
   "summary": {
     "jsTotal": 13530,
     "jsPass": 13468,

--- a/scripts/emit/query-emit.py
+++ b/scripts/emit/query-emit.py
@@ -42,6 +42,7 @@ import sys
 import argparse
 import re
 import json
+import hashlib
 from collections import Counter
 from pathlib import Path
 
@@ -49,6 +50,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from lib.query_snapshot import load_snapshot, print_top_counter, print_truncated_more
 
 DETAIL_FILE = Path(__file__).parent / "emit-detail.json"
+SNAPSHOT_FILE = Path(__file__).parent / "emit-snapshot.json"
 ROOT_DIR = Path(__file__).resolve().parents[2]
 README_FILE = ROOT_DIR / "README.md"
 
@@ -164,6 +166,14 @@ def load_detail():
     return load_snapshot(DETAIL_FILE, "Run: ./scripts/emit/run.sh --json-out")
 
 
+def load_emit_snapshot(path=SNAPSHOT_FILE):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except OSError:
+        return None
+
+
 def emit_summary(data):
     summary = data.get("summary", {})
     return {
@@ -199,11 +209,157 @@ def emit_summary_from_readme_text(text):
     return summary if required.issubset(summary) else None
 
 
+def emit_snapshot_summary(snapshot):
+    if not snapshot:
+        return None
+    summary = snapshot.get("summary")
+    if not summary:
+        return None
+    required = {"jsPass", "jsTotal", "dtsPass", "dtsTotal"}
+    return emit_summary({"summary": summary}) if required.issubset(summary) else None
+
+
 def emit_summary_from_readme(path=README_FILE):
     try:
         return emit_summary_from_readme_text(path.read_text())
     except OSError:
         return None
+
+
+def emit_detail_row_summary(data):
+    results = data.get("results")
+    if not isinstance(results, list):
+        return None
+
+    summary = {
+        "jsPass": 0,
+        "jsFail": 0,
+        "jsSkip": 0,
+        "jsTimeout": 0,
+        "dtsPass": 0,
+        "dtsFail": 0,
+        "dtsSkip": 0,
+    }
+    for result in results:
+        js_status = result.get("jsStatus")
+        dts_status = result.get("dtsStatus")
+        if js_status == "pass":
+            summary["jsPass"] += 1
+        elif js_status == "fail":
+            summary["jsFail"] += 1
+        elif js_status == "timeout":
+            summary["jsFail"] += 1
+            summary["jsTimeout"] += 1
+        else:
+            summary["jsSkip"] += 1
+
+        if dts_status == "pass":
+            summary["dtsPass"] += 1
+        elif dts_status == "fail":
+            summary["dtsFail"] += 1
+        elif dts_status == "timeout":
+            summary["dtsFail"] += 1
+        else:
+            summary["dtsSkip"] += 1
+
+    summary["jsTotal"] = summary["jsPass"] + summary["jsFail"]
+    summary["dtsTotal"] = summary["dtsPass"] + summary["dtsFail"]
+    return summary
+
+
+def emit_detail_rows_match_summary(data):
+    row_summary = emit_detail_row_summary(data)
+    detail_summary = data.get("summary", {})
+    if row_summary is None:
+        return False
+
+    keys = (
+        "jsPass",
+        "jsFail",
+        "jsSkip",
+        "jsTimeout",
+        "jsTotal",
+        "dtsPass",
+        "dtsFail",
+        "dtsSkip",
+        "dtsTotal",
+    )
+    return all(row_summary.get(key) == detail_summary.get(key) for key in keys)
+
+
+def emit_detail_row_fingerprint(data):
+    results = data.get("results")
+    if not isinstance(results, list):
+        return None
+
+    rows = []
+    for result in results:
+        rows.append({
+            "baselineFile": result.get("baselineFile"),
+            "dtsError": result.get("dtsError"),
+            "dtsStatus": result.get("dtsStatus"),
+            "jsError": result.get("jsError"),
+            "jsStatus": result.get("jsStatus"),
+            "name": result.get("name"),
+            "testPath": result.get("testPath"),
+        })
+    encoded = json.dumps(
+        sorted(rows, key=lambda row: (
+            row.get("name") or "",
+            row.get("baselineFile") or "",
+            row.get("testPath") or "",
+        )),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def emit_row_freshness(data, public_summary):
+    snapshot = load_emit_snapshot()
+    snapshot_summary = emit_snapshot_summary(snapshot)
+    detail_summary = emit_summary(data)
+    row_fingerprint = emit_detail_row_fingerprint(data)
+    snapshot_fingerprint = (snapshot or {}).get("detailFingerprint")
+    expected_count = (snapshot or {}).get("detailResultCount")
+    actual_count = len(data.get("results", [])) if isinstance(data.get("results"), list) else None
+    rows_match_summary = emit_detail_rows_match_summary(data)
+
+    proven = (
+        rows_match_summary
+        and row_fingerprint is not None
+        and row_fingerprint == snapshot_fingerprint
+        and expected_count == actual_count
+        and snapshot_summary == detail_summary
+        and snapshot_summary == public_summary
+    )
+
+    if proven:
+        evidence = "emit-snapshot-detail-fingerprint"
+    elif snapshot_fingerprint is None:
+        evidence = "missing-snapshot-fingerprint"
+    elif row_fingerprint != snapshot_fingerprint:
+        evidence = "snapshot-fingerprint-mismatch"
+    elif not rows_match_summary:
+        evidence = "detail-rows-summary-mismatch"
+    elif expected_count != actual_count:
+        evidence = "detail-result-count-mismatch"
+    elif snapshot_summary != detail_summary:
+        evidence = "snapshot-summary-mismatch"
+    elif snapshot_summary != public_summary:
+        evidence = "snapshot-public-summary-mismatch"
+    else:
+        evidence = "unproven"
+
+    return {
+        "proven": proven,
+        "evidence": evidence,
+        "detailFingerprint": row_fingerprint,
+        "snapshotFingerprint": snapshot_fingerprint,
+        "detailResultCount": actual_count,
+        "snapshotDetailResultCount": expected_count,
+        "detailRowsMatchSummary": rows_match_summary,
+    }
 
 
 def emit_freshness_note(detail_summary, public_summary):
@@ -250,22 +406,33 @@ def emit_freshness_status(detail_summary, public_summary):
     return {"state": "aggregate-match", **status}
 
 
-def emit_freshness_report(detail_summary, public_summary):
+def emit_freshness_report(detail_summary, public_summary, detail_data=None):
     status = emit_freshness_status(detail_summary, public_summary)
     aggregate_matches_public = status["state"] == "aggregate-match"
+    row_freshness = (
+        emit_row_freshness(detail_data, public_summary)
+        if detail_data is not None and aggregate_matches_public
+        else None
+    )
+    row_freshness_proven = bool(row_freshness and row_freshness["proven"])
     return {
         "state": status["state"],
         "detailSummary": detail_summary,
         "publicSummary": public_summary,
         "detailIsCurrent": emit_detail_is_current(status),
         "detailAggregateMatchesPublic": aggregate_matches_public,
-        "rowFreshnessProven": False,
-        "rowFreshnessEvidence": "aggregate-only" if aggregate_matches_public else status["state"],
+        "rowFreshnessProven": row_freshness_proven,
+        "rowFreshnessEvidence": (
+            row_freshness["evidence"]
+            if row_freshness is not None
+            else ("aggregate-only" if aggregate_matches_public else status["state"])
+        ),
+        "rowFreshness": row_freshness,
         "jsPassDelta": status.get("jsPassDelta"),
         "dtsPassDelta": status.get("dtsPassDelta"),
         "jsTotalDelta": status.get("jsTotalDelta"),
         "dtsTotalDelta": status.get("dtsTotalDelta"),
-        "message": emit_freshness_status_line_from_status(status),
+        "message": emit_freshness_status_line_from_report(status, row_freshness),
     }
 
 
@@ -273,6 +440,21 @@ def emit_freshness_status_line(data):
     detail_summary = emit_summary(data)
     public_summary = emit_summary_from_readme()
     status = emit_freshness_status(detail_summary, public_summary)
+    row_freshness = (
+        emit_row_freshness(data, public_summary)
+        if status["state"] == "aggregate-match"
+        else None
+    )
+    return emit_freshness_status_line_from_report(status, row_freshness)
+
+
+def emit_freshness_status_line_from_report(status, row_freshness):
+    if status["state"] == "aggregate-match" and row_freshness and row_freshness["proven"]:
+        return (
+            "Emit detail freshness: row-proven "
+            "(README/public aggregate matches checked detail; "
+            "emit-snapshot fingerprint matches detail rows)."
+        )
     return emit_freshness_status_line_from_status(status)
 
 
@@ -382,7 +564,7 @@ def print_emit_freshness_status(data):
 def print_emit_freshness_json(data):
     print(
         json.dumps(
-            emit_freshness_report(emit_summary(data), emit_summary_from_readme()),
+            emit_freshness_report(emit_summary(data), emit_summary_from_readme(), data),
             sort_keys=True,
         )
     )
@@ -584,10 +766,11 @@ def failure_count_by_surface(data, surface):
     return sum(len(results) for results in collect_failures_by_family(data, surface).values())
 
 
-def failure_family_report(data, top=20, include_stale_detail=False):
-    detail_summary = emit_summary(data)
+def failure_family_report(data, top=20, include_stale_detail=False, freshness_data=None):
+    freshness_data = freshness_data or data
+    detail_summary = emit_summary(freshness_data)
     public_summary = emit_summary_from_readme()
-    freshness = emit_freshness_report(detail_summary, public_summary)
+    freshness = emit_freshness_report(detail_summary, public_summary, freshness_data)
     families_suppressed = freshness["state"] == "stale" and not include_stale_detail
 
     surfaces = []
@@ -615,19 +798,25 @@ def failure_family_report(data, top=20, include_stale_detail=False):
     }
 
 
-def print_failure_families_json(data, top=20, include_stale_detail=False):
+def print_failure_families_json(data, top=20, include_stale_detail=False, freshness_data=None):
     print(
         json.dumps(
-            failure_family_report(data, top=top, include_stale_detail=include_stale_detail),
+            failure_family_report(
+                data,
+                top=top,
+                include_stale_detail=include_stale_detail,
+                freshness_data=freshness_data,
+            ),
             sort_keys=True,
         )
     )
 
 
-def show_failure_families(data, top=20, include_stale_detail=False):
+def show_failure_families(data, top=20, include_stale_detail=False, freshness_data=None):
     print("Emit failure families")
     print()
-    detail_summary = emit_summary(data)
+    freshness_data = freshness_data or data
+    detail_summary = emit_summary(freshness_data)
     public_summary = emit_summary_from_readme()
     freshness_status = emit_freshness_status(detail_summary, public_summary)
     if freshness_status["state"] == "stale" and not include_stale_detail:
@@ -635,10 +824,10 @@ def show_failure_families(data, top=20, include_stale_detail=False):
         return
 
     if freshness_status["state"] == "aggregate-match":
-        print(emit_freshness_status_line_from_status(freshness_status))
+        print(emit_freshness_status_line(freshness_data))
         print()
     else:
-        print_emit_freshness_note(data)
+        print_emit_freshness_note(freshness_data)
 
     for surface, title in (("js", "JavaScript"), ("dts", "Declaration")):
         families = collect_failures_by_family(data, surface)
@@ -762,9 +951,19 @@ def main():
     elif args.top_errors:
         show_top_errors(filtered_data, args.top)
     elif args.families_json:
-        print_failure_families_json(filtered_data, args.top, args.include_stale_detail)
+        print_failure_families_json(
+            filtered_data,
+            args.top,
+            args.include_stale_detail,
+            freshness_data=data,
+        )
     elif args.families:
-        show_failure_families(filtered_data, args.top, args.include_stale_detail)
+        show_failure_families(
+            filtered_data,
+            args.top,
+            args.include_stale_detail,
+            freshness_data=data,
+        )
     elif args.close:
         show_close(filtered_data, args.top)
     elif args.status:

--- a/scripts/emit/src/runner.ts
+++ b/scripts/emit/src/runner.ts
@@ -160,6 +160,25 @@ function stableStringify(value: Record<string, unknown>): string {
   return JSON.stringify(obj);
 }
 
+function detailRowsFingerprint(results: Array<Record<string, unknown>>): string {
+  const rows = results.map(result => ({
+    baselineFile: result.baselineFile ?? null,
+    dtsError: result.dtsError ?? null,
+    dtsStatus: result.dtsStatus ?? null,
+    jsError: result.jsError ?? null,
+    jsStatus: result.jsStatus ?? null,
+    name: result.name ?? null,
+    testPath: result.testPath ?? null,
+  })).sort((left, right) => {
+    const leftKey = `${left.name ?? ''}\0${left.baselineFile ?? ''}\0${left.testPath ?? ''}`;
+    const rightKey = `${right.name ?? ''}\0${right.baselineFile ?? ''}\0${right.testPath ?? ''}`;
+    if (leftKey < rightKey) return -1;
+    if (leftKey > rightKey) return 1;
+    return 0;
+  });
+  return `sha256:${hashString(JSON.stringify(rows))}`;
+}
+
 function getCacheKey(
   sourceKey: string,
   target: number,
@@ -1519,6 +1538,8 @@ async function main() {
     const dtsTotal = dtsPass + dtsFail;
     const detail = {
       timestamp: new Date().toISOString(),
+      detailFingerprint: detailRowsFingerprint(allResults),
+      detailResultCount: allResults.length,
       summary: {
         jsTotal,
         jsPass,

--- a/scripts/emit/test_query_emit_families.py
+++ b/scripts/emit/test_query_emit_families.py
@@ -182,6 +182,142 @@ after
         self.assertFalse(report["rowFreshnessProven"])
         self.assertEqual(report["rowFreshnessEvidence"], "aggregate-only")
 
+    def test_freshness_report_marks_matching_snapshot_fingerprint_as_row_proven(self):
+        data = {
+            "summary": {
+                "jsPass": 1,
+                "jsFail": 1,
+                "jsSkip": 1,
+                "jsTimeout": 0,
+                "jsTotal": 2,
+                "dtsPass": 2,
+                "dtsFail": 1,
+                "dtsSkip": 0,
+                "dtsTotal": 3,
+            },
+            "results": [
+                {
+                    "name": "alpha",
+                    "baselineFile": "alpha.js",
+                    "testPath": "tests/cases/compiler/alpha.ts",
+                    "jsStatus": "pass",
+                    "dtsStatus": "pass",
+                },
+                {
+                    "name": "beta",
+                    "baselineFile": "beta.js",
+                    "testPath": "tests/cases/compiler/beta.ts",
+                    "jsStatus": "fail",
+                    "dtsStatus": "pass",
+                    "jsError": "+1/-1 lines",
+                },
+                {
+                    "name": "gamma",
+                    "baselineFile": "gamma.js",
+                    "testPath": "tests/cases/compiler/gamma.ts",
+                    "jsStatus": "skip",
+                    "dtsStatus": "fail",
+                    "dtsError": "+1/-1 lines",
+                },
+            ],
+        }
+        public_summary = self.mod.emit_summary(data)
+        fingerprint = self.mod.emit_detail_row_fingerprint(data)
+        original = self.mod.load_emit_snapshot
+        self.mod.load_emit_snapshot = lambda: {
+            "detailFingerprint": fingerprint,
+            "detailResultCount": 3,
+            "summary": dict(data["summary"]),
+        }
+        try:
+            report = self.mod.emit_freshness_report(
+                self.mod.emit_summary(data),
+                public_summary,
+                data,
+            )
+        finally:
+            self.mod.load_emit_snapshot = original
+
+        self.assertTrue(report["rowFreshnessProven"])
+        self.assertEqual(
+            report["rowFreshnessEvidence"],
+            "emit-snapshot-detail-fingerprint",
+        )
+        self.assertTrue(report["rowFreshness"]["detailRowsMatchSummary"])
+        self.assertIn("row-proven", report["message"])
+
+    def test_freshness_report_rejects_snapshot_fingerprint_mismatch(self):
+        data = {
+            "summary": {
+                "jsPass": 1,
+                "jsFail": 0,
+                "jsSkip": 0,
+                "jsTimeout": 0,
+                "jsTotal": 1,
+                "dtsPass": 1,
+                "dtsFail": 0,
+                "dtsSkip": 0,
+                "dtsTotal": 1,
+            },
+            "results": [
+                {
+                    "name": "alpha",
+                    "baselineFile": "alpha.js",
+                    "testPath": "tests/cases/compiler/alpha.ts",
+                    "jsStatus": "pass",
+                    "dtsStatus": "pass",
+                },
+            ],
+        }
+        original = self.mod.load_emit_snapshot
+        self.mod.load_emit_snapshot = lambda: {
+            "detailFingerprint": "sha256:not-the-detail",
+            "detailResultCount": 1,
+            "summary": dict(data["summary"]),
+        }
+        try:
+            report = self.mod.emit_freshness_report(
+                self.mod.emit_summary(data),
+                self.mod.emit_summary(data),
+                data,
+            )
+        finally:
+            self.mod.load_emit_snapshot = original
+
+        self.assertFalse(report["rowFreshnessProven"])
+        self.assertEqual(
+            report["rowFreshnessEvidence"],
+            "snapshot-fingerprint-mismatch",
+        )
+
+    def test_detail_row_summary_counts_dts_timeout_as_failure(self):
+        data = {
+            "summary": {
+                "jsPass": 1,
+                "jsFail": 0,
+                "jsSkip": 0,
+                "jsTimeout": 0,
+                "jsTotal": 1,
+                "dtsPass": 0,
+                "dtsFail": 1,
+                "dtsSkip": 0,
+                "dtsTotal": 1,
+            },
+            "results": [
+                {
+                    "name": "alpha",
+                    "baselineFile": "alpha.js",
+                    "testPath": "tests/cases/compiler/alpha.ts",
+                    "jsStatus": "pass",
+                    "dtsStatus": "timeout",
+                    "dtsError": "TIMEOUT",
+                },
+            ],
+        }
+
+        self.assertEqual(self.mod.emit_detail_row_summary(data), data["summary"])
+        self.assertTrue(self.mod.emit_detail_rows_match_summary(data))
+
     def test_freshness_note_ignores_different_emit_domains(self):
         note = self.mod.emit_freshness_note(
             {
@@ -510,6 +646,75 @@ after
         self.assertIn("Emit detail freshness: aggregate-match", text)
         self.assertIn("per-row freshness is not proven", text)
         self.assertIn("JavaScript: 1 failures/timeouts", text)
+
+    def test_filtered_family_json_uses_full_detail_for_row_freshness(self):
+        data = {
+            "summary": {
+                "jsPass": 1,
+                "jsFail": 1,
+                "jsSkip": 0,
+                "jsTimeout": 0,
+                "jsTotal": 2,
+                "dtsPass": 2,
+                "dtsFail": 0,
+                "dtsSkip": 0,
+                "dtsTotal": 2,
+            },
+            "results": [
+                {
+                    **make_result("classUsedBeforeInitializedVariables", js_error="+1/-1 lines"),
+                    "dtsStatus": "pass",
+                },
+                {
+                    **make_result("mappedTypeProperties"),
+                    "jsStatus": "pass",
+                    "dtsStatus": "pass",
+                    "jsError": "",
+                    "dtsError": "",
+                },
+            ],
+        }
+        fingerprint = self.mod.emit_detail_row_fingerprint(data)
+        original_argv = sys.argv
+        original_load_detail = self.mod.load_detail
+        original_readme = self.mod.emit_summary_from_readme
+        original_snapshot = self.mod.load_emit_snapshot
+        self.mod.load_detail = lambda: data
+        self.mod.emit_summary_from_readme = lambda: self.mod.emit_summary(data)
+        self.mod.load_emit_snapshot = lambda: {
+            "detailFingerprint": fingerprint,
+            "detailResultCount": 2,
+            "summary": dict(data["summary"]),
+        }
+        sys.argv = [
+            "query-emit.py",
+            "--families-json",
+            "--filter",
+            "class",
+        ]
+        try:
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                rc = self.mod.main()
+        finally:
+            sys.argv = original_argv
+            self.mod.load_detail = original_load_detail
+            self.mod.emit_summary_from_readme = original_readme
+            self.mod.load_emit_snapshot = original_snapshot
+
+        self.assertEqual(rc, 0)
+        report = json.loads(out.getvalue())
+        self.assertTrue(report["freshness"]["rowFreshnessProven"])
+        self.assertEqual(
+            report["freshness"]["rowFreshnessEvidence"],
+            "emit-snapshot-detail-fingerprint",
+        )
+        self.assertEqual(report["freshness"]["rowFreshness"]["detailResultCount"], 2)
+        self.assertEqual(report["surfaces"][0]["checkedDetailFailures"], 1)
+        self.assertEqual(
+            report["surfaces"][0]["families"][0]["examples"],
+            ["classUsedBeforeInitializedVariables"],
+        )
 
     def test_stale_headline_summary_uses_public_aggregate(self):
         detail_summary = {


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Studio-Opus infrastructure / emit evidence freshness

## Invariant
When README/public emit aggregates match the checked detail summary, tsz tooling may cite named JS/DTS failure rows only if the checked-in snapshot proves that the detail rows produced that aggregate; this PR makes `query-emit` require a snapshot detail-row fingerprint, matching result count, matching detail summary, and matching README aggregate before reporting row-proven evidence.

## Scope
- Add stable detail-row fingerprinting and row-summary recomputation to `scripts/emit/query-emit.py`.
- Store the current detail-row fingerprint and result count in `scripts/emit/emit-snapshot.json`.
- Teach the emit runner JSON output to include `detailFingerprint` and `detailResultCount` for future refreshes.
- Document the row-proven evidence contract in `docs/development/TOOLING.md`.

## Project Corpus Impact
- Row: n/a
- Bug family: emit metric/evidence freshness
- Evidence: no compiler behavior or project-row metadata changes; this only strengthens offline emit evidence used by Studio-C and release metric triage.

## Verification
- python3 scripts/emit/test_query_emit_families.py
- python3 scripts/ci/test_refresh_readme.py
- python3 scripts/emit/query-emit.py --freshness-json
- python3 scripts/emit/query-emit.py --families
- python3 scripts/emit/query-emit.py --families-json
- scripts/emit/run.sh --max=1 --json-out=/tmp/tsz-emit-detail-smoke.json
- git diff --check origin/main...HEAD
- Draft CI Light Summary: pass (run 27050047564)

## Coordination Notes
- Ready for PR-head CI. No overlap with Studio-C emit output fixes; this is evidence plumbing for emit-family triage and public metric confidence.
- `node_modules/.bin/tsc -p scripts/emit/tsconfig.json --noEmit` could not run locally because the checkout lacks `@types/node`; the emit wrapper built the runner successfully during the one-test smoke.
