### PR TITLE
refactor(checker): route batched flow exclusions through boundary

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -346,9 +346,14 @@ impl<'a> FlowAnalyzer<'a> {
                 let narrowed = if excluded_types.is_empty() {
                     type_id
                 } else if target_is_switch_expr {
-                    narrowing.narrow_excluding_types(type_id, &excluded_types)
+                    flow_query::narrow_excluding_types_in_context(
+                        narrowing,
+                        type_id,
+                        &excluded_types,
+                    )
                 } else if let Some((ref path, _, _)) = discriminant_info {
-                    narrowing.narrow_by_excluding_discriminant_values(
+                    flow_query::narrow_by_excluding_discriminant_values_in_context(
+                        narrowing,
                         type_id,
                         path,
                         &excluded_types,
@@ -561,13 +566,18 @@ impl<'a> FlowAnalyzer<'a> {
             if !excluded_types.is_empty() {
                 if target_is_switch_expr {
                     // Use batched narrowing for O(N) instead of O(N²)
-                    return narrowing.narrow_excluding_types(type_id, &excluded_types);
+                    return flow_query::narrow_excluding_types_in_context(
+                        narrowing,
+                        type_id,
+                        &excluded_types,
+                    );
                 } else if let Some((path, is_optional, _)) = discriminant_info {
                     if is_optional && excluded_types.contains(&TypeId::UNDEFINED) {
                         return type_id;
                     }
                     // Use batched discriminant narrowing
-                    return narrowing.narrow_by_excluding_discriminant_values(
+                    return flow_query::narrow_by_excluding_discriminant_values_in_context(
+                        narrowing,
                         type_id,
                         &path,
                         &excluded_types,
@@ -1331,7 +1341,8 @@ impl<'a> FlowAnalyzer<'a> {
             //     return standard strings at runtime, so the condition is always
             //     false; the complement narrows to primitives)
             if effective_truth {
-                return narrowing.narrow_excluding_types(
+                return flow_query::narrow_excluding_types_in_context(
+                    narrowing,
                     type_id,
                     &[TypeId::STRING, TypeId::NUMBER, TypeId::BOOLEAN],
                 );

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -420,6 +420,34 @@ pub(crate) fn narrow_by_property_truthiness_in_context(
     narrowing.narrow_by_property_truthiness(type_id, property_path, is_true_branch)
 }
 
+/// Exclude known values from a flow type using the caller's active flow
+/// narrowing context.
+///
+/// The checker owns discovering the control-flow fact and deciding when a broad
+/// primitive source should remain unchanged. The solver owns the set algebra
+/// used to subtract those values.
+pub(crate) fn narrow_excluding_types_in_context(
+    narrowing: &NarrowingContext<'_>,
+    type_id: TypeId,
+    excluded_types: &[TypeId],
+) -> TypeId {
+    narrowing.narrow_excluding_types(type_id, excluded_types)
+}
+
+/// Exclude known values from a discriminant-property flow fact using the
+/// caller's active flow narrowing context.
+///
+/// The checker owns syntax/path discovery and optional-chain guard rails. The
+/// solver owns filtering union members by discriminant value.
+pub(crate) fn narrow_by_excluding_discriminant_values_in_context(
+    narrowing: &NarrowingContext<'_>,
+    type_id: TypeId,
+    property_path: &[tsz_common::interner::Atom],
+    excluded_types: &[TypeId],
+) -> TypeId {
+    narrowing.narrow_by_excluding_discriminant_values(type_id, property_path, excluded_types)
+}
+
 /// Narrow a value to the object-like branch of an `instanceof`-style check.
 pub(crate) fn narrow_to_objectish(
     db: &dyn QueryDatabase,

--- a/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
@@ -317,3 +317,36 @@ fn condition_property_truthiness_uses_flow_query_boundary() {
         "condition narrowing should not apply property-truthiness narrowing directly"
     );
 }
+
+#[test]
+fn condition_batched_exclusions_use_flow_query_boundary() {
+    let condition_source = fs::read_to_string("src/flow/control_flow/condition_narrowing.rs")
+        .expect("failed to read condition narrowing source");
+    let boundary_source = fs::read_to_string("src/query_boundaries/flow_analysis.rs")
+        .expect("failed to read flow analysis boundary source");
+    let compact_condition: String = condition_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let compact_boundary: String = boundary_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+
+    assert!(
+        compact_boundary.contains("fnnarrow_excluding_types_in_context(")
+            && compact_boundary.contains("fnnarrow_by_excluding_discriminant_values_in_context("),
+        "flow analysis boundary should own batched exclusion narrowing helpers"
+    );
+    assert!(
+        compact_condition.contains("flow_query::narrow_excluding_types_in_context(")
+            && compact_condition
+                .contains("flow_query::narrow_by_excluding_discriminant_values_in_context("),
+        "condition batched exclusion narrowing should route through the flow query boundary"
+    );
+    assert!(
+        !compact_condition.contains("narrowing.narrow_excluding_types(")
+            && !compact_condition.contains("narrowing.narrow_by_excluding_discriminant_values("),
+        "condition narrowing should not apply batched exclusion narrowing directly"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
M1-D - flow graph and solver-owned narrowing predicates; refactor.

## Invariant
When checker has discovered batched control-flow exclusion facts such as switch case exclusions, discriminant-switch exclusions, or non-standard `typeof` primitive exclusions, `tsc` narrows by subtracting those semantic constituents. In tsz, checker owns syntax/fact discovery and guard rails; solver-owned narrowing computes the excluded type through `query_boundaries::flow_analysis` helpers that preserve the active `NarrowingContext`.

## Scope
- Add flow-analysis query-boundary helpers for batched type exclusions and discriminant-value exclusions using the caller's active `NarrowingContext`.
- Route condition switch/default and non-standard `typeof` batched exclusions in `condition_narrowing.rs` through those helpers.
- Add a source architecture guard preventing direct batched exclusion narrowing in condition narrowing.
- Keep existing broad-primitive and optional-chain fallback behavior unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: flow/narrowing boundary debt
- Impact: No project-row behavior change intended. This is a boundary ratchet for M1-D batched flow exclusion narrowing.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib flow_guard_boundary_tests enum_residual_narrowing_tests zod_type_query_regression_tests::switch_discriminant_can_use_const_object_member_cases zod_type_query_regression_tests::switch_discriminant_can_use_array_to_enum_member_cases`
- `cargo fmt --check`
- `git diff --check`

## Coordination Notes
- Built on `origin/main` after #12776 landed.
- M1-D/M4-C owned work was clear before starting this slice.
- Neighboring inference, relation, module-resolution, and project-row issues found in issue search are owned by other lanes; this PR stays in checker flow boundary files only.
- Performance: no benchmark claim.
