### PR TITLE
fix(checker): accept input-only generic method drops in class implements (#10804)

### DIFF
--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -1492,6 +1492,18 @@ impl<'a> CheckerState<'a> {
                                     interface_member_type,
                                     class_member_idx,
                                 )
+                                // A non-generic class member validly implements a
+                                // generic interface method by dropping the method-local
+                                // type parameter(s) to their constraint(s) when those
+                                // appear only in input positions. The strict own-member
+                                // relation rejects that sound specialization (false
+                                // TS2416); the same suppression already governs the
+                                // interface-/class-`extends` paths, so all three heritage
+                                // forms make identical variance decisions.
+                                && !self.nongeneric_input_only_generic_override_is_valid(
+                                    class_member_type,
+                                    interface_member_type,
+                                )
                             {
                                 incompatible_members.push((
                                     class_member_idx,
@@ -1514,6 +1526,13 @@ impl<'a> CheckerState<'a> {
                                     inherited_type,
                                     interface_member_type,
                                     class_idx,
+                                )
+                                // Same input-only generic-drop specialization rule as
+                                // the own-member branch above, for a member the class
+                                // inherits from its base class to satisfy the interface.
+                                && !self.nongeneric_input_only_generic_override_is_valid(
+                                    inherited_type,
+                                    interface_member_type,
                                 )
                             {
                                 incompatible_members.push((

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -132,6 +132,9 @@ mod class_extends_generic_override_variance_tests;
 #[path = "tests/class_extends_index_relation_routing_arch_tests.rs"]
 mod class_extends_index_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/class_implements_generic_override_variance_tests.rs"]
+mod class_implements_generic_override_variance_tests;
+#[cfg(test)]
 #[path = "tests/class_implements_index_relation_routing_arch_tests.rs"]
 mod class_implements_index_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/class_implements_generic_override_variance_tests.rs
+++ b/crates/tsz-checker/src/tests/class_implements_generic_override_variance_tests.rs
@@ -1,0 +1,194 @@
+//! Regression tests for issue #10804 — generic method override variance through
+//! the class `implements` interface heritage form (mixed inheritance chains).
+//!
+//! When a class `implements` an interface whose method is *generic* and the
+//! class member drops the method-local type parameter(s) to a concrete type,
+//! the member is a valid implementation **iff** the dropped parameter appears
+//! only in **input** (contravariant) positions: the wider concrete parameter
+//! admits every instantiation. A method-local generic used covariantly in the
+//! return is *not* satisfiable by a concrete type (a caller relies on getting a
+//! specific instantiation back), so it must still be rejected.
+//!
+//! `tsc`'s `compareSignaturesRelated` makes exactly this decision for all three
+//! heritage forms. The interface-`extends` (TS2430) and class-`extends`
+//! (TS2416) paths already routed through
+//! `nongeneric_input_only_generic_override_is_valid`; the `implements` member
+//! check used the strict no-erase relation directly, producing a false TS2416 on
+//! the sound input-only drop. These tests pin the implements form to the same
+//! variance decision (own members and members inherited from a base class).
+//!
+//! The decision is structural — keyed on the signature shapes, not on any
+//! identifier — so the accepted/rejected cases below vary the method, interface,
+//! and type-parameter names.
+
+use crate::test_utils::check_source_codes;
+
+fn assert_has_2416(src: &str) {
+    let codes = check_source_codes(src);
+    assert!(
+        codes.contains(&2416),
+        "expected TS2416, got none. Got: {codes:?}\nSource:\n{src}"
+    );
+}
+
+fn assert_no_2416(src: &str) {
+    let codes = check_source_codes(src);
+    assert!(
+        !codes.contains(&2416),
+        "unexpected TS2416 (false positive). Got: {codes:?}\nSource:\n{src}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Must be ACCEPTED (input-only generic dropped to its constraint). These were
+// false positives before the fix.
+// ---------------------------------------------------------------------------
+
+// Input-only constrained generic, same interface return type.
+#[test]
+fn no_false_2416_implements_input_only_same_return() {
+    assert_no_2416(
+        "interface Builder { with<K extends string>(k: K): Builder; }
+         class Impl implements Builder { with(k: string): Builder { return this; } }",
+    );
+}
+
+// Renamed method-local type parameter — proves the rule is structural.
+#[test]
+fn no_false_2416_implements_input_only_same_return_renamed() {
+    assert_no_2416(
+        "interface Builder { attach<C extends string>(k: C): Builder; }
+         class Impl implements Builder { attach(k: string): Builder { return this; } }",
+    );
+}
+
+// Input-only generic with a covariant (subtype) return narrows soundly.
+#[test]
+fn no_false_2416_implements_input_only_covariant_return() {
+    assert_no_2416(
+        "interface Builder { with<K extends string>(k: K): Builder; }
+         class Sub implements Builder { with(k: string): Sub { return this; } }",
+    );
+}
+
+// Input-only generic with a `void` return.
+#[test]
+fn no_false_2416_implements_input_only_void_return() {
+    assert_no_2416(
+        "interface Builder { with<K extends string>(k: K): void; }
+         class Impl implements Builder { with(k: string): void {} }",
+    );
+}
+
+// Unconstrained input-only generic dropped to `unknown`.
+#[test]
+fn no_false_2416_implements_input_only_unconstrained() {
+    assert_no_2416(
+        "interface Sink { push<T>(x: T): void; }
+         class Impl implements Sink { push(x: unknown): void {} }",
+    );
+}
+
+// Phantom (unused) method-local generic dropped — sound to drop.
+#[test]
+fn no_false_2416_implements_phantom_unused_generic() {
+    assert_no_2416(
+        "interface Reader { read<Z>(): number; }
+         class Impl implements Reader { read(): number { return 0; } }",
+    );
+}
+
+// The satisfying member is INHERITED from a base class (mixed chain:
+// `class Impl extends BaseImpl implements Builder`).
+#[test]
+fn no_false_2416_implements_inherited_member_input_only() {
+    assert_no_2416(
+        "interface Builder { with<K extends string>(k: K): Builder; }
+         class BaseImpl { with(k: string): Builder { return this as unknown as Builder; } }
+         class Impl extends BaseImpl implements Builder {}",
+    );
+}
+
+// Inherited member, renamed binders.
+#[test]
+fn no_false_2416_implements_inherited_member_input_only_renamed() {
+    assert_no_2416(
+        "interface Builder { join<P extends string>(k: P): Builder; }
+         class BaseImpl { join(k: string): Builder { return this as unknown as Builder; } }
+         class Impl extends BaseImpl implements Builder {}",
+    );
+}
+
+// Class member re-declares the same method-local generic — universal
+// quantification preserved, already accepted; kept as a guard.
+#[test]
+fn no_false_2416_implements_matching_generic_redeclared() {
+    assert_no_2416(
+        "interface Box { get<T extends string>(x: T): T; }
+         class Impl implements Box { get<U extends string>(x: U): U { return x; } }",
+    );
+}
+
+// Three-level mixed chain whose every drop is input-only.
+#[test]
+fn no_false_2416_implements_three_level_input_only_chain() {
+    assert_no_2416(
+        "interface Top { tag<K extends string>(k: K): Top; }
+         interface Mid extends Top { tag(k: string): Mid; }
+         class Leaf implements Mid { tag(k: string): Leaf { return this; } }",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Must STILL be REJECTED (TS2416) — the suppression must not over-fire. A
+// method-local generic used covariantly in the return, or a genuine parameter /
+// callback-position mismatch, is not a valid implementation.
+// ---------------------------------------------------------------------------
+
+// Bare method-local generic in the return position.
+#[test]
+fn keeps_2416_implements_return_only_generic() {
+    assert_has_2416(
+        "interface Box { get<T>(): T; }
+         class Impl implements Box { get(): string { return \"\"; } }",
+    );
+}
+
+// Constrained method-local generic used in BOTH input and output: a concrete
+// `string` return is not assignable to the opaque `T`.
+#[test]
+fn keeps_2416_implements_constrained_generic_covariant_return() {
+    assert_has_2416(
+        "interface Spec { run<T extends string>(x: T): T; }
+         class Svc implements Spec { run(x: string): string { return x; } }",
+    );
+}
+
+// Two method-local generics, one input one output: the output one is unsound.
+#[test]
+fn keeps_2416_implements_two_generics_one_output() {
+    assert_has_2416(
+        "interface Conv { map<I, O>(i: I): O; }
+         class Impl implements Conv { map(i: string): number { return 0; } }",
+    );
+}
+
+// Method-local generic in a callback RETURN position is still covariant.
+#[test]
+fn keeps_2416_implements_callback_return_generic() {
+    assert_has_2416(
+        "interface Mapper { each<U>(f: () => U): U; }
+         class Impl implements Mapper { each(f: () => string): string { return f(); } }",
+    );
+}
+
+// Genuine callback-PARAMETER mismatch must not be hidden by the erased
+// bivariant check: `(x: number) => void` is not assignable to the erased
+// `(x: string) => void`.
+#[test]
+fn keeps_2416_implements_genuine_callback_param_mismatch() {
+    assert_has_2416(
+        "interface Sink { take<T extends string>(cb: (x: T) => void): void; }
+         class Impl implements Sink { take(cb: (x: number) => void): void {} }",
+    );
+}


### PR DESCRIPTION
AgentName: lucid-hopper-opus48

Track: conformance / checker false-positive (generic method override variance)

## Invariant
When a non-generic class member **implements** a generic interface method and
drops the method-local type parameter(s) to their constraint(s), the member is
a valid implementation **iff** those parameters appear only in **input**
(contravariant) positions. tsz now accepts that shape (matching `tsc`) instead
of emitting a false **TS2416**, while still rejecting a method-local generic
used covariantly in the return or a genuine parameter/callback-position
mismatch.

```ts
interface Builder { with<K extends string>(k: K): Builder; }
class Impl implements Builder { with(k: string): Builder { return this; } }
// tsc 6.0.2 & tsz now: OK (was: TS2416 "not assignable to the same property")

interface Spec { run<T extends string>(x: T): T; }
class Svc implements Spec { run(x: string): string { return x; } }
// tsc & tsz: still TS2416 — T is used covariantly in the return.
```

## Structural rule
> When a non-generic method implements a generic interface method, `tsc`'s
> `compareSignaturesRelated` accepts dropping a method-local type parameter that
> occurs only in input positions (the wider concrete parameter admits every
> instantiation) and rejects one used in a covariant return/output position.
> tsz now makes the same decision through the `implements` member-compatibility
> boundary.

The `implements` member check routed methods straight through the strict
no-erase relation (`should_report_own_member_type_mismatch` /
`should_report_member_type_mismatch`), which rejects **both** the sound
input-only drop and the unsound covariant-return drop — a false TS2416 on the
former. The interface-`extends` (TS2430, #12554) and class-`extends` (TS2416)
paths already gate on `nongeneric_input_only_generic_override_is_valid`; this
brings the third heritage form into line so all three make identical variance
decisions.

## Owner layer
- **Checker** — `crates/tsz-checker/src/classes/class_implements_checker/core.rs`.
  The existing `nongeneric_input_only_generic_override_is_valid` suppression is
  added as an AND term at the two `implements` member-comparison sites: the
  own-member branch and the branch for a member inherited from a base class.
  No solver/relation change.
- The helper composes two existing relation entrypoints (no new solver policy,
  no printer-output inspection, no identifier/file-name literals): an erased
  bivariant relation (accepts input-only, rejects genuine param/callback
  mismatch) and a no-erase relation on the **return types** (rejects covariant
  return use). It is gated to the over-report regime (base method generic,
  override not) via `generic_erasure_fallback_is_safe`, so ordinary non-generic
  and matching-generic overrides keep the strict relation's decision.

## Scope
- `crates/tsz-checker/src/classes/class_implements_checker/core.rs`: add the
  suppression term at the own-member and inherited-member `implements` sites.
- `crates/tsz-checker/src/tests/class_implements_generic_override_variance_tests.rs`:
  new regression suite (15 cases) + module registration in `lib.rs`.

## Adjacent-case matrix (verified against tsc 6.0.2)
Accepted (were false TS2416):
- input-only generic dropped to constraint, same-interface / covariant-subtype / `void` return ✅
- renamed method + interface + type parameter (anti-hardcoding) ✅
- unconstrained input-only generic (`push<T>(x: T)` → `push(x: unknown)`) ✅
- phantom (unused) method-local generic dropped ✅
- satisfying member **inherited** from a base class (`class Impl extends BaseImpl implements Builder`), plain + renamed ✅
- three-level mixed `interface → interface → class` chain, all input-only ✅
- matching generic re-declared by the class member (guard, unchanged path) ✅

Still rejected (TS2416, suppression must not over-fire):
- method-local generic in **return** (`get<T>(): T` → `get(): string`) ✅
- generic in param **and** return (`run<T extends string>(x: T): T`) ✅
- two generics, one input one output (`map<I, O>(i: I): O`) ✅
- method-local generic in callback **return** (`each<U>(f: () => U): U`) ✅
- genuine callback-**parameter** mismatch (`take(cb: (x: number) => void)` for `take<T extends string>(cb: (x: T) => void)`) ✅

## Project Corpus Impact
- Row: rxjs-project (`#10804` witness; `implements` of generic interfaces is
  pervasive there). Broader generic-method-override variance family also covers
  `#10796` / `#10812` / `#10828` / `#12178`.
- Bug family: generic method override variance through class `implements`.
- The change **only removes false positives** (suppresses a spurious TS2416); it
  never introduces a new diagnostic, so no required project-corpus row should
  regress.

## Verification
- New suite `class_implements_generic_override_variance_tests` → **15 passed, 0 failed**.
- Differential vs `tsc 6.0.2` (`--noEmit --strict --target es2020 --skipLibCheck`)
  over a 26-case mixed-inheritance matrix: every previously-divergent
  `implements` input-only case now matches `tsc`, and every genuine rejection
  still fires identically.
- Regression batches (`-- implements extends override variance heritage`,
  `relation_routing_arch`, `boundary_fallback`): failure set **identical to
  `main`** (confirmed by stashing the change and diffing before/after — the
  pre-existing failures `delegate_cross_arena_source_interface_with_heritage_still_falls_back`
  and six `*_relation_routing_arch_tests` are unrelated and present on `main`).
  **0 new failures.**
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib` clean.
- `python3 scripts/arch/arch_guard.py` → passed (core.rs 1997 ≤ 2000).
- `/simplify` run to convergence.
- Rebased onto current `origin/main` (`87f5104`); no conflicts.

## Coordination Notes
- Continues `#10804`: PR #12554 fixed the interface-`extends` direction and
  explicitly deferred the other heritage forms. This closes the `implements`
  false-positive direction.
- Scope is intentionally the **false-positive** direction (removes errors,
  conformance-safe). Two symmetric **false-negatives** observed during the
  differential remain out of scope as they *add* diagnostics (conformance-drift
  risk, CI-owned): `interface extends class` with a covariant-return generic
  drop (tsc TS2430, tsz misses), and an **abstract** member in
  `class implements` with a covariant-return generic drop (tsc TS2416, tsz
  misses; the non-abstract form already reports correctly).
- Anti-hardcoding gate: structural relation decisions only; tests vary binder,
  method, and type-parameter names.

https://claude.ai/code/session_017WYqzar85Lgnyp3bgeJ3cB

---
_Generated by [Claude Code](https://claude.ai/code/session_017WYqzar85Lgnyp3bgeJ3cB)_