### PR TITLE
refactor(checker): route condition guard narrowing through boundary

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -10,7 +10,7 @@ use tsz_parser::parser::node::BinaryExprData;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
-use tsz_solver::narrowing::{GuardSense, NarrowingContext, TypeGuard, TypeofKind};
+use tsz_solver::narrowing::{NarrowingContext, TypeGuard, TypeofKind};
 
 impl<'a> FlowAnalyzer<'a> {
     fn narrow_to_falsy_via_flow_boundary(&self, type_id: TypeId) -> TypeId {
@@ -36,18 +36,12 @@ impl<'a> FlowAnalyzer<'a> {
 
     fn narrow_with_guard_via_flow_boundary(
         &self,
+        narrowing: &NarrowingContext<'_>,
         type_id: TypeId,
         guard: &TypeGuard,
         is_true_branch: bool,
     ) -> TypeId {
-        let env_borrow = self.type_environment.as_ref().map(|env| env.borrow());
-        flow_query::narrow_with_guard(
-            self.interner,
-            env_borrow.as_deref(),
-            type_id,
-            guard,
-            is_true_branch,
-        )
+        flow_query::narrow_with_guard_in_context(narrowing, type_id, guard, is_true_branch)
     }
 
     fn union_logical_condition_branches(&self, types: Vec<TypeId>) -> TypeId {
@@ -810,10 +804,11 @@ impl<'a> FlowAnalyzer<'a> {
                             // This applies to ALL guards, not just typeof
                             // For `x !== "string"` or `x.kind !== "circle"`, the true branch should EXCLUDE
                             // Delegate to Solver for the calculation (Solver responsibility: RESULT)
-                            let result = narrowing.narrow_type(
+                            let result = self.narrow_with_guard_via_flow_boundary(
+                                &narrowing,
                                 type_id,
                                 &guard,
-                                GuardSense::from(effective_sense),
+                                effective_sense,
                             );
                             if effective_sense
                                 && matches!(guard, TypeGuard::Typeof(TypeofKind::Object))
@@ -971,12 +966,12 @@ impl<'a> FlowAnalyzer<'a> {
                 let condition_ref = self.arena.skip_parenthesized_and_assertions(condition_idx);
                 let matches = self.is_matching_reference(condition_ref, target);
                 if matches {
-                    let narrowed = narrowing.narrow_type(
+                    return self.narrow_with_guard_via_flow_boundary(
+                        &narrowing,
                         type_id,
                         &TypeGuard::Truthy,
-                        GuardSense::from(is_true_branch),
+                        is_true_branch,
                     );
-                    return narrowed;
                 }
 
                 if let Some((base, prop_names)) = self.binding_element_property_alias(condition_ref)
@@ -1313,6 +1308,7 @@ impl<'a> FlowAnalyzer<'a> {
                 let typeof_base_type =
                     flow_boundary::catch_variable_typeof_base_from_flow(type_id, is_catch_var);
                 let narrowed = self.narrow_with_guard_via_flow_boundary(
+                    narrowing,
                     typeof_base_type,
                     &TypeGuard::Typeof(typeof_kind),
                     effective_truth,
@@ -1529,16 +1525,18 @@ impl<'a> FlowAnalyzer<'a> {
                         {
                             return right_type;
                         }
-                        return narrowing.narrow_type(
+                        return self.narrow_with_guard_via_flow_boundary(
+                            narrowing,
                             type_id,
                             &TypeGuard::LiteralEquality(right_type),
-                            GuardSense::Positive,
+                            true,
                         );
                     } else if is_unit_type(self.interner, right_type) {
-                        return narrowing.narrow_type(
+                        return self.narrow_with_guard_via_flow_boundary(
+                            narrowing,
                             type_id,
                             &TypeGuard::LiteralEquality(right_type),
-                            GuardSense::Negative,
+                            false,
                         );
                     }
                 }
@@ -1558,16 +1556,18 @@ impl<'a> FlowAnalyzer<'a> {
                         {
                             return left_type;
                         }
-                        return narrowing.narrow_type(
+                        return self.narrow_with_guard_via_flow_boundary(
+                            narrowing,
                             type_id,
                             &TypeGuard::LiteralEquality(left_type),
-                            GuardSense::Positive,
+                            true,
                         );
                     } else if is_unit_type(self.interner, left_type) {
-                        return narrowing.narrow_type(
+                        return self.narrow_with_guard_via_flow_boundary(
+                            narrowing,
                             type_id,
                             &TypeGuard::LiteralEquality(left_type),
-                            GuardSense::Negative,
+                            false,
                         );
                     }
                 }
@@ -1897,10 +1897,11 @@ impl<'a> FlowAnalyzer<'a> {
                 } else {
                     self.make_narrowing_context()
                 };
-                return Some(narrowing.narrow_type(
+                return Some(self.narrow_with_guard_via_flow_boundary(
+                    &narrowing,
                     type_id,
                     &TypeGuard::Truthy,
-                    GuardSense::from(is_true_branch),
+                    is_true_branch,
                 ));
             }
         }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1170,6 +1170,9 @@ mod this_context_self_type_tests;
 #[path = "tests/this_void_method_call_tests.rs"]
 mod this_void_method_call_tests;
 #[cfg(test)]
+#[path = "tests/truthiness_promise_coercion_tests.rs"]
+mod truthiness_promise_coercion_tests;
+#[cfg(test)]
 #[path = "tests/ts1101_with_in_strict_mode_tests.rs"]
 mod ts1101_with_in_strict_mode_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -269,6 +269,18 @@ pub(crate) fn narrow_with_guard(
     narrowing.narrow_type(type_id, guard, GuardSense::from(is_true_branch))
 }
 
+/// Apply a solver-owned type guard using the caller's active flow narrowing
+/// context. This preserves the flow pass's resolver and shared narrowing cache
+/// while keeping the guard application behind the query boundary.
+pub(crate) fn narrow_with_guard_in_context(
+    narrowing: &NarrowingContext<'_>,
+    type_id: TypeId,
+    guard: &TypeGuard,
+    is_true_branch: bool,
+) -> TypeId {
+    narrowing.narrow_type(type_id, guard, GuardSense::from(is_true_branch))
+}
+
 /// Apply a runtime `typeof` result to a flow type.
 ///
 /// The checker owns recognizing `typeof x === "..."` or switch-case syntax and

--- a/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
@@ -257,3 +257,33 @@ fn condition_typeof_narrowing_uses_flow_query_boundary() {
         "condition narrowing should not call solver typeof narrowing directly"
     );
 }
+
+#[test]
+fn condition_guard_application_uses_flow_query_boundary() {
+    let condition_source = fs::read_to_string("src/flow/control_flow/condition_narrowing.rs")
+        .expect("failed to read condition narrowing source");
+    let boundary_source = fs::read_to_string("src/query_boundaries/flow_analysis.rs")
+        .expect("failed to read flow analysis boundary source");
+    let compact_condition: String = condition_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let compact_boundary: String = boundary_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+
+    assert!(
+        compact_boundary.contains("fnnarrow_with_guard(")
+            && compact_boundary.contains("narrowing.narrow_type(type_id,guard,"),
+        "flow analysis boundary should own reusable solver guard application"
+    );
+    assert!(
+        compact_condition.contains("self.narrow_with_guard_via_flow_boundary("),
+        "condition guard application should route through the flow query boundary"
+    );
+    assert!(
+        !compact_condition.contains(".narrow_type("),
+        "condition narrowing should not apply solver guards directly"
+    );
+}

--- a/crates/tsz-checker/src/tests/truthiness_promise_coercion_tests.rs
+++ b/crates/tsz-checker/src/tests/truthiness_promise_coercion_tests.rs
@@ -1,0 +1,70 @@
+use crate::context::CheckerOptions;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn codes_with_libs(src: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(
+        src,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .map(|d| d.code)
+    .collect()
+}
+
+#[test]
+fn promise_truthiness_coercion_emits_awaitable_diagnostics() {
+    let c = codes_with_libs(
+        r#"
+declare const p: Promise<number>;
+declare const p2: null | Promise<number>;
+declare const obj: { p: Promise<unknown> };
+declare function pf(): Promise<boolean>;
+
+async function f() {
+    if (p) {}
+    if (!!p) {}
+    if (p2) {}
+    p ? f.arguments : f.arguments;
+    !!p ? f.arguments : f.arguments;
+    p2 ? f.arguments : f.arguments;
+}
+
+async function g() {
+    if (p) {
+        p;
+    }
+    if (p && p.then.length) {}
+}
+
+async function h() {
+    if (obj.p) {}
+    if (obj.p) {
+        await obj.p;
+    }
+    if (obj.p && await obj.p) {}
+}
+
+async function i(): Promise<string> {
+    if (pf()) {
+        return "true";
+    }
+    if (pf()) {
+        pf().then();
+    }
+    return "false";
+}
+"#,
+    );
+
+    let ts2801 = c.iter().filter(|&&code| code == 2801).count();
+    assert_eq!(
+        ts2801, 5,
+        "expected the five tsc awaitable-truthiness diagnostics from truthinessPromiseCoercion, got {c:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
M1-D - flow graph and solver-owned narrowing predicates; refactor.

## Invariant
When a condition produces a `TypeGuard`, `tsc` applies the guard as semantic flow narrowing. This PR keeps tsz checker-owned work to target/context and branch-sense extraction, then applies the semantic narrowing through `query_boundaries::flow_analysis` using the active flow `NarrowingContext` so resolver/cache semantics are preserved.

## Scope
- Route direct binary guards, truthiness checks, bidirectional literal equality, and logical compound-assignment truthiness in `condition_narrowing.rs` through `narrow_with_guard_via_flow_boundary`.
- Add `flow_analysis::narrow_with_guard_in_context` for condition-flow callers that already own the current `NarrowingContext`; keep the existing DB/env boundary for other callers.
- Add a flow-boundary architecture test preventing new direct `.narrow_type(...)` calls in condition narrowing.
- Add a regression for `truthinessPromiseCoercion.ts` so always-defined Promise truthiness still emits TS2801 while nullable/double-negation/body-use cases remain compatible.
- Leave non-guard discriminant/exclusion helpers that still require existing `NarrowingContext` methods unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: flow/narrowing boundary debt
- Impact: No project-row behavior change intended. This is a boundary ratchet that keeps condition guard narrowing on the solver-owned path used by M1-D.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib truthiness_promise_coercion_tests flow_guard_boundary_tests`
- `cargo fmt --check`
- `git diff --check`
- Attempted `./scripts/conformance/conformance.sh run --filter "truthinessPromiseCoercion" --verbose`; local checkout has no TypeScript test corpus, so the harness reported `No test files found`.
- GitHub merge-group run `27057580016` on previous head found unlisted conformance regression `TypeScript/tests/cases/compiler/truthinessPromiseCoercion.ts`; fixed on amended head `ce90bd93f4212394c8d8ae6357485cd18f4ab143`.

## Coordination Notes
- M1-D owned work was clear before starting.
- Open neighboring inference/perf PRs are owned by Studio-B/M4-B; this PR does not touch those files or cache logic.
- Existing `in`, `typeof`, predicate, and instanceof flow-boundary tests remain passing.
- Performance: no benchmark claim.
