### PR TITLE
refactor(dts): pass declaration summary into emitter

### DIFF
--- a/crates/tsz-binder/src/lib.rs
+++ b/crates/tsz-binder/src/lib.rs
@@ -20,6 +20,7 @@ pub mod symbols;
 // Re-export core data types at crate root for convenience.
 pub use flow::{FlowNode, FlowNodeArena, FlowNodeId, flow_flags};
 pub use scopes::{ContainerKind, Scope, ScopeContext, ScopeId};
+pub use state::declaration_summary::DeclarationSummary;
 pub use state::export_surface::{ExportSurface, ExportedSymbol, NamedReexport, WildcardReexport};
 pub use state::{
     BinderOptions, BinderState, CrossFileNodeSymbols, DeclarationArenaMap, FileFeatures,

--- a/crates/tsz-binder/src/state/declaration_summary.rs
+++ b/crates/tsz-binder/src/state/declaration_summary.rs
@@ -1,0 +1,73 @@
+//! Precomputed declaration-emission facts for a single source file.
+//!
+//! `DeclarationSummary` is the binder-owned boundary consumed by declaration
+//! emit. It groups stable, reusable facts needed while printing `.d.ts` output
+//! so the emitter does not rediscover them during the emit walk.
+
+use crate::{BinderState, ExportSurface};
+use rustc_hash::FxHashSet;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeArena;
+
+/// Structured declaration-emission facts for one source file.
+///
+/// The first populated family is the file's exported surface: exported locals,
+/// re-exports, public-API scope, and top-level overload grouping. Future DTS
+/// summary facts should extend this type instead of adding more ad hoc emitter
+/// discovery state.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct DeclarationSummary {
+    pub export_surface: ExportSurface,
+}
+
+impl DeclarationSummary {
+    /// Build declaration facts from binder state and AST structure.
+    pub fn from_binder(
+        binder: &BinderState,
+        arena: &NodeArena,
+        file_name: &str,
+        root_idx: NodeIndex,
+    ) -> Self {
+        Self {
+            export_surface: ExportSurface::from_binder(binder, arena, file_name, root_idx),
+        }
+    }
+
+    /// Top-level function overload names that should suppress implementation
+    /// signatures during declaration emit.
+    pub const fn overloaded_functions(&self) -> &FxHashSet<String> {
+        &self.export_surface.overloaded_functions
+    }
+
+    /// Whether declaration emit should filter the file to its public API.
+    pub const fn has_public_api_scope(&self) -> bool {
+        self.export_surface.has_public_api_scope
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_summary_has_no_public_surface_facts() {
+        let summary = DeclarationSummary::default();
+
+        assert!(summary.overloaded_functions().is_empty());
+        assert!(!summary.has_public_api_scope());
+        assert_eq!(summary.export_surface.public_api_size(), 0);
+    }
+
+    #[test]
+    fn summary_exposes_export_surface_overload_facts() {
+        let mut summary = DeclarationSummary::default();
+        summary
+            .export_surface
+            .overloaded_functions
+            .insert("parse".to_string());
+        summary.export_surface.has_public_api_scope = true;
+
+        assert!(summary.overloaded_functions().contains("parse"));
+        assert!(summary.has_public_api_scope());
+    }
+}

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -5,6 +5,7 @@
 
 mod core;
 mod core_jsdoc;
+pub mod declaration_summary;
 pub mod export_surface;
 mod flow_helpers;
 mod lib_merge;

--- a/crates/tsz-cli/src/driver/emit.rs
+++ b/crates/tsz-cli/src/driver/emit.rs
@@ -608,16 +608,16 @@ pub(crate) fn emit_outputs(
                 // direct imports (TS2307) but doesn't suppress the portability
                 // check on inferred types in declaration emit.
 
-                // Precompute the export surface summary for this file.
-                // This seeds the overload pre-scan so the emitter doesn't
+                // Precompute declaration facts for this file. This seeds the
+                // exported-surface overload pre-scan so the emitter doesn't
                 // need to discover overloads incrementally during the walk.
-                let surface = tsz_binder::ExportSurface::from_binder(
+                let summary = tsz_binder::DeclarationSummary::from_binder(
                     &binder,
                     &file.arena,
                     &file.file_name,
                     file.source_file,
                 );
-                emitter.set_export_surface(surface);
+                emitter.set_declaration_summary(summary);
                 if !duplicate_global_var_names.is_empty() {
                     emitter.set_bundled_duplicate_global_var_types(
                         bundled_duplicate_global_var_types_for_file(

--- a/crates/tsz-cli/src/driver/sources.rs
+++ b/crates/tsz-cli/src/driver/sources.rs
@@ -1317,11 +1317,11 @@ mod tests {
         )
         .unwrap();
         std::fs::write(
-            &dir.path().join("src/first.ts"),
+            dir.path().join("src/first.ts"),
             "export const a = 1; export const c = 2;\n",
         )
         .unwrap();
-        std::fs::write(&dir.path().join("src/second.ts"), "export const b = 1;\n").unwrap();
+        std::fs::write(dir.path().join("src/second.ts"), "export const b = 1;\n").unwrap();
 
         assert_eq!(
             root_dep_file_names(dir.path(), &root),

--- a/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/emit_declarations.rs
@@ -28,12 +28,12 @@ impl<'a> DeclarationEmitter<'a> {
         self.emitted_scope_marker = false;
         self.emitted_module_indicator = false;
 
-        // Seed overload tracking from precomputed ExportSurface if available.
-        // This replaces the incremental on-the-fly detection for top-level
-        // functions, ensuring overload grouping is correct even if the surface
-        // was built in a previous pass.
-        if let Some(ref surface) = self.export_surface {
-            self.function_names_with_overloads = surface.overloaded_functions.clone();
+        // Seed overload tracking from the precomputed declaration summary.
+        // This replaces incremental on-the-fly discovery for top-level
+        // functions, ensuring overload grouping is correct even when the
+        // exported surface was built in a previous pass.
+        if let Some(ref summary) = self.declaration_summary {
+            self.function_names_with_overloads = summary.overloaded_functions().clone();
         }
 
         // Prepare import metadata for elision BEFORE running UsageAnalyzer
@@ -141,12 +141,12 @@ impl<'a> DeclarationEmitter<'a> {
         self.source_is_declaration_file = source_file.is_declaration_file;
         self.source_is_js_file = self.source_file_is_js(source_file);
         self.current_source_file_idx = Some(root_idx);
-        // Prefer the pre-computed flag from ExportSurface when available;
+        // Prefer the precomputed declaration summary flag when available;
         // fall back to the existing AST walk for JS files (which need
         // CommonJS-specific detection the surface doesn't cover yet).
-        self.emit_public_api_only = if let Some(ref surface) = self.export_surface {
+        self.emit_public_api_only = if let Some(ref summary) = self.declaration_summary {
             if !self.source_is_js_file {
-                surface.has_public_api_scope
+                summary.has_public_api_scope()
             } else {
                 self.has_public_api_exports(source_file)
             }

--- a/crates/tsz-emitter/src/declaration_emitter/core/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/mod.rs
@@ -63,8 +63,8 @@ pub struct DeclarationEmitter<'a> {
     pub(super) type_interner: Option<&'a TypeInterner>,
     /// Binder state for symbol resolution (used by `UsageAnalyzer`)
     pub(super) binder: Option<&'a BinderState>,
-    /// Precomputed export surface summary (replaces ad-hoc re-extraction).
-    pub(super) export_surface: Option<tsz_binder::ExportSurface>,
+    /// Precomputed declaration facts (replaces ad-hoc re-extraction).
+    pub(super) declaration_summary: Option<tsz_binder::DeclarationSummary>,
     /// Map of symbols to their usage kind (Type, Value, or Both) for import elision
     pub(super) used_symbols:
         Option<FxHashMap<SymbolId, crate::declaration_emitter::usage_analyzer::UsageKind>>,

--- a/crates/tsz-emitter/src/declaration_emitter/core/setup.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/setup.rs
@@ -30,7 +30,7 @@ impl<'a> DeclarationEmitter<'a> {
             current_source_file_idx: None,
             type_interner: None,
             binder: None,
-            export_surface: None,
+            declaration_summary: None,
             used_symbols: None,
             foreign_symbols: None,
             current_arena: None,
@@ -158,7 +158,7 @@ impl<'a> DeclarationEmitter<'a> {
             current_source_file_idx: None,
             type_interner: Some(type_interner),
             binder: Some(binder),
-            export_surface: None,
+            declaration_summary: None,
             used_symbols: None,
             foreign_symbols: None,
             current_arena: None,
@@ -309,12 +309,21 @@ impl<'a> DeclarationEmitter<'a> {
         self.binder = binder;
     }
 
-    /// Set a precomputed export surface summary.
+    /// Set precomputed declaration-emission facts.
     ///
-    /// When set, the emitter uses the summary's overload pre-scan instead
-    /// of discovering overloads incrementally during the emit walk.
+    /// When set, the emitter uses the summary's exported-surface overload
+    /// pre-scan instead of discovering top-level overload groups
+    /// incrementally during the emit walk.
+    pub fn set_declaration_summary(&mut self, summary: tsz_binder::DeclarationSummary) {
+        self.declaration_summary = Some(summary);
+    }
+
+    /// Compatibility shim for callers that still construct only an
+    /// `ExportSurface`.
     pub fn set_export_surface(&mut self, surface: tsz_binder::ExportSurface) {
-        self.export_surface = Some(surface);
+        self.set_declaration_summary(tsz_binder::DeclarationSummary {
+            export_surface: surface,
+        });
     }
 
     /// Set the current file's arena and path for distinguishing local vs foreign symbols.

--- a/crates/tsz-emitter/src/declaration_emitter/tests/class_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/class_features.rs
@@ -491,6 +491,34 @@ fn test_function_overloads_emit_only_signatures() {
     );
 }
 
+#[test]
+fn declaration_summary_precomputes_function_overload_suppression() {
+    let source = r#"
+    export function parse(input: any): any { return input; }
+    export const keep = 1;
+    "#;
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut summary = tsz_binder::DeclarationSummary::default();
+    summary
+        .export_surface
+        .overloaded_functions
+        .insert("parse".to_string());
+
+    let mut emitter = DeclarationEmitter::new(&parser.arena);
+    emitter.set_declaration_summary(summary);
+    let output = emitter.emit(root);
+
+    assert!(
+        !output.contains("export declare function parse(input: any): any;"),
+        "Expected precomputed overload summary to suppress implementation: {output}"
+    );
+    assert!(
+        output.contains("export declare const keep"),
+        "Expected adjacent export to prove declaration emit still ran: {output}"
+    );
+}
+
 // =============================================================================
 // 12. Interface Heritage
 // =============================================================================


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Emit/DTS architecture tech-debt slice for #8275.

## Invariant
When DTS emit needs reusable exported-surface facts, the binder owns the structured `DeclarationSummary`; declaration emit consumes that summary for output planning without checker semantics, semantic validation, or output surgery.

## Scope
- Adds `tsz_binder::DeclarationSummary` as the binder-owned declaration-emission fact boundary.
- Switches CLI declaration emit setup from direct `ExportSurface` handoff to `DeclarationSummary::from_binder`.
- Stores `DeclarationSummary` in `DeclarationEmitter` and reads its overload/public-API accessors.
- Keeps a compatibility `set_export_surface` shim for existing callers.
- Adds focused binder and emitter tests for summary facts and precomputed overload suppression.
- Fixes two pre-existing `tsz-cli` test needless-borrow clippy findings surfaced by CI lint.

## Project Corpus Impact
- Row: n/a
- Bug family: DTS architecture/summary boundary; no project-row behavior change intended.
- Evidence: `node scripts/bench/project-row-summary.mjs --markdown` was consistent before this slice; `python3 scripts/emit/query-emit.py --families` reports JavaScript: 0 failures/timeouts and Declaration: 0 failures/timeouts after the change.

## Verification
- `cargo fmt`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy --profile ci-lint -p tsz-binder -p tsz-emitter -p tsz-cli --all-targets -- -D warnings`
- `cargo nextest run -p tsz-binder declaration_summary`
- `cargo nextest run -p tsz-emitter declaration_summary_precomputes_function_overload_suppression`
- `cargo nextest run -p tsz-emitter test_function_overloads_emit_only_signatures`
- `cargo check -p tsz-cli`
- `python3 scripts/emit/query-emit.py --families`
- `python3 scripts/emit/audit-output-surgery.py`
- `python3 scripts/arch/arch_guard.py`
- Exact-head CI pass on `dc23dffd044e2b7ff1183aa5827fd4bea13b5df1` (`CI Summary` pass, run 27074862491)

## Coordination Notes
- Part of #8275; this lands the first structured declaration-summary family and intentionally leaves broader class/interface summary expansion as follow-up issue work.
- Open PR overlap checked with `gh pr list --state open --limit 100 --json number,title,isDraft,headRefName,baseRefName,labels,updatedAt,url`; no Studio-Opus PRs or same-path active PRs found.
- `scripts/agents/ensure-agent-labels.sh --audit` still reports unrelated pre-existing unlabeled PRs/issues; this PR carries exactly one canonical agent label.
- Ready for merge queue after exact-head CI.