### PR TITLE
fix(solver): normalize variadic alias reductions (#10801)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/application_reduction.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/application_reduction.rs
@@ -66,6 +66,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         break;
                     }
                     let result = self.substitute_infer(cond_true, &bindings);
+                    let result = self.evaluate(result);
                     let result = self
                         .try_recover_application_from_display_alias(result)
                         .unwrap_or(result);

--- a/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
@@ -120,6 +120,85 @@ fn evaluate_application_unknown_body_keeps_application_opaque() {
     );
 }
 
+fn tuple_elem(type_id: TypeId) -> TupleElement {
+    TupleElement {
+        type_id,
+        name: None,
+        optional: false,
+        rest: false,
+    }
+}
+
+fn rest_tuple_elem(type_id: TypeId) -> TupleElement {
+    TupleElement {
+        type_id,
+        name: None,
+        optional: false,
+        rest: true,
+    }
+}
+
+#[test]
+fn evaluate_application_variadic_prepend_flattens_tail_application() {
+    let interner = TypeInterner::new();
+
+    let head_param = unconstrained_param(&interner, "Head");
+    let tail_param = unconstrained_param(&interner, "Tail");
+    let source_param = unconstrained_param(&interner, "Source");
+    let ignored_head = interner.intern(TypeData::Infer(unconstrained_param(&interner, "Ignored")));
+    let rest = interner.intern(TypeData::Infer(unconstrained_param(&interner, "Rest")));
+
+    let head_type = interner.intern(TypeData::TypeParameter(head_param));
+    let tail_type = interner.intern(TypeData::TypeParameter(tail_param));
+    let source_type = interner.intern(TypeData::TypeParameter(source_param));
+
+    let prepend_body = interner.tuple(vec![tuple_elem(head_type), rest_tuple_elem(tail_type)]);
+    let tail_body = interner.conditional(ConditionalType {
+        check_type: source_type,
+        extends_type: interner.tuple(vec![tuple_elem(ignored_head), rest_tuple_elem(rest)]),
+        true_type: rest,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    });
+
+    let mut env = TypeEnvironment::new();
+    let tail_source = interner.tuple(vec![
+        tuple_elem(TypeId::NUMBER),
+        tuple_elem(TypeId::BOOLEAN),
+    ]);
+    let tail_app = alias_application(
+        &interner,
+        &mut env,
+        DefId(301),
+        DefKind::TypeAlias,
+        tail_body,
+        vec![source_param],
+        vec![tail_source],
+    );
+    let prepend_app = alias_application(
+        &interner,
+        &mut env,
+        DefId(302),
+        DefKind::TypeAlias,
+        prepend_body,
+        vec![head_param, tail_param],
+        vec![TypeId::STRING, tail_app],
+    );
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    let result = evaluator.evaluate(prepend_app);
+    let expected = interner.tuple(vec![
+        tuple_elem(TypeId::STRING),
+        tuple_elem(TypeId::NUMBER),
+        tuple_elem(TypeId::BOOLEAN),
+    ]);
+
+    assert_eq!(
+        result, expected,
+        "Prepend<Head, Tail<Source>> must preserve exact tail arity through a rest Application"
+    );
+}
+
 /// Phase 5 — homomorphic mapped-type passthrough. `Box<number>` where
 /// `Box<T> = { [P in keyof T]: T[P] }` returns the primitive argument
 /// directly without expanding the mapped body, matching tsc.


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Benchmark blocker / semantic campaign for #10801 (`rxjs-project`, variadic-tuples).

## Invariant
When a conditional alias reduction substitutes an `infer` result into a tuple rest slot and that result is an alias application which evaluates to a tuple, `tsc` preserves the exact tuple tail arity and positions. This PR routes the solver alias-reduction result through tuple evaluation before conditional matching observes it, so rest applications like `Prepend<Head, Tail<Source>>` flatten to the same tuple shape as `tsc` instead of leaking an unevaluated rest application.

## Scope
- `crates/tsz-solver/src/evaluation/evaluate_rules/conditional/application_reduction.rs`: normalize substituted conditional alias-reduction results through the evaluator before recovering application display aliases.
- `crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs`: add a renamed-binder lazy-alias regression for `Prepend<Head, Tail<Source>>` preserving exact tuple tail arity.

## Project Corpus Impact
- Row: `rxjs-project`.
- Bug family: variadic tuple spread inference / tuple tail arity through wrapper aliases.
- Evidence: #10801 is the active row witness. This PR targets the solver alias-reduction path that can expose tuple rest applications to conditional matching. Ready CI passed `project-corpus-pr-body`, `project-compile-guard`, and `project-compile-canary`. No local project-corpus or benchmark run was performed.

## Verification
- Exact head: `168295c1aa1d5aa918c4209d3ad78659f7cb3ccb`.
- Ready CI run `27060301855` passed `CI Summary`, `gate`, `project-row-drift`, `project-corpus-pr-body`, `conformance-snapshot-gate`, `cargo-shear`, `cargo-deny`, `lint`, `unit`, `unit-checker-integration`, `unit-cloudbuild`, `dist-binaries`, `wasm`, `wasm-web`, `node-harness-prep`, `emit`, `lsp-e2e`, `project-compile-guard`, `project-compile-canary`, conformance shards `0..5`, `conformance-aggregate`, fourslash shards `0..5`, and `fourslash-aggregate`.
- Draft-light CI run `27060095931` passed: `gate`, `project-row-drift`, `cargo-shear`, `cargo-deny`, `lint`, `unit`, `unit-checker-integration`, `unit-cloudbuild`, `dist-binaries`, and `CI Light Summary`.
- Local tests were not run.
- Pre-commit formatting hook ran during commit.

## Coordination Notes
- Ready for manager/queue-owner review after full ready CI passed on exact head `168295c1aa1d5aa918c4209d3ad78659f7cb3ccb`.
- I did not add `merge-queue`; implementation-agent handoff leaves queue ordering to the manager/queue owner.
- #10801 is the single active Studio-B WIP bug after #10816 landed.
- Overlap check: #10812 has an active M4-B PR (#12734), so this PR avoids that issue family.
- Fixes #10801.
