### PR TITLE
refactor(checker): route equality narrowing through boundary

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -827,7 +827,11 @@ impl<'a> FlowAnalyzer<'a> {
                                     target,
                                 )
                             {
-                                return narrowing.narrow_excluding_type(result, TypeId::NULL);
+                                return flow_query::narrow_excluding_type_in_context(
+                                    &narrowing,
+                                    result,
+                                    TypeId::NULL,
+                                );
                             }
                             return result;
                         }
@@ -1329,7 +1333,11 @@ impl<'a> FlowAnalyzer<'a> {
                     && typeof_kind == TypeofKind::Object
                     && self.antecedent_chain_excludes_null_for_target(antecedent_id, target)
                 {
-                    return narrowing.narrow_excluding_type(narrowed, TypeId::NULL);
+                    return flow_query::narrow_excluding_type_in_context(
+                        narrowing,
+                        narrowed,
+                        TypeId::NULL,
+                    );
                 }
                 return narrowed;
             }
@@ -1394,7 +1402,8 @@ impl<'a> FlowAnalyzer<'a> {
                 if is_optional && discriminant_type == TypeId::UNDEFINED && effective_truth {
                     return type_id;
                 }
-                return narrowing.narrow_by_discriminant_for_type(
+                return flow_query::narrow_by_discriminant_for_type_in_context(
+                    narrowing,
                     type_id,
                     &property_path,
                     discriminant_type,
@@ -1408,7 +1417,7 @@ impl<'a> FlowAnalyzer<'a> {
                 if effective_truth {
                     return nullish;
                 }
-                return narrowing.narrow_excluding_type(type_id, nullish);
+                return flow_query::narrow_excluding_type_in_context(narrowing, type_id, nullish);
             }
 
             let nullish_union = self.interner.union2(TypeId::NULL, TypeId::UNDEFINED);
@@ -1461,7 +1470,8 @@ impl<'a> FlowAnalyzer<'a> {
                             base_type,
                         );
                     }
-                    let narrowed = narrowing.narrow_by_discriminant_for_type(
+                    let narrowed = flow_query::narrow_by_discriminant_for_type_in_context(
+                        narrowing,
                         base_type,
                         &property_path,
                         literal_type,
@@ -1482,11 +1492,16 @@ impl<'a> FlowAnalyzer<'a> {
                 && let Some(literal_type) = self.literal_comparison(bin.left, bin.right, target)
             {
                 if effective_truth {
-                    let narrowed = narrowing.narrow_to_type(type_id, literal_type);
+                    let narrowed =
+                        flow_query::narrow_to_type_in_context(narrowing, type_id, literal_type);
                     if narrowed != TypeId::NEVER {
                         return narrowed;
                     }
-                    if narrowing.literal_assignable_to(literal_type, type_id) {
+                    if flow_query::literal_assignable_to_in_context(
+                        narrowing,
+                        literal_type,
+                        type_id,
+                    ) {
                         return literal_type;
                     }
                     return TypeId::NEVER;
@@ -1494,7 +1509,11 @@ impl<'a> FlowAnalyzer<'a> {
                 if !is_unit_type(self.interner, literal_type) {
                     return type_id;
                 }
-                return narrowing.narrow_excluding_type(type_id, literal_type);
+                return flow_query::narrow_excluding_type_in_context(
+                    narrowing,
+                    type_id,
+                    literal_type,
+                );
             }
 
             // Equality narrowing of `unknown` / `any` against a primitive-
@@ -1514,7 +1533,7 @@ impl<'a> FlowAnalyzer<'a> {
                     self.literal_comparison_for_unknown_target(bin.left, bin.right, target)
             {
                 if effective_truth {
-                    return narrowing.narrow_to_type(type_id, literal_type);
+                    return flow_query::narrow_to_type_in_context(narrowing, type_id, literal_type);
                 }
                 return type_id;
             }

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -13,7 +13,7 @@ use tsz_parser::parser::node::{CallExprData, NodeArena};
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::computation::TypeEnvironment;
-use tsz_solver::narrowing::{GuardSense, NarrowingCache, NarrowingContext};
+use tsz_solver::narrowing::{NarrowingCache, NarrowingContext};
 use tsz_solver::{ParamInfo, TupleElement, TypeId, TypePredicate};
 
 type FlowCache = FxHashMap<(FlowNodeId, SymbolId, TypeId), TypeId>;
@@ -1550,7 +1550,8 @@ impl<'a> FlowAnalyzer<'a> {
                 env_borrow = env.borrow();
                 narrowing = narrowing.with_resolver(&*env_borrow);
             }
-            return narrowing.narrow_by_discriminant(
+            return query::narrow_by_discriminant_in_context(
+                &narrowing,
                 narrowed_pre_type,
                 &property_path,
                 predicate_type,
@@ -1585,9 +1586,13 @@ impl<'a> FlowAnalyzer<'a> {
                     } else {
                         self.make_narrowing_context()
                     };
-                    // Apply the guard with NEGATIVE sense (because of the !)
-                    let narrowed =
-                        narrowing.narrow_type(narrowed_pre_type, &guard, GuardSense::Negative);
+                    // Apply the guard with negative sense because of the `!`.
+                    let narrowed = query::narrow_with_guard_in_context(
+                        &narrowing,
+                        narrowed_pre_type,
+                        &guard,
+                        false,
+                    );
                     if narrowed != narrowed_pre_type {
                         return narrowed;
                     }

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -434,6 +434,19 @@ pub(crate) fn narrow_excluding_types_in_context(
     narrowing.narrow_excluding_types(type_id, excluded_types)
 }
 
+/// Exclude one known value from a flow type using the caller's active flow
+/// narrowing context.
+///
+/// The checker owns discovering the equality/nullish fact. The solver owns the
+/// semantic set subtraction.
+pub(crate) fn narrow_excluding_type_in_context(
+    narrowing: &NarrowingContext<'_>,
+    type_id: TypeId,
+    excluded_type: TypeId,
+) -> TypeId {
+    narrowing.narrow_excluding_type(type_id, excluded_type)
+}
+
 /// Exclude known values from a discriminant-property flow fact using the
 /// caller's active flow narrowing context.
 ///
@@ -446,6 +459,53 @@ pub(crate) fn narrow_by_excluding_discriminant_values_in_context(
     excluded_types: &[TypeId],
 ) -> TypeId {
     narrowing.narrow_by_excluding_discriminant_values(type_id, property_path, excluded_types)
+}
+
+/// Narrow a flow type by a discriminant equality fact using the caller's active
+/// flow narrowing context.
+///
+/// The checker owns property-path discovery and branch selection. The solver
+/// owns filtering by discriminant value, including constraint and intersection
+/// handling.
+pub(crate) fn narrow_by_discriminant_for_type_in_context(
+    narrowing: &NarrowingContext<'_>,
+    type_id: TypeId,
+    property_path: &[tsz_common::interner::Atom],
+    literal_type: TypeId,
+    is_true_branch: bool,
+) -> TypeId {
+    narrowing.narrow_by_discriminant_for_type(type_id, property_path, literal_type, is_true_branch)
+}
+
+/// Narrow a union-like assertion target by a discriminant equality fact.
+///
+/// Assertion handling owns recognizing the predicate target. The solver owns
+/// the discriminant filter itself.
+pub(crate) fn narrow_by_discriminant_in_context(
+    narrowing: &NarrowingContext<'_>,
+    type_id: TypeId,
+    property_path: &[tsz_common::interner::Atom],
+    literal_type: TypeId,
+) -> TypeId {
+    narrowing.narrow_by_discriminant(type_id, property_path, literal_type)
+}
+
+/// Keep only values compatible with a literal equality fact.
+pub(crate) fn narrow_to_type_in_context(
+    narrowing: &NarrowingContext<'_>,
+    type_id: TypeId,
+    literal_type: TypeId,
+) -> TypeId {
+    narrowing.narrow_to_type(type_id, literal_type)
+}
+
+/// Return whether a literal comparison target is assignable to the flow type.
+pub(crate) fn literal_assignable_to_in_context(
+    narrowing: &NarrowingContext<'_>,
+    literal_type: TypeId,
+    type_id: TypeId,
+) -> bool {
+    narrowing.literal_assignable_to(literal_type, type_id)
 }
 
 /// Narrow a value to the object-like branch of an `instanceof`-style check.

--- a/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
@@ -350,3 +350,52 @@ fn condition_batched_exclusions_use_flow_query_boundary() {
         "condition narrowing should not apply batched exclusion narrowing directly"
     );
 }
+
+#[test]
+fn condition_equality_narrowing_uses_flow_query_boundary() {
+    let condition_source = fs::read_to_string("src/flow/control_flow/condition_narrowing.rs")
+        .expect("failed to read condition narrowing source");
+    let core_source = fs::read_to_string("src/flow/control_flow/core.rs")
+        .expect("failed to read flow core source");
+    let boundary_source = fs::read_to_string("src/query_boundaries/flow_analysis.rs")
+        .expect("failed to read flow analysis boundary source");
+    let compact_condition: String = condition_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let compact_core: String = core_source.chars().filter(|c| !c.is_whitespace()).collect();
+    let compact_boundary: String = boundary_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+
+    assert!(
+        compact_boundary.contains("fnnarrow_excluding_type_in_context(")
+            && compact_boundary.contains("fnnarrow_by_discriminant_for_type_in_context(")
+            && compact_boundary.contains("fnnarrow_to_type_in_context(")
+            && compact_boundary.contains("fnliteral_assignable_to_in_context("),
+        "flow analysis boundary should own equality/discriminant narrowing helpers"
+    );
+    assert!(
+        compact_condition.contains("flow_query::narrow_excluding_type_in_context(")
+            && compact_condition
+                .contains("flow_query::narrow_by_discriminant_for_type_in_context(")
+            && compact_condition.contains("flow_query::narrow_to_type_in_context(")
+            && compact_condition.contains("flow_query::literal_assignable_to_in_context("),
+        "condition equality narrowing should route semantic narrowing through the flow query boundary"
+    );
+    assert!(
+        compact_core.contains("query::narrow_by_discriminant_in_context(")
+            && compact_core.contains("query::narrow_with_guard_in_context("),
+        "assertion flow narrowing should route solver predicate application through the flow query boundary"
+    );
+    assert!(
+        !compact_condition.contains("narrowing.narrow_excluding_type(")
+            && !compact_condition.contains("narrowing.narrow_by_discriminant_for_type(")
+            && !compact_condition.contains("narrowing.narrow_to_type(")
+            && !compact_condition.contains("narrowing.literal_assignable_to(")
+            && !compact_core.contains("narrowing.narrow_by_discriminant(")
+            && !compact_core.contains("narrowing.narrow_type("),
+        "flow orchestration should not call solver equality/discriminant narrowing directly"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
M1-D / Track 6 flow graph and solver-owned narrowing predicates; refactor-only boundary ratchet.

## Invariant
When flow observes equality, nullish, literal, discriminant, or assertion-predicate facts, the checker owns AST/reference matching and branch orchestration; semantic narrowed types are computed through `query_boundaries::flow_analysis` using the active `NarrowingContext`.

## Scope
- Add context-preserving flow query helpers for single exclusions, discriminant equality narrowing, literal narrowing, and literal assignability probes.
- Route equality/nullish/discriminant narrowing in `condition_narrowing.rs` through those helpers.
- Route assertion discriminant and negated assertion guard application in `core.rs` through the flow query boundary.
- Extend flow boundary source guards to prevent these call paths from regressing back to direct solver narrowing calls.

## Project Corpus Impact
- Row: n/a.
- Bug family: flow/narrowing architecture substrate for Kysely/Zod guard reductions.
- Evidence: behavior intended unchanged; nearby discriminant, assertion, and condition-narrowing tests passed locally.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib flow_guard_boundary_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib flow_guard_boundary_tests object_spread_discriminant_narrowing_tests conditional_break_narrowing_tests assertion_type_predicate_diagnostics_tests::generic_assertion_with_param_in_both_predicate_and_arg_still_resolves assertion_type_predicate_diagnostics_tests::assertion_false_condition_emits_unreachable_code assertion_type_predicate_diagnostics_tests::generic_assertion_with_explicit_type_arg_narrows_correctly`
- `cargo fmt --check`
- `git diff --check`
- `scripts/arch/check-checker-boundaries.sh`
- line cap check: touched files remain under 2000 physical lines.

## Coordination Notes
- No open `agent:M1-D` or `agent:M4-C` PRs/issues were present at intake.
- This continues the M1-D boundary-ratchet sequence after #12760, #12776, and #12787.
- No behavior policy changes, no new identifier/file-name/source-text predicates, and no project-row smoke required for this refactor-only slice.
