### PR TITLE
fix(solver): elaborate union-source member when annotation union subtype-reduces

### DIFF
--- a/crates/tsz-checker/tests/union_source_structural_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/union_source_structural_elaboration_tests.rs
@@ -583,3 +583,59 @@ const t: Target = s;
         );
     }
 }
+
+/// Subtype-reducible written union: when a union annotation contains a member
+/// that is a structural subtype of a sibling (`[string, string]` is assignable
+/// to `string[]`), tsc keeps *both* members under `UnionReduction.Literal` and
+/// elaborates the first failing member when the whole union is rejected. tsz
+/// previously subtype-reduced the *resolved* source to the single widest member
+/// (`string[]`) while still displaying the full union, which silently dropped
+/// the union-member elaboration line entirely.
+///
+/// Structural rule: union-source member elaboration must walk the members the
+/// printer displays (the literal-reduced annotation union), not a
+/// subtype-reduced collapse of it.
+#[test]
+fn union_member_subtype_reducible_keeps_member_elaboration() {
+    let diags = diagnostics(
+        r#"
+type Source = string[] | [string, string];
+declare const s: Source;
+const n: 1 = s;
+"#,
+    );
+    let chain = ts2322_chain(&diags);
+    assert!(
+        chain_has(&chain, 0, |m| m.contains("string[]")
+            && m.contains("is not assignable to type")
+            && m.contains("'1'")),
+        "subtype-reducible union must still drill into the failing member; got {chain:?}"
+    );
+}
+
+/// Renamed binders + a flipped declaration order for the same subtype-reducible
+/// union family: the member elaboration must not depend on alias spelling or on
+/// which member is written first (the widest member `string[]` is the failing
+/// member either way).
+#[test]
+fn union_member_subtype_reducible_renamed_and_reordered() {
+    for source in [
+        r#"
+type Listish = string[] | [string, string];
+declare const v: Listish;
+const m: 0 = v;
+"#,
+        r#"
+type Collection = [string, string] | string[];
+declare const c: Collection;
+const k: 0 = c;
+"#,
+    ] {
+        let chain = ts2322_chain(&diagnostics(source));
+        assert!(
+            chain_has(&chain, 0, |m| m.contains("string[]")
+                && m.contains("is not assignable to type")),
+            "renamed/reordered subtype-reducible union must still drill the member; got {chain:?}"
+        );
+    }
+}

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -373,6 +373,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // Application expansion may produce a Mapped type (e.g., Required<Foo> →
         // { [K in keyof Foo]-?: Foo[K] }) which needs further evaluation to a concrete
         // object type so property enumeration can generate TS2739/TS2741 diagnostics.
+        //
+        // Preserve the pre-evaluation source union for member elaboration. tsc
+        // applies `UnionReduction.Literal` to written/annotation unions: it absorbs
+        // literals into their primitive but never drops a member merely because it
+        // is a structural subtype of a sibling. `evaluate_type` re-normalizes via
+        // the default (subtype-reducing) union path, so a written union like
+        // `string[] | [string, string]` collapses to `string[]` here even though
+        // tsc keeps both members. Capture the member-preserving union so the
+        // union-source elaboration below can still drill into the failing member.
+        let pre_eval_source = resolved_source;
         let eval_source = self.evaluate_type(resolved_source);
         if eval_source != resolved_source {
             resolved_source = eval_source;
@@ -970,10 +980,25 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // assignable to type 'T'.`). Without this, the chain stops at the bare
         // union line and hides why the assignment fails (e.g. the `undefined`
         // member contributed by an optional property).
-        if let Some(member_list) = union_list_id(self.interner, resolved_source) {
+        //
+        // Prefer the evaluated `resolved_source` when it is still a union (e.g. a
+        // conditional/mapped type that evaluates *into* a union). Otherwise fall
+        // back to `pre_eval_source`: when subtype reduction during `evaluate_type`
+        // collapsed a written union of structurally-related members (e.g.
+        // `string[] | [string, string]` -> `string[]`), the member elaboration
+        // must still walk the members tsc preserves under `UnionReduction.Literal`.
+        let (union_member_source, union_member_list) =
+            match union_list_id(self.interner, resolved_source) {
+                Some(list) => (resolved_source, Some(list)),
+                None => (
+                    pre_eval_source,
+                    union_list_id(self.interner, pre_eval_source),
+                ),
+            };
+        if let Some(member_list) = union_member_list {
             let members = self.interner.type_list(member_list);
             for &member in members.iter() {
-                if member == source || member == resolved_source {
+                if member == source || member == union_member_source {
                     // Defensive: avoid self-recursion on a degenerate union.
                     continue;
                 }

--- a/crates/tsz-solver/src/tests/file_size_baselines.txt
+++ b/crates/tsz-solver/src/tests/file_size_baselines.txt
@@ -27,7 +27,7 @@ solver_file_narrowing_core 2718
 solver_file_relations_compat 2950
 solver_file_constraints_walker 2348
 solver_file_diag_format_mod 2318
-solver_file_eval_mapped 1965
+solver_file_eval_mapped 1982
 solver_file_subtype_generics 2217
 solver_file_call_args 2097
 solver_file_eval_index_access 2226


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Conformance / diagnostics semantic campaign for #10823.

## Invariant
When a written/annotation union is assigned to an incompatible target, `tsc` keeps every union member under `UnionReduction.Literal` and elaborates the failing member. It absorbs literals into their primitive but never drops a member merely because it is a structural subtype of a sibling. This PR makes tsz own that through `tsz_solver::relations::subtype::explain`, the relation -> reason -> diagnostic gateway.

Closes #10823.

## Scope
Diagnostic parity for union-source assignment failures where the written union contains a member that is a structural subtype of a sibling, especially mixed array/tuple unions.

Changed files:
- `crates/tsz-solver/src/relations/subtype/explain.rs`
- `crates/tsz-checker/tests/union_source_structural_elaboration_tests.rs`
- `crates/tsz-solver/src/tests/file_size_baselines.txt`

## Structural rule
`When a written/annotation union is assigned to an incompatible target, tsc keeps every union member under UnionReduction.Literal and elaborates the failing member (Type 'A | B' is not assignable to type 'T'. -> Type 'A' is not assignable to type 'T'.). It absorbs literals into their primitive but never drops a member merely because it is a structural subtype of a sibling.`

tsz owns this through `tsz_solver::relations::subtype::explain`.

## Root cause
In `explain_failure`, tsz re-normalized the source via `evaluate_type`, which uses the default subtype-reducing union path (`normalize_union` -> `reduce_union_subtypes`). A written union of structurally-related members such as `string[] | [string, string]` collapsed to a single `string[]`, so the union-source member-elaboration loop was skipped and the failing-member line was silently dropped while the top-level line still displayed the full union.

Before / after vs `tsc` 6.x:

```ts
type T = string[] | [string, string];
declare const t: T;
const x: 1 = t;
```

- `tsc`: `Type 'string[] | [string, string]' is not assignable to type '1'.` -> `Type 'string[]' is not assignable to type '1'.`
- `tsz` before: top line only, member elaboration dropped.
- `tsz` after: matches `tsc`.

## Fix
Capture the pre-`evaluate_type` source and use it for union-member elaboration when the evaluated source is no longer a union. Member elaboration now walks the members the printer displays, not a subtype-reduced collapse of it. The change is confined to the already-failed diagnostic path; the relation/semantic result is unchanged.

Altitude note: a deeper change making `evaluate_type` / `normalize_union` never subtype-reduce annotation unions was considered and rejected as too broad for a targeted diagnostic fix. `evaluate_type` is used throughout inference, narrowing, and conditional evaluation, and changing its union-reduction semantics carries large conformance blast radius. The collapse is set-preserving, so the observable gap here is the elaboration line.

## Adjacent-case matrix
| source union | member relation | before | after |
|---|---|---|---|
| `string[] | [string,string]` | tuple <: array | dropped | `string[]` |
| `[string,string] | string[]` | reordered | dropped | `string[]` |
| `string[] | number[]` | none | already matched | `string[]` |
| `[string,string] | [number,number]` | none | already matched | `[string,string]` |
| `string[] | []` | empty tuple <: array | dropped | `string[]` |
| alias `type T = string[] | [string,string]` | via alias | dropped | `string[]` |
| distributive conditional over tuple union (#10823 repro) | n/a, semantics already correct | matched | matched |

Tests vary binder/alias spellings and declaration order so a name-keyed fix would not satisfy them.

## Project Corpus Impact
- Row: zod-project
- Bug family: distributive-conditional-tuple-union-diagnostics
- Evidence: Targets the `zod-project` bench row family for tuple-like union diagnostics. The distributive-conditional semantics in the #10823 repro were already correct; the observable divergence was the dropped union-member elaboration. No semantic types change; only the diagnostic chain for an already-failing assignment gains the member line. Smoke rows `kysely-project` and `type-challenges-solutions-project` are unaffected because there is no semantic type change.

## Verification
- `cargo test -p tsz-checker --test union_source_structural_elaboration_tests` (19 passed, including 2 new regressions)
- `cargo test -p tsz-checker --test union_source_missing_property_elaboration_tests --test union_target_missing_property_elaboration_tests` (green)
- `cargo test -p tsz-solver` (6554 passed; see coordination notes re: file-size baseline)
- `cargo clippy -p tsz-solver --all-targets` clean
- CLI parity confirmed against `tsc` 6.x for the adjacent-case matrix above.
- Exact-head CI at `6b0010ae47d9` passed broad required jobs; `project-corpus-pr-body` failed only because it did not detect the required `- Row:` and `- Bug family:` lines before this body normalization.

## Coordination Notes
The PR bumps the pre-existing `solver_file_eval_mapped` ratchet baseline (1965 -> 1982) to match the current `mapped.rs` line count already on `main` after #12739. `mapped.rs` itself is untouched by this PR.

Metadata-only follow-up on 2026-06-06 normalized this PR body to the required `## Project Corpus Impact`, `- Row:`, and `- Bug family:` fields after `project-corpus-pr-body` failed in run `27054662214`, job `79856637228`.

Session note: https://claude.ai/code/session_015WD6X1BatfiEPKpeNSCVZj
