### PR TITLE
fix(driver): collect JSDoc import("pkg") type-references as module references

### DIFF
--- a/crates/tsz-cli/src/driver/resolution/discovery.rs
+++ b/crates/tsz-cli/src/driver/resolution/discovery.rs
@@ -29,14 +29,23 @@ pub(crate) fn collect_module_requests_from_text(
     if !text_may_contain_module_specifiers(text) {
         return Vec::new();
     }
-    if let Some(requests) = collect_simple_module_requests_from_text(text) {
+    // The token-based fast path cannot see specifiers that live inside JSDoc
+    // comments (`@import ... from` tags or `import("...")` type expressions),
+    // because the scanner treats comments as trivia. A code-level `import(`
+    // already forces the full parse (the token scanner bails on it), so gating
+    // on `import(` here only additionally routes JSDoc-only import-type files to
+    // the full parse, where `collect_module_specifiers_for_source_discovery`
+    // collects them.
+    if !text.contains("import(")
+        && let Some(requests) = collect_simple_module_requests_from_text(text)
+    {
         return requests;
     }
     let file_name = path.to_string_lossy().into_owned();
     let mut parser = ParserState::new(file_name, text.to_string());
     let source_file = parser.parse_source_file();
     let (arena, _diagnostics) = parser.into_parts();
-    let mut requests: Vec<_> = collect_module_specifiers_for_source_discovery(&arena, source_file)
+    collect_module_specifiers_for_source_discovery(&arena, source_file)
         .into_iter()
         .map(
             |(specifier, specifier_idx, import_kind, resolution_mode_override)| {
@@ -48,15 +57,7 @@ pub(crate) fn collect_module_requests_from_text(
                 )
             },
         )
-        .collect();
-    if let Some(source) = arena.get_source_file_at(source_file) {
-        requests.extend(collect_jsdoc_import_requests(source).into_iter().map(
-            |(specifier, import_kind, resolution_mode_override)| {
-                (specifier, import_kind, resolution_mode_override, false)
-            },
-        ));
-    }
-    requests
+        .collect()
 }
 
 /// Quick text scan to determine if a source file might contain module specifiers.
@@ -326,7 +327,18 @@ pub(crate) fn reject_import_attributes_after_string(
     }
 }
 
-pub(crate) fn collect_jsdoc_import_requests(
+/// Collect JSDoc module references from a source file's comments in a single
+/// pass: `@import ... from "..."` tags and `import("...")` type expressions
+/// (`@typedef`/`@type`/`@param`/`@returns`, indexed/array/union forms, etc.).
+///
+/// tsc treats both as module references: each target is pulled into the program
+/// and resolved like a real import. tsz previously collected `import(...)` only
+/// from AST type nodes, so a JSDoc import-type to a bare/package specifier never
+/// populated `resolved_module_paths`; the checker's JSDoc resolver then failed
+/// to find the export, silently degrading `@param` to `any` and emitting a false
+/// TS2304/TS2552 in `@type` position. These specifiers originate from comment
+/// text rather than AST nodes, so callers pair each with a `NodeIndex::NONE`.
+pub(crate) fn collect_jsdoc_module_requests(
     source: &tsz::parser::node::SourceFileData,
 ) -> Vec<(
     String,
@@ -336,30 +348,98 @@ pub(crate) fn collect_jsdoc_import_requests(
     use tsz::module_resolver::ImportKind;
     use tsz_common::comments::{get_jsdoc_content, is_jsdoc_comment};
 
-    if source.comments.is_empty() || !source.text.contains("@import") {
+    let source_text = source.text.as_ref();
+    let has_import_tag = source_text.contains("@import");
+    let has_import_call = source_text.contains("import(");
+    if source.comments.is_empty() || (!has_import_tag && !has_import_call) {
         return Vec::new();
     }
 
-    let source_text = source.text.as_ref();
     let mut requests = Vec::new();
     for comment in &source.comments {
         if !is_jsdoc_comment(comment, source_text) {
             continue;
         }
-
-        let content = get_jsdoc_content(comment, source_text);
-        for line in content.lines() {
-            let trimmed = line.trim_start_matches('*').trim();
-            let Some(rest) = strip_jsdoc_import_tag_prefix(trimmed) else {
-                continue;
-            };
-            if let Some(specifier) = parse_jsdoc_import_module_specifier(rest) {
-                requests.push((specifier, ImportKind::EsmImport, None));
+        // `import("...")` type expressions anywhere in the comment text.
+        if has_import_call {
+            let end = (comment.end as usize).min(source_text.len());
+            let start = (comment.pos as usize).min(end);
+            let mut specifiers = Vec::new();
+            push_jsdoc_import_call_specifiers(&source_text[start..end], &mut specifiers);
+            requests.extend(
+                specifiers
+                    .into_iter()
+                    .map(|specifier| (specifier, ImportKind::EsmImport, None)),
+            );
+        }
+        // `@import ... from "..."` tags, parsed per content line.
+        if has_import_tag {
+            let content = get_jsdoc_content(comment, source_text);
+            for line in content.lines() {
+                let trimmed = line.trim_start_matches('*').trim();
+                let Some(rest) = strip_jsdoc_import_tag_prefix(trimmed) else {
+                    continue;
+                };
+                if let Some(specifier) = parse_jsdoc_import_module_specifier(rest) {
+                    requests.push((specifier, ImportKind::EsmImport, None));
+                }
             }
         }
     }
 
     requests
+}
+
+/// True for bytes that can appear inside a JS identifier (so the byte before an
+/// `import` keyword can be checked for a word boundary).
+const fn is_identifier_part_byte(byte: u8) -> bool {
+    byte == b'_' || byte == b'$' || byte.is_ascii_alphanumeric()
+}
+
+/// Append every `import(<quote>specifier<quote>)` specifier found in `text` to
+/// `out`. Requires a word boundary before `import` so identifiers ending in
+/// `import` (e.g. `reimport(`) are not matched. Whitespace between `(` and the
+/// string literal is tolerated.
+pub(crate) fn push_jsdoc_import_call_specifiers(text: &str, out: &mut Vec<String>) {
+    let bytes = text.as_bytes();
+    let mut search_from = 0usize;
+    while let Some(rel) = text[search_from..].find("import(") {
+        let keyword_start = search_from + rel;
+        let mut cursor = keyword_start + "import(".len();
+        // Reject when `import` is the tail of a longer identifier.
+        if keyword_start
+            .checked_sub(1)
+            .is_some_and(|i| is_identifier_part_byte(bytes[i]))
+        {
+            search_from = keyword_start + "import".len();
+            continue;
+        }
+        // Skip whitespace between `(` and the string literal.
+        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        let Some(&quote) = bytes.get(cursor) else {
+            break;
+        };
+        if quote != b'"' && quote != b'\'' && quote != b'`' {
+            search_from = cursor + 1;
+            continue;
+        }
+        cursor += 1;
+        let spec_start = cursor;
+        while cursor < bytes.len() && bytes[cursor] != quote {
+            cursor += 1;
+        }
+        if cursor >= bytes.len() {
+            // Unterminated specifier — stop scanning this comment.
+            break;
+        }
+        let specifier = &text[spec_start..cursor];
+        if !specifier.is_empty() {
+            out.push(specifier.to_string());
+        }
+        search_from = cursor + 1;
+    }
 }
 
 pub(crate) fn strip_jsdoc_import_tag_prefix(text: &str) -> Option<&str> {
@@ -719,6 +799,16 @@ pub(crate) fn collect_module_specifiers_impl(
         &strip_quotes,
         &mut specifiers,
     );
+
+    // JSDoc module references (`@import ... from "..."` tags and `import("...")`
+    // type expressions inside `@typedef`/`@type`/`@param`/`@returns`). These
+    // live in comment text, so they are invisible to the AST and token scans
+    // above. Pair each with `NodeIndex::NONE` since there is no AST node to
+    // anchor a span to; module-not-found diagnostics for JSDoc imports are
+    // emitted by the JSDoc checker, not by import-node resolution.
+    for (specifier, kind, resolution_mode_override) in collect_jsdoc_module_requests(source) {
+        specifiers.push((specifier, NodeIndex::NONE, kind, resolution_mode_override));
+    }
 
     specifiers
 }

--- a/crates/tsz-cli/src/driver/resolution_tests.rs
+++ b/crates/tsz-cli/src/driver/resolution_tests.rs
@@ -1869,6 +1869,112 @@ fn test_default_type_roots_walks_parent_directories() {
     );
 }
 
+mod jsdoc_import_type_specifier_collection_tests {
+    use super::*;
+
+    fn jsdoc_import_specifiers(text: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        push_jsdoc_import_call_specifiers(text, &mut out);
+        out
+    }
+
+    #[test]
+    fn push_finds_single_and_double_quoted_import_calls() {
+        assert_eq!(
+            jsdoc_import_specifiers("import('@scope/pkg')"),
+            ["@scope/pkg"]
+        );
+        assert_eq!(jsdoc_import_specifiers("import(\"pkg\")"), ["pkg"]);
+        assert_eq!(jsdoc_import_specifiers("import('./rel')"), ["./rel"]);
+    }
+
+    #[test]
+    fn push_tolerates_whitespace_before_specifier() {
+        assert_eq!(jsdoc_import_specifiers("import(  'pkg' )"), ["pkg"]);
+    }
+
+    #[test]
+    fn push_finds_multiple_import_calls_in_one_comment() {
+        let text = "@type {(a: import('a').A, b: import(\"b\").B) => import('c').C}";
+        assert_eq!(jsdoc_import_specifiers(text), ["a", "b", "c"]);
+    }
+
+    #[test]
+    fn push_requires_word_boundary_before_import() {
+        // `reimport(` must not be treated as an `import(` call.
+        assert!(jsdoc_import_specifiers("reimport('pkg')").is_empty());
+    }
+
+    #[test]
+    fn push_ignores_unquoted_and_unterminated() {
+        assert!(jsdoc_import_specifiers("import(foo)").is_empty());
+        assert!(jsdoc_import_specifiers("import('unterminated").is_empty());
+    }
+
+    #[test]
+    fn text_collection_finds_jsdoc_typedef_import_type() {
+        let path = Path::new("test.js");
+        let text = r#"
+/** @typedef {import('@lion/ajax').LionRequestInit} LionRequestInit */
+/** @type {LionRequestInit} */
+let v;
+"#;
+        let specifiers = collect_module_specifiers_from_text(path, text);
+        assert!(
+            specifiers.contains(&"@lion/ajax".to_string()),
+            "JSDoc @typedef import-type specifier should be collected, got: {specifiers:?}"
+        );
+    }
+
+    #[test]
+    fn text_collection_finds_jsdoc_param_and_type_import_types() {
+        let path = Path::new("test.js");
+        let text = r#"
+/** @param {import('pkg-a').A} a */
+function f(a) {}
+/** @type {(x: import('pkg-b').B) => void} */
+let g;
+"#;
+        let specifiers = collect_module_specifiers_from_text(path, text);
+        assert!(
+            specifiers.contains(&"pkg-a".to_string()),
+            "got: {specifiers:?}"
+        );
+        assert!(
+            specifiers.contains(&"pkg-b".to_string()),
+            "got: {specifiers:?}"
+        );
+    }
+
+    #[test]
+    fn text_collection_finds_jsdoc_import_type_without_other_imports() {
+        // Regression: a file whose ONLY module reference is a JSDoc import-type
+        // (no code import, no `@import` tag) must still bypass the token-only
+        // fast path and collect the specifier.
+        let path = Path::new("test.js");
+        let text = "/** @type {import('only-jsdoc').T} */\nlet v;\n";
+        let specifiers = collect_module_specifiers_from_text(path, text);
+        assert!(
+            specifiers.contains(&"only-jsdoc".to_string()),
+            "JSDoc-only import-type must be collected via full parse, got: {specifiers:?}"
+        );
+    }
+
+    #[test]
+    fn text_collection_ignores_import_call_outside_jsdoc_comment() {
+        // `import('x')` appearing only inside a string literal in code is not a
+        // JSDoc reference; the comment-scan must not pick it up. (The AST/token
+        // path owns real dynamic imports.)
+        let path = Path::new("test.js");
+        let text = "const s = \"import('not-a-module')\";\n";
+        let specifiers = collect_module_specifiers_from_text(path, text);
+        assert!(
+            !specifiers.contains(&"not-a-module".to_string()),
+            "string-literal text must not be collected as a JSDoc import, got: {specifiers:?}"
+        );
+    }
+}
+
 #[path = "resolution_tests_path_mappings.rs"]
 mod resolution_tests_path_mappings;
 

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -50,7 +50,6 @@ TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules
 TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
-TypeScript/tests/cases/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
 TypeScript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts
 TypeScript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts
@@ -100,3 +99,17 @@ TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
 # lives. It now returns `false` when there is no excess at the mapped level,
 # deferring to the recursion-capable simple-object/intersection branches. Covered
 # by recursive_mapped_intersection_nested_excess_property_tests.
+
+
+# jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts: RESOLVED. A JSDoc
+# `import("pkg").T` type (in `@typedef`/`@type`/`@param`/`@returns`) was never
+# collected as a module reference: only AST `import(...)` type nodes and JSDoc
+# `@import ... from` tags were gathered, so a JSDoc import-type to a bare/package
+# specifier never populated `resolved_module_paths`. The checker's JSDoc resolver
+# then failed to find the export, silently degrading `@param` to `any` and
+# emitting a false TS2552/TS2304 in `@type` position ("Cannot find name 'T'").
+# `collect_module_specifiers_impl` now also scans JSDoc comment text for
+# `import("...")` type specifiers (and `@import` tags), and the source-discovery
+# fast path defers to the full parse when a comment-only `import(` is present, so
+# both relative and package JSDoc import-types resolve like tsc. Covered by
+# jsdoc_import_type_specifier_collection_tests.


### PR DESCRIPTION
AgentName: lucid-hopper-iMQ1f
Track: conformance / module-resolution
Closes #12909

## Invariant

When a JSDoc comment contains an `import("specifier")` type expression (in `@typedef`, `@type`, `@param`, `@returns`, indexed/array/union forms, etc.), tsc treats `specifier` as a module reference: the target is pulled into the program and resolved like a real `import("...")` type node. tsz must collect the same specifiers during module-specifier discovery so `resolved_module_paths` is populated and the checker's JSDoc import-type resolution finds the export.

## Scope

**Structural rule:** `When a JSDoc import("pkg").T type appears, tsc resolves pkg as a module and T as its export; tsz must derive the same module reference through the driver's module-specifier discovery (collect_module_specifiers_impl), the same layer that already owns AST import() types and @import tags.`

**Root cause.** tsz collected `import(...)` specifiers only from AST type nodes (`collect_non_static_module_specifiers`) and JSDoc `@import ... from "..."` tags. A JSDoc `import("...")` **type** lives in comment text (there is no JSDoc AST), so it was collected nowhere — neither source discovery (no file pull-in) nor the check-time map (`resolved_module_paths`). The checker's JSDoc resolver `resolve_jsdoc_import_member -> resolve_cross_file_export_from_file -> resolve_import_target_from_file` then failed for bare/package specifiers (relative ones partly limped via the file-name index but still degraded to `any`). Result:
- `@param {import('pkg').T} x` silently became `any` (no diagnostic, wrong type);
- `@type {import('pkg').T}` (and arrow/array/`Array<>` forms) emitted a **false TS2304 / TS2552** "Cannot find name 'T'".

**Owner layer.** `crates/tsz-cli/src/driver/resolution/discovery.rs`. The fix scans JSDoc comment text for `import("...")` specifiers (`push_jsdoc_import_call_specifiers`, word-boundary aware) and folds it together with the existing `@import` tag scan into a single-pass `collect_jsdoc_module_requests`, wired into `collect_module_specifiers_impl` (feeds both check-time `resolved_module_paths` and source-discovery file pull-in). The token-only fast path now defers to the full parse when a comment-only `import(` is present. No checker/solver change — once the module resolves, the existing JSDoc resolver finds the export.

**Adjacent matrix (verified vs tsc):** `@typedef`/`@type`/`@param`/`@returns`; bare scoped (`@scope/pkg`), bare unscoped, and relative specifiers; package `exports.types` and top-level `types`; import-type alias re-export chains; arrow / array / `Array<>` / union type positions; renamed binders; word boundary (`reimport(` not matched); unterminated/unquoted ignored; `import(` inside a code string literal not collected; unresolvable package unchanged (no crash, no spurious extra diagnostic).

**Fallback.** A JSDoc import to a genuinely missing module behaves exactly as before (no new TS2307 path; the JSDoc checker still owns module-not-found for these sites).

## Project Corpus Impact

- Row: n/a
- Bug family: jsdoc-import-type-module-resolution

Removes `compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts` from `scripts/conformance/conformance-accepted-regressions.txt` (it now matches tsc's expected `[TS2565]` exactly — the extra `TS2552` is gone). Broadly improves any JS/checkJs project that types values via `@typedef {import('pkg').T}` against package types (the witnessing pattern is common in real `.js` codebases). No required project benchmark row is affected by this change; no fixture-name fast paths.

## Verification

- `conformance/compiler/jsDocDeclarationEmitDoesNotUseNodeModulesPathWithoutError.ts`: was `[TS2552, TS2565]`, now **PASS** (`[TS2565]`) via the conformance runner against the pinned tsc cache.
- New unit tests `jsdoc_import_type_specifier_collection_tests` (9): quote styles, whitespace, multiple per comment, word boundary, unquoted/unterminated, `@typedef`/`@type`/`@param` end-to-end collection, JSDoc-only-import fast-path bypass, and string-literal-not-collected.
- `cargo test -p tsz-cli --lib resolution_tests::` — 69 passed (incl. the 9 new + existing `collect_module_specifiers`/`@import`-tag tests).
- `cargo clippy -p tsz-cli --lib` — clean.
- Minimal repros confirmed: `@param` now resolves to the real interface (`takesFoo(123)` -> TS2559, matching tsc) instead of `any`; `@type` no longer emits the false TS2304/TS2552.

Broad conformance / fourslash / emit suites are left to ready-review CI (the local checkout intentionally lacks the full TypeScript corpus).

## Coordination Notes

Two pre-existing `tsz-checker` unit failures observed locally (`jsdoc_cross_file_typedef_tests::jsdoc_type_from_required_js_es_module_export_resolves_class_instance`, `jsdoc_import_type_constraints_relation_routing_arch_tests::...`) are in a crate this PR does not touch (`tsz-checker` has no dependency on `tsz-cli`) and are independent of this change.