### PR TITLE
fix(checker): honor explicit variance on empty interfaces

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
+++ b/crates/tsz-checker/src/assignability/assignability_diagnostics.rs
@@ -574,6 +574,27 @@ impl<'a> CheckerState<'a> {
         {
             return false;
         }
+        {
+            let flags = self.ctx.pack_relation_flags();
+            let inputs = crate::query_boundaries::assignability::AssignabilityQueryInputs {
+                db: self.ctx.types,
+                resolver: &self.ctx,
+                source,
+                target,
+                flags,
+                inheritance_graph: &self.ctx.inheritance_graph,
+                sound_mode: self.ctx.sound_mode(),
+            };
+            if matches!(
+                crate::query_boundaries::assignability::check_application_variance_assignability(
+                    &inputs,
+                ),
+                Some(false)
+            ) {
+                self.error_type_not_assignable_at_with_raw_display_types(source, target, diag_idx);
+                return false;
+            }
+        }
         if !force_nested_error_nullish_report
             && !exact_optional_mismatch
             && self.should_suppress_assignability_diagnostic(source, target)

--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -895,13 +895,12 @@ impl<'a> CheckerState<'a> {
 
         let declared_recursive_tuple_assignment =
             self.recursive_tuple_declared_assignment_types(left_idx, right_idx);
-        let declared_alias_application_assignment =
-            self.declared_same_alias_application_assignment_types(left_idx, right_idx);
+        let declared_application_assignment =
+            self.declared_same_application_assignment_types(left_idx, right_idx);
         let (compat_source_type, compat_target_type, declared_application_any_target_accepted) =
             if let Some((source_declared, target_declared)) = declared_recursive_tuple_assignment {
                 (source_declared, target_declared, false)
-            } else if let Some((source_declared, target_declared)) =
-                declared_alias_application_assignment
+            } else if let Some((source_declared, target_declared)) = declared_application_assignment
             {
                 let accepts_any_target =
                     self.declared_application_any_target_accepts(source_declared, target_declared);
@@ -1040,8 +1039,7 @@ impl<'a> CheckerState<'a> {
             }
 
             if check_assignability
-                && let Some((source_declared, target_declared)) =
-                    declared_alias_application_assignment
+                && let Some((source_declared, target_declared)) = declared_application_assignment
                 && self.same_type_alias_application_args_reject(source_declared, target_declared)
             {
                 self.error_type_not_assignable_at_with_anchor(
@@ -1926,7 +1924,7 @@ impl<'a> CheckerState<'a> {
         Some((source_declared, target_declared))
     }
 
-    fn declared_same_alias_application_assignment_types(
+    fn declared_same_application_assignment_types(
         &mut self,
         left_idx: NodeIndex,
         right_idx: NodeIndex,
@@ -1937,12 +1935,6 @@ impl<'a> CheckerState<'a> {
         let (target_base, target_args) = self.application_info_or_display_alias(target_declared)?;
         let (source_base, source_args) = self.application_info_or_display_alias(source_declared)?;
         if target_base != source_base || target_args.len() != source_args.len() {
-            return None;
-        }
-
-        let def_id = crate::query_boundaries::common::lazy_def_id(self.ctx.types, target_base)?;
-        let def = self.ctx.definition_store.get(def_id)?;
-        if def.kind != tsz_solver::def::DefKind::TypeAlias {
             return None;
         }
 

--- a/crates/tsz-checker/tests/ts2636_method_bivariance_tests.rs
+++ b/crates/tsz-checker/tests/ts2636_method_bivariance_tests.rs
@@ -12,7 +12,7 @@
 //! > callback) position. Purely method-bivariant occurrences satisfy both
 //! > `in T` and `out T` declarations and must not emit TS2636.
 
-use tsz_checker::test_utils::check_source_codes;
+use tsz_checker::test_utils::{check_source_codes, check_source_diagnostics, diagnostic_count};
 
 // =========================================================================
 // Issue repro — purely method-bivariant T with `in` annotation
@@ -107,5 +107,76 @@ fn invariant_annotation_always_ok() {
         !diags.contains(&2636),
         "in out T must not emit TS2636; got: {:?}",
         diags.to_vec(),
+    );
+}
+
+#[test]
+fn conflicting_merged_interface_annotations_are_invariant() {
+    let source = r#"
+interface Channel<out T> {}
+interface Channel<in T> {}
+
+declare let wide: Channel<unknown>;
+declare let narrow: Channel<string>;
+
+wide = narrow;
+narrow = wide;
+"#;
+
+    let diags = check_source_diagnostics(source);
+
+    assert_eq!(
+        diagnostic_count(&diags, 2322),
+        2,
+        "out+in merged interface annotations must reject both assignment directions; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn matching_merged_interface_annotations_keep_direction() {
+    let covariant_source = r#"
+interface Reader<out T> {}
+interface Reader<out T> {}
+
+declare let wide: Reader<unknown>;
+declare let narrow: Reader<string>;
+
+wide = narrow;
+narrow = wide;
+"#;
+    let covariant_diags = check_source_diagnostics(covariant_source);
+    assert_eq!(
+        diagnostic_count(&covariant_diags, 2322),
+        1,
+        "out+out merged interface annotations must remain covariant; got: {:?}",
+        covariant_diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+
+    let contravariant_source = r#"
+interface Sink<in T> {}
+interface Sink<in T> {}
+
+declare let wide: Sink<unknown>;
+declare let narrow: Sink<string>;
+
+wide = narrow;
+narrow = wide;
+"#;
+    let contravariant_diags = check_source_diagnostics(contravariant_source);
+    assert_eq!(
+        diagnostic_count(&contravariant_diags, 2322),
+        1,
+        "in+in merged interface annotations must remain contravariant; got: {:?}",
+        contravariant_diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
     );
 }

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -64,7 +64,6 @@ TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientCo
 TypeScript/tests/cases/conformance/jsdoc/importTag17.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes2.ts
-TypeScript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts
 # covariantCallbacks.ts: RESOLVED by PR #12482. tsz now detects nullable-union
 # callback method parameters the way tsc does (getSingleCallSignature(
 # getNonNullableType(t))), so lib `Promise<A>` -> `Promise<B>` reports its


### PR DESCRIPTION
AgentName: Studio-A

## Track
conformance / checker assignability

## Invariant
Explicit `in`/`out` variance annotations on generic applications remain authoritative even when the interface body is structurally empty; merged `out`+`in` annotations combine to invariant and reject both assignment directions through the shared assignability boundary.

## Scope
- Preserve same-base declared generic application types for assignment checks beyond type aliases, so interface applications can reach the variance-aware relation.
- Emit TS2322 before empty-object suppression when `check_application_variance_assignability` returns a conclusive rejection.
- Add focused merged-interface variance regression tests.
- Retire `varianceAnnotations.ts` from the accepted-regression ledger after focused conformance passes.

## Project Corpus Impact
- Row: n/a
- Bug family: conformance accepted-regression / explicit variance on empty merged interfaces
- Evidence: accepted-regression ledger 19 -> 18; dashboard remains 12585/12585 with 0 conformance detail failures.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts2636_method_bivariance_tests`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter varianceAnnotations --verbose`
- `python3 scripts/conformance/check-accepted-regression-growth.py --base-ref origin/main --head-ref HEAD --allow-unavailable-base`
- `python3 scripts/conformance/query-conformance.py --dashboard`

## Coordination Notes
- Focused PR for one accepted-regression row; no project-row or emit surface changes.
- Current cycle artifacts: conformance dashboard 12585/12585 with accepted-regression gate at 18, emit JS/DTS 0 failures, and all 19 project rows consistent.