### PR TITLE
perf(checker): lower builtin DOM alias bodies directly

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs
@@ -272,7 +272,7 @@ impl<'a> CheckerState<'a> {
             })
     }
 
-    fn symbol_type_alias_declarations_are_proven_actual_lib_only(
+    fn symbol_type_alias_declarations_are_proven_builtin_lib_only(
         &self,
         sym_id: SymbolId,
         symbol: &tsz_binder::Symbol,
@@ -284,7 +284,7 @@ impl<'a> CheckerState<'a> {
                 if let Some(arenas) = self.ctx.binder.declaration_arenas.get(&(sym_id, decl_idx)) {
                     return !arenas.is_empty()
                         && arenas.iter().all(|arena| {
-                            is_direct_actual_lib_declaration_arena(arena.as_ref())
+                            is_builtin_lib_declaration_arena(arena.as_ref())
                                 && Self::lib_type_alias_declaration_name_matches(
                                     arena.as_ref(),
                                     decl_idx,
@@ -293,7 +293,7 @@ impl<'a> CheckerState<'a> {
                         });
                 }
 
-                is_direct_actual_lib_declaration_arena(delegate_arena)
+                is_builtin_lib_declaration_arena(delegate_arena)
                     && Self::lib_type_alias_declaration_name_matches(delegate_arena, decl_idx, name)
             })
     }
@@ -424,7 +424,7 @@ impl<'a> CheckerState<'a> {
             );
             return None;
         }
-        if !self.symbol_type_alias_declarations_are_proven_actual_lib_only(
+        if !self.symbol_type_alias_declarations_are_proven_builtin_lib_only(
             sym_id,
             symbol,
             name,
@@ -462,7 +462,7 @@ impl<'a> CheckerState<'a> {
                     .map(|arenas| arenas.iter().map(std::convert::AsRef::as_ref).collect())
                     .unwrap_or_else(|| vec![delegate_arena]);
                 for decl_arena in decl_arenas {
-                    if !is_direct_actual_lib_declaration_arena(decl_arena) {
+                    if !is_builtin_lib_declaration_arena(decl_arena) {
                         continue;
                     }
                     let Some(node) = decl_arena.get(decl_idx) else {
@@ -577,7 +577,10 @@ impl<'a> CheckerState<'a> {
         {
             return Some(result);
         }
-        if !is_direct_actual_lib_declaration_arena(delegate_arena) {
+        let is_type_alias = symbol.has_any_flags(symbol_flags::TYPE_ALIAS);
+        if !(is_direct_actual_lib_declaration_arena(delegate_arena)
+            || is_type_alias && is_builtin_lib_declaration_arena(delegate_arena))
+        {
             return None;
         }
         let intl_namespace_export =

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
@@ -213,10 +213,37 @@ fn direct_cross_file_interface_lowering_handles_simple_builtin_dom_interfaces() 
         crate::query_boundaries::common::lazy_def_id(state.ctx.types, html_div_ty).is_some(),
         "HTMLDivElement should use a type-position Lazy ref",
     );
+
+    let document_sym_id = state
+        .ctx
+        .binder
+        .file_locals
+        .get("document")
+        .expect("document should resolve to a dom lib variable");
+    let document_arena = state
+        .ctx
+        .binder
+        .symbol_arenas
+        .get(&document_sym_id)
+        .map(std::convert::AsRef::as_ref)
+        .expect("document should have a delegate arena");
+    let (document_ty, document_params) = state
+        .direct_actual_lib_symbol_type(
+            document_sym_id,
+            CrossArenaSymbolMissSource::SymbolArena,
+            Some(document_arena),
+            false,
+        )
+        .expect("builtin DOM variables with simple type-reference annotations should stay lazy");
+    assert!(document_params.is_empty());
+    assert!(
+        crate::query_boundaries::common::lazy_def_id(state.ctx.types, document_ty).is_some(),
+        "document should use a type-position Lazy ref",
+    );
 }
 
 #[test]
-fn direct_actual_lib_symbol_type_keeps_dom_alias_bodies_on_fallback() {
+fn direct_actual_lib_symbol_type_lowers_builtin_dom_alias_bodies() {
     let lib_files = load_lib_files(&["es5.d.ts", "dom.d.ts"]);
     let mut parser = ParserState::new("fixture.ts".to_string(), "let value;".to_string());
     let root = parser.parse_source_file();
@@ -264,16 +291,19 @@ fn direct_actual_lib_symbol_type_keeps_dom_alias_bodies_on_fallback() {
             .get(&sym_id)
             .map(std::convert::AsRef::as_ref)
             .unwrap_or_else(|| panic!("{name} should have a delegate arena"));
+        let (ty, params) = state
+            .direct_actual_lib_symbol_type(
+                sym_id,
+                CrossArenaSymbolMissSource::SymbolArena,
+                Some(delegate_arena),
+                false,
+            )
+            .unwrap_or_else(|| panic!("{name} should lower through the direct builtin alias path"));
+        assert_ne!(ty, TypeId::UNKNOWN, "{name} must not lower to unknown");
+        assert_ne!(ty, TypeId::ERROR, "{name} must not lower to error");
         assert!(
-            state
-                .direct_actual_lib_symbol_type(
-                    sym_id,
-                    CrossArenaSymbolMissSource::SymbolArena,
-                    Some(delegate_arena),
-                    false,
-                )
-                .is_none(),
-            "{name} should stay on child-checker fallback until DOM alias direct answers preserve conformance fingerprints",
+            params.is_empty(),
+            "{name} should not synthesize type params"
         );
     }
 }


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Track 10 performance / checker cross-arena delegation cleanup

## Invariant
When a non-augmented builtin lib type-alias symbol is delegated from a builtin declaration arena, `tsc` resolves the declared alias body from the lib declaration; this PR lets tsz do the same through the existing checker direct actual-lib alias lowering path. Non-alias DOM interfaces and value/interface pairs stay on their existing direct-interface, lazy, or child-checker paths.

## Scope
- Admit builtin lib declaration arenas, including DOM, for proven type-alias body lowering.
- Keep declaration-name proof and local-shadow checks before returning a direct answer.
- Add focused coverage for selected DOM aliases and the DOM `document` lazy variable path.

## Project Corpus Impact
- Row: `vite-vanilla-ts-app`
- Bug family: builtin DOM type-alias cross-arena delegation misses
- Attribution mode, baseline `/tmp/vite-main.perf.json` to `/tmp/vite-dom-alias-direct.perf.json`:
  - `DelegateCrossArenaSymbol` child checker constructions: `240 -> 113` (`-127`).
  - Delegation misses: `241 -> 114` (`-127`).
  - `compute_type_of_symbol` calls: `1356 -> 1228` (`-128`).
  - DOM type-alias miss family removed; remaining misses are DOM/client interfaces plus two source functions and the `document` variable.
- Timing mode artifact: `/tmp/vite-dom-alias-direct-bench.json` reports `tsz 90.37ms` vs `tsgo 77.04ms`; this PR does not claim a 2x row win.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `scripts/safe-run.sh cargo check -p tsz-checker`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --all-targets -- -D warnings`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib direct_actual_lib_symbol_type_lowers_builtin_dom_alias_bodies direct_cross_file_interface_lowering_handles_simple_builtin_dom_interfaces direct_actual_lib_symbol_type_handles_selected_value_interfaces`
- `TSZ_PERF_COUNTERS=1 TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=536870912 scripts/safe-run.sh cargo run -q -p tsz-cli --features perf-tools --bin tsz -- --extendedDiagnostics --perf-counters-json /tmp/vite-dom-alias-direct.perf.json --noEmit -p .target-bench/external/vite-vanilla-ts-live/tsconfig.json`
- `python3 scripts/perf/query-perf-counters.py --json /tmp/vite-dom-alias-direct.perf.json --baseline /tmp/vite-main.perf.json --by-reason`
- `scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --filter 'vite-vanilla-ts-app' --json-file /tmp/vite-dom-alias-direct-bench.json`
- `python3 scripts/arch/arch_guard.py`
- Hosted draft light CI on head `1de26e0d090b87f68acf3b1a22e3b80470e6f0c2`: `CI Light Summary`, `unit`, `unit-checker-integration`, `unit-cloudbuild`, `lint`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `gate` passed.
- Hosted full PR-head CI run `27082783937` on head `1de26e0d090b87f68acf3b1a22e3b80470e6f0c2`: `CI Summary` passed with 33 successful jobs and 3 skipped jobs.

## Coordination Notes
- M1-B reviewed the latest head and promoted from draft after hosted draft light CI passed; full PR-head CI is now green at the same head.
- No overlap found with open Studio-Opus PRs; no owned PRs were open at intake.
- Follow-up work remains for DOM interface heritage/computed-name residue on the same row; aliases are no longer the dominant child-checker family.
