### PR TITLE
fix(checker): decompose baked contextual wrappers in return-context inference

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -36,6 +36,9 @@ stacker = "0.1.23"
 name = "assertion_source_literal_display_tests"
 path = "tests/assertion_source_literal_display_tests.rs"
 [[test]]
+name = "return_context_identity_wrapper_literal_tests"
+path = "tests/return_context_identity_wrapper_literal_tests.rs"
+[[test]]
 name = "nested_mapped_optional_modifier_inline_application_tests"
 path = "tests/nested_mapped_optional_modifier_inline_application_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/call_inference.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference.rs
@@ -539,6 +539,50 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Recover the canonical `Application(base, args)` for a type used during
+    /// return-context inference.
+    ///
+    /// A contextual return type such as `Readonly<WithNode>` can exist in the
+    /// interner in two shapes: the as-written `Application(Readonly, [WithNode])`
+    /// and the *baked* (already-evaluated) structural object that merely displays
+    /// as `Readonly<WithNode>`. The baked form has no `TypeData::Application`, so
+    /// the application-aware matchers below cannot decompose it and any tracked
+    /// type parameter on the source side is left unbound — the inner generic
+    /// call's fresh object literal then widens (e.g. `kind: 'WithNode'` becomes
+    /// `string`), yielding a spurious `TS2322`/`TS2345`.
+    ///
+    /// The evaluator records a display-alias back-reference from the baked form
+    /// to its originating application, so consult it (in addition to a fresh
+    /// evaluation) to restore the structural decomposition through the validated
+    /// Application↔Application path instead of relying on rendered type text.
+    pub(crate) fn return_context_application_info(
+        &mut self,
+        type_id: TypeId,
+    ) -> Option<(TypeId, Vec<TypeId>)> {
+        if let Some(info) = common::application_info(self.ctx.types, type_id) {
+            return Some(info);
+        }
+        if let Some(info) = self
+            .ctx
+            .types
+            .get_display_alias(type_id)
+            .and_then(|alias| common::application_info(self.ctx.types, alias))
+        {
+            return Some(info);
+        }
+        let evaluated = self.evaluate_for_return_context_substitution(type_id);
+        if evaluated == type_id {
+            return None;
+        }
+        if let Some(info) = common::application_info(self.ctx.types, evaluated) {
+            return Some(info);
+        }
+        self.ctx
+            .types
+            .get_display_alias(evaluated)
+            .and_then(|alias| common::application_info(self.ctx.types, alias))
+    }
+
     pub(crate) fn instantiate_generic_function_argument_against_target_for_refinement(
         &mut self,
         source_ty: TypeId,

--- a/crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs
@@ -80,32 +80,9 @@ impl<'a> CheckerState<'a> {
         )
     }
 
-    fn return_context_type_head(&self, type_id: TypeId) -> Option<String> {
-        let display = self.format_type(type_id);
-        let trimmed = display.trim();
-        if !trimmed.contains('<') {
-            return None;
-        }
-
-        Some(
-            trimmed
-                .split('<')
-                .next()
-                .unwrap_or(trimmed)
-                .trim()
-                .to_string(),
-        )
-    }
-
     fn return_context_types_share_outer_structure(&mut self, left: TypeId, right: TypeId) -> bool {
-        let left_application = common::application_info(self.ctx.types, left).or_else(|| {
-            let evaluated = self.evaluate_for_return_context_substitution(left);
-            (evaluated != left).then(|| common::application_info(self.ctx.types, evaluated))?
-        });
-        let right_application = common::application_info(self.ctx.types, right).or_else(|| {
-            let evaluated = self.evaluate_for_return_context_substitution(right);
-            (evaluated != right).then(|| common::application_info(self.ctx.types, evaluated))?
-        });
+        let left_application = self.return_context_application_info(left);
+        let right_application = self.return_context_application_info(right);
         if let (Some((left_base, _)), Some((right_base, _))) = (left_application, right_application)
             && self.return_context_application_bases_match(left_base, right_base)
         {
@@ -376,14 +353,8 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let source_application = common::application_info(self.ctx.types, source).or_else(|| {
-            let evaluated = self.evaluate_for_return_context_substitution(source);
-            (evaluated != source).then(|| common::application_info(self.ctx.types, evaluated))?
-        });
-        let target_application = common::application_info(self.ctx.types, target).or_else(|| {
-            let evaluated = self.evaluate_for_return_context_substitution(target);
-            (evaluated != target).then(|| common::application_info(self.ctx.types, evaluated))?
-        });
+        let source_application = self.return_context_application_info(source);
+        let target_application = self.return_context_application_info(target);
 
         // Handle Application types like Readonly<T>, Promise<T>, etc.
         // When source is Application(Base, [args...]) and target is NOT
@@ -400,10 +371,7 @@ impl<'a> CheckerState<'a> {
                     .is_some_and(|(target_base, target_args)| {
                         self.return_context_application_bases_match(*source_base, *target_base)
                             && target_args.len() == source_args.len()
-                    })
-                    || (target_application.is_none()
-                        && self.return_context_type_head(source)
-                            == self.return_context_type_head(target));
+                    });
             if !target_same_base {
                 // When the source Application evaluates to a callable type
                 // (e.g., Mapper<T, U> = (x: T) => U) and the target is also

--- a/crates/tsz-checker/tests/return_context_identity_wrapper_literal_tests.rs
+++ b/crates/tsz-checker/tests/return_context_identity_wrapper_literal_tests.rs
@@ -1,0 +1,137 @@
+//! Return-context inference for identity-wrapper factories must preserve literal
+//! discriminants and must keep reporting genuine mismatches.
+//!
+//! Structural rule: when a generic identity wrapper `freeze<T>(obj: T):
+//! Readonly<T>` is called with a fresh object literal whose discriminant has a
+//! string-literal initializer, and the call sits in a contextual-return
+//! position (`create(): Readonly<XNode>`), `tsc` infers `T` with the literal
+//! preserved (`kind: 'XNode'`) because the contextual return type pins the
+//! unconstrained `T`. The return-context substitution that recovers this
+//! pinning must decompose the contextual wrapper structurally (via the
+//! application/display-alias provenance) rather than by inspecting rendered type
+//! text, and must not erase real discriminant mismatches.
+//!
+//! Witness family: the `operation-node` factories behind the Kysely project row
+//! (issue #10663).
+
+use tsz_checker::context::{CheckerOptions, ScriptTarget};
+use tsz_checker::test_utils::{check_multi_file_with_libs, load_default_lib_files};
+use tsz_common::diagnostics::Diagnostic;
+
+fn ts_options() -> CheckerOptions {
+    CheckerOptions {
+        target: ScriptTarget::ES2015,
+        ..CheckerOptions::default()
+    }
+}
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    let libs = load_default_lib_files();
+    check_multi_file_with_libs(files, entry, ts_options(), &libs)
+}
+
+fn codes(diags: &[Diagnostic]) -> Vec<u32> {
+    diags.iter().map(|d| d.code).collect()
+}
+
+fn assert_no_widening_false_positive(files: &[(&str, &str)], context: &str) {
+    let diags = check(files, files[0].0);
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert!(
+        ts2322.is_empty(),
+        "{context}: expected no TS2322 literal-widening false positive, got: {:#?}",
+        ts2322
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Inner identity wrapper whose contextual return type is supplied directly by
+/// the surrounding annotation. The literal `kind: "WithNode"` must survive.
+#[test]
+fn inner_wrapper_with_direct_contextual_return_preserves_literal() {
+    assert_no_widening_false_positive(
+        &[(
+            "direct.ts",
+            r#"
+function freeze<T>(obj: T): Readonly<T> { return obj; }
+interface WithNode { readonly kind: "WithNode"; readonly count: number; }
+const create: (count: number) => Readonly<WithNode> =
+    (count) => freeze({ kind: "WithNode", count });
+"#,
+        )],
+        "direct contextual return",
+    );
+}
+
+/// Object literal contextually typed by the factory interface directly (no outer
+/// generic call). The unannotated method body's nested wrapper must be pinned.
+#[test]
+fn factory_object_literal_preserves_literal_through_method_wrapper() {
+    assert_no_widening_false_positive(
+        &[(
+            "factory.ts",
+            r#"
+function freeze<T>(obj: T): Readonly<T> { return obj; }
+interface WithNode { readonly kind: "WithNode"; readonly count: number; }
+interface WithNodeFactory { create(count: number): Readonly<WithNode>; }
+const WithNode: WithNodeFactory = {
+    create(count: number) {
+        return freeze({ kind: "WithNode", count });
+    },
+};
+"#,
+        )],
+        "factory object literal",
+    );
+}
+
+/// Context-sensitive method (unannotated parameter) routed through the deferred
+/// contextual pass must also preserve the literal discriminant.
+#[test]
+fn context_sensitive_factory_method_preserves_literal() {
+    assert_no_widening_false_positive(
+        &[(
+            "ctxsens.ts",
+            r#"
+function freeze<T>(obj: T): Readonly<T> { return obj; }
+interface WithNode { readonly kind: "WithNode"; readonly count: number; }
+interface WithNodeFactory { create(count: number): Readonly<WithNode>; }
+const WithNode: WithNodeFactory = freeze({
+    create(count) {
+        return freeze({ kind: "WithNode", count });
+    },
+});
+"#,
+        )],
+        "context-sensitive method",
+    );
+}
+
+/// Negative: a factory whose `create` returns the *wrong* literal discriminant
+/// must still report `TS2322`. The literal pinning must not erase real
+/// mismatches by widening both sides.
+#[test]
+fn identity_wrapper_factory_still_reports_wrong_literal_kind() {
+    let wrong = r#"
+function freeze<T>(obj: T): Readonly<T> { return obj; }
+interface SelectNode { readonly kind: "SelectNode"; readonly value: number; }
+interface SelectNodeFactory { create(value: number): Readonly<SelectNode>; }
+const SelectNode: SelectNodeFactory = {
+    create(value: number): Readonly<SelectNode> {
+        return freeze({ kind: "NotSelectNode", value });
+    },
+};
+"#;
+    let files = vec![("select-node.ts", wrong)];
+    let diags = check(&files, "select-node.ts");
+    assert!(
+        codes(&diags).contains(&2322),
+        "expected TS2322 for the wrong literal discriminant, got: {:#?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Hardens return-context generic inference for identity-wrapper factories — the
`operation-node` false-positive family that dominates the **Kysely** project
row (#10663) — by removing a rendered-text predicate and decomposing contextual
wrapper types structurally through the display-alias provenance.

Two coupled defects in the return-context substitution path:

1. **Anti-hardcoding violation.** `return_context_type_head` rendered each side
   with `format_type` and compared the text before the first `<` to decide
   whether two types shared an outer generic base. The Anti-Hardcoding Gate
   forbids using formatted type output as a semantic predicate (the printer may
   read types; types must not read printer output).
2. **Baked applications were not decomposed.** A contextual return type such as
   `Readonly<WithNode>` exists in the interner in two shapes: the as-written
   `Application(Readonly, [WithNode])` and the *baked* (already-evaluated)
   structural object that merely displays as `Readonly<WithNode>`. The baked
   form has no `TypeData::Application`, so the application-aware matchers left
   the tracked type parameter unbound and the inner identity wrapper's fresh
   object literal could widen (`kind: 'WithNode'` → `string`), yielding spurious
   `TS2322`/`TS2345`. This is exactly the slice diagnosed in #10663's thread
   (the `return_context_type_head` / `get_display_alias` note).

## Structural rule

When the source (declared return) type and the target (contextual) type are
applications of the same base — recovering baked/display-aliased wrapper forms —
`tsc` binds the return-position type parameter through structural decomposition.
tsz now does the same through the validated Application↔Application matcher in
the solver-backed return-context boundary, instead of comparing rendered type
text.

## Owner layer

Checker generic-call inference, return-context substitution
(`types/computation/call_inference/return_context_substitution.rs`). No new
relation semantics and no new hot-path evaluation — the recovery consults the
display-alias provenance (an O(1) back-reference recorded by the evaluator) and
reuses the evaluation fallback that already existed on this path, and it routes
through the existing arg-validated Application↔Application matcher.

## Changes

- Add `return_context_application_info`: recovers the canonical
  `Application(base, args)` for a return-context type, consulting the
  display-alias back-reference (and the pre-existing evaluation fallback) so
  baked wrapper forms are decomposed structurally.
- Replace the inline `application_info`/evaluate recovery in
  `return_context_substitution.rs` (both `source_application`/`target_application`
  and `return_context_types_share_outer_structure`) with the shared helper.
- Delete `return_context_type_head` and its `format_type`-based disjunct in the
  `target_same_base` computation; the baked-form case is now handled
  structurally by the recovered application.

## Adjacent-case matrix (new test file)

`return_context_identity_wrapper_literal_tests.rs`:

- inner wrapper with a direct contextual return — literal preserved;
- factory object literal typed by the interface directly — literal preserved
  through the unannotated method's nested wrapper;
- context-sensitive factory method (unannotated parameter) — literal preserved
  through the deferred contextual pass;
- **negative**: a `create` returning the wrong discriminant still reports
  `TS2322` (pinning must not erase real mismatches).

## Scope

Lands the structural-decomposition + anti-hardcoding slice of the #10663
tracker. A separate facet remains and is **intentionally not** addressed here:
when an object literal is the argument to an *outer* generic call and a
**non-context-sensitive** method (all parameters annotated) returns a nested
generic call, the contextual return type is not propagated into that nested call
during the outer call's argument inference, so its literal widens. That is the
contextual-inference cluster tracked by #8773; it needs the deeper
contextual-typing change called out in the thread and is not parity-clean as a
one-shot.

## Project Corpus Impact

- Row: kysely-project
- Bug family: operation-node identity-wrapper return-context literal widening (`TS2322`/`TS2345`)
- Targets a slice of the Kysely `operation-node` false-positive family; no
  required row regressed (no new hot-path evaluation; the removed
  `format_type` predicate is replaced by an O(1) display-alias lookup).

## Verification

- New `return_context_identity_wrapper_literal_tests` (4 cases) pass.
- `cargo test -p tsz-checker --lib` passes with this change except two failures
  that reproduce identically on `main` without it
  (`zod_parse_async_promise_resolve_awaited_union_flattens_to_sync_return`
  overflows the debug-build stack locally;
  `zod_cross_file_lib_partial_omit_preserves_imported_path_property` is a
  pre-existing red) — neither is caused by this PR.
- Ready-review CI owns the broad conformance / emit / fourslash suites.

## Coordination Notes

Refs #10663 (Kysely row tracker), #8773 (remaining contextual-inference facet).
The Anti-Hardcoding Gate item (formatted type text used as a semantic predicate)
is removed.

AgentName: brave-volta
Track: conformance / checker
Invariant: return-context inference matches `tsc` literal pinning; no rendered
type text used as a semantic predicate.