### PR TITLE
perf(checker): skip per-identifier lib-context scan via prebuilt lib-name index

### DIFF
--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -207,6 +207,7 @@ program_alias_partners = { lifetime = "ProgramStable", capability = "ProgramLook
 resolved_module_paths = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }
 resolved_module_request_paths = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }
 resolved_module_ts_extension_flags = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }
+lib_file_local_names = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable lib file-local name index; valid until the compilation or loaded lib set changes" }
 current_file_idx = { lifetime = "FileLocalReset", capability = "CheckerInputs", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 inference_placeholder_state = { lifetime = "FileLocalReset", capability = "RelationSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 resolved_modules = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -279,6 +279,7 @@ impl<'a> CheckerContext<'a> {
             type_only_nodes: FxHashSet::default(),
             lib_contexts: Arc::new(Vec::new()),
             lib_binders_cached: Arc::new(Vec::new()),
+            lib_file_local_names: None,
             actual_lib_file_count: 0,
             typescript_dom_replacement_loaded: false,
             typescript_dom_replacement_has_window: false,

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -19,6 +19,28 @@ use tsz_solver::TypeId;
 
 use super::{CheckerContext, LibContext, ResolutionError, TypeCache};
 
+/// Build the union of every name declared in any lib context's `file_locals`.
+///
+/// Used to populate [`CheckerContext::lib_file_local_names`]. Returns `None`
+/// when there are no lib contexts (no index needed; lib scans are already
+/// skipped via `ignore_libs`/`has_lib_loaded`). The set owns its `String` keys
+/// so it is lifetime-free and can be shared (`Arc`) across per-file checkers.
+#[must_use]
+pub fn build_lib_file_local_names(lib_contexts: &[LibContext]) -> Option<Arc<FxHashSet<String>>> {
+    if lib_contexts.is_empty() {
+        return None;
+    }
+    let mut names: FxHashSet<String> = FxHashSet::default();
+    for lib_ctx in lib_contexts {
+        for (name, _sym_id) in lib_ctx.binder.file_locals.iter() {
+            if !names.contains(name.as_str()) {
+                names.insert(name.clone());
+            }
+        }
+    }
+    Some(Arc::new(names))
+}
+
 /// Kill-switch for order-independent cross-file alias/`export =` resolution.
 ///
 /// When enabled (default), overlay writes that record a symbol's owning file
@@ -321,10 +343,20 @@ impl<'a> CheckerContext<'a> {
                 .map(|lc| Arc::clone(&lc.binder))
                 .collect(),
         );
+        self.lib_file_local_names = build_lib_file_local_names(&lib_contexts);
         self.lib_contexts = Arc::new(lib_contexts);
     }
 
     /// Set pre-wrapped Arc lib contexts (for O(1) sharing between checkers).
+    ///
+    /// Clears [`Self::lib_file_local_names`] rather than rebuilding it: the name
+    /// index is `O(total lib symbols)` to build and this is the hot per-file
+    /// path, so the caller shares a prebuilt index via
+    /// [`Self::set_lib_file_local_names`] *after* this call (the parallel checker
+    /// builds it once). Clearing also guarantees a stale index from a previous
+    /// `lib_contexts` can never pair with these contexts; when the index is
+    /// absent, identifier resolution falls back to the full lib scan, so
+    /// correctness never depends on it being set.
     pub fn set_lib_contexts_shared(&mut self, lib_contexts: Arc<Vec<LibContext>>) {
         self.lib_binders_cached = Arc::new(
             lib_contexts
@@ -332,7 +364,28 @@ impl<'a> CheckerContext<'a> {
                 .map(|lc| Arc::clone(&lc.binder))
                 .collect(),
         );
+        self.lib_file_local_names = None;
         self.lib_contexts = lib_contexts;
+    }
+
+    /// Share a prebuilt lib `file_locals` name index (see
+    /// [`Self::lib_file_local_names`]). Cheap `Arc` clone; built once per program.
+    pub fn set_lib_file_local_names(&mut self, names: Option<Arc<rustc_hash::FxHashSet<String>>>) {
+        self.lib_file_local_names = names;
+    }
+
+    /// Whether `name` could be declared in any loaded lib `file_locals`.
+    ///
+    /// Returns `true` when the index is absent (forcing the full scan, so
+    /// behavior is unchanged) and otherwise `true` only when the prebuilt index
+    /// contains `name`. A `false` result means no lib context declares `name`,
+    /// so a direct `lib_contexts` `file_locals` scan is a guaranteed no-op and
+    /// can be skipped without changing the resolved symbol.
+    #[must_use]
+    pub fn lib_name_possible(&self, name: &str) -> bool {
+        self.lib_file_local_names
+            .as_ref()
+            .is_none_or(|names| names.contains(name))
     }
 
     /// Set the count of actual lib files loaded (not including user files).
@@ -1768,6 +1821,39 @@ mod tests {
             cache.def_to_name.get(&def_id).map(String::as_str),
             Some("ConcatArray")
         );
+    }
+
+    #[test]
+    fn lib_name_possible_gates_on_index_membership() {
+        let arena = NodeArena::new();
+        let binder = BinderState::new();
+        let types = TypeInterner::new();
+        let store = Arc::new(DefinitionStore::new());
+        let mut ctx = CheckerContext::new_with_shared_def_store(
+            &arena,
+            &binder,
+            &types,
+            "test.ts".to_string(),
+            CheckerOptions::default(),
+            store,
+        );
+
+        // No index: every name forces the full scan (behavior unchanged).
+        assert!(ctx.lib_name_possible("Anything"));
+        assert!(ctx.lib_name_possible("HTMLDivElement"));
+
+        // With an index, only names present in it may be in a lib `file_locals`.
+        // A name absent from the index cannot match any `file_locals.get(name)`,
+        // so the scan is safely skippable (`lib_name_possible == false`).
+        let mut names = FxHashSet::default();
+        names.insert("HTMLDivElement".to_string());
+        names.insert("Array".to_string());
+        ctx.set_lib_file_local_names(Some(Arc::new(names)));
+
+        assert!(ctx.lib_name_possible("HTMLDivElement"));
+        assert!(ctx.lib_name_possible("Array"));
+        assert!(!ctx.lib_name_possible("MyProjectUtility"));
+        assert!(!ctx.lib_name_possible("BuildTuple"));
     }
 
     #[test]

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -23,6 +23,7 @@ pub use cross_file_type_params_cache::{
 };
 mod constructors;
 mod core;
+pub use core::build_lib_file_local_names;
 mod cross_file_query;
 mod diagnostic_indices;
 mod diagnostic_push;
@@ -1344,6 +1345,25 @@ pub struct CheckerContext<'a> {
     ///
     /// Wrapped in `Arc` for the same O(1) sharing reasons as `lib_contexts`.
     pub lib_binders_cached: Arc<Vec<Arc<tsz_binder::BinderState>>>,
+
+    /// Union of every name declared in any `lib_contexts[*].binder.file_locals`,
+    /// precomputed once and shared (`Arc`) across all per-file checkers.
+    ///
+    /// Type/value-position identifier resolution probes `lib_contexts` directly
+    /// for module-scoped lib symbols the binder merge intentionally excludes
+    /// (see `resolve_identifier_symbol*`). That probe is an `O(num_lib_files)`
+    /// scan of `file_locals` run per unresolved identifier. The overwhelming
+    /// majority of names a project resolves (its own type aliases, generics,
+    /// imports) are absent from every lib, so the scan is a guaranteed no-op for
+    /// them. Gating the scan on membership in this set turns the common case
+    /// into one hash lookup while staying byte-identical: a name absent from the
+    /// set cannot match any `file_locals.get(name)`, so skipping the loop is
+    /// exactly equivalent to running it and finding nothing.
+    ///
+    /// `None` means the index was not built for this context (e.g. a child
+    /// checker created without it); callers then fall back to the full scan, so
+    /// resolution stays correct regardless of whether the index is present.
+    pub lib_file_local_names: Option<Arc<rustc_hash::FxHashSet<String>>>,
 
     /// Number of actual lib files loaded (not including user files).
     /// Used by `has_lib_loaded()` to correctly determine if standard library is available.

--- a/crates/tsz-checker/src/symbols/symbol_resolver.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver.rs
@@ -621,34 +621,39 @@ impl<'a> CheckerState<'a> {
         if result.is_none() && !ignore_libs {
             // Get the identifier name
             let name = self.ctx.arena.get_identifier_at(idx)?.escaped_text.as_str();
-            // Check lib_contexts directly for global symbols
-            for (lib_idx, lib_ctx) in self.ctx.lib_contexts.iter().enumerate() {
-                if let Some(lib_sym_id) = lib_ctx.binder.file_locals.get(name) {
-                    trace!(
-                        name = name,
-                        lib_idx = lib_idx,
-                        lib_sym_id = ?lib_sym_id,
-                        "Found symbol in lib_context"
-                    );
-                    if !should_skip_lib_symbol(lib_sym_id) {
-                        // Use file binder's sym_id for correct ID space after lib merge.
-                        // Never return lib-context SymbolIds directly: they may collide with
-                        // unrelated symbols in the current binder ID space.
-                        let Some(file_sym_id) = self.ctx.binder.file_locals.get(name) else {
-                            continue;
-                        };
-                        // Filter out string-literal ambient module symbols (e.g., `declare module "foobar"`)
-                        // — they should not resolve as bare identifiers.
-                        if self.is_string_literal_module_symbol(file_sym_id, &lib_binders) {
-                            continue;
-                        }
+            // Check lib_contexts directly for global symbols. Skip the whole
+            // scan when the prebuilt index proves no lib declares `name`: the
+            // loop body keys every probe on `file_locals.get(name)`, so an
+            // absent name makes it a guaranteed no-op (byte-identical skip).
+            if self.ctx.lib_name_possible(name) {
+                for (lib_idx, lib_ctx) in self.ctx.lib_contexts.iter().enumerate() {
+                    if let Some(lib_sym_id) = lib_ctx.binder.file_locals.get(name) {
                         trace!(
                             name = name,
-                            file_sym_id = ?file_sym_id,
+                            lib_idx = lib_idx,
                             lib_sym_id = ?lib_sym_id,
-                            "Returning symbol from lib_contexts fallback"
+                            "Found symbol in lib_context"
                         );
-                        return Some(file_sym_id);
+                        if !should_skip_lib_symbol(lib_sym_id) {
+                            // Use file binder's sym_id for correct ID space after lib merge.
+                            // Never return lib-context SymbolIds directly: they may collide with
+                            // unrelated symbols in the current binder ID space.
+                            let Some(file_sym_id) = self.ctx.binder.file_locals.get(name) else {
+                                continue;
+                            };
+                            // Filter out string-literal ambient module symbols (e.g., `declare module "foobar"`)
+                            // — they should not resolve as bare identifiers.
+                            if self.is_string_literal_module_symbol(file_sym_id, &lib_binders) {
+                                continue;
+                            }
+                            trace!(
+                                name = name,
+                                file_sym_id = ?file_sym_id,
+                                lib_sym_id = ?lib_sym_id,
+                                "Returning symbol from lib_contexts fallback"
+                            );
+                            return Some(file_sym_id);
+                        }
                     }
                 }
             }
@@ -943,7 +948,7 @@ impl<'a> CheckerState<'a> {
         // Robustness audit (PR #B, item 2): see the matching comment at
         // `resolve_identifier_symbol`. This is the type-position twin of
         // that bypass.
-        if !ignore_libs && !name_in_local_scope {
+        if !ignore_libs && !name_in_local_scope && self.ctx.lib_name_possible(name) {
             for lib_ctx in self.ctx.lib_contexts.iter() {
                 if let Some(lib_sym_id) = lib_ctx.binder.file_locals.get(name) {
                     // After lib merge, the file binder has the same symbols with

--- a/crates/tsz-core/src/parallel/core/checking.rs
+++ b/crates/tsz-core/src/parallel/core/checking.rs
@@ -416,6 +416,11 @@ struct ParallelCheckPlan<'a> {
     resolved_modules: Arc<FxHashSet<String>>,
     checker_lib_files: Vec<Arc<LibFile>>,
     lib_contexts: Arc<Vec<LibContext>>,
+    /// Prebuilt union of lib `file_locals` names, shared (`Arc`) into every
+    /// per-file checker so identifier resolution can skip the `O(num_lib_files)`
+    /// `file_locals` scan for names no lib declares. Built once here rather than
+    /// per file (it is `O(total lib symbols)`).
+    lib_file_local_names: Option<Arc<FxHashSet<String>>>,
     all_binders: Arc<Vec<Arc<BinderState>>>,
     all_arenas: Arc<Vec<Arc<NodeArena>>>,
     global_symbol_file_index: Arc<FxHashMap<tsz_binder::SymbolId, usize>>,
@@ -458,6 +463,13 @@ impl<'a> ParallelCheckPlan<'a> {
                 })
                 .collect(),
         );
+
+        // Build the lib `file_locals` name index once and share it (Arc) into
+        // every per-file checker, so type/value-position identifier resolution
+        // can skip the per-identifier `O(num_lib_files)` lib scan for names no
+        // lib declares (the common case for a project's own symbols).
+        let lib_file_local_names =
+            tsz_checker::context::build_lib_file_local_names(&lib_contexts);
 
         // PERF: Pre-compute merged augmentation data ONCE instead of per-file.
         // This reduces augmentation merging from O(N_files^2) to O(N_files).
@@ -557,6 +569,7 @@ impl<'a> ParallelCheckPlan<'a> {
             resolved_modules,
             checker_lib_files,
             lib_contexts,
+            lib_file_local_names,
             all_binders,
             all_arenas,
             global_symbol_file_index,
@@ -642,6 +655,9 @@ impl<'a> ParallelCheckPlan<'a> {
             checker
                 .ctx
                 .set_lib_contexts_shared(Arc::clone(&self.lib_contexts));
+            checker
+                .ctx
+                .set_lib_file_local_names(self.lib_file_local_names.clone());
             checker.ctx.set_actual_lib_file_count(self.lib_contexts.len());
         }
 

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -379,7 +379,7 @@ toward the `2x` target or move a red runtime/residency row toward green.
 Track these as counters or periodic audit bullets. They are more useful than
 subjective "cleanup" language.
 
-1. `CheckerContext` field count, currently pinned at `238`, plus the number of
+1. `CheckerContext` field count, currently pinned at `241`, plus the number of
    checker `source_text.contains` / file-name / rendered-message
    diagnostic decisions.
 2. Number of post-check `rewrite_*_fingerprints` passes still active.

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -14,7 +14,7 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        238,
+        241,
     ),
 ]
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -992,7 +992,7 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        240,
+        241,
     ),
 ]
 


### PR DESCRIPTION
AgentName: lucid-hopper-fwmqky
Track: Performance / checker symbol resolution
**Refs:** #12271 (contributing efficiency slice — does **not** close it; see Coordination Notes)

## Invariant
Identifier resolution returns the exact same symbol with this change on or off. A name absent from the prebuilt lib-name index cannot match any `lib_ctx.binder.file_locals.get(name)`, and both gated loop bodies live entirely inside `if let Some(_) = file_locals.get(name)`, so skipping the scan is *exactly* equivalent to running it and finding nothing.

## Structural rule
When resolving a type/value-position identifier whose name is declared by **no** loaded lib `file_locals`, tsz must not scan every lib context's `file_locals` for it — the scan is a guaranteed no-op. `tsc`/`tsgo` resolve the name once; tsz was re-scanning all lib files per unresolved identifier.

## Scope
- `crates/tsz-checker/src/context/core.rs` — `build_lib_file_local_names` (union of all lib `file_locals` names, built once); `lib_name_possible(name)` gate; `set_lib_file_local_names`; `set_lib_contexts_shared` now clears the index so a stale one can never pair with mismatched contexts.
- `crates/tsz-checker/src/context/mod.rs` — `lib_file_local_names: Option<Arc<FxHashSet<String>>>` field (+ re-export).
- `crates/tsz-checker/src/symbols/symbol_resolver.rs` — gate the two direct `lib_contexts` scans (value- and type-position) on `lib_name_possible`.
- `crates/tsz-core/src/parallel/core/checking.rs` — build the index once per program and share it (`Arc`) into each per-file checker.

`Option` + `None`-means-scan keeps every other code path (child/cross-file checkers, tests) on the existing full-scan behavior, so correctness never depends on the index being present.

## Project Corpus Impact
- Row: `ts-toolbelt-project` (#12271)
- Bug family: checker symbol resolution / redundant lib-context `file_locals` scans
- Evidence: profiling (callgrind, pinned `millsp/ts-toolbelt@b8a49285`, bench guard config) attributed ~3.2M `SymbolTable::get` calls to this per-identifier lib scan. The change eliminates those probes for project-local names, while ts-toolbelt stays at **0 diagnostics** (matches `tsc`).
- **Honest wall-clock note:** the ts-toolbelt row is dominated by recursive conditional/mapped/index-access evaluation, so end-to-end Check time is within run-to-run noise (~3.2s before and after) — this removes redundant resolver work (instruction count / hash probes) rather than moving the headline number. The benefit is broad and grows with lib-set size; it is strictly an efficiency reduction, not a behavior change.

## Verification
- Byte-identical diagnostics with the index on vs off:
  - lib-heavy A/B (`Array`/`Promise`/`Map`/`ReadonlyArray`/`HTMLDivElement` + user types): **IDENTICAL**
  - multi-file synthetic project: **IDENTICAL**
  - ts-toolbelt: **0 errors**, unchanged
- New unit test `lib_name_possible_gates_on_index_membership` (gate returns scan-everything when absent; only indexed names when present).
- `cargo check -p tsz-checker -p tsz-core` clean; `cargo fmt --check` clean; `core.rs` 1918 lines (< 2000 cap).
- Ran `/simplify` ×3: removed an earlier fragile pattern (27 manual per-child-site index copies) in favor of building once on the hot path and falling back to scan elsewhere.

## Coordination Notes
This is a **safe, byte-identical efficiency slice**, not a close of #12271. The dominant ts-toolbelt cost is recursive type evaluation; its natural lever — sharing the solver's `application_eval_cache` across files — is **intentionally not shared** today (`crates/tsz-solver/src/caches/query_cache.rs:127`: parallel file checking can observe incomplete lib-merge). That soundness-gated change is left for separate work and is why #12271 stays open. Overlaps `agent:Studio-B`'s recursive-utility work only at the analysis level; this PR touches only symbol-resolution scanning and cannot conflict with solver-core changes.

https://claude.ai/code/session_01T7SqabFtQ8H6UvtHgLrTMQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7SqabFtQ8H6UvtHgLrTMQ)_
