### PR TITLE
fix(solver): distribute nullish-filter intersections that drop impossible arms

### DIFF
--- a/crates/tsz-solver/src/intern/intersection.rs
+++ b/crates/tsz-solver/src/intern/intersection.rs
@@ -31,6 +31,35 @@ impl TypeInterner {
         }
     }
 
+    /// Check if a type is a nullish-removal filter union, i.e. a union whose
+    /// every member is the empty object `{}` or a nullish type (`null` /
+    /// `undefined` / `void`).
+    ///
+    /// These are the unions TypeScript intersects against to subtract
+    /// nullishness — `{} | null` ("everything except `undefined`"), `{} |
+    /// undefined` ("everything except `null`"), `null | undefined`, etc. When
+    /// such a filter is intersected with a value union, the distributed cross
+    /// product drops the impossible nullish arms (`undefined & {}`,
+    /// `undefined & null`, …) and the remaining arms are exactly the value
+    /// restricted to non-nullishness. This is the canonical witness for the
+    /// distribution acceptance below; a genuine object-alternative union such as
+    /// `{ a: string } | { b: number }` is deliberately NOT a nullish filter, so
+    /// `T1 & ({ a } | { b })` keeps its conservative non-distributed form.
+    fn is_nullish_filter_union(&self, id: TypeId) -> bool {
+        if id.is_intrinsic() {
+            return false;
+        }
+        match self.lookup(id) {
+            Some(TypeData::Union(list_id)) => {
+                let members = self.type_list(list_id);
+                members
+                    .iter()
+                    .all(|&m| m.is_nullable() || self.is_empty_object(m))
+            }
+            _ => false,
+        }
+    }
+
     /// Check if a type is a "widening" primitive intrinsic — i.e., the wide
     /// `string` / `number` / `boolean` / `bigint` / `symbol` types whose
     /// literal subtypes get absorbed during union normalization.
@@ -394,10 +423,30 @@ impl TypeInterner {
                 let is_simpler = match self.lookup(distributed) {
                     Some(TypeData::Union(members)) => {
                         let list = self.type_list(members);
-                        !list.iter().any(|&m| {
+                        let no_intersection_members = !list.iter().any(|&m| {
                             !m.is_intrinsic()
                                 && matches!(self.lookup(m), Some(TypeData::Intersection(_)))
-                        })
+                        });
+                        // Distribution genuinely simplifies the type when either no
+                        // intersection members remain, or a nullish-removal filter
+                        // (`{} | null` and friends) eliminated at least one impossible
+                        // combination — an arm reduced to `never` and was dropped,
+                        // leaving fewer members than the full cross product. This
+                        // matches tsc, which forms the distributed cross product and
+                        // drops its `never` constituents. The canonical witness is
+                        // `(T | undefined) & ({} | null)` (e.g. `Partial<X>[K] & ({} |
+                        // null)`): `undefined & {}` and `undefined & null` are both
+                        // `never`, so it reduces to `(T & {}) | (T & null)`, which is
+                        // assignable to `T`.
+                        //
+                        // The nullish-filter guard keeps the conservative form for
+                        // genuine value-union cross products such as
+                        // `T1 & ({ a: string } | { b: number })` (display- and
+                        // relation-complexity-sensitive) — those eliminate arms too,
+                        // but distributing them would drop the alias display tsc keeps.
+                        let eliminated_via_nullish_filter = list.len() < cross_product
+                            && flat.iter().any(|&id| self.is_nullish_filter_union(id));
+                        no_intersection_members || eliminated_via_nullish_filter
                     }
                     _ => true,
                 };

--- a/crates/tsz-solver/tests/intersection_type_param_tests.rs
+++ b/crates/tsz-solver/tests/intersection_type_param_tests.rs
@@ -36,6 +36,115 @@ fn test_intersection_with_empty_object_assignable_to_type_param() {
 }
 
 #[test]
+fn test_type_param_union_undefined_intersect_empty_or_null_assignable_to_type_param() {
+    // Regression: `(T | undefined) & ({} | null)` must be assignable to `T`.
+    //
+    // This is the `indexedAccessAndNullableNarrowing` shape: `Partial<X>[K]` is
+    // `T[K] | undefined`, and tsc narrows / intersects it with the "non-undefined"
+    // filter `{} | null`. Distributing the cross product drops the impossible
+    // arms (`undefined & {}` and `undefined & null` are both `never`), leaving
+    // `(T & {}) | (T & null)`, which is assignable to `T`. Without the
+    // distribution the intersection survives unsimplified and the relation
+    // cannot prove the subtype, producing a spurious TS2322.
+    let interner = TypeInterner::new();
+
+    let t_name = interner.intern_string("T");
+    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: t_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+    }));
+
+    let empty_obj = interner.object(vec![]);
+
+    // (T | undefined)
+    let t_or_undefined = interner.union(vec![t_param, TypeId::UNDEFINED]);
+    // ({} | null)
+    let empty_or_null = interner.union(vec![empty_obj, TypeId::NULL]);
+    // (T | undefined) & ({} | null)
+    let source = interner.intersection(vec![t_or_undefined, empty_or_null]);
+
+    let mut checker = SubtypeChecker::new(&interner);
+    assert!(
+        checker.is_subtype_of(source, t_param),
+        "(T | undefined) & ({{}} | null) should be assignable to T"
+    );
+
+    // The companion `& {}` form (single non-union filter) must keep working too.
+    let source_empty_only = interner.intersection(vec![t_or_undefined, empty_obj]);
+    assert!(
+        checker.is_subtype_of(source_empty_only, t_param),
+        "(T | undefined) & {{}} should be assignable to T"
+    );
+}
+
+#[test]
+fn test_non_reducing_cross_product_intersection_is_not_distributed() {
+    // Guard: a cross product whose arms cannot merge and where nothing reduces
+    // to `never` — `(A | B) & (C | D)` over distinct type parameters — must NOT
+    // be distributed. It stays an intersection of unions exactly as tsc keeps
+    // it, pinning the boundary of the distribution refinement above (which only
+    // fires when an impossible arm is eliminated).
+    let interner = TypeInterner::new();
+
+    let mk = |n: &str| {
+        interner.intern(TypeData::TypeParameter(TypeParamInfo {
+            name: interner.intern_string(n),
+            constraint: None,
+            default: None,
+            is_const: false,
+        }))
+    };
+    let (a, b, c, d) = (mk("A"), mk("B"), mk("C"), mk("D"));
+
+    let a_or_b = interner.union(vec![a, b]);
+    let c_or_d = interner.union(vec![c, d]);
+    let result = interner.intersection(vec![a_or_b, c_or_d]);
+
+    assert!(
+        matches!(interner.lookup(result), Some(TypeData::Intersection(_))),
+        "non-reducing cross product should remain an intersection, got {:?}",
+        interner.lookup(result)
+    );
+}
+
+#[test]
+fn test_value_union_filter_intersection_is_not_distributed() {
+    // Guard against over-eager distribution: `(T | undefined) & ({ a } | { b })`
+    // eliminates `undefined & { a }` / `undefined & { b }` arms, but `{ a } | { b }`
+    // is a genuine value union, NOT a nullish-removal filter. Distributing it would
+    // drop the alias display tsc keeps and perturb relation-complexity accounting
+    // (regression witness: relationComplexityError.ts). It must stay an intersection.
+    let interner = TypeInterner::new();
+
+    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    }));
+    let obj_a = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("a"),
+        TypeId::STRING,
+    )]);
+    let obj_b = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("b"),
+        TypeId::NUMBER,
+    )]);
+
+    let t_or_undefined = interner.union(vec![t_param, TypeId::UNDEFINED]);
+    let a_or_b = interner.union(vec![obj_a, obj_b]);
+    let result = interner.intersection(vec![t_or_undefined, a_or_b]);
+
+    assert!(
+        matches!(interner.lookup(result), Some(TypeData::Intersection(_))),
+        "value-union filter intersection should remain an intersection, got {:?}",
+        interner.lookup(result)
+    );
+}
+
+#[test]
 fn test_intersection_with_type_param_and_constraint() {
     // T & string should be assignable to T extends string
     let interner = TypeInterner::new();

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -51,7 +51,6 @@ TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules
 TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
-TypeScript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts
 TypeScript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts
@@ -72,3 +71,13 @@ TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
 # (store_parametric_structural_back_reference). Provenance is now recorded for
 # those instances, so display matches tsc. Covered by
 # recursive_generic_interface_application_display_tests.
+# indexedAccessAndNullableNarrowing.ts: RESOLVED. A false TS2322 fired on
+# `T[K] = Partial<T>[K] & ({} | null)` because `(X | undefined) & ({} | null)`
+# was kept as an unsimplified intersection-of-unions: neither constituent is a
+# subtype of `X`, so the relation rejected it. tsc forms the distributed cross
+# product and drops its `never` constituents (`undefined & {}` and
+# `undefined & null`), leaving `(X & {}) | (X & null)`, which is assignable to
+# `X`. The all-union distribution gate now accepts a distributed result that
+# eliminated at least one impossible arm. Covered by
+# intersection_type_param_tests::
+# test_type_param_union_undefined_intersect_empty_or_null_assignable_to_type_param.


### PR DESCRIPTION
AgentName: claude-brave-volta-NYIJM

Closes #12855

## Track
Conformance / solver intersection normalization. Removes the `indexedAccessAndNullableNarrowing.ts` accepted-regression witness.

## Invariant
When an all-union intersection is distributed and a **nullish-removal filter** union (`{} | null` and friends — every member empty-object/`null`/`undefined`) eliminates at least one impossible cross-product combination (an arm reduces to `never`), the distributed result is adopted — matching `tsc`, which forms the distributed cross product and drops its `never` constituents. Genuine value-union cross products (e.g. `T1 & ({ a } | { b })`, `(A | B) & (C | D)`) stay an intersection, unchanged.

## Problem / Structural rule
A false `TS2322` fired on `t = p2` where `t: T[K]` and `p2: Partial<T>[K] & ({} | null)` (the `indexedAccessAndNullableNarrowing` fixture; clean under `tsc`).

`Partial<T>[K]` is `T[K] | undefined`, so the source is `(T[K] | undefined) & ({} | null)`. Neither constituent (`T[K] | undefined`, `{} | null`) is a subtype of `T[K]`, so the relation rejected it. `tsc` distributes the cross product and drops the `never` arms (`undefined & {}` and `undefined & null`), leaving `(T[K] & {}) | (T[K] & null)`, which is assignable to `T[K]`.

`normalize_intersection`'s all-union distribution gate previously accepted a distributed result **only** when no intersection members remained. `(T[K] & {}) | (T[K] & null)` still has intersection arms, so the gate discarded the simplification and kept the unrelatable intersection-of-unions.

| source | tsz before | tsz after / tsc |
| --- | --- | --- |
| `(X \| undefined) & ({} \| null)` &lt;: `X` | TS2322 | ok |
| `(X \| undefined) & {}` &lt;: `X` | ok | ok (unchanged) |
| `(string \| undefined) & ({} \| null)` &lt;: `string` | ok | ok (unchanged) |
| `T1 & ({ a } \| { b })` (value union) | intersection | intersection (unchanged) |
| `(A \| B) & (C \| D)` (distinct type params) | intersection | intersection (unchanged) |

## Why the nullish-filter guard
The first cut accepted **any** distributed all-union result with fewer members than the cross product. That also distributed `T1 & ({ a: string } | { b: number })` (where `T1` carries `undefined`), which eliminates `undefined & { a }` / `undefined & { b }` arms — but `{ a } | { b }` is a genuine value union, not a nullishness filter. Distributing it dropped the alias display `tsc` keeps and perturbed relation-complexity accounting, regressing `relationComplexityError.ts` (TS2859 rendered the distributed members instead of `T1 & T2`). The acceptance is now scoped to nullish-removal filters, so that fixture is untouched.

## Owner layer
Solver — `crates/tsz-solver/src/intern/intersection.rs`, `normalize_intersection` all-union branch. New `is_nullish_filter_union` predicate; the gate accepts a distributed union with fewer members than the cross product only when a nullish-filter union drove the elimination. No relation logic changed; the type is fixed at its normalization source so display, narrowing, and relations all benefit.

## Scope
- `crates/tsz-solver/src/intern/intersection.rs`: `is_nullish_filter_union` helper + widened (but scoped) all-union distribution acceptance gate.
- `crates/tsz-solver/tests/intersection_type_param_tests.rs`: positive regression (`(T | undefined) & ({} | null)` and `(T | undefined) & {}` assignable to `T`) plus two boundary guards (`(A | B) & (C | D)` type params, and `(T | undefined) & ({ a } | { b })` value union — both stay intersections).
- `scripts/conformance/conformance-accepted-regressions.txt`: remove `indexedAccessAndNullableNarrowing.ts`; add a RESOLVED note.

## Anti-hardcoding
Structural gate on the distributed cross-product member count + structural nullish-filter predicate (empty-object/nullable members); no user-name/file-name literals, no formatted-string predicates. Tests vary binder names.

## Project Corpus Impact
- Row: n/a
- Bug family: nullable-filtered intersection over generics (#12855)
- Removes a spurious `TS2322` on the indexed-access/nullable-narrowing assignability surface; no diagnostics added on the hot path.

## Verification
- `cargo build -p tsz-cli --bin tsz` + repro: `indexedAccessAndNullableNarrowing.ts` compiles clean (matches the empty `tsc` baseline); `relationComplexityError.ts` still reports `TS2859 ... 'T1 & T2' and 'T1 | null'` (aliased, not distributed); minimal repros `r1`–`r6` all behave like `tsc`.
- `cargo test -p tsz-solver --lib intersection_type_param_tests` → 11 passed (incl. 3 new).
- `cargo test -p tsz-solver --lib` → 6578 passed; the only 2 failures (`evaluate_application_variadic_prepend_flattens_tail_application`, `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`) are **pre-existing on clean `main`**.
- `cargo test -p tsz-checker --lib`: failing-test set **identical** with and without this change (73 pre-existing lib-availability failures) — zero new failures.
- `cargo test -p tsz-checker --test conformance_issues_types`: 1 pre-existing failure, unchanged.
- `cargo fmt --check`, `cargo clippy -p tsz-solver --lib` clean; `scripts/arch/arch_guard.py` + `check-checker-boundaries.sh` pass.
- Rebased on current `origin/main`; builds clean, no conflicts. The first CI run caught the `relationComplexityError.ts` regression; this revision scopes the gate to nullish filters and resolves it.

## Coordination Notes
- Picked from the accepted-regression ledger (other `bug`-labeled issues were already claimed); filed and claimed #12855 for this previously issue-less regression, per the ledger's own "track in an issue instead of growing this ledger" guidance.

https://claude.ai/code/session_01Fwt6a3ypBXe6w6xWY6pZyS