### PR TITLE
fix(conformance): retire resolved accepted-regression entries

### DIFF
--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -34,6 +34,9 @@
 # - PR #12702 run 27037509191 at exact head 591b1dee210f found six rows
 #   unlisted and eleven previous accepted rows resolved after the recovered
 #   generic-parameter-tail parser fix.
+# - PR #12748 run 27057787055 at synthetic merge bf33f5f1ef found four
+#   current-main rows still failing on exact-head aggregate after rebasing on
+#   current main.
 # Keep these visible as accepted-regression debt until their owning parity
 # fixes remove them from exact-head aggregate output.
 TypeScript/tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts
@@ -50,8 +53,8 @@ TypeScript/tests/cases/compiler/letInConstDeclarations_ES6.ts
 TypeScript/tests/cases/compiler/letInLetConstDeclOfForOfAndForIn_ES6.ts
 TypeScript/tests/cases/compiler/letInLetDeclarations_ES6.ts
 TypeScript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts
-TypeScript/tests/cases/compiler/promisesWithConstraints.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
+TypeScript/tests/cases/compiler/promisesWithConstraints.ts
 TypeScript/tests/cases/compiler/strictModeReservedWord.ts
 TypeScript/tests/cases/compiler/unicodeEscapesInNames02.ts
 TypeScript/tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts
@@ -67,7 +70,6 @@ TypeScript/tests/cases/conformance/node/nodeModulesImportTypeModeDeclarationEmit
 TypeScript/tests/cases/conformance/parser/ecmascript5/Fuzz/parser0_004152.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes2.ts
-TypeScript/tests/cases/conformance/types/rest/genericRestParameters3.ts
 TypeScript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts
 # covariantCallbacks.ts: RESOLVED by PR #12482. tsz now detects nullable-union
 # callback method parameters the way tsc does (getSingleCallSignature(


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Conformance strictness / accepted-regression ledger cleanup.

## Invariant
When exact-head conformance aggregate no longer returns accepted-regression paths, those paths should be removed from `scripts/conformance/conformance-accepted-regressions.txt`; rows still returned by aggregate remain listed until focused parity fixes remove them.

## Scope
- `scripts/conformance/conformance-accepted-regressions.txt`

## Project Corpus Impact
- Row: n/a
- Bug family: accepted-regression strictness ledger

No project-corpus behavior or benchmark rows change. Exact-head aggregate run 27057787055 at synthetic merge `bf33f5f1ef` showed four current-main rows still failing after rebasing on current main, so this branch keeps those rows listed with the rest of the current accepted-regression debt.

## Verification
- `python3 scripts/conformance/query-conformance.py --dashboard` -> `12585/12585`, accepted-regression gate `32 listed tests`
- `python3 -m unittest scripts.conformance.test_query_conformance scripts.conformance.test_link_regression_issues`
- `git diff --check`
- Exact-head CI run 27058217365 at head `1e1793a591`: full PR-head CI passed, including `conformance-aggregate` and `CI Summary`.
- Pending fresh exact-head CI for rebased head `ae5a422c00` before queueing/landing.

## Coordination Notes
- User requested focused PRs, so this PR only updates the strictness ledger to the current exact-head aggregate truth; it does not attempt to clear the remaining accepted-regression debt.
- Current open accepted-regression policy issue remains #12545; this PR ratchets the checked ledger by preserving exact-head still-failing rows and avoiding stale “resolved” reporting.