### PR TITLE
refactor(checker): expand source interface heritage direct path

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct.rs
@@ -81,3 +81,7 @@ mod tests;
 #[cfg(test)]
 #[path = "cross_file_direct_source_option_bag_tests.rs"]
 mod source_option_bag_tests;
+
+#[cfg(test)]
+#[path = "cross_file_direct_source_heritage_tests.rs"]
+mod source_heritage_tests;

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/interface_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/interface_methods.rs
@@ -61,8 +61,8 @@ impl<'a> CheckerState<'a> {
             };
             record_complex_reason(reason);
         };
-        if direct_source_file_arena {
-            if has_heritage || has_computed_names {
+        let declarations = if direct_source_file_arena {
+            if has_computed_names {
                 record(DirectCrossFileInterfaceLoweringOutcome::ComplexDeclaration);
                 heritage_or_computed_reason();
                 return None;
@@ -75,11 +75,17 @@ impl<'a> CheckerState<'a> {
                 record_complex_reason(DirectCrossFileInterfaceComplexReason::SourceFileShape);
                 return None;
             }
+            Self::source_file_expand_direct_lowerable_interface_heritage(
+                &declarations,
+                delegate_binder,
+            )?
         } else if !allow_complex_declarations && (has_heritage || has_computed_names) {
             record(DirectCrossFileInterfaceLoweringOutcome::ComplexDeclaration);
             heritage_or_computed_reason();
             return None;
-        }
+        } else {
+            declarations
+        };
 
         let def_id = self.ctx.get_or_create_def_id(sym_id);
         let name_resolver = |type_name: &str| -> Option<tsz_solver::def::DefId> {

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/source_shape_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/source_shape_methods.rs
@@ -780,7 +780,12 @@ impl<'a> CheckerState<'a> {
             }
 
             seen_type_names.push(interface_name);
-            let result = interface.members.nodes.iter().copied().all(|member_idx| {
+            let result = Self::source_file_interface_heritage_is_direct_lowerable(
+                arena,
+                delegate_binder,
+                interface,
+                seen_type_names,
+            ) && interface.members.nodes.iter().copied().all(|member_idx| {
                 let Some(member_node) = arena.get(member_idx) else {
                     return false;
                 };
@@ -808,6 +813,179 @@ impl<'a> CheckerState<'a> {
             seen_type_names.pop();
             result
         })
+    }
+
+    fn source_file_interface_heritage_is_direct_lowerable<'b>(
+        arena: &'b NodeArena,
+        delegate_binder: &BinderState,
+        interface: &tsz_parser::parser::node::InterfaceData,
+        seen_type_names: &mut Vec<&'b str>,
+    ) -> bool {
+        let Some(heritage_clauses) = interface.heritage_clauses.as_ref() else {
+            return true;
+        };
+
+        heritage_clauses.nodes.iter().copied().all(|clause_idx| {
+            let Some(heritage) = arena.get_heritage_clause_at(clause_idx) else {
+                return false;
+            };
+            heritage.types.nodes.iter().copied().all(|heritage_type_idx| {
+                let Some(base_name) =
+                    Self::source_file_simple_heritage_identifier(arena, heritage_type_idx)
+                else {
+                    return false;
+                };
+                let Some(base_decl_idx) = Self::source_file_direct_heritage_base_decl(
+                    arena,
+                    delegate_binder,
+                    base_name,
+                    seen_type_names,
+                ) else {
+                    return false;
+                };
+                Self::source_file_interface_declarations_are_direct_lowerable_with_seen(
+                    &[(base_decl_idx, arena)],
+                    delegate_binder,
+                    seen_type_names,
+                )
+            })
+        })
+    }
+
+    fn source_file_simple_heritage_identifier(
+        arena: &NodeArena,
+        heritage_type_idx: NodeIndex,
+    ) -> Option<&str> {
+        let heritage_node = arena.get(heritage_type_idx)?;
+        if let Some(identifier) = arena.get_identifier(heritage_node) {
+            return Some(identifier.escaped_text.as_str());
+        }
+        if let Some(expr_type_args) = arena.get_expr_type_args(heritage_node) {
+            if expr_type_args
+                .type_arguments
+                .as_ref()
+                .is_some_and(|args| !args.nodes.is_empty())
+            {
+                return None;
+            }
+            return arena
+                .get(expr_type_args.expression)
+                .and_then(|name_node| arena.get_identifier(name_node))
+                .map(|ident| ident.escaped_text.as_str());
+        }
+
+        let type_ref = arena.get_type_ref(heritage_node)?;
+        if type_ref
+            .type_arguments
+            .as_ref()
+            .is_some_and(|args| !args.nodes.is_empty())
+        {
+            return None;
+        }
+        arena
+            .get(type_ref.type_name)
+            .and_then(|name_node| arena.get_identifier(name_node))
+            .map(|ident| ident.escaped_text.as_str())
+    }
+
+    fn source_file_direct_heritage_base_decl<'b>(
+        arena: &'b NodeArena,
+        delegate_binder: &BinderState,
+        base_name: &'b str,
+        seen_type_names: &[&'b str],
+    ) -> Option<NodeIndex> {
+        if seen_type_names.contains(&base_name) {
+            return None;
+        }
+        let base_sym_id = delegate_binder.file_locals.get(base_name)?;
+        let base_symbol = delegate_binder.get_symbol(base_sym_id)?;
+        if base_symbol.flags & symbol_flags::INTERFACE == 0
+            || base_symbol.flags
+                & (symbol_flags::VALUE
+                    | symbol_flags::CLASS
+                    | symbol_flags::TYPE_ALIAS
+                    | symbol_flags::VALUE_MODULE
+                    | symbol_flags::NAMESPACE_MODULE)
+                != 0
+            || base_symbol.declarations.len() != 1
+        {
+            return None;
+        }
+        let base_decl_idx = base_symbol.declarations[0];
+        if !Self::lib_declaration_name_matches(arena, base_decl_idx, base_name) {
+            return None;
+        }
+        let base_node = arena.get(base_decl_idx)?;
+        arena.get_interface(base_node)?;
+        Some(base_decl_idx)
+    }
+
+    pub(super) fn source_file_expand_direct_lowerable_interface_heritage<'b>(
+        declarations: &[(NodeIndex, &'b NodeArena)],
+        delegate_binder: &BinderState,
+    ) -> Option<Vec<(NodeIndex, &'b NodeArena)>> {
+        fn append_bases<'b>(
+            arena: &'b NodeArena,
+            delegate_binder: &BinderState,
+            interface: &tsz_parser::parser::node::InterfaceData,
+            seen_type_names: &mut Vec<&'b str>,
+            expanded: &mut Vec<(NodeIndex, &'b NodeArena)>,
+        ) -> Option<()> {
+            let Some(heritage_clauses) = interface.heritage_clauses.as_ref() else {
+                return Some(());
+            };
+            for clause_idx in heritage_clauses.nodes.iter().copied() {
+                let heritage = arena.get_heritage_clause_at(clause_idx)?;
+                for heritage_type_idx in heritage.types.nodes.iter().copied() {
+                    let base_name =
+                        CheckerState::source_file_simple_heritage_identifier(
+                            arena,
+                            heritage_type_idx,
+                        )?;
+                    let base_decl_idx = CheckerState::source_file_direct_heritage_base_decl(
+                        arena,
+                        delegate_binder,
+                        base_name,
+                        seen_type_names,
+                    )?;
+                    let base_node = arena.get(base_decl_idx)?;
+                    let base_interface = arena.get_interface(base_node)?;
+                    seen_type_names.push(base_name);
+                    append_bases(
+                        arena,
+                        delegate_binder,
+                        base_interface,
+                        seen_type_names,
+                        expanded,
+                    )?;
+                    seen_type_names.pop();
+                    expanded.push((base_decl_idx, arena));
+                }
+            }
+            Some(())
+        }
+
+        let mut expanded = Vec::new();
+        let mut seen_type_names = Vec::new();
+        for (decl_idx, arena) in declarations.iter().copied() {
+            let node = arena.get(decl_idx)?;
+            let interface = arena.get_interface(node)?;
+            let interface_name = arena
+                .get(interface.name)
+                .and_then(|name_node| arena.get_identifier(name_node))
+                .map(|ident| ident.escaped_text.as_str())?;
+            seen_type_names.push(interface_name);
+            append_bases(
+                arena,
+                delegate_binder,
+                interface,
+                &mut seen_type_names,
+                &mut expanded,
+            )?;
+            seen_type_names.pop();
+            expanded.push((decl_idx, arena));
+        }
+        Some(expanded)
     }
 
     fn source_file_interface_declarations_are_direct_lowerable(

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_source_heritage_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_source_heritage_tests.rs
@@ -1,0 +1,102 @@
+use crate::context::{CheckerContext, CheckerOptions};
+use crate::query_boundaries::common::TypeInterner;
+use crate::state::CheckerState;
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_parser::parser::ParserState;
+
+fn parse_bound_source(
+    source: &str,
+) -> (
+    Arc<tsz_parser::parser::node::NodeArena>,
+    Arc<BinderState>,
+    TypeInterner,
+) {
+    let mut parser = ParserState::new("fixture.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    (
+        Arc::new(parser.get_arena().clone()),
+        Arc::new(binder),
+        TypeInterner::new(),
+    )
+}
+
+#[test]
+fn direct_cross_file_interface_lowering_expands_source_option_bag_heritage() {
+    let (arena, binder, types) = parse_bound_source(
+        r#"
+                interface BaseShape { title: string; logo: string; }
+                interface DerivedShape extends BaseShape { count: number; }
+            "#,
+    );
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    let state = CheckerState { ctx };
+    let derived_sym = binder
+        .file_locals
+        .get("DerivedShape")
+        .expect("derived symbol");
+
+    let (derived_type, params) = state
+        .direct_cross_file_interface_lowering(
+            derived_sym,
+            binder.as_ref(),
+            arena.as_ref(),
+            false,
+            true,
+        )
+        .expect("simple same-file option-bag heritage should lower directly");
+
+    assert!(params.is_empty());
+    for property in ["title", "logo", "count"] {
+        let atom = types.intern_string(property);
+        assert!(
+            crate::query_boundaries::common::raw_property_type(
+                state.ctx.types.as_type_database(),
+                derived_type,
+                atom,
+            )
+            .is_some(),
+            "directly lowered derived interface should include {property}"
+        );
+    }
+}
+
+#[test]
+fn direct_cross_file_interface_lowering_rejects_generic_source_heritage() {
+    let (arena, binder, types) = parse_bound_source(
+        r#"
+                interface Boxed<T> { value: T; }
+                interface Wrapped extends Boxed<string> { label: string; }
+            "#,
+    );
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    let state = CheckerState { ctx };
+    let wrapped_sym = binder.file_locals.get("Wrapped").expect("wrapped symbol");
+
+    assert!(
+        state
+            .direct_cross_file_interface_lowering(
+                wrapped_sym,
+                binder.as_ref(),
+                arena.as_ref(),
+                false,
+                true,
+            )
+            .is_none(),
+        "generic source heritage stays on the child-checker path"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 10 checker architecture / direct cross-file source option-bag fast path; supports Track 7/9 generated-app project rows.

## Invariant
When a source-file option-bag interface extends a same-file, nongeneric interface whose members are already direct-lowerable, tsz expands that base declaration inside the checker direct-cross-file lowering path and preserves the inherited properties. Generic, computed, recursive, qualified/nonlocal, or otherwise non-direct heritage still falls back to the child-checker path.

## Scope
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct/interface_methods.rs`
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct/source_shape_methods.rs`
- `crates/tsz-checker/src/state/type_analysis/cross_file_direct_source_heritage_tests.rs`
- Test module wiring in `cross_file_direct.rs`

## Project Corpus Impact
- Row: vite-vanilla-ts-app
- Bug family: checker direct cross-file/source option-bag architecture
- Evidence: Vite compile smoke remains green; narrow timing still shows the row below the 2x target, so this PR does not claim to close the generated-app performance gap. The remaining attribution blocker is DOM/lib cross-arena delegation.

## Verification
- `cargo fmt --all --check`
- `python3 scripts/arch/arch_guard.py`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' scripts/safe-run.sh cargo nextest run -p tsz-checker --lib direct_cross_file_interface_lowering`
- `TSZ_PROJECT_COMPILE_FILTER='^vite-vanilla-ts-app$' scripts/safe-run.sh scripts/ci/project-compile-guard.sh`
- `git diff --check HEAD~1..HEAD`
- `CARGO_INCREMENTAL=0 RUSTFLAGS='-C debuginfo=0' scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`
- Attribution: `TSZ_PERF_COUNTERS=1 ... --perf-counters-json /tmp/tsz-vite-gap-current/vite-after.perf.json --noEmit -p .../vite-vanilla-ts-live/tsconfig.json` completed with 0 diagnostics; total/check time 0.78s/0.63s in dev attribution mode.
- Timing: `EXTERNAL_BENCH_DIR=... scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --quick --rebuild --filter '^vite-vanilla-ts-app$' --json-file /tmp/tsz-vite-gap-current/vite-timing-after.json` => `tsz` 88.65 ms, `tsgo` 77.80 ms, tsgo 1.14x faster.

## Coordination Notes
- Ready for manager review after exact-head CI passed on head `7dda2c1a13`.
- Disk recovery followed `.agents/skills/tsz-disk-cache-hygiene`: cache-preserving cleanup was insufficient, then a targeted last-resort `cargo clean --target-dir .target -p tsz-checker` removed current-checkout checker build artifacts only. `.target-bench`, TypeScript, fixtures, and sibling worktrees were preserved.

