### PR TITLE
perf(checker): scope type-only reexport traversal paths

### DIFF
--- a/crates/tsz-checker/src/types/queries/mod.rs
+++ b/crates/tsz-checker/src/types/queries/mod.rs
@@ -33,3 +33,20 @@ pub(crate) mod lib_scoped_heritage;
 pub(crate) mod type_only;
 mod type_only_module_exports;
 mod type_only_reexports;
+
+fn with_type_only_query_path<F>(
+    visited: &mut rustc_hash::FxHashSet<(usize, String)>,
+    key: (usize, String),
+    query: F,
+) -> bool
+where
+    F: FnOnce(&mut rustc_hash::FxHashSet<(usize, String)>) -> bool,
+{
+    if !visited.insert(key.clone()) {
+        return false;
+    }
+
+    let result = query(visited);
+    visited.remove(&key);
+    result
+}

--- a/crates/tsz-checker/src/types/queries/type_only.rs
+++ b/crates/tsz-checker/src/types/queries/type_only.rs
@@ -1454,9 +1454,6 @@ impl<'a> CheckerState<'a> {
         export_name: &str,
         visited: &mut rustc_hash::FxHashSet<(usize, String)>,
     ) -> bool {
-        const PURE_TYPE: u32 =
-            symbol_flags::INTERFACE | symbol_flags::TYPE_ALIAS | symbol_flags::TYPE_PARAMETER;
-
         // Resolve the specifier to a target file index
         let Some(target_file_idx) = self
             .ctx
@@ -1466,9 +1463,19 @@ impl<'a> CheckerState<'a> {
         };
 
         let key = (target_file_idx, export_name.to_string());
-        if !visited.insert(key) {
-            return false; // cycle
-        }
+        super::with_type_only_query_path(visited, key, |visited| {
+            self.is_export_type_only_in_resolved_file(target_file_idx, export_name, visited)
+        })
+    }
+
+    fn is_export_type_only_in_resolved_file(
+        &self,
+        target_file_idx: usize,
+        export_name: &str,
+        visited: &mut rustc_hash::FxHashSet<(usize, String)>,
+    ) -> bool {
+        const PURE_TYPE: u32 =
+            symbol_flags::INTERFACE | symbol_flags::TYPE_ALIAS | symbol_flags::TYPE_PARAMETER;
 
         let Some(target_binder) = self.ctx.get_binder_for_file(target_file_idx) else {
             return false;
@@ -1724,22 +1731,18 @@ impl<'a> CheckerState<'a> {
                     continue; // Skip type-only wildcards in pass 1
                 }
                 // Non-type-only wildcard: check if name exists as a value in source.
-                // Use a separate visited set for the existence + type-only check
-                // to avoid polluting the main cycle detection.
-                let mut exists_visited = visited.clone();
                 let exists_in_source = self.name_exists_in_module_exports(
                     target_file_idx,
                     source_module,
                     export_name,
-                    &mut exists_visited,
+                    visited,
                 );
                 if exists_in_source {
-                    let mut type_only_visited = visited.clone();
                     let is_type_only_in_source = self.is_export_type_only_in_file(
                         target_file_idx,
                         source_module,
                         export_name,
-                        &mut type_only_visited,
+                        visited,
                     );
                     if !is_type_only_in_source {
                         // Value export found — name is NOT type-only

--- a/crates/tsz-checker/src/types/queries/type_only_reexports.rs
+++ b/crates/tsz-checker/src/types/queries/type_only_reexports.rs
@@ -17,10 +17,17 @@ impl<'a> CheckerState<'a> {
         };
 
         let key = (target_file_idx, export_name.to_string());
-        if !visited.insert(key) {
-            return false;
-        }
+        super::with_type_only_query_path(visited, key, |visited| {
+            self.is_export_type_only_syntax_in_resolved_file(target_file_idx, export_name, visited)
+        })
+    }
 
+    fn is_export_type_only_syntax_in_resolved_file(
+        &self,
+        target_file_idx: usize,
+        export_name: &str,
+        visited: &mut rustc_hash::FxHashSet<(usize, String)>,
+    ) -> bool {
         let Some(target_binder) = self.ctx.get_binder_for_file(target_file_idx) else {
             return false;
         };
@@ -120,10 +127,17 @@ impl<'a> CheckerState<'a> {
         };
 
         let key = (target_file_idx, format!("exists:{export_name}"));
-        if !visited.insert(key) {
-            return false;
-        }
+        super::with_type_only_query_path(visited, key, |visited| {
+            self.name_exists_in_resolved_module_exports(target_file_idx, export_name, visited)
+        })
+    }
 
+    fn name_exists_in_resolved_module_exports(
+        &self,
+        target_file_idx: usize,
+        export_name: &str,
+        visited: &mut rustc_hash::FxHashSet<(usize, String)>,
+    ) -> bool {
         let Some(target_binder) = self.ctx.get_binder_for_file(target_file_idx) else {
             return false;
         };


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Performance / checker type-only re-export traversal

## Invariant
Type-only export, syntax-only export, and export-existence walkers use `visited` as the active recursion path for `(target_file_idx, export_name)` queries. A key is removed when that query returns, so sibling wildcard branches do not need cloned visited sets while active cycles still short-circuit.

## Scope
- Introduces one shared query-path helper in `types::queries`.
- Splits resolved-file bodies for the type-only and type-only syntax walkers.
- Reuses the same mutable path through wildcard existence/type-only checks instead of cloning it.

## Project Corpus Impact
- Row: n/a
- Bug family: checker type-only wildcard re-export traversal pressure
- Evidence: No row status change claimed. This burns down checker traversal debt that can affect barrel-heavy project rows; artifact evidence is `scripts/perf/visited-clone-report.py --json`, reducing total visited.clone hits from 5 to 3 and removing both checker `type_only.rs` hits.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts1362_false_positive_tests --test type_only_import_reexport_tests --test type_only_import_value_use_attribution_tests --test ts1361_chain_attribution_tests` (33 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ambient_module_renamed_export_ts2460_tests --test ts2527_unique_symbol_via_reexport_tests` (18 passed)
- `python3 scripts/perf/visited-clone-report.py --json` (total=3; checker type-only hits removed)
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- Exact-head CI pass on `b32d363c1c51dec0722b08e987c2daaf272a639d` (`CI Summary` pass, run 27073996234)

## Coordination Notes
- Avoids active Studio-B ts-toolbelt/Vite target-gap work and keeps this PR to cross-cutting checker traversal debt.
- No full conformance, emit, or project benchmark run locally per repo instructions.
- Ready for merge queue after exact-head CI.