### PR TITLE
refactor(checker): execute relation request policy

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -1154,11 +1154,11 @@ pub(crate) struct RelationOutcome {
 /// 2. When not related, collects a structured failure reason.
 /// 3. Detects weak-union violations.
 ///
-/// The boundary currently translates only `allow_erased_generic_signature_retry`
-/// into solver flags. Freshness, excess-property mode, and missing-property mode
-/// are carried on `RelationRequest` as explicit policy descriptors for follow-up
-/// centralization, but existing caller-side EPC/missing-property diagnostics still
-/// own those decisions.
+/// The boundary translates request policy into solver flags and the
+/// property-classification work the diagnostic layer can consume. Existing
+/// caller-side EPC/missing-property emission still owns source anchors and
+/// diagnostic wording, but the request decides whether property classification
+/// is part of the relation outcome.
 pub(crate) fn execute_relation<R: tsz_solver::relations::subtype::TypeResolver>(
     request: &RelationRequest,
     db: &dyn QueryDatabase,
@@ -1236,11 +1236,11 @@ pub(crate) fn execute_relation<R: tsz_solver::relations::subtype::TypeResolver>(
         None => (false, None),
     };
 
-    // Always populate property classification when the relation fails.
-    // This provides the canonical property-level analysis that callers like
-    // `should_skip_weak_union_error` need without re-enumerating properties.
-    let property_classification =
-        classify_object_properties(db.as_type_database(), request.source, request.target);
+    let property_classification = if request.requires_property_classification() {
+        classify_object_properties(db.as_type_database(), request.source, request.target)
+    } else {
+        None
+    };
 
     // Suppress ExcessProperty failure when the target has structural features
     // that make EPC inapplicable.

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -15,7 +15,7 @@ use tsz_solver::relations::relation_queries::{
 };
 
 use super::relation_policy;
-pub(crate) use super::relation_request::{RelationKind, RelationRequest};
+pub(crate) use super::relation_request::RelationRequest;
 
 pub(crate) use super::common::{contains_type_parameters, is_callable_type, object_shape_for_type};
 
@@ -1176,22 +1176,10 @@ pub(crate) fn execute_relation<R: tsz_solver::relations::subtype::TypeResolver>(
     )
     .entered();
 
-    let mut relation_flags = flags;
-    if request.allow_erased_generic_signature_retry {
-        relation_flags |= RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY;
-    }
-
     // BivariantCallbacks treats callback parameter types bivariantly by stripping
     // strict-function-types. The decision and the failure reason both run under
     // this policy so they cannot diverge.
-    let (solver_kind, solver_flags) = if request.kind == RelationKind::BivariantCallbacks {
-        (
-            SolverRelationKind::AssignableBivariantCallbacks,
-            relation_flags & !RelationFlags::STRICT_FUNCTION_TYPES,
-        )
-    } else {
-        (SolverRelationKind::Assignable, relation_flags)
-    };
+    let (solver_kind, solver_flags) = request.solver_relation_policy(flags);
 
     // Decide the relation and, on failure, capture the structured reason from the
     // SAME configured checker (single pass). This is the canonical fix for the

--- a/crates/tsz-checker/src/query_boundaries/relation_request.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_request.rs
@@ -224,13 +224,13 @@ pub(crate) struct RelationRequest {
     pub source: TypeId,
     /// Prepared target type for the relation.
     pub target: TypeId,
-    /// Diagnostic/tracing context. Currently advisory only.
+    /// Diagnostic/tracing context and relation-mode selector.
     pub kind: RelationKind,
-    /// Requested excess-property policy. Currently advisory.
+    /// Requested excess-property policy for boundary-level property analysis.
     pub excess_property_mode: ExcessPropertyMode,
-    /// Requested missing-property policy. Currently advisory.
+    /// Requested missing-property policy for boundary-level property analysis.
     pub missing_property_mode: MissingPropertyMode,
-    /// Fresh object literal marker. Currently advisory.
+    /// Fresh object literal marker for excess-property classification.
     pub source_is_fresh: bool,
     /// Allow targeted erased-signature retry for interface property compatibility.
     pub allow_erased_generic_signature_retry: bool,
@@ -675,6 +675,19 @@ impl RelationRequest {
     pub(crate) const fn with_missing_property_mode(mut self, mode: MissingPropertyMode) -> Self {
         self.missing_property_mode = mode;
         self
+    }
+
+    pub(crate) const fn requires_property_classification(&self) -> bool {
+        let checks_excess_properties = match self.excess_property_mode {
+            ExcessPropertyMode::Skip => false,
+            ExcessPropertyMode::Check | ExcessPropertyMode::CheckExplicitOnly => true,
+        };
+        let reports_missing_properties = match self.missing_property_mode {
+            MissingPropertyMode::Report => true,
+            MissingPropertyMode::Suppress => false,
+        };
+
+        self.source_is_fresh || checks_excess_properties || reports_missing_properties
     }
 
     /// Allow a failed generic-signature inference to retry with erased signatures.

--- a/crates/tsz-checker/src/query_boundaries/relation_request.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_request.rs
@@ -690,6 +690,28 @@ impl RelationRequest {
         self.source_is_fresh || checks_excess_properties || reports_missing_properties
     }
 
+    pub(crate) fn solver_relation_policy(
+        &self,
+        base_flags: u16,
+    ) -> (tsz_solver::relations::relation_queries::RelationKind, u16) {
+        let mut flags = base_flags;
+        if self.allow_erased_generic_signature_retry {
+            flags |= tsz_solver::RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY.bits() as u16;
+        }
+
+        if self.kind == RelationKind::BivariantCallbacks {
+            (
+                tsz_solver::relations::relation_queries::RelationKind::AssignableBivariantCallbacks,
+                flags & !(tsz_solver::RelationFlags::STRICT_FUNCTION_TYPES.bits() as u16),
+            )
+        } else {
+            (
+                tsz_solver::relations::relation_queries::RelationKind::Assignable,
+                flags,
+            )
+        }
+    }
+
     /// Allow a failed generic-signature inference to retry with erased signatures.
     pub(crate) const fn with_erased_generic_signature_retry(mut self) -> Self {
         self.allow_erased_generic_signature_retry = true;

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -133,3 +133,4 @@ include!("architecture_contract_tests_parts/part_00.rs");
 include!("architecture_contract_tests_parts/part_01.rs");
 include!("architecture_contract_tests_parts/part_02.rs");
 include!("architecture_contract_tests_parts/part_03.rs");
+include!("architecture_contract_tests_parts/part_04.rs");

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_04.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_04.rs
@@ -1,0 +1,28 @@
+/// Relation request property policy must be executable boundary input, not
+/// future-facing documentation that callers can ignore.
+#[test]
+fn test_relation_request_property_policy_is_executed() {
+    let request_source = fs::read_to_string("src/query_boundaries/relation_request.rs")
+        .expect("failed to read query_boundaries/relation_request.rs");
+    let boundary_source = fs::read_to_string("src/query_boundaries/assignability.rs")
+        .expect("failed to read query_boundaries/assignability.rs");
+
+    assert!(
+        !request_source.contains("Currently advisory"),
+        "RelationRequest property-policy fields must not be documented as advisory-only"
+    );
+    assert!(
+        request_source.contains("fn requires_property_classification(&self) -> bool"),
+        "RelationRequest must expose an executable policy query for property classification"
+    );
+
+    let execute_body = boundary_source
+        .split("pub(crate) fn execute_relation")
+        .nth(1)
+        .and_then(|tail| tail.split("fn suppress_excess_property_failure_if_needed").next())
+        .expect("failed to locate execute_relation body");
+    assert!(
+        execute_body.contains("request.requires_property_classification()"),
+        "execute_relation must use request property policy before classifying object properties"
+    );
+}

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_04.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_04.rs
@@ -15,6 +15,10 @@ fn test_relation_request_property_policy_is_executed() {
         request_source.contains("fn requires_property_classification(&self) -> bool"),
         "RelationRequest must expose an executable policy query for property classification"
     );
+    assert!(
+        request_source.contains("fn solver_relation_policy("),
+        "RelationRequest must expose executable solver relation kind/flag policy"
+    );
 
     let execute_body = boundary_source
         .split("pub(crate) fn execute_relation")
@@ -24,5 +28,9 @@ fn test_relation_request_property_policy_is_executed() {
     assert!(
         execute_body.contains("request.requires_property_classification()"),
         "execute_relation must use request property policy before classifying object properties"
+    );
+    assert!(
+        execute_body.contains("request.solver_relation_policy("),
+        "execute_relation must ask RelationRequest for solver kind/flags instead of open-coding request policy"
     );
 }


### PR DESCRIPTION
## Agent
AgentName: M5Refactorer

## Track
Checker relation/query-boundary refactor for #8227.

## Invariant
When checker asks a diagnostic-bearing assignability relation question, request-owned policy decides the solver relation kind, solver flag adjustments, and whether property classification belongs in the `RelationOutcome`; `execute_relation` consumes that policy instead of open-coding advisory fields.

## Scope
- Move `RelationRequest` property-policy fields from advisory documentation into executable helper methods.
- Centralize bivariant-callback and erased-generic-signature retry policy on `RelationRequest`.
- Add an architecture ratchet so `execute_relation` must consume request-owned property and solver policy.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only checker/query-boundary routing change; default relation-request property classification remains enabled through `MissingPropertyMode::Report`, preserving existing diagnostic behavior.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib test_relation_request_property_policy_is_executed`
- `cargo fmt --check`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`

## Coordination Notes
- Refs #8227.
- Uses canonical `agent:M1-B` label because `M5Refactorer` is the assigned AgentName but not a canonical repo ownership label.
- Not stacked; based on current `origin/main`.