### PR TITLE
fix(checker): render keyof composite-alias assignment targets by their key set

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs
@@ -246,19 +246,106 @@ impl<'a> CheckerState<'a> {
             })
             .unwrap_or(rest.len());
         let operand = rest[..end].trim();
+        // This textual fallback only validly reconstructs a *bare named* operand
+        // (`type X = keyof Foo`). A compound operand cannot be stitched together
+        // from source text: the scan above stops at the first `{`, so a
+        // parenthesized operand such as `keyof ({ a: 1 } & { b: 2 })` would
+        // otherwise leave a dangling `(` and emit the malformed `keyof (`.
+        //
+        // For such an alias `tsc` renders the *evaluated key set* (`"a" | "b"`),
+        // because the `keyof` of an anonymous composite carries no writable name.
+        // Eager `keyof` evaluation has already erased the operator from the alias
+        // body, but the source spelling here proves the alias is a `keyof`, so
+        // render the reduced literal key union directly.
         if operand.is_empty()
             || operand.contains('|')
             || operand.contains('&')
             || operand.contains('[')
             || operand.contains('{')
+            || operand.contains('(')
+            || operand.contains(')')
             || operand.contains("=>")
         {
-            return None;
+            return self.keyof_alias_reduced_keyset_display(name);
         }
         Some(format!(
             "keyof {}",
             self.format_annotation_like_type(operand)
         ))
+    }
+
+    /// Render the evaluated key set of a non-generic `keyof` type alias by its
+    /// members (`"a" | "b"`), matching how `tsc` displays the `keyof` of an
+    /// anonymous composite operand whose result has no writable `keyof Name`
+    /// form. Returns `None` unless the alias body reduces to a finite union (or
+    /// a single instance) of string/number literal keys.
+    fn keyof_alias_reduced_keyset_display(&mut self, name: &str) -> Option<String> {
+        let name_atom = self.ctx.types.intern_string(name);
+        let def_id = self
+            .ctx
+            .definition_store
+            .find_defs_by_name(name_atom)?
+            .into_iter()
+            .find(|&def_id| {
+                self.ctx.definition_store.get(def_id).is_some_and(|def| {
+                    def.kind == tsz_solver::def::DefKind::TypeAlias
+                        && def.type_params.is_empty()
+                        && def.name == name_atom
+                })
+            })?;
+        let body = self.ctx.definition_store.get(def_id)?.body?;
+        let evaluated = self.evaluate_type_for_assignability(body);
+        self.finite_literal_keyset_display(evaluated)
+    }
+
+    /// Format `ty` as a literal key union (`"a" | "b"`) when it is a finite union
+    /// (or a single instance) of string/number literals. Members are rendered
+    /// directly from their literal values rather than through the type formatter,
+    /// so an unrelated global `union -> keyof Name` display alias on a shared
+    /// literal cannot repaint a reduced key. Returns `None` for any other shape.
+    fn finite_literal_keyset_display(&mut self, ty: TypeId) -> Option<String> {
+        if let Some(value) = crate::query_boundaries::common::literal_value(self.ctx.types, ty) {
+            return self.literal_key_display(value);
+        }
+        let members: Vec<TypeId> =
+            crate::query_boundaries::common::union_members(self.ctx.types, ty)?
+                .iter()
+                .copied()
+                .collect();
+        if members.is_empty() {
+            return None;
+        }
+        let mut parts = Vec::with_capacity(members.len());
+        for member in members {
+            let value = crate::query_boundaries::common::literal_value(self.ctx.types, member)?;
+            parts.push(self.literal_key_display(value)?);
+        }
+        Some(parts.join(" | "))
+    }
+
+    /// Render a single literal key as `tsc` does in a key union: string keys are
+    /// quoted (`"a"`), number keys are bare (`0`). Non-key literals (`boolean`)
+    /// return `None`.
+    fn literal_key_display(&self, value: tsz_solver::LiteralValue) -> Option<String> {
+        match value {
+            tsz_solver::LiteralValue::String(atom) => {
+                Some(format!("\"{}\"", self.ctx.types.resolve_atom_ref(atom)))
+            }
+            tsz_solver::LiteralValue::Number(value) => {
+                let value = value.0;
+                if value == 0.0 {
+                    Some("0".to_string())
+                } else if value.is_finite() && value.fract() == 0.0 {
+                    Some(format!("{value:.0}"))
+                } else {
+                    Some(value.to_string())
+                }
+            }
+            tsz_solver::LiteralValue::BigInt(atom) => {
+                Some(format!("{}n", self.ctx.types.resolve_atom_ref(atom)))
+            }
+            tsz_solver::LiteralValue::Boolean(_) => None,
+        }
     }
 }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -945,6 +945,9 @@ mod jsx_type_arg_arity_suppresses_ts2604_tests;
 #[path = "tests/jsx_union_props_relation_routing_arch_tests.rs"]
 mod jsx_union_props_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/keyof_alias_composite_display_tests.rs"]
+mod keyof_alias_composite_display_tests;
+#[cfg(test)]
 #[path = "../tests/keyof_function_type_is_never_tests.rs"]
 mod keyof_function_type_is_never_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/keyof_alias_composite_display_tests.rs
+++ b/crates/tsz-checker/src/tests/keyof_alias_composite_display_tests.rs
@@ -14,7 +14,7 @@ fn target_displays(source: &str) -> Vec<String> {
     check_source_diagnostics(source)
         .into_iter()
         .filter(|d| d.code == 2322)
-        .map(|d| d.message_text.clone())
+        .map(|d| d.message_text)
         .collect()
 }
 

--- a/crates/tsz-checker/src/tests/keyof_alias_composite_display_tests.rs
+++ b/crates/tsz-checker/src/tests/keyof_alias_composite_display_tests.rs
@@ -1,0 +1,116 @@
+//! Regression coverage for the display of `keyof` type aliases whose operand is
+//! a *grouped/composite* type, e.g. `type K = keyof ({ a: 1 } & { b: 2 })`.
+//!
+//! `keyof` of an anonymous composite has no writable `keyof Name` form, so `tsc`
+//! renders the evaluated key set (`"a" | "b"`). The textual reconstruction of the
+//! operand from source text previously stopped at the first `{` inside the
+//! parentheses and emitted the malformed string `keyof (` in the assignment
+//! diagnostic. The display path now renders the reduced literal key union, and a
+//! *named* operand still keeps its `keyof Name` spelling.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn target_displays(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.message_text.clone())
+        .collect()
+}
+
+#[test]
+fn keyof_alias_over_anonymous_object_intersection_renders_key_union() {
+    let msgs = target_displays(
+        r#"
+type Keys = keyof ({ a: 1 } & { b: 2 });
+declare let k: Keys;
+k = "c";
+"#,
+    );
+    assert_eq!(msgs.len(), 1, "expected exactly one TS2322; got: {msgs:?}");
+    let msg = &msgs[0];
+    assert!(
+        !msg.contains("keyof ("),
+        "must not emit the malformed `keyof (`; got: {msg}"
+    );
+    assert!(
+        msg.contains("\"a\" | \"b\""),
+        "keyof of an anonymous intersection must render its reduced key union; got: {msg}"
+    );
+}
+
+#[test]
+fn keyof_alias_over_anonymous_object_union_renders_key_set() {
+    // `keyof (A | B)` reduces to the *common* keys; with disjoint anonymous
+    // members that is `never`. The display must not leak a malformed `keyof (`.
+    let msgs = target_displays(
+        r#"
+type Keys = keyof ({ a: 1 } | { b: 2 });
+declare let k: Keys;
+k = "z";
+"#,
+    );
+    assert_eq!(msgs.len(), 1, "expected exactly one TS2322; got: {msgs:?}");
+    assert!(
+        !msgs[0].contains("keyof ("),
+        "must not emit the malformed `keyof (`; got: {}",
+        msgs[0]
+    );
+}
+
+#[test]
+fn keyof_alias_over_single_anonymous_object_renders_key_union() {
+    let msgs = target_displays(
+        r#"
+type Keys = keyof { x: 1; y: 2 };
+declare let k: Keys;
+k = "z";
+"#,
+    );
+    assert_eq!(msgs.len(), 1, "expected exactly one TS2322; got: {msgs:?}");
+    assert!(
+        msgs[0].contains("\"x\" | \"y\""),
+        "keyof of an anonymous object alias renders its key union; got: {}",
+        msgs[0]
+    );
+}
+
+#[test]
+fn keyof_alias_over_named_interface_keeps_keyof_name() {
+    // Negative control: a *named* operand keeps `keyof Name` (tsc does not reduce
+    // it in this position). Renamed binder to prove the rule follows structure,
+    // not a specific identifier.
+    let msgs = target_displays(
+        r#"
+interface Shape { a: 1; b: 2 }
+type Keys = keyof Shape;
+declare let k: Keys;
+k = "c";
+"#,
+    );
+    assert_eq!(msgs.len(), 1, "expected exactly one TS2322; got: {msgs:?}");
+    assert!(
+        msgs[0].contains("keyof Shape"),
+        "a named-operand keyof keeps its `keyof Name` spelling; got: {}",
+        msgs[0]
+    );
+}
+
+#[test]
+fn keyof_alias_composite_display_is_binder_name_independent() {
+    // The reduction must depend on operand structure, not on the alias or
+    // property identifiers chosen.
+    let msgs = target_displays(
+        r#"
+type Selected = keyof ({ first: 1 } & { second: 2 });
+declare let s: Selected;
+s = "third";
+"#,
+    );
+    assert_eq!(msgs.len(), 1, "expected exactly one TS2322; got: {msgs:?}");
+    let msg = &msgs[0];
+    assert!(
+        !msg.contains("keyof (") && msg.contains("\"first\"") && msg.contains("\"second\""),
+        "renamed binders must still reduce to the key union; got: {msg}"
+    );
+}


### PR DESCRIPTION
AgentName: claude-brave-volta-Xf1By

Refs #12179

## Track
Checker diagnostic display (diagnostics family #12179) — assignment-target rendering of `keyof` type aliases.

## Invariant
When a relation/checker failure is known, tsz preserves the same target type display `tsc` reports, independent of alias spelling. A `keyof` of an anonymous composite renders its evaluated key set; a named operand keeps `keyof Name`.

## Wrong semantic operation
Diagnostic display only — `TS2322` target rendering. Not a relation/inference/narrowing/evaluation change: the assignability decision and the underlying type are already correct (the target union `"a" | "b"` is computed); only the rendered text was wrong (malformed).

## Structural rule
> When the target of a `TS2322` is a non-generic `type K = keyof (<grouped operand>)` alias whose operand is an anonymous composite, `tsc` renders the evaluated literal key set (`"a" | "b"`), because the `keyof` of an anonymous composite has no writable `keyof Name` form. A *named* operand keeps `keyof Name`.

tsz's checker reconstructs the operand textually from source (`keyof_type_alias_textual_definition_display`) because eager `keyof` evaluation erases the operator from the alias body. That scan stops at the first `{`; inside `keyof ({ a: 1 } & { b: 2 })` the first `{` is one char past the `(`, so the operand became the bare `(` and the rejection guard (`| & [ { =>`) did not cover grouping parens — emitting the malformed string **`keyof (`**.

## Fix
`crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs`:
- Reject grouping parens (`(` / `)`) in the textual operand.
- For such a (provably-`keyof`, from the source spelling) alias, render the **reduced literal key union** directly: resolve the alias def, evaluate its body, and format a finite union/instance of string/number literal keys. Members are rendered from their `LiteralValue` (not via the type formatter) so an unrelated global `union -> keyof Name` display alias on a shared literal cannot repaint a key. Non-literal/deferred results return `None` (no malformed output; falls back to the existing path).

No emitter/solver/binder change; the printer reads types, never the reverse.

## Owner layer
Checker `error_reporter` (assignment-target display). Distinct from the assignment-**source** `keyof` reduced-key-set display already landed in #12807.

## Adjacent-case matrix (`keyof_alias_composite_display_tests`)
- `keyof ({ a: 1 } & { b: 2 })` target → `"a" | "b"` and never `keyof (`.
- `keyof ({ a: 1 } | { b: 2 })` target → reduced (common keys), never `keyof (`.
- `keyof { x: 1; y: 2 }` single anonymous object alias → `"x" | "y"`.
- Named-operand negative control: `keyof Shape` keeps `keyof Shape` (renamed binder).
- Binder-name independence: `keyof ({ first: 1 } & { second: 2 })` → reduces (renamed identifiers), proving the rule follows structure not spelling.

## Project Corpus Impact
- Row: n/a (diagnostic display text only; no diagnostic codes, project-row pass/fail, or emit change).
- Bug family: diagnostics display (#12179) — stable display witness.
- Differential vs `tsc` 6.0.2 confirms the displayed target now matches (`"a" | "b"`).

## Verification
- `cargo test -p tsz-checker --lib keyof_alias_composite_display_tests` — 5/5 pass.
- `cargo test -p tsz-checker --lib keyof` — 93 pass; the only failure (`keyof_keeps_computed_unique_like_string_property_as_string_key`) is **pre-existing** and byte-identical on clean `main`.
- `cargo test -p tsz-checker --lib assignment` / `annotation` — zero new failures vs `main` (the 5 `assignment` failures — mapped-enum display + an arch-contract test — all fail identically on clean `main`).
- `cargo fmt --check`, `cargo clippy -p tsz-checker --lib`, `python3 scripts/arch/arch_guard.py` — all clean.
- Ready CI owns full conformance/emit/fourslash and project rows.

## Anti-hardcoding
No user-name/file-name predicates; no formatted-diagnostic-as-predicate driving logic. The trigger is the structural shape (`keyof` source spelling + alias body evaluating to a finite literal key set), and tests vary binder names (`Keys`/`Selected`, `a`/`b`/`first`/`second`, `Shape`) to prove the behavior follows structure.

## Coordination Notes
Focused display witness under the #12179 diagnostics family. The assignment-source side of `keyof` display landed in #12807; this is the orthogonal target side. No overlap with open PRs.

https://claude.ai/code/session_01N1Emv8z3iiyPqAxZyCwrjV

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1Emv8z3iiyPqAxZyCwrjV)_