### PR TITLE
fix(checker): stop identity mapped-alias applications from polluting argument display (#12174)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -150,6 +150,9 @@ path = "tests/ts2513_abstract_super_access_tests.rs"
 name = "generic_alias_assignability_pollution_tests"
 path = "tests/generic_alias_assignability_pollution_tests.rs"
 [[test]]
+name = "mapped_identity_alias_display_pollution_tests"
+path = "tests/mapped_identity_alias_display_pollution_tests.rs"
+[[test]]
 name = "generic_type_alias_lazy_body_tests"
 path = "tests/generic_type_alias_lazy_body_tests.rs"
 

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -350,19 +350,17 @@ impl<'a> CheckerState<'a> {
                 crate::query_boundaries::common::is_conditional_type(db, result)
                     || crate::query_boundaries::common::is_index_access_type(db, result)
                     || crate::query_boundaries::common::is_mapped_type(db, result);
-            let result_is_non_empty_object = query::object_shape(self.ctx.types, result)
-                .is_some_and(|shape| {
-                    !shape.properties.is_empty()
-                        || shape.string_index.is_some()
-                        || shape.number_index.is_some()
-                });
-            let result_is_application_arg = app_info.is_some_and(|(_, args)| {
+            // Suppress the reverse alias when the result IS one of the
+            // application's own (resolved) arguments: an identity helper like
+            // `Id<U> = { [K in keyof U]: U[K] }` interns its result to the same
+            // `TypeId` as `U`, so recording `U -> Id<U>` repaints every later
+            // occurrence of `U` (`Id<Id<U>>`, sibling `Part<U>` -> `Part<Id<U>>`).
+            // Must not be gated on result shape — unions/intersections were the leak.
+            let result_is_application_arg = app_info.as_ref().is_some_and(|(_, args)| {
                 args.iter()
                     .any(|&arg| arg == result || self.evaluate_type_with_resolution(arg) == result)
             });
-            if (!has_param_args || is_safe_for_generic_alias)
-                && !(result_is_application_arg && result_is_non_empty_object)
-            {
+            if (!has_param_args || is_safe_for_generic_alias) && !result_is_application_arg {
                 self.ctx.types.store_display_alias(result, type_id);
             }
         }

--- a/crates/tsz-checker/tests/mapped_identity_alias_display_pollution_tests.rs
+++ b/crates/tsz-checker/tests/mapped_identity_alias_display_pollution_tests.rs
@@ -1,0 +1,172 @@
+//! Identity-style generic mapped aliases must not pollute the global display
+//! alias of their argument.
+//!
+//! An identity homomorphic mapped alias such as `Id<T> = { [K in keyof T]: T[K] }`
+//! evaluates to a type that interns to the *same* `TypeId` as its (resolved)
+//! argument. tsz keys diagnostic display aliases globally by `TypeId`, so
+//! recording `U -> Id<U>` for the result would repaint every later occurrence of
+//! the argument `U`. That produced two order-dependent defects in `TS2322`
+//! source display:
+//!
+//! * the identity application rendered as `Id<Id<U>>` (the argument re-wrapped in
+//!   its own alias), and
+//! * an *unrelated* sibling alias over the same argument — e.g. `Part<U>` checked
+//!   later in the same program — rendered as `Part<Id<U>>`.
+//!
+//! `tsc` never produces either form. The fix suppresses the reverse alias
+//! whenever the evaluated result is one of the application's own arguments,
+//! regardless of the result's shape (the original guard only fired for non-empty
+//! object results, which excluded the union/intersection results these aliases
+//! produce).
+//!
+//! Negative control: a generic alias whose result is a *distinct* type (e.g.
+//! `Dict<V> = { [k: string]: V }`) is unaffected and keeps showing its
+//! application name. Binder/alias/type-parameter names are varied across cases so
+//! the behavior is proven structural, not keyed on an identifier.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_common::diagnostics::Diagnostic;
+
+fn check_strict(source: &str) -> Vec<Diagnostic> {
+    let options = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..Default::default()
+    };
+    tsz_checker::test_utils::check_source(source, "test.ts", options)
+}
+
+fn single(diags: &[Diagnostic], code: u32) -> &Diagnostic {
+    let matches: Vec<&Diagnostic> = diags.iter().filter(|d| d.code == code).collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one TS{code}, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    matches[0]
+}
+
+fn nth(diags: &[Diagnostic], code: u32, index: usize) -> &Diagnostic {
+    let matches: Vec<&Diagnostic> = diags.iter().filter(|d| d.code == code).collect();
+    assert!(
+        matches.len() > index,
+        "expected at least {} TS{code}, got: {:?}",
+        index + 1,
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    matches[index]
+}
+
+/// Core: an identity mapped alias applied to a named union alias must not
+/// re-wrap the argument in its own alias name (`Id<Id<U>>`).
+#[test]
+fn identity_mapped_over_union_alias_does_not_double_wrap() {
+    let diags = check_strict(
+        "type LeftBox = { a: 1 };\n\
+         type RightBox = { b: 2 };\n\
+         type Either = LeftBox | RightBox;\n\
+         type Echo<S> = { [P in keyof S]: S[P] };\n\
+         const bad: number = (null as any as Echo<Either>);\n",
+    );
+    let diag = single(&diags, 2322);
+    assert!(
+        !diag.message_text.contains("Echo<Echo<"),
+        "identity mapped alias must not re-wrap its argument; got: {}",
+        diag.message_text
+    );
+    // The argument alias itself must still be reachable (the source is the
+    // `Either` union, however it is named), and must never gain a spurious
+    // `Echo<` prefix on the inner argument.
+    assert!(
+        !diag.message_text.contains("Echo<Either>>"),
+        "no nested self-application of the argument; got: {}",
+        diag.message_text
+    );
+}
+
+/// Core: evaluating an identity mapped alias over a union must not pollute the
+/// display of an unrelated sibling alias over the same union checked afterward.
+#[test]
+fn identity_mapped_does_not_pollute_sibling_alias_display() {
+    let diags = check_strict(
+        "type Hot = { readonly a?: number; b: string };\n\
+         type Cold = { b: string; readonly c?: boolean };\n\
+         type Mix = Hot | Cold;\n\
+         type Same<S> = { [P in keyof S]: S[P] };\n\
+         type Loose<S> = { [P in keyof S]?: S[P] };\n\
+         const first: number = (null as any as Same<Mix>);\n\
+         const second: number = (null as any as Loose<Mix>);\n",
+    );
+    // The `Loose<Mix>` diagnostic is the second TS2322. Its source must be the
+    // `Loose<...>` application, never repainted with the sibling `Same` alias.
+    let loose = nth(&diags, 2322, 1);
+    assert!(
+        loose.message_text.contains("Loose<"),
+        "sibling alias must keep its own application name; got: {}",
+        loose.message_text
+    );
+    assert!(
+        !loose.message_text.contains("Same<"),
+        "sibling alias display must not be polluted by the earlier identity alias; got: {}",
+        loose.message_text
+    );
+}
+
+/// Intersection argument: the identity alias over a named intersection alias is
+/// the same family and must not double-wrap either.
+#[test]
+fn identity_mapped_over_intersection_alias_does_not_double_wrap() {
+    let diags = check_strict(
+        "type Front = { a: 1 };\n\
+         type Back = { b: 2 };\n\
+         type Both = Front & Back;\n\
+         type Clone<U> = { [Q in keyof U]: U[Q] };\n\
+         const bad: number = (null as any as Clone<Both>);\n",
+    );
+    let diag = single(&diags, 2322);
+    assert!(
+        !diag.message_text.contains("Clone<Clone<"),
+        "identity mapped alias over an intersection must not re-wrap; got: {}",
+        diag.message_text
+    );
+}
+
+/// Negative control: a generic alias whose result is a *distinct* type (an
+/// object with an index signature, never equal to its argument) must keep
+/// rendering as its application form. This guards against over-suppression.
+#[test]
+fn distinct_result_alias_keeps_application_name() {
+    let diags = check_strict(
+        "type Bag<V> = { [k: string]: V };\n\
+         const bad: number = (null as any as Bag<string>);\n",
+    );
+    let diag = single(&diags, 2322);
+    assert!(
+        diag.message_text.contains("Bag<string>"),
+        "a distinct-result generic alias must keep its application name; got: {}",
+        diag.message_text
+    );
+}
+
+/// Negative control with a two-parameter object alias and varied names — still
+/// distinct from its arguments, so the application name is preserved.
+#[test]
+fn distinct_pair_alias_keeps_application_name() {
+    let diags = check_strict(
+        "type Couple<X, Y> = { left: X; right: Y };\n\
+         const bad: number = (null as any as Couple<number, string>);\n",
+    );
+    let diag = single(&diags, 2322);
+    assert!(
+        diag.message_text.contains("Couple<number, string>"),
+        "a distinct multi-arg alias must keep its application name; got: {}",
+        diag.message_text
+    );
+}


### PR DESCRIPTION
AgentName: brave-volta-I0XaG

Refs #12174. Lands a reproducible defect in the mapped-key-over-aliased-composite diagnostics family that #12174 tracks. The issue's literal "lose optional/readonly modifier intent" claim no longer reproduces on `main` (closed by the merged #12847); a fresh differential sweep against `tsc` 6.0.2 confirms modifier intent is preserved through aliasing/intersection/union. This PR fixes the adjacent, order-dependent **display-pollution** bug on the same surface.

## Track
Checker diagnostic display-alias bookkeeping for generic alias applications (mapped-over-aliased-composite source).

## Invariant
A type's global display alias is never overwritten by an alias application whose evaluated result IS one of its own (resolved) arguments. Identity-style helper aliases (`Id<U> = { [K in keyof U]: U[K] }`) must not repaint their argument's display, for **any** result shape — union, intersection, primitive, tuple, or object.

## Wrong semantic operation
Diagnostic display provenance (not relation / inference / narrowing / evaluation). The evaluated result is correct; only the reverse `result -> application` display alias was recorded where it pollutes a shared `TypeId`.

## Structural rule
> When a generic alias application `A<X>` evaluates to a type structurally equal to (and interned as the same `TypeId` as) its argument `X`, `tsc` keeps the per-reference alias on that occurrence only; `tsz` must not record a global `X -> A<X>` reverse display alias, because that repaints every other occurrence of `X`.

Because `Id<U>` is an identity over `U`, its result interns to the same `TypeId` as the resolved `U`. The checker's reverse-alias gate in `evaluate_application_type` only skipped recording when the result was a non-empty **object**; union/intersection results — exactly the shapes `Id<aliasedUnion>` / `Id<aliasedIntersection>` produce — bypassed the skip. The stored `U -> Id<U>` then surfaced wherever `U` was later displayed:
- the application itself rendered `Id<Id<U>>` (the argument re-wrapped in its own alias), and
- an **unrelated** sibling alias over the same union, e.g. `Part<U>` checked later in the same program, rendered `Part<Id<U>>`.

Both are order-dependent (only triggered once `Id<U>` was evaluated earlier in the program) and neither is ever produced by `tsc`.

## Owner layer
Checker `state/type_environment/core.rs::evaluate_application_type` — the reverse display-alias recording gate. No relation/inference/evaluation change; solver and emitter are untouched. The argument resolution (`evaluate_type_with_resolution`) needed to recognize a named-alias argument was already present; the fix only removes the object-shape gate that excluded union/intersection results.

## Scope
- `crates/tsz-checker/src/state/type_environment/core.rs` — drop the `result_is_non_empty_object` gate from the `result_is_application_arg` suppression so it fires for any shared-`TypeId` argument shape.
- `crates/tsz-checker/tests/mapped_identity_alias_display_pollution_tests.rs` — new regression suite (5 tests).
- `crates/tsz-checker/Cargo.toml` — register the test target.

## Adjacent-case matrix (tsz vs tsc 6.0.2, binder names varied)
- identity mapped alias over named union (`Echo<Either>`): no `Echo<Echo<...>>`.
- identity mapped alias over named intersection (`Clone<Both>`): no `Clone<Clone<...>>`.
- sibling pollution: `Same<Mix>` then `Loose<Mix>` — `Loose<...>` keeps its own name, no `Same<` leak.
- negative controls (must keep application name): `Bag<string> = { [k: string]: V }`, `Couple<number, string>`, `Record<string, number>`, `Pair<number, string>` — all byte-identical to `tsc`.
- DTS emit of `export const idu: Id<AU>` — byte-identical to `tsc` (`export declare const idu: Id<AU>;`); emit uses the annotation form and is unaffected.

**Residual (documented, not a regression):** the identity application's own *source* display now renders as the argument's name (`AU`) rather than `tsc`'s `Id<AU>`. `tsz` collapses `Id<AU>` to the same `TypeId` as `AU`, so a global display-alias map cannot label both occurrences distinctly; the prior behavior (`Id<Id<AU>>` + cross-alias pollution) was strictly worse and is removed. Full `Id<AU>` parity needs per-reference alias tracking in the diagnostic source path and is out of scope here.

## Project Corpus Impact
- Row: rxjs / kysely / type-fest / utility-types families (mapped-over-aliased-composite diagnostics in #12174's witness set).
- Bug family: #12174 (mapped key operations / aliased re-evaluation diagnostics).
- Behavior-preserving for relations and emit; only the source-type rendering of identity-over-argument applications changes (strictly toward `tsc`). Broad conformance owned by ready-review CI.

## Verification
- New `mapped_identity_alias_display_pollution_tests` (5) pass.
- Adjacent display/alias suites green: `conditional_alias_source_display_tests` (7), `generic_alias_assignability_pollution_tests` (2), `homomorphic_mapped_index_display_tests` (6), `bare_alias_display_tests` (4), `extract_alias_distributive_mapped_tests` (10), `distributive_alias_wrapped_conditional_tests` (5), `union_property_optional_modifier_tests` (3, the #12847 guard), `union_origin_display_tests` (19), `fresh_intersection_display_tests` (5), `mapped_type_errors_conformance_tests` (6) — 72 total, 0 fail.
- Differential `tsz` vs `tsc` 6.0.2 across the matrix above — all match except the documented residual.
- `cargo fmt -p tsz-checker --check`, `git diff --check`, `cargo clippy -p tsz-checker --lib` — clean.
- Rebased onto current `origin/main` (`cf27769`, includes #12884); no conflicts, no file overlap.

## Coordination Notes
- AgentName brave-volta lane. No open PR touches `evaluate_application_type`'s display-alias gate. Builds on merged #12847 (which closed the modifier-intent half of #12174). Does **not** close #12174 (parent tracker with remaining display witnesses).

https://claude.ai/code/session_018aHhgdSTWcBUAkVZycn2io

---
_Generated by [Claude Code](https://claude.ai/code/session_018aHhgdSTWcBUAkVZycn2io)_