### PR TITLE
perf(binder): expose resolution cache residency stats

### DIFF
--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -101,13 +101,18 @@ type EnclosingScopeCacheStorage = CloneableRwLock<EnclosingScopeCache>;
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct BinderResolutionCacheStatistics {
     pub export_cache_entries: usize,
+    pub export_type_only_cache_entries: usize,
     pub identifier_cache_entries: usize,
+    pub enclosing_scope_cache_entries: usize,
 }
 
 impl BinderResolutionCacheStatistics {
     #[must_use]
     pub const fn total_entries(&self) -> usize {
-        self.export_cache_entries + self.identifier_cache_entries
+        self.export_cache_entries
+            + self.export_type_only_cache_entries
+            + self.identifier_cache_entries
+            + self.enclosing_scope_cache_entries
     }
 
     #[must_use]
@@ -115,10 +120,16 @@ impl BinderResolutionCacheStatistics {
         const BUCKET_OVERHEAD: usize = 8;
         let export_entry =
             BUCKET_OVERHEAD + (2 * size_of::<String>()) + size_of::<Option<SymbolId>>();
+        let export_type_only_entry =
+            BUCKET_OVERHEAD + (2 * size_of::<String>()) + size_of::<Option<(SymbolId, bool)>>();
         let identifier_entry =
             BUCKET_OVERHEAD + size_of::<(usize, u32)>() + size_of::<Option<SymbolId>>();
+        let enclosing_scope_entry =
+            BUCKET_OVERHEAD + size_of::<(usize, u32)>() + size_of::<ScopeId>();
         (self.export_cache_entries * export_entry)
+            + (self.export_type_only_cache_entries * export_type_only_entry)
             + (self.identifier_cache_entries * identifier_entry)
+            + (self.enclosing_scope_cache_entries * enclosing_scope_entry)
     }
 }
 
@@ -1049,10 +1060,20 @@ impl BinderState {
                 .read()
                 .expect("resolved_export_cache RwLock poisoned")
                 .len(),
+            export_type_only_cache_entries: self
+                .resolved_export_type_only_cache
+                .read()
+                .expect("resolved_export_type_only_cache RwLock poisoned")
+                .len(),
             identifier_cache_entries: self
                 .resolved_identifier_cache
                 .read()
                 .expect("resolved_identifier_cache RwLock poisoned")
+                .len(),
+            enclosing_scope_cache_entries: self
+                .find_enclosing_scope_cache
+                .read()
+                .expect("find_enclosing_scope_cache RwLock poisoned")
                 .len(),
         }
     }

--- a/crates/tsz-binder/src/state/tests/state_storage.rs
+++ b/crates/tsz-binder/src/state/tests/state_storage.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::ScopeId;
 
 #[test]
 fn semantic_defs_identity_stable_with_changed_bodies() {
@@ -426,17 +427,35 @@ declare module \"virtual:env\" {
             .is_empty(),
         "resolved_identifier_cache must be empty after deserialize"
     );
+    assert!(
+        restored
+            .resolved_export_type_only_cache
+            .read()
+            .expect("RwLock should not be poisoned")
+            .is_empty(),
+        "resolved_export_type_only_cache must be empty after deserialize"
+    );
+    assert!(
+        restored
+            .find_enclosing_scope_cache
+            .read()
+            .expect("RwLock should not be poisoned")
+            .is_empty(),
+        "find_enclosing_scope_cache must be empty after deserialize"
+    );
 }
 
 #[test]
 fn binder_resolution_cache_statistics_track_entries_and_clear() {
     let mut binder = BinderState::new();
-    seed_both_caches(&mut binder);
+    seed_resolution_caches(&mut binder);
 
     let stats = binder.resolution_cache_statistics();
     assert_eq!(stats.export_cache_entries, 1);
+    assert_eq!(stats.export_type_only_cache_entries, 1);
     assert_eq!(stats.identifier_cache_entries, 1);
-    assert_eq!(stats.total_entries(), 2);
+    assert_eq!(stats.enclosing_scope_cache_entries, 1);
+    assert_eq!(stats.total_entries(), 4);
     assert!(stats.estimated_size_bytes() > 0);
 
     binder.clear_resolution_caches();
@@ -480,13 +499,13 @@ fn next_persistent_scope_id_reserves_none_sentinel() {
 // Resolution cache invariants across rebind
 //
 // The export cache maps (module_specifier, export_name) -> SymbolId.  After
-// any rebind the SymbolIds for declarations may change, so both resolution
-// caches must be cleared at the start of every bind entry-point.  Failing to
+// any rebind the SymbolIds for declarations may change, so resolution caches
+// must be cleared at the start of every bind entry-point. Failing to
 // do so lets callers observe stale SymbolIds ("binder-7-20" family of bench
 // regressions reported in issues #11465, #11566, #11627).
 // =============================================================================
 
-fn seed_both_caches(binder: &mut BinderState) {
+fn seed_resolution_caches(binder: &mut BinderState) {
     binder
         .resolved_export_cache
         .write()
@@ -497,18 +516,39 @@ fn seed_both_caches(binder: &mut BinderState) {
         .write()
         .expect("not poisoned")
         .insert((0xdead, 0xbeef), Some(SymbolId(77)));
+    binder
+        .resolved_export_type_only_cache
+        .write()
+        .expect("not poisoned")
+        .insert(
+            ("stub.ts".to_string(), "T".to_string()),
+            Some((SymbolId(88), true)),
+        );
+    binder
+        .find_enclosing_scope_cache
+        .write()
+        .expect("not poisoned")
+        .insert((0xcafe, 0xbabe), ScopeId(66));
 }
 
-fn assert_both_caches_cleared(binder: &BinderState, ctx: &str) {
+fn assert_resolution_caches_cleared(binder: &BinderState, ctx: &str) {
     let s = binder.resolution_cache_statistics();
     assert_eq!(s.export_cache_entries, 0, "{ctx}: export cache not cleared");
+    assert_eq!(
+        s.export_type_only_cache_entries, 0,
+        "{ctx}: export type-only cache not cleared"
+    );
     assert_eq!(
         s.identifier_cache_entries, 0,
         "{ctx}: identifier cache not cleared"
     );
+    assert_eq!(
+        s.enclosing_scope_cache_entries, 0,
+        "{ctx}: enclosing scope cache not cleared"
+    );
 }
 
-/// `bind_source_file` must clear both caches so a second bind of the same
+/// `bind_source_file` must clear resolution caches so a second bind of the same
 /// binder state never returns `SymbolId`s from the previous pass.
 #[test]
 fn bind_source_file_clears_both_caches() {
@@ -520,12 +560,12 @@ fn bind_source_file_clears_both_caches() {
     let mut binder = BinderState::new();
     binder.bind_source_file(parser.get_arena(), root);
 
-    seed_both_caches(&mut binder);
+    seed_resolution_caches(&mut binder);
     binder.bind_source_file(parser.get_arena(), root);
-    assert_both_caches_cleared(&binder, "bind_source_file");
+    assert_resolution_caches_cleared(&binder, "bind_source_file");
 }
 
-/// `bind_source_file_incremental` must clear both caches even on the early-
+/// `bind_source_file_incremental` must clear resolution caches even on the early-
 /// return path (empty prefix), so no rebind path can leave a stale entry.
 #[test]
 fn bind_source_file_incremental_clears_both_caches() {
@@ -537,7 +577,7 @@ fn bind_source_file_incremental_clears_both_caches() {
     let mut binder = BinderState::new();
     binder.bind_source_file(parser.get_arena(), root);
 
-    seed_both_caches(&mut binder);
+    seed_resolution_caches(&mut binder);
 
     // Empty prefix triggers the early-return path; caches must still be cleared.
     let ok = binder.bind_source_file_incremental(parser.get_arena(), root, &[], &[], &[], 0);
@@ -546,17 +586,17 @@ fn bind_source_file_incremental_clears_both_caches() {
         "empty prefix must cause bind_source_file_incremental to return false"
     );
 
-    assert_both_caches_cleared(&binder, "bind_source_file_incremental");
+    assert_resolution_caches_cleared(&binder, "bind_source_file_incremental");
 }
 
-/// `merge_lib_contexts_into_binder` must clear both caches because the merge
+/// `merge_lib_contexts_into_binder` must clear resolution caches because the merge
 /// reassigns `SymbolId`s; any cached (module, name) → `old_id` mapping is invalid.
 #[test]
 fn merge_lib_contexts_into_binder_clears_both_caches() {
     let mut binder = BinderState::new();
 
-    seed_both_caches(&mut binder);
+    seed_resolution_caches(&mut binder);
     binder.merge_lib_contexts_into_binder(&[]);
 
-    assert_both_caches_cleared(&binder, "merge_lib_contexts_into_binder");
+    assert_resolution_caches_cleared(&binder, "merge_lib_contexts_into_binder");
 }


### PR DESCRIPTION
AgentName: Studio-Opus
Track: Performance infrastructure / cache residency visibility
Invariant: Binder resolution caches remain regenerable, are cleared together by `clear_resolution_caches`, and their residency is observable through `BinderResolutionCacheStatistics` without changing lookup keys, cache invalidation, or resolution behavior.
Scope: Adds entry and estimated-size accounting for the existing type-only re-export cache and enclosing-scope cache, and extends binder cache-clear/serde tests to cover all four binder resolution caches.

## Project Corpus Impact
- Row: benchmark/project metadata and compiler behavior unchanged.
- Bug family: cache observability debt for binder resolution caches (`ExportTypeOnlyCache`, `EnclosingScopeCache`).
- Project Corpus Impact: performance telemetry only; no row semantics, emit, diagnostics, or timings changed.

## Verification
- `cargo nextest run -p tsz-binder binder_resolution_cache_statistics_track_entries_and_clear`
- `cargo nextest run -p tsz-binder bind_source_file_clears_both_caches bind_source_file_incremental_clears_both_caches merge_lib_contexts_into_binder_clears_both_caches`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/perf/cache-visibility-report.py --json | jq '.summary'` -> `needs_review: 3`, `with_size_signal: 94`, `with_stats_signal: 94` (down from 5 missing signals before this change)

## Coordination Notes
- Avoids active Studio-B compiler performance PR #12829 and M4-B solver correctness PR #12815.
- Leaves the three remaining cache visibility review items (`CheckerContext::type_param_node_cache`, LSP auto-import module specifier cache, solver `closed_eval_cache`) for separately scoped owners.
