### PR TITLE
fix(checker): recurse into nested literals for concrete mapped excess targets

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1113,6 +1113,9 @@ mod recursive_conditional_infer_termination_tests;
 #[path = "tests/recursive_generic_arrow_tests.rs"]
 mod recursive_generic_arrow_tests;
 #[cfg(test)]
+#[path = "tests/recursive_mapped_intersection_nested_excess_property_tests.rs"]
+mod recursive_mapped_intersection_nested_excess_property_tests;
+#[cfg(test)]
 #[path = "tests/recursive_path_default_type_param_tests.rs"]
 mod recursive_path_default_type_param_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs
+++ b/crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs
@@ -68,6 +68,20 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        if first_excess.is_none() {
+            // No excess property at *this* level. The present properties may still
+            // carry nested object literals with deeper excess properties — e.g. a
+            // recursive homomorphic mapped utility `{ [K in keyof T]: F<T[K]> }`
+            // whose evaluated property values are themselves object/intersection
+            // shapes (`excessPropertyCheckIntersectionWithRecursiveType`). Returning
+            // `false` defers to the recursion-capable simple-object / intersection
+            // branches in `check_object_literal_excess_properties`, which descend
+            // into each present property's nested literal against the evaluated
+            // (already-expanded) target. Claiming the check is fully handled here
+            // would skip that descent and silently drop the nested TS2353 that tsc
+            // reports.
+            return false;
+        }
         // Display the expanded object shape (matching tsc), not the deferred mapped form.
         self.emit_tracked_excess_property(first_excess, evaluated_target);
         true

--- a/crates/tsz-checker/src/tests/recursive_mapped_intersection_nested_excess_property_tests.rs
+++ b/crates/tsz-checker/src/tests/recursive_mapped_intersection_nested_excess_property_tests.rs
@@ -1,0 +1,152 @@
+//! Nested excess-property (TS2353) checking through a *concrete* homomorphic
+//! mapped target whose evaluated property values are themselves object /
+//! intersection shapes — the recursive-utility-over-intersection family from
+//! `excessPropertyCheckIntersectionWithRecursiveType` (TypeScript #44750).
+//!
+//! Structural rule: when a fresh object literal is checked against a concrete
+//! homomorphic mapped target `{ [K in keyof T]: F<T[K]> }` and every top-level
+//! key is present, tsc still descends into each present property's nested
+//! object literal and reports a deeper excess key. tsz's
+//! `report_concrete_mapped_target_excess_property` used to check excess only at
+//! the mapped level and then claim the literal was fully handled, which skipped
+//! that descent and silently dropped the nested TS2353. The fix defers to the
+//! recursion-capable simple-object / intersection branches when there is no
+//! excess at the mapped level.
+//!
+//! The witness needs two structural ingredients together: (1) the mapped target
+//! stays a *raw* mapped type at the property position (it does not get evaluated
+//! to a plain object before the excess walk), which happens when a recursive
+//! conditional alias places its `& Example<T>` *inside* the conditional branches
+//! rather than outside; and (2) at least two levels of nesting, so the excess
+//! sits below the mapped level. Binder names are varied so the behaviour is
+//! structural, not spelling specific.
+
+use crate::test_utils::check_source_strict_messages_without_missing_libs;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_strict_messages_without_missing_libs(source)
+        .into_iter()
+        .map(|(code, _)| code)
+        .collect()
+}
+
+/// Conditional alias with `& Example<T>` *inside* both branches (the Schema2
+/// shape). The inner `props` mapped target stays a raw mapped type, so the
+/// nested excess key two levels down was previously dropped.
+#[test]
+fn intersection_inside_branch_recursive_mapped_flags_nested_excess() {
+    let diags = check_source_strict_messages_without_missing_libs(
+        "type Req = { l1: { l2: boolean } };\n\
+         type Example<T> = { ex?: T | null };\n\
+         type Schema<T> = (T extends boolean\n\
+            ? { type: 'boolean' } & Example<T>\n\
+            : { props: { [P in keyof T]: Schema<T[P]> } } & Example<T>);\n\
+         const o: Schema<Req> = { props: { l1: { props: { l2: { type: 'boolean' }, invalid: false } } } };",
+    );
+    let cs: Vec<u32> = diags.iter().map(|(c, _)| *c).collect();
+    assert!(
+        cs.contains(&2353),
+        "nested excess key 'invalid' two levels under a recursive mapped target must be TS2353; got {diags:?}"
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|(c, m)| *c == 2353 && m.contains("invalid")),
+        "the TS2353 must name the excess key 'invalid'; got {diags:?}"
+    );
+}
+
+/// The sibling shape with `& Example<T>` *outside* the conditional (Schema1):
+/// the property value is evaluated to a plain object before the excess walk, so
+/// this already worked. Kept as a control that the fix did not disturb it.
+#[test]
+fn intersection_outside_branch_recursive_mapped_flags_nested_excess() {
+    let cs = codes(
+        "type Req = { l1: { l2: boolean } };\n\
+         type Example<T> = { ex?: T | null };\n\
+         type Schema<T> = (T extends boolean\n\
+            ? { type: 'boolean' }\n\
+            : { props: { [P in keyof T]: Schema<T[P]> } }) & Example<T>;\n\
+         const o: Schema<Req> = { props: { l1: { props: { l2: { type: 'boolean' }, invalid: false } } } };",
+    );
+    assert!(
+        cs.contains(&2353),
+        "nested excess key must be TS2353 for the outside-intersection shape too; got {cs:?}"
+    );
+}
+
+/// `Example<T>` placed first in the intersection (Schema3) — order independence.
+#[test]
+fn intersection_leading_example_recursive_mapped_flags_nested_excess() {
+    let cs = codes(
+        "type Req = { l1: { l2: boolean } };\n\
+         type Example<T> = { ex?: T | null };\n\
+         type Schema<T> = Example<T> & (T extends boolean\n\
+            ? { type: 'boolean' }\n\
+            : { props: { [P in keyof T]: Schema<T[P]> } });\n\
+         const o: Schema<Req> = { props: { l1: { props: { l2: { type: 'boolean' }, invalid: false } } } };",
+    );
+    assert!(
+        cs.contains(&2353),
+        "nested excess key must be TS2353 with leading Example<T>; got {cs:?}"
+    );
+}
+
+/// Renamed binders prove the rule is structural rather than spelling specific.
+#[test]
+fn renamed_binders_recursive_mapped_flags_nested_excess() {
+    let diags = check_source_strict_messages_without_missing_libs(
+        "type Tree = { branch: { leaf: boolean } };\n\
+         type Wrap<U> = { tag?: U | null };\n\
+         type Node<U> = (U extends boolean\n\
+            ? { kind: 'boolean' } & Wrap<U>\n\
+            : { members: { [Q in keyof U]: Node<U[Q]> } } & Wrap<U>);\n\
+         const tree: Node<Tree> = { members: { branch: { members: { leaf: { kind: 'boolean' }, bogus: 1 } } } };",
+    );
+    let cs: Vec<u32> = diags.iter().map(|(c, _)| *c).collect();
+    assert!(
+        cs.contains(&2353),
+        "renamed-binder recursive mapped target must still flag nested excess; got {diags:?}"
+    );
+    assert!(
+        diags.iter().any(|(c, m)| *c == 2353 && m.contains("bogus")),
+        "the TS2353 must name the excess key 'bogus'; got {diags:?}"
+    );
+}
+
+/// Excess sitting three levels deep is still reported (the descent is not
+/// bounded to a single recursion step).
+#[test]
+fn deep_nested_excess_under_recursive_mapped_is_reported() {
+    let cs = codes(
+        "type Req = { a: { b: { c: boolean } } };\n\
+         type Example<T> = { ex?: T | null };\n\
+         type Schema<T> = (T extends boolean\n\
+            ? { type: 'boolean' } & Example<T>\n\
+            : { props: { [P in keyof T]: Schema<T[P]> } } & Example<T>);\n\
+         const o: Schema<Req> = { props: { a: { props: { b: { props: { c: { type: 'boolean' }, nope: 0 } } } } } };",
+    );
+    assert!(
+        cs.contains(&2353),
+        "excess key three levels deep must be TS2353; got {cs:?}"
+    );
+}
+
+/// Negative control: a structurally valid literal (no extra key) must NOT
+/// produce a spurious TS2353. Guards against the fix over-firing on present
+/// properties.
+#[test]
+fn valid_recursive_mapped_literal_has_no_excess_error() {
+    let cs = codes(
+        "type Req = { l1: { l2: boolean } };\n\
+         type Example<T> = { ex?: T | null };\n\
+         type Schema<T> = (T extends boolean\n\
+            ? { type: 'boolean' } & Example<T>\n\
+            : { props: { [P in keyof T]: Schema<T[P]> } } & Example<T>);\n\
+         const o: Schema<Req> = { props: { l1: { props: { l2: { type: 'boolean' } } } } };",
+    );
+    assert!(
+        !cs.contains(&2353),
+        "a valid recursive-mapped literal must not report excess; got {cs:?}"
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -50,7 +50,6 @@ TypeScript/tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts
 TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules1.ts
 TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
-TypeScript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts
 TypeScript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts
@@ -81,3 +80,13 @@ TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
 # eliminated at least one impossible arm. Covered by
 # intersection_type_param_tests::
 # test_type_param_union_undefined_intersect_empty_or_null_assignable_to_type_param.
+# excessPropertyCheckIntersectionWithRecursiveType.ts: RESOLVED. A nested TS2353
+# was dropped for a fresh literal checked against a recursive homomorphic mapped
+# target `{ [K in keyof T]: F<T[K]> }` whose property value stays a *raw* mapped
+# type (the Schema2 shape, where `& Example<T>` lives inside the conditional
+# branches). `report_concrete_mapped_target_excess_property` checked excess only
+# at the mapped level and then returned `true` (fully handled), skipping the
+# descent into each present property's nested literal where the real excess key
+# lives. It now returns `false` when there is no excess at the mapped level,
+# deferring to the recursion-capable simple-object/intersection branches. Covered
+# by recursive_mapped_intersection_nested_excess_property_tests.


### PR DESCRIPTION
AgentName: lucid-hopper-xtVKY

Refs #8432 (retire accepted-regression debt through a solver/checker parity fix).

## Track
Checker — object-literal excess-property (TS2353) recursion through concrete homomorphic mapped targets.

## Invariant
When a fresh object literal is checked against a concrete homomorphic mapped target `{ [K in keyof T]: F<T[K]> }` and every top-level key is present, `tsz` matches `tsc` by descending into each present property's nested object literal and reporting any deeper excess key.

## Wrong semantic operation
Diagnostic emission / excess-property recursion (not a relation, inference, or evaluation change). `report_concrete_mapped_target_excess_property` checked excess **only at the mapped level** and then returned `true` ("fully handled"), short-circuiting the nested-literal recursion that the simple-object / intersection branches of `check_object_literal_excess_properties` perform.

## Structural rule
> When a fresh literal is assigned to a concrete homomorphic mapped target and has no excess key at the mapped level, `tsc` still recurses into each present property's nested literal to report deeper excess keys.

The witness needs two ingredients together: (1) the mapped target stays a **raw** mapped type at the property position (not pre-evaluated to a plain object) — which happens when a recursive conditional alias places its `& Example<T>` **inside** the conditional branches (the `Schema2` shape) rather than outside (`Schema1`); and (2) at least two levels of nesting, so the excess sits below the mapped level.

```ts
type Req = { l1: { l2: boolean } };
type Example<T> = { ex?: T | null };
// Schema2: `& Example<T>` INSIDE both branches -> inner `props` mapped stays raw
type S2<T> = (T extends boolean
  ? { type: 'boolean' } & Example<T>
  : { props: { [P in keyof T]: S2<T[P]> } } & Example<T>);
const o: S2<Req> = { props: { l1: { props: { l2: { type: 'boolean' }, invalid: false } } } };
// tsc 6.0.3: TS2353 'invalid'   tsz before: (silently accepted)   tsz after: TS2353 'invalid'
```

`Schema1` (`& Example<T>` *outside* the conditional) already worked only because its property value is evaluated to a plain object first, hitting the recursion-capable simple-object branch.

## Fix
`report_concrete_mapped_target_excess_property` now returns `false` when there is **no excess at the mapped level**, so the caller falls through to the recursion-capable simple-object / intersection branches — whose `effective_target` / `resolved_target` is already the evaluated (expanded) object — which descend into each present property's nested literal. When an excess key **is** present at the mapped level, the prior `true` + expanded-shape display is preserved unchanged. This reuses the single existing recursion mechanism rather than duplicating descent logic.

## Owner layer
Checker (`state_checking::mapped_object_literals`). No solver/binder/emitter change; the printer reads types, never the reverse.

## Scope
- `crates/tsz-checker/src/state/state_checking/mapped_object_literals.rs`: early `return false` on the no-excess path of `report_concrete_mapped_target_excess_property`.
- `crates/tsz-checker/src/tests/recursive_mapped_intersection_nested_excess_property_tests.rs` (new): 6 regression tests.
- `crates/tsz-checker/src/lib.rs`: register the test module.
- `scripts/conformance/conformance-accepted-regressions.txt`: remove `excessPropertyCheckIntersectionWithRecursiveType.ts` + RESOLVED note.

## Anti-hardcoding
No user-name / file-name predicates; no formatted-diagnostic-as-predicate. The trigger is the structural shape (concrete homomorphic mapped target with present keys). Tests vary binder names (`Schema`/`Node`, `Example`/`Wrap`, `props`/`members`, `l1`/`branch`, `invalid`/`bogus`/`nope`) to prove the behaviour follows structure, and assert diagnostic codes + key names rather than rendered type strings.

## Adjacent-case matrix (`recursive_mapped_intersection_nested_excess_property_tests`)
- `& Example<T>` inside both branches (Schema2) -> nested TS2353 (the fix).
- `& Example<T>` outside the conditional (Schema1) -> still TS2353 (control, undisturbed).
- Leading `Example<T> & (...)` (Schema3) -> TS2353 (order independence).
- Renamed binders -> TS2353 (structural, not spelling).
- Excess three levels deep -> TS2353 (descent is not bounded to one step).
- Valid literal (no extra key) -> **no** TS2353 (negative control; fix does not over-fire).

## Project Corpus Impact
- Row: n/a (retires a `compiler/*` conformance accepted-regression; no required project row should flip).
- Bug family: mapped/keyof/inference conformance debt (#8432).
- Differential vs `tsc` 6.0.3 on `excessPropertyCheckIntersectionWithRecursiveType.ts`: all six diagnostics now match byte-for-byte (line/column/message), including the previously-missing nested `TS2353` at `test.ts:27`.

## Verification
- `cargo test -p tsz-checker --lib recursive_mapped_intersection_nested_excess` — 6/6 pass.
- `RUST_MIN_STACK=536870912 cargo test -p tsz-checker --lib` — 6267 passed / 74 failed; the 74-failure set is **byte-identical** to clean `main` (captured before/after by stashing this change): clean `main` is 6261 passed / 74 failed, so this PR is +6 new passing tests, 0 new failures.
- Differential `tsz` vs `tsc` 6.0.3 on the full fixture + reduced witnesses (Schema1/2/3/4, 1/2/3-level nesting): all match.
- `cargo fmt --check`, `cargo clippy -p tsz-checker --lib` — clean.
- Ready-review CI owns full conformance aggregate / emit / fourslash / project rows.

## Coordination Notes
Focused single-entry retirement under the #8432 accepted-regression family; the issue explicitly asks to retire these through solver/checker fixes rather than ledger churn. No overlap with open PRs (`report_concrete_mapped_target_excess_property` is touched by none of the in-flight solver/checker PRs). Ran `/simplify` (4 parallel reuse/simplification/efficiency/altitude reviewers): the deferral-to-shared-recursion form was confirmed the correct altitude and already clean.

https://claude.ai/code/session_017Mamt42PTC7ZVzPJEqhuK3

---
_Generated by [Claude Code](https://claude.ai/code/session_017Mamt42PTC7ZVzPJEqhuK3)_