### PR TITLE
ci: require project canary before summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1244,6 +1244,7 @@ jobs:
       - dist-binaries
       - lsp-e2e
       - project-compile-guard
+      - project-compile-canary
       - wasm
       - wasm-web
       - node-harness-prep
@@ -1280,6 +1281,7 @@ jobs:
           arch_tool_only = gate.get("outputs", {}).get("arch_tool_only") == "true"
           metadata_only_skip = gate.get("outputs", {}).get("metadata_only_skip") == "true"
           compiler_checks_required = gate.get("outputs", {}).get("compiler_checks_required") != "false"
+          required_summary = gate.get("outputs", {}).get("required_summary") == "true"
 
           gate_result = gate.get("result")
           if gate_result != "success":
@@ -1316,20 +1318,24 @@ jobs:
               runs = github_json(f"/repos/{repository}/actions/workflows/ci.yml/runs?{query}").get("workflow_runs", [])
               runs = [run for run in runs if int(run.get("id", 0)) != current_run_id]
               runs.sort(key=lambda run: run.get("created_at", ""), reverse=True)
+              accepted_summary_names = ("CI Summary",) if required_summary else ("CI Summary", "CI Light Summary")
+              accepted_summary_label = "CI Summary" if required_summary else "CI Summary or CI Light Summary"
               for run in runs:
                   jobs = github_json(f"/repos/{repository}/actions/runs/{run['id']}/jobs?per_page=100").get("jobs", [])
-                  summaries = [job for job in jobs if job.get("name") == "CI Summary"]
+                  summaries = [job for job in jobs if job.get("name") in accepted_summary_names]
                   if not summaries:
                       continue
-                  summary = summaries[-1]
+                  summaries.sort(key=lambda job: 0 if job.get("name") == "CI Summary" else 1)
+                  summary = summaries[0]
+                  summary_name = summary.get("name") or "CI Summary"
                   conclusion = summary.get("conclusion")
                   url = summary.get("html_url") or run.get("html_url")
                   if conclusion == "success":
-                      print(f"Metadata-only CI mirrors successful CI Summary from run {run['id']}: {url}")
+                      print(f"Metadata-only CI mirrors successful {summary_name} from run {run['id']}: {url}")
                       return
-                  print(f"Previous CI Summary for this head was {conclusion or 'missing'} in run {run['id']}: {url}")
+                  print(f"Previous {summary_name} for this head was {conclusion or 'missing'} in run {run['id']}: {url}")
                   sys.exit(1)
-              print(f"Metadata-only CI could not find a previous required CI Summary for head {head_sha}.")
+              print(f"Metadata-only CI could not find a previous {accepted_summary_label} for head {head_sha}.")
               sys.exit(1)
 
           if not should_run:
@@ -1369,6 +1375,7 @@ jobs:
           if full_run and compiler_checks_required:
               required.update({
                   "project-compile-guard",
+                  "project-compile-canary",
                   "conformance-snapshot-gate",
               })
               required.update({

--- a/scripts/ci/test-pr-ready-state.mjs
+++ b/scripts/ci/test-pr-ready-state.mjs
@@ -139,8 +139,18 @@ assert.match(
 );
 assert.match(
   ciWorkflow,
-  /github\.event\.action }}"\s*==\s*"edited"[\s\S]+?PR metadata edited[\s\S]+?should_run=false[\s\S]+?full_run=false[\s\S]+?required_summary=false[\s\S]+?compiler_checks_required=false/,
-  "edited PR events should refresh body/ready-state gates without publishing protected CI Summary",
+  /if \[\[ "\$\{\{ github\.event\.action \}\}" == "edited" \]\]; then[\s\S]+?PR metadata edited[\s\S]+?should_run=false[\s\S]+?full_run=false[\s\S]+?metadata_only_skip=true[\s\S]+?compiler_checks_required=false[\s\S]+?fi/,
+  "edited PR events should refresh body/ready-state gates without heavy CI",
+);
+assert.match(
+  ciWorkflow,
+  /accepted_summary_names = \("CI Summary",\) if required_summary else \("CI Summary", "CI Light Summary"\)[\s\S]+?job\.get\("name"\) in accepted_summary_names[\s\S]+?Metadata-only CI mirrors successful \{summary_name\}/,
+  "metadata-only edited runs should require prior full summaries when publishing protected CI Summary",
+);
+assert.match(
+  ciWorkflow,
+  /accepted_summary_label = "CI Summary" if required_summary else "CI Summary or CI Light Summary"[\s\S]+?previous \{accepted_summary_label\}/,
+  "metadata-only edited runs should report the accepted prior summary class when no mirror exists",
 );
 
 assert.match(
@@ -165,6 +175,12 @@ assert.doesNotMatch(
   ciWorkflow,
   /Treating as neutral/,
   "CI Summary must not treat cancelled required jobs as a neutral protected check",
+);
+
+assert.match(
+  ciWorkflow,
+  /\n\s{2}ci-summary:\n[\s\S]+?needs:[\s\S]+?- project-compile-guard\s*\n\s+- project-compile-canary[\s\S]+?"project-compile-guard",\s*\n\s+"project-compile-canary",/,
+  "CI Summary must wait for the project compile canary before reporting required full-run success",
 );
 
 for (const job of ["lint", "cargo-shear", "cargo-deny"]) {


### PR DESCRIPTION
AgentName: Studio-Opus

## Track
Studio CI / project corpus infrastructure

## Invariant
When full compiler CI runs, CI Summary must wait for project-compile-canary to finish before reporting required success. The canary remains continue-on-error, but the protected summary cannot go green before the canary artifact/status surface is complete. Metadata-only edited runs must mirror a previous successful summary for the same head; when they publish the protected CI Summary context, only prior full CI Summary evidence is accepted.

## Scope
- Add project-compile-canary to ci-summary needs in .github/workflows/ci.yml.
- Add project-compile-canary to the full-run required set in the CI Summary verifier.
- Teach metadata-only edited runs to mirror a previous successful CI Summary or CI Light Summary for the same head only when the current metadata job is light; protected CI Summary metadata jobs require prior protected CI Summary evidence.
- Add workflow regression assertions in scripts/ci/test-pr-ready-state.mjs so the canary dependency and metadata mirror behavior stay paired with the summary implementation.

## Project Corpus Impact
- Row: n/a (CI/project corpus infrastructure)
- Bug family: project-compile canary CI summary freshness
- Preserves project compile canary evidence for PR-head and merge-group runs. This directly addresses the race observed while landing #12744: PR-head run 27051041254 and merge-group run 27051345800 had CI Summary green while project-compile-canary was still active; #12744 merged at 2026-06-06T03:44:22Z while the merge-group workflow still reported in_progress because the canary was still tailing.

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml-ok"'
- node scripts/ci/test-pr-ready-state.mjs
- node scripts/ci/test-cloudbuild-config-paths.mjs
- wc -l .github/workflows/ci.yml scripts/ci/test-pr-ready-state.mjs
- PR-head full CI run 27052895774 on 51d485bb0fffcd6aacb1d3992e926d9c89fa9997: CI Summary passed after project-compile-canary passed. All required full-run checks passed, including project-corpus-pr-body, project-row-drift, conformance aggregate, emit, fourslash aggregate, LSP, WASM, dist, unit, project-compile-guard, and project-compile-canary.
- Live race proof from run 27052895774: all other required checks passed while project-compile-canary was still pending, and CI Summary remained absent until project-compile-canary completed.
- CI-debug evidence: metadata-only edited run 27052018223 failed before this fix because it could not find a previous required CI Summary for a draft/light head; later queue review showed ready metadata edits must preserve protected CI Summary eligibility, so the final head accepts CI Light Summary only for light metadata jobs. Metadata-only edited run 27053252287 then published CI Summary and passed by mirroring the prior full CI Summary for this head.

## Coordination Notes
No owned Studio-Opus PRs were open at intake; recent Studio-Opus PR #12744 is merged into origin/main. PR #12745 has exact-head full CI proof and is ready for merge queue after the final metadata-only body-edit refresh passes.