### PR TITLE
perf(checker): skip terminal return flow scans

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -169,6 +169,9 @@ path = "tests/generator_annotation_mismatch_display_tests.rs"
 name = "generator_return_type_widening_tests"
 path = "tests/generator_return_type_widening_tests.rs"
 [[test]]
+name = "function_terminal_return_flow_tests"
+path = "tests/function_terminal_return_flow_tests.rs"
+[[test]]
 name = "implicit_any_nullish_return_tests"
 path = "tests/implicit_any_nullish_return_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs
@@ -1210,11 +1210,14 @@ impl<'a> CheckerState<'a> {
             || check_no_implicit_returns
             || needs_unknown_empty_body_scan
             || needs_ts2355_undefined_union_scan;
+        let terminal_return_flow = self.top_level_terminal_return_flow(func.body);
         let (has_return, falls_through) = if need_return_flow_scan {
-            (
-                self.body_has_return_with_value(func.body),
-                self.function_body_falls_through(func.body),
-            )
+            terminal_return_flow.unwrap_or_else(|| {
+                (
+                    self.body_has_return_with_value(func.body),
+                    self.function_body_falls_through(func.body),
+                )
+            })
         } else {
             (false, false)
         };
@@ -1225,7 +1228,13 @@ impl<'a> CheckerState<'a> {
         // but it does require the function to never complete normally).
         if has_declared_return
             && check_return_type == TypeId::NEVER
-            && self.function_body_falls_through(func.body)
+            && if need_return_flow_scan {
+                falls_through
+            } else {
+                terminal_return_flow
+                    .map(|(_, falls_through)| falls_through)
+                    .unwrap_or_else(|| self.function_body_falls_through(func.body))
+            }
         {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
             let error_node = if has_type_annotation {
@@ -1249,8 +1258,20 @@ impl<'a> CheckerState<'a> {
         if has_type_annotation
             && can_check_generator_completion
             && check_return_type == TypeId::UNKNOWN
-            && self.function_body_falls_through(func.body)
-            && !self.body_has_return_with_value(func.body)
+            && if need_return_flow_scan {
+                falls_through
+            } else {
+                terminal_return_flow
+                    .map(|(_, falls_through)| falls_through)
+                    .unwrap_or_else(|| self.function_body_falls_through(func.body))
+            }
+            && if need_return_flow_scan {
+                !has_return
+            } else {
+                terminal_return_flow
+                    .map(|(has_return, _)| !has_return)
+                    .unwrap_or_else(|| !self.body_has_return_with_value(func.body))
+            }
         {
             let error_node = func.type_annotation;
             use crate::diagnostics::diagnostic_codes;
@@ -1395,6 +1416,29 @@ impl<'a> CheckerState<'a> {
                 diagnostic_messages::NOT_ALL_CODE_PATHS_RETURN_A_VALUE,
                 diagnostic_codes::NOT_ALL_CODE_PATHS_RETURN_A_VALUE,
             );
+        }
+    }
+
+    fn top_level_terminal_return_flow(&self, body: NodeIndex) -> Option<(bool, bool)> {
+        let body_node = self.ctx.arena.get(body)?;
+        if body_node.kind != syntax_kind_ext::BLOCK {
+            return None;
+        }
+
+        let block = self.ctx.arena.get_block(body_node)?;
+        let last_stmt = block.statements.nodes.last().copied()?;
+        let last_node = self.ctx.arena.get(last_stmt)?;
+        match last_node.kind {
+            syntax_kind_ext::RETURN_STATEMENT => {
+                let has_return_value = self
+                    .ctx
+                    .arena
+                    .get_return_statement(last_node)
+                    .is_some_and(|return_data| return_data.expression.is_some());
+                Some((has_return_value, false))
+            }
+            syntax_kind_ext::THROW_STATEMENT => Some((false, false)),
+            _ => None,
         }
     }
 }

--- a/crates/tsz-checker/tests/function_terminal_return_flow_tests.rs
+++ b/crates/tsz-checker/tests/function_terminal_return_flow_tests.rs
@@ -1,0 +1,94 @@
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn diagnostic_codes(source: &str, no_implicit_returns: bool) -> Vec<u32> {
+    check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            no_implicit_returns,
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .map(|diagnostic| diagnostic.code)
+    .collect()
+}
+
+#[test]
+fn terminal_value_return_suppresses_no_implicit_returns() {
+    let codes = diagnostic_codes(
+        r#"
+function renamedTerminal(flag: boolean) {
+    if (flag) {
+        return 1;
+    }
+    return 2;
+}
+"#,
+        true,
+    );
+
+    assert!(
+        !codes.contains(&7030),
+        "terminal value return should prove the function does not fall through; got {codes:?}"
+    );
+}
+
+#[test]
+fn nonterminal_partial_return_still_reports_no_implicit_returns() {
+    let codes = diagnostic_codes(
+        r#"
+function renamedPartial(flag: boolean) {
+    if (flag) {
+        return 1;
+    }
+    flag;
+}
+"#,
+        true,
+    );
+
+    assert!(
+        codes.contains(&7030),
+        "partial return without a terminal return/throw must still run fallthrough analysis; got {codes:?}"
+    );
+}
+
+#[test]
+fn terminal_throw_satisfies_declared_number_return_completeness() {
+    let codes = diagnostic_codes(
+        r#"
+function renamedThrow(): number {
+    throw 1;
+}
+"#,
+        false,
+    );
+
+    assert!(
+        !codes.iter().any(|code| matches!(code, 2355 | 2366)),
+        "terminal throw should not emit return-completeness diagnostics; got {codes:?}"
+    );
+}
+
+#[test]
+fn terminal_bare_return_preserves_unknown_return_completeness() {
+    let codes = diagnostic_codes(
+        r#"
+function renamedUnknown(flag: boolean): unknown {
+    if (flag) {
+        return 1;
+    }
+    return;
+}
+"#,
+        false,
+    );
+
+    assert!(
+        !codes.contains(&2355),
+        "terminal bare return should not look like an empty falling-through unknown body; got {codes:?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 benchmark blocker / performance-residency slice for #12271.

## Invariant
When a checked function body is a block whose final top-level statement is an unconditional `return` or `throw`, tsc treats the body as unable to fall through. This PR lets checker return-path analysis derive that flow fact syntactically before invoking the heavier block fallthrough and return-value scans.

## Scope
- `crates/tsz-checker/src/state/state_checking_members/function_declaration_checks.rs`: add a checker-local terminal-block flow fast path for function declaration return-path diagnostics.
- `crates/tsz-checker/tests/function_terminal_return_flow_tests.rs`: cover terminal value return, terminal bare return, terminal throw, and nonterminal partial-return fallback behavior.
- `crates/tsz-checker/Cargo.toml`: wire the focused integration test target.
- Does not change solver semantics, relation behavior, emitted output, or fixture-specific benchmark selection.

## Project Corpus Impact
- Row: #12271 `200 generic functions` target-gap family.
- Bug family: annotated generic/async functions where repeated return-flow scans contribute fixed checker overhead.
- Evidence: many functions in the target family end with a final top-level `return`; this PR avoids redundant return-flow scans when that final statement already proves no fallthrough.
- Timing claim: not made locally; row movement requires a later project benchmark artifact after full CI/merge.

## Verification
- `cargo fmt -p tsz-checker --check`
- `git diff --check origin/main...HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test function_terminal_return_flow_tests --test implicit_any_nullish_return_tests --test async_return_promise_identity_tests --test generator_return_type_widening_tests --no-fail-fast` -> 11 passed
- `scripts/safe-run.sh python3 scripts/arch/arch_guard.py` -> passed
- `scripts/arch/check-checker-boundaries.sh` -> passed
- Prior draft CI run `27059789332` was not a compiler failure; `CI Light Summary` failed because required jobs were cancelled before summary. Fresh CI should run on pushed head `2ec2e84525`.

## Coordination Notes
- AgentName: Studio-B
- #12693 has merged; this PR is now independent on `main`.
- #12779 remains the generated-project file-local reset-boundary slice.
- This PR is intentionally separate: single-file generic/async return-path checker orchestration, with no overlap in CLI reuse policy or file-session reset state.
- Ready once exact-head CI on `2ec2e84525` is green; no merge queue action while draft or while CI is red/pending.
