### PR TITLE
perf(checker): resolve cross-arena delegation symbol once across guard blocks (#7531)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,9 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "cross_file_delegation_lookup_consolidation_tests"
+path = "tests/cross_file_delegation_lookup_consolidation_tests.rs"
+[[test]]
 name = "keyof_source_display_tests"
 path = "tests/keyof_source_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -374,8 +374,14 @@ impl<'a> CheckerState<'a> {
         // the lib arena. Delegating to the lib arena loses the type alias declaration (which
         // lives in the user arena), causing property access on the instantiated type to fail.
         // If the type alias declaration exists in the current arena, handle it locally.
+        //
+        // Resolved once and reused across the read-only guard blocks below (the first
+        // guard already required it unconditionally): avoids re-running the alias-pin +
+        // `resolve_symbol_file_index` + binder lookups (and the fallback O(N) binder
+        // scan) several times per delegation. Byte-identical — no guard mutates state.
+        let cross_file_symbol = self.get_cross_file_symbol(sym_id);
         {
-            let sym_found = self.get_cross_file_symbol(sym_id);
+            let sym_found = cross_file_symbol;
             let has_type_alias =
                 sym_found.is_some_and(|s| s.has_any_flags(symbol_flags::TYPE_ALIAS));
             if has_type_alias {
@@ -403,7 +409,7 @@ impl<'a> CheckerState<'a> {
         // compute_class_symbol_type to fail to find the class node and return UNKNOWN,
         // triggering false TS18046 errors. Handle the class locally instead.
         {
-            let sym_found = self.get_cross_file_symbol(sym_id);
+            let sym_found = cross_file_symbol;
             if let Some(symbol) = sym_found
                 && symbol.has_any_flags(symbol_flags::CLASS)
             {
@@ -423,7 +429,7 @@ impl<'a> CheckerState<'a> {
         // When the user re-declares a lib global function, keep the user's overloads in scope
         // (delegating to the lib arena would drop them and mis-resolve calls).
         {
-            let sym_found = self.get_cross_file_symbol(sym_id);
+            let sym_found = cross_file_symbol;
             if let Some(symbol) = sym_found
                 && symbol.has_any_flags(symbol_flags::FUNCTION)
                 && !symbol.has_any_flags(
@@ -446,7 +452,7 @@ impl<'a> CheckerState<'a> {
         let is_known_cross_file = self.ctx.has_symbol_file_index(sym_id);
 
         if !is_known_cross_file
-            && let Some(symbol) = self.get_cross_file_symbol(sym_id)
+            && let Some(symbol) = cross_file_symbol
             && symbol.has_any_flags(symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE)
         {
             return None;
@@ -474,7 +480,7 @@ impl<'a> CheckerState<'a> {
         // this decision for merged interfaces across user files.
         let mut interface_has_local_decl = false;
         if delegate_arena.is_some_and(|arena| !std::ptr::eq(arena, self.ctx.arena))
-            && let Some(symbol) = self.get_cross_file_symbol(sym_id)
+            && let Some(symbol) = cross_file_symbol
             && symbol.has_any_flags(symbol_flags::INTERFACE)
         {
             let has_local_interface = symbol.declarations.iter().any(|&d| {
@@ -517,7 +523,7 @@ impl<'a> CheckerState<'a> {
         }
 
         if delegate_arena.is_none_or(|arena| std::ptr::eq(arena, self.ctx.arena))
-            && let Some(symbol) = self.get_cross_file_symbol(sym_id)
+            && let Some(symbol) = cross_file_symbol
         {
             // For INTERFACE symbols whose primary arena is already the current arena,
             // do NOT scan per-declaration arenas for delegation. Interfaces split across

--- a/crates/tsz-checker/tests/cross_file_delegation_lookup_consolidation_tests.rs
+++ b/crates/tsz-checker/tests/cross_file_delegation_lookup_consolidation_tests.rs
@@ -1,0 +1,106 @@
+//! Regression coverage for the cross-arena delegation hot path
+//! (`delegate_cross_arena_symbol_resolution`).
+//!
+//! The delegation entry point resolves the requested symbol once and reuses that
+//! identity across its read-only guard blocks (TYPE_ALIAS / CLASS / FUNCTION /
+//! NAMESPACE / INTERFACE). These tests pin that the consolidated single lowering
+//! still drives every guard branch correctly: a clean program importing each
+//! symbol kind across files must type-check with no spurious cross-file
+//! diagnostics (`TS2304` cannot-find-name, `TS2307` cannot-find-module,
+//! `TS2305` no-exported-member, `TS2339` property-missing, `TS18046` unknown).
+//!
+//! Binder names are varied between cases so nothing keys off a specific
+//! identifier (anti-hardcoding contract).
+
+use tsz_checker::CheckerOptions;
+use tsz_checker::test_utils::check_all_multi_file_with_global_index;
+
+/// Codes that would indicate the cross-arena delegation path failed to resolve
+/// an imported symbol (mis-routed arena, dropped declaration, or `UNKNOWN`).
+const CROSS_FILE_RESOLUTION_FAILURE_CODES: [u32; 5] = [2304, 2307, 2305, 2339, 18046];
+
+fn delegation_failure_codes(files: &[(&str, &str)]) -> Vec<u32> {
+    check_all_multi_file_with_global_index(files, CheckerOptions::default())
+        .into_iter()
+        .map(|d| d.code)
+        .filter(|code| CROSS_FILE_RESOLUTION_FAILURE_CODES.contains(code))
+        .collect()
+}
+
+#[test]
+fn cross_file_interface_alias_class_function_all_resolve_through_delegation() {
+    // One target module declares every symbol kind the delegation guards branch
+    // on; the entry module imports and uses each in a well-typed position.
+    let files = [
+        (
+            "lib_alpha.ts",
+            r#"
+                export interface OptionBag {
+                    enabled: boolean;
+                    retries: number;
+                }
+                export type Mode = "fast" | "slow";
+                export class Worker {
+                    run(): number { return 1; }
+                }
+                export function build(): number { return 0; }
+            "#,
+        ),
+        (
+            "entry_alpha.ts",
+            r#"
+                import { OptionBag, Mode, Worker, build } from "./lib_alpha";
+                const opts: OptionBag = { enabled: true, retries: 3 };
+                const flag: boolean = opts.enabled;
+                const mode: Mode = "fast";
+                const w: Worker = new Worker();
+                const n: number = w.run();
+                const m: number = build();
+            "#,
+        ),
+    ];
+    assert_eq!(
+        delegation_failure_codes(&files),
+        Vec::<u32>::new(),
+        "clean cross-file program must resolve every imported symbol kind",
+    );
+}
+
+#[test]
+fn cross_file_interface_alias_class_function_resolve_with_renamed_binders() {
+    // Same shape, different identifiers — the consolidated single fetch is keyed
+    // by SymbolId, never by name, so the renamed program must behave identically.
+    let files = [
+        (
+            "lib_beta.ts",
+            r#"
+                export interface SettingsRecord {
+                    verbose: boolean;
+                    attempts: number;
+                }
+                export type Speed = "high" | "low";
+                export class Runner {
+                    execute(): string { return ""; }
+                }
+                export function assemble(): string { return ""; }
+            "#,
+        ),
+        (
+            "entry_beta.ts",
+            r#"
+                import { SettingsRecord, Speed, Runner, assemble } from "./lib_beta";
+                const cfg: SettingsRecord = { verbose: false, attempts: 1 };
+                const v: boolean = cfg.verbose;
+                const s: Speed = "low";
+                const r: Runner = new Runner();
+                const out: string = r.execute();
+                const a: string = assemble();
+            "#,
+        ),
+    ];
+    assert_eq!(
+        delegation_failure_codes(&files),
+        Vec::<u32>::new(),
+        "renamed cross-file program must resolve identically (no name-keyed behavior)",
+    );
+}

--- a/crates/tsz-checker/tests/cross_file_delegation_lookup_consolidation_tests.rs
+++ b/crates/tsz-checker/tests/cross_file_delegation_lookup_consolidation_tests.rs
@@ -2,8 +2,8 @@
 //! (`delegate_cross_arena_symbol_resolution`).
 //!
 //! The delegation entry point resolves the requested symbol once and reuses that
-//! identity across its read-only guard blocks (TYPE_ALIAS / CLASS / FUNCTION /
-//! NAMESPACE / INTERFACE). These tests pin that the consolidated single lowering
+//! identity across its read-only guard blocks (`TYPE_ALIAS` / `CLASS` /
+//! `FUNCTION` / `NAMESPACE` / `INTERFACE`). These tests pin that the consolidated single lowering
 //! still drives every guard branch correctly: a clean program importing each
 //! symbol kind across files must type-check with no spurious cross-file
 //! diagnostics (`TS2304` cannot-find-name, `TS2307` cannot-find-module,


### PR DESCRIPTION
AgentName: lucid-hopper-dcl3ua
Track: Performance / checker cross-arena delegation hot path (#7531)

## Invariant

`tsz` matches `tsc` exactly. This is a pure allocation/CPU-traffic reduction on
the cross-arena symbol-delegation hot path with **byte-for-byte identical**
diagnostics and resolved types.

## Structural rule

> When `delegate_cross_arena_symbol_resolution` decides how to resolve a
> cross-file `SymbolId`, it walks a sequence of read-only guard blocks
> (TYPE_ALIAS / CLASS / FUNCTION / NAMESPACE / INTERFACE local-declaration
> checks). None of those guards mutate checker state, and the very first guard
> already resolves the symbol unconditionally — so the cross-file symbol
> identity must be resolved **once** and reused, not re-resolved per guard.

`delegate_cross_arena_symbol_resolution`
(`crates/tsz-checker/src/state/type_analysis/cross_file.rs`) called
`get_cross_file_symbol(sym_id)` up to **six** times for the same id across its
guards. Each call repeats `local_import_alias`, `resolve_symbol_file_index` (a
`RefCell` borrow plus two map lookups), and per-binder `get_symbol` lookups, with
a fallback **O(N) scan over all binders** when the id is not yet indexed. On
multi-file / lib-heavy programs (`ts-essentials-project`, `vite-vanilla-ts-app`,
`nextjs-fresh-app`) this entry path runs for every delegation call, so the
redundant resolutions add up across the universal cross-arena hot path #7531
tracks.

## Owner layer

Checker — `tsz-checker` cross-file delegation orchestration. No solver / relation
/ printer / emit change; no new user-name or file-name literals; the symbol is
keyed by `SymbolId`, never by identifier text.

## Scope

- `crates/tsz-checker/src/state/type_analysis/cross_file.rs`: hoist a single
  `let cross_file_symbol = self.get_cross_file_symbol(sym_id);` before the guard
  blocks and reuse it at the six guard sites. The post-mutation lib-delegation
  cache-hit lookup (after `symbol_types.insert`) intentionally keeps its own
  fresh call. The `let symbol = self.ctx.binder.get_symbol(sym_id)` local-binder
  guard is deliberately left as a *local* lookup (raw `SymbolId`s collide across
  binders — see the in-code comment), so it is **not** folded into the shared
  cross-file fetch.
- `crates/tsz-checker/tests/cross_file_delegation_lookup_consolidation_tests.rs`
  (new): multi-kind multi-file delegation regression test + a renamed-binder
  variant.

### Complexity / invalidation

Per delegation entry: was up to 6 × (alias-pin + `resolve_symbol_file_index` +
binder lookups, + fallback O(N) binder scan); now 1 ×, with the result reused.
No cache, no key, no invalidation — the value is a borrow held only across the
read-only guard region and dropped before any `&mut self` work, so there is
nothing to invalidate and resolution order is unchanged. Eligibility/branch
decisions are identical because the resolved symbol is identical.

## Project Corpus Impact

- Row: ts-essentials-project, vite-vanilla-ts-app, nextjs-fresh-app (cross-arena
  delegation / option-bag overhead per #7531)
- Bug family: cross-arena delegation overhead — redundant per-guard symbol
  re-resolution
- No required project row changes diagnostics (behavior-preserving). This is a
  CPU/allocation reduction on the delegation entry path; it does not touch the
  child-checker-construction (`with_parent_cache`) lever or the direct-lowering
  eligibility gate, so it carries none of the conformance-drift risk that the
  prior direct-lowering experiments (#8177) did.

## Verification

- `cargo check -p tsz-checker` clean (the single hoisted borrow type-checks
  across the guard region).
- Full `cross_file` lib suite **single-threaded**: 252 passed / 8 failed, with
  the failing set **identical with and without this diff** (`git stash` A/B). The
  8 are pre-existing local-baseline failures (submodule/lib-loading and global
  perf-counter isolation; e.g. `direct_source_file_type_alias_lowers_imported_typeof_marker_leaf`,
  flagged pre-existing in #12899/#12721). Under multi-threaded runs the two
  global-perf-counter option-bag tests flake on counter races; both pass in
  isolation and single-threaded.
- New `cross_file_delegation_lookup_consolidation_tests` (2 tests): a clean
  cross-file program importing an interface, type alias, class, and function
  resolves with zero `TS2304/TS2307/TS2305/TS2339/TS18046`, and an
  identically-shaped renamed-binder variant behaves the same.
- `cargo fmt -p tsz-checker --check` and `cargo clippy -p tsz-checker --lib`
  clean. `cross_file.rs` is 2000 lines (at the arch cap, not over).
- `/simplify` reviewed (reuse/simplification/efficiency/altitude): the hoist is
  at the correct depth — generalizing to a memoized `get_cross_file_symbol`
  would add overlay-growth invalidation risk and break byte-identity, so the
  function-local single fetch is the right level.
- Broad conformance / emit / fourslash / project-bench suites are owned by
  ready-review CI.

## Coordination Notes

#7531 was unowned (tracking PR #8177 closed unmerged; the landed partial #7701
explicitly states it is "not a full fix"); Studio-B declined to claim it from a
low-disk worktree. Claimed here and marked `WIP` on the issue. This is the safe,
byte-identical slice of the remaining delegation overhead; the regression-prone
direct-lowering/child-construction lever is intentionally untouched, so the issue
stays open for that deeper (and riskier) work.

https://claude.ai/code/session_01Bw9Fy2tHjQphrhohY2psEd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bw9Fy2tHjQphrhohY2psEd)_