### PR TITLE
fix(checker): emit strict let binding diagnostic

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/strict_names.rs
+++ b/crates/tsz-checker/src/state/state_checking/strict_names.rs
@@ -108,6 +108,19 @@ impl<'a> CheckerState<'a> {
         if self.ctx.has_parse_errors {
             return;
         }
+        if self.ctx.is_js_file()
+            && self.ctx.diagnostics.iter().any(|d| {
+                !matches!(
+                    d.code,
+                    diagnostic_codes::IDENTIFIER_EXPECTED_IS_A_RESERVED_WORD_IN_STRICT_MODE
+                        | diagnostic_codes::IDENTIFIER_EXPECTED_IS_A_RESERVED_WORD_IN_STRICT_MODE_CLASS_DEFINITIONS_ARE_AUTO
+                        | diagnostic_codes::IDENTIFIER_EXPECTED_IS_A_RESERVED_WORD_IN_STRICT_MODE_MODULES_ARE_AUTOMATICALLY
+                ) && (tsz_common::diagnostics::is_parser_grammar_diagnostic(d.code)
+                    || tsz_common::diagnostics::is_js_grammar_diagnostic(d.code))
+            })
+        {
+            return;
+        }
         // Prevent duplicate TS1212/TS1213/TS1214 at the same position.
         // Multiple paths (type resolution, identifier resolution, parameter checking)
         // can trigger this for the same identifier; tsc only emits one.

--- a/crates/tsz-checker/src/state/variable_checking/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/core.rs
@@ -538,7 +538,6 @@ impl<'a> CheckerState<'a> {
         if !is_ambient
             && !name_has_unicode_escape
             && self.is_strict_mode_for_node(var_decl.name)
-            && !is_let_name_in_lexical_declaration
             && let Some(ref name) = var_name
             && crate::state_checking::is_strict_mode_reserved_name(name)
             && !(name.as_str() == "arguments" && in_non_ambient_class)

--- a/crates/tsz-checker/tests/class_reserved_word_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/class_reserved_word_diagnostics_tests.rs
@@ -1,4 +1,7 @@
-use tsz_checker::test_utils::{check_js_source_code_messages, check_source_code_messages};
+use tsz_checker::test_utils::{
+    check_js_source_code_messages, check_source_code_messages, check_with_options_code_messages,
+};
+use tsz_common::CheckerOptions;
 
 #[test]
 fn class_reserved_word_diagnostics_match_strict_class_context() {
@@ -65,7 +68,66 @@ class H extends package.A { }
 }
 
 #[test]
-fn js_module_let_named_lexical_declaration_uses_ts2480_not_ts1214() {
+fn strict_let_named_lexical_declaration_emits_ts1212_and_ts2480() {
+    let diagnostics = check_with_options_code_messages(
+        r#"
+"use strict";
+let let = 1;
+function f() {
+    let let = 2;
+}
+"#,
+        CheckerOptions {
+            always_strict: false,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let ts1212_let_count = diagnostics
+        .iter()
+        .filter(|(code, message)| *code == 1212 && message.contains("'let'"))
+        .count();
+    let ts2480_let_count = diagnostics
+        .iter()
+        .filter(|(code, message)| *code == 2480 && message.contains("'let'"))
+        .count();
+
+    assert_eq!(
+        ts1212_let_count, 2,
+        "expected TS1212 for each strict lexical `let` binding named `let`; got {diagnostics:#?}"
+    );
+    assert_eq!(
+        ts2480_let_count, 2,
+        "expected TS2480 for each lexical `let` binding named `let`; got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn non_strict_let_named_lexical_declaration_keeps_only_ts2480() {
+    let diagnostics = check_with_options_code_messages(
+        "let let = 1;",
+        CheckerOptions {
+            always_strict: false,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        diagnostics
+            .iter()
+            .any(|(code, message)| *code == 2480 && message.contains("'let'")),
+        "expected TS2480 for `let` as a lexical binding name; got {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|(code, message)| *code != 1212 || !message.contains("'let'")),
+        "did not expect TS1212 for sloppy `let` as a lexical binding name; got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn js_module_let_named_lexical_declaration_uses_ts1214_and_ts2480() {
     let diagnostics = check_js_source_code_messages(
         r#"
 export const marker = 0;
@@ -83,13 +145,43 @@ const yield = 2;
     assert!(
         diagnostics
             .iter()
+            .any(|(code, message)| *code == 1214 && message.contains("'let'")),
+        "expected TS1214 for `let` as a JS module lexical binding name; got {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
             .any(|(code, message)| *code == 1214 && message.contains("'yield'")),
         "expected adjacent JS module `yield` binding to keep TS1214; got {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn checked_js_with_grammar_errors_suppresses_strict_let_noise() {
+    let diagnostics = check_js_source_code_messages(
+        r#"
+class C {
+    const x = 1
+}
+export const marker = 0;
+let let = 1;
+"#,
+    );
+
+    assert!(
+        diagnostics.iter().any(|(code, _)| *code == 8009),
+        "expected JS grammar diagnostic for class field `const`; got {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|(code, message)| *code == 2480 && message.contains("'let'")),
+        "expected TS2480 for `let` as a lexical binding name; got {diagnostics:#?}"
     );
     assert!(
         diagnostics
             .iter()
             .all(|(code, message)| *code != 1214 || !message.contains("'let'")),
-        "did not expect TS1214 for `let` as a lexical binding name; got {diagnostics:#?}"
+        "did not expect TS1214 noise for checked JS after grammar errors; got {diagnostics:#?}"
     );
 }

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -49,17 +49,12 @@ TypeScript/tests/cases/compiler/inferFromNestedSameShapeTuple.ts
 TypeScript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts
-TypeScript/tests/cases/compiler/letInConstDeclarations_ES6.ts
-TypeScript/tests/cases/compiler/letInLetConstDeclOfForOfAndForIn_ES6.ts
-TypeScript/tests/cases/compiler/letInLetDeclarations_ES6.ts
 TypeScript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
 TypeScript/tests/cases/compiler/promisesWithConstraints.ts
-TypeScript/tests/cases/compiler/strictModeReservedWord.ts
 TypeScript/tests/cases/compiler/unicodeEscapesInNames02.ts
 TypeScript/tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts
-TypeScript/tests/cases/conformance/es6/for-ofStatements/for-of51.ts
 TypeScript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts
 TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
conformance / accepted-regression strictness

## Invariant
When strict mode applies and a `let`/`const` lexical declaration binds an identifier named `let`, `tsc` emits the normal strict reserved-word diagnostic at the binding name in addition to TS2480; outside strict mode, only TS2480 is emitted. For checked JS files that already have parser or JS-grammar diagnostics, `tsc` suppresses this strict reserved-word noise. This PR makes tsz do that through checker declaration-name diagnostics.

## Scope
- Remove the checker-side suppression that skipped TS1212/TS1214 when a lexical `let` declaration used `let` as its binding name.
- Suppress strict reserved-word noise in checked JS files once parser/JS-grammar diagnostics already exist, preserving clean checked-JS module behavior.
- Add focused checker tests for explicit strict scripts, sloppy-script fallback, checked-JS module auto-strict behavior, and checked-JS grammar-error suppression.
- Retire `strictModeReservedWord.ts`, the three `letIn...` entries, and `for-of51.ts` from `scripts/conformance/conformance-accepted-regressions.txt`.

## Project Corpus Impact
- Row: n/a
- Bug family: strict-mode reserved lexical binding diagnostics
- Evidence: accepted-regression gate drops from 32 to 27 listed tests; no project-corpus row changes.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test class_reserved_word_diagnostics_tests`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter strictModeReservedWord --verbose`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter plainJSGrammarErrors --verbose`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter letIn --verbose`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter for-of51 --verbose`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `git diff --check`

## Coordination Notes
- Owner layer: checker declaration-name diagnostics, not solver or emitter.
- Adjacent matrix: explicit strict TS script (`TS1212 + TS2480`), sloppy TS script (`TS2480` only), clean checked-JS module auto-strict (`TS1214 + TS2480`), checked-JS grammar-error suppression, and adjacent `yield` module strict behavior.
