### PR TITLE
fix(solver): key evaluation caches on exactOptionalPropertyTypes (#10970)

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -36,7 +36,15 @@ use std::sync::Arc;
 use tsz_binder::SymbolId;
 use tsz_common::interner::Atom;
 
-type ApplicationEvalCacheKey = (DefId, smallvec::SmallVec<[TypeId; 4]>, bool);
+// The trailing two `bool`s are `no_unchecked_indexed_access` and
+// `exact_optional_property_types`. Evaluating a generic application can expand a
+// homomorphic mapped type whose optional-modifier stripping depends on
+// `exactOptionalPropertyTypes`, so both options are part of the cache identity
+// (issue #10970).
+type ApplicationEvalCacheKey = (DefId, smallvec::SmallVec<[TypeId; 4]>, bool, bool);
+// Element access (indexed access) of an optional property includes `undefined`
+// under both `exactOptionalPropertyTypes` settings (matching tsc), so the result
+// does not depend on that option and it is intentionally not part of this key.
 type ElementAccessTypeCacheKey = (TypeId, TypeId, Option<u32>, bool);
 type PropertyAccessCacheKey = (TypeId, Atom, bool, bool);
 
@@ -974,6 +982,7 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
             def_id,
             smallvec::SmallVec::from_slice(args),
             no_unchecked_indexed_access,
+            self.exact_optional_property_types(),
         ))
     }
 
@@ -990,6 +999,7 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
                 def_id,
                 smallvec::SmallVec::from_slice(args),
                 no_unchecked_indexed_access,
+                self.exact_optional_property_types(),
             ),
             result,
         );
@@ -1005,6 +1015,7 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
             .get(&EvaluationCacheKey::new(
                 type_id,
                 no_unchecked_indexed_access,
+                self.exact_optional_property_types(),
             ))
             .copied()
     }
@@ -1016,7 +1027,11 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
         result: TypeId,
     ) {
         self.closed_eval_cache.borrow_mut().insert(
-            EvaluationCacheKey::new(type_id, no_unchecked_indexed_access),
+            EvaluationCacheKey::new(
+                type_id,
+                no_unchecked_indexed_access,
+                self.exact_optional_property_types(),
+            ),
             result,
         );
     }
@@ -1412,7 +1427,8 @@ impl QueryDatabase for QueryCache<'_> {
         }
 
         let request = EvaluationRequest::new(type_id)
-            .with_no_unchecked_indexed_access(no_unchecked_indexed_access);
+            .with_no_unchecked_indexed_access(no_unchecked_indexed_access)
+            .with_exact_optional_property_types(self.exact_optional_property_types());
         let key = request.cache_key();
         let cached = self.eval_cache.borrow().get(&key).copied();
 

--- a/crates/tsz-solver/src/evaluation/request.rs
+++ b/crates/tsz-solver/src/evaluation/request.rs
@@ -7,17 +7,31 @@
 use crate::types::TypeId;
 
 /// Cache key for option-sensitive type evaluation.
+///
+/// Both `no_unchecked_indexed_access` and `exact_optional_property_types` are
+/// part of the key because both compiler options change evaluation results
+/// (indexed access of optional/array members, homomorphic mapped-modifier
+/// stripping). A cache key that omitted either would return a result computed
+/// under a different option set if the owning interner's options ever change
+/// between writes and reads (the explicit cache reset boundary described in
+/// issue #10970).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct EvaluationCacheKey {
     type_id: TypeId,
     no_unchecked_indexed_access: bool,
+    exact_optional_property_types: bool,
 }
 
 impl EvaluationCacheKey {
-    pub const fn new(type_id: TypeId, no_unchecked_indexed_access: bool) -> Self {
+    pub const fn new(
+        type_id: TypeId,
+        no_unchecked_indexed_access: bool,
+        exact_optional_property_types: bool,
+    ) -> Self {
         Self {
             type_id,
             no_unchecked_indexed_access,
+            exact_optional_property_types,
         }
     }
 
@@ -28,18 +42,24 @@ impl EvaluationCacheKey {
     pub const fn no_unchecked_indexed_access(self) -> bool {
         self.no_unchecked_indexed_access
     }
+
+    pub const fn exact_optional_property_types(self) -> bool {
+        self.exact_optional_property_types
+    }
 }
 
 /// Options that affect type evaluation results.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct EvaluationOptions {
     no_unchecked_indexed_access: bool,
+    exact_optional_property_types: bool,
 }
 
 impl EvaluationOptions {
     pub const fn new() -> Self {
         Self {
             no_unchecked_indexed_access: false,
+            exact_optional_property_types: false,
         }
     }
 
@@ -48,8 +68,17 @@ impl EvaluationOptions {
         self
     }
 
+    pub const fn with_exact_optional_property_types(mut self, enabled: bool) -> Self {
+        self.exact_optional_property_types = enabled;
+        self
+    }
+
     pub const fn no_unchecked_indexed_access(self) -> bool {
         self.no_unchecked_indexed_access
+    }
+
+    pub const fn exact_optional_property_types(self) -> bool {
+        self.exact_optional_property_types
     }
 }
 
@@ -82,6 +111,11 @@ impl EvaluationRequest {
         self
     }
 
+    pub const fn with_exact_optional_property_types(mut self, enabled: bool) -> Self {
+        self.options = self.options.with_exact_optional_property_types(enabled);
+        self
+    }
+
     pub const fn type_id(self) -> TypeId {
         self.type_id
     }
@@ -94,8 +128,16 @@ impl EvaluationRequest {
         self.options.no_unchecked_indexed_access()
     }
 
+    pub const fn exact_optional_property_types(self) -> bool {
+        self.options.exact_optional_property_types()
+    }
+
     pub const fn cache_key(self) -> EvaluationCacheKey {
-        EvaluationCacheKey::new(self.type_id, self.options.no_unchecked_indexed_access())
+        EvaluationCacheKey::new(
+            self.type_id,
+            self.options.no_unchecked_indexed_access(),
+            self.options.exact_optional_property_types(),
+        )
     }
 }
 
@@ -114,7 +156,7 @@ mod tests {
         assert!(!request.no_unchecked_indexed_access());
         assert_eq!(
             request.cache_key(),
-            EvaluationCacheKey::new(TypeId::STRING, false)
+            EvaluationCacheKey::new(TypeId::STRING, false, false)
         );
         assert_eq!(request.cache_key().type_id(), TypeId::STRING);
         assert!(!request.cache_key().no_unchecked_indexed_access());
@@ -130,11 +172,34 @@ mod tests {
         assert!(request.no_unchecked_indexed_access());
         assert_eq!(
             request.cache_key(),
-            EvaluationCacheKey::new(TypeId::NUMBER, true)
+            EvaluationCacheKey::new(TypeId::NUMBER, true, false)
         );
         assert_eq!(
             request.with_type_id(TypeId::BOOLEAN).cache_key(),
-            EvaluationCacheKey::new(TypeId::BOOLEAN, true)
+            EvaluationCacheKey::new(TypeId::BOOLEAN, true, false)
+        );
+    }
+
+    #[test]
+    fn request_cache_key_tracks_exact_optional_property_types() {
+        let request = EvaluationRequest::with_options(
+            TypeId::NUMBER,
+            EvaluationOptions::new().with_exact_optional_property_types(true),
+        );
+
+        assert!(request.exact_optional_property_types());
+        assert!(!request.no_unchecked_indexed_access());
+        assert!(request.cache_key().exact_optional_property_types());
+        assert!(!request.cache_key().no_unchecked_indexed_access());
+        assert_eq!(
+            request.cache_key(),
+            EvaluationCacheKey::new(TypeId::NUMBER, false, true)
+        );
+        // The two option flags are independent discriminants: flipping one must
+        // not collide with the other being set.
+        assert_ne!(
+            EvaluationCacheKey::new(TypeId::NUMBER, true, false),
+            EvaluationCacheKey::new(TypeId::NUMBER, false, true)
         );
     }
 

--- a/crates/tsz-solver/tests/db_tests.rs
+++ b/crates/tsz-solver/tests/db_tests.rs
@@ -1,3 +1,4 @@
+use crate::caches::db::TypeApplicationEvalCache;
 use crate::construction::{QueryCache, QueryCacheStatistics, RelationCacheProbe};
 use crate::relations::relation_queries::RelationPolicy;
 use crate::{
@@ -459,5 +460,87 @@ fn query_cache_statistics_merge_preserves_estimated_size() {
         merged_size,
         size_a + size_b,
         "merged estimated_size_bytes should equal sum of parts"
+    );
+}
+
+/// Regression for issue #10970: the closed-evaluation cache must encode
+/// `exactOptionalPropertyTypes` in its key.
+///
+/// A closed type's evaluation can depend on `exactOptionalPropertyTypes` (a
+/// homomorphic mapped type's optional-modifier stripping is gated on it). The
+/// owning interner's option can change between a cache write and a later read
+/// (the explicit reset boundary the issue asks for). Without the option in the
+/// key, a stale result computed under the old option value would be returned.
+///
+/// This drives the `TypeApplicationEvalCache` boundary directly: a value is
+/// stored under one option value, then the option is flipped. Before the fix
+/// the lookup ignored the option and returned the stale entry; after the fix
+/// the key differs and the lookup correctly misses.
+#[test]
+fn closed_eval_cache_keys_on_exact_optional_property_types() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let key_type = interner.literal_string("payload");
+    let stored = TypeId::STRING;
+
+    // Store a result under exactOptionalPropertyTypes = false.
+    db.set_exact_optional_property_types(false);
+    db.insert_closed_eval_cache(key_type, false, stored);
+    assert_eq!(
+        db.lookup_closed_eval_cache(key_type, false),
+        Some(stored),
+        "the entry must be visible under the option value it was written with"
+    );
+
+    // Flip the option. The entry computed under the old value must not be
+    // reused: the option is part of the cache identity.
+    db.set_exact_optional_property_types(true);
+    assert_eq!(
+        db.lookup_closed_eval_cache(key_type, false),
+        None,
+        "closed-eval lookup must miss after exactOptionalPropertyTypes changes"
+    );
+
+    // Restoring the original option value makes the original entry visible
+    // again, proving the two option values address distinct slots.
+    db.set_exact_optional_property_types(false);
+    assert_eq!(db.lookup_closed_eval_cache(key_type, false), Some(stored));
+}
+
+/// Companion to the closed-eval test for the generic-application evaluation
+/// cache, which shares the same option-sensitivity (a `Foo<Args>` application
+/// can expand to a mapped type whose stripping depends on the option).
+#[test]
+fn application_eval_cache_keys_on_exact_optional_property_types() {
+    use crate::def::DefId;
+
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let def_id = DefId(7);
+    let args = [TypeId::STRING];
+    let stored = TypeId::NUMBER;
+
+    db.set_exact_optional_property_types(false);
+    // Disambiguate from the inherent `QueryCache::insert_application_eval_cache`
+    // (which takes a pre-built tuple key) by calling the trait method directly.
+    TypeApplicationEvalCache::insert_application_eval_cache(&db, def_id, &args, false, stored);
+    assert_eq!(
+        db.lookup_application_eval_cache(def_id, &args, false),
+        Some(stored)
+    );
+
+    db.set_exact_optional_property_types(true);
+    assert_eq!(
+        db.lookup_application_eval_cache(def_id, &args, false),
+        None,
+        "application-eval lookup must miss after exactOptionalPropertyTypes changes"
+    );
+
+    db.set_exact_optional_property_types(false);
+    assert_eq!(
+        db.lookup_application_eval_cache(def_id, &args, false),
+        Some(stored)
     );
 }


### PR DESCRIPTION
## Summary

Closes #10970.

The solver's evaluation, closed-evaluation, and generic-application evaluation caches keyed only on `noUncheckedIndexedAccess`, even though their cached results can also depend on `exactOptionalPropertyTypes` (homomorphic mapped-type optional-modifier stripping in `strip_removed_optional_undefined`, and mapped index reads in `index_access`). Because the owning interner's options are mutable (`set_exact_optional_property_types`), a result computed under one option value could be reused after the option flipped between a cache write and a later read — an implicit, incorrect cache reuse boundary.

This completes the cache identity by threading `exactOptionalPropertyTypes` through `EvaluationOptions` / `EvaluationRequest` / `EvaluationCacheKey` and `ApplicationEvalCacheKey`, mirroring the existing `resolve_property_access_with_options` precedent (the property cache already keys on both options). The element-access cache is intentionally left unchanged: indexed access of an optional property includes `undefined` under both settings (matching `tsc`), so its result does not depend on the option.

AgentName: Studio-B

**Track:** Performance / solver memoization cache identity

**Invariant:** A solver memoization key must encode every compiler option the cached result depends on. Evaluation results depend on both `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`; therefore both are part of the evaluation/closed-eval/application-eval cache keys. The reset boundary across runs is explicit: option-compatible runs may reuse memoization, option-incompatible runs address distinct slots.

**Structural rule:** When a cached evaluation result is gated on `exactOptionalPropertyTypes` (e.g. mapped `-?` optional stripping), `tsc` computes it per the active option; tsz must too, through a cache key that encodes the option — owned by the solver `caches/query_cache` boundary and `evaluation/request`.

**Scope:**
- `crates/tsz-solver/src/evaluation/request.rs` — add `exact_optional_property_types` to `EvaluationOptions`/`EvaluationRequest`/`EvaluationCacheKey`, mirroring the existing `no_unchecked_indexed_access` field/builders/accessors.
- `crates/tsz-solver/src/caches/query_cache.rs` — thread the option into the eval, closed-eval, and application-eval cache keys; document why element-access stays single-option.
- `crates/tsz-solver/tests/db_tests.rs` — regression tests for the closed-eval and application-eval cache boundaries.

## Project Corpus Impact

- Row: n/a
- Bug family: solver memoization cache identity for compiler-option-dependent evaluation results
- Evidence: within a single compilation the option is constant, so every existing run produces byte-identical keys and results; this is behavior-preserving. It hardens correctness for option-changing cache reuse and makes the reset boundary explicit, which is the prerequisite the issue calls for to preserve memoization across compatible project-row runs.

**Verification:**
- New unit tests fail on the pre-fix keys (stale hit) and pass after: `closed_eval_cache_keys_on_exact_optional_property_types`, `application_eval_cache_keys_on_exact_optional_property_types`, `request_cache_key_tracks_exact_optional_property_types`.
- `cargo test -p tsz-solver --lib` — all pre-existing passing tests still pass (the only two failures, `evaluate_application_variadic_prepend_flattens_tail_application` and `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`, fail identically on the base branch and are unrelated to this change).
- `cargo test -p tsz-solver --lib architecture_guards::evaluation_engine_keeps_request_stage_boundary` — passes (`request.cache_key()` boundary preserved).
- `cargo check -p tsz-checker` and `cargo clippy -p tsz-solver --tests` — clean.

**Coordination Notes:** Rebased onto current `main`; no conflicts. No roadmap change (routine cache-correctness fix). Element-access deliberately excluded with rationale documented inline.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GEVECrWGBikxGbb791krg6)_

