### PR TITLE
fix(solver): reduce conditional-bodied alias applications to any resolved shape (#10914)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1549,6 +1549,23 @@ impl<'a> CheckerState<'a> {
                 // registration below to stay clear of free type parameters and
                 // self-referential cycles, and only runs once the cheap
                 // structural gates above have matched.
+                //
+                // The shape gate stays object/mapped-only here on purpose,
+                // even though the solver formatter's
+                // `reducing_conditional_application_display` reduces *every*
+                // resolved shape (scalar, tuple, union, object) for direct and
+                // nested `Application` display. The two paths own different
+                // surfaces: the formatter renders an application node in place,
+                // whereas marking a body "computed" here also drives the def
+                // store's `find_type_alias_by_body` reverse lookup. A reduced
+                // *scalar* never needs the mark (a primitive-bodied alias
+                // already displays as its underlying type), and a reduced
+                // *tuple*/*union* shares its interned `TypeId` with any
+                // directly-written alias of the same shape — marking it
+                // "computed" would let that shared shape repaint the structural
+                // result with the colliding alias's name. So this top-level
+                // name-display gate stays conservative; the formatter owns the
+                // broader shape reduction where no reverse lookup intervenes.
                 let reducing_object_application = alias_is_non_generic
                     && diagnostic_query::application_base_has_conditional_alias_body(
                         self.ctx.types.as_type_database(),

--- a/crates/tsz-checker/tests/conditional_alias_source_display_tests.rs
+++ b/crates/tsz-checker/tests/conditional_alias_source_display_tests.rs
@@ -177,3 +177,78 @@ fn deferred_generic_conditional_keeps_alias_name() {
         diag.message_text
     );
 }
+
+/// Core #10914 repro: a *recursive* conditional-bodied alias must expand to a
+/// fully resolved structural type — every nested helper application, down to
+/// the scalar leaves, drops its name. tsc 6.0.2 renders
+/// `{ readonly a: { readonly b: number; }; readonly c: string; }`, never
+/// leaking `DeepReadonly<number>` / `DeepReadonly<string>` internals.
+#[test]
+fn recursive_conditional_alias_expands_fully_without_leaking_helper_names() {
+    let diags = check_strict(
+        "type DeepRO<V> = V extends object ? { readonly [K in keyof V]: DeepRO<V[K]> } : V;\n\
+         type Settings = { a: { b: number }; c: string };\n\
+         const bad: number = (null as any as DeepRO<Settings>);\n",
+    );
+    let diag = single(&diags, 2322);
+    assert!(
+        diag.message_text.contains(
+            "Type '{ readonly a: { readonly b: number; }; readonly c: string; }' \
+             is not assignable to type 'number'"
+        ),
+        "recursive conditional alias must expand fully to the resolved object; got: {}",
+        diag.message_text
+    );
+    assert!(
+        !diag.message_text.contains("DeepRO<"),
+        "no internal helper application may leak into the diagnostic; got: {}",
+        diag.message_text
+    );
+}
+
+/// A conditional-bodied alias application that reduces to a *scalar* drops its
+/// alias name like the object case — tsc renders `number`, never
+/// `DeepRO<number>`. Binder names differ from the recursive case so the
+/// rendering is proven structural.
+#[test]
+fn conditional_alias_reducing_to_scalar_shows_resolved_scalar() {
+    let diags = check_strict(
+        "type DeepRO<W> = W extends object ? { readonly [P in keyof W]: DeepRO<W[P]> } : W;\n\
+         const bad: 1 = (null as any as DeepRO<number>);\n",
+    );
+    let diag = single(&diags, 2322);
+    assert!(
+        diag.message_text
+            .contains("Type 'number' is not assignable to type '1'"),
+        "a scalar-reducing conditional alias must show the resolved scalar; got: {}",
+        diag.message_text
+    );
+    assert!(
+        !diag.message_text.contains("DeepRO<"),
+        "the reduced conditional must drop its alias name; got: {}",
+        diag.message_text
+    );
+}
+
+/// A conditional-bodied alias application that reduces (non-distributively) to a
+/// *union* shows the resolved union, not the application form. tsc 6.0.2
+/// renders `"a" | "b"`.
+#[test]
+fn conditional_alias_reducing_to_union_branch_shows_resolved_union() {
+    let diags = check_strict(
+        "type FirstTwo<S> = S extends string ? \"a\" | \"b\" : never;\n\
+         const bad: 1 = (null as any as FirstTwo<\"x\">);\n",
+    );
+    let diag = single(&diags, 2322);
+    assert!(
+        diag.message_text
+            .contains("Type '\"a\" | \"b\"' is not assignable to type '1'"),
+        "a union-reducing conditional must show the resolved union; got: {}",
+        diag.message_text
+    );
+    assert!(
+        !diag.message_text.contains("FirstTwo<"),
+        "the reduced conditional must drop its alias name; got: {}",
+        diag.message_text
+    );
+}

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -300,15 +300,19 @@ impl<'a> TypeFormatter<'a> {
     /// A non-distributive application of a generic alias whose *declared body is
     /// a conditional type* loses its alias symbol when the conditional resolves:
     /// the operator resolves into its branch and never stamps the enclosing
-    /// alias onto anonymous object/mapped results, so tsc renders those results
-    /// structurally (`DeepReadonly<{ b: number }>` →
-    /// `{ readonly b: number; }`, issue #10914), not as `Name<Args>`.
+    /// alias onto the result, so tsc renders the resolved type structurally for
+    /// any shape — scalar (`DeepReadonly<number>` → `number`), tuple
+    /// (`Parameters<F>` → `[a: number]`), union (`A | B`), and object
+    /// (`DeepReadonly<{ b: number }>` → `{ readonly b: number; }`, issue
+    /// #10914) alike — not as `Name<Args>`.
     ///
     /// Returns the evaluated type to format in place of the application form.
-    /// Returns `None` for a mapped/object-bodied application (`Partial<T>` keeps
-    /// its alias symbol), for a result that stays generic, and for a result that
-    /// fails to reduce (a still-deferred conditional), so those keep their
-    /// existing display. The distributive form is handled earlier by
+    /// Returns `None` only when the conditional cannot drop its name: a
+    /// mapped/object-bodied application (`Partial<T>` keeps its alias symbol)
+    /// fails the structural gate, a result that stays generic is rejected
+    /// above, and a result that fails to reduce (a still-deferred conditional,
+    /// or one whose evaluation made no progress) keeps the application form.
+    /// The distributive form is handled earlier by
     /// [`Self::distributed_conditional_application_display`].
     fn reducing_conditional_application_display(&self, type_id: TypeId) -> Option<TypeId> {
         let def_store = self.def_store?;
@@ -348,14 +352,25 @@ impl<'a> TypeFormatter<'a> {
         }
         // A conditional still deferred after evaluation never reduced (an
         // unresolved operand); the raw node is no more informative than the
-        // application form, so keep the application form. Non-object results
-        // also keep the application surface; expanding tuple/scalar helper
-        // applications produces conformance fingerprint drift in assignment
-        // diagnostics where tsc preserves the helper spelling.
+        // application form, so keep the application form. A result identical to
+        // the application itself made no progress, so keep it too — formatting
+        // it again would recurse forever.
+        //
+        // Every *resolved* shape reduces, not just objects: `tsc` drops the
+        // alias `aliasSymbol` once a non-distributive conditional resolves with
+        // concrete arguments, then renders the resolved type structurally for
+        // any shape — scalar (`DeepReadonly<number>` → `number`,
+        // `IsString<number>` → `false`), tuple (`Parameters<F>` →
+        // `[a: number]`), union (`T extends X ? A | B : C` → `A | B`), and
+        // object alike (issue #10914, verified against `tsc` 6.0.2). A result
+        // that is itself a *named* target re-paints its own name through the
+        // formatter's named-type path, so only the dropped outer alias is
+        // suppressed; distributive conditionals keep the outer alias on the
+        // separate distribution path above.
         if matches!(
             self.interner.lookup(evaluated),
             Some(TypeData::Conditional(_))
-        ) || !crate::type_queries::is_object_or_mapped_type(self.interner, evaluated)
+        ) || evaluated == type_id
         {
             return None;
         }

--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
@@ -859,7 +859,7 @@ fn conditional_alias_application_resolving_to_object_renders_structurally() {
 }
 
 #[test]
-fn conditional_alias_application_resolving_to_tuple_keeps_application_surface() {
+fn conditional_alias_application_resolving_to_tuple_renders_structurally() {
     let db = TypeInterner::new();
     let def_store = crate::def::DefinitionStore::new();
 
@@ -891,11 +891,18 @@ fn conditional_alias_application_resolving_to_tuple_keeps_application_surface() 
     let app = db.application(db.lazy(tuple_box_def), vec![TypeId::STRING]);
     let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
 
+    // `TupleBox<string>` reduces (non-distributively) to `[string]`; the
+    // resolved conditional drops the alias `aliasSymbol`, so tsc renders the
+    // resolved tuple structurally, never `TupleBox<string>` (issue #10914,
+    // verified against tsc 6.0.2: `type TupleBox<T> = T extends string ? [T]
+    // : never; TupleBox<string>` elaborates as `[string]`). Every resolved
+    // shape reduces — scalar, tuple, union, and object alike — not just
+    // anonymous object/mapped results.
     assert_eq!(
         fmt.format(app),
-        "TupleBox<string>",
-        "Only anonymous object/mapped conditional alias application results \
-         expand structurally; tuple results keep the application surface"
+        "[string]",
+        "A resolved conditional alias application must render its resolved \
+         shape structurally, including tuple results"
     );
 }
 


### PR DESCRIPTION
Fixes #10914.

AgentName: lucid-hopper

## Track
Diagnostics / type display — conditional-bodied type-alias application rendering parity with `tsc`.

## Invariant
When a non-distributive conditional-bodied generic-alias application resolves with concrete arguments, `tsz` renders the resolved type structurally for **every** shape (scalar, tuple, union, object), exactly as `tsc` does once the conditional drops its `aliasSymbol` — and keeps the alias/application form only for a still-deferred conditional or a result that stays generic.

## Summary
PR #12839 fixed the top-level object reduction for #10914 but its follow-up restricted the solver formatter's `reducing_conditional_application_display` to **object/mapped** results only. That left the scalar and tuple **leaves** of a recursive utility leaking internal helper names into diagnostics. For `type DeepReadonly<T> = T extends object ? { readonly [K in keyof T]: DeepReadonly<T[K]> } : T;` applied as `DeepReadonly<{ a: { b: number }; c: string }>`:

| compiler | TS2322 source-type display |
|---|---|
| `tsc` 6.0.2 | `{ readonly a: { readonly b: number; }; readonly c: string; }` |
| `tsz` (before) | `{ readonly a: { readonly b: DeepReadonly<number>; }; readonly c: DeepReadonly<string>; }` |
| `tsz` (after) | `{ readonly a: { readonly b: number; }; readonly c: string; }` ✓ (byte-identical to `tsc`) |

### Structural rule
> When a conditional-bodied alias application resolves (non-distributively, with concrete arguments) to a concrete type, `tsc` drops the alias `aliasSymbol` and renders that type structurally for any shape — scalar, tuple, union, object alike. It keeps the application form only for a still-deferred conditional or a result that stays generic; a result that is itself a *named* target re-paints its own name through the formatter's named-type path; distributive conditionals stay on the separate distribution path.

The guard now drops the object-only restriction and instead keeps the application form only when the result is a still-deferred `Conditional` or made no progress (`evaluated == type_id`).

## Scope
- `crates/tsz-solver/src/diagnostics/format/mod.rs` — `reducing_conditional_application_display`: object-only gate → "still-deferred / no-progress" gate; doc + inline comments updated.
- `crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs` — corrected the unit test that asserted tuple results keep the application surface to the `tsc`-verified structural form (`[string]`).
- `crates/tsz-checker/src/state/type_analysis/core.rs` — comment-only: documents why the **top-level name-display gate stays object/mapped-only on purpose**. That gate also drives the def-store `find_type_alias_by_body` reverse lookup, where a reduced tuple/union shares its interned `TypeId` with a directly-written alias of the same shape and would be repainted with the colliding name; the solver formatter owns the broader shape reduction where no reverse lookup intervenes.
- `crates/tsz-checker/tests/conditional_alias_source_display_tests.rs` — 3 new regression tests (recursive full expansion, scalar leaf, union branch).

### Owner layer
Solver formatter (`tsz-solver::diagnostics::format`). The checker change is comment-only; type-shape inspection stays on the `query_boundaries` gateway and the printer reads types, never the reverse.

## Adjacent-case matrix (binder names varied)
- recursive `DeepReadonly` → fully resolved object (no leaked helper names)
- conditional → scalar (`number`, `false`), tuple (`[a: number, b: string]`), union (`"a" | "b"`)
- `ReturnType` / `Parameters` / `Awaited` / `NonNullable` reductions
- **negative controls:** mapped-bodied `Partial<T>` / `MyReadonly<Shape>` keeps its name; deferred-generic `Tail<U>` keeps its `Alias<T>` form; distributive conditionals keep the outer alias on the distribution path.

## Project Corpus Impact
- Row: utility-types-project (alias chains in recursive errors no longer render internal helper names)
- Bug family: type-display / diagnostic-chain (#10914)
- Verified `tsz` vs `tsc` 6.0.2 differentially across the matrix above; every case matches. The change can only improve scalar/tuple/union-reducing fixtures (old `tsz` showed the application form, which `tsc` never does for a resolved non-distributive conditional). The one corner where a reduced tuple/union coincides with a separately-named alias is a pre-existing def-store reverse-lookup limitation shared by the already-shipped object path, kept out of scope by the intentional checker-side conservatism described above.

## Verification
- `cargo fmt --check` clean; `git diff --check` clean.
- `cargo clippy -p tsz-solver -p tsz-checker --lib` clean.
- `cargo test -p tsz-solver --lib diagnostics::format` — 221 pass, 0 fail.
- `cargo test -p tsz-checker --test conditional_alias_source_display_tests` — 10 pass (incl. 3 new), 0 fail (post-rebase onto current `main`).
- Differential `tsz` vs `tsc` 6.0.2 on a 12-case matrix — all match.
- Broad conformance owned by ready-review CI per repo contract.

## Coordination Notes
Continues #12839 (which fixed the top-level object case and left scalar/tuple/union leaves restricted). No open PR targets #10914; prior `confident-hawking` / `lucid-hopper` claim branches were never pushed. Rebased onto current `origin/main` (ec6313a); clean, no conflicts; none of the touched files were modified by recent `main` commits.

https://claude.ai/code/session_01NEnCNbVjjsryQEQDoo74tJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEnCNbVjjsryQEQDoo74tJ)_