### PR TITLE
ci: avoid metadata summary racing real suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,49 @@ jobs:
       compiler_checks_required: ${{ steps.gate.outputs.compiler_checks_required }}
       unit_packages: ${{ steps.gate.outputs.unit_packages }}
     steps:
+      - id: metadata-active-suite
+        if: github.event_name == 'pull_request' && github.event.action == 'edited'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          active_suite=""
+          for attempt in 1 2 3 4 5 6; do
+            active_suite=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${PR_HEAD_SHA}&event=pull_request&per_page=20" \
+              2>/dev/null \
+              | jq -r --argjson current_run_id "${GITHUB_RUN_ID}" '
+                [.workflow_runs[]
+                  | select((.status == "queued" or .status == "in_progress" or .status == "waiting" or .status == "requested" or .status == "pending")
+                  and (.id != $current_run_id))]
+                  | sort_by(.created_at)
+                  | last
+                  | if . == null then empty else [.id, .status, .html_url] | @tsv end
+              ' || true)
+            if [[ -n "$active_suite" ]]; then
+              break
+            fi
+            if [[ "$attempt" -lt 6 ]]; then
+              echo "No active real CI suite for edited PR head is visible yet (attempt ${attempt}/6); retrying."
+              sleep 5
+            fi
+          done
+          if [[ -n "$active_suite" ]]; then
+            echo "active_suite_found=true" >> "$GITHUB_OUTPUT"
+            active_suite_id=$(printf '%s' "$active_suite" | cut -f1)
+            active_suite_status=$(printf '%s' "$active_suite" | cut -f2)
+            active_suite_url=$(printf '%s' "$active_suite" | cut -f3)
+            echo "Exact-head CI suite ${active_suite_id} is ${active_suite_status}; metadata CI will publish CI Light Summary: ${active_suite_url}"
+          else
+            echo "active_suite_found=false" >> "$GITHUB_OUTPUT"
+          fi
       - id: gate
         env:
           GH_TOKEN: ${{ github.token }}
           CI_EVENT_NAME: ${{ github.event_name }}
+          METADATA_ACTIVE_SUITE_FOUND: ${{ steps.metadata-active-suite.outputs.active_suite_found }}
         shell: bash
         run: |
           set -euo pipefail
@@ -69,18 +108,14 @@ jobs:
             echo "Native merge queue group - running full Cloud Run CI for the queued merge commit."
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             if [[ "${{ github.event.action }}" == "edited" ]]; then
-              # Body/title edits can repair AgentName, project-corpus, or WIP
-              # metadata without changing the PR head SHA. Refresh only the
-              # metadata gates so stale failed PR-body checks can clear without
-              # asking agents to push a no-op code commit. The summary job
-              # mirrors the previous real CI Summary for this exact head SHA so
-              # native merge queue still sees the protected context without a
-              # light run masking a failed full run.
               echo "PR metadata edited — refreshing body/ready-state checks without heavy CI."
               should_run=false
               full_run=false
               metadata_only_skip=true
               compiler_checks_required=false
+              if [[ "${METADATA_ACTIVE_SUITE_FOUND:-false}" == "true" ]]; then
+                required_summary=false
+              fi
             fi
             # The `labeled` event triggers on every label add. We only care
             # about the `ci-approved` label (used to opt fork PRs into CI).

--- a/scripts/ci/test-pr-ready-state.mjs
+++ b/scripts/ci/test-pr-ready-state.mjs
@@ -149,6 +149,11 @@ assert.match(
 );
 assert.match(
   ciWorkflow,
+  /id: metadata-active-suite[\s\S]+?if: github\.event_name == 'pull_request' && github\.event\.action == 'edited'[\s\S]+?actions\/workflows\/ci\.yml\/runs\?head_sha=\$\{PR_HEAD_SHA\}&event=pull_request[\s\S]+?\.status == "queued"[\s\S]+?\.status == "in_progress"[\s\S]+?\.id != \$current_run_id[\s\S]+?active_suite_found=true[\s\S]+?metadata CI will publish CI Light Summary[\s\S]+?METADATA_ACTIVE_SUITE_FOUND: \$\{\{ steps\.metadata-active-suite\.outputs\.active_suite_found \}\}[\s\S]+?PR metadata edited[\s\S]+?required_summary=false/,
+  "metadata-only edited runs should publish CI Light Summary while the exact-head real suite is active",
+);
+assert.match(
+  ciWorkflow,
   /accepted_summary_label = "CI Summary" if required_summary else "CI Summary or CI Light Summary"[\s\S]+?previous \{accepted_summary_label\}/,
   "metadata-only edited runs should report the accepted prior summary class when no mirror exists",
 );


### PR DESCRIPTION
## Agent
AgentName: Studio-C

## Track
CI coordination / PR metadata gate hygiene.

## Invariant
When a pull_request.edited metadata run starts while the exact-head real CI suite is still queued or running, the metadata run must not publish a protected CI Summary result. This PR changes the CI gate so that case publishes CI Light Summary instead, while preserving the existing previous-summary mirror behavior when no real suite is active.

## Scope
- `.github/workflows/ci.yml`
- `scripts/ci/test-pr-ready-state.mjs`

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: CI workflow/test-only change; no compiler, emitter, checker, solver, or benchmark runtime behavior changes.

## Verification
- `node scripts/ci/test-pr-ready-state.mjs`
- `git diff --check`
- `wc -l .github/workflows/ci.yml scripts/ci/test-pr-ready-state.mjs`
- `gh workflow run ci.yml --repo tsz-org/tsz --ref codex/studio-c-ci-metadata-summary-20260606` accepted after the split-step fix; duplicate manual run was cancelled after the PR run appeared.

## Coordination Notes
- AgentName: Studio-C
- Root cause observed on #12763: a `pull_request.edited` metadata run produced a failing protected `CI Summary` while the exact-head `synchronize` suite was still in progress.
- Confirmed with `gh api orgs/tsz-org/members/mohsen1` that `mohsen1` is a `tsz-org` member, and checked the affected PR APIs; the visible Studio-C PRs are same-repo, not fork PRs.
- This PR intentionally does not relax the fork `ci-approved` trust boundary.