### PR TITLE
ci(conformance): unify accepted-regression ledger guard and add integrity gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1151,6 +1151,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+      - name: Validate accepted-regression ledger integrity
+        # Runs on every event (pull_request, merge_group, push): the ledger
+        # must stay canonical (no duplicate / non-normalized / malformed
+        # entries) so the visible counter and the CI aggregate matcher agree.
+        # Needs only HEAD, so no base fetch is required.
+        run: |
+          python3 scripts/conformance/check-accepted-regression-growth.py --integrity-only
       - name: Compare conformance snapshots with PR base
         if: github.event_name == 'pull_request'
         run: |

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -432,6 +432,8 @@ run_lint() {
   python3 scripts/ci/test_gcp_full_ci_emit_metrics.py || return $?
   python3 scripts/ci/test_refresh_readme.py || return $?
   python3 scripts/conformance/test_query_conformance.py || return $?
+  python3 scripts/conformance/test_check_accepted_regression_growth.py || return $?
+  python3 scripts/conformance/lib/test_accepted_regressions.py || return $?
   python3 scripts/emit/test_query_emit_families.py || return $?
   # Use the dedicated ci-lint profile (debug=false, incremental=false,
   # codegen-units=256). Workspace clippy artifacts go to .target/ci-lint/

--- a/scripts/conformance/check-accepted-regression-growth.py
+++ b/scripts/conformance/check-accepted-regression-growth.py
@@ -1,20 +1,36 @@
 #!/usr/bin/env python3
-"""Fail when a PR adds entries to the accepted-conformance-regression ledger.
+"""Guard the accepted-conformance-regression ledger.
 
 The accepted-regression file records conformance tests that are temporarily
 allowed to fail.  Its budget is monotonically non-increasing on main: a PR
 may remove entries (progress) but must never add new ones (regression debt).
+The ledger must also stay canonical (no duplicate, non-normalized, or
+malformed entries) so the visible counter and the CI aggregate matcher agree.
 
 Usage:
+    # Growth + integrity (default): additions are rejected, removals allowed.
     python3 check-accepted-regression-growth.py --base-ref origin/main
     python3 check-accepted-regression-growth.py --base-ref origin/main --head-ref HEAD
+
+    # Integrity only: validate HEAD's ledger hygiene without a base ref.
+    # Safe to run on any event (push, merge_group, ...).
+    python3 check-accepted-regression-growth.py --integrity-only
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
 import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+
+from accepted_regressions import (  # noqa: E402  (path injected above)
+    check_growth,
+    check_integrity,
+    entry_set,
+)
 
 REGRESSIONS_PATH = "scripts/conformance/conformance-accepted-regressions.txt"
 
@@ -31,38 +47,35 @@ def _read_ref_text(ref: str, path: str) -> str | None:
         return None
 
 
-def load_entries(ref: str, path: str = REGRESSIONS_PATH) -> frozenset[str] | None:
-    """Return normalized non-comment entries at ref, or None if the ref is unavailable."""
-    raw = _read_ref_text(ref, path)
-    if raw is None:
-        return None
-    entries: set[str] = set()
-    for line in raw.splitlines():
-        stripped = line.strip()
-        if stripped and not stripped.startswith("#"):
-            entries.add(stripped)
-    return frozenset(entries)
+def _report_integrity(ref_label: str, text: str) -> bool:
+    """Print integrity problems for a ledger text. Return True when clean."""
+    problems = check_integrity(text)
+    if not problems:
+        print(f"Accepted-regression ledger integrity passed ({ref_label}).")
+        return True
 
-
-def check_growth(
-    base_entries: frozenset[str],
-    head_entries: frozenset[str],
-) -> tuple[frozenset[str], frozenset[str]]:
-    """Return (added, removed) entry sets relative to base."""
-    return head_entries - base_entries, base_entries - head_entries
+    print(
+        f"Accepted-regression ledger has {len(problems)} integrity problem(s) "
+        f"({ref_label}):"
+    )
+    for problem in problems:
+        print(f"  - {problem.format()}")
+        print(f"::error::accepted-regression ledger: {problem.format()}")
+    return False
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description=(
-            "Fail if the accepted-regression ledger grew between a base ref and HEAD. "
-            "Removals are always allowed; additions are never allowed."
+            "Guard the accepted-regression ledger: additions are never allowed, "
+            "removals are always allowed, and the ledger must stay canonical "
+            "(no duplicate / non-normalized / malformed entries)."
         )
     )
     parser.add_argument(
         "--base-ref",
-        required=True,
-        help="Base git ref to compare against (e.g. origin/main).",
+        help="Base git ref to compare against (e.g. origin/main). "
+        "Required unless --integrity-only is set.",
     )
     parser.add_argument(
         "--head-ref",
@@ -75,6 +88,14 @@ def main(argv: list[str] | None = None) -> int:
         help=f"Path to accepted-regression file (default: {REGRESSIONS_PATH}).",
     )
     parser.add_argument(
+        "--integrity-only",
+        action="store_true",
+        help=(
+            "Only validate ledger hygiene at --head-ref; skip the base "
+            "comparison. Safe to run on any event (push, merge_group, ...)."
+        ),
+    )
+    parser.add_argument(
         "--allow-unavailable-base",
         action="store_true",
         help=(
@@ -84,26 +105,38 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    base_entries = load_entries(args.base_ref, args.path)
-    if base_entries is None:
-        msg = (
-            f"could not read {args.path} from {args.base_ref!r}; "
-            "accepted-regression growth check skipped."
-        )
-        if args.allow_unavailable_base:
-            print(f"warning: {msg}", file=sys.stderr)
-            return 0
-        print(f"error: {msg}", file=sys.stderr)
-        return 1
-
-    head_entries = load_entries(args.head_ref, args.path)
-    if head_entries is None:
+    head_text = _read_ref_text(args.head_ref, args.path)
+    if head_text is None:
         print(
             f"error: could not read {args.path} from {args.head_ref!r}",
             file=sys.stderr,
         )
         return 1
 
+    # Ledger hygiene is checked on every invocation: a malformed ledger makes
+    # both the visible counter and the growth comparison untrustworthy.
+    integrity_ok = _report_integrity(repr(args.head_ref), head_text)
+
+    if args.integrity_only:
+        return 0 if integrity_ok else 1
+
+    if not args.base_ref:
+        parser.error("--base-ref is required unless --integrity-only is set")
+
+    base_text = _read_ref_text(args.base_ref, args.path)
+    if base_text is None:
+        msg = (
+            f"could not read {args.path} from {args.base_ref!r}; "
+            "accepted-regression growth check skipped."
+        )
+        if args.allow_unavailable_base:
+            print(f"warning: {msg}", file=sys.stderr)
+            return 0 if integrity_ok else 1
+        print(f"error: {msg}", file=sys.stderr)
+        return 1
+
+    base_entries = entry_set(base_text)
+    head_entries = entry_set(head_text)
     added, removed = check_growth(base_entries, head_entries)
 
     print(
@@ -119,12 +152,14 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Added entries ({len(added)}) — this is not allowed:")
         for entry in sorted(added):
             print(f"  + {entry}")
-        print()
+            print(f"::error::accepted-regression ledger must not grow: {entry} was added.")
         print(
-            "::error::The accepted-regression ledger must not grow. "
-            "File a parity issue and track the regression there instead of "
-            "adding a new entry to conformance-accepted-regressions.txt."
+            "File a parity issue and track each regression there instead of "
+            "adding entries to conformance-accepted-regressions.txt."
         )
+        return 1
+
+    if not integrity_ok:
         return 1
 
     print("Accepted-regression growth gate passed.")

--- a/scripts/conformance/lib/accepted_regressions.py
+++ b/scripts/conformance/lib/accepted_regressions.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Canonical parsing and validation for the accepted-conformance-regression ledger.
+
+The accepted-regression ledger
+(`scripts/conformance/conformance-accepted-regressions.txt`) records conformance
+tests that are temporarily allowed to fail in CI without blocking the aggregate
+gate. Its budget is monotonically non-increasing on `main`: a PR may remove
+entries (progress) but must never add new ones (regression debt).
+
+This module is the single source of truth for how that ledger is parsed,
+normalized, and validated. It is shared by:
+
+  * `check-accepted-regression-growth.py` - the CI growth/integrity gate.
+  * `query-conformance.py` - the `--dashboard` accepted-regression counter.
+
+The CI aggregate matcher in `scripts/ci/lib/gcp-full-ci-conformance.sh` (the
+`_check_conformance_regression_allowlist` heredoc) applies the same `normalize`
+rule when it compares per-shard failure lists against this ledger.
+`test_accepted_regressions.py` pins that contract so the inline copy in the
+shell heredoc and this module cannot drift apart silently. (A second, display-
+only `normalize` copy in the same shell file falls back to `os.path.basename`
+and is deliberately not mirrored here -- it does not govern the ledger.)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Every accepted regression names a TypeScript conformance test case. The
+# aggregate matcher only keys on the ``TypeScript`` segment, so this prefix is
+# intentionally stricter than the matcher: the ledger has only ever held
+# ``tests/cases/`` fixtures, and the tighter shape catches typos. Widen it here
+# if a legitimate failing fixture ever lives outside ``tests/cases/``.
+TEST_CASE_PREFIX = "TypeScript/tests/cases/"
+
+# TypeScript fixtures use these source extensions. A ledger entry that does not
+# end in one of them can never match a real failing test path and is almost
+# certainly a typo.
+TEST_CASE_SUFFIXES = (".ts", ".tsx", ".js", ".jsx", ".mts", ".cts")
+
+
+def normalize(path: str) -> str:
+    """Return the ledger-canonical form of a test path.
+
+    Mirrors the aggregate-matcher ``normalize`` helper in
+    ``scripts/ci/lib/gcp-full-ci-conformance.sh``: backslashes become forward
+    slashes and the path is sliced from its first ``TypeScript`` segment so that
+    absolute shard paths and repo-relative ledger entries compare equal.
+
+    This deliberately differs from the adjacent
+    ``lib/results.normalize_harness_path``, which slices from the *last*
+    ``TypeScript/`` and does not convert backslashes; do not unify them, or the
+    CI matcher parity pinned by ``test_accepted_regressions.py`` breaks.
+    """
+    parts = path.replace("\\", "/").split("/")
+    for index, part in enumerate(parts):
+        if part == "TypeScript":
+            return "/".join(parts[index:])
+    return "/".join(parts)
+
+
+def iter_raw_entries(text: str):
+    """Yield ``(lineno, value)`` for each non-blank, non-comment ledger line.
+
+    ``lineno`` is 1-based. ``value`` is the stripped (but not yet normalized)
+    line, so integrity checks can flag non-canonical spellings before they are
+    collapsed by :func:`normalize`.
+    """
+    for lineno, raw_line in enumerate(text.splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        yield lineno, stripped
+
+
+def parse_entries(text: str) -> list[str]:
+    """Return stripped ledger entries in file order (duplicates preserved)."""
+    return [value for _lineno, value in iter_raw_entries(text)]
+
+
+def normalized_entries(text: str) -> list[str]:
+    """Return normalized ledger entries in file order (duplicates preserved)."""
+    return [normalize(value) for value in parse_entries(text)]
+
+
+def entry_set(text: str) -> frozenset[str]:
+    """Return the deduplicated, normalized set of ledger entries.
+
+    This is the set CI actually treats as "accepted", so it is the right basis
+    for growth comparison and for the visible dashboard counter.
+    """
+    return frozenset(normalized_entries(text))
+
+
+def check_growth(
+    base_entries: frozenset[str],
+    head_entries: frozenset[str],
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Return ``(added, removed)`` normalized entry sets relative to ``base``."""
+    return head_entries - base_entries, base_entries - head_entries
+
+
+@dataclass(frozen=True)
+class IntegrityProblem:
+    """A single ledger hygiene violation, suitable for a CI annotation."""
+
+    kind: str
+    value: str
+    lineno: int | None
+    message: str
+
+    def format(self) -> str:
+        location = f"line {self.lineno}: " if self.lineno is not None else ""
+        return f"{location}{self.message}"
+
+
+def check_integrity(text: str) -> list[IntegrityProblem]:
+    """Return ledger hygiene violations, in a stable reporting order.
+
+    A healthy ledger is the trustworthy basis for the visible counter and for
+    the growth gate, so this rejects three classes that would otherwise enter
+    silently:
+
+      * non-canonical entries (``value != normalize(value)``), which would make
+        the growth set disagree with CI's aggregate matcher;
+      * duplicate entries (after normalization), which inflate the counter and
+        can mask a removal;
+      * malformed entries that do not look like a real
+        ``TypeScript/tests/cases/<...>`` test path and so could never match a
+        failing test.
+    """
+    problems: list[IntegrityProblem] = []
+    first_seen: dict[str, int] = {}
+
+    for lineno, value in iter_raw_entries(text):
+        canonical = normalize(value)
+
+        if value != canonical:
+            problems.append(
+                IntegrityProblem(
+                    kind="non-canonical",
+                    value=value,
+                    lineno=lineno,
+                    message=(
+                        f"entry {value!r} is not in canonical form; "
+                        f"write it as {canonical!r}"
+                    ),
+                )
+            )
+
+        if canonical in first_seen:
+            problems.append(
+                IntegrityProblem(
+                    kind="duplicate",
+                    value=canonical,
+                    lineno=lineno,
+                    message=(
+                        f"duplicate entry {canonical!r} "
+                        f"(first listed on line {first_seen[canonical]})"
+                    ),
+                )
+            )
+        else:
+            first_seen[canonical] = lineno
+
+        if not canonical.startswith(TEST_CASE_PREFIX) or not canonical.endswith(
+            TEST_CASE_SUFFIXES
+        ):
+            problems.append(
+                IntegrityProblem(
+                    kind="malformed",
+                    value=canonical,
+                    lineno=lineno,
+                    message=(
+                        f"entry {canonical!r} does not look like a test path "
+                        f"under {TEST_CASE_PREFIX!r} ending in one of "
+                        f"{', '.join(TEST_CASE_SUFFIXES)}"
+                    ),
+                )
+            )
+
+    return problems

--- a/scripts/conformance/lib/test_accepted_regressions.py
+++ b/scripts/conformance/lib/test_accepted_regressions.py
@@ -1,0 +1,199 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("accepted_regressions.py")
+SPEC = importlib.util.spec_from_file_location("accepted_regressions", SCRIPT_PATH)
+mod = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = mod
+SPEC.loader.exec_module(mod)
+
+normalize = mod.normalize
+parse_entries = mod.parse_entries
+normalized_entries = mod.normalized_entries
+entry_set = mod.entry_set
+check_growth = mod.check_growth
+check_integrity = mod.check_integrity
+
+
+class NormalizeTests(unittest.TestCase):
+    def test_repo_relative_path_is_unchanged(self):
+        path = "TypeScript/tests/cases/compiler/foo.ts"
+        self.assertEqual(normalize(path), path)
+
+    def test_absolute_path_is_sliced_from_typescript_segment(self):
+        self.assertEqual(
+            normalize("/runner/work/tsz/TypeScript/tests/cases/compiler/foo.ts"),
+            "TypeScript/tests/cases/compiler/foo.ts",
+        )
+
+    def test_backslashes_are_normalized(self):
+        self.assertEqual(
+            normalize("TypeScript\\tests\\cases\\compiler\\foo.ts"),
+            "TypeScript/tests/cases/compiler/foo.ts",
+        )
+
+    def test_path_without_typescript_segment_collapses_separators(self):
+        self.assertEqual(normalize("a\\b/c"), "a/b/c")
+
+    def test_mirrors_aggregate_matcher_contract(self):
+        # This pins the exact behavior duplicated inline in
+        # scripts/ci/lib/gcp-full-ci-conformance.sh. If that copy changes, this
+        # assertion must change with it (and vice versa).
+        def aggregate_normalize(path):
+            parts = path.replace("\\", "/").split("/")
+            for i, part in enumerate(parts):
+                if part == "TypeScript":
+                    return "/".join(parts[i:])
+            return "/".join(parts)
+
+        for sample in [
+            "TypeScript/tests/cases/compiler/foo.ts",
+            "/abs/TypeScript/tests/cases/conformance/bar.ts",
+            "TypeScript\\tests\\cases\\compiler\\baz.tsx",
+            "no/typescript/here.ts",
+        ]:
+            self.assertEqual(normalize(sample), aggregate_normalize(sample))
+
+
+class ParseTests(unittest.TestCase):
+    def test_comments_and_blanks_filtered(self):
+        text = "# c\n\nTypeScript/tests/cases/compiler/foo.ts\n   \n# d\nbar\n"
+        self.assertEqual(
+            parse_entries(text),
+            ["TypeScript/tests/cases/compiler/foo.ts", "bar"],
+        )
+
+    def test_normalized_entries_preserve_order_and_dups(self):
+        text = (
+            "/abs/TypeScript/tests/cases/compiler/foo.ts\n"
+            "TypeScript/tests/cases/compiler/foo.ts\n"
+        )
+        self.assertEqual(
+            normalized_entries(text),
+            [
+                "TypeScript/tests/cases/compiler/foo.ts",
+                "TypeScript/tests/cases/compiler/foo.ts",
+            ],
+        )
+
+    def test_entry_set_dedups_on_normalized_form(self):
+        text = (
+            "/abs/TypeScript/tests/cases/compiler/foo.ts\n"
+            "TypeScript/tests/cases/compiler/foo.ts\n"
+            "TypeScript/tests/cases/compiler/bar.ts\n"
+        )
+        self.assertEqual(
+            entry_set(text),
+            frozenset(
+                [
+                    "TypeScript/tests/cases/compiler/foo.ts",
+                    "TypeScript/tests/cases/compiler/bar.ts",
+                ]
+            ),
+        )
+
+    def test_empty_text_is_empty_set(self):
+        self.assertEqual(entry_set(""), frozenset())
+
+
+class GrowthTests(unittest.TestCase):
+    def test_no_change_passes(self):
+        entries = frozenset(["a.ts", "b.ts"])
+        self.assertEqual(check_growth(entries, entries), (frozenset(), frozenset()))
+
+    def test_addition_detected(self):
+        added, removed = check_growth(frozenset(["a.ts"]), frozenset(["a.ts", "b.ts"]))
+        self.assertEqual(added, frozenset(["b.ts"]))
+        self.assertEqual(removed, frozenset())
+
+    def test_removal_only_allowed(self):
+        added, removed = check_growth(frozenset(["a.ts", "b.ts"]), frozenset(["a.ts"]))
+        self.assertEqual(added, frozenset())
+        self.assertEqual(removed, frozenset(["b.ts"]))
+
+    def test_growth_uses_normalized_sets_via_entry_set(self):
+        base = entry_set("TypeScript/tests/cases/compiler/foo.ts\n")
+        # Same test, non-canonical spelling -> not a real addition.
+        head = entry_set("/abs/TypeScript/tests/cases/compiler/foo.ts\n")
+        added, removed = check_growth(base, head)
+        self.assertEqual(added, frozenset())
+        self.assertEqual(removed, frozenset())
+
+
+class IntegrityTests(unittest.TestCase):
+    def test_clean_ledger_has_no_problems(self):
+        text = (
+            "# header\n"
+            "TypeScript/tests/cases/compiler/foo.ts\n"
+            "TypeScript/tests/cases/conformance/bar.tsx\n"
+        )
+        self.assertEqual(check_integrity(text), [])
+
+    def test_duplicate_detected(self):
+        text = (
+            "TypeScript/tests/cases/compiler/foo.ts\n"
+            "TypeScript/tests/cases/compiler/foo.ts\n"
+        )
+        kinds = [p.kind for p in check_integrity(text)]
+        self.assertIn("duplicate", kinds)
+
+    def test_normalized_duplicate_detected(self):
+        text = (
+            "TypeScript/tests/cases/compiler/foo.ts\n"
+            "/abs/TypeScript/tests/cases/compiler/foo.ts\n"
+        )
+        kinds = [p.kind for p in check_integrity(text)]
+        self.assertIn("non-canonical", kinds)
+        self.assertIn("duplicate", kinds)
+
+    def test_non_canonical_detected(self):
+        text = "/abs/TypeScript/tests/cases/compiler/foo.ts\n"
+        problems = check_integrity(text)
+        self.assertEqual([p.kind for p in problems], ["non-canonical"])
+        self.assertIn("canonical form", problems[0].message)
+
+    def test_malformed_wrong_prefix(self):
+        text = "TypeScript/src/compiler/checker.ts\n"
+        kinds = [p.kind for p in check_integrity(text)]
+        self.assertIn("malformed", kinds)
+
+    def test_malformed_wrong_suffix(self):
+        text = "TypeScript/tests/cases/compiler/foo.txt\n"
+        kinds = [p.kind for p in check_integrity(text)]
+        self.assertIn("malformed", kinds)
+
+    def test_accepts_all_known_suffixes(self):
+        text = "".join(
+            f"TypeScript/tests/cases/compiler/foo{suffix}\n"
+            for suffix in mod.TEST_CASE_SUFFIXES
+        )
+        self.assertEqual(check_integrity(text), [])
+
+    def test_problem_format_includes_line_number(self):
+        text = "\nTypeScript/tests/cases/compiler/foo.txt\n"
+        problems = check_integrity(text)
+        self.assertEqual(len(problems), 1)
+        self.assertTrue(problems[0].format().startswith("line 2: "))
+
+
+class RealLedgerTests(unittest.TestCase):
+    """The checked-in ledger must satisfy the integrity invariant it enforces."""
+
+    def test_checked_in_ledger_is_clean(self):
+        ledger = SCRIPT_PATH.parent.parent / "conformance-accepted-regressions.txt"
+        text = ledger.read_text(encoding="utf-8")
+        problems = check_integrity(text)
+        self.assertEqual(
+            problems,
+            [],
+            msg="checked-in ledger violates integrity: "
+            + "; ".join(p.format() for p in problems),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/conformance/query-conformance.py
+++ b/scripts/conformance/query-conformance.py
@@ -61,6 +61,9 @@ from lib.conformance_query import (
     load_detail,
 )
 
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+from accepted_regressions import normalized_entries  # noqa: E402  (path injected above)
+
 DEFAULT_TSC_CACHE_PATH = Path(__file__).with_name("tsc-cache-full.json")
 
 # =============================================================================
@@ -253,13 +256,13 @@ def load_accepted_regressions(path=DEFAULT_ACCEPTED_REGRESSIONS_PATH):
     if not os.path.exists(path):
         return {"path": path, "exists": False, "entries": []}
 
-    entries = []
     with open(path, encoding="utf-8") as handle:
-        for raw_line in handle:
-            line = raw_line.strip()
-            if not line or line.startswith("#"):
-                continue
-            entries.append(line)
+        text = handle.read()
+
+    # Deduplicate on the normalized form so the visible counter matches the set
+    # the CI aggregate matcher actually treats as accepted. dict.fromkeys keeps
+    # first-occurrence order for stable display.
+    entries = list(dict.fromkeys(normalized_entries(text)))
     return {"path": path, "exists": True, "entries": entries}
 
 

--- a/scripts/conformance/test_check_accepted_regression_growth.py
+++ b/scripts/conformance/test_check_accepted_regression_growth.py
@@ -12,16 +12,9 @@ sys.modules[SPEC.name] = mod
 SPEC.loader.exec_module(mod)
 
 check_growth = mod.check_growth
-
-
-def _parse(text: str) -> frozenset[str]:
-    """Parse accepted-regression text directly (mirrors load_entries logic)."""
-    entries: set[str] = set()
-    for line in text.splitlines():
-        stripped = line.strip()
-        if stripped and not stripped.startswith("#"):
-            entries.add(stripped)
-    return frozenset(entries)
+# Parse through the shared library so the test's notion of an "entry" stays in
+# lock-step with production (normalization + dedup), rather than re-deriving it.
+_parse = mod.entry_set
 
 
 class CheckAcceptedRegressionGrowthTests(unittest.TestCase):


### PR DESCRIPTION
AgentName: brave-volta

Track: Conformance strictness / CI gate (release-gate debt protection)

Invariant: The accepted-regression budget is monotonic non-increasing on `main`, and the ledger stays canonical — every entry is a unique, normalized `TypeScript/tests/cases/...` test path — so the visible counter, the growth gate, and the CI aggregate matcher all agree on the same set. Closes #12545.

## Problem

The accepted-regression ledger (`scripts/conformance/conformance-accepted-regressions.txt`) had **three divergent parsers**:

1. `check-accepted-regression-growth.py` — raw stripped-line set, no normalization.
2. `query-conformance.py::load_accepted_regressions` — raw list, **no dedup/normalize**, so the dashboard `N listed tests` counter (acceptance criterion #5) could drift from what CI actually accepts.
3. `scripts/ci/lib/gcp-full-ci-conformance.sh` — the authoritative matcher, which `normalize()`s and set-dedups.

So the visible counter and the growth gate could disagree with the real CI matcher, and nothing prevented duplicate / non-canonical / malformed entries from silently entering the ledger (inflating the counter or never matching a real failure). The additions-blocking half of the invariant already landed; this completes it.

## Scope

- **New** `scripts/conformance/lib/accepted_regressions.py` — single source of truth: `normalize`, `parse_entries`, `normalized_entries`, `entry_set`, `check_growth`, and a structural `check_integrity` (rejects non-canonical, duplicate, and malformed entries). `normalize` mirrors the aggregate-matcher copy in the shell gate; a unit test pins that cross-language contract so they cannot drift.
- `check-accepted-regression-growth.py` consumes the shared module, gains an integrity check and an `--integrity-only` mode, and emits per-entry `::error::` annotations for additions with a single remediation note.
- `query-conformance.py` dashboard counter now dedups on the normalized form (matches CI).
- `.github/workflows/ci.yml` — the `conformance-snapshot-gate` job runs the integrity check on **every** event (pull_request, merge_group, push), needing only HEAD, so the ledger stays trustworthy at merge-queue time.
- `scripts/ci/gcp-full-ci.sh` — registers the growth + shared-module test suites in the lint job (the growth test was previously not run in CI at all).
- The old hand-rolled `_parse` test helper now delegates to the shared `entry_set`.

Additions remain disallowed; removals remain allowed (stale removals stay caught by the aggregate unlisted-failure check at full-run/merge time). No checker/solver behavior is touched.

## Anti-Hardcoding

No user/file-name literals drive logic; `TEST_CASE_PREFIX`/`TEST_CASE_SUFFIXES` are structural facts of the conformance corpus declared as named constants. The integrity `malformed` check is intentionally (and documentedly) stricter than the matcher's bare `TypeScript`-segment rule, with a comment on how to widen it if a fixture ever lives outside `tests/cases/`.

## Project Corpus Impact

- Row: n/a
- Bug family: conformance accepted-regression ledger guard / CI integrity gate
- Evidence: Tooling/CI only - no compiler row behavior, diagnostics, or timings change. The checked-in ledger (15 entries) already satisfies the new integrity invariant (pinned by `RealLedgerTests`).

## Verification

- `python3 -m unittest discover -s scripts/conformance -p 'test_*.py'` → 61 passed
- `python3 -m unittest discover -s scripts/conformance/lib -p 'test_*.py'` → 50 passed
- `python3 scripts/conformance/check-accepted-regression-growth.py --base-ref origin/main --head-ref HEAD` → integrity passed, 15→15, growth gate passed
- `python3 scripts/conformance/check-accepted-regression-growth.py --integrity-only` → passed
- `python3 scripts/conformance/query-conformance.py --dashboard` → `Accepted-regression gate: 15 listed tests`
- `ruff check` on all new/changed lines clean (3 pre-existing errors in `query-conformance.py` unrelated lines left untouched); `bash -n scripts/ci/gcp-full-ci.sh` and YAML parse OK
- Cleaned via three `/simplify` passes (shared dedup, doc precision, single remediation message, inlined a half-used wrapper).
- Fresh PR-head `CI Summary` success on 2026-06-07 for head `44c44fd4929c4fa2deb9b64825a3fbbd9ab4a791`.

## Coordination Notes

Claimed #12545 earlier with signed coordination. Current state: ready after fresh PR-head CI on head `44c44fd4929c4fa2deb9b64825a3fbbd9ab4a791`; this stays in conformance/CI tooling, not compiler semantics, and does not overlap the open compiler/bench PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KphDgy72FzAAAzyExjQzeB)_