### PR TITLE
fix(solver): assign a type parameter to a `Pick`-subset homomorphic mapped type

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1695,3 +1695,6 @@ path = "tests/fuel_budget_callback_context_tests.rs"
 [[test]]
 name = "union_property_optional_modifier_tests"
 path = "tests/union_property_optional_modifier_tests.rs"
+[[test]]
+name = "type_param_pick_subset_assignability_tests"
+path = "tests/type_param_pick_subset_assignability_tests.rs"

--- a/crates/tsz-checker/tests/type_param_pick_subset_assignability_tests.rs
+++ b/crates/tsz-checker/tests/type_param_pick_subset_assignability_tests.rs
@@ -1,0 +1,164 @@
+//! Regression tests for assignability of a bare type parameter `T` to a
+//! homomorphic mapped type over a *key subset* of `keyof T` — the `Pick<T, K>`
+//! shape `{ [P in K]: T[P] }`.
+//!
+//! `tsc` accepts `T <: Pick<T, SomeKeys<T>>` whenever `SomeKeys<T>` is a subset
+//! of `keyof T`: every demanded key `P` is a key of `T`, so `T` supplies each
+//! property with a matching type. tsz previously only recognized the *full*
+//! `keyof T` case (`Pick<T, keyof T>`) and emitted a spurious `TS2322` for any
+//! computed subset (`Pick<T, FunctionPropertyNames<T>>`, `Pick<T, keyof T & string>`,
+//! …). This is the false positive that lined `conditionalTypes1.ts` on the
+//! accepted-regression ledger (the `f7` block: `y = x` / `z = x`).
+//!
+//! The rule must stay sound in the other direction: a `Pick<T, A>` subset is NOT
+//! assignable back to `T` (it is missing keys), nor to a `Pick<T, B>` with a
+//! different key subset.
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+/// Count of `TS2322` (type-not-assignable) diagnostics in `source`.
+fn ts2322_count(source: &str) -> usize {
+    check_source_diagnostics(source)
+        .iter()
+        .filter(|diag| diag.code == 2322)
+        .count()
+}
+
+#[test]
+fn type_param_assignable_to_pick_over_computed_subset() {
+    // `StringKeys<T>` is a proper subset of `keyof T`; `T` carries every such
+    // property, so `T <: Pick<T, StringKeys<T>>`. No lib types are referenced so
+    // the fixture stays hermetic.
+    let source = r#"
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+type StringKeys<T> = { [K in keyof T]: T[K] extends string ? K : never }[keyof T];
+
+function f<T>(x: T, y: Pick<T, StringKeys<T>>) {
+    y = x;
+}
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        0,
+        "T should be assignable to Pick<T, StringKeys<T>> (subset of keyof T)"
+    );
+}
+
+#[test]
+fn type_param_assignable_to_intersection_key_subset() {
+    // `keyof T & string` is a subset of `keyof T`.
+    let source = r#"
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+
+function f<T>(x: T, y: Pick<T, keyof T & string>) {
+    y = x;
+}
+"#;
+    assert_eq!(ts2322_count(source), 0);
+}
+
+#[test]
+fn type_param_assignable_to_inline_subset_mapped() {
+    // The same shape spelled inline (not via a `Pick` alias).
+    let source = r#"
+type StringKeys<T> = { [K in keyof T]: T[K] extends string ? K : never }[keyof T];
+
+function f<T>(x: T, y: { [P in StringKeys<T>]: T[P] }) {
+    y = x;
+}
+"#;
+    assert_eq!(ts2322_count(source), 0);
+}
+
+#[test]
+fn rule_is_structural_not_keyed_on_binder_names() {
+    // Renaming every binder (type parameter and key parameter) must not change
+    // the outcome: the rule is structural, never name-driven.
+    let source = r#"
+type Subset<Elem, Prop extends keyof Elem> = { [Each in Prop]: Elem[Each] };
+type TextKeys<Elem> = { [Each in keyof Elem]: Elem[Each] extends string ? Each : never }[keyof Elem];
+
+function widget<Elem>(whole: Elem, part: Subset<Elem, TextKeys<Elem>>) {
+    part = whole;
+}
+"#;
+    assert_eq!(ts2322_count(source), 0);
+}
+
+#[test]
+fn pick_subset_not_assignable_back_to_type_param() {
+    // Sound direction: the subset `Pick<T, K>` is missing T's other keys, so it
+    // is NOT assignable to `T`.
+    let source = r#"
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+type StringKeys<T> = { [K in keyof T]: T[K] extends string ? K : never }[keyof T];
+
+function f<T>(x: T, y: Pick<T, StringKeys<T>>) {
+    x = y;
+}
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        1,
+        "Pick<T, subset> must not be assignable back to the whole T"
+    );
+}
+
+#[test]
+fn distinct_key_subsets_are_not_mutually_assignable() {
+    // Two Picks over disjoint computed key subsets are not interchangeable.
+    let source = r#"
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+type StringKeys<T> = { [K in keyof T]: T[K] extends string ? K : never }[keyof T];
+type NumberKeys<T> = { [K in keyof T]: T[K] extends number ? K : never }[keyof T];
+
+function f<T>(y: Pick<T, StringKeys<T>>, z: Pick<T, NumberKeys<T>>) {
+    y = z;
+}
+"#;
+    assert_eq!(ts2322_count(source), 1);
+}
+
+#[test]
+fn full_keyof_pick_round_trips_in_both_assignment_directions() {
+    // The pre-existing full-`keyof` case keeps working: `T` and `Pick<T, keyof T>`
+    // have the same key set, so assignment succeeds both ways.
+    let source = r#"
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+
+function f<T>(x: T, y: Pick<T, keyof T>) {
+    y = x;
+    x = y;
+}
+"#;
+    assert_eq!(ts2322_count(source), 0);
+}
+
+#[test]
+fn function_and_non_function_property_subsets_match_tsc() {
+    // The exact `conditionalTypes1.ts` `f7` witness, spelled with a `string`-based
+    // discriminator instead of the lib `Function` type so the fixture is
+    // hermetic. `y = x` and `z = x` (T into a Pick subset) are clean; the four
+    // cross-direction / cross-subset assignments stay errors.
+    let source = r#"
+type Pick<T, K extends keyof T> = { [P in K]: T[P] };
+type TextNames<T> = { [K in keyof T]: T[K] extends string ? K : never }[keyof T];
+type OtherNames<T> = { [K in keyof T]: T[K] extends string ? never : K }[keyof T];
+type TextProperties<T> = Pick<T, TextNames<T>>;
+type OtherProperties<T> = Pick<T, OtherNames<T>>;
+
+function f<T>(x: T, y: TextProperties<T>, z: OtherProperties<T>) {
+    x = y;  // error: subset not assignable to whole
+    x = z;  // error: subset not assignable to whole
+    y = x;  // ok: T assignable to its text-key subset
+    y = z;  // error: disjoint subsets
+    z = x;  // ok: T assignable to its other-key subset
+    z = y;  // error: disjoint subsets
+}
+"#;
+    assert_eq!(
+        ts2322_count(source),
+        4,
+        "only the four cross-direction / cross-subset assignments should error"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/unions.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/unions.rs
@@ -181,23 +181,54 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return false;
         }
 
-        // Constraint must be keyof(S) for some S
-        let Some(constraint_source) = keyof_inner_type(self.interner, mapped.constraint) else {
-            return false;
-        };
-
-        // Fast path: Template is exactly S[K] where K is the iteration parameter
-        let is_identity_template = if let Some((template_obj, template_idx)) =
-            index_access_parts(self.interner, mapped.template)
-        {
-            if let Some(idx_param) = type_param_info(self.interner, template_idx) {
-                idx_param.name == mapped.type_param.name && template_obj == constraint_source
-            } else {
-                false
-            }
-        } else {
-            false
-        };
+        // Determine the "picked-from" object `S` and ensure the mapped type's key
+        // set is within `keyof S`. Two shapes are accepted:
+        //   * the constraint is exactly `keyof S` (the classic homomorphic case), or
+        //   * the constraint is a *subset* of `keyof S` and the template is the
+        //     identity `S[P]` — the `Pick<S, K>` shape `{ [P in K]: S[P] }`, where
+        //     every demanded key `P ∈ K` is a key of `S`, so a `T` carrying `S`'s
+        //     shape supplies each demanded property with a matching type. tsc
+        //     accepts `T <: Pick<T, SomeKeys<T>>` for exactly this reason.
+        // `is_identity_template` is set true when the constraint-source is derived
+        // from an identity `S[P]` template, so the general `S[K] <: Template` check
+        // below can be skipped.
+        let (constraint_source, is_identity_template) =
+            match keyof_inner_type(self.interner, mapped.constraint) {
+                Some(source) => {
+                    // Classic case: detect an identity `S[P]` template so the
+                    // general check can be skipped.
+                    let identity = index_access_parts(self.interner, mapped.template)
+                        .and_then(|(template_obj, template_idx)| {
+                            let idx_param = type_param_info(self.interner, template_idx)?;
+                            Some(idx_param.name == mapped.type_param.name && template_obj == source)
+                        })
+                        .unwrap_or(false);
+                    (source, identity)
+                }
+                None => {
+                    // Subset (`Pick`) shape: the template must be the identity
+                    // indexed access `S[P]` with `P` the iteration parameter, and
+                    // the picked key set must be a subset of `keyof S` (`keyof S`
+                    // covers the constraint). Matching this shape proves the
+                    // template is identity, so `is_identity_template` is true.
+                    let Some((template_obj, template_idx)) =
+                        index_access_parts(self.interner, mapped.template)
+                    else {
+                        return false;
+                    };
+                    let Some(idx_param) = type_param_info(self.interner, template_idx) else {
+                        return false;
+                    };
+                    if idx_param.name != mapped.type_param.name {
+                        return false;
+                    }
+                    let full_key_set = self.interner.keyof(template_obj);
+                    if !self.mapped_key_constraint_covers(full_key_set, mapped.constraint) {
+                        return false;
+                    }
+                    (template_obj, true)
+                }
+            };
 
         if !is_identity_template {
             // General case: construct S[K] (source value type at key K) and check


### PR DESCRIPTION
AgentName: claude-lucid-hopper-q6lik6
Track: Compiler / solver relation (homomorphic mapped-type assignability)
Invariant: A bare type parameter `T` is assignable to a homomorphic mapped type over a *subset* of `keyof T` exactly when `tsc` accepts it — `T <: Pick<T, K>` for any `K ⊆ keyof T`, while `Pick<T, K>` stays unassignable back to `T` or to a `Pick<T, K2>` over a different subset.

## Structural rule

> When the source is a bare type parameter `T` and the target is a homomorphic mapped type `{ [P in K]: S[P] }` whose key set `K` is a subset of `keyof S` (the identity template `S[P]` with `P` the iteration parameter), `tsc` relates `T` to it: every demanded key `P ∈ K` is a key of `S`, so a `T` carrying `S`'s shape supplies each property with a matching type. tsz now does the same through the solver type-parameter-source relation.

`crates/tsz-solver/src/relations/subtype/rules/unions.rs::is_assignable_to_homomorphic_mapped` previously required the mapped constraint to be *exactly* `keyof S` (`keyof_inner_type`). A `Pick<T, K>` whose key set is a computed/generic subset — `Pick<T, FunctionPropertyNames<T>>`, `Pick<T, keyof T & string>`, `{ [P in StringKeys<T>]: T[P] }` — has a constraint that is **not** a bare `keyof`, so the function bailed and the relation reported a spurious `TS2322`.

This is the false positive that lines `conformance/types/conditional/conditionalTypes1.ts` on the accepted-regression ledger: in the `f7` block, `y = x` and `z = x` (assigning `T` into `FunctionProperties<T>` / `NonFunctionProperties<T>`, both `Pick<T, …>`) wrongly errored.

## Owner layer

Solver — `relations/subtype/rules/unions.rs` (type-parameter-source path reached from `check_type_parameter_subtype`). No checker/printer/emit changes; no new user-name/file-name literals; the subset decision is structural, built on the existing `index_access_parts` / `type_param_info` / `mapped_key_constraint_covers` helpers.

When the constraint is not a bare `keyof S`, the relation now falls back to the `Pick` shape: require the identity template `S[P]` and `mapped_key_constraint_covers(keyof S, K)` (i.e. `K ⊆ keyof S`). Soundness holds because the existing source-relation check (`T`'s name matches `S`, or `T`'s constraint `<: S`) still gates acceptance — a `Pick<T, K>` source is not a bare type parameter and never reaches this arm, so `Pick<T, A> <: T` and `Pick<T, A> <: Pick<T, B>` keep failing.

A previous attempt also patched the parallel `generics.rs` source-to-mapped-expansion path (where the source is not a bare type parameter); it was reverted as out of scope — only the type-parameter-source path is needed for this family, keeping the change minimal.

## Scope / adjacent matrix

Verified against `tsc` 6.0.2 (all match):
- `T <: Pick<T, StringKeys<T>>` (computed subset) — accepted.
- `T <: Pick<T, keyof T & string>` (intersection subset) — accepted.
- `T <: { [P in StringKeys<T>]: T[P] }` (inline, no alias) — accepted.
- Renamed binders (`Subset<Elem, Prop>`, key param `Each`) — identical outcome (rule is structural, not name-keyed).
- `Pick<T, keyof T>` (full key set) round-trips both directions — unchanged.
- **Negative:** `Pick<T, K> <: T` still errors (`TS2322`).
- **Negative:** `Pick<T, A> <: Pick<T, B>` over disjoint subsets still errors.
- The exact `conditionalTypes1.ts` `f7` shape: only the four cross-direction / cross-subset assignments error; `y = x` / `z = x` are clean.

## Project Corpus Impact

- Row: n/a
- Bug family: solver mapped/keyof/inference relation (the `#8432` aggregate family); the `Pick<T, subset>` pattern is pervasive in utility-type-heavy code.
- This strictly *removes* false-positive `TS2322` from a sound assignment; no row is expected to regress. After this change `conditionalTypes1.ts` has no extra tsz diagnostics; one residual divergence remains (line 33, a separate `NonNullable<T["x"]>` false-negative), so the fixture stays on the ledger pending that orthogonal fix. Heavy conformance / emit / fourslash / project-corpus rows are owned by ready-review CI.

## Verification

- New `crates/tsz-checker/tests/type_param_pick_subset_assignability_tests.rs` (8 tests, binder names varied; positive, sound-negative, full-keyof, and the `f7` witness).
- `cargo test -p tsz-solver --lib`: 6592 pass; the only 2 failures (`variadic_prepend_flattens_tail_application`, `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`) reproduce identically on clean `HEAD` (pre-existing, unrelated).
- Adjacent checker suites green: `mapped_type_errors_conformance_tests` (19), `recursive_conditional_mapped_infer_tests` (7), `index_signature_argument_assignability_tests` (14), `type_parameter_source_constraint_chain_tests` (7).
- CLI parity vs `tsc` 6.0.2 across the matrix above; broad differential sweep (20+ varied snippets) unchanged.
- `cargo fmt --check`, `cargo clippy -p tsz-solver --lib`, `git diff --check`, `scripts/arch/arch_guard.py` all clean.
- `/simplify` run 3×: pass 1 removed a duplicated `index_access_parts`/`type_param_info` re-extraction (the subset arm now yields `is_identity_template` by construction); passes 2–3 converged with no further changes.

## Coordination Notes

Advances the `#8432` mapped/keyof/inference conformance family (a focused slice; does not close the tracker). No overlap with in-flight inference PRs — this touches only the type-parameter-source homomorphic-mapped relation arm.

https://claude.ai/code/session_01XMF5QJkRtZMmjiSjRH4WcB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMF5QJkRtZMmjiSjRH4WcB)_