### PR TITLE
fix(checker): converge nested concrete Awaited&lt;Promise&lt;…&gt;&gt; to inner literal (#11586)

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -238,7 +238,24 @@ impl<'a> CheckerState<'a> {
                     // cached == ERROR but type_parameter_scope is non-empty: re-resolve
                     // cached != ERROR and type_parameter_scope non-empty: re-resolve (type params may differ)
                 }
-                let result = self.get_type_from_type_reference(idx);
+                let mut result = self.get_type_from_type_reference(idx);
+                // Eagerly reduce a concrete `Awaited<…>` reference to its
+                // unwrapped form, the way tsc computes `getAwaitedType` at the
+                // reference site. The solver's lazy conditional/`infer`
+                // evaluation of the standard-library `Awaited<T>` alias does not
+                // converge once the awaited argument is a nested
+                // `Promise<Promise<…>>` whose inner layers have materialized to
+                // their structural `{ then }` Object shape: the outer conditional
+                // bails to its `: T` branch and yields the still-wrapped
+                // argument, so the relation sees `Promise<Promise<2>>` instead of
+                // `2`. Folding here makes every `Awaited<…>` annotation position
+                // converge to the same literal `tsc` reports. The fold returns
+                // `None` for generic / non-thenable arguments (it only fires when
+                // it actually unwraps a thenable), so deferred and non-`Awaited`
+                // references are unchanged.
+                if let Some(reduced) = self.try_evaluate_awaited_application(result) {
+                    result = reduced;
+                }
                 self.ctx.node_types.insert(idx.0, result);
                 return result;
             }

--- a/crates/tsz-checker/src/types/computation/access_await.rs
+++ b/crates/tsz-checker/src/types/computation/access_await.rs
@@ -187,7 +187,44 @@ impl<'a> CheckerState<'a> {
                 .collect();
             return (self.ctx.types.factory().union(unwrapped), changed);
         }
-        if let Some(inner) = self.builtin_promise_like_application_arg(type_id) {
+        // Unwrap a single thenable layer. The fast path matches the
+        // Application form (`Promise<T>` / `PromiseLike<T>`) without
+        // materializing the structural Promise shape.
+        let mut inner = self.builtin_promise_like_application_arg(type_id);
+        if inner.is_none() {
+            // Not a lib `Promise`/`PromiseLike` application. It may still be a
+            // structural thenable: either an already-materialized `{ then }`
+            // Object shape (a nested lib `Promise` argument that was lowered to
+            // its structural form, which is why the Application fast path misses
+            // it) or a user-declared thenable interface/alias whose Object shape
+            // only appears after evaluation. Evaluate to the structural form and
+            // unwrap through the thenable-aware extractor, mirroring tsc's
+            // `getAwaitedType`, which inspects the `then`/`onfulfilled` callback
+            // at every level regardless of how the thenable was declared. A
+            // non-thenable (plain object, primitive, literal) extracts to `None`,
+            // so the fold stops there and the value passes through unchanged.
+            // Folding both forms keeps the fold a faithful `getAwaitedType`, so
+            // short-circuiting the solver here can never under- or over-reduce.
+            let evaluated = self.evaluate_type_with_env(type_id);
+            let structural = if evaluated != type_id {
+                evaluated
+            } else {
+                type_id
+            };
+            if matches!(
+                query::classify_promise_type(self.ctx.types, structural),
+                query::PromiseTypeKind::Object(_)
+            ) {
+                inner = self.promise_like_return_type_argument(structural);
+            }
+        }
+        if let Some(inner) = inner {
+            // A self-referential thenable (`onfulfilled` yields the thenable
+            // itself) must not spin; stop and let the conditional evaluator and
+            // its cycle detection own that case.
+            if inner == type_id {
+                return (type_id, false);
+            }
             let (awaited, _) = self.compute_explicit_awaited_application_type(inner, depth + 1);
             return (awaited, true);
         }

--- a/crates/tsz-cli/tests/recursive_conditional_infer_termination_tests.rs
+++ b/crates/tsz-cli/tests/recursive_conditional_infer_termination_tests.rs
@@ -149,3 +149,73 @@ fn lib_awaited_promise_literal_terminates() {
         "type X = Awaited<Promise<Promise<2>>>;\n",
     );
 }
+
+/// Convergence (#11586): a *nested concrete* `Awaited<Promise<Promise<…>>>` must
+/// resolve to the inner literal — exactly like `tsc` — not just terminate. The
+/// lazy conditional/`infer` evaluation of the standard-library `Awaited<T>` alias
+/// did not converge once the inner `Promise` materialized to its structural
+/// `{ then }` Object shape (the outer conditional bailed to its `: T` branch and
+/// yielded the still-wrapped argument), so assigning the unwrapped literal back
+/// spuriously failed. We assert the *functional* outcome by source line: the
+/// matching-literal assignment must type-check and the mismatching one must error
+/// (proving the type converged to the precise literal, not an opaque/widened
+/// form). `assert_terminates` also enforces termination within the deadline.
+fn assert_awaited_convergence(name: &str, source: &str, ok_line: u32, bad_line: u32) {
+    let out = assert_terminates(name, source);
+    if out.is_empty() {
+        return; // binary not found; assert_terminates already logged the skip.
+    }
+    assert!(
+        out.contains(&format!("repro.ts({bad_line},")),
+        "expected a diagnostic on the mismatching assignment (line {bad_line}) for `{name}`, \
+         showing the nested Awaited resolved to its precise inner literal.\noutput:\n{out}"
+    );
+    assert!(
+        !out.contains(&format!("repro.ts({ok_line},")),
+        "the matching-literal assignment (line {ok_line}) must type-check for `{name}` — the \
+         nested Awaited converged to the wrong value.\noutput:\n{out}"
+    );
+}
+
+/// Two levels of plain `Promise` nesting around a numeric literal.
+#[test]
+fn awaited_nested_promise_converges_to_inner_literal() {
+    assert_awaited_convergence(
+        "awaited_converge_num",
+        "declare const a: Awaited<Promise<Promise<2>>>;\n\
+         const ok: 2 = a;\n\
+         const bad: 3 = a;\n",
+        2,
+        3,
+    );
+}
+
+/// Three levels of nesting around a string literal — convergence must hold at
+/// arbitrary depth, not just two.
+#[test]
+fn awaited_deeply_nested_promise_converges_to_inner_string() {
+    assert_awaited_convergence(
+        "awaited_converge_str",
+        "declare const a: Awaited<Promise<Promise<Promise<\"deep\">>>>;\n\
+         const ok: \"deep\" = a;\n\
+         const bad: \"other\" = a;\n",
+        2,
+        3,
+    );
+}
+
+/// A user-declared structural thenable nested inside a `Promise` is unwrapped
+/// too — the fold stays a faithful `getAwaitedType` and does not stop one layer
+/// early on a non-lib thenable. Renamed binders keep the check structural.
+#[test]
+fn awaited_unwraps_user_thenable_nested_in_promise() {
+    assert_awaited_convergence(
+        "awaited_converge_thenable",
+        "interface Holder<Carried> { then(cb: (value: Carried) => void): void; }\n\
+         declare const a: Awaited<Promise<Holder<7>>>;\n\
+         const ok: 7 = a;\n\
+         const bad: 8 = a;\n",
+        3,
+        4,
+    );
+}


### PR DESCRIPTION
AgentName: brave-volta-nDGyg

Track: solver / `Awaited` reduction parity — checker-boundary `getAwaitedType` (issue #11586, the nested-lib `Awaited` witness left out of scope by #12815).

## Invariant
A concrete `Awaited<Promise<Promise<…>>>` (any nesting depth) resolves to the same unwrapped inner type `tsc` reports — `Awaited<Promise<Promise<2>>>` → `2`, not the still-wrapped `Promise<Promise<2>>`. Generic / non-thenable / deferred `Awaited<…>` references are unchanged.

## Wrong semantic operation
Type-reference **resolution** of the standard-library `Awaited<T>` alias (not relation or inference). tsc computes `getAwaitedType` eagerly at the reference site; tsz left `Awaited<…>` as a lazy conditional `Application` for the solver. The solver's conditional/`infer` evaluation does **not** converge once the awaited argument is a nested `Promise<Promise<…>>` whose inner `Promise` layers have materialized to their structural `{ then }` Object shape: the outer `T extends { then(onfulfilled: infer F …) }` conditional bails to its `: T` branch and yields the still-wrapped argument. The relation then compared `Promise<Promise<2>>` against `2` and spuriously reported **TS2322**.

Confirmed by trace: the checker's existing eager fold already computes the correct literal (`Awaited<Promise<Promise<2>>>` → `2`) but that result never reached the relation, because the variable/annotation type handed to the solver was the unreduced application.

## Structural rule
> When a type reference resolves to a concrete `Awaited<X>` whose argument unwraps through one or more thenable layers, tsc reduces it to the fully-awaited type at the reference site. tsz now does the same through `CheckerState::try_evaluate_awaited_application`, applied where `get_type_from_type_node` resolves a `TYPE_REFERENCE`. The fold returns `None` for generic / non-thenable arguments, so deferred and non-`Awaited` references are untouched.

The eager fold (`compute_explicit_awaited_application_type`) is extended to remain a faithful `getAwaitedType`: besides the `Promise`/`PromiseLike` Application fast path, it now unwraps **structural thenables** — both already-materialized `{ then }` Object shapes (the nested-lib case) and user-declared thenable interfaces/aliases (evaluated to their Object shape, then unwrapped via the same thenable-aware extractor the `await`-expression path uses). A non-thenable (object, primitive, literal) passes through unchanged, so the fold can never under- or over-reduce — which is what makes short-circuiting the solver safe.

## Owner layer
Checker (`tsz-checker`): type-reference resolution boundary + the existing `Awaited` fold helper. No solver/binder/emitter algorithm changes.

## Scope
- `crates/tsz-checker/src/state/type_environment/type_node_resolution.rs` — reduce a concrete `Awaited<…>` `TYPE_REFERENCE` via the existing fold before caching/returning the node type.
- `crates/tsz-checker/src/types/computation/access_await.rs` — `compute_explicit_awaited_application_type` also unwraps structural-thenable (`{ then }` Object) layers, so the fold matches `getAwaitedType` for nested-lib and user thenables.
- `crates/tsz-cli/tests/recursive_conditional_infer_termination_tests.rs` — 3 new end-to-end convergence tests (real binary + full lib): two-level numeric, three-level string, and a user thenable nested in a `Promise`; each asserts the matching-literal assignment type-checks and the mismatching one errors (proving precise-literal convergence, not opaque/widening).

## Adjacent-case matrix
- Depth 2 and depth 3 of plain `Promise` nesting; numeric and string literals; `1 | 2` union payload.
- Negative: assigning the converged literal to a *different* literal still reports TS2322 with the precise rendered literal (`'2' is not assignable to '3'`, matching tsc) — no widening/dropping to silence the check.
- User-declared structural thenable nested in a `Promise` (`Awaited<Promise<Holder<7>>>` → `7`), renamed binders — behaviour follows structure, not spelling.
- Non-thenable (`Awaited<string>`, `Awaited<number | undefined>`, `Awaited<null>`) and generic (`Awaited<Promise<T>>`) cases unchanged (existing `awaited_generic_application_fold_tests` still green).

## Project Corpus Impact
- Row: n/a — only affects inputs that previously emitted a false TS2322 (or could not be in a passing row); no required row should flip.
- Bug family: `Awaited` nested-lib convergence (#11586).

## Verification
- `cargo test -p tsz-cli --test recursive_conditional_infer_termination_tests` — 7 pass (4 existing termination + 3 new convergence).
- `cargo test -p tsz-checker --test awaited_generic_application_fold_tests` — 8 pass.
- Manual parity vs `tsc 6.0.3` on the witness matrix: identical diagnostics (only the genuine literal-mismatch errors, with tsz now rendering the converged literal).
- Regression sweep across `ts2322_tests`, `conditional_infer_tests`, `async_return_widening_tests`, `deeply_nested_conditional_mapped_recursion_tests`, `nonnull_contextual_type_arg_inference_tests`, `await_*`, `async_*`, `promise_*`, `recursive_alias_resolution_tests`, `lib_resolution_identity_tests`, conditional-alias display suites — **every failure observed is pre-existing on clean `main`** (verified by stashing this change); this change adds no new failures.
- `cargo fmt --check` and `cargo clippy -p tsz-checker` clean.

## Coordination Notes
- Complements open PR #12815 (M4-B / lucid-hopper), which converges the `Unbox`/`Peel` **cross-instance churn** half of #11586. That PR's own notes scope out the nested-lib `Awaited<Promise<Promise<2>>>` case as "a separate, pre-existing issue (fails fast, not via the cross-instance churn)"; this PR fixes exactly that case at the checker boundary, in non-overlapping files (no solver changes), so the two land independently.
- Branch based on `e77a095`; verified no file overlap with newer `main` commits and a clean merge-tree against `origin/main`.

Refs #11586

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFgkeLzGKShkCCvRFWjAR8)_