### PR TITLE
perf(checker): skip satisfied bare param constraints early

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/bare_param_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/bare_param_constraint_helpers.rs
@@ -1,0 +1,31 @@
+use crate::query_boundaries::checkers::generic as query;
+use crate::state::CheckerState;
+use tsz_solver::{TypeId, TypeParamInfo};
+
+impl<'a> CheckerState<'a> {
+    pub(super) fn bare_type_param_base_satisfies_instantiated_constraint(
+        &mut self,
+        type_arg: TypeId,
+        base: TypeId,
+        constraint: TypeId,
+        type_params: &[TypeParamInfo],
+        type_args: &[TypeId],
+    ) -> bool {
+        if !query::is_bare_type_parameter(self.ctx.types.as_type_database(), type_arg)
+            || base == TypeId::UNKNOWN
+            || query::contains_free_type_parameters(self.ctx.types, base)
+        {
+            return false;
+        }
+
+        let constraint_resolved = self.resolve_lazy_type(constraint);
+        let inst_constraint =
+            self.instantiate_constraint_with_type_args(constraint_resolved, type_params, type_args);
+        inst_constraint == TypeId::UNKNOWN
+            || inst_constraint == TypeId::ANY
+            || (!query::contains_type_parameters(self.ctx.types, inst_constraint)
+                && self
+                    .type_arg_constraint_relation_outcome(base, inst_constraint)
+                    .related)
+    }
+}

--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -5,36 +5,6 @@ use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
-    /// Returns true when an arity diagnostic was emitted inside `type_arg_idx`.
-    fn type_arg_subtree_has_arity_error(&self, type_arg_idx: NodeIndex) -> bool {
-        let Some(node) = self.ctx.arena.get(type_arg_idx) else {
-            return false;
-        };
-        let (start, end) = (node.pos, node.end);
-        if end <= start {
-            return false;
-        }
-        self.ctx
-            .diagnostics
-            .iter()
-            .any(|d| matches!(d.code, 2314 | 2315 | 2707) && d.start >= start && d.start < end)
-    }
-
-    fn type_arg_subtree_has_value_used_as_type_error(&self, type_arg_idx: NodeIndex) -> bool {
-        let Some(node) = self.ctx.arena.get(type_arg_idx) else {
-            return false;
-        };
-        let (start, end) = (node.pos, node.end);
-        if end <= start {
-            return false;
-        }
-        let code = crate::diagnostics::diagnostic_codes::REFERS_TO_A_VALUE_BUT_IS_BEING_USED_AS_A_TYPE_HERE_DID_YOU_MEAN_TYPEOF;
-        self.ctx
-            .diagnostics
-            .iter()
-            .any(|d| d.code == code && d.start >= start && d.start < end)
-    }
-
     /// Validate each type argument against its corresponding type parameter
     /// constraint. Reports TS2344 when a type argument doesn't satisfy its
     /// constraint. Shared by call expressions, new expressions, and type refs.
@@ -510,6 +480,18 @@ impl<'a> CheckerState<'a> {
                 {
                     base_constraint_type = Some(ast_base);
                     base_constraint_from_indexed_access_ast = true;
+                }
+                if type_arg_contains_type_parameters
+                    && let Some(base) = base_constraint_type
+                    && self.bare_type_param_base_satisfies_instantiated_constraint(
+                        type_arg,
+                        base,
+                        constraint,
+                        type_params,
+                        &type_args,
+                    )
+                {
+                    continue;
                 }
                 if type_arg_contains_type_parameters {
                     let constraint_resolved = self.resolve_lazy_type(constraint);

--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -1433,6 +1433,7 @@ impl<'a> CheckerState<'a> {
 }
 
 mod array_like_constraint_helpers;
+mod bare_param_constraint_helpers;
 mod boolean_probe_constraints;
 mod callable_constraint_helpers;
 mod conditional_constraint_helpers;
@@ -1450,4 +1451,5 @@ mod merged_interface_constraints;
 mod object_alias_constraint_helpers;
 mod recursive_heritage_constraint;
 mod symbol_declaration_helpers;
+mod type_arg_error_helpers;
 mod union_constraint_helpers;

--- a/crates/tsz-checker/src/checkers/generic_checker/type_arg_error_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/type_arg_error_helpers.rs
@@ -1,0 +1,37 @@
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+
+impl<'a> CheckerState<'a> {
+    /// Returns true when an arity diagnostic was emitted inside `type_arg_idx`.
+    pub(super) fn type_arg_subtree_has_arity_error(&self, type_arg_idx: NodeIndex) -> bool {
+        let Some(node) = self.ctx.arena.get(type_arg_idx) else {
+            return false;
+        };
+        let (start, end) = (node.pos, node.end);
+        if end <= start {
+            return false;
+        }
+        self.ctx
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.code, 2314 | 2315 | 2707) && d.start >= start && d.start < end)
+    }
+
+    pub(super) fn type_arg_subtree_has_value_used_as_type_error(
+        &self,
+        type_arg_idx: NodeIndex,
+    ) -> bool {
+        let Some(node) = self.ctx.arena.get(type_arg_idx) else {
+            return false;
+        };
+        let (start, end) = (node.pos, node.end);
+        if end <= start {
+            return false;
+        }
+        let code = crate::diagnostics::diagnostic_codes::REFERS_TO_A_VALUE_BUT_IS_BEING_USED_AS_A_TYPE_HERE_DID_YOU_MEAN_TYPEOF;
+        self.ctx
+            .diagnostics
+            .iter()
+            .any(|d| d.code == code && d.start >= start && d.start < end)
+    }
+}

--- a/crates/tsz-checker/tests/ts2344_generic_ref_scoped_param_concrete_constraint.rs
+++ b/crates/tsz-checker/tests/ts2344_generic_ref_scoped_param_concrete_constraint.rs
@@ -142,6 +142,29 @@ type BadArrayQ<Q> = Box<Array<Q>>;
 }
 
 #[test]
+fn bare_type_params_with_matching_constraints_are_accepted() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type Pair<Left extends string, Right extends string> = [Left, Right];
+type Forward<Name extends string, Delimiter extends string> = Pair<Name, Delimiter>;
+
+type List<T> = T[];
+type Box<Value extends List<string>> = Value;
+type ForwardList<Items extends List<string>> = Box<Items>;
+"#,
+    );
+
+    let ts2344: Vec<_> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2344)
+        .collect();
+    assert!(
+        ts2344.is_empty(),
+        "Expected bare type params whose declared constraints satisfy the target constraints to pass, got: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn explicit_type_alias_args_violating_callable_constraint_emit_ts2344() {
     let diagnostics = compile_and_get_diagnostics(
         r#"


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 performance / ts-toolbelt green-row target gap.

## Invariant
When a type argument is a bare type parameter and its declared base constraint is already assignable to the instantiated required type-parameter constraint, `tsc` cannot emit TS2344 for that argument. This PR lets tsz reach the existing satisfied-constraint conclusion before the heavier conditional/application constraint paths, through the checker generic-constraint validator.

## Scope
- `crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs`: add an early satisfied bare-type-parameter constraint check after existing base-constraint discovery.
- `crates/tsz-checker/src/checkers/generic_checker/bare_param_constraint_helpers.rs`: keep the satisfied bare-parameter relation check below the shard cap.
- `crates/tsz-checker/src/checkers/generic_checker/type_arg_error_helpers.rs`: move existing type-argument subtree diagnostic helpers below the shard cap.
- `crates/tsz-checker/tests/ts2344_generic_ref_scoped_param_concrete_constraint.rs`: add renamed bare-parameter positive cases while retaining adjacent mismatch guards.

## Project Corpus Impact
- Row: `ts-toolbelt-project`
- Bug family: green-row target gap / generic constraint validation hot path
- `ts-toolbelt-project` remains green and still below the 2x target.
- Before artifact: `artifacts/perf/studio-b-autopath-filter-ts-toolbelt-20260606.json` / `.tsgo-winners.json` showed tsz `957.52 ms`, tsgo `136.51 ms`, tsgo `7.01x`, target gap factor `14.03`.
- Exact-head after artifact: `artifacts/perf/studio-b-bare-param-constraint-rebased2-ts-toolbelt-20260606.json` / `.tsgo-winners.json` shows tsz `936.67 ms`, tsgo `136.28 ms`, tsgo `6.87x` on head `c7e7d03822` rebased onto `c3efc6fc35`.
- Earlier same-change attribution: `artifacts/perf/studio-b-bare-param-constraint-rebased-ts-toolbelt-20260606.perf.json`; `_AutoPath` body validation dropped from `2884.77 ms` to `2803.50 ms` versus the prior sidecar. Delegation counts were unchanged.

## Verification
- `cargo fmt -p tsz-checker --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test ts2344_generic_ref_scoped_param_concrete_constraint --no-fail-fast`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`
- `scripts/safe-run.sh python3 scripts/arch/arch_guard.py`
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --filter 'ts-toolbelt-project' --json-file artifacts/perf/studio-b-bare-param-constraint-rebased2-ts-toolbelt-20260606.json`
- `node scripts/bench/tsgo-winner-report.mjs artifacts/perf/studio-b-bare-param-constraint-rebased2-ts-toolbelt-20260606.json artifacts/perf/studio-b-bare-param-constraint-rebased2-ts-toolbelt-20260606.tsgo-winners.json`
- `scripts/safe-run.sh env TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 TSZ_PERF_COUNTERS=1 cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --noEmit -p .target-bench/external/ts-toolbelt/tsconfig.flat.json --pretty false --perf-counters-json artifacts/perf/studio-b-bare-param-constraint-rebased-ts-toolbelt-20260606.perf.json`
- `python3 scripts/perf/query-perf-counters.py --json artifacts/perf/studio-b-bare-param-constraint-rebased-ts-toolbelt-20260606.perf.json --baseline artifacts/perf/studio-b-autopath-filter-ts-toolbelt-20260606.perf.json`

## Coordination Notes
- This is a small shrink, not a target closure. Studio-B should continue on ts-toolbelt/Vite target gaps after this lands.
- Negative Vite probe discarded: relaxing generic lib method-group lowering did not improve Vite (`artifacts/perf/studio-b-generic-lib-method-vite-20260606.json`, tsz `85.13 ms`, tsgo `77.16 ms`).
- No fixture-name fast paths; the check is structural and keeps existing fallback behavior when the base constraint is absent, generic, or not related.
