### PR TITLE
chore(ci): disable empty checker doctests

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -14,6 +14,9 @@ categories.workspace = true
 [features]
 default = []
 
+[lib]
+doctest = false
+
 [dependencies]
 tsz-common = { workspace = true }
 tsz-scanner = { workspace = true }


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Tech-debt / CI dependency-hygiene cleanup.

## Invariant
When a crate has no doctest examples, its lib target should not run an empty doctest harness; this PR makes `tsz-checker` match neighboring library crates by setting `doctest = false`.

## Scope
- Add `[lib] doctest = false` to `crates/tsz-checker/Cargo.toml`.

## Project Corpus Impact
- Row: n/a (CI/dependency hygiene only)
- Bug family: cargo-shear warning noise / crate metadata drift

## Verification
- `git diff --check`
- `cargo metadata --no-deps --format-version 1`
- `cargo shear` (passes; warning count drops from 8 to 7 and the `tsz_checker` empty-doctest warning is gone)
- Exact-head PR CI run `27054495035` on `89c54f218eea9398471db4146b26d173d7454350`: `cargo-shear`, `project-row-drift`, `project-corpus-pr-body`, `lint`, `cargo-deny`, `unit`, `dist-binaries`, `emit`, `lsp-e2e`, `project-compile-guard`, `project-compile-canary`, conformance/fourslash aggregates, WASM, and `CI Summary` passed. `CI Summary` started after `project-compile-canary` completed.

## Coordination Notes
- No open Studio-Opus PRs were active before this branch.
- Open Studio-B/M1/M4 semantic and performance PRs are unrelated; this does not touch compiler behavior.
- Earlier draft/light run `27054490165` was canceled by the ready-state run and left stale failed matrix-summary entries in flat `gh pr checks`; branch protection is clean on the ready run.
