### PR TITLE
chore(conformance): retire unicode accepted regression

### DIFF
--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -52,7 +52,6 @@ TypeScript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWit
 TypeScript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
 TypeScript/tests/cases/compiler/promisesWithConstraints.ts
-TypeScript/tests/cases/compiler/unicodeEscapesInNames02.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts
 TypeScript/tests/cases/conformance/externalModules/circularReference.ts
 TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Conformance strictness ledger cleanup.

## Invariant
When `TypeScript/tests/cases/compiler/unicodeEscapesInNames02.ts` no longer appears in the exact conformance failure set, the accepted-regression ledger should not keep counting it as release strictness debt. This PR changes only the conformance accepted-regression artifact.

## Scope
- Remove `TypeScript/tests/cases/compiler/unicodeEscapesInNames02.ts` from `scripts/conformance/conformance-accepted-regressions.txt`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: ledger-only conformance strictness cleanup; project-row summary remains current from cycle intake with all 19 rows consistent.

## Verification
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter unicodeEscapesInNames02 --verbose`
- `python3 scripts/conformance/check-accepted-regression-growth.py --base-ref origin/main --head-ref HEAD --allow-unavailable-base`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `git diff --check HEAD~1..HEAD`

## Coordination Notes
- Focused removal-only PR after #12804 landed.
- Accepted-regression strictness gate drops from 25 to 24 listed tests.
- Agent label audit before publish found pre-existing unlabeled PRs/issues outside Studio-A; no Studio-A owned PRs were open.