### PR TITLE
refactor(checker): route instanceof guard payloads through boundary

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/narrowing.rs
@@ -5,7 +5,6 @@ use tsz_common::interner::Atom;
 use tsz_parser::parser::node::CallExprData;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
-use tsz_solver::narrowing::TypeGuard;
 use tsz_solver::{ParamInfo, TypeId, TypePredicate, TypePredicateTarget};
 
 use super::{FlowAnalyzer, PredicateSignature};
@@ -579,20 +578,12 @@ impl<'a> FlowAnalyzer<'a> {
 
         let env_borrow = self.type_environment.as_ref().map(|env| env.borrow());
 
-        let guard = if use_predicate_guard {
-            TypeGuard::Predicate {
-                type_id: Some(instance_type),
-                asserts: false,
-            }
-        } else {
-            TypeGuard::Instanceof(instance_type, false)
-        };
-
-        flow_query::narrow_with_guard(
+        flow_query::narrow_by_instanceof_target(
             self.interner,
             env_borrow.as_deref(),
             type_id,
-            &guard,
+            instance_type,
+            use_predicate_guard,
             is_true_branch,
         )
     }

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -580,6 +580,32 @@ pub(crate) fn narrow_to_objectish(
     narrowing.narrow_to_objectish(type_id)
 }
 
+/// Apply an `instanceof` target or `[Symbol.hasInstance]` predicate result.
+///
+/// The checker owns matching the binary expression and resolving the constructor
+/// to an instance target. This boundary owns the solver guard payload choice so
+/// `Symbol.hasInstance` predicates and normal `instanceof` guards stay behind
+/// the flow query boundary.
+pub(crate) fn narrow_by_instanceof_target(
+    db: &dyn QueryDatabase,
+    env: Option<&tsz_solver::relations::subtype::TypeEnvironment>,
+    type_id: TypeId,
+    instance_type: TypeId,
+    use_predicate_guard: bool,
+    is_true_branch: bool,
+) -> TypeId {
+    let guard = if use_predicate_guard {
+        TypeGuard::Predicate {
+            type_id: Some(instance_type),
+            asserts: false,
+        }
+    } else {
+        TypeGuard::Instanceof(instance_type, false)
+    };
+
+    narrow_with_guard(db, env, type_id, &guard, is_true_branch)
+}
+
 /// Apply an inferred predicate guard to a parameter type.
 ///
 /// The checker owns recognizing an inferable predicate body and matching the

--- a/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
@@ -448,3 +448,40 @@ fn predicate_payload_application_uses_flow_query_boundary() {
         "flow predicate callers should not construct solver predicate payloads locally"
     );
 }
+
+#[test]
+fn instanceof_guard_payload_uses_flow_query_boundary() {
+    let narrowing_source = fs::read_to_string("src/flow/control_flow/narrowing.rs")
+        .expect("failed to read flow narrowing source");
+    let boundary_source = fs::read_to_string("src/query_boundaries/flow_analysis.rs")
+        .expect("failed to read flow analysis boundary source");
+    let compact_narrowing: String = narrowing_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let compact_boundary: String = boundary_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let instanceof_fn = compact_narrowing
+        .split("fninstance_type_from_constructor(")
+        .next()
+        .and_then(|before_constructor| before_constructor.split("fnnarrow_by_instanceof(").nth(1))
+        .expect("failed to locate narrow_by_instanceof body");
+
+    assert!(
+        compact_boundary.contains("fnnarrow_by_instanceof_target(")
+            && compact_boundary.contains("TypeGuard::Predicate{")
+            && compact_boundary.contains("TypeGuard::Instanceof("),
+        "flow analysis boundary should own instanceof guard payload construction"
+    );
+    assert!(
+        instanceof_fn.contains("flow_query::narrow_by_instanceof_target("),
+        "instanceof flow narrowing should route guard payload application through the flow query boundary"
+    );
+    assert!(
+        !instanceof_fn.contains("TypeGuard::Predicate{")
+            && !instanceof_fn.contains("TypeGuard::Instanceof("),
+        "instanceof flow narrowing should not construct solver guard payloads locally"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
M1-D / Track 6 flow graph and solver-owned narrowing predicates; refactor-only boundary ratchet.

## Invariant
When flow applies an `instanceof` guard, checker owns expression matching and constructor target resolution; `query_boundaries::flow_analysis` owns choosing and applying the solver `TypeGuard` payload for normal `instanceof` targets and `[Symbol.hasInstance]` predicate targets.

## Scope
- Add a flow query helper for `instanceof` target narrowing that constructs the solver guard payload inside the boundary.
- Route `narrow_by_instanceof` through the new helper instead of constructing predicate or instanceof guards in flow orchestration.
- Extend flow boundary source guards to keep `instanceof` guard payload construction out of flow code.

## Project Corpus Impact
- Row: n/a.
- Bug family: flow/narrowing architecture substrate for `instanceof` and `[Symbol.hasInstance]` predicate reductions.
- Evidence: behavior intended unchanged; focused flow-boundary, instance-constructor, and symbol-has-instance narrowing tests passed locally.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib flow_guard_boundary_tests instance_type_from_constructor_tests symbol_has_instance_narrowing_tests`
- `cargo fmt --check`
- `git diff --check`
- `scripts/arch/check-checker-boundaries.sh`
- line cap check: touched files remain under 2000 physical lines.

## Coordination Notes
- `scripts/agents/list-owned-work.sh M1-D` was clear immediately before commit.
- Builds on the merged M1-D boundary-ratchet sequence through #12760, #12776, #12787, #12798, and #12802.
- No behavior policy changes, no new identifier/file-name/source-text predicates, and no project-row smoke required for this refactor-only slice.
