### PR TITLE
fix(checker): report TS2687 for class member modifier disagreements (#11585)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1632,6 +1632,10 @@ name = "duplicate_property_modifier_ts2687_tests"
 path = "tests/duplicate_property_modifier_ts2687_tests.rs"
 
 [[test]]
+name = "class_member_modifier_ts2687_tests"
+path = "tests/class_member_modifier_ts2687_tests.rs"
+
+[[test]]
 name = "type_alias_signature_body_validation_tests"
 path = "tests/type_alias_signature_body_validation_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/state_checking/class.rs
+++ b/crates/tsz-checker/src/state/state_checking/class.rs
@@ -818,6 +818,9 @@ impl<'a> CheckerState<'a> {
         // Check for duplicate member names (TS2300, TS2393)
         self.check_duplicate_class_members(&class.members.nodes);
 
+        // Check for duplicate-member modifier disagreements (TS2687)
+        self.check_class_member_modifier_disagreements(&class.members.nodes);
+
         // Check for missing method/constructor implementations (2389, 2390, 2391)
         // Skip for declared classes (ambient declarations don't need implementations)
         if !is_declared {
@@ -1195,6 +1198,9 @@ impl<'a> CheckerState<'a> {
 
         // Check for duplicate member names (TS2300, TS2393)
         self.check_duplicate_class_members(&class.members.nodes);
+
+        // Check for duplicate-member modifier disagreements (TS2687)
+        self.check_class_member_modifier_disagreements(&class.members.nodes);
 
         // Check for missing method/constructor implementations (2389, 2390, 2391)
         self.check_class_member_implementations(&class.members.nodes);

--- a/crates/tsz-checker/src/state/state_checking_members/class_member_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/class_member_checks.rs
@@ -124,7 +124,7 @@ impl CheckerState<'_> {
         Some((name, method.name, type_id))
     }
 
-    fn get_class_member_name_info(
+    pub(super) fn get_class_member_name_info(
         &self,
         member_idx: NodeIndex,
     ) -> Option<(String, NodeIndex, bool)> {

--- a/crates/tsz-checker/src/state/state_checking_members/class_member_modifiers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/class_member_modifiers.rs
@@ -1,0 +1,191 @@
+//! TS2687 modifier-agreement checking for class members.
+//!
+//! `tsc` raises TS2687 ("All declarations of '{0}' must have identical
+//! modifiers.") from `checkVariableLikeDeclaration` whenever a class **property**
+//! declaration's modifier flags disagree with the other declarations of the same
+//! member symbol. The compared flags are the optional (`?`) token plus the
+//! `getSelectedEffectiveModifierFlags` mask
+//! `{Private, Protected, Async, Abstract, Readonly, Static}` — notably *not*
+//! `public`, `override`, `declare`, or the `accessor` keyword.
+//!
+//! This mirrors the merged type-literal / interface path in
+//! `duplicate_property_modifiers.rs`, but classes need the broader flag set and
+//! must distinguish member kinds: accessors and methods participate in the
+//! member group (and can be the reference declaration), yet TS2687 is only ever
+//! emitted on property declarations because it originates from
+//! `checkVariableLikeDeclaration`, which never runs on accessors or methods.
+//! (The existing `check_duplicate_class_members` grouping cannot be reused here
+//! because it tracks accessors in a separate map, whereas the reference model
+//! below needs properties, methods, and accessors interleaved in source order.)
+//!
+//! Targeting follows `tsc`: the value declaration (the first declaration in
+//! source order) is the reference. Every later property declaration whose flags
+//! differ from the reference is flagged, and the reference property itself is
+//! flagged once if any other property declaration disagrees with it (`tsc`'s
+//! `isVariableLike` restricts the "some other declaration differs" probe to
+//! property declarations).
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+
+/// The modifier signature of a single class member declaration. Two
+/// declarations of the same member must carry identical flags or `tsc` reports
+/// TS2687. Matches `tsc`'s `areDeclarationFlagsIdentical`: the optional token
+/// plus the `{Private, Protected, Async, Abstract, Readonly, Static}` mask.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct ClassMemberModifierFlags {
+    readonly: bool,
+    optional: bool,
+    private: bool,
+    protected: bool,
+    is_abstract: bool,
+    is_async: bool,
+    is_static: bool,
+}
+
+impl CheckerState<'_> {
+    /// Report TS2687 for class member declarations that share a name but
+    /// disagree on modifiers.
+    ///
+    /// Instance and static members are grouped separately (they resolve to
+    /// distinct symbols in `tsc`), and only groups with more than one
+    /// declaration can disagree — so this allocates nothing extra for the common
+    /// no-duplicate class body. The groups are visited in hash order;
+    /// diagnostics are sorted by source position downstream (as in the sibling
+    /// type-literal path), so iteration order does not affect output.
+    pub(crate) fn check_class_member_modifier_disagreements(&mut self, members: &[NodeIndex]) {
+        use rustc_hash::FxHashMap;
+
+        // Canonical group key (`"static:name"` / `"name"`) -> member declaration
+        // nodes in source order.
+        let mut groups: FxHashMap<String, Vec<NodeIndex>> = FxHashMap::default();
+        for &member_idx in members {
+            let Some(key) = self.class_member_modifier_group_key(member_idx) else {
+                continue;
+            };
+            groups.entry(key).or_default().push(member_idx);
+        }
+
+        for member_nodes in groups.into_values() {
+            if member_nodes.len() < 2 {
+                continue;
+            }
+            self.report_class_member_modifier_disagreements(&member_nodes);
+        }
+    }
+
+    /// The canonical grouping key for a participating class member, or `None`
+    /// when the member does not participate (constructor, index signature,
+    /// static block) or carries a computed/late-bound name we cannot
+    /// canonicalize syntactically.
+    ///
+    /// Reuses [`Self::get_class_member_name_info`] (the same name + static-ness
+    /// extraction the duplicate-member scan uses) and skips late-bound names,
+    /// which `tsc` keys on the resolved symbol.
+    fn class_member_modifier_group_key(&mut self, member_idx: NodeIndex) -> Option<String> {
+        let (name, name_node, is_static) = self.get_class_member_name_info(member_idx)?;
+        if name.is_empty() || self.is_late_bound_member_name(name_node) {
+            return None;
+        }
+        Some(if is_static {
+            format!("static:{name}")
+        } else {
+            name
+        })
+    }
+
+    /// Emit TS2687 for a single name group (members in source order).
+    fn report_class_member_modifier_disagreements(&mut self, member_nodes: &[NodeIndex]) {
+        use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+
+        if member_nodes.len() < 2 {
+            return;
+        }
+
+        // The reference (`tsc`'s value declaration) is the first declaration,
+        // and may be a property, method, or accessor.
+        let reference_idx = member_nodes[0];
+        let Some((reference_is_property, reference_flags)) =
+            self.class_member_modifier_info(reference_idx)
+        else {
+            return;
+        };
+
+        // Collect every later property declaration that disagrees with the
+        // reference. Methods and accessors are never flagged and never count as
+        // a disagreeing "other declaration" (`tsc`'s `isVariableLike` probe is
+        // restricted to property declarations).
+        let mut nodes_to_flag: Vec<NodeIndex> = member_nodes[1..]
+            .iter()
+            .copied()
+            .filter(|&idx| {
+                self.class_member_modifier_info(idx)
+                    .is_some_and(|(is_property, flags)| is_property && flags != reference_flags)
+            })
+            .collect();
+
+        // The reference property is flagged once if any later property differs.
+        if reference_is_property && !nodes_to_flag.is_empty() {
+            nodes_to_flag.push(reference_idx);
+        }
+
+        for member_idx in nodes_to_flag {
+            // Every flagged node was grouped through `get_class_member_name_info`,
+            // so its name (and name node) resolve here too.
+            let Some((name, name_node, _)) = self.get_class_member_name_info(member_idx) else {
+                continue;
+            };
+            // `tsc` renders the name with `declarationNameToString`; reuse the
+            // shared member-name display text so string/numeric literal names
+            // match (e.g. `"1.0"` not `1`).
+            let display_name = self.get_member_name_display_text(name_node).unwrap_or(name);
+            let message = format_message(
+                diagnostic_messages::ALL_DECLARATIONS_OF_MUST_HAVE_IDENTICAL_MODIFIERS,
+                &[&display_name],
+            );
+            self.error_at_node(
+                name_node,
+                &message,
+                diagnostic_codes::ALL_DECLARATIONS_OF_MUST_HAVE_IDENTICAL_MODIFIERS,
+            );
+        }
+    }
+
+    /// Whether `member_idx` is a property declaration, paired with the modifier
+    /// flags `tsc` compares for TS2687. Returns `None` for non-participating
+    /// member kinds (constructor, index signature, static block). A single arena
+    /// lookup serves both the property-kind test and the flag extraction.
+    fn class_member_modifier_info(
+        &self,
+        member_idx: NodeIndex,
+    ) -> Option<(bool, ClassMemberModifierFlags)> {
+        let member_node = self.ctx.arena.get(member_idx)?;
+        let (modifiers, optional, is_property) = match member_node.kind {
+            k if k == syntax_kind_ext::PROPERTY_DECLARATION => {
+                let prop = self.ctx.arena.get_property_decl(member_node)?;
+                (&prop.modifiers, prop.question_token, true)
+            }
+            k if k == syntax_kind_ext::METHOD_DECLARATION => {
+                let method = self.ctx.arena.get_method_decl(member_node)?;
+                (&method.modifiers, method.question_token, false)
+            }
+            k if k == syntax_kind_ext::GET_ACCESSOR || k == syntax_kind_ext::SET_ACCESSOR => {
+                let accessor = self.ctx.arena.get_accessor(member_node)?;
+                (&accessor.modifiers, false, false)
+            }
+            _ => return None,
+        };
+
+        let flags = ClassMemberModifierFlags {
+            readonly: self.has_readonly_modifier(modifiers),
+            optional,
+            private: self.has_private_modifier(modifiers),
+            protected: self.has_protected_modifier(modifiers),
+            is_abstract: self.has_abstract_modifier(modifiers),
+            is_async: self.has_async_modifier(modifiers),
+            is_static: self.has_static_modifier(modifiers),
+        };
+        Some((is_property, flags))
+    }
+}

--- a/crates/tsz-checker/src/state/state_checking_members/mod.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/mod.rs
@@ -4,6 +4,7 @@ mod ambient_signature_checks;
 mod class_expression_initializers;
 mod class_member_checks;
 mod class_member_context;
+mod class_member_modifiers;
 mod class_type_param_checks;
 mod decorator_signature_checks;
 mod function_declaration_checks;

--- a/crates/tsz-checker/tests/class_member_modifier_ts2687_tests.rs
+++ b/crates/tsz-checker/tests/class_member_modifier_ts2687_tests.rs
@@ -1,0 +1,189 @@
+//! TS2687 ("All declarations of '{0}' must have identical modifiers.") for
+//! duplicate property declarations in **classes**.
+//!
+//! `tsc` raises TS2687 from `checkVariableLikeDeclaration` whenever two or more
+//! class member declarations resolve to the same name but disagree on the
+//! optional (`?`) token or the `{readonly, private, protected, abstract, async,
+//! static}` modifier mask. The diagnostic is only ever emitted on property
+//! declarations (accessors/methods serve as the reference but are never
+//! flagged). Targeting follows `tsc`: the first declaration in source order is
+//! the reference; every later property whose flags differ is flagged, and the
+//! reference property is flagged once if any other property disagrees.
+//!
+//! All expectations below were verified against `tsc` 6.0.2.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn count_ts2687(source: &str) -> usize {
+    check_source(source, "test.ts", CheckerOptions::default())
+        .iter()
+        .filter(|d| d.code == 2687)
+        .count()
+}
+
+#[test]
+fn class_readonly_vs_mutable_reports_ts2687_on_both() {
+    assert_eq!(
+        count_ts2687("class C { readonly a: number = 1; a: number = 2; }"),
+        2
+    );
+}
+
+#[test]
+fn class_optional_vs_required_reports_ts2687_on_both() {
+    assert_eq!(count_ts2687("class C { b?: number; b: number = 2; }"), 2);
+}
+
+#[test]
+fn class_private_vs_public_reports_ts2687_on_both() {
+    assert_eq!(count_ts2687("class C { private a = 1; a = 2; }"), 2);
+}
+
+#[test]
+fn class_protected_vs_public_reports_ts2687_on_both() {
+    assert_eq!(
+        count_ts2687("class C { protected a = 1; public a = 2; }"),
+        2
+    );
+}
+
+#[test]
+fn class_abstract_vs_concrete_reports_ts2687_on_both() {
+    assert_eq!(
+        count_ts2687("abstract class C { abstract a: number; a: number = 2; }"),
+        2
+    );
+}
+
+#[test]
+fn class_identical_modifiers_report_no_ts2687() {
+    assert_eq!(
+        count_ts2687("class C { readonly a: number = 1; readonly a: number = 2; }"),
+        0
+    );
+    assert_eq!(count_ts2687("class C { a = 1; a = 2; }"), 0);
+}
+
+#[test]
+fn class_public_keyword_vs_implicit_reports_no_ts2687() {
+    // `public` is the absence of private/protected — same effective flags.
+    assert_eq!(count_ts2687("class C { public a = 1; a = 2; }"), 0);
+}
+
+#[test]
+fn class_override_and_declare_keywords_do_not_trigger_ts2687() {
+    // `override`, `declare`, and the `accessor` keyword are outside the compared
+    // modifier mask.
+    assert_eq!(count_ts2687("class C { override a = 1; a = 2; }"), 0);
+    assert_eq!(count_ts2687("class C { accessor a = 1; a = 2; }"), 0);
+}
+
+#[test]
+fn class_declare_readonly_disagreement_still_reports_ts2687() {
+    // `declare` is ignored, but the `readonly` disagreement still fires.
+    assert_eq!(
+        count_ts2687("class C { declare readonly a: number; declare a: number; }"),
+        2
+    );
+}
+
+#[test]
+fn class_three_declarations_flag_reference_and_differing() {
+    // [readonly, mutable, readonly]: reference is readonly; only the mutable one
+    // differs -> reference + mutable flagged (2 total).
+    assert_eq!(
+        count_ts2687("class C { readonly a = 1; a = 2; readonly a = 3; }"),
+        2
+    );
+    // [mutable, readonly, readonly]: both later declarations differ from the
+    // mutable reference -> all three flagged.
+    assert_eq!(
+        count_ts2687("class C { a = 1; readonly a = 2; readonly a = 3; }"),
+        3
+    );
+}
+
+#[test]
+fn class_static_and_instance_grouped_separately() {
+    // Static `readonly a` vs static `a` disagree -> 2687 x2.
+    assert_eq!(
+        count_ts2687("class C { static readonly a = 1; static a = 2; }"),
+        2
+    );
+    // A static member and an instance member with the same name are distinct
+    // symbols -> no disagreement.
+    assert_eq!(count_ts2687("class C { static readonly a = 1; a = 2; }"), 0);
+}
+
+#[test]
+fn class_getter_before_property_flags_only_the_property() {
+    // The getter is the reference (value declaration); the readonly property
+    // differs from it -> only the property is flagged.
+    assert_eq!(
+        count_ts2687("class C { get a() { return 1; } readonly a = 2; }"),
+        1
+    );
+}
+
+#[test]
+fn class_property_before_getter_reports_no_ts2687() {
+    // The property is the reference; the only other declaration is a getter,
+    // which is not a property declaration, so the reference probe finds nothing.
+    assert_eq!(
+        count_ts2687("class C { readonly a = 2; get a() { return 1; } }"),
+        0
+    );
+}
+
+#[test]
+fn class_accessor_then_property_mix_matches_reference_model() {
+    // [getter, mutable, readonly]: reference is the getter (no readonly); the
+    // mutable property matches it, the readonly property differs -> only the
+    // readonly property flagged.
+    assert_eq!(
+        count_ts2687("class C { get a() { return 3; } a = 1; readonly a = 2; }"),
+        1
+    );
+}
+
+#[test]
+fn class_method_then_property_flags_only_the_property() {
+    assert_eq!(count_ts2687("class C { m(): void {} readonly m = 2; }"), 1);
+}
+
+#[test]
+fn class_property_then_method_reports_no_ts2687() {
+    assert_eq!(count_ts2687("class C { readonly m = 2; m(): void {} }"), 0);
+}
+
+#[test]
+fn class_method_overloads_report_no_ts2687() {
+    assert_eq!(
+        count_ts2687("class C { m(x: number): void; m(x: string): void; m(x: any): void {} }"),
+        0
+    );
+}
+
+#[test]
+fn class_single_declaration_reports_no_ts2687() {
+    assert_eq!(count_ts2687("class C { readonly a: number = 1; }"), 0);
+}
+
+#[test]
+fn class_modifier_disagreement_follows_structure_not_name() {
+    // Behaviour depends on the modifier shape, not the chosen identifier.
+    assert_eq!(
+        count_ts2687("class Renamed { readonly zebra = 1; zebra = 2; }"),
+        2
+    );
+}
+
+#[test]
+fn class_expression_also_reports_ts2687() {
+    // The same check runs for class expressions, not only declarations.
+    assert_eq!(
+        count_ts2687("const C = class { readonly a = 1; a = 2; };"),
+        2
+    );
+}


### PR DESCRIPTION
AgentName: brave-volta-7M7aL

Track: checker / duplicate-member diagnostics (declaration modifier agreement)

## Invariant

When two or more class member declarations resolve to the same member name (instance and static kept in separate symbol groups) but disagree on the `readonly`, optional (`?`), `private`, `protected`, `abstract`, or `async` modifier, the checker reports TS2687 ("All declarations of '{0}' must have identical modifiers."), matching `tsc` exactly — including which declarations are flagged. Declarations that agree on modifiers are unaffected.

## Summary

Classes never emitted TS2687. The merged type-literal / interface path (#12877) explicitly scoped itself to property signatures and excluded classes; this PR extends the same duplicate-member-modifier-agreement family (issue #11585) to class bodies **and** class expressions.

```ts
class C { readonly a: number = 1; a: number = 2; }   // tsc: TS2687 x2 (+TS2300); tsz before: only TS2300
class D { b?: number; b: number = 2; }               // tsc: TS2687 x2; tsz before: none
class E { private a = 1; a = 2; }                    // tsc: TS2687 x2
abstract class F { abstract a: number; a = 2; }      // tsc: TS2687 x2
class G { static readonly a = 1; static a = 2; }     // tsc: TS2687 x2 (static/instance grouped separately)
```

## Wrong semantic operation

`diagnostic display` / member-declaration validation — a checker diagnostic that was simply absent for class members.

## Structural rule

Reverse-engineered from `tsc`'s `checkVariableLikeDeclaration` + `areDeclarationFlagsIdentical`:

> When two or more class member declarations resolve to the same name, `tsc` compares each declaration's optional token plus its `getSelectedEffectiveModifierFlags` mask `{Private, Protected, Async, Abstract, Readonly, Static}` against the symbol's value declaration (the first declaration in source order). TS2687 is emitted **only on property declarations** — it originates from `checkVariableLikeDeclaration`, which never runs on accessors or methods — but accessors and methods still serve as the reference. The reference property is flagged once if any other property declaration disagrees with it (`tsc`'s `isVariableLike` probe is restricted to property declarations); every later property whose flags differ from the reference is flagged.

The reference/targeting model was validated against `tsc` across property/accessor/method orderings (get-then-prop, prop-then-get, three-declaration mixes) and confirmed that `public`/`override`/`declare`/`accessor`-keyword and constructor parameter-property cases emit nothing.

## Owner layer

Checker (`tsz-checker`). New module `state/state_checking_members/class_member_modifiers.rs` owns `check_class_member_modifier_disagreements`, routed from the two `check_duplicate_class_members` call sites (class declarations + class expressions). It reuses `get_class_member_name_info` for name/static-ness extraction and does one arena lookup per member. It groups property/method/accessor declarations interleaved in source order — which the existing `check_duplicate_class_members` grouping cannot supply because that pass segregates accessors into a separate map. No solver/binder/emitter changes; no hard-coded identifier or name-string predicate.

## Scope

- NEW `crates/tsz-checker/src/state/state_checking_members/class_member_modifiers.rs`
- `state/state_checking_members/mod.rs` — module registration
- `state/state_checking_members/class_member_checks.rs` — widen `get_class_member_name_info` to `pub(super)` for reuse
- `state/state_checking/class.rs` — run the check after duplicate-member detection at both call sites
- NEW `crates/tsz-checker/tests/class_member_modifier_ts2687_tests.rs` (+ Cargo.toml test target)

## Adjacent-case matrix

- `readonly`, optional, `private`, `protected`, `abstract` disagreements; identical-modifier groups emit nothing.
- Two- and three-declaration targeting (reference-vs-rest; all-three case).
- Accessor/method interleavings: getter-before-property (only property flagged), property-before-getter (none), getter+property+property mixes, method-before/after-property.
- Static and instance members grouped separately; method overloads emit nothing.
- `public`/`override`/`declare`/`accessor` keywords are outside the compared mask.
- Renamed binders — behaviour follows modifier structure, not the identifier.
- Class expressions, not only declarations.

## Project Corpus Impact

- Row: n/a — adds a previously-missing diagnostic; no required row should lose a diagnostic.
- Bug family: duplicate-member-modifier-agreement (#11585), extending #12877 from type literals/interfaces to classes.
- Common-path cost: the modifier check only allocates per genuine duplicate group; a class body with no duplicate names allocates the grouping map but populates nothing extra.

## Verification

- NEW `class_member_modifier_ts2687_tests` — 20 pass.
- Regression suites green: `ts2300_tests` (71), `duplicate_property_modifier_ts2687_tests` (13), `duplicate_identifier_grouping_allocation_tests` (10), `class_interface_namespace_merge_tests` (11), `ts2300_duplicate_reexport_tests` (11), `class_reserved_word_diagnostics_tests` (5).
- `cargo fmt -p tsz-checker --check` and `cargo clippy -p tsz-checker` clean.
- End-to-end CLI parity vs `tsc` 6.0.2: identical spans, message text, and TS2687/TS2300 set, e.g. `class C { readonly a = 1; a = 2; }` → TS2687 at (2,12) and (3,3) plus TS2300 at (3,3).
- Pre-existing unrelated `--lib` failures (72) reproduce identically on clean `main` (verified by stash); this change adds zero regressions.

## Coordination Notes

- Branch built on current `origin/main` (37cc30f); no conflicts. Ready-review CI owns the broad conformance/emit suites.
- Refs #11585. The synthetic mapped-intersection representative shapes already pass on `main`; the type-literal/interface TS2687 witness landed in #12877; this completes the class context.

https://claude.ai/code/session_01NnoDBk9mJtSJoJGRyNJooT

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnoDBk9mJtSJoJGRyNJooT)_