### PR TITLE
refactor(checker): route predicate payload narrowing through boundary

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/call_condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/call_condition_narrowing.rs
@@ -126,16 +126,12 @@ impl<'a> FlowAnalyzer<'a> {
             return None;
         }
 
-        let property_guard = TypeGuard::Predicate {
-            type_id: Some(predicate_property_type),
-            asserts: false,
-        };
         let env = self.type_environment.map(std::cell::RefCell::borrow);
-        let narrowed = flow_query::narrow_inferred_predicate_guard(
+        let narrowed = flow_query::narrow_property_type_by_predicate(
             self.interner,
             env.as_deref(),
             type_id,
-            &property_guard,
+            predicate_property_type,
         );
         (narrowed != type_id).then_some(narrowed)
     }

--- a/crates/tsz-checker/src/flow/control_flow/narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/narrowing.rs
@@ -454,19 +454,16 @@ impl<'a> FlowAnalyzer<'a> {
         let env = env_borrow.as_deref();
 
         if let Some(predicate_type) = predicate.type_id {
-            // Route through TypeGuard::Predicate for proper intersection semantics.
+            // Route through flow query predicate narrowing for proper intersection semantics.
             // When source and target don't overlap (e.g. successive type guards
             // hasLegs then hasWings), the solver falls back to intersection.
-            let guard = TypeGuard::Predicate {
-                type_id: Some(predicate_type),
-                asserts: predicate.asserts,
-            };
-            let narrowed = flow_query::narrow_with_guard(
+            let narrowed = flow_query::narrow_type_predicate(
                 self.interner,
                 env,
                 type_id,
-                &guard,
-                effective_true_branch,
+                predicate_type,
+                predicate.asserts,
+                is_true_branch,
             );
 
             // Fallback for cross-file asserted predicates whose target is an
@@ -521,16 +518,9 @@ impl<'a> FlowAnalyzer<'a> {
         }
 
         // Assertion guards without type predicate (asserts x) narrow to truthy
-        // This is the CRITICAL fix: use TypeGuard::Truthy instead of just excluding null/undefined
+        // This is the CRITICAL fix: use truthiness narrowing instead of just excluding null/undefined
         if effective_true_branch {
-            // Delegate to narrow_type with TypeGuard::Truthy for comprehensive narrowing
-            return flow_query::narrow_with_guard(
-                self.interner,
-                env,
-                type_id,
-                &TypeGuard::Truthy,
-                true,
-            );
+            return flow_query::narrow_asserts_truthy(self.interner, env, type_id);
         }
 
         // Use Solver's narrow_to_falsy for correct NaN handling

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -508,6 +508,65 @@ pub(crate) fn literal_assignable_to_in_context(
     narrowing.literal_assignable_to(literal_type, type_id)
 }
 
+/// Apply a function type-predicate fact to a flow type.
+///
+/// The checker owns resolving the called signature, target expression, and
+/// branch sense. The boundary owns constructing the solver predicate payload
+/// and applying it through the semantic narrowing engine.
+pub(crate) fn narrow_type_predicate(
+    db: &dyn QueryDatabase,
+    env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
+    type_id: TypeId,
+    predicate_type: TypeId,
+    asserts: bool,
+    is_true_branch: bool,
+) -> TypeId {
+    narrow_with_guard(
+        db,
+        env,
+        type_id,
+        &TypeGuard::Predicate {
+            type_id: Some(predicate_type),
+            asserts,
+        },
+        asserts || is_true_branch,
+    )
+}
+
+/// Apply an assertion predicate without an explicit type (`asserts value`).
+///
+/// The checker owns recognizing that the asserted value is known true after the
+/// call. The solver owns truthiness narrowing beyond plain nullish removal.
+pub(crate) fn narrow_asserts_truthy(
+    db: &dyn QueryDatabase,
+    env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
+    type_id: TypeId,
+) -> TypeId {
+    narrow_with_guard(db, env, type_id, &TypeGuard::Truthy, true)
+}
+
+/// Apply a receiver-property predicate to the property flow type.
+///
+/// The checker owns identifying the receiver property and extracting its
+/// contextual predicate type. The solver owns the predicate guard semantics for
+/// the property value.
+pub(crate) fn narrow_property_type_by_predicate(
+    db: &dyn QueryDatabase,
+    env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
+    type_id: TypeId,
+    predicate_property_type: TypeId,
+) -> TypeId {
+    narrow_inferred_predicate_guard(
+        db,
+        env,
+        type_id,
+        &TypeGuard::Predicate {
+            type_id: Some(predicate_property_type),
+            asserts: false,
+        },
+    )
+}
+
 /// Narrow a value to the object-like branch of an `instanceof`-style check.
 pub(crate) fn narrow_to_objectish(
     db: &dyn QueryDatabase,

--- a/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
@@ -399,3 +399,52 @@ fn condition_equality_narrowing_uses_flow_query_boundary() {
         "flow orchestration should not call solver equality/discriminant narrowing directly"
     );
 }
+
+#[test]
+fn predicate_payload_application_uses_flow_query_boundary() {
+    let narrowing_source = fs::read_to_string("src/flow/control_flow/narrowing.rs")
+        .expect("failed to read flow narrowing source");
+    let call_source = fs::read_to_string("src/flow/control_flow/call_condition_narrowing.rs")
+        .expect("failed to read call condition narrowing source");
+    let boundary_source = fs::read_to_string("src/query_boundaries/flow_analysis.rs")
+        .expect("failed to read flow analysis boundary source");
+    let compact_narrowing: String = narrowing_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let compact_call: String = call_source.chars().filter(|c| !c.is_whitespace()).collect();
+    let compact_boundary: String = boundary_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let predicate_fn = compact_narrowing
+        .split("fnnarrow_by_instanceof(")
+        .next()
+        .and_then(|before_instanceof| {
+            before_instanceof
+                .split("fnapply_type_predicate_narrowing(")
+                .nth(1)
+        })
+        .expect("failed to locate apply_type_predicate_narrowing body");
+
+    assert!(
+        compact_boundary.contains("fnnarrow_type_predicate(")
+            && compact_boundary.contains("&TypeGuard::Predicate{")
+            && compact_boundary.contains("fnnarrow_asserts_truthy(")
+            && compact_boundary.contains("&TypeGuard::Truthy")
+            && compact_boundary.contains("fnnarrow_property_type_by_predicate("),
+        "flow analysis boundary should own predicate payload construction"
+    );
+    assert!(
+        predicate_fn.contains("flow_query::narrow_type_predicate(")
+            && predicate_fn.contains("flow_query::narrow_asserts_truthy(")
+            && compact_call.contains("flow_query::narrow_property_type_by_predicate("),
+        "flow predicate callers should route predicate payload application through the flow query boundary"
+    );
+    assert!(
+        !predicate_fn.contains("TypeGuard::Predicate{")
+            && !predicate_fn.contains("&TypeGuard::Truthy")
+            && !compact_call.contains("letproperty_guard=TypeGuard::Predicate{"),
+        "flow predicate callers should not construct solver predicate payloads locally"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
M1-D / Track 6 flow graph and solver-owned narrowing predicates; refactor-only boundary ratchet.

## Invariant
When flow applies function, assertion, or receiver-property predicate facts, the checker owns target/call matching and branch orchestration; `query_boundaries::flow_analysis` owns constructing the solver `TypeGuard` payload and computing the narrowed type.

## Scope
- Add flow query helpers for type-predicate, assertion-truthy, and receiver-property predicate narrowing.
- Route `apply_type_predicate_narrowing` through predicate-specific flow query helpers instead of constructing predicate/truthy guards locally.
- Route receiver-property predicate payload application in call-condition narrowing through the flow query boundary.
- Extend source guards to prevent these predicate payload applications from moving back into flow orchestration.

## Project Corpus Impact
- Row: n/a.
- Bug family: flow/narrowing architecture substrate for imported predicates and Kysely/Zod guard reductions.
- Evidence: behavior intended unchanged; focused predicate, imported predicate, assertion, and flow-boundary tests passed locally.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib flow_guard_boundary_tests flow_inferred_predicate_boundary_tests imported_predicate_false_branch_tests assertion_type_predicate_diagnostics_tests::generic_assertion_with_explicit_type_arg_narrows_correctly assertion_type_predicate_diagnostics_tests::generic_assertion_with_param_in_both_predicate_and_arg_still_resolves assertion_type_predicate_diagnostics_tests::assertion_false_condition_emits_unreachable_code`
- `cargo fmt --check`
- `git diff --check`
- `scripts/arch/check-checker-boundaries.sh`
- line cap check: touched files remain under 2000 physical lines.

## Coordination Notes
- `scripts/agents/list-owned-work.sh M1-D` was clear immediately before commit.
- Builds on the merged M1-D boundary-ratchet sequence through #12760, #12776, #12787, and #12798.
- No behavior policy changes, no new identifier/file-name/source-text predicates, and no project-row smoke required for this refactor-only slice.
