### PR TITLE
perf(checker): admit method signatures to source-file direct interface lowering (#12021)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct/source_shape_methods.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct/source_shape_methods.rs
@@ -786,12 +786,49 @@ impl<'a> CheckerState<'a> {
                 interface,
                 seen_type_names,
             ) && interface.members.nodes.iter().copied().all(|member_idx| {
-                let Some(member_node) = arena.get(member_idx) else {
-                    return false;
-                };
-                if member_node.kind != syntax_kind_ext::PROPERTY_SIGNATURE {
-                    return false;
-                }
+                Self::source_file_interface_member_is_direct_lowerable(
+                    arena,
+                    delegate_binder,
+                    member_idx,
+                    seen_type_names,
+                )
+            });
+            seen_type_names.pop();
+            result
+        })
+    }
+
+    /// Decide whether a single source-file interface member can be lowered on
+    /// the direct cross-file path (no child checker).
+    ///
+    /// The direct path reuses the same `TypeLowering` member collection as the
+    /// mature path, so it produces an identical member type *as long as every
+    /// type referenced by the member resolves through the option-bag guard*
+    /// (primitives, `Array`/`ReadonlyArray`, and direct-lowerable sibling
+    /// interfaces/aliases). Anything the guard cannot prove resolvable falls
+    /// back to the child-checker path, which preserves correctness.
+    ///
+    /// Two member shapes qualify:
+    /// - Plain property signatures whose annotation is option-bag lowerable.
+    /// - Non-generic method signatures whose every parameter annotation and
+    ///   return annotation are option-bag lowerable. Optional and rest
+    ///   parameters are fine (the shared collector models them identically on
+    ///   both paths); `this` parameters and own method type parameters need the
+    ///   mature generic/self path and are rejected.
+    ///
+    /// Call/construct/index signatures, accessors, computed names, and members
+    /// with unannotated parameters or return types stay on the child path.
+    fn source_file_interface_member_is_direct_lowerable<'b>(
+        arena: &'b NodeArena,
+        delegate_binder: &BinderState,
+        member_idx: NodeIndex,
+        seen_type_names: &mut Vec<&'b str>,
+    ) -> bool {
+        let Some(member_node) = arena.get(member_idx) else {
+            return false;
+        };
+        match member_node.kind {
+            k if k == syntax_kind_ext::PROPERTY_SIGNATURE => {
                 let Some(signature) = arena.get_signature(member_node) else {
                     return false;
                 };
@@ -809,10 +846,55 @@ impl<'a> CheckerState<'a> {
                         signature.type_annotation,
                         seen_type_names,
                     )
-            });
-            seen_type_names.pop();
-            result
-        })
+            }
+            k if k == syntax_kind_ext::METHOD_SIGNATURE => {
+                let Some(signature) = arena.get_signature(member_node) else {
+                    return false;
+                };
+                // Own method type parameters (`foo<T>(...)`) need the mature
+                // generic instantiation path.
+                if signature
+                    .type_parameters
+                    .as_ref()
+                    .is_some_and(|params| !params.nodes.is_empty())
+                {
+                    return false;
+                }
+                signature.parameters.as_ref().is_none_or(|params| {
+                    params.nodes.iter().copied().all(|param_idx| {
+                        let Some(param_node) = arena.get(param_idx) else {
+                            return false;
+                        };
+                        let Some(parameter) = arena.get_parameter(param_node) else {
+                            return false;
+                        };
+                        !Self::source_file_parameter_is_this(arena, parameter)
+                            && Self::source_file_type_node_is_option_bag_lowerable(
+                                arena,
+                                delegate_binder,
+                                parameter.type_annotation,
+                                seen_type_names,
+                            )
+                    })
+                }) && Self::source_file_type_node_is_option_bag_lowerable(
+                    arena,
+                    delegate_binder,
+                    signature.type_annotation,
+                    seen_type_names,
+                )
+            }
+            _ => false,
+        }
+    }
+
+    fn source_file_parameter_is_this(
+        arena: &NodeArena,
+        parameter: &tsz_parser::parser::node::ParameterData,
+    ) -> bool {
+        arena
+            .get(parameter.name)
+            .and_then(|name_node| arena.get_identifier(name_node))
+            .is_some_and(|ident| ident.escaped_text == "this")
     }
 
     fn source_file_interface_heritage_is_direct_lowerable<'b>(

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_source_heritage_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_source_heritage_tests.rs
@@ -1,8 +1,11 @@
 use crate::context::{CheckerContext, CheckerOptions};
+use crate::diagnostics::diagnostic_codes;
 use crate::query_boundaries::common::TypeInterner;
 use crate::state::CheckerState;
+use crate::test_utils::check_multi_file;
 use std::sync::Arc;
 use tsz_binder::BinderState;
+use tsz_common::common::ModuleKind;
 use tsz_parser::parser::ParserState;
 
 fn parse_bound_source(
@@ -98,5 +101,281 @@ fn direct_cross_file_interface_lowering_rejects_generic_source_heritage() {
             )
             .is_none(),
         "generic source heritage stays on the child-checker path"
+    );
+}
+
+/// A non-generic method signature whose parameter/return annotations are
+/// option-bag lowerable now lowers on the direct path, and the lowered member
+/// is callable.
+#[test]
+fn direct_cross_file_interface_lowering_admits_source_method_signatures() {
+    let (arena, binder, types) = parse_bound_source(
+        r#"
+                interface Gauge {
+                    label: string;
+                    measure(sample: number, scale: number): number;
+                    reset(): void;
+                }
+            "#,
+    );
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    let state = CheckerState { ctx };
+    let gauge_sym = binder.file_locals.get("Gauge").expect("gauge symbol");
+
+    let (gauge_type, params) = state
+        .direct_cross_file_interface_lowering(
+            gauge_sym,
+            binder.as_ref(),
+            arena.as_ref(),
+            false,
+            true,
+        )
+        .expect("method-bearing option-bag interface should lower directly");
+
+    assert!(params.is_empty());
+    let db = state.ctx.types.as_type_database();
+    for property in ["label", "measure", "reset"] {
+        let atom = types.intern_string(property);
+        assert!(
+            crate::query_boundaries::common::raw_property_type(db, gauge_type, atom).is_some(),
+            "directly lowered interface should include {property}"
+        );
+    }
+    for method in ["measure", "reset"] {
+        let atom = types.intern_string(method);
+        let member = crate::query_boundaries::common::raw_property_type(db, gauge_type, atom)
+            .expect("method member type");
+        assert!(
+            crate::query_boundaries::common::has_call_signatures(db, member),
+            "lowered method {method} should be callable"
+        );
+    }
+}
+
+/// Heritage expansion now flattens inherited method signatures too, so a derived
+/// interface exposes both its own and its base's methods on the direct path.
+#[test]
+fn direct_cross_file_interface_lowering_expands_source_heritage_methods() {
+    let (arena, binder, types) = parse_bound_source(
+        r#"
+                interface Loader {
+                    open(target: string): void;
+                    size: number;
+                }
+                interface CachingLoader extends Loader {
+                    prime(count: number): boolean;
+                }
+            "#,
+    );
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    let state = CheckerState { ctx };
+    let derived_sym = binder
+        .file_locals
+        .get("CachingLoader")
+        .expect("derived symbol");
+
+    let (derived_type, params) = state
+        .direct_cross_file_interface_lowering(
+            derived_sym,
+            binder.as_ref(),
+            arena.as_ref(),
+            false,
+            true,
+        )
+        .expect("method heritage should lower directly");
+
+    assert!(params.is_empty());
+    let db = state.ctx.types.as_type_database();
+    for member in ["open", "size", "prime"] {
+        let atom = types.intern_string(member);
+        assert!(
+            crate::query_boundaries::common::raw_property_type(db, derived_type, atom).is_some(),
+            "directly lowered derived interface should include {member}"
+        );
+    }
+    for method in ["open", "prime"] {
+        let atom = types.intern_string(method);
+        let member = crate::query_boundaries::common::raw_property_type(db, derived_type, atom)
+            .expect("method member type");
+        assert!(
+            crate::query_boundaries::common::has_call_signatures(db, member),
+            "inherited/own method {method} should be callable"
+        );
+    }
+}
+
+/// A method with its own type parameters needs the mature generic path.
+#[test]
+fn direct_cross_file_interface_lowering_rejects_generic_method_signature() {
+    let (arena, binder, types) = parse_bound_source(
+        r#"
+                interface Mapper {
+                    convert<T>(input: T): T;
+                }
+            "#,
+    );
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    let state = CheckerState { ctx };
+    let mapper_sym = binder.file_locals.get("Mapper").expect("mapper symbol");
+
+    assert!(
+        state
+            .direct_cross_file_interface_lowering(
+                mapper_sym,
+                binder.as_ref(),
+                arena.as_ref(),
+                false,
+                true,
+            )
+            .is_none(),
+        "generic method signatures stay on the child-checker path"
+    );
+}
+
+/// A method whose parameter references a type the option-bag guard cannot prove
+/// resolvable falls back to the child-checker path.
+#[test]
+fn direct_cross_file_interface_lowering_rejects_unresolvable_method_param() {
+    let (arena, binder, types) = parse_bound_source(
+        r#"
+                interface Sink {
+                    accept(value: Unresolved): void;
+                }
+            "#,
+    );
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    let state = CheckerState { ctx };
+    let sink_sym = binder.file_locals.get("Sink").expect("sink symbol");
+
+    assert!(
+        state
+            .direct_cross_file_interface_lowering(
+                sink_sym,
+                binder.as_ref(),
+                arena.as_ref(),
+                false,
+                true,
+            )
+            .is_none(),
+        "unresolvable method parameter types stay on the child-checker path"
+    );
+}
+
+/// A method declaring an explicit `this` parameter needs the mature self path.
+#[test]
+fn direct_cross_file_interface_lowering_rejects_this_parameter_method() {
+    let (arena, binder, types) = parse_bound_source(
+        r#"
+                interface Handle {
+                    detach(this: Handle, force: boolean): void;
+                }
+            "#,
+    );
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    let state = CheckerState { ctx };
+    let handle_sym = binder.file_locals.get("Handle").expect("handle symbol");
+
+    assert!(
+        state
+            .direct_cross_file_interface_lowering(
+                handle_sym,
+                binder.as_ref(),
+                arena.as_ref(),
+                false,
+                true,
+            )
+            .is_none(),
+        "`this`-parameter methods stay on the child-checker path"
+    );
+}
+
+/// End-to-end: a cross-file interface method (including one inherited through
+/// heritage) is callable with correct arguments and reports `TS2345` on a
+/// mismatched argument — proving the directly-lowered method type carries the
+/// right parameter types through the real relation engine.
+#[test]
+fn cross_file_interface_method_argument_checks_match_tsc() {
+    let files = &[
+        (
+            "./contract.ts",
+            r#"
+export interface Probe {
+    inspect(token: string, depth: number): boolean;
+}
+export interface DeepProbe extends Probe {
+    drill(levels: number): void;
+}
+"#,
+        ),
+        (
+            "./main.ts",
+            r#"
+import type { DeepProbe } from "./contract";
+
+declare const probe: DeepProbe;
+
+const ok: boolean = probe.inspect("alpha", 3);
+probe.drill(2);
+
+probe.inspect("beta", "not-a-number");
+"#,
+        ),
+    ];
+
+    let diagnostics = check_multi_file(
+        files,
+        "./main.ts",
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let argument_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.code
+                == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+        })
+        .collect();
+    assert_eq!(
+        argument_errors.len(),
+        1,
+        "exactly one mismatched argument should report TS2345, got: {:?}",
+        diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.code, diagnostic.message_text.as_str()))
+            .collect::<Vec<_>>()
     );
 }


### PR DESCRIPTION
AgentName: Studio-B

Track: performance / cross-arena delegation (#12021)

## Invariant

`tsc` parity is preserved. The directly-lowered member type is byte-identical
to the mature child-checker member type (both use the same `TypeLowering`
member collection); anything the structural guard cannot prove resolvable
falls back to the child-checker path, so no new diagnostics or shapes can
leak from the fast path.

## Scope

Issue #12021 tracks closing the `vite-vanilla-ts-app` target gap, whose
dominant attribution is `checker:cross-arena-delegation` — interfaces that
miss the direct fast path and construct a child checker per delegation. The
source-file direct-lowering guard previously admitted **only property
signatures**, so any cross-file source interface carrying a method member
(extremely common in app/lib service interfaces) was forced onto the slow
delegation path, both for the interface itself and for any interface that
extends it.

This PR broadens the guard
(`source_file_interface_declarations_are_direct_lowerable`) to also admit
**non-generic method signatures** whose every parameter annotation and the
return annotation are themselves option-bag lowerable. Because the same guard
feeds the heritage-expansion path
(`source_file_expand_direct_lowerable_interface_heritage`), inherited methods
flatten through the direct path too. This is intentionally broad: it covers a
whole class of source-file interfaces rather than the bug's single witness.

### Structural rule

When a cross-file source-file interface member is a plain property signature,
or a non-generic method signature whose parameter and return annotations all
resolve through the option-bag guard (primitives, `Array`/`ReadonlyArray`,
and direct-lowerable sibling interfaces/aliases), `tsz` lowers it directly
through `TypeLowering` (owner: checker `cross_file_direct` →
`tsz-lowering`). Members the guard cannot prove resolvable stay on the
child-checker path.

### Owner layer

Checker `state/type_analysis/cross_file_direct` (the direct cross-file fast
path), delegating member lowering to `tsz-lowering`. No solver internals,
no printer reads, no raw `TypeKey` construction. The only literal compared is
the language keyword `this` (to reject `this`-parameter methods), matching
existing convention in 4 other checker sites — not a user-chosen identifier.

### Adjacent-case matrix (new tests)

- method-only / mixed property+method interface lowers directly, members callable
- heritage: derived interface inherits base **methods** through expansion
- negative: own method type parameter (`convert<T>`) → child path
- negative: unresolvable parameter type → child path
- negative: explicit `this` parameter → child path
- end-to-end (`check_multi_file`): cross-file + inherited method call with a
  correct argument is clean and a mismatched argument reports exactly one
  `TS2345`, proving parameter types survive the direct path through the real
  relation engine

### Fallback

Every shape the guard rejects (call/construct/index signatures, accessors,
computed names, generic members, unannotated params/returns, `this` params,
unresolvable annotations) returns `false` and is resolved by the existing
mature child-checker path. Correctness is independent of the fast path.

## Project Corpus Impact

- Row: `vite-vanilla-ts-app`, `type-fest-project`, `utility-types-project`, `ts-essentials-project`
- Bug family: `checker:cross-arena-delegation` child-checker construction for source-file interfaces with method members
- Evidence: no correctness change to project rows; rejected shapes are unchanged and admitted shapes lower to the identical type. Numeric row deltas are owned by ready-review project-corpus CI (the local environment has no `target-bench`/fixtures).

## Verification

- `cargo test -p tsz-checker --lib source_heritage_tests` — 8/8 pass
  (5 new unit + 1 new end-to-end + 2 pre-existing)
- `cargo test -p tsz-checker --lib cross_file_direct` — 170 pass; the only
  failures are pre-existing and reproduce on `main` HEAD with no change
  applied (lib-fixture-absent / stale option-bag heritage counters / a
  Windows-path assertion in `detects_npm_and_source_tree_builtin_lib_names`)
- Full `tsz-checker` lib suite diffed with vs. without this change: the
  with-change failure set is a strict **subset** of the clean-tree set —
  **zero** new failures introduced (the local env runs without lib fixtures,
  so a fixed background of lib-dependent tests fails regardless)
- `cargo clippy -p tsz-checker --lib` clean, `cargo fmt --check` clean,
  `git diff --check` clean
- `/simplify` run; applied the two in-scope micro-simplifications it surfaced

Broad suites (conformance, emit, fourslash, WASM, project guards) are owned
by ready-review CI per the agent contract.

## Coordination Notes

This is the safe, structural slice repeatedly flagged in #12021's thread:
broaden the **source-file** direct heritage/interface lowering rather than
re-attempt the reverted DOM declaration-file value/interface or type-alias
direct-delegation shortcuts (which regressed Vite with TS2812/TS2339/TS2322).
It does not touch the declaration-file/DOM path. #12021 stays open for the
remaining declaration-file heritage residual.

https://claude.ai/code/session_017D3RebDAL58FeCGz8yA2Ju

---
_Generated by [Claude Code](https://claude.ai/code/session_017D3RebDAL58FeCGz8yA2Ju)_
