### PR TITLE
Route namespace mismatch through RelationRequest

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -115,7 +115,12 @@ impl<'a> CheckerState<'a> {
                 .iter()
                 .find(|source_prop| source_prop.name == target_prop.name)
                 .is_some_and(|source_prop| {
-                    !self.is_assignable_to(source_prop.type_id, target_prop.type_id)
+                    !self
+                        .namespace_property_mismatch_relation_outcome(
+                            source_prop.type_id,
+                            target_prop.type_id,
+                        )
+                        .related
                 })
         })
     }
@@ -135,14 +140,8 @@ impl<'a> CheckerState<'a> {
         (source, target)
     }
 
-    /// Execute a `RelationRequest` through the canonical boundary, returning
-    /// a structured `RelationOutcome`.
-    ///
-    /// This is the single authoritative checker-level entry point for relation
-    /// queries that need both the assignability result AND structured failure
-    /// information. It replaces the pattern of calling `is_assignable_to` +
-    /// `analyze_assignability_failure` + `is_weak_union_violation` separately.
-    ///
+    /// Execute a `RelationRequest` through the canonical boundary, returning a
+    /// structured `RelationOutcome` for diagnostic-bearing relation queries.
     /// The request must contain **prepared** (evaluated) source/target types.
     pub(crate) fn execute_relation_request(
         &mut self,

--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -1267,6 +1267,21 @@ impl<'a> CheckerState<'a> {
         self.execute_relation_request(&request)
     }
 
+    /// Execute a namespace-module property mismatch relation for raw checker
+    /// types, preserving the canonical downgrade request shape.
+    pub(crate) fn namespace_property_mismatch_relation_outcome(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> crate::query_boundaries::assignability::RelationOutcome {
+        let (source, target) = self.prepare_assignability_inputs(source, target);
+        let request =
+            crate::query_boundaries::assignability::RelationRequest::namespace_property_mismatch(
+                source, target,
+            );
+        self.execute_relation_request(&request)
+    }
+
     /// Execute a diagnostic-bearing `satisfies` relation for raw checker
     /// types, preserving the canonical satisfies relation request shape.
     pub(crate) fn satisfies_relation_outcome(

--- a/crates/tsz-checker/src/query_boundaries/relation_request.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_request.rs
@@ -181,6 +181,8 @@ pub(crate) enum RelationKind {
     PrivateMemberAccess,
     /// Function type contextual/recovery compatibility probe.
     FunctionTypeCompatibility,
+    /// Namespace-module property mismatch downgrade compatibility probe.
+    NamespacePropertyMismatch,
     /// Satisfies expression: `expr satisfies T`
     Satisfies,
     /// Bivariant callback assignment where function parameter types are checked bivariantly.
@@ -621,6 +623,10 @@ impl RelationRequest {
 
     pub(crate) const fn function_type_compatibility(source: TypeId, target: TypeId) -> Self {
         Self::new(source, target, RelationKind::FunctionTypeCompatibility)
+    }
+
+    pub(crate) const fn namespace_property_mismatch(source: TypeId, target: TypeId) -> Self {
+        Self::new(source, target, RelationKind::NamespacePropertyMismatch)
     }
 
     pub(crate) const fn bivariant_callbacks(source: TypeId, target: TypeId) -> Self {

--- a/crates/tsz-checker/src/tests/namespace_property_mismatch_boundary_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/namespace_property_mismatch_boundary_arch_tests.rs
@@ -32,4 +32,12 @@ fn namespace_property_mismatch_uses_narrow_boundaries() {
         function.matches("object_shape_for_type").count() >= 2,
         "namespace object-shape fallback order should route through the assignability boundary"
     );
+    assert!(
+        function.contains("namespace_property_mismatch_relation_outcome("),
+        "namespace property comparisons should route through a named RelationRequest helper"
+    );
+    assert!(
+        !function.contains("is_assignable_to("),
+        "namespace property mismatch should not use a raw relation call for diagnostic downgrade"
+    );
 }


### PR DESCRIPTION
AgentName: M1-B

## Track
Checker orchestration - relation diagnostic routing / query-boundary cleanup (#8227).

## Invariant
Diagnostic-bearing assignability downgrades should route relation truth through named RelationRequest / RelationOutcome helpers instead of embedding raw is_assignable_to calls in checker-side diagnostic decisions.

## Scope
- Adds RelationKind::NamespacePropertyMismatch and RelationRequest::namespace_property_mismatch.
- Adds namespace_property_mismatch_relation_outcome for the namespace-module property downgrade path.
- Replaces the raw nested property is_assignable_to call in namespace_source_has_matching_property_mismatch with the named outcome helper.
- Tightens the namespace property mismatch architecture test to require the named helper and reject the raw relation call.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostic routing / query-boundary cleanup
- Impact: None expected. This is a focused checker routing cleanup for an existing namespace-module assignability downgrade; no parser, emitter, benchmark metadata, or project-row behavior is intentionally changed.

## Verification
- cargo fmt
- scripts/safe-run.sh cargo nextest run -p tsz-checker --lib namespace_property_mismatch_uses_narrow_boundaries
- scripts/arch/check-checker-boundaries.sh
- scripts/safe-run.sh cargo nextest run -p tsz-checker --test class_interface_namespace_merge_tests class_only_namespace_excess_property_still_flagged class_interface_namespace_excess_property_still_flagged
- Exact-head PR CI passed on 52be948c8f511c155925c3391633c8b4f09831b2 before the branch was rebased onto current main; CI is rerunning on 54e52ab66e65862bf0acab6a81ac04158094d586 after the clean rebase.

## Coordination Notes
Opened as draft per M1-B runway rules, then marked ready after initial exact-head checks passed. Structural rule: when a namespace-module source matches a target property name but the property value relation fails, tsz should downgrade assignability through the checker-owned relation request boundary; the solver relation policy remains unchanged. Adjacent coverage keeps namespace/class excess-property behavior green and the architecture guard prevents regression to a raw property relation call.