### PR TITLE
fix(checker): preserve literal source for keyof-of-union/intersection diagnostic targets (#11585)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs
@@ -19,10 +19,9 @@ impl<'a> CheckerState<'a> {
             && self.lookup_type_alias_name_for_display(operand).is_none()
     }
 
-    /// True when `ty` is a `keyof X` whose operand `X` resolves to a plain object
-    /// type with no string/number index signature. Only that shape yields a
-    /// finite unit-literal key set (`"a" | "b"`, `0 | 1`), which tsc treats as a
-    /// literal context — the assignment-source literal must then be displayed
+    /// True when `ty` is a `keyof X` whose operand `X` yields a finite, statically
+    /// enumerable unit-literal key set (`"a" | "b"`, `0 | 1`), which tsc treats as
+    /// a literal context — the assignment-source literal must then be displayed
     /// as-written, not widened. An index signature contributes the `string` or
     /// `number` primitive base to the key set, and a mapped/computed/generic
     /// operand has no statically-enumerable literal keys; both lack a literal
@@ -35,31 +34,63 @@ impl<'a> CheckerState<'a> {
         else {
             return false;
         };
-        // Resolve a non-generic alias operand to its body so the object shape is
-        // visible; a direct object operand already exposes its shape.
-        let resolved =
-            if crate::query_boundaries::common::object_shape_for_type(self.ctx.types, operand)
-                .is_some()
-            {
-                operand
-            } else if let Some(def_id) =
-                crate::query_boundaries::common::lazy_def_id(self.ctx.types, operand)
-            {
-                self.ctx
-                    .type_env
-                    .borrow()
-                    .get_def(def_id)
-                    .or_else(|| {
-                        self.ctx
-                            .definition_store
-                            .get(def_id)
-                            .and_then(|def| def.body)
-                    })
-                    .unwrap_or(operand)
-            } else {
-                operand
-            };
-        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, resolved)
+        self.keyof_operand_yields_concrete_literal_keyset(operand)
+    }
+
+    /// True when the `X` in `keyof X` reduces to a finite literal key set: a plain
+    /// object type with no string/number index signature, or a union/intersection
+    /// of such objects.
+    ///
+    /// Composites distribute through `keyof` with dual set operations on the
+    /// members' key sets:
+    /// - `keyof (A | B)` = `keyof A & keyof B` — the *intersection* of the key
+    ///   sets, which stays a finite literal set as soon as **any** member
+    ///   contributes one (intersecting with a finite literal set cannot introduce
+    ///   a primitive base).
+    /// - `keyof (A & B)` = `keyof A | keyof B` — the *union* of the key sets, so
+    ///   **every** member must contribute a finite literal key set (a single
+    ///   `string`/`number` base from an index signature pollutes it).
+    ///
+    /// tsc keeps the assignment-source literal as-written whenever the target key
+    /// set is such a literal context. Recognising the composite forms also makes
+    /// the decision depend only on the operand's structure rather than on whether
+    /// the `keyof` happened to be reduced to its key set already (which is
+    /// evaluation-order sensitive for union operands and previously made the
+    /// widening flip on incidental source formatting).
+    fn keyof_operand_yields_concrete_literal_keyset(&mut self, operand: TypeId) -> bool {
+        // The members are collected into an owned `Vec` so the borrow of
+        // `self.ctx.types` taken by `union_members` / `intersection_members` is
+        // released before the `&mut self` recursive call below.
+        if let Some(members) =
+            crate::query_boundaries::common::union_members(self.ctx.types, operand)
+        {
+            let members: Vec<TypeId> = members.iter().copied().collect();
+            return members
+                .into_iter()
+                .any(|member| self.keyof_operand_yields_concrete_literal_keyset(member));
+        }
+        if let Some(members) =
+            crate::query_boundaries::common::intersection_members(self.ctx.types, operand)
+        {
+            let members: Vec<TypeId> = members.iter().copied().collect();
+            return !members.is_empty()
+                && members
+                    .into_iter()
+                    .all(|member| self.keyof_operand_yields_concrete_literal_keyset(member));
+        }
+        // A direct object operand exposes its shape; otherwise resolve a
+        // non-generic alias to its body first so the shape becomes visible.
+        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, operand)
+            .or_else(|| {
+                let def_id = crate::query_boundaries::common::lazy_def_id(self.ctx.types, operand)?;
+                let body = self.ctx.type_env.borrow().get_def(def_id).or_else(|| {
+                    self.ctx
+                        .definition_store
+                        .get(def_id)
+                        .and_then(|def| def.body)
+                })?;
+                crate::query_boundaries::common::object_shape_for_type(self.ctx.types, body)
+            })
             .is_some_and(|shape| shape.string_index.is_none() && shape.number_index.is_none())
     }
 

--- a/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
+++ b/crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs
@@ -975,6 +975,124 @@ function f<T extends { a: number }>(k: keyof T) {
 }
 
 #[test]
+fn test_concrete_keyof_union_operand_target_preserves_source_literal() {
+    // Issue #11585 family: `keyof (A | B)` reduces to `keyof A & keyof B`, a finite
+    // unit-literal key set (the common keys), so it is just as much a literal
+    // context as `keyof A`. A fresh literal source assigned to such a target must
+    // keep its as-written spelling — including a literal that *is* a key of one
+    // member but not of the intersection (`"a"`), which previously triggered the
+    // widening. tsz formerly only recognised a single object operand as concrete,
+    // so a union operand widened the source to `string` — and, because the union
+    // key reduction is evaluation-order sensitive, did so only for some incidental
+    // source formatting.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type A = { a: number; c: boolean };
+type B = { b: string; c: boolean };
+type KU = keyof (A | B);
+const k1: KU = "a";
+const k2: KU = "zzz";
+const k3: KU = 5;
+"#,
+    );
+    for (lit, target) in [("\"a\"", "\"c\""), ("\"zzz\"", "\"c\""), ("5", "\"c\"")] {
+        assert!(
+            diagnostics.iter().any(|(code, message)| {
+                *code == 2322
+                    && message == &format!("Type '{lit}' is not assignable to type '{target}'.")
+            }),
+            "Expected `keyof (A | B)` target to preserve source literal {lit} (target {target}).\nActual: {diagnostics:#?}"
+        );
+    }
+    assert!(
+        !diagnostics.iter().any(|(code, message)| {
+            *code == 2322
+                && (message.contains("Type 'string' is not assignable")
+                    || message.contains("Type 'number' is not assignable"))
+        }),
+        "Did not expect a widened 'string'/'number' source for a concrete union keyof target.\nActual: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_concrete_keyof_intersection_operand_target_preserves_source_literal() {
+    // The dual reduction `keyof (A & B)` = `keyof A | keyof B` is likewise a
+    // finite literal key set, so the source literal must be preserved as well.
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type A = { a: number };
+type B = { b: string };
+type KI = keyof (A & B);
+const k: KI = "z";
+"#,
+    );
+    assert!(
+        diagnostics.iter().any(|(code, message)| {
+            *code == 2322
+                && message.contains("Type '\"z\"' is not assignable to type '\"a\" | \"b\"'")
+        }),
+        "Expected `keyof (A & B)` target to preserve source literal '\"z\"'.\nActual: {diagnostics:#?}"
+    );
+    assert!(
+        !diagnostics.iter().any(|(code, message)| {
+            *code == 2322 && message.contains("Type 'string' is not assignable")
+        }),
+        "Did not expect a widened 'string' source for a concrete intersection keyof target.\nActual: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_keyof_union_with_indexed_member_preserves_source() {
+    // `keyof (A | B)` = `keyof A & keyof B`. An index signature on one union member
+    // does NOT pollute the result: `"a" & (string | number)` reduces back to the
+    // literal `"a"`, so tsc still treats it as a literal context and keeps the
+    // source `true` as-written. The union rule is therefore "any member literal",
+    // not "all members literal".
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type A = { a: number };
+type B = { [key: string]: number };
+type KU = keyof (A | B);
+const k: KU = true;
+"#,
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|(code, message)| { *code == 2322 && message.contains("Type 'true'") }),
+        "Expected `keyof (A | B)` with an indexed member to preserve source 'true'.\nActual: {diagnostics:#?}"
+    );
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|(code, message)| { *code == 2322 && message.contains("Type 'boolean'") }),
+        "Did not expect a widened 'boolean' source for a union keyof whose intersection stays literal.\nActual: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn test_keyof_intersection_with_indexed_member_widens_source() {
+    // `keyof (A & B)` = `keyof A | keyof B`. An index signature on any member adds
+    // the `string`/`number` primitive base to the union, so the key set is no
+    // longer a pure literal context and tsc widens the source `true` -> `boolean`.
+    // The intersection rule is "all members literal".
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+type A = { a: number };
+type B = { [key: string]: number };
+type KI = keyof (A & B);
+const k: KI = true;
+"#,
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|(code, message)| { *code == 2322 && message.contains("Type 'boolean'") }),
+        "Expected a widened 'boolean' source when an intersection member has an index signature.\nActual: {diagnostics:#?}"
+    );
+}
+
+#[test]
 fn test_generic_string_index_constraint_allows_read_but_rejects_write_via_dot_access() {
     let diagnostics = compile_and_get_diagnostics(
         r#"


### PR DESCRIPTION
AgentName: brave-volta

Track: checker / assignability diagnostic display (keyof literal-context source widening)

## Invariant

When the assignment **target** is `keyof X` whose key set is a finite union of
unit literals, tsc keeps the **source** literal as-written in `TS2322`
(`'"a"'`, not `'string'`). This now holds for composite operands —
`keyof (A | B)`, `keyof (A & B)` — exactly as it already did for `keyof R` over a
single object, independent of incidental source formatting. A generic/deferred
`keyof T`, or a key set polluted by a `string`/`number` index-signature base,
still widens, matching tsc.

## Wrong semantic operation

`diagnostic display` — the assignment-source type formatter. The binding's actual
type and the assignability result were already correct; only the rendered source
type in the message was wrong (and unstable).

## Structural rule

> A `keyof X` target provides a literal context iff `X`'s key set is a finite
> union of unit literals. `keyof` distributes over composites with dual set
> operations on the members' key sets:
> - `keyof (A | B)` = `keyof A & keyof B` — the **intersection**; literal as soon
>   as **any** member yields a finite literal key set (intersecting with a finite
>   literal set cannot introduce a primitive base).
> - `keyof (A & B)` = `keyof A | keyof B` — the **union**; literal only when
>   **every** member does (one `string`/`number` index base pollutes it).

`keyof_target_has_concrete_object_operand` previously only recognised a single
object operand, so a union/intersection operand fell through and the source was
widened to `string`/`number`. Because the union key reduction is evaluation-order
sensitive, the widening also flipped on incidental whitespace inside the object
literals (`{ a: number }` vs `{a:number}`) — the new classifier depends only on
the operand's structure, removing that instability.

## Owner layer

Checker error reporter
(`crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs`).
The single-operand check is generalised into a new recursive helper
`keyof_operand_yields_concrete_literal_keyset`. No solver/binder/emitter changes;
no hard-coded identifier, alias, or file-name predicate — the decision is purely
the operand's structural shape (object / index-signature / union / intersection).

## Scope

- `crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs` —
  generalise `keyof_target_has_concrete_object_operand` to composite operands.
- `crates/tsz-checker/tests/conformance_issues/errors/error_cases.rs` — 4 new
  regression tests (union/intersection concrete operands preserve; union member
  with an index signature still preserves via the intersection reduction;
  intersection member with an index signature widens).

## Adjacent-case matrix

- Union and intersection concrete operands; string / number / boolean / bigint
  sources; valid key (no error) vs partial-key vs non-key literal.
- Renamed binders and key names (behaviour follows structure, not names).
- Index-signature member: preserved under union (`"a" & (string|number)` → `"a"`),
  widened under intersection (`"a" | (string|number)`).
- Negative controls retained: generic/deferred `keyof T` still widens; a single
  object operand with an index signature still widens; a user-written literal
  union is not repainted as `keyof X`.
- CLI parity vs `tsc` 6.0.2 across the matrix (source column identical;
  remaining differences are pre-existing `keyof`-**target** display divergences,
  out of scope).

## Project Corpus Impact

- Row: n/a — diagnostic-display-only; no required row gains or loses a
  diagnostic code (source/target codes and counts unchanged; only the rendered
  source **type text** is corrected).
- Bug family: keyof literal-context source display (#11585 mapped/keyof family).
- Common-path cost: none — the helper runs only on the `TS2322` error path; the
  recursion is over already-interned union/intersection members.

## Verification

- NEW `error_cases` keyof tests — 20 pass (4 new + 16 existing), incl. the
  #9695 single-object preservation and generic/index-signature widening
  controls.
- Full suites green and unchanged: `ts2322_literal_source_display_tests`,
  `contextual_literal_keyof_lib_tests`, `homomorphic_mapped_index_display_tests`,
  `keyof_array_literal_diagnostic_tests`, `keyof_well_known_symbol_key_tests`.
- Pre-existing unrelated failures (`ts2322_tests` index-access/mapped
  elaboration; `conformance_issues_errors` TS2536/TS2344/overload) reproduce
  identically on clean `main` (verified by stash).
- `cargo fmt -p tsz-checker --check` and `cargo clippy -p tsz-checker` clean.

## Coordination Notes

- Refs #11585 (claimed; WIP label added). The original solver
  over-instantiation and the TS2687 facet (#12877) of that fuzzing family are
  already on `main`; this addresses a separate, reproducible diagnostic-display
  witness surfaced in the same mapped/keyof neighbourhood.
- Branch built on current `origin/main`; ready-review CI owns the broad
  conformance/emit suites.

https://claude.ai/code/session_01G13LjTxg2HrdHB3R9kzrCX

---
_Generated by [Claude Code](https://claude.ai/code/session_01G13LjTxg2HrdHB3R9kzrCX)_