### PR TITLE
fix(resolver): never resolve relative/rooted specifiers through tsconfig paths (#11577)

### DIFF
--- a/crates/tsz-core/src/module_resolver/mod.rs
+++ b/crates/tsz-core/src/module_resolver/mod.rs
@@ -545,12 +545,17 @@ impl ModuleResolver {
             );
         }
 
-        // Step 2: Try path mappings first (if configured and baseUrl is available).
-        // TypeScript treats `paths` mappings as requiring `baseUrl` to avoid surprising
-        // absolute lookups that behave like relative resolution.
+        // Step 2: Try path mappings, but only for non-relative, non-rooted
+        // specifiers (see `is_external_module_name_relative`); a catch-all `"*"`
+        // mapping would otherwise intercept `./sibling` imports and resolve them
+        // to the mapped stub instead of the adjacent source file. This keeps the
+        // solver-backed core resolver — which `lookup` consults first — in
+        // agreement with the CLI driver and tsc. The config gate runs first so
+        // projects without `paths` never scan the specifier.
         let mut path_mapping_attempted = false;
-        if let Some(base_url) = self.base_url.as_deref()
-            && !self.path_mappings.is_empty()
+        if !self.path_mappings.is_empty()
+            && let Some(base_url) = self.base_url.as_deref()
+            && !is_external_module_name_relative(specifier)
         {
             let attempt = self.try_path_mappings(specifier, base_url, importer_package_type);
             if let Some(resolved) = attempt.resolved {

--- a/crates/tsz-core/src/module_resolver/request_types.rs
+++ b/crates/tsz-core/src/module_resolver/request_types.rs
@@ -381,6 +381,14 @@ pub const fn is_path_relative(specifier: &str) -> bool {
     )
 }
 
+/// Matches TypeScript's `isExternalModuleNameRelative`: a specifier is relative
+/// for resolution purposes when it is [`is_path_relative`] (`./`, `../`, `.`,
+/// `..`) or a rooted disk path (`/…`). tsconfig `paths`/`baseUrl` are consulted
+/// only for names where this returns `false`.
+pub const fn is_external_module_name_relative(specifier: &str) -> bool {
+    is_path_relative(specifier) || matches!(specifier.as_bytes(), [b'/', ..])
+}
+
 impl ModuleExtension {
     /// Parse extension from file path
     pub fn from_path(path: &Path) -> Self {

--- a/crates/tsz-core/src/module_resolver/tests/path_mapping.rs
+++ b/crates/tsz-core/src/module_resolver/tests/path_mapping.rs
@@ -680,3 +680,88 @@ fn test_path_mapping_unbalanced_parent_dirs_preserve_leading_dotdot() {
         resolved.resolved_path,
     );
 }
+
+// ── relative / rooted specifiers bypass `paths` ──────────────────────────────
+//
+// tsc consults tsconfig `paths`/`baseUrl` only for module names that are NOT
+// relative and NOT rooted (`tryLoadModuleUsingOptionalResolutionSettings` is
+// gated on `!isExternalModuleNameRelative`, i.e. `pathIsRelative ||
+// isRootedDiskPath`). A catch-all `"*"` pattern matches *every* string,
+// including `./sibling`, so without that guard the core resolver intercepts
+// relative imports and resolves them to the catch-all stub — a wrong module
+// identity that surfaces as false `TS2307`/`TS2614`/`TS2305`. The witness rows
+// vary the binder names and the relative shape so the rule stays structural.
+
+#[test]
+fn test_path_mapping_catch_all_does_not_intercept_relative_imports() {
+    // The catch-all `"*"` must not capture relative imports (see banner above).
+    struct Row {
+        sibling: &'static str,
+        importer: &'static str,
+        specifier: &'static str,
+    }
+    let rows = [
+        Row {
+            sibling: "sibling.ts",
+            importer: "main.ts",
+            specifier: "./sibling",
+        },
+        Row {
+            sibling: "shared/api.ts",
+            importer: "shared/sub/consumer.ts",
+            specifier: "../api",
+        },
+        Row {
+            sibling: "feature/nested/widget.ts",
+            importer: "feature/host.ts",
+            specifier: "./nested/widget",
+        },
+    ];
+    for row in rows {
+        let fx = TempFixture::new();
+        fx.write(row.sibling, "export const value = 1;");
+        fx.write(row.importer, "");
+        // The catch-all target exists on disk; the relative target must still
+        // win, proving `paths` was not consulted for the relative specifier.
+        fx.write("stub.d.ts", "declare const v: any; export default v;");
+
+        let options = make_options(fx.path(), vec![pm("*", "", &["./stub.d.ts"])]);
+        let mut resolver = ModuleResolver::new(&options);
+        let resolved = resolver
+            .resolve(row.specifier, &fx.join(row.importer), Span::new(0, 1))
+            .unwrap_or_else(|_| panic!("{} must resolve relative to its importer", row.specifier));
+        assert_eq!(
+            resolved.resolved_path,
+            fx.join(row.sibling),
+            "{}: a relative import must resolve to its sibling file, not the \
+             catch-all \"*\" stub",
+            row.specifier,
+        );
+    }
+}
+
+#[test]
+fn test_path_mapping_catch_all_still_resolves_bare_specifiers_alongside_relative() {
+    // Control for the guard above: with the same catch-all `"*"` mapping, a
+    // *bare* (non-relative) specifier must still resolve through it. The guard
+    // only excludes relative/rooted names, not bare module names.
+    let fx = TempFixture::new();
+    fx.write("sibling.ts", "export const value = 1;");
+    fx.write("stub.d.ts", "declare const v: any; export default v;");
+    fx.write("main.ts", "");
+
+    let options = make_options(fx.path(), vec![pm("*", "", &["./stub.d.ts"])]);
+    let mut resolver = ModuleResolver::new(&options);
+
+    // Relative: resolves to the sibling, bypassing the catch-all.
+    let relative = resolver
+        .resolve("./sibling", &fx.join("main.ts"), Span::new(0, 1))
+        .expect("./sibling must resolve to the sibling file");
+    assert_eq!(relative.resolved_path, fx.join("sibling.ts"));
+
+    // Bare: still flows through the catch-all to the stub.
+    let bare = resolver
+        .resolve("some-bare-pkg", &fx.join("main.ts"), Span::new(0, 1))
+        .expect("a bare specifier must still resolve through the catch-all");
+    assert_eq!(bare.resolved_path, fx.join("stub.d.ts"));
+}


### PR DESCRIPTION
AgentName: claude-brave-volta

**Track:** module-resolution / conformance parity
**Invariant:** tsz module resolution matches `tsc` exactly.
**Scope:** `tsz-core::module_resolver` (solver-backed resolution boundary). No checker/emitter/printer involvement.

Fixes the live tsc-parity gap behind #11577 (`module-resolution` wildcard-`paths` family). The issue's *original* witness — `try_path_mappings` skipping explicit-extension targets, and single-best-pattern selection — is already landed on `main` (#12825, #12181) and I verified it end-to-end with a built `tsz` against the nextjs-shaped guard config. This PR closes the **broader, still-live** bug in the same subsystem.

## Structural rule

When a module specifier is **relative** (`./`, `../`, `.`, `..`) or **rooted** (`/…`), `tsc` resolves it against the importing file and **never** consults tsconfig `paths`/`baseUrl` — `tryLoadModuleUsingOptionalResolutionSettings` is gated on `!isExternalModuleNameRelative(moduleName)` (= `pathIsRelative || isRootedDiskPath`).

`tsz-core::ModuleResolver::resolve` ran path mapping (Step 2) **before** its relative/absolute branches (Steps 3–4) with no such gate. A catch-all `"*"` pattern (`PathMapping::match_specifier` has empty prefix+suffix) matches **every** string — including `./sibling` — so the core resolver intercepted relative imports and resolved them to the mapped target. Because the driver's `lookup` consults the solver-backed core resolver **before** its own (correctly-guarded) fallback, the wrong result won.

## Owner layer

`tsz-core::module_resolver` — Step 2 is now gated on `!is_external_module_name_relative(specifier)`, a new shared `const` helper composing the existing `is_path_relative` with a rooted-path check, placed beside `is_path_relative` in `request_types.rs`. The cheap `paths`/`baseUrl` config checks run first so projects without `paths` never scan the specifier. This brings the core resolver into agreement with the CLI driver (already guarded on relative/absolute before path mapping) and tsc.

## Observable impact (built `tsz`, `moduleResolution: bundler`, `paths: { "*": ["./stub.d.ts"] }`)

```ts
// main.ts — sibling.ts exports `value`
import { value } from "./sibling";
```
- **before:** `./sibling` → `stub.d.ts` → false `TS2614: Module './sibling' has no exported member 'value'`
- **after:** `./sibling` → `sibling.ts` → clean (matches tsc)

This is broad: it affects **every** relative import in any project carrying a catch-all `"*"` `paths` entry — exactly the guard-config shape used across bench rows (nextjs/kysely/…).

## Adjacent matrix

`./sibling`, `../api`, `./nested/widget` all bypass the catch-all and resolve to their siblings (binder names + relative shapes varied per the anti-hardcoding contract); a **bare** specifier still flows through `"*"` (positive control); non-relative nested-wildcard / multi-target / longest-prefix selection unchanged (existing tests green).

## Project Corpus Impact

- Row: nextjs
- Bug family: module-resolution

Strictly removes false positives; no row should regress. Relative imports that previously misresolved to a catch-all stub now resolve to their real sibling, matching tsc. Non-relative path-mapping behavior (the only thing the bench guard configs exercise for resolution) is unchanged — verified end-to-end against the nextjs-shaped config (catch-all `"*"`, nested `next/dist/*`, multi-target `@fixture/*` with `.ts`/`.js`): all resolve as before.

## Verification

- `cargo test -p tsz-core --lib module_resolver::` → **241 passed, 0 failed** (incl. 2 new regression tests).
- `cargo clippy -p tsz-core --lib` → clean. `cargo fmt` applied.
- Built `tsz` end-to-end: relative-import-vs-catch-all repro now clean (exit 0); nextjs-shaped non-relative config still resolves (exit 0).
- `/simplify` run 3× (helper extraction, operand reorder for short-circuit, comment de-duplication); final pass reported clean.

## Coordination Notes

Claimed #11577 and marked `WIP` (signed comment on the issue). Supersedes the original narrow root cause (already fixed). The `.tsx`-without-`jsx` quirk in the standalone core resolver's relative probe (masked by the driver fallback) is orthogonal and out of scope — noted, not touched here.

---
_Generated by Claude Code_