### PR TITLE
fix(checker): relate full overload sets in interface heritage (TS2430)

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker_compat_overloads.rs
+++ b/crates/tsz-checker/src/classes/class_checker_compat_overloads.rs
@@ -16,69 +16,6 @@ pub(crate) struct InterfaceOverloadCoverageCtx<'a> {
     pub(crate) interface_self_type: Option<TypeId>,
 }
 
-fn overload_method_wrapper_value_type(
-    types: &dyn tsz_solver::construction::QueryDatabase,
-    type_id: TypeId,
-) -> Option<TypeId> {
-    if let Some(shape) = crate::query_boundaries::common::object_shape_for_type(types, type_id)
-        && shape.properties.len() == 1
-        && shape.properties[0].is_method
-    {
-        return Some(shape.properties[0].type_id);
-    }
-    None
-}
-
-fn function_signature_uses_own_type_params(
-    checker: &CheckerState<'_>,
-    shape: &tsz_solver::FunctionShape,
-) -> bool {
-    let own_type_params = shape
-        .type_params
-        .iter()
-        .map(|param| checker.ctx.types.type_param(*param))
-        .collect::<Vec<_>>();
-    if own_type_params.is_empty() {
-        return false;
-    }
-
-    let contains_own_param = |type_id: TypeId| {
-        own_type_params.iter().copied().any(|param_type| {
-            crate::query_boundaries::common::contains_type_by_id(
-                checker.ctx.types,
-                type_id,
-                param_type,
-            )
-        })
-    };
-
-    shape
-        .params
-        .iter()
-        .any(|param| contains_own_param(param.type_id))
-        || shape.this_type.is_some_and(contains_own_param)
-        || contains_own_param(shape.return_type)
-}
-
-fn can_use_fresh_generic_overload_assignability(
-    checker: &CheckerState<'_>,
-    source: TypeId,
-    target: TypeId,
-) -> bool {
-    let (Some(source_shape), Some(target_shape)) = (
-        crate::query_boundaries::common::function_shape_for_type(checker.ctx.types, source),
-        crate::query_boundaries::common::function_shape_for_type(checker.ctx.types, target),
-    ) else {
-        return false;
-    };
-
-    !source_shape.type_params.is_empty()
-        && source_shape.type_params.len() == target_shape.type_params.len()
-        && source_shape.params.len() == target_shape.params.len()
-        && function_signature_uses_own_type_params(checker, &source_shape)
-        && function_signature_uses_own_type_params(checker, &target_shape)
-}
-
 impl<'a> CheckerState<'a> {
     pub(crate) fn check_interface_overload_coverage(
         &mut self,
@@ -145,112 +82,6 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        let signature_has_literal_parameter = |type_id: TypeId| -> bool {
-            let has_literal_param = |params: &[crate::query_boundaries::common::ParamInfo]| {
-                params.iter().any(|param| {
-                    crate::query_boundaries::common::is_literal_type(self.ctx.types, param.type_id)
-                })
-            };
-
-            if let Some(signatures) =
-                crate::query_boundaries::common::call_signatures_for_type(self.ctx.types, type_id)
-            {
-                return signatures
-                    .iter()
-                    .any(|signature| has_literal_param(&signature.params));
-            }
-
-            if let Some(shape) =
-                crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
-            {
-                return has_literal_param(&shape.params);
-            }
-
-            if let Some(shape) =
-                crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, type_id)
-            {
-                return shape
-                    .call_signatures
-                    .iter()
-                    .any(|signature| has_literal_param(&signature.params));
-            }
-
-            if let Some(shape) =
-                crate::query_boundaries::common::object_shape_for_type(self.ctx.types, type_id)
-                && shape.properties.len() == 1
-                && shape.properties[0].is_method
-            {
-                let method_type = shape.properties[0].type_id;
-                if let Some(signatures) = crate::query_boundaries::common::call_signatures_for_type(
-                    self.ctx.types,
-                    method_type,
-                ) {
-                    return signatures
-                        .iter()
-                        .any(|signature| has_literal_param(&signature.params));
-                }
-                if let Some(shape) = crate::query_boundaries::common::function_shape_for_type(
-                    self.ctx.types,
-                    method_type,
-                ) {
-                    return has_literal_param(&shape.params);
-                }
-                if let Some(shape) = crate::query_boundaries::common::callable_shape_for_type(
-                    self.ctx.types,
-                    method_type,
-                ) {
-                    return shape
-                        .call_signatures
-                        .iter()
-                        .any(|signature| has_literal_param(&signature.params));
-                }
-            }
-
-            false
-        };
-
-        let select_implementation_signature = |signatures: &[TypeId]| -> Option<TypeId> {
-            if signatures.is_empty() {
-                return None;
-            }
-
-            let mut last_non_specialized: Option<TypeId> = None;
-            for &signature in signatures {
-                if !signature_has_literal_parameter(signature) {
-                    last_non_specialized = Some(signature);
-                }
-            }
-
-            last_non_specialized.or_else(|| signatures.last().copied())
-        };
-
-        let has_non_specialized_signature = |signatures: &[TypeId]| -> bool {
-            signatures
-                .iter()
-                .any(|&signature| !signature_has_literal_parameter(signature))
-        };
-
-        let select_implementation_signature_with_node =
-            |signatures: &[(TypeId, NodeIndex)]| -> Option<(TypeId, NodeIndex)> {
-                if signatures.is_empty() {
-                    return None;
-                }
-
-                let mut last_non_specialized: Option<(TypeId, NodeIndex)> = None;
-                for &(signature, node_idx) in signatures {
-                    if !signature_has_literal_parameter(signature) {
-                        last_non_specialized = Some((signature, node_idx));
-                    }
-                }
-
-                last_non_specialized.or_else(|| signatures.last().copied())
-            };
-
-        let has_non_specialized_signature_with_node = |signatures: &[(TypeId, NodeIndex)]| -> bool {
-            signatures
-                .iter()
-                .any(|&(signature, _)| !signature_has_literal_parameter(signature))
-        };
         let signature_contains_error = |signature: TypeId| {
             crate::query_boundaries::common::contains_error_type_in_args(self.ctx.types, signature)
         };
@@ -263,8 +94,23 @@ impl<'a> CheckerState<'a> {
             "overload coverage check"
         );
 
-        // For overloaded method inheritance, tsc compatibility hinges on the trailing
-        // implementation signature.
+        // tsc checks interface heritage with `checkTypeAssignableTo(derived, base)`:
+        // the derived member's *entire* overload set must be assignable to the
+        // base member's entire overload set. For overloaded function/method types
+        // that is `signaturesRelatedTo`'s N×M rule — every base (target)
+        // signature must be matched by some derived (source) signature, with
+        // method signatures compared bivariantly.
+        //
+        // Comparing only a single "trailing" signature per side (the previous
+        // heuristic) was wrong in both directions: it missed real mismatches
+        // (a derived set that drops a base overload it cannot service, e.g. a
+        // derived `pipe(op1, op2)` that no longer covers the base's one-argument
+        // `pipe(op1)`), and it raised false `TS2430`s (a valid generic, specialized,
+        // or superset override whose trailing signature happened not to relate to
+        // the base's trailing signature). Build the full overload callables for
+        // both sides and route them through the standard relation, which already
+        // implements the N×M rule (`check_callable_subtype`), including method
+        // bivariance and method-local generic erasure for multi-signature shapes.
         'overload_check: for (method_name, base_sigs) in &base_method_overloads {
             let Some(derived_sigs) = derived_method_overloads.get(method_name) else {
                 tracing::debug!(method = method_name, "no derived overloads found");
@@ -277,61 +123,56 @@ impl<'a> CheckerState<'a> {
             {
                 continue;
             }
-            if has_non_specialized_signature(base_sigs)
-                && !has_non_specialized_signature_with_node(derived_sigs)
-            {
-                tracing::debug!(
-                    method = method_name,
-                    "base has non-specialized but derived does not -> error"
-                );
-                self.error_at_node(
-                    iface_name,
-                    &format!(
-                        "Interface '{derived_name}' incorrectly extends interface '{base_name}'."
-                    ),
-                    diagnostic_codes::INTERFACE_INCORRECTLY_EXTENDS_INTERFACE,
-                );
-                break 'overload_check;
-            }
-            let Some(base_trailing_sig) = select_implementation_signature(base_sigs) else {
+
+            let Some(base_callable) =
+                crate::query_boundaries::class::combine_overloaded_method_callable(
+                    self.ctx.types,
+                    base_sigs,
+                    method_name,
+                )
+            else {
                 continue;
             };
-            let Some((derived_trailing_sig, derived_trailing_idx)) =
-                select_implementation_signature_with_node(derived_sigs)
+            let Some(derived_callable) =
+                crate::query_boundaries::class::build_method_overload_callable(
+                    self.ctx.types,
+                    derived_sigs.iter().map(|(sig, _)| *sig),
+                    method_name,
+                    1,
+                )
             else {
                 continue;
             };
 
-            let derived_method_value =
-                overload_method_wrapper_value_type(self.ctx.types, derived_trailing_sig);
-            let base_method_value =
-                overload_method_wrapper_value_type(self.ctx.types, base_trailing_sig);
-            let (derived_compare_sig, base_compare_sig) =
-                match (derived_method_value, base_method_value) {
-                    (Some(derived), None) => (derived, base_trailing_sig),
-                    (None, Some(base)) => (derived_trailing_sig, base),
-                    _ => (derived_trailing_sig, base_trailing_sig),
-                };
+            // Identical interned overload sets (a derived interface re-declaring
+            // the inherited signatures verbatim) are trivially assignable.
+            if derived_callable == base_callable {
+                continue;
+            }
 
-            // When the no-erase check fails for equivalent generic trailing
-            // overload signatures, allow the normal relation to fresh-instantiate
-            // the method-local type params. Keep this gated to matching generic
-            // shapes so ordinary TS2430 overload mismatches still report.
-            let assignable =
-                crate::query_boundaries::class::interface_overload_trailing_signature_assignable(
-                    self,
-                    derived_compare_sig,
-                    base_compare_sig,
-                    can_use_fresh_generic_overload_assignability(
-                        self,
-                        derived_compare_sig,
-                        base_compare_sig,
-                    ),
-                );
+            // The override is valid when the derived overload set is assignable to
+            // the base overload set. Allow the fresh method-local generic retry so
+            // alpha-equivalent generic overloads (rxjs/kysely-style builders whose
+            // method-local type parameters carry different `TypeId`s on each side)
+            // are accepted, mirroring tsc's `compareSignaturesRelated`.
+            let assignable = crate::query_boundaries::class::interface_overload_set_assignable(
+                self,
+                derived_callable,
+                base_callable,
+                true,
+            );
+
+            // Anchor parse-recovery suppression on the last derived signature
+            // node (non-empty: `build_method_overload_callable(.., 1)` above
+            // returned `Some`, which requires at least one gathered signature).
+            let derived_anchor_idx = derived_sigs
+                .last()
+                .expect("derived overload set is non-empty")
+                .1;
             if !assignable
                 && !self.should_suppress_assignability_for_parse_recovery(
-                    derived_trailing_idx,
-                    derived_trailing_idx,
+                    derived_anchor_idx,
+                    derived_anchor_idx,
                 )
             {
                 self.error_at_node(

--- a/crates/tsz-checker/src/query_boundaries/class.rs
+++ b/crates/tsz-checker/src/query_boundaries/class.rs
@@ -471,12 +471,15 @@ pub(crate) fn should_report_member_type_mismatch(
     true
 }
 
-/// Check interface trailing overload compatibility through the class relation boundary.
+/// Check whether a derived interface member's overload set is assignable to a
+/// base member's overload set, through the class relation boundary.
 ///
-/// The strict path uses `no_erase_generics` to preserve overload compatibility
-/// behavior. The optional retry mirrors `tsc`'s fresh generic instantiation for
-/// equivalent method-local generic overload shapes.
-pub(crate) fn interface_overload_trailing_signature_assignable(
+/// `source` and `target` are the full overload callables for the member (see
+/// `build_method_overload_callable`), so the strict `no_erase_generics` probe
+/// applies tsc's N×M `signaturesRelatedTo` rule. The optional retry mirrors
+/// `tsc`'s fresh generic instantiation for equivalent method-local generic
+/// overload shapes.
+pub(crate) fn interface_overload_set_assignable(
     checker: &mut CheckerState<'_>,
     source: TypeId,
     target: TypeId,
@@ -929,10 +932,31 @@ pub(crate) fn combine_overloaded_method_callable(
     member_object_types: &[TypeId],
     name: &str,
 ) -> Option<TypeId> {
+    build_method_overload_callable(db, member_object_types.iter().copied(), name, 2)
+}
+
+/// Build a single `Callable` carrying the call signatures contributed by each
+/// member-wrapper object type in `member_object_types`. Each entry is a
+/// `{ name(...): ... }` wrapper (or already a function/callable), so the result
+/// is the full overload set for the method `name`.
+///
+/// `min_signatures` is the floor below which `None` is returned:
+///   - `2` builds a callable only for genuinely overloaded members
+///     (`combine_overloaded_method_callable`).
+///   - `1` keeps a single-signature member as a one-signature callable, which
+///     the interface-heritage overload-coverage check needs for the derived
+///     side: a derived interface may legitimately collapse a base's overload
+///     set down to a single compatible signature.
+pub(crate) fn build_method_overload_callable(
+    db: &dyn QueryDatabase,
+    member_object_types: impl IntoIterator<Item = TypeId>,
+    name: &str,
+    min_signatures: usize,
+) -> Option<TypeId> {
     use tsz_solver::types::{CallSignature, CallableShape};
     let tdb = db.as_type_database();
     let mut call_signatures: Vec<CallSignature> = Vec::new();
-    for &object_ty in member_object_types {
+    for object_ty in member_object_types {
         let fn_ty = crate::query_boundaries::common::find_property_by_str(tdb, object_ty, name)
             .map(|p| p.type_id)
             .unwrap_or(object_ty);
@@ -950,7 +974,7 @@ pub(crate) fn combine_overloaded_method_callable(
             call_signatures.extend(shape.call_signatures.iter().cloned());
         }
     }
-    if call_signatures.len() < 2 {
+    if call_signatures.len() < min_signatures {
         return None;
     }
     Some(db.factory().callable(CallableShape {

--- a/crates/tsz-checker/src/tests/class_boundary_fallback_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/class_boundary_fallback_relation_routing_arch_tests.rs
@@ -9,7 +9,7 @@ fn class_member_fallback_relations_use_relation_outcome_boundary() {
     .expect("failed to read class.rs");
 
     let overload_helper = source
-        .split("pub(crate) fn interface_overload_trailing_signature_assignable")
+        .split("pub(crate) fn interface_overload_set_assignable")
         .nth(1)
         .and_then(|tail| {
             tail.split("pub(crate) fn should_report_own_member_type_mismatch")

--- a/crates/tsz-checker/tests/ts2430_tests.rs
+++ b/crates/tsz-checker/tests/ts2430_tests.rs
@@ -587,11 +587,17 @@ interface Derived<K, V> extends Base<K, V> {
 }
 
 #[test]
-fn test_overloaded_non_generic_method_incompatible_return_still_errors() {
-    // Non-generic overloads with a return type mismatch in the trailing
-    // (non-specialized) signature must still produce TS2430. The fallback
-    // `is_assignable_to` call does not affect non-generic signatures, so
-    // genuine incompatibilities are preserved.
+fn test_overloaded_non_generic_method_specialized_overload_covers_general_no_ts2430() {
+    // tsc relates interface heritage with the full N×M overload rule: every base
+    // (target) overload must be matched by *some* derived (source) overload, with
+    // method signatures compared bivariantly. Here the derived's specialized
+    // `concat("literal"): number` overload covers the base's general
+    // `concat(string): number` overload (`"literal"` relates to `string`
+    // bivariantly, returns match), so even though the derived's own
+    // `concat(string)` overload returns `string`, the override is valid and tsc
+    // emits no TS2430. (Verified against `tsc --strict`.) The previous trailing-
+    // signature heuristic compared only the last signature on each side and
+    // over-reported here.
     let source = r#"
 interface Base {
     concat(x: "literal"): number;
@@ -603,18 +609,44 @@ interface Derived extends Base {
 }
 "#;
     let diags = get_diagnostics(source);
+    let ts2430 = diags.iter().filter(|d| d.0 == 2430).collect::<Vec<_>>();
     assert!(
-        diags.iter().any(|d| d.0 == 2430),
-        "Should emit TS2430 when non-generic overloaded method trailing signature has \
-         incompatible return type. Got: {diags:?}"
+        ts2430.is_empty(),
+        "Should NOT emit TS2430: derived's specialized overload covers the base's \
+         general overload (tsc parity). Got: {diags:?}"
     );
 }
 
 #[test]
-fn test_overloaded_generic_method_incompatible_return_still_errors() {
-    // The fresh-instantiation fallback is only for structurally matching
-    // generic trailing overloads. A real generic return mismatch must still
-    // report TS2430.
+fn test_overloaded_non_generic_method_uncovered_overload_still_errors() {
+    // Negative control: no derived overload can service the base's general
+    // `concat(string): number` overload — the only candidates are
+    // `concat(number)` (param `number` does not relate to `string`) and
+    // `concat(string): string` (return `string` ≠ `number`). tsc reports TS2430.
+    let source = r#"
+interface Base {
+    concat(x: number): number;
+    concat(x: string): number;
+}
+interface Derived extends Base {
+    concat(x: number): number;
+    concat(x: string): string;
+}
+"#;
+    let diags = get_diagnostics(source);
+    assert!(
+        diags.iter().any(|d| d.0 == 2430),
+        "Should emit TS2430 when no derived overload covers a base overload. Got: {diags:?}"
+    );
+}
+
+#[test]
+fn test_overloaded_generic_method_specialized_overload_covers_general_no_ts2430() {
+    // Generic analogue of the specialized-covers-general case: after method-local
+    // generic erasure, the derived's `merge("literal"): { value: T }` overload
+    // covers the base's general `merge(x: T): { value: T }` overload, so tsc emits
+    // no TS2430 even though the derived's own general overload returns
+    // `{ other: T }`. (Verified against `tsc --strict`.)
     let source = r#"
 interface Base {
     merge<T>(x: "literal"): { value: T };
@@ -626,10 +658,34 @@ interface Derived extends Base {
 }
 "#;
     let diags = get_diagnostics(source);
+    let ts2430 = diags.iter().filter(|d| d.0 == 2430).collect::<Vec<_>>();
+    assert!(
+        ts2430.is_empty(),
+        "Should NOT emit TS2430: derived's specialized generic overload covers the \
+         base's general overload (tsc parity). Got: {diags:?}"
+    );
+}
+
+#[test]
+fn test_overloaded_generic_method_dropped_overload_still_errors() {
+    // Negative control: the derived drops the base's one-argument overload and
+    // keeps only the two-argument one, which cannot be called with a single
+    // argument. tsc reports TS2430. (The old trailing-only heuristic missed this
+    // because both sides' trailing signatures matched.)
+    let source = r#"
+interface Base {
+    pipe<A>(op1: (x: number) => A): A;
+    pipe<A, B>(op1: (x: number) => A, op2: (x: A) => B): B;
+}
+interface Derived extends Base {
+    pipe<A, B>(op1: (x: number) => A, op2: (x: A) => B): B;
+}
+"#;
+    let diags = get_diagnostics(source);
     assert!(
         diags.iter().any(|d| d.0 == 2430),
-        "Should emit TS2430 when generic overloaded method trailing signature has \
-         an incompatible return shape. Got: {diags:?}"
+        "Should emit TS2430 when the derived drops a base overload it cannot service. \
+         Got: {diags:?}"
     );
 }
 


### PR DESCRIPTION
AgentName: claude-brave-volta-MECuw

Refs #10804 (rxjs), #10812 (type-fest), #10796 (ts-essentials) — the
"generic method override checks mis-handle variance in mixed inheritance
chains" family.

## Track
Conformance / checker — interface-heritage overloaded-method compatibility
(TS2430) parity with `tsc`.

## Invariant
When a derived interface extends a base interface and re-declares an
**overloaded** method, `tsc` accepts the override iff the derived member's
*entire* overload set is assignable to the base member's entire overload set
(`signaturesRelatedTo`'s N×M rule: every base signature matched by some
derived signature, method signatures compared bivariantly). tsz now applies
exactly that rule. Single-signature methods, property-typed call-signature
members, and non-overloaded members are unchanged.

## Problem / Structural rule
`check_interface_overload_coverage` compared only a single "trailing"
signature on each side, which diverged from `tsc` in both directions:

| case | `tsc` | tsz before | tsz after |
| --- | --- | --- | --- |
| derived keeps the shorter overload of a generic `pipe` (rxjs/kysely builder) | accept | **false TS2430** | accept |
| derived keeps a specialized (`"literal"`) overload, drops the general one | accept | **false TS2430** | accept |
| derived is a superset (adds a compatible extra overload) | accept | **false TS2430** | accept |
| derived keeps only the longer overload, dropping a base overload it can't service | **TS2430** | **missed** | TS2430 |

Example false positive (matches the rxjs witness in #10804):

```ts
type UF<A, B> = (a: A) => B;
interface Base<T> {
  pipe<A>(op1: UF<T, A>): T;
  pipe<A, B>(op1: UF<T, A>, op2: UF<A, B>): B;
}
interface Derived<U> extends Base<U> {
  pipe<A>(op1: UF<U, A>): U; // tsc: OK · tsz before: TS2430 · tsz after: OK
}
```

Example missed error:

```ts
interface Base {
  concat(x: string): number;
  concat(x: string, y: string): number;
}
interface Derived extends Base {
  concat(x: string, y: string): number; // tsc: TS2430 · tsz before: silent · tsz after: TS2430
}
```

## Owner layer
Solver-backed query boundary. The checker (`check_interface_overload_coverage`)
now builds the full overload callables for both members and routes them through
`query_boundaries::class::interface_overload_set_assignable`, which uses the
existing relation (`check_callable_subtype`). That relation already implements
the N×M rule, method bivariance, and method-local generic erasure for
multi-signature shapes — so the bespoke trailing-signature/specialized-signature
heuristics (~190 lines) are deleted, not relocated. No new checker-side type
logic, no name/identifier/file-name predicates.

## Adjacent matrix (all verified against `tsc --strict`)
- Generic and non-generic overload sets; renamed type parameters.
- Fewer overloads (shorter, specialized, superset) — accepted.
- Dropped/uncoverable base overload, incompatible return — rejected (TS2430).
- Property-typed call-signature members keep their existing (correct) behavior.

## Project Corpus Impact
- Row: rxjs-project, kysely-project, type-fest-project, ts-essentials-project
- Bug family: #10804/#10812/#10796 generic method overload compatibility (TS2430)
- Evidence:
Targets the rxjs/kysely/type-fest/ts-essentials false-positive families.
Removes spurious TS2430s on generic builder interfaces while restoring missed
TS2430s; no fixture-name fast paths.

## Verification
- `cargo test -p tsz-checker --test ts2430_tests` — 53 passed.
- `cargo test -p tsz-checker --lib -- overload` + arch routing tests — 211 passed.
- Heritage/overload integration suites
  (`class_implements_overloaded_method_ts2416_tests`,
  `generic_method_override_constraint_ts2416_tests`,
  `interface_heritage_display_tests`, `abstract_method_overload_ts2416_tests`,
  `class_expression_heritage_ts2416_tests`, `mixin_base_no_member_no_ts2416_tests`,
  `overload_modifier_tests`) — all green.
- Full `tsz-checker` lib delta vs `main`: zero new failures (pre-existing
  environment failures excluded; the one apparent diff is parallel-test
  shared-state flakiness that passes in isolation and under per-process CI).
- `clippy -p tsz-checker` clean for the changed files.
- Two negative-control tests that encoded the old heuristic's over-report were
  corrected to `tsc` parity (each case re-verified with `tsc --strict`) and
  paired with genuine-mismatch controls.

## Coordination Notes
The renamed helper `interface_overload_set_assignable` (was
`interface_overload_trailing_signature_assignable`) is pinned by
`class_boundary_fallback_relation_routing_arch_tests`; that anchor is updated in
this PR. Sibling issues #10812/#10796 share the same root cause and are
addressed structurally here.

https://claude.ai/code/session_01TMYAbwje3ZczzPfnqCWcFx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMYAbwje3ZczzPfnqCWcFx)_
