### PR TITLE
refactor(checker): route jsx key probes through props relation

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
@@ -365,10 +365,10 @@ impl<'a> CheckerState<'a> {
                     if attr_name == "key"
                         && expected_special_type.is_some_and(|expected_type| {
                             !self
-                                .assign_relation_outcome(TypeId::STRING, expected_type)
+                                .jsx_props_relation_outcome(TypeId::STRING, expected_type)
                                 .related
                                 && !self
-                                    .assign_relation_outcome(TypeId::NUMBER, expected_type)
+                                    .jsx_props_relation_outcome(TypeId::NUMBER, expected_type)
                                     .related
                         })
                     {

--- a/crates/tsz-checker/src/tests/jsx_props_resolution_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_props_resolution_relation_routing_arch_tests.rs
@@ -9,8 +9,12 @@ fn jsx_props_resolution_uses_relation_outcome_boundary() {
 
     assert_eq!(
         source.matches("jsx_props_relation_outcome(").count(),
-        4,
+        6,
         "JSX props resolution relation probes should route through JSX props relation outcomes"
+    );
+    assert!(
+        !source.contains("assign_relation_outcome("),
+        "JSX props resolution should not regress to generic assignment relation routing"
     );
     assert!(
         !source.contains("diagnostic_relation_boolean_guard("),


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker architecture / relation routing cleanup for #8227.

## Invariant
When JSX props resolution probes whether the special `key` attribute accepts `string` or `number`, TypeScript treats that as JSX props compatibility, and tsz now routes the probe through the JSX props relation outcome boundary. Checker remains the attribute orchestration and span owner; relation request handling remains the compatibility owner.

## Scope
- Route JSX `key` special-attribute string/number probes through `jsx_props_relation_outcome` instead of generic assignment relation routing.
- Tighten the JSX props resolution routing architecture test so future generic assignment probes in that source are grep-visible.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: behavior-preserving checker architecture cleanup only; no project-row fixture or solver policy change.

## Verification
- `git diff --check origin/main...HEAD`
- `cargo fmt --check`
- `rg -n "assign_relation_outcome\\(" crates/tsz-checker/src/checkers/jsx/props/resolution.rs` (no matches)
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker jsx_props_resolution_uses_relation_outcome_boundary`

## Coordination Notes
- Avoids M1-A diagnostic-display overlap by not touching assignment formatting/object-literal display paths.
- Avoids M4/Studio solver-policy overlap by staying in checker JSX relation routing and existing query-boundary calls.
- Pre-publish `scripts/agents/ensure-agent-labels.sh --audit` reported unrelated open PR #12750 missing `agent:Studio-B`; no M1-B label drift found.
