### PR TITLE
fix(checker): normalize whitespace in indexed-access TS2536/TS2339 object display

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -579,10 +579,13 @@ impl<'a> CheckerState<'a> {
             ) {
                 return;
             }
-            // Clean up object type text: strip enclosing parens and any trailing
-            // index access syntax that may leak from the object_type node span.
+            // Clean up object type text: normalize stray whitespace (so the
+            // display matches tsc's printer), strip enclosing parens, and drop
+            // any trailing index access syntax that may leak from the node span.
+            let normalized_object_text =
+                object_format::normalize_indexed_access_object_text(&raw_object_text);
             let object_type_str = {
-                let trimmed = raw_object_text.trim();
+                let trimmed = normalized_object_text.trim();
                 let trimmed = trimmed.strip_prefix('(').unwrap_or(trimmed);
                 let trimmed = trimmed.strip_suffix(')').unwrap_or(trimmed);
                 if let Some(pos) = trimmed.find(")[") {
@@ -939,6 +942,7 @@ impl<'a> CheckerState<'a> {
         if foreign_keyof_indexed_constraint {
             let obj_type_str = self
                 .node_text(data.object_type)
+                .map(|text| object_format::normalize_indexed_access_object_text(&text))
                 .unwrap_or_else(|| self.format_type(object_type));
             let index_type_str = self.format_type(index_type);
             let message_2536 = format_message(
@@ -1433,6 +1437,8 @@ impl<'a> CheckerState<'a> {
                         let object_type_str = self
                             .node_text(data.object_type)
                             .map(|text| {
+                                let text =
+                                    object_format::normalize_indexed_access_object_text(&text);
                                 let trimmed = text.trim();
                                 let trimmed = trimmed.strip_prefix('(').unwrap_or(trimmed);
                                 let trimmed = trimmed.strip_suffix(')').unwrap_or(trimmed);

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/object_format.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/object_format.rs
@@ -8,6 +8,38 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
+/// Normalize an indexed-access object's source text so its display matches the
+/// type printer's canonical form instead of leaking the original span.
+///
+/// `tsc` renders the object type through its printer, which never carries the
+/// stray whitespace a source slice can ("`A[ F ]`", or a `keyof   T` written
+/// across lines). This collapses runs of insignificant whitespace to a single
+/// space and drops the spaces that hug `[`/`]`, so unusual spacing renders the
+/// same as `tsc`. Cleanly-written source has no stray spacing, so it is returned
+/// unchanged — this only repairs the irregular cases and never rewrites the
+/// common one. Source text is retained (rather than a printed type) because it
+/// preserves the written alias name, which a resolved/rebuilt type would expand.
+pub(super) fn normalize_indexed_access_object_text(text: &str) -> String {
+    let mut collapsed = String::with_capacity(text.len());
+    let mut prev_was_space = false;
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            if !prev_was_space {
+                collapsed.push(' ');
+            }
+            prev_was_space = true;
+        } else {
+            collapsed.push(ch);
+            prev_was_space = false;
+        }
+    }
+    collapsed
+        .replace("[ ", "[")
+        .replace(" ]", "]")
+        .trim()
+        .to_string()
+}
+
 impl<'a> CheckerState<'a> {
     pub(super) fn format_ts2536_object_type(
         &self,
@@ -22,6 +54,7 @@ impl<'a> CheckerState<'a> {
             )
             && let Some(text) = self.node_text(object_node_idx)
         {
+            let text = normalize_indexed_access_object_text(&text);
             let text = text.trim();
             let text = text.strip_prefix('(').unwrap_or(text);
             let text = text.strip_suffix(')').unwrap_or(text).trim();

--- a/crates/tsz-checker/tests/conformance_issues/types/indexed_access.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/indexed_access.rs
@@ -1518,3 +1518,51 @@ const fiBad: FromIdx = "no";
         "Both genuine TS2322 assignment errors must still be reported.\nActual diagnostics: {diagnostics:#?}"
     );
 }
+
+/// TS2536's object display normalizes the object's source span the way `tsc`'s
+/// type printer renders it: stray whitespace written inside an indexed access
+/// (`DataFetchFns[ F ]`, or a type split across lines) must not leak into the
+/// message. Source text is retained for the object so the written alias name is
+/// preserved (a resolved type would expand the alias), but the irregular spacing
+/// is collapsed to the canonical form.
+#[test]
+fn ts2536_object_display_normalizes_source_whitespace() {
+    let diagnostics = compile_and_get_diagnostics(
+        r"
+type DataFetchFns = {
+    Boat: { name: (id: string) => string };
+    Plane: { name: (id: string) => string };
+};
+type WithWhitespace<T extends keyof DataFetchFns, F extends keyof DataFetchFns[T]> =
+    DataFetchFns[ F ][ T ];
+type WithParens<T extends keyof DataFetchFns, F extends keyof DataFetchFns[T]> =
+    (DataFetchFns[F])[T];
+",
+    );
+
+    let ts2536: Vec<&String> = diagnostics
+        .iter()
+        .filter(|(code, _)| *code == 2536)
+        .map(|(_, message)| message)
+        .collect();
+
+    assert!(
+        !ts2536.is_empty(),
+        "Expected TS2536 for the unresolved nested indexed accesses.\nActual diagnostics: {diagnostics:#?}"
+    );
+
+    for message in &ts2536 {
+        assert!(
+            !message.contains("[ F ]") && !message.contains("[ T ]"),
+            "TS2536 object display must collapse source whitespace inside the indexed access.\nMessage: {message}"
+        );
+    }
+
+    // The alias name is preserved (not expanded) and rendered in canonical form.
+    assert!(
+        ts2536
+            .iter()
+            .any(|message| message.contains("cannot be used to index type 'DataFetchFns[F]'")),
+        "Expected the normalized `DataFetchFns[F]` object display.\nActual TS2536: {ts2536:#?}"
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: claude-brave-volta-no914

## Track
Diagnostic display parity for indexed-access errors (TS2536 / TS2339). Adjacent hardening for the `constraintWithIndexedAccess` area tracked by #12771.

## Invariant
The object portion of a TS2536 ("cannot be used to index type") or TS2339 ("does not exist on type") indexed-access diagnostic is rendered in `tsc`'s canonical printer form: it never carries the stray whitespace a raw source span can (`A[ F ]`, or a type written across lines). tsz keeps using the object's source text so the written alias name is preserved, but normalizes the whitespace to match.

## Scope
- `crates/tsz-checker/src/types/type_checking/indexed_access/object_format.rs`: new pure `normalize_indexed_access_object_text` helper (collapse insignificant whitespace, drop the spaces hugging `[`/`]`); applied in `format_ts2536_object_type`.
- `crates/tsz-checker/src/types/type_checking/indexed_access.rs`: route the three remaining inline TS2536/TS2339 object source-text sites through the same helper. Type-selection logic is unchanged; only the whitespace of the chosen source string is normalized.
- `crates/tsz-checker/tests/conformance_issues/types/indexed_access.rs`: regression test locking the normalized display.

## Problem / Structural rule
`Obj[K]` diagnostics used the raw object source span, leaking whitespace `tsc`'s printer never emits:

| source | before (tsz) | after / tsc |
| --- | --- | --- |
| `DataFetchFns[ F ][ T ]` | `... index type 'DataFetchFns[ F ]'` | `... index type 'DataFetchFns[F]'` |
| `(DataFetchFns[F])[T]` | parens-dependent display | `... index type 'DataFetchFns[F]'` |

The normalization is a no-op on cleanly formatted source. Source text is intentionally retained rather than printing a reconstructed type because tsz's type for an aliased indexed access does not carry the alias symbol; a printed/rebuilt type would render the expanded object literal instead of `DataFetchFns[T]`, diverging from `tsc`.

## Project Corpus Impact
- Row: n/a
- Bug family: diagnostic display / indexed-access object rendering (TS2536/TS2339)
- Evidence: presentation-only error-path change. No relation, inference, narrowing, project row, accepted-regression ledger, or emit semantics changed.

## Verification
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter constraintWithIndexedAccess --verbose` -> 1/1 passed, 0 fingerprint-only
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter infiniteConstraints --verbose` -> 1/1 passed, 0 fingerprint-only
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test conformance_issues_types ts2536_object_display_normalizes_source_whitespace` -> 1 passed, 322 skipped
- `cargo fmt --check -p tsz-checker` -> passed
- `git diff --check` -> passed
- `scripts/arch/check-checker-boundaries.sh` -> architecture guardrails passed; checker field-lifetime inventory passed (240 fields)
- Full PR-head CI on `8150b8fcf4871d583eab72499555d82ae6cebd32` -> success (33 success, 3 skipped)

## Coordination Notes
- AgentName: claude-brave-volta-no914
- M1-B drained the PR, disabled re-armed auto-merge, and verified the forced-update head `8150b8fcf4871d583eab72499555d82ae6cebd32`; canonical owner label is `agent:M1-A` because this is diagnostic-display parity.
- Refs #12771. The literal `constraintWithIndexedAccess.ts` regression was already resolved on main by #12693; this PR is broader hardening of the same TS2536/TS2339 display surface.
- An earlier revision tried printer-based reconstruction of the object type, but that expanded type aliases and regressed `constraintWithIndexedAccess.ts` / `infiniteConstraints.ts` in the conformance aggregate. This version keeps source text for alias preservation and only normalizes display whitespace.

https://claude.ai/code/session_01FE6NhebZRQy5k7hzB6btP7