### PR TITLE
Route mapped diagnostic probes through RelationRequest

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -307,7 +307,7 @@ impl<'a> CheckerState<'a> {
             property_classification: None,
         };
 
-        if source == target || self.is_assignable_to_with_env(source, target) {
+        if source == target || self.diagnostic_relation_boolean_guard_with_env(source, target) {
             return outcome(true);
         }
 

--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -658,6 +658,32 @@ impl<'a> CheckerState<'a> {
         self.execute_relation_request(&request)
     }
 
+    pub(crate) fn broad_mapped_index_signature_display_relation_outcome(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> crate::query_boundaries::assignability::RelationOutcome {
+        let (source, target) = self.prepare_assignability_inputs(source, target);
+        let request =
+            crate::query_boundaries::assignability::RelationRequest::broad_mapped_index_signature_display(
+                source, target,
+            );
+        self.execute_relation_request(&request)
+    }
+
+    pub(crate) fn mapped_object_literal_excess_value_relation_outcome(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> crate::query_boundaries::assignability::RelationOutcome {
+        let (source, target) = self.prepare_assignability_inputs(source, target);
+        let request =
+            crate::query_boundaries::assignability::RelationRequest::mapped_object_literal_excess_value(
+                source, target,
+            );
+        self.execute_relation_request(&request)
+    }
+
     /// Execute a diagnostic-bearing polymorphic `this` receiver relation for raw
     /// checker types, preserving the canonical receiver request shape.
     pub(crate) fn polymorphic_this_receiver_relation_outcome(

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -1812,7 +1812,10 @@ impl<'a> CheckerState<'a> {
         ) {
             return None;
         }
-        if self.assign_relation_outcome(source, target).related {
+        if self
+            .broad_mapped_index_signature_display_relation_outcome(source, target)
+            .related
+        {
             return None;
         }
 

--- a/crates/tsz-checker/src/query_boundaries/relation_request.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_request.rs
@@ -101,6 +101,10 @@ pub(crate) enum RelationKind {
     DiagnosticSourceNarrowing,
     /// Diagnostic overlap/comparability probes.
     DiagnosticOverlap,
+    /// Broad mapped index-signature display suppression probes.
+    BroadMappedIndexSignatureDisplay,
+    /// Mapped object-literal excess-property value classification probes.
+    MappedObjectLiteralExcessValue,
     /// Polymorphic `this` receiver/member compatibility probes for diagnostics.
     PolymorphicThisReceiver,
     /// Class extends index-signature value compatibility probes.
@@ -431,6 +435,21 @@ impl RelationRequest {
 
     pub(crate) const fn diagnostic_overlap(source: TypeId, target: TypeId) -> Self {
         Self::new(source, target, RelationKind::DiagnosticOverlap)
+    }
+
+    pub(crate) const fn broad_mapped_index_signature_display(
+        source: TypeId,
+        target: TypeId,
+    ) -> Self {
+        Self::new(
+            source,
+            target,
+            RelationKind::BroadMappedIndexSignatureDisplay,
+        )
+    }
+
+    pub(crate) const fn mapped_object_literal_excess_value(source: TypeId, target: TypeId) -> Self {
+        Self::new(source, target, RelationKind::MappedObjectLiteralExcessValue)
     }
 
     pub(crate) const fn polymorphic_this_receiver(source: TypeId, target: TypeId) -> Self {

--- a/crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs
+++ b/crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs
@@ -589,7 +589,8 @@ impl<'a> CheckerState<'a> {
         }
         let widened = crate::query_boundaries::common::widen_freshness(self.ctx.types, source);
         matches!(
-            self.assign_relation_outcome(widened, target).failure,
+            self.mapped_object_literal_excess_value_relation_outcome(widened, target)
+                .failure,
             Some(crate::query_boundaries::relation_types::RelationFailure::IncompatiblePropertyValue {
                 target_property_type,
                 ..

--- a/crates/tsz-checker/src/tests/relation_routing_residual_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/relation_routing_residual_arch_tests.rs
@@ -92,6 +92,27 @@ fn assign_relation_outcome_fast_path_uses_named_diagnostic_guard() {
 }
 
 #[test]
+fn relation_outcome_with_env_fast_path_uses_named_diagnostic_guard() {
+    let source = fs::read_to_string("src/assignability/assignability_relation.rs")
+        .expect("failed to read assignability relation source");
+    let body = function_body_between(
+        &source,
+        "fn relation_outcome_with_env(",
+        "pub(crate) fn assign_relation_outcome_with_env(",
+    );
+    let compact: String = body.chars().filter(|ch| !ch.is_whitespace()).collect();
+
+    assert!(
+        compact.contains("self.diagnostic_relation_boolean_guard_with_env(source,target)"),
+        "relation_outcome_with_env should name its env-aware boolean fast path as a diagnostic guard"
+    );
+    assert!(
+        !compact.contains("self.is_assignable_to_with_env(source,target)"),
+        "relation_outcome_with_env should not embed a raw env-aware assignability fast path"
+    );
+}
+
+#[test]
 fn production_checker_relation_truth_uses_outcome_boundaries() {
     let mut violations = Vec::new();
 


### PR DESCRIPTION
AgentName: M1-B

## Track
Checker orchestration - relation diagnostic routing / query-boundary cleanup (#8227).

## Invariant
Diagnostic and display/recovery assignability probes should route relation truth through named RelationRequest / RelationOutcome helpers instead of production checker callers invoking generic assign outcomes or raw relation fast paths directly.

## Scope
- Routes the env-aware relation_outcome_with_env fast path through diagnostic_relation_boolean_guard_with_env.
- Adds RelationKind entries and outcome helpers for broad mapped index-signature display suppression and mapped object-literal excess-value classification.
- Replaces two production checker assign_relation_outcome calls with the named helpers.
- Extends the residual routing architecture test to keep relation_outcome_with_env grep-distinct from raw env-aware relation calls.

## Project Corpus Impact
- Row: n/a
- Bug family: checker relation diagnostic routing / query-boundary cleanup
- Impact: None expected. This is a behavior-preserving routing cleanup for existing diagnostic/display and mapped-object excess probes; no parser, emitter, benchmark metadata, or project-row behavior is intentionally changed.

## Verification
- cargo fmt
- scripts/safe-run.sh cargo nextest run -p tsz-checker --lib relation_outcome_with_env_fast_path_uses_named_diagnostic_guard production_checker_relation_truth_uses_outcome_boundaries
- scripts/arch/check-checker-boundaries.sh
- scripts/safe-run.sh cargo nextest run -p tsz-checker --lib test_mapped_object_literal_property_diagnostics_use_display_relation_helper
- scripts/safe-run.sh cargo nextest run -p tsz-checker --lib optional_mapped_target

## Coordination Notes
Opened as draft per M1-B runway rules. Structural rule: when checker diagnostic/display recovery needs relation truth for mapped object or mapped index display probes, tsz should name the checker relation role through RelationRequest and RelationOutcome; solver relation policy remains unchanged. Adjacent mapped-object excess behavior stayed green, and the residual architecture ratchet now passes after removing the generic production assign_relation_outcome calls.