### PR TITLE
perf(solver): fast reject disjoint literal discriminants

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -2,7 +2,7 @@
 
 use crate::instantiation::instantiate::instantiate_generic_cached;
 use crate::relations::subtype::TypeResolver;
-use crate::types::{ConditionalType, TypeData, TypeId};
+use crate::types::{ConditionalType, PropertyInfo, TypeData, TypeId};
 use tracing::trace;
 
 use super::super::super::evaluate::TypeEvaluator;
@@ -171,6 +171,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // intrinsic as satisfying callable targets. Ordinary
             // assignment intentionally remains stricter.
             true
+        } else if self.object_literals_have_conflicting_required_property(check_type, extends_type)
+        {
+            // `Extract<Union, { kind: "x" }>` and similar discriminant filters
+            // distribute over every union member. If both sides expose the same
+            // required property with distinct literal values, the relation is
+            // definitively false, so avoid the full structural subtype walk.
+            false
         } else {
             let mut strict_checker = self.conditional_subtype_checker();
             strict_checker.is_subtype_of(check_type, extends_type)
@@ -178,6 +185,49 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         CONDITIONAL_SUBTYPE_DEPTH.with(|d| d.set(d.get().saturating_sub(1)));
         self.cache_conditional_subtype(check_type, extends_type, result);
         result
+    }
+
+    fn object_literals_have_conflicting_required_property(
+        &self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        let source_shape_id = match self.interner().lookup(source) {
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => shape_id,
+            _ => return false,
+        };
+        let target_shape_id = match self.interner().lookup(target) {
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => shape_id,
+            _ => return false,
+        };
+
+        let source_shape = self.interner().object_shape(source_shape_id);
+        let target_shape = self.interner().object_shape(target_shape_id);
+
+        target_shape
+            .properties
+            .iter()
+            .filter(|prop| !prop.optional)
+            .any(|target_prop| {
+                let Some(source_prop) =
+                    PropertyInfo::find_in_slice(&source_shape.properties, target_prop.name)
+                else {
+                    return false;
+                };
+                Self::literal_values_are_disjoint(
+                    self.interner().lookup(source_prop.type_id),
+                    self.interner().lookup(target_prop.type_id),
+                )
+            })
+    }
+
+    fn literal_values_are_disjoint(source: Option<TypeData>, target: Option<TypeData>) -> bool {
+        match (source, target) {
+            (Some(TypeData::Literal(source)), Some(TypeData::Literal(target))) => {
+                source.primitive_type_id() == target.primitive_type_id() && source != target
+            }
+            _ => false,
+        }
     }
 
     /// Detect a tail-call pattern in `branch` and return the continuation step.


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 benchmark blocker: `200 union members` / conditional discriminant filtering.

## Invariant
When a conditional subtype check compares two object-shaped operands that share a required property with distinct literal values, `tsc` can determine the relation is false through discriminant incompatibility. This PR makes tsz do the same through the solver conditional-evaluation subtype gate, before falling back to full structural relation.

## Scope
- `crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs`
- Adds a solver-local negative fast path for object literal property conflicts.
- No checker name, file, fixture, or rendered-message predicates.

## Project Corpus Impact
- Row: `200 union members`
- Bug family: Track 10 conditional discriminant filtering / #12271 severe tsgo-winning row.
- Latest useful Bench artifact inspected: run `27058125889`, where `200 union members` had `tsz_ms=299.96`, `tsgo_ms=499.69`, `tsz_speedup_vs_tsgo=1.6658554473929859`, and `target_gap_factor=1.2005843623046288`.
- The same structural path should also help `Extract<WideUnion, { discriminant: literal }>` patterns in project rows, but this PR makes no timing claim until Bench artifacts prove it.

## Verification
- Not run locally; per lane policy, no local broad benchmarks/tests were run.
- Pre-commit formatting ran during commit.
- Expected CI: draft/light checks first; timing requires a later Bench artifact before any speedup claim.

## Coordination Notes
- Issue: https://github.com/tsz-org/tsz/issues/12271
- Non-overlap: separate from active Studio-B generated-project, generic-functions, and BCT PRs.
- Current target-gap evidence from `/tmp/tsz-bench-27058125889/bench-results-tsgo-winners.json`: `45` eligible green rows, `30` meeting target, `15` below target.
