### PR TITLE
refactor(dts): hide declaration summary export surface

### DIFF
--- a/crates/tsz-binder/src/state/declaration_summary.rs
+++ b/crates/tsz-binder/src/state/declaration_summary.rs
@@ -17,7 +17,7 @@ use tsz_parser::parser::node::NodeArena;
 /// discovery state.
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct DeclarationSummary {
-    pub export_surface: ExportSurface,
+    export_surface: ExportSurface,
 }
 
 impl DeclarationSummary {
@@ -33,6 +33,16 @@ impl DeclarationSummary {
         }
     }
 
+    /// Build declaration facts from an already-computed exported surface.
+    ///
+    /// This is a compatibility bridge for callers that have not moved to
+    /// `from_binder()` yet; new facts should still be added to
+    /// `DeclarationSummary` query methods rather than exposing `ExportSurface`
+    /// directly to emit callers.
+    pub const fn from_export_surface(export_surface: ExportSurface) -> Self {
+        Self { export_surface }
+    }
+
     /// Top-level function overload names that should suppress implementation
     /// signatures during declaration emit.
     pub const fn overloaded_functions(&self) -> &FxHashSet<String> {
@@ -42,6 +52,21 @@ impl DeclarationSummary {
     /// Whether declaration emit should filter the file to its public API.
     pub const fn has_public_api_scope(&self) -> bool {
         self.export_surface.has_public_api_scope
+    }
+
+    /// Check whether a name is directly exported from this file.
+    pub fn is_exported(&self, name: &str) -> bool {
+        self.export_surface.is_exported(name)
+    }
+
+    /// Check whether a direct export is type-only.
+    pub fn is_type_only_export(&self, name: &str) -> bool {
+        self.export_surface.is_type_only_export(name)
+    }
+
+    /// Return the total number of unique public API entries.
+    pub fn public_api_size(&self) -> usize {
+        self.export_surface.public_api_size()
     }
 }
 
@@ -55,19 +80,37 @@ mod tests {
 
         assert!(summary.overloaded_functions().is_empty());
         assert!(!summary.has_public_api_scope());
-        assert_eq!(summary.export_surface.public_api_size(), 0);
+        assert_eq!(summary.public_api_size(), 0);
     }
 
     #[test]
     fn summary_exposes_export_surface_overload_facts() {
-        let mut summary = DeclarationSummary::default();
-        summary
-            .export_surface
+        let mut export_surface = ExportSurface::default();
+        export_surface
             .overloaded_functions
             .insert("parse".to_string());
-        summary.export_surface.has_public_api_scope = true;
+        export_surface.has_public_api_scope = true;
+        let summary = DeclarationSummary::from_export_surface(export_surface);
 
         assert!(summary.overloaded_functions().contains("parse"));
         assert!(summary.has_public_api_scope());
+    }
+
+    #[test]
+    fn summary_wraps_export_surface_queries() {
+        let mut export_surface = ExportSurface::default();
+        export_surface.module_exports.insert(
+            "PublicType".to_string(),
+            crate::ExportedSymbol {
+                symbol_id: crate::SymbolId(1),
+                flags: 0,
+                is_type_only: true,
+            },
+        );
+        let summary = DeclarationSummary::from_export_surface(export_surface);
+
+        assert!(summary.is_exported("PublicType"));
+        assert!(summary.is_type_only_export("PublicType"));
+        assert_eq!(summary.public_api_size(), 1);
     }
 }

--- a/crates/tsz-emitter/src/declaration_emitter/core/setup.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/setup.rs
@@ -321,9 +321,7 @@ impl<'a> DeclarationEmitter<'a> {
     /// Compatibility shim for callers that still construct only an
     /// `ExportSurface`.
     pub fn set_export_surface(&mut self, surface: tsz_binder::ExportSurface) {
-        self.set_declaration_summary(tsz_binder::DeclarationSummary {
-            export_surface: surface,
-        });
+        self.set_declaration_summary(tsz_binder::DeclarationSummary::from_export_surface(surface));
     }
 
     /// Set the current file's arena and path for distinguishing local vs foreign symbols.

--- a/crates/tsz-emitter/src/declaration_emitter/tests/class_features.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/class_features.rs
@@ -499,11 +499,11 @@ fn declaration_summary_precomputes_function_overload_suppression() {
     "#;
     let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
     let root = parser.parse_source_file();
-    let mut summary = tsz_binder::DeclarationSummary::default();
-    summary
-        .export_surface
+    let mut export_surface = tsz_binder::ExportSurface::default();
+    export_surface
         .overloaded_functions
         .insert("parse".to_string());
+    let summary = tsz_binder::DeclarationSummary::from_export_surface(export_surface);
 
     let mut emitter = DeclarationEmitter::new(&parser.arena);
     emitter.set_declaration_summary(summary);


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Emit/DTS architecture tech-debt slice for #8275.

## Invariant
When declaration emit needs exported-surface facts, callers consume `DeclarationSummary` query methods; this PR keeps the raw `ExportSurface` behind the binder-owned summary boundary instead of exposing it as mutable emitter-facing state.

## Scope
- Makes `DeclarationSummary::export_surface` private.
- Adds `DeclarationSummary::from_export_surface` as a compatibility bridge for existing `ExportSurface` callers.
- Adds summary query methods for direct exported names, type-only exports, and public API size.
- Updates the declaration-emitter compatibility shim and focused overload-summary test to use the summary constructor.

## Project Corpus Impact
- Row: n/a
- Bug family: DTS architecture/summary boundary; behavior unchanged.
- Evidence: This is an API-boundary refactor around already-computed binder facts. `python3 scripts/emit/query-emit.py --families` still reports JavaScript: 0 failures/timeouts and Declaration: 0 failures/timeouts.

## Verification
- `cargo fmt --check`
- `cargo nextest run -p tsz-binder declaration_summary`
- `cargo nextest run -p tsz-emitter declaration_summary_precomputes_function_overload_suppression`
- `cargo check -p tsz-cli`
- `python3 scripts/emit/query-emit.py --families`
- `python3 scripts/emit/audit-output-surgery.py`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`

## Coordination Notes
- Continues #8275 after #12837 landed the first binder-owned declaration summary slice.
- No emitted-output behavior change intended; this PR narrows the public mutation surface so future DTS facts attach to `DeclarationSummary` queries rather than emitter-side `ExportSurface` access.
- Open PR overlap checked with `gh pr list --state open --limit 100 --json number,title,isDraft,headRefName,baseRefName,labels,updatedAt,url`; no active same-path Studio-Opus PRs remain.
- `scripts/agents/ensure-agent-labels.sh --audit` still reports unrelated pre-existing label findings (#12797 and issues #12843/#12101/#10799); this PR will carry exactly one canonical agent label.
