### PR TITLE
fix(checker): elaborate tuple-arity failures of union source members (#12179)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -754,28 +754,30 @@ impl<'a> CheckerState<'a> {
                 source_count,
                 target_count,
             } => {
+                // The arity leaf is identical at every depth: direction picks the
+                // catalog message — a source longer than a closed target ->
+                // "target allows only M" (`TS2619`); shorter than required ->
+                // "target requires M" (`TS2618`). Only its framing differs by
+                // depth (top-level headline vs. drilled leaf), so compute it once.
+                let (arity_message, arity_code) = if source_count > target_count {
+                    (
+                        diagnostic_messages::SOURCE_HAS_ELEMENT_S_BUT_TARGET_ALLOWS_ONLY,
+                        diagnostic_codes::SOURCE_HAS_ELEMENT_S_BUT_TARGET_ALLOWS_ONLY,
+                    )
+                } else {
+                    (
+                        diagnostic_messages::SOURCE_HAS_ELEMENT_S_BUT_TARGET_REQUIRES,
+                        diagnostic_codes::SOURCE_HAS_ELEMENT_S_BUT_TARGET_REQUIRES,
+                    )
+                };
+                let arity_text = format_message(
+                    arity_message,
+                    &[&source_count.to_string(), &target_count.to_string()],
+                );
                 if depth == 0 {
                     // Top level: tsc keeps the `TS2322` headline and attaches the
                     // arity reason as a nested elaboration line, matching the
-                    // sibling function-arity elaboration above. Direction picks the
-                    // catalog message: a source longer than a closed target ->
-                    // "target allows only M" (`TS2619`); shorter than required ->
-                    // "target requires M" (`TS2618`).
-                    let (arity_message, arity_code) = if source_count > target_count {
-                        (
-                            diagnostic_messages::SOURCE_HAS_ELEMENT_S_BUT_TARGET_ALLOWS_ONLY,
-                            diagnostic_codes::SOURCE_HAS_ELEMENT_S_BUT_TARGET_ALLOWS_ONLY,
-                        )
-                    } else {
-                        (
-                            diagnostic_messages::SOURCE_HAS_ELEMENT_S_BUT_TARGET_REQUIRES,
-                            diagnostic_codes::SOURCE_HAS_ELEMENT_S_BUT_TARGET_REQUIRES,
-                        )
-                    };
-                    let arity_text = format_message(
-                        arity_message,
-                        &[&source_count.to_string(), &target_count.to_string()],
-                    );
+                    // sibling function-arity elaboration above.
                     let (source_str, target_str) =
                         self.format_top_level_assignability_message_types_at(source, target, idx);
                     let base = format_message(
@@ -800,14 +802,11 @@ impl<'a> CheckerState<'a> {
                     });
                     diag
                 } else {
-                    // Nested rendering is preserved as-is: this PR's scope is the
-                    // top-level (`depth == 0`) elaboration that was missing. The
-                    // nested wording is left untouched to avoid perturbing existing
-                    // diagnostic chains in conformance fixtures.
-                    let message = format!(
-                        "Tuple type has {source_count} elements but target requires {target_count}."
-                    );
-                    Diagnostic::error(file_name, start, length, message, reason.diagnostic_code())
+                    // Nested (depth >= 1) render: a closed-tuple arity mismatch
+                    // drilled beneath a member/property header (e.g. a failing
+                    // union member or `Types of property 'p' …`). tsc emits the
+                    // same `TS2618`/`TS2619` leaf here as at the top level.
+                    Diagnostic::error(file_name, start, length, arity_text, arity_code)
                 }
             }
             SubtypeFailureReason::TupleArityMismatch(arity) => {

--- a/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure/nested_application_property_mismatch.rs
@@ -962,6 +962,12 @@ impl<'a> CheckerState<'a> {
             reason,
             tsz_solver::SubtypeFailureReason::TupleElementTypeMismatch { .. }
                 | tsz_solver::SubtypeFailureReason::TupleVariadicPositionMismatch { .. }
+                // Tuple fixed-/variadic-arity count leaves (`Source has N
+                // element(s) …`) carry no member name, so the union renderer
+                // emits the `Type 'M' is not assignable to type 'T'.` header
+                // before drilling the arity leaf.
+                | tsz_solver::SubtypeFailureReason::TupleElementMismatch { .. }
+                | tsz_solver::SubtypeFailureReason::TupleArityMismatch(_)
                 | tsz_solver::SubtypeFailureReason::PropertyTypeMismatch { .. }
                 | tsz_solver::SubtypeFailureReason::IndexSignatureMismatch { .. }
                 | tsz_solver::SubtypeFailureReason::ReturnTypeMismatch { .. }

--- a/crates/tsz-checker/tests/tuple_arity_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/tuple_arity_elaboration_tests.rs
@@ -120,6 +120,115 @@ const single: [number] = (null as unknown as Coords);
     );
 }
 
+/// A union source whose failing member is a closed-tuple arity mismatch must
+/// elaborate that member beneath the union line — the member header
+/// (`Type '[2, 3]' is not assignable to type '[number]'.`) and the arity leaf
+/// (`Source has 2 element(s) but target allows only 1.`), matching tsc. The
+/// union elaboration previously dropped this whole chain, leaving only the
+/// bare `Type '[2, 3] | [4]' …` headline.
+#[test]
+fn union_member_closed_tuple_arity_elaborates_with_header_and_leaf() {
+    // `Pick`-free distributive identity keeps `[2, 3] | [4]` as a written union
+    // member set so the failing `[2, 3]` member survives to elaboration.
+    let source = r#"
+type Identity<T> = T extends unknown ? T : never;
+const target: [number] = (null as unknown as Identity<[2, 3] | [4]>);
+"#;
+    let diags = check_strict(source);
+    let diag = ts2322(&diags);
+    assert!(
+        diag.message_text
+            .contains("is not assignable to type '[number]'"),
+        "headline targets the 1-tuple; got: {}",
+        diag.message_text
+    );
+    let related: Vec<(u32, &str)> = diag
+        .related_information
+        .iter()
+        .map(|r| (r.code, r.message_text.as_str()))
+        .collect();
+    assert!(
+        related.iter().any(|(code, msg)| *code == 2322
+            && msg.contains("Type '[2, 3]'")
+            && msg.contains("is not assignable to type '[number]'")),
+        "expected the failing-member header line; related: {related:?}"
+    );
+    assert!(
+        related.iter().any(|(code, msg)| *code == 2619
+            && *msg == "Source has 2 element(s) but target allows only 1."),
+        "expected the nested arity leaf; related: {related:?}"
+    );
+}
+
+/// The member header sits one indent above the arity leaf (header depth < leaf
+/// depth), so the chain reads union -> member -> arity rather than collapsing.
+#[test]
+fn union_member_tuple_arity_chain_is_nested_in_order() {
+    let source = r#"
+type Pass<T> = T extends unknown ? T : never;
+const target: [string] = (null as unknown as Pass<[string, string] | [boolean]>);
+"#;
+    let diags = check_strict(source);
+    let diag = ts2322(&diags);
+    let header = diag
+        .related_information
+        .iter()
+        .find(|r| r.code == 2322 && r.message_text.contains("Type '[string, string]'"))
+        .expect("member header present");
+    let leaf = diag
+        .related_information
+        .iter()
+        .find(|r| r.code == 2619)
+        .expect("arity leaf present");
+    assert!(
+        leaf.depth > header.depth,
+        "arity leaf must nest beneath the member header; header depth {} leaf depth {}",
+        header.depth,
+        leaf.depth
+    );
+}
+
+/// Renamed binders/aliases must not change the structural elaboration — proves
+/// the chain is keyed on shape, not identifiers.
+#[test]
+fn union_member_tuple_arity_elaboration_is_structural_under_renaming() {
+    let source = r#"
+type Echo<Element> = Element extends unknown ? Element : never;
+type WideRow = [number, number, number];
+type NarrowRow = [number];
+const slot: NarrowRow = (null as unknown as Echo<WideRow | [number]>);
+"#;
+    let diags = check_strict(source);
+    let diag = ts2322(&diags);
+    assert!(
+        diag.related_information.iter().any(|r| r.code == 2619
+            && r.message_text == "Source has 3 element(s) but target allows only 1."),
+        "renamed aliases must still attach the arity leaf; related: {:?}",
+        diag.related_information
+            .iter()
+            .map(|r| (r.code, &r.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Anti-regression: a union whose members are all assignable must not error.
+#[test]
+fn union_member_tuple_all_assignable_has_no_arity_diagnostic() {
+    let source = r#"
+type Keep<T> = T extends unknown ? T : never;
+const ok: [number] = (null as unknown as Keep<[1] | [2]>);
+"#;
+    let diags = check_strict(source);
+    assert!(
+        !diags.iter().any(|d| d.code == 2322),
+        "all-assignable union members must not error; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
 /// Anti-regression: matching arity must NOT produce a TS2322 or a spurious
 /// arity reason.
 #[test]

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1044,12 +1044,20 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // line and hides which member fails.
                 //
                 // The set is intentionally limited to member-failure shapes whose
-                // render composes exactly with `tsc` here. Notably excluded:
-                //   * `TupleElementMismatch` (fixed-arity count mismatch) — its
-                //     nested `TS2618`/`TS2619` (`Source has N element(s) but
-                //     target requires/allows only M`) leaf render is owned
-                //     separately; surfacing it before that lands emits a non-tsc
-                //     line.
+                // render composes exactly with `tsc` here.
+                //
+                // Tuple fixed-arity (`TupleElementMismatch`) and variadic-arity
+                // (`TupleArityMismatch`) count mismatches are header-led leaves:
+                // their `TS2618`/`TS2619` (`Source has N element(s) but target
+                // requires/allows only M`) text carries no member name, so the
+                // union renderer supplies the `Type 'M' is not assignable to type
+                // 'T'.` member header (via `union_member_nested_needs_header`)
+                // before drilling the arity leaf — matching tsc:
+                //   Type '[2, 3] | [4]' is not assignable to type '[number]'.
+                //     Type '[2, 3]' is not assignable to type '[number]'.
+                //       Source has 2 element(s) but target allows only 1.
+                //
+                // Notably excluded:
                 //   * `OptionalPropertyRequired`/`ReadonlyPropertyMismatch` — `tsc`
                 //     leads these with the member header (and they only arise in
                 //     narrow `exactOptionalPropertyTypes` / readonly-index shapes),
@@ -1064,6 +1072,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                             | SubtypeFailureReason::MissingProperty { .. }
                             | SubtypeFailureReason::MissingProperties { .. }
                             | SubtypeFailureReason::TupleElementTypeMismatch { .. }
+                            | SubtypeFailureReason::TupleElementMismatch { .. }
+                            | SubtypeFailureReason::TupleArityMismatch(_)
                             | SubtypeFailureReason::TupleVariadicPositionMismatch { .. }
                             | SubtypeFailureReason::PropertyTypeMismatch { .. }
                             | SubtypeFailureReason::ArrayElementMismatch { .. }


### PR DESCRIPTION
AgentName: claude-brave-volta-5Qh4l

Refs #12179 (diagnostics tracker — the "union-member elaboration chain collapsed by one level for distributed conditionals over a tuple union" sub-defect named in the verified-reduction comment).

## Track
Conformance / diagnostics — assignability reason-chain parity for union source members.

## Invariant
When a union source fails assignability to a target because one member fails on a tuple **arity** mismatch, tsz now renders the full per-member elaboration chain `tsc` produces, instead of stopping at the bare union headline. Members that fail for any other reason, and tuple-arity failures that are **not** under a union, are unchanged.

## Problem / Structural rule
A union source assigned to a tuple target dropped the failing member's elaboration when that member's failure was a tuple element-count mismatch:

```ts
type Identity<T> = T extends unknown ? T : never;
const target: [number] = (null as unknown as Identity<[2, 3] | [4]>);
```

| compiler | output |
| --- | --- |
| `tsc` | `Type '[2, 3] \| [4]' is not assignable to type '[number]'.`<br>&nbsp;&nbsp;`Type '[2, 3]' is not assignable to type '[number]'.`<br>&nbsp;&nbsp;&nbsp;&nbsp;`Source has 2 element(s) but target allows only 1.` |
| tsz (before) | `Type '[2, 3] \| [4]' is not assignable to type '[number]'.` (chain dropped) |
| tsz (after) | matches `tsc` |

The solver's union-source elaboration gate intentionally **excluded** the tuple fixed-arity (`TupleElementMismatch`) and variadic-arity (`TupleArityMismatch`) count reasons, because the checker rendered a non-`tsc` placeholder (`Tuple type has N elements but target requires M.`) for `TupleElementMismatch` when nested at `depth >= 1`. Both reasons are *header-led leaves*: their `TS2618`/`TS2619` text carries no member name, so the union renderer must supply the `Type 'M' is not assignable to type 'T'.` member header before drilling the leaf — exactly the shape it already produces for `TupleElementTypeMismatch`, `PropertyTypeMismatch`, etc.

> When a union source's failing member is a tuple arity (element-count) mismatch, `tsc` elaborates that member beneath the union line with a member header and the `TS2618`/`TS2619` arity leaf; tsz now does the same through the solver union-elaboration gate + the checker union-member header path.

## Owner layer
- **Solver** `crates/tsz-solver/src/relations/subtype/explain.rs`: admit `TupleElementMismatch` / `TupleArityMismatch` into the union-member elaboration allow-list so the failing member is surfaced as `UnionSourceMismatch`. No relation/acceptance logic changed — only which reason is produced for an already-failing relation.
- **Checker** `error_reporter/render_failure/nested_application_property_mismatch.rs`: classify both arity reasons as header-led in `union_member_nested_needs_header` so the member header precedes the arity leaf.
- **Checker** `error_reporter/render_failure.rs`: render the `depth >= 1` `TupleElementMismatch` leaf with the real direction-aware `TS2618`/`TS2619` wording (mirroring the top-level branch and the sibling `TupleArityMismatch`) instead of the placeholder. The shared arity `(message, code, text)` computation is hoisted above the depth split (no duplication).

This is display-only: no `TypeId` is constructed/mutated, no relation decision changes; the printer reads solver reasons, never its own output.

## Adjacent-case matrix (new tests, binder names varied)
- closed-tuple union member arity (`[2, 3] | [4]` → `[number]`): member header + `TS2619` leaf
- variadic/longer union member (`[string, string] | [boolean]` → `[string]`): chain nests in order (leaf depth > header depth)
- renamed aliases (`Echo<WideRow | [number]>`): arity leaf still attached — structural, not identifier-keyed
- negative: all-assignable union members (`[1] | [2]` → `[number]`) → no error
- negative: matching arity → no error / no spurious arity reason (pre-existing guard retained)

## Anti-hardcoding
Routing is on the structural reason variant (`TupleElementMismatch` / `TupleArityMismatch`), not on rendered text or user/file names. No formatted-string-as-predicate. Tests vary binder/alias names.

## Project Corpus Impact
- Row: n/a
- Bug family: #12179 diagnostic reason-chain — union-source tuple-arity elaboration (display only).
- No accept/reject outcome changes, so project-row pass/fail counts are unaffected; only the related-information chain of already-emitted `TS2322` errors gains the missing member + arity lines. No accepted-regression ledger change.

## Verification
- Built `tsz` CLI; the `[2, 3] | [4]` / variadic repros now match the `tsc` 3-line chain; bare (non-union) tuple-arity output unchanged.
- `cargo test -p tsz-checker --test tuple_arity_elaboration_tests` → 8 passed (4 new).
- Adjacent suites green: `tuple_argument_mismatch_elaboration_tests` (7), `tuple_call_argument_elaboration_tests` (6), `union_source_missing_property_elaboration_tests` (8), `union_source_structural_elaboration_tests` (5), `union_target_missing_property_elaboration_tests` (19), `tuple_variadic_position_elaboration_tests` (13), `contextual_tuple_tests` (4), `mapped_readonly_tuple_tests` (9), `intersection_target_missing_property_elaboration_tests` (19), `homomorphic_mapped_union_distribution_tests` (26).
- Solver `cargo test -p tsz-solver --lib explain` (30) and `tuple` (576) green.
- The 5 `optional_property_required_elaboration_tests` failures are **pre-existing on clean `main`** (local lib availability) — identical set with this change stashed.
- `cargo fmt --check`, `cargo clippy -p tsz-solver --lib` / `-p tsz-checker --lib` clean.
- `scripts/arch/arch_guard.py` and `scripts/arch/check-checker-boundaries.sh` passed.
- Broad conformance owned by ready-review CI.

## Coordination Notes
- Picked from the open bug queue (other bug issues were already claimed); this lands the still-open tuple-union arity slice of the #12179 diagnostics tracker (item 1, source-position under-expansion, landed earlier via #12363; the `keyof`-anon slice via #12481). Does not overlap any pushed branch.
- No roadmap change (routine diagnostic parity fix).

https://claude.ai/code/session_017SYHoEYc7Yf5RaUVRqjXZy

---
_Generated by [Claude Code](https://claude.ai/code/session_017SYHoEYc7Yf5RaUVRqjXZy)_