### PR TITLE
fix(checker): render computed tuple/array-union alias source structurally in TS2322

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -462,6 +462,14 @@ impl<'a> CheckerState<'a> {
         if self.declared_source_annotation_names_type_query_alias(expr_idx) {
             return false;
         }
+        // A computed-body alias carries no `aliasSymbol` in tsc, so its source is
+        // rendered structurally, never by name. Scalar bodies already expand (the
+        // index-signature gate below returns `false`), but tuple/array bodies slip
+        // past that gate via their numeric index signature; route them through the
+        // shared display policy so every reducible body drops the alias annotation.
+        if self.source_declared_type_is_displayed_as_underlying(expr_type) {
+            return false;
+        }
         if annotation.contains("`${") {
             return true;
         }
@@ -524,6 +532,20 @@ impl<'a> CheckerState<'a> {
         }
 
         false
+    }
+
+    /// True when `ty` resolves to a non-generic type alias that tsc renders by
+    /// its underlying (computed) type rather than its declared name — see
+    /// [`crate::query_boundaries::assignability_alias_display::type_displayed_as_underlying`],
+    /// which owns the `Lazy(DefId)` / resolved-shape resolution behind the query
+    /// boundary.
+    fn source_declared_type_is_displayed_as_underlying(&self, ty: TypeId) -> bool {
+        crate::query_boundaries::assignability_alias_display::type_displayed_as_underlying(
+            self.ctx.types.as_type_database(),
+            &self.ctx.definition_store,
+            ty,
+        )
+        .is_some()
     }
 
     pub(crate) fn format_type_diagnostic_structural(&self, ty: TypeId) -> String {

--- a/crates/tsz-checker/src/query_boundaries/assignability_alias_display.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability_alias_display.rs
@@ -23,6 +23,24 @@ pub(crate) fn type_alias_displayed_as_underlying(
     tsz_solver::type_alias_displayed_as_underlying(db, definitions, def_id)
 }
 
+/// As [`type_alias_displayed_as_underlying`], but accepts a `TypeId` instead of
+/// a `DefId`: resolves `ty` to the non-generic type alias it references — either
+/// a `Lazy(DefId)` alias reference or the already-resolved structural result
+/// that still maps back to the alias `DefId` via the def store — then applies
+/// the shared underlying-display policy. Returns the underlying `TypeId` to
+/// display in place of the alias name, or `None` when `ty` is not such an alias.
+///
+/// Keeping the `Lazy` resolution here (rather than at the checker call site)
+/// avoids growing the `query_boundaries::common` quarantine in checker modules.
+pub(crate) fn type_displayed_as_underlying(
+    db: &dyn TypeDatabase,
+    definitions: &DefinitionStore,
+    ty: TypeId,
+) -> Option<TypeId> {
+    let def_id = common::lazy_def_id(db, ty).or_else(|| definitions.find_def_for_type(ty))?;
+    type_alias_displayed_as_underlying(db, definitions, def_id)
+}
+
 pub(crate) fn source_preserves_declared_generic_alias_display(
     db: &dyn TypeDatabase,
     source: TypeId,

--- a/crates/tsz-checker/src/tests/computed_alias_source_display_tests.rs
+++ b/crates/tsz-checker/src/tests/computed_alias_source_display_tests.rs
@@ -179,3 +179,106 @@ const sink_k: 0 = witness_k;
         "Box_K<string>",
     );
 }
+
+// --- tuple-like-union family (#10799 rxjs-project repro) -------------------
+//
+// A non-generic alias whose computed body reduces to a tuple, an array, or a
+// union of those carries no `aliasSymbol` in tsc, so the *source* of a TS2322
+// must render the structural shape — not the alias name. Scalar-bodied aliases
+// already expanded; tuple/array bodies regressed because they expose a numeric
+// index signature that bypassed the source annotation-preference gate, so the
+// declared alias name leaked into the message (`L` instead of `[string, number]`).
+
+#[test]
+fn conditional_tuple_alias_source_renders_underlying_tuple() {
+    assert_source_display(
+        r#"
+type Pair_L = true extends true ? [string, number] : never;
+declare const witness_l: Pair_L;
+const sink_l: 0 = witness_l;
+"#,
+        "[string, number]",
+    );
+}
+
+#[test]
+fn conditional_tuple_union_alias_source_renders_underlying_union() {
+    assert_source_display(
+        r#"
+type Variant_M = true extends true ? [string] | [number] : never;
+declare const witness_m: Variant_M;
+const sink_m: 0 = witness_m;
+"#,
+        "[string] | [number]",
+    );
+}
+
+#[test]
+fn conditional_array_union_alias_source_renders_underlying_union() {
+    assert_source_display(
+        r#"
+type Lists_N = true extends true ? string[] | number[] : never;
+declare const witness_n: Lists_N;
+const sink_n: 0 = witness_n;
+"#,
+        "string[] | number[]",
+    );
+}
+
+#[test]
+fn inline_conditional_mixed_tuple_union_source_renders_underlying() {
+    // The issue's literal repro family: an inline (non-generic) conditional whose
+    // body is a mixed tuple union — including the empty tuple — resolves away with
+    // no `aliasSymbol`, so tsc renders the structural union. (A generic *utility
+    // application* like `Classify<U>` instead keeps its alias name, since tsc
+    // stamps the application result — see `generic_application_alias_*` above.)
+    assert_source_display(
+        r#"
+type Result_O = true extends true ? [string, string] | [number, number] | [] : never;
+declare const witness_o: Result_O;
+const sink_o: 0 = witness_o;
+"#,
+        "[string, string] | [number, number] | []",
+    );
+}
+
+#[test]
+fn indexed_access_tuple_alias_source_renders_underlying_tuple() {
+    assert_source_display(
+        r#"
+type Lookup_P = { field: [boolean, string] }["field"];
+declare const witness_p: Lookup_P;
+const sink_p: 0 = witness_p;
+"#,
+        "[boolean, string]",
+    );
+}
+
+#[test]
+fn direct_tuple_alias_source_keeps_alias_name() {
+    // A directly-written tuple alias is `aliasSymbol`-stamped by tsc, so the
+    // source keeps its name — the rewrite must stay scoped to computed bodies.
+    assert_source_display(
+        r#"
+type Pair_Q = [string, number];
+declare const witness_q: Pair_Q;
+const sink_q: 0 = witness_q;
+"#,
+        "Pair_Q",
+    );
+}
+
+#[test]
+fn object_mentioning_union_alias_source_keeps_alias_name() {
+    // A computed body whose union mentions an object stays deferred to the
+    // alias name (the shared-shape reverse-lookup repaint is unsafe to expand);
+    // this guards that the tuple/array rewrite does not widen that exclusion.
+    assert_source_display(
+        r#"
+type Mixed_R = true extends true ? { a: 1 } | string : never;
+declare const witness_r: Mixed_R;
+const sink_r: 0 = witness_r;
+"#,
+        "Mixed_R",
+    );
+}


### PR DESCRIPTION
AgentName: brave-volta-skUeu
Track: conformance / diagnostic display (#10799 rxjs-project, distributive-conditional over tuple-like unions)

## Invariant
A `TS2322` source-type display is identical across the three diagnostic pipelines (solver `TypeFormatter`, checker target display, checker source display): a non-generic alias with a computed body that tsc renders without an `aliasSymbol` is shown structurally in every position, and aliases tsc keeps by name keep their name in every position.

## Structural rule
When a **non-generic** type alias has a **computed** body — an inline conditional or indexed-access that *resolves away* into a tuple, an array, or a union of those — tsc attaches no `aliasSymbol` to the shared result and renders it **structurally** (`[string, number]`, `string[] | number[]`, `[string, string] | [number, number] | []`). tsz did this for the **target** of a `TS2322` and for scalar-bodied sources, but the **source** of a `TS2322` printed the alias name for tuple/array bodies (`Variant_M`, `Pair_L`, …).

Root cause: `should_prefer_declared_source_annotation_display` bails (returns `false`, → structural) at the `!formatted.starts_with('{') && !has_index_signature` gate for scalars, but a tuple/array exposes a **numeric index signature**, so it slipped past that gate and reached `!annotation.starts_with('{') → return true`, preferring the declared alias-name annotation.

## Owner layer
Checker `error_reporter` source display only — **no** relation / inference / narrowing / emit change. The source path is now routed through the shared `query_boundaries::assignability_alias_display::type_alias_displayed_as_underlying` policy that the solver `TypeFormatter` (`alias_underlying.rs`) and the checker target-display path (`core_formatting.rs`) already consume, so all three diagnostic pipelines agree instead of the source path diverging.

## Scope
- New guard + helper `source_declared_type_is_displayed_as_underlying` in `crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs`.
- The helper resolves the declared type to its alias `DefId` (via `lazy_def_id` or the resolved-shape `find_def_for_type`) and asks the shared underlying-display policy whether tsc drops the name.

## Adjacent-case matrix (all in `computed_alias_source_display_tests`, binder names varied)
Positive (now structural): inline-conditional single tuple; conditional tuple-union; conditional array-union; inline distributive conditional over a mixed tuple union **including the empty tuple** (the issue's literal repro family); indexed-access reducing to a tuple.
Negative / fallback (still keep the name, matching tsc): directly-written tuple alias (`aliasSymbol`-stamped); conditional whose union **mentions an object** (deliberate reverse-lookup-repaint exclusion preserved); generic utility application (`Classify<U>` keeps its name — tsc stamps application results).

## Project Corpus Impact
- Row: rxjs-project
- Bug family: distributive-conditional-over-tuple-like-union diagnostic display (#10799)

No required-row regression expected: change is confined to TS2322 source-string rendering for computed non-generic tuple/array aliases. The fix tightens parity in the exact rxjs-project family the issue tracks; existing object-union / direct-alias / generic-application behavior is unchanged (those return `None` from the shared policy).

## Verification
- `cargo test -p tsz-checker --lib computed_alias_source_display_tests` (18) — green (7 new).
- `type_alias_computed_display_tests`, `type_alias_primitive_display_tests`, `union_tuple_source_display_tests`, solver `diagnostics::format` (220) — green.
- `cargo clippy -p tsz-checker --lib` — clean.
- Diff of the `alias`/`display` lib suites clean-vs-fix: **zero** new failures (pre-existing, lib-dependent CI-owned failures unchanged). Broad conformance/emit left to ready-review CI per repo policy.

## Coordination Notes
Closes the display follow-up left open on #10799 by prior investigations (semantic over-constraining confirmed non-reproducible; this is the remaining tractable display drift). The two architecturally-deferred items — union member ordering, and object-mentioning-union alias display — are intentionally **not** touched and remain guarded by their existing pins.

https://claude.ai/code/session_01T7Usi7YoVU1nsU7sQmat2X