### PR TITLE
fix(checker): check member compatibility on abstract class implements (#10804)

### DIFF
--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -899,11 +899,12 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
-        // Abstract classes don't need to implement interface members —
-        // their abstract members satisfy the interface contract.
-        if self.has_abstract_modifier(&class_data.modifiers) {
-            return;
-        }
+        // Abstract classes are exempt only from the *completeness* requirement (they
+        // need not implement every member — subclasses do), but a member they *do*
+        // declare must still be type-/visibility-compatible (tsc still reports
+        // TS2416/TS2420). Per-member checks keep running; only the completeness
+        // diagnostics below are gated by `is_abstract_class`.
+        let is_abstract_class = self.has_abstract_modifier(&class_data.modifiers);
 
         let mut class_type_param_names: rustc_hash::FxHashSet<String> =
             rustc_hash::FxHashSet::default();
@@ -1559,27 +1560,15 @@ impl<'a> CheckerState<'a> {
                                     diagnostic_codes::CLASS_INCORRECTLY_IMPLEMENTS_INTERFACE,
                                 );
                             }
-                        } else {
-                            // Before reporting as missing, check the class instance type.
-                            // Members from module augmentations or declaration merging appear
-                            // in the computed instance type but not in the AST body or
-                            // inheritance chain. E.g., `class X implements X {}` where X is
-                            // augmented from another file via `declare module`.
-                            let in_instance_type = {
-                                let inst = self.get_class_instance_type(class_idx, class_data);
-                                if let Some(shape) =
-                                    crate::query_boundaries::common::object_shape_for_type(
-                                        self.ctx.types,
-                                        inst,
-                                    )
-                                {
-                                    let member_atom = self.ctx.types.intern_string(&member_name);
-                                    shape.properties.iter().any(|p| p.name == member_atom)
-                                } else {
-                                    false
-                                }
-                            };
-                            if !in_instance_type {
+                        } else if !is_abstract_class {
+                            // Abstract classes may leave members unimplemented (skip the
+                            // probe). Otherwise report missing unless the instance type
+                            // exposes it (module-augmented / merged members).
+                            if !self.class_instance_type_has_member(
+                                class_idx,
+                                class_data,
+                                &member_name,
+                            ) {
                                 missing_members.push(member_name);
                             }
                         }
@@ -1592,7 +1581,11 @@ impl<'a> CheckerState<'a> {
                     // instead of silently passing. We detect this by checking
                     // assignability through the solver, which includes weak type
                     // detection via the compat layer.
-                    if missing_members.is_empty() && incompatible_members.is_empty() {
+                    // Weak-type detection is a completeness check; abstract exempt.
+                    if !is_abstract_class
+                        && missing_members.is_empty()
+                        && incompatible_members.is_empty()
+                    {
                         // Check if the interface is a weak type: all properties optional
                         let is_weak = !interface_properties.is_empty()
                             && interface_properties.iter().all(|p| p.optional)
@@ -1632,12 +1625,15 @@ impl<'a> CheckerState<'a> {
                     // For interfaces, the type-level check is only done when
                     // member-by-member found no issues (catches index signature
                     // incompatibilities that member-by-member misses).
+                    // Whole-type assignability is a completeness check, so restrict it
+                    // to concrete classes (matching tsc).
                     let extends_same_base =
                         is_class && self.class_extends_same_base(class_data, &interface_name);
-                    let check_whole_type = extends_same_base
-                        || (interface_has_index_signature
-                            && missing_members.is_empty()
-                            && incompatible_members.is_empty());
+                    let check_whole_type = !is_abstract_class
+                        && (extends_same_base
+                            || (interface_has_index_signature
+                                && missing_members.is_empty()
+                                && incompatible_members.is_empty()));
                     if check_whole_type {
                         let class_instance_type =
                             self.get_class_instance_type(class_idx, class_data);
@@ -1742,7 +1738,10 @@ impl<'a> CheckerState<'a> {
                         }
                     }
 
-                    if report_inaccessible_privates
+                    // Inaccessible-private brand satisfaction is a completeness check
+                    // (whole-type), so abstract classes are exempt too.
+                    if !is_abstract_class
+                        && report_inaccessible_privates
                         && missing_members.is_empty()
                         && incompatible_members.is_empty()
                     {

--- a/crates/tsz-checker/src/classes/class_implements_checker/member_probe.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/member_probe.rs
@@ -1,0 +1,28 @@
+//! Small structural probes shared by the `implements` member checker.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+
+impl<'a> CheckerState<'a> {
+    /// True when the class's computed instance type exposes `member_name`.
+    ///
+    /// A member can be absent from the class AST body and inheritance chain yet
+    /// still present on the instance type — e.g. added by a `declare module`
+    /// augmentation or declaration merging (`class X implements X {}`). The
+    /// missing-member check consults this before reporting a member missing.
+    pub(super) fn class_instance_type_has_member(
+        &mut self,
+        class_idx: NodeIndex,
+        class_data: &tsz_parser::parser::node::ClassData,
+        member_name: &str,
+    ) -> bool {
+        let inst = self.get_class_instance_type(class_idx, class_data);
+        let Some(shape) =
+            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, inst)
+        else {
+            return false;
+        };
+        let member_atom = self.ctx.types.intern_string(member_name);
+        shape.properties.iter().any(|p| p.name == member_atom)
+    }
+}

--- a/crates/tsz-checker/src/classes/class_implements_checker/mod.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/mod.rs
@@ -2,3 +2,4 @@
 
 mod core;
 mod jsdoc_heritage;
+mod member_probe;

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -132,6 +132,9 @@ mod class_extends_generic_override_variance_tests;
 #[path = "tests/class_extends_index_relation_routing_arch_tests.rs"]
 mod class_extends_index_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/class_implements_abstract_member_compat_tests.rs"]
+mod class_implements_abstract_member_compat_tests;
+#[cfg(test)]
 #[path = "tests/class_implements_generic_override_variance_tests.rs"]
 mod class_implements_generic_override_variance_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/class_implements_abstract_member_compat_tests.rs
+++ b/crates/tsz-checker/src/tests/class_implements_abstract_member_compat_tests.rs
@@ -1,0 +1,201 @@
+//! Regression tests for issue #10804 — member compatibility on **abstract**
+//! classes that `implements` an interface.
+//!
+//! An abstract class is exempt only from the *completeness* requirement: it need
+//! not provide an implementation for every interface member (a concrete subclass
+//! does, and `tsc` enforces that on the subclass). But a member the abstract
+//! class *does* declare — concrete or `abstract` — must still be type- and
+//! visibility-compatible with the interface. `tsc` reports TS2416 / TS2420 for an
+//! incompatible member regardless of whether the class is abstract.
+//!
+//! Previously `tsz` short-circuited the entire `implements` member check for any
+//! abstract class, so it silently accepted genuinely incompatible members (a
+//! false negative — the symmetric gap to the `implements` false-positive closed
+//! in PR #12848). These tests pin the abstract form to the same per-member
+//! variance decision used for concrete classes, while keeping abstract classes
+//! exempt from the missing-member / weak-type / whole-type completeness
+//! diagnostics.
+//!
+//! The decision is structural — keyed on the signature shapes, not on any
+//! identifier — so the cases below vary the method, interface, and type-parameter
+//! names.
+
+use crate::test_utils::check_source_codes;
+
+fn assert_has_2416(src: &str) {
+    let codes = check_source_codes(src);
+    assert!(
+        codes.contains(&2416),
+        "expected TS2416, got none. Got: {codes:?}\nSource:\n{src}"
+    );
+}
+
+fn assert_no_2416(src: &str) {
+    let codes = check_source_codes(src);
+    assert!(
+        !codes.contains(&2416),
+        "unexpected TS2416 (false positive). Got: {codes:?}\nSource:\n{src}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Must REPORT TS2416 — declared member on an abstract class is incompatible
+// with the interface. These were false negatives before the fix (the abstract
+// class short-circuited the whole check).
+// ---------------------------------------------------------------------------
+
+// Plain property type mismatch on an abstract member.
+#[test]
+fn reports_2416_abstract_property_type_mismatch() {
+    assert_has_2416(
+        "interface Spec { x: number; }
+         abstract class Svc implements Spec { abstract x: string; }",
+    );
+}
+
+// Plain method return-type mismatch on an abstract member.
+#[test]
+fn reports_2416_abstract_method_return_mismatch() {
+    assert_has_2416(
+        "interface Spec { read(): number; }
+         abstract class Svc implements Spec { abstract read(): string; }",
+    );
+}
+
+// The documented witness: a method-local generic used covariantly in the
+// return cannot be satisfied by a concrete return type, even abstractly.
+#[test]
+fn reports_2416_abstract_covariant_return_generic_drop() {
+    assert_has_2416(
+        "interface Spec { run<T>(): T; }
+         abstract class Svc implements Spec { abstract run(): string; }",
+    );
+}
+
+// Renamed method, interface, and type parameter — proves the rule is
+// structural, not identifier-keyed.
+#[test]
+fn reports_2416_abstract_covariant_return_generic_drop_renamed() {
+    assert_has_2416(
+        "interface Contract { produce<U>(): U; }
+         abstract class Worker implements Contract { abstract produce(): number; }",
+    );
+}
+
+// Generic in param AND return: still covariant in the return, still rejected.
+#[test]
+fn reports_2416_abstract_in_out_generic_drop() {
+    assert_has_2416(
+        "interface Spec { map<T>(x: T): T; }
+         abstract class Svc implements Spec { abstract map(x: string): string; }",
+    );
+}
+
+// A *concrete* method on an abstract class is also checked (mixed members).
+#[test]
+fn reports_2416_abstract_class_concrete_member_mismatch() {
+    assert_has_2416(
+        "interface Spec { id(): number; other(): void; }
+         abstract class Svc implements Spec {
+             id(): string { return \"\"; }
+             abstract other(): void;
+         }",
+    );
+}
+
+// The incompatible member is *inherited* from a base class of the abstract
+// class — the inherited-member branch must run for abstract classes too.
+#[test]
+fn reports_2416_abstract_class_inherited_member_mismatch() {
+    assert_has_2416(
+        "interface Spec { value(): number; }
+         class BaseImpl { value(): string { return \"\"; } }
+         abstract class Svc extends BaseImpl implements Spec {}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Must NOT report — abstract classes stay exempt from completeness, and the
+// input-only generic-drop specialization stays valid (no false positives).
+// ---------------------------------------------------------------------------
+
+// Member left entirely unimplemented: legal for an abstract class.
+#[test]
+fn no_2416_abstract_class_member_left_unimplemented() {
+    let codes = check_source_codes(
+        "interface Spec { run(): number; other(): string; }
+         abstract class Svc implements Spec {}",
+    );
+    assert!(
+        !codes.contains(&2416) && !codes.contains(&2420),
+        "abstract class may leave interface members unimplemented; got {codes:?}"
+    );
+}
+
+// Declared abstract member that is exactly compatible: no error.
+#[test]
+fn no_2416_abstract_member_compatible() {
+    assert_no_2416(
+        "interface Spec { run(): number; }
+         abstract class Svc implements Spec { abstract run(): number; }",
+    );
+}
+
+// Input-only generic dropped to its constraint on an abstract member: the wider
+// concrete parameter admits every instantiation, so this stays valid (the
+// false-positive suppression must still apply on the abstract path).
+#[test]
+fn no_2416_abstract_input_only_generic_drop() {
+    assert_no_2416(
+        "interface Builder { with<K extends string>(k: K): Builder; }
+         abstract class Impl implements Builder { abstract with(k: string): Builder; }",
+    );
+}
+
+// Renamed binders for the input-only acceptance case.
+#[test]
+fn no_2416_abstract_input_only_generic_drop_renamed() {
+    assert_no_2416(
+        "interface Factory { make<P extends string>(p: P): Factory; }
+         abstract class Plant implements Factory { abstract make(p: string): Factory; }",
+    );
+}
+
+// A covariant-subtype return on an abstract member is still a valid override.
+#[test]
+fn no_2416_abstract_member_covariant_subtype_return() {
+    assert_no_2416(
+        "interface Animal { kind: string; }
+         interface Dog extends Animal { bark(): void; }
+         interface Spec { pet(): Animal; }
+         abstract class Shelter implements Spec { abstract pet(): Dog; }",
+    );
+}
+
+// A *compatible* member inherited from a base class satisfies the interface on
+// an abstract class with no false positive (success path of the inherited
+// branch, complementing the inherited-mismatch case above).
+#[test]
+fn no_2416_abstract_class_inherited_member_compatible() {
+    assert_no_2416(
+        "interface Spec { value(): number; }
+         class BaseImpl { value(): number { return 42; } }
+         abstract class Svc extends BaseImpl implements Spec {}",
+    );
+}
+
+// An interface that inherits an inaccessible private brand from a base class is
+// a whole-type completeness check; an abstract class that leaves those members
+// for a concrete subclass stays exempt (no false TS2420 / TS2416).
+#[test]
+fn no_error_abstract_class_unimplemented_inaccessible_private_interface() {
+    let codes = check_source_codes(
+        "class Secret { private s: number = 0; }
+         interface Spec extends Secret { run(): void; }
+         abstract class Svc implements Spec {}",
+    );
+    assert!(
+        !codes.contains(&2416) && !codes.contains(&2420),
+        "abstract class may leave brand-carrying members unimplemented; got {codes:?}"
+    );
+}


### PR DESCRIPTION
AgentName: lucid-hopper-XxISe

Track: conformance / checker false-negative (generic method override variance — abstract `implements` heritage form)

## Invariant
An abstract class that `implements` an interface is exempt **only** from the
*completeness* requirement (it need not provide an implementation for every
interface member — a concrete subclass does). A member it **does** declare —
concrete or `abstract` — must still be type- and visibility-compatible with the
interface. `tsz` now reports TS2416 / TS2420 for an incompatible member declared
on an abstract class, matching `tsc`, instead of silently accepting it.

```ts
interface Spec { run<T>(): T; }
abstract class Svc implements Spec { abstract run(): string; }
// tsc 6.x & tsz now: TS2416 — T is used covariantly in the return.

interface I { x: number; }
abstract class A implements I { abstract x: string; }
// tsc & tsz now: TS2416 — declared member type mismatch.

interface Spec2 { run(): number; other(): string; }
abstract class Svc2 implements Spec2 {}
// tsc & tsz: OK — an abstract class may leave members for its subclasses.
```

## Structural rule
> When an abstract class declares a member (concrete or `abstract`) that overrides a
> generic interface method and drops a method-local type parameter used covariantly
> in the return — or is otherwise type/visibility-incompatible — `tsc` reports
> TS2416 / TS2420 regardless of the `abstract` modifier. `tsz` now makes the same
> decision through the `implements` member-compatibility boundary.

This closes the **abstract** false-negative explicitly deferred when the
`implements` false-*positive* direction was fixed in #12554 / #12848. It is the
symmetric completion of that family for the abstract heritage form.

## Owner layer
- **Checker** — `crates/tsz-checker/src/classes/class_implements_checker/core.rs`.
  `check_implements_clauses` previously short-circuited with a blanket early
  return for any abstract class, skipping **all** member checks. That return is
  replaced with an `is_abstract_class` flag that gates only the four
  *completeness* diagnostics — missing-member, weak-type (TS2559), whole-type
  (TS2420/TS2720), and inaccessible-private brand (TS2420) — while the per-member
  type/visibility compatibility check keeps running.
- The per-member path is unchanged and reuses the existing
  `nongeneric_input_only_generic_override_is_valid` suppression, so the sound
  input-only generic-drop specialization stays valid on the abstract path too
  (no new false positives). No solver/relation change.

## Scope
- `crates/tsz-checker/src/classes/class_implements_checker/core.rs`: replace the
  abstract early-return with `is_abstract_class`; gate the four completeness
  sites; skip the instance-type membership probe for abstract classes.
- `crates/tsz-checker/src/classes/class_implements_checker/member_probe.rs`
  (new): extract the instance-type membership probe so `core.rs` stays under the
  2000-line architecture boundary.
- `crates/tsz-checker/src/classes/class_implements_checker/mod.rs`: register the
  new module.
- `crates/tsz-checker/src/tests/class_implements_abstract_member_compat_tests.rs`
  (new): 14-case regression suite + module registration in `lib.rs`.

## Adjacent-case matrix (14 cases)
Reported TS2416 (were false negatives):
- abstract property type mismatch ✅
- abstract method return mismatch ✅
- abstract covariant-return generic drop (+ renamed method/interface/type-param) ✅
- generic in param **and** return ✅
- concrete + abstract member mix, the abstract one incompatible ✅
- incompatible member **inherited** from a base class ✅

Must NOT report (completeness exemption + false-positive guard preserved):
- interface members left entirely unimplemented (no TS2416/TS2420) ✅
- compatible abstract member ✅
- input-only generic dropped to its constraint (+ renamed) ✅
- covariant-subtype return ✅
- compatible inherited member ✅
- interface inheriting an inaccessible-private brand, left unimplemented ✅

## Project Corpus Impact
- Row: rxjs-project (`#10804` witness; the broader generic-method-override
  variance family also covers `#10796` / `#10812`). `implements` of generic
  interfaces by abstract classes is common in such projects.
- Bug family: generic method override variance through the abstract `implements`
  heritage form.
- Direction is **false-negative → corrected**: the change adds genuine TS2416 /
  TS2420 diagnostics that `tsc` also reports, and reuses the validated per-member
  compatibility logic already used for concrete classes, so no required
  project-corpus row should regress.

## Verification
- New suite `class_implements_abstract_member_compat_tests` → **14 passed, 0 failed**.
- Full `cargo nextest run -p tsz-checker --lib` failure set is **identical to
  `main`** (73 pre-existing unique failures; **0 new, 0 fixed-by-side-effect**),
  confirmed by diffing the failure sets before/after on a clean stash.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib`
  clean; `python3 scripts/arch/arch_guard.py` passed (`core.rs` 1996 ≤ 2000).
- `/simplify` run to convergence (3 cleanup cycles): added the missed
  inaccessible-privates gate, short-circuited the wasted instance-type probe for
  abstract classes, and extracted the probe to keep the file under the LOC
  boundary.
- Rebased onto current `origin/main`; no conflicts.

## Coordination Notes
- Continues `#10804`: #12554 fixed interface-`extends`, #12848 fixed class
  `implements` — both for the false-*positive* direction; this closes the
  abstract `implements` false-*negative*.
- Still out of scope (separate relation/property-resolution gap, not abstract):
  `interface extends class` with a covariant-return generic drop, where the base
  class method's method-local generic is erased during property access so the
  strict relation never flags it (tsc TS2430, tsz misses). Tracked under the same
  family for a follow-up.
- Anti-hardcoding gate: structural relation decisions only; tests vary binder,
  method, interface, and type-parameter names.

https://claude.ai/code/session_012DFVeQq1Pz5F5dWSqu1czz

---
_Generated by [Claude Code](https://claude.ai/code/session_012DFVeQq1Pz5F5dWSqu1czz)_