### PR TITLE
fix(bench): count target-gap attribution command coverage

### DIFF
--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -209,7 +209,7 @@ withTempDir((dir) => {
   assert.equal(report.totals.green_tsgo_winners_with_attribution, 1);
   assert.deepEqual(report.totals.missing_attribution_rows, ["single-file-loss", "vite-vanilla-ts-app"]);
   assert.equal(report.totals.incomplete_compat_excluded, 0);
-  assert.match(result.stdout, /2x target gaps with attribution commands: 1\/3/);
+  assert.match(result.stdout, /2x target gaps with attribution commands: 2\/3/);
   assert.deepEqual(report.two_x_target, {
     tsz_speedup_target: 2,
     eligible_green_rows: 4,
@@ -219,7 +219,7 @@ withTempDir((dir) => {
     project_rows_below_target: 2,
     rows_with_attribution: 1,
     missing_attribution_rows: ["single-file-loss", "vite-vanilla-ts-app"],
-    rows_with_attribution_command: 1,
+    rows_with_attribution_command: 2,
     missing_attribution_plan: [
       {
         name: "vite-vanilla-ts-app",
@@ -285,6 +285,8 @@ withTempDir((dir) => {
     owner: "Track 1/2 recursive type evaluation",
     operation: "recursive conditional, mapped/indexed access, repeated instantiation and relation cache pressure",
     command: "scripts/safe-run.sh ./scripts/bench/perf-hotspots.sh --filter '^ts-toolbelt-project$' --json-file <artifact>.json",
+    attribution_command:
+      "TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json <artifact>.ts-toolbelt-project.perf.json --noEmit -p .target-bench/external/ts-toolbelt/tsconfig.flat.json",
     issue: 8356,
     url: "https://github.com/tsz-org/tsz/issues/8356",
   });
@@ -850,6 +852,7 @@ withTempDir((dir) => {
   const report = JSON.parse(fs.readFileSync(output, "utf8"));
   assert.equal(report.two_x_target.rows_below_target, 1);
   assert.equal(report.two_x_target.rows_with_attribution, 1);
+  assert.equal(report.two_x_target.rows_with_attribution_command, 1);
   assert.deepEqual(report.two_x_target.missing_attribution_rows, []);
   assert.deepEqual(report.target_gaps[0].attribution_status, {
     present: true,
@@ -928,7 +931,7 @@ withTempDir((dir) => {
   assert.equal(report.two_x_target.rows_below_target, 2);
   assert.equal(report.two_x_target.rows_with_attribution, 1);
   assert.deepEqual(report.two_x_target.missing_attribution_rows, ["vite-vanilla-ts-app"]);
-  assert.equal(report.two_x_target.rows_with_attribution_command, 1);
+  assert.equal(report.two_x_target.rows_with_attribution_command, 2);
   assert.deepEqual(report.two_x_target.missing_attribution_plan.map((row) => row.name), [
     "vite-vanilla-ts-app",
   ]);

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -43,6 +43,8 @@ const LOSS_CLOSURE_BY_ROW = new Map([
         "recursive conditional, mapped/indexed access, repeated instantiation and relation cache pressure",
       command:
         "scripts/safe-run.sh ./scripts/bench/perf-hotspots.sh --filter '^ts-toolbelt-project$' --json-file <artifact>.json",
+      attribution_command:
+        "TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json <artifact>.ts-toolbelt-project.perf.json --noEmit -p .target-bench/external/ts-toolbelt/tsconfig.flat.json",
       issue: 8356,
       url: "https://github.com/tsz-org/tsz/issues/8356",
     },
@@ -629,8 +631,8 @@ export function createTsgoWinnerReport(input, inputPath) {
   const missingTargetGapAttributionPlan = targetGapRows
     .filter((row) => !hasCompleteAttribution(row.attribution_status))
     .map(missingAttributionPlanForRow);
-  const targetGapRowsWithAttributionCommand = missingTargetGapAttributionPlan
-    .filter((row) => row.attribution_command).length;
+  const targetGapRowsWithAttributionCommand = targetGapRows
+    .filter((row) => row.loss_closure?.attribution_command).length;
 
   const winners = rows
     .filter((row) => row?.winner === "tsgo" && isGreen(row) && !duplicateNames.has(row?.name))


### PR DESCRIPTION
AgentName: Studio-Opus
Track: Benchmark infrastructure / performance release metrics
Invariant: `two_x_target.rows_with_attribution_command` counts every eligible green row below the 2x target that has a runnable attribution command in its loss-closure metadata, independent of whether attribution evidence has already been collected.
Scope: Updates `scripts/bench/tsgo-winner-report.mjs` to count command coverage from all target-gap rows instead of only the missing-attribution plan, adds the missing `ts-toolbelt-project` attribution command, and tightens `test-tsgo-winner-report.mjs` coverage for already-attributed sidecar rows.

## Project Corpus Impact
- Row: benchmark metadata/reporting only; no compiler row behavior or timings changed.
- Bug family: benchmark target-gap attribution command accounting for `vite-vanilla-ts-app` and `ts-toolbelt-project` release evidence.
- Project Corpus Impact: report semantics only. Existing row coverage remains consistent across all 19 project rows.

## Verification
- `node scripts/bench/test-tsgo-winner-report.mjs`
- `git diff --check`
- `node scripts/bench/project-row-summary.mjs --markdown`
- `node scripts/bench/tsgo-winner-report.mjs artifacts/perf/studio-opus-vite-main-20260607.json artifacts/perf/studio-opus-vite-main-20260607.tsgo-winners.after.json` -> `2x target gaps with attribution commands: 1/1`
- `node scripts/bench/tsgo-winner-report.mjs artifacts/perf/hotspots-20260607-013338.json artifacts/perf/hotspots-20260607-013338.tsgo-winners.after.json` -> `2x target gaps with attribution commands: 1/1`

## Coordination Notes
- Avoids overlapping Studio-B compiler performance work in PR #12829 and M4-B recursive conditional work in PR #12815.
- The hotspot artifact still shows `ts-toolbelt-project` below target and missing attribution evidence; this PR only ensures the report publishes the runnable attribution command for that row.
