### PR TITLE
fix(solver): expand indexed-access type-alias applications structurally (#10834)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -252,6 +252,9 @@ mod index_sig_param_intersection_validity_tests;
 #[path = "tests/index_sig_param_resolved_key_type_tests.rs"]
 mod index_sig_param_resolved_key_type_tests;
 #[cfg(test)]
+#[path = "../tests/indexed_access_alias_application_relation_tests.rs"]
+mod indexed_access_alias_application_relation_tests;
+#[cfg(test)]
 #[path = "tests/instantiation_expression_inline_utility_modifier_tests.rs"]
 mod instantiation_expression_inline_utility_modifier_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/tests/indexed_access_alias_application_relation_tests.rs
+++ b/crates/tsz-checker/tests/indexed_access_alias_application_relation_tests.rs
@@ -1,0 +1,140 @@
+//! Regression tests for relating two applications of an *indexed-access* type
+//! alias (issue #10834 family — recursive utility expansion / structural
+//! comparison of computed aliases).
+//!
+//! `DefKind::TypeAlias` is transparent: `tsc` never compares two applications of
+//! a type alias nominally — it substitutes the arguments and relates the
+//! resulting structural types. For an alias whose body is an `IndexAccess`
+//! transform — the TypeBox shape `Static<T> = T['static']` /
+//! `Static<T,P> = (T & {params:P})['static']` — tsz previously took the same-base
+//! variance fast path, comparing the raw arguments. Through their nested
+//! same-base applications that comparison hit the coinductive cycle assumption
+//! and silently reported `Static<A>` assignable to `Static<B>` even when the
+//! expanded objects differed by a (deeply nested) property. The relation now
+//! skips the variance fast path for indexed-access alias bases and compares the
+//! evaluated structural forms, matching `tsc`.
+//!
+//! The assertions check diagnostic *codes* and direction, not the rendered type
+//! strings (tsz renders the user's alias name where tsc expands structurally;
+//! both are valid and the rendering is asserted elsewhere).
+
+use crate::test_utils::check_source_diagnostics;
+
+fn error_codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+const SCHEMA_PRELUDE: &str = r#"
+interface TSchema { static: unknown }
+interface TString extends TSchema { static: string }
+interface TObject<T extends Record<string, TSchema>> extends TSchema {
+  static: { [K in keyof T]: Static<T[K]> }
+}
+type Static<T extends TSchema> = T["static"];
+"#;
+
+/// `Static<In>` whose expansion is missing a deeply nested property must not be
+/// assignable to `Static<Out>` — the variance fast path used to relate them.
+#[test]
+fn indexed_access_alias_application_rejects_missing_nested_property() {
+    let source = format!(
+        "{SCHEMA_PRELUDE}
+type In = TObject<{{ a: TString; b: TObject<{{ c: TString }}> }}>;
+type Out = TObject<{{ a: TString; b: TObject<{{ c: TString; d: TString }}> }}>;
+const bad: Static<Out> = null as any as Static<In>;
+"
+    );
+    let codes = error_codes(&source);
+    assert_eq!(
+        codes,
+        vec![2322],
+        "Static<In> (missing nested `d`) must not be assignable to Static<Out>; got {codes:?}"
+    );
+}
+
+/// The opposite direction is sound: a structurally wider `Static<Out>` is
+/// assignable to the narrower `Static<In>`, so no diagnostic is reported. This
+/// guards against the fix over-rejecting (it must expand structurally, not
+/// blanket-reject same-base alias applications).
+#[test]
+fn indexed_access_alias_application_accepts_wider_source() {
+    let source = format!(
+        "{SCHEMA_PRELUDE}
+type In = TObject<{{ a: TString; b: TObject<{{ c: TString }}> }}>;
+type Out = TObject<{{ a: TString; b: TObject<{{ c: TString; d: TString }}> }}>;
+const ok: Static<In> = null as any as Static<Out>;
+"
+    );
+    let codes = error_codes(&source);
+    assert!(
+        codes.is_empty(),
+        "structurally wider Static<Out> must be assignable to Static<In>; got {codes:?}"
+    );
+}
+
+/// Equal arguments still relate (the structural-expansion path must agree with
+/// the identity case), so two identical `Static<Same>` are mutually assignable.
+#[test]
+fn indexed_access_alias_application_accepts_identical_arguments() {
+    let source = format!(
+        "{SCHEMA_PRELUDE}
+type Same = TObject<{{ a: TString; b: TObject<{{ c: TString }}> }}>;
+const x: Static<Same> = null as any as Static<Same>;
+"
+    );
+    let codes = error_codes(&source);
+    assert!(
+        codes.is_empty(),
+        "identical Static<Same> must be mutually assignable; got {codes:?}"
+    );
+}
+
+/// The behavior follows the structural shape, not the `Static`/`TObject`
+/// spellings: a renamed indexed-access schema alias rejects the same mismatch.
+#[test]
+fn indexed_access_alias_application_is_name_agnostic() {
+    let source = r#"
+interface SchemaBase { kind: unknown }
+interface StringSchema extends SchemaBase { kind: string }
+interface ObjectSchema<T extends Record<string, SchemaBase>> extends SchemaBase {
+  kind: { [K in keyof T]: Resolve<T[K]> }
+}
+type Resolve<T extends SchemaBase> = T["kind"];
+type Narrow = ObjectSchema<{ a: StringSchema }>;
+type Wide = ObjectSchema<{ a: StringSchema; b: StringSchema }>;
+const bad: Resolve<Wide> = null as any as Resolve<Narrow>;
+"#;
+    let codes = error_codes(source);
+    assert_eq!(
+        codes,
+        vec![2322],
+        "renamed indexed-access schema must reject the missing-property mismatch; got {codes:?}"
+    );
+}
+
+/// A two-parameter indexed-access alias over an intersection
+/// (`Static<T,P> = (T & {params:P})['static']`, the full TypeBox `Static`) must
+/// still expand structurally for the relation and reject a nested mismatch.
+#[test]
+fn indexed_access_alias_application_two_param_intersection_rejects_mismatch() {
+    let source = r#"
+interface TSchema { params: unknown[]; static: unknown }
+interface TString extends TSchema { static: string }
+interface TObject<T extends Record<string, TSchema>> extends TSchema {
+  static: { [K in keyof T]: Static<T[K], []> }
+}
+type Static<T extends TSchema, P extends unknown[] = []> = (T & { params: P })["static"];
+type In = TObject<{ a: TString; b: TObject<{ c: TString }> }>;
+type Out = TObject<{ a: TString; b: TObject<{ c: TString; d: TString }> }>;
+const bad: Static<Out> = null as any as Static<In>;
+"#;
+    let codes = error_codes(source);
+    assert_eq!(
+        codes,
+        vec![2322],
+        "two-param intersection Static must expand structurally and reject; got {codes:?}"
+    );
+}

--- a/crates/tsz-checker/tests/indexed_access_alias_application_relation_tests.rs
+++ b/crates/tsz-checker/tests/indexed_access_alias_application_relation_tests.rs
@@ -5,7 +5,7 @@
 //! `DefKind::TypeAlias` is transparent: `tsc` never compares two applications of
 //! a type alias nominally — it substitutes the arguments and relates the
 //! resulting structural types. For an alias whose body is an `IndexAccess`
-//! transform — the TypeBox shape `Static<T> = T['static']` /
+//! transform — the `TypeBox` shape `Static<T> = T['static']` /
 //! `Static<T,P> = (T & {params:P})['static']` — tsz previously took the same-base
 //! variance fast path, comparing the raw arguments. Through their nested
 //! same-base applications that comparison hit the coinductive cycle assumption
@@ -116,7 +116,7 @@ const bad: Resolve<Wide> = null as any as Resolve<Narrow>;
 }
 
 /// A two-parameter indexed-access alias over an intersection
-/// (`Static<T,P> = (T & {params:P})['static']`, the full TypeBox `Static`) must
+/// (`Static<T,P> = (T & {params:P})['static']`, the full `TypeBox` `Static`) must
 /// still expand structurally for the relation and reject a nested mismatch.
 #[test]
 fn indexed_access_alias_application_two_param_intersection_rejects_mismatch() {

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -1083,4 +1083,47 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
         false
     }
+
+    /// Whether an `Application` base is an *indexed-access* type alias that must
+    /// be expanded structurally rather than compared through the same-base
+    /// variance fast path.
+    ///
+    /// `DefKind::TypeAlias` is transparent: `tsc` never compares two
+    /// applications of a type alias nominally — it substitutes the arguments and
+    /// relates the resulting structural types. For an alias whose body is an
+    /// `IndexAccess` transform — the `TypeBox` shape
+    /// `Static<T, P> = (T & { params: P })['static']` — the alias has no sound
+    /// declared variance: the same-base variance fast path would compare the raw
+    /// arguments (`typeof Input` vs `typeof Output`) and, through their nested
+    /// same-base applications, hit the coinductive cycle assumption — silently
+    /// reporting `Static<typeof Input>` assignable to `Static<typeof Output>`
+    /// even when the expanded objects differ (a missing property). Skipping the
+    /// fast path routes the comparison through structural expansion, which
+    /// evaluates both applications to their concrete shapes and relates those,
+    /// matching `tsc`.
+    ///
+    /// Conditional-bodied aliases are handled separately (their variance path is
+    /// intentionally retained for differing arguments so genuine leaf mismatches
+    /// are caught). Plain (union/object/tuple-bodied) type aliases and nominal
+    /// interface/class applications keep the variance fast path; mapped-type
+    /// alias bodies rely on the variance prober's structural-fallback signal.
+    pub(crate) fn is_indexed_access_alias_base_inline(&self, base: TypeId) -> bool {
+        let Some(def_id) = lazy_def_id(self.interner, base) else {
+            return false;
+        };
+        if !matches!(
+            self.resolver.get_def_kind(def_id),
+            Some(crate::def::DefKind::TypeAlias)
+        ) {
+            return false;
+        }
+        let Some(body) = self.resolver.resolve_lazy(def_id, self.interner) else {
+            note_lazy_resolve_failure();
+            return false;
+        };
+        matches!(
+            self.interner.lookup(body),
+            Some(TypeData::IndexAccess(_, _))
+        )
+    }
 }

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -369,8 +369,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // When both applications have the same base (e.g., Array<T>), we can use
         // variance annotations to check type arguments without expanding the
         // entire structure. This is critical for O(1) performance.
+        //
+        // Exception: an indexed-access type-alias base (a transform such as
+        // TypeBox's `Static<T,P> = (T & {params:P})['static']`) has no sound
+        // declared variance — `DefKind::TypeAlias` is transparent and `tsc`
+        // always expands it. Comparing the raw arguments here instead lets nested
+        // same-base applications hit the coinductive cycle assumption and wrongly
+        // report `Static<A>` assignable to `Static<B>`. Skip the fast path for
+        // those bases so the structural-expansion slow path evaluates both to
+        // concrete shapes. (Conditional-bodied alias bases keep their existing
+        // variance handling, which is intentionally retained for differing args.)
         // =======================================================================
-        if same_application_family {
+        if same_application_family && !self.is_indexed_access_alias_base_inline(s_app.base) {
             // Try to resolve DefId from the base to query variance
             let def_id = variance_def_id;
 
@@ -626,6 +636,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // mechanism). When arguments differ, keep the variance path available
         // so genuine leaf mismatches are not hidden by a DefId-only cycle.
         if s_app.args == t_app.args && self.is_conditional_alias_base_inline(s_app.base) {
+            return None;
+        }
+
+        // An indexed-access type alias (`Static<T,P> = (T & {params:P})['static']`)
+        // is transparent and has no sound declared variance: comparing its raw
+        // arguments here lets nested same-base applications hit the coinductive
+        // cycle assumption and hide a real leaf mismatch (a missing property in
+        // the expanded object). `tsc` always expands type aliases, so force the
+        // structural-expansion path for these bases instead of the variance fast
+        // path.
+        if self.is_indexed_access_alias_base_inline(s_app.base) {
             return None;
         }
 


### PR DESCRIPTION
AgentName: Studio-B

Refs #10834

## Track
Solver / relations — structural comparison of recursive-utility (computed) type-alias applications (#10834 family: recursive utility expansion / over-instantiation under alias fan-out).

## Invariant
When two applications of the **same indexed-access type alias** (`Static<T> = T['static']`, the TypeBox shape) are related, `tsc` substitutes the arguments and relates the resulting **structural** types — type aliases are transparent and carry no nominal variance. `tsz` now does the same: it skips the same-base variance fast path for indexed-access alias bases and routes through structural expansion. Conditional-bodied alias bases, nominal interface/class applications, and plain (union/object/tuple) type aliases are unchanged.

## Wrong semantic operation
Relation — `relate` (subtype) of two `Application` types sharing an indexed-access type-alias base. Not an evaluation/inference/display bug: the types evaluate correctly; the relation took a nominal shortcut where `tsc` expands.

## Structural rule
When `source` and `target` are both `Application(Static, …)` and `Static` is a `DefKind::TypeAlias` whose declared body is an `IndexAccess` (`(T & {params:P})['static']`), `tsc` expands both applications and relates the structural results; `tsz` previously used the same-base **variance fast path**, comparing the raw arguments (`typeof Input` vs `typeof Output`, or `TObject<{…}>` vs `TObject<{…,bar}>`). Through the arguments' own nested same-base applications that comparison reached the relation's coinductive cycle assumption (`def_guard` / `ONE_SIDED_APP_EXPANSION_MAX_DEPTH`) and returned *related*, **silently masking a real (deeply nested) property mismatch** — a false negative: `Static<In>` was accepted as assignable to `Static<Out>` even though `Out` requires a property `In` lacks.

## Owner layer
Solver (`tsz-solver`), two coordinated sites of one mechanism plus a shared classifier:
- `relations/subtype/cache.rs`: new `is_indexed_access_alias_base_inline` — a base is an indexed-access alias when it resolves to a `DefKind::TypeAlias` whose body is `TypeData::IndexAccess`. Mirrors the existing `is_conditional_alias_base_inline` helper.
- `relations/subtype/rules/generics.rs`: both `check_application_to_application_subtype` and the early `try_variance_fast_path` now bail out of the variance path for such bases, falling through to the structural-expansion slow path that evaluates both applications and relates the concrete shapes.

No evaluation, inference, display, or checker algorithm changed.

## Scope
- `cache.rs`: `is_indexed_access_alias_base_inline` classifier (+doc).
- `generics.rs`: skip the same-base variance fast path for indexed-access alias bases in the two entry points.
- `tests/indexed_access_alias_application_relation_tests.rs` (new): end-to-end checker regression coverage.
- `lib.rs`: register the new test module.

## Anti-hardcoding
No user-name/file-name string predicates; no formatted-diagnostic-as-predicate. The trigger is the structural classification `DefKind::TypeAlias` + `IndexAccess` body via the resolver/def-store — not the `Static`/`TObject` spellings. Tests vary binder names (`Static`/`Resolve`, `TObject`/`ObjectSchema`, `TString`/`StringSchema`) to prove the behavior follows structure, and assert diagnostic **codes**/direction rather than rendered type strings.

## Adjacent-case matrix
- Missing deeply-nested property → rejected (`Static<In>` ⟂ `Static<Out>`), single- and two-parameter (`& {params:P}`) forms.
- Wider source accepted (`Static<Out>` <: `Static<In>`) — guards against over-rejection (must expand, not blanket-reject same-base aliases).
- Identical arguments accepted (identity/structural agreement).
- Renamed binders (`Resolve`/`ObjectSchema`/`StringSchema`) — structure, not spelling.
- Conditional-bodied alias bases: unchanged (existing variance handling retained for differing args).
- Nominal `Array<T>`/`Promise<T>`/interface/class applications and union/object/tuple-bodied aliases: unaffected (still use the variance fast path).

## Project Corpus Impact
- Row: kysely-project and other rows that exercise TypeBox-style `Static<T>` schemas / computed indexed-access utility aliases.
- Bug family: recursive utility expansion / computed-alias structural comparison (#10834).
- Expected effect: removes a false negative (now matches `tsc` by catching the mismatch); the relation does strictly more correct structural work for these aliases. No relation change for nominal generics. Project-row CI owns confirmation (rows are not run locally per the contract).

## Verification
- `cargo test -p tsz-checker --lib indexed_access_alias_application` — 5/5 pass (the mismatch is **accepted** on clean `main`; this PR rejects it, matching tsc).
- `RUST_MIN_STACK=536870912 cargo test -p tsz-checker --lib` — 6258 passed / 74 failed; the 74 failures are **identical** to clean `main` (captured before/after) — zero regressions, +5 new passing tests.
- `cargo test -p tsz-solver --lib` — 6578 passed / 2 failed; the 2 failures (`evaluate_application_variadic_prepend_flattens_tail_application`, `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`) are **pre-existing on clean `main`** (documented in #12815) — zero regressions.
- `cargo fmt --check`, `cargo clippy -p tsz-solver --lib`, `cargo clippy -p tsz-checker --lib`, `python3 scripts/arch/arch_guard.py` — all clean.
- Oracle: `tsc` 6.0.2 rejects `Static<In>` → `Static<Out>` with the structural message; tsz now reports TS2322 at the same site (the rendered source uses the alias name where tsc expands — both valid; full tsc-structural expansion of `Static<typeof X>` *display* additionally depends on `typeof`-of-merged-symbol resolution and polymorphic-`this`-through-intersection binding, identified as separate follow-ups).
- Ready CI owns full conformance and project-row drift.

## Coordination Notes
Picks up the recursive-utility-expansion family from #10834 (kysely-project row witness). While investigating, the broader TypeBox `Static<typeof Input>` parity was scoped into three layers: (1) this relation false negative — fixed here; (2) `typeof X` resolution for a merged type-alias+value symbol (the value-space type), which fixes a real infinite-recursion/over-instantiation hang; (3) polymorphic-`this`-through-intersection binding for full structural *display*. (2) and (3) are deeper (checker resolver + an architectural `this`-binding model change) and are left as follow-ups so this lands a focused, regression-free relation correctness fix. No overlap with in-flight solver work (#12815 recursive-conditional convergence; #12862 DOM heritage).

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkpSavEBZSdF7BSP1W4f7z)_