### PR TITLE
perf(checker): prove object alias constraints cheaply

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -364,6 +364,18 @@ impl<'a> CheckerState<'a> {
                 if type_arg_contains_type_parameters
                     && query::is_application_type(self.ctx.types.as_type_database(), type_arg)
                 {
+                    let constraint_resolved = self.resolve_lazy_type(constraint);
+                    let inst_constraint = self.instantiate_constraint_with_type_args(
+                        constraint_resolved,
+                        type_params,
+                        &type_args,
+                    );
+                    if self.generic_alias_application_satisfies_object_constraint(
+                        type_arg,
+                        inst_constraint,
+                    ) {
+                        continue;
+                    }
                     let evaluated_arg = self.evaluate_type_for_assignability(type_arg);
                     if evaluated_arg != type_arg
                         && !matches!(
@@ -372,12 +384,6 @@ impl<'a> CheckerState<'a> {
                         )
                         && !query::contains_type_parameters(self.ctx.types, evaluated_arg)
                     {
-                        let constraint_resolved = self.resolve_lazy_type(constraint);
-                        let inst_constraint = self.instantiate_constraint_with_type_args(
-                            constraint_resolved,
-                            type_params,
-                            &type_args,
-                        );
                         if self.conditional_result_branches_satisfy_constraint(
                             type_arg,
                             inst_constraint,

--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -1447,6 +1447,7 @@ mod infer_conditional_helpers;
 mod instantiation_expression_constraints;
 mod mapped_constraint_helpers;
 mod merged_interface_constraints;
+mod object_alias_constraint_helpers;
 mod recursive_heritage_constraint;
 mod symbol_declaration_helpers;
 mod union_constraint_helpers;

--- a/crates/tsz-checker/src/checkers/generic_checker/object_alias_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/object_alias_constraint_helpers.rs
@@ -1,0 +1,19 @@
+use crate::state::CheckerState;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn generic_alias_application_satisfies_object_constraint(
+        &self,
+        type_arg: TypeId,
+        constraint: TypeId,
+    ) -> bool {
+        if constraint != TypeId::OBJECT {
+            return false;
+        }
+        crate::query_boundaries::checkers::generic::alias_application_satisfies_object_constraint(
+            self.ctx.types.as_type_database(),
+            &self.ctx.definition_store,
+            type_arg,
+        )
+    }
+}

--- a/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
@@ -1,6 +1,6 @@
 use crate::state::CheckerState;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
-use tsz_solver::{DefinitionStore, TypeId, TypeParamInfo};
+use tsz_solver::{DefId, DefinitionStore, TypeId, TypeParamInfo};
 
 pub(crate) use super::super::common::{
     callable_shape_for_type, contains_free_type_parameters, contains_generic_type_parameters,
@@ -678,6 +678,84 @@ pub(crate) fn application_base_def_and_args(
     let app = db.type_application(app_id);
     let base_def = tsz_solver::visitor::lazy_def_id(db, app.base);
     Some((base_def, app.args.clone()))
+}
+
+pub(crate) fn alias_application_satisfies_object_constraint(
+    db: &dyn TypeDatabase,
+    definitions: &DefinitionStore,
+    type_arg: TypeId,
+) -> bool {
+    alias_application_body_is_object_like(db, definitions, type_arg, &mut Vec::new(), 0)
+}
+
+fn alias_application_body_is_object_like(
+    db: &dyn TypeDatabase,
+    definitions: &DefinitionStore,
+    type_id: TypeId,
+    stack: &mut Vec<DefId>,
+    depth: usize,
+) -> bool {
+    if depth > 16 {
+        return false;
+    }
+    let Some(base_def) = application_base_def_id(db, type_id) else {
+        return type_surface_is_object_like(db, definitions, type_id, stack, depth + 1);
+    };
+    let Some(def) = definitions.get(base_def) else {
+        return false;
+    };
+    if def.kind != tsz_solver::def::DefKind::TypeAlias || stack.contains(&base_def) {
+        return false;
+    }
+    let Some(body) = definitions.get_body(base_def) else {
+        return false;
+    };
+    stack.push(base_def);
+    let result = type_surface_is_object_like(db, definitions, body, stack, depth + 1);
+    stack.pop();
+    result
+}
+
+fn type_surface_is_object_like(
+    db: &dyn TypeDatabase,
+    definitions: &DefinitionStore,
+    type_id: TypeId,
+    stack: &mut Vec<DefId>,
+    depth: usize,
+) -> bool {
+    if depth > 16 {
+        return false;
+    }
+    if matches!(type_id, TypeId::OBJECT | TypeId::NEVER) {
+        return true;
+    }
+    if crate::query_boundaries::common::is_mapped_type(db, type_id)
+        || crate::query_boundaries::common::object_shape_for_type(db, type_id).is_some()
+    {
+        return true;
+    }
+    if let Some(constraint) =
+        crate::query_boundaries::common::type_parameter_constraint(db, type_id)
+    {
+        return type_surface_is_object_like(db, definitions, constraint, stack, depth + 1);
+    }
+    if let Some(members) = crate::query_boundaries::common::union_members(db, type_id) {
+        return members
+            .iter()
+            .all(|&member| type_surface_is_object_like(db, definitions, member, stack, depth + 1));
+    }
+    if let Some(members) = crate::query_boundaries::common::intersection_members(db, type_id) {
+        return members
+            .iter()
+            .all(|&member| type_surface_is_object_like(db, definitions, member, stack, depth + 1));
+    }
+    if let Some((_check, _extends, true_type, false_type)) =
+        full_conditional_type_components(db, type_id)
+    {
+        return type_surface_is_object_like(db, definitions, true_type, stack, depth + 1)
+            && type_surface_is_object_like(db, definitions, false_type, stack, depth + 1);
+    }
+    alias_application_body_is_object_like(db, definitions, type_id, stack, depth + 1)
 }
 
 // =========================================================================

--- a/crates/tsz-checker/tests/ts2344_generic_ref_scoped_param_concrete_constraint.rs
+++ b/crates/tsz-checker/tests/ts2344_generic_ref_scoped_param_concrete_constraint.rs
@@ -270,6 +270,46 @@ declare function setup<TActors extends Record<string, unknown>>(_: {
 }
 
 #[test]
+fn object_constraint_accepts_object_producing_alias_application() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type Pickish<O extends object, K extends keyof O> = { [P in K]: O[P] } & {};
+type Wrapper<O extends object> = Pickish<O, keyof O>;
+type NeedsObject<T extends object> = T;
+
+type Use<Source extends object> = NeedsObject<Wrapper<Source>>;
+"#,
+    );
+
+    assert!(
+        diagnostics.iter().all(|(code, _)| *code != 2344),
+        "Object-producing alias applications should satisfy lowercase object constraints. Got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn object_constraint_rejects_primitive_producing_alias_application() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type RenamedText<Value> = string;
+type NeedsObject<T extends object> = T;
+
+type Use<Source extends object> = NeedsObject<RenamedText<Source>>;
+"#,
+    );
+
+    let ts2344: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2344)
+        .collect();
+    assert_eq!(
+        ts2344.len(),
+        1,
+        "Primitive-producing alias applications must still fail object constraints. Got: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn generic_ref_with_tuple_constraint_defers_mapped_tuple_result() {
     let diagnostics = compile_and_get_diagnostics(
         r#"


### PR DESCRIPTION
AgentName: Studio-B

## Track
Track 1/2 recursive type evaluation pressure; supports Studio-B performance/residency gate.

## Invariant
When an explicit generic type argument is an alias application that still contains scoped type parameters, and the required constraint is lowercase `object`, tsz can accept the constraint without evaluating the whole application only if the alias body's registered surface is structurally object-producing. The proof is bounded and structural: mapped/object surfaces, object-constrained type parameters, all-members object-like unions/intersections, object-like conditional branches, and recursively object-producing type-alias applications. Primitive-producing alias bodies still route through normal TS2344 validation.

## Scope
Adds a checker query-boundary helper for object-producing alias applications and calls it before the expensive assignability evaluation branch in generic constraint validation. Adds adjacent TS2344 tests for object-producing mapped/intersection wrappers and renamed primitive-producing aliases.

## Project Corpus Impact
- Row: ts-toolbelt-project
- Bug family: recursive type evaluation pressure / TS2344 alias body validation fan-out
- Impact: Clears the ts-toolbelt runtime slowdown row on amended head 88d0882f60. Before current-head baseline was red: ts-toolbelt-project tsz 5574.67 ms vs tsgo 140.23 ms, 39.75x slowdown, threshold 8x. After this PR on amended head: tsz 1015.44 ms vs tsgo 138.92 ms, tsgo 7.31x, exit success. This makes the row green but still a 2x target gap; no speed claim beyond removing the runtime threshold row.
- Remaining gap: Vite remains a separate green tsgo-winning target gap: rerun tsz 87.56 ms vs tsgo 76.50 ms, tsgo 1.14x. ts-toolbelt also remains below the 2x speed target after the runtime threshold row is cleared.

## Verification
- `cargo fmt -p tsz-checker --check`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts2344_generic_ref_scoped_param_concrete_constraint --no-fail-fast`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test generic_conditional_default_assignability_tests --no-fail-fast`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test recursive_utility_alias_fanout_tests --no-fail-fast`
- Exact-head timing: `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --filter 'ts-toolbelt-project' --json-file artifacts/perf/studio-b-object-alias-constraint-amended-ts-toolbelt-20260606.json`
- Exact-head attribution: `scripts/safe-run.sh env TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 TSZ_PERF_COUNTERS=1 cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --noEmit -p .target-bench/external/ts-toolbelt/tsconfig.flat.json --pretty false --perf-counters-json artifacts/perf/studio-b-object-alias-constraint-amended-ts-toolbelt-20260606.perf.json`
- Winner report: `node scripts/bench/tsgo-winner-report.mjs artifacts/perf/studio-b-object-alias-constraint-amended-ts-toolbelt-20260606.json artifacts/perf/studio-b-object-alias-constraint-amended-ts-toolbelt-20260606.tsgo-winners.json`
- Vite rerun: `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --filter 'vite-vanilla-ts-app' --json-file artifacts/perf/studio-b-object-alias-constraint-vite-rerun-20260606.json`
- Vite attribution/report generated at `artifacts/perf/studio-b-object-alias-constraint-vite-rerun-20260606.vite-vanilla-ts-app.perf.json` and `artifacts/perf/studio-b-object-alias-constraint-vite-rerun-20260606.tsgo-winners.json`.

## Coordination Notes
Owned PRs were drained before this work. This PR does not close the Studio-B goal: ts-toolbelt and Vite remain eligible green rows below the 2x target after the runtime threshold row is removed. A transient disk-full condition occurred during artifact regeneration; resolved by repo cleanup plus removing reproducible `.target/debug` build output, with disk guard afterward reporting OK.
