### PR TITLE
fix(emit): preserve single exported conditional type-alias in inferred d.ts

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_declared_call.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_declared_call.rs
@@ -508,10 +508,17 @@ impl<'a> DeclarationEmitter<'a> {
                     let decl_node = source_arena.get(decl_idx)?;
                     let callable = Self::callable_decl_parts_from_node(source_arena, decl_node)?;
                     callable.type_annotation.is_some().then(|| {
+                        // A single, top-level conditional type-alias reference is
+                        // preserved as-written by declaration emit (see
+                        // `return_annotation_is_preservable_local_conditional_alias`),
+                        // so it must not be diverted onto the expand-the-body path.
                         self.source_type_contains_conditional_alias_application(
                             source_arena,
                             callable.type_annotation,
                             0,
+                        ) && !self.return_annotation_is_preservable_local_conditional_alias(
+                            source_arena,
+                            callable.type_annotation,
                         )
                     })
                 })

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_surface.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_return_surface.rs
@@ -1,6 +1,7 @@
 //! Return-surface helpers for source call declaration inference.
 
 use super::super::DeclarationEmitter;
+use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{NodeAccess, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
@@ -27,10 +28,22 @@ impl<'a> DeclarationEmitter<'a> {
         {
             return Some(self.print_type_id_for_inferred_declaration(type_id));
         }
+        // A single, top-level conditional type-alias reference (e.g. an inferred
+        // `const x = f(arg): Cond<string>`) is preserved as-written rather than
+        // expanded, mirroring `tsc`'s declaration emit. Expansion stays in force
+        // when the conditional alias is only *nested* inside a larger synthesized
+        // return type, where the alias name does not stand for the whole type.
         if self.source_type_contains_conditional_alias_application(source_arena, type_annotation, 0)
-            && let Some(type_id) = self.get_node_type_or_names(&[expr_idx])
         {
-            return Some(self.print_type_id_expanded_for_inferred_declaration(type_id));
+            if self.return_annotation_is_preservable_local_conditional_alias(
+                source_arena,
+                type_annotation,
+            ) {
+                return Some(type_text.to_string());
+            }
+            if let Some(type_id) = self.get_node_type_or_names(&[expr_idx]) {
+                return Some(self.print_type_id_expanded_for_inferred_declaration(type_id));
+            }
         }
         if explicit_type_args.is_empty()
             && !has_call_site_type_param_substitutions
@@ -82,6 +95,86 @@ impl<'a> DeclarationEmitter<'a> {
                     depth + 1,
                 )
             })
+    }
+
+    /// Returns true when `type_annotation` is exactly a single top-level
+    /// reference to a conditional-bodied type alias that is declared **and
+    /// exported** in the current emit file. In that situation the alias name is
+    /// itself emitted into the `.d.ts`, so the inferred declaration can name the
+    /// alias application (e.g. `Cond<string>`) instead of expanding its
+    /// conditional body — matching `tsc`'s "recursive conditional alias
+    /// preserved" declaration emit.
+    ///
+    /// The check intentionally bails out when:
+    /// - the callee is not declared in the current file (cross-file aliases are
+    ///   handled by the import-aware type-id path), or
+    /// - the conditional alias is only nested inside a larger return type, or
+    /// - the alias is not exported (so the `.d.ts` would not contain a
+    ///   declaration the reference could resolve to).
+    pub(in crate::declaration_emitter) fn return_annotation_is_preservable_local_conditional_alias(
+        &self,
+        source_arena: &NodeArena,
+        type_annotation: NodeIndex,
+    ) -> bool {
+        if !std::ptr::eq(source_arena, self.arena) {
+            return false;
+        }
+        let Some(binder) = self.binder else {
+            return false;
+        };
+        let Some(top_reference) =
+            self.single_top_level_type_reference(source_arena, type_annotation)
+        else {
+            return false;
+        };
+        let Some(sym_id) = self.declaration_type_symbol_from_type_node(source_arena, top_reference)
+        else {
+            return false;
+        };
+        let Some(symbol) = binder.symbols.get(sym_id) else {
+            return false;
+        };
+        // The alias must be an exported type alias: declaration emit only emits a
+        // (re-usable) `type Alias = …` for exported aliases, so an inferred
+        // reference can resolve against it. Non-exported aliases stay expanded.
+        if symbol.flags & symbol_flags::TYPE_ALIAS == 0
+            || !(symbol.is_exported || symbol.has_any_flags(symbol_flags::EXPORT_VALUE))
+        {
+            return false;
+        }
+        // Only conditional-bodied aliases are mis-expanded today; non-conditional
+        // alias applications already round-trip through the normal reuse path.
+        self.with_symbol_declarations(sym_id, |alias_arena, decl_idx| {
+            let decl_node = alias_arena.get(decl_idx)?;
+            if decl_node.kind != syntax_kind_ext::TYPE_ALIAS_DECLARATION {
+                return None;
+            }
+            let alias = alias_arena.get_type_alias(decl_node)?;
+            Some(self.type_node_is_conditional_after_parens(alias_arena, alias.type_node, 0))
+        })
+        .unwrap_or(false)
+    }
+
+    /// Strips enclosing parentheses and returns the node index when
+    /// `type_idx` is exactly one top-level `TYPE_REFERENCE`. Returns `None` for
+    /// composite types (unions, intersections, object literals, function types,
+    /// …) where a contained alias reference does not name the whole type.
+    fn single_top_level_type_reference(
+        &self,
+        source_arena: &NodeArena,
+        type_idx: NodeIndex,
+    ) -> Option<NodeIndex> {
+        // Skip enclosing parentheses; the bound guards against a malformed arena
+        // with a parenthesis cycle.
+        let mut type_idx = type_idx;
+        for _ in 0..=16 {
+            let type_node = source_arena.get(type_idx)?;
+            if type_node.kind != syntax_kind_ext::PARENTHESIZED_TYPE {
+                return (type_node.kind == syntax_kind_ext::TYPE_REFERENCE).then_some(type_idx);
+            }
+            type_idx = source_arena.get_wrapped_type(type_node)?.type_node;
+        }
+        None
     }
 
     fn type_node_is_conditional_after_parens(
@@ -192,6 +285,82 @@ interface Box<T> {
             &parser.arena,
             return_type,
             0
+        ));
+    }
+
+    fn first_function_return_annotation_is_preservable(source: &str) -> bool {
+        use crate::type_cache_view::TypeCacheView;
+        use tsz_binder::BinderState;
+        use tsz_solver::construction::TypeInterner;
+
+        let mut parser = ParserState::new("preserve.ts".to_string(), source.to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(&parser.arena, root);
+        let interner = TypeInterner::new();
+        let type_cache = TypeCacheView::default();
+        let emitter =
+            DeclarationEmitter::with_type_info(&parser.arena, type_cache, &interner, &binder);
+
+        let annotation = parser
+            .arena
+            .nodes
+            .iter()
+            .find_map(|node| {
+                if node.kind != syntax_kind_ext::FUNCTION_DECLARATION {
+                    return None;
+                }
+                let func = parser.arena.get_function(node)?;
+                func.type_annotation
+                    .is_some()
+                    .then_some(func.type_annotation)
+            })
+            .expect("function return annotation");
+
+        emitter.return_annotation_is_preservable_local_conditional_alias(&parser.arena, annotation)
+    }
+
+    #[test]
+    fn exported_single_conditional_alias_reference_is_preservable() {
+        assert!(first_function_return_annotation_is_preservable(
+            r#"
+export type Cond<T> = T extends string ? { s: T } : { n: T };
+declare function make<T>(t: T): Cond<T>;
+"#,
+        ));
+    }
+
+    #[test]
+    fn unexported_conditional_alias_reference_is_not_preservable() {
+        assert!(!first_function_return_annotation_is_preservable(
+            r#"
+type Cond<T> = T extends string ? { s: T } : { n: T };
+declare function make<T>(t: T): Cond<T>;
+"#,
+        ));
+    }
+
+    #[test]
+    fn exported_non_conditional_alias_reference_is_not_preservable() {
+        // Non-conditional alias applications already round-trip through the
+        // normal reuse path, so they are intentionally excluded.
+        assert!(!first_function_return_annotation_is_preservable(
+            r#"
+export type Plain<T> = { value: T };
+declare function make<T>(t: T): Plain<T>;
+"#,
+        ));
+    }
+
+    #[test]
+    fn nested_conditional_alias_reference_is_not_preservable() {
+        // The conditional alias is not the *whole* return type, so the alias name
+        // does not stand for the inferred type and must not be preserved here.
+        assert!(!first_function_return_annotation_is_preservable(
+            r#"
+export type Cond<T> = T extends string ? { s: T } : { n: T };
+declare function wrap<T>(t: T): { value: Cond<T> };
+"#,
         ));
     }
 }

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
@@ -909,3 +909,26 @@ export function withRest({ enum: _enum, ...rest }: P) {
         "rest binding element must still emit a source-annotation-derived return type: {output}"
     );
 }
+
+// Inferred `const` whose initializer is a call returning a single, top-level
+// exported conditional type-alias application is preserved as `Alias<args>`
+// rather than expanded to the conditional body — mirroring `tsc`'s
+// `declarationEmitRecursiveConditionalAliasPreserved` declaration emit.
+#[test]
+fn fix_inferred_call_return_preserves_exported_conditional_alias() {
+    let output = emit_dts_with_usage_analysis(
+        r#"
+export type Cond<T> = T extends string ? { s: T } : { n: T };
+declare function make<T>(t: T): Cond<T>;
+export const viaFn = make("x");
+"#,
+    );
+    assert!(
+        output.contains("export declare const viaFn: Cond<string>;"),
+        "single exported conditional alias application should be preserved, got: {output}"
+    );
+    assert!(
+        !output.contains("viaFn: {"),
+        "conditional alias body must not be expanded inline, got: {output}"
+    );
+}


### PR DESCRIPTION
AgentName: Studio-Opus
Implementation runner: M1-A

## Track
Declaration emit parity — conditional/recursive type-alias preservation (#12770).

## Invariant
When an inferred declaration type is exactly a single, nameable type-alias
application, `tsc` preserves the alias reference (e.g. `Cond<string>`) in the
emitted `.d.ts` instead of expanding the alias body. This is the rule the
`declarationEmitRecursiveConditionalAliasPreserved` baseline encodes.

## Structural rule
`When the inferred type of a const is exactly a single, top-level reference to a
conditional-bodied type alias that is locally declared and exported, tsc emits
the alias application as-written; tsz now does the same through the declaration
emitter's return-surface path.`

Previously tsz expanded the conditional body for such inferred consts, e.g.

```ts
export type Cond<T> = T extends string ? { s: T } : { n: T };
declare function make<T>(t: T): Cond<T>;
export const viaFn = make("x");
```

emitted `export declare const viaFn: { s: string };` instead of
`export declare const viaFn: Cond<string>;`.

## Scope
- Owner layer: emitter only (`crates/tsz-emitter/.../declaration_emitter`). No
  solver/checker/diagnostic changes.
- New helper `return_annotation_is_preservable_local_conditional_alias`
  recognizes a single top-level reference to an exported, local,
  conditional-bodied type alias.
- `call_expression_declared_return_surface_text` preserves the substituted alias
  text for that case instead of expanding.
- The divert-to-expansion gate
  (`call_expression_declared_return_has_source_conditional_alias`) is relaxed
  for the same case so the const reaches the reuse path.
- Adjacent-case matrix (all verified):
  - exported local conditional alias via function-declaration call → preserved (fixed)
  - imported conditional alias → preserved (unchanged; existing type-id path)
  - non-exported local conditional alias → expanded (unchanged; not nameable)
  - conditional alias nested inside a composite return type → expanded (unchanged)
  - non-conditional alias application → reused as before (unchanged)
  - explicit-annotation witness `Power<Num, PowerOf>` → preserved (unchanged)

## Project Corpus Impact
- Row: n/a
- Bug family: declaration-emit conditional/recursive type-alias preservation
- None expected: emitter-only text change that moves toward `tsc` baselines for
  inferred conditional-alias declaration emit; no checker/solver semantics
  change, so diagnostics and assignability are unaffected.

## Verification
- `cargo test -p tsz-emitter --lib declaration_emitter::` → 1472 passed, 0 failed.
- New unit tests in `type_inference_return_surface.rs` cover the preservable /
  unexported / non-conditional / nested discrimination.
- New e2e test in `fix_verification_returned.rs` asserts `viaFn: Cond<string>`.
- `cargo fmt -p tsz-emitter --check` and `cargo clippy -p tsz-emitter` clean.
- Manual CLI emit confirms the matrix above and the original #12770 witness
  (`declarationEmitRecursiveConditionalAliasPreserved`) still emits the
  preserved `Power<Num, PowerOf>` return annotation.

## Coordination Notes
- Addresses the declaration-emit / conditional-alias parity theme tracked in
  #12770. The specific accepted-regression witness already passes (its ledger
  entry was retired); this PR fixes the broader inferred-const family the issue
  describes.
- Out of scope (separate follow-ups, not regressed here): interface-method
  generic calls that drop the alias / mis-evaluate mapped-bodied returns
  (`obj.m("x")` → `boolean`), which are solver-side, not emitter-side.