### PR TITLE
refactor(checker): remove duplicate common boundary helpers

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -28,44 +28,6 @@ pub(crate) use super::construct_signatures::construct_signatures_for_type;
 pub(crate) use super::generic_instantiation::{instantiate_generic, instantiate_type};
 pub(crate) use super::type_rewrite::replace_type_queries_and_lazies_with;
 
-pub(crate) fn is_compiler_managed_type(name: &str) -> bool {
-    tsz_solver::is_compiler_managed_type(name)
-}
-
-/// If `ty` is `Lazy(def_id)` for a non-generic `TypeAlias` whose body is the
-/// canonical self-keyof indexed-access shape `Foo[keyof Foo]`, return the
-/// body `TypeId` so the caller can evaluate it with a resolver-equipped
-/// evaluator. Otherwise return `None`.
-///
-/// tsc loses the outer alias when this reduction collapses to a concrete type.
-/// The match is intentionally narrow: generic indexed-access aliases and
-/// non-self-keyof aliases stay opaque to avoid recursion-fuel blowups and
-/// spurious TS2589s.
-pub(crate) fn indexed_access_alias_body(
-    db: &dyn TypeDatabase,
-    def_store: &tsz_solver::def::DefinitionStore,
-    ty: TypeId,
-) -> Option<TypeId> {
-    let def_id = tsz_solver::type_queries::get_lazy_def_id(db, ty)?;
-    let def = def_store.get(def_id)?;
-    if def.kind != tsz_solver::def::DefKind::TypeAlias || !def.type_params.is_empty() {
-        return None;
-    }
-    let body = def.body?;
-    // Only match the `Foo[keyof Foo]` self-keyof shape — narrower than
-    // "any IndexAccess" to avoid evaluating legitimately-deferred forms.
-    tsz_solver::type_queries::indexed_access_self_keyof(db, body)?;
-    Some(body)
-}
-
-/// Returns true if `ty` is still a deferred form (`Lazy` or `IndexAccess`)
-/// that the solver could not reduce. Used after attempting a full evaluate
-/// to decide whether to keep the original alias display or use the resolved
-/// form.
-pub(crate) fn is_unresolved_for_display(db: &dyn TypeDatabase, ty: TypeId) -> bool {
-    tsz_solver::type_queries::is_deferred_lazy_or_indexed_access(db, ty)
-}
-
 /// Thin wrapper around `tsz_solver::deep_reduce_for_display`.
 ///
 /// Deeply reduce meta-type applications (e.g. `InstanceType<typeof Foo>`)


### PR DESCRIPTION
## Agent
AgentName: M5Refactorer

## Track
Checker/query-boundary simplification (#8227/#8225)

## Invariant
When a helper already has a domain query boundary, checker callers should use that owner and `query_boundaries::common` should not retain duplicate definitions.

## Scope
- Removes duplicate `is_compiler_managed_type`, `indexed_access_alias_body`, and `is_unresolved_for_display` definitions from `query_boundaries::common`.
- Keeps existing domain owners in `query_boundaries::type_predicates` and `query_boundaries::diagnostics`.
- No caller changes: current main already routes callers through the domain boundaries.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: Behavior-preserving boundary cleanup; no compiler behavior path changes beyond removing unused duplicate wrappers.

## Verification
- `scripts/safe-run.sh cargo test -p tsz-checker --lib test_display_diagnostic_helpers_have_domain_boundary -- --nocapture`
- `scripts/safe-run.sh cargo test -p tsz-checker --lib test_compiler_managed_name_predicate_has_domain_boundary -- --nocapture`
- `scripts/safe-run.sh python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Builds on merged #12882 and #12883 after refreshing to current `origin/main`.
- Open PR overlap checked: #12915 is website metadata, #12914 is checker perf/lib-context and does not touch this file.
- `scripts/agents/ensure-agent-labels.sh --audit` currently reports pre-existing unrelated findings for #12914 and issue #10799.