### PR TITLE
fix(binder): register enum/class inside `declare global` as global augmentations

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -88,6 +88,28 @@ impl BinderState {
         sym_id
     }
 
+    /// Register a value-producing declaration that appears inside a
+    /// `declare global { ... }` block as a global augmentation.
+    ///
+    /// Variables, functions, classes, and enums declared inside `declare global`
+    /// in an external module contribute a value binding to the global scope. They
+    /// must be hoisted to `file_locals` (the gateway for cross-file visibility)
+    /// and recorded in `global_augmentations` so cross-file resolution can find
+    /// them; otherwise a bare reference reports a false `TS2304`.
+    fn record_global_value_augmentation(
+        &mut self,
+        name: &str,
+        sym_id: SymbolId,
+        decl: NodeIndex,
+        flags: u32,
+    ) {
+        self.file_locals.set(name.to_string(), sym_id);
+        Arc::make_mut(&mut self.global_augmentations)
+            .entry(name.to_string())
+            .or_default()
+            .push(crate::state::GlobalAugmentation::new(decl, flags));
+    }
+
     // Declaration binding methods
 
     pub(crate) fn bind_variable_declaration(
@@ -154,11 +176,7 @@ impl BinderState {
                 // namespace X` conflicting with `declare global { const X }`).
                 // This mirrors the interface hoisting at bind_interface_declaration.
                 if self.in_global_augmentation {
-                    self.file_locals.set(name.to_string(), sym_id);
-                    Arc::make_mut(&mut self.global_augmentations)
-                        .entry(name.to_string())
-                        .or_default()
-                        .push(crate::state::GlobalAugmentation::new(idx, flags));
+                    self.record_global_value_augmentation(name, sym_id, idx, flags);
                 }
             } else {
                 let flags = if is_block_scoped {
@@ -184,11 +202,7 @@ impl BinderState {
                             is_exported,
                         );
                         if self.in_global_augmentation {
-                            self.file_locals.set(name.to_string(), sym_id);
-                            Arc::make_mut(&mut self.global_augmentations)
-                                .entry(name.to_string())
-                                .or_default()
-                                .push(crate::state::GlobalAugmentation::new(ident_idx, flags));
+                            self.record_global_value_augmentation(name, sym_id, ident_idx, flags);
                         }
                     }
                 }
@@ -238,14 +252,12 @@ impl BinderState {
                 let sym_id =
                     self.declare_symbol(arena, name, symbol_flags::FUNCTION, idx, is_exported);
                 if self.in_global_augmentation {
-                    self.file_locals.set(name.to_string(), sym_id);
-                    Arc::make_mut(&mut self.global_augmentations)
-                        .entry(name.to_string())
-                        .or_default()
-                        .push(crate::state::GlobalAugmentation::new(
-                            idx,
-                            symbol_flags::FUNCTION,
-                        ));
+                    self.record_global_value_augmentation(
+                        name,
+                        sym_id,
+                        idx,
+                        symbol_flags::FUNCTION,
+                    );
                 }
                 let tp_count = func
                     .type_parameters
@@ -735,6 +747,16 @@ impl BinderState {
                         ..Default::default()
                     },
                 );
+
+                // Track class declarations inside `declare global { }` blocks as
+                // global augmentations, just like variables, functions, interfaces,
+                // and namespaces. Without this, `declare global { class C { } }`
+                // declared in an external module's `.d.ts` is invisible to
+                // cross-file global resolution, so a bare reference like `new C()`
+                // reports a false TS2304.
+                if self.in_global_augmentation {
+                    self.record_global_value_augmentation(name, sym_id, idx, flags);
+                }
             }
 
             // Enter class scope for members, pre-sized for member count to avoid hash map resizing
@@ -1267,6 +1289,16 @@ impl BinderState {
                     ..Default::default()
                 },
             );
+
+            // Track enum declarations inside `declare global { }` blocks as global
+            // augmentations, just like variables, functions, interfaces, and
+            // namespaces. Without this, `declare global { const enum F { ... } }`
+            // (and regular `enum`) declared in an external module's `.d.ts` is
+            // invisible to cross-file global resolution, so a bare reference like
+            // `F.A` reports a false TS2304 instead of resolving to the global enum.
+            if self.in_global_augmentation {
+                self.record_global_value_augmentation(name, enum_sym_id, idx, enum_flags);
+            }
 
             // Get existing exports (for namespace merging)
             let mut exports = SymbolTable::new();

--- a/crates/tsz-binder/src/state/tests/module_augments.rs
+++ b/crates/tsz-binder/src/state/tests/module_augments.rs
@@ -150,6 +150,100 @@ declare global {
     );
 }
 
+#[test]
+fn declare_global_const_enum_is_cross_file_global() {
+    // A `const enum` declared inside `declare global` in an external module is a
+    // value-level global. Without tracking it as a global augmentation it is
+    // invisible to cross-file resolution and a bare `Color.Red` reports TS2304.
+    // Binder name is deliberately non-default to prove nothing keys on an
+    // identifier string.
+    let (binder, _parser) = parse_and_bind(
+        r#"
+export {};
+declare global {
+    const enum Color { Red, Green, Blue }
+}
+"#,
+    );
+
+    let sym_id = binder
+        .file_locals
+        .get("Color")
+        .expect("declare global const enum should be visible through file_locals");
+    let symbol = binder
+        .get_symbol(sym_id)
+        .expect("declare global const enum symbol exists");
+    assert!(
+        symbol.has_any_flags(symbol_flags::CONST_ENUM),
+        "declare global const enum should keep CONST_ENUM flags"
+    );
+    assert!(
+        binder.global_augmentations.contains_key("Color"),
+        "declare global const enum should be tracked as a global augmentation"
+    );
+}
+
+#[test]
+fn declare_global_regular_enum_is_cross_file_global() {
+    // A regular `enum` inside `declare global` is also a value-level global and
+    // must be tracked so cross-file references resolve like tsc.
+    let (binder, _parser) = parse_and_bind(
+        r#"
+export {};
+declare global {
+    enum Direction { Up, Down }
+}
+"#,
+    );
+
+    let sym_id = binder
+        .file_locals
+        .get("Direction")
+        .expect("declare global enum should be visible through file_locals");
+    let symbol = binder
+        .get_symbol(sym_id)
+        .expect("declare global enum symbol exists");
+    assert!(
+        symbol.has_any_flags(symbol_flags::REGULAR_ENUM),
+        "declare global enum should keep REGULAR_ENUM flags"
+    );
+    assert!(
+        binder.global_augmentations.contains_key("Direction"),
+        "declare global enum should be tracked as a global augmentation"
+    );
+}
+
+#[test]
+fn declare_global_class_is_cross_file_global() {
+    // A `class` inside `declare global` provides a value (its constructor) and a
+    // type. It must be tracked as a global augmentation so a bare `new Widget()`
+    // resolves cross-file instead of reporting TS2304.
+    let (binder, _parser) = parse_and_bind(
+        r#"
+export {};
+declare global {
+    class Widget { id: number; }
+}
+"#,
+    );
+
+    let sym_id = binder
+        .file_locals
+        .get("Widget")
+        .expect("declare global class should be visible through file_locals");
+    let symbol = binder
+        .get_symbol(sym_id)
+        .expect("declare global class symbol exists");
+    assert!(
+        symbol.has_any_flags(symbol_flags::CLASS),
+        "declare global class should keep CLASS flags"
+    );
+    assert!(
+        binder.global_augmentations.contains_key("Widget"),
+        "declare global class should be tracked as a global augmentation"
+    );
+}
+
 // Regression for #6164: a `declare module "<self>"` augmentation must bind its
 // interface declaration to a separate `SymbolId` from the file-scope interface
 // of the same name. Merging the augmentation's declaration node into the

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -54,7 +54,6 @@ TypeScript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWit
 TypeScript/tests/cases/compiler/objectLiteralMemberWithoutBlock1.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts
-TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts
 TypeScript/tests/cases/conformance/jsdoc/importTag17.ts
 TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
 # covariantCallbacks.ts: RESOLVED by PR #12482. tsz now detects nullable-union


### PR DESCRIPTION
AgentName: lucid-hopper-8qXsj
Track: Compiler / Binder — global-augmentation resolution (conformance parity)
Closes #12907

## Invariant

When a value-producing declaration (`var`, `function`, `class`, `enum`, `const enum`) appears inside a `declare global { ... }` block in an external module's `.d.ts`, `tsc` adds it to the global scope. A bare cross-file reference must resolve to it, not report a false **TS2304 "Cannot find name"**.

## Structural rule

> tsz registers `declare global` declarations as global augmentations (hoist to `file_locals` + record in `global_augmentations`) so cross-file resolution finds them. `bind_variable_declaration` and `bind_function_declaration` already did this when `in_global_augmentation`; `bind_enum_declaration` and `bind_class_declaration` did **not**, so `enum`/`const enum`/`class` declared inside `declare global` were invisible — a bare `F.A` / `new C()` reported TS2304. The fix adds the same registration to the enum and class binders.

Once the global enum symbol resolves, the **existing** `TS2748` ("Cannot access ambient const enums when 'verbatimModuleSyntax' is enabled") access check fires unchanged — no checker/solver change is needed.

## Scope

- Owner layer: **binder** — `crates/tsz-binder/src/binding/declaration.rs`.
  - `bind_enum_declaration`: register the enum (regular + const) as a global augmentation when `in_global_augmentation`.
  - `bind_class_declaration`: register the class likewise.
  - Extract the shared `file_locals` + `global_augmentations` registration into `record_global_value_augmentation`; adopt it at the variable, function, enum, and class sites (behavior-identical).
- `scripts/conformance/conformance-accepted-regressions.txt`: remove `verbatimModuleSyntaxAmbientConstEnum.ts` (now passes exact-head).
- Tests: `crates/tsz-binder/src/state/tests/module_augments.rs` — 3 new binder tests (const enum, regular enum, class) with non-default binder names.

### Adjacent-case matrix (verified vs `tsc` 6.0.3)

| Decl inside `declare global` | before | after |
| --- | --- | --- |
| `const enum` (value + `F.A`) | TS2304 | resolves; `F.A` → TS2748 under verbatimModuleSyntax (matches tsc) |
| regular `enum` | TS2304 | resolves, clean |
| `class` (`new C()`) | TS2304 | resolves, clean |
| `var` / `function` / `interface` / `namespace` | resolve | resolve (unchanged) |
| renamed binders | — | resolve (nothing keys on identifier text) |

Out of scope (separate root cause, noted in #12907): a `type` alias inside `declare global` still fails in **type position** via `resolve_identifier_symbol_in_type_position` despite already being pushed to `global_augmentations`.

## Project Corpus Impact

- Row: n/a
- Bug family: declare-global-value-declaration-resolution

No project row is expected to flip: the change removes false TS2304 diagnostics for `declare global` enum/class (matching tsc) and is gated to the `in_global_augmentation` path. The value/function paths are refactored to a helper with byte-identical behavior.

## Verification

Built `dist-fast` `tsz` + `tsz-conformance` against pinned TypeScript `050880ce` (v6.0.3) with `TSZ_LIB_DIR=TypeScript/lib` and the checked-in `tsc-cache-full.json`.

- `verbatimModuleSyntaxAmbientConstEnum.ts`: **1/1 pass** (was the ledger row; TS2304 gone, TS2748 now emitted at `a.ts:4:1` like tsc).
- No regressions across exact-head local sweeps (all FAILs cross-checked identical on the pre-change binary): `compiler/` (max 2500) 2491/2500, `conformance/types/` 843/844, `conformance/externalModules/` 226/227, `conformance/classes/` 464/464, `global` 25/25, `enum` 81/81, `ambient` 59/59, `constEnum` 30/30. The handful of residual FAILs are pre-existing accepted-regression/local-harness artifacts identical with and without this change.
- `cargo test -p tsz-binder --lib`: 396 passed (incl. 3 new `declare_global_*_is_cross_file_global`).
- `cargo fmt -p tsz-binder --check` clean; `cargo clippy -p tsz-binder --lib` clean.

## Coordination Notes

`/simplify` run (3 passes): the registration block was deduplicated into `record_global_value_augmentation` (reuse/altitude); the per-kind `if in_global_augmentation` guard is kept explicit (matches the established per-kind binder altitude). Ready for review; relying on ready-review CI for the broad conformance/emit/fourslash aggregate.

https://claude.ai/code/session_012iXfD55wnfBpnvbPDCan8H

---
_Generated by [Claude Code](https://claude.ai/code/session_012iXfD55wnfBpnvbPDCan8H)_