### PR TITLE
perf(checker): avoid duplicate alias type-arg validation walks

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -1380,12 +1380,33 @@ impl<'a> CheckerState<'a> {
                         {
                             return;
                         }
-                        if let Some(type_arguments) = &type_ref.type_arguments {
+                        let explicit_validation_done =
+                            self.check_explicit_type_reference_for_alias_body_validation(node_idx);
+                        let type_arguments_checked_by_validation = explicit_validation_done
+                            && type_ref
+                                .type_arguments
+                                .as_ref()
+                                .is_some_and(|type_arguments| {
+                                    type_arguments.nodes.iter().all(|arg_idx| {
+                                        self.ctx
+                                            .type_reference_validation_caches
+                                            .type_node_validation
+                                            .contains(&(
+                                                arg_idx.0,
+                                                child_nested_in_type_literal,
+                                                scope_key,
+                                                active_alias_key,
+                                            ))
+                                    })
+                                });
+                        if !type_arguments_checked_by_validation
+                            && let Some(type_arguments) = &type_ref.type_arguments
+                        {
                             for &arg_idx in &type_arguments.nodes {
                                 check_child_type_node!(self, arg_idx);
                             }
                         }
-                        if !self.check_explicit_type_reference_for_alias_body_validation(node_idx) {
+                        if !explicit_validation_done {
                             let _ = if nested_in_type_literal {
                                 self.get_type_from_type_node_in_type_literal(node_idx)
                             } else {

--- a/scripts/ci/gcp-cache.sh
+++ b/scripts/ci/gcp-cache.sh
@@ -39,6 +39,25 @@ source scripts/ci/suite-metadata.sh
 CACHE_BUCKET="${_TSZ_CI_CACHE_BUCKET:?_TSZ_CI_CACHE_BUCKET is required}"
 CACHE_BUCKET="${CACHE_BUCKET%/}"
 
+ensure_gcs_auth() {
+  if [[ -n "${SCCACHE_GCS_KEY_JSON:-}" && -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+    local key_file="/tmp/sccache-gcs-key.json"
+    printf '%s' "$SCCACHE_GCS_KEY_JSON" > "$key_file"
+    chmod 600 "$key_file"
+    export GOOGLE_APPLICATION_CREDENTIALS="$key_file"
+    echo "gcs-auth: using service account key from SCCACHE_GCS_KEY_JSON"
+  fi
+
+  # Cloud Run runners can arrive with `gcloud auth` already configured. Make
+  # the bundled gsutil use that account instead of falling back to anonymous
+  # requests during early cache restore.
+  if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] && command -v gcloud >/dev/null 2>&1; then
+    if gcloud auth print-access-token >/dev/null 2>&1; then
+      gcloud config set pass_credentials_to_gsutil true >/dev/null 2>&1 || true
+    fi
+  fi
+}
+
 cache_uri() {
   printf '%s/%s\n' "$CACHE_BUCKET" "$1"
 }
@@ -634,6 +653,8 @@ save_caches() {
 }
 
 main() {
+  ensure_gcs_auth
+
   case "${1:-}" in
     restore)
       restore_caches

--- a/scripts/ci/test-gcp-cache-auth.mjs
+++ b/scripts/ci/test-gcp-cache-auth.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
+const cacheScript = fs.readFileSync(
+  path.join(ROOT, "scripts", "ci", "gcp-cache.sh"),
+  "utf8",
+);
+
+const authFn = cacheScript.match(/ensure_gcs_auth\(\) \{[\s\S]+?\n\}/);
+assert.ok(authFn, "gcp-cache.sh should define ensure_gcs_auth");
+assert.match(
+  authFn[0],
+  /SCCACHE_GCS_KEY_JSON[\s\S]+GOOGLE_APPLICATION_CREDENTIALS/,
+  "GCS cache auth should accept the same service-account secret used by sccache",
+);
+assert.match(
+  authFn[0],
+  /gcloud auth print-access-token[\s\S]+pass_credentials_to_gsutil true/,
+  "GCS cache auth should let gsutil use an already-authenticated gcloud account",
+);
+
+const mainOffset = cacheScript.indexOf("main() {");
+assert.notEqual(mainOffset, -1, "gcp-cache.sh should keep a main function");
+const mainBody = cacheScript.slice(mainOffset, cacheScript.indexOf("case \"${1:-}\"", mainOffset));
+assert.match(
+  mainBody,
+  /ensure_gcs_auth/,
+  "gcp-cache.sh should authenticate before restore/save dispatch",
+);
+
+console.log("test-gcp-cache-auth: ok");


### PR DESCRIPTION
AgentName: Studio-B
Track: Performance / CI infrastructure (`agent:Studio-B`)
Invariant: Alias-body validation diagnostics remain unchanged; this only avoids a duplicate child type-node validation walk when the explicit generic validation path has already completed and cached those children.

## Scope

This PR makes two small fixes:

- Avoid re-walking type-reference arguments during type-alias body validation when `validate_type_reference_type_arguments` already checked and cached the same child type nodes. This trims work in recursive utility stacks like ts-toolbelt's `List/Omit` path without skipping diagnostics when validation did not prove the child nodes clean.
- Authenticate `scripts/ci/gcp-cache.sh` before restore/save dispatch. The cache helper now uses `SCCACHE_GCS_KEY_JSON` like sccache does, and also enables `pass_credentials_to_gsutil` when the Cloud Run runner already has an authenticated `gcloud` account. This addresses early cache restores falling back to anonymous GCS requests before `gcp-full-ci.sh` configures credentials.

## Project Corpus Impact

- Row: ts-toolbelt-project
- Bug family: recursive utility alias validation fan-out / Cloud Run GCS cache restore auth
- Impact: No diagnostic or emit behavior change expected. The checker change only reuses a successful validation cache entry for child type nodes; the CI change restores the intended authenticated GCS cache path for Cloud Run/gcloud runners.

## Verification

- `cargo check -p tsz-checker`
- `cargo clippy -p tsz-checker --all-targets -- -D warnings`
- `node scripts/ci/test-gcp-cache-auth.mjs`
- `bash -n scripts/ci/gcp-cache.sh scripts/ci/github-suite.sh scripts/ci/gcp-full-ci.sh`
- `git diff --check`
- `BENCH_PGO=0 TSZ_BENCH_PROJECT_SLOWDOWN_FAILURE_FACTOR=0 scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-toolbelt-project$' --json-file artifacts/perf/ts-toolbelt-dupwalk-20260606.json --rebuild`

Benchmark result:

- main baseline: ts-toolbelt-project `12159.66 ms`, tsgo `102.53 ms`, tsgo `118.60x` faster
- this branch: ts-toolbelt-project `11328.14 ms`, tsgo `102.22 ms`, tsgo `110.82x` faster

Note: `TSZ_CI_CACHE_RESTORE=0 TSZ_CI_CACHE_SAVE=0 scripts/ci/github-suite.sh lint` was attempted locally but stopped at workspace metadata validation because this checkout's remote metadata expects `https://github.com/mohsen1/tsz` while the workspace declares `https://github.com/tsz-org/tsz`.

