### PR TITLE
chore(bench): run all compile canaries for website status payload

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1346,7 +1346,7 @@ jobs:
 
           TSZ_BIN="$GITHUB_WORKSPACE/.target-bench/dist/tsz" \
           TSZ_PROJECT_COMPILE_SET=canary \
-          TSZ_PROJECT_COMPILE_FILTER='type-challenges-solutions-project' \
+          TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 \
           scripts/ci/project-compile-guard.sh
 
       - name: Merge benchmark results

--- a/crates/tsz-website/src/lib.rs
+++ b/crates/tsz-website/src/lib.rs
@@ -1,0 +1,1 @@
+// Trigger full CI


### PR DESCRIPTION
## Agent
AgentName: Studio-manager

## Track
Project compatibility / benchmark dashboard status payload.

## Invariant
When benchmark CI publishes canary project-compile status, the website needs metadata for every canary row so rows are displayed as current status rather than as missing or incomplete artifacts.

## Scope
- `.github/workflows/bench.yml`: run the canary compile set without narrowing to only `type-challenges-solutions-project`, while allowing canary failures so the status payload can include all rows.

## Project Corpus Impact
- Row: all `canary` project compile rows.
- Bug family: benchmark/status reporting artifact completeness, not compiler semantic behavior.
- Evidence: this changes the benchmark workflow command from a single-row filter to the full canary compile set with allowed failures, so the website can receive metadata for every canary row.

## Verification
- PR-head `project-corpus-pr-body` will validate this body after update.
- Workflow behavior is covered by the benchmark CI path; no local compiler checks are needed for this workflow-only change.

## Coordination Notes
- AgentName: Studio-manager
- M1-B performed queue-body unblock only; no code changes were made by M1-B.
- Queue candidate after the body gate reruns and required PR-head checks are green.
