### PR TITLE
refactor(checker): route truthiness guards through boundary

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -976,15 +976,14 @@ impl<'a> FlowAnalyzer<'a> {
             }
 
             // Truthiness check: if (x)
-            // Use Solver-First architecture: delegate to TypeGuard::Truthy
+            // Use Solver-First architecture: delegate truthiness to the flow boundary.
             _ => {
                 let condition_ref = self.arena.skip_parenthesized_and_assertions(condition_idx);
                 let matches = self.is_matching_reference(condition_ref, target);
                 if matches {
-                    return self.narrow_with_guard_via_flow_boundary(
+                    return flow_query::narrow_to_truthy_in_context(
                         &narrowing,
                         type_id,
-                        &TypeGuard::Truthy,
                         is_true_branch,
                     );
                 }
@@ -1929,10 +1928,9 @@ impl<'a> FlowAnalyzer<'a> {
                 } else {
                     self.make_narrowing_context()
                 };
-                return Some(self.narrow_with_guard_via_flow_boundary(
+                return Some(flow_query::narrow_to_truthy_in_context(
                     &narrowing,
                     type_id,
-                    &TypeGuard::Truthy,
                     is_true_branch,
                 ));
             }

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -406,6 +406,19 @@ pub(crate) fn narrow_to_falsy(
     narrowing.narrow_to_falsy(type_id)
 }
 
+/// Apply truthiness narrowing with the caller's active flow narrowing context.
+///
+/// The checker owns deciding that the condition matches the target reference.
+/// The boundary owns constructing the solver truthiness guard and applying it
+/// through the semantic narrowing engine.
+pub(crate) fn narrow_to_truthy_in_context(
+    narrowing: &NarrowingContext<'_>,
+    type_id: TypeId,
+    is_true_branch: bool,
+) -> TypeId {
+    narrow_with_guard_in_context(narrowing, type_id, &TypeGuard::Truthy, is_true_branch)
+}
+
 /// Narrow a union by whether a property path is truthy/falsy.
 ///
 /// The checker owns extracting the property path from syntax and deciding

--- a/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
+++ b/crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs
@@ -289,6 +289,47 @@ fn condition_guard_application_uses_flow_query_boundary() {
 }
 
 #[test]
+fn condition_truthiness_payload_uses_flow_query_boundary() {
+    let condition_source = fs::read_to_string("src/flow/control_flow/condition_narrowing.rs")
+        .expect("failed to read condition narrowing source");
+    let boundary_source = fs::read_to_string("src/query_boundaries/flow_analysis.rs")
+        .expect("failed to read flow analysis boundary source");
+    let compact_condition: String = condition_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let compact_boundary: String = boundary_source
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    let condition_truthiness_fn = compact_condition
+        .split("fnnarrow_logical_assignment_condition(")
+        .next()
+        .and_then(|before_assignment| before_assignment.split("_=>{letcondition_ref=").nth(1))
+        .expect("failed to locate condition truthiness narrowing body");
+    let logical_assignment_body = compact_condition
+        .split("ifcrate::query_boundaries::operator_wrappers::is_logical_compound_assignment_operator(")
+        .nth(1)
+        .expect("failed to locate logical assignment truthiness body");
+
+    assert!(
+        compact_boundary.contains("fnnarrow_to_truthy_in_context(")
+            && compact_boundary.contains("&TypeGuard::Truthy"),
+        "flow analysis boundary should own truthiness guard payload construction"
+    );
+    assert!(
+        condition_truthiness_fn.contains("flow_query::narrow_to_truthy_in_context(")
+            && logical_assignment_body.contains("flow_query::narrow_to_truthy_in_context("),
+        "condition truthiness callers should route truthiness payloads through the flow query boundary"
+    );
+    assert!(
+        !condition_truthiness_fn.contains("&TypeGuard::Truthy")
+            && !logical_assignment_body.contains("&TypeGuard::Truthy"),
+        "condition truthiness callers should not construct solver truthiness payloads locally"
+    );
+}
+
+#[test]
 fn condition_property_truthiness_uses_flow_query_boundary() {
     let condition_source = fs::read_to_string("src/flow/control_flow/condition_narrowing.rs")
         .expect("failed to read condition narrowing source");


### PR DESCRIPTION
## Agent
AgentName: M1-D

## Track
M1-D flow graph and solver-owned narrowing predicates; architecture refactor.

## Invariant
When condition or logical-assignment flow matches the narrowed reference, tsc truthiness behavior is preserved; this PR changes the checker/query-boundary surface so the flow analysis boundary owns `TypeGuard::Truthy` payload construction for those paths.

## Scope
- `crates/tsz-checker/src/query_boundaries/flow_analysis.rs`: add active-context truthiness helper.
- `crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs`: route condition/logical-assignment truthiness through the boundary helper.
- `crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs`: add source guard coverage for the boundary ownership.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: architecture-only routing change for existing truthiness semantics; no project-row behavior targeted.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib flow_guard_boundary_tests condition_logical_narrowing_tests condition_break_narrowing_tests`
- `git diff --check origin/main...HEAD`
- `scripts/arch/check-checker-boundaries.sh`
- `wc -l crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs crates/tsz-checker/src/query_boundaries/flow_analysis.rs crates/tsz-checker/src/tests/flow_guard_boundary_tests.rs`

## Coordination Notes
- No owned M1-D/M4-C PRs or issues were open at start of this slice.
- Avoided M4-C implementation because several currently open unlabelled PRs overlap inference/contextual-typing territory.
- `scripts/agents/ensure-agent-labels.sh --audit` still fails on pre-existing unlabelled PRs/issues outside this branch; this PR is labelled `agent:M1-D`.
- Structural owner rule: checker decides syntax/reference match; `query_boundaries::flow_analysis` constructs and applies the solver truthiness guard.
- Adjacent matrix: direct `if (x)` truthiness and logical compound assignment truthiness; property truthiness, predicate truthiness, equality, typeof, and instanceof paths remain covered by existing boundary tests.