### PR TITLE
fix(parser): match tsc recovery for body-less object methods and bracket-terminated arrays (#12903)

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -1597,7 +1597,27 @@ impl ParserState {
                         self.token(),
                         SyntaxKind::CloseParenToken | SyntaxKind::CloseBraceToken
                     ) {
-                        self.error_comma_expected();
+                        // `error_comma_expected()` suppresses the comma when the
+                        // closer is `)` immediately followed by `;` (a shape it
+                        // treats as call-argument / arrow recovery). For an array
+                        // literal terminated by `)` — e.g. `a0([1, 2);` where the
+                        // inner `[` is never closed — tsc still reports the missing
+                        // separator before the closer, so suppressing it would leak
+                        // a misleading `']' expected` from `parse_expected(])` below.
+                        // Emit `',' expected` directly for that case to match tsc.
+                        let paren_then_semicolon = self.is_token(SyntaxKind::CloseParenToken)
+                            && self.speculate(|parser| {
+                                parser.next_token();
+                                parser.is_token(SyntaxKind::SemicolonToken)
+                            });
+                        if paren_then_semicolon {
+                            self.parse_error_at_current_token(
+                                "',' expected.",
+                                diagnostic_codes::EXPECTED,
+                            );
+                        } else {
+                            self.error_comma_expected();
+                        }
                     }
                     break;
                 }

--- a/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
@@ -927,15 +927,36 @@ impl ParserState {
             self.pop_label_scope();
             self.context_flags = saved_flags;
             return NodeIndex::NONE;
+        } else if dot_tail_recovery && self.is_token(SyntaxKind::SemicolonToken) {
+            // Dot-tail recovery (`{ a.b }`-style) already produced the relevant
+            // diagnostics; drop the speculative ones and suppress the missing-body
+            // `'{' expected` for the trailing `;` so recovery matches tsc.
+            self.parse_diagnostics.truncate(dot_tail_diag_len);
+            self.last_error_pos = self
+                .parse_diagnostics
+                .last()
+                .map_or(0, |diagnostic| diagnostic.start);
+            NodeIndex::NONE
         } else {
-            if dot_tail_recovery && self.is_token(SyntaxKind::SemicolonToken) {
-                self.parse_diagnostics.truncate(dot_tail_diag_len);
-                self.last_error_pos = self
-                    .parse_diagnostics
-                    .last()
-                    .map_or(0, |diagnostic| diagnostic.start);
-            }
-            if !self.is_token(SyntaxKind::SemicolonToken) {
+            // An object-literal method whose `{` body is missing is reported by
+            // tsc as `'{' expected` at the current token. For a trailing `;`,
+            // tsc only does so when the method is the *final* member (the `;` is
+            // followed by `}` / EOF); when another member follows, the `;`
+            // recovers as a delimiter and the missing comma is reported at that
+            // member instead. tsz previously suppressed `'{' expected` for *any*
+            // `;`, so the last-member case (`var v = { foo(); }`) wrongly emitted
+            // a spurious `',' expected` from the outer object-literal loop.
+            //
+            // Mirror tsc: emit `'{' expected` here unless a `;` is followed by a
+            // further member. The outer loop's same-position comma error is then
+            // deduped, leaving exactly tsc's single `'{' expected`.
+            let separating_semicolon = self.is_token(SyntaxKind::SemicolonToken)
+                && self.speculate(|parser| {
+                    parser.next_token();
+                    !parser.is_token(SyntaxKind::CloseBraceToken)
+                        && !parser.is_token(SyntaxKind::EndOfFileToken)
+                });
+            if !separating_semicolon {
                 use tsz_common::diagnostics::diagnostic_codes;
                 self.parse_error_at_current_token("'{' expected.", diagnostic_codes::EXPECTED);
             }

--- a/crates/tsz-parser/tests/parser_improvement_object_array_literal_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_object_array_literal_recovery_tests.rs
@@ -591,3 +591,75 @@ fn object_property_with_explicit_colon_and_missing_value_keeps_distinct_initiali
         "missing value must be a distinct node so the emitter renders `prop:`"
     );
 }
+
+/// Assert that a body-less object method which is the final member reports a
+/// single TS1005 `'{' expected.` at the trailing `;`, with no spurious
+/// `',' expected.` from the outer member-list loop — mirroring tsc.
+fn assert_open_brace_at_final_semicolon(source: &str) {
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+    let semicolon_pos = source.find(';').expect("semicolon position") as u32;
+
+    assert!(
+        diagnostics.iter().any(|diag| diag.code == 1005
+            && diag.start == semicolon_pos
+            && diag.message == "'{' expected."),
+        "expected `'{{' expected.` at the trailing `;` for {source:?}, got {diagnostics:?}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diag| diag.message != "',' expected."),
+        "no spurious `',' expected.` for {source:?}, got {diagnostics:?}"
+    );
+}
+
+/// An object-literal method whose `{` body is missing and which is the final
+/// member (the trailing `;` is followed by `}` / EOF) reports the single TS1005
+/// `'{' expected.` tsc would, not the `',' expected.` tsz used to emit.
+#[test]
+fn object_method_missing_body_as_last_member_reports_open_brace() {
+    assert_open_brace_at_final_semicolon("var v = { foo(); }");
+}
+
+/// Same rule with an explicit return-type annotation before the missing body.
+#[test]
+fn object_method_missing_body_with_return_type_reports_open_brace() {
+    assert_open_brace_at_final_semicolon("var v = { foo(): number; }");
+}
+
+/// The rule also applies when the body-less method follows other members.
+#[test]
+fn object_method_missing_body_after_prior_member_reports_open_brace() {
+    assert_open_brace_at_final_semicolon("var v = { a: 1, foo(); }");
+}
+
+/// When a *further member* follows the `;`, tsc recovers the `;` as a delimiter
+/// and reports a missing comma at the next member instead of `'{' expected.`.
+/// This locks in the surgical scope: the fix must NOT emit `'{' expected.` here.
+#[test]
+fn object_method_missing_body_followed_by_member_keeps_comma_recovery() {
+    let source = "var v = { foo(); b: 2 }";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diag| diag.message != "'{' expected."),
+        "a `;` followed by a further member must not report `'{{' expected.`, got {diagnostics:?}"
+    );
+}
+
+/// A well-formed object method (`foo() {}`) is unaffected: no TS1005.
+#[test]
+fn object_method_with_body_reports_no_missing_brace() {
+    let source = "var v = { foo() {} }";
+    let (parser, _root) = parse_source(source);
+    let diagnostics = parser.get_diagnostics();
+
+    assert!(
+        diagnostics.iter().all(|diag| diag.code != 1005),
+        "a well-formed object method must not produce TS1005, got {diagnostics:?}"
+    );
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -52,12 +52,21 @@ TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts
-TypeScript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts
 TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts
 TypeScript/tests/cases/conformance/jsdoc/importTag17.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
+# objectLiteralMemberWithoutBlock1.ts: RESOLVED. `var v = { foo(); }` parsed the
+# body-less object method but suppressed the missing-body `'{' expected` whenever
+# the next token was `;`, so the outer object-literal member loop emitted a
+# spurious `',' expected` instead. tsc reports `'{' expected` at the `;` for a
+# body-less method that is the final member (the `;` is followed by `}`/EOF); when
+# a further member follows, the `;` recovers as a delimiter and the missing comma
+# is reported at that member. The parser now mirrors that, so the single
+# `'{' expected` matches tsc. Covered by
+# parser_improvement_object_array_literal_recovery_tests::
+# object_method_missing_body_as_last_member_reports_open_brace (and siblings).
 # covariantCallbacks.ts: RESOLVED by PR #12482. tsz now detects nullable-union
 # callback method parameters the way tsc does (getSingleCallSignature(
 # getNonNullableType(t))), so lib `Promise<A>` -> `Promise<B>` reports its


### PR DESCRIPTION
AgentName: lucid-hopper-4A1Zi
Track: Compiler / Parser-recovery conformance
Closes #12903

## Invariant

When a delimited list (object-literal members, array elements) lacks a separator
before an unexpected closer, tsz reports the same TS1005 diagnostic `tsc` does:
the missing separator is reported first and the closer diagnostic dedups at the
same position. For a body-less object method, the missing `{` body is reported as
`'{' expected` when the method is the final member (the trailing `;` is followed
by `}`/EOF); when a further member follows, the `;` recovers as a delimiter and
the missing comma is reported at that member.

## Scope

Parser recovery only — no checker/solver/emitter changes.

- `crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs`
  — `parse_object_method_after_name_with_optional`: a missing method body now
  reports `'{' expected` unless the `;` is followed by a further member. The
  outer object-literal loop's same-position `',' expected` then dedups, leaving
  exactly tsc's single `'{' expected`. (Previously any `;` suppressed
  `'{' expected`, so the last-member case leaked a spurious `',' expected`.)
- `crates/tsz-parser/src/parser/state_expressions_literals.rs` — array-literal
  loop: when the array is terminated by `)` immediately followed by `;`
  (`a0([1, 2);`), emit `',' expected` directly rather than via
  `error_comma_expected()`, whose `)`-then-`;` suppression (intended for
  call-argument / arrow recovery) would otherwise leak a `']' expected` from
  `parse_expected(])`. This completes the previously-added, failing regression
  test `test_array_terminated_by_close_paren_emits_comma_expected`.
- `crates/tsz-parser/tests/parser_improvement_object_array_literal_recovery_tests.rs`
  — 5 new tests (last-member `;`, with return type, after prior member,
  further-member-keeps-comma-recovery, well-formed-unchanged), sharing one
  assertion helper.
- `scripts/conformance/conformance-accepted-regressions.txt` — removed the now
  resolved `objectLiteralMemberWithoutBlock1.ts` entry; documented it under the
  RESOLVED comment block.

### Structural rule (§ anti-hardcoding)

> When an object-literal method's `{` body is missing, tsc reports `'{' expected`;
> for a trailing `;` it does so only when no further member follows. When a
> delimited list is terminated by an unexpected closer with no separator, tsc
> reports the missing separator before the closer. tsz now mirrors both via
> structural token lookahead (`speculate`), with no identifier/file-name/string
> predicates.

## Project Corpus Impact

- Row: n/a (parser error-recovery diagnostics on malformed input).
- Bug family: `parser-delimited-list-missing-separator-recovery`.
- Resolves accepted-regression `objectLiteralMemberWithoutBlock1.ts` (removed from
  the ledger). Partially advances `destructuringParameterDeclaration2.ts` (its
  `',' expected` line now matches tsc) but that fixture stays in the ledger — its
  baseline has 61 errors (binding-element implicit-any, etc.) that are out of
  scope, so it is intentionally **not** removed.

## Verification

Differential vs `tsc` 6.0.2 (`--target es2015`):

| input | tsc | tsz (after) |
|---|---|---|
| `var v = { foo(); }` | `(1,16) '{' expected.` | matches |
| `var v = { foo(): number; }` | `(1,24) '{' expected.` | matches |
| `var v = { a: 1, foo(); }` | `'{' expected.` at `;` | matches |
| `var v = { async foo(); }` / `{ *foo(); }` | `'{' expected.` | matches |
| `var v = { foo(); b: 2 }` | `',' expected.` at member | unchanged (comma recovery) |
| `var v = { foo() {} }` | (no error) | unchanged |
| `a0([1, "string", [["world"]]);` | `',' expected.` at `)` | matches |
| `foo([1, 2);` / `f([1, 2)` | `',' expected.` at `)` | matches |

- Exact fixture `objectLiteralMemberWithoutBlock1.ts`: tsz output is byte-identical
  to tsc.
- `cargo test -p tsz-parser --lib`: **1402 passed, 0 failed** (was 1401/1 — the
  pre-existing failing array test now passes).
- `cargo clippy -p tsz-parser --all-targets`: clean.

Both changes only alter outputs where tsz already diverged from tsc (object:
`,`→`{`; array: `]`→`,`), so no previously-matching fixture can regress.

## Coordination Notes

Isolated parser-recovery change; no overlap with open solver/checker PRs. The
array fix completes the intent of the regression test added in `f72dfd1` (which
landed the test plus a `)`-then-`;` comma suppression that broke it for arrays).


---
_Generated by [Claude Code](https://claude.ai/code/session_01D9nHSaDTE1ZUFthRTbiCEW)_