### PR TITLE
bench: close attribution commands for 2x gaps

### DIFF
--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -12,6 +12,7 @@ const SCRIPT = path.join(ROOT, "scripts", "bench", "tsgo-winner-report.mjs");
 const BENCH_WORKFLOW = path.join(ROOT, ".github", "workflows", "bench.yml");
 const GH_PAGES_WORKFLOW = path.join(ROOT, ".github", "workflows", "gh-pages.yml");
 const WEBSITE_ELEVENTY = path.join(ROOT, "crates", "tsz-website", ".eleventy.js");
+const WEBSITE_BENCH_SNAPSHOT = path.join(ROOT, "crates", "tsz-website", "bench-snapshot.json");
 
 function withTempDir(fn) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-tsgo-winner-report-"));
@@ -28,6 +29,24 @@ function writeJson(file, value) {
 }
 
 const { createTsgoWinnerReport } = await import(pathToFileURL(SCRIPT));
+
+{
+  const report = createTsgoWinnerReport(
+    JSON.parse(fs.readFileSync(WEBSITE_BENCH_SNAPSHOT, "utf8")),
+    WEBSITE_BENCH_SNAPSHOT,
+  );
+  assert.equal(report.two_x_target.rows_below_target, 15);
+  assert.equal(
+    report.two_x_target.rows_with_attribution_command,
+    report.two_x_target.rows_below_target,
+  );
+  assert.deepEqual(
+    report.two_x_target.missing_attribution_plan
+      .filter((row) => !row.attribution_command)
+      .map((row) => row.name),
+    [],
+  );
+}
 
 withTempDir((dir) => {
   const input = path.join(dir, "bench.json");
@@ -360,6 +379,15 @@ withTempDir((dir) => {
         factor: 1.06,
       },
       {
+        name: "100 generic functions",
+        lines: 2200,
+        kb: 70,
+        tsz_ms: 190,
+        tsgo_ms: 160,
+        winner: "tsgo",
+        factor: 1.19,
+      },
+      {
         name: "200 generic functions",
         lines: 4200,
         kb: 120,
@@ -367,6 +395,33 @@ withTempDir((dir) => {
         tsgo_ms: 404.57,
         winner: "tsz",
         factor: 1.02,
+      },
+      {
+        name: "CFA branches=100",
+        lines: 900,
+        kb: 28,
+        tsz_ms: 180,
+        tsgo_ms: 150,
+        winner: "tsgo",
+        factor: 1.2,
+      },
+      {
+        name: "CFA branches=150",
+        lines: 1200,
+        kb: 38,
+        tsz_ms: 220,
+        tsgo_ms: 170,
+        winner: "tsgo",
+        factor: 1.29,
+      },
+      {
+        name: "Template literal N=45",
+        lines: 420,
+        kb: 18,
+        tsz_ms: 205,
+        tsgo_ms: 200,
+        winner: "tsgo",
+        factor: 1.03,
       },
     ],
   });
@@ -382,25 +437,58 @@ withTempDir((dir) => {
     /TSZ_PERF_COUNTERS=1 .*<generated-200-classes>\.ts/,
   );
   assert.match(
+    byName.get("100 generic functions").loss_closure.attribution_command,
+    /TSZ_PERF_COUNTERS=1 .*<generated-100-generic-functions>\.ts/,
+  );
+  assert.match(
     report.target_gaps
       .find((row) => row.name === "200 generic functions")
       .loss_closure.attribution_command,
     /TSZ_PERF_COUNTERS=1 .*<generated-200-generic-functions>\.ts/,
   );
+  assert.match(
+    byName.get("CFA branches=100").loss_closure.attribution_command,
+    /TSZ_PERF_COUNTERS=1 .*<generated-cfa-branches-100>\.ts/,
+  );
+  assert.match(
+    byName.get("CFA branches=150").loss_closure.attribution_command,
+    /TSZ_PERF_COUNTERS=1 .*<generated-cfa-branches-150>\.ts/,
+  );
+  assert.match(
+    byName.get("Template literal N=45").loss_closure.attribution_command,
+    /TSZ_PERF_COUNTERS=1 .*<generated-template-literal-45>\.ts/,
+  );
   assert.deepEqual(report.totals.missing_attribution_rows, [
+    "100 generic functions",
     "200 classes",
     "BCT candidates=200",
+    "CFA branches=100",
+    "CFA branches=150",
+    "Template literal N=45",
   ]);
   assert.deepEqual(
     report.target_gaps.map((row) => row.name),
-    ["BCT candidates=200", "200 classes", "200 generic functions"],
+    [
+      "CFA branches=150",
+      "CFA branches=100",
+      "100 generic functions",
+      "BCT candidates=200",
+      "200 classes",
+      "Template literal N=45",
+      "200 generic functions",
+    ],
   );
-  assert.equal(report.two_x_target.rows_below_target, 3);
+  assert.equal(report.two_x_target.rows_below_target, 7);
   assert.equal(report.two_x_target.rows_with_attribution, 0);
+  assert.equal(report.two_x_target.rows_with_attribution_command, 7);
   assert.deepEqual(report.two_x_target.missing_attribution_rows, [
+    "100 generic functions",
     "200 classes",
     "200 generic functions",
     "BCT candidates=200",
+    "CFA branches=100",
+    "CFA branches=150",
+    "Template literal N=45",
   ]);
 });
 
@@ -408,6 +496,21 @@ withTempDir((dir) => {
   const input = path.join(dir, "bench.json");
   writeJson(input, {
     results: [
+      {
+        name: "utility-types-project",
+        tsz_ms: 100,
+        tsgo_ms: 90,
+        winner: "tsgo",
+        factor: 1.11,
+        compatibility: {
+          state: "green",
+          exit_class: "exit success",
+          phase: "check",
+          last_successful_phase: "check",
+          diagnostic_status: "none",
+          semantic_owner_family: "baseline utility mapped/conditional surface",
+        },
+      },
       {
         name: "ts-essentials-project",
         tsz_ms: 100,
@@ -438,11 +541,58 @@ withTempDir((dir) => {
           semantic_owner_family: "generated app dependency graph",
         },
       },
+      {
+        name: "nextjs",
+        tsz_ms: 100,
+        tsgo_ms: 90,
+        winner: "tsgo",
+        factor: 1.11,
+        compatibility: {
+          state: "green",
+          exit_class: "exit success",
+          phase: "check",
+          last_successful_phase: "check",
+          diagnostic_status: "none",
+          semantic_owner_family: "Next.js full project module graph",
+        },
+      },
+      {
+        name: "ts-essentials/xor.ts",
+        tsz_ms: 100,
+        tsgo_ms: 90,
+        winner: "tsgo",
+        factor: 1.11,
+      },
+      {
+        name: "ts-essentials/paths.ts",
+        tsz_ms: 100,
+        tsgo_ms: 90,
+        winner: "tsgo",
+        factor: 1.11,
+      },
+      {
+        name: "ts-essentials/deep-pick.ts",
+        tsz_ms: 100,
+        tsgo_ms: 90,
+        winner: "tsgo",
+        factor: 1.11,
+      },
+      {
+        name: "ts-essentials/deep-readonly.ts",
+        tsz_ms: 100,
+        tsgo_ms: 90,
+        winner: "tsgo",
+        factor: 1.11,
+      },
     ],
   });
 
   const report = createTsgoWinnerReport(JSON.parse(fs.readFileSync(input, "utf8")), input);
   const byName = new Map(report.rows.map((row) => [row.name, row]));
+  assert.match(
+    byName.get("utility-types-project").loss_closure.attribution_command,
+    /--perf-counters-json <artifact>\.utility-types-project\.perf\.json --noEmit -p .*utility-types\/tsconfig\.flat\.json/,
+  );
   assert.match(
     byName.get("ts-essentials-project").loss_closure.attribution_command,
     /--perf-counters-json <artifact>\.ts-essentials-project\.perf\.json --noEmit -p .*ts-essentials\/tsconfig\.flat\.json/,
@@ -451,6 +601,27 @@ withTempDir((dir) => {
     byName.get("nextjs-fresh-app").loss_closure.attribution_command,
     /--perf-counters-json <artifact>\.nextjs-fresh-app\.perf\.json --noEmit -p .*next-app-live\/tsconfig\.json/,
   );
+  assert.match(
+    byName.get("nextjs").loss_closure.attribution_command,
+    /--perf-counters-json <artifact>\.nextjs\.perf\.json --noEmit -p .*nextjs\/packages\/next\/tsconfig\.tsz-bench\.json/,
+  );
+  assert.match(
+    byName.get("ts-essentials/xor.ts").loss_closure.attribution_command,
+    /--perf-counters-json <artifact>\.ts-essentials-xor\.perf\.json --noEmit --lib es2018 .*ts-essentials\/lib\/xor\/index\.ts/,
+  );
+  assert.match(
+    byName.get("ts-essentials/paths.ts").loss_closure.attribution_command,
+    /--perf-counters-json <artifact>\.ts-essentials-paths\.perf\.json --noEmit --lib es2018 .*ts-essentials\/lib\/paths\/index\.ts/,
+  );
+  assert.match(
+    byName.get("ts-essentials/deep-pick.ts").loss_closure.attribution_command,
+    /--perf-counters-json <artifact>\.ts-essentials-deep-pick\.perf\.json --noEmit --lib es2018 .*ts-essentials\/lib\/deep-pick\/index\.ts/,
+  );
+  assert.match(
+    byName.get("ts-essentials/deep-readonly.ts").loss_closure.attribution_command,
+    /--perf-counters-json <artifact>\.ts-essentials-deep-readonly\.perf\.json --noEmit --lib es2018 .*ts-essentials\/lib\/deep-readonly\/index\.ts/,
+  );
+  assert.equal(report.two_x_target.rows_with_attribution_command, 8);
 });
 
 // Duplicate known project rows make the green-tsgo-winner summary non-authoritative.

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -23,6 +23,19 @@ function asNumber(value) {
 
 const LOSS_CLOSURE_BY_ROW = new Map([
   [
+    "utility-types-project",
+    {
+      owner: "Track 1/2/5 utility type key-space and mapped type evaluation",
+      operation: "utility-type mapped/key-space workload with cross-file helper imports",
+      command:
+        "scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^utility-types-project$' --json-file <artifact>.json",
+      attribution_command:
+        "TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json <artifact>.utility-types-project.perf.json --noEmit -p .target-bench/external/utility-types/tsconfig.flat.json",
+      issue: 7378,
+      url: "https://github.com/tsz-org/tsz/issues/7378",
+    },
+  ],
+  [
     "ts-toolbelt-project",
     {
       owner: "Track 1/2 recursive type evaluation",
@@ -61,6 +74,58 @@ const LOSS_CLOSURE_BY_ROW = new Map([
     },
   ],
   [
+    "ts-essentials/xor.ts",
+    {
+      owner: "Track 1/2/5 utility type key-space and union exclusion evaluation",
+      operation: "large XOR helper with repeated Exclude/keyof intersections and union normalization",
+      command:
+        "scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials/xor\\.ts$' --json-file <artifact>.json",
+      attribution_command:
+        "TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json <artifact>.ts-essentials-xor.perf.json --noEmit --lib es2018 .target-bench/external/ts-essentials/lib/xor/index.ts",
+      issue: 7378,
+      url: "https://github.com/tsz-org/tsz/issues/7378",
+    },
+  ],
+  [
+    "ts-essentials/paths.ts",
+    {
+      owner: "Track 1/2/5 recursive path utility and cross-file helper evaluation",
+      operation: "recursive path/key utility expansion with imported helper aliases",
+      command:
+        "scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials/paths\\.ts$' --json-file <artifact>.json",
+      attribution_command:
+        "TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json <artifact>.ts-essentials-paths.perf.json --noEmit --lib es2018 .target-bench/external/ts-essentials/lib/paths/index.ts",
+      issue: 7378,
+      url: "https://github.com/tsz-org/tsz/issues/7378",
+    },
+  ],
+  [
+    "ts-essentials/deep-pick.ts",
+    {
+      owner: "Track 1/2/5 recursive key-path mapped type evaluation",
+      operation: "deep-pick recursive mapped/key-path helper expansion",
+      command:
+        "scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials/deep-pick\\.ts$' --json-file <artifact>.json",
+      attribution_command:
+        "TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json <artifact>.ts-essentials-deep-pick.perf.json --noEmit --lib es2018 .target-bench/external/ts-essentials/lib/deep-pick/index.ts",
+      issue: 7378,
+      url: "https://github.com/tsz-org/tsz/issues/7378",
+    },
+  ],
+  [
+    "ts-essentials/deep-readonly.ts",
+    {
+      owner: "Track 1/2/5 recursive mapped readonly evaluation",
+      operation: "deep-readonly recursive mapped helper expansion over imported utility aliases",
+      command:
+        "scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^ts-essentials/deep-readonly\\.ts$' --json-file <artifact>.json",
+      attribution_command:
+        "TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json <artifact>.ts-essentials-deep-readonly.perf.json --noEmit --lib es2018 .target-bench/external/ts-essentials/lib/deep-readonly/index.ts",
+      issue: 7378,
+      url: "https://github.com/tsz-org/tsz/issues/7378",
+    },
+  ],
+  [
     "nextjs-fresh-app",
     {
       owner: "Track 7/9 generated app dependency graph",
@@ -69,6 +134,19 @@ const LOSS_CLOSURE_BY_ROW = new Map([
         "scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^nextjs-fresh-app$' --json-file <artifact>.json",
       attribution_command:
         "TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json <artifact>.nextjs-fresh-app.perf.json --noEmit -p .target-bench/external/next-app-live/tsconfig.json",
+      issue: 7378,
+      url: "https://github.com/tsz-org/tsz/issues/7378",
+    },
+  ],
+  [
+    "nextjs",
+    {
+      owner: "Track 7/9 large app module graph and lib identity",
+      operation: "Next.js package graph checking, module resolution, and lib/global symbol residency",
+      command:
+        "NEXTJS_BENCHMARK_ENABLED=1 scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^nextjs$' --json-file <artifact>.json",
+      attribution_command:
+        "TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json <artifact>.nextjs.perf.json --noEmit -p .target-bench/external/nextjs/packages/next/tsconfig.tsz-bench.json",
       issue: 7378,
       url: "https://github.com/tsz-org/tsz/issues/7378",
     },
@@ -100,6 +178,20 @@ const LOSS_CLOSURE_BY_ROW = new Map([
     },
   ],
   [
+    "100 generic functions",
+    {
+      owner: "Track 10 generic function scaling guard",
+      operation:
+        "generic async function checking with recursive DeepPartial option types and Promise<Result<T>> return construction",
+      command:
+        "scripts/safe-run.sh ./scripts/bench/perf-hotspots.sh --filter '^100 generic functions$' --json-file <artifact>.json",
+      attribution_command:
+        "TSZ_PERF_COUNTERS=1 .target/release/tsz --extendedDiagnostics --perf-counters-json <artifact>.perf.json --noEmit <generated-100-generic-functions>.ts",
+      issue: 12271,
+      url: "https://github.com/tsz-org/tsz/issues/12271",
+    },
+  ],
+  [
     "200 generic functions",
     {
       owner: "Track 10 generic function scaling guard",
@@ -109,6 +201,45 @@ const LOSS_CLOSURE_BY_ROW = new Map([
         "scripts/safe-run.sh ./scripts/bench/perf-hotspots.sh --filter '^200 generic functions$' --json-file <artifact>.json",
       attribution_command:
         "TSZ_PERF_COUNTERS=1 .target/release/tsz --extendedDiagnostics --perf-counters-json <artifact>.perf.json --noEmit <generated-200-generic-functions>.ts",
+      issue: 12271,
+      url: "https://github.com/tsz-org/tsz/issues/12271",
+    },
+  ],
+  [
+    "CFA branches=100",
+    {
+      owner: "Track 10 control-flow analysis scaling guard",
+      operation: "control-flow narrowing across many generated branch joins",
+      command:
+        "scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^CFA branches=100$' --json-file <artifact>.json",
+      attribution_command:
+        "TSZ_PERF_COUNTERS=1 .target/release/tsz --extendedDiagnostics --perf-counters-json <artifact>.perf.json --noEmit <generated-cfa-branches-100>.ts",
+      issue: 12271,
+      url: "https://github.com/tsz-org/tsz/issues/12271",
+    },
+  ],
+  [
+    "CFA branches=150",
+    {
+      owner: "Track 10 control-flow analysis scaling guard",
+      operation: "control-flow narrowing across many generated branch joins",
+      command:
+        "scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^CFA branches=150$' --json-file <artifact>.json",
+      attribution_command:
+        "TSZ_PERF_COUNTERS=1 .target/release/tsz --extendedDiagnostics --perf-counters-json <artifact>.perf.json --noEmit <generated-cfa-branches-150>.ts",
+      issue: 12271,
+      url: "https://github.com/tsz-org/tsz/issues/12271",
+    },
+  ],
+  [
+    "Template literal N=45",
+    {
+      owner: "Track 10 template literal expansion scaling guard",
+      operation: "template literal Cartesian-product expansion and string manipulation helper evaluation",
+      command:
+        "scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --filter '^Template literal N=45$' --json-file <artifact>.json",
+      attribution_command:
+        "TSZ_PERF_COUNTERS=1 .target/release/tsz --extendedDiagnostics --perf-counters-json <artifact>.perf.json --noEmit <generated-template-literal-45>.ts",
       issue: 12271,
       url: "https://github.com/tsz-org/tsz/issues/12271",
     },


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Benchmark infrastructure / Studio deep debt for the 2x `tsgo` target.

## Invariant
When an eligible green benchmark row is below the 2x `tsgo` speed target, the companion `*.tsgo-winners.json` report should name the owning work family and provide an attribution command so the next performance PR can collect evidence without rediscovering the row by hand.

## Scope
- Add loss-closure metadata and attribution commands for the remaining current 2x target gap rows: `nextjs`, `utility-types-project`, `CFA branches=100/150`, `100 generic functions`, `Template literal N=45`, and the `ts-essentials/*` single-file rows.
- Extend `scripts/bench/test-tsgo-winner-report.mjs` with focused coverage and a checked-in snapshot guard that every current target gap has an attribution command.

## Project Corpus Impact
- Row: `nextjs`, `utility-types-project`, `CFA branches=100`, `CFA branches=150`, `100 generic functions`, `Template literal N=45`, `ts-essentials/xor.ts`, `ts-essentials/paths.ts`, `ts-essentials/deep-pick.ts`, `ts-essentials/deep-readonly.ts`
- Bug family: 2x `tsgo` target gap attribution metadata for benchmark/project rows

Benchmark companion artifact metadata only. The current checked-in `crates/tsz-website/bench-snapshot.json` still has 15 green rows below the 2x target, but after this PR all 15 missing-attribution plan rows include an attribution command. No compiler behavior, benchmark timings, or public compatibility numerators change.

## Verification
- Exact pushed head: `64341bab04c0ecc5c57a3da1e15e88fd541f2201`
- Exact-head CI after main sync: pending
- `node scripts/bench/test-tsgo-winner-report.mjs`
- `node scripts/bench/tsgo-winner-report.mjs crates/tsz-website/bench-snapshot.json /tmp/tsz-winners-after.json`
  - `2x target gaps: 15/68`
  - `2x target gaps with attribution commands: 15/15`
- `git diff --check`
- `scripts/agents/ensure-agent-labels.sh --audit`

## Coordination Notes
- Studio-B remains the owner for the actual residency/timing fixes. This PR only closes the report metadata gap that prevented every current 2x target gap from carrying an evidence command.
- During startup hygiene I added missing canonical owner labels to #12775, #12774, #12772, and #7574 based on PR bodies / lane assignment.

