### PR TITLE
perf(checker): keep lazy identity call returns deferred

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/constructors/callable_type_arguments.rs
+++ b/crates/tsz-checker/src/state/type_resolution/constructors/callable_type_arguments.rs
@@ -223,6 +223,9 @@ impl<'a> CheckerState<'a> {
             if !sig.type_params.is_empty() {
                 continue;
             }
+            if self.substituted_return_can_stay_lazy_identity(sig.return_type) {
+                continue;
+            }
             // Only evaluate the return type. Params, `this`, and predicate
             // are intentionally left as substituted-but-not-evaluated:
             // contextual-typing and contravariant matching paths rely on
@@ -232,6 +235,36 @@ impl<'a> CheckerState<'a> {
             // resolution).
             sig.return_type = eval(sig.return_type);
         }
+    }
+
+    fn substituted_return_can_stay_lazy_identity(&self, return_type: TypeId) -> bool {
+        let db = self.ctx.types.as_type_database();
+        let mut saw_identity = false;
+        if let Some(members) = common_query::union_members(db, return_type) {
+            for member in members.iter() {
+                if matches!(*member, TypeId::NULL | TypeId::UNDEFINED) {
+                    continue;
+                }
+                if !self.type_is_lazy_class_or_interface_identity(*member) {
+                    return false;
+                }
+                saw_identity = true;
+            }
+            return saw_identity;
+        }
+        self.type_is_lazy_class_or_interface_identity(return_type)
+    }
+
+    fn type_is_lazy_class_or_interface_identity(&self, type_id: TypeId) -> bool {
+        let db = self.ctx.types.as_type_database();
+        let base = common_query::type_application(db, type_id)
+            .map_or(type_id, |application| application.base);
+        query::lazy_def_id(db, base).is_some_and(|def_id| {
+            matches!(
+                self.ctx.definition_store.get_kind(def_id),
+                Some(DefKind::Class | DefKind::Interface)
+            )
+        })
     }
 
     fn instantiate_instantiation_expression_signature(


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance/residency: Vite explicit generic DOM call residual.

## Invariant
When an explicitly instantiated callable return substitutes to only lazy class/interface identity surfaces, optionally unioned with `null` or `undefined`, `tsz` can keep that return deferred. Mapped, conditional, indexed-access, alias, primitive, and non-identity substituted returns still use the existing evaluation path so downstream `ReturnType`, `Parameters`, `infer`, and property-access behavior keep their structural answers.

## Scope
- `crates/tsz-checker/src/state/type_resolution/constructors/callable_type_arguments.rs`

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: explicit-generic-dom-call-return-residency
- Fresh canonical quick artifact from this PR head: `artifacts/perf/studio-b-12761-queryselector-vite-quick-canonical-20260606.json`
- Companion report: `artifacts/perf/studio-b-12761-queryselector-vite-quick-canonical-20260606.tsgo-winners.json`
- Result: `tsz` 79.99ms vs `tsgo` 77.84ms; `tsgo` is 1.03x faster, so this draft does not close the 2x target. Companion report shows `two_x_target.rows_below_target = 1` and `target_gap_factor = 2.055241521068859`.
- Non-claim artifact from explicit `TSZ=.target/dist-fast/tsz` override: `artifacts/perf/studio-b-12761-queryselector-vite-quick-20260606.json`; this is retained only as debug evidence because the companion identifies `measurement_profile.mode = "tsz-override"`.
- Prior evidence source: #12616 local/sibling artifacts, not a fresh timing claim from this PR head.
- Prior best local report found: `artifacts/perf/studio-b-12616-plus-12607-vite-quick-20260605.tsgo-winners.json`, `tsz` 49.44ms vs `tsgo` 78.16ms, speedup 1.58x, target gap factor 1.2650972364380757.
- Prior synced #12616 report: `artifacts/perf/studio-b-12616-main-sync-vite-quick-20260605.tsgo-winners.json`, `tsz` 57.31ms vs `tsgo` 77.44ms, speedup 1.35x, target gap factor 1.4801136363636365.
- Attribution in #12616 pointed at `checker:semantic-check`, hotspot `document.querySelector<HTMLDivElement>("#app")`, with cross-arena residue mostly drained (`delegate misses` 0, `with_parent_cache` 0).
- This draft extracts the isolated lazy-identity return rule from that stack so CI and follow-up benchmarking can evaluate it independently. Current timing indicates the isolated rule is insufficient by itself.

## Verification
- `cargo fmt -p tsz-checker --check`
- `git diff --check origin/main...HEAD`
- `scripts/setup/link-ts-submodule.sh`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib explicit_generic_call querySelector dom_fuel_exhaustion --no-fail-fast`
- `scripts/safe-run.sh --limit 75% -- cargo build --profile dist-fast -p tsz-cli --bin tsz`
- `scripts/safe-run.sh env TSZ_PROJECT_COMPILE_FILTER='^vite-vanilla-ts-app$' TSZ_PROJECT_COMPILE_INCLUDE_GENERATED_APPS=1 scripts/ci/project-compile-guard.sh`
- `scripts/safe-run.sh scripts/bench/bench-vs-tsgo.sh --quick --json --json-file artifacts/perf/studio-b-12761-queryselector-vite-quick-canonical-20260606.json --filter '^vite-vanilla-ts-app$' --rebuild`
- `node scripts/bench/tsgo-winner-report.mjs artifacts/perf/studio-b-12761-queryselector-vite-quick-canonical-20260606.json artifacts/perf/studio-b-12761-queryselector-vite-quick-canonical-20260606.tsgo-winners.json`
- PR-head light CI is green as of 2026-06-06: gate, lint, unit, unit-cloudbuild, dist-binaries, cargo-deny, cargo-shear, project-row-drift, CI Light Summary.

## Coordination Notes
- AgentName: Studio-B
- Draft PR remains draft because fresh canonical quick timing is below `tsgo` and below the 2x target.
- Does not take ownership of #12616, which Studio-manager currently owns as stacked/conflicting coordination work.
- This branch is synced with current `origin/main` via merge commit after the implementation commit.
- No merge-queue action while draft or before fresh performance/correctness evidence supports readiness.
