### PR TITLE
bench: block project-crash artifacts from latest

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1408,6 +1408,16 @@ jobs:
           fi
           exit "$status"
 
+      - name: Check public benchmark project timings
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/bench/check-artifact-readiness.mjs \
+            --json \
+            --require-project-timing-pairs=1 \
+            "$GITHUB_WORKSPACE/bench-results.json" \
+            > "$GITHUB_WORKSPACE/bench-results-readiness.json"
+
       - name: Upload merged benchmark artifact
         uses: actions/upload-artifact@v4
         with:
@@ -1417,6 +1427,7 @@ jobs:
             bench-results-tsgo-winners.json
             bench-results-project-winner-regressions.json
             bench-results-project-winner-regressions.md
+            bench-results-readiness.json
           retention-days: 30
           if-no-files-found: error
           compression-level: 1

--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -855,7 +855,7 @@ function loadBenchmarks() {
   const selectedArtifact = selectLatestBenchmarkArtifact([
     ...benchmarkArtifactFiles(),
     snapshotPath,
-  ]);
+  ], { minimumProjectTimingPairs: 1 });
   if (selectedArtifact) {
     return sanitizeLegacyBenchmarkData(selectedArtifact.data);
   }

--- a/crates/tsz-website/src/_data/benchmark_mean_chart.js
+++ b/crates/tsz-website/src/_data/benchmark_mean_chart.js
@@ -73,7 +73,7 @@ function loadBenchmarks() {
   const selectedArtifact = selectLatestBenchmarkArtifact([
     ...artifactFiles,
     path.join(ROOT, "crates/tsz-website/bench-snapshot.json"),
-  ]);
+  ], { minimumProjectTimingPairs: 1 });
   if (selectedArtifact) {
     return sanitizeLegacyBenchmarkResults(selectedArtifact.data);
   }

--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -169,6 +169,7 @@ while [[ $# -gt 0 ]]; do
             echo "  BENCH_PGO_PANIC_UNWIND=1  Build the trainer with panic=unwind for crashy inputs (default: 0)"
             echo "  BENCH_PGO_EXTRA_INPUTS=<path[:path]>  Extra .ts or tsconfig files to feed the PGO trainer"
             echo "  BENCH_PGO_VERBOSE=1    Print per-input wall time during PGO Step 2"
+            echo "  BENCH_RUST_TARGET_CPU=<cpu>  Rust target-cpu for bench builds (default: native)"
             exit 0
             ;;
         *) shift ;;

--- a/scripts/bench/benchmark-artifact-selection.mjs
+++ b/scripts/bench/benchmark-artifact-selection.mjs
@@ -1,5 +1,12 @@
 import fs from "node:fs";
 
+import {
+  PROJECT_ROWS_BY_NAME,
+} from "./project-rows.mjs";
+import {
+  isGreen,
+} from "./row-utils.mjs";
+
 export function readBenchmarkArtifact(file) {
   try {
     const data = JSON.parse(fs.readFileSync(file, "utf8"));
@@ -14,15 +21,38 @@ export function benchmarkGeneratedAtMs(data) {
   return Number.isFinite(timestamp) ? timestamp : Number.NEGATIVE_INFINITY;
 }
 
-export function selectLatestBenchmarkArtifact(files) {
+function hasTiming(value) {
+  const time = Number(value);
+  return Number.isFinite(time) && time > 0;
+}
+
+export function successfulProjectTimingPairCount(data) {
+  return (Array.isArray(data?.results) ? data.results : []).filter((row) => (
+    Object.hasOwn(PROJECT_ROWS_BY_NAME, String(row?.name || "")) &&
+    hasTiming(row?.tsz_ms) &&
+    hasTiming(row?.tsgo_ms) &&
+    row?.winner !== "error" &&
+    isGreen(row)
+  )).length;
+}
+
+export function hasSuccessfulProjectTimingPairs(data, minimum = 1) {
+  return successfulProjectTimingPairCount(data) >= minimum;
+}
+
+export function selectLatestBenchmarkArtifact(files, options = {}) {
+  const minimumProjectTimingPairs = Math.max(0, Number(options.minimumProjectTimingPairs ?? 0));
   const candidates = [];
   for (const [index, file] of files.entries()) {
     const data = readBenchmarkArtifact(file);
     if (!data) continue;
+    const projectTimingPairs = successfulProjectTimingPairCount(data);
+    if (projectTimingPairs < minimumProjectTimingPairs) continue;
     candidates.push({
       file,
       data,
       generatedAtMs: benchmarkGeneratedAtMs(data),
+      projectTimingPairs,
       index,
     });
   }

--- a/scripts/bench/check-artifact-readiness.mjs
+++ b/scripts/bench/check-artifact-readiness.mjs
@@ -18,7 +18,7 @@
  * is absent (exit 2) so callers reliably get machine-readable status in all cases.
  *
  * Usage:
- *   node scripts/bench/check-artifact-readiness.mjs [--json] [--require-green] [--require-clean-metadata] [--expect-source-commit=<sha>] [--require-source-current] <artifact.json>
+ *   node scripts/bench/check-artifact-readiness.mjs [--json] [--require-green] [--require-clean-metadata] [--require-project-timing-pairs[=<n>]] [--expect-source-commit=<sha>] [--require-source-current] <artifact.json>
  */
 
 import fs from "node:fs";
@@ -42,6 +42,7 @@ function parseArgs(rawArgs) {
     requireGreen: false,
     requireCleanMetadata: false,
     requireSourceCurrent: false,
+    requiredProjectTimingPairs: 0,
     expectedSourceCommit: process.env.TSZ_BENCH_EXPECT_SOURCE_COMMIT ?? null,
     filePath: null,
   };
@@ -56,6 +57,16 @@ function parseArgs(rawArgs) {
       options.requireCleanMetadata = true;
     } else if (arg === "--require-source-current") {
       options.requireSourceCurrent = true;
+    } else if (arg === "--require-project-timing-pairs") {
+      const next = rawArgs[i + 1] ?? "";
+      if (/^\d+$/.test(next)) {
+        options.requiredProjectTimingPairs = Number(next);
+        i += 1;
+      } else {
+        options.requiredProjectTimingPairs = 1;
+      }
+    } else if (arg.startsWith("--require-project-timing-pairs=")) {
+      options.requiredProjectTimingPairs = Number(arg.slice("--require-project-timing-pairs=".length));
     } else if (arg === "--expect-source-commit") {
       options.expectedSourceCommit = rawArgs[i + 1] ?? "";
       i += 1;
@@ -74,9 +85,14 @@ const {
   requireGreen,
   requireCleanMetadata,
   requireSourceCurrent,
+  requiredProjectTimingPairs: rawRequiredProjectTimingPairs,
   expectedSourceCommit: rawExpectedSourceCommit,
   filePath,
 } = parseArgs(args);
+
+const requiredProjectTimingPairs = Number.isFinite(rawRequiredProjectTimingPairs)
+  ? Math.max(0, rawRequiredProjectTimingPairs)
+  : 0;
 
 function currentGitHead() {
   try {
@@ -258,6 +274,14 @@ function analyzeArtifact(artifact, expectedCommit) {
     validationWarnings: analyzeValidationWarnings(artifact),
     sourceFreshness: analyzeSourceFreshness(artifact, expectedCommit),
     rows,
+    successfulProjectTimingPairs: rows.filter((row) => (
+      row.state === "green" &&
+      Number.isFinite(Number(row.tsz_ms)) &&
+      Number(row.tsz_ms) > 0 &&
+      Number.isFinite(Number(row.tsgo_ms)) &&
+      Number(row.tsgo_ms) > 0 &&
+      row.winner !== "error"
+    )),
     missing: rows.filter((r) => r.state === "missing"),
     red: rows.filter((r) => r.state === "red"),
     yellow: rows.filter((r) => r.state === "yellow"),
@@ -276,7 +300,7 @@ function uniqueRowsByName(rows) {
   return [...byName.values()];
 }
 
-function buildJson({ artifactAbsent, parseError, artifact, measurementProfile, validationWarnings, sourceFreshness, rows, missing, red, yellow, gray, green, duplicates }) {
+function buildJson({ artifactAbsent, parseError, artifact, measurementProfile, validationWarnings, sourceFreshness, rows, successfulProjectTimingPairs, missing, red, yellow, gray, green, duplicates }) {
   const missingNames = missing?.map((r) => r.name) ?? REQUIRED_PROJECT_ROWS;
   const metadataWarningsList = metadataWarnings(measurementProfile, validationWarnings);
   const nonGreenRows = rows
@@ -309,6 +333,8 @@ function buildJson({ artifactAbsent, parseError, artifact, measurementProfile, v
     metadata_clean: metadataWarningsList.length === 0,
     metadata_warnings_total: metadataWarningsList.length,
     required_row_count: rows?.length ?? REQUIRED_PROJECT_ROWS.length,
+    successful_project_timing_pairs: successfulProjectTimingPairs?.length ?? 0,
+    required_project_timing_pairs: requiredProjectTimingPairs,
     green: green?.length ?? 0,
     yellow: yellow?.length ?? 0,
     red: red?.length ?? 0,
@@ -417,7 +443,7 @@ function artifactAge(generatedAt) {
   return `${h} h ago`;
 }
 
-function buildReport({ artifact, measurementProfile, validationWarnings, sourceFreshness, rows, missing, red, yellow, gray, green, duplicates }) {
+function buildReport({ artifact, measurementProfile, validationWarnings, sourceFreshness, rows, successfulProjectTimingPairs, missing, red, yellow, gray, green, duplicates }) {
   const sourceCommit = artifact?.source_commit?.slice(0, 10) ?? "unknown";
   const generatedAt = artifact?.generated_at ?? null;
   const workflowUrl = artifact?.workflow_run_url ?? null;
@@ -445,6 +471,7 @@ function buildReport({ artifact, measurementProfile, validationWarnings, sourceF
     `| PGO profile | ${profile.profile_fingerprint ? `\`${profile.profile_fingerprint.slice(0, 12)}\`` : "—"} |`,
     `| PGO training | ${profile.training_fingerprint ? `\`${profile.training_fingerprint.slice(0, 12)}\`` : "—"} |`,
     `| Required rows | ${rows.length} |`,
+    `| Successful project timing pairs | ${successfulProjectTimingPairs.length} |`,
     `| ✅ green | ${green.length} |`,
     `| ⚠️ yellow | ${yellow.length} |`,
     `| ❌ red | ${red.length} |`,
@@ -547,6 +574,7 @@ if (artifactAbsent || parseError) {
         gray: null,
         green: null,
         duplicates: null,
+        successfulProjectTimingPairs: null,
       })) + "\n",
     );
   }
@@ -554,7 +582,19 @@ if (artifactAbsent || parseError) {
 }
 
 const analysis = analyzeArtifact(artifact, expectedSourceCommit);
-const { measurementProfile, validationWarnings, sourceFreshness, rows, missing, red, yellow, gray, green, duplicates } = analysis;
+const {
+  measurementProfile,
+  validationWarnings,
+  sourceFreshness,
+  rows,
+  successfulProjectTimingPairs,
+  missing,
+  red,
+  yellow,
+  gray,
+  green,
+  duplicates,
+} = analysis;
 
 writeReport(buildReport({ artifact, ...analysis }));
 
@@ -568,6 +608,7 @@ if (jsonOutput) {
       validationWarnings,
       sourceFreshness,
       rows,
+      successfulProjectTimingPairs,
       missing,
       red,
       yellow,
@@ -617,6 +658,14 @@ if (requireCleanMetadata) {
 if (requireSourceCurrent && sourceFreshness.current !== true) {
   process.stderr.write(
     `bench-artifact-readiness: source freshness failed: ${sourceFreshness.warning ?? "no expected source commit provided"}\n`,
+  );
+  process.exit(1);
+}
+
+if (successfulProjectTimingPairs.length < requiredProjectTimingPairs) {
+  process.stderr.write(
+    `bench-artifact-readiness: ${successfulProjectTimingPairs.length} successful project timing pair(s); ` +
+      `required ${requiredProjectTimingPairs} before publishing latest benchmark data\n`,
   );
   process.exit(1);
 }

--- a/scripts/bench/lib/bench-vs-tsgo-prereqs.sh
+++ b/scripts/bench/lib/bench-vs-tsgo-prereqs.sh
@@ -29,6 +29,7 @@ pgo_profile_fingerprint() {
         printf 'BENCH_PGO_FETCH_CORE_PROJECTS=%s\n' "${BENCH_PGO_FETCH_CORE_PROJECTS:-0}"
         printf 'BENCH_PGO_PANIC_UNWIND=%s\n' "${BENCH_PGO_PANIC_UNWIND:-0}"
         printf 'BENCH_PGO_EXTRA_INPUTS=%s\n' "${BENCH_PGO_EXTRA_INPUTS:-}"
+        printf 'BENCH_RUST_TARGET_CPU=%s\n' "${BENCH_RUST_TARGET_CPU:-native}"
         printf 'UTILITY_TYPES_REF=%s\n' "$UTILITY_TYPES_REF"
         printf 'TS_TOOLBELT_REF=%s\n' "$TS_TOOLBELT_REF"
         printf 'TS_ESSENTIALS_REF=%s\n' "$TS_ESSENTIALS_REF"
@@ -63,6 +64,7 @@ pgo_training_fingerprint() {
         printf 'BENCH_PGO_PANIC_UNWIND=%s\n' "${BENCH_PGO_PANIC_UNWIND:-0}"
         printf 'BENCH_PGO_EXTRA_INPUTS=%s\n' "${BENCH_PGO_EXTRA_INPUTS:-}"
         printf 'BENCH_PGO_TSZ_TIMEOUT=%s\n' "$BENCH_PGO_TSZ_TIMEOUT"
+        printf 'BENCH_RUST_TARGET_CPU=%s\n' "${BENCH_RUST_TARGET_CPU:-native}"
         local label
         for label in "${BENCH_PGO_TRAINING_INPUTS[@]}"; do
             printf 'training_input=%s\n' "$label"
@@ -90,6 +92,7 @@ write_pgo_training_metadata() {
         printf 'BENCH_PGO_PANIC_UNWIND=%s\n' "${BENCH_PGO_PANIC_UNWIND:-0}"
         printf 'BENCH_PGO_EXTRA_INPUTS=%s\n' "${BENCH_PGO_EXTRA_INPUTS:-}"
         printf 'BENCH_PGO_TSZ_TIMEOUT=%s\n' "$BENCH_PGO_TSZ_TIMEOUT"
+        printf 'BENCH_RUST_TARGET_CPU=%s\n' "${BENCH_RUST_TARGET_CPU:-native}"
         printf 'training_input_count=%s\n' "${#BENCH_PGO_TRAINING_INPUTS[@]}"
         printf 'training_failure_count=%s\n' "${#BENCH_PGO_TRAINING_FAILED_INPUTS[@]}"
         local label
@@ -117,6 +120,7 @@ write_pgo_training_unavailable_metadata() {
         printf 'BENCH_PGO_PANIC_UNWIND=%s\n' "${BENCH_PGO_PANIC_UNWIND:-0}"
         printf 'BENCH_PGO_EXTRA_INPUTS=%s\n' "${BENCH_PGO_EXTRA_INPUTS:-}"
         printf 'BENCH_PGO_TSZ_TIMEOUT=%s\n' "$BENCH_PGO_TSZ_TIMEOUT"
+        printf 'BENCH_RUST_TARGET_CPU=%s\n' "${BENCH_RUST_TARGET_CPU:-native}"
         printf 'training_input_count=0\n'
         printf 'training_failure_count=0\n'
     } > "$out_file"
@@ -857,6 +861,8 @@ check_prerequisites() {
         local pgo_cache_profdata="$pgo_cache_dir/merged.profdata"
         local pgo_cache_marker="$pgo_cache_dir/profile.fingerprint"
         local pgo_cache_metadata="$pgo_cache_dir/profile.metadata"
+        local bench_rust_target_cpu="${BENCH_RUST_TARGET_CPU:-native}"
+        local bench_rust_target_flags="-Ctarget-cpu=${bench_rust_target_cpu}"
         local pgo_target_dir
         local optimized_target_dir
         local pgo_profile_data_source="fresh"
@@ -905,7 +911,7 @@ check_prerequisites() {
                 # CFG hash mismatches during profile-use. BENCH_PGO_PANIC_UNWIND=1
                 # is still useful when deliberately training on crashy inputs,
                 # because panic=abort can skip LLVM's profiling atexit flush.
-                local pgo_generate_rustflags="-Cprofile-generate=$pgo_dir -Ctarget-cpu=native"
+                local pgo_generate_rustflags="-Cprofile-generate=$pgo_dir ${bench_rust_target_flags}"
                 if [[ "${BENCH_PGO_PANIC_UNWIND:-0}" == "1" ]]; then
                     pgo_generate_rustflags="$pgo_generate_rustflags -Cpanic=unwind"
                 fi
@@ -964,7 +970,7 @@ check_prerequisites() {
                     "PGO Step 3/3: optimized binary build" \
                     CARGO_TARGET_DIR="$optimized_target_dir" \
                     CARGO_INCREMENTAL=0 \
-                    RUSTFLAGS="-Cprofile-use=$pgo_merged -Ctarget-cpu=native" \
+                    RUSTFLAGS="-Cprofile-use=$pgo_merged ${bench_rust_target_flags}" \
                     cargo build --profile dist -p tsz-cli --bin tsz; then
                     if [[ "${BENCH_REQUIRE_PGO:-0}" == "1" ]]; then
                         echo -e "${RED}✗ PGO dist build failed and BENCH_REQUIRE_PGO=1${NC}"
@@ -979,7 +985,7 @@ check_prerequisites() {
                         "PGO Step 3 fallback: standard dist build" \
                         CARGO_TARGET_DIR="$optimized_target_dir" \
                         CARGO_INCREMENTAL=0 \
-                        RUSTFLAGS="-Ctarget-cpu=native" \
+                        RUSTFLAGS="$bench_rust_target_flags" \
                         cargo build --profile dist -p tsz-cli --bin tsz
                 else
                     pgo_optimized=true
@@ -996,7 +1002,7 @@ check_prerequisites() {
                     "PGO Step 3: standard dist build" \
                     CARGO_TARGET_DIR="$optimized_target_dir" \
                     CARGO_INCREMENTAL=0 \
-                    RUSTFLAGS="-Ctarget-cpu=native" \
+                    RUSTFLAGS="$bench_rust_target_flags" \
                     cargo build --profile dist -p tsz-cli --bin tsz
             fi
             mkdir -p "$TSZ_OUTPUT_DIR"
@@ -1022,7 +1028,7 @@ check_prerequisites() {
                 "Standard dist build" \
                 CARGO_TARGET_DIR="$optimized_target_dir" \
                 CARGO_INCREMENTAL=0 \
-                RUSTFLAGS="-Ctarget-cpu=native" \
+                RUSTFLAGS="$bench_rust_target_flags" \
                 cargo build --profile dist -p tsz-cli --bin tsz
             mkdir -p "$TSZ_OUTPUT_DIR"
             install -m 755 "$optimized_target_dir/dist/tsz" "$TSZ"

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -13,9 +13,16 @@ const BENCH_SHARD_CLOUDBUILD = path.join(
   "cloudbuild",
   "cloudbuild-bench-shard.yaml",
 );
+const BENCH_PREPARE_CLOUDBUILD = path.join(
+  ROOT,
+  "scripts",
+  "cloudbuild",
+  "cloudbuild-bench-prepare.yaml",
+);
 
 const workflow = fs.readFileSync(BENCH_WORKFLOW, "utf8");
 const shardCloudbuild = fs.readFileSync(BENCH_SHARD_CLOUDBUILD, "utf8");
+const prepareCloudbuild = fs.readFileSync(BENCH_PREPARE_CLOUDBUILD, "utf8");
 
 const successGraceWindows = workflow.match(
   /success_seen_at=""[\s\S]+?success_grace_seconds=7200/g,
@@ -66,6 +73,17 @@ assert.match(
   workflow,
   /- name: Upload benchmark prep diagnostics[\s\S]+if: failure\(\)[\s\S]+name: bench-prep-diagnostics[\s\S]+bench-prep-cloudbuild\.log[\s\S]+cloudbuild-artifacts\.json[\s\S]+latest-bench-prep\.env/,
   "bench-prep-artifact should upload Cloud Build handoff diagnostics when prep artifact polling fails",
+);
+
+assert.match(
+  prepareCloudbuild,
+  /BENCH_RUST_TARGET_CPU=x86-64/,
+  "Cloud Build benchmark prep should build portable PGO binaries instead of target-cpu=native",
+);
+assert.match(
+  shardCloudbuild,
+  /BENCH_RUST_TARGET_CPU=x86-64/,
+  "Cloud Build benchmark shards should inherit the same portable bench target CPU",
 );
 
 assert.match(

--- a/scripts/bench/test-benchmark-artifact-selection.mjs
+++ b/scripts/bench/test-benchmark-artifact-selection.mjs
@@ -14,6 +14,24 @@ function writeArtifact(name, generatedAt, results = [{ name: "row", tsz_ms: 1, t
   return file;
 }
 
+function projectRow(name, state = "green") {
+  const ok = state === "green";
+  return {
+    name,
+    tsz_ms: ok ? 10 : null,
+    tsgo_ms: ok ? 20 : null,
+    winner: ok ? "tsz" : "error",
+    status: ok ? null : "tsz error; tsc ok",
+    compatibility: {
+      state,
+      phase: "check",
+      last_successful_phase: ok ? "check" : null,
+      exit_class: ok ? "exit success" : "crash",
+      diagnostic_status: ok ? "none" : "compiler crashed",
+    },
+  };
+}
+
 try {
   const snapshot = writeArtifact("bench-snapshot.json", "2026-05-17T01:23:02.991Z");
   const github = writeArtifact("bench-vs-tsgo-github-latest.json", "2026-05-28T02:14:24.444Z");
@@ -34,6 +52,19 @@ try {
     selectLatestBenchmarkArtifact([empty, github])?.file,
     github,
     "empty benchmark JSON should not mask the latest usable artifact",
+  );
+  const goodProject = writeArtifact("good-project.json", "2026-05-30T00:00:00.000Z", [
+    projectRow("utility-types-project"),
+    { name: "micro", tsz_ms: 1, tsgo_ms: 2, winner: "tsz" },
+  ]);
+  const badProject = writeArtifact("bad-project.json", "2026-06-01T00:00:00.000Z", [
+    projectRow("utility-types-project", "red"),
+    { name: "micro", tsz_ms: 1, tsgo_ms: 2, winner: "tsz" },
+  ]);
+  assert.equal(
+    selectLatestBenchmarkArtifact([goodProject, badProject], { minimumProjectTimingPairs: 1 })?.file,
+    goodProject,
+    "a newer artifact with no successful project timings should not mask older public project timing data",
   );
   assert.equal(
     selectLatestBenchmarkArtifact([path.join(tempDir, "missing.json")]),

--- a/scripts/bench/test-check-artifact-readiness.mjs
+++ b/scripts/bench/test-check-artifact-readiness.mjs
@@ -72,9 +72,9 @@ function makeRow(name, state = "green", opts = {}) {
     name,
     lines: 100,
     kb: 10,
-    tsz_ms: opts.tsz_ms ?? 50,
-    tsgo_ms: opts.tsgo_ms ?? 40,
-    winner: opts.winner ?? "tsgo",
+    tsz_ms: Object.hasOwn(opts, "tsz_ms") ? opts.tsz_ms : 50,
+    tsgo_ms: Object.hasOwn(opts, "tsgo_ms") ? opts.tsgo_ms : 40,
+    winner: Object.hasOwn(opts, "winner") ? opts.winner : "tsgo",
     ratio: 1.25,
     ...(opts.errorStatus ? { status: opts.errorStatus } : {}),
     compatibility: makeCompatibility(state),
@@ -171,6 +171,40 @@ withTempDir((dir) => {
   assert.match(result.stderr, /PGO training.*123456abcdef/, "should show PGO training fingerprint");
 });
 console.log("✅ complete all-green artifact exits 0");
+
+// ---------------------------------------------------------------------------
+// Test: --require-project-timing-pairs accepts a present artifact with at least
+// one successful project timing row.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const rows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+  writeJson(file, makeArtifact(rows, { measurement_profile: SAMPLE_MEASUREMENT_PROFILE }));
+  const result = run(file, ["--json", "--require-project-timing-pairs=1"]);
+  assert.equal(result.status, 0, `project timing pair gate should pass on green timed rows:\n${result.stderr}`);
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(
+    parsed.successful_project_timing_pairs,
+    REQUIRED_PROJECT_ROWS.length,
+    "JSON should count successful project timing pairs",
+  );
+});
+console.log("✅ --require-project-timing-pairs passes with project timing data");
+
+// ---------------------------------------------------------------------------
+// Test: bare --require-project-timing-pairs defaults to one timing pair without
+// consuming the artifact path as a value.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const rows = REQUIRED_PROJECT_ROWS.map((name) => makeRow(name, "green"));
+  writeJson(file, makeArtifact(rows));
+  const result = run(file, ["--json", "--require-project-timing-pairs"]);
+  assert.equal(result.status, 0, `bare project timing pair gate should pass:\n${result.stderr}`);
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.required_project_timing_pairs, 1);
+});
+console.log("✅ bare --require-project-timing-pairs defaults to one pair");
 
 // ---------------------------------------------------------------------------
 // Test: expected source commit marks an artifact current when it matches.
@@ -383,6 +417,25 @@ withTempDir((dir) => {
   );
 });
 console.log("✅ red row present in artifact exits 0 (not missing)");
+
+// ---------------------------------------------------------------------------
+// Test: --require-project-timing-pairs fails an otherwise complete artifact
+// when every project row crashed before timing.
+// ---------------------------------------------------------------------------
+withTempDir((dir) => {
+  const file = path.join(dir, "bench.json");
+  const rows = REQUIRED_PROJECT_ROWS.map((name) =>
+    makeRow(name, "red", { errorStatus: "tsz error; tsc ok", tsz_ms: null, tsgo_ms: null, winner: "error" }),
+  );
+  writeJson(file, makeArtifact(rows));
+  const result = run(file, ["--json", "--require-project-timing-pairs=1"]);
+  assert.equal(result.status, 1, "publish gate should fail when no project timing pairs succeeded");
+  const parsed = JSON.parse(result.stdout.trim());
+  assert.equal(parsed.successful_project_timing_pairs, 0, "JSON should show zero successful project timings");
+  assert.equal(parsed.required_project_timing_pairs, 1, "JSON should include the requested timing-pair floor");
+  assert.match(result.stderr, /0 successful project timing pair\(s\); required 1/);
+});
+console.log("✅ --require-project-timing-pairs fails all-crashed project artifacts");
 
 // ---------------------------------------------------------------------------
 // Test: --require-green fails when any present required row is red.

--- a/scripts/bench/test-project-winner-regression-report.mjs
+++ b/scripts/bench/test-project-winner-regression-report.mjs
@@ -189,5 +189,15 @@ assert.match(
   /bench-results-project-winner-regressions\.md/,
   "merged benchmark artifact should include the project winner regression markdown report",
 );
+assert.match(
+  benchWorkflow,
+  /check-artifact-readiness\.mjs\s+\\\s*\n\s+--json\s+\\\s*\n\s+--require-project-timing-pairs=1\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results\.json"/,
+  "bench publish should reject artifacts with no successful project timing pairs before publishing latest.json",
+);
+assert.match(
+  benchWorkflow,
+  /bench-results-readiness\.json/,
+  "merged benchmark artifact should include the public publish readiness JSON report",
+);
 
 console.log("project winner regression report tests passed");

--- a/scripts/cloudbuild/cloudbuild-bench-prepare.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-prepare.yaml
@@ -9,6 +9,7 @@ steps:
       - 'BENCH_COLD=1'
       - 'BENCH_PGO=1'
       - 'BENCH_REQUIRE_PGO=1'
+      - 'BENCH_RUST_TARGET_CPU=x86-64'
       - 'TSC_NPM_SPEC=6.0.2'
       - 'CARGO_BUILD_JOBS=32'
       - 'CARGO_INCREMENTAL=0'

--- a/scripts/cloudbuild/cloudbuild-bench-shard.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-shard.yaml
@@ -53,6 +53,7 @@ steps:
       - 'BENCH_COLD=1'
       - 'BENCH_PGO=1'
       - 'BENCH_REQUIRE_PGO=1'
+      - 'BENCH_RUST_TARGET_CPU=x86-64'
       - 'TSC_NPM_SPEC=6.0.2'
       - 'CARGO_INCREMENTAL=0'
       - 'RUST_MIN_STACK=16777216'


### PR DESCRIPTION
## Agent
AgentName: Studio-manager

## Track
Track 1 / Studio-A benchmark blocker; public benchmark artifact guardrail and benchmark runner portability.

## Invariant
When a merged benchmark artifact has no successful project timing pairs because project checks crash before timing, it must not replace public latest benchmark data; this PR changes the benchmark publish gate, website artifact selection, and Cloud Build bench build target CPU.

## Scope
- Add successful project timing pair counting to benchmark artifact selection and readiness reporting.
- Require at least one successful project timing pair before the merged benchmark artifact is uploaded for public latest publishing.
- Make website benchmark data and mean-chart auto-selection skip newer artifacts with zero successful project timing pairs, while preserving explicit `TSZ_WEBSITE_BENCHMARK_ARTIFACT` overrides.
- Add `BENCH_RUST_TARGET_CPU` for bench builds and set Cloud Build prepare/shard jobs to portable `x86-64` instead of implicit `native`.
- Cover the regression in focused benchmark harness tests.

## Project Corpus Impact
- Row: all required project benchmark rows.
- Bug family: benchmark artifact crash/readiness; current public page selected a newer artifact with project `tsz` crashes and no usable project timing pairs.
- Evidence: GitHub benchmark run `27053272297` artifact had `0` successful project timing pairs; every timed project row had `tsc`/`tsgo` success but `tsz` exit `132`, so the public Benchmarks page showed micro timings while project timings were empty. The checked-in snapshot still has successful project timing data and is now selected as the fallback.

## Verification
- `git diff --check HEAD~1..HEAD`
- `node scripts/bench/test-benchmark-artifact-selection.mjs`
- `node scripts/bench/test-check-artifact-readiness.mjs`
- `node scripts/bench/test-project-winner-regression-report.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs && node scripts/bench/test-ci-health-benchmark-readiness.mjs`
- Replay against live bad artifact: `node scripts/bench/check-artifact-readiness.mjs --json --require-project-timing-pairs=1 /tmp/tsz-bench-27053272297/bench-results.json` exits `1` with `successful_project_timing_pairs: 0`.
- Selector replay with the bad artifact plus `crates/tsz-website/bench-snapshot.json` selects the healthy snapshot.
- Not run: `node crates/tsz-website/scripts/benchmark-data-smoke.mjs`; this side worktree has no website `node_modules`, and `marked` is not installed.

## Coordination Notes
- Overlap checked with open PR list and `scripts/agents/ensure-agent-labels.sh --audit`; no overlapping benchmark artifact PR found and label audit passes.
- No compiler semantics changed.
- Ready for review; not queued until exact-head checks pass.
