### PR TITLE
chore(emit): safe-slice expression recovery scan

### DIFF
--- a/crates/tsz-emitter/src/emitter/statements/expression_statement_helpers.rs
+++ b/crates/tsz-emitter/src/emitter/statements/expression_statement_helpers.rs
@@ -1,4 +1,5 @@
 use super::super::Printer;
+use crate::safe_slice;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::Node;
 use tsz_parser::parser::syntax_kind_ext;
@@ -26,7 +27,7 @@ impl<'a> Printer<'a> {
         let end = node.end as usize;
         start < end
             && end <= source_text.len()
-            && source_text[start..end].contains('\\')
-            && source_text[start..end].contains(';')
+            && safe_slice::span_contains_byte(source_text, start, end, b'\\')
+            && safe_slice::span_contains_byte(source_text, start, end, b';')
     }
 }

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -359,7 +359,7 @@ REGEX_LINE_COUNT_CHECKS = [
         "Emitter boundary: source_text contains recovery decisions (Track 9/10)",
         [ROOT / "crates" / "tsz-emitter" / "src"],
         re.compile(r"\bsource_text(?:\[[^\n\]]+\])?\.contains\s*\("),
-        3,
+        1,
     ),
     (
         "Emitter boundary: recovered variable typeof tails use parser facts (#8276)",

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1390,7 +1390,7 @@ REGEX_LINE_COUNT_CHECKS = [
         "Emitter boundary: source_text contains recovery decisions (Track 9/10)",
         [ROOT / "crates" / "tsz-emitter" / "src"],
         re.compile(r"\bsource_text(?:\[[^\n\]]+\])?\.contains\s*\("),
-        3,
+        1,
     ),
     (
         "Emitter boundary: recovered variable typeof tails use parser facts (#8276)",


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 9/10 emit architecture debt burn-down / refactor only.

## Invariant
When expression-statement recovery needs to know whether the parser-owned expression gap contains invalid backslash and semicolon bytes, the emitter asks the shared span helper instead of slicing source text inline. Behavior is unchanged; this PR changes the emit recovery helper and architecture guard counter only.

## Scope
- Route `expression_statement_consumed_invalid_backslash_semicolon` through `safe_slice::span_contains_byte`.
- Ratchet `Emitter boundary: source_text contains recovery decisions` from 3 to 1 in both arch guard definitions.

## Project Corpus Impact
- Row: n/a.
- Bug family: emit/source-text recovery architecture debt (#8276).
- Evidence: JS and DTS emit are already exact on current artifacts; this reduces the source-text recovery counter without changing output policy.

## Verification
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter span_contains_byte --no-fail-fast`
- `python3 scripts/arch/test_arch_guard_policy.py`
- `python3 scripts/emit/audit-output-surgery.py`
- `python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Open PR scan found no `agent:Studio-Opus` PRs before starting.
- `scripts/agents/ensure-agent-labels.sh --audit` still reports unrelated existing PR/issue ownership gaps (#12810, #12807, #12800, #12797, #12789, #10799); this PR uses the canonical `agent:Studio-Opus` label.
- Remaining counted emitter `source_text.contains` line is the DTS synthetic class extends source-text preference in `declaration_emitter/helpers/variable_decl.rs`; this PR intentionally leaves that separate semantic/display question untouched.