### PR TITLE
bench: surface attribution plan for 2x gaps

### DIFF
--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -186,6 +186,7 @@ withTempDir((dir) => {
   assert.equal(report.totals.green_tsgo_winners_with_attribution, 1);
   assert.deepEqual(report.totals.missing_attribution_rows, ["single-file-loss", "vite-vanilla-ts-app"]);
   assert.equal(report.totals.incomplete_compat_excluded, 0);
+  assert.match(result.stdout, /2x target gaps with attribution commands: 1\/3/);
   assert.deepEqual(report.two_x_target, {
     tsz_speedup_target: 2,
     eligible_green_rows: 4,
@@ -195,6 +196,33 @@ withTempDir((dir) => {
     project_rows_below_target: 2,
     rows_with_attribution: 1,
     missing_attribution_rows: ["single-file-loss", "vite-vanilla-ts-app"],
+    rows_with_attribution_command: 1,
+    missing_attribution_plan: [
+      {
+        name: "vite-vanilla-ts-app",
+        target_gap_factor: report.target_gaps[1].target_gap_factor,
+        tsz_speedup_vs_tsgo: report.target_gaps[1].tsz_speedup_vs_tsgo,
+        semantic_owner_family: "generated Vite dependency graph",
+        owner: "Track 7/9 generated app lib/module identity",
+        issue: 7378,
+        url: "https://github.com/tsz-org/tsz/issues/7378",
+        attribution_command: report.target_gaps[1].loss_closure.attribution_command,
+        timing_command: report.target_gaps[1].loss_closure.command,
+        attribution_warning: "attribution artifact missing",
+      },
+      {
+        name: "single-file-loss",
+        target_gap_factor: report.target_gaps[2].target_gap_factor,
+        tsz_speedup_vs_tsgo: report.target_gaps[2].tsz_speedup_vs_tsgo,
+        semantic_owner_family: null,
+        owner: null,
+        issue: null,
+        url: null,
+        attribution_command: null,
+        timing_command: null,
+        attribution_warning: "attribution artifact missing",
+      },
+    ],
     worst_gap: report.target_gaps[0],
   });
   assert.deepEqual(
@@ -702,6 +730,14 @@ withTempDir((dir) => {
   assert.equal(report.two_x_target.rows_below_target, 2);
   assert.equal(report.two_x_target.rows_with_attribution, 1);
   assert.deepEqual(report.two_x_target.missing_attribution_rows, ["vite-vanilla-ts-app"]);
+  assert.equal(report.two_x_target.rows_with_attribution_command, 1);
+  assert.deepEqual(report.two_x_target.missing_attribution_plan.map((row) => row.name), [
+    "vite-vanilla-ts-app",
+  ]);
+  assert.match(
+    report.two_x_target.missing_attribution_plan[0].attribution_command,
+    /nextjs-fresh-app|vite-vanilla-ts-app/,
+  );
   const tsEssentials = report.target_gaps.find((row) => row.name === "ts-essentials-project");
   assert.deepEqual(tsEssentials.attribution_status, {
     present: true,

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -322,6 +322,22 @@ function hasCompleteAttribution(status) {
   return Boolean(status?.present && status?.dominant_subsystem && !status?.warning);
 }
 
+function missingAttributionPlanForRow(row) {
+  const closure = row?.loss_closure ?? null;
+  return {
+    name: row.name,
+    target_gap_factor: row.target_gap_factor,
+    tsz_speedup_vs_tsgo: row.tsz_speedup_vs_tsgo,
+    semantic_owner_family: row.semantic_owner_family ?? null,
+    owner: closure?.owner ?? null,
+    issue: closure?.issue ?? null,
+    url: closure?.url ?? null,
+    attribution_command: closure?.attribution_command ?? null,
+    timing_command: closure?.command ?? null,
+    attribution_warning: row.attribution_status?.warning ?? null,
+  };
+}
+
 function targetGapFactor(speedup) {
   if (speedup == null || speedup <= 0) return null;
   return TARGET_TSZ_SPEEDUP / speedup;
@@ -410,6 +426,11 @@ export function createTsgoWinnerReport(input, inputPath) {
     .filter((row) => !hasCompleteAttribution(row.attribution_status))
     .map((row) => row.name)
     .sort();
+  const missingTargetGapAttributionPlan = targetGapRows
+    .filter((row) => !hasCompleteAttribution(row.attribution_status))
+    .map(missingAttributionPlanForRow);
+  const targetGapRowsWithAttributionCommand = missingTargetGapAttributionPlan
+    .filter((row) => row.attribution_command).length;
 
   const winners = rows
     .filter((row) => row?.winner === "tsgo" && isGreen(row) && !duplicateNames.has(row?.name))
@@ -482,6 +503,8 @@ export function createTsgoWinnerReport(input, inputPath) {
       project_rows_below_target: targetGapRows.filter((row) => row.semantic_owner_family).length,
       rows_with_attribution: targetGapRows.length - missingTargetGapAttributionRows.length,
       missing_attribution_rows: missingTargetGapAttributionRows,
+      rows_with_attribution_command: targetGapRowsWithAttributionCommand,
+      missing_attribution_plan: missingTargetGapAttributionPlan,
       worst_gap: targetGapRows[0] ?? null,
     },
     measurement_profile: measurementProfileStatus(input),
@@ -515,6 +538,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       `project green tsgo winners: ${report.totals.project_green_tsgo_winners}`,
       `2x target gaps: ${report.two_x_target.rows_below_target}/${report.two_x_target.eligible_green_rows}`,
       `2x target gaps with attribution: ${report.two_x_target.rows_with_attribution}/${report.two_x_target.rows_below_target}`,
+      `2x target gaps with attribution commands: ${report.two_x_target.rows_with_attribution_command}/${report.two_x_target.rows_below_target}`,
       `report: ${path.relative(process.cwd(), outputPath).split(path.sep).join("/")}`,
     ].join("\n"),
   );


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 10 / benchmark infrastructure and 2x-target evidence.

## Invariant
When a green benchmark row is still below the `2x` tsgo speed target and lacks attribution, the canonical `*.tsgo-winners.json` report should expose the available attribution command and ownership context so performance lanes can gather the missing evidence before making speed claims.

## Scope
- Add `two_x_target.rows_with_attribution_command` and `two_x_target.missing_attribution_plan` to `scripts/bench/tsgo-winner-report.mjs`.
- Extend winner-report tests for the new summary and CLI line.

## Project Corpus Impact
- Row: n/a (benchmark artifact/reporting infrastructure; checked against current benchmark snapshot)
- Bug family: 2x target attribution evidence gaps

## Verification
- `node scripts/bench/test-tsgo-winner-report.mjs`
- `git diff --check`
- `node scripts/bench/tsgo-winner-report.mjs crates/tsz-website/bench-snapshot.json /tmp/tsz-winners-new.json` -> current snapshot reports `2x target gaps with attribution commands: 5/15`.
- Exact-head CI: https://github.com/tsz-org/tsz/actions/runs/27055602946 passed for `c678d1823a92b83d55dcf619466c4149225393be`.

## Coordination Notes
- Does not touch compiler behavior or benchmark timing values.
- Open Studio-B performance PRs own semantic/runtime fixes for project rows; this PR makes the canonical winner report more actionable for those lanes.
- Local `scripts/conformance/conformance-accepted-regressions.txt` changes pre-existed this branch and are intentionally not included.
