### PR TITLE
perf(checker): trim per-pass allocations in the duplicate-identifier pass (#11617)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1618,6 +1618,10 @@ name = "global_augmentation_const_enum_rebind_tests"
 path = "tests/global_augmentation_const_enum_rebind_tests.rs"
 
 [[test]]
+name = "duplicate_identifier_grouping_allocation_tests"
+path = "tests/duplicate_identifier_grouping_allocation_tests.rs"
+
+[[test]]
 name = "type_alias_signature_body_validation_tests"
 path = "tests/type_alias_signature_body_validation_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers.rs
@@ -46,61 +46,19 @@ impl<'a> CheckerState<'a> {
             .and_then(|m| crate::context::lookup_is_external_module_in_map(m, &self.ctx.file_name))
             .unwrap_or_else(|| self.ctx.binder.is_external_module());
 
-        // When libs are loaded, scope tables contain ~2000+ merged lib symbols alongside
-        // user symbols. Processing all of them in the loops below is a 40-50ms bottleneck
-        // per file due to HashMap lookups for each symbol's declarations.
-        // Optimization: pre-build a set of user-code symbols from node_symbols, then
-        // intersect with non-class scope symbols to preserve the Class-scope exclusion.
-        let mut symbol_ids: FxHashSet<tsz_binder::SymbolId> = if has_libs {
-            let user_syms: FxHashSet<tsz_binder::SymbolId> =
-                self.ctx.binder.node_symbols.values().copied().collect();
-            let mut result = FxHashSet::default();
-            if !self.ctx.binder.scopes.is_empty() {
-                for scope in self.ctx.binder.scopes.iter() {
-                    if scope.kind == tsz_binder::ContainerKind::Class {
-                        continue;
-                    }
-                    for (_, &id) in scope.table.iter() {
-                        if user_syms.contains(&id) {
-                            result.insert(id);
-                        }
-                    }
-                }
-            } else {
-                for (_, &id) in self.ctx.binder.file_locals.iter() {
-                    if user_syms.contains(&id) {
-                        result.insert(id);
-                    }
-                }
-            }
-            result
-        } else {
-            // No libs: use scope tables or file_locals (all are user symbols)
-            let mut result = FxHashSet::default();
-            if !self.ctx.binder.scopes.is_empty() {
-                for scope in self.ctx.binder.scopes.iter() {
-                    if scope.kind == tsz_binder::ContainerKind::Class {
-                        continue;
-                    }
-                    for (_, &id) in scope.table.iter() {
-                        result.insert(id);
-                    }
-                }
-            } else {
-                for (_, &id) in self.ctx.binder.file_locals.iter() {
-                    result.insert(id);
-                }
-            }
-            result
-        };
+        // Collect the user-code symbols this file's pass must examine. When libs
+        // are loaded this skips the merged lib symbols that share the scope tables
+        // (see `collect_duplicate_check_symbol_ids`).
+        let mut symbol_ids = self.collect_duplicate_check_symbol_ids(has_libs);
 
         // Declarations inside `declare module {}` / `declare global {}` blocks are not
         // guaranteed to appear in top-level scope tables, but they still participate in
         // duplicate-name checks for the current file.
         self.extend_duplicate_symbol_ids_with_local_augmentation_decls(&mut symbol_ids);
         let mut cross_file_conflicts = Vec::new();
+        // One entry per distinct symbol name; bounded by the symbol set (#11617).
         let mut global_scope_conflict_cache: FxHashMap<String, DuplicateDeclList> =
-            FxHashMap::default();
+            FxHashMap::with_capacity_and_hasher(symbol_ids.len(), Default::default());
         let may_have_default_import_alias_conflicts = !is_external_module
             && self.ctx.all_arenas.is_some()
             && self.current_file_has_named_default_export_identifier();
@@ -725,8 +683,12 @@ impl<'a> CheckerState<'a> {
                             .collect();
 
                         type ScopeGroupEntry = (NodeIndex, u32, u32, bool);
+                        // At most one distinct scope per declaration (#11617).
                         let mut scope_groups: FxHashMap<NodeIndex, Vec<ScopeGroupEntry>> =
-                            FxHashMap::default();
+                            FxHashMap::with_capacity_and_hasher(
+                                decl_info.len(),
+                                Default::default(),
+                            );
                         for &(decl_idx, flags, space, exported, scope) in &decl_info {
                             scope_groups
                                 .entry(scope)
@@ -799,7 +761,7 @@ impl<'a> CheckerState<'a> {
             if interface_decls.len() > 1 {
                 use tsz_binder::SymbolId;
                 let mut interface_decls_by_scope: FxHashMap<SymbolId, Vec<NodeIndex>> =
-                    FxHashMap::default();
+                    FxHashMap::with_capacity_and_hasher(interface_decls.len(), Default::default());
                 for &decl_idx in &interface_decls {
                     let scope = self.get_enclosing_namespace_symbol(decl_idx);
                     interface_decls_by_scope
@@ -842,7 +804,11 @@ impl<'a> CheckerState<'a> {
                 .collect();
             if class_interface_decls.len() > 1 {
                 use tsz_binder::SymbolId;
-                let mut decls_by_scope: FxHashMap<SymbolId, Vec<NodeIndex>> = FxHashMap::default();
+                let mut decls_by_scope: FxHashMap<SymbolId, Vec<NodeIndex>> =
+                    FxHashMap::with_capacity_and_hasher(
+                        class_interface_decls.len(),
+                        Default::default(),
+                    );
                 for &decl_idx in &class_interface_decls {
                     let scope = self.get_enclosing_namespace_symbol(decl_idx);
                     decls_by_scope.entry(scope).or_default().push(decl_idx);
@@ -1533,8 +1499,14 @@ impl<'a> CheckerState<'a> {
                     .map(|(idx, _, _, _, _)| (*idx, self.get_enclosing_block_scope(*idx)))
                     .collect();
 
-                let mut scope_groups: std::collections::HashMap<NodeIndex, Vec<NodeIndex>> =
-                    std::collections::HashMap::new();
+                // Group duplicate function implementations by block scope via the
+                // fast `FxHashMap` (not the default SipHash map), pre-sized to the
+                // candidate count (#11617).
+                let mut scope_groups: FxHashMap<NodeIndex, Vec<NodeIndex>> =
+                    FxHashMap::with_capacity_and_hasher(
+                        func_impls_with_scope.len(),
+                        Default::default(),
+                    );
                 for &(idx, scope) in &func_impls_with_scope {
                     scope_groups.entry(scope).or_default().push(idx);
                 }

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_merge.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_merge.rs
@@ -52,23 +52,27 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
 
-            let member_nodes: Vec<NodeIndex> = match node.kind {
+            // Borrow the member list rather than clone: the loop only reads from
+            // `&self` (member-name and visibility queries), so the arena borrow
+            // persists across iterations instead of allocating a fresh `Vec` per
+            // merged class / interface declaration.
+            let member_nodes: &[NodeIndex] = match node.kind {
                 syntax_kind_ext::CLASS_DECLARATION => self
                     .ctx
                     .arena
                     .get_class(node)
-                    .map(|class_data| class_data.members.nodes.clone())
+                    .map(|class_data| class_data.members.nodes.as_slice())
                     .unwrap_or_default(),
                 syntax_kind_ext::INTERFACE_DECLARATION => self
                     .ctx
                     .arena
                     .get_interface(node)
-                    .map(|interface_data| interface_data.members.nodes.clone())
+                    .map(|interface_data| interface_data.members.nodes.as_slice())
                     .unwrap_or_default(),
-                _ => Vec::new(),
+                _ => &[],
             };
 
-            for &member_idx in &member_nodes {
+            for &member_idx in member_nodes {
                 let Some(member_node) = self.ctx.arena.get(member_idx) else {
                     continue;
                 };

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_symbol_set.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_symbol_set.rs
@@ -1,0 +1,65 @@
+//! Symbol-id collection for the per-file duplicate-identifier pass.
+//!
+//! Split out of `duplicate_identifiers.rs` so the main pass stays under the
+//! checker size ceiling. The collection itself is on the hot path: it runs once
+//! per file and, when libs are loaded, has to skip the ~2000+ merged lib symbols
+//! that share the scope tables with user code.
+
+use crate::state::CheckerState;
+use rustc_hash::FxHashSet;
+use tsz_binder::{ContainerKind, SymbolId};
+
+impl<'a> CheckerState<'a> {
+    /// Collect the user-code symbol ids whose declarations the duplicate-identifier
+    /// pass must examine for the current file.
+    ///
+    /// When libs are loaded the scope tables also hold the merged lib symbols;
+    /// processing all of them is a 40-50ms-per-file bottleneck, so we pre-build a
+    /// set of user-code symbols from `node_symbols` and intersect it with the
+    /// non-class scope symbols (preserving the Class-scope exclusion). The result
+    /// is a subset of the user symbols, so it is pre-sized to that bound and never
+    /// rehashes on growth (#11617).
+    pub(super) fn collect_duplicate_check_symbol_ids(&self, has_libs: bool) -> FxHashSet<SymbolId> {
+        if !has_libs {
+            // No libs: scope tables / file_locals are already all user symbols.
+            let mut result = FxHashSet::default();
+            self.extend_scope_symbol_ids(&mut result, |_| true);
+            return result;
+        }
+
+        let user_syms: FxHashSet<SymbolId> =
+            self.ctx.binder.node_symbols.values().copied().collect();
+        let mut result = FxHashSet::with_capacity_and_hasher(user_syms.len(), Default::default());
+        self.extend_scope_symbol_ids(&mut result, |id| user_syms.contains(&id));
+        result
+    }
+
+    /// Insert every non-class scope symbol (or file-local symbol when no scopes
+    /// exist) that passes `keep` into `result`. Shared by the lib / no-lib paths
+    /// of [`collect_duplicate_check_symbol_ids`] so the Class-scope exclusion and
+    /// the scope/file-local fallback live in exactly one place.
+    fn extend_scope_symbol_ids(
+        &self,
+        result: &mut FxHashSet<SymbolId>,
+        keep: impl Fn(SymbolId) -> bool,
+    ) {
+        if !self.ctx.binder.scopes.is_empty() {
+            for scope in self.ctx.binder.scopes.iter() {
+                if scope.kind == ContainerKind::Class {
+                    continue;
+                }
+                for (_, &id) in scope.table.iter() {
+                    if keep(id) {
+                        result.insert(id);
+                    }
+                }
+            }
+        } else {
+            for (_, &id) in self.ctx.binder.file_locals.iter() {
+                if keep(id) {
+                    result.insert(id);
+                }
+            }
+        }
+    }
+}

--- a/crates/tsz-checker/src/types/type_checking/mod.rs
+++ b/crates/tsz-checker/src/types/type_checking/mod.rs
@@ -26,6 +26,7 @@ mod duplicate_identifiers_export_surface;
 mod duplicate_identifiers_global_augmentation;
 mod duplicate_identifiers_helpers;
 mod duplicate_identifiers_remote_lib;
+mod duplicate_identifiers_symbol_set;
 mod duplicate_index_signatures;
 mod global;
 mod indexed_access;

--- a/crates/tsz-checker/tests/duplicate_identifier_grouping_allocation_tests.rs
+++ b/crates/tsz-checker/tests/duplicate_identifier_grouping_allocation_tests.rs
@@ -1,0 +1,90 @@
+//! Regression locks for the duplicate-identifier grouping diagnostics whose
+//! per-pass temporary containers were size-tuned / de-cloned for #11617.
+//!
+//! These passes group merged declarations by scope (`scope_groups`,
+//! `interface_decls_by_scope`, `decls_by_scope`, the duplicate-function-impl
+//! grouping) or scan merged class/interface members (the modifier-consistency
+//! check that previously cloned the member-node list). The container changes are
+//! purely allocation-traffic reductions, so every diagnostic these paths produce
+//! must be byte-for-byte unchanged. The matrix below pins the codes and counts
+//! for the matched (no-error), single (no-group), and conflicting cases — plus a
+//! renamed-binder variant — so the size hints and the borrow-instead-of-clone
+//! cannot quietly drop or duplicate a diagnostic.
+
+use tsz_checker::test_utils::check_source_codes as get_codes;
+
+fn count(source: &str, code: u32) -> usize {
+    get_codes(source).iter().filter(|&&c| c == code).count()
+}
+
+// --- TS2428: merged interface declarations must have identical type params ---
+// (`interface_decls_by_scope` grouping)
+
+#[test]
+fn matched_interface_type_params_no_2428() {
+    let source = "interface Box<T> { a: T; }\ninterface Box<T> { b: T; }\n";
+    assert_eq!(count(source, 2428), 0);
+}
+
+#[test]
+fn mismatched_interface_type_params_reports_2428() {
+    let source = "interface Box<T> { a: T; }\ninterface Box<T, U> { b: U; }\n";
+    assert!(count(source, 2428) >= 1);
+}
+
+#[test]
+fn mismatched_interface_type_params_reports_2428_renamed_binder() {
+    // Same structure, different binder name: behavior follows shape, not spelling.
+    let source = "interface Crate<T> { a: T; }\ninterface Crate<T, U> { b: U; }\n";
+    assert!(count(source, 2428) >= 1);
+}
+
+// --- TS2687: merged class/interface members must have identical modifiers ---
+// (the `decls_by_scope` grouping path + the member-scan that previously cloned
+// `members.nodes`)
+
+#[test]
+fn matched_member_visibility_no_2687() {
+    let source = "class Cfg { x: number = 0; }\ninterface Cfg { y: number; }\n";
+    assert_eq!(count(source, 2687), 0);
+}
+
+#[test]
+fn mismatched_member_visibility_reports_2687() {
+    let source = "class Cfg { private x: number = 0; }\ninterface Cfg { x: number; }\n";
+    assert!(count(source, 2687) >= 1);
+}
+
+#[test]
+fn mismatched_member_visibility_reports_2687_renamed_binder() {
+    let source = "class Holder { private slot: number = 0; }\ninterface Holder { slot: number; }\n";
+    assert!(count(source, 2687) >= 1);
+}
+
+// --- TS2393: duplicate function implementations (the FxHashMap-converted
+// function-impl scope grouping) ---
+
+#[test]
+fn single_function_implementation_no_2393() {
+    let source = "function run() {}\n";
+    assert_eq!(count(source, 2393), 0);
+}
+
+#[test]
+fn overload_with_one_implementation_no_2393() {
+    // A declaration + a single implementation is a valid overload set.
+    let source = "function run(): void;\nfunction run() {}\n";
+    assert_eq!(count(source, 2393), 0);
+}
+
+#[test]
+fn duplicate_function_implementations_report_2393() {
+    let source = "function run() {}\nfunction run() {}\n";
+    assert!(count(source, 2393) >= 1);
+}
+
+#[test]
+fn duplicate_function_implementations_report_2393_renamed_binder() {
+    let source = "function execute() {}\nfunction execute() {}\n";
+    assert!(count(source, 2393) >= 1);
+}


### PR DESCRIPTION
AgentName: Studio-B

Refs #11617

## Track
Performance — per-pass temporary-container allocation in the checker's duplicate-identifier pass (`bug-family(performance)`, `type-challenges-solutions-project` row witness).

## Invariant
Behavior-preserving. Every diagnostic the duplicate-identifier pass produces (TS2300 / TS2393 / TS2395 / TS2428 / TS2687 / TS2386 …) is byte-for-byte unchanged; only the heap traffic the pass pays on each invocation is reduced.

## Wrong semantic operation
None — this is not a semantics fix. The pass was *correct* but allocated fresh, default-capacity grouping containers (and cloned a member-node list) on every per-file / per-symbol invocation. Issue #11617's structural rule: checker passes that group declarations should avoid allocating fresh `HashMap`/`Vec` containers on every pass when a stable input order, interned names, or **pre-sized storage** can preserve identical diagnostics with less heap traffic.

## Status of the originally-scoped helpers
The two helpers the issue body named are **already optimized on `main`**:
- `check_type_literal_overload_optionality` (TS2386) already uses a source-ordered `Vec` + adjacent scan instead of the former `FxHashMap<String, Vec<…>>` (landed via #12817).
- `check_global_augmentation_const_enum_rebind_diagnostics` already iterates statement/inner indices directly instead of cloning `statements.nodes`.

So this PR **broadens** the same structural rule to the rest of the duplicate-identifier hot path rather than re-doing finished work.

## Owner layer
Checker (`tsz-checker`), `types/type_checking/duplicate_identifiers*`. No solver/binder/emitter algorithm touched; no relation/inference/display change.

## Scope
- **Pre-size grouping containers to their already-known input bounds** so they no longer rehash on growth:
  - `global_scope_conflict_cache` ← `symbol_ids.len()`
  - `scope_groups` (TS2395 export-consistency) ← `decl_info.len()`
  - `interface_decls_by_scope` (TS2428) ← `interface_decls.len()`
  - `decls_by_scope` (TS2428 class+interface) ← `class_interface_decls.len()`
  - duplicate-function-implementation `scope_groups` ← `func_impls_with_scope.len()`
- **Upgrade the duplicate-function-implementation grouping** from the default SipHash `std::collections::HashMap` to `FxHashMap` (the checker's standard fast map).
- **Borrow instead of clone** the merged class/interface member list in the TS2687 modifier-consistency scan (`duplicate_identifiers_merge.rs`): the loop only reads through `&self`, so the `members.nodes.clone()` `Vec` per merged declaration was pure waste.
- **Extract** the per-file user-symbol collection into a new `duplicate_identifiers_symbol_set` module (`collect_duplicate_check_symbol_ids` + a shared `extend_scope_symbol_ids` scope-walk helper), deduplicating the lib / no-lib branches into one place and keeping `duplicate_identifiers.rs` under the 2000-line checker ceiling (1964 LOC, under the 1992 ratchet — no ceiling raised).

## Anti-hardcoding
No user-name/file-name string predicates; no formatted-diagnostic-as-predicate; no source-text scoped suppression. Pre-sizing keys are structural slice lengths; the FxHashMap upgrade is a hasher choice. Tests assert diagnostic **codes/counts** and vary binder names (`Box`/`Crate`, `Cfg`/`Holder`, `run`/`execute`) to prove behavior follows shape, not spelling.

## Adjacent-case matrix (`duplicate_identifier_grouping_allocation_tests`)
- TS2428: matched interface type params (no error) / mismatched arity (error) / renamed binder.
- TS2687: matched member visibility (no error) / mismatched visibility across a class+interface merge (error) / renamed binder — exercises both `decls_by_scope` grouping and the de-cloned member scan.
- TS2393: single impl (no error) / overload + one impl (no error) / duplicate impls (error) / renamed binder — exercises the FxHashMap-converted grouping.

## Project Corpus Impact
- Row: `type-challenges-solutions-project` (issue witness) and any row exercising heavy merged-declaration / duplicate-identifier checking.
- Bug family: per-pass temporary-map allocation (#11617).
- Expected effect: strictly less heap/CPU per duplicate-identifier pass; no diagnostic flips. Project-row CI owns cross-row confirmation (rows are not run locally per the contract).

## Verification
- `cargo test -p tsz-checker --test duplicate_identifier_grouping_allocation_tests` — 10/10 pass.
- Related suites all green: `ts2300_tests`, `enum_merge_tests`, `const_enum_merge_ts2567_tests`, `merged_symbol_tests`, `type_literal_overload_optionality_tests`, `global_augmentation_const_enum_rebind_tests`, `ts2769_anchor_disagreeing_overloads_tests`, plus `--lib duplicate` (62/62).
- The 3 failures in `module_augmentation_declaration_identity_tests` are **pre-existing on clean `main`** (verified by stashing this change) — zero regressions.
- `cargo fmt -p tsz-checker --check`, `cargo clippy -p tsz-checker --lib` (clean), `python3 scripts/arch/arch_guard.py` (passed) — all clean.
- Ready CI owns full conformance / fourslash / emit / project-row drift.

## Coordination Notes
Picks up the #11617 performance family. The issue's named helpers were already done (#12817); this finishes the allocation-reduction sweep across the rest of the duplicate-identifier hot path. No overlap with open PRs (#12867 solver, #12865 interface heritage, #12862 DOM heritage, #12860 DTS, #12845 parser, #12815 solver). Branch is exactly on top of `origin/main` — no merge conflict.

---
_Generated by [Claude Code](https://claude.ai/code/session_01THtskbp8fEdyZnyFeQJJd3)_