### PR TITLE
perf(checker): preserve stable class symbol cache

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -791,14 +791,16 @@ impl<'a> CheckerState<'a> {
         if !preserve_stable_class_shape_cache {
             self.ctx.class_constructor_type_cache.remove(&stmt_idx);
         }
-        if let Some(sym_id) = self.ctx.binder.get_node_symbol(stmt_idx) {
-            self.ctx.symbol_types.remove(&sym_id);
-        }
-        if class.name.is_some()
-            && let Some(ident) = self.ctx.arena.get_identifier_at(class.name)
-            && let Some(name_sym) = self.ctx.binder.file_locals.get(&ident.escaped_text)
-        {
-            self.ctx.symbol_types.remove(&name_sym);
+        if !preserve_stable_class_shape_cache {
+            if let Some(sym_id) = self.ctx.binder.get_node_symbol(stmt_idx) {
+                self.ctx.symbol_types.remove(&sym_id);
+            }
+            if class.name.is_some()
+                && let Some(ident) = self.ctx.arena.get_identifier_at(class.name)
+                && let Some(name_sym) = self.ctx.binder.file_locals.get(&ident.escaped_text)
+            {
+                self.ctx.symbol_types.remove(&name_sym);
+            }
         }
 
         // Class bodies reset the async context — field initializers and static blocks
@@ -974,15 +976,17 @@ impl<'a> CheckerState<'a> {
         self.pop_type_parameters(type_param_updates);
 
         let mut refresh_symbols = Vec::new();
-        if let Some(sym_id) = self.ctx.binder.get_node_symbol(stmt_idx) {
-            refresh_symbols.push(sym_id);
-        }
-        if class.name.is_some()
-            && let Some(ident) = self.ctx.arena.get_identifier_at(class.name)
-            && let Some(name_sym) = self.ctx.binder.file_locals.get(&ident.escaped_text)
-            && !refresh_symbols.contains(&name_sym)
-        {
-            refresh_symbols.push(name_sym);
+        if !preserve_stable_class_shape_cache {
+            if let Some(sym_id) = self.ctx.binder.get_node_symbol(stmt_idx) {
+                refresh_symbols.push(sym_id);
+            }
+            if class.name.is_some()
+                && let Some(ident) = self.ctx.arena.get_identifier_at(class.name)
+                && let Some(name_sym) = self.ctx.binder.file_locals.get(&ident.escaped_text)
+                && !refresh_symbols.contains(&name_sym)
+            {
+                refresh_symbols.push(name_sym);
+            }
         }
 
         self.ctx.checked_classes.insert(stmt_idx);


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance benchmark blocker for #12271.

## Invariant
When a class declaration has a stable explicit shape already present in the class instance/constructor caches, checker member diagnostics must still run, but class symbol type eviction/refresh is unnecessary. This PR keeps the checker orchestration cache path hot for that stable-shape case.

## Scope
- `crates/tsz-checker/src/state/state_checking/class.rs`
- Preserves stable class symbol cache entries when the existing stable class-shape gate says instance/constructor caches can remain valid.
- Does not add fixture-name fast paths, checker source-text predicates, or display-string predicates.

## Project Corpus Impact
- Row: `200 classes`
- Bug family: class declaration/member-table construction and checker/binder symbol lookup pressure.
- Evidence: latest artifact-backed `tsgo-winners` report from Bench run `27058125889` lists `200 classes` below the 2x target, with owner context pointing at class declaration/member-table construction and checker/binder lookup pressure. This PR targets repeated symbol type eviction after the existing stable class-shape cache gate preserves instance/constructor caches.

No speedup claim is made for this PR until a post-head/post-merge Bench artifact proves the `200 classes` target gap moved.

## Verification
- Draft/light CI run `27060712879` on head `ab64a71fc2ecbc9c41aaed4bffc4e693faff45c3`: `CI Light Summary`, `dist-binaries`, `unit`, `unit-checker-integration`, `unit-cloudbuild`, `lint`, `cargo-shear`, `cargo-deny`, `project-row-drift`, and `gate` passed.
- Earlier local verification before opening draft: `git diff --check`.
- Local tests/benchmarks not run per current lane instruction.
- Full ready-state CI is expected after marking ready.

## Coordination Notes
- AgentName: Studio-B
- Overlap checked against live `agent:Studio-B` PRs: active fresh slices cover generated project file-local reset (#12779), generic functions (#12782), BCT siblings (#12785), variadic tuple semantics (#12788), and union members (#12790); this slice targets the remaining `200 classes` target gap.
- Bench artifact state before ready handoff: newer inspected Bench runs still had no usable result artifacts (`27060971645`, `27060743018`, and `27060437649` had zero artifacts; `27060201695` had only `bench-prep-ready`).
- Studio-manager can review after ready/full CI settles; do not queue solely from this handoff without reviewing latest exact-head checks.
