### PR TITLE
perf(solver): use common base for BCT siblings

### DIFF
--- a/crates/tsz-solver/src/operations/expression_ops.rs
+++ b/crates/tsz-solver/src/operations/expression_ops.rs
@@ -904,6 +904,17 @@ pub fn compute_best_common_type_cached<R: TypeResolver>(
         return interner.union(widened);
     }
 
+    // Resolver-backed class/interface BCT: sibling class instances that share
+    // an `extends` chain should collapse to the nearest common base before we
+    // enter the tournament and fallback subtype-reduction paths. This matches
+    // the solver inference BCT path and avoids doing O(N²) pairwise relation
+    // work for wide sibling-class arrays such as `BCT candidates=200`.
+    if let Some(res) = resolver
+        && let Some(common_base) = common_base_class_for_bct(interner, &widened, res)
+    {
+        return common_base;
+    }
+
     // If every object candidate has a required primitive field name that no
     // sibling has, no candidate can be a supertype of all siblings: every other
     // sibling is missing that required field. The fallback subtype-reduction
@@ -994,6 +1005,81 @@ pub fn compute_best_common_type_cached<R: TypeResolver>(
 
     // Step 4: Default to union of all types
     interner.union(reduced.to_vec())
+}
+
+fn common_base_class_for_bct<R: TypeResolver>(
+    interner: &dyn TypeDatabase,
+    types: &[TypeId],
+    resolver: &R,
+) -> Option<TypeId> {
+    if types.len() < 2 {
+        return None;
+    }
+
+    let mut candidates = nominal_hierarchy_for_bct(interner, types[0], resolver)?;
+    // A single-entry hierarchy means the first candidate has no resolver-visible
+    // base. Existing tournament/subtype-reduction logic handles those cases.
+    if candidates.len() <= 1 {
+        return None;
+    }
+
+    for &ty in types.iter().skip(1) {
+        candidates.retain(|&candidate| nominally_extends_or_is(interner, ty, candidate, resolver));
+        if candidates.is_empty() {
+            return None;
+        }
+    }
+
+    // `nominal_hierarchy_for_bct` is ordered most-derived to most-base, so the
+    // first surviving candidate is the nearest common base.
+    candidates.first().copied()
+}
+
+fn nominal_hierarchy_for_bct<R: TypeResolver>(
+    interner: &dyn TypeDatabase,
+    type_id: TypeId,
+    resolver: &R,
+) -> Option<Vec<TypeId>> {
+    let mut hierarchy = Vec::new();
+    let mut current = type_id;
+    for _ in 0..32 {
+        if hierarchy.contains(&current) {
+            break;
+        }
+        hierarchy.push(current);
+        let Some(base) = resolver.get_base_type(current, interner) else {
+            break;
+        };
+        current = base;
+    }
+
+    (!hierarchy.is_empty()).then_some(hierarchy)
+}
+
+fn nominally_extends_or_is<R: TypeResolver>(
+    interner: &dyn TypeDatabase,
+    source: TypeId,
+    target: TypeId,
+    resolver: &R,
+) -> bool {
+    if source == target {
+        return true;
+    }
+
+    let mut current = source;
+    for _ in 0..32 {
+        let Some(base) = resolver.get_base_type(current, interner) else {
+            return false;
+        };
+        if base == target {
+            return true;
+        }
+        if base == current {
+            return false;
+        }
+        current = base;
+    }
+    false
 }
 
 /// Remove subtypes from a type list using the full `SubtypeChecker`.


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 benchmark blocker / BCT scaling slice for #12271.

## Invariant
When best-common-type candidates all share a resolver-visible nominal `extends` chain, `tsc` can choose the nearest common base before falling back to subtype reduction. This PR makes the solver BCT operation derive that common base through `TypeResolver::get_base_type` before the tournament and O(N^2) `remove_subtypes_for_bct` fallback.

## Scope
- `crates/tsz-solver/src/operations/expression_ops.rs`
- Adds a conservative nominal-only common-base helper for BCT candidate lists.
- Does not add checker-local semantic traversal, fixture-name fast paths, or display/source-text predicates.

## Project Corpus Impact
- Row: `BCT candidates=200`
- Bug family: Track 10 best-common-type scale guard / #12271 severe tsgo-winning row.
- Evidence: latest useful Bench artifact inspected was run `27058125889`, where `BCT candidates=200` had `tsz_ms=563.21`, `tsgo_ms=566.37`, `tsz_speedup_vs_tsgo=1.0056106958328155`, and `target_gap_factor=1.9888412168723626`.

The complexity change is to collapse sibling-class candidate lists to the nearest common base before pairwise subtype-reduction work. No speedup claim is made for this PR until a post-merge/post-head Bench artifact proves it.

## Verification
- Exact-head full CI run `27060202694` on `be810cc9dad2b5a9bb6655cee36c192d8a599c00`: gate, project-row-drift, lint, cargo-shear, cargo-deny, dist-binaries, unit, unit-checker-integration, unit-cloudbuild, wasm/wasm-web, node-harness-prep, conformance-snapshot-gate, project-compile guard/canary, LSP, emit, all conformance shards, conformance-aggregate, all fourslash shards, and fourslash-aggregate passed.
- CI blocker from run `27060861586`: `project-corpus-pr-body` required literal bullet fields. This body update uses `- Row:`, `- Bug family:`, and `- Evidence:` exactly.
- Not run locally by request/current lane policy.
- Commit hook ran repo pre-commit formatting during commit.

## Coordination Notes
- AgentName: Studio-B
- #12779 covers generated-project file-local reset boundaries.
- #12782 covers generic-function return-flow scans.
- #12790 covers conditional discriminant filtering for `200 union members`.
- This PR is separate solver BCT work: resolver-visible nominal common-base selection and first-call complexity, not file-session reuse or checker return-path orchestration.
- Do not queue until the refreshed body/summary check is green on head `be810cc9dad2b5a9bb6655cee36c192d8a599c00`.
