### PR TITLE
refactor(checker): route rest element probe through boundary

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/type_checking_utilities.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_checking_utilities.rs
@@ -1,4 +1,4 @@
-use tsz_solver::construction::TypeDatabase;
+use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::{TupleListId, TypeId};
 
 /// Returns `true` when `type_id`'s outer shape performs fresh tuple synthesis
@@ -32,6 +32,38 @@ pub(crate) fn classify_literal_type(db: &dyn TypeDatabase, type_id: TypeId) -> L
 
 pub(crate) fn classify_array_like(db: &dyn TypeDatabase, type_id: TypeId) -> ArrayLikeKind {
     tsz_solver::type_queries::classify_array_like(db, type_id)
+}
+
+/// Outcome-shaped relation for rest tuple element array-like probes.
+///
+/// `TypeNodeChecker` does not own a full checker state, so it cannot call the
+/// checker-state rest-parameter relation helper directly. Keep the database
+/// relation inside this boundary while exposing the same [`RelationOutcome`]
+/// shape that checker-state relation helpers use.
+///
+/// [`RelationOutcome`]: super::assignability::RelationOutcome
+pub(crate) fn rest_element_array_like_relation_outcome(
+    db: &dyn QueryDatabase,
+    source: TypeId,
+    target: TypeId,
+) -> super::assignability::RelationOutcome {
+    let result = tsz_solver::relations::relation_queries::query_relation(
+        db.as_type_database(),
+        source,
+        target,
+        tsz_solver::relations::relation_queries::RelationKind::Assignable,
+        tsz_solver::relations::relation_queries::RelationPolicy::unflagged_compatibility(),
+        tsz_solver::relations::relation_queries::RelationContext::default(),
+    );
+
+    super::assignability::RelationOutcome {
+        related: result.related,
+        depth_exceeded: result.depth_exceeded,
+        iteration_exceeded: result.iteration_exceeded,
+        failure: None,
+        weak_union_violation: false,
+        property_classification: None,
+    }
 }
 
 pub(crate) use super::common::unwrap_readonly as unwrap_readonly_for_lookup;

--- a/crates/tsz-checker/src/tests/rest_parameter_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/rest_parameter_relation_routing_arch_tests.rs
@@ -60,3 +60,31 @@ fn rest_parameter_relation_outcome_uses_rest_parameter_request() {
         "rest parameter array diagnostics should have a request-shaped RelationKind::RestParameter helper"
     );
 }
+
+#[test]
+fn rest_tuple_element_array_like_probe_uses_relation_outcome_boundary() {
+    let helper_source = fs::read_to_string("src/types/type_node_helpers.rs")
+        .expect("failed to read type_node_helpers.rs");
+    let boundary_source = fs::read_to_string("src/query_boundaries/type_checking_utilities.rs")
+        .expect("failed to read type_checking_utilities.rs");
+    let compact_helper: String = helper_source
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect();
+
+    assert!(
+        compact_helper.contains(
+            "rest_element_array_like_relation_outcome(self.ctx.types,t,readonly_any_array).related"
+        ),
+        "TS2574 rest tuple element array-like probes should consume an outcome-shaped boundary"
+    );
+    assert!(
+        !compact_helper.contains("self.ctx.types.is_assignable_to(t,readonly_any_array)"),
+        "TS2574 rest tuple element array-like probes should not call raw TypeDatabase assignability"
+    );
+    assert!(
+        boundary_source.contains("fn rest_element_array_like_relation_outcome(")
+            && boundary_source.contains("relation_queries::query_relation("),
+        "type-node rest element relation truth should live behind a query boundary"
+    );
+}

--- a/crates/tsz-checker/src/types/type_node_helpers.rs
+++ b/crates/tsz-checker/src/types/type_node_helpers.rs
@@ -721,7 +721,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         type_id: tsz_solver::TypeId,
         depth: u32,
     ) -> bool {
-        use crate::query_boundaries::common as q;
+        use crate::query_boundaries::{common as q, type_checking_utilities as type_utils};
         // Bound the constraint/wrapper/union recursion; an undecided type is not
         // "definitely" non-array-like, so give up in the legal direction.
         if depth > 8 {
@@ -794,7 +794,8 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             let factory = self.ctx.types.factory();
             factory.readonly_type(factory.array(TypeId::ANY))
         };
-        !self.ctx.types.is_assignable_to(t, readonly_any_array)
+        !type_utils::rest_element_array_like_relation_outcome(self.ctx.types, t, readonly_any_array)
+            .related
     }
 
     /// Resolve a rest-element type to its inspectable shape for the TS2574


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Checker architecture/query-boundary cleanup for #8227 and #8225.

## Invariant
When TS2574 rest tuple element checking resolves a concrete rest element type and probes whether it is array-like by assignability to `readonly any[]`, TypeNodeChecker owns the AST recovery and recursive type-node traversal, while the relation question is routed through a named query boundary returning RelationOutcome shape. This PR changes the checker/query-boundary surface only; solver relation policy is unchanged.

## Scope
- Adds `rest_element_array_like_relation_outcome` in `query_boundaries/type_checking_utilities.rs`.
- Routes the TS2574 rest tuple array-like probe in `types/type_node_helpers.rs` through that boundary instead of raw `TypeDatabase::is_assignable_to`.
- Adds an architecture regression test proving this specific probe consumes the outcome-shaped boundary and no longer calls the raw database relation.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: boundary-only checker refactor for an existing TS2574 relation probe; no emit, parser, project compile, or solver-policy behavior changed.

## Verification
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib rest_tuple_element_array_like_probe_uses_relation_outcome_boundary`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib ts2574_rest_tuple_element_type_tests`

## Coordination Notes
- Avoids M1-A diagnostic-display work by not touching assignment formatting or mapped object literal diagnostic surfacing.
- Avoids M1-D narrowing work by not touching flow/narrowing handoff paths.
- Avoids Studio-B performance and M4 solver-policy work by preserving relation policy and changing only the checker query-boundary routing surface.
- Disk note: local verification initially hit machine disk exhaustion from broad nextest enumeration; recovered via the repo cleanup ladder by removing merged stale M1-B worktree #12729, then reran focused checks successfully on rebased head `f00f4c664563`.
