### PR TITLE
perf(checker): bound extract-like constraints before true branch

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -416,6 +416,24 @@ impl<'a> CheckerState<'a> {
                     return false;
                 }
 
+                if true_type == check {
+                    let extends_resolved = self.resolve_lazy_type(extends_type);
+                    let extends_evaluated = self.evaluate_type_for_assignability(extends_resolved);
+                    let constraint_evaluated = self.evaluate_type_for_assignability(constraint);
+                    return self
+                        .conditional_constraint_component_relation_outcome(
+                            extends_evaluated,
+                            constraint_evaluated,
+                        )
+                        .related
+                        || self
+                            .conditional_constraint_component_relation_outcome(
+                                extends_resolved,
+                                constraint,
+                            )
+                            .related;
+                }
+
                 let true_resolved = self.resolve_lazy_type(true_type);
                 let true_evaluated = self.evaluate_type_for_assignability(true_resolved);
                 let constraint_evaluated = self.evaluate_type_for_assignability(constraint);
@@ -437,23 +455,7 @@ impl<'a> CheckerState<'a> {
                     return true;
                 }
 
-                if true_type != check {
-                    return false;
-                }
-                let extends_resolved = self.resolve_lazy_type(extends_type);
-                let extends_evaluated = self.evaluate_type_for_assignability(extends_resolved);
-                return self
-                    .conditional_constraint_component_relation_outcome(
-                        extends_evaluated,
-                        constraint_evaluated,
-                    )
-                    .related
-                    || self
-                        .conditional_constraint_component_relation_outcome(
-                            extends_resolved,
-                            constraint,
-                        )
-                        .related;
+                return false;
             }
 
             let Some(app) =

--- a/crates/tsz-checker/tests/ts2344_generic_ref_scoped_param_concrete_constraint.rs
+++ b/crates/tsz-checker/tests/ts2344_generic_ref_scoped_param_concrete_constraint.rs
@@ -371,3 +371,24 @@ type Use<A> = Box<ExecPath<A>>;
         "Conditional filters like Select<..., string> should satisfy string constraints. Got: {diagnostics:?}"
     );
 }
+
+#[test]
+fn nested_generic_alias_filtering_to_string_satisfies_string_constraint() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type Box<T extends string> = T;
+type DropStrings<T> = T extends string ? never : T;
+type Values<T> = T[keyof T];
+type KeepMatching<U, M> = U extends M ? U : never;
+type NextText<OP> = KeepMatching<Values<DropStrings<OP> & {}>, string>;
+type ExecText<A> = NextText<{ value: string; next: A }>;
+
+type Use<A> = Box<ExecText<A>>;
+"#,
+    );
+
+    assert!(
+        diagnostics.iter().all(|(code, _)| *code != 2344),
+        "Nested conditional filters should satisfy string constraints through their extends branch. Got: {diagnostics:?}"
+    );
+}


### PR DESCRIPTION
AgentName: Studio-B

## Track
Track 1/2 recursive type evaluation pressure; supports Studio-B performance/residency gate.

## Invariant
When a conditional type has the Extract-like surface `T extends C ? T : never`, its result is bounded by `C`. During TS2344 constraint validation, tsz can therefore test `C` against the required constraint before evaluating the potentially expensive true branch. Non-Extract-like conditionals still use the existing true-branch proof or fall back to normal validation.

## Scope
Reorders the existing `type_alias_application_filters_to_constraint` proof so the `true_type == check` branch checks the extends side first. Adds a renamed nested filter test covering a string-constrained generic alias through `Values<DropStrings<OP> & {}>` and `KeepMatching<..., string>`.

## Project Corpus Impact
- Row: ts-toolbelt-project
- Bug family: recursive type evaluation pressure / TS2344 alias body validation fan-out
- Impact: Shrinks the remaining ts-toolbelt green-row target gap after #12831. Baseline artifact after #12831: tsz 1015.44 ms vs tsgo 138.92 ms, tsgo 7.31x. This PR first timing: tsz 957.52 ms vs tsgo 136.51 ms, tsgo 7.01x. Rerun: tsz 962.77 ms vs tsgo 135.73 ms, tsgo 7.09x. The row remains green but below the 2x speed target; no claim that this closes the target gap.
- Remaining gap: ts-toolbelt remains a 2x target gap, and Vite remains a separate green target gap.

## Verification
- `cargo fmt -p tsz-checker --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts2344_generic_ref_scoped_param_concrete_constraint --no-fail-fast`
- Timing: `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --filter 'ts-toolbelt-project' --json-file artifacts/perf/studio-b-autopath-filter-ts-toolbelt-20260606.json`
- Timing rerun: `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --filter 'ts-toolbelt-project' --json-file artifacts/perf/studio-b-autopath-filter-ts-toolbelt-rerun-20260606.json`
- Attribution: `scripts/safe-run.sh env TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 TSZ_PERF_COUNTERS=1 cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --noEmit -p .target-bench/external/ts-toolbelt/tsconfig.flat.json --pretty false --perf-counters-json artifacts/perf/studio-b-autopath-filter-ts-toolbelt-20260606.perf.json`
- Winner report: `node scripts/bench/tsgo-winner-report.mjs artifacts/perf/studio-b-autopath-filter-ts-toolbelt-20260606.json artifacts/perf/studio-b-autopath-filter-ts-toolbelt-20260606.tsgo-winners.json`

## Coordination Notes
Owned PRs were drained before this work; #12831 landed on main first. This PR does not close the Studio-B goal: eligible green rows still remain below the 2x target after this measured shrink.
