### PR TITLE
fix(checker): preserve literal members when contextually typing object literals against object unions (#10864)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1309,6 +1309,9 @@ path = "tests/object_element_access_diagnostics_tests.rs"
 name = "object_literal_normalization_tests"
 path = "tests/object_literal_normalization_tests.rs"
 [[test]]
+name = "object_literal_union_contextual_typing_tests"
+path = "tests/object_literal_union_contextual_typing_tests.rs"
+[[test]]
 name = "intersection_index_signature_fingerprint_tests"
 path = "tests/intersection_index_signature_fingerprint_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/object_literal_context.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_context.rs
@@ -1312,6 +1312,36 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// True when `union` collapses to `member` as a set: `member` is one of its
+    /// arms (checked by the caller) and every arm is assignable to `member`, so
+    /// `union` and `member` denote the same value set (`2 | number` vs
+    /// `number`). The un-reduced `union` is then the literal-preserving
+    /// contextual form (`UnionReduction.None`) and must not be collapsed to the
+    /// bare `member`. When `union` is *not* assignable to `member` it is
+    /// genuinely wider (`string | number` vs `number`) and the narrower member
+    /// stays preferred.
+    ///
+    /// Callable operands are excluded: literal preservation is about data
+    /// unions, while a union of overloaded call signatures is collapsed to a
+    /// specific member by the dedicated callable-specificity comparison that
+    /// runs immediately after the membership rules. Keeping a callable union
+    /// here would steal that decision and drop the precise signature used to
+    /// contextually type a method/callback property (`then`, `set`, …).
+    fn contextual_union_reduces_to_member(&self, union: TypeId, member: TypeId) -> bool {
+        let union_eval = common::evaluate_type(self.ctx.types, union);
+        let member_eval = common::evaluate_type(self.ctx.types, member);
+        if crate::query_boundaries::common::is_callable_type(self.ctx.types, union_eval)
+            || crate::query_boundaries::common::is_callable_type(self.ctx.types, member_eval)
+        {
+            return false;
+        }
+        crate::query_boundaries::assignability::is_fresh_subtype_of(
+            self.ctx.types,
+            union_eval,
+            member_eval,
+        )
+    }
+
     fn prefer_more_specific_contextual_property_type(
         &self,
         current: Option<TypeId>,
@@ -1343,15 +1373,28 @@ impl<'a> CheckerState<'a> {
             return Some(current);
         }
 
-        if common::union_members(self.ctx.types, current)
-            .is_some_and(|members| members.contains(&candidate))
-        {
-            return Some(candidate);
-        }
-        if common::union_members(self.ctx.types, candidate)
-            .is_some_and(|members| members.contains(&current))
-        {
-            return Some(current);
+        // One operand being a union that *contains* the other as a member is
+        // usually a signal that the lone member is the more specific contextual
+        // type. But when the union reduces to exactly that member as a set —
+        // every arm is assignable to it, e.g. `2 | number` collapses to
+        // `number` — the un-reduced union is the literal-preserving form tsc
+        // keeps under `UnionReduction.None`. Collapsing to the bare member there
+        // drops the literal arm and widens a fresh property/element, so a literal
+        // object/array assigned to a differing-arity union (`{ k: 2 }` to
+        // `{ k: 2 } | { k: number; j: boolean }`) loses the arm it matched and
+        // reports a spurious TS2322. Keep the union in that case; only collapse
+        // when the member is a *strict* subset (the union is genuinely wider).
+        // Checked in both orderings, since either operand may be the union.
+        for (union, member) in [(current, candidate), (candidate, current)] {
+            if common::union_members(self.ctx.types, union)
+                .is_some_and(|members| members.contains(&member))
+            {
+                return Some(if self.contextual_union_reduces_to_member(union, member) {
+                    union
+                } else {
+                    member
+                });
+            }
         }
 
         if common::intersection_members(self.ctx.types, current)

--- a/crates/tsz-checker/tests/object_literal_union_contextual_typing_tests.rs
+++ b/crates/tsz-checker/tests/object_literal_union_contextual_typing_tests.rs
@@ -1,0 +1,185 @@
+//! Tests for contextual typing of object literals against union-of-objects targets.
+//!
+//! When the declared type is a union whose members share a property at different
+//! literal-vs-widened precision (e.g. `{ k: 2 } | { k: number; j: boolean }`), a
+//! fresh object literal on the right-hand side must be contextually typed
+//! per-property: property `k` sees `2 | number` as its contextual type, which
+//! preserves the number literal `2` instead of widening it to `number`. Without
+//! literal preservation the inferred `{ k: number }` matches neither arm (the
+//! literal arm by value, the wider arm by arity) and tsz emitted a spurious
+//! TS2322.
+//!
+//! Root cause: `contextual_object_literal_property_type` already builds the
+//! per-property contextual type with `union_preserve_members` (`2 | number`),
+//! mirroring tsc's `getTypeOfPropertyOfContextualType` under
+//! `UnionReduction.None`. But `prefer_more_specific_contextual_property_type`
+//! then collapsed that union back to its widened member `number` via the
+//! "union contains the candidate" rule, dropping the literal arm.
+//!
+//! Fix: only collapse a union to a contained member when the member is a
+//! *strict* subset. When the union reduces to exactly that member as a set
+//! (`2 | number` denotes the same values as `number`), the un-reduced union is
+//! the literal-preserving form and is kept.
+//!
+//! This is the object-literal counterpart of
+//! `tuple_union_contextual_typing_tests.rs`.
+
+use tsz_checker::test_utils::check_source_codes;
+
+// ---------------------------------------------------------------------------
+// Core cases - differing-arity object unions, literal arm preserved
+// ---------------------------------------------------------------------------
+
+/// Assigning `{ k: 2 }` to `{ k: 2 } | { k: number; j: boolean }` must NOT emit
+/// TS2322: the fresh `2` is preserved by the `2 | number` contextual type and
+/// matches the literal arm.
+#[test]
+fn object_literal_assignable_to_number_literal_arm() {
+    let codes = check_source_codes(
+        r#"
+const a: { k: number; j: boolean } | { k: 2 } = { k: 2 };
+const b: { k: 2 } | { k: number; j: boolean } = { k: 2 };
+"#,
+    );
+    assert!(!codes.contains(&2322), "expected no TS2322, got: {codes:?}");
+}
+
+/// Same shape with string literals.
+#[test]
+fn object_literal_assignable_to_string_literal_arm() {
+    let codes = check_source_codes(
+        r#"
+const a: { a: string; b: number } | { a: "x" } = { a: "x" };
+const b: { a: "x" } | { a: string; b: number } = { a: "x" };
+"#,
+    );
+    assert!(!codes.contains(&2322), "expected no TS2322, got: {codes:?}");
+}
+
+/// Same shape with bigint literals.
+#[test]
+fn object_literal_assignable_to_bigint_literal_arm() {
+    let codes = check_source_codes(
+        r#"
+const a: { n: bigint; extra: boolean } | { n: 2n } = { n: 2n };
+"#,
+    );
+    assert!(!codes.contains(&2322), "expected no TS2322, got: {codes:?}");
+}
+
+/// Renamed binders (different property/alias names) must behave identically —
+/// the rule is structural, not keyed on any identifier.
+#[test]
+fn object_literal_union_renamed_binders() {
+    let codes = check_source_codes(
+        r#"
+type Wide = { value: number; flag: boolean };
+type Narrow = { value: 7 };
+const a: Wide | Narrow = { value: 7 };
+const b: Narrow | Wide = { value: 7 };
+"#,
+    );
+    assert!(!codes.contains(&2322), "expected no TS2322, got: {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Through a type alias (the original large-ts-repo witness shape)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn object_literal_union_through_alias() {
+    let codes = check_source_codes(
+        r#"
+type Lit = { k: 2 };
+const a: Lit | { k: number; j: boolean } = { k: 2 };
+"#,
+    );
+    assert!(!codes.contains(&2322), "expected no TS2322, got: {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Nested object literals
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nested_object_literal_union_preserves_literal() {
+    let codes = check_source_codes(
+        r#"
+const a: { o: { k: 2 } } | { o: { k: number; j: boolean } } = { o: { k: 2 } };
+"#,
+    );
+    assert!(!codes.contains(&2322), "expected no TS2322, got: {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Discriminated unions (same-key, same-arity) must remain unaffected
+// ---------------------------------------------------------------------------
+
+#[test]
+fn discriminated_union_object_literal_ok() {
+    let codes = check_source_codes(
+        r#"
+type Shape = { tag: "a"; v: number } | { tag: "b"; v: string };
+const a: Shape = { tag: "b", v: "hi" };
+const b: Shape = { tag: "a", v: 3 };
+"#,
+    );
+    assert!(!codes.contains(&2322), "expected no TS2322, got: {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Negative cases - genuine mismatches must STILL error
+// ---------------------------------------------------------------------------
+
+/// A literal that matches no arm by value or arity must still emit TS2322.
+#[test]
+fn object_literal_not_in_union_still_errors() {
+    let codes = check_source_codes(
+        r#"
+const z: { k: 2 } | { m: string } = { k: 3 };
+"#,
+    );
+    assert!(codes.contains(&2322), "expected TS2322, got: {codes:?}");
+}
+
+/// A string literal outside both arms' literal sets must still error.
+#[test]
+fn object_literal_wrong_string_literal_still_errors() {
+    let codes = check_source_codes(
+        r#"
+const z: { a: "x" } | { a: "y"; b: number } = { a: "z" };
+"#,
+    );
+    assert!(codes.contains(&2322), "expected TS2322, got: {codes:?}");
+}
+
+/// The literal arm is matched, but a missing required property in the only
+/// arm whose discriminant fits must still error (no accidental over-acceptance).
+#[test]
+fn object_literal_missing_required_property_still_errors() {
+    let codes = check_source_codes(
+        r#"
+const z: { k: 2; extra: string } | { k: number; j: boolean } = { k: 2 };
+"#,
+    );
+    assert!(codes.contains(&2322), "expected TS2322, got: {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Genuinely-wider union member must still be preferred (no over-fix)
+// ---------------------------------------------------------------------------
+
+/// When the union does NOT reduce to a single contained member — the two arms
+/// carry disjoint primitive property types (`string` vs `number`) — the
+/// per-property contextual type is a real `string | number` and a literal
+/// argument is still accepted on the matching side.
+#[test]
+fn object_literal_disjoint_primitive_union_ok() {
+    let codes = check_source_codes(
+        r#"
+const a: { v: string } | { v: number } = { v: "hello" };
+const b: { v: string } | { v: number } = { v: 42 };
+"#,
+    );
+    assert!(!codes.contains(&2322), "expected no TS2322, got: {codes:?}");
+}


### PR DESCRIPTION
AgentName: brave-volta
Track: checker / contextual typing
Invariant: contextual property types for object literals against object unions preserve literal members (UnionReduction.None)

Closes #10864 (object-literal counterpart explicitly deferred out of scope by the issue body).

## Structural rule

When deriving the per-property contextual type for a fresh object literal element from a union of object types, `tsc` keeps the literal-bearing union (`{ k: 2 } | { k: number; j: boolean }` ⇒ `k: 2 | number`); `tsz` now does the same through the checker's contextual-property merge, routing the set-equality decision through the `query_boundaries::assignability` gateway.

## Root cause

`contextual_object_literal_property_type` already builds the per-property union with `union_preserve_members` (`2 | number`), mirroring `UnionReduction.None`. But `prefer_more_specific_contextual_property_type` then collapsed it back to its widened member `number` via the "union contains the candidate" membership rule. The fresh `2` then widened to `number`, producing `{ k: number }`, which matches neither arm — the literal arm by value, the wider arm by arity — so tsz emitted a spurious **TS2322**.

```ts
const o:  { k: number; j: boolean } | { k: 2 }   = { k: 2 };    // tsz before: TS2322   tsc: OK
const o2: { a: string; b: number }  | { a: "x" } = { a: "x" };  // tsz before: TS2322   tsc: OK
```

## Fix (owner layer: checker contextual-property merge)

`prefer_more_specific_contextual_property_type` now only collapses a union to a contained member when the member is a **strict** subset. When the union reduces to exactly that member as a set (`2 | number` denotes the same values as `number`), the un-reduced, literal-preserving union is kept. A new helper `contextual_union_reduces_to_member` performs the set-equality check via `is_fresh_subtype_of` and excludes callable operands so the dedicated callable-specificity comparison that follows still selects the precise signature (`then`/`set` method-property contextual typing is unchanged).

The change is set-theoretic — no user-name, alias, property-name, or fixture-name checks — and consistent with the surrounding code, which already consults `query_boundaries::assignability` relations for its narrowing decisions. It is the object-literal counterpart of the landed tuple-union contextual fix.

## Scope

- `crates/tsz-checker/src/types/computation/object_literal_context.rs` — `prefer_more_specific_contextual_property_type` membership rule + `contextual_union_reduces_to_member` helper.
- `crates/tsz-checker/tests/object_literal_union_contextual_typing_tests.rs` — new regression matrix (registered in `Cargo.toml`).

### Adjacent-case matrix (new tests)

- number / string / bigint literal arms; both union orderings.
- renamed binders (`Wide | Narrow` with differing property names) — structural, not name-keyed.
- through a type alias; nested object literals.
- same-key discriminated unions (unaffected).
- negative / fallback: literal outside both arms still TS2322; wrong string literal still TS2322; missing required property still TS2322; genuinely disjoint primitive union (`{ v: string } | { v: number }`) still accepts the matching literal (no over-fix).

## Project Corpus Impact

- Row: large-ts-repo
- Bug family: tuple/object-union contextual literal preservation (#10864; shares the contextual surface with #10872 / #10823 / #10815 / #10834 / #10875)

Behavior-narrowing only where tsz previously over-reported TS2322; no new diagnostics introduced for the negative cases above. `conformance-snapshot-gate` and `project-row-drift` are green on this head.

## Verification

- New suite `object_literal_union_contextual_typing_tests`: 11/11 pass.
- Adjacent suites pass: `tuple_union_contextual_typing_tests` (10), `contextual_typing_tests`, `object_literal_normalization_tests`, `object_literal_getter_widening_tests`, `object_literal_property_target_display_tests`, `generic_multi_prop_object_literal_tests`, `object_union_assignability_fast_path_tests`, `satisfies_generic_inference_literal_widening_tests`, `jsx_union_callback_context_tests`, `literal_source_widening_position_parity_tests`, `block_body_callback_literal_widening_tests`, `generic_callback_local_literal_widening_tests`, `union_target_literal_primitive_mismatch_tests`.
- `cargo clippy -p tsz-checker --lib`: clean.
- CLI repro of the issue cases and adjacent cases verified against expected `tsc` behavior.
- `/simplify` run; the two symmetric membership branches were unified into a single both-orderings loop.

One unrelated pre-existing local failure, `dynamic_import_defer_tests::import_defer_then_callback_is_contextually_typed`, reproduces on a clean tree without this change and is not affected by it.

## Coordination Notes

This picks up the object-literal gap the #10864 body explicitly tracked separately; the tuple half already landed in the solver contextual extractors. The collapse fixed here is in the checker's candidate merge, not the solver extraction (which already preserves members) — real member access (`u.k ⇒ number`) must still reduce, so the preservation belongs at the contextual merge, not in property access.

_Generated by [Claude Code](https://claude.ai/code)_