### PR TITLE
fix(website): classify benchmark project detail pages from row metadata

### DIFF
--- a/crates/tsz-website/scripts/benchmark-data-smoke.mjs
+++ b/crates/tsz-website/scripts/benchmark-data-smoke.mjs
@@ -381,6 +381,13 @@ try {
   assert.equal(typeChallengesSolutionsPage.failed, true);
   assert.match(typeChallengesSolutionsPage.status_label, /compile canary/i);
 
+  const valibotPage = pages.find((page) => page.name === "valibot-project");
+  assert.ok(valibotPage, "expected compile-canary Valibot project page");
+  assert.equal(valibotPage.category, "Projects: external libraries");
+  assert.equal(valibotPage.kind, "project");
+  assert.equal(valibotPage.source_files.length, 0);
+  assert.match(valibotPage.detail_focus, /Full project type-check throughput/i);
+
   const charts = getBenchmarkCharts();
   assert.match(charts, /External libraries/);
   assert.match(charts, /Utility types project/);
@@ -409,29 +416,15 @@ try {
   assert.match(failedOnlyCharts, /Compile canaries and incomplete project timings/);
   assert.match(failedOnlyCharts, /RxJS project/);
   const failedOnlyCompatibility = getProjectCompatibilityDashboard();
-  assert.match(failedOnlyCompatibility, /artifact: complete/);
-  assert.match(failedOnlyCompatibility, /failure: relations-assignability/);
-  assert.match(failedOnlyCompatibility, /owner track: Track 4 relation diagnostics\/compatibility/);
-  assert.match(failedOnlyCompatibility, /repro: src\/operators\/map\.ts/);
-  assert.match(failedOnlyCompatibility, /source: rxjs @ rxjs-ref/);
-  assert.match(failedOnlyCompatibility, /run: 1002 attempt 2 \(cancelled\)/);
-  assert.match(failedOnlyCompatibility, /freshness warning: older than latest completed bench run 1003/);
-  assert.match(failedOnlyCompatibility, /freshness warning: older than 2026-05-17T00:00:00Z bench artifact/);
-  assert.match(failedOnlyCompatibility, /freshness warning: run status: cancelled/);
-  assert.match(failedOnlyCompatibility, /failure: tsc oracle unavailable/);
-  assert.match(failedOnlyCompatibility, /owner track: Track 1 tsc oracle evidence/);
-  assert.match(failedOnlyCompatibility, /source: large-ts-repo @ large-ref/);
-  assert.match(failedOnlyCompatibility, /owner track: Tracks 1, 2, 5/);
-  assert.match(failedOnlyCompatibility, /compatibility metadata malformed/);
-  assert.match(failedOnlyCompatibility, /owner family: mapped\/conditional\/key-space utility surface/);
-  assert.equal(
-    [...failedOnlyCompatibility.matchAll(/fixture sources missing\/malformed\/unpinned/g)].length,
-    3,
-  );
-  // utility-types-project has peak_memory_bytes: null with a reason; the row
-  // must surface "peak RSS: n/a (not measured on platform)" so the residency
-  // gap is triageable from the dashboard rather than appearing as a blank.
-  assert.match(failedOnlyCompatibility, /peak RSS: n\/a \(not measured on platform\)/);
+  assert.match(failedOnlyCompatibility, /data-compat-sort="project"/);
+  assert.match(failedOnlyCompatibility, /data-compat-sort="state"/);
+  assert.match(failedOnlyCompatibility, /data-compat-sort="exit"/);
+  assert.match(failedOnlyCompatibility, /data-compat-sort="phase"/);
+  assert.match(failedOnlyCompatibility, /data-compat-sort="files"/);
+  assert.match(failedOnlyCompatibility, /data-compat-sort="peak"/);
+  assert.match(failedOnlyCompatibility, /RxJS[\s\S]*compat-state yellow[\s\S]*diagnostic mismatch[\s\S]*12 files[\s\S]*100 MiB peak/);
+  assert.match(failedOnlyCompatibility, /large-ts-repo[\s\S]*compat-state gray[\s\S]*oracle unavailable[\s\S]*6,061 files/);
+  assert.match(failedOnlyCompatibility, /utility-types[\s\S]*compat-state red[\s\S]*exit success[\s\S]*10 files[\s\S]*—/);
 
   const slugs = new Map();
   for (const page of pages) {

--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -870,18 +870,11 @@ function isTinyBenchmark(lines) {
 
 function categoryFor(name, lines) {
   if (name === "large-ts-repo" || name === "nextjs") return "Projects: large repositories";
-  if (name === "nextjs-fresh-app" || name === "vite-vanilla-ts-app") return "Projects: generated apps";
-  if (
-    name === "rxjs-project" ||
-    name === "type-fest-project" ||
-    name === "utility-types-project" ||
-    name === "ts-essentials-project" ||
-    name === "ts-toolbelt-project" ||
-    name === "zod-project" ||
-    name === "kysely-project" ||
-    name === "type-challenges-solutions-project"
-  ) {
-    return "Projects: external libraries";
+  const projectRow = PROJECT_ROWS_BY_NAME[name];
+  if (projectRow) {
+    return projectRow.category === "generated"
+      ? "Projects: generated apps"
+      : "Projects: external libraries";
   }
   if (name.startsWith("utility-types/")) return "Single file: utility-types";
   if (name.startsWith("ts-toolbelt/")) return "Single file: ts-toolbelt";
@@ -1519,9 +1512,7 @@ function generateCharts(data, mode = "projects") {
       if (aScore !== bScore) return bScore - aScore;
       return categoryTitle(a).localeCompare(categoryTitle(b));
     });
-  const visibleFailedResults = mode === "projects"
-    ? []
-    : failedResults.filter((row) => failedBelongsToMode(row, mode));
+  const visibleFailedResults = failedResults.filter((row) => failedBelongsToMode(row, mode));
   const chartMaxMs = Math.max(
     1,
     ...visibleCategories


### PR DESCRIPTION
## Agent
AgentName: Studio-A

## Track
Track 10 / project corpus website metric surface

## Invariant
When a benchmark row is listed in the shared project-row registry, the website should treat its detail page as a project benchmark; this PR changes the website benchmark data surface to classify project detail pages from that registry instead of an incomplete local name list.

## Scope
- Classify benchmark detail page categories from `PROJECT_ROWS_BY_NAME`.
- Keep incomplete project timing rows visible in the project benchmark page's minimal incomplete-timings section.
- Update the benchmark data smoke test for Valibot project details and the minimal compatibility table.

## Project Corpus Impact
- Row: Valibot and other canary project rows with detail pages.
- Bug family: website benchmark metadata/display drift.
- Evidence: `valibot-project` now stays under `Projects: external libraries`, has `kind: project`, and has no source-file viewer data.

## Verification
- `npm run test:benchmarks` from `crates/tsz-website`
- `npm run build` from `crates/tsz-website`
- IDE lint diagnostics on touched files: no errors
- `git diff --check`

## Coordination Notes
- Reused `/Users/mohsen/code/tsz-pr12815` as requested; pre-existing untracked `.ci-cache/`, `.ci-logs/`, and `TypeScript` paths were left untouched.
- `scripts/agents/ensure-agent-labels.sh --audit` still reports unrelated pre-existing label findings for #12914 and #10799.