### PR TITLE
fix(module-resolution): select one tsc-best paths pattern, no fall-through

### DIFF
--- a/crates/tsz-cli/src/driver/resolution/path_resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution/path_resolution.rs
@@ -331,17 +331,13 @@ pub(crate) fn select_path_mapping(
     mappings: &[PathMapping],
     specifier: &str,
 ) -> Option<(usize, String)> {
-    // `build_path_mappings` sorts by TypeScript precedence:
-    // longest prefix, then longest pattern, then lexical pattern. The first
-    // match is therefore the best match.
-    for (idx, mapping) in mappings.iter().enumerate() {
-        let Some(wildcard) = mapping.match_specifier(specifier) else {
-            continue;
-        };
-        return Some((idx, wildcard));
-    }
-
-    None
+    // Route through the shared `PathMapping::select_best` so the driver and the
+    // `tsz-core` checker resolver pick the same single tsc-best pattern
+    // (`matchPatternOrExact` -> `findBestPatternMatch`): an exact wildcard-free
+    // key wins outright, otherwise the longest-prefix wildcard. Neither falls
+    // through to a less-specific pattern when the chosen one's targets are
+    // missing on disk.
+    PathMapping::select_best(mappings, specifier)
 }
 
 pub(crate) fn substitute_path_target(target: &str, wildcard: &str) -> String {

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -1456,6 +1456,14 @@ fn build_path_mappings(paths: &FxHashMap<String, Vec<String>>) -> Vec<PathMappin
         right
             .specificity()
             .cmp(&left.specificity())
+            // tsc's `matchPatternOrExact` returns an exact, wildcard-free key
+            // equal to the specifier *before* it consults any wildcard pattern
+            // via `findBestPatternMatch`. An exact key always has a prefix as
+            // long as the specifier, so it can only tie (never lose) on
+            // `specificity` against a matching wildcard; break that tie in
+            // favour of the literal key so the pre-sorted "first match wins"
+            // selection mirrors tsc's exact-beats-wildcard precedence.
+            .then_with(|| left.pattern.contains('*').cmp(&right.pattern.contains('*')))
             .then_with(|| right.pattern.len().cmp(&left.pattern.len()))
             .then_with(|| left.pattern.cmp(&right.pattern))
     });

--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -228,6 +228,41 @@ impl PathMapping {
     pub const fn specificity(&self) -> usize {
         self.prefix.len()
     }
+
+    /// Select the single tsc-best mapping in `mappings` for `specifier`,
+    /// mirroring tsc's `matchPatternOrExact` -> `findBestPatternMatch`.
+    ///
+    /// An exact, wildcard-free key equal to the specifier wins outright;
+    /// otherwise the matching wildcard with the longest prefix (highest
+    /// [`specificity`](Self::specificity)) is chosen, keeping the first such
+    /// mapping on a tie. The selection is computed explicitly, so it is correct
+    /// for any ordering — it does not rely on `mappings` being pre-sorted by
+    /// `build_path_mappings`. Returns the winning mapping's index together with
+    /// the captured wildcard text (the substring the `*` matched, or an empty
+    /// string for an exact key), so callers can both reference the mapping and
+    /// cache the result by index.
+    ///
+    /// Both module resolvers (the `tsz-core` checker resolver and the CLI
+    /// driver) route pattern selection through this one helper so the
+    /// "exactly one pattern, no fall-through" rule has a single owner.
+    pub fn select_best(mappings: &[PathMapping], specifier: &str) -> Option<(usize, String)> {
+        let mut best: Option<(usize, String)> = None;
+        let mut best_specificity = 0;
+        for (idx, mapping) in mappings.iter().enumerate() {
+            let Some(star_match) = mapping.match_specifier(specifier) else {
+                continue;
+            };
+            if !mapping.pattern.contains('*') {
+                // Exact wildcard-free key equal to the specifier wins outright.
+                return Some((idx, star_match));
+            }
+            if best.is_none() || mapping.specificity() > best_specificity {
+                best_specificity = mapping.specificity();
+                best = Some((idx, star_match));
+            }
+        }
+        best
+    }
 }
 
 impl ResolvedCompilerOptions {
@@ -869,4 +904,66 @@ pub fn resolve_compiler_options(
     }
 
     Ok(resolved)
+}
+
+#[cfg(test)]
+mod path_mapping_selection_tests {
+    use super::PathMapping;
+
+    fn mapping(pattern: &str, targets: &[&str]) -> PathMapping {
+        let (prefix, suffix) = match pattern.find('*') {
+            Some(star) => (pattern[..star].to_string(), pattern[star + 1..].to_string()),
+            None => (pattern.to_string(), String::new()),
+        };
+        PathMapping {
+            pattern: pattern.to_string(),
+            prefix,
+            suffix,
+            targets: targets.iter().map(|t| t.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn exact_key_beats_equal_prefix_wildcard_regardless_of_order() {
+        // `matchPatternOrExact` returns an exact wildcard-free key before any
+        // wildcard. `"alias"` and `"alias*"` tie on prefix length for the
+        // specifier `"alias"`; the literal key must win in either ordering.
+        for order in [
+            vec![
+                mapping("alias", &["./exact"]),
+                mapping("alias*", &["./wild"]),
+            ],
+            vec![
+                mapping("alias*", &["./wild"]),
+                mapping("alias", &["./exact"]),
+            ],
+        ] {
+            let (idx, star) =
+                PathMapping::select_best(&order, "alias").expect("a mapping must be selected");
+            assert_eq!(order[idx].pattern, "alias", "exact key must win the tie");
+            assert_eq!(star, "");
+        }
+    }
+
+    #[test]
+    fn longest_prefix_wildcard_wins_independent_of_order() {
+        // The longest-prefix wildcard is chosen even when the input is not
+        // pre-sorted by specificity, proving the selection does not depend on
+        // `build_path_mappings`' ordering.
+        let unsorted = vec![
+            mapping("*", &["./external.d.ts"]),
+            mapping("next/dist/*", &["./src/*"]),
+            mapping("next/dist/compiled/*", &["./compiled/*"]),
+        ];
+        let (idx, star) = PathMapping::select_best(&unsorted, "next/dist/compiled/react")
+            .expect("a wildcard must be selected");
+        assert_eq!(unsorted[idx].pattern, "next/dist/compiled/*");
+        assert_eq!(star, "react");
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let mappings = vec![mapping("@app/*", &["./src/*"])];
+        assert!(PathMapping::select_best(&mappings, "unrelated/thing").is_none());
+    }
 }

--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -588,8 +588,17 @@ impl ModuleResolver {
             );
         }
 
-        // Step 5: Try baseUrl fallback for non-relative specifiers
-        if let Some(base_url) = &self.base_url {
+        // Step 5: Try baseUrl fallback for non-relative specifiers.
+        //
+        // tsc only reaches the bare `baseUrl` join when *no* `paths` pattern
+        // matched the specifier: `tryLoadModuleUsingOptionalResolutionSettings`
+        // returns the matched-pattern result (even when it found nothing on
+        // disk) before it ever consults `tryLoadModuleUsingBaseUrl`. When a
+        // pattern matched but its targets were missing, tsc commits to that
+        // pattern and skips baseUrl, continuing only to `node_modules`. Gating
+        // on `!path_mapping_attempted` mirrors that and keeps this resolver
+        // consistent with the driver's `candidates.is_empty()` guard.
+        if !path_mapping_attempted && let Some(base_url) = &self.base_url {
             let candidate = base_url.join(specifier);
             if let Some(resolved) = self.try_file_or_directory(&candidate, importer_package_type) {
                 return (

--- a/crates/tsz-core/src/module_resolver/path_mapping.rs
+++ b/crates/tsz-core/src/module_resolver/path_mapping.rs
@@ -1,6 +1,7 @@
 //! Path mapping resolution from tsconfig `paths` and `baseUrl`.
 
 use super::{ModuleExtension, ModuleResolver, PackageType, ResolvedModule};
+use crate::config::PathMapping;
 use crate::resolution::helpers::apply_wildcard_substitution;
 use std::path::Path;
 
@@ -12,12 +13,23 @@ pub(super) struct PathMappingAttempt {
 impl ModuleResolver {
     /// Try resolving through path mappings.
     ///
-    /// tsc resolves path mapping targets by probing the substituted path
-    /// (relative to `baseUrl`) with its normal file/directory lookup, regardless
-    /// of whether the substituted target already has an explicit extension.
-    /// Targets with explicit extensions (e.g. `"./foo.d.ts"`, `"./lib/*.ts"`)
-    /// are checked as-is; `try_file_or_directory` handles extension substitution
-    /// and declaration-sidecar probing the same way it does for any other path.
+    /// tsc selects exactly **one** `paths` pattern for a specifier
+    /// (`matchPatternOrExact` -> `findBestPatternMatch`, shared with the CLI
+    /// driver via [`PathMapping::select_best`]): an exact, wildcard-free key
+    /// equal to the specifier wins outright; otherwise the matching wildcard
+    /// with the longest prefix is chosen. Only that single pattern's targets are
+    /// probed (in declaration order, first on-disk hit wins). tsc never falls
+    /// through to a *less specific* pattern when the chosen pattern's targets are
+    /// missing on disk — so neither do we. Previously this method iterated every
+    /// matching pattern and returned the first that resolved, which let a missing
+    /// target under a specific pattern silently fall through to a catch-all
+    /// (`"*"`), resolving where tsc reports `TS2307`.
+    ///
+    /// Path mapping targets are probed regardless of whether the substituted
+    /// target already has an explicit extension. Targets with explicit
+    /// extensions (e.g. `"./foo.d.ts"`, `"./lib/*.ts"`) are checked as-is;
+    /// `try_file_or_directory` handles extension substitution and
+    /// declaration-sidecar probing the same way it does for any other path.
     ///
     /// `base` is the resolved `baseUrl` directory; callers must only invoke this
     /// method when `base_url` is set (the type system enforces it via `&Path`).
@@ -27,39 +39,41 @@ impl ModuleResolver {
         base: &Path,
         importer_package_type: Option<PackageType>,
     ) -> PathMappingAttempt {
-        // `self.path_mappings` is pre-sorted by specificity descending at
-        // construction time (`build_path_mappings` in config/mod.rs).
-        let mut attempted = false;
-        for mapping in &self.path_mappings {
-            if let Some(star_match) = mapping.match_specifier(specifier) {
-                attempted = true;
-                for target in &mapping.targets {
-                    let substituted = apply_wildcard_substitution(target, &star_match, false);
-                    let candidate = base.join(&substituted);
+        let Some((mapping_idx, star_match)) =
+            PathMapping::select_best(&self.path_mappings, specifier)
+        else {
+            return PathMappingAttempt {
+                resolved: None,
+                attempted: false,
+            };
+        };
+        let mapping = &self.path_mappings[mapping_idx];
 
-                    if let Some(resolved) =
-                        self.try_file_or_directory(&candidate, importer_package_type)
-                    {
-                        let extension = ModuleExtension::from_path(&resolved);
-                        return PathMappingAttempt {
-                            resolved: Some(ResolvedModule {
-                                resolved_path: resolved,
-                                resolved_using_ts_extension: false,
-                                is_external: false,
-                                package_name: None,
-                                original_specifier: specifier.to_string(),
-                                extension,
-                            }),
-                            attempted,
-                        };
-                    }
-                }
+        // Only the chosen pattern's targets are probed; a miss does not fall
+        // through to any other pattern.
+        for target in &mapping.targets {
+            let substituted = apply_wildcard_substitution(target, &star_match, false);
+            let candidate = base.join(&substituted);
+
+            if let Some(resolved) = self.try_file_or_directory(&candidate, importer_package_type) {
+                let extension = ModuleExtension::from_path(&resolved);
+                return PathMappingAttempt {
+                    resolved: Some(ResolvedModule {
+                        resolved_path: resolved,
+                        resolved_using_ts_extension: false,
+                        is_external: false,
+                        package_name: None,
+                        original_specifier: specifier.to_string(),
+                        extension,
+                    }),
+                    attempted: true,
+                };
             }
         }
 
         PathMappingAttempt {
             resolved: None,
-            attempted,
+            attempted: true,
         }
     }
 }

--- a/crates/tsz-core/src/module_resolver/tests/path_mapping.rs
+++ b/crates/tsz-core/src/module_resolver/tests/path_mapping.rs
@@ -500,6 +500,160 @@ fn test_path_mapping_same_file_via_two_paths_shares_resolved_path() {
     }
 }
 
+// ── single best-pattern selection (issue #11577) ─────────────────────────────
+//
+// tsc selects exactly one `paths` pattern (`matchPatternOrExact` ->
+// `findBestPatternMatch`) and probes only that pattern's targets. A missing
+// target under the chosen pattern must NOT fall through to a less-specific
+// pattern (notably a catch-all `"*"`). The witness rows vary the binder names
+// so the rule stays structural rather than fixture-keyed.
+
+#[test]
+fn test_path_mapping_missing_specific_target_does_not_fall_through_to_catch_all() {
+    // The specific pattern matches but its on-disk target is missing. tsc
+    // commits to that pattern and reports the module unresolved; it does NOT
+    // resolve via the catch-all `"*"`. A specifier that only matches the
+    // catch-all still resolves through it.
+    let rows: &[(&str, &str, &[&str])] = &[
+        ("next/dist/*", "next/dist/", &["./src/*"]),
+        ("@scope/*", "@scope/", &["./packages/*"]),
+        ("lib/*", "lib/", &["./internal/*"]),
+    ];
+    for (pattern, prefix, targets) in rows {
+        let fx = TempFixture::new();
+        // The catch-all target exists; the specific target does not.
+        fx.write("external.d.ts", "declare const v: any; export default v;");
+        fx.write("index.ts", "");
+
+        let options = make_options(
+            fx.path(),
+            vec![
+                pm(pattern, prefix, targets),
+                pm("*", "", &["./external.d.ts"]),
+            ],
+        );
+        let mut resolver = ModuleResolver::new(&options);
+
+        // Matches the specific pattern, whose target is missing: must fail
+        // rather than fall through to the catch-all `external.d.ts`.
+        let specific_specifier = format!("{prefix}missing-entry");
+        let missed = resolver.resolve(&specific_specifier, &fx.join("index.ts"), Span::new(0, 1));
+        assert!(
+            missed.is_err(),
+            "{specific_specifier}: a missing target under {pattern} must not fall through to the \"*\" catch-all",
+        );
+
+        // A specifier that only the catch-all matches still resolves via it.
+        let catch_all = resolver
+            .resolve(
+                "totally-unrelated-pkg",
+                &fx.join("index.ts"),
+                Span::new(0, 1),
+            )
+            .expect("catch-all \"*\" must still resolve specifiers no other pattern matches");
+        assert_eq!(catch_all.resolved_path, fx.join("external.d.ts"));
+    }
+}
+
+#[test]
+fn test_path_mapping_exact_key_beats_equal_prefix_wildcard() {
+    // `matchPatternOrExact` returns an exact, wildcard-free key before
+    // consulting any wildcard. `"foo"` and `"foo*"` tie on prefix length for
+    // the specifier `"foo"`, but the literal key must win — even when the
+    // wildcard is listed first and the wildcard target also exists on disk.
+    let fx = TempFixture::new();
+    fx.write("exact.ts", "export const exact = 1;");
+    fx.write("wild.ts", "export const wild = 1;");
+    fx.write("index.ts", "");
+
+    let options = make_options(
+        fx.path(),
+        vec![
+            pm("alias*", "alias", &["./wild.ts"]),
+            pm("alias", "alias", &["./exact.ts"]),
+        ],
+    );
+    let mut resolver = ModuleResolver::new(&options);
+    let resolved = resolver
+        .resolve("alias", &fx.join("index.ts"), Span::new(0, 1))
+        .expect("exact key \"alias\" must resolve");
+    assert_eq!(
+        resolved.resolved_path,
+        fx.join("exact.ts"),
+        "exact wildcard-free key must outrank an equal-prefix wildcard",
+    );
+}
+
+#[test]
+fn test_path_mapping_longest_prefix_wins_on_miss_without_fallthrough() {
+    // Three nested patterns match `next/dist/compiled/x`. The longest-prefix
+    // pattern (`next/dist/compiled/*`) is chosen; when its target is missing,
+    // resolution fails rather than retrying `next/dist/*` or `"*"`.
+    let fx = TempFixture::new();
+    // Targets for the two *less* specific patterns exist; only the chosen
+    // (most specific) pattern's target is missing.
+    fx.write("src/compiled/react.ts", "export const r = 1;");
+    fx.write("external.d.ts", "declare const v: any; export default v;");
+    fx.write("index.ts", "");
+
+    let options = make_options(
+        fx.path(),
+        vec![
+            pm(
+                "next/dist/compiled/*",
+                "next/dist/compiled/",
+                &["./missing/*"],
+            ),
+            pm("next/dist/*", "next/dist/", &["./src/*"]),
+            pm("*", "", &["./external.d.ts"]),
+        ],
+    );
+    let mut resolver = ModuleResolver::new(&options);
+    let missed = resolver.resolve(
+        "next/dist/compiled/react",
+        &fx.join("index.ts"),
+        Span::new(0, 1),
+    );
+    assert!(
+        missed.is_err(),
+        "longest-prefix pattern is chosen; its missing target must not fall through to next/dist/* \
+         (which has ./src/compiled/react.ts) or the \"*\" catch-all",
+    );
+}
+
+#[test]
+fn test_path_mapping_matched_pattern_miss_skips_base_url_fallback() {
+    // tsc reaches the bare `baseUrl` join only when NO `paths` pattern matched.
+    // When a pattern matched but its target is missing, baseUrl is skipped. The
+    // control row (a specifier matching no pattern) still resolves via baseUrl.
+    let fx = TempFixture::new();
+    // `baseUrl + "shared/widget"` exists on disk, so the only way these
+    // resolutions could succeed is the (incorrect) baseUrl fallback.
+    fx.write("shared/widget.ts", "export const w = 1;");
+    fx.write("loose/thing.ts", "export const t = 1;");
+    fx.write("index.ts", "");
+
+    let options = make_options(
+        fx.path(),
+        vec![pm("shared/*", "shared/", &["./nonexistent/*"])],
+    );
+    let mut resolver = ModuleResolver::new(&options);
+
+    // `shared/widget` matches `shared/*`; its target `./nonexistent/widget` is
+    // missing. baseUrl must be skipped, so resolution fails.
+    let matched_miss = resolver.resolve("shared/widget", &fx.join("index.ts"), Span::new(0, 1));
+    assert!(
+        matched_miss.is_err(),
+        "a matched-but-missing pattern must skip the baseUrl fallback (tsc commits to the pattern)",
+    );
+
+    // `loose/thing` matches no pattern, so baseUrl resolution still applies.
+    let unmatched = resolver
+        .resolve("loose/thing", &fx.join("index.ts"), Span::new(0, 1))
+        .expect("a specifier matching no pattern must still resolve via baseUrl");
+    assert_eq!(unmatched.resolved_path, fx.join("loose/thing.ts"));
+}
+
 #[test]
 fn test_path_mapping_unbalanced_parent_dirs_preserve_leading_dotdot() {
     // When there is nothing to pop, the leading `..` must be preserved. The


### PR DESCRIPTION
AgentName: Studio-A
Implementation runner: claude-opus-48-lucid-hopper
Track: module-resolution
Invariant: tsz selects the same single `paths` pattern as tsc and never falls through to a less-specific pattern when the chosen pattern's targets are missing on disk.

## Summary

Fixes the structural module-resolution gap behind issue #11577 (nextjs row `module-resolution-18-20`, plus its consolidated duplicate row witnesses).

### Structural rule

When several `paths` patterns match a specifier, tsc (`matchPatternOrExact` → `findBestPatternMatch`) selects **exactly one**: an exact, wildcard-free key equal to the specifier wins outright; otherwise the matching wildcard with the **longest prefix** is chosen. Only that single pattern's targets are probed (in declaration order, first on-disk hit wins). tsc never falls through to a less-specific pattern — and, once a pattern matched, it commits to it and does **not** consult the bare `baseUrl` join (it continues only to `node_modules`).

The `tsz-core` `ModuleResolver::try_path_mappings` instead iterated **every** matching pattern and returned the first that resolved on disk, so a missing target under a specific pattern silently fell through to a catch-all `"*"`, resolving where tsc reports `TS2307`. Because the core resolver runs *before* the driver fallback inside `ModuleResolver::lookup`, this drove the project-row divergence even though the CLI driver already selected a single pattern.

## Scope

All changes live in the solver-adjacent `module_resolver` / config boundary; no checker, printer, or emitter involvement.

- **`config/resolved_options.rs`** — new `PathMapping::select_best`, the single owner of the "exactly one pattern, no fall-through" rule. Selection is explicit and order-independent (exact key wins, else longest-prefix wildcard), returning `(index, wildcard-text)`.
- **`module_resolver/path_mapping.rs`** — `try_path_mappings` now selects via `PathMapping::select_best` and probes only the chosen pattern's targets.
- **`driver/resolution/path_resolution.rs`** — the driver's `select_path_mapping` now delegates to `PathMapping::select_best`, so both resolvers share one implementation (removes the duplicated selection logic).
- **`module_resolver/mod.rs`** — the baseUrl fallback (Step 5) is gated on `!path_mapping_attempted`, matching tsc and the driver's `candidates.is_empty()` guard.
- **`config/mod.rs`** — `build_path_mappings` breaks specificity ties in favour of literal keys, keeping the sorted `Vec` in tsc precedence order for any first-match consumer (e.g. LSP).

### Adjacent-case matrix (tests)

- missing target under a specific pattern does **not** fall through to a catch-all `"*"` (3 binder-varied rows)
- exact wildcard-free key beats an equal-prefix wildcard, regardless of list order and even when the wildcard target exists
- longest-prefix wildcard wins; its missing target does **not** retry less-specific patterns
- a matched-but-missing pattern **skips** the baseUrl fallback; a specifier matching no pattern still resolves via baseUrl
- multi-target fallback **within** the chosen pattern still honored (existing test preserved)
- order-independent unit coverage for `PathMapping::select_best`

## Project Corpus Impact

- Row: nextjs
- Bug family: module-resolution-18-20 (wildcard path-mapping selection)

Targets the `nextjs` required row (`module-resolution-18-20`) and the consolidated duplicate row witnesses (utility-types, ts-essentials, rxjs, type-fest, ts-toolbelt, zod, kysely, large-ts-repo, nextjs-fresh-app, vite-vanilla-ts-app). The fix removes spurious resolutions through a catch-all `"*"` where tsc reports `TS2307`. No fixture-name fast paths; the rule is purely structural over pattern prefixes.

## Verification

- `cargo test -p tsz-core --lib path_mapping` → 24 passed (existing + new)
- `cargo test -p tsz-cli --lib resolution` → 115 passed; the only failure, `tsc_parity_ts6046_module_resolution`, is a pre-existing environmental mismatch (the locally installed `tsc` lists fewer `--moduleResolution` values in its TS6046 message) and is unrelated to path mapping
- `cargo clippy -p tsz-core -p tsz-cli` → clean
- Rebased cleanly onto latest `main`

## Coordination Notes

Picked from the unclaimed bug set; the narrow root cause from the original report (`has_path_mapping_target_extension`) was already fixed on `main`, so this closes the remaining tsc-parity gap in wildcard path-mapping selection as flagged in the issue's latest triage. ready-review CI owns the broad conformance/emit/project-bench suites.

https://claude.ai/code/session_01ST6BWj1EoasX5CrWvmEojr