### PR TITLE
fix(solver): keep covariant application-mediated return params opaque in assignability (#10812)

### DIFF
--- a/crates/tsz-checker/src/tests/generic_method_member_variance_assignability_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_method_member_variance_assignability_tests.rs
@@ -13,6 +13,14 @@
 //! comparison. A concrete implementation whose result merely satisfies the
 //! constraint was then wrongly accepted, hiding the TS2322 that `tsc` reports.
 //!
+//! The fix extends the covariant guard from bare occurrences (`T`, `T[]`,
+//! `T | null`) to *application-mediated* ones (`Box<T>`, `Cell<T>`) by asking
+//! the variance computer whether the parameter is observable covariantly (or
+//! invariantly) through the return type. Purely contravariant (`FBox<T>` with
+//! `apply(value: T)`) and phantom occurrences carry no covariant bit, so they
+//! stay erasable; the overloaded-builder row stays accepted through the
+//! separate multi-signature erase-to-`any` retry.
+//!
 //! The structural rule (verified against `tsc` 6.0.2): erasing a target method
 //! type parameter to its constraint *widens* it. That is safe in a
 //! contravariant (parameter) position — method-parameter bivariance already
@@ -145,35 +153,64 @@ fn keeps_2322_array_element_context() {
 }
 
 // ---------------------------------------------------------------------------
-// Known remaining gap (documented, not yet at parity).
-//
-// When the method type parameter appears in the return type *only* as a generic
-// application argument (`Box<T>`, `RawBuilder<A>`, `PromiseLike<T>`, …), tsz
-// still erases it to its constraint, so the concrete member is accepted even
-// though `tsc` reports TS2322. That erase path is load-bearing for generic
-// inference and overloaded-builder rows (a `PromiseLike<TResult>` return drives
-// `Promise.then` inference, for instance), so widening the covariant guard to
-// cover application-mediated returns is deferred to dedicated follow-up work.
-// These tests pin the *current* behavior so a future fix surfaces here.
+// Application-mediated covariant return positions: the method type parameter
+// appears in the return type *only* as a generic application argument
+// (`Box<T>`, `RawBuilder<A>`, …) whose enclosing generic reads it out. The
+// caller still observes the parameter covariantly, so a concrete member is not
+// a valid implementation and `tsc` reports TS2322 — matched now via the
+// variance-aware covariant guard. (Previously a documented gap.)
 // ---------------------------------------------------------------------------
 
 #[test]
-fn known_gap_application_mediated_covariant_return_box() {
-    // `tsc` 6.0.2 reports TS2322 here; tsz currently does not.
-    assert_no_2322(
+fn keeps_2322_application_mediated_covariant_return_box() {
+    assert_has_2322(
         "interface Box<V> { v: V }
          type A = { m<T extends string>(): Box<T> };
          const a: A = { m(): Box<string> { return { v: '' }; } };",
     );
 }
 
+// Renamed parameters — proves the guard reads structure, not identifiers.
 #[test]
-fn known_gap_application_mediated_covariant_return_builder() {
-    // `tsc` 6.0.2 reports TS2322 here; tsz currently does not.
-    assert_no_2322(
+fn keeps_2322_application_mediated_covariant_return_box_renamed() {
+    assert_has_2322(
+        "interface Holder<W> { w: W }
+         type A = { m<K extends string>(): Holder<K> };
+         const a: A = { m(): Holder<string> { return { w: '' }; } };",
+    );
+}
+
+#[test]
+fn keeps_2322_application_mediated_covariant_return_builder() {
+    assert_has_2322(
         "interface RawBuilder<O> { o: O }
          interface DB { raw<A extends object>(): RawBuilder<A>; }
          const db: DB = { raw(): RawBuilder<object> { return { o: {} }; } };",
+    );
+}
+
+// Invariant application (`Cell<T>` reads and writes `T`) is also observable
+// covariantly, so it stays opaque and the concrete member is rejected.
+#[test]
+fn keeps_2322_application_mediated_invariant_return_cell() {
+    assert_has_2322(
+        "interface Cell<P extends string> { read: P; write(v: P): void }
+         type A = { m<T extends string>(x: number): Cell<T> };
+         const a: A = { m(x: number): Cell<string> { return {} as any; } };",
+    );
+}
+
+// Application-mediated covariant return nested one level deeper inside another
+// covariant application (`Wrap<Box<T>>`) — kept lib-independent with two
+// user-defined covariant wrappers so the variance composition is exercised
+// without depending on the test harness's global lib surface.
+#[test]
+fn keeps_2322_application_mediated_covariant_return_nested() {
+    assert_has_2322(
+        "interface Box<V> { v: V }
+         interface Wrap<X> { x: X }
+         type A = { m<T extends string>(): Wrap<Box<T>> };
+         const a: A = { m(): Wrap<Box<string>> { return { x: { v: '' } }; } };",
     );
 }
 
@@ -209,6 +246,21 @@ fn no_false_2322_contravariant_parameter_wrapped() {
         "interface Box<O> { o: O }
          interface DB { take<A extends object>(b: Box<A>): void; }
          const db: DB = { take(b: Box<object>): void {} };",
+    );
+}
+
+// Contravariant application-mediated *return* position: `FBox<T>` only writes
+// `T` (`apply(value: T)`), so the parameter is observed contravariantly and
+// carries no covariant bit. The concrete `FBox<string>` member is a valid
+// implementation — method-parameter bivariance covers it — and must stay
+// accepted, proving the covariant guard discriminates by variance rather than
+// blanket-rejecting every application-mediated return occurrence.
+#[test]
+fn no_false_2322_application_mediated_contravariant_return() {
+    assert_no_2322(
+        "interface FBox<P extends string> { apply(value: P): void }
+         type A = { m<T extends string>(x: number): FBox<T> };
+         const a: A = { m(x: number): FBox<string> { return {} as any; } };",
     );
 }
 

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -564,7 +564,21 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                                 .this_type
                                 .is_some_and(|t| self.type_param_appears_bare(t, tp_id))
                             || self.type_param_appears_bare(target_instantiated.return_type, tp_id);
-                        if !appears_bare {
+                        // Even when the parameter never appears bare, an
+                        // application-mediated covariant (or invariant) occurrence
+                        // in the return -- `Box<T>`, `Cell<T>`, `T[]`, `T | null`
+                        // -- keeps the parameter observable to a caller, so it must
+                        // stay opaque to match tsc's per-signature variance
+                        // comparison. Only purely contravariant or phantom
+                        // occurrences remain erasable. The variance walk runs only
+                        // when the cheaper syntactic check already permits erasure.
+                        // (Issue #10812.)
+                        if !appears_bare
+                            && !self.type_param_covariant_in_return(
+                                target_instantiated.return_type,
+                                tp.name,
+                            )
+                        {
                             target_canonical.insert(tp.name, constraint);
                         }
                     }

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/generic_constraints.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/generic_constraints.rs
@@ -1,8 +1,10 @@
 //! Generic type-parameter constraint helpers for function subtype checks.
 
 use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
+use crate::relations::variance::compute_variance_with_resolver;
 use crate::type_param_info;
-use crate::types::{TypeData, TypeId, TypeParamInfo};
+use crate::types::{TypeData, TypeId, TypeParamInfo, Variance};
+use tsz_common::interner::Atom;
 
 use super::super::super::super::{SubtypeChecker, TypeResolver};
 
@@ -131,6 +133,33 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // erased -- this preserves existing relation behavior for those shapes.
             _ => true,
         }
+    }
+
+    /// Whether `tp_name` is observable with *covariant* (or *invariant*)
+    /// polarity through a signature's return type -- including application-only
+    /// occurrences such as `Box<T>` whose enclosing generic reads `T` out
+    /// (`{ tag: T }`), `Cell<T>` that both reads and writes it, `T[]`, or
+    /// `T | null`.
+    ///
+    /// A target method-local type parameter a caller can observe covariantly
+    /// through the result must stay opaque when a concrete (non-generic) member
+    /// is related against the generic target in general assignability: erasing
+    /// it to its constraint would silently accept a concrete `(): Box<string>`
+    /// for a universally quantified `<T extends string>(): Box<T>`, where tsc
+    /// reports TS2322 (`'T' could be instantiated with a different subtype of
+    /// constraint 'string'`). Purely contravariant occurrences (`FBox<T>` with
+    /// `apply(value: T)`) and phantom occurrences (`PBox<T>` with `T` unused)
+    /// carry no covariant bit, so they remain erasable -- matching tsc's
+    /// `getErasedSignature` leniency. The overloaded-builder escape hatch is
+    /// unaffected: that path retries through the multi-signature erase-to-`any`
+    /// route rather than this constraint erase. (Issue #10812.)
+    pub(super) fn type_param_covariant_in_return(
+        &self,
+        return_type: TypeId,
+        tp_name: Atom,
+    ) -> bool {
+        compute_variance_with_resolver(self.interner, self.resolver, return_type, tp_name)
+            .contains(Variance::COVARIANT)
     }
 
     /// Walk a chain of single-argument generic applications (e.g. `Array<Array<T>>`)


### PR DESCRIPTION
AgentName: lucid-hopper

Track: solver / function-signature member compatibility (generic-method variance in general assignability)

## Invariant

When a non-generic method member is related to a **single-signature**
generic-method target in the **general assignability** relation, a target
method-local type parameter observable with **covariant (or invariant)**
polarity through the return type — including application-mediated occurrences
whose enclosing generic reads it out (`Box`/`Cell`/`Wrap` of the parameter) —
stays opaque, so a concrete member that only satisfies the constraint is
rejected with `TS2322`, matching `tsc` 6.0.2 exactly. Purely contravariant
(`FBox` with `apply(value)`) and phantom occurrences carry no covariant bit and
remain erasable; the overloaded-builder row stays accepted through the separate
multi-signature erase-to-`any` retry.

## Summary

Closes the remaining documented gap on the #10812 row. #12734 fixed *bare*
covariant returns. An *application-mediated* covariant/invariant return was
still erased to its constraint in the general assignability path and a concrete
member silently accepted, where `tsc` reports `TS2322`:

```ts
interface Box<V> { v: V }
type A = { m<T extends string>(): Box<T> };
const a: A = { m(): Box<string> { return { v: '' }; } }; // tsc: TS2322; tsz (before): accepted
```

Verified against `tsc` 6.0.2: covariant `Box<P>` and invariant `Cell<P>`
returns are rejected; contravariant `FBox<P>` and phantom `PBox<P>` are
accepted; the two-overload builder is accepted.

## Wrong semantic operation

Relation — the erase-to-constraint gate in the function-subtype relation. The
gate kept a parameter opaque only when it `appears_bare` (a syntactic
occurrence check that does not see through a generic application); an
application-only covariant occurrence read as "absent" and was widened to its
constraint, a covariant leak accepting a concrete member for a universally
quantified one.

## Structural rule

> When a non-generic member is related to a single-signature generic-method
> target in general assignability, a target method-local type parameter
> observable with covariant (or invariant) polarity through the return type
> must stay opaque; `tsc` rejects the concrete member with `TS2322`.

Owner layer: `tsz-solver` `relations/subtype/rules/functions` constraint-erase
gate. The decision now also consults `compute_variance` for the return type, so
the gate is variance-aware rather than purely syntactic. The change is
*additive* — it only adds opacity, never removes any existing opacity — so the
load-bearing erase for contravariant/phantom/overloaded-builder rows is intact.

## Scope

- `crates/tsz-solver/.../functions/checking.rs` — erase gate also keeps a param
  opaque when it is covariant-in-return (short-circuited behind the cheaper
  syntactic check).
- `crates/tsz-solver/.../functions/checking/generic_constraints.rs` — new
  `type_param_covariant_in_return` helper wrapping `compute_variance_with_resolver`.
- `crates/tsz-checker/src/tests/generic_method_member_variance_assignability_tests.rs`
  — the two `known_gap_*` tests that pinned the bug become positive `keeps_2322_*`
  regressions, plus renamed/invariant/nested adjacent cases and a
  contravariant-return negative control.

Adjacent matrix (all verified against `tsc` 6.0.2): covariant container rejects;
renamed parameter rejects; builder application rejects; invariant container
rejects; nested application rejects; contravariant container accepts; phantom
accepts; overloaded builder accepts; `Promise.then`-style rejects (already
correct before this PR).

## Project Corpus Impact

- Row: type-fest-project
- Bug family: generic-method-variance

Targets the `type-fest-project` row (generic method variance in mixed
inheritance / structural assignability). No required project row is expected to
regress; the change narrows a false-negative (adds `TS2322` where `tsc` already
errors) and preserves every accepted case in the existing #10812 suite.

## Verification

- `tsz` vs `tsc` 6.0.2 differential on 9 + 5 hand-reduced witnesses — all match.
- `cargo nextest run -p tsz-checker --lib generic_method_member_variance_assignability` — 21 passed.
- `cargo nextest run -p tsz-checker --lib override_variance` — 69 passed.
- `cargo nextest run -p tsz-solver --lib` — 6585 passed; the only 2 failures
  reproduce identically on the base commit (pre-existing, unrelated).
- Broad checker lib filter (`variance|overload|assignab|generic_method|ts2416|ts2322`):
  identical failure set on base vs this change (regression set empty); 4 new
  tests all pass.
- `cargo clippy -p tsz-solver --lib` — clean.

## Coordination Notes

Builds directly on #12734 (bare covariant returns) and #10869 (override paths);
the member-compat (`implements`/`extends`) path was already correct and is
untouched. The deeper refactor — replacing the syntactic `appears_bare` return
check with a fully variance-driven gate — was deliberately deferred: it would
change behavior for contravariant bare-in-return params currently kept opaque
and warrants its own differential pass.

https://claude.ai/code/session_01NH2LJLA6Y53ieNwq2968t8