### PR TITLE
fix(solver,checker): stop recursion-limited & sticky-flag artifacts poisoning recursive-utility evaluation

### DIFF
--- a/crates/tsz-checker/src/types/computation/array_literal.rs
+++ b/crates/tsz-checker/src/types/computation/array_literal.rs
@@ -1304,6 +1304,20 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // Snapshot the solver's `union_too_complex` flag before computing this
+        // array's element union. The flag is global and sticky: a recursive
+        // type-alias evaluation triggered while computing the *contextual* element
+        // type (e.g. `RecArray<T> = Array<T | RecArray<T>>` in a generic call
+        // argument position) can set it, and an unrelated earlier expression can
+        // leave it set. Reading it unconditionally below would misattribute that
+        // pre-existing complexity to this array literal — returning `Array<error>`
+        // and emitting a spurious TS2590 — which then poisons argument inference
+        // (the `error` element silently satisfies every assignability check) in a
+        // declaration/cache-order-dependent way. Mirror the evaluator
+        // (`commit_closed_eval_writes`): attribute complexity only when this
+        // array's own union computation newly trips the flag.
+        let union_too_complex_before = self.ctx.types.is_union_too_complex();
+
         // TS2590: Pre-check element count before BCT. tsc's removeSubtypes only
         // increments its cost counter for StructuredOrInstantiable source types —
         // identity-comparable primitives/literals (number/string/boolean literals,
@@ -1358,7 +1372,11 @@ impl<'a> CheckerState<'a> {
 
         // TS2590: Also check the solver's flag in case the union was constructed
         // through a different path (e.g., preserve_literal_types or internal union ops).
-        if self.ctx.types.take_union_too_complex() {
+        // Only attribute the complexity to this array when its own union computation
+        // newly tripped the flag — a flag inherited from contextual-type evaluation
+        // or an earlier expression must not turn this array into `Array<error>`.
+        let union_too_complex_now = self.ctx.types.take_union_too_complex();
+        if union_too_complex_now && !union_too_complex_before {
             use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
             self.error_at_node(
                 idx,

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1466,6 +1466,7 @@ impl QueryDatabase for QueryCache<'_> {
             query_id
         });
 
+        let union_too_complex_before = self.interner.is_union_too_complex();
         let mut evaluator = self.query_backed_evaluator();
         let result = evaluator.evaluate_request_result(request).into_type_id();
 
@@ -1475,7 +1476,23 @@ impl QueryDatabase for QueryCache<'_> {
         // that would otherwise be recomputed in subsequent top-level evaluate
         // calls. Only persist entries where the result differs from the input
         // (identity mappings are free to recompute) and skip intrinsics.
-        {
+        //
+        // CORRECTNESS GATE: a run that hit a recursion / depth / iteration /
+        // union-complexity limit must NOT persist its results here. The
+        // `eval_cache` key is `(TypeId, options)` — it does not capture the
+        // ambient stack depth at which a bail occurred — so a depth-bailed
+        // intermediate (e.g. a recursive array alias `RecArray<T> =
+        // Array<T | RecArray<T>>` evaluated while the def-depth was already high,
+        // collapsing to `error`) would otherwise be cached and then read back at
+        // top level where it should have converged. That poisons later
+        // type-checking (an `error` element silently satisfies assignability) in a
+        // declaration/cache-order-dependent way — the exact non-determinism that
+        // makes recursive-utility fixtures flip with surrounding code. This
+        // mirrors the gate the evaluator already applies to `closed_eval_cache`
+        // and `application_eval_cache` (see `recursion_limit_hit`).
+        let newly_union_too_complex =
+            self.interner.is_union_too_complex() && !union_too_complex_before;
+        if !evaluator.recursion_limit_hit() && !newly_union_too_complex {
             let mut cache = self.eval_cache.borrow_mut();
             cache.insert(key, result);
             // Also write to shared cache for cross-file benefit.

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -501,7 +501,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// key does not capture the ambient stack depth (`closed_eval_cache`,
     /// `application_eval_cache`); see the respective limit gates.
     #[inline]
-    const fn recursion_limit_hit(&self) -> bool {
+    pub(crate) const fn recursion_limit_hit(&self) -> bool {
         self.guard.is_exceeded() || self.silent_depth_bailed || self.deep_recursion_seen
     }
 


### PR DESCRIPTION
AgentName: lucid-hopper

Refs #12876 (and the same evaluation-cache-determinism family: #12177, #12174). Hardens the recursive-utility evaluation-cache determinism root those issues track. Does **not** by itself close #12876 — see Coordination Notes for the remaining within-evaluation determinism work.

## Track
Solver evaluation-cache identity + checker array-literal complexity attribution — determinism of recursive type-alias evaluation.

## Invariant
A run that hit a recursion / depth / iteration / union-complexity limit must not persist its `error`/opaque result to a cache whose key does not capture the ambient stack depth, and a global "union too complex" signal must only be attributed to the construct that actually produced it. Both already hold for `closed_eval_cache` / `application_eval_cache`; this brings the primary `eval_cache` and the array-literal TS2590 path into line.

## Wrong semantic operation
Semantic caching / diagnostic attribution (not relation or inference): a depth-bailed recursive alias result was cached and read back where it should have converged, and an inherited sticky flag was misattributed.

## Structural rule
> When evaluating a recursive type alias (e.g. `RecArray<T> = Array<T | RecArray<T>>`) bottoms out on a depth/iteration guard, `tsc` keeps the reference deferred and re-derives it per use site; tsz must not freeze that bail into a project-wide cache, and must not let a `union_too_complex` flag raised during contextual-type evaluation turn an unrelated array literal into `Array<error>` + TS2590.

The order-dependence this removes: a recursive array alias evaluated while the def-depth was already high collapses to `error`; persisting that (or misattributing the complexity flag) makes the `error` element silently satisfy argument inference, so the same call (`flat([1, ['a']])`) flips between the correct `TS2322` and a false accept depending only on surrounding declarations — the "latent bug masked by cache-population order" the issue describes.

## Owner layer
- Solver `caches/query_cache` + `evaluation/evaluate` (`recursion_limit_hit` gate).
- Checker `types/computation/array_literal` (TS2590 attribution).

## Scope
- `crates/tsz-solver/src/evaluation/evaluate.rs` — widen `recursion_limit_hit` to `pub(crate)` so the cache layer can consult it (no behavior change).
- `crates/tsz-solver/src/caches/query_cache.rs` — gate the `eval_cache` (and shared cross-file) result + drained-intermediate writes on `!recursion_limit_hit()` and on not newly tripping `union_too_complex`, mirroring the `closed_eval_cache` / `application_eval_cache` gates.
- `crates/tsz-checker/src/types/computation/array_literal.rs` — snapshot `union_too_complex` before the element union and only emit TS2590 / return `Array<error>` when the array's own union newly trips it.

## Project Corpus Impact
- Row: recursive-utility-heavy rows (rxjs / kysely / ts-toolbelt / utility-types families) — reduces order-dependent `error`-poisoning fan-out.
- Bug family: evaluation-cache determinism (#12876 / #12177 / #12174).
- Behavior-preserving on tested cases: the `recursiveTypeReferences1.ts` fixture still emits exactly its expected diagnostics (the `flat`/`flat1`/`flat2` `TS2322`s and `Box2` `TS2322`), unchanged from `main`. Broad conformance is owned by ready-review CI per repo contract.

## Verification
- `cargo build -p tsz-cli`, `cargo fmt --check` — clean.
- `cargo test -p tsz-solver --lib caches::` (34) and `evaluation::` (1144) pass; the single `evaluate_application_variadic_prepend_flattens_tail_application` failure is **pre-existing on clean `main`** (documented in #12815, confirmed by stash-and-run here) and unrelated.
- `cargo test -p tsz-checker --lib array_literal` (57, incl. the existing `ts2590_array_literal_identity_skip_tests`) pass.
- CLI: `recursiveTypeReferences1.ts` (es2015, strict, declaration) diagnostics byte-match `main` / `tsc`'s `recursiveTypeReferences1.errors.txt`.

## Coordination Notes
Same `lucid-hopper` lane that investigated #12876. This PR lands the **conformance-safe** half of that investigation (cache/flag determinism). The remaining half — the *within-evaluation* recursive-alias-to-`error` collapse plus tsc's `inferToMultipleTypes` single-naked-type-variable union rule needed to make the reduced `flat([1, 'a', [2]])` repro clean — is left open on #12876 with a full root-cause writeup, because a surface inference fix regresses the `recursiveTypeReferences1` fixture until that within-evaluation determinism is also fixed. No open PR touches these files.

https://claude.ai/code/session_015MHDGtFXzHNP8VxbB3AcRu

---
_Generated by [Claude Code](https://claude.ai/code/session_015MHDGtFXzHNP8VxbB3AcRu)_