### PR TITLE
refactor(checker): route numeric display probes through diagnostics boundary

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_numeric_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_numeric_display.rs
@@ -35,10 +35,8 @@ impl<'a> CheckerState<'a> {
         let evaluated = self.evaluate_type_for_assignability(type_id);
         let other_evaluated = self.evaluate_type_for_assignability(other_type);
         if evaluated != type_id
-            && crate::query_boundaries::common::function_shape_for_type(self.ctx.types, evaluated)
-                .is_none()
-            && crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, evaluated)
-                .is_none()
+            && diagnostic_query::function_shape_for_type(self.ctx.types, evaluated).is_none()
+            && diagnostic_query::callable_shape_for_type(self.ctx.types, evaluated).is_none()
         {
             self.collect_numeric_literal_union_display_replacements(
                 evaluated,
@@ -84,8 +82,7 @@ impl<'a> CheckerState<'a> {
         seen.push(type_id);
 
         if self.is_number_literal_union_for_display_order(type_id)
-            && let Some(members) =
-                crate::query_boundaries::common::union_members(self.ctx.types, type_id)
+            && let Some(members) = diagnostic_query::union_members(self.ctx.types, type_id)
         {
             let member_displays = members
                 .iter()
@@ -201,7 +198,7 @@ impl<'a> CheckerState<'a> {
         match diagnostic_query::assignment_numeric_display_children(self.ctx.types, type_id) {
             diagnostic_query::AssignmentNumericDisplayChildren::Application { base, args } => {
                 let other_args = other_type.and_then(|other| {
-                    crate::query_boundaries::common::application_info(self.ctx.types, other)
+                    diagnostic_query::application_info(self.ctx.types, other)
                         .and_then(|(other_base, args)| (other_base == base).then_some(args))
                 });
                 for (index, &arg) in args.iter().enumerate() {
@@ -232,7 +229,7 @@ impl<'a> CheckerState<'a> {
                 self.collect_numeric_literal_union_display_replacements(
                     element,
                     other_type.and_then(|other| {
-                        crate::query_boundaries::common::array_element_type(self.ctx.types, other)
+                        diagnostic_query::array_element_type(self.ctx.types, other)
                     }),
                     rewrite_alias_origin,
                     seen,
@@ -240,9 +237,8 @@ impl<'a> CheckerState<'a> {
                 );
             }
             diagnostic_query::AssignmentNumericDisplayChildren::Tuple(elements) => {
-                let other_elements = other_type.and_then(|other| {
-                    crate::query_boundaries::common::tuple_elements(self.ctx.types, other)
-                });
+                let other_elements = other_type
+                    .and_then(|other| diagnostic_query::tuple_elements(self.ctx.types, other));
                 for (index, element) in elements.iter().enumerate() {
                     self.collect_numeric_literal_union_display_replacements(
                         element.type_id,
@@ -320,16 +316,14 @@ impl<'a> CheckerState<'a> {
         &mut self,
         type_id: TypeId,
     ) -> Option<TypeId> {
-        if crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
-            .is_some()
-            || crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, type_id)
-                .is_some()
+        if diagnostic_query::function_shape_for_type(self.ctx.types, type_id).is_some()
+            || diagnostic_query::callable_shape_for_type(self.ctx.types, type_id).is_some()
         {
             return None;
         }
 
         if self.is_number_literal_union_for_display_order(type_id)
-            || crate::query_boundaries::common::application_info(self.ctx.types, type_id).is_some()
+            || diagnostic_query::application_info(self.ctx.types, type_id).is_some()
             || self.source_type_contains_number_literal_only_union(type_id)
         {
             return Some(type_id);
@@ -337,17 +331,14 @@ impl<'a> CheckerState<'a> {
 
         let evaluated = self.evaluate_type_for_assignability(type_id);
         if evaluated == type_id
-            || crate::query_boundaries::common::function_shape_for_type(self.ctx.types, evaluated)
-                .is_some()
-            || crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, evaluated)
-                .is_some()
+            || diagnostic_query::function_shape_for_type(self.ctx.types, evaluated).is_some()
+            || diagnostic_query::callable_shape_for_type(self.ctx.types, evaluated).is_some()
         {
             return None;
         }
 
         if self.is_number_literal_union_for_display_order(evaluated)
-            || crate::query_boundaries::common::application_info(self.ctx.types, evaluated)
-                .is_some()
+            || diagnostic_query::application_info(self.ctx.types, evaluated).is_some()
         {
             Some(evaluated)
         } else {
@@ -359,10 +350,8 @@ impl<'a> CheckerState<'a> {
         &mut self,
         type_id: TypeId,
     ) -> Option<TypeId> {
-        if crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
-            .is_some()
-            || crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, type_id)
-                .is_some()
+        if diagnostic_query::function_shape_for_type(self.ctx.types, type_id).is_some()
+            || diagnostic_query::callable_shape_for_type(self.ctx.types, type_id).is_some()
         {
             return None;
         }
@@ -451,7 +440,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let members = crate::query_boundaries::common::union_members(self.ctx.types, type_id)?;
+        let members = diagnostic_query::union_members(self.ctx.types, type_id)?;
         let mut unmatched = Vec::new();
         let mut matched = Vec::new();
         for member in members {
@@ -486,7 +475,7 @@ impl<'a> CheckerState<'a> {
             return Some(vec![number]);
         }
 
-        let members = crate::query_boundaries::common::union_members(self.ctx.types, type_id)?;
+        let members = diagnostic_query::union_members(self.ctx.types, type_id)?;
         let mut numbers = Vec::with_capacity(members.len());
         for member in members {
             numbers.push(self.numeric_literal_value(member)?);

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -240,7 +240,10 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         #
         # Ratcheted 3197→3191 after assignment flow operator/property/literal
         # queries moved through query_boundaries::flow_analysis.
-        3191,
+        #
+        # Ratcheted 3191→3174 after assignment numeric display shape queries
+        # moved through query_boundaries::diagnostics.
+        3174,
     ),
 ]
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1267,7 +1267,10 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         #
         # Ratcheted 3197→3191 after assignment flow operator/property/literal
         # queries moved through query_boundaries::flow_analysis.
-        3191,
+        #
+        # Ratcheted 3191→3174 after assignment numeric display shape queries
+        # moved through query_boundaries::diagnostics.
+        3174,
     ),
 ]
 


### PR DESCRIPTION
## Agent
AgentName: M1-B

## Track
Track 3 checker architecture refactor: query-boundary cleanup for diagnostic display routing.

## Invariant
When assignment numeric-literal display needs type-shape facts for rendering, tsz asks through the checker diagnostics query boundary; this PR preserves behavior while removing direct checker calls into the broad query_boundaries::common quarantine.

## Scope
- Route numeric assignment display probes through query_boundaries::diagnostics.
- Ratchet the direct query_boundaries::common checker-reference cap from 3191 to 3174.
- No solver policy, relation policy, or diagnostic text changes intended.

## Project Corpus Impact
- Row: none expected; display-only boundary routing with behavior unchanged.
- Bug family: checker query-boundary cleanup / assignment diagnostic display routing.

## Verification
- cargo fmt
- git diff --check
- PYTHONPATH=scripts/arch python3 -m unittest scripts.arch.test_arch_guard_counts.ArchGuardQueryBoundaryCommonReferenceTests
- scripts/safe-run.sh cargo nextest run -p tsz-checker --test conformance_issues_types membership_semantics
- scripts/arch/check-checker-boundaries.sh
- python3 scripts/arch/arch_guard.py
- Exact-head CI Summary passed on run 27072946035 for head 319c6373f92edc173d955b2f880851ca771a398d.

## Coordination Notes
- AgentName: M1-B
- Drains owned PRs first: no live M1-B PRs at cycle start after #12832 merged.
- Stacked on origin/main after #12832; avoids solver-policy changes and only reuses existing diagnostics boundary exports.
- Marked ready after local verification and remote body/label verification.
- Fresh metadata-only run requested after exact-head CI passed so branch protection sees the current successful summary.