### PR TITLE
fix(parser): keep import.defer missing paren diagnostic

### DIFF
--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -1450,6 +1450,7 @@ impl ParserState {
 
     pub(crate) fn parse_error_at(&mut self, start: u32, length: u32, message: &str, code: u32) {
         if code == tsz_common::diagnostics::diagnostic_codes::EXPECTED
+            && message == "')' expected."
             && self.is_token(SyntaxKind::CloseParenToken)
             && start == self.token_pos()
             && self.speculate(|parser| {
@@ -1460,6 +1461,7 @@ impl ParserState {
             return;
         }
         if code == tsz_common::diagnostics::diagnostic_codes::EXPECTED
+            && message == "')' expected."
             && self.get_source_text().as_bytes().get(start as usize) == Some(&b')')
             && self.get_source_text().as_bytes().get(start as usize + 1) == Some(&b';')
         {

--- a/crates/tsz-parser/src/parser/state_diagnostics.rs
+++ b/crates/tsz-parser/src/parser/state_diagnostics.rs
@@ -5,6 +5,7 @@ use tsz_scanner::scanner_impl::TokenFlags;
 impl ParserState {
     pub fn parse_error_at_current_token(&mut self, message: &str, code: u32) {
         if code == tsz_common::diagnostics::diagnostic_codes::EXPECTED
+            && message == "')' expected."
             && self.is_token(SyntaxKind::CloseParenToken)
             && self.speculate(|parser| {
                 parser.next_token();

--- a/crates/tsz-parser/tests/parser_improvement_import_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_import_recovery_tests.rs
@@ -476,6 +476,43 @@ fn test_import_dot_defer_standalone_emits_ts1005() {
 }
 
 #[test]
+fn test_import_dot_defer_invalid_standalone_fingerprints_match_tsc() {
+    let function_arg_source = "Function(import.defer);";
+    let (function_arg_parser, _root) = parse_source(function_arg_source);
+    assert!(
+        function_arg_parser
+            .get_diagnostics()
+            .iter()
+            .any(|d| d.code == 1005 && d.message == "'(' expected."),
+        "Expected Function(import.defer) to report missing call paren; diagnostics: {:?}",
+        function_arg_parser.get_diagnostics()
+    );
+
+    let source =
+        "import.defer;\n\n(import.defer)(\"a\");\n\nFunction(import.defer);\n\nimport.defer";
+    let (parser, _root) = parse_source(source);
+
+    let ts1005: Vec<_> = parser
+        .get_diagnostics()
+        .iter()
+        .filter(|d| d.code == 1005 && d.message == "'(' expected.")
+        .map(|d| d.start)
+        .collect();
+    let expected = vec![
+        source.find(';').expect("first semicolon") as u32,
+        source.find(")(\"a\")").expect("parenthesized close paren") as u32,
+        source.find(");\n\nimport.defer").expect("call close paren") as u32,
+        source.len() as u32,
+    ];
+    assert_eq!(
+        ts1005,
+        expected,
+        "Expected import.defer without call parens to report at each missing '(' anchor; diagnostics: {:?}",
+        parser.get_diagnostics()
+    );
+}
+
+#[test]
 fn test_import_dot_invalid_meta_property_ts17012() {
     // `import.foo` (not in call) should emit TS17012
     let source = r"const x = import.foo;";

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -58,7 +58,6 @@ TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
 TypeScript/tests/cases/compiler/promisesWithConstraints.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts
 TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts
-TypeScript/tests/cases/conformance/importDefer/dynamicImportDeferInvalidStandalone.ts
 TypeScript/tests/cases/conformance/jsdoc/importTag17.ts
 TypeScript/tests/cases/conformance/node/nodeModulesImportAttributesTypeModeDeclarationEmitErrors.ts
 TypeScript/tests/cases/conformance/node/nodeModulesImportTypeModeDeclarationEmitErrors1.ts


### PR DESCRIPTION
AgentName: Studio-A
Track: conformance
Invariant: Parser recovery must not suppress unrelated TS1005 diagnostics at a close paren; `import.defer` without a following call must still report `'(' expected.` in statement, parenthesized-call, argument, and EOF positions.
Scope: Narrow the close-paren-before-semicolon TS1005 suppressor to `')' expected.` diagnostics and add an import-defer recovery regression test.

## Project Corpus Impact
- Row: n/a
- Bug family: conformance accepted-regression / parser recovery
- Impact: Accepted-regression ledger drops from 23 to 22 by retiring `TypeScript/tests/cases/conformance/importDefer/dynamicImportDeferInvalidStandalone.ts`; project rows unchanged.

Verification:
- `scripts/safe-run.sh cargo nextest run -p tsz-parser test_import_dot_defer_invalid_standalone_fingerprints_match_tsc test_import_dot_defer_standalone_emits_ts1005 test_import_dot_defer_call_no_parse_error`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter dynamicImportDeferInvalidStandalone --verbose`
- `python3 scripts/conformance/check-accepted-regression-growth.py --base-ref origin/main --head-ref HEAD --allow-unavailable-base`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `git diff --check`
Coordination Notes: Focused Studio-A ledger cleanup. No owned PRs were open at cycle start; issue #10663 remains unrelated project-row tracking.