### PR TITLE
fix(solver): re-generalize piped generic functions (#10816)

### DIFF
--- a/crates/tsz-solver/src/operations/core/call_evaluator.rs
+++ b/crates/tsz-solver/src/operations/core/call_evaluator.rs
@@ -245,11 +245,11 @@ pub struct CallEvaluator<'a, C: AssignabilityChecker> {
     /// or stale state.
     pub(crate) current_call_inference_placeholders: FxHashSet<tsz_common::Atom>,
     /// Subset of [`Self::current_call_inference_placeholders`] that appears in
-    /// more than one parameter of the callee signature. When an argument's
-    /// contextual target uses a shared placeholder (e.g. the middle type `B` in
-    /// `compose(f: (a: A) => B, g: (b: B) => C)`), the argument's free type
-    /// parameters must instead chain through the shared inference variable, so
-    /// higher-order re-generalization of that argument is suppressed.
+    /// more than one parameter of the callee signature. Shared placeholders are
+    /// tracked as call-shape metadata for inference ordering decisions; pure
+    /// higher-order generic arguments may still re-generalize through them so
+    /// wrappers such as `pipe(f: (a: A) => B, g: (b: B) => C)` preserve the
+    /// middle return-to-parameter flow.
     pub(crate) shared_inference_placeholders: FxHashSet<tsz_common::Atom>,
 }
 

--- a/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
+++ b/crates/tsz-solver/src/operations/generic_call/inference_helpers.rs
@@ -1751,16 +1751,17 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 .map(|&pt| self.outer_inference_placeholder_atom(pt))
                 .collect();
             // Fail closed: only re-generalize when the placeholders belong to the
-            // call currently being resolved (guards against nested/stale state)
-            // and none of them is shared across multiple callee parameters (which
-            // would chain this argument's type parameters through a shared
-            // inference variable, e.g. `compose`'s middle type `B`).
+            // call currently being resolved (guards against nested/stale state).
+            // Shared placeholders are allowed here: in pure higher-order wrappers
+            // like `pipe`, the shared middle type is exactly how tsc carries a
+            // source placeholder from one generic function argument's return into
+            // the next generic function argument's parameter before the final
+            // result is re-generalized.
             let safe_to_regeneralize = placeholder_atoms.as_ref().is_some_and(|atoms| {
                 !atoms.is_empty()
-                    && atoms.iter().all(|atom| {
-                        self.current_call_inference_placeholders.contains(atom)
-                            && !self.shared_inference_placeholders.contains(atom)
-                    })
+                    && atoms
+                        .iter()
+                        .all(|atom| self.current_call_inference_placeholders.contains(atom))
             });
             if safe_to_regeneralize {
                 return source_ty;

--- a/crates/tsz-solver/tests/operations_tests_parts/part_07.rs
+++ b/crates/tsz-solver/tests/operations_tests_parts/part_07.rs
@@ -649,3 +649,181 @@ fn test_union_new_all_fail_requires_all_member_success() {
         "string arg where member1 fails should fail the union. Got: {result:?}"
     );
 }
+
+#[test]
+fn higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+    let mut evaluator = CallEvaluator::new(&interner, &mut checker);
+
+    let a_param = TypeParamInfo {
+        name: interner.intern_string("A"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let b_param = TypeParamInfo {
+        name: interner.intern_string("B"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let c_param = TypeParamInfo {
+        name: interner.intern_string("C"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let a_type = interner.type_param(a_param);
+    let b_type = interner.type_param(b_param);
+    let c_type = interner.type_param(c_param);
+
+    let first_step = interner.function(FunctionShape {
+        type_params: vec![],
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string("input")),
+            type_id: a_type,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: b_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let second_step = interner.function(FunctionShape {
+        type_params: vec![],
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string("middle")),
+            type_id: b_type,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: c_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let piped_return = interner.function(FunctionShape {
+        type_params: vec![],
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string("value")),
+            type_id: a_type,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: c_type,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let pipe = interner.function(FunctionShape {
+        type_params: vec![a_param, b_param, c_param],
+        params: vec![
+            ParamInfo {
+                name: Some(interner.intern_string("left")),
+                type_id: first_step,
+                optional: false,
+                rest: false,
+            },
+            ParamInfo {
+                name: Some(interner.intern_string("right")),
+                type_id: second_step,
+                optional: false,
+                rest: false,
+            },
+        ],
+        this_type: None,
+        return_type: piped_return,
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    let x_param = TypeParamInfo {
+        name: interner.intern_string("X"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let y_param = TypeParamInfo {
+        name: interner.intern_string("Y"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let x_type = interner.type_param(x_param);
+    let y_type = interner.type_param(y_param);
+    let list = interner.function(FunctionShape {
+        type_params: vec![x_param],
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string("item")),
+            type_id: x_type,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: interner.array(x_type),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let wrap = interner.function(FunctionShape {
+        type_params: vec![y_param],
+        params: vec![ParamInfo {
+            name: Some(interner.intern_string("entry")),
+            type_id: y_type,
+            optional: false,
+            rest: false,
+        }],
+        this_type: None,
+        return_type: interner.array(y_type),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    let result = evaluator.resolve_call(pipe, &[list, wrap]);
+    let CallResult::Success(return_type) = result else {
+        panic!("expected higher-order generic composition to succeed, got {result:?}");
+    };
+    let Some(TypeData::Function(shape_id)) = interner.lookup(return_type) else {
+        panic!("expected composed return to be a function, got {:?}", interner.lookup(return_type));
+    };
+    let shape = interner.function_shape(shape_id);
+    assert_eq!(
+        shape.type_params.len(),
+        1,
+        "tsc re-generalizes the composed function instead of collapsing it to unknown"
+    );
+    let hoisted = shape.type_params[0].name;
+    let Some(TypeData::TypeParameter(param_info)) = interner.lookup(shape.params[0].type_id) else {
+        panic!(
+            "expected composed parameter to be the hoisted type parameter, got {:?}",
+            interner.lookup(shape.params[0].type_id)
+        );
+    };
+    assert_eq!(param_info.name, hoisted);
+    let Some(TypeData::Array(outer)) = interner.lookup(shape.return_type) else {
+        panic!(
+            "expected composed return to be an array, got {:?}",
+            interner.lookup(shape.return_type)
+        );
+    };
+    let Some(TypeData::Array(inner)) = interner.lookup(outer) else {
+        panic!(
+            "expected composed return to be a nested array, got {:?}",
+            interner.lookup(outer)
+        );
+    };
+    let Some(TypeData::TypeParameter(return_info)) = interner.lookup(inner) else {
+        panic!(
+            "expected nested array element to be the hoisted type parameter, got {:?}",
+            interner.lookup(inner)
+        );
+    };
+    assert_eq!(return_info.name, hoisted);
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Benchmark blocker / semantic campaign for #10816 (`ts-toolbelt-project`, generic-inference).

## Invariant
When a pure higher-order wrapper composes generic function arguments through a shared middle type parameter, `tsc` preserves the source generic argument/return flow and re-generalizes the returned function. This PR makes tsz keep that flow through the solver generic-call source-placeholder path instead of collapsing the shared placeholder path to `unknown`.

## Scope
- `crates/tsz-solver/src/operations/generic_call/inference_helpers.rs`: allow pure higher-order source-placeholder re-generalization even when the contextual placeholder is shared across callee parameters.
- `crates/tsz-solver/src/operations/core/call_evaluator.rs`: update the shared-placeholder metadata contract comment.
- `crates/tsz-solver/tests/operations_tests_parts/part_07.rs`: add a renamed-binder `pipe(list, wrap)` regression for re-generalizing the returned function.

## Project Corpus Impact
- Row: `ts-toolbelt-project`.
- Bug family: higher-order generic composition / generic-inference wrapper flow.
- Evidence: #10816 is the active row witness; #10792 was the canonical duplicate-family context. This PR targets the structural solver path described there. No local project-corpus run was performed; draft CI project-row drift passed and broad project-corpus gates were skipped until ready CI.

## Verification
- Exact head: `c6fee1b9f07653d695247655910208d6d0b8f2e6`.
- GitHub draft CI passed: `CI Light Summary`, `unit`, `unit-cloudbuild`, `lint`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `gate`.
- Local tests were not run.
- Ready-review follow-up: full ready CI should run after this PR is marked ready.

## Coordination Notes
- Ready for manager review / ready CI after draft-light checks passed.
- Issue #10816 remains the single active claimed bug for Studio-B until this fix lands or is superseded with evidence.
- Overlap checked against open PRs: no open PR references #10816. Nearby Studio-B solver/perf PRs are separate cache/perf or other bug-family work.
- Fixes #10816.
