### PR TITLE
fix(checker): render reduced conditional/indexed-access generic applications structurally in diagnostic source position (#10799)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/conditional_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/conditional_alias_display.rs
@@ -50,6 +50,16 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
+        // `tsc` only drops the `aliasSymbol` once the application is instantiated
+        // with *concrete* arguments. An application whose arguments still mention
+        // a free type parameter (`ReturnType<T[M]>`) keeps its alias spelling even
+        // when the conditional reduces to a concrete type (e.g. `unknown` once the
+        // constraint is applied) — tsc renders `ReturnType<T[M]>`, not `unknown`.
+        // Decline before evaluating so the deferred application keeps its name.
+        if crate::query_boundaries::common::contains_type_parameters(self.ctx.types, candidate) {
+            return None;
+        }
+
         let evaluated = self.evaluate_type_for_assignability(candidate);
         // `tsc` renders a reduced conditional/indexed-access application
         // structurally, but a *union* result's member ordering follows `tsc`'s

--- a/crates/tsz-checker/src/error_reporter/conditional_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/conditional_alias_display.rs
@@ -17,6 +17,30 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// Source/argument-position entry for the reduced conditional/indexed-access
+    /// application display. It defers a *non-generic* type alias whose body is
+    /// such an application (`type RO = DeepReadonly<Config>`) to the established
+    /// non-generic computed-body path in `format_type_for_assignability_message`:
+    /// that path drops the wrapping alias symbol and renders the resolved
+    /// structural object, whereas `reduced_alias_app_display` would re-emit the
+    /// bare alias name (`RO`) because the application-alias skip does not strip a
+    /// non-generic alias. Direct generic applications (`Classify<"x">`) and the
+    /// concrete shapes they reduce to (which carry an *application* display alias,
+    /// not a Lazy non-generic reference) still flow through.
+    pub(in crate::error_reporter) fn reduced_generic_application_source_display(
+        &mut self,
+        ty: TypeId,
+    ) -> Option<String> {
+        if let Some(def_id) = crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty)
+            && let Some(def) = self.ctx.definition_store.get(def_id)
+            && def.kind == tsz_solver::def::DefKind::TypeAlias
+            && def.type_params.is_empty()
+        {
+            return None;
+        }
+        self.reduced_alias_app_display(ty)
+    }
+
     fn reduced_alias_app_candidate_display(&mut self, candidate: TypeId) -> Option<String> {
         if !crate::query_boundaries::diagnostics::alias_application_body_reduces_through_conditional_or_indexed(
             self.ctx.types,
@@ -27,6 +51,33 @@ impl<'a> CheckerState<'a> {
         }
 
         let evaluated = self.evaluate_type_for_assignability(candidate);
+        // `tsc` renders a reduced conditional/indexed-access application
+        // structurally, but a *union* result's member ordering follows `tsc`'s
+        // global lazy creation order, which tsz does not reproduce (it sorts
+        // unions canonically). Expanding a union-reducing application would only
+        // trade the alias-name surface for a member-order divergence, so keep the
+        // alias name for unions and leave them to the separate union-ordering
+        // work. Single object/tuple/array/primitive reductions have no such
+        // ambiguity and match `tsc` exactly.
+        if crate::query_boundaries::common::is_union_type(self.ctx.types, evaluated) {
+            return None;
+        }
+        // When the reduced shape is registered against a *non-generic* type alias
+        // (`type RO = DeepReadonly<Config>` — the wrapping alias survives onto the
+        // resolved object), the application-alias skip cannot drop it and would
+        // re-emit the bare alias name (`RO`). `tsc` renders such a non-generic
+        // alias structurally, but that is already owned by the non-generic
+        // computed-body path in `format_type_for_assignability_message`, so defer
+        // to it rather than leak the alias here. `registered_non_generic_type_alias_def`
+        // resolves the name through the same registration the formatter consults,
+        // so a direct generic application (which registers only a generic — or no —
+        // alias) still flows through to its structure (`Classify<"x">` → `{ s: "x"; }`).
+        if self
+            .registered_non_generic_type_alias_def(evaluated)
+            .is_some()
+        {
+            return None;
+        }
         (self.should_use_evaluated_assignability_display(candidate, evaluated)
             || crate::query_boundaries::diagnostics::evaluated_alias_application_has_concrete_display(
                 self.ctx.types,

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source.rs
@@ -2,6 +2,7 @@
 
 mod assignment_formatting;
 mod assignment_source_preservation;
+mod assignment_widening;
 mod compound_assignment_context;
 mod computed_index_source_display;
 mod contextual_index_display;

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -162,6 +162,20 @@ impl<'a> CheckerState<'a> {
             return display;
         }
 
+        // A generic application of a conditional/indexed-access-bodied type alias
+        // (`Classify<"x">`, `Head<[a, b]>`, `Val<{…}>`, including through an alias
+        // chain) drops tsc's `aliasSymbol` once it reduces to a concrete shape, so
+        // tsc prints the resolved structural form (`{ s: "x"; }`, `[a, b]`, …).
+        // The identifier-source fallbacks below otherwise repaint the source with
+        // the declared annotation text and leak the `Classify<"x">` surface. The
+        // shared reduction policy keeps the alias for free-type-parameter, stalled,
+        // and mapped-bodied applications, and defers a non-generic alias wrapping
+        // such an application (`type RO = DeepReadonly<C>`) to the established
+        // computed-body path, matching tsc.
+        if let Some(display) = self.reduced_generic_application_source_display(source) {
+            return display;
+        }
+
         let has_optional_callable_param =
             crate::query_boundaries::common::function_shape_for_type(self.ctx.types, source)
                 .is_some_and(|shape| shape.params.iter().any(|param| param.optional))

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_formatting.rs
@@ -3,9 +3,7 @@
 //! Extracted from `error_reporter/core/diagnostic_source.rs` to keep that
 //! file under the LOC ceiling. Pure file-organization move; no logic changes.
 
-use super::literal_widening_helpers::{
-    literal_display_appropriate_for_undefined_null_target, target_accepts_literal_primitive_kind,
-};
+use super::literal_widening_helpers::literal_display_appropriate_for_undefined_null_target;
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
@@ -1886,120 +1884,5 @@ impl<'a> CheckerState<'a> {
         self.node_text(assertion.type_node)
             .and_then(|text| self.sanitize_type_annotation_text_for_diagnostic(text, false))
             .map(|text| self.format_annotation_like_type(&text))
-    }
-
-    /// Whether to suppress the AST-literal short-circuit for an
-    /// object-literal-property elaboration when the property elaboration has
-    /// already widened the source (e.g. `1` → `number`). Mirrors tsc's
-    /// `getWidenedLiteralLikeTypeForContextualType`: keep the literal display
-    /// when the source's primitive kind appears as a literal kind somewhere in
-    /// the target, otherwise widen.
-    pub(in crate::error_reporter) fn property_elaboration_widening_required_for_display(
-        &self,
-        expr_idx: NodeIndex,
-        source: TypeId,
-        target: TypeId,
-    ) -> bool {
-        if !self.is_property_assignment_initializer(expr_idx) {
-            return false;
-        }
-        // Only fire when the caller passed in a non-literal primitive source
-        // (i.e. the property elaboration already widened the literal). For
-        // direct `let x: 1 = "abc"` style mismatches the source is still the
-        // literal type, so this guard short-circuits.
-        if !crate::query_boundaries::common::is_primitive_type(self.ctx.types, source) {
-            return false;
-        }
-        if crate::query_boundaries::common::literal_value(self.ctx.types, source).is_some() {
-            return false;
-        }
-        let primitive_kind = source;
-        !target_accepts_literal_primitive_kind(self.ctx.types, target, primitive_kind)
-    }
-
-    pub(in crate::error_reporter) fn array_elaboration_widening_required_for_display(
-        &self,
-        source: TypeId,
-        target: TypeId,
-    ) -> bool {
-        use crate::query_boundaries::common;
-
-        let source_primitive = if let Some(value) = common::literal_value(self.ctx.types, source) {
-            value.primitive_type_id()
-        } else if matches!(
-            source,
-            TypeId::STRING | TypeId::NUMBER | TypeId::BIGINT | TypeId::BOOLEAN
-        ) {
-            source
-        } else {
-            return false;
-        };
-        let target = common::evaluate_type(self.ctx.types, target);
-        if target == TypeId::UNDEFINED || target == TypeId::NULL {
-            return source_primitive != TypeId::BOOLEAN;
-        }
-
-        !target_accepts_literal_primitive_kind(self.ctx.types, target, source_primitive)
-    }
-
-    pub(in crate::error_reporter) fn array_literal_element_source_widening_required_for_display(
-        &self,
-        anchor_idx: NodeIndex,
-        source: TypeId,
-        target: TypeId,
-    ) -> bool {
-        if !self.array_elaboration_widening_required_for_display(source, target) {
-            return false;
-        }
-
-        let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(anchor_idx);
-        self.ctx
-            .arena
-            .parent_of(expr_idx)
-            .and_then(|parent_idx| self.ctx.arena.get(parent_idx))
-            .is_some_and(|parent| parent.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION)
-    }
-
-    pub(in crate::error_reporter) fn is_object_rest_assignment_target_anchor(
-        &self,
-        anchor_idx: NodeIndex,
-    ) -> bool {
-        let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(anchor_idx);
-        let mut current = expr_idx;
-        let mut saw_spread_wrapper = false;
-        let mut object_idx = None;
-
-        while let Some(parent_idx) = self.ctx.arena.parent_of(current) {
-            let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
-                return false;
-            };
-            if parent_node.kind == syntax_kind_ext::SPREAD_ELEMENT
-                || parent_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT
-            {
-                saw_spread_wrapper = true;
-                current = parent_idx;
-                continue;
-            }
-            if parent_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION && saw_spread_wrapper
-            {
-                object_idx = Some(parent_idx);
-                break;
-            }
-            if parent_node.kind == syntax_kind_ext::BINARY_EXPRESSION
-                || parent_node.kind == syntax_kind_ext::VARIABLE_DECLARATION
-                || parent_node.kind == syntax_kind_ext::EXPRESSION_STATEMENT
-            {
-                break;
-            }
-            current = parent_idx;
-        }
-        let Some(object_idx) = object_idx else {
-            return false;
-        };
-
-        self.assignment_target_expression(anchor_idx)
-            .is_some_and(|target_idx| {
-                self.ctx.arena.skip_parenthesized_and_assertions(target_idx) == object_idx
-            })
     }
 }

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_widening.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/assignment_widening.rs
@@ -1,0 +1,123 @@
+//! Assignment source widening helpers for TS2322-family diagnostics.
+
+use super::literal_widening_helpers::target_accepts_literal_primitive_kind;
+use crate::state::CheckerState;
+use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Whether to suppress the AST-literal short-circuit for an
+    /// object-literal-property elaboration when the property elaboration has
+    /// already widened the source (e.g. `1` -> `number`). Mirrors tsc's
+    /// `getWidenedLiteralLikeTypeForContextualType`: keep the literal display
+    /// when the source's primitive kind appears as a literal kind somewhere in
+    /// the target, otherwise widen.
+    pub(in crate::error_reporter) fn property_elaboration_widening_required_for_display(
+        &self,
+        expr_idx: NodeIndex,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        if !self.is_property_assignment_initializer(expr_idx) {
+            return false;
+        }
+        // Only fire when the caller passed in a non-literal primitive source
+        // (i.e. the property elaboration already widened the literal). For
+        // direct `let x: 1 = "abc"` style mismatches the source is still the
+        // literal type, so this guard short-circuits.
+        if !crate::query_boundaries::common::is_primitive_type(self.ctx.types, source) {
+            return false;
+        }
+        if crate::query_boundaries::common::literal_value(self.ctx.types, source).is_some() {
+            return false;
+        }
+        let primitive_kind = source;
+        !target_accepts_literal_primitive_kind(self.ctx.types, target, primitive_kind)
+    }
+
+    pub(in crate::error_reporter) fn array_elaboration_widening_required_for_display(
+        &self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        use crate::query_boundaries::common;
+
+        let source_primitive = if let Some(value) = common::literal_value(self.ctx.types, source) {
+            value.primitive_type_id()
+        } else if matches!(
+            source,
+            TypeId::STRING | TypeId::NUMBER | TypeId::BIGINT | TypeId::BOOLEAN
+        ) {
+            source
+        } else {
+            return false;
+        };
+        let target = common::evaluate_type(self.ctx.types, target);
+        if target == TypeId::UNDEFINED || target == TypeId::NULL {
+            return source_primitive != TypeId::BOOLEAN;
+        }
+
+        !target_accepts_literal_primitive_kind(self.ctx.types, target, source_primitive)
+    }
+
+    pub(in crate::error_reporter) fn array_literal_element_source_widening_required_for_display(
+        &self,
+        anchor_idx: NodeIndex,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        if !self.array_elaboration_widening_required_for_display(source, target) {
+            return false;
+        }
+
+        let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(anchor_idx);
+        self.ctx
+            .arena
+            .parent_of(expr_idx)
+            .and_then(|parent_idx| self.ctx.arena.get(parent_idx))
+            .is_some_and(|parent| parent.kind == syntax_kind_ext::ARRAY_LITERAL_EXPRESSION)
+    }
+
+    pub(in crate::error_reporter) fn is_object_rest_assignment_target_anchor(
+        &self,
+        anchor_idx: NodeIndex,
+    ) -> bool {
+        let expr_idx = self.ctx.arena.skip_parenthesized_and_assertions(anchor_idx);
+        let mut current = expr_idx;
+        let mut saw_spread_wrapper = false;
+        let mut object_idx = None;
+
+        while let Some(parent_idx) = self.ctx.arena.parent_of(current) {
+            let Some(parent_node) = self.ctx.arena.get(parent_idx) else {
+                return false;
+            };
+            if parent_node.kind == syntax_kind_ext::SPREAD_ELEMENT
+                || parent_node.kind == syntax_kind_ext::SPREAD_ASSIGNMENT
+            {
+                saw_spread_wrapper = true;
+                current = parent_idx;
+                continue;
+            }
+            if parent_node.kind == syntax_kind_ext::OBJECT_LITERAL_EXPRESSION && saw_spread_wrapper
+            {
+                object_idx = Some(parent_idx);
+                break;
+            }
+            if parent_node.kind == syntax_kind_ext::BINARY_EXPRESSION
+                || parent_node.kind == syntax_kind_ext::VARIABLE_DECLARATION
+                || parent_node.kind == syntax_kind_ext::EXPRESSION_STATEMENT
+            {
+                break;
+            }
+            current = parent_idx;
+        }
+        let Some(object_idx) = object_idx else {
+            return false;
+        };
+
+        self.assignment_target_expression(anchor_idx)
+            .is_some_and(|target_idx| {
+                self.ctx.arena.skip_parenthesized_and_assertions(target_idx) == object_idx
+            })
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/core_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core_alias_display.rs
@@ -2,6 +2,30 @@ use crate::state::CheckerState;
 use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
+    /// The non-generic `TypeAlias` `DefId` registered against `ty`, if any.
+    /// Prefers the raw alias body registration (`find_type_alias_by_body`) and
+    /// falls back to the checker's evaluated-form registration
+    /// (`find_def_for_type`); generic aliases (which need type-argument display)
+    /// return `None`. The diagnostic formatter resolves an alias name through the
+    /// same registration, so this is the canonical "does `ty` render as a bare
+    /// non-generic alias name" query.
+    pub(crate) fn registered_non_generic_type_alias_def(
+        &self,
+        ty: TypeId,
+    ) -> Option<tsz_solver::def::DefId> {
+        let def_id = self
+            .ctx
+            .definition_store
+            .find_type_alias_by_body(ty)
+            .or_else(|| {
+                let def_id = self.ctx.definition_store.find_def_for_type(ty)?;
+                let def = self.ctx.definition_store.get(def_id)?;
+                (def.kind == tsz_solver::def::DefKind::TypeAlias).then_some(def_id)
+            })?;
+        let def = self.ctx.definition_store.get(def_id)?;
+        def.type_params.is_empty().then_some(def_id)
+    }
+
     /// Look up a displayable non-generic type alias name for a `TypeId`.
     pub(crate) fn lookup_type_alias_name_for_display(&self, ty: TypeId) -> Option<String> {
         // Only check composite types - tsc does NOT preserve alias names for
@@ -62,27 +86,11 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        // Try body_to_alias first (raw alias body), then fall back to
-        // type_to_def (evaluated alias form registered by the checker).
-        let def_id = self
-            .ctx
-            .definition_store
-            .find_type_alias_by_body(ty)
-            .or_else(|| {
-                let def_id = self.ctx.definition_store.find_def_for_type(ty)?;
-                let def = self.ctx.definition_store.get(def_id)?;
-                if def.kind == tsz_solver::def::DefKind::TypeAlias {
-                    Some(def_id)
-                } else {
-                    None
-                }
-            })?;
+        // Only a non-generic type alias registered against this `TypeId` is a
+        // candidate; generic aliases need type-argument display (`B<string>`,
+        // not `B`).
+        let def_id = self.registered_non_generic_type_alias_def(ty)?;
         let def = self.ctx.definition_store.get(def_id)?;
-        // Only use the alias for non-generic type aliases. Generic aliases
-        // need type argument display (e.g., B<string> not B).
-        if !def.type_params.is_empty() {
-            return None;
-        }
         // `type T = typeof value` aliases display as the resolved value type
         // in assignment diagnostics. Do not repaint that resolved body as `T`.
         if def.body.is_some_and(|body| {

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -256,6 +256,23 @@ impl<'a> CheckerState<'a> {
             return self.format_type_for_assignability_message_skip_application_alias(ty);
         }
 
+        // A *still-deferred* generic application whose alias body reduces through
+        // a conditional or indexed access (`Classify<"x">`, `Head<[a, b]>`,
+        // `Val<{…}>`, and the same through an alias chain) drops tsc's
+        // `aliasSymbol` once it resolves to a concrete shape, so tsc prints the
+        // evaluated structural form. The scalar/literal reductions already reach
+        // the eager-evaluation path below (the checker collapses them to a shared
+        // singleton with no alias), but object/tuple/array reductions retain the
+        // application surface and would otherwise leak `Classify<"x">` through the
+        // `lookup_type_alias_name_for_display` short-circuit further down. Reuse
+        // the same target-side reduction policy so both diagnostic pair sides
+        // agree; the helper keeps the alias for free-type-parameter, stalled, and
+        // mapped-bodied applications (`Wrap<T>`, `Cond<T>`, `MapIt<…>`) and defers
+        // a non-generic alias wrapping such an application to the path below.
+        if let Some(display) = self.reduced_generic_application_source_display(ty) {
+            return display;
+        }
+
         if let Some(def_id) = crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty)
             && let Some(def) = self.ctx.definition_store.get(def_id)
             && def.kind == tsz_solver::def::DefKind::TypeAlias

--- a/crates/tsz-checker/src/tests/computed_alias_source_display_tests.rs
+++ b/crates/tsz-checker/src/tests/computed_alias_source_display_tests.rs
@@ -39,6 +39,20 @@ fn assert_source_display(source: &str, expected_source: &str) {
     );
 }
 
+fn assert_argument_source_display(source: &str, expected_source: &str) {
+    let messages: Vec<String> = check_source_diagnostics(source)
+        .into_iter()
+        .filter(|d| d.code == 2345)
+        .map(|d| d.message_text)
+        .collect();
+    assert!(
+        messages.iter().any(|m| m.contains(&format!(
+            "Argument of type '{expected_source}' is not assignable"
+        ))),
+        "expected argument source display '{expected_source}', got: {messages:?}"
+    );
+}
+
 #[test]
 fn conditional_scalar_alias_source_renders_underlying() {
     // `Pick_A` reduces to `string`; tsc shows `string`, not `Pick_A`.
@@ -280,5 +294,163 @@ declare const witness_r: Mixed_R;
 const sink_r: 0 = witness_r;
 "#,
         "Mixed_R",
+    );
+}
+
+// --- generic conditional/indexed-access applications -----------------------
+//
+// A *generic* application whose alias body is a conditional or indexed access
+// (`Classify<"x">`, `Head<[a, b]>`, `Val<{…}>`) drops tsc's `aliasSymbol` once
+// it reduces to a concrete shape, so the diagnostic source must render the
+// resolved structural form. The scalar/literal reductions already collapsed to
+// a shared singleton; the object/tuple/array reductions retained the
+// application surface and leaked the `Classify<"x">` spelling. Binder names are
+// varied so the rule is structural, not keyed on `Classify`/`Head`/`Val`.
+
+#[test]
+fn generic_conditional_application_to_object_renders_structural() {
+    assert_source_display(
+        r#"
+type Sort_Sa<T> = T extends string ? { s: T } : { n: T };
+declare const probe_sa: Sort_Sa<"x">;
+const sink_sa: 0 = probe_sa;
+"#,
+        "{ s: \"x\"; }",
+    );
+}
+
+#[test]
+fn renamed_generic_conditional_application_to_tuple_renders_structural() {
+    assert_source_display(
+        r#"
+type LeadTail_Tb<U> = U extends [infer H, ...infer R] ? [H, ...R] : [];
+declare const probe_tb: LeadTail_Tb<[string, number]>;
+const sink_tb: 0 = probe_tb;
+"#,
+        "[string, number]",
+    );
+}
+
+#[test]
+fn generic_conditional_application_to_array_renders_structural() {
+    assert_source_display(
+        r#"
+type Listify_Uc<V> = V extends unknown ? V[] : never;
+declare const probe_uc: Listify_Uc<string>;
+const sink_uc: 0 = probe_uc;
+"#,
+        "string[]",
+    );
+}
+
+#[test]
+fn generic_indexed_access_application_to_object_renders_structural() {
+    assert_source_display(
+        r#"
+type Center_Vd<W> = W[keyof W];
+declare const probe_vd: Center_Vd<{ only: { z: 1 } }>;
+const sink_vd: 0 = probe_vd;
+"#,
+        "{ z: 1; }",
+    );
+}
+
+#[test]
+fn generic_application_through_alias_chain_renders_structural() {
+    // `Outer_We -> Inner_We<…>` (a generic conditional through an alias chain)
+    // still drops every name down to the resolved object.
+    assert_source_display(
+        r#"
+type Inner_We<X> = X extends unknown ? { wrapped: X } : never;
+type Outer_We<X> = Inner_We<X>;
+declare const probe_we: Outer_We<number>;
+const sink_we: 0 = probe_we;
+"#,
+        "{ wrapped: number; }",
+    );
+}
+
+#[test]
+fn generic_conditional_application_argument_position_renders_structural() {
+    // The same reduction applies to a TS2345 call-argument source.
+    assert_argument_source_display(
+        r#"
+type Shape_Xf<T> = T extends string ? { s: T } : { n: T };
+declare function take_xf(value: 0): void;
+declare const probe_xf: Shape_Xf<"y">;
+take_xf(probe_xf);
+"#,
+        "{ s: \"y\"; }",
+    );
+}
+
+#[test]
+fn generic_mapped_application_keeps_alias_name() {
+    // A mapped body is not a conditional/indexed access; tsc keeps the
+    // homomorphic application name, so the reduction must not fire.
+    assert_source_display(
+        r#"
+type Clone_Yg<T> = { [K in keyof T]: T[K] };
+declare const probe_yg: Clone_Yg<{ a: string }>;
+const sink_yg: 0 = probe_yg;
+"#,
+        "Clone_Yg<{ a: string; }>",
+    );
+}
+
+#[test]
+fn generic_conditional_application_to_union_keeps_alias_name() {
+    // A single application reducing to a *union* keeps its alias name: tsc orders
+    // union members by global creation order, which tsz does not reproduce, so
+    // expanding here would trade an alias surface for a member-order divergence.
+    assert_source_display(
+        r#"
+type Spread_Zh<T> = T extends unknown ? { v: T } : never;
+declare const probe_zh: Spread_Zh<1 | 2>;
+const sink_zh: 0 = probe_zh;
+"#,
+        "Spread_Zh<1 | 2>",
+    );
+}
+
+#[test]
+fn unreduced_generic_conditional_application_keeps_alias_name() {
+    // A free type parameter leaves the conditional deferred, so tsc keeps the
+    // `Defer_Ai<T>` spelling rather than a partially-resolved shape.
+    let messages = ts2322_messages(
+        r#"
+type Defer_Ai<T> = T extends unknown ? { v: T } : never;
+function probe_ai<T>(value: Defer_Ai<T>): void {
+  const sink_ai: 0 = value;
+}
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Type 'Defer_Ai<T>' is not assignable")),
+        "expected deferred application to keep its alias name, got: {messages:?}"
+    );
+}
+
+#[test]
+fn non_generic_alias_wrapping_conditional_application_keeps_alias_in_identifier_source() {
+    // Negative guard for the scope boundary: when a *non-generic* alias wraps a
+    // reducible generic application (`type Frozen_Bj = Resolve_Bj<{ a: number }>`)
+    // and appears as a bare identifier source, the reduction here is intentionally
+    // deferred to the non-generic computed-body path (which currently keeps the
+    // `Frozen_Bj` spelling in this position). This proves the generic-application
+    // reduction does not leak into the non-generic-alias identifier-source path —
+    // that residual is tracked separately. The assertion-source RO case (which the
+    // computed-body path *does* render structurally) is covered in
+    // `type_alias_computed_display_tests`.
+    assert_source_display(
+        r#"
+type Resolve_Bj<T> = T extends object ? { readonly [K in keyof T]: T[K] } : T;
+type Frozen_Bj = Resolve_Bj<{ a: number }>;
+declare const probe_bj: Frozen_Bj;
+const sink_bj: 0 = probe_bj;
+"#,
+        "Frozen_Bj",
     );
 }

--- a/crates/tsz-checker/src/tests/computed_alias_source_display_tests.rs
+++ b/crates/tsz-checker/src/tests/computed_alias_source_display_tests.rs
@@ -434,6 +434,32 @@ function probe_ai<T>(value: Defer_Ai<T>): void {
 }
 
 #[test]
+fn free_type_parameter_application_reducing_to_concrete_keeps_alias_name() {
+    // Regression for the conformance fixture
+    // `genericConditionalConstrainedToUnknownNotAssignableToConcreteObject`: tsc
+    // only drops the `aliasSymbol` once an application is instantiated with
+    // *concrete* arguments. `Ret_Cj<T>` reduces to a concrete type under `T`'s
+    // constraint, but its argument `T` is a free type parameter, so tsc keeps
+    // `Ret_Cj<T>` rather than rendering the reduced result. (Mirrors the fixture's
+    // `ReturnType<T[M]>`, whose argument `T[M]` reduces to `unknown` with the lib
+    // loaded yet stays spelled `ReturnType<T[M]>`.)
+    let messages = ts2322_messages(
+        r#"
+type Ret_Cj<F> = F extends () => infer R ? R : never;
+function probe_cj<T extends () => string>(value: Ret_Cj<T>, sink: number) {
+  sink = value;
+}
+"#,
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("Type 'Ret_Cj<T>' is not assignable")),
+        "expected free-type-parameter application to keep its alias name, got: {messages:?}"
+    );
+}
+
+#[test]
 fn non_generic_alias_wrapping_conditional_application_keeps_alias_in_identifier_source() {
     // Negative guard for the scope boundary: when a *non-generic* alias wraps a
     // reducible generic application (`type Frozen_Bj = Resolve_Bj<{ a: number }>`)


### PR DESCRIPTION
AgentName: brave-volta-dtvTP

**Track:** Conformance / diagnostic display (#10799 conditional-tuple-union family)

Closes the remaining display residual called out in #10799: the top-level / argument source type for a *generic application* of a conditional- or indexed-access-bodied alias.

## Structural rule
When the source of a `TS2322`/`TS2345` is a generic application whose alias body reduces through a conditional or indexed access (`Classify<T>` applied as `Classify<"x">`, `Head<[a, b]>`, `Val<{…}>`, including through an alias chain) **with concrete arguments** and it resolves to a concrete **object / tuple / array** shape, `tsc` drops the `aliasSymbol` and renders the resolved structural form. tsz already did this for scalar/literal reductions (the checker collapses those to a shared singleton carrying no alias) and on the target side, but object/tuple/array reductions kept the application surface and leaked the `Classify<"x">` spelling through the `lookup_type_alias_name_for_display` / declared-annotation short-circuits in the source-display path.

Verified against `tsc` 6.0.2: with `type Classify<T> = T extends string ? { s: T } : { n: T }` and `declare const a: Classify<"x">`, the statement `const e: 0 = a;` now reports `Type '{ s: "x"; }' …` on both `tsc` and tsz (previously tsz showed `Classify<"x">`).

## Owner layer
Checker `error_reporter` source-display only — no relation/inference/narrowing/stored-type change. Both the general assignability formatter (`format_type_for_assignability_message`) and the assignment source path (`format_assignment_source_type_for_diagnostic`) now route through the existing target-side reduction policy (`reduced_alias_app_display`), so the source and target sides of a diagnostic pair agree.

## Adjacent-case matrix (all checked vs `tsc` 6.0.2, renamed binders)
Positive (now structural): conditional→object, conditional→tuple, conditional→array, indexed-access→object, generic application through an alias chain, and the same in TS2345 call-argument / return / nested-property positions.

Negative (kept as `tsc` keeps them):
- free type parameter / stalled conditional (`Wrap<T>`, `Cond<T>`) → alias name;
- **application whose arguments still mention a free type parameter** (`ReturnType<T[M]>`, `Ret<T>`) → alias name, even when the conditional reduces to a concrete type once the constraint is applied (this is the `genericConditionalConstrainedToUnknownNotAssignableToConcreteObject` conformance fixture: `tsc` only drops the `aliasSymbol` for concretely-instantiated applications);
- mapped-bodied application (`MapIt<…>`, `Partial<…>`) → alias name;
- single application reducing to a **union** → alias name (deferred: `tsc` orders union members by global creation order, which tsz does not yet reproduce — expanding would only trade an alias surface for a member-order divergence; tracked with the separate union-ordering work);
- non-generic alias wrapping such an application in identifier-source position (`type RO = DeepReadonly<C>`) → deferred to the established non-generic computed-body path via the shared `registered_non_generic_type_alias_def` registration query, so it does not re-emit the bare `RO` name.

## Invariant
Match `tsc` exactly for diagnostic source display; no semantic/assignability behavior change. Anti-hardcoding: no identifier/file-name literals; structural decisions go through solver/query-boundary helpers (`alias_application_body_reduces_through_conditional_or_indexed`, `contains_type_parameters`, `is_union_type`, `registered_non_generic_type_alias_def`); the printer reads types, never the reverse.

## Scope
`crates/tsz-checker/src/error_reporter/{conditional_alias_display,core_alias_display,core_formatting}.rs` and `core/diagnostic_source/assignment_formatting.rs`; tests in `tests/computed_alias_source_display_tests.rs`. A duplicated registration lookup was consolidated into the shared `registered_non_generic_type_alias_def` helper (now reused by `lookup_type_alias_name_for_display`).

## Project Corpus Impact
Diagnostic-display only; improves rxjs/type-fest/kysely-style elaboration parity (the #10799 benchmark family) without changing which diagnostics are produced. No project-row diagnostic counts change (alias name → structural text for the same error). Full conformance/fourslash/emit suites green on CI after the free-type-parameter guard.
- Row: rxjs-project
- Bug family: conditional-types/diagnostic-display (#10799 distributive-conditional-over-tuple-union source display)

## Verification
- `tsc` 6.0.2 vs tsz on the full positive/negative probe matrix above — positives now match exactly; negatives unchanged; conformance fixture `genericConditionalConstrainedToUnknownNotAssignableToConcreteObject` keeps `ReturnType<T[M]>`.
- `cargo test -p tsz-checker --lib computed_alias_source_display_tests::` → 29 passed (11 new), `type_alias_computed_display_tests::` → 18 passed, `type_alias_primitive_display` → 9 passed, `conditional` → 158 passed.
- `cargo clippy -p tsz-checker --lib` clean.
- CI: all conformance shards + `conformance-aggregate`, fourslash, unit, emit green on head `79941d6`.

## Coordination Notes
Builds on #12399 / #12888 / #10914 (named-alias and conditional-application display halves already on `main`). The union-member-ordering divergence remains the explicitly-deferred follow-up in this family.