### PR TITLE
refactor(checker): route assignment flow helpers through boundary

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/assignment.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment.rs
@@ -4,13 +4,12 @@
 //! has been extracted to `condition_narrowing.rs`.
 
 use super::{FlowAnalyzer, PropertyKey};
-use crate::query_boundaries::common::{
+use crate::query_boundaries::flow_analysis::{
+    PropertyAccessResult, array_type, fallback_compound_assignment_result, get_array_element_type,
     is_assignment_operator as boundary_is_assignment_operator, is_compound_assignment_operator,
     is_logical_compound_assignment_operator, map_compound_assignment_to_binary,
-};
-use crate::query_boundaries::flow_analysis::{
-    array_type, fallback_compound_assignment_result, get_array_element_type,
-    tuple_elements_for_type, union_members_for_type, widen_literal_to_primitive,
+    new_binary_op_evaluator, tuple_elements_for_type, union_members_for_type,
+    widen_literal_to_primitive,
 };
 use crate::query_boundaries::type_computation::core::BinaryOpResult;
 use rustc_hash::FxHashSet;
@@ -167,7 +166,7 @@ impl<'a> FlowAnalyzer<'a> {
         };
 
         match access_result {
-            crate::query_boundaries::common::PropertyAccessResult::Success {
+            PropertyAccessResult::Success {
                 type_id,
                 write_type: Some(write_type),
                 from_index_signature: false,
@@ -697,14 +696,14 @@ impl<'a> FlowAnalyzer<'a> {
     /// Evaluate `left <op> right` through the shared binary-operation boundary,
     /// mapping a type error to `any` to avoid cascading diagnostics. Shared by
     /// the compound-assignment result paths so both route through a single
-    /// `query_boundaries::common` call site.
+    /// flow query-boundary call site.
     fn evaluate_binary_op(
         &self,
         left_type: TypeId,
         right_type: TypeId,
         op_str: &'static str,
     ) -> TypeId {
-        let evaluator = crate::query_boundaries::common::new_binary_op_evaluator(self.interner);
+        let evaluator = new_binary_op_evaluator(self.interner);
         match evaluator.evaluate(left_type, right_type, op_str) {
             BinaryOpResult::Success(result) => result,
             BinaryOpResult::TypeError { .. } => TypeId::ANY,
@@ -1095,7 +1094,6 @@ impl<'a> FlowAnalyzer<'a> {
     }
 
     fn destructuring_type_from_key(&self, source_ty: TypeId, key: &PropertyKey) -> TypeId {
-        use crate::query_boundaries::common::PropertyAccessResult;
         match key {
             PropertyKey::Index(index) => self.destructuring_numeric_access_type(source_ty, *index),
             PropertyKey::Atom(atom) => match self.interner.resolve_property_access_with_options(

--- a/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment_fallback.rs
@@ -5,12 +5,11 @@
 //! Used by `get_assigned_type` in `assignment.rs` for flow-sensitive narrowing.
 
 use super::FlowAnalyzer;
-use crate::query_boundaries::common::{
-    TypeSubstitution, construct_signatures_for_type, instantiate_type,
-};
 use crate::query_boundaries::flow_analysis::{
-    call_signatures_for_type, function_return_type, get_application_info, is_promise_like_type,
-    union_members_for_type, unwrap_promise_type_argument, widen_literal_to_primitive,
+    TypeSubstitution, call_signatures_for_type, construct_signatures_for_type,
+    function_return_type, get_application_info, instantiate_type, is_promise_like_type,
+    literal_value, union_members_for_type, unwrap_promise_type_argument,
+    widen_literal_to_primitive,
 };
 use crate::types_domain::queries::lib_resolution::keyword_syntax_to_type_id;
 use tsz_common::interner::Atom;
@@ -371,9 +370,7 @@ impl<'a> FlowAnalyzer<'a> {
         }
         if let Some(computed) = self.arena.get_computed_property(name_node) {
             let key_type = self.fallback_expression_type_from_syntax(computed.expression)?;
-            if let Some(literal) =
-                crate::query_boundaries::common::literal_value(self.interner, key_type)
-            {
+            if let Some(literal) = literal_value(self.interner, key_type) {
                 return Some(match literal {
                     tsz_solver::LiteralValue::Number(value) => {
                         self.interner.intern_string(&value.0.to_string())

--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -10,13 +10,15 @@ use super::{
 };
 
 pub(crate) use super::common::{
-    LiteralValueKind, PredicateSignatureKind, TypeResolver, TypeSubstitution,
+    LiteralValueKind, PredicateSignatureKind, PropertyAccessResult, TypeResolver, TypeSubstitution,
     array_element_type as get_array_element_type, call_signatures_for_type,
     classify_for_literal_value, classify_for_predicate_signature, construct_signatures_for_type,
     contains_type_parameter_named, contains_type_parameters, function_shape_for_type,
-    instantiate_type, is_keyof_type, is_literal_type_through_type_constraints,
+    instantiate_type, is_assignment_operator, is_compound_assignment_operator, is_keyof_type,
+    is_literal_type_through_type_constraints, is_logical_compound_assignment_operator,
     is_narrowing_literal, is_type_parameter_like, is_union_type, is_unit_type,
-    is_unknown_narrowing_literal, object_shape_for_type, stringify_literal_type,
+    is_unknown_narrowing_literal, literal_value, map_compound_assignment_to_binary,
+    new_binary_op_evaluator, object_shape_for_type, stringify_literal_type,
     tuple_elements as tuple_elements_for_type, type_contains_undefined,
     union_members as union_members_for_type,
 };

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -237,7 +237,10 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # Ratcheted 3202→3197 after generic predicate-target instantiation
         # moved five flow/narrowing substitution queries through
         # query_boundaries::flow_analysis instead of the broad common barrel.
-        3197,
+        #
+        # Ratcheted 3197→3191 after assignment flow operator/property/literal
+        # queries moved through query_boundaries::flow_analysis.
+        3191,
     ),
 ]
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1264,7 +1264,10 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # Ratcheted 3202→3197 after generic predicate-target instantiation
         # moved five flow/narrowing substitution queries through
         # query_boundaries::flow_analysis instead of the broad common barrel.
-        3197,
+        #
+        # Ratcheted 3197→3191 after assignment flow operator/property/literal
+        # queries moved through query_boundaries::flow_analysis.
+        3191,
     ),
 ]
 


### PR DESCRIPTION
AgentName: M1-B
Track: checker orchestration / query-boundary cleanup
Invariant: Behavior unchanged. Assignment flow remains checker orchestration; operator, property-access-result, literal, signature-construction, and instantiation helpers are reached through `query_boundaries::flow_analysis` instead of the broad `query_boundaries::common` barrel.
Scope: Re-export existing helpers from `flow_analysis`; retarget `flow/control_flow/assignment.rs` and `assignment_fallback.rs`; ratchet the direct common-reference architecture cap from 3197 to 3191.

## Project Corpus Impact
- Row: none expected; refactor-only boundary routing with no semantic policy changes.
- Bug family: checker flow/narrowing query-boundary cleanup; no project-row behavior intended.

## Verification
- `cargo fmt`
- `git diff --check`
- `PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard_counts.ArchGuardQueryBoundaryCommonReferenceTests`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test flow_observation_boundary_tests assignment_destructuring_default_strips_undefined computed_binding_destructuring_default for_of_array_destructuring_with_defaults`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts2364_import_meta_assignment_tests simple_array_destructuring_is_valid simple_object_destructuring_assignment_is_valid`

## Coordination Notes
Draft opened early per M1-B ownership. No solver policy changes. Structural rule: when assignment flow needs reusable type/operator/property/literal semantics, checker should call the flow query boundary; the boundary owns the stable semantic helper routing.