### PR TITLE
chore(bench): publish target-gap attribution plan

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1378,7 +1378,8 @@ jobs:
           set -euo pipefail
           node scripts/bench/tsgo-winner-report.mjs \
             "$GITHUB_WORKSPACE/bench-results.json" \
-            "$GITHUB_WORKSPACE/bench-results-tsgo-winners.json"
+            "$GITHUB_WORKSPACE/bench-results-tsgo-winners.json" \
+            "$GITHUB_WORKSPACE/bench-results-missing-attribution.md"
 
       - name: Compare project winner regressions
         continue-on-error: true
@@ -1425,6 +1426,7 @@ jobs:
           path: |
             bench-results.json
             bench-results-tsgo-winners.json
+            bench-results-missing-attribution.md
             bench-results-project-winner-regressions.json
             bench-results-project-winner-regressions.md
             bench-results-readiness.json
@@ -1447,6 +1449,9 @@ jobs:
           gsutil -q cp "$GITHUB_WORKSPACE/bench-results-tsgo-winners.json" \
             "${_TSZ_CI_CACHE_BUCKET}/bench-runs/${TIMESTAMP}.tsgo-winners.json"
           echo "Published: ${_TSZ_CI_CACHE_BUCKET}/bench-runs/${TIMESTAMP}.tsgo-winners.json"
+          gsutil -q cp "$GITHUB_WORKSPACE/bench-results-missing-attribution.md" \
+            "${_TSZ_CI_CACHE_BUCKET}/bench-runs/${TIMESTAMP}.missing-attribution.md"
+          echo "Published: ${_TSZ_CI_CACHE_BUCKET}/bench-runs/${TIMESTAMP}.missing-attribution.md"
 
           if [[ -n "${MAIN_SHA}" && "${TARGET_SHA}" != "${MAIN_SHA}" ]]; then
             echo "Bench target ${TARGET_SHA} is behind current main ${MAIN_SHA}; publishing because active benchmark runs are intentionally allowed to finish."
@@ -1458,6 +1463,9 @@ jobs:
           gsutil -q cp "$GITHUB_WORKSPACE/bench-results-tsgo-winners.json" \
             "${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.tsgo-winners.json"
           echo "Published: ${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.tsgo-winners.json"
+          gsutil -q cp "$GITHUB_WORKSPACE/bench-results-missing-attribution.md" \
+            "${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.missing-attribution.md"
+          echo "Published: ${_TSZ_CI_CACHE_BUCKET}/bench-runs/latest.missing-attribution.md"
           echo "should_redeploy=true" >> "$GITHUB_OUTPUT"
 
       - name: Report severe benchmark gaps

--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -28,7 +28,9 @@ function writeJson(file, value) {
   fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-const { createTsgoWinnerReport } = await import(pathToFileURL(SCRIPT));
+const { createTsgoWinnerReport, renderMissingAttributionPlanMarkdown } = await import(
+  pathToFileURL(SCRIPT)
+);
 
 {
   const report = createTsgoWinnerReport(
@@ -51,6 +53,7 @@ const { createTsgoWinnerReport } = await import(pathToFileURL(SCRIPT));
 withTempDir((dir) => {
   const input = path.join(dir, "bench.json");
   const output = path.join(dir, "report.json");
+  const attributionPlan = path.join(dir, "missing-attribution.md");
   writeJson(input, {
     benchmark_runner: "scripts/bench/bench-vs-tsgo.sh",
     quick_mode: true,
@@ -188,11 +191,12 @@ withTempDir((dir) => {
     ],
   });
 
-  const result = spawnSync(process.execPath, [SCRIPT, input, output], {
+  const result = spawnSync(process.execPath, [SCRIPT, input, output, attributionPlan], {
     cwd: ROOT,
     encoding: "utf8",
   });
   assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /missing attribution plan:/);
 
   const report = JSON.parse(fs.readFileSync(output, "utf8"));
   assert.equal(report.source.quick_mode, true);
@@ -248,6 +252,14 @@ withTempDir((dir) => {
     report.target_gaps.map((row) => row.name),
     ["ts-toolbelt-project", "vite-vanilla-ts-app", "single-file-loss"],
   );
+  const planMarkdown = fs.readFileSync(attributionPlan, "utf8");
+  assert.match(planMarkdown, /^# 2x Target Gap Attribution Plan/m);
+  assert.match(planMarkdown, /Rows below 2x target \| 3/);
+  assert.match(planMarkdown, /## 1\. vite-vanilla-ts-app/);
+  assert.match(planMarkdown, /## 2\. single-file-loss/);
+  assert.match(planMarkdown, /Attribution command:/);
+  assert.match(planMarkdown, /vite-vanilla-ts-app\.perf\.json/);
+  assert.match(planMarkdown, /Attribution command: n\/a/);
   assert.equal(report.target_gaps[0].semantic_owner_family, "recursive type evaluation pressure");
   assert.equal(report.target_gaps[0].tsz_speedup_vs_tsgo, 106.15 / 873.92);
   assert.equal(report.target_gaps[0].target_gap_factor, 2 / (106.15 / 873.92));
@@ -323,6 +335,21 @@ withTempDir((dir) => {
   assert.equal(importedReport.totals.green_tsgo_winners, 3);
   assert.equal(importedReport.worst.name, "ts-toolbelt-project");
 });
+
+{
+  const markdown = renderMissingAttributionPlanMarkdown({
+    generated_at: "2026-06-06T00:00:00.000Z",
+    source: { path: "bench-results.json" },
+    two_x_target: {
+      eligible_green_rows: 1,
+      rows_below_target: 0,
+      project_rows_below_target: 0,
+      rows_with_attribution: 0,
+      missing_attribution_plan: [],
+    },
+  });
+  assert.match(markdown, /All current 2x target gap rows have attribution evidence\./);
+}
 
 withTempDir((dir) => {
   const input = path.join(dir, "bench.json");
@@ -982,13 +1009,13 @@ withTempDir((dir) => {
 const benchWorkflow = fs.readFileSync(BENCH_WORKFLOW, "utf8");
 assert.match(
   benchWorkflow,
-  /node scripts\/bench\/tsgo-winner-report\.mjs\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results\.json"\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results-tsgo-winners\.json"/,
+  /node scripts\/bench\/tsgo-winner-report\.mjs\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results\.json"\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results-tsgo-winners\.json"\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results-missing-attribution\.md"/,
   "bench workflow should generate the green tsgo winner report from merged results",
 );
 assert.match(
   benchWorkflow,
-  /bench-results\.json\s*\n\s+bench-results-tsgo-winners\.json/,
-  "merged benchmark artifact should upload the green tsgo winner report",
+  /bench-results\.json\s*\n\s+bench-results-tsgo-winners\.json\s*\n\s+bench-results-missing-attribution\.md/,
+  "merged benchmark artifact should upload the green tsgo winner report and attribution plan",
 );
 assert.match(
   benchWorkflow,
@@ -997,8 +1024,18 @@ assert.match(
 );
 assert.match(
   benchWorkflow,
+  /bench-runs\/\$\{TIMESTAMP\}\.missing-attribution\.md/,
+  "benchmark publish step should write timestamped missing-attribution plans",
+);
+assert.match(
+  benchWorkflow,
   /bench-runs\/latest\.tsgo-winners\.json/,
   "benchmark publish step should write latest green tsgo winner reports",
+);
+assert.match(
+  benchWorkflow,
+  /bench-runs\/latest\.missing-attribution\.md/,
+  "benchmark publish step should write latest missing-attribution plans",
 );
 assert.match(
   benchWorkflow,

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -469,6 +469,75 @@ function missingAttributionPlanForRow(row) {
   };
 }
 
+function markdownValue(value) {
+  if (value == null || value === "") return "n/a";
+  return String(value).replaceAll("|", "\\|");
+}
+
+function formatNumber(value, digits = 2) {
+  const number = asNumber(value);
+  return number == null ? "n/a" : number.toFixed(digits);
+}
+
+export function renderMissingAttributionPlanMarkdown(report) {
+  const target = report?.two_x_target ?? {};
+  const rows = Array.isArray(target.missing_attribution_plan)
+    ? target.missing_attribution_plan
+    : [];
+  const lines = [
+    "# 2x Target Gap Attribution Plan",
+    "",
+    `Generated: ${markdownValue(report?.generated_at)}`,
+    `Source: ${markdownValue(report?.source?.path)}`,
+    "",
+    "| Metric | Value |",
+    "| --- | ---: |",
+    `| Eligible green rows | ${markdownValue(target.eligible_green_rows)} |`,
+    `| Rows below 2x target | ${markdownValue(target.rows_below_target)} |`,
+    `| Project rows below 2x target | ${markdownValue(target.project_rows_below_target)} |`,
+    `| Rows with attribution | ${markdownValue(target.rows_with_attribution)} |`,
+    `| Missing attribution rows | ${rows.length} |`,
+    "",
+  ];
+
+  if (rows.length === 0) {
+    lines.push("All current 2x target gap rows have attribution evidence.", "");
+    return `${lines.join("\n")}\n`;
+  }
+
+  lines.push(
+    "| Rank | Row | Speedup vs tsgo | Gap factor | Owner | Issue |",
+    "| ---: | --- | ---: | ---: | --- | --- |",
+  );
+  rows.forEach((row, index) => {
+    lines.push(
+      `| ${index + 1} | \`${markdownValue(row.name)}\` | ${formatNumber(row.tsz_speedup_vs_tsgo)}x | ${formatNumber(row.target_gap_factor)}x | ${markdownValue(row.owner)} | ${row.url ? `[${markdownValue(row.issue)}](${row.url})` : markdownValue(row.issue)} |`,
+    );
+  });
+
+  lines.push("");
+  rows.forEach((row, index) => {
+    lines.push(
+      `## ${index + 1}. ${markdownValue(row.name)}`,
+      "",
+      `Owner: ${markdownValue(row.owner)}`,
+      `Semantic family: ${markdownValue(row.semantic_owner_family)}`,
+      `Attribution status: ${markdownValue(row.attribution_warning)}`,
+      "",
+    );
+    if (row.attribution_command) {
+      lines.push("Attribution command:", "", "```bash", row.attribution_command, "```", "");
+    } else {
+      lines.push("Attribution command: n/a", "");
+    }
+    if (row.timing_command) {
+      lines.push("Timing command:", "", "```bash", row.timing_command, "```", "");
+    }
+  });
+
+  return `${lines.join("\n")}\n`;
+}
+
 function targetGapFactor(speedup) {
   if (speedup == null || speedup <= 0) return null;
   return TARGET_TSZ_SPEEDUP / speedup;
@@ -654,25 +723,37 @@ export function writeTsgoWinnerReport(inputPath, outputPath) {
   return report;
 }
 
+export function writeMissingAttributionPlan(report, outputPath) {
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, renderMissingAttributionPlanMarkdown(report));
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const [inputPath, outputPath] = process.argv.slice(2);
+  const [inputPath, outputPath, attributionPlanPath] = process.argv.slice(2);
 
   if (!inputPath || !outputPath) {
-    console.error("usage: tsgo-winner-report.mjs <bench-results.json> <output.json>");
+    console.error("usage: tsgo-winner-report.mjs <bench-results.json> <output.json> [missing-attribution.md]");
     process.exit(2);
   }
 
   const report = writeTsgoWinnerReport(inputPath, outputPath);
-  console.log(
-    [
-      `green tsgo winners: ${report.totals.green_tsgo_winners}`,
-      `project green tsgo winners: ${report.totals.project_green_tsgo_winners}`,
-      `2x target gaps: ${report.two_x_target.rows_below_target}/${report.two_x_target.eligible_green_rows}`,
-      `2x target gaps with attribution: ${report.two_x_target.rows_with_attribution}/${report.two_x_target.rows_below_target}`,
-      `2x target gaps with attribution commands: ${report.two_x_target.rows_with_attribution_command}/${report.two_x_target.rows_below_target}`,
-      `report: ${path.relative(process.cwd(), outputPath).split(path.sep).join("/")}`,
-    ].join("\n"),
-  );
+  if (attributionPlanPath) {
+    writeMissingAttributionPlan(report, attributionPlanPath);
+  }
+  const outputLines = [
+    `green tsgo winners: ${report.totals.green_tsgo_winners}`,
+    `project green tsgo winners: ${report.totals.project_green_tsgo_winners}`,
+    `2x target gaps: ${report.two_x_target.rows_below_target}/${report.two_x_target.eligible_green_rows}`,
+    `2x target gaps with attribution: ${report.two_x_target.rows_with_attribution}/${report.two_x_target.rows_below_target}`,
+    `2x target gaps with attribution commands: ${report.two_x_target.rows_with_attribution_command}/${report.two_x_target.rows_below_target}`,
+    `report: ${path.relative(process.cwd(), outputPath).split(path.sep).join("/")}`,
+  ];
+  if (attributionPlanPath) {
+    outputLines.push(
+      `missing attribution plan: ${path.relative(process.cwd(), attributionPlanPath).split(path.sep).join("/")}`,
+    );
+  }
+  console.log(outputLines.join("\n"));
 
   if (report.totals.duplicate_project_rows > 0) {
     console.error(


### PR DESCRIPTION
AgentName: Studio-Opus
Track: Track 10 benchmark evidence / performance attribution
Invariant: When eligible green timed rows miss the 2x target, benchmark artifacts must expose a ranked, runnable attribution plan. This PR changes only benchmark reporting and publication; compiler semantics, timing behavior, and row readiness decisions are unchanged.
Scope: Adds optional Markdown rendering to scripts/bench/tsgo-winner-report.mjs, wires the Bench workflow to upload and publish bench-results-missing-attribution.md, and extends report/workflow tests.

## Project Corpus Impact
- Row: n/a (benchmark artifact/reporting only; no project row readiness or compiler behavior change)
- Bug family: benchmark artifact schema / 2x target attribution evidence
- Impact: No project row behavior changes. A smoke run against workflow artifact 27065012419 regenerated a plan for the current 14 target gaps, including 5 project rows; worst current project gap is vite-vanilla-ts-app at 0.56x vs tsgo / 3.54x gap factor.

Verification:
- node scripts/bench/test-tsgo-winner-report.mjs
- node scripts/bench/test-bench-readiness-banner.mjs
- node scripts/bench/test-perf-hotspots.mjs
- git diff --check
- node scripts/bench/tsgo-winner-report.mjs /tmp/tsz-bench-27065012419/bench-results-merged/bench-results.json /tmp/tsz-bench-27065012419/bench-results-merged/regenerated-tsgo-winners.json /tmp/tsz-bench-27065012419/bench-results-merged/regenerated-missing-attribution.md
Coordination Notes: Studio-Opus artifact infrastructure PR. This gives Studio-A/B/C and performance lanes a first-class missing-attribution worklist without claiming ordinary compiler speedups or altering winner/readiness gates.