### PR TITLE
perf(checker): drop per-node Vec clones in recursive type-alias body validation (#11617)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1628,6 +1628,10 @@ name = "duplicate_identifier_grouping_allocation_tests"
 path = "tests/duplicate_identifier_grouping_allocation_tests.rs"
 
 [[test]]
+name = "type_alias_body_walk_allocation_tests"
+path = "tests/type_alias_body_walk_allocation_tests.rs"
+
+[[test]]
 name = "duplicate_property_modifier_ts2687_tests"
 path = "tests/duplicate_property_modifier_ts2687_tests.rs"
 

--- a/crates/tsz-checker/src/types/type_checking/duplicate_property_modifiers.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_property_modifiers.rs
@@ -22,6 +22,18 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn check_type_literal_duplicate_properties(&mut self, members: &[NodeIndex]) {
         use crate::diagnostics::diagnostic_codes;
 
+        // A duplicate name (TS2300), a subsequent-declaration type mismatch
+        // (TS2717), or a modifier disagreement (TS2687) all require at least two
+        // property signatures that share a name, so a literal with fewer than two
+        // members can never trip any of them. Bail before touching the heap — this
+        // is the common case (most object types carry zero or one members) and the
+        // check runs on every type literal in the program. (TS1170/TS2464 computed
+        // -property checks live in a separate per-member pass in `core.rs` and are
+        // unaffected by this early return.) (#11617)
+        if members.len() < 2 {
+            return;
+        }
+
         // Track (member_idx, type_annotation, is_syntactic_name) for TS2717 comparison.
         // `is_syntactic_name` is true when the name was determined from syntax alone
         // (literal property name), false when it required evaluating a computed expression.

--- a/crates/tsz-checker/src/types/type_checking/type_alias_body_validation.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_body_validation.rs
@@ -60,8 +60,11 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        let members = type_lit.members.nodes.clone();
-        if !members.iter().copied().all(|member_idx| {
+        // Arena-backed `&'a` borrow (never mutated during checking): scan and walk
+        // the member list in place — including across the `&mut self` checks in the
+        // loop below — instead of cloning a throwaway `Vec` per signature-only
+        // type-literal alias (#11617).
+        if !type_lit.members.nodes.iter().all(|&member_idx| {
             self.ctx.arena.get(member_idx).is_some_and(|member| {
                 member.kind == syntax_kind_ext::CALL_SIGNATURE
                     || member.kind == syntax_kind_ext::CONSTRUCT_SIGNATURE
@@ -70,7 +73,7 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        for member_idx in members {
+        for &member_idx in &type_lit.members.nodes {
             let Some(member_node) = self.ctx.arena.get(member_idx) else {
                 continue;
             };

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -1658,8 +1658,9 @@ impl<'a> CheckerState<'a> {
                 // Recurse into tuple elements to validate nested type nodes
                 // (e.g., indexed access types inside tuples need TS2536/TS4105 checks).
                 if let Some(tuple) = self.ctx.arena.get_tuple_type(node) {
-                    let elements = tuple.elements.nodes.clone();
-                    for &element_idx in &elements {
+                    // Arena-backed `&'a` borrow (never mutated during checking):
+                    // iterate in place instead of cloning a throwaway `Vec` per node (#11617).
+                    for &element_idx in &tuple.elements.nodes {
                         check_child_type_node!(self, element_idx);
                     }
                 }
@@ -1680,11 +1681,12 @@ impl<'a> CheckerState<'a> {
                 // the time we reach this sibling check the scope no longer contains
                 // the inner signature's type parameters.
                 if let Some(func_type) = self.ctx.arena.get_function_type(node) {
-                    let type_parameters = func_type.type_parameters.clone();
-                    let parameters = func_type.parameters.nodes.clone();
-                    let type_annotation = func_type.type_annotation;
-                    let (_type_params, tp_updates) = self.push_type_parameters(&type_parameters);
-                    for &param_idx in &parameters {
+                    // Arena-backed `&'a` borrow: `func_type`'s type-parameter and
+                    // parameter lists outlive the `&mut self` checks below, so reference
+                    // them in place instead of cloning two throwaway `Vec`s per node (#11617).
+                    let (_type_params, tp_updates) =
+                        self.push_type_parameters(&func_type.type_parameters);
+                    for &param_idx in &func_type.parameters.nodes {
                         let param_type_annotation = (|| {
                             let param_node = self.ctx.arena.get(param_idx)?;
                             let param = self.ctx.arena.get_parameter(param_node)?;
@@ -1697,10 +1699,10 @@ impl<'a> CheckerState<'a> {
                             check_child_type_node_in_current_scope!(self, param_type_annotation);
                         }
                     }
-                    if type_annotation.is_some() {
-                        check_child_type_node_in_current_scope!(self, type_annotation);
+                    if func_type.type_annotation.is_some() {
+                        check_child_type_node_in_current_scope!(self, func_type.type_annotation);
                     }
-                    self.check_rest_parameter_types(&parameters);
+                    self.check_rest_parameter_types(&func_type.parameters.nodes);
                     self.pop_type_parameters(tp_updates);
                 }
             }
@@ -1709,8 +1711,10 @@ impl<'a> CheckerState<'a> {
                 if let Some(type_query) = self.ctx.arena.get_type_query(node)
                     && let Some(args) = &type_query.type_arguments
                 {
-                    let args_nodes = args.nodes.clone();
-                    for &arg_idx in &args_nodes {
+                    // Arena-backed `&'a` borrow: the type-argument list outlives the
+                    // `&mut self` checks, so iterate and reuse it in place instead of
+                    // cloning a throwaway `Vec` per node (#11617).
+                    for &arg_idx in &args.nodes {
                         check_child_type_node!(self, arg_idx);
                     }
                     let expr_name = type_query.expr_name;
@@ -1724,12 +1728,12 @@ impl<'a> CheckerState<'a> {
                     } else {
                         self.get_type_of_node(expr_name)
                     };
-                    let num_type_args = args_nodes.len();
+                    let num_type_args = args.nodes.len();
                     self.check_instantiation_expression_type_args(
                         expr_type,
                         num_type_args,
                         node_idx,
-                        &args_nodes,
+                        &args.nodes,
                     );
                 }
             }

--- a/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_missing_name_coverage.rs
@@ -688,8 +688,9 @@ impl<'a> CheckerState<'a> {
             }
             k if k == syntax_kind_ext::TUPLE_TYPE => {
                 if let Some(tuple) = self.ctx.arena.get_tuple_type(node) {
-                    let elements = tuple.elements.nodes.clone();
-                    for element_idx in elements {
+                    // Arena-backed `&'a` borrow (never mutated during checking):
+                    // iterate in place instead of cloning a throwaway `Vec` per node (#11617).
+                    for &element_idx in &tuple.elements.nodes {
                         self.check_type_alias_body_for_missing_names_after_type_node_check(
                             element_idx,
                         );
@@ -708,8 +709,9 @@ impl<'a> CheckerState<'a> {
             }
             k if k == syntax_kind_ext::UNION_TYPE || k == syntax_kind_ext::INTERSECTION_TYPE => {
                 if let Some(composite) = self.ctx.arena.get_composite_type(node) {
-                    let members = composite.types.nodes.clone();
-                    for member_idx in members {
+                    // Arena-backed `&'a` borrow: iterate the constituent list in place
+                    // rather than cloning it on every union/intersection node (#11617).
+                    for &member_idx in &composite.types.nodes {
                         self.check_type_alias_body_for_missing_names_after_type_node_check(
                             member_idx,
                         );
@@ -806,8 +808,8 @@ impl<'a> CheckerState<'a> {
                         self.ctx.report_mapped_type_missing_template(type_idx);
                     }
                     if let Some(ref members) = mapped.members {
-                        let member_nodes = members.nodes.clone();
-                        for member_idx in member_nodes {
+                        // Arena-backed `&'a` borrow: no throwaway clone per mapped node (#11617).
+                        for &member_idx in &members.nodes {
                             self.check_type_member_for_missing_names(member_idx);
                         }
                     }
@@ -825,8 +827,8 @@ impl<'a> CheckerState<'a> {
             }
             k if k == syntax_kind_ext::TEMPLATE_LITERAL_TYPE => {
                 if let Some(template) = self.ctx.arena.get_template_literal_type(node) {
-                    let spans = template.template_spans.nodes.clone();
-                    for span_idx in spans {
+                    // Arena-backed `&'a` borrow: no throwaway clone per template node (#11617).
+                    for &span_idx in &template.template_spans.nodes {
                         let Some(span_node) = self.ctx.arena.get(span_idx) else {
                             continue;
                         };
@@ -932,8 +934,9 @@ impl<'a> CheckerState<'a> {
         args: Option<&tsz_parser::parser::base::NodeList>,
     ) {
         if let Some(args) = args {
-            let arg_nodes = args.nodes.clone();
-            for arg_idx in arg_nodes {
+            // `args` borrows the caller's arena-backed node list, not `self`, so the
+            // recursive walk can iterate it in place without a throwaway clone (#11617).
+            for &arg_idx in &args.nodes {
                 self.check_type_alias_body_for_missing_names_after_type_node_check(arg_idx);
             }
         }

--- a/crates/tsz-checker/tests/type_alias_body_walk_allocation_tests.rs
+++ b/crates/tsz-checker/tests/type_alias_body_walk_allocation_tests.rs
@@ -1,0 +1,148 @@
+//! Regression locks for the recursive type-alias body validation walk whose
+//! per-node `Vec<NodeIndex>` clones were removed for #11617.
+//!
+//! `CheckerState` holds the AST as a shared `&'a NodeArena` that never mutates
+//! during checking, so the child-node lists of tuple / union / intersection /
+//! mapped / template-literal / function / `typeof` type nodes outlive the
+//! `&mut self` recursion and can be iterated in place instead of cloned at every
+//! nesting level. That change is a pure allocation-traffic reduction, so the
+//! walk must still:
+//!   1. visit every nested child (broken children keep reporting), and
+//!   2. not invent or drop diagnostics on well-formed nested types.
+//!
+//! The matrix below pins both directions — including a renamed-binder variant so
+//! the behavior follows type *shape*, not identifier spelling — across the exact
+//! arms that lost their clone. It also covers the duplicate-property early-bail
+//! added in the same change (a 0/1-member object type can never trip TS2300 /
+//! TS2717 / TS2687).
+
+use tsz_checker::test_utils::{check_source_diagnostics as diagnose, diagnostic_count};
+
+// --- Walk completeness: well-formed nested types stay clean ------------------
+// (No clone is no excuse to skip a child or double-visit one; any drift here
+//  would surface as a spurious diagnostic on a valid alias.)
+
+#[test]
+fn nested_tuple_alias_is_clean() {
+    // Exercises the TUPLE_TYPE arm at every depth.
+    assert_eq!(
+        diagnose("type Deep = [string, [number, [boolean, string]]];\n").len(),
+        0
+    );
+}
+
+#[test]
+fn union_and_intersection_alias_is_clean() {
+    // Exercises the UNION_TYPE / INTERSECTION_TYPE arms.
+    assert_eq!(
+        diagnose("type U = ({ a: 1 } & { b: 2 }) | string | number;\n").len(),
+        0
+    );
+}
+
+#[test]
+fn function_type_alias_with_array_rest_is_clean() {
+    // Exercises the FUNCTION_TYPE arm (param walk + rest check) with a valid rest.
+    assert_eq!(
+        diagnose("type F = (a: string, b: number, ...rest: number[]) => void;\n").len(),
+        0
+    );
+}
+
+#[test]
+fn template_literal_alias_is_clean() {
+    // Exercises the TEMPLATE_LITERAL_TYPE arm (span walk).
+    assert_eq!(diagnose("type Tpl = `a${string}b${number}c`;\n").len(), 0);
+}
+
+#[test]
+fn mapped_type_alias_is_clean() {
+    // Exercises the MAPPED_TYPE arm (member walk).
+    assert_eq!(
+        diagnose("type M = { [K in \"a\" | \"b\"]: number };\n").len(),
+        0
+    );
+}
+
+#[test]
+fn typeof_with_type_arguments_alias_is_clean() {
+    // Exercises the TYPE_QUERY arm (type-argument walk + reuse after the loop).
+    assert_eq!(
+        diagnose("declare function g<T>(x: T): T;\ntype Q = typeof g<string>;\n").len(),
+        0
+    );
+}
+
+// --- Walk reachability: broken nested children still report ------------------
+// Each case plants the error one or more levels *inside* a de-cloned child list,
+// so a dropped child would silently lose the diagnostic.
+
+#[test]
+fn function_type_alias_non_array_rest_reports_ts2370() {
+    // Hits the de-cloned `&func_type.parameters.nodes` passed to the rest check.
+    let d = diagnose("type F = (a: string, ...rest: number) => void;\n");
+    assert!(diagnostic_count(&d, 2370) >= 1, "diags: {d:?}");
+}
+
+#[test]
+fn function_type_alias_missing_param_type_reports_ts2304() {
+    // Hits the param loop over the de-cloned parameter list.
+    let d = diagnose("type F = (x: NopeMissingTypeName) => void;\n");
+    assert!(diagnostic_count(&d, 2304) >= 1, "diags: {d:?}");
+}
+
+#[test]
+fn missing_name_inside_tuple_element_reports_ts2304() {
+    // Hits the de-cloned tuple element walk.
+    let d = diagnose("type T = [NopeMissingTypeName, number];\n");
+    assert!(diagnostic_count(&d, 2304) >= 1, "diags: {d:?}");
+}
+
+#[test]
+fn missing_name_inside_union_constituent_reports_ts2304() {
+    // Hits the de-cloned union/intersection constituent walk.
+    let d = diagnose("type U = NopeMissingTypeName | number;\n");
+    assert!(diagnostic_count(&d, 2304) >= 1, "diags: {d:?}");
+}
+
+#[test]
+fn missing_name_inside_union_constituent_reports_ts2304_renamed() {
+    // Same shape, different spelling: behavior follows structure, not the name.
+    let d = diagnose("type RenamedAlias = AlsoMissingButRenamed | boolean;\n");
+    assert!(diagnostic_count(&d, 2304) >= 1, "diags: {d:?}");
+}
+
+// --- Duplicate-property early bail (< 2 members can never trip 2300/2717/2687)
+
+#[test]
+fn duplicate_property_names_still_report_ts2300_and_ts2717() {
+    let d = diagnose("type T = { a: string; a: number };\n");
+    assert!(diagnostic_count(&d, 2300) >= 1, "diags: {d:?}");
+    assert!(diagnostic_count(&d, 2717) >= 1, "diags: {d:?}");
+}
+
+#[test]
+fn duplicate_property_names_still_report_ts2300_renamed_binder() {
+    // Behavior follows shape, not the property/alias spelling.
+    let d = diagnose("type Crate = { slot: string; slot: number };\n");
+    assert!(diagnostic_count(&d, 2300) >= 1, "diags: {d:?}");
+}
+
+#[test]
+fn readonly_disagreement_still_reports_ts2687() {
+    let d = diagnose("type T = { readonly a: string; a: string };\n");
+    assert!(diagnostic_count(&d, 2687) >= 1, "diags: {d:?}");
+}
+
+#[test]
+fn single_member_object_type_reports_no_duplicate_family() {
+    let d = diagnose("type T = { a: string };\n");
+    assert_eq!(diagnostic_count(&d, 2300), 0);
+    assert_eq!(diagnostic_count(&d, 2717), 0);
+    assert_eq!(diagnostic_count(&d, 2687), 0);
+}
+
+#[test]
+fn empty_object_type_is_clean() {
+    assert_eq!(diagnose("type T = {};\n").len(), 0);
+}


### PR DESCRIPTION
Fixes #11617.

AgentName: claude-brave-volta-Q3874

**Track:** checker per-pass allocation traffic — recursive type-alias body validation walk

**Invariant:** `tsz` matches `tsc` exactly; this is a pure allocation-traffic reduction with byte-for-byte identical diagnostics.

## Structural rule

> When the checker walks a type-alias body, the child node-list of a tuple / union / intersection / mapped / template-literal / function / `typeof` / signature-only type node is reached through `self.ctx.arena`, which is a shared `&'a NodeArena` that never mutates during checking. That list therefore borrows the arena (lifetime `'a`), not `self`, and stays valid across the `&mut self` recursive checks — so it must be iterated in place, never cloned to "escape" a borrow that never needed escaping.

`tsz`'s recursive type-alias validation cloned the child `Vec<NodeIndex>` at **every** nesting level of **every** type-alias body purely as a borrow-escape, allocating throwaway vectors per node — hot on the recursive-utility / type-challenges / type-fest benchmark rows that nest aliases deeply. The clones are provably unnecessary: the proof is already in-tree, since the mapped-type arm holds an `&'a` arena borrow across multiple `&mut self` calls and compiles.

## Scope

Owner layer: checker AST-orchestration (type-alias body validation). No solver/relation/emit semantics touched; no diagnostic strings used as predicates; no identifier/file-name fast paths.

De-cloned arms (iterate the arena-backed `&'a` list in place):
- `type_alias_checking.rs`: tuple elements, function/constructor parameters + type-parameters, `typeof` type-arguments.
- `type_alias_missing_name_coverage.rs`: tuple elements, union/intersection constituents, mapped-type members, template-literal spans, type-reference arguments.
- `type_alias_body_validation.rs`: signature-only type-literal members (scan + walk).

Adjacent allocation bail (same pass family): `check_type_literal_duplicate_properties` now returns before its duplicate-scan `FxHashMap` allocation when the literal has `< 2` members. TS2300 / TS2717 / TS2687 all require at least two same-named property signatures, so a 0/1-member object type can never trip them. The TS1170 / TS2464 computed-property checks live in a separate per-member pass in `core.rs` and are unaffected.

### Complexity / invalidation

Per type-alias-body node: was 1 heap allocation (`Vec<NodeIndex>` of `n` `u32`s) + `n` copies + `n` iterations; now 0 allocations + `n` iterations over the live `&'a` slice. The arena is immutable for the duration of the walk, so in-place iteration yields exactly the original children in the original order — no cache key, fuel, or ordering changes. Diagnostics are position-sorted and deduped downstream regardless.

## Project Corpus Impact

- Row: type-challenges-solutions-project, type-fest-project (recursive-utility / deeply-nested alias hot path; behavior-preserving, no row diagnostics change)
- Bug family: per-pass temporary allocations in the checker (the #11617 theme), on the recursive type-alias validation hot path
- No required project row changes diagnostics (behavior-preserving).

## Verification

- New `crates/tsz-checker/tests/type_alias_body_walk_allocation_tests.rs` (16 cases) pins both directions of every de-cloned arm: walk-completeness (well-formed nested tuple / union+intersection / function / template / mapped / `typeof` aliases stay clean) and walk-reachability (broken nested children still report — TS2370 non-array rest, TS2304 missing names inside tuple/union/param), plus a renamed-binder variant and the duplicate-property early-bail family (TS2300 / TS2717 / TS2687 still fire on ≥2 members; 0/1-member and empty literals clean).
- Existing regression suites green: `type_alias_signature_body_validation_tests` (7), `duplicate_property_modifier_ts2687_tests` (10), `type_literal_overload_optionality_tests` (13), `duplicate_identifier_grouping_allocation_tests` (13).
- Filtered lib unit tests for the touched modules (`rest_parameter`, `type_alias`, `duplicate`, `missing_name`, `tuple_type`): 322 pass, 1 fail — `direct_source_file_type_alias_lowers_imported_typeof_marker_leaf`, confirmed **pre-existing** (fails identically on a clean `main` checkout; a global-state/isolation test unrelated to this change).
- `cargo clippy -p tsz-checker --lib --tests` clean.
- `/simplify` run three times: pass 1 reused the shared `diagnostic_count` test helper + cached the checker run per test + tightened repeated rationale comments; passes 2–3 extended the same safe `&'a` pattern to the signature-only arm and confirmed convergence. The altitude review confirmed per-site in-place iteration is the right depth (a shared `for_each_child` helper would obscure each site's distinct borrowing reason) and that the remaining clones in other modules are legitimately load-bearing.

## Coordination Notes

Issue #11617's two originally-named witnesses (`check_type_literal_overload_optionality` grouping and the `duplicate_identifiers` member-scan de-clone) were already addressed in earlier passes on `main`; this PR closes out the broader pattern the issue names by removing the remaining per-node clones in the recursive type-alias validation walk. The prior claim on the issue pushed no branch and opened no PR (branch `claude/confident-thompson-rvOeh` does not exist on the remote); re-claimed under `agent:M4-Opus`. No overlap with the open recursive-conditional / heritage-merge PRs — this touches only the syntactic type-alias body validation walk, not relation/instantiation semantics.

https://claude.ai/code/session_01RyLwy1fmuqqzoXgoxM2bzC