### PR TITLE
fix(checker): keep recursive generic type-alias name in assignability diagnostics

### DIFF
--- a/crates/tsz-checker/src/error_reporter/type_display_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/type_display_policy.rs
@@ -95,6 +95,31 @@ impl<'a> CheckerState<'a> {
             }
             _ => ty,
         };
+        // A recursive generic type-alias application (e.g. `T2<U>` for
+        // `type T2<T> = [42, T2<{ x: T }>]`) can never be expanded structurally
+        // in a diagnostic: the alias body refers back to itself, so any
+        // structural rendering is unbounded (`[42, [42, [..., ...]]]`). tsc
+        // keeps the alias form (`T2<U>`) in every assignability role. Render the
+        // application name here, before the role-specific structural/raw-tuple
+        // fallbacks below evaluate the application into its self-referential
+        // body. This shared guard extends the same rule the assignment-target
+        // path already applied to the call-argument, call-parameter, and bare
+        // assignability roles, which previously expanded the body.
+        if matches!(
+            role,
+            DiagnosticTypeDisplayRole::Assignability
+                | DiagnosticTypeDisplayRole::AssignmentSource { .. }
+                | DiagnosticTypeDisplayRole::AssignmentTarget { .. }
+                | DiagnosticTypeDisplayRole::CallArgument { .. }
+                | DiagnosticTypeDisplayRole::CallParameter { .. }
+                | DiagnosticTypeDisplayRole::WeakCallParameter { .. }
+        ) && crate::query_boundaries::recursive_alias::is_recursive_type_alias_application(
+            self.ctx.types,
+            &self.ctx.definition_store,
+            ty,
+        ) {
+            return self.format_type_diagnostic(ty);
+        }
         match role {
             DiagnosticTypeDisplayRole::DefaultDiagnostic => self.format_type_diagnostic(ty),
             DiagnosticTypeDisplayRole::WidenedDiagnostic => self.format_type_diagnostic_widened(ty),

--- a/crates/tsz-checker/src/error_reporter/type_display_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/type_display_policy.rs
@@ -95,16 +95,14 @@ impl<'a> CheckerState<'a> {
             }
             _ => ty,
         };
-        // A recursive generic type-alias application (e.g. `T2<U>` for
-        // `type T2<T> = [42, T2<{ x: T }>]`) can never be expanded structurally
-        // in a diagnostic: the alias body refers back to itself, so any
-        // structural rendering is unbounded (`[42, [42, [..., ...]]]`). tsc
-        // keeps the alias form (`T2<U>`) in every assignability role. Render the
-        // application name here, before the role-specific structural/raw-tuple
-        // fallbacks below evaluate the application into its self-referential
-        // body. This shared guard extends the same rule the assignment-target
-        // path already applied to the call-argument, call-parameter, and bare
-        // assignability roles, which previously expanded the body.
+        // Recursive tuple aliases (e.g. `T2<U>` for
+        // `type T2<T> = [42, T2<{ x: T }>]`) cannot be expanded structurally
+        // without producing an unbounded tuple display. Preserve those alias
+        // applications before the role-specific tuple fallbacks evaluate the
+        // application into its self-referential body. Recursive object/mapped
+        // aliases still flow through the normal role-specific formatters: those
+        // paths can reduce property values through mapped type substitutions
+        // where tsc displays the concrete value type instead of the alias.
         if matches!(
             role,
             DiagnosticTypeDisplayRole::Assignability
@@ -113,11 +111,8 @@ impl<'a> CheckerState<'a> {
                 | DiagnosticTypeDisplayRole::CallArgument { .. }
                 | DiagnosticTypeDisplayRole::CallParameter { .. }
                 | DiagnosticTypeDisplayRole::WeakCallParameter { .. }
-        ) && crate::query_boundaries::recursive_alias::is_recursive_type_alias_application(
-            self.ctx.types,
-            &self.ctx.definition_store,
-            ty,
-        ) {
+        ) && self.is_recursive_tuple_alias_application_for_diagnostic(ty)
+        {
             return self.format_type_diagnostic(ty);
         }
         match role {
@@ -177,5 +172,15 @@ impl<'a> CheckerState<'a> {
                 self.format_property_receiver_type_for_diagnostic(ty)
             }
         }
+    }
+
+    fn is_recursive_tuple_alias_application_for_diagnostic(&mut self, ty: TypeId) -> bool {
+        let evaluated = self.evaluate_type_with_env(ty);
+        crate::query_boundaries::recursive_alias::is_recursive_tuple_type_alias_application(
+            self.ctx.types,
+            &self.ctx.definition_store,
+            ty,
+            evaluated,
+        )
     }
 }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1107,6 +1107,9 @@ mod recursive_generic_arrow_tests;
 #[path = "tests/recursive_path_default_type_param_tests.rs"]
 mod recursive_path_default_type_param_tests;
 #[cfg(test)]
+#[path = "tests/recursive_tuple_alias_diagnostic_display_tests.rs"]
+mod recursive_tuple_alias_diagnostic_display_tests;
+#[cfg(test)]
 #[path = "tests/ref_type_params_cache_tests.rs"]
 mod ref_type_params_cache_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/recursive_alias.rs
+++ b/crates/tsz-checker/src/query_boundaries/recursive_alias.rs
@@ -101,6 +101,28 @@ pub(crate) fn is_recursive_type_alias_application(
     type_reaches_alias_def(db, body, def_id, &mut visited)
 }
 
+/// True when `type_id` is a recursive generic type-alias application whose
+/// current or evaluated shape is tuple-like.
+///
+/// Tuple recursion is the assignability-display case where structural expansion
+/// runs away (`[number, [number, [..., ...]]]`). Recursive object and mapped
+/// aliases still need role-specific display handling so mapped property values
+/// can reduce to their concrete value types.
+pub(crate) fn is_recursive_tuple_type_alias_application(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    type_id: TypeId,
+    evaluated: TypeId,
+) -> bool {
+    if !is_recursive_type_alias_application(db, def_store, type_id) {
+        return false;
+    }
+    tsz_solver::type_queries::is_tuple_like_type(db, type_id)
+        || (evaluated != type_id
+            && evaluated != TypeId::ERROR
+            && tsz_solver::type_queries::is_tuple_like_type(db, evaluated))
+}
+
 fn type_reaches_alias_def(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/src/tests/recursive_tuple_alias_diagnostic_display_tests.rs
+++ b/crates/tsz-checker/src/tests/recursive_tuple_alias_diagnostic_display_tests.rs
@@ -165,6 +165,42 @@ n = s;
     );
 }
 
+/// Recursive mapped-object aliases still need the role-specific formatter: tsc
+/// reduces through mapped property substitutions here and reports the concrete
+/// property value type (`string`), not the recursive alias application.
+#[test]
+fn recursive_mapped_alias_property_value_still_reduces() {
+    let messages = assignability_messages(
+        r#"
+type Envelope<Subject, Extra> = {
+    readonly[Key in keyof Subject]: {
+        value: Subject[Key];
+        also: Extra;
+        readonly children: Envelope<Subject[Key], Extra>;
+    };
+}
+
+interface Payload {
+    name: string;
+    count: number;
+}
+
+declare const output: Envelope<Payload, boolean>;
+const shouldFail: { important: boolean } = output.name.children;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m == "Type 'string' is not assignable to type '{ important: boolean; }'."),
+        "recursive mapped property value should reduce to the concrete source, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("Envelope<string")),
+        "mapped/object recursion must not be preserved by the tuple guard, got: {messages:?}"
+    );
+}
+
 /// Fallback boundary: a *non-recursive* tuple alias is NOT affected by the
 /// recursive guard. `tsc` expands a non-recursive tuple alias structurally in
 /// the assignment-target position, so the guard must leave that behavior intact.

--- a/crates/tsz-checker/src/tests/recursive_tuple_alias_diagnostic_display_tests.rs
+++ b/crates/tsz-checker/src/tests/recursive_tuple_alias_diagnostic_display_tests.rs
@@ -1,0 +1,188 @@
+//! Tests for recursive generic type-alias display in assignability diagnostics.
+//!
+//! Structural rule: when a type that appears in a TS2322/TS2345 message is a
+//! *recursive* generic type-alias application — a generic alias whose body
+//! transitively references the alias itself, e.g.
+//! `type List<T> = [number, List<{ x: T }>]` — `tsc` renders it by its alias
+//! name (`List<U>`), never by structural expansion. Structural expansion of a
+//! self-referential body is unbounded (`[number, [number, [..., ...]]]`), so it
+//! is both wrong and unbounded.
+//!
+//! Before the fix, only the assignment *target* preserved the alias name (via
+//! the as-written annotation). The assignment *source*, call-argument,
+//! call-parameter, and return-type roles evaluated the application into its body
+//! and printed the runaway expansion. The shared diagnostic-role guard now
+//! applies the alias-name rule to every assignability role, so both operands of
+//! the message keep their alias spelling regardless of position.
+//!
+//! Binder names are varied across cases so the rule is proven structurally, not
+//! against a specific alias spelling.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn assignability_messages(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == 2322 || d.code == 2345)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+/// The original #48524/#52722/#49226 repro shape: both operands are recursive
+/// generic tuple aliases. Neither may expand structurally.
+#[test]
+fn recursive_tuple_alias_assignment_keeps_alias_on_both_operands() {
+    let messages = assignability_messages(
+        r#"
+type T1<T> = [number, T1<{ x: T }>];
+type T2<T> = [42, T2<{ x: T }>];
+function qq<U>(x: T1<U>, y: T2<U>) {
+    y = x;
+}
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m == "Type 'T1<U>' is not assignable to type 'T2<U>'."),
+        "both recursive aliases must keep their names, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("..., ...")),
+        "no runaway structural expansion may leak, got: {messages:?}"
+    );
+}
+
+/// Renamed binders prove the rule is structural, not keyed off `T1`/`T2`.
+#[test]
+fn recursive_tuple_alias_assignment_renamed_binders() {
+    let messages = assignability_messages(
+        r#"
+type Alpha<Q> = [number, Alpha<{ x: Q }>];
+type Beta<Q> = [42, Beta<{ x: Q }>];
+function check<Elem>(left: Alpha<Elem>, right: Beta<Elem>) {
+    right = left;
+}
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m == "Type 'Alpha<Elem>' is not assignable to type 'Beta<Elem>'."),
+        "renamed recursive aliases must keep their names, got: {messages:?}"
+    );
+}
+
+/// Concrete type arguments still render by alias name on both sides.
+#[test]
+fn recursive_tuple_alias_assignment_concrete_args() {
+    let messages = assignability_messages(
+        r#"
+type T1<T> = [number, T1<{ x: T }>];
+type T2<T> = [42, T2<{ x: T }>];
+declare let a: T1<number>;
+declare let b: T2<number>;
+b = a;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.starts_with("Type 'T1<number>' is not assignable to type 'T2<number>'.")),
+        "concrete-arg recursive aliases must keep their names, got: {messages:?}"
+    );
+}
+
+/// Call-argument position (TS2345): both the argument (source) and the
+/// parameter (target) keep their alias names.
+#[test]
+fn recursive_tuple_alias_call_argument_keeps_alias() {
+    let messages = assignability_messages(
+        r#"
+type T1<T> = [number, T1<{ x: T }>];
+type T2<T> = [42, T2<{ x: T }>];
+declare function consume(p: T2<number>): void;
+declare const arg: T1<number>;
+consume(arg);
+"#,
+    );
+    assert!(
+        messages.iter().any(|m| m.starts_with(
+            "Argument of type 'T1<number>' is not assignable to parameter of type 'T2<number>'."
+        )),
+        "call argument/parameter recursive aliases must keep their names, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("..., ...")),
+        "no runaway structural expansion may leak in call diagnostics, got: {messages:?}"
+    );
+}
+
+/// Return-type position (TS2322): the return-statement value (source) and the
+/// declared return type (target) keep their alias names.
+#[test]
+fn recursive_tuple_alias_return_type_keeps_alias() {
+    let messages = assignability_messages(
+        r#"
+type T1<T> = [number, T1<{ x: T }>];
+type T2<T> = [42, T2<{ x: T }>];
+declare const value: T1<number>;
+function produce(): T2<number> {
+    return value;
+}
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.starts_with("Type 'T1<number>' is not assignable to type 'T2<number>'.")),
+        "return-type recursive aliases must keep their names, got: {messages:?}"
+    );
+    assert!(
+        !messages.iter().any(|m| m.contains("..., ...")),
+        "no runaway structural expansion may leak in return diagnostics, got: {messages:?}"
+    );
+}
+
+/// Recursive *object* aliases already kept their names (objects carry a symbol
+/// stamp); this locks in that the guard does not disturb them.
+#[test]
+fn recursive_object_alias_assignment_keeps_alias() {
+    let messages = assignability_messages(
+        r#"
+type Node1<T> = { value: T; next: Node1<T> };
+declare let s: Node1<string>;
+declare let n: Node1<number>;
+n = s;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m
+                .starts_with("Type 'Node1<string>' is not assignable to type 'Node1<number>'.")),
+        "recursive object aliases must keep their names, got: {messages:?}"
+    );
+}
+
+/// Fallback boundary: a *non-recursive* tuple alias is NOT affected by the
+/// recursive guard. `tsc` expands a non-recursive tuple alias structurally in
+/// the assignment-target position, so the guard must leave that behavior intact.
+#[test]
+fn non_recursive_tuple_alias_target_still_expands() {
+    let messages = assignability_messages(
+        r#"
+type Pair<T> = [T, T];
+declare let a: Pair<string>;
+declare let b: Pair<number>;
+b = a;
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m
+                .starts_with("Type 'Pair<string>' is not assignable to type '[number, number]'.")),
+        "non-recursive tuple alias target must still expand structurally, got: {messages:?}"
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -51,7 +51,6 @@ TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules
 TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
-TypeScript/tests/cases/compiler/inferFromNestedSameShapeTuple.ts
 TypeScript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts


### PR DESCRIPTION
AgentName: M1-A
Implementation runner: claude-lucid-hopper

Closes #12843.

## Structural rule

When a type shown in a `TS2322`/`TS2345` message is a *recursive tuple* generic
type-alias application — a generic alias whose body transitively references the
alias itself through a tuple shape, e.g. `type T2<T> = [42, T2<{ x: T }>]` —
`tsc` renders it by its alias name (`T2<U>`) in assignability roles, not by
runaway structural expansion. Recursive mapped/object aliases still flow through
role-specific formatting so mapped property values can reduce to their concrete
value type.

## Owner layer

`tsz_checker::error_reporter` diagnostic-role dispatcher
(`format_type_for_diagnostic_role`), reusing the solver-backed query boundary
`query_boundaries::recursive_alias::is_recursive_tuple_type_alias_application`.
The checker asks for the structural recursive-tuple display predicate rather than
pattern-matching solver internals.

## Track

Type-display parity (conformance).

## Invariant

`tsc` diagnostic parity: a recursive tuple type-alias application is displayed
by alias name (`Name<Args>`) in assignability messages; non-recursive tuple
aliases continue to expand structurally, and recursive mapped/object aliases can
still reduce mapped property values exactly as before.

## Scope

- `crates/tsz-checker/src/error_reporter/type_display_policy.rs`: one shared
  recursive-tuple guard at the role dispatcher, applied to the `Assignability`,
  `AssignmentSource`, `AssignmentTarget`, `CallArgument`, `CallParameter`, and
  `WeakCallParameter` roles before their role-specific tuple fallbacks run.
- `crates/tsz-checker/src/query_boundaries/recursive_alias.rs`: adds the
  `is_recursive_tuple_type_alias_application` boundary helper so the checker
  does not add another broad `query_boundaries::common` reach-through.
- `crates/tsz-checker/src/tests/recursive_tuple_alias_diagnostic_display_tests.rs`
  (+ `lib.rs` wiring): regression matrix — assignment source+target,
  call-argument (`TS2345`), return type, concrete vs generic args, renamed
  binders (anti-hardcoding), recursive object aliases, recursive mapped alias property reduction, and a
  non-recursive boundary case.
- `scripts/conformance/conformance-accepted-regressions.txt`: removed
  `compiler/inferFromNestedSameShapeTuple.ts`.

This completes the partial #5158 work, which fixed only the target role and left
the source side of `y = x` expanding (so the row regressed back into the ledger).

## Adjacent-case matrix

| role | recursive (generic args) | recursive (concrete args) | non-recursive |
| --- | --- | --- | --- |
| assignment source | `T1<U>` ✓ | `T1<number>` ✓ | `Pair<string>` (unchanged) |
| assignment target | `T2<U>` ✓ | `T2<number>` ✓ | `[number, number]` (unchanged) |
| call argument/param (`TS2345`) | ✓ | `T1<number>` / `T2<number>` ✓ | unchanged |
| return type | ✓ | `T1<number>` / `T2<number>` ✓ | unchanged |
| recursive object alias | `L<string>` / `L<number>` ✓ | — | — |
| recursive mapped property | `string` reduction ✓ | — | alias guard not applied |

## Project Corpus Impact

- Row: n/a
- Bug family: #12843 recursive generic type-alias diagnostic display
- Evidence: Diagnostic-display-only change for recursive generic type-alias applications; type relations, inference, emit, and project-row semantics are untouched.

## Verification

- `compiler/inferFromNestedSameShapeTuple.ts` now emits exactly
  `TS2322: Type 'T1<U>' is not assignable to type 'T2<U>'.`, matching the tsc
  fingerprint; removed from the accepted-regression ledger.
- `python3 scripts/conformance/check-accepted-regression-growth.py
  --base-ref origin/main --head-ref HEAD` — passes (15 -> 14, one removal).
- `cargo test -p tsz-checker --lib ts2322` — 16 -> 14 failures (2 pre-existing
  failures fixed, 0 new regressions); `ts2345` unchanged (1, pre-existing);
  `recursive` (122) and `render` (73) suites green; new module 7/7 green.
- Verified recursive intersection/union alias displays are byte-identical to
  `main` (no regression).
- `cargo clippy -p tsz-checker --lib --tests` — clean.
- M1-B follow-up `b008150300`: `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib recursive_tuple_alias_assignment_keeps_alias_on_both_operands recursive_tuple_alias_assignment_renamed_binders recursive_tuple_alias_call_argument_keeps_alias recursive_tuple_alias_return_type_keeps_alias recursive_mapped_alias_property_value_still_reduces non_recursive_tuple_alias_target_still_expands` — 6/6 passed.
- M1-B follow-up `b008150300`: `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter inferFromNestedSameShapeTuple --verbose` — 1/1 passed.
- M1-B follow-up `b008150300`: `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter mappedTypeWithCombinedTypeMappers --verbose` — 1/1 passed.
- M1-B follow-up `b008150300`: `git diff --check` — passed.

## Coordination Notes

Rebased on current `origin/main`; no conflicts. Broad conformance/emit suites
left to ready-review CI per repo policy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qk9q82qwnGVrkQLw2bm4fR)_

