### PR TITLE
docs: update merge queue command guidance

### DIFF
--- a/.agents/skills/tsz-ci-pr/SKILL.md
+++ b/.agents/skills/tsz-ci-pr/SKILL.md
@@ -36,7 +36,9 @@ now.
    `gh pr ready <pr>`.
 4. Queue with GitHub's native merge queue only when exact-head PR-head checks
    such as `CI Summary` pass and policy permits:
-   `gh pr merge --queue <pr>`.
+   `gh pr merge <pr> --match-head-commit <sha>`.
+   Do not pass `--auto`; with branch protection and passing checks, current
+   `gh` adds the PR to the native merge queue directly.
 5. Inspect `merge_group` CI runs if queue validation stalls.
 6. Verify final merge:
    `gh pr view <pr> --json state,mergedAt,mergedBy,url`.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -97,10 +97,10 @@ Hard rules:
   blocker/current work, next owner/action, and verification already run.
 - Close PRs/issues only when merged, user-requested, exact duplicate, or fully
   superseded with evidence and preserved findings.
-- Ready PRs land through GitHub's native merge queue. Queue with
-  `gh pr merge --queue <pr>` only if you own the PR, it is not
-  WIP/draft/blocked, exact-head PR-head checks pass, and you reviewed the
-  latest head. Do not use auto-merge as a watcher.
+- Ready PRs land through GitHub's native merge queue. After exact-head
+  PR-head checks pass and you reviewed the latest head, queue with
+  `gh pr merge <pr> --match-head-commit <sha>` only if you own the PR and it
+  is not WIP/draft/blocked. Do not use auto-merge as a watcher.
 - Native `merge_group` CI owns queued-merge summary validation after enqueue.
 
 ## Repo Skills

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,9 +16,10 @@ WASM, conformance, emit, fourslash, and snapshot gates.
 
 When a ready PR's exact head has passed the PR-head gates (`CI Summary`,
 and any review/body checks), the merge manager
-queues it with GitHub's native merge queue (`gh pr merge --queue`). The native
-queue creates a `merge_group` run that keeps the required queue summary check
-on the synthetic merge before merging.
+queues it with GitHub's native merge queue
+(`gh pr merge <pr> --match-head-commit <sha>`). The native queue creates a
+`merge_group` run that keeps the required queue summary check on the synthetic
+merge before merging.
 
 See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for the full development guide.
 
@@ -67,8 +68,9 @@ python3 scripts/conformance/query-conformance.py --dashboard
 7. **Push updates to the draft PR** — let CI run build, lint, and unit tests; do not wait idle
 8. **Mark ready for review** — triggers conformance, emit, fourslash, WASM, and snapshot gates
 9. **Hand off to the merge queue** — after exact-head PR-head gates pass,
-   the manager queues the PR with `gh pr merge --queue`; native queue admission
-   and summary validation run through the `merge_group` CI event
+   the manager queues the PR with
+   `gh pr merge <pr> --match-head-commit <sha>`; native queue admission and
+   summary validation run through the `merge_group` CI event
 
 Include your stable `AgentName` in every PR body and substantive PR comment.
 Use the draft PR body for scope, invariants, findings, verification, and

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -162,7 +162,8 @@ GitHub is the coordination surface.
    Address other agents by `AgentName` when coordination matters.
 8. Use only canonical ownership labels from `docs/plan/agents/README.md`.
    Replace generated runner labels or `agnet:*` typos with the correct lane
-   before marking a PR ready or queueing it with `gh pr merge --queue`.
+   before marking a PR ready or queueing it with
+   `gh pr merge <pr> --match-head-commit <sha>`.
 9. Never merge work that is still draft, labeled `WIP`, titled with `[WIP]`, or
    described as not ready.
 10. Treat `ready` plus a `WIP` label as WIP. Remove the label before merge.

--- a/docs/plan/agents/README.md
+++ b/docs/plan/agents/README.md
@@ -88,11 +88,13 @@ intake only after that queue is drained, queued, or explicitly blocked.
 1. Run the lane's `Start Every Cycle` commands.
 2. If open PRs carry the lane label, inspect each one and move it to the next
    concrete state before starting new issue work: fix/rebase it, mark it ready,
-   queue it with `gh pr merge --queue`, restore draft/WIP with a signed blocker, hand it off, or
-   close it only as duplicate/superseded with evidence.
+   queue it with `gh pr merge <pr> --match-head-commit <sha>`, restore
+   draft/WIP with a signed blocker, hand it off, or close it only as
+   duplicate/superseded with evidence.
 3. If an owned ready `main` PR has passing PR-head `CI Summary`, is not
    dirty/conflicting, and is not WIP or blocked, queue it with
-   `gh pr merge --queue` or ask `Studio-manager` to queue it.
+   `gh pr merge <pr> --match-head-commit <sha>` or ask `Studio-manager` to
+   queue it.
 4. Treat stale drafts as live debt. Drafts older than 24 hours without fresh
    commits/comments, and owners over two unstacked drafts, must be refreshed,
    handed off, marked help-wanted, or documented as blocked before new PRs.

--- a/docs/plan/agents/Studio-manager.md
+++ b/docs/plan/agents/Studio-manager.md
@@ -114,5 +114,6 @@ follow-up instead of posting one comment per PR.
 - Use `node scripts/ci/pr-ownership-report.mjs` for PR topology.
 - Use `scripts/agents/ensure-agent-labels.sh --audit --json-report /tmp/tsz-agent-label-audit.json` for label hygiene.
 - Use `scripts/ci/check-wip-state-comments.mjs` when changing WIP state.
-- Use GitHub PR-head check status before queueing with `gh pr merge --queue`.
+- Use GitHub PR-head check status before queueing with
+  `gh pr merge <pr> --match-head-commit <sha>`.
 - No compiler suite is needed for metadata-only cleanup.


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 10 tooling/guardrail docs: refactor-only workflow cleanup.

## Invariant
When a ready PR's exact head has passed PR-head checks, TSZ agents should use the `gh` command shape supported by the installed CLI to enter GitHub's native merge queue. This PR updates lane-control docs and skills from the removed `--queue` flag to exact-head `gh pr merge <pr> --match-head-commit <sha>` guidance.

## Scope
- `AGENTS.md` / `.claude/CLAUDE.md` queue handoff contract
- `.agents/skills/tsz-ci-pr/SKILL.md` landing workflow
- `docs/CONTRIBUTING.md` contributor queue handoff text
- `docs/plan/ROADMAP.md` coordination rule
- `docs/plan/agents/README.md` and `docs/plan/agents/Studio-manager.md` lane-control guidance

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: docs/skill-only workflow correction; no compiler, emit, LSP, WASM, or benchmark behavior path changes.

## Verification
- `scripts/agents/llm-context-audit.py`
- `rg -n "gh pr merge --queue" .`
- `git diff --check origin/main..HEAD`
- `scripts/agents/ensure-agent-labels.sh --audit` (reports pre-existing unlabelled PRs/issues outside this PR scope)
- Draft PR-head `CI Light Summary` passed on run 27072776178.

## Coordination Notes
- Opened after PR #12830 hit the stale documented command during queue handoff; installed `gh` reports `unknown flag: --queue`, while `gh pr merge <pr> --match-head-commit <sha>` reports queued/queues native branch-protected PRs.
- Ready for manager review on exact head `ec1f323e62d2f64ddf0df43f1d148b998d571d77`; no WIP blocker.
