### PR TITLE
techdebt(dts): guard declaration summary export surface bridge

### DIFF
--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -246,7 +246,10 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         #
         # Ratcheted 3174→3163 after missing-property display shape queries
         # moved through query_boundaries::diagnostics.
-        3163,
+        #
+        # Ratcheted 3163→3155 after arch-smoke caught current-main slack in the
+        # live direct-reference count.
+        3155,
     ),
 ]
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1406,6 +1406,16 @@ REGEX_LINE_COUNT_CHECKS = [
         0,
     ),
     (
+        # `set_export_surface` is the one documented compatibility bridge for
+        # older declaration-emitter callers. New DTS facts should enter through
+        # `DeclarationSummary` query methods instead of growing raw
+        # `ExportSurface` handoff points.
+        "Emitter DTS boundary: raw ExportSurface handoff compatibility bridge (#8275)",
+        [ROOT / "crates" / "tsz-emitter" / "src" / "declaration_emitter"],
+        re.compile(r"\bfn\s+set_export_surface\s*\("),
+        1,
+    ),
+    (
         "Emitter boundary: recovered variable typeof tails use parser facts (#8276)",
         [
             ROOT

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1273,7 +1273,10 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         #
         # Ratcheted 3174→3163 after missing-property display shape queries
         # moved through query_boundaries::diagnostics.
-        3163,
+        #
+        # Ratcheted 3163→3155 after arch-smoke caught current-main slack in the
+        # live direct-reference count.
+        3155,
     ),
 ]
 

--- a/scripts/arch/test_arch_guard_policy.py
+++ b/scripts/arch/test_arch_guard_policy.py
@@ -71,6 +71,21 @@ class ArchGuardRegexLineCountTests(unittest.TestCase):
         self.assertIn("recovery.rs:1", hits[0])
         self.assertIn("recovery.rs:2", hits[1])
 
+    def test_flags_extra_export_surface_handoff_bridges(self):
+        pattern, max_lines = self._check_by_name("ExportSurface handoff")
+        root = self._make_tree(
+            {
+                "crates/tsz-emitter/src/declaration_emitter/core/setup.rs": (
+                    "pub fn set_export_surface(&mut self, surface: ExportSurface) {}\n"
+                    "pub fn set_export_surface(&mut self, surface: ExportSurface) {}\n"
+                ),
+            }
+        )
+        hits = self.arch_guard.scan_regex_line_count([root], pattern, max_lines)
+        self.assertEqual(len(hits), 3, f"unexpected hits: {hits!r}")
+        self.assertIn("setup.rs:1", hits[0])
+        self.assertIn("setup.rs:2", hits[1])
+
     def test_flags_recovered_variable_typeof_source_scanners(self):
         pattern, _max_lines = self._check_by_name("recovered variable typeof")
         root = self._make_tree(
@@ -500,6 +515,7 @@ class ArchGuardRegexLineCountTests(unittest.TestCase):
         self.assertTrue(any("post-check" in name for name in names))
         self.assertTrue(any("source_text.contains" in name for name in names))
         self.assertTrue(any("Emitter boundary" in name for name in names))
+        self.assertTrue(any("ExportSurface handoff" in name for name in names))
         self.assertTrue(any("file-name/path" in name for name in names))
         self.assertTrue(any("rendered type strings" in name for name in names))
         self.assertTrue(any("rendered message predicates" in name for name in names))


### PR DESCRIPTION
## Agent
AgentName: Studio-Opus

## Track
Emit/DTS architecture tech-debt slice for #8275.

## Invariant
When declaration emit needs exported-surface facts, `DeclarationSummary` is the binder-owned boundary. The raw `ExportSurface` handoff remains a single documented compatibility bridge and new DTS facts should enter through summary queries instead of growing emitter-facing export-surface paths.

## Scope
- Adds an architecture guard ratchet that pins `DeclarationEmitter::set_export_surface` to the one existing compatibility bridge.
- Adds focused policy coverage proving extra raw export-surface handoff methods trip the regex count guard.
- Leaves emitted behavior unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: DTS architecture/summary boundary; no compiler behavior change intended.
- Evidence: startup cycle project-row and emit-family checks were green before this slice; this PR only changes architecture guard policy/tests.

## Verification
- `python3 -m unittest test_arch_guard_policy.ArchGuardRegexLineCountTests.test_flags_extra_export_surface_handoff_bridges test_arch_guard_policy.ArchGuardRegexLineCountTests.test_track10_checks_are_registered test_arch_guard_policy.ArchGuardRegexLineCountTests.test_real_counts_pass_at_pinned_caps` from `scripts/arch`
- `python3 scripts/arch/arch_guard.py`
- `git diff --check`
- Exact-head CI pass on `59fc428f0f7d18f8b46abeb8a3ceef1dc826de8d` (`gate`, `arch-tool-smoke`, and `CI Light Summary` pass; run 27083623573)

## Coordination Notes
- Continues #8275 after #12837 and #12846 established and narrowed the `DeclarationSummary` boundary.
- Open PR overlap checked before coding; no active Studio-Opus PRs or same-path PRs were present.
- Ready for merge queue after exact-head CI.
