### PR TITLE
fix(dts): preserve object assign portability alias

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/core.rs
@@ -1394,6 +1394,15 @@ impl<'a> CheckerState<'a> {
         if initializer_is_object_assign {
             return;
         }
+        if initializer.is_some()
+            && self
+                .ctx
+                .arena
+                .get(initializer)
+                .is_some_and(|node| node.kind == syntax_kind_ext::TAGGED_TEMPLATE_EXPRESSION)
+        {
+            return;
+        }
 
         if name == "globalThis"
             && initializer.is_some()

--- a/crates/tsz-cli/tests/tsc_compat_tests_parts/part_00.rs
+++ b/crates/tsz-cli/tests/tsc_compat_tests_parts/part_00.rs
@@ -945,6 +945,99 @@ export const x = foo();
 }
 
 #[test]
+fn declaration_emit_default_object_assign_reports_namespace_alias_for_default_only() {
+    let temp = TempDir::new("default_object_assign_namespace_alias").expect("temp dir");
+
+    write_file(
+        &temp.path.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "declaration": true,
+            "emitDeclarationOnly": true,
+            "outDir": "dist",
+            "rootDir": "r",
+            "target": "es2017",
+            "module": "commonjs",
+            "moduleResolution": "node",
+            "ignoreDeprecations": "6.0",
+            "skipLibCheck": true,
+            "strict": true,
+            "typeRoots": ["./empty-types"]
+          },
+          "files": ["r/entry.ts"]
+        }"#,
+    );
+    std::fs::create_dir_all(temp.path.join("empty-types")).expect("empty typeRoots");
+    write_file(
+        &temp
+            .path
+            .join("r/node_modules/styled-components/node_modules/hoist-non-react-statics/index.d.ts"),
+        r#"interface Statics {
+    "$$whatever": string;
+}
+declare namespace hoistNonReactStatics {
+    type NonReactStatics<T> = {[X in Exclude<keyof T, keyof Statics>]: T[X]}
+}
+export = hoistNonReactStatics;
+"#,
+    );
+    write_file(
+        &temp.path.join("r/node_modules/styled-components/index.d.ts"),
+        r#"import * as hoistNonReactStatics from "hoist-non-react-statics";
+export interface DefaultTheme {}
+export type StyledComponent<TTag extends string, TTheme = DefaultTheme, TStyle = {}, TWhatever = never> =
+    string
+    & StyledComponentBase<TTag, TTheme, TStyle, TWhatever>
+    & hoistNonReactStatics.NonReactStatics<TTag>;
+export interface StyledComponentBase<TTag extends string, TTheme = DefaultTheme, TStyle = {}, TWhatever = never> {
+    tag: TTag;
+    theme: TTheme;
+    style: TStyle;
+    whatever: TWhatever;
+}
+export interface StyledInterface {
+    div: (a: TemplateStringsArray) => StyledComponent<"div">;
+}
+declare const styled: StyledInterface;
+export default styled;
+"#,
+    );
+    write_file(
+        &temp.path.join("r/entry.ts"),
+        r#"import styled from "styled-components";
+
+const A = styled.div``;
+const B = styled.div``;
+export const C = styled.div``;
+
+export default Object.assign(A, {
+    B,
+    C
+});
+"#,
+    );
+
+    let (code, output) =
+        run_tsz_with_exit_code(&temp.path, &["-p", "tsconfig.json"]).expect("tsz should run");
+    assert_ne!(code, 0, "tsz should report TS2883");
+    assert_eq!(
+        output.matches("TS2883").count(),
+        1,
+        "expected exactly one TS2883 diagnostic, got:\n{output}"
+    );
+    assert!(
+        output.contains("inferred type of 'default'")
+            && output.contains("NonReactStatics")
+            && output.contains("styled-components/node_modules/hoist-non-react-statics"),
+        "expected default TS2883 to name NonReactStatics, got:\n{output}"
+    );
+    assert!(
+        !output.contains("inferred type of 'C'") && !output.contains("reference to 'Statics'"),
+        "named tagged-template export should not report helper Statics, got:\n{output}"
+    );
+}
+
+#[test]
 fn declaration_emit_preserves_template_literal_type_text_from_dependency() {
     let temp = TempDir::new("template_literal_type_text_from_dependency").expect("temp dir");
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_check.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_check.rs
@@ -978,6 +978,7 @@ impl<'a> DeclarationEmitter<'a> {
             && collect.seen.insert(result.clone())
         {
             collect.results.push(result);
+            return;
         }
 
         if let Some(identifier) = arena.get_identifier(node) {
@@ -1473,6 +1474,9 @@ impl<'a> DeclarationEmitter<'a> {
         let Some(root_expr) = self.skip_parenthesized_expression(expr_idx) else {
             return false;
         };
+        if self.tagged_template_has_nameable_surface_type(root_expr) {
+            return false;
+        }
         let mut current = root_expr;
         loop {
             let Some(node) = self.arena.get(current) else {
@@ -1509,6 +1513,28 @@ impl<'a> DeclarationEmitter<'a> {
             return true;
         }
         self.emit_non_portable_symbol_declaration_diagnostic(sym_id, decl_name, file, pos, length)
+    }
+
+    fn tagged_template_has_nameable_surface_type(&self, expr_idx: NodeIndex) -> bool {
+        if self
+            .arena
+            .get(expr_idx)
+            .is_none_or(|node| node.kind != syntax_kind_ext::TAGGED_TEMPLATE_EXPRESSION)
+        {
+            return false;
+        }
+
+        self.tagged_template_declared_return_type_text(expr_idx)
+            .or_else(|| self.preferred_expression_type_text(expr_idx))
+            .or_else(|| {
+                self.get_node_type(expr_idx)
+                    .map(|type_id| self.print_type_id(type_id))
+            })
+            .is_some_and(|type_text| {
+                self.type_text_is_directly_nameable_reference(&type_text)
+                    && (Self::type_text_starts_with_import_type(&type_text)
+                        || type_text.contains(['<', '.']))
+            })
     }
 
     fn type_text_identifier_is_mapped_key_import_member(type_text: &str, start: usize) -> bool {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
@@ -1699,6 +1699,11 @@ impl<'a> DeclarationEmitter<'a> {
                 if let Some(result) =
                     emitter.check_symbol_portability(sym_id, binder, current_file_path, visit)
                 {
+                    if let Some(alias_result) =
+                        emitter.alias_reference_covering_helper_symbol(sym_id, binder, &result.0)
+                    {
+                        return Some(alias_result);
+                    }
                     return Some(result);
                 }
                 if let Some(result) = emitter
@@ -1919,5 +1924,77 @@ impl<'a> DeclarationEmitter<'a> {
         }
 
         None
+    }
+
+    fn alias_reference_covering_helper_symbol(
+        &self,
+        helper_sym_id: SymbolId,
+        binder: &BinderState,
+        from_path: &str,
+    ) -> Option<(String, String)> {
+        let helper_source_path = self.get_symbol_source_path(helper_sym_id, binder)?;
+        let helper_source_path = helper_source_path.replace('\\', "/");
+
+        binder.symbols.iter().find_map(|candidate| {
+            if candidate.id == helper_sym_id {
+                return None;
+            }
+            let candidate_source_path = self
+                .get_symbol_source_path(candidate.id, binder)?
+                .replace('\\', "/");
+            if candidate_source_path != helper_source_path {
+                return None;
+            }
+            let source_arena = binder
+                .symbol_arenas
+                .get(&candidate.id)
+                .or_else(|| self.global_symbol_arenas.get(&candidate.id))?;
+            candidate.declarations.iter().copied().find_map(|decl_idx| {
+                let decl_node = source_arena.get(decl_idx)?;
+                let alias = source_arena.get_type_alias(decl_node)?;
+                if matches!(source_arena.get(alias.type_node), Some(node) if node.kind == syntax_kind_ext::TYPE_LITERAL) {
+                    return None;
+                }
+                self.type_node_subtree_references_symbol(
+                    source_arena.as_ref(),
+                    alias.type_node,
+                    helper_sym_id,
+                )
+                .then(|| (from_path.to_string(), candidate.escaped_name.clone()))
+            })
+        })
+    }
+
+    fn type_node_subtree_references_symbol(
+        &self,
+        arena: &NodeArena,
+        node_idx: NodeIndex,
+        target_sym_id: SymbolId,
+    ) -> bool {
+        if !node_idx.is_some() {
+            return false;
+        }
+        if let Some(binder) = self.binder
+            && let Some(sym_id) = binder.get_node_symbol(node_idx)
+            && self.resolve_portability_declaration_symbol(sym_id, binder)
+                == self.resolve_portability_declaration_symbol(target_sym_id, binder)
+        {
+            return true;
+        }
+        if arena.get(node_idx).is_none() {
+            return false;
+        };
+        if let Some(node) = arena.get(node_idx)
+            && let Some(identifier) = arena.get_identifier(node)
+            && let Some(sym_id) = self.find_symbol_in_arena_by_name(arena, &identifier.escaped_text)
+            && let Some(binder) = self.binder
+            && self.resolve_portability_declaration_symbol(sym_id, binder)
+                == self.resolve_portability_declaration_symbol(target_sym_id, binder)
+        {
+            return true;
+        }
+        arena.get_children(node_idx).into_iter().any(|child_idx| {
+            self.type_node_subtree_references_symbol(arena, child_idx, target_sym_id)
+        })
     }
 }

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -47,7 +47,6 @@
 # Keep these visible as accepted-regression debt until their owning parity
 # fixes remove them from exact-head aggregate output.
 TypeScript/tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts
-TypeScript/tests/cases/compiler/declarationEmitObjectAssignedDefaultExport.ts
 TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules1.ts
 TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
@@ -58,12 +57,10 @@ TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts
 TypeScript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
-TypeScript/tests/cases/compiler/promisesWithConstraints.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts
 TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts
 TypeScript/tests/cases/conformance/jsdoc/importTag17.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
-TypeScript/tests/cases/conformance/types/conditional/conditionalTypes2.ts
 # covariantCallbacks.ts: RESOLVED by PR #12482. tsz now detects nullable-union
 # callback method parameters the way tsc does (getSingleCallSignature(
 # getNonNullableType(t))), so lib `Promise<A>` -> `Promise<B>` reports its


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Conformance / declaration emit portability accepted-regression cleanup

## Invariant
When a named exported tagged-template value has a reusable public package surface, `tsc` does not report TS2883 for private helper types inside that surface; when an anonymous default `Object.assign` inference still exposes a transitive package alias, `tsc` reports the namespace alias rather than the helper internals. This PR makes tsz do that through the checker exported-variable precheck and declaration emitter portability resolver.

## Scope
- Defer checker TS2883 prechecks for exported tagged-template initializers to declaration emit.
- Treat namespace-member type-node references as portability boundaries during declaration walks.
- Prefer a same-package exported alias that structurally covers a helper symbol before reporting the helper symbol directly.
- Remove `declarationEmitObjectAssignedDefaultExport.ts` plus stale resolved `promisesWithConstraints.ts` and `conditionalTypes2.ts` entries from accepted-regression debt.

## Project Corpus Impact
- Row: n/a
- Bug family: conformance accepted-regression / declaration portability TS2883 for `Object.assign` default export

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-common -p tsz-scanner -p tsz-parser -p tsz-binder -p tsz-solver -p tsz-checker -p tsz-emitter -p tsz-lowering -p tsz-lsp --all-targets -- -D warnings`
- `scripts/safe-run.sh cargo nextest run -p tsz-cli --test tsc_compat_tests declaration_emit_default_object_assign_reports_namespace_alias_for_default_only`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter declarationEmitObjectAssignedDefaultExport --verbose`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter declarationEmitUsingTypeAlias1 --verbose`
- `python3 scripts/conformance/check-accepted-regression-growth.py --base-ref origin/main --head-ref HEAD --allow-unavailable-base`
- `python3 scripts/conformance/query-conformance.py --dashboard`
- `python3 scripts/emit/query-emit.py --families`

## Coordination Notes
- AgentName: Studio-A
- Focused PR: fixes `declarationEmitObjectAssignedDefaultExport.ts` and removes two stale resolved ledger entries, reducing the accepted-regression gate from 18 to 15 on this branch.
- `declarationEmitUsingTypeAlias1.ts` is verified directly instead of added to the ledger; type-literal container aliases keep walking to nested member types so `bar` reports `Other` like `tsc`.
- No project-row status change; emit families remain at 0 JS and 0 declaration failures.



