### PR TITLE
fix(solver): restrict generic-function identity-sharing to free type params

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -759,6 +759,9 @@ mod generic_class_constructor_literal_preservation_tests;
 #[path = "tests/generic_class_self_ref_method_param_tests.rs"]
 mod generic_class_self_ref_method_param_tests;
 #[cfg(test)]
+#[path = "tests/generic_function_param_name_collision_assignability_tests.rs"]
+mod generic_function_param_name_collision_assignability_tests;
+#[cfg(test)]
 #[path = "../tests/generic_inference_manual.rs"]
 mod generic_inference_manual;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/generic_function_param_name_collision_assignability_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_function_param_name_collision_assignability_tests.rs
@@ -1,0 +1,152 @@
+//! Regression tests: assigning a generic function to a concrete function type
+//! must instantiate the generic source's type parameters regardless of whether
+//! the *target* parameter/return type happens to contain a nested generic
+//! signature whose type parameter shares a *name* with the source's.
+//!
+//! tsz interns `TypeParameter`s structurally by name, so two unrelated `T`s
+//! collapse to the same `TypeId`. The function-subtype relation previously had a
+//! shortcut that, on seeing the source's type-parameter `TypeId` anywhere inside
+//! the target, assumed shared identity and cleared the source quantifier without
+//! instantiation — leaving the source parameter free and producing a spurious
+//! `'X' is not assignable to 'T'` (`TS2322`/`TS2345`). The shortcut now only
+//! fires on *free* occurrences, so a coincidentally same-named parameter bound
+//! by a nested signature in the target no longer derails instantiation.
+//!
+//! Witness family: kysely's `build: ColumnDefinitionBuilderCallback = noop`,
+//! where `noop<T>(obj: T): T` is assigned to a callback whose parameter type
+//! (`ColumnDefinitionBuilder`) declares a generic method `$call<T>(...)`.
+use crate::test_utils::{check_source_diagnostics, diagnostics_with_code};
+
+/// Core repro: source `<T>(obj: T) => T` assigned to `(b: Box) => Box` where
+/// `Box` carries a generic method `call<T>` (same name as the source's `T`).
+/// The nested-bound `T` must not be mistaken for the source's `T`.
+#[test]
+fn generic_identity_assignable_to_callback_with_colliding_nested_param() {
+    let diags = check_source_diagnostics(
+        r#"
+function noop<T>(obj: T): T { return obj; }
+
+interface Box {
+  brand: "box";
+  call<T>(f: (x: this) => T): T;
+}
+type BoxCb = (b: Box) => Box;
+
+// Force `Box` to materialize to its full member shape (with `call<T>`).
+declare const probe: Box;
+const forced = probe.call((x) => x);
+
+const cb: BoxCb = noop; // must be OK — T instantiates to Box
+"#,
+    );
+
+    let ts2322 = diagnostics_with_code(&diags, 2322);
+    assert!(
+        ts2322.is_empty(),
+        "unexpected TS2322 assigning generic identity to colliding callback: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Name-independence: the same program with the nested parameter renamed must
+/// behave identically (no diagnostics). Demonstrates the fix is structural, not
+/// keyed on a particular identifier.
+#[test]
+fn generic_identity_assignable_to_callback_with_renamed_nested_param() {
+    let diags = check_source_diagnostics(
+        r#"
+function ident<Elem>(value: Elem): Elem { return value; }
+
+interface Widget {
+  brand: "widget";
+  apply<Result>(f: (x: this) => Result): Result;
+}
+type WidgetCb = (w: Widget) => Widget;
+
+declare const probe: Widget;
+const forced = probe.apply((x) => x);
+
+const cb: WidgetCb = ident; // OK regardless of the nested type-param name
+"#,
+    );
+
+    let ts2322 = diagnostics_with_code(&diags, 2322);
+    assert!(
+        ts2322.is_empty(),
+        "renamed nested param should not change assignability: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The same collision in argument position (`TS2345`): passing the generic
+/// identity to a parameter whose type declares a nested `<T>` method.
+#[test]
+fn generic_identity_passable_as_argument_with_colliding_nested_param() {
+    let diags = check_source_diagnostics(
+        r#"
+function noop<T>(obj: T): T { return obj; }
+
+interface Col {
+  brand: "col";
+  pipe<T>(f: (x: this) => T): T;
+}
+
+declare function addColumn(build: (b: Col) => Col): void;
+
+declare const probe: Col;
+const forced = probe.pipe((x) => x);
+
+addColumn(noop); // must be OK — argument instantiates T to Col
+"#,
+    );
+
+    let ts2345 = diagnostics_with_code(&diags, 2345);
+    assert!(
+        ts2345.is_empty(),
+        "unexpected TS2345 passing generic identity as colliding callback arg: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Covariant self-returning override across generic builder classes whose
+/// methods carry their own same-named type parameters must not raise a spurious
+/// `TS2416` (the kysely `Kysely<DB>`/`QueryCreator<DB>` family). The derived
+/// override returns the more specific instance type.
+#[test]
+fn self_returning_override_with_colliding_method_param_no_ts2416() {
+    let diags = check_source_diagnostics(
+        r#"
+class QueryCreator<DB> {
+  withPlugin(): QueryCreator<DB> { return this; }
+  call<T>(f: (x: this) => T): T { return f(this); }
+}
+
+class Kysely<DB> extends QueryCreator<DB> {
+  override withPlugin(): Kysely<DB> { return this; }
+  override call<T>(f: (x: this) => T): T { return f(this); }
+}
+
+declare const k: Kysely<{ a: number }>;
+const forced = k.call((x) => x);
+"#,
+    );
+
+    let ts2416 = diagnostics_with_code(&diags, 2416);
+    assert!(
+        ts2416.is_empty(),
+        "unexpected TS2416 on self-returning override with colliding method param: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -32,6 +32,37 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.check_function_subtype_impl(source, target, allow_constructor_bivariance)
     }
 
+    /// True when any of `candidate_tp_ids` occurs *free* in `shape`'s parameter
+    /// or return positions.
+    ///
+    /// Used when relating a generic signature to a non-generic one to detect a
+    /// genuine type-parameter identity shared between them (from contextual
+    /// seeding). tsz interns `TypeParameter`s structurally by name, so a
+    /// same-named parameter *bound* by a nested generic signature in `shape`
+    /// (e.g. a method `call<T>(...)` on a parameter type) shares the candidate's
+    /// `TypeId` without sharing identity; restricting to *free* occurrences
+    /// avoids treating that coincidence as identity-sharing, which would
+    /// otherwise skip contextual instantiation and emit spurious
+    /// `TS2322`/`TS2345`/`TS2416`.
+    fn shape_free_type_params_overlap(
+        &self,
+        candidate_tp_ids: &[TypeId],
+        shape: &FunctionShape,
+    ) -> bool {
+        if candidate_tp_ids.is_empty() {
+            return false;
+        }
+        let free = crate::visitors::visitor_predicates::free_type_parameter_ids_in(
+            self.interner,
+            shape
+                .params
+                .iter()
+                .map(|p| p.type_id)
+                .chain(std::iter::once(shape.return_type)),
+        );
+        candidate_tp_ids.iter().any(|id| free.contains(id))
+    }
+
     fn check_function_subtype_impl(
         &mut self,
         source: &FunctionShape,
@@ -405,20 +436,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // the source's type parameter TypeIds. In this case, the source and target already share
             // the same type parameter identity — no erasure or inference is needed; just clear the
             // source type params so structural comparison proceeds with matching TypeIds.
+            //
+            // Identity here must be a *free* occurrence of the source parameter in
+            // the target. tsz interns `TypeParameter`s structurally by name, so an
+            // unrelated same-named parameter bound by a nested generic signature in
+            // the target (e.g. a method `$call<T>(...)` on the target's parameter
+            // type) shares the source `T`'s `TypeId` without sharing its identity.
+            // Counting those bound occurrences would wrongly skip instantiation and
+            // leave the source parameter free, producing spurious TS2322/TS2345
+            // (`'X' is not assignable to 'T'`). Restrict the check to free
+            // occurrences so only genuine contextual-seeding shares identity.
             let source_tp_ids: Vec<TypeId> = source_instantiated
                 .type_params
                 .iter()
                 .map(|tp| self.interner.type_param(*tp))
                 .collect();
-            let target_refs_source_params = target_instantiated.params.iter().any(|p| {
-                source_tp_ids.contains(&p.type_id)
-                    || source_tp_ids.iter().any(|&tp_id| {
-                        crate::visitor::collect_all_types(self.interner, p.type_id).contains(&tp_id)
-                    })
-            }) || source_tp_ids.iter().any(|&tp_id| {
-                crate::visitor::collect_all_types(self.interner, target_instantiated.return_type)
-                    .contains(&tp_id)
-            });
+            let target_refs_source_params =
+                self.shape_free_type_params_overlap(&source_tp_ids, &target_instantiated);
 
             if target_refs_source_params {
                 // Target references source's type params — they share identity.
@@ -458,6 +492,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // same TypeParam as in the contextual type `<A>(x: A) => A[]`).
         // In this case, treat the source as effectively generic with the same type params.
         // Otherwise, fall back to erasing target type params to constraints.
+        //
+        // As with the generic-source branch above, only a *free* occurrence of the
+        // target parameter in the source signifies shared identity. A same-named
+        // parameter bound by a nested generic signature inside the source shares the
+        // interned `TypeId` without sharing identity and must not be counted, or a
+        // concrete source member is spuriously rejected as a subtype of the
+        // universally quantified target (false TS2416/TS2430).
         if source_instantiated.type_params.is_empty() && !target_instantiated.type_params.is_empty()
         {
             let target_tp_ids: Vec<TypeId> = target_instantiated
@@ -465,15 +506,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 .iter()
                 .map(|tp| self.interner.type_param(*tp))
                 .collect();
-            let source_refs_target_params = source_instantiated.params.iter().any(|p| {
-                target_tp_ids.contains(&p.type_id)
-                    || target_tp_ids.iter().any(|&tp_id| {
-                        crate::visitor::collect_all_types(self.interner, p.type_id).contains(&tp_id)
-                    })
-            }) || target_tp_ids.iter().any(|&tp_id| {
-                crate::visitor::collect_all_types(self.interner, source_instantiated.return_type)
-                    .contains(&tp_id)
-            });
+            let source_refs_target_params =
+                self.shape_free_type_params_overlap(&target_tp_ids, &source_instantiated);
 
             if source_refs_target_params {
                 if !self.erase_generics {

--- a/crates/tsz-solver/src/visitors/visitor_predicates.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates.rs
@@ -544,5 +544,5 @@ pub use content::{
     contains_free_type_parameters_except_name, contains_infer_types, contains_this_type,
     contains_type_by_id, contains_type_matching, contains_type_parameter_identity_shallow,
     contains_type_parameter_named, contains_type_parameter_named_shallow, contains_type_parameters,
-    references_any_type_param_named,
+    free_type_parameter_ids_in, references_any_type_param_named,
 };

--- a/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
@@ -3,7 +3,7 @@
 use crate::construction::TypeDatabase;
 use crate::types::IntrinsicKind;
 use crate::{TypeData, TypeId};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_common::Atom;
 
 use super::predicate_pool::with_predicate_buffers;
@@ -890,6 +890,259 @@ impl<'a> FreeTypeParamChecker<'a> {
             TypeData::StringIntrinsic { type_arg, .. } => self.check(*type_arg),
             TypeData::Enum(_def_id, member_type) => self.check(*member_type),
         }
+    }
+}
+
+/// Collect the `TypeId`s of every `TypeParameter`/`Infer` that occurs *free*
+/// across `roots`, i.e. not bound by an enclosing generic function/callable
+/// signature.
+///
+/// Type parameters in tsz are interned structurally by name, so two unrelated
+/// `T`s share a `TypeId`. Callers that compare against a specific parameter's
+/// identity must therefore only consider free occurrences: a parameter *bound*
+/// by a nested generic signature in the traversed type is a distinct
+/// declaration that merely shares an interned name, and must not be reported.
+///
+/// This mirrors [`FreeTypeParamChecker`]'s binder handling — the body of a
+/// nested generic signature is skipped wholesale rather than re-scoped — but
+/// returns the set of free parameter ids instead of a boolean. The result is a
+/// pure function of the input types and is memoized across all `roots` in a
+/// single pass (so e.g. a signature's parameters and return type share the
+/// walk); the walk is `stacker`-guarded because it runs inside the (already
+/// deep) subtype relation.
+///
+/// A `TypeParameter`'s `constraint`/`default` are metadata, not free uses, so
+/// they are not traversed — matching the rest of the free-parameter walkers.
+pub fn free_type_parameter_ids_in(
+    types: &dyn TypeDatabase,
+    roots: impl IntoIterator<Item = TypeId>,
+) -> FxHashSet<TypeId> {
+    let mut collector = FreeTypeParamCollector {
+        types,
+        memo: FxHashMap::default(),
+        guard: crate::recursion::RecursionGuard::with_profile(
+            crate::recursion::RecursionProfile::ShallowTraversal,
+        ),
+    };
+    let mut out = FxHashSet::default();
+    for root in roots {
+        out.extend(collector.free(root));
+    }
+    out
+}
+
+struct FreeTypeParamCollector<'a> {
+    types: &'a dyn TypeDatabase,
+    /// Memoized free-parameter set per `TypeId`. Freeness is a pure function of
+    /// the type (a generic signature contributes nothing; everything else is the
+    /// union of its children), so it can be cached without an ambient scope.
+    /// Memoization also keeps the walk linear over a shared type DAG — without it
+    /// a signature reused across many positions would be re-expanded and can
+    /// overflow the stack on real-world types.
+    memo: FxHashMap<TypeId, FxHashSet<TypeId>>,
+    guard: crate::recursion::RecursionGuard<TypeId>,
+}
+
+impl<'a> FreeTypeParamCollector<'a> {
+    fn free(&mut self, type_id: TypeId) -> FxHashSet<TypeId> {
+        if type_id.is_intrinsic() {
+            return FxHashSet::default();
+        }
+        if let Some(cached) = self.memo.get(&type_id) {
+            return cached.clone();
+        }
+        let Some(key) = self.types.lookup(type_id) else {
+            return FxHashSet::default();
+        };
+        // Terminal-kind fast path: these variants have no children and contribute
+        // no free parameters, so skip the recursion-guard/memo bookkeeping
+        // entirely. Mirrors `FreeTypeParamChecker::check`. `TypeParameter`/`Infer`
+        // are intentionally excluded — they are the leaves we collect.
+        if matches!(
+            key,
+            TypeData::Intrinsic(_)
+                | TypeData::Literal(_)
+                | TypeData::Error
+                | TypeData::ThisType
+                | TypeData::BoundParameter(_)
+                | TypeData::Lazy(_)
+                | TypeData::Recursive(_)
+                | TypeData::TypeQuery(_)
+                | TypeData::UniqueSymbol(_)
+                | TypeData::ModuleNamespace(_)
+                | TypeData::UnresolvedTypeName(_)
+        ) {
+            return FxHashSet::default();
+        }
+        // Cycle back-edges contribute no new free parameters (the parameter is
+        // already reachable from the ancestor on the stack), so return empty on
+        // re-entry and do not memoize the partial result.
+        match self.guard.enter(type_id) {
+            crate::recursion::RecursionResult::Entered => {}
+            _ => return FxHashSet::default(),
+        }
+        // Grow the native stack on demand: this walk runs *inside* the already
+        // deep subtype-relation recursion, so a deeply nested type can otherwise
+        // overflow. Mirrors `RecursiveTypeCollector::visit`.
+        let result =
+            stacker::maybe_grow(256 * 1024, 2 * 1024 * 1024, || self.free_key(type_id, &key));
+        self.guard.leave(type_id);
+        self.memo.insert(type_id, result.clone());
+        result
+    }
+
+    /// Free parameters of a signature. A *generic* signature binds its own type
+    /// parameters, so its body is skipped entirely — mirroring
+    /// [`FreeTypeParamChecker`]. This intentionally does not descend into a
+    /// generic signature to recover an outer parameter threaded through it; that
+    /// extra precision is unnecessary for the identity-sharing decision this
+    /// helper drives, and descending makes the walk dramatically deeper on
+    /// real-world recursive signature graphs. A *non-generic* signature binds
+    /// nothing, so its children's free parameters pass through.
+    fn free_signature(
+        &mut self,
+        is_generic: bool,
+        params: impl Iterator<Item = TypeId>,
+        return_type: TypeId,
+        this_type: Option<TypeId>,
+    ) -> FxHashSet<TypeId> {
+        let mut set = FxHashSet::default();
+        if is_generic {
+            return set;
+        }
+        for p in params {
+            set.extend(self.free(p));
+        }
+        set.extend(self.free(return_type));
+        if let Some(t) = this_type {
+            set.extend(self.free(t));
+        }
+        set
+    }
+
+    fn free_key(&mut self, type_id: TypeId, key: &TypeData) -> FxHashSet<TypeId> {
+        let mut set = FxHashSet::default();
+        match key {
+            TypeData::TypeParameter(_) | TypeData::Infer(_) => {
+                // A free occurrence. Its constraint/default are metadata, not
+                // free uses, so they are intentionally not traversed.
+                set.insert(type_id);
+            }
+            TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
+                // `object_shape` returns an owned `Arc`, so the iteration borrow
+                // is independent of `&mut self` and needs no intermediate Vec.
+                let shape = self.types.object_shape(*shape_id);
+                for child in shape
+                    .properties
+                    .iter()
+                    .map(|p| p.type_id)
+                    .chain(shape.string_index.as_ref().map(|i| i.value_type))
+                    .chain(shape.number_index.as_ref().map(|i| i.value_type))
+                {
+                    set.extend(self.free(child));
+                }
+            }
+            TypeData::Union(list_id) | TypeData::Intersection(list_id) => {
+                let members = self.types.type_list(*list_id);
+                for &m in members.iter() {
+                    set.extend(self.free(m));
+                }
+            }
+            TypeData::Array(elem) => set.extend(self.free(*elem)),
+            TypeData::Tuple(list_id) => {
+                let elems = self.types.tuple_list(*list_id);
+                for e in elems.iter() {
+                    set.extend(self.free(e.type_id));
+                }
+            }
+            TypeData::Function(shape_id) => {
+                let shape = self.types.function_shape(*shape_id);
+                set = self.free_signature(
+                    !shape.type_params.is_empty(),
+                    shape.params.iter().map(|p| p.type_id),
+                    shape.return_type,
+                    shape.this_type,
+                );
+            }
+            TypeData::Callable(shape_id) => {
+                let shape = self.types.callable_shape(*shape_id);
+                for s in shape
+                    .call_signatures
+                    .iter()
+                    .chain(shape.construct_signatures.iter())
+                {
+                    set.extend(self.free_signature(
+                        !s.type_params.is_empty(),
+                        s.params.iter().map(|p| p.type_id),
+                        s.return_type,
+                        s.this_type,
+                    ));
+                }
+                for p in shape.properties.iter() {
+                    set.extend(self.free(p.type_id));
+                }
+            }
+            TypeData::Application(app_id) => {
+                let app = self.types.type_application(*app_id);
+                for &a in app.args.iter() {
+                    set.extend(self.free(a));
+                }
+            }
+            TypeData::Conditional(cond_id) => {
+                let cond = self.types.get_conditional(*cond_id);
+                let parts = [
+                    cond.check_type,
+                    cond.extends_type,
+                    cond.true_type,
+                    cond.false_type,
+                ];
+                for part in parts {
+                    set.extend(self.free(part));
+                }
+            }
+            TypeData::Mapped(mapped_id) => {
+                let mapped = self.types.get_mapped(*mapped_id);
+                for part in [
+                    Some(mapped.constraint),
+                    Some(mapped.template),
+                    mapped.name_type,
+                ]
+                .into_iter()
+                .flatten()
+                {
+                    set.extend(self.free(part));
+                }
+            }
+            TypeData::IndexAccess(obj, idx) => {
+                set.extend(self.free(*obj));
+                set.extend(self.free(*idx));
+            }
+            TypeData::TemplateLiteral(list_id) => {
+                let spans = self.types.template_list(*list_id);
+                for span in spans.iter() {
+                    if let crate::types::TemplateSpan::Type(t) = span {
+                        set.extend(self.free(*t));
+                    }
+                }
+            }
+            TypeData::KeyOf(inner) | TypeData::ReadonlyType(inner) | TypeData::NoInfer(inner) => {
+                set.extend(self.free(*inner));
+            }
+            TypeData::StringIntrinsic { type_arg, .. } => set.extend(self.free(*type_arg)),
+            TypeData::Enum(_def_id, member_type) => set.extend(self.free(*member_type)),
+            TypeData::Intrinsic(_)
+            | TypeData::Literal(_)
+            | TypeData::Error
+            | TypeData::ThisType
+            | TypeData::BoundParameter(_)
+            | TypeData::Lazy(_)
+            | TypeData::Recursive(_)
+            | TypeData::TypeQuery(_)
+            | TypeData::UniqueSymbol(_)
+            | TypeData::ModuleNamespace(_)
+            | TypeData::UnresolvedTypeName(_) => {}
+        }
+        set
     }
 }
 


### PR DESCRIPTION
AgentName: M4-B
Implementation runner: lucid-hopper

## Summary

Fixes a soundness gap in the function-subtype relation that produced spurious
`TS2322`/`TS2345` (and could feed `TS2416`) when a **generic function** is
assigned to / passed where a **concrete function type** is expected, and the
target's parameter or return type structurally contains a *nested generic
signature* whose type parameter happens to share a **name** with the source's.

`tsz` interns type parameters structurally by name (+constraint/default), so two
unrelated `T`s (e.g. `noop`'s `T` and a method `call`'s `T` on the target's
parameter type) collapse to the **same `TypeId`**. The generic-source to
non-generic-target branch of `check_function_subtype_impl` had a shortcut that,
on seeing the source's type-parameter `TypeId` *anywhere* inside the target,
assumed shared identity and cleared the source quantifier **without
instantiation** — leaving the source parameter free and yielding
`'X' is not assignable to 'T'`.

### Structural rule

> When a generic source signature is related to a non-generic target signature,
> the source's type parameters are shared with the target only if they occur
> **free** in the target. A type parameter **bound** by a nested generic
> signature inside the target is a distinct declaration that merely shares an
> interned name; it must not suppress contextual instantiation
> (`instantiateSignatureInContextOf`). tsc resolves this via per-declaration
> type-parameter identity; tsz now restricts the identity-sharing shortcut to
> free occurrences via a binder-aware walk.

The symmetric non-generic-source to generic-target check (which gates strict
member-compatibility `TS2416`/`TS2430`) is fixed the same way, so a concrete
member is no longer spuriously rejected against a universally-quantified base
when a nested method shares a type-parameter name.

### Witness

kysely's `addColumn(build: ColumnDefinitionBuilderCallback = noop)` where
`noop` is the generic identity `(obj: T) => T` assigned to a callback whose
parameter type (`ColumnDefinitionBuilder`) declares a generic method `$call`.
The error only surfaced once `ColumnDefinitionBuilder` was materialized to its
full member shape, which is why it presented as an order-/whole-program-dependent
false positive.

## Track
Solver — relations (function subtype / contextual signature instantiation).

## Invariant
Type-parameter identity in relations is per-declaration, not per-interned-name:
a parameter bound by a nested signature in the counterpart type must not be
treated as the same parameter. Assignability of a generic function to a
concrete function type is name-independent.

## Scope
- `crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs`:
  replace `collect_all_types(...).contains(tp_id)` (which counts bound nested
  params) with a free-type-parameter membership test, for both the
  generic-source-to-non-generic-target and non-generic-source-to-generic-target
  branches.
- `crates/tsz-solver/src/visitors/visitor_predicates/content.rs`: add
  `free_type_parameter_ids_in`, a binder-aware collector mirroring
  `FreeTypeParamChecker` (skips bodies of nested generic signatures, memoized,
  `stacker`-guarded), shared by both call sites via a
  `shape_free_type_params_overlap` helper.
- Re-export in `visitor_predicates.rs`.
- Checker regression tests:
  `generic_function_param_name_collision_assignability_tests.rs` (assignment
  `TS2322`, argument `TS2345`, self-returning override `TS2416`, plus a
  renamed-binder control proving name-independence).

## Project Corpus Impact
- Row: kysely-project
- Bug family: generic-function-to-concrete-function assignability (type-parameter name-collision; TS2322/TS2345, symmetric TS2416/TS2430)

kysely guard config (`tsconfig.tsz-guard.json`), deterministic:
- Before: **189** diagnostics.
- After: **176** diagnostics (−13; the entire `noop` callback-default
  `TS2322` family across `schema/alter-table-builder.ts` and
  `schema/create-table-builder.ts`).

No new diagnostics introduced. The remaining kysely families (`withPlugin`
self-referential `TS2416` recursion; `selectFrom` contextual-generic chains,
#8773) are distinct root causes tracked separately under #10663.

## Verification
- Deterministic minimal repro (generic identity assigned to a concrete callback
  whose parameter type carries a generic method named `T`): errored before,
  clean after; renamed-param control clean both ways.
- kysely guard-config counts above (clean checkout).
- New checker regression tests pass (4/4).
- `cargo test -p tsz-solver --lib`: 6565 passed, 2 failed — both failures
  pre-exist on the clean baseline (unrelated `evaluate_application_variadic_…`
  and `higher_order_generic_pipe_…`).

## Coordination Notes
Component fix toward #10663 (kysely row). Does not touch the `TS2416`
`withPlugin` self-recursion or the #8773 contextual-generic chain — left for
follow-ups. No public API changes beyond the new internal solver helper
(`free_type_parameter_ids_in`).

Follow-up (out of scope here):
`checking/generic_constraints.rs::type_param_appears_bare` uses the same
`collect_all_types(...).contains(tp_id)` pattern and walks into nested generic
signature bodies, so it shares the latent name-collision hazard in the
constraint-erasure path. It can later be rerouted through
`free_type_parameter_ids_in`. Left untouched to keep this change focused and
avoid altering the erase-generics path without dedicated coverage.

Note on local suites: `cargo test -p tsz-checker --lib` and `-p tsz-solver
--lib` have pre-existing failures on this branch (and a pre-existing stack
overflow in the full checker lib run) that are unrelated to this change —
verified by running the same tests on the clean baseline. Broad validation is
owned by ready-review CI per the repo contract.

https://claude.ai/code/session_01D25MxKNPULcxUQBfyeZ4N2