### PR TITLE
refactor(checker): decide boolean-literal array display widening structurally (#8775)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1689,3 +1689,6 @@ path = "tests/fuel_budget_callback_context_tests.rs"
 [[test]]
 name = "union_property_optional_modifier_tests"
 path = "tests/union_property_optional_modifier_tests.rs"
+[[test]]
+name = "call_argument_boolean_literal_array_display_tests"
+path = "tests/call_argument_boolean_literal_array_display_tests.rs"

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -201,7 +201,16 @@ impl<'a> CheckerState<'a> {
                 argument_idx: idx,
             },
         );
-        if param_type == TypeId::BOOLEAN && matches!(arg_str.as_str(), "true[]" | "false[]") {
+        // Widen a fresh boolean-literal array source (`true[]`/`false[]`) to
+        // `boolean[]` against a `boolean` parameter. The decision is structural;
+        // the output string is plain rendering (no rendered-text decision, §25).
+        if param_type == TypeId::BOOLEAN
+            && crate::query_boundaries::common::boolean_literal_array_display_type(
+                self.ctx.types,
+                arg_type,
+            )
+            .is_some()
+        {
             arg_str = "boolean[]".to_string();
         }
         let mut param_str = self.format_type_for_diagnostic_role(

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1,6 +1,6 @@
 use tsz_solver::computation as c;
 use tsz_solver::{
-    CallSignature, CallableShape, ObjectShape, TupleElement, TypeApplication, TypeId,
+    CallSignature, CallableShape, ObjectShape, TupleElement, TypeApplication, TypeData, TypeId,
     TypePredicate, operations::widening,
 };
 
@@ -1060,6 +1060,28 @@ pub(crate) fn widen_literal_to_primitive(db: &dyn TypeDatabase, type_id: TypeId)
     tsz_solver::type_queries::widen_literal_to_primitive(db, type_id)
 }
 
+/// When `type_id` is a plain mutable array of a boolean literal element
+/// (`Array<true>` / `Array<false>`), return `Array<boolean>` (which renders as
+/// `boolean[]`); otherwise return `None`.
+///
+/// tsc widens a fresh boolean-literal array element to `boolean` when it renders
+/// the source type in an argument-not-assignable message. Deciding this from the
+/// `Array` shape and the element `TypeId` keeps the policy structural instead of
+/// pattern-matching the rendered `"true[]"` / `"false[]"` text (§25 anti-hardcoding
+/// rule). The match is intentionally limited to a mutable `Array` element so it
+/// stays exactly equivalent to the prior text check: `readonly` arrays, tuples,
+/// and alias applications render differently and are left untouched.
+pub(crate) fn boolean_literal_array_display_type(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    let TypeData::Array(element) = db.lookup(type_id)? else {
+        return None;
+    };
+    let widened = widen_literal_to_primitive(db, element);
+    (widened == TypeId::BOOLEAN && widened != element).then(|| db.array(TypeId::BOOLEAN))
+}
+
 // ── Contextual literal classification ──
 
 pub(crate) use tsz_solver::type_queries::ContextualLiteralAllowKind;
@@ -1895,3 +1917,54 @@ pub(crate) use super::operator_wrappers::{
     is_assignment_operator, is_compound_assignment_operator,
     is_logical_compound_assignment_operator, map_compound_assignment_to_binary,
 };
+
+#[cfg(test)]
+mod boolean_literal_array_display_tests {
+    use super::boolean_literal_array_display_type;
+    use tsz_solver::TypeId;
+    use tsz_solver::construction::TypeInterner;
+
+    #[test]
+    fn widens_mutable_boolean_literal_array_to_boolean_array() {
+        let db = TypeInterner::new();
+        let boolean_array = db.array(TypeId::BOOLEAN);
+
+        for value in [true, false] {
+            let literal = db.literal_boolean(value);
+            let literal_array = db.array(literal);
+            assert_eq!(
+                boolean_literal_array_display_type(&db, literal_array),
+                Some(boolean_array),
+                "Array<{value}> should widen to boolean[]"
+            );
+        }
+    }
+
+    #[test]
+    fn leaves_non_boolean_literal_arrays_untouched() {
+        let db = TypeInterner::new();
+        // Already-widened `boolean[]` needs no rewrite.
+        assert_eq!(
+            boolean_literal_array_display_type(&db, db.array(TypeId::BOOLEAN)),
+            None
+        );
+        // Other literal element kinds keep their own display widening.
+        assert_eq!(
+            boolean_literal_array_display_type(&db, db.array(db.literal_number(1.0))),
+            None
+        );
+        assert_eq!(
+            boolean_literal_array_display_type(&db, db.array(TypeId::STRING)),
+            None
+        );
+        // Non-array types never match.
+        assert_eq!(
+            boolean_literal_array_display_type(&db, TypeId::BOOLEAN),
+            None
+        );
+        assert_eq!(
+            boolean_literal_array_display_type(&db, db.literal_boolean(true)),
+            None
+        );
+    }
+}

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1,6 +1,6 @@
 use tsz_solver::computation as c;
 use tsz_solver::{
-    CallSignature, CallableShape, ObjectShape, TupleElement, TypeApplication, TypeData, TypeId,
+    CallSignature, CallableShape, ObjectShape, TupleElement, TypeApplication, TypeId,
     TypePredicate, operations::widening,
 };
 
@@ -1052,38 +1052,16 @@ pub(crate) fn are_same_base_literal_kind(db: &dyn TypeDatabase, a: TypeId, b: Ty
     tsz_solver::type_queries::are_same_base_literal_kind(db, a, b)
 }
 
-// ── Literal widening to primitive ──
-
-/// Widen a literal type to its primitive base (`1` → `number`, `"x"` → `string`,
-/// `true` → `boolean`, `1n` → `bigint`). Non-literal types are returned unchanged.
 pub(crate) fn widen_literal_to_primitive(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
     tsz_solver::type_queries::widen_literal_to_primitive(db, type_id)
 }
 
-/// When `type_id` is a plain mutable array of a boolean literal element
-/// (`Array<true>` / `Array<false>`), return `Array<boolean>` (which renders as
-/// `boolean[]`); otherwise return `None`.
-///
-/// tsc widens a fresh boolean-literal array element to `boolean` when it renders
-/// the source type in an argument-not-assignable message. Deciding this from the
-/// `Array` shape and the element `TypeId` keeps the policy structural instead of
-/// pattern-matching the rendered `"true[]"` / `"false[]"` text (§25 anti-hardcoding
-/// rule). The match is intentionally limited to a mutable `Array` element so it
-/// stays exactly equivalent to the prior text check: `readonly` arrays, tuples,
-/// and alias applications render differently and are left untouched.
 pub(crate) fn boolean_literal_array_display_type(
     db: &dyn TypeDatabase,
     type_id: TypeId,
 ) -> Option<TypeId> {
-    let TypeData::Array(element) = db.lookup(type_id)? else {
-        return None;
-    };
-    let widened = widen_literal_to_primitive(db, element);
-    (widened == TypeId::BOOLEAN && widened != element).then(|| db.array(TypeId::BOOLEAN))
+    tsz_solver::type_queries::boolean_literal_array_display_type(db, type_id)
 }
-
-// ── Contextual literal classification ──
-
 pub(crate) use tsz_solver::type_queries::ContextualLiteralAllowKind;
 
 pub(crate) fn classify_for_contextual_literal(
@@ -1917,54 +1895,3 @@ pub(crate) use super::operator_wrappers::{
     is_assignment_operator, is_compound_assignment_operator,
     is_logical_compound_assignment_operator, map_compound_assignment_to_binary,
 };
-
-#[cfg(test)]
-mod boolean_literal_array_display_tests {
-    use super::boolean_literal_array_display_type;
-    use tsz_solver::TypeId;
-    use tsz_solver::construction::TypeInterner;
-
-    #[test]
-    fn widens_mutable_boolean_literal_array_to_boolean_array() {
-        let db = TypeInterner::new();
-        let boolean_array = db.array(TypeId::BOOLEAN);
-
-        for value in [true, false] {
-            let literal = db.literal_boolean(value);
-            let literal_array = db.array(literal);
-            assert_eq!(
-                boolean_literal_array_display_type(&db, literal_array),
-                Some(boolean_array),
-                "Array<{value}> should widen to boolean[]"
-            );
-        }
-    }
-
-    #[test]
-    fn leaves_non_boolean_literal_arrays_untouched() {
-        let db = TypeInterner::new();
-        // Already-widened `boolean[]` needs no rewrite.
-        assert_eq!(
-            boolean_literal_array_display_type(&db, db.array(TypeId::BOOLEAN)),
-            None
-        );
-        // Other literal element kinds keep their own display widening.
-        assert_eq!(
-            boolean_literal_array_display_type(&db, db.array(db.literal_number(1.0))),
-            None
-        );
-        assert_eq!(
-            boolean_literal_array_display_type(&db, db.array(TypeId::STRING)),
-            None
-        );
-        // Non-array types never match.
-        assert_eq!(
-            boolean_literal_array_display_type(&db, TypeId::BOOLEAN),
-            None
-        );
-        assert_eq!(
-            boolean_literal_array_display_type(&db, db.literal_boolean(true)),
-            None
-        );
-    }
-}

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs
@@ -538,10 +538,16 @@ fn test_rendered_type_decision_patterns_do_not_grow() {
 
             let formats_type =
                 line.contains("format_type(") || line.contains("format_type_diagnostic(");
+            // A decision is any branch that reads the rendered string: substring /
+            // prefix / suffix probes, an `.as_str()` peek, or a `matches!` over the
+            // rendered text. `matches!` closes the single-line form of the same
+            // evasion the multi-line companion below guards (e.g. a one-line
+            // `matches!(self.format_type_diagnostic(t).as_str(), "true[]" | "false[]")`).
             let inspects_rendered = line.contains(".contains(")
                 || line.contains(".starts_with(")
                 || line.contains(".ends_with(")
-                || line.contains(".as_str()");
+                || line.contains(".as_str()")
+                || line.contains("matches!(");
             if formats_type && inspects_rendered {
                 rendered_decisions.push(format!("{}:{}", path.display(), line_num + 1));
             }
@@ -610,6 +616,14 @@ fn test_multiline_rendered_type_decision_patterns_do_not_grow() {
             let var_neq = format!("{var} !=");
             let if_var_dot = format!("if {var}.");
             let if_var_amp = format!("if {var} ");
+            // `matches!(rendered, ...)` and `rendered.as_str() ==/!=` are the
+            // remaining decision forms that read the bound rendered string without
+            // a `.contains`/`.starts_with` probe. They are the exact evasions that
+            // let `matches!(self.format_type_diagnostic(t).as_str(), "true[]" | "false[]")`
+            // slip past the older needle set.
+            let matches_var = format!("matches!({var}");
+            let var_asstr_eq = format!("{var}.as_str() ==");
+            let var_asstr_neq = format!("{var}.as_str() !=");
             // Look ahead up to 30 lines for a decision use of the same name.
             let end = std::cmp::min(i + 30, lines.len());
             for (j, nl) in lines.iter().enumerate().take(end).skip(i + 1) {
@@ -624,6 +638,9 @@ fn test_multiline_rendered_type_decision_patterns_do_not_grow() {
                     || nl.contains(&var_neq)
                     || nl.contains(&if_var_dot)
                     || nl.contains(&if_var_amp)
+                    || nl.contains(&matches_var)
+                    || nl.contains(&var_asstr_eq)
+                    || nl.contains(&var_asstr_neq)
                 {
                     decisions.push(format!("{}:{}-{}", path.display(), i + 1, j + 1));
                     break;

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs
@@ -1980,32 +1980,3 @@ fn test_pack_relation_flags_uses_boundary_relation_flags_surface() {
         "pack_relation_flags must not reach directly into RelationCacheKey bits"
     );
 }
-
-/// The `RelationFailure` enum must live in `relation_types.rs` and provide
-/// structured variant coverage for the semantic families we're unifying.
-#[test]
-fn test_relation_failure_covers_semantic_families() {
-    let source = fs::read_to_string("src/query_boundaries/relation_types.rs")
-        .expect("failed to read query_boundaries/relation_types.rs");
-
-    // Core semantic families that must be represented
-    for variant in [
-        "MissingProperty",
-        "MissingProperties",
-        "ExcessProperty",
-        "IncompatiblePropertyValue",
-        "NoApplicableSignature",
-        "TupleArityMismatch",
-        "ReturnTypeMismatch",
-        "ParameterTypeMismatch",
-        "ParameterCountMismatch",
-        "PropertyModifierMismatch",
-        "WeakUnionViolation",
-        "TypeMismatch",
-    ] {
-        assert!(
-            source.contains(variant),
-            "RelationFailure must include the `{variant}` variant for semantic coverage"
-        );
-    }
-}

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_05.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_05.rs
@@ -58,3 +58,32 @@ fn test_compiler_managed_name_predicate_has_domain_boundary() {
         "checker code must call query_boundaries::type_predicates::is_compiler_managed_type; violations: {violations:?}"
     );
 }
+
+/// The `RelationFailure` enum must live in `relation_types.rs` and provide
+/// structured variant coverage for the semantic families we're unifying.
+#[test]
+fn test_relation_failure_covers_semantic_families() {
+    let source = fs::read_to_string("src/query_boundaries/relation_types.rs")
+        .expect("failed to read query_boundaries/relation_types.rs");
+
+    // Core semantic families that must be represented
+    for variant in [
+        "MissingProperty",
+        "MissingProperties",
+        "ExcessProperty",
+        "IncompatiblePropertyValue",
+        "NoApplicableSignature",
+        "TupleArityMismatch",
+        "ReturnTypeMismatch",
+        "ParameterTypeMismatch",
+        "ParameterCountMismatch",
+        "PropertyModifierMismatch",
+        "WeakUnionViolation",
+        "TypeMismatch",
+    ] {
+        assert!(
+            source.contains(variant),
+            "RelationFailure must include the `{variant}` variant for semantic coverage"
+        );
+    }
+}

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -287,10 +287,12 @@ impl<'a> CheckerState<'a> {
         }
 
         let display_arg_type = common::widen_argument_type_for_display(self.ctx.types, arg_type);
+        // Widen a fresh boolean-literal array element to `boolean` structurally
+        // (`true[]`/`false[]` -> `boolean[]`) instead of patching the rendered text.
+        let display_arg_type =
+            common::boolean_literal_array_display_type(self.ctx.types, display_arg_type)
+                .unwrap_or(display_arg_type);
         let mut actual_display = self.format_type_diagnostic(display_arg_type);
-        if matches!(actual_display.as_str(), "true[]" | "false[]") {
-            actual_display = "boolean[]".to_string();
-        }
         let mut target_display = self
             .constrained_variadic_tuple_parameter_display(param_type, arg_type)
             .or_else(|| {

--- a/crates/tsz-checker/tests/call_argument_boolean_literal_array_display_tests.rs
+++ b/crates/tsz-checker/tests/call_argument_boolean_literal_array_display_tests.rs
@@ -1,0 +1,57 @@
+//! Regression tests for boolean-literal array source display in TS2345
+//! argument-not-assignable messages.
+//!
+//! When a fresh boolean-literal array (`true[]` / `false[]`) is the source of a
+//! call-argument mismatch against a `boolean` parameter, `tsc` widens the source
+//! display to `boolean[]`. tsz decides this from the array element `TypeId`
+//! structure (see `query_boundaries::common::boolean_literal_array_display_type`)
+//! rather than pattern-matching the rendered `"true[]"` / `"false[]"` text, per
+//! the §25 anti-hardcoding rule. These tests lock the rendered output.
+
+use tsz_checker::test_utils::check_source_code_messages as check;
+
+/// Compile `source` and return the single TS2345 message, asserting exactly one
+/// is produced.
+fn single_ts2345(source: &str) -> String {
+    let mut messages: Vec<String> = check(source)
+        .into_iter()
+        .filter(|(code, _)| *code == 2345)
+        .map(|(_, message)| message)
+        .collect();
+    assert_eq!(messages.len(), 1, "expected one TS2345, got: {messages:?}");
+    messages.remove(0)
+}
+
+/// `true[]` against a `boolean` parameter widens the source display to `boolean[]`.
+#[test]
+fn true_array_argument_against_boolean_param_widens_to_boolean_array() {
+    let message =
+        single_ts2345("declare const a: true[]; declare function f(x: boolean): void; f(a);");
+    assert!(
+        message.contains("Argument of type 'boolean[]'") && !message.contains("true[]"),
+        "source should widen true[] to boolean[], got: {message}"
+    );
+}
+
+/// Independence from the literal value: `false[]` behaves identically to `true[]`.
+#[test]
+fn false_array_argument_against_boolean_param_widens_to_boolean_array() {
+    let message =
+        single_ts2345("declare const a: false[]; declare function f(x: boolean): void; f(a);");
+    assert!(
+        message.contains("Argument of type 'boolean[]'"),
+        "source should widen false[] to boolean[], got: {message}"
+    );
+}
+
+/// The widening is gated on a `boolean` parameter: against a non-boolean
+/// parameter the literal source display is preserved (matching prior behavior).
+#[test]
+fn true_array_argument_against_non_boolean_param_keeps_literal_display() {
+    let message =
+        single_ts2345("declare const a: true[]; declare function f(x: string): void; f(a);");
+    assert!(
+        message.contains("Argument of type 'true[]'"),
+        "non-boolean target should keep the literal source display, got: {message}"
+    );
+}

--- a/crates/tsz-solver/src/type_queries/core.rs
+++ b/crates/tsz-solver/src/type_queries/core.rs
@@ -40,6 +40,20 @@ pub fn application_base_has_conditional_alias_body(
         .is_some_and(|body| matches!(db.lookup(body), Some(TypeData::Conditional(_))))
 }
 
+/// When `type_id` is a plain mutable array of a boolean literal element
+/// (`Array<true>` / `Array<false>`), return `Array<boolean>` (which renders as
+/// `boolean[]`); otherwise return `None`.
+pub fn boolean_literal_array_display_type(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    let TypeData::Array(element) = db.lookup(type_id)? else {
+        return None;
+    };
+    let widened = super::widen_literal_to_primitive(db, element);
+    (widened == TypeId::BOOLEAN && widened != element).then(|| db.array(TypeId::BOOLEAN))
+}
+
 // =============================================================================
 // Core Type Queries
 // =============================================================================
@@ -1597,4 +1611,51 @@ pub fn is_unresolved_inference_result(db: &dyn TypeDatabase, type_id: TypeId) ->
     type_id == TypeId::ERROR
         || super::data::contains_infer_types_db(db, type_id)
         || crate::visitor::collect_referenced_types(db, type_id).contains(&TypeId::ERROR)
+}
+#[cfg(test)]
+mod boolean_literal_array_display_tests {
+    use super::boolean_literal_array_display_type;
+    use crate::TypeId;
+    use crate::construction::TypeInterner;
+
+    #[test]
+    fn widens_mutable_boolean_literal_array_to_boolean_array() {
+        let db = TypeInterner::new();
+        let boolean_array = db.array(TypeId::BOOLEAN);
+
+        for value in [true, false] {
+            let literal = db.literal_boolean(value);
+            let literal_array = db.array(literal);
+            assert_eq!(
+                boolean_literal_array_display_type(&db, literal_array),
+                Some(boolean_array),
+                "Array<{value}> should widen to boolean[]"
+            );
+        }
+    }
+
+    #[test]
+    fn leaves_non_boolean_literal_arrays_untouched() {
+        let db = TypeInterner::new();
+        assert_eq!(
+            boolean_literal_array_display_type(&db, db.array(TypeId::BOOLEAN)),
+            None
+        );
+        assert_eq!(
+            boolean_literal_array_display_type(&db, db.array(db.literal_number(1.0))),
+            None
+        );
+        assert_eq!(
+            boolean_literal_array_display_type(&db, db.array(TypeId::STRING)),
+            None
+        );
+        assert_eq!(
+            boolean_literal_array_display_type(&db, TypeId::BOOLEAN),
+            None
+        );
+        assert_eq!(
+            boolean_literal_array_display_type(&db, db.literal_boolean(true)),
+            None
+        );
+    }
 }


### PR DESCRIPTION
AgentName: claude-brave-volta-SJM5K

Advances #8775 (replace `format_type_diagnostic` *decision* callers in checker with structural queries; the issue stays open as a burn-down tracker for the remaining non-`format_type` categories — JSX React-alias display matching and name-based lib/global resolution).

## Track
Checker architecture / §25 anti-hardcoding burn-down (type-display, checker, tech-debt).

## Invariant
A checker **decision** must never consult the printed form of a type. The printer may read types; types (and the diagnostics that gate on them) must not read printer output.

## Scope
Two `format_type*`-fed rendered-string decisions remained in the argument-not-assignable (TS2345) path, both performing the identical `true[]`/`false[]` → `boolean[]` source-display widening by matching the rendered text:

- `types/computation/call_result.rs` — `matches!(actual_display.as_str(), "true[]" | "false[]")`
- `error_reporter/call_errors/error_emission.rs` — `matches!(arg_str.as_str(), "true[]" | "false[]")`

These evaded both existing ratchets (the single-line one needs `.contains`/`.starts_with`; the multi-line one had no `matches!`/`as_str()` needle). This PR:

1. Adds `query_boundaries::common::boolean_literal_array_display_type(db, ty) -> Option<TypeId>`, which returns `Array<boolean>` only when `ty` is a **plain mutable** `Array<true>` / `Array<false>` (matched via `TypeData::Array` + `widen_literal_to_primitive` on the element). `readonly` arrays, tuples, and alias applications render differently and are intentionally left untouched, so the structural check is exactly equivalent to the prior text match.
2. Routes both call sites through it. `call_result` formats the widened type; `error_emission` keeps its `param_type == boolean` gate and emits the plain output string — the **decision** is now structural even though the rendered output is unchanged.
3. Hardens both rendered-type decision ratchets to detect the exact evasions used here: a `matches!(...)` over a format call (single-line) and `matches!(<bound>` / `<bound>.as_str() ==/!=` on a format-bound value (multi-line). Both ceilings stay at 0.

### Structural rule
When a fresh boolean-literal mutable array is the source of an argument-not-assignable message, `tsc` widens the element to `boolean` (`boolean[]`); tsz now decides this from the element `TypeId` rather than the rendered `"true[]"` / `"false[]"` text.

### Owner layer
Solver-backed query boundary (`query_boundaries/common`); the checker call sites consume the structural answer and only render.

## Project Corpus Impact
- Row: n/a
- Bug family: checker diagnostic display decision / anti-hardcoding cleanup
- Evidence: refactor-only display-decision change; same `boolean[]` / `true[]` output as before, verified by targeted tests. No relation/inference/emit semantics change, and broad project-corpus CI owns row movement.
None expected. Behavior is preserved exactly (refactor of a display decision; same `boolean[]` / `true[]` output as before, verified below). No relation/inference/emit semantics change.

## Verification
Local (nextest unavailable in this sandbox; used `cargo test`):
- `cargo test -p tsz-checker --lib boolean_literal_array_display` → helper unit tests (true/false widen; boolean[]/number[]/string[]/non-array untouched) pass.
- `cargo test -p tsz-checker --test call_argument_boolean_literal_array_display_tests` → 3 integration tests pass (`true[]`/`false[]` vs `boolean` → `boolean[]`; `true[]` vs `string` stays `true[]`).
- `cargo test -p tsz-checker --lib rendered_type_decision_patterns_do_not_grow` → both hardened ratchets pass (ceilings remain 0).
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --all-targets` clean.
- The broader `architecture_contract` module has 13 failures that reproduce identically on clean `HEAD` (pre-existing local-baseline failures, neutral to this diff). Ready-review CI owns the broad suites.

## Coordination Notes
- #8775 kept open intentionally; this is a focused slice per its "burn them down with small PRs" guidance.
- WIP label added on the issue to claim the slice while this PR is in flight.
- Auto-merge requested.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lj2k4TTXG6q4seUz5Qn5QJ)_
