### PR TITLE
perf(lsp): expose auto-import module specifier cache stats

### DIFF
--- a/crates/tsz-lsp/src/project/import_collect.rs
+++ b/crates/tsz-lsp/src/project/import_collect.rs
@@ -5,6 +5,7 @@
 //! orchestration-shaped.
 
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::mem;
 
 use crate::code_actions::{ImportCandidate, ImportCandidateKind};
 
@@ -75,6 +76,14 @@ impl<'a> AutoImportCandidateContext<'a> {
 
     pub(super) fn request_file_name(&self) -> &str {
         self.from_file.file_name()
+    }
+
+    pub(super) fn module_specifiers_cache_entries(&self) -> usize {
+        self.module_specifiers_cache.len()
+    }
+
+    pub(super) fn module_specifiers_cache_estimated_size_bytes(&self) -> usize {
+        module_specifiers_cache_estimated_size_bytes(&self.module_specifiers_cache)
     }
 
     pub(super) fn is_regular_file_excluded(&self, file_name: &str) -> bool {
@@ -160,5 +169,45 @@ fn import_candidate_kind_key(kind: &ImportCandidateKind) -> String {
         ImportCandidateKind::Named { export_name } => format!("named:{export_name}"),
         ImportCandidateKind::Default => "default".to_string(),
         ImportCandidateKind::Namespace => "namespace".to_string(),
+    }
+}
+
+fn module_specifiers_cache_estimated_size_bytes(cache: &FxHashMap<String, Vec<String>>) -> usize {
+    let entries_size = cache.capacity().saturating_mul(
+        mem::size_of::<String>()
+            .saturating_add(mem::size_of::<Vec<String>>())
+            .saturating_add(8),
+    );
+    let key_size = cache.keys().map(String::len).sum::<usize>();
+    let value_size = cache
+        .values()
+        .map(|specifiers| {
+            specifiers
+                .capacity()
+                .saturating_mul(mem::size_of::<String>())
+                .saturating_add(specifiers.iter().map(String::len).sum::<usize>())
+        })
+        .sum::<usize>();
+    entries_size
+        .saturating_add(key_size)
+        .saturating_add(value_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn module_specifiers_cache_statistics_report_entries_and_size() {
+        let mut cache = FxHashMap::default();
+        assert_eq!(module_specifiers_cache_estimated_size_bytes(&cache), 0);
+
+        cache.insert(
+            "/workspace/src/source.ts".to_string(),
+            vec!["./source".to_string(), "pkg/source".to_string()],
+        );
+
+        assert_eq!(cache.len(), 1);
+        assert!(module_specifiers_cache_estimated_size_bytes(&cache) > 0);
     }
 }

--- a/crates/tsz-lsp/src/project/imports/mod.rs
+++ b/crates/tsz-lsp/src/project/imports/mod.rs
@@ -150,6 +150,12 @@ impl Project {
                 &mut sink,
             );
         }
+        tracing::trace!(
+            module_specifiers_cache_entries = context.module_specifiers_cache_entries(),
+            module_specifiers_cache_estimated_size_bytes =
+                context.module_specifiers_cache_estimated_size_bytes(),
+            "auto-import module specifier cache"
+        );
     }
 
     /// Collect import candidates for symbols matching a prefix.
@@ -230,6 +236,12 @@ impl Project {
                 &mut sink,
             );
         }
+        tracing::trace!(
+            module_specifiers_cache_entries = context.module_specifiers_cache_entries(),
+            module_specifiers_cache_estimated_size_bytes =
+                context.module_specifiers_cache_estimated_size_bytes(),
+            "auto-import prefix module specifier cache"
+        );
     }
 }
 


### PR DESCRIPTION
AgentName: Studio-Opus
Track: Performance infrastructure / cache residency visibility
Invariant: `module_specifiers_cache` remains request-local to `AutoImportCandidateContext`, keyed by file name and populated only through existing `auto_import_module_specifiers_from_files`; this PR only exposes entry/size trace accounting and a helper test without changing candidate filtering, cache keys, or lifetime.
Scope: Adds request-local entry/estimated-size accessors for `module_specifiers_cache`, traces them at the end of auto-import collection requests, and covers the estimator with a focused LSP test.

## Project Corpus Impact
- Row: n/a (telemetry-only LSP request-local cache visibility; no project-row compile, diagnostic, emit, or timing semantics changed)
- Bug family: performance infrastructure / cache visibility
- Cache visibility report now reaches `needs_review: 0`, `with_size_signal: 97`, `with_stats_signal: 97`.

## Verification
- `cargo fmt --check`
- `cargo check -p tsz-lsp`
- `cargo nextest run -p tsz-lsp module_specifiers_cache_statistics_report_entries_and_size`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-lsp --all-targets -- -D warnings`
- `git diff --check`
- `python3 scripts/perf/cache-visibility-report.py --json | jq '.summary'`

## Coordination Notes
- Removes the last `needs_review` cache-visibility blind spot from the performance cache report.
- Does not overlap active Studio-A/B/C correctness or emit PRs; this is LSP request-local telemetry infrastructure only.
