### PR TITLE
fix(checker): render declared literal-typed targets verbatim in union-source assignability diagnostics (#12179)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1213,6 +1213,18 @@ impl<'a> CheckerState<'a> {
         })
     }
 
+    /// Whether `ty` (or its assignability-evaluated form `evaluated`) carries
+    /// fresh object-literal `display_properties` — the provenance marker that
+    /// distinguishes a fresh expression literal (whose canonical shape is
+    /// widened, so it is text-widened for display) from a declared annotation /
+    /// named type (rendered verbatim). Shared by the source- and target-side
+    /// non-literal display rewrites so both apply the same fresh-vs-declared
+    /// discipline.
+    fn type_or_evaluated_has_display_properties(&self, ty: TypeId, evaluated: TypeId) -> bool {
+        self.ctx.types.get_display_properties(ty).is_some()
+            || self.ctx.types.get_display_properties(evaluated).is_some()
+    }
+
     pub(super) fn rewrite_source_display_for_non_literal_target_assignability(
         &mut self,
         source: TypeId,
@@ -1225,12 +1237,8 @@ impl<'a> CheckerState<'a> {
                 || crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, target)
                     .is_some_and(|shape| !shape.construct_signatures.is_empty());
         let evaluated_source = self.evaluate_type_for_assignability(source);
-        let source_has_display_props = self.ctx.types.get_display_properties(source).is_some()
-            || self
-                .ctx
-                .types
-                .get_display_properties(evaluated_source)
-                .is_some();
+        let source_has_display_props =
+            self.type_or_evaluated_has_display_properties(source, evaluated_source);
         if let Some(display) = self.typeof_result_source_display(evaluated_source, target) {
             return display.to_string();
         }
@@ -1386,6 +1394,25 @@ impl<'a> CheckerState<'a> {
         if Self::type_displays_as_application(self.ctx.types, target) {
             return target_display;
         }
+
+        // A *declared* target — an annotation or named type with no fresh
+        // object-literal display provenance — carries canonical literal members
+        // that tsc renders verbatim at every nesting depth. Only a genuinely
+        // fresh object-literal target (which interns a widened canonical shape
+        // and therefore carries `display_properties`) is text-widened. Mirror
+        // the fresh-vs-declared discipline the source side already applies in
+        // `rewrite_source_display_for_non_literal_target_assignability`, so a
+        // non-object source (e.g. a union) assigned to an anonymous object
+        // annotation like `{ a: 1 }` keeps the declared literal target instead
+        // of leaking a widened `{ a: number }` (#12179). Fresh-literal targets
+        // (with `display_properties`) still widen, preserving the existing
+        // role-swapped behavior.
+        let target_has_display_props =
+            self.type_or_evaluated_has_display_properties(target, evaluated);
+        if !target_has_display_props && self.source_carries_canonical_literal_member(evaluated) {
+            return target_display;
+        }
+
         let widened = crate::query_boundaries::common::widen_type(self.ctx.types, evaluated);
         let widened = self.widen_function_like_display_type(widened);
         let widened_display = self

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1260,6 +1260,9 @@ mod union_index_signature_relation_routing_arch_tests;
 #[path = "tests/union_multi_overload_unified_sig_tests.rs"]
 mod union_multi_overload_unified_sig_tests;
 #[cfg(test)]
+#[path = "tests/union_source_literal_target_display_tests.rs"]
+mod union_source_literal_target_display_tests;
+#[cfg(test)]
 #[path = "tests/unique_symbol_assignment_ts2322_tests.rs"]
 mod unique_symbol_assignment_ts2322_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/union_source_literal_target_display_tests.rs
+++ b/crates/tsz-checker/src/tests/union_source_literal_target_display_tests.rs
@@ -1,0 +1,188 @@
+//! Regression coverage for declared literal-typed *target* display in
+//! assignability diagnostics (#12179 diagnostics family — "diagnostics lose
+//! root context, stable display, or source span").
+//!
+//! tsc renders a *declared* target type — an annotation or named type — exactly
+//! as written, including its literal property types, at every nesting depth. A
+//! target's literal members are only ever widened in a message when the target
+//! is itself a *fresh* object literal (which interns a widened canonical shape).
+//!
+//! tsz previously over-widened: whenever the assignability message went through
+//! the union/best-match top-level builder (which fires when the *source* is a
+//! union), the declared object target `{ a: 1 }` was text-widened to
+//! `{ a: number }`, leaking a type the user never wrote. The fix mirrors the
+//! fresh-vs-declared discipline the source side already applies, so a declared
+//! object annotation keeps its literal members regardless of the source's shape.
+//!
+//! Verified against tsc 6.0.2. Binder/property names vary so a hardcoded fix
+//! cannot satisfy these.
+
+use crate::test_utils::check_source_diagnostics;
+
+#[track_caller]
+fn ts2322(source: &str) -> String {
+    let diags = check_source_diagnostics(source);
+    let ts2322: Vec<_> = diags.iter().filter(|d| d.code == 2322).collect();
+    assert_eq!(
+        ts2322.len(),
+        1,
+        "expected exactly one TS2322, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    ts2322[0].message_text.clone()
+}
+
+// 1. Union source assigned to an anonymous object annotation with a numeric
+//    literal property: the declared target keeps `{ a: 1; }` (was `{ a: number; }`).
+#[test]
+fn union_source_keeps_numeric_literal_object_target() {
+    let msg = ts2322(
+        r#"
+type T = { a: 1 } | { a: 2 };
+declare const x: T;
+const y: { a: 1 } = x;
+"#,
+    );
+    assert!(
+        msg.contains("to type '{ a: 1; }'"),
+        "expected declared literal target `{{ a: 1; }}`, got: {msg}"
+    );
+    assert!(
+        !msg.contains("a: number"),
+        "target literal must not be widened to `number`, got: {msg}"
+    );
+}
+
+// 2. Multiple literal properties — every declared literal member is preserved.
+#[test]
+fn union_source_keeps_all_literal_object_members() {
+    let msg = ts2322(
+        r#"
+type Choice = { a: 1 } | { a: 2; b: string };
+declare const value: Choice;
+const out: { a: 1; d: 3 } = value;
+"#,
+    );
+    assert!(
+        msg.contains("to type '{ a: 1; d: 3; }'"),
+        "expected `{{ a: 1; d: 3; }}`, got: {msg}"
+    );
+    assert!(
+        !msg.contains("number"),
+        "no declared literal member may widen to `number`, got: {msg}"
+    );
+}
+
+// 3. String-literal property — widening would turn `"x"` into `string`.
+#[test]
+fn union_source_keeps_string_literal_object_target() {
+    let msg = ts2322(
+        r#"
+type Mode = { kind: "x" } | { kind: "y" };
+declare const mode: Mode;
+const picked: { kind: "x" } = mode;
+"#,
+    );
+    assert!(
+        msg.contains(r#"to type '{ kind: "x"; }'"#),
+        "expected `{{ kind: \"x\"; }}`, got: {msg}"
+    );
+    assert!(
+        !msg.contains("kind: string"),
+        "string-literal target member must not widen, got: {msg}"
+    );
+}
+
+// 4. Nested object literal — the declared literal must survive at depth, not
+//    just the top level.
+#[test]
+fn union_source_keeps_nested_literal_object_target() {
+    let msg = ts2322(
+        r#"
+type Wrapped = { a: 1 } | { a: 2 };
+declare const w: Wrapped;
+const dest: { a: 1; e: { f: 9 } } = w;
+"#,
+    );
+    assert!(
+        msg.contains("e: { f: 9; }"),
+        "expected nested declared literal `{{ f: 9; }}`, got: {msg}"
+    );
+    assert!(
+        !msg.contains("f: number"),
+        "nested literal must not widen, got: {msg}"
+    );
+}
+
+// 5. Renamed binders / different property spellings — the rule is structural,
+//    not keyed on a particular identifier.
+#[test]
+fn renamed_union_source_keeps_literal_object_target() {
+    let msg = ts2322(
+        r#"
+type Selector = { tag: 10 } | { tag: 20 };
+declare const sel: Selector;
+const chosen: { tag: 10 } = sel;
+"#,
+    );
+    assert!(
+        msg.contains("to type '{ tag: 10; }'") && !msg.contains("tag: number"),
+        "expected `{{ tag: 10; }}` with no widening, got: {msg}"
+    );
+}
+
+// 6. The literal target reached through a type alias is still rendered by name
+//    (named declared targets are shown by their alias, never widened).
+#[test]
+fn named_literal_target_keeps_alias_name() {
+    let msg = ts2322(
+        r#"
+type Source = { a: 1 } | { a: 2 };
+interface Target { a: 1 }
+declare const s: Source;
+const t: Target = s;
+"#,
+    );
+    assert!(
+        msg.contains("to type 'Target'") && !msg.contains("a: number"),
+        "expected named target `Target` with no widening, got: {msg}"
+    );
+}
+
+// 7. Negative / unaffected: a concrete (non-union) object source already kept
+//    the declared literal target — pin it so the fix stays symmetric.
+#[test]
+fn concrete_object_source_keeps_literal_object_target() {
+    let msg = ts2322(
+        r#"
+declare const x: { a: 2; b: string };
+const y: { a: 1 } = x;
+"#,
+    );
+    assert!(
+        msg.contains("to type '{ a: 1; }'") && !msg.contains("a: number"),
+        "concrete-source target display must stay `{{ a: 1; }}`, got: {msg}"
+    );
+}
+
+// 8. Negative / unaffected: a *fresh* object literal SOURCE is still widened for
+//    display when assigned to a non-literal-preserving target — the fix only
+//    touches the declared-target side and must not disturb source widening.
+#[test]
+fn fresh_object_literal_source_still_widens_for_nonliteral_target() {
+    let msg = ts2322(
+        r#"
+interface Box { value: boolean }
+const b: Box = { value: 1 };
+"#,
+    );
+    // A property-level TS2322 (`number` not assignable to `boolean`) is what tsc
+    // reports here; the source side is unchanged by this fix.
+    assert!(
+        msg.contains("number") && msg.contains("boolean"),
+        "fresh-source widening behavior must be unchanged, got: {msg}"
+    );
+}


### PR DESCRIPTION
AgentName: lucid-hopper
Track: checker / diagnostics — type display (#12179 family, "stable display" slice)
Invariant: a *declared* assignability target (annotation or named type) is rendered verbatim — including its literal property types at every nesting depth — regardless of the source's shape. Only a genuinely fresh object-literal target is text-widened for display.

## Structural rule

When the **source** of an assignability failure is a union (or any non-object type) and the **target** is an anonymous object type carrying literal-typed properties, `tsc` renders the declared target exactly as written:

```ts
type T = { a: 1 } | { a: 2 };
declare const x: T;
const y: { a: 1 } = x;
//    tsc: Type 'T' is not assignable to type '{ a: 1; }'.
//    tsz (before): Type 'T' is not assignable to type '{ a: number; }'.   ← leaked a type the user never wrote
```

The widening reproduced for string literals (`{ kind: "x" }` → `{ kind: string }`), multiple members (`{ a: 1; d: 3 }` → `{ a: number; d: number }`), and nested objects (`{ a: 1; e: { f: 9 } }` → `{ a: number; e: { f: number } }`). Verified against `tsc` 6.0.2.

## Root cause / owner layer

Owner: checker `error_reporter` display policy (`crates/tsz-checker/src/error_reporter/assignability.rs`).

`rewrite_target_display_for_non_literal_assignability` text-widened **any** anonymous object target with literal members, with no fresh-vs-declared guard. The sibling source-side rewrite (`rewrite_source_display_for_non_literal_target_assignability`) already distinguishes a *fresh* object literal (interns a widened canonical shape — widen for display) from a *declared* annotation/named type (carries canonical literal members — render verbatim) via `source_carries_canonical_literal_member`. The concrete-source path is additionally guarded syntactically in `render_failure/type_mismatch.rs` (`has_declared_target_annotation`), so the leak only surfaced through the union/best-match top-level builder (`format_top_level_assignability_message_types`), which calls the target rewrite unconditionally.

## Fix

Apply the same fresh-vs-declared discipline on the target side: a declared target (no fresh `display_properties`, carrying canonical literal members) is returned verbatim; a fresh object-literal target (with `display_properties`) still widens. The `display_properties` probe is extracted into a shared `type_or_evaluated_has_display_properties` helper used by both the source and target rewrites.

No user-name / file-name / property-name literals; no formatted-string predicate; the decision is purely the structural `display_properties` provenance marker.

## Scope

- `crates/tsz-checker/src/error_reporter/assignability.rs` — declared-target guard + shared `type_or_evaluated_has_display_properties` helper (source side refactored to use it).
- `crates/tsz-checker/src/tests/union_source_literal_target_display_tests.rs` — new regression suite (registered in `lib.rs`).

### Adjacent matrix (new tests, binder/property names varied)

numeric literal target, multiple literal members, string-literal member, nested literal object, renamed binders, named target keeps its alias (negative), concrete-source control (unaffected), fresh object-literal source still widens (negative — source path untouched).

## Project Corpus Impact

- Row: n/a (display-only; no relation/inference/emit change)
- Bug family: #12179 — diagnostics lose root context / **stable display**.
- **Display-only and strictly subtractive of incorrect widening.** `tsc` never widens a declared target, so any currently-passing conformance fixture already produced the non-widened form (this code path did not fire there); the change can only move fixtures failing→passing. Conformance pass-count cannot regress.

## Verification

- New suite `union_source_literal_target_display_tests`: 8/8 pass.
- `cargo test -p tsz-checker --lib`: green except two failures (`zod_type_query_regression_tests::generic_promise_then_flattens_promise_return_from_callback`, `…::zod_cross_file_lib_partial_omit_preserves_imported_path_property`) that are **pre-existing on clean `main`** (verified by stashing this change) and unrelated to display.
- Display integration suites checked (`ts2322_literal_source_display_tests`, `fresh_intersection_display_tests`, `union_target_literal_primitive_mismatch_tests`, `generic_property_mismatch_display_tests`, `async_return_widening_tests`, …): every surfaced failure reproduces identically on clean `main` (pre-existing); no new failures introduced.
- CLI parity vs `tsc` 6.0.2 on the union-source → literal-object-target repro family (numeric/string/multiple/nested): all match.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib` clean.
- `/simplify` run 3×: pass 1 extracted the shared `display_properties` helper; passes 2–3 confirmed clean.

## Coordination Notes

This lands the "declared literal-typed target display" slice of #12179. It is distinct from the alias-chain helper-name leak (#10914), whose headline was fixed in #12839. No open PR touches `rewrite_target_display_for_non_literal_assignability`; checked before coding. Branch `claude/lucid-hopper-Hript`.

https://claude.ai/code/session_01GiaKVTNzSy6edhGiiN1cZY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GiaKVTNzSy6edhGiiN1cZY)_