### PR TITLE
refactor(checker): move display helpers to diagnostic boundary

### DIFF
--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
@@ -1,6 +1,7 @@
 //! Call parameter display helpers for call diagnostics.
 
 use crate::query_boundaries::common as query_common;
+use crate::query_boundaries::diagnostics as query_diagnostics;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -587,7 +588,7 @@ impl<'a> CheckerState<'a> {
         }
         let shape = query_common::callable_shape_for_type(self.ctx.types, evaluated)?;
         if shape.call_signatures.len() <= 1
-            || !query_common::function_signature_has_typeof(self.ctx.types, evaluated)
+            || !query_diagnostics::function_signature_has_typeof(self.ctx.types, evaluated)
         {
             return None;
         }

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -944,7 +944,10 @@ impl<'a> CheckerState<'a> {
             // referential typeof (e.g. `(t: typeof C.g) => void` where `C.g`
             // IS that function) produces an extra outer wrapper. tsc keeps
             // the typeof reference intact in the rendered message.
-            if crate::query_boundaries::common::function_signature_has_typeof(self.ctx.types, ty) {
+            if crate::query_boundaries::diagnostics::function_signature_has_typeof(
+                self.ctx.types,
+                ty,
+            ) {
                 visiting.remove(&ty);
                 return ty;
             }
@@ -1423,7 +1426,7 @@ impl<'a> CheckerState<'a> {
         // (return-side) or extra wrapping like `(t: (t: typeof g) => void)
         // => void` (param-side, for recursive `typeof X` referring to the
         // enclosing function).
-        if crate::query_boundaries::common::function_signature_has_typeof(self.ctx.types, ty) {
+        if crate::query_boundaries::diagnostics::function_signature_has_typeof(self.ctx.types, ty) {
             return false;
         }
 

--- a/crates/tsz-checker/src/error_reporter/type_display_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/type_display_policy.rs
@@ -54,7 +54,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         ty: TypeId,
     ) -> TypeId {
-        let body = match crate::query_boundaries::common::indexed_access_alias_body(
+        let body = match crate::query_boundaries::diagnostics::indexed_access_alias_body(
             self.ctx.types.as_type_database(),
             &self.ctx.definition_store,
             ty,
@@ -64,7 +64,7 @@ impl<'a> CheckerState<'a> {
         };
         let resolved = self.evaluate_type_with_env(body);
         if resolved == body
-            || crate::query_boundaries::common::is_unresolved_for_display(
+            || crate::query_boundaries::diagnostics::is_unresolved_for_display(
                 self.ctx.types.as_type_database(),
                 resolved,
             )

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -32,40 +32,6 @@ pub(crate) fn is_compiler_managed_type(name: &str) -> bool {
     tsz_solver::is_compiler_managed_type(name)
 }
 
-/// If `ty` is `Lazy(def_id)` for a non-generic `TypeAlias` whose body is the
-/// canonical self-keyof indexed-access shape `Foo[keyof Foo]`, return the
-/// body `TypeId` so the caller can evaluate it with a resolver-equipped
-/// evaluator. Otherwise return `None`.
-///
-/// tsc loses the outer alias when this reduction collapses to a concrete type.
-/// The match is intentionally narrow: generic indexed-access aliases and
-/// non-self-keyof aliases stay opaque to avoid recursion-fuel blowups and
-/// spurious TS2589s.
-pub(crate) fn indexed_access_alias_body(
-    db: &dyn TypeDatabase,
-    def_store: &tsz_solver::def::DefinitionStore,
-    ty: TypeId,
-) -> Option<TypeId> {
-    let def_id = tsz_solver::type_queries::get_lazy_def_id(db, ty)?;
-    let def = def_store.get(def_id)?;
-    if def.kind != tsz_solver::def::DefKind::TypeAlias || !def.type_params.is_empty() {
-        return None;
-    }
-    let body = def.body?;
-    // Only match the `Foo[keyof Foo]` self-keyof shape — narrower than
-    // "any IndexAccess" to avoid evaluating legitimately-deferred forms.
-    tsz_solver::type_queries::indexed_access_self_keyof(db, body)?;
-    Some(body)
-}
-
-/// Returns true if `ty` is still a deferred form (`Lazy` or `IndexAccess`)
-/// that the solver could not reduce. Used after attempting a full evaluate
-/// to decide whether to keep the original alias display or use the resolved
-/// form.
-pub(crate) fn is_unresolved_for_display(db: &dyn TypeDatabase, ty: TypeId) -> bool {
-    tsz_solver::type_queries::is_deferred_lazy_or_indexed_access(db, ty)
-}
-
 /// Thin wrapper around `tsz_solver::deep_reduce_for_display`.
 ///
 /// Deeply reduce meta-type applications (e.g. `InstanceType<typeof Foo>`)
@@ -159,10 +125,6 @@ pub(crate) fn is_type_deeply_any(db: &dyn TypeDatabase, type_id: TypeId) -> bool
 
 pub(crate) fn has_property_by_str(db: &dyn TypeDatabase, type_id: TypeId, name: &str) -> bool {
     tsz_solver::type_queries::type_has_property_by_str(db, type_id, name)
-}
-
-pub(crate) fn type_may_display_iterator_protocol(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    tsz_solver::type_queries::type_may_display_iterator_protocol(db, type_id)
 }
 
 pub(crate) fn has_nonpublic_property(db: &dyn TypeDatabase, type_id: TypeId, name: &str) -> bool {
@@ -1251,31 +1213,6 @@ pub(crate) fn has_call_signatures(db: &dyn TypeDatabase, type_id: TypeId) -> boo
 
 pub(crate) fn is_type_query_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::is_type_query_type(db, type_id)
-}
-
-/// Return `true` if `type_id` resolves to a `Function` shape — or a
-/// `Callable` whose call signatures collectively — carry a `TypeQuery`
-/// in any param or return position. Used by display-side normalization
-/// to skip `evaluate_type_for_assignability` on self-referential
-/// `typeof X` shapes (so the inner reference stays as `typeof X`
-/// rather than being expanded into another wrapper of the same shape).
-pub(crate) fn function_signature_has_typeof(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    if let Some(shape) = function_shape_for_type(db, type_id)
-        && (is_type_query_type(db, shape.return_type)
-            || shape
-                .params
-                .iter()
-                .any(|p| is_type_query_type(db, p.type_id)))
-    {
-        return true;
-    }
-    if let Some(shape) = callable_shape_for_type(db, type_id) {
-        return shape.call_signatures.iter().any(|sig| {
-            is_type_query_type(db, sig.return_type)
-                || sig.params.iter().any(|p| is_type_query_type(db, p.type_id))
-        });
-    }
-    false
 }
 
 pub(crate) fn needs_evaluation_for_merge(db: &dyn TypeDatabase, type_id: TypeId) -> bool {

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -15,9 +15,9 @@ pub(crate) use super::common::{
     is_template_literal_type, keyof_inner_type, lazy_def_id, literal_value, mapped_type_id,
     mapped_type_info, no_infer_inner_type, object_shape_for_type, readonly_inner_type,
     return_type_for_type, string_literal_value, tuple_elements, type_has_displayable_name,
-    type_is_conditional_type_result_with_unresolved_inference, type_may_display_iterator_protocol,
-    type_param_info, type_parameter_constraint, union_list_id, union_members,
-    widen_literal_to_primitive, widen_type_deep,
+    type_is_conditional_type_result_with_unresolved_inference, type_param_info,
+    type_parameter_constraint, union_list_id, union_members, widen_literal_to_primitive,
+    widen_type_deep,
 };
 pub(crate) use tsz_solver::type_queries::AssignmentNumericDisplayChildren;
 
@@ -26,6 +26,54 @@ pub(crate) fn assignment_numeric_display_children(
     type_id: TypeId,
 ) -> AssignmentNumericDisplayChildren {
     tsz_solver::type_queries::assignment_numeric_display_children(db, type_id)
+}
+
+/// Return the body of a non-generic alias shaped as `Foo[keyof Foo]`.
+pub(crate) fn indexed_access_alias_body(
+    db: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
+    ty: TypeId,
+) -> Option<TypeId> {
+    let def_id = tsz_solver::type_queries::get_lazy_def_id(db, ty)?;
+    let def = def_store.get(def_id)?;
+    if def.kind != DefKind::TypeAlias || !def.type_params.is_empty() {
+        return None;
+    }
+    let body = def.body?;
+    tsz_solver::type_queries::indexed_access_self_keyof(db, body)?;
+    Some(body)
+}
+
+/// Returns true if `ty` is still a deferred form after display reduction.
+pub(crate) fn is_unresolved_for_display(db: &dyn TypeDatabase, ty: TypeId) -> bool {
+    tsz_solver::type_queries::is_deferred_lazy_or_indexed_access(db, ty)
+}
+
+pub(crate) fn type_may_display_iterator_protocol(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    tsz_solver::type_queries::type_may_display_iterator_protocol(db, type_id)
+}
+
+/// Return `true` if a function/callable signature contains a `typeof` query.
+pub(crate) fn function_signature_has_typeof(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    if let Some(shape) = tsz_solver::type_queries::get_function_shape(db, type_id)
+        && (tsz_solver::is_type_query_type(db, shape.return_type)
+            || shape
+                .params
+                .iter()
+                .any(|p| tsz_solver::is_type_query_type(db, p.type_id)))
+    {
+        return true;
+    }
+    if let Some(shape) = tsz_solver::type_queries::get_callable_shape(db, type_id) {
+        return shape.call_signatures.iter().any(|sig| {
+            tsz_solver::is_type_query_type(db, sig.return_type)
+                || sig
+                    .params
+                    .iter()
+                    .any(|p| tsz_solver::is_type_query_type(db, p.type_id))
+        });
+    }
+    false
 }
 
 /// `true` when `type_id` is an anonymous object type, or a union / intersection

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_04.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_04.rs
@@ -34,3 +34,29 @@ fn test_relation_request_property_policy_is_executed() {
         "execute_relation must ask RelationRequest for solver kind/flags instead of open-coding request policy"
     );
 }
+
+/// Display-only diagnostic helpers should not live in the catch-all
+/// `query_boundaries::common` module.
+#[test]
+fn test_display_diagnostic_helpers_have_domain_boundary() {
+    let common_source = fs::read_to_string("src/query_boundaries/common.rs")
+        .expect("failed to read query_boundaries/common.rs");
+    let diagnostic_source = fs::read_to_string("src/query_boundaries/diagnostics.rs")
+        .expect("failed to read query_boundaries/diagnostics.rs");
+
+    for helper in [
+        "indexed_access_alias_body",
+        "is_unresolved_for_display",
+        "type_may_display_iterator_protocol",
+        "function_signature_has_typeof",
+    ] {
+        assert!(
+            !common_source.contains(&format!("fn {helper}(")),
+            "{helper} belongs in query_boundaries::diagnostics, not common.rs"
+        );
+        assert!(
+            diagnostic_source.contains(&format!("fn {helper}(")),
+            "{helper} must remain available through query_boundaries::diagnostics"
+        );
+    }
+}


### PR DESCRIPTION
## Agent
AgentName: M5Refactorer

## Track
Checker/query-boundary simplification (#8227/#8225)

## Invariant
Display-only diagnostic helper queries should live behind `query_boundaries::diagnostics`, not the catch-all `query_boundaries::common` module.

## Scope
- Moves four display/diagnostic helpers from `common.rs` to `diagnostics.rs`.
- Updates display callers to use the diagnostic boundary.
- Adds an architecture ratchet to prevent those helpers from sliding back into `common.rs`.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: Behavior-preserving ownership refactor; no project-corpus rows expected to change.

## Verification
- `scripts/safe-run.sh cargo test -p tsz-checker --lib test_display_diagnostic_helpers_have_domain_boundary -- --nocapture`
- `scripts/safe-run.sh python3 scripts/arch/arch_guard.py`
- Attempted `scripts/safe-run.sh cargo nextest run -p tsz-checker architecture_contract_tests`; it hung after compilation in this fresh worktree and was terminated.
- `scripts/safe-run.sh cargo test -p tsz-checker --lib architecture_contract_tests_src -- --nocapture` fails on pre-existing unrelated architecture ratchets from main.

## Coordination Notes
- Follows merged PR #12880 by reducing the remaining `query_boundaries::common` wrapper forest.
- Avoids the claimed #8225 work and keeps the slice limited to display/diagnostic ownership.