### PR TITLE
refactor(checker): route property truthiness narrowing through boundary

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -931,7 +931,8 @@ impl<'a> FlowAnalyzer<'a> {
                 // `{flag: "hello"; data: string} | {flag: ""; data: number}`,
                 // narrow x based on whether `flag` is truthy or falsy.
                 if let Some(property_path) = self.discriminant_property(condition_idx, target) {
-                    let narrowed = narrowing.narrow_by_property_truthiness(
+                    let narrowed = flow_query::narrow_by_property_truthiness_in_context(
+                        &narrowing,
                         type_id,
                         &property_path,
                         is_true_branch,
@@ -980,7 +981,8 @@ impl<'a> FlowAnalyzer<'a> {
                         self.binder.resolve_identifier(self.arena, condition_ref)
                     && !self.is_alias_reference_mutated(alias_sym_id, target, antecedent_id)
                 {
-                    let narrowed = narrowing.narrow_by_property_truthiness(
+                    let narrowed = flow_query::narrow_by_property_truthiness_in_context(
+                        &narrowing,
                         type_id,
                         &prop_names,
                         is_true_branch,

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -406,6 +406,20 @@ pub(crate) fn narrow_to_falsy(
     narrowing.narrow_to_falsy(type_id)
 }
 
+/// Narrow a union by whether a property path is truthy/falsy.
+///
+/// The checker owns extracting the property path from syntax and deciding
+/// whether a `never` result is admissible for a non-union source. The solver
+/// owns evaluating property truthiness across the type.
+pub(crate) fn narrow_by_property_truthiness_in_context(
+    narrowing: &NarrowingContext<'_>,
+    type_id: TypeId,
+    property_path: &[tsz_common::interner::Atom],
+    is_true_branch: bool,
+) -> TypeId {
+    narrowing.narrow_by_property_truthiness(type_id, property_path, is_true_branch)
+}
+
 /// Narrow a value to the object-like branch of an `instanceof`-style check.
 pub(crate) fn narrow_to_objectish(
     db: &dyn QueryDatabase,

--- a/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
@@ -287,3 +287,33 @@ fn condition_guard_application_uses_flow_query_boundary() {
         "condition narrowing should not apply solver guards directly"
     );
 }
+
+#[test]
+fn condition_property_truthiness_uses_flow_query_boundary() {
+    let condition_source = fs::read_to_string("src/flow/control_flow/condition_narrowing.rs")
+        .expect("failed to read condition narrowing source");
+    let boundary_source = fs::read_to_string("src/query_boundaries/flow_analysis.rs")
+        .expect("failed to read flow analysis boundary source");
+    let compact_condition: String = condition_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let compact_boundary: String = boundary_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+
+    assert!(
+        compact_boundary.contains("fnnarrow_by_property_truthiness_in_context(")
+            && compact_boundary.contains("narrowing.narrow_by_property_truthiness("),
+        "flow analysis boundary should own property-truthiness narrowing"
+    );
+    assert!(
+        compact_condition.contains("flow_query::narrow_by_property_truthiness_in_context("),
+        "condition property truthiness should route through the flow query boundary"
+    );
+    assert!(
+        !compact_condition.contains(".narrow_by_property_truthiness("),
+        "condition narrowing should not apply property-truthiness narrowing directly"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
M1-D - flow graph and solver-owned narrowing predicates; refactor.

## Invariant
When checker recognizes a property path used as a truthiness discriminant or binding-element alias, `tsc` narrows by property truthiness. In tsz, checker owns syntax/path discovery and the non-union `never` fallback; solver-owned narrowing computes the semantic narrowed type through `query_boundaries::flow_analysis::narrow_by_property_truthiness_in_context`.

## Scope
- Add a flow-analysis query boundary for property-truthiness narrowing using the caller's active `NarrowingContext`.
- Route discriminant-property truthiness and binding-element property alias truthiness in `condition_narrowing.rs` through that boundary.
- Add a source architecture guard preventing direct `.narrow_by_property_truthiness(...)` calls in condition narrowing.
- Leave existing union/non-union fallback behavior unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: flow/narrowing boundary debt
- Impact: No project-row behavior change intended. This is a boundary ratchet for M1-D property truthiness narrowing.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib flow_guard_boundary_tests`
- `cargo fmt --check`
- `git diff --check`

## Coordination Notes
- Built on `origin/main` after #12760 landed.
- M1-D/M4-C owned work was clear before starting this slice.
- Neighboring project-row and inference issues found in issue search are owned by other lanes; this PR stays in checker flow boundary files only.
- Performance: no benchmark claim.
