### PR TITLE
fix(resolver): unify tsconfig `paths` wildcard-target substitution across resolvers (#12181)

### DIFF
--- a/crates/tsz-cli/src/driver/resolution/path_resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution/path_resolution.rs
@@ -250,7 +250,12 @@ fn paths_mapping_candidates(
     let base = options.base_url.as_deref().unwrap_or(base_dir);
     let mut candidates = Vec::new();
     for target in &mapping.targets {
-        let substituted = substitute_path_target(target, &wildcard);
+        // Route through the shared `PathMapping::substitute_target` so the
+        // driver and the `tsz-core` resolver substitute wildcard targets
+        // identically (tsc replaces only the first `*`; an exact-key target is
+        // used verbatim). A divergent replace-all here would mint a different
+        // file identity than the resolver for any target with two `*`.
+        let substituted = mapping.substitute_target(target, &wildcard);
         let path = if Path::new(&substituted).is_absolute() {
             PathBuf::from(substituted)
         } else {
@@ -338,14 +343,6 @@ pub(crate) fn select_path_mapping(
     // through to a less-specific pattern when the chosen one's targets are
     // missing on disk.
     PathMapping::select_best(mappings, specifier)
-}
-
-pub(crate) fn substitute_path_target(target: &str, wildcard: &str) -> String {
-    if target.contains('*') {
-        target.replace('*', wildcard)
-    } else {
-        target.to_string()
-    }
 }
 
 pub(crate) fn expand_module_path_candidates(

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -1440,6 +1440,15 @@ fn build_path_mappings(paths: &FxHashMap<String, Vec<String>>) -> Vec<PathMappin
             continue;
         }
         let pattern = normalize_path_pattern(pattern);
+        // tsc's `tryParsePattern` returns `undefined` for a key containing more
+        // than one `*`, so `tryParsePatterns` drops it from path mapping
+        // entirely. `split_path_pattern` only consults the first `*`, so a
+        // multi-`*` key would otherwise build a bogus `prefix`/`suffix` and
+        // match specifiers tsc never maps. Reject it here, at the parser, so no
+        // such mapping ever reaches either resolver.
+        if pattern.matches('*').count() > 1 {
+            continue;
+        }
         let targets = targets
             .iter()
             .map(|target| normalize_path_pattern(target))

--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -212,6 +212,16 @@ impl PathMapping {
             return (self.pattern == specifier).then(String::new);
         }
 
+        // tsc's `tryParsePattern` returns `undefined` for a key containing more
+        // than one `*`: such a key is neither an exact match nor a usable
+        // single-`*` wildcard, so `tryParsePatterns` drops it from path mapping
+        // entirely. Honoring only the first `*` (as `split_path_pattern` does
+        // when it builds `prefix`/`suffix`) would let the key match and mint a
+        // file identity tsc never produces.
+        if self.pattern.matches('*').count() > 1 {
+            return None;
+        }
+
         if !specifier.starts_with(&self.prefix) || !specifier.ends_with(&self.suffix) {
             return None;
         }
@@ -227,6 +237,32 @@ impl PathMapping {
 
     pub const fn specificity(&self) -> usize {
         self.prefix.len()
+    }
+
+    /// Substitute the wildcard text captured by [`match_specifier`](Self::match_specifier)
+    /// into one of this mapping's targets, mirroring tsc's
+    /// `tryLoadModuleUsingPaths`:
+    ///
+    /// - For a wildcard key, tsc computes `subst.replace("*", matchedStar)`.
+    ///   JavaScript's `String.prototype.replace` with a string pattern replaces
+    ///   only the **first** `*`, so a target like `"./gen/*/*.js"` becomes
+    ///   `"./gen/<star>/*.js"` — the trailing `*` is left untouched. A target
+    ///   with no `*` is used verbatim.
+    /// - For an exact, wildcard-free key, tsc leaves `matchedStar` undefined and
+    ///   uses the target verbatim (`path = subst`), so a literal `*` in the
+    ///   target is preserved rather than stripped.
+    ///
+    /// Both the `tsz-core` resolver and the CLI driver route tsconfig-`paths`
+    /// target substitution through this one method so the substituted path — and
+    /// thus the file identity it resolves to — cannot drift between them. (Node
+    /// package `exports`/`imports` substitution is a separate Node-spec concern
+    /// and does not use this method.)
+    pub fn substitute_target(&self, target: &str, captured: &str) -> String {
+        if self.pattern.contains('*') {
+            target.replacen('*', captured, 1)
+        } else {
+            target.to_string()
+        }
     }
 
     /// Select the single tsc-best mapping in `mappings` for `specifier`,
@@ -965,5 +1001,74 @@ mod path_mapping_selection_tests {
     fn no_match_returns_none() {
         let mappings = vec![mapping("@app/*", &["./src/*"])];
         assert!(PathMapping::select_best(&mappings, "unrelated/thing").is_none());
+    }
+
+    #[test]
+    fn multi_star_key_is_dropped_like_tsc_try_parse_pattern() {
+        // tsc's `tryParsePattern` returns `undefined` for a key with two `*`,
+        // so the key never matches anything. Honoring only its first `*` would
+        // wrongly match the specifier on `prefix`/`suffix`.
+        let two_star = mapping("a/*/*", &["./x/*"]);
+        assert_eq!(two_star.match_specifier("a/foo/bar"), None);
+        assert_eq!(two_star.match_specifier("a/foo//"), None);
+
+        // A dropped multi-`*` key must not win selection over a valid catch-all.
+        let mappings = vec![
+            mapping("a/*/*", &["./wrong/*"]),
+            mapping("*", &["./types/*"]),
+        ];
+        let (idx, star) =
+            PathMapping::select_best(&mappings, "a/foo/bar").expect("catch-all must match");
+        assert_eq!(mappings[idx].pattern, "*");
+        assert_eq!(star, "a/foo/bar");
+    }
+
+    #[test]
+    fn single_star_key_still_matches() {
+        // The multi-`*` guard must not regress an ordinary single-`*` wildcard.
+        let one_star = mapping("@app/*", &["./src/*"]);
+        assert_eq!(
+            one_star.match_specifier("@app/util"),
+            Some("util".to_string())
+        );
+    }
+
+    #[test]
+    fn wildcard_target_substitutes_only_first_star() {
+        // tsc uses `subst.replace("*", matchedStar)`, which replaces only the
+        // first `*`. A target with a second `*` keeps it verbatim.
+        let m = mapping("@gen/*", &["./gen/*/*.js"]);
+        let star = m.match_specifier("@gen/foo").expect("wildcard matches");
+        assert_eq!(m.substitute_target(&m.targets[0], &star), "./gen/foo/*.js");
+    }
+
+    #[test]
+    fn wildcard_target_without_star_is_used_verbatim() {
+        let m = mapping("@fallback/*", &["./shim.d.ts"]);
+        let star = m
+            .match_specifier("@fallback/anything")
+            .expect("wildcard matches");
+        assert_eq!(m.substitute_target(&m.targets[0], &star), "./shim.d.ts");
+    }
+
+    #[test]
+    fn wildcard_target_with_empty_capture_substitutes_empty() {
+        // Specifier equal to prefix+suffix captures an empty `*`; tsc still
+        // substitutes (the empty string), unlike an exact key.
+        let m = mapping("@app/*", &["./src/*"]);
+        let star = m.match_specifier("@app/").expect("empty capture matches");
+        assert_eq!(star, "");
+        assert_eq!(m.substitute_target(&m.targets[0], &star), "./src/");
+    }
+
+    #[test]
+    fn exact_key_target_is_used_verbatim_keeping_literal_star() {
+        // For an exact, wildcard-free key tsc leaves `matchedStar` undefined and
+        // uses the target verbatim (`path = subst`), so a literal `*` in the
+        // target is preserved rather than stripped.
+        let m = mapping("foo", &["./bar/*"]);
+        let star = m.match_specifier("foo").expect("exact key matches");
+        assert_eq!(star, "");
+        assert_eq!(m.substitute_target(&m.targets[0], &star), "./bar/*");
     }
 }

--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -212,16 +212,10 @@ impl PathMapping {
             return (self.pattern == specifier).then(String::new);
         }
 
-        // tsc's `tryParsePattern` returns `undefined` for a key containing more
-        // than one `*`: such a key is neither an exact match nor a usable
-        // single-`*` wildcard, so `tryParsePatterns` drops it from path mapping
-        // entirely. Honoring only the first `*` (as `split_path_pattern` does
-        // when it builds `prefix`/`suffix`) would let the key match and mint a
-        // file identity tsc never produces.
-        if self.pattern.matches('*').count() > 1 {
-            return None;
-        }
-
+        // Keys with more than one `*` are rejected up front by
+        // `build_path_mappings` (mirroring tsc's `tryParsePattern`), so every
+        // mapping that reaches here has exactly one `*` and a well-formed
+        // `prefix`/`suffix`.
         if !specifier.starts_with(&self.prefix) || !specifier.ends_with(&self.suffix) {
             return None;
         }
@@ -1004,19 +998,25 @@ mod path_mapping_selection_tests {
     }
 
     #[test]
-    fn multi_star_key_is_dropped_like_tsc_try_parse_pattern() {
-        // tsc's `tryParsePattern` returns `undefined` for a key with two `*`,
-        // so the key never matches anything. Honoring only its first `*` would
-        // wrongly match the specifier on `prefix`/`suffix`.
-        let two_star = mapping("a/*/*", &["./x/*"]);
-        assert_eq!(two_star.match_specifier("a/foo/bar"), None);
-        assert_eq!(two_star.match_specifier("a/foo//"), None);
+    fn multi_star_key_is_dropped_at_build_like_tsc_try_parse_pattern() {
+        use super::build_path_mappings;
+        use rustc_hash::FxHashMap;
 
-        // A dropped multi-`*` key must not win selection over a valid catch-all.
-        let mappings = vec![
-            mapping("a/*/*", &["./wrong/*"]),
-            mapping("*", &["./types/*"]),
-        ];
+        // tsc's `tryParsePattern` returns `undefined` for a key with two `*`, so
+        // `tryParsePatterns` never builds a mapping for it. `build_path_mappings`
+        // must drop it at the parser so it can never match a specifier (which it
+        // would, on its mis-derived first-`*` `prefix`/`suffix`).
+        let mut paths: FxHashMap<String, Vec<String>> = FxHashMap::default();
+        paths.insert("a/*/*".to_string(), vec!["./wrong/*".to_string()]);
+        paths.insert("*".to_string(), vec!["./types/*".to_string()]);
+
+        let mappings = build_path_mappings(&paths);
+        assert!(
+            mappings.iter().all(|m| m.pattern != "a/*/*"),
+            "multi-`*` key must be dropped at build time"
+        );
+
+        // With the malformed key gone, only the valid catch-all can match.
         let (idx, star) =
             PathMapping::select_best(&mappings, "a/foo/bar").expect("catch-all must match");
         assert_eq!(mappings[idx].pattern, "*");

--- a/crates/tsz-core/src/module_resolver/path_mapping.rs
+++ b/crates/tsz-core/src/module_resolver/path_mapping.rs
@@ -2,7 +2,6 @@
 
 use super::{ModuleExtension, ModuleResolver, PackageType, ResolvedModule};
 use crate::config::PathMapping;
-use crate::resolution::helpers::apply_wildcard_substitution;
 use std::path::Path;
 
 pub(super) struct PathMappingAttempt {
@@ -52,7 +51,11 @@ impl ModuleResolver {
         // Only the chosen pattern's targets are probed; a miss does not fall
         // through to any other pattern.
         for target in &mapping.targets {
-            let substituted = apply_wildcard_substitution(target, &star_match, false);
+            // tsc's `tryLoadModuleUsingPaths` replaces only the first `*` of a
+            // wildcard target and uses an exact-key target verbatim; the shared
+            // `PathMapping::substitute_target` owns that rule so this resolver
+            // and the CLI driver cannot drift.
+            let substituted = mapping.substitute_target(target, &star_match);
             let candidate = base.join(&substituted);
 
             if let Some(resolved) = self.try_file_or_directory(&candidate, importer_package_type) {


### PR DESCRIPTION
AgentName: claude-brave-volta-m4o7h

Track: module-resolution (bug-family #12181 — module/file identity drift)

## Invariant
When `tsc` maps a specifier through a tsconfig `paths` entry, the resolved file
identity is the same regardless of which resolver runs. tsz had two resolvers
(`tsz-core` checker resolver and the CLI driver) that each implemented `paths`
wildcard-target substitution and **diverged from each other and from tsc**, so
the same import could mint a different canonical file identity per pass — exactly
the drift tracked by #12181.

Structural rule (`When <condition>, tsc does X; tsz does X through <owner>`):
- **When a wildcard `paths` key maps to a target containing `*`**, tsc replaces
  only the **first** `*` (`subst.replace("*", matchedStar)` — JS string replace
  is single-shot). tsz now does this through the single shared owner
  `PathMapping::substitute_target`. (Previously the CLI driver used
  `str::replace`, replacing **all** `*`, while the core resolver used
  `replacen(.., 1)` — a cross-resolver identity drift on any 2-`*` target.)
- **When an exact, wildcard-free key maps to a target containing `*`**, tsc
  leaves `matchedStar` undefined and uses the target verbatim (`path = subst`),
  keeping the literal `*`. tsz now preserves it instead of stripping it.
- **When a `paths` key contains more than one `*`**, tsc's `tryParsePattern`
  returns `undefined` and `tryParsePatterns` drops the key entirely. tsz now
  rejects it in `build_path_mappings` (the parser), so a malformed key never
  becomes a `PathMapping` and can never match a specifier on a mis-derived
  first-`*` `prefix`/`suffix`.

## Scope
- `crates/tsz-core/src/config/resolved_options.rs` — new shared owner
  `PathMapping::substitute_target`; `match_specifier` now documents that
  multi-`*` keys are rejected at build time.
- `crates/tsz-core/src/config/mod.rs` — `build_path_mappings` drops multi-`*`
  keys (tsc `tryParsePatterns` parity), at the parser, once per config build.
- `crates/tsz-core/src/module_resolver/path_mapping.rs` — core resolver routes
  target substitution through `PathMapping::substitute_target`.
- `crates/tsz-cli/src/driver/resolution/path_resolution.rs` — CLI driver routes
  through the same owner; removed the divergent `substitute_path_target`
  (`str::replace`).
- Node package `exports`/`imports` substitution (`apply_wildcard_substitution`,
  with its directory-match branch) is intentionally **unchanged** — a separate
  Node-spec path.

## Project Corpus Impact
- Row: n/a (no single project row; hardens tsconfig `paths` identity broadly across rows)
- Bug family: module-resolution (#12181)

No row regressions expected. The two divergences only differ from the previous
behavior for `paths` targets/keys containing two or more `*` (rare, malformed,
or multi-segment generated targets) and for exact keys whose target contains a
literal `*`. Common single-`*` wildcard rows are byte-for-byte identical (the
core resolver already used `replacen(.., 1)`). The fix makes the CLI driver
agree with the core resolver and with tsc, removing a class of cross-pass
identity drift rather than changing well-formed resolutions.

## Verification
- `cargo test -p tsz-core --lib config::resolved_options::path_mapping_selection_tests`
  — 9 passed (6 new tests: first-`*`-only substitution, exact-key verbatim
  with literal `*`, empty-capture, wildcard target without `*`, single-`*`
  regression guard, and build-time multi-`*` drop).
- `cargo test -p tsz-core --lib pattern_matching` — 14 passed (Node
  exports/imports substitution unchanged).
- `cargo test -p tsz-core --lib module_resol` — 407 passed.
- `cargo test -p tsz-core --lib config::tests::module_resolution` — 78 passed.
- `cargo test -p tsz-cli --lib paths_imports` — 8 passed.
- `cargo test -p tsz-cli --lib resolution::` — 83 passed.
- `cargo fmt -p tsz-core -p tsz-cli -- --check` — clean; `cargo clippy -p tsz-core -p tsz-cli` — clean.
- Anti-hardcoding: no user-name/file-name literals; tests vary binder names
  (`@app`, `@gen`, `@fallback`, `foo`, `a/*/*`); decisions are purely structural
  (`*` count / first-`*` substitution), no rendered-string predicates.

## Coordination Notes
Claims one concrete, broadly-applicable slice of the #12181 family (the shared
`paths` substitution/parse owner). Issue #12181 marked WIP. The fix establishes
a single owner for every tsconfig-`paths` concern — parse (`build_path_mappings`),
select (`select_best`), substitute (`substitute_target`) — so the two resolvers
cannot drift here again.