### PR TITLE
chore(conformance): retire resolved accepted regressions

### DIFF
--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -41,6 +41,9 @@
 #   circularReference.ts resolved after rebasing on current main. It also found
 #   privateNamesAndIndexedAccess.ts as a new unlisted row; that row is tracked
 #   in an issue instead of growing this ledger.
+# - PR #12822 run 27068748412 at synthetic merge 7260874ab3 found three
+#   non-compiler rows resolved; the compiler/* rows still appear in the
+#   exact-head aggregate and stay listed.
 # Keep these visible as accepted-regression debt until their owning parity
 # fixes remove them from exact-head aggregate output.
 TypeScript/tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts
@@ -59,9 +62,6 @@ TypeScript/tests/cases/compiler/promisesWithConstraints.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts
 TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts
 TypeScript/tests/cases/conformance/jsdoc/importTag17.ts
-TypeScript/tests/cases/conformance/node/nodeModulesImportAttributesTypeModeDeclarationEmitErrors.ts
-TypeScript/tests/cases/conformance/node/nodeModulesImportTypeModeDeclarationEmitErrors1.ts
-TypeScript/tests/cases/conformance/parser/ecmascript5/Fuzz/parser0_004152.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes2.ts
 TypeScript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
conformance accepted-regression ledger cleanup

## Invariant
When exact-head conformance aggregate reports accepted-regression entries as resolved, the strictness ledger should retire those rows and keep still-failing rows visible. This PR updates only the accepted-regression artifact.

## Scope
- Remove three resolved accepted-regression rows from `scripts/conformance/conformance-accepted-regressions.txt`: the two node type-mode declaration emit rows and `parser0_004152.ts`.
- Record that the earlier compiler rows still fail in exact-head aggregate and remain listed.

## Project Corpus Impact
- Row: n/a
- Bug family: conformance accepted-regression strictness
- Evidence: Project corpus rows unchanged; this only reduces the accepted-regression ledger from 22 to 19 using exact-head aggregate evidence from PR #12822 run 27068748412.

## Verification
- `python3 scripts/conformance/check-accepted-regression-growth.py --base-ref origin/main --head-ref HEAD --allow-unavailable-base`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `git diff --check origin/main..HEAD`
- CI evidence: PR #12822 run 27068748412 reported the three removed rows as `RESOLVED` and kept the compiler rows as still regressed; branch was corrected and rebased onto current `origin/main`.

## Coordination Notes
- No owned Studio-A PRs were open at cycle start.
- Issue #10663 remains the owned Kysely row tracker, but its current implementation slice is WIP-claimed by another agent in comments, so this PR does not touch it.
- `scripts/agents/ensure-agent-labels.sh --audit` still reports pre-existing unlabeled PRs/issues outside this PR scope.
