### PR TITLE
fix(checker): keep inherited lib-interface members after a heritage cycle (#12299)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1082,6 +1082,19 @@ impl<'a> CheckerState<'a> {
         })
     }
 
+    /// Whether `sym_id` is a library interface whose most recent resolution left
+    /// an incomplete heritage body — a base interface was dropped while it was
+    /// itself mid-resolution (the `Element`/`HTMLElement` ⇒ `Node` DOM diamond in
+    /// #12299). Such a partial body must not be cached: the symbol caches are not
+    /// invalidated when the base later completes, so a frozen partial shape would
+    /// keep producing false missing-member / non-assignability errors. Leaving it
+    /// uncached makes the next lookup recompute the full shape.
+    fn lib_symbol_heritage_incomplete(&self, sym_id: SymbolId) -> bool {
+        self.get_cross_file_symbol(sym_id)
+            .filter(|symbol| symbol.has_any_flags(symbol_flags::INTERFACE))
+            .is_some_and(|symbol| self.lib_name_heritage_incomplete(&symbol.escaped_name))
+    }
+
     fn get_type_of_symbol_inner(&mut self, sym_id: SymbolId) -> TypeId {
         use tsz_solver::SymbolRef;
         let factory = self.ctx.types.factory();
@@ -1307,20 +1320,27 @@ impl<'a> CheckerState<'a> {
                 .zip(self.ctx.get_existing_def_id(sym_id))
                 .is_some_and(|(ld, od)| ld == od)
         };
+        // An incomplete lib-interface heritage body (#12299) must not be frozen
+        // into any symbol cache; those caches are never invalidated when the
+        // dropped base finishes resolving.
+        let lib_heritage_incomplete = self.lib_symbol_heritage_incomplete(sym_id);
         if let Some(file_idx) = cross_file_owner_idx {
-            self.ctx.cache_cross_file_symbol_type(
-                sym_id,
-                file_idx as u32,
-                result,
-                type_params.clone(),
-            );
+            if !lib_heritage_incomplete {
+                self.ctx.cache_cross_file_symbol_type(
+                    sym_id,
+                    file_idx as u32,
+                    result,
+                    type_params.clone(),
+                );
+            }
         } else {
-            let result_cached_locally = if result_is_lazy_to_self
-                && self
-                    .ctx
-                    .binder
-                    .get_symbol(sym_id)
-                    .is_some_and(|s| s.has_any_flags(symbol_flags::CLASS))
+            let result_cached_locally = if lib_heritage_incomplete
+                || (result_is_lazy_to_self
+                    && self
+                        .ctx
+                        .binder
+                        .get_symbol(sym_id)
+                        .is_some_and(|s| s.has_any_flags(symbol_flags::CLASS)))
             {
                 self.ctx.symbol_types.remove(&sym_id);
                 false

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs
@@ -735,13 +735,25 @@ impl<'a> CheckerState<'a> {
         // base declared in the same namespace. The body-only lowerings above
         // drop them; this runs the namespace-aware heritage merge keyed by the
         // qualified name so the base interface members are instantiated in.
-        let (direct_type, params) = match heritage_merge_name {
+        let (direct_type, params, incomplete) = match heritage_merge_name {
             Some(merge_name) => {
-                let merged = self.merge_lib_interface_heritage(direct_type, &merge_name).0;
-                (merged, params)
+                let (merged, incomplete) =
+                    self.merge_lib_interface_heritage(direct_type, &merge_name);
+                (merged, params, incomplete)
             }
-            None => (direct_type, params),
+            // `direct_type` came from `resolve_lib_type_by_name(&name)` above, which
+            // records an incomplete heritage merge (a base dropped mid-resolution)
+            // via the lib-resolution marker.
+            None => (direct_type, params, self.lib_name_heritage_incomplete(&name)),
         };
+        if incomplete {
+            // Do not freeze an incomplete heritage body (missing inherited
+            // members from an in-progress base — the #12299 DOM diamond) into the
+            // symbol/delegation caches, which are never invalidated when the base
+            // finishes. Serve this query but leave the caches empty so the next
+            // request recomputes the full shape.
+            return Some((direct_type, params));
+        }
         self.ctx.symbol_types.insert(sym_id, direct_type);
         self.ctx
             .lib_delegation_cache

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -1608,7 +1608,14 @@ impl<'a> CheckerState<'a> {
             && self.ctx.has_lib_loaded()
         {
             if let Some(resolved) = self.resolve_lib_type_by_name(&name) {
-                self.try_insert_def_in_type_env(def_id, resolved);
+                // Do not freeze an incomplete heritage body (a base dropped while
+                // mid-resolution — the #12299 DOM diamond) into `type_env`: that
+                // def-body cache is not invalidated when the base completes, so
+                // the partial shape would be reused. Serve this query but leave
+                // the def body unset so the next resolution recomputes in full.
+                if !self.lib_name_heritage_incomplete(&name) {
+                    self.try_insert_def_in_type_env(def_id, resolved);
+                }
                 return Some(resolved);
             }
             return Some(self.ctx.types.lazy(def_id));

--- a/crates/tsz-checker/src/types/queries/lib_resolution.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution.rs
@@ -1041,7 +1041,16 @@ impl<'a> CheckerState<'a> {
         // Finalize after heritage merge — `merge_lib_interface_heritage`
         // above may have produced a new TypeId; helper rewires type→def
         // and the DefId body so literal and annotation paths agree.
-        if let Some(ty) = lib_type_id {
+        //
+        // Skip this entirely when the heritage merge was incomplete: a body that
+        // dropped an in-progress base (the DOM `Element`/`HTMLElement` ⇒ `Node`
+        // diamond in #12299) is missing inherited members, and freezing it into
+        // the def store / `symbol_types` lets that incomplete shape outlive the
+        // cycle — the recompute the old code relied on does not reliably overwrite
+        // a frozen def body. Persisting only complete bodies keeps the incomplete
+        // shape out of every store, so the next request recomputes it in full once
+        // the base has finished resolving.
+        if !heritage_incomplete && let Some(ty) = lib_type_id {
             self.register_finalized_lib_body(name, ty);
             // Update the symbol_types cache for the INTERFACE type position.
             // compute_type_of_symbol may have cached a DIFFERENT TypeId
@@ -1070,9 +1079,9 @@ impl<'a> CheckerState<'a> {
             // `lib_type_id` is missing inherited members. Mark `name` incomplete
             // and do NOT persist the type: remove the local slot and skip the
             // shared cache so the next request recomputes once the base has
-            // completed. The def body / `symbol_types` entries written above are
-            // overwritten by that recompute (`register_finalized_lib_body`
-            // rewires the body and clears eval caches). See #12299.
+            // completed. The finalize block above is skipped while incomplete, so
+            // no def body / `symbol_types` entry is frozen for this name. See
+            // #12299.
             set_lib_resolution_mark(name, LibResolutionMark::Incomplete);
             self.ctx.lib_type_resolution_cache.remove(name);
             return lib_type_id;

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
@@ -1198,6 +1198,47 @@ const instance: HTMLElement = new mod.HTML5Element();
         );
     }
 
+    /// Program-mode regression for #12299: when the DOM lib is checked as source
+    /// files, `Element`/`HTMLElement` reach `Node` both directly and through
+    /// `ChildNode`/`ParentNode` (a diamond). A heritage base resolved while it is
+    /// itself mid-resolution used to be frozen into the symbol/def caches as an
+    /// incomplete body, dropping every inherited member. After honoring the
+    /// existing incomplete-heritage signal at the cross-arena freeze sites, the
+    /// inherited members are visible to `keyof` and indexed access again.
+    #[test]
+    fn dom_element_keyof_and_indexed_access_see_inherited_node_members_12299() {
+        let lib_files = tsz::checker::test_utils::load_lib_files(&["es5.d.ts", "dom.d.ts"]);
+        assert!(
+            !lib_files.is_empty(),
+            "es5/dom libs must be available for this regression"
+        );
+
+        // `appendChild`/`cloneNode` are declared on `Node`; `Element` and
+        // `HTMLElement` inherit them through the heritage diamond. `keyof` and
+        // indexed access must therefore accept these inherited keys.
+        let files = [(
+            "/p/dom.ts",
+            r#"
+const ek: keyof Element = "appendChild";
+const hk: keyof HTMLElement = "cloneNode";
+type EAppend = Element["appendChild"];
+type HClone = HTMLElement["cloneNode"];
+"#,
+        )];
+        let diagnostics = collect_test_diagnostics_with_lib_files(&files, &lib_files);
+        // No "not assignable to keyof" (TS2322) and no "property does not exist on
+        // type" indexed-access failures (TS2536) for the inherited members.
+        let offending: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| matches!(d.code, 2322 | 2339 | 2536))
+            .collect();
+        assert!(
+            offending.is_empty(),
+            "Element/HTMLElement must expose inherited Node members to keyof/indexed access \
+             in program mode (#12299). Got: {offending:?}. All: {diagnostics:?}"
+        );
+    }
+
     #[test]
     fn class_extends_identity_shortcut_preserves_member_relation_checks() {
         let diagnostics = collect_test_diagnostics(&[(


### PR DESCRIPTION
AgentName: claude-brave-volta-jr1qw

Refs #12299 (DOM lib-interface heritage drop). Builds on the #12335 incomplete-heritage discipline and the #12480 root-cause investigation.

## Track
Conformance / checker — library-interface heritage resolution under resolution-order cycles (program/conformance path).

## Invariant
When a library interface's `extends` base is resolved while that base is itself mid-resolution, the derived body is incomplete (missing inherited members). `tsc` never exposes that partial shape; `tsz` already detects the condition (#12335) and marks the name incomplete. This PR makes every library def-body / symbol-cache write honor that signal, so an incomplete body is never frozen — it is recomputed in full once the base finishes. Complete resolutions are byte-for-byte unchanged.

## Problem / Structural rule
The DOM `Element`/`HTMLElement` interfaces reach `Node` directly **and** through `ChildNode`/`ParentNode` (a diamond). In the program-mode path (lib checked as source files), resolving `Node` pulls `Element`/`HTMLElement` in before `Node`'s own body is built, so the heritage merge drops `Node` and yields a partial body. `resolve_lib_type_by_name` already declined to cache that (per #12335), but the other freeze sites dropped the `incomplete` flag (`.0`) and froze the partial body into caches that are **never invalidated** when the base later completes. The result was inherited members invisible to `keyof`/indexed access (`keyof Element` missing `appendChild`, `Element["cloneNode"]` failing).

`When a lib-interface heritage merge drops a base that is still mid-resolution, tsc keeps the deferred/complete members; tsz now refuses to freeze the partial body at every cache write, through the existing incomplete-heritage marker.`

## Owner layer
Checker library-resolution + symbol/def cache boundary. No solver/emitter changes, no new type algorithms, and no user-name/file-name predicates — the gate is the pre-existing structural `lib_name_heritage_incomplete` marker.

## Scope
- `types/queries/lib_resolution.rs` — skip the finalize/`register_finalized_lib_body` block while the merge is incomplete (only complete bodies are persisted).
- `state/type_analysis/core.rs` — `get_type_of_symbol` no longer caches an incomplete lib-interface body into the cross-file or local symbol caches (new `lib_symbol_heritage_incomplete` helper).
- `state/type_analysis/cross_file_direct/actual_lib_methods.rs` — do not freeze an incomplete body into `symbol_types`/`lib_delegation_cache`.
- `state/type_environment/lazy.rs` — `resolve_and_insert_def_type` does not insert an incomplete body into the type-environment def store.
- `crates/tsz-cli/.../check_tests_part1.rs` — program-mode regression test.

## Adjacent matrix
- `keyof Element` / `keyof HTMLElement` include inherited `Node` members; `Element["appendChild"]` / `HTMLElement["cloneNode"]` indexed access resolve.
- LibContext-mode heritage diamond (`lib_heritage_cycle_dom_tests`, 9 cases) unchanged and green.
- Complete (non-cyclic) lib interfaces: behavior and caching unchanged (gate is inert when the marker is unset).

## Project Corpus Impact
- Row: n/a (no required row should flip; this only affects inputs whose lib-interface body was previously frozen incomplete).
- Bug family: #12299 lib-interface heritage cache-cycle (program-mode `keyof`/indexed-access surface).

## Verification
- New `dom_element_keyof_and_indexed_access_see_inherited_node_members_12299` — **fails on `main`** (`TS2322 '"appendChild"' is not assignable to 'keyof Element'`), **passes** with this change.
- `cargo test -p tsz-checker --test lib_heritage_cycle_dom_tests` — 9 passed.
- `cargo test -p tsz-checker --lib` — only the 2 pre-existing `zod_type_query_regression_tests` failures (verified identical on clean `main` by stashing this change); **zero new failures**.
- `cargo fmt --check` and `cargo clippy -p tsz-checker -p tsz-cli` — clean.

## Coordination Notes
Scoped, low-risk slice of #12299: each gate fires only on the precise pre-existing incomplete marker, so it can only improve genuinely-incomplete bodies (recompute) and cannot change correct resolutions. The broader **assignability** surface (false `TS2740` `Element`/`HTMLElement` not assignable to `Node`) has a separate silent heritage-drop root cause — the "dedicated campaign" #12480 identified — and is intentionally **out of scope** here; #12299 stays open for it.

https://claude.ai/code/session_019yqcurKp7LXyyG5c1zhdXP

---
_Generated by [Claude Code](https://claude.ai/code/session_019yqcurKp7LXyyG5c1zhdXP)_