### PR TITLE
fix(checker): validate keyof/readonly/unique type-operator operands

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -87,6 +87,9 @@ path = "tests/cross_file_lib_generic_heritage_tests.rs"
 name = "lib_heritage_cycle_dom_tests"
 path = "tests/lib_heritage_cycle_dom_tests.rs"
 [[test]]
+name = "keyof_operand_indexed_access_validation_tests"
+path = "tests/keyof_operand_indexed_access_validation_tests.rs"
+[[test]]
 name = "union_protected_intersection_property_tests"
 path = "tests/union_protected_intersection_property_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -1364,6 +1364,16 @@ impl<'a> CheckerState<'a> {
                     check_child_type_node!(self, wrapped.type_node);
                 }
             }
+            k if k == syntax_kind_ext::TYPE_OPERATOR => {
+                // `keyof`/`readonly`/`unique` operators wrap a regular operand type
+                // node. Recurse into it so nested errors (e.g. an invalid indexed
+                // access `keyof A[T]` → TS2536, or an unresolved name) are reported
+                // just as tsc validates them — the operand was previously dropped by
+                // the catch-all arm, silently swallowing those diagnostics.
+                if let Some(type_op) = self.ctx.arena.get_type_operator(node) {
+                    check_child_type_node!(self, type_op.type_node);
+                }
+            }
             k if k == syntax_kind_ext::TYPE_REFERENCE => {
                 if let Some(type_ref) = self.ctx.arena.get_type_ref(node) {
                     let is_bare_scoped_type_parameter = self

--- a/crates/tsz-checker/tests/keyof_operand_indexed_access_validation_tests.rs
+++ b/crates/tsz-checker/tests/keyof_operand_indexed_access_validation_tests.rs
@@ -1,0 +1,128 @@
+//! Regression coverage: errors inside a `keyof` / `readonly` / `unique`
+//! type-operator operand must be reported.
+//!
+//! The checker's recursive type-node validation (`check_type_node`) had no arm
+//! for `TYPE_OPERATOR`, so the operand of `keyof <T>` (and `readonly`/`unique`)
+//! fell through the catch-all and was never validated. Any diagnostic that lives
+//! inside that operand — most visibly `TS2536` for an invalid indexed access
+//! (`keyof A[K]` where `K` cannot index `A`) but also `TS2304` for an unresolved
+//! name — was silently dropped. `tsc` validates the operand like any other nested
+//! type node, so tsz must too.
+//!
+//! Structural rule: when a type node contains an indexed access `A[I]` where `I`
+//! cannot index `A`, `tsc` reports `TS2536` at that node regardless of the
+//! surrounding syntactic position (bare, under `keyof`, under another indexed
+//! access, in a type-parameter constraint, or inside an array element). The bare
+//! position already worked; this exercises the previously-dropped operator
+//! positions.
+//!
+//! Witnessed while reducing the `intersectionsOfLargeUnions.ts` accepted
+//! regression (the `HTMLElementTagNameMap[T][P]` / `keyof ElementTagNameMap[T]`
+//! shapes), and verified against `tsc` 6.0.2.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source, diagnostic_codes};
+
+fn codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    diagnostic_codes(&check_source(source, "test.ts", options))
+}
+
+fn count(source: &str, code: u32) -> usize {
+    codes(source).into_iter().filter(|&c| c == code).count()
+}
+
+const MAPS: &str = "interface MapA { a: 1; b: 2; }\ninterface MapB { a: 1; }\n";
+
+#[test]
+fn keyof_invalid_indexed_access_in_alias_body_reports_ts2536() {
+    // `K` ranges over `keyof MapA` ("a" | "b") but "b" is not a key of MapB,
+    // so `MapB[K]` — and therefore `keyof MapB[K]` — is invalid.
+    let src = format!("{MAPS}type T<K extends keyof MapA> = keyof MapB[K];");
+    assert_eq!(
+        count(&src, 2536),
+        1,
+        "keyof of an invalid indexed access must report exactly one TS2536: {:?}",
+        codes(&src)
+    );
+}
+
+#[test]
+fn keyof_invalid_indexed_access_in_type_parameter_constraint_reports_ts2536() {
+    // The invalid indexed access is inside a type-parameter constraint
+    // (`P extends keyof MapB[K]`), a `keyof` operand position.
+    let src = format!("{MAPS}type T<K extends keyof MapA, P extends keyof MapB[K]> = [K, P];");
+    assert_eq!(
+        count(&src, 2536),
+        1,
+        "keyof operand in a constraint must report TS2536: {:?}",
+        codes(&src)
+    );
+}
+
+#[test]
+fn keyof_unresolved_name_in_operand_reports_ts2304() {
+    // The operand recursion also surfaces an unresolved name that previously
+    // hid inside the `keyof` operand.
+    let src = "type T = keyof DoesNotExistAnywhere;";
+    assert!(
+        codes(src).contains(&2304),
+        "unresolved name inside a keyof operand must report TS2304: {:?}",
+        codes(src)
+    );
+}
+
+#[test]
+fn keyof_array_of_invalid_indexed_access_reports_ts2536() {
+    // The operand is an array type whose element is the invalid indexed access:
+    // the walker must recurse keyof -> array -> indexed access.
+    let src = format!("{MAPS}type T<K extends keyof MapA> = keyof (MapB[K])[];");
+    assert_eq!(
+        count(&src, 2536),
+        1,
+        "keyof of an array of an invalid indexed access must report TS2536: {:?}",
+        codes(&src)
+    );
+}
+
+#[test]
+fn bare_invalid_indexed_access_still_reports_single_ts2536() {
+    // Guard: the previously-working bare position is unchanged (no double report).
+    let src = format!("{MAPS}type T<K extends keyof MapA> = MapB[K];");
+    assert_eq!(
+        count(&src, 2536),
+        1,
+        "bare invalid indexed access keeps exactly one TS2536: {:?}",
+        codes(&src)
+    );
+}
+
+#[test]
+fn keyof_of_valid_indexed_access_reports_nothing() {
+    // Negative control: when `K` is constrained to `keyof MapB`, the index is
+    // valid and no TS2536 must appear.
+    let src = format!("{MAPS}type T<K extends keyof MapB> = keyof MapB[K];");
+    assert!(
+        !codes(&src).contains(&2536),
+        "valid keyof operand must not report TS2536: {:?}",
+        codes(&src)
+    );
+}
+
+#[test]
+fn keyof_operand_validation_is_binder_name_independent() {
+    // Anti-hardcoding: the same structural error with renamed binders/params
+    // must still report TS2536 — nothing keys off specific identifiers.
+    let src = "interface Lookup { foo: 1; bar: 2; }\n\
+               interface Narrow { foo: 1; }\n\
+               type Pick<Key extends keyof Lookup> = keyof Narrow[Key];";
+    assert_eq!(
+        count(src, 2536),
+        1,
+        "renamed binders must still surface the keyof-operand TS2536: {:?}",
+        codes(src)
+    );
+}


### PR DESCRIPTION
AgentName: claude-lucid-hopper-xia3wh
Track: Compiler / checker type-node validation (diagnostic parity)
Invariant: An error that lives inside a `keyof` / `readonly` / `unique` type-operator operand is reported exactly as `tsc` reports it, independent of the surrounding syntactic position.

## Structural rule

> When a type node contains an indexed access `A[I]` where `I` cannot index `A`, `tsc` reports `TS2536` at that node regardless of the surrounding syntactic position — bare (`A[I]`), under `keyof` (`keyof A[I]`), under another indexed access (`A[I][J]`), in a type-parameter constraint (`P extends keyof A[I]`), or inside an array element (`keyof (A[I])[]`). The same applies to any other diagnostic that lives inside the operand (e.g. `TS2304` for an unresolved name).

tsz's recursive type-node validation walker `check_type_node`
(`crates/tsz-checker/src/types/type_checking/type_alias_checking.rs`) had explicit
arms for `INDEXED_ACCESS_TYPE`, `UNION`/`INTERSECTION`, `ARRAY_TYPE`,
`OPTIONAL`/`REST`/`PARENTHESIZED`, `TYPE_REFERENCE`, `TYPE_LITERAL`,
`CONDITIONAL_TYPE`, `MAPPED_TYPE`, `TUPLE_TYPE`, `FUNCTION_TYPE`, and
`TYPE_QUERY` — but **no `TYPE_OPERATOR` arm**. The operand of a `keyof` (and
`readonly` / `unique`) operator therefore fell through the catch-all `_ =>` arm
and was never validated, silently swallowing every diagnostic inside it.

Minimal witness (matches `tsc` 6.0.2 exactly after the fix). With
`interface MapA { a: 1; b: 2 }` and `interface MapB { a: 1 }`, and a type
parameter `K` constrained to `keyof MapA` (so `K` ranges over `"a" | "b"`,
and `"b"` is not a key of `MapB`):

- `MapB[K]` as an alias body → `TS2536` (already worked).
- `keyof MapB[K]` as an alias body → `TS2536` — **was dropped**, now reported.
- `keyof MapB[K]` in a type-parameter constraint → `TS2536` — **was dropped**, now reported.
- `keyof (MapB[K])[]` (array-wrapped operand) → `TS2536` — **was dropped**, now reported.
- `keyof DoesNotExist` → `TS2304` — **was dropped**, now reported.

## Owner layer

Checker — `check_type_node_with_literal_context` in
`crates/tsz-checker/src/types/type_checking/type_alias_checking.rs`. The fix adds
the missing `TYPE_OPERATOR` arm, which recurses into the operand
(`type_op.type_node`) through the same `check_child_type_node!` macro the sibling
wrapper arms use. No solver / printer / emit change; no new user-name or file-name
literals; the recursion is guarded by the existing per-node `type_node_validation`
cache, so every node is still validated at most once.

## Scope

- Adds one match arm (4 code lines) to the validation walker.
- New regression suite `keyof_operand_indexed_access_validation_tests` (7 cases):
  alias-body position, constraint position, array-wrapped operand, unresolved
  name (`TS2304`), bare-position guard (no double report), valid negative control,
  and a renamed-binder case (anti-hardcoding — nothing keys off identifiers).

## Project Corpus Impact

- Row: n/a
- Bug family: checker type-node validation / keyof-readonly-unique operand diagnostics
- Evidence: no required project row should be affected; the change only adds diagnostics that `tsc` already emits inside `keyof` / `readonly` / `unique` operands. Differential testing against `tsc` 6.0.2 over sampled keyof / indexed-access / mapped conformance fixtures showed no new false positives, and ready-review CI owns broad project-corpus validation.
No required project row should be affected — the change only adds diagnostics that
`tsc` already emits inside `keyof` / `readonly` / `unique` operands. Differential
testing against `tsc` 6.0.2 over a sample of keyof / indexed-access / mapped
conformance fixtures (`keyofAndIndexedAccess`, `keyofAndIndexedAccess2`,
`keyofAndIndexedAccessErrors`, `mappedTypeConstraints2`, `mappedTypeRelationships`,
`keyofGenericExtendsStringNumberPair`, `indexedAccessRelation`, `indexSignatures1`,
`unionAndIntersectionInference1`, …) showed **no new false positives** — every
sampled fixture matches `tsc` after the change.

Found while reducing the `intersectionsOfLargeUnions.ts` accepted regression. That
fixture has a *separate*, distinct divergence (the inner `HTMLElementTagNameMap[T]`
of `HTMLElementTagNameMap[T][P]` is suppressed through the large-DOM-map relation
path, not the `keyof`-operand path), so it is intentionally **left on the
accepted-regression ledger** here.

## Verification

- `cargo test -p tsz-checker --test keyof_operand_indexed_access_validation_tests` — 7 passed.
- Targeted regression suites green: `ts2536_keyof_string_index_signature_tests`,
  `ts2344_keyof_bare_tparam_defer_tests`, `homomorphic_indexed_access_tests`,
  `homomorphic_indexed_access_edge_cases`, `keyof_mapped_as_clause_tests`,
  `deferred_keyof_index_access_assignability_tests`, `keyof_array_literal_diagnostic_tests`,
  `keyof_class_unique_symbol_key_tests`, `indexed_access_unconstrained_param_tests`,
  `intersection_indexed_access_source_suppression_tests`,
  `tuple_index_access_tests`, `ts4105_signature_position_indexed_access_tests`.
  (One pre-existing failure on `main`, `test_computed_unique_prefix_property_stays_string_key`,
  was confirmed to fail identically without this change — unrelated.)
- `tsz` vs `tsc` 6.0.2 differential confirms exact-match output on the witnesses above.
- Relying on ready-review CI for the full conformance / fourslash / emit aggregates.

## Coordination Notes

Standalone checker parity fix; no overlap with the in-flight indexed-access /
keyof PRs. Leaves `intersectionsOfLargeUnions.ts` on the ledger for the separate
large-DOM-map relation path noted above.

https://claude.ai/code/session_017nce3jCtrCNFChsW5n28n2
