### PR TITLE
refactor(emit): record recovered typeof tails in parser

### DIFF
--- a/crates/tsz-emitter/src/emitter/statements/recovered_variable_statement.rs
+++ b/crates/tsz-emitter/src/emitter/statements/recovered_variable_statement.rs
@@ -124,110 +124,46 @@ impl<'a> Printer<'a> {
         // Only recover when every declaration in the statement lacks an initializer.
         // If any declaration has an initializer, .typeof( is a valid property call
         // in a value expression that was already emitted — not a type-annotation tail.
-        if let Some(var_stmt) = self.arena.get_variable(node) {
-            if !self.all_declarations_lack_initializer(&var_stmt.declarations) {
-                return;
-            }
+        let Some(var_stmt) = self.arena.get_variable(node) else {
+            return;
+        };
+        if !self.all_declarations_lack_initializer(&var_stmt.declarations) {
+            return;
+        }
+        let recovered_calls: Vec<_> = var_stmt
+            .declarations
+            .nodes
+            .iter()
+            .filter_map(|decl_list| {
+                self.arena
+                    .get(*decl_list)
+                    .and_then(|node| self.arena.get_variable(node))
+            })
+            .flat_map(|decl_list| decl_list.recovered_typeof_member_calls.clone())
+            .collect();
+        if recovered_calls.is_empty() {
+            return;
         }
 
         let Some(text) = self.source_text else {
             return;
         };
-        let start = self.skip_trivia_forward(node.pos, node.end) as usize;
-        let end = std::cmp::min(node.end as usize, text.len());
-        if start >= end {
-            return;
-        }
-        let Some(typeof_pos) = self.find_source_pattern_outside_quoted_text(start, end, ".typeof(")
-        else {
-            return;
-        };
-        let open = typeof_pos + ".typeof".len();
-        let Some(close) = self.find_matching_source_paren(open, end) else {
-            return;
-        };
-        let argument = text[open + 1..close].trim();
-        if argument.is_empty() {
-            return;
-        }
-
-        self.write_line();
-        self.write("typeof (");
-        self.write(argument);
-        self.write(");");
-    }
-
-    fn find_source_pattern_outside_quoted_text(
-        &self,
-        start: usize,
-        limit: usize,
-        pattern: &str,
-    ) -> Option<usize> {
-        let text = self.source_text?;
-        let bytes = text.as_bytes();
-        let pattern = pattern.as_bytes();
-        let mut i = start;
-        let limit = limit.min(bytes.len());
-        while i + pattern.len() <= limit {
-            match bytes[i] {
-                b'\'' | b'"' | b'`' => {
-                    i = self.skip_quoted_source_text(i, limit);
-                    continue;
-                }
-                _ if bytes.get(i..i + pattern.len()) == Some(pattern) => return Some(i),
-                _ => i += 1,
-            }
-        }
-        None
-    }
-
-    fn find_matching_source_paren(&self, open: usize, limit: usize) -> Option<usize> {
-        let text = self.source_text?;
-        let bytes = text.as_bytes();
-        if bytes.get(open) != Some(&b'(') {
-            return None;
-        }
-
-        let mut depth = 1u32;
-        let mut i = open + 1;
-        while i < limit && i < bytes.len() {
-            match bytes[i] {
-                b'\'' | b'"' | b'`' => {
-                    i = self.skip_quoted_source_text(i, limit);
-                    continue;
-                }
-                b'(' => depth += 1,
-                b')' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        return Some(i);
-                    }
-                }
-                _ => {}
-            }
-            i += 1;
-        }
-        None
-    }
-
-    fn skip_quoted_source_text(&self, quote_start: usize, limit: usize) -> usize {
-        let Some(text) = self.source_text else {
-            return quote_start + 1;
-        };
-        let bytes = text.as_bytes();
-        let quote = bytes[quote_start];
-        let mut i = quote_start + 1;
-        while i < limit && i < bytes.len() {
-            if bytes[i] == b'\\' {
-                i = (i + 2).min(limit);
+        for recovered_call in recovered_calls {
+            let argument_start = recovered_call.argument_pos as usize;
+            let argument_end = recovered_call.argument_end as usize;
+            if argument_start > argument_end || argument_end > text.len() {
                 continue;
             }
-            if bytes[i] == quote {
-                return i + 1;
+            let argument = text[argument_start..argument_end].trim();
+            if argument.is_empty() {
+                continue;
             }
-            i += 1;
+
+            self.write_line();
+            self.write("typeof (");
+            self.write(argument);
+            self.write(");");
         }
-        i
     }
 
     fn source_text_with_quoted_spans_masked(segment: &str) -> String {

--- a/crates/tsz-emitter/src/safe_slice.rs
+++ b/crates/tsz-emitter/src/safe_slice.rs
@@ -92,6 +92,17 @@ pub fn slice(s: &str, start: usize, end: usize) -> Result<&str, SliceError> {
     Ok(&s[start..end])
 }
 
+/// Return whether the byte span contains a line break.
+///
+/// Invalid spans return `false`, matching recovery/trivia callers that should
+/// simply skip malformed ranges instead of panicking during emit.
+pub fn span_contains_line_break(s: &str, start: usize, end: usize) -> bool {
+    let Ok(text) = slice(s, start, end) else {
+        return false;
+    };
+    text.bytes().any(|byte| byte == b'\n' || byte == b'\r')
+}
+
 #[cfg(test)]
 #[path = "../tests/safe_slice.rs"]
 mod tests;

--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -647,7 +647,11 @@ impl<'a> ES5ClassTransformer<'a> {
             if comment.end as usize > end {
                 break;
             }
-            if !source_text[comment_start..comment.pos as usize].contains('\n') {
+            if !crate::safe_slice::span_contains_line_break(
+                source_text,
+                comment_start,
+                comment.pos as usize,
+            ) {
                 continue;
             }
             let text = &source_text[comment.pos as usize..comment.end as usize];

--- a/crates/tsz-emitter/src/transforms/enum_es5.rs
+++ b/crates/tsz-emitter/src/transforms/enum_es5.rs
@@ -450,7 +450,11 @@ impl<'a> EnumES5Transformer<'a> {
             if range.end > member_pos {
                 break;
             }
-            if !source_text[scan_start as usize..range.pos as usize].contains('\n') {
+            if !crate::safe_slice::span_contains_line_break(
+                source_text,
+                scan_start as usize,
+                range.pos as usize,
+            ) {
                 continue;
             }
             let text = &source_text[range.pos as usize..range.end as usize];

--- a/crates/tsz-emitter/tests/safe_slice.rs
+++ b/crates/tsz-emitter/tests/safe_slice.rs
@@ -110,3 +110,20 @@ fn explicit_empty_fallback_still_available_via_unwrap_or() {
     assert_eq!(slice(s, 100, 200).unwrap_or(""), "");
     assert_eq!(slice(s, 5, 3).unwrap_or(""), "");
 }
+
+#[test]
+fn span_contains_line_break_reports_newline_or_carriage_return() {
+    let s = "same line\nnext\r\nlast";
+    assert!(!span_contains_line_break(s, 0, 9));
+    assert!(span_contains_line_break(s, 0, 10));
+    assert!(span_contains_line_break(s, 14, 15));
+    assert!(span_contains_line_break(s, 14, 16));
+}
+
+#[test]
+fn span_contains_line_break_returns_false_for_invalid_spans() {
+    let s = "hello 🦀 world";
+    assert!(!span_contains_line_break(s, 10, 6));
+    assert!(!span_contains_line_break(s, 0, 100));
+    assert!(!span_contains_line_break(s, 7, 10));
+}

--- a/crates/tsz-emitter/tests/statements.rs
+++ b/crates/tsz-emitter/tests/statements.rs
@@ -1466,6 +1466,22 @@ fn recovered_typeof_member_type_tail_emits_as_statement() {
 }
 
 #[test]
+fn recovered_typeof_member_tail_emits_from_parser_recorded_span() {
+    let source = r#"class C {
+    foo() {
+        const x: "".typeof(/* keep */ this.foo);
+    }
+}"#;
+
+    let output = parse_and_print(source);
+
+    assert!(
+        output.contains("typeof (/* keep */ this.foo);"),
+        "Recovered `.typeof(...)` should reproduce the parser-recorded argument span.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn typeof_text_inside_string_literal_type_is_erased() {
     let source = r#"var a: ".typeof(foo)";"#;
 

--- a/crates/tsz-parser/src/parser/node.rs
+++ b/crates/tsz-parser/src/parser/node.rs
@@ -314,11 +314,19 @@ pub struct ExpressionStatementData {
     pub expression: NodeIndex,
 }
 
+/// Parser-owned recovery fact for malformed `''.typeof(expr)` declaration tails.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RecoveredTypeofMemberCallData {
+    pub argument_pos: u32,
+    pub argument_end: u32,
+}
+
 /// Data for variable declarations
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct VariableData {
     pub modifiers: Option<NodeList>,
     pub declarations: NodeList,
+    pub recovered_typeof_member_calls: Vec<RecoveredTypeofMemberCallData>,
 }
 
 /// Data for type references

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -1191,6 +1191,7 @@ impl ParserState {
             VariableData {
                 modifiers: None,
                 declarations: declarations_list,
+                recovered_typeof_member_calls: Vec::new(),
             },
             flags,
         )

--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -2,7 +2,10 @@
 use super::state::{CONTEXT_FLAG_IN_BLOCK, IncrementalParseResult, ParserState};
 use crate::parser::{
     NodeIndex, NodeList,
-    node::{BlockData, QualifiedNameData, SourceFileData, VariableData, VariableDeclarationData},
+    node::{
+        BlockData, QualifiedNameData, RecoveredTypeofMemberCallData, SourceFileData, VariableData,
+        VariableDeclarationData,
+    },
     syntax_kind_ext,
 };
 use tsz_common::diagnostics::diagnostic_codes;
@@ -1087,6 +1090,7 @@ impl ParserState {
             VariableData {
                 modifiers,
                 declarations: self.make_node_list(vec![declaration_list]),
+                recovered_typeof_member_calls: Vec::new(),
             },
         )
     }
@@ -1139,6 +1143,7 @@ impl ParserState {
 
         // Parse declarations with enhanced error recovery
         let mut declarations = Vec::new();
+        let mut recovered_typeof_member_calls = Vec::new();
         let mut had_decl_expected_error = false;
         loop {
             // Check if we can start a variable declaration
@@ -1699,6 +1704,7 @@ impl ParserState {
                     }
                     if was_dot && token_is_keyword(self.token()) {
                         use tsz_common::diagnostics::diagnostic_messages;
+                        let recovered_keyword = self.token();
                         let word = self.current_keyword_text();
                         let msg =
                             diagnostic_messages::IS_NOT_ALLOWED_AS_A_VARIABLE_DECLARATION_NAME
@@ -1718,6 +1724,7 @@ impl ParserState {
                             && !self.scanner.has_preceding_line_break()
                         {
                             self.next_token(); // consume `(`
+                            let argument_pos = self.token_full_start();
                             let mut paren_depth = 1u32;
                             while !matches!(
                                 self.token(),
@@ -1731,6 +1738,14 @@ impl ParserState {
                                     SyntaxKind::CloseParenToken => {
                                         paren_depth -= 1;
                                         if paren_depth == 0 {
+                                            if recovered_keyword == SyntaxKind::TypeOfKeyword {
+                                                recovered_typeof_member_calls.push(
+                                                    RecoveredTypeofMemberCallData {
+                                                        argument_pos,
+                                                        argument_end: self.token_pos(),
+                                                    },
+                                                );
+                                            }
                                             self.next_token();
                                             break;
                                         }
@@ -1840,6 +1855,7 @@ impl ParserState {
             VariableData {
                 modifiers: None,
                 declarations: self.make_node_list(declarations),
+                recovered_typeof_member_calls,
             },
             flags,
         )

--- a/crates/tsz-parser/tests/state_statement_tests_parts/part_00.rs
+++ b/crates/tsz-parser/tests/state_statement_tests_parts/part_00.rs
@@ -1399,6 +1399,34 @@ fn reserved_word_tail_after_missing_comma_in_type_annotation_stops_after_ts1389(
 }
 
 #[test]
+fn recovered_typeof_member_tail_records_argument_span_on_variable_list() {
+    let source = "const x: \"\".typeof(/* keep */ this.foo);";
+    let (parser, root) = parse_source(source);
+    let arena = parser.get_arena();
+    let sf = arena.get_source_file_at(root).expect("source file");
+    let stmt = arena
+        .get(sf.statements.nodes[0])
+        .and_then(|node| arena.get_variable(node))
+        .expect("variable statement");
+    let decl_list = arena
+        .get(stmt.declarations.nodes[0])
+        .and_then(|node| arena.get_variable(node))
+        .expect("declaration list");
+
+    assert_eq!(
+        decl_list.recovered_typeof_member_calls.len(),
+        1,
+        "parser should expose the recovered typeof tail as structured data"
+    );
+    let recovered = &decl_list.recovered_typeof_member_calls[0];
+    assert_eq!(
+        &source[recovered.argument_pos as usize..recovered.argument_end as usize],
+        "/* keep */ this.foo",
+        "recorded span should cover only the recovered typeof argument"
+    );
+}
+
+#[test]
 fn member_call_tail_after_missing_comma_in_type_annotation_emits_second_comma_error() {
     let source = "declare const x: \"foo\".charCodeAt(0);";
     let (parser, _root) = parse_source(source);

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -359,7 +359,23 @@ REGEX_LINE_COUNT_CHECKS = [
         "Emitter boundary: source_text contains recovery decisions (Track 9/10)",
         [ROOT / "crates" / "tsz-emitter" / "src"],
         re.compile(r"\bsource_text(?:\[[^\n\]]+\])?\.contains\s*\("),
-        6,
+        4,
+    ),
+    (
+        "Emitter boundary: recovered variable typeof tails use parser facts (#8276)",
+        [
+            ROOT
+            / "crates"
+            / "tsz-emitter"
+            / "src"
+            / "emitter"
+            / "statements"
+            / "recovered_variable_statement.rs"
+        ],
+        re.compile(
+            r"\b(?:find_source_pattern_outside_quoted_text|find_matching_source_paren|skip_quoted_source_text)\b"
+        ),
+        0,
     ),
     (
         "Solver API boundary: flat root wildcard compatibility re-exports (#8204)",

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1390,7 +1390,23 @@ REGEX_LINE_COUNT_CHECKS = [
         "Emitter boundary: source_text contains recovery decisions (Track 9/10)",
         [ROOT / "crates" / "tsz-emitter" / "src"],
         re.compile(r"\bsource_text(?:\[[^\n\]]+\])?\.contains\s*\("),
-        6,
+        4,
+    ),
+    (
+        "Emitter boundary: recovered variable typeof tails use parser facts (#8276)",
+        [
+            ROOT
+            / "crates"
+            / "tsz-emitter"
+            / "src"
+            / "emitter"
+            / "statements"
+            / "recovered_variable_statement.rs"
+        ],
+        re.compile(
+            r"\b(?:find_source_pattern_outside_quoted_text|find_matching_source_paren|skip_quoted_source_text)\b"
+        ),
+        0,
     ),
     (
         "Solver API boundary: flat root wildcard compatibility re-exports (#8204)",

--- a/scripts/arch/test_arch_guard_policy.py
+++ b/scripts/arch/test_arch_guard_policy.py
@@ -71,6 +71,21 @@ class ArchGuardRegexLineCountTests(unittest.TestCase):
         self.assertIn("recovery.rs:1", hits[0])
         self.assertIn("recovery.rs:2", hits[1])
 
+    def test_flags_recovered_variable_typeof_source_scanners(self):
+        pattern, _max_lines = self._check_by_name("recovered variable typeof")
+        root = self._make_tree(
+            {
+                "crates/tsz-emitter/src/emitter/statements/recovered_variable_statement.rs": (
+                    "self.find_source_pattern_outside_quoted_text(start, end, \".typeof(\");\n"
+                    "self.find_matching_source_paren(open, end);\n"
+                ),
+            }
+        )
+        hits = self.arch_guard.scan_regex_line_count([root], pattern, 0)
+        self.assertEqual(len(hits), 3, f"unexpected hits: {hits!r}")
+        self.assertIn("recovered_variable_statement.rs:1", hits[0])
+        self.assertIn("recovered_variable_statement.rs:2", hits[1])
+
     def test_flags_file_name_and_path_substring_decisions(self):
         pattern, _max_lines = self._check_by_name("file-name/path")
         root = self._make_tree(


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 9/10 emit architecture tech-debt burn-down for #8276.

## Invariant
When parser recovery consumes a malformed variable declaration tail shaped like `"".typeof(expr)`, `tsc` reports the declaration-list diagnostics and the emitter may reproduce the recovered `typeof` statement from parser-owned recovery facts. This PR makes tsz record the recovered argument span on the parsed variable declaration list and makes the emitter consume that fact instead of scanning raw source text for `.typeof(`. Trivia newline checks over source spans remain span-preservation work, but they must use safe slicing instead of unchecked direct byte ranges.

## Scope
- Add `RecoveredTypeofMemberCallData` to parser variable data.
- Capture recovered `typeof(...)` argument spans in variable declaration-list recovery.
- Emit recovered `typeof` statements from parser facts and remove the emitter source-pattern/parens scanner.
- Route class/enum transformed-comment newline checks through `safe_slice::span_contains_line_break`, lowering the emitter source-text contains guard from 6 to 4.
- Add parser/emitter/safe-slice/arch guard coverage for comments, quoted text, valid property calls, invalid spans, and the removed scanner helper family.

## Project Corpus Impact
- Row: n/a
- Bug family: emit source-text recovery / output-surgery pressure (#8276)
- Evidence: no project-row truth changes expected. This is an emit architecture ratchet under #8276; the slice only changes malformed source recovery data plus trivia span-preservation helpers consumed by JS emit.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo nextest run -p tsz-parser recovered_typeof_member_tail_records_argument_span_on_variable_list`
- `cargo nextest run -p tsz-emitter recovered_typeof_member`
- `cargo nextest run -p tsz-emitter safe_slice`
- `python3 scripts/arch/test_arch_guard_policy.py`
- `python3 scripts/emit/audit-output-surgery.py`
- `python3 scripts/arch/arch_guard.py`
- `scripts/agents/ensure-agent-labels.sh --audit` failed only on unrelated pre-existing unlabelled PRs/issues (#12797, #12795, #12793, #12792, #12789, #12786).

## Coordination Notes
- Ready for CI/manager review after local verification and exact-head PR body repair.
- Coordinates with #8276.
- Remaining source-text inventory: 4 raw `source_text.contains` decisions.
- Follow-up source-text recovery slices should continue migrating one decision family at a time behind parser or emit-summary facts rather than banning trivia/span source reads globally.
