### PR TITLE
fix(parser): classify assignment-start recovery diagnostics

### DIFF
--- a/crates/tsz-parser/src/parser/state_switch_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_switch_recovery.rs
@@ -393,7 +393,12 @@ impl ParserState {
                 SyntaxKind::CommaToken | SyntaxKind::QuestionToken
             );
         let mut expression = if started_with_assignment_operator {
-            self.error_expression_expected();
+            if self.should_report_error() {
+                self.parse_error_at_current_token(
+                    "Declaration or statement expected.",
+                    diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
+                );
+            }
             let operator_token = self.token() as u16;
             self.next_token();
             let mut right = self.parse_assignment_expression();

--- a/crates/tsz-parser/tests/parser_improvement_expression_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_expression_recovery_tests.rs
@@ -2,6 +2,7 @@
 
 use crate::parser::syntax_kind_ext;
 use crate::parser::test_fixture::parse_source;
+use tsz_common::diagnostics::diagnostic_codes;
 use tsz_scanner::SyntaxKind;
 
 /// Walk every node in the arena and return the operator tokens of binary
@@ -207,6 +208,72 @@ fn test_statement_starting_with_assignment_operator_keeps_missing_left_binary() 
             "expected `<missing> {op:?} rhs` recovery for source {source:?}, got {ops:?}"
         );
     }
+}
+
+#[test]
+fn test_statement_starting_with_assignment_operator_reports_statement_recovery() {
+    let cases = [
+        ("= replacement;\n", SyntaxKind::EqualsToken, "="),
+        ("^= replacement;\n", SyntaxKind::CaretEqualsToken, "^="),
+        (
+            "&&= fallback;\n",
+            SyntaxKind::AmpersandAmpersandEqualsToken,
+            "&&=",
+        ),
+        (
+            "??= defaultValue;\n",
+            SyntaxKind::QuestionQuestionEqualsToken,
+            "??=",
+        ),
+        (
+            "function bar() { } *= value;\n",
+            SyntaxKind::AsteriskEqualsToken,
+            "*=",
+        ),
+    ];
+
+    for (source, op, op_text) in cases {
+        let (parser, _root) = parse_source(source);
+        let diagnostics = parser.get_diagnostics();
+        let operator_pos = source.find(op_text).expect("source contains operator") as u32;
+
+        assert!(
+            diagnostics.iter().any(|diag| {
+                diag.code == diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED
+                    && diag.start == operator_pos
+            }),
+            "expected TS1128 at {op:?} for source {source:?}, got {diagnostics:?}"
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diag| diag.code != diagnostic_codes::EXPRESSION_EXPECTED
+                    || diag.start != operator_pos),
+            "statement-start assignment recovery should not report TS1109 at {op:?}; got {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn test_invalid_private_name_indexed_access_does_not_gain_assignment_statement_cascade() {
+    let source = r#"
+class C {
+    foo = 3;
+    #bar = 3;
+    constructor () {
+        const badForNow: C[#bar] = 3;
+    }
+}
+"#;
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diag| diag.code != diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED),
+        "invalid private-name indexed access should not cascade into TS1128: {diagnostics:?}"
+    );
 }
 
 #[test]

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -53,9 +53,7 @@ TypeScript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
 TypeScript/tests/cases/compiler/promisesWithConstraints.ts
 TypeScript/tests/cases/compiler/unicodeEscapesInNames02.ts
-TypeScript/tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts
-TypeScript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts
 TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts
 TypeScript/tests/cases/conformance/importDefer/dynamicImportDeferInvalidStandalone.ts


### PR DESCRIPTION
AgentName: Studio-A

## Track
conformance / accepted-regression strictness

## Invariant
When a statement starts at an assignment operator because the intended left-hand side was already recovered as a complete or invalid statement, tsc reports statement-level TS1128 at that operator. tsz keeps the same recovery AST but now reports the diagnostic through parser statement recovery instead of missing-expression TS1109, while preserving existing parser-error suppression to avoid nearby malformed-type cascades.

## Scope
- Reclassify reportable statement-start assignment-operator recovery from TS1109 to TS1128.
- Keep existing missing-left binary/RHS recovery behavior for emit/recovery shape.
- Preserve suppression for nearby malformed-type recovery so private-name indexed access does not gain a TS1128 cascade.
- Add parser tests for bare assignment starts, logical assignment starts, function-expression tail recovery, and the private-name indexed-access non-regression.
- Retire the compound assignment and compound exponentiation LHS accepted-regression entries.

## Project Corpus Impact
- Row: n/a
- Bug family: parser statement-tail recovery diagnostics
- Evidence: accepted-regression gate drops from 27 to 25 listed tests; accepted-regression growth gate passes with removals only; no project-corpus row changes.

## Verification
- scripts/safe-run.sh cargo nextest run -p tsz-parser test_statement_starting_with_assignment_operator test_invalid_private_name_indexed_access_does_not_gain_assignment_statement_cascade
- scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter compound --verbose
- scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter privateNamesAndIndexedAccess --verbose
- scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter unicodeEscapesInNames02 --verbose
- python3 scripts/conformance/check-accepted-regression-growth.py --base-ref origin/main --head-ref HEAD --allow-unavailable-base
- python3 scripts/conformance/query-conformance.py --dashboard
- git diff --check HEAD~1..HEAD

## Coordination Notes
- Owner layer: parser statement recovery, not checker, solver, or emitter.
- Structural rule: assignment operators that begin a recovered statement surface TS1128 when outside the parser suppression window, while preserving the existing recovered expression structure for downstream consumers.
- Adjacent matrix: plain equals, bitwise assignment, logical assignment, nullish assignment, function-expression compound assignment tail, conformance regex/function-expression compound-assignment cascades, and malformed private-name indexed access fallback.