### PR TITLE
fix(emit): align es2015 static super field temps

### DIFF
--- a/crates/tsz-emitter/src/emitter/comments/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/comments/helpers.rs
@@ -1138,13 +1138,19 @@ impl<'a> Printer<'a> {
         let bytes = text.as_bytes();
         for c in &self.all_comments {
             if c.pos >= range_start && c.end <= actual_start {
-                // Only collect block comments (/* ... */), not line comments (// ...).
-                // Line comments between members are trailing comments of the previous
-                // member (e.g. `get p() { ... } // error`), not leading comments of
-                // the next property being lowered into the constructor.
                 if c.pos as usize + 1 < bytes.len()
                     && bytes[c.pos as usize] == b'/'
                     && bytes[c.pos as usize + 1] == b'*'
+                    && let Ok(comment_text) =
+                        crate::safe_slice::slice(text, c.pos as usize, c.end as usize)
+                {
+                    result.push(comment_text.to_string());
+                } else if c.pos as usize + 1 < bytes.len()
+                    && bytes[c.pos as usize] == b'/'
+                    && bytes[c.pos as usize + 1] == b'/'
+                    && text
+                        .get(range_start as usize..c.pos as usize)
+                        .is_some_and(|between| between.contains('\n'))
                     && let Ok(comment_text) =
                         crate::safe_slice::slice(text, c.pos as usize, c.end as usize)
                 {

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -992,6 +992,11 @@ pub struct Printer<'a> {
     /// as a destructuring assignment target and should become a writable setter.
     pub(crate) scoped_static_super_assignment_target: bool,
 
+    /// When true, value-producing scoped static `super` writes in lowered static
+    /// field initializers use tsc's hoisted-temp comma expression form instead
+    /// of the decorator/static-block IIFE form.
+    pub(crate) scoped_static_super_value_write_as_comma: bool,
+
     /// Temporary alias for named class expressions that are wrapped in a comma
     /// expression, e.g. `(_a = class Foo { m() { return _a; } }, _a.x = 1, _a)`.
     pub(crate) scoped_class_expression_self_alias: Option<(Arc<str>, Arc<str>)>,

--- a/crates/tsz-emitter/src/emitter/core_setup.rs
+++ b/crates/tsz-emitter/src/emitter/core_setup.rs
@@ -412,6 +412,7 @@ impl<'a> Printer<'a> {
             scoped_static_super_index_alias: None,
             scoped_static_super_index_value_access: false,
             scoped_static_super_assignment_target: false,
+            scoped_static_super_value_write_as_comma: false,
             scoped_class_expression_self_alias: None,
             scoped_class_expression_self_alias_ancestors: Vec::new(),
             pending_tc39_class_expression_name: None,
@@ -909,12 +910,15 @@ impl<'a> Printer<'a> {
             self.comment_emit_idx = first_inner;
         }
 
+        let prev_value_write_as_comma = self.scoped_static_super_value_write_as_comma;
+        self.scoped_static_super_value_write_as_comma = true;
         self.emit_expression_with_scoped_static_initializer_mode(
             init_idx,
             this_alias,
             super_base_alias,
             super_direct_access,
         );
+        self.scoped_static_super_value_write_as_comma = prev_value_write_as_comma;
 
         // Never move the cursor backwards relative to where emission left it,
         // and never expose comments the surrounding code already consumed.

--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_after_body.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_es6_after_body.rs
@@ -8,6 +8,7 @@ use crate::emitter::core::{PrivateAccessorDef, PrivateMethodDef};
 use std::sync::Arc;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{ClassData, Node};
+use tsz_scanner::SyntaxKind;
 
 pub(super) struct ClassEs6AfterBody<'a> {
     pub(super) node: &'a Node,
@@ -601,44 +602,74 @@ impl<'a> Printer<'a> {
                             s.clone()
                         }
                     };
-                    self.write("Object.defineProperty(");
-                    self.write(&class_name);
-                    self.write(", ");
-                    self.write(&define_name);
-                    self.write(", {");
-                    self.write_line();
-                    self.increase_indent();
-                    self.write("enumerable: true,");
-                    self.write_line();
-                    self.write("configurable: true,");
-                    self.write_line();
-                    self.write("writable: true,");
-                    self.write_line();
-                    self.write("value: ");
-                    let before = self.writer.len();
-                    self.emit_static_field_initializer_with_inner_comments(
-                        *init_idx,
-                        static_initializer_this_binding,
-                        static_initializer_super_base,
-                        externalized_static_initializer_uses_undefined_receiver,
-                    );
-                    let after = self.writer.len();
-                    if let Some(alias) =
-                        static_initializer_self_alias.or(static_initializer_class_alias.as_deref())
-                        && !class_name.is_empty()
-                        && class_name != alias
-                    {
-                        let full = self.writer.get_output().to_string();
-                        let segment = &full[before..after];
-                        let replaced = replace_identifier(segment, &class_name, alias);
-                        if replaced != segment {
-                            self.writer.truncate(before);
-                            self.write(&replaced);
+                    if self.static_field_initializer_is_object_rest_assignment(*init_idx) {
+                        self.write("Object.defineProperty(");
+                        self.write(&class_name);
+                        self.write(", ");
+                        self.write(&define_name);
+                        self.write(", Object.assign({ enumerable: true, configurable: true, writable: true, value: ");
+                        let before = self.writer.len();
+                        self.emit_static_field_initializer_with_inner_comments(
+                            *init_idx,
+                            static_initializer_this_binding,
+                            static_initializer_super_base,
+                            externalized_static_initializer_uses_undefined_receiver,
+                        );
+                        let after = self.writer.len();
+                        if let Some(alias) = static_initializer_self_alias
+                            .or(static_initializer_class_alias.as_deref())
+                            && !class_name.is_empty()
+                            && class_name != alias
+                        {
+                            let full = self.writer.get_output().to_string();
+                            let segment = &full[before..after];
+                            let replaced = replace_identifier(segment, &class_name, alias);
+                            if replaced != segment {
+                                self.writer.truncate(before);
+                                self.write(&replaced);
+                            }
                         }
+                        self.write(" }));");
+                    } else {
+                        self.write("Object.defineProperty(");
+                        self.write(&class_name);
+                        self.write(", ");
+                        self.write(&define_name);
+                        self.write(", {");
+                        self.write_line();
+                        self.increase_indent();
+                        self.write("enumerable: true,");
+                        self.write_line();
+                        self.write("configurable: true,");
+                        self.write_line();
+                        self.write("writable: true,");
+                        self.write_line();
+                        self.write("value: ");
+                        let before = self.writer.len();
+                        self.emit_static_field_initializer_with_inner_comments(
+                            *init_idx,
+                            static_initializer_this_binding,
+                            static_initializer_super_base,
+                            externalized_static_initializer_uses_undefined_receiver,
+                        );
+                        let after = self.writer.len();
+                        if let Some(alias) = static_initializer_self_alias
+                            .or(static_initializer_class_alias.as_deref())
+                            && !class_name.is_empty()
+                            && class_name != alias
+                        {
+                            let full = self.writer.get_output().to_string();
+                            let segment = &full[before..after];
+                            let replaced = replace_identifier(segment, &class_name, alias);
+                            if replaced != segment {
+                                self.writer.truncate(before);
+                                self.write(&replaced);
+                            }
+                        }
+                        self.write_line();
+                        self.decrease_indent();
+                        self.write("});");
                     }
-                    self.write_line();
-                    self.decrease_indent();
-                    self.write("});");
                 } else {
                     self.write(&class_name);
                     match name_emit {
@@ -1080,5 +1111,16 @@ impl<'a> Printer<'a> {
             );
             self.scoped_class_expression_self_alias = prev_self_alias;
         }
+    }
+
+    fn static_field_initializer_is_object_rest_assignment(&self, init_idx: NodeIndex) -> bool {
+        let Some(init_node) = self.arena.get(init_idx) else {
+            return false;
+        };
+        let Some(binary) = self.arena.get_binary_expr(init_node) else {
+            return false;
+        };
+        binary.operator_token == SyntaxKind::EqualsToken as u16
+            && self.assignment_pattern_has_object_rest(binary.left)
     }
 }

--- a/crates/tsz-emitter/src/emitter/expressions/static_super.rs
+++ b/crates/tsz-emitter/src/emitter/expressions/static_super.rs
@@ -134,6 +134,11 @@ impl<'a> Printer<'a> {
             return false;
         }
 
+        if self.scoped_static_super_value_write_as_comma {
+            self.emit_scoped_static_super_value_assignment_comma(member, operator, right);
+            return true;
+        }
+
         self.emit_scoped_static_super_value_iife(|this| {
             let key_temp = if operator == SyntaxKind::EqualsToken as u16 {
                 None
@@ -182,6 +187,11 @@ impl<'a> Printer<'a> {
             return false;
         }
 
+        if self.scoped_static_super_value_write_as_comma {
+            self.emit_scoped_static_super_value_update_comma(member, operator, is_prefix);
+            return true;
+        }
+
         self.emit_scoped_static_super_value_iife(|this| {
             let key_temp = this.scoped_static_super_element_key_temp(member);
             let result_temp = this.make_unique_name();
@@ -221,6 +231,74 @@ impl<'a> Printer<'a> {
             this.write_semicolon();
         });
         true
+    }
+
+    fn emit_scoped_static_super_value_assignment_comma(
+        &mut self,
+        member: &StaticSuperMember,
+        operator: u16,
+        right: NodeIndex,
+    ) {
+        let key_temp = if operator == SyntaxKind::EqualsToken as u16 {
+            None
+        } else {
+            self.scoped_static_super_element_key_temp(member)
+        };
+        let result_temp = self.make_unique_name_hoisted();
+
+        self.write("(");
+        self.emit_scoped_static_super_set_start_with_key(member, key_temp.as_deref(), true);
+        self.write(&result_temp);
+        self.write(" = ");
+        if operator == SyntaxKind::EqualsToken as u16 {
+            self.emit(right);
+        } else {
+            self.emit_scoped_static_super_get_with_key(member, key_temp.as_deref(), false);
+            self.write(" ");
+            self.write(self.static_super_compound_base_operator(operator));
+            self.write(" ");
+            self.emit(right);
+        }
+        self.emit_scoped_static_super_set_end();
+        self.write(", ");
+        self.write(&result_temp);
+        self.write(")");
+    }
+
+    fn emit_scoped_static_super_value_update_comma(
+        &mut self,
+        member: &StaticSuperMember,
+        operator: u16,
+        is_prefix: bool,
+    ) {
+        let key_temp = self.scoped_static_super_element_key_temp(member);
+        let result_temp = self.make_unique_name_hoisted();
+        let value_temp = self.make_unique_name_hoisted();
+        let op_text = get_operator_text(operator);
+
+        self.write("(");
+        self.emit_scoped_static_super_set_start_with_key(member, key_temp.as_deref(), true);
+        self.write("(");
+        self.write(&value_temp);
+        self.write(" = ");
+        self.emit_scoped_static_super_get_with_key(member, key_temp.as_deref(), false);
+        self.write(", ");
+        self.write(&result_temp);
+        self.write(" = ");
+        if is_prefix {
+            self.write(op_text);
+            self.write(&value_temp);
+        } else {
+            self.write(&value_temp);
+            self.write(op_text);
+            self.write(", ");
+            self.write(&value_temp);
+        }
+        self.write(")");
+        self.emit_scoped_static_super_set_end();
+        self.write(", ");
+        self.write(&result_temp);
+        self.write(")");
     }
 
     fn emit_scoped_static_super_value_iife(&mut self, emit_body: impl FnOnce(&mut Self)) {

--- a/crates/tsz-emitter/src/emitter/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/helpers.rs
@@ -1124,6 +1124,11 @@ impl<'a> Printer<'a> {
                     self.estimate_object_rest_assignment_pattern_temps(binary.left, source_simple);
             }
 
+            if self.arena.get_class(node).is_some() {
+                self.push_class_static_initializer_temp_children(node, &mut stack);
+                continue;
+            }
+
             if self.is_logical_assignment_temp_scope_boundary(node) {
                 continue;
             }
@@ -1134,6 +1139,28 @@ impl<'a> Printer<'a> {
         }
 
         count
+    }
+
+    fn push_class_static_initializer_temp_children(&self, node: &Node, stack: &mut Vec<NodeIndex>) {
+        let Some(class) = self.arena.get_class(node) else {
+            return;
+        };
+
+        for &member_idx in &class.members.nodes {
+            let Some(member) = self.arena.get(member_idx) else {
+                continue;
+            };
+            if member.kind != syntax_kind_ext::PROPERTY_DECLARATION {
+                continue;
+            }
+            let Some(prop) = self.arena.get_property_decl(member) else {
+                continue;
+            };
+            if !self.arena.is_static(&prop.modifiers) || prop.initializer.is_none() {
+                continue;
+            }
+            stack.push(prop.initializer);
+        }
     }
 
     fn estimate_object_rest_assignment_pattern_temps(

--- a/crates/tsz-emitter/src/emitter/source_file/class_static_alias_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/class_static_alias_tests.rs
@@ -260,3 +260,80 @@ fn es2015_mixin_arrow_typed_param_and_return_keeps_single_line_block() {
         "Annotated mixin static field should be a comma item.\nOutput:\n{output}"
     );
 }
+
+#[test]
+fn es2015_define_static_super_writes_use_hoisted_comma_temps() {
+    let source = "\
+declare class Base { static a: any; }
+class C extends Base {
+    static assign = super.a = 0;
+    static add = super.a += 1;
+    static rest = { ...super.a } = { x: 0 };
+    static pre = ++super.a;
+    static elem = ++super[(\"a\")];
+    static post = super.a++;
+
+    // keep instance comment
+    x = 1;
+}
+";
+    let output = emit_with_define(source, ScriptTarget::ES2015, true);
+
+    assert!(
+        output.contains("var _a;\nvar _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m;"),
+        "Object-rest assignment temp should be declared before class/static-super temps in tsc order.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("class C extends (_c = Base)") && output.contains("_b = C;"),
+        "Static field initializers should use separate class and base aliases.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("value: (Reflect.set(_c, \"a\", _d = 0, _b), _d)")
+            && output.contains("value: (Reflect.set(_c, \"a\", _e = Reflect.get(_c, \"a\", _b) + 1, _b), _e)")
+            && output.contains("value: (Reflect.set(_c, \"a\", (_g = Reflect.get(_c, \"a\", _b), _f = ++_g), _b), _f)")
+            && output.contains("value: (Reflect.set(_c, _h = (\"a\"), (_k = Reflect.get(_c, _h, _b), _j = ++_k), _b), _j)")
+            && output.contains("value: (Reflect.set(_c, \"a\", (_m = Reflect.get(_c, \"a\", _b), _l = _m++, _m), _b), _l)"),
+        "Value-producing static `super` writes should use hoisted comma expressions, not IIFEs.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("Object.defineProperty(C, \"rest\", Object.assign({ enumerable: true, configurable: true, writable: true, value: (_a = { x: 0 },"),
+        "Define-mode object-rest static initializer should use tsc's compact `Object.assign` descriptor.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains(
+            "        // keep instance comment\n        Object.defineProperty(this, \"x\""
+        ),
+        "Leading comments before lowered instance fields should remain in the synthesized constructor.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn es2015_assign_static_super_writes_use_hoisted_comma_temps() {
+    let source = "\
+declare class Base { static a: any; }
+class C extends Base {
+    static assign = super.a = 0;
+    static add = super.a += 1;
+    static pre = ++super.a;
+
+    // keep instance comment
+    x = 1;
+}
+";
+    let output = emit_with_define(source, ScriptTarget::ES2015, false);
+
+    assert!(
+        output.contains("class C extends (_b = Base)") && output.contains("_a = C;"),
+        "Assignment-mode static field initializers should keep class/base aliases stable.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("C.assign = (Reflect.set(_b, \"a\", _c = 0, _a), _c);")
+            && output.contains("C.add = (Reflect.set(_b, \"a\", _d = Reflect.get(_b, \"a\", _a) + 1, _a), _d);")
+            && output.contains("C.pre = (Reflect.set(_b, \"a\", (_f = Reflect.get(_b, \"a\", _a), _e = ++_f), _a), _e);"),
+        "Assignment-mode static `super` writes should also use hoisted comma expressions.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("        // keep instance comment\n        this.x = 1;"),
+        "Leading comments before lowered assignment-mode instance fields should be preserved.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/emit.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit.rs
@@ -1912,18 +1912,12 @@ impl<'a> Printer<'a> {
             .collect();
 
         if !self.ctx.options.legacy_decorators {
-            let mut same_location_ref_vars = file_level_class_temps;
-            same_location_ref_vars.extend(
-                self.hoisted_deferred_static_class_result_temps
-                    .iter()
-                    .cloned(),
+            self.insert_nonlegacy_same_location_hoists(
+                hoist_byte_offset,
+                hoist_line,
+                file_level_class_temps,
+                ref_vars,
             );
-            same_location_ref_vars.extend(ref_vars);
-            if !same_location_ref_vars.is_empty() {
-                let var_decl = format!("var {};", same_location_ref_vars.join(", "));
-                self.writer
-                    .insert_line_at(hoist_byte_offset, hoist_line, &var_decl);
-            }
         } else {
             if !self.hoisted_deferred_static_class_result_temps.is_empty() {
                 let var_decl = format!(

--- a/crates/tsz-emitter/src/emitter/source_file/emit_parts/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/emit_parts/helpers.rs
@@ -76,6 +76,43 @@ impl<'a> Printer<'a> {
         self.prepare_file_level_class_temp_reservations(statements);
     }
 
+    pub(in crate::emitter) fn insert_nonlegacy_same_location_hoists(
+        &mut self,
+        hoist_byte_offset: usize,
+        hoist_line: u32,
+        file_level_class_temps: Vec<String>,
+        ref_vars: Vec<String>,
+    ) {
+        let first_class_temp_rank = file_level_class_temps
+            .iter()
+            .filter_map(|name| temp_name_rank(name))
+            .min();
+        let (early_ref_vars, trailing_ref_vars): (Vec<_>, Vec<_>) =
+            ref_vars.into_iter().partition(|name| {
+                first_class_temp_rank.is_some_and(|rank| {
+                    temp_name_rank(name).is_some_and(|name_rank| name_rank < rank)
+                })
+            });
+
+        let mut same_location_ref_vars = file_level_class_temps;
+        same_location_ref_vars.extend(
+            self.hoisted_deferred_static_class_result_temps
+                .iter()
+                .cloned(),
+        );
+        same_location_ref_vars.extend(trailing_ref_vars);
+        if !same_location_ref_vars.is_empty() {
+            let var_decl = format!("var {};", same_location_ref_vars.join(", "));
+            self.writer
+                .insert_line_at(hoist_byte_offset, hoist_line, &var_decl);
+        }
+        if !early_ref_vars.is_empty() {
+            let var_decl = format!("var {};", early_ref_vars.join(", "));
+            self.writer
+                .insert_line_at(hoist_byte_offset, hoist_line, &var_decl);
+        }
+    }
+
     pub(in crate::emitter) fn prepare_source_file_comments(
         &mut self,
         statements: &NodeList,
@@ -490,6 +527,15 @@ impl<'a> Printer<'a> {
                 .as_ref()
                 .is_some_and(|args| args.nodes.len() >= 2)
     }
+}
+
+fn temp_name_rank(name: &str) -> Option<u32> {
+    let tail = name.strip_prefix('_')?;
+    let bytes = tail.as_bytes();
+    if bytes.len() == 1 && bytes[0].is_ascii_lowercase() {
+        return Some(u32::from(bytes[0] - b'a'));
+    }
+    tail.parse::<u32>().ok().map(|rank| rank + 26)
 }
 
 pub(in crate::emitter) fn jsx_dev_file_name(file_name: &str) -> String {


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
Emit parity - JS ES2015 static `this`/`super` field lowering.

## Invariant
When ES2015 lowering emits static fields that read/write `this` or `super`, class/base aliases and value-producing `super` writes follow tsc's temp order and expression shape; decorated static-super field captures keep their IIFE form.

## Scope
- Adds a scoped static-super value-write mode for lowered static field initializers.
- Emits value-producing static `super` assignments/updates as hoisted-temp comma expressions in that mode.
- Preallocates object-rest assignment temps inside lowered static field initializers before class/base aliases.
- Preserves standalone line comments that lead lowered instance fields.
- Emits define-mode object-rest static field descriptors with tsc's compact `Object.assign` shape.
- Adds focused static-super alias tests and keeps nearby decorator regressions green.

## Project Corpus Impact
- Row: n/a
- Bug family: JS emit static-super/class-field lowering parity
- Evidence: focused emit rows `thisAndSuperInStaticMembers1(target=es2015)` and `thisAndSuperInStaticMembers2(target=es2015)` pass locally; no project-corpus fixture row is affected.

## Verification
- `cargo fmt --all`
- `cargo nextest run -p tsz-emitter es2015_define_static_super_writes_use_hoisted_comma_temps es2015_assign_static_super_writes_use_hoisted_comma_temps decorated_class_static_field_initializers_rewrite_super_member_writes tc39_es2015_decorated_static_super_write_hoists_reflect_set_iife tc39_es2015_decorated_static_super_prefix_update_hoists_reflect`
- `scripts/emit/run.sh --filter='thisAndSuperInStaticMembers1(target=es2015)' --js-only --verbose --json-out=/tmp/tsz-js-this-super-1-rebased.json`
- `scripts/emit/run.sh --filter='thisAndSuperInStaticMembers2(target=es2015)' --js-only --verbose --json-out=/tmp/tsz-js-this-super-2-rebased.json`
- `git diff --check`
- `python3 scripts/emit/audit-output-surgery.py`
- `wc -l crates/tsz-emitter/src/emitter/comments/helpers.rs crates/tsz-emitter/src/emitter/core.rs crates/tsz-emitter/src/emitter/core_setup.rs crates/tsz-emitter/src/emitter/declarations/class/emit_es6_after_body.rs crates/tsz-emitter/src/emitter/expressions/static_super.rs crates/tsz-emitter/src/emitter/helpers.rs crates/tsz-emitter/src/emitter/source_file/class_static_alias_tests.rs crates/tsz-emitter/src/emitter/source_file/emit.rs crates/tsz-emitter/src/emitter/source_file/emit_parts/helpers.rs`

## Coordination Notes
- #12702 has merged and covered `reachabilityChecksNoCrash1`.
- #12763 covers `unusedLocalsAndParameters`; it was rebased to current main and is waiting for exact-head CI to appear/rerun.
- This PR covers the remaining known real JS rows from the stale emit evidence: `thisAndSuperInStaticMembers1(target=es2015)` and `thisAndSuperInStaticMembers2(target=es2015)`.
- `merge-queue` intentionally not applied; exact-head PR checks need to run first.
