### PR TITLE
chore(ci): drop stale cargo-shear rayon ignore

### DIFF
--- a/crates/tsz-solver/Cargo.toml
+++ b/crates/tsz-solver/Cargo.toml
@@ -29,9 +29,6 @@ stacker = "0.1.23"
 rayon = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-[package.metadata.cargo-shear]
-ignored = ["rayon"]
-
 [lints]
 workspace = true
 


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Tech-debt / CI dependency-hygiene cleanup.

## Invariant
When a dependency is actively used by a crate target, cargo-shear should not keep a stale ignore entry for it; this PR removes only the obsolete tsz-solver metadata while preserving the `rayon` dev-dependency.

## Scope
- Remove the redundant `rayon` cargo-shear ignore from `crates/tsz-solver/Cargo.toml`.

## Project Corpus Impact
- Row: n/a (CI/dependency hygiene only)
- Bug family: cargo-shear warning noise / dependency metadata drift

## Verification
- `git diff --check`
- `cargo shear` (passes; existing unlinked-file/doctest warnings remain, and the previous redundant `rayon` ignore warning is gone)
- Exact-head PR CI run `27053645877` on `734685bf75f246c8d1864c092eac7563703fa668`: `cargo-shear`, `project-row-drift`, `project-corpus-pr-body`, `lint`, `cargo-deny`, `unit`, `dist-binaries`, `emit`, `lsp-e2e`, `project-compile-guard`, `project-compile-canary`, conformance/fourslash aggregates, WASM, and `CI Summary` passed. `CI Summary` started after `project-compile-canary` completed.

## Coordination Notes
- No open Studio-Opus PRs were active before this branch.
- Open Studio-B/M1/M4 semantic and performance PRs are unrelated; this does not touch compiler behavior.
- Earlier draft/light run `27053641040` was canceled by the ready-state run and left stale failed matrix-summary entries in flat `gh pr checks`; branch protection is clean on the ready run.
