### PR TITLE
chore(arch): track async yield source fallback

### DIFF
--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1409,6 +1409,22 @@ REGEX_LINE_COUNT_CHECKS = [
         0,
     ),
     (
+        # The async ES5 lowering path still has one source-text fallback for
+        # recovered `yield` detection. Keep it visible so the future parser- or
+        # lowering-owned fact can ratchet this to zero in the same PR.
+        "Emitter boundary: async yield source-text fallback (#8276)",
+        [
+            ROOT
+            / "crates"
+            / "tsz-emitter"
+            / "src"
+            / "transforms"
+            / "async_es5_ir_discovery.rs"
+        ],
+        re.compile(r"\bfn\s+node_text_contains_yield\s*\("),
+        1,
+    ),
+    (
         "Solver API boundary: flat root wildcard compatibility re-exports (#8204)",
         [ROOT / "crates" / "tsz-solver" / "src" / "lib.rs"],
         re.compile(r"^pub use (?:[A-Za-z_][A-Za-z0-9_]*::)+\*;"),

--- a/scripts/arch/test_arch_guard_policy.py
+++ b/scripts/arch/test_arch_guard_policy.py
@@ -86,6 +86,21 @@ class ArchGuardRegexLineCountTests(unittest.TestCase):
         self.assertIn("recovered_variable_statement.rs:1", hits[0])
         self.assertIn("recovered_variable_statement.rs:2", hits[1])
 
+    def test_flags_async_yield_source_text_fallback(self):
+        pattern, _max_lines = self._check_by_name("async yield source-text")
+        root = self._make_tree(
+            {
+                "crates/tsz-emitter/src/transforms/async_es5_ir_discovery.rs": (
+                    "pub(super) fn node_text_contains_yield(&self, idx: NodeIndex) -> bool {\n"
+                    "    self.node_text_contains(idx, \"yield\")\n"
+                    "}\n"
+                ),
+            }
+        )
+        hits = self.arch_guard.scan_regex_line_count([root], pattern, 0)
+        self.assertEqual(len(hits), 2, f"unexpected hits: {hits!r}")
+        self.assertIn("async_es5_ir_discovery.rs:1", hits[0])
+
     def test_flags_file_name_and_path_substring_decisions(self):
         pattern, _max_lines = self._check_by_name("file-name/path")
         root = self._make_tree(

--- a/scripts/arch/test_arch_guard_project.py
+++ b/scripts/arch/test_arch_guard_project.py
@@ -665,6 +665,21 @@ class ArchGuardRegexLineCountTests(unittest.TestCase):
         self.assertIn("recovery.rs:1", hits[0])
         self.assertIn("recovery.rs:2", hits[1])
 
+    def test_flags_async_yield_source_text_fallback(self):
+        pattern, _max_lines = self._check_by_name("async yield source-text")
+        root = self._make_tree(
+            {
+                "crates/tsz-emitter/src/transforms/async_es5_ir_discovery.rs": (
+                    "pub(super) fn node_text_contains_yield(&self, idx: NodeIndex) -> bool {\n"
+                    "    self.node_text_contains(idx, \"yield\")\n"
+                    "}\n"
+                ),
+            }
+        )
+        hits = self.arch_guard.scan_regex_line_count([root], pattern, 0)
+        self.assertEqual(len(hits), 2, f"unexpected hits: {hits!r}")
+        self.assertIn("async_es5_ir_discovery.rs:1", hits[0])
+
     def test_flags_file_name_and_path_substring_decisions(self):
         pattern, _max_lines = self._check_by_name("file-name/path")
         root = self._make_tree(


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 9/10 architecture guard and emit tech-debt ratchet.

## Invariant
When async ES5 lowering needs to detect a recovered `yield` shape and no structured node fact is available, tsz currently falls back through one named emitter source-text helper. This PR does not change emit behavior; it makes that remaining fallback a pinned architecture-guard count so a future parser/lowering-owned fact can ratchet it to zero with evidence.

## Scope
- Add an arch-guard regex count for the async yield source-text fallback in `async_es5_ir_discovery.rs`.
- Add guard policy/project tests proving the new count matches the intended helper shape.
- No checker, solver, parser, or emitter behavior changes.

## Project Corpus Impact
- No direct project-row behavior change.
- Reduces metadata/architecture blind spots for Studio emit debt under #8276.
- Keeps existing project-row and emit surfaces unchanged while making the next recovery-decision migration measurable.

## Verification
- `python3 -m unittest test_arch_guard_policy` from `scripts/arch`
- `python3 -m unittest test_arch_guard_project` from `scripts/arch`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`

## Coordination Notes
- Coordinates with #8276 after #12814 lowered the direct `source_text.contains` recovery guard to zero.
- Leaves ordinary Studio-C emit implementation work unclaimed; this is only the cross-Studio guard/infrastructure slice.
