### PR TITLE
fix(solver): union property optional when optional in any member (#12174)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1659,3 +1659,6 @@ path = "tests/index_signature_type_check_probe_tests.rs"
 [[test]]
 name = "fuel_budget_callback_context_tests"
 path = "tests/fuel_budget_callback_context_tests.rs"
+[[test]]
+name = "union_property_optional_modifier_tests"
+path = "tests/union_property_optional_modifier_tests.rs"

--- a/crates/tsz-checker/tests/union_property_optional_modifier_tests.rs
+++ b/crates/tsz-checker/tests/union_property_optional_modifier_tests.rs
@@ -1,0 +1,153 @@
+//! Regression tests for issue #12174 (mapped key operations lose optional/
+//! readonly modifier intent across project rows).
+//!
+//! Structural rule: `tsc`'s `createUnionOrIntersectionProperty` aggregates a
+//! union member's modifiers with `optionalFlag |= prop.flags & Optional` and
+//! marks the property readonly when it is readonly in any constituent — so a
+//! union property is OPTIONAL/READONLY when ANY member is, while an intersection
+//! property is only when EVERY declaring member is. tsz previously merged the
+//! union's optionality with ALL-member semantics, so a non-distributing
+//! homomorphic mapped type (`Pick<A | B, K>`) over a heterogeneous union — whose
+//! members are not subtype-related, so the union is never collapsed by subtype
+//! reduction — silently dropped the optional intent. These tests use a
+//! locally-defined `Pick`-style alias (the test lib has no utility types) over
+//! inline composite sources, plus direct union property access, to pin both
+//! directions and the negative case.
+
+use tsz_checker::test_utils::{check_source_diagnostics, diagnostic_count, has_diagnostic_code};
+use tsz_common::diagnostics::Diagnostic;
+
+/// Diagnostics with the bare-lib noise (2318 "no global `Object`", 2304 "cannot
+/// find name") removed, leaving only the behavior under test.
+fn relevant(source: &str) -> Vec<Diagnostic> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| !matches!(d.code, 2318 | 2304))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Optional intent survives a `Pick`-style mapped type over a union
+// ---------------------------------------------------------------------------
+
+/// `a` is optional in one constituent, so the union property — and therefore a
+/// homomorphic `{ [Q in K]: T[Q] }` picked over it — must keep it optional. The
+/// members carry distinct discriminants so the union is not collapsed by subtype
+/// reduction, which is what surfaced the bug.
+#[test]
+fn picked_property_over_union_keeps_optional_from_any_member() {
+    let diags = relevant(
+        r#"
+        type MyPick<T, K extends keyof T> = { [Q in K]: T[Q] };
+        type Picked = MyPick<{ a: number; tag: 1 } | { a?: number; tag: 2 }, "a">;
+
+        const empty: Picked = {};                     // a optional -> ok
+        declare const value: Picked;
+        const widened: number | undefined = value.a;  // ok
+    "#,
+    );
+    assert!(
+        diags.is_empty(),
+        "expected optional `a` to survive Pick over heterogeneous union, got: {diags:?}"
+    );
+}
+
+/// Reading the preserved-optional property without allowing `undefined` must
+/// surface the dropped-`undefined` as TS2322 (the witness from the issue).
+#[test]
+fn picked_property_over_union_read_includes_undefined() {
+    let diags = relevant(
+        r#"
+        type MyPick<T, K extends keyof T> = { [Q in K]: T[Q] };
+        type OnlyValue = MyPick<{ value: number; kind: "a" } | { value?: number; kind: "b" }, "value">;
+
+        declare const field: OnlyValue;
+        const exact: number = field.value; // number | undefined -> TS2322
+    "#,
+    );
+    assert!(
+        has_diagnostic_code(&diags, 2322),
+        "expected TS2322 from reading union-optional property, got: {diags:?}"
+    );
+}
+
+/// Negative control: when no constituent makes the property optional, the picked
+/// property stays required and an empty object is rejected (TS2741). Guards
+/// against over-correcting to "always optional".
+#[test]
+fn picked_property_over_union_required_when_no_member_optional() {
+    let diags = relevant(
+        r#"
+        type MyPick<T, K extends keyof T> = { [Q in K]: T[Q] };
+        type IdOnly = MyPick<{ id: number; side: "l" } | { id: number; side: "r" }, "id">;
+
+        const missing: IdOnly = {}; // id required -> TS2741
+    "#,
+    );
+    assert!(
+        has_diagnostic_code(&diags, 2741),
+        "expected TS2741 for required union property, got: {diags:?}"
+    );
+}
+
+/// `readonly` in one constituent makes the union property readonly, and that
+/// survives the picked mapped type.
+#[test]
+fn picked_property_over_union_keeps_readonly_from_any_member() {
+    let diags = relevant(
+        r#"
+        type MyPick<T, K extends keyof T> = { [Q in K]: T[Q] };
+        type Named = MyPick<{ name: string; v: 1 } | { readonly name: string; v: 2 }, "name">;
+
+        declare const named: Named;
+        named.name = "next"; // readonly -> TS2540
+    "#,
+    );
+    assert_eq!(
+        diagnostic_count(&diags, 2540),
+        1,
+        "expected one TS2540 for readonly union property, got: {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Intersection sources: optional only when every declaring member is optional
+// ---------------------------------------------------------------------------
+
+/// `a` is optional in the only constituent that declares it, so the picked
+/// property over the intersection is optional.
+#[test]
+fn picked_property_over_intersection_keeps_optional_from_declaring_member() {
+    let diags = relevant(
+        r#"
+        type MyPick<T, K extends keyof T> = { [Q in K]: T[Q] };
+        type Picked = MyPick<{ a?: number; t: 1 } & { z: boolean }, "a">;
+
+        const empty: Picked = {}; // a optional -> ok
+    "#,
+    );
+    assert!(
+        diags.is_empty(),
+        "expected optional `a` to survive Pick over intersection, got: {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Direct union property access exercises the shared collection path
+// ---------------------------------------------------------------------------
+
+/// Plain property access on a heterogeneous union keeps the optional read type
+/// `number | undefined`, exercising the union property collection directly.
+#[test]
+fn direct_union_property_access_includes_undefined() {
+    let diags = relevant(
+        r#"
+        declare const node: { weight?: number; n: "o" } | { weight: number; n: "r" };
+        const w: number = node.weight; // number | undefined -> TS2322
+    "#,
+    );
+    assert!(
+        has_diagnostic_code(&diags, 2322),
+        "expected TS2322 for direct union property access, got: {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/objects/collect.rs
+++ b/crates/tsz-solver/src/objects/collect.rs
@@ -468,7 +468,14 @@ impl<'a, R: TypeResolver> PropertyCollector<'a, R> {
         for prop in first {
             let mut present_in_all = true;
             let mut type_ids = vec![prop.type_id];
-            let mut all_optional = prop.optional;
+            // A union property is OPTIONAL/READONLY when ANY constituent is,
+            // matching tsc's `createUnionOrIntersectionProperty`
+            // (`optionalFlag |= prop.flags & Optional`). The previous
+            // `all_optional` (require every member) dropped optionality for
+            // heterogeneous unions like `Pick<A | B, 'a'>` where only one member
+            // has `a?`, since such unions are never collapsed by subtype
+            // reduction so the wrong modifier survived.
+            let mut any_optional = prop.optional;
             let mut any_readonly = prop.readonly;
             let mut visibility = prop.visibility;
 
@@ -478,7 +485,7 @@ impl<'a, R: TypeResolver> PropertyCollector<'a, R> {
                         if let Some(other_prop) = PropertyInfo::find_in_slice(properties, prop.name)
                         {
                             type_ids.push(other_prop.type_id);
-                            all_optional = all_optional && other_prop.optional;
+                            any_optional = any_optional || other_prop.optional;
                             any_readonly = any_readonly || other_prop.readonly;
                             visibility = merge_visibility(visibility, other_prop.visibility);
                         } else {
@@ -507,7 +514,12 @@ impl<'a, R: TypeResolver> PropertyCollector<'a, R> {
                     existing.type_id = self
                         .interner
                         .intersect_types_raw2(existing.type_id, union_type);
-                    existing.optional = existing.optional && all_optional;
+                    // The union's contribution joins an accumulator built from
+                    // sibling intersection members, so it combines with
+                    // intersection semantics (optional only when both sides are
+                    // optional). `any_optional`/`any_readonly` already encode the
+                    // union's own ANY-member modifiers.
+                    existing.optional = existing.optional && any_optional;
                     existing.readonly = existing.readonly || any_readonly;
                 } else {
                     let new_idx = self.properties.len();
@@ -516,7 +528,7 @@ impl<'a, R: TypeResolver> PropertyCollector<'a, R> {
                         name: prop.name,
                         type_id: union_type,
                         write_type: union_type,
-                        optional: all_optional,
+                        optional: any_optional,
                         readonly: any_readonly,
                         visibility,
                         is_method: prop.is_method,


### PR DESCRIPTION
AgentName: lucid-hopper

## Summary

Fixes a member of bug-family #12174 (mapped key operations lose optional/readonly modifier intent).

`PropertyCollector::collect_union_common` aggregated a union property's **optional** modifier with ALL-member semantics (`all_optional`): a property stayed optional only when *every* constituent declared it optional. `tsc`'s `createUnionOrIntersectionProperty` instead uses `optionalFlag |= prop.flags & Optional` — a union property is optional when it is optional in **any** member. (Readonly already followed the correct ANY-member rule.)

The wrong rule was masked when union members were subtype-related, because such unions collapse under subtype reduction. It surfaced for *heterogeneous* unions whose members are not subtype-related — e.g. a non-distributing homomorphic mapped type `Pick<A | B, 'a'>` where one member has `a?`: tsz dropped the optional intent, reported a spurious `TS2741` for an empty object, and lost the `| undefined` read type, all diverging from `tsc`.

## Metadata

- AgentName: lucid-hopper
- Track: conformance / solver property collection
- Invariant: union/intersection property modifier merging matches `tsc`'s `createUnionOrIntersectionProperty` — union: optional/readonly if ANY member; intersection: optional/readonly only if ALL declaring members.
- Scope: `crates/tsz-solver/src/objects/collect.rs` (`collect_union_common`). The union's own modifier becomes ANY-member; the union-within-intersection accumulation still combines with intersection semantics (`existing && any_optional`). No other layer changed — this is the shared property-collection primitive, so all consumers (direct property access, mapped picks, nested intersections) are fixed at once.

## Structural rule

When a property is present in every member of a union, `tsc` reports it optional iff it is optional in any member; tsz now does the same through `collect_union_common`.

## Verification

- New regression suite `crates/tsz-checker/tests/union_property_optional_modifier_tests.rs` (6 tests): optional/required/readonly modifiers picked over heterogeneous union and intersection sources, plus direct union property access. All pass.
- `cargo test -p tsz-solver --lib` — 6572 passed; the only 2 failures are pre-existing on `main` (`evaluate_application_variadic_prepend_flattens_tail_application`, `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`), unaffected by this change.
- Targeted checker suites green: `homomorphic_mapped_union_distribution_tests`, `object_union_assignability_fast_path_tests`, `large_union_index_merge_regression_tests`, `indexed_access_resolved_union_property_tests`, `mapped_type_errors_conformance_tests`, `union_source/target_*_elaboration_tests`, `ts2339_union_narrow_display_tests`, and more.
- Oracle-checked against `tsc` 6.0.2: `Pick`/`Omit` over heterogeneous union and intersection, and direct union property access, now match.

## Project Corpus Impact

- Row: n/a
- Bug family: #12174

No project rows run locally (CI owns broad suites). The change only makes more union properties carry their correct optional modifier, matching `tsc`; targeted union/mapped/elaboration suites show no regressions.

## Coordination Notes

A residual, separate gap remains for *user-defined* homomorphic mapped types over **aliased** heterogeneous union/intersection sources (e.g. `type A = {...}; MyPick<A | B, 'a'>`), where `homomorphic_mapped_source` detection is inconsistent across evaluation contexts and the source modifiers are not always resolved. Real-world code using the library utility types (`Pick`/`Omit`/`Partial`/`Required`/`Readonly`) is fixed by this change; the aliased user-mapped case is left for a follow-up under #12174.

https://claude.ai/code/session_019AgTu8pUF1An1Myncq4CdY