### PR TITLE
refactor(cli): separate no-check diagnostic collection from project graph traversal (#9411)

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -118,6 +118,106 @@ pub(super) struct CollectDiagnosticsResult {
     pub module_dep_stats: Option<super::ModuleDependencyStats>,
 }
 
+/// Inputs for parse-only short-circuit paths that bypass the full checker
+/// pipeline (either `--noCheck` without `--declaration`, or `--noEmit
+/// --skipLibCheck` on a pure `.d.ts` project).
+struct ParseOnlyDiagnosticsInput<'a> {
+    program: &'a MergedProgram,
+    options: &'a ResolvedCompilerOptions,
+    program_has_real_syntax_errors: bool,
+    include_isolated_declaration_diagnostics: bool,
+    per_file_ts7016_diagnostics: &'a [Vec<Diagnostic>],
+    cache: Option<&'a mut CompilationCache>,
+    base_dir: &'a Path,
+    file_is_esm_map: &'a FxHashMap<String, bool>,
+    resolved_module_paths: &'a FxHashMap<(usize, String), usize>,
+    collect_compile_stats: bool,
+    request_cache_counters: RequestCacheCounters,
+}
+
+/// Collect parse-only diagnostics and return an early `CollectDiagnosticsResult`
+/// for paths that skip the full checker pipeline.
+///
+/// Used by two short-circuit arms in `collect_diagnostics_with_source_resolutions`:
+/// - `--noCheck` (without `--declaration`): collects parse + isolated-declarations
+///   diagnostics and returns before any checker binder or `ProgramContext` setup.
+/// - `--noEmit --skipLibCheck` on a pure `.d.ts` project: collects parse
+///   diagnostics only and returns before expensive checker infrastructure.
+///
+/// Both arms share the same post-collection steps: extend with per-file TS7016
+/// diagnostics, trim the `CompilationCache`, detect missing-tslib helpers, and
+/// build the optional module-dependency stats.
+fn collect_parse_only_diagnostics_result(
+    input: ParseOnlyDiagnosticsInput<'_>,
+) -> CollectDiagnosticsResult {
+    let ParseOnlyDiagnosticsInput {
+        program,
+        options,
+        program_has_real_syntax_errors,
+        include_isolated_declaration_diagnostics,
+        per_file_ts7016_diagnostics,
+        cache,
+        base_dir,
+        file_is_esm_map,
+        resolved_module_paths,
+        collect_compile_stats,
+        request_cache_counters,
+    } = input;
+
+    let all_file_indices: Vec<usize> = (0..program.files.len()).collect();
+
+    let mut diagnostics: Vec<Diagnostic> =
+        collect_no_check_diagnostics_for_files(NoCheckDiagnosticsInput {
+            files: &program.files,
+            file_indices: &all_file_indices,
+            options,
+            program_has_real_syntax_errors,
+            include_isolated_declaration_diagnostics,
+        })
+        .into_iter()
+        .flat_map(|file_diags| file_diags.diagnostics)
+        .collect();
+
+    let mut used_paths =
+        FxHashSet::with_capacity_and_hasher(program.files.len(), Default::default());
+    for (file_idx, file_diags) in per_file_ts7016_diagnostics.iter().enumerate() {
+        diagnostics.extend(file_diags.iter().cloned());
+        if let Some(file) = program.files.get(file_idx) {
+            used_paths.insert(PathBuf::from(&file.file_name));
+        }
+    }
+
+    if let Some(c) = cache {
+        c.type_caches.retain(|path, _| used_paths.contains(path));
+        c.diagnostics.retain(|path, _| used_paths.contains(path));
+        c.export_hashes.retain(|path, _| used_paths.contains(path));
+    }
+
+    diagnostics.extend(detect_missing_tslib_helper_diagnostics(
+        program,
+        options,
+        base_dir,
+        file_is_esm_map,
+    ));
+
+    let module_dep_stats = if collect_compile_stats {
+        Some(compute_module_dependency_stats(
+            program.files.len(),
+            resolved_module_paths,
+        ))
+    } else {
+        None
+    };
+
+    CollectDiagnosticsResult {
+        diagnostics,
+        request_cache_counters,
+        query_cache_stats: Some(tsz_solver::construction::QueryCacheStatistics::default()),
+        def_store_stats: None,
+        module_dep_stats,
+    }
+}
+
 #[derive(Default)]
 pub(super) struct CheckerLibSet {
     pub(super) files: Vec<Arc<LibFile>>,
@@ -462,56 +562,19 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
     // errors via the `if !no_check` guard around `check_source_file`); the
     // type_caches it produces feed declaration emit.
     if options.no_check && !options.emit_declarations {
-        let all_file_indices: Vec<usize> = (0..program.files.len()).collect();
-
-        let mut diagnostics: Vec<Diagnostic> =
-            collect_no_check_diagnostics_for_files(NoCheckDiagnosticsInput {
-                files: &program.files,
-                file_indices: &all_file_indices,
-                options,
-                program_has_real_syntax_errors,
-                include_isolated_declaration_diagnostics: true,
-            })
-            .into_iter()
-            .flat_map(|file_diags| file_diags.diagnostics)
-            .collect();
-
-        for (file_idx, file_diags) in per_file_ts7016_diagnostics.iter().enumerate() {
-            diagnostics.extend(file_diags.iter().cloned());
-            if let Some(file) = program.files.get(file_idx) {
-                used_paths.insert(PathBuf::from(&file.file_name));
-            }
-        }
-
-        if let Some(c) = cache {
-            c.type_caches.retain(|path, _| used_paths.contains(path));
-            c.diagnostics.retain(|path, _| used_paths.contains(path));
-            c.export_hashes.retain(|path, _| used_paths.contains(path));
-        }
-
-        diagnostics.extend(detect_missing_tslib_helper_diagnostics(
+        return collect_parse_only_diagnostics_result(ParseOnlyDiagnosticsInput {
             program,
             options,
+            program_has_real_syntax_errors,
+            include_isolated_declaration_diagnostics: true,
+            per_file_ts7016_diagnostics: &per_file_ts7016_diagnostics,
+            cache,
             base_dir,
-            &file_is_esm_map,
-        ));
-
-        let module_dep_stats = if collect_compile_stats {
-            Some(compute_module_dependency_stats(
-                program.files.len(),
-                resolved_module_paths.as_ref(),
-            ))
-        } else {
-            None
-        };
-
-        return CollectDiagnosticsResult {
-            diagnostics,
+            file_is_esm_map: &file_is_esm_map,
+            resolved_module_paths: &resolved_module_paths,
+            collect_compile_stats,
             request_cache_counters,
-            query_cache_stats: Some(tsz_solver::construction::QueryCacheStatistics::default()),
-            def_store_stats: None,
-            module_dep_stats,
-        };
+        });
     }
 
     // `skipLibCheck` skips semantic checking for declaration files, but the
@@ -530,56 +593,19 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
             .iter()
             .all(|file| is_declaration_file(&file.file_name))
     {
-        let all_file_indices: Vec<usize> = (0..program.files.len()).collect();
-
-        let mut diagnostics: Vec<Diagnostic> =
-            collect_no_check_diagnostics_for_files(NoCheckDiagnosticsInput {
-                files: &program.files,
-                file_indices: &all_file_indices,
-                options,
-                program_has_real_syntax_errors,
-                include_isolated_declaration_diagnostics: false,
-            })
-            .into_iter()
-            .flat_map(|file_diags| file_diags.diagnostics)
-            .collect();
-
-        for (file_idx, file_diags) in per_file_ts7016_diagnostics.iter().enumerate() {
-            diagnostics.extend(file_diags.iter().cloned());
-            if let Some(file) = program.files.get(file_idx) {
-                used_paths.insert(PathBuf::from(&file.file_name));
-            }
-        }
-
-        if let Some(c) = cache {
-            c.type_caches.retain(|path, _| used_paths.contains(path));
-            c.diagnostics.retain(|path, _| used_paths.contains(path));
-            c.export_hashes.retain(|path, _| used_paths.contains(path));
-        }
-
-        diagnostics.extend(detect_missing_tslib_helper_diagnostics(
+        return collect_parse_only_diagnostics_result(ParseOnlyDiagnosticsInput {
             program,
             options,
+            program_has_real_syntax_errors,
+            include_isolated_declaration_diagnostics: false,
+            per_file_ts7016_diagnostics: &per_file_ts7016_diagnostics,
+            cache,
             base_dir,
-            &file_is_esm_map,
-        ));
-
-        let module_dep_stats = if collect_compile_stats {
-            Some(compute_module_dependency_stats(
-                program.files.len(),
-                resolved_module_paths.as_ref(),
-            ))
-        } else {
-            None
-        };
-
-        return CollectDiagnosticsResult {
-            diagnostics,
+            file_is_esm_map: &file_is_esm_map,
+            resolved_module_paths: &resolved_module_paths,
+            collect_compile_stats,
             request_cache_counters,
-            query_cache_stats: Some(tsz_solver::construction::QueryCacheStatistics::default()),
-            def_store_stats: None,
-            module_dep_stats,
-        };
+        });
     }
 
     // Pre-compute merged augmentations once for all binder reconstruction paths.


### PR DESCRIPTION
AgentName: M1-Opus

## Track
Tech-debt — CLI no-check diagnostic collection separated from graph traversal.

## Invariant
When collecting diagnostics in no-check mode, tsz isolates that path in named helpers separate from project-graph traversal; emitted diagnostics, ordering, and CLI output are unchanged.

## Scope
Behavior-preserving extraction in crates/tsz-cli/src/driver/check.rs. No diagnostic/ordering/output changes.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a (CLI driver internal refactor)

## Verification
```
scripts/safe-run.sh cargo check -p tsz-cli
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 04s

scripts/safe-run.sh cargo nextest run -p tsz-cli check
    Starting 223 tests across 14 binaries (1741 tests skipped)
    Summary [68.581s] 223 tests run: 219 passed, 4 failed, 1741 skipped
    FAIL tsz-cli driver::core::check::check_tests::project_mode_imported_class_with_then_method_is_promise_like
    FAIL tsz-cli driver_tests::checked_js_declaration_emit_self_referential_prototype_method_type_does_not_recurse
    FAIL tsz-cli driver_tests::compile_jsdoc_enum_initializer_values_are_checked
    FAIL tsz-cli driver_tests::compile_vue_query_style_promise_chain_and_const_key_has_no_checker_errors
```

All 4 failures are pre-existing on clean `origin/main` (verified by running same tests on stashed HEAD). No new regressions introduced.

## Coordination Notes
Closes #9411. Pure code movement; no-check collection extracted into `collect_parse_only_diagnostics_result` + `ParseOnlyDiagnosticsInput` (new named helper and input struct at the top of `check.rs`, before `CheckerLibSet`). File sizes: check.rs 1706 → 1732 lines (net +26: shared helper replaces 2 × ~50-line duplicate inline blocks).