### PR TITLE
refactor(checker): route predicate substitutions through flow boundary

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/predicate_resolution.rs
+++ b/crates/tsz-checker/src/flow/control_flow/predicate_resolution.rs
@@ -92,11 +92,8 @@ impl<'a> FlowAnalyzer<'a> {
                         .collect();
                     if concrete_members.iter().any(|&m| {
                         let evaluated = flow_query::evaluate_type_structure(self.interner, m);
-                        crate::query_boundaries::common::contains_type_parameters(self.interner, m)
-                            || crate::query_boundaries::common::contains_type_parameters(
-                                self.interner,
-                                evaluated,
-                            )
+                        flow_query::contains_type_parameters(self.interner, m)
+                            || flow_query::contains_type_parameters(self.interner, evaluated)
                             || crate::query_boundaries::state::checking::object_shape(
                                 self.interner,
                                 evaluated,
@@ -132,7 +129,7 @@ impl<'a> FlowAnalyzer<'a> {
         // Case 2: Complex predicate type CONTAINS type parameters (e.g., mapped types
         // like `target is { readonly [K in P]: unknown }`). Build a substitution from
         // function type params to call argument types and instantiate the predicate type.
-        let mut substitution = crate::query_boundaries::common::TypeSubstitution::new();
+        let mut substitution = flow_query::TypeSubstitution::new();
         for tp in &type_params {
             for (i, param) in params.iter().enumerate() {
                 if let Some(info) = flow_query::type_param_info(self.interner, param.type_id)
@@ -211,11 +208,7 @@ impl<'a> FlowAnalyzer<'a> {
         let predicate_still_generic = !predicate_target_is_bare_type_param
             && type_params.iter().any(|tp| {
                 substitution.get(tp.name).is_none()
-                    && crate::query_boundaries::common::contains_type_parameter_named(
-                        self.interner,
-                        pred_type,
-                        tp.name,
-                    )
+                    && flow_query::contains_type_parameter_named(self.interner, pred_type, tp.name)
             });
         if predicate_still_generic {
             let param_arg_pairs: Vec<(TypeId, TypeId)> = params
@@ -239,11 +232,8 @@ impl<'a> FlowAnalyzer<'a> {
         }
 
         if !substitution.is_empty() {
-            let instantiated = crate::query_boundaries::common::instantiate_type(
-                self.interner,
-                pred_type,
-                &substitution,
-            );
+            let instantiated =
+                flow_query::instantiate_type(self.interner, pred_type, &substitution);
             if instantiated != pred_type {
                 // Evaluate to resolve mapped types (e.g., `{ [K in "length"]: unknown }` -> `{ length: unknown }`)
                 let evaluated = flow_query::evaluate_type_structure(self.interner, instantiated);

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -10,13 +10,14 @@ use super::{
 };
 
 pub(crate) use super::common::{
-    LiteralValueKind, PredicateSignatureKind, TypeResolver,
+    LiteralValueKind, PredicateSignatureKind, TypeResolver, TypeSubstitution,
     array_element_type as get_array_element_type, call_signatures_for_type,
     classify_for_literal_value, classify_for_predicate_signature, construct_signatures_for_type,
-    contains_type_parameters, function_shape_for_type, is_keyof_type,
-    is_literal_type_through_type_constraints, is_narrowing_literal, is_type_parameter_like,
-    is_union_type, is_unit_type, is_unknown_narrowing_literal, object_shape_for_type,
-    stringify_literal_type, tuple_elements as tuple_elements_for_type, type_contains_undefined,
+    contains_type_parameter_named, contains_type_parameters, function_shape_for_type,
+    instantiate_type, is_keyof_type, is_literal_type_through_type_constraints,
+    is_narrowing_literal, is_type_parameter_like, is_union_type, is_unit_type,
+    is_unknown_narrowing_literal, object_shape_for_type, stringify_literal_type,
+    tuple_elements as tuple_elements_for_type, type_contains_undefined,
     union_members as union_members_for_type,
 };
 

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -233,7 +233,11 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # `common` barrel). It is an existing request-shaped helper already used
         # throughout this file — no new quarantine entry.
         # Ratcheted 3278→3202 after current arch-smoke caught live-count slack.
-        3202,
+        #
+        # Ratcheted 3202→3197 after generic predicate-target instantiation
+        # moved five flow/narrowing substitution queries through
+        # query_boundaries::flow_analysis instead of the broad common barrel.
+        3197,
     ),
 ]
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1260,7 +1260,11 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # source-display query.
         #
         # Ratcheted 3213→3202 after current arch-smoke caught live-count slack.
-        3202,
+        #
+        # Ratcheted 3202→3197 after generic predicate-target instantiation
+        # moved five flow/narrowing substitution queries through
+        # query_boundaries::flow_analysis instead of the broad common barrel.
+        3197,
     ),
 ]
 


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track: checker orchestration / query-boundary cleanup (#8225, #8227)

## Invariant
When generic type-predicate narrowing needs to instantiate a predicate target from argument-derived type-parameter substitutions, `tsc` preserves the instantiated predicate target; this PR keeps tsz behavior unchanged while routing the substitution queries through the `flow_analysis` query boundary instead of direct `query_boundaries::common` quarantine calls.

## Scope
- Re-export the existing type-parameter/substitution helpers through `query_boundaries::flow_analysis`.
- Route `flow/control_flow/predicate_resolution.rs` through that flow boundary for generic predicate substitution checks and instantiation.
- Ratchet the direct `query_boundaries::common` reference cap from 3202 to 3197 in both arch guard config copies.

## Project Corpus Impact
- Row: none expected; behavior-preserving boundary cleanup only.
- Bug family: flow-sensitive generic predicate narrowing / query-boundary quarantine cleanup.

## Verification
- `cargo fmt`
- `git diff --check origin/main..HEAD`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard_counts.ArchGuardQueryBoundaryCommonReferenceTests`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test predicate_alias_generic_inference_tests generic_alias_predicate_narrows_without_self_intersection generic_alias_predicate_renamed_binders_narrows_without_self_intersection generic_alias_predicate_keeps_element_type_usable`

## Coordination Notes
- Built on current `origin/main` after #12822 and #12823 landed.
- No solver policy changes; this only narrows checker-side access from the broad common quarantine to the existing flow-analysis boundary.
- `scripts/agents/ensure-agent-labels.sh --audit` still reports unrelated open PRs/issues missing labels; this PR will carry `agent:M1-B`.
