### PR TITLE
refactor(checker): route compiler-managed predicate through boundary

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -28,10 +28,6 @@ pub(crate) use super::construct_signatures::construct_signatures_for_type;
 pub(crate) use super::generic_instantiation::{instantiate_generic, instantiate_type};
 pub(crate) use super::type_rewrite::replace_type_queries_and_lazies_with;
 
-pub(crate) fn is_compiler_managed_type(name: &str) -> bool {
-    tsz_solver::is_compiler_managed_type(name)
-}
-
 /// If `ty` is `Lazy(def_id)` for a non-generic `TypeAlias` whose body is the
 /// canonical self-keyof indexed-access shape `Foo[keyof Foo]`, return the
 /// body `TypeId` so the caller can evaluate it with a resolver-equipped

--- a/crates/tsz-checker/src/query_boundaries/type_predicates.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_predicates.rs
@@ -1,7 +1,9 @@
 use tsz_solver::TypeId;
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 
-pub(crate) use super::common::is_compiler_managed_type;
+pub(crate) fn is_compiler_managed_type(name: &str) -> bool {
+    tsz_solver::is_compiler_managed_type(name)
+}
 
 pub(crate) fn is_top_level_error_or_error_union_member(
     db: &dyn TypeDatabase,

--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -164,7 +164,7 @@ impl CheckerState<'_> {
         }
 
         let name = symbol.escaped_name.clone();
-        if crate::query_boundaries::common::is_compiler_managed_type(&name) {
+        if crate::query_boundaries::type_predicates::is_compiler_managed_type(&name) {
             return None;
         }
         if self.ctx.file_local_type_shadow_for_lib_name(&name) {

--- a/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_alias.rs
@@ -1,5 +1,6 @@
 //! Helpers for computing type aliases in `compute_type_of_symbol`.
 
+use crate::query_boundaries::type_predicates::is_compiler_managed_type;
 use crate::state::CheckerState;
 use crate::symbols_domain::name_text::expression_name_text_in_arena;
 use tsz_binder::{SymbolId, symbol_flags};
@@ -7,7 +8,6 @@ use tsz_lowering::TypeLowering;
 use tsz_parser::parser::node::{NodeAccess, NodeArena, TypeAliasData};
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
-use tsz_solver::is_compiler_managed_type;
 use tsz_solver::{SymbolRef, TupleElement, TypeId};
 
 impl<'a> CheckerState<'a> {

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -1799,8 +1799,8 @@ impl<'a> CheckerState<'a> {
         decl_idx: NodeIndex,
         sym_id: SymbolId,
     ) -> TypeId {
+        use crate::query_boundaries::type_predicates::is_compiler_managed_type;
         use tsz_lowering::TypeLowering;
-        use tsz_solver::is_compiler_managed_type;
 
         let arena_ref: &tsz_parser::parser::node::NodeArena = arena.as_ref();
         let lib_binders = self.get_lib_binders();

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/actual_lib_methods.rs
@@ -390,7 +390,8 @@ impl<'a> CheckerState<'a> {
             .get(type_ref.type_name)
             .and_then(|name_node| arena.get_identifier(name_node))
             .map(|ident| ident.escaped_text.as_str())?;
-        if common::is_compiler_managed_type(name) || self.ctx.file_local_type_shadow_for_lib_name(name)
+        if crate::query_boundaries::type_predicates::is_compiler_managed_type(name)
+            || self.ctx.file_local_type_shadow_for_lib_name(name)
         {
             return None;
         }
@@ -521,7 +522,7 @@ impl<'a> CheckerState<'a> {
                 // marker and get their structural representation at use sites.
                 // This helper is restricted to compiler-managed built-ins and
                 // still runs after actual-lib declaration proof above.
-                || common::is_compiler_managed_type(name));
+                || crate::query_boundaries::type_predicates::is_compiler_managed_type(name));
         let outcome = if non_generic_alias_has_resolved_body || generic_alias_has_admitted_body {
             DirectActualLibAliasBodyOutcome::Success
         } else if !params.is_empty() {

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -2,6 +2,7 @@
 //! interface type construction, and type-reference-with-params computation.
 
 use crate::query_boundaries::state::type_resolution as query;
+use crate::query_boundaries::type_predicates::is_compiler_managed_type;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use crate::symbols_domain::name_text::{entity_name_text_in_arena, expression_name_text_in_arena};
@@ -11,7 +12,6 @@ use tsz_parser::parser::node::{NodeAccess, NodeArena};
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
-use tsz_solver::is_compiler_managed_type;
 
 impl<'a> CheckerState<'a> {
     pub(crate) fn type_reference_symbol_type(&mut self, sym_id: SymbolId) -> TypeId {

--- a/crates/tsz-checker/src/symbols/symbol_resolver.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver.rs
@@ -8,6 +8,7 @@
 //! This module extends `CheckerState` with additional methods for symbol-related
 //! operations, providing cleaner APIs for common patterns.
 
+use crate::query_boundaries::type_predicates::is_compiler_managed_type;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use crate::symbols_domain::name_text::entity_name_text_in_arena;
@@ -18,7 +19,6 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
-use tsz_solver::is_compiler_managed_type;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TypeSymbolResolution {

--- a/crates/tsz-checker/src/tests/architecture_contract_tests.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests.rs
@@ -134,3 +134,4 @@ include!("architecture_contract_tests_parts/part_01.rs");
 include!("architecture_contract_tests_parts/part_02.rs");
 include!("architecture_contract_tests_parts/part_03.rs");
 include!("architecture_contract_tests_parts/part_04.rs");
+include!("architecture_contract_tests_parts/part_05.rs");

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs
@@ -48,7 +48,6 @@ fn test_solver_imports_go_through_query_boundaries() {
         "recursion::RecursionResult",
         // Misc free functions used by a small number of checker files
         // (all others must go through query_boundaries/)
-        "is_compiler_managed_type",
         "type_contains_undefined",
     ];
 

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_05.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_05.rs
@@ -1,0 +1,60 @@
+/// Compiler-managed-name checks are semantic predicates and should have a
+/// domain query boundary instead of being allowlisted as direct solver access.
+#[test]
+fn test_compiler_managed_name_predicate_has_domain_boundary() {
+    let common_source = fs::read_to_string("src/query_boundaries/common.rs")
+        .expect("failed to read query_boundaries/common.rs");
+    let predicates_source = fs::read_to_string("src/query_boundaries/type_predicates.rs")
+        .expect("failed to read query_boundaries/type_predicates.rs");
+    let import_guard_source =
+        fs::read_to_string("src/tests/architecture_contract_tests_parts/part_01.rs")
+            .expect("failed to read architecture_contract_tests_parts/part_01.rs");
+
+    assert!(
+        !common_source.contains("fn is_compiler_managed_type("),
+        "is_compiler_managed_type belongs in query_boundaries::type_predicates, not common.rs"
+    );
+    assert!(
+        predicates_source.contains("fn is_compiler_managed_type("),
+        "query_boundaries::type_predicates must own is_compiler_managed_type"
+    );
+    assert!(
+        !import_guard_source.contains("\"is_compiler_managed_type\""),
+        "is_compiler_managed_type must not be a direct solver import allowlist entry"
+    );
+
+    fn walk_rs(dir: &Path, files: &mut Vec<std::path::PathBuf>) {
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                walk_rs(&path, files);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                files.push(path);
+            }
+        }
+    }
+
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    walk_rs(&src, &mut files);
+    let mut violations = Vec::new();
+    for file in files {
+        let rel = file.strip_prefix(&src).unwrap_or(&file);
+        if rel.starts_with("query_boundaries") || rel.starts_with("tests") {
+            continue;
+        }
+        let source = fs::read_to_string(&file).expect("failed to read checker source");
+        if source.contains("tsz_solver::is_compiler_managed_type")
+            || source.contains("use tsz_solver::is_compiler_managed_type")
+        {
+            violations.push(rel.display().to_string());
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "checker code must call query_boundaries::type_predicates::is_compiler_managed_type; violations: {violations:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/queries/lib_resolution.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution.rs
@@ -2,6 +2,7 @@
 //! augmentations. Keep resolver logic here as shared helpers to preserve stable
 //! SymbolId/DefId identity across lib arenas.
 
+use crate::query_boundaries::type_predicates::is_compiler_managed_type;
 use crate::state::CheckerState;
 use rustc_hash::FxHashMap;
 use std::sync::Arc;
@@ -11,7 +12,6 @@ use tsz_parser::parser::{NodeArena, NodeIndex};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 use tsz_solver::computation::TypeResolver;
-use tsz_solver::is_compiler_managed_type;
 
 pub(crate) use super::lib_decls::{
     collect_lib_decls_with_arenas, collect_lib_decls_with_arenas_in_contexts, dedup_decl_arenas,

--- a/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
@@ -438,7 +438,9 @@ impl<'a> CheckerState<'a> {
                 | "symbol"
                 | "object"
         );
-        if (tsz_solver::is_compiler_managed_type(name) || primitive_type) && !shadows_managed_array
+        if (crate::query_boundaries::type_predicates::is_compiler_managed_type(name)
+            || primitive_type)
+            && !shadows_managed_array
         {
             return true;
         }
@@ -889,7 +891,8 @@ impl<'a> CheckerState<'a> {
                 | "symbol"
                 | "object"
         );
-        if (tsz_solver::is_compiler_managed_type(name.as_str()) || primitive_type)
+        if (crate::query_boundaries::type_predicates::is_compiler_managed_type(name.as_str())
+            || primitive_type)
             && !shadows_managed_array
         {
             self.check_type_alias_body_type_reference_args(type_arguments.as_ref());

--- a/crates/tsz-checker/src/types/type_node.rs
+++ b/crates/tsz-checker/src/types/type_node.rs
@@ -1554,9 +1554,9 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
     /// TYPE, `REGULAR_ENUM`, or `CONST_ENUM` flags. Returns the raw symbol ID (u32).
     /// Skips unshadowed compiler-managed types handled specially by `TypeLowering`.
     pub(crate) fn resolve_type_symbol(&self, node_idx: NodeIndex) -> Option<u32> {
+        use crate::query_boundaries::type_predicates::is_compiler_managed_type;
         use tsz_binder::symbol_flags;
         use tsz_parser::parser::syntax_kind_ext;
-        use tsz_solver::is_compiler_managed_type;
 
         let ident = self.ctx.arena.get_identifier_at(node_idx)?;
         let name = ident.escaped_text.as_str();

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -4,6 +4,7 @@
 //! Contains methods for ensuring type alias bodies are registered in the
 //! type environment and for resolving `DefIds` from qualified names.
 
+use crate::query_boundaries::type_predicates::is_compiler_managed_type;
 use crate::symbols_domain::name_text::{entity_name_text_in_arena, expression_name_text_in_arena};
 use crate::types_domain::unique_symbol_arena::{
     has_declared_unique_symbol_owner, is_unique_symbol_type_annotation_unwrapped,
@@ -11,7 +12,6 @@ use crate::types_domain::unique_symbol_arena::{
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::{NodeAccess, NodeArena};
 use tsz_solver::TypeId;
-use tsz_solver::is_compiler_managed_type;
 
 use super::type_node::TypeNodeChecker;
 


### PR DESCRIPTION
## Agent
AgentName: M5Refactorer

## Track
Checker/query-boundary simplification (#8227/#8225)

## Invariant
Compiler-managed-name checks are checker semantic predicates and should go through `query_boundaries::type_predicates`, not direct solver imports or the catch-all `query_boundaries::common` module.

## Scope
- Moves the `is_compiler_managed_type` wrapper from `common.rs` to `type_predicates.rs`.
- Removes the direct solver import allowlist entry for that predicate.
- Updates checker call sites to use `query_boundaries::type_predicates`.
- Adds a dedicated architecture ratchet shard for the predicate ownership rule.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: Behavior-preserving query-boundary ownership refactor; no project-corpus rows expected to change.

## Verification
- `scripts/safe-run.sh cargo test -p tsz-checker --lib test_compiler_managed_name_predicate_has_domain_boundary -- --nocapture`
- `scripts/safe-run.sh python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Opened while #12882 is in CI. Both PRs reduce `query_boundaries::common`; if #12882 lands first, this branch may need a small refresh around `common.rs` context before queueing.