### PR TITLE
fix(bench): preserve required row timing blockers

### DIFF
--- a/scripts/bench/merge-results.mjs
+++ b/scripts/bench/merge-results.mjs
@@ -79,6 +79,9 @@ function mergeCompatibilityCanaries(results, compatibilityJsonlFiles) {
       if (!canaryNames.has(name)) continue;
       const existing = byName.get(name);
       if (existing) {
+        if (REQUIRED_PROJECT_ROW_SET.has(name)) {
+          continue;
+        }
         existing.compatibility = compatibility;
         existing.status ||= "compile canary tracked in CI; not timed by vs-tsgo benchmarks";
         continue;

--- a/scripts/bench/test-merge-results.mjs
+++ b/scripts/bench/test-merge-results.mjs
@@ -300,6 +300,58 @@ withTempDir((dir) => {
 });
 
 withTempDir((dir) => {
+  const requiredCanaryRow = "ts-toolbelt-project";
+  assert.ok(COMPILE_CANARY_PROJECT_ROWS.includes(requiredCanaryRow));
+  assert.ok(REQUIRED_PROJECT_ROWS.includes(requiredCanaryRow));
+  const slowdownCompatibility = {
+    ...SAMPLE_COMPATIBILITY,
+    state: "red",
+    exit_class: "slowdown",
+    first_failure_class: "runtime slowdown during project timing",
+    owner_track: "Track 10 runtime slowdown triage",
+    phase: "timing",
+    last_successful_phase: null,
+    diagnostic_status: "runtime slowdown",
+    diagnostic_deltas: ["timing failure: tsz 356 ms, tsgo 10 ms, ratio 35.61x, threshold 8x"],
+    known_blockers: ["runtime slowdown during project timing", "timing phase blocker"],
+  };
+  const rows = REQUIRED_PROJECT_ROWS.map((name) => {
+    if (name !== requiredCanaryRow) return projectRow(name);
+    return {
+      ...projectRow(name, slowdownCompatibility),
+      tsz_ms: null,
+      tsgo_ms: null,
+      tsz_lps: null,
+      tsgo_lps: null,
+      winner: "error",
+      factor: 0,
+      status: "tsz slowdown (35.61x slower than tsgo; threshold 8x)",
+    };
+  });
+  const input = writeInput(dir, "input.json", rows);
+  const compatibilityJsonl = path.join(dir, "project-compatibility.jsonl");
+  fs.writeFileSync(
+    compatibilityJsonl,
+    `${JSON.stringify({ ...SAMPLE_COMPATIBILITY, name: requiredCanaryRow })}\n`,
+    "utf8",
+  );
+
+  const result = runMergeInputs(dir, ["--compat-jsonl", compatibilityJsonl, input]);
+  assert.equal(result.status, 0, result.stderr);
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  const row = merged.results.find((candidate) => candidate.name === requiredCanaryRow);
+  assert.ok(row, "expected required canary benchmark row");
+  assert.equal(row.status, "tsz slowdown (35.61x slower than tsgo; threshold 8x)");
+  assert.equal(row.compatibility.state, "red");
+  assert.equal(row.compatibility.exit_class, "slowdown");
+  assert.equal(row.compatibility.first_failure_class, "runtime slowdown during project timing");
+  assert.deepEqual(row.compatibility.known_blockers, [
+    "runtime slowdown during project timing",
+    "timing phase blocker",
+  ]);
+});
+
+withTempDir((dir) => {
   const canaryRow = COMPILE_ONLY_CANARY_PROJECT_ROWS[0];
   const { diagnostic_subsystems: _diagnosticSubsystems, ...compatibility } = SAMPLE_COMPATIBILITY;
   const result = runMerge(dir, [projectRow(canaryRow, compatibility)]);


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Studio-Opus benchmark infrastructure / project corpus truthfulness

## Invariant
Required benchmark rows are authoritative for their timing/check phase metadata. Compile-canary JSONL may add or enrich compile-only canary rows, but it must not overwrite a required timed row's failure classification.

## Scope
- Preserve existing required project rows in `scripts/bench/merge-results.mjs` when merging compile-canary compatibility JSONL.
- Add a regression for `ts-toolbelt-project`, which is both `benchmark_set=required` and `guard_set=canary`, so a green compile-canary row cannot mask a timing slowdown.

## Project Corpus Impact
- Row: `ts-toolbelt-project`, plus the same required/canary overlap class for `zod-project` and `kysely-project`.
- Bug family: benchmark artifact schema/summary truthfulness for required rows with compile-canary coverage.
- Evidence: Bench artifact `27062642363` had `bench-results-projects.json` correctly reporting `ts-toolbelt-project` as `red / slowdown / runtime slowdown during project timing`, while the merged artifact showed `exit success` from compile-canary compatibility. This PR keeps the timing classification visible in merged readiness output.

## Verification
- `node scripts/bench/test-merge-results.mjs`
- `node scripts/bench/project-row-summary.mjs --markdown`
- `git diff --check`
- Artifact smoke: remerged `/tmp/tsz-bench-27062642363/bench-results-projects/bench-results-projects.json` and `bench-results-large-ts-repo.json` with synthetic green compile-canary JSONL; `ts-toolbelt-project` remained `state=red`, `exit_class=slowdown`, `phase=timing`, `first_failure_class=runtime slowdown during project timing`.
- Readiness smoke on the remixed artifact exited `1` as expected for real red rows and reported `ts-toolbelt-project` as `red/slowdown/timing` with family `runtime slowdown during project timing`.

## Coordination Notes
- This is benchmark infrastructure only; no compiler behavior changes.
- After this lands, Studio performance lanes can trust merged readiness output to distinguish compile failures, timeouts, and timing slowdowns on required rows that also have compile-canary coverage.
