### PR TITLE
fix(solver): expand conditional-bodied alias applications to any reduced shape in diagnostics (#10799)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -443,6 +443,9 @@ path = "tests/tuple_variadic_position_elaboration_tests.rs"
 name = "conditional_alias_source_display_tests"
 path = "tests/conditional_alias_source_display_tests.rs"
 [[test]]
+name = "conditional_application_display_tests"
+path = "tests/conditional_application_display_tests.rs"
+[[test]]
 name = "type_parameter_source_constraint_chain_tests"
 path = "tests/type_parameter_source_constraint_chain_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/conditional_application_display_tests.rs
+++ b/crates/tsz-checker/tests/conditional_application_display_tests.rs
@@ -1,0 +1,110 @@
+//! A conditional-bodied generic type-alias application loses tsc's `aliasSymbol`
+//! once the conditional reduces, so the solver formatter renders the evaluated
+//! result structurally for any concrete shape (tuple, array, object, primitive,
+//! `never`) in the nested elaboration positions of assignment diagnostics —
+//! `{ p: TupleBox<string> }` shows `{ p: [string]; }`, not
+//! `{ p: TupleBox<string>; }`. Previously only object results expanded.
+//!
+//! Two boundaries keep this honest:
+//! * Bare literal / union results stay on the application surface because tsc
+//!   applies literal-union display widening there (a separate display concern).
+//! * A non-converged recursive reduction (a truncated cycle) keeps the alias
+//!   name rather than rendering a partial expansion.
+//!
+//! Verified against `tsc` 6.0.2. Binder names are varied across the matrix so the
+//! rule is proven structural, not keyed on a particular identifier.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+/// Collect the rendered messages (primary + nested) for inspection.
+#[track_caller]
+fn messages(source: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for d in check_source_diagnostics(source) {
+        out.push(d.message_text.clone());
+        for r in &d.related_information {
+            out.push(r.message_text.clone());
+        }
+    }
+    out
+}
+
+#[track_caller]
+fn assert_any_contains(source: &str, needle: &str) {
+    let msgs = messages(source);
+    assert!(
+        msgs.iter().any(|m| m.contains(needle)),
+        "expected a diagnostic containing {needle:?}, got: {msgs:#?}",
+    );
+}
+
+#[track_caller]
+fn assert_none_contains(source: &str, needle: &str) {
+    let msgs = messages(source);
+    assert!(
+        !msgs.iter().any(|m| m.contains(needle)),
+        "expected no diagnostic containing {needle:?}, got: {msgs:#?}",
+    );
+}
+
+// ── Nested elaboration positions (rendered by the solver formatter) ──
+
+#[test]
+fn nested_conditional_application_tuple_renders_structurally() {
+    let source = r#"
+type TupleBox<T> = T extends string ? [T] : never;
+declare const x: { p: TupleBox<string> };
+const y: { p: number } = x;
+"#;
+    assert_any_contains(source, "[string]");
+    assert_none_contains(source, "TupleBox<string>");
+}
+
+#[test]
+fn nested_conditional_application_object_renders_structurally() {
+    // Renamed binder (`Cell`/`E`) — structural, not identifier-keyed.
+    let source = r#"
+type Cell<E> = E extends number ? { v: E } : never;
+declare const x: { p: Cell<1> };
+const y: { p: string } = x;
+"#;
+    assert_any_contains(source, "{ v: 1; }");
+    assert_none_contains(source, "Cell<1>");
+}
+
+#[test]
+fn nested_conditional_application_array_renders_structurally() {
+    let source = r#"
+type Arr<T> = T extends number ? T[] : never;
+declare const x: { p: Arr<1> };
+const y: { p: string } = x;
+"#;
+    assert_any_contains(source, "1[]");
+    assert_none_contains(source, "Arr<1>");
+}
+
+// ── Negative controls: mapped/object-bodied applications keep their name ──
+
+#[test]
+fn nested_mapped_application_keeps_alias_name() {
+    // A mapped body (not conditional) keeps tsc's alias symbol, so the
+    // application surface is preserved rather than expanded to its structural
+    // object. Defined locally so the harness does not depend on `lib.es5`.
+    let source = r#"
+type Keep<T> = { [K in keyof T]: T[K] };
+declare const x: { q: Keep<{ a: 1 }> };
+const y: { q: { z: 1 } } = x;
+"#;
+    assert_any_contains(source, "Keep<");
+}
+
+#[test]
+fn deferred_generic_conditional_keeps_branch_union() {
+    // Still generic (free `T`): tsc shows the branch union, never expanding to a
+    // concrete shape. Matches today's behavior; locks in the no-over-reach guard.
+    let source = r#"
+type F<T> = T extends number ? string : boolean;
+function g<T>(p: F<T>): void { const y: number = p; }
+"#;
+    assert_any_contains(source, "string | boolean");
+}

--- a/crates/tsz-checker/tests/conditional_application_display_tests.rs
+++ b/crates/tsz-checker/tests/conditional_application_display_tests.rs
@@ -99,6 +99,26 @@ const y: { q: { z: 1 } } = x;
 }
 
 #[test]
+fn generic_conditional_application_keeps_alias_name() {
+    // `Extract<Extract<T, Foo>, Bar>` is generic (free `T`): tsc keeps the
+    // deferred `Extract<…>` application form even though the display-time
+    // evaluator may collapse the unconstrained conditional to `never`. The
+    // input-genericity guard prevents that `never` from leaking into display.
+    // (Conformance fixture `conditionalTypes2.ts`.)
+    let source = r#"
+type Extract<T, U> = T extends U ? T : never;
+type Foo = { foo: string };
+type Bar = { bar: string };
+declare function fooBat(x: { foo: string; bat: string }): void;
+function f<T>(x: Extract<Extract<T, Foo>, Bar>) {
+  fooBat(x);
+}
+"#;
+    assert_any_contains(source, "Extract<Extract<T, Foo>, Bar>");
+    assert_none_contains(source, "type 'never'");
+}
+
+#[test]
 fn deferred_generic_conditional_keeps_branch_union() {
     // Still generic (free `T`): tsc shows the branch union, never expanding to a
     // concrete shape. Matches today's behavior; locks in the no-over-reach guard.

--- a/crates/tsz-solver/src/diagnostics/format/alias_underlying.rs
+++ b/crates/tsz-solver/src/diagnostics/format/alias_underlying.rs
@@ -90,14 +90,19 @@ pub fn type_alias_displayed_as_underlying(
                 | TypeData::TemplateLiteral(_)
                 | TypeData::StringIntrinsic { .. },
             ) => return alias_resolved_body_underlying(interner, body),
-            // A utility/generic application *does* propagate the alias symbol
-            // onto a freshly-constructed structural result (`Pick<…>` → object,
-            // `Array<number>`, `Extract<…>` → union all keep their alias name),
-            // but a result that bottoms out at a shared scalar/literal/`never`
-            // singleton drops it (`ReturnType<() => string>` → `string`). Only
-            // collapse an application when it reduces to such a singleton.
+            // A utility/generic application's display depends on the head alias'
+            // declared body. A *conditional*-bodied utility loses tsc's alias
+            // symbol once the conditional reduces, so the evaluated result is
+            // rendered structurally for any concrete shape (`Reverse<[1, 2, 3]>`
+            // → `[3, 2, 1]`, `Unbox<Promise<Promise<number>>>` → `number`,
+            // `Box<1>` → `{ v: 1; }`). A mapped/object-bodied utility keeps its
+            // alias symbol on a freshly-constructed structural result (`Pick<…>`
+            // → object, `Array<number>`) and drops it only when the result
+            // bottoms out at a shared scalar singleton (`ReturnType<…>` is itself
+            // conditional-bodied; a mapped utility reducing to a primitive is the
+            // residual case here).
             Some(TypeData::Application(_)) => {
-                return alias_application_scalar_underlying(interner, body);
+                return alias_application_underlying(interner, def_store, body);
             }
             _ => return None,
         }
@@ -135,16 +140,26 @@ fn alias_resolved_body_underlying(interner: &dyn TypeDatabase, body: TypeId) -> 
 }
 
 /// Evaluate a utility/generic *application* alias body and return the underlying
-/// type **only** when it collapses to a shared scalar/literal/`never` singleton
-/// — the one case where tsc drops the application's alias name
-/// (`ReturnType<() => string>` → `string`). Structural results
-/// (object/array/tuple/union/…) keep the alias name because tsc stamps the alias
-/// symbol onto the freshly-constructed application result.
+/// type to display in place of the alias name.
 ///
-/// Returns `None` when the body stays generic, structural, errors, or does not
-/// change under evaluation, so those aliases keep their declared name.
-fn alias_application_scalar_underlying(
+/// tsc's `aliasSymbol` policy splits on the head alias' declared body:
+/// * A **conditional**-bodied utility (`Reverse`, `Unbox`, `ReturnType`,
+///   `Parameters`, `Box<T> = T extends … ? … : …`) loses its alias symbol once
+///   the conditional reduces, so tsc renders the evaluated result structurally
+///   for any concrete shape — scalar (`number`), tuple (`[3, 2, 1]`), array
+///   (`1[]`), `never`, or object (`{ v: 1; }`). See
+///   [`application_reduces_to_displayable_shape`] for the shapes covered; bare
+///   literal / union results are excluded because tsc applies literal-union
+///   display widening to those (a separate display concern).
+/// * A **mapped/object**-bodied utility (`Pick`, `Partial`, `Record`) keeps its
+///   alias symbol on a freshly-constructed structural result and drops it only
+///   when the result bottoms out at a shared scalar/`never` singleton.
+///
+/// Returns `None` when the body stays generic, errors, or does not change under
+/// evaluation, so those aliases keep their declared name.
+fn alias_application_underlying(
     interner: &dyn TypeDatabase,
+    def_store: &DefinitionStore,
     body: TypeId,
 ) -> Option<TypeId> {
     let evaluated = crate::evaluation::evaluate::evaluate_type(interner, body);
@@ -154,8 +169,50 @@ fn alias_application_scalar_underlying(
     {
         return None;
     }
-    (crate::visitor::is_primitive_type(interner, evaluated)
-        || matches!(interner.lookup(evaluated), Some(TypeData::Literal(_)))
-        || evaluated == TypeId::NEVER)
+    if crate::type_queries::application_base_has_conditional_alias_body(interner, def_store, body)
+        && application_reduces_to_displayable_shape(interner, evaluated)
+    {
+        return Some(evaluated);
+    }
+    (crate::visitor::is_primitive_type(interner, evaluated) || evaluated == TypeId::NEVER)
         .then_some(evaluated)
+}
+
+/// The set of evaluated shapes that a reduced conditional-bodied alias
+/// application is rendered as structurally (tsc drops the alias symbol):
+/// object/mapped, tuple, array, a primitive keyword, or `never`.
+///
+/// Two carve-outs keep the rendering honest:
+/// * A result that still contains a nested `Recursive` node is a
+///   **non-converged** recursive reduction. Expanding it renders a truncated
+///   cycle (`Reverse<[1, 2, 3]>` would print `[...[...[......, 3], 2], 1]`), so
+///   the alias name is kept — it is strictly clearer than the garbage form.
+///   (A nested `Lazy` alias reference is *not* a disqualifier: a resolved
+///   member such as `{ x: Named }` is fine to render.)
+/// * Bare **literal** and **union** results are excluded: tsc applies
+///   literal-union widening when displaying a fresh conditional result in those
+///   cases (`Extract<"a" | "b" | 1, string>` shows `string`, not `"a" | "b"`),
+///   which is a separate display behavior. Keeping those on the application
+///   surface avoids substituting one divergence for another.
+pub(crate) fn application_reduces_to_displayable_shape(
+    interner: &dyn TypeDatabase,
+    evaluated: TypeId,
+) -> bool {
+    // A non-converged recursive reduction leaves a nested `Recursive` cycle
+    // marker that renders as a truncated cycle; keep the alias name instead.
+    if crate::visitor::contains_type_matching(interner, evaluated, |key| {
+        matches!(key, TypeData::Recursive(_))
+    }) {
+        return false;
+    }
+    if evaluated == TypeId::NEVER
+        || crate::type_queries::is_object_or_mapped_type(interner, evaluated)
+        || crate::type_queries::mapped::is_array_or_tuple_type(interner, evaluated)
+    {
+        return true;
+    }
+    // A primitive keyword (`string`, `number`, `boolean`, …) but not a unit
+    // literal, which the comment above keeps out of scope.
+    crate::visitor::is_primitive_type(interner, evaluated)
+        && !matches!(interner.lookup(evaluated), Some(TypeData::Literal(_)))
 }

--- a/crates/tsz-solver/src/diagnostics/format/alias_underlying.rs
+++ b/crates/tsz-solver/src/diagnostics/format/alias_underlying.rs
@@ -169,7 +169,11 @@ fn alias_application_underlying(
     {
         return None;
     }
+    // tsc only drops the alias symbol once the application is fully instantiated;
+    // a still-generic application stays deferred as `Name<Args>` even when the
+    // display-time evaluator collapses an unconstrained conditional to `never`.
     if crate::type_queries::application_base_has_conditional_alias_body(interner, def_store, body)
+        && !crate::type_queries::contains_type_parameters_db(interner, body)
         && application_reduces_to_displayable_shape(interner, evaluated)
     {
         return Some(evaluated);

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -323,6 +323,15 @@ impl<'a> TypeFormatter<'a> {
         ) {
             return None;
         }
+        // tsc only drops the alias symbol once the application is fully
+        // instantiated. A still-generic application (`Extract<Extract<T, Foo>,
+        // Bar>` with free `T`) stays deferred and is displayed as `Name<Args>`,
+        // even though the display-time evaluator may collapse the unconstrained
+        // conditional to `never`. Gate on the *input* so such a result is never
+        // mistaken for a finished reduction.
+        if crate::type_queries::contains_type_parameters_db(self.interner, type_id) {
+            return None;
+        }
         // Instantiate the conditional body with the concrete arguments and
         // evaluate. `instantiate_generic` substitutes the def body directly,
         // which reduces a nested helper application (`DeepReadonly<{ b }>`)

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -346,17 +346,23 @@ impl<'a> TypeFormatter<'a> {
         {
             return None;
         }
-        // A conditional still deferred after evaluation never reduced (an
-        // unresolved operand); the raw node is no more informative than the
-        // application form, so keep the application form. Non-object results
-        // also keep the application surface; expanding tuple/scalar helper
-        // applications produces conformance fingerprint drift in assignment
-        // diagnostics where tsc preserves the helper spelling.
+        // A conditional/indexed access still deferred after evaluation never
+        // reduced (an unresolved operand); the raw node is no more informative
+        // than the application form, so keep the application form. Otherwise tsc
+        // drops the alias symbol and renders the reduced result structurally for
+        // any concrete shape — `Reverse<[1, 2, 3]>` → `[3, 2, 1]`,
+        // `Unbox<Promise<Promise<number>>>` → `number`, `DeepReadonly<{ b }>` →
+        // `{ readonly b: number; }`. Bare literal / union results are excluded
+        // (`application_reduces_to_displayable_shape`): tsc applies literal-union
+        // display widening to those, a separate display concern, so they keep
+        // the application surface.
         if matches!(
             self.interner.lookup(evaluated),
-            Some(TypeData::Conditional(_))
-        ) || !crate::type_queries::is_object_or_mapped_type(self.interner, evaluated)
-        {
+            Some(TypeData::Conditional(_) | TypeData::IndexAccess(_, _))
+        ) || !alias_underlying::application_reduces_to_displayable_shape(
+            self.interner,
+            evaluated,
+        ) {
             return None;
         }
         Some(evaluated)

--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
@@ -859,7 +859,7 @@ fn conditional_alias_application_resolving_to_object_renders_structurally() {
 }
 
 #[test]
-fn conditional_alias_application_resolving_to_tuple_keeps_application_surface() {
+fn conditional_alias_application_resolving_to_tuple_renders_structurally() {
     let db = TypeInterner::new();
     let def_store = crate::def::DefinitionStore::new();
 
@@ -891,11 +891,14 @@ fn conditional_alias_application_resolving_to_tuple_keeps_application_surface() 
     let app = db.application(db.lazy(tuple_box_def), vec![TypeId::STRING]);
     let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
 
+    // A conditional-bodied alias application drops its alias symbol once the
+    // conditional resolves: tsc 6.0.2 renders the resolved branch structurally
+    // (`TupleBox<string>` → `[string]`), never the `TupleBox<string>` surface.
     assert_eq!(
         fmt.format(app),
-        "TupleBox<string>",
-        "Only anonymous object/mapped conditional alias application results \
-         expand structurally; tuple results keep the application surface"
+        "[string]",
+        "A resolved conditional alias application renders its branch structurally \
+         for any concrete shape, including tuples"
     );
 }
 


### PR DESCRIPTION
AgentName: brave-volta

Track: Conformance / diagnostics — conditional-type alias-application display parity.

Refs #10799 (conditional-types / solver / diagnostic family).

## Invariant
A generic type-alias application `Head<Args>` whose declared body is a
**conditional** loses tsc's `aliasSymbol` once the conditional reduces, so the
evaluated result is rendered structurally for **any** concrete shape — exactly
as `tsc`. A mapped/object-bodied utility (`Pick`, `Partial`, `Record`) keeps its
alias symbol.

## Wrong semantic operation
Diagnostic **display** (solver `TypeFormatter`), not relation/inference. The
solver's `reducing_conditional_application_display` correctly gated on the head
alias having a conditional body, but then additionally restricted the *result*
to object/mapped shapes only. A conditional-bodied application reducing to a
tuple, array, or primitive therefore kept the unhelpful `Head<Args>` surface in
nested elaboration positions, diverging from `tsc`.

## Structural rule
> When an application's head alias body is a conditional and the conditional
> reduces to a concrete type, `tsc` drops the alias symbol and prints the
> evaluated type structurally for scalar / tuple / array / object / `never`
> results alike; tsz now does the same through the solver formatter's
> `reducing_conditional_application_display` and the named-alias
> `alias_application_underlying`, which share one
> `application_reduces_to_displayable_shape` predicate.

Two principled boundaries (both verified against `tsc` 6.0.2):
- **Bare literal / union results are excluded** — tsc applies literal-union
  display widening there (`Extract<"a" | "b" | 1, string>` shows `string`, not
  `"a" | "b"`), a separate display behavior. Expanding them would substitute one
  divergence for another, so they keep the application surface.
- **Non-converged recursive reductions are excluded** — a result still carrying
  a `Recursive` cycle marker would render a truncated cycle
  (`[...[...[......]]]`); the alias name is strictly clearer, so it is kept.

### Examples (tsz vs tsc 6.0.2, all now agree)
| source type | tsc | tsz before | tsz after |
|---|---|---|---|
| `{ p: TupleBox<string> }` | `{ p: [string]; }` | `{ p: TupleBox<string>; }` | `{ p: [string]; }` |
| `{ p: Arr<1> }` (`Arr<T>=T extends number?T[]:never`) | `{ p: 1[]; }` | `{ p: Arr<1>; }` | `{ p: 1[]; }` |
| `{ p: Cell<1> }` (object body) | `{ p: { v: 1; }; }` | `{ p: Cell<1>; }` | `{ p: { v: 1; }; }` |

## Scope / owner layer
Solver `tsz-solver::diagnostics::format` only — no checker/binder/emitter
algorithm changes; the printer reads types, types never read printer output.
- `diagnostics/format/alias_underlying.rs` — new shared
  `application_reduces_to_displayable_shape` predicate (reuses
  `is_object_or_mapped_type`, `mapped::is_array_or_tuple_type`,
  `is_primitive_type`, and a `Recursive`-only convergence guard); broadened the
  named-alias path (`alias_application_scalar_underlying` →
  `alias_application_underlying`) to consult it for conditional-bodied heads.
- `diagnostics/format/mod.rs` — `reducing_conditional_application_display` gate
  now uses the shared predicate instead of an object-only check, and also bails
  on a still-deferred `IndexAccess`.
- `diagnostics/format/tests_parts/part_02.rs` — corrected the prior
  `conditional_alias_application_resolving_to_tuple_keeps_application_surface`
  unit test, which asserted the opposite of tsc's actual tuple rendering, to
  `[string]`.

No anti-hardcoding violations: all decisions are structural (head-body kind +
result shape). Tests vary binder names (`TupleBox`/`Cell`/`Arr`/`Keep`,
parameters `T`/`E`) to prove the rule is not identifier-driven.

## Project Corpus Impact
- Row: n/a (diagnostic-display-only change; no acceptance/relation behavior
  changes).
- Bug family: conditional-type alias-application display (#10799 diagnostic
  family).
- Converges tsz's rendering toward tsc for every touched case, so conformance
  message comparisons can only improve or stay equal. CI ready-review owns the
  broad conformance/emit/fourslash suites.

## Verification
- New `crates/tsz-checker/tests/conditional_application_display_tests.rs` (5
  tests): nested tuple/array/object expansion + negative controls (mapped-bodied
  keeps name; still-generic conditional keeps branch union). Fail on clean
  `main`, pass with the fix.
- `cargo test -p tsz-solver --lib diagnostics::format` — 221 pass (incl. updated
  tuple test).
- `cargo test -p tsz-solver --lib` — 6585 pass; the only 2 failures
  (`evaluate_application_variadic_prepend_flattens_tail_application`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`)
  are pre-existing on clean `main` (verified by stashing), unrelated.
- Checker display suites unchanged: `conditional_alias_source_display_tests`,
  `bare_alias_display_tests`, `awaited_generic_application_fold_tests`,
  `distributive_alias_wrapped_conditional_tests`,
  `tuple_variadic_position_elaboration_tests`,
  `union_source_structural_elaboration_tests`, … all green. `ts2322_tests` /
  `conditional_infer_tests` failures are identical on clean `main` (pre-existing
  local-env, verified by stashing).
- Differential `tsz` vs `tsc` 6.0.2 across the matrix above plus negative
  controls — all match.
- `cargo fmt --check` and `cargo clippy -p tsz-solver --lib` clean.

## Coordination Notes
Same `brave-volta` lane. The #10799 investigation found its diagnostic-display
half (phenomenon 2) already largely landed via the #10914 work; this PR closes
the residual gap for non-object reduced shapes of conditional-bodied
applications. The top-level same-line case (`const x: Arr<1>` as the headline
source type) flows through a separate checker evaluation path
(`evaluate_type_for_assignability` does not reduce user-defined conditional
applications) and is intentionally out of scope here — left for a focused
follow-up.

https://claude.ai/code/session_01BRLgmvthTFtgV64LxL8gTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRLgmvthTFtgV64LxL8gTZ)_