### PR TITLE
refactor(checker): route interface heritage fallback outcomes

### DIFF
--- a/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
+++ b/crates/tsz-checker/src/classes/interface_heritage_index_compat.rs
@@ -209,7 +209,10 @@ impl<'a> CheckerState<'a> {
         if crate::query_boundaries::class::generic_erasure_fallback_is_safe(self, derived, base) {
             return false;
         }
-        if !self.diagnostic_relation_boolean_guard_bivariant(derived, base) {
+        if !self
+            .bivariant_callbacks_relation_outcome(derived, base)
+            .related
+        {
             return false;
         }
         let (Some(derived_return), Some(base_return)) = (
@@ -218,7 +221,8 @@ impl<'a> CheckerState<'a> {
         ) else {
             return false;
         };
-        self.diagnostic_relation_boolean_guard_no_erase_generics(derived_return, base_return)
+        self.no_erase_generics_relation_outcome(derived_return, base_return)
+            .related
     }
 
     /// Return type of a callable member that has exactly one call signature and
@@ -277,7 +281,8 @@ impl<'a> CheckerState<'a> {
         )
         .map(|p| p.type_id)
         .unwrap_or(raw_derived_member);
-        self.diagnostic_relation_boolean_guard_no_erase_generics(derived, base_member)
+        self.no_erase_generics_relation_outcome(derived, base_member)
+            .related
     }
 
     pub(super) fn type_base_def_id(&self, type_id: TypeId) -> Option<tsz_solver::def::DefId> {

--- a/crates/tsz-checker/src/tests/class_boundary_fallback_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/class_boundary_fallback_relation_routing_arch_tests.rs
@@ -87,7 +87,7 @@ fn class_boundary_no_erase_generic_probes_use_relation_outcome_boundary() {
 }
 
 #[test]
-fn interface_heritage_member_fallbacks_use_named_diagnostic_relation_guards() {
+fn interface_heritage_member_fallbacks_use_relation_outcome_boundaries() {
     let source = fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("src/classes/interface_heritage_index_compat.rs"),
@@ -100,20 +100,23 @@ fn interface_heritage_member_fallbacks_use_named_diagnostic_relation_guards() {
         .and_then(|tail| tail.split("fn single_call_signature_return_type").next())
         .expect("failed to isolate nongeneric override fallback helper");
     assert!(
-        nongeneric_override_helper
-            .contains("diagnostic_relation_boolean_guard_bivariant(derived, base)"),
-        "non-generic override fallback should name the bivariant diagnostic boolean guard"
+        nongeneric_override_helper.contains("bivariant_callbacks_relation_outcome(derived, base)")
+            && nongeneric_override_helper.contains(".related"),
+        "non-generic override fallback should route the bivariant probe through RelationOutcome"
     );
     assert!(
-        nongeneric_override_helper.contains(
-            "diagnostic_relation_boolean_guard_no_erase_generics(derived_return, base_return)"
-        ),
-        "non-generic override fallback should name the no-erase return diagnostic boolean guard"
+        nongeneric_override_helper
+            .contains("no_erase_generics_relation_outcome(derived_return, base_return)")
+            && nongeneric_override_helper.contains(".related"),
+        "non-generic override fallback should route the no-erase return probe through RelationOutcome"
     );
     assert!(
         !nongeneric_override_helper.contains("is_assignable_to_bivariant(")
-            && !nongeneric_override_helper.contains("is_assignable_to_no_erase_generics("),
-        "non-generic override fallback should not embed raw relation predicates"
+            && !nongeneric_override_helper.contains("is_assignable_to_no_erase_generics(")
+            && !nongeneric_override_helper.contains("diagnostic_relation_boolean_guard_bivariant(")
+            && !nongeneric_override_helper
+                .contains("diagnostic_relation_boolean_guard_no_erase_generics("),
+        "non-generic override fallback should not embed raw relation predicates or boolean guards"
     );
 
     let this_member_helper = source
@@ -122,13 +125,14 @@ fn interface_heritage_member_fallbacks_use_named_diagnostic_relation_guards() {
         .and_then(|tail| tail.split("pub(super) fn type_base_def_id").next())
         .expect("failed to isolate polymorphic this fallback helper");
     assert!(
-        this_member_helper
-            .contains("diagnostic_relation_boolean_guard_no_erase_generics(derived, base_member)"),
-        "polymorphic-this fallback should name the no-erase diagnostic boolean guard"
+        this_member_helper.contains("no_erase_generics_relation_outcome(derived, base_member)")
+            && this_member_helper.contains(".related"),
+        "polymorphic-this fallback should route the no-erase probe through RelationOutcome"
     );
     assert!(
-        !this_member_helper.contains("is_assignable_to_no_erase_generics("),
-        "polymorphic-this fallback should not embed a raw no-erase relation predicate"
+        !this_member_helper.contains("is_assignable_to_no_erase_generics(")
+            && !this_member_helper.contains("diagnostic_relation_boolean_guard_no_erase_generics("),
+        "polymorphic-this fallback should not embed a raw no-erase relation predicate or boolean guard"
     );
 }
 


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Semantic campaign / refactor-only relation diagnostic routing (#8227).

## Invariant
When interface-heritage TS2430 fallback logic checks a non-generic override against a generic base method or a polymorphic `this` member against a base member, `tsc` makes the compatibility decision through relation semantics; this PR keeps tsz behavior the same while routing the checker fallback through RelationOutcome-shaped helpers instead of checker-local diagnostic boolean guards.

## Scope
- `crates/tsz-checker/src/classes/interface_heritage_index_compat.rs`: route bivariant and no-erase fallback probes through existing RelationOutcome helpers.
- `crates/tsz-checker/src/tests/class_boundary_fallback_relation_routing_arch_tests.rs`: ratchet the architecture test so these fallback paths stay on RelationOutcome boundaries.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only checker relation-routing cleanup; no project-row-specific behavior change intended.

## Verification
- `cargo fmt`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib interface_heritage_member_fallbacks_use_relation_outcome_boundaries class_boundary_no_erase_generic_probes_use_relation_outcome_boundary`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib no_false_2430_method_param_narrowing_stays_bivariant no_false_2430_nongeneric_method_can_override_generic_input_only` (matched/passed the bivariant test; second filter is stale/no match)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib no_false_2430_input_only_constrained_generic_covariant_return no_false_2430_input_only_constrained_generic_renamed no_false_2430_method_param_narrowing_stays_bivariant keeps_2430_bare_generic_return_dropped`
- `scripts/arch/check-checker-boundaries.sh`
- Draft PR CI on head `521767afb239d4b446e108e7fb34011d33b57be9`: CI Light Summary passed.

## Coordination Notes
- Ready after local verification plus green draft CI on inspected head `521767afb239d4b446e108e7fb34011d33b57be9`.
- Owned PR intake before this slice: no open `agent:M1-B` PRs; #11346 and #8225 have active WIP elsewhere, so this continues #8227 without overlap.
- `scripts/agents/ensure-agent-labels.sh --audit` failed only on unrelated open PRs/issues missing canonical labels; this PR has `agent:M1-B`.
