### PR TITLE
fix(solver): infer recursive array-utility element unions instead of over-constraining (#12876)

### DIFF
--- a/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
+++ b/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
@@ -1344,6 +1344,31 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             return Some(elem);
         }
 
+        // The context-free `get_array_element_type` above cannot always reduce a
+        // generic alias application to its underlying array form — recursive
+        // aliases such as `type RecArray<T> = Array<T | RecArray<T>>` are left as
+        // an opaque `Application` because the memoized full `evaluate_type`'s
+        // recursion guard can leave them unreduced depending on cache-population
+        // order (which is exactly what makes the inference for these aliases
+        // order-dependent). Expand the alias body a *single* deterministic step
+        // and accept it only when that body is *directly* an array/readonly-array
+        // form. The strict, non-evaluating shape check keeps this from widening
+        // array-likeness to mapped/conditional/interface aliases (e.g. `Promise`),
+        // so it touches only genuine recursive array aliases.
+        if let Some(expanded) = self.checker.expand_type_alias_application(type_id) {
+            let unwrapped = match self.interner.lookup(expanded) {
+                Some(TypeData::ReadonlyType(inner)) => inner,
+                _ => expanded,
+            };
+            if let Some(TypeData::Array(elem)) = self.interner.lookup(unwrapped) {
+                return Some(elem);
+            }
+        }
+
+        // Final fallback: a non-alias reduction that exposes a named array object
+        // (e.g. a mapped form resolving to an `ObjectWithIndex` array shape). This
+        // mirrors the pre-existing behaviour and intentionally does *not* treat an
+        // arbitrary evaluated `Array` as array-like, to avoid broadening matches.
         let evaluated = self.checker.evaluate_type(type_id);
         (evaluated != type_id)
             .then(|| self.named_array_object_element_for_constraint(evaluated))

--- a/crates/tsz-solver/src/operations/constraints/walker.rs
+++ b/crates/tsz-solver/src/operations/constraints/walker.rs
@@ -627,10 +627,79 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                     target
                 };
 
-                for &member in s_members.iter() {
-                    // Skip source members that directly match a fixed target member
-                    if !fixed_targets.contains(&member) {
-                        self.constrain_types(ctx, var_map, member, reduced_target, priority);
+                // Classify the parameterized target arms into the single naked
+                // type variable (`T`) and structured members that merely contain a
+                // placeholder (`RecArray<T>`, `Array<T>`, …). When the union has the
+                // recursive array-alias shape `T | RecArray<T>` (one naked arm, and
+                // every structured arm is array-like), mirror tsc's
+                // `inferFromMatchingTypes` + `inferToMultipleTypes`: peel each source
+                // member that structurally matches a structured arm into that arm,
+                // then infer the *residual source members as one union* against the
+                // naked `T`. Inferring the residual as a single union — rather than
+                // per-member — is what lets `flat([1, 'a', [2]])` infer
+                // `T = string | number` instead of collapsing to one element through
+                // the common-supertype tournament. The shape is restricted to
+                // array-like structured arms so other `T | F<T>` unions (notably
+                // `T | PromiseLike<T>`) keep their established per-member
+                // decomposition.
+                let naked_targets: Vec<TypeId> = t_members_list
+                    .iter()
+                    .copied()
+                    .filter(|member| var_map.contains_key(member))
+                    .collect();
+                // Only the `T | Structured<T>` shape (exactly one naked arm) takes
+                // the residual-union path; classify the structured arms lazily so
+                // the common case short-circuits before the placeholder walk and
+                // the array-like probe.
+                let structured_targets: Vec<TypeId> = if naked_targets.len() == 1 {
+                    with_placeholder_visited(|visited| {
+                        t_members_list
+                            .iter()
+                            .copied()
+                            .filter(|&member| {
+                                if var_map.contains_key(&member) {
+                                    return false;
+                                }
+                                visited.clear();
+                                self.type_contains_placeholder(member, var_map, visited)
+                            })
+                            .collect()
+                    })
+                } else {
+                    Vec::new()
+                };
+                let all_structured_array_like = !structured_targets.is_empty()
+                    && structured_targets
+                        .iter()
+                        .all(|&t| self.array_like_element_for_constraint(t).is_some());
+
+                if let (Some(&naked), true) = (naked_targets.first(), all_structured_array_like) {
+                    let mut leftover: Vec<TypeId> = Vec::new();
+                    for &member in s_members.iter() {
+                        if fixed_targets.contains(&member) {
+                            continue;
+                        }
+                        let mut matched_any = false;
+                        for &structured in &structured_targets {
+                            if self.types_share_outer_structure_for_constraint(member, structured) {
+                                matched_any = true;
+                                self.constrain_types(ctx, var_map, member, structured, priority);
+                            }
+                        }
+                        if !matched_any {
+                            leftover.push(member);
+                        }
+                    }
+                    if !leftover.is_empty() {
+                        let leftover_union = crate::utils::union_or_single(self.interner, leftover);
+                        self.constrain_types(ctx, var_map, leftover_union, naked, priority);
+                    }
+                } else {
+                    for &member in s_members.iter() {
+                        // Skip source members that directly match a fixed target member
+                        if !fixed_targets.contains(&member) {
+                            self.constrain_types(ctx, var_map, member, reduced_target, priority);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
AgentName: lucid-hopper

**Track:** solver / generic call inference — recursive array-utility element inference

## Invariant

When a generic array-flattening utility parameter has the recursive
union-element shape `T | RecArray<T>` (e.g. `type RecArray<T> = Array<T |
RecArray<T>>`), array-like source members are inferred against the recursive
arm and the residual source members are inferred as a **single union** against
the naked type variable, so tsz infers `T = string | number` for
`flat([1, 'a', [2]])` and friends — matching `tsc` — rather than collapsing
`T` to one element and emitting false `TS2322`.

## Summary

Closes the inference over-constraint behind #12876. `tsz` emitted false
`TS2322` on recursive array-flattening utilities where `tsc` is clean:

```ts
type RecArray<T> = Array<T | RecArray<T>>;
declare function flat<T>(a: RecArray<T>): Array<T>;

flat([1, 'a', [2]]);   // tsc: T = string | number, ok.  tsz (before): TS2322
flat([1, [2, 'a']]);   // tsc: ok.                        tsz (before): TS2322
```

The element type of the array argument was over-constrained to one inferred
branch instead of the union.

## Wrong semantic operation

Inference — recursive/distributive array-utility evaluation plus
argument-element union routing in the solver constraint walker (not checker
orchestration).

## Structural rule

When the parameter element is a union `T | RecArray<T>` whose structured arm
evaluates to an array, tsc routes array-like source members into the recursive
arm and infers the residual source union against the naked `T` (one candidate),
through `inferFromMatchingTypes` + `inferToMultipleTypes`; tsz now does the same
through the generic-call constraint walker.

Two solver fixes:

1. **`array_like_element_for_constraint`** (`operations/constraints/reverse_mapped.rs`)
   now recognizes a recursive array-alias application deterministically via a
   single-step alias-body expansion that accepts only a directly
   `Array`/`ReadonlyArray`-shaped body. The pre-existing path relied on the
   memoized full `evaluate_type`, whose recursion guard can leave such an
   application unreduced depending on cache-population order — the exact latent
   masking noted in the issue. The one-step expansion is order-independent and
   strictly shaped, so it does not broaden array-likeness to
   mapped/conditional/interface aliases such as `Promise`.

2. **`(Union, Union)` constraint walker** (`operations/constraints/walker.rs`)
   detects the `T | RecArray<T>` shape (exactly one naked arm + all structured
   arms array-like) and mirrors tsc's `inferFromMatchingTypes` +
   `inferToMultipleTypes`: array-like source members are peeled into the
   recursive arm, and the residual source members are inferred as a single
   union against the naked `T`. Other `T | F<T>` unions (notably
   `T | PromiseLike<T>`) fall through to the established per-member
   decomposition.

## Scope

- Owner layer: solver (inference / constraint collection). No checker, emitter,
  or printer changes.
- Adjacent matrix (verified against `tsc` 6.x semantics, isolated):
  - `flat`/`flat1`/`flat2` mixed-element calls (`[1, 'a', [2]]`,
    `[1, [2, 'a']]`): clean, `T = string | number`.
  - `flat([1, ['a']])` / `flat1` / `flat2` variants: still error (`T = string`,
    `number` element rejected), matching the fixture's expected `TS2322` lines.
  - `T | PromiseLike<T>` (Promise.then / async return), tuple/readonly index,
    and generic-pipe inference: unchanged (gated out by the array-like shape
    restriction).

## Project Corpus Impact

- Row: n/a
- Bug family: recursive-types / type-inference
- None expected. The change is gated to the recursive-array-alias union shape
  and the structured-arm array-like restriction; non-array `T | F<T>` unions
  keep their prior behavior.

## Verification

- `cargo test -p tsz-solver --lib`: 6585 passed; the only 2 failures
  (`evaluate_application_variadic_prepend_flattens_tail_application`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`)
  are **pre-existing on `main`** (verified by reverting the change) — zero new
  solver regressions.
- `cargo test -p tsz-checker --lib`: identical failing set to pristine `main`
  (those lib-dependent failures are environmental, from the un-checked-out
  TypeScript submodule, not this change) — zero new checker regressions.
- CLI repro on the minimal fixture: false `TS2322` on the mixed cases removed;
  the three expected `TS2322` errors reproduced with the exact target types
  (`string | RecArray<string>`, `string | string[]`,
  `string | (string | string[])[]`).
- `cargo fmt` / `cargo clippy -p tsz-solver`: clean.

## Coordination Notes

- The full `recursiveTypeReferences1.ts` fixture retains a residual
  declaration-order sensitivity in tsz's recursive-alias evaluation cache (the
  pre-existing latent issue #12876 describes): declaring the deeply-nested
  `flat2` alias alongside the recursive preamble can still perturb the
  `flat`/`flat1`/`flat2` element-error inference in the full-file ordering. That
  upstream evaluation-cache determinism is out of scope here; this PR fixes the
  inference over-constraint itself and removes the false positives. The
  fixture's conformance code-set (`{TS2304, TS2322}`) is unchanged by this
  change, so the committed snapshot signature is preserved.

https://claude.ai/code/session_013vA7VDPdux7ux9GiHxmimZ