### PR TITLE
refactor(checker): route JSX props probes through boundary

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/extraction_react_alias.rs
+++ b/crates/tsz-checker/src/checkers/jsx/extraction_react_alias.rs
@@ -234,12 +234,16 @@ impl<'a> CheckerState<'a> {
         }
         let alias_evaluated = self.evaluate_type_with_env(alias);
         if alias_evaluated != TypeId::ERROR
-            && self
-                .jsx_props_relation_outcome(alias_evaluated, props_type)
-                .related
-            && self
-                .jsx_props_relation_outcome(props_type, alias_evaluated)
-                .related
+            && crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self,
+                alias_evaluated,
+                props_type,
+            )
+            && crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self,
+                props_type,
+                alias_evaluated,
+            )
         {
             self.ctx.types.store_display_alias(props_type, alias);
         }

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/component_props.rs
@@ -693,10 +693,11 @@ impl<'a> CheckerState<'a> {
                 if !crate::query_boundaries::common::is_template_literal_type(
                     self.ctx.types,
                     key_type,
-                ) || !self
-                    .jsx_props_relation_outcome(tag_literal, key_type)
-                    .related
-                {
+                ) || !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                    self,
+                    tag_literal,
+                    key_type,
+                ) {
                     continue;
                 }
 
@@ -716,23 +717,31 @@ impl<'a> CheckerState<'a> {
             let mut i = 0;
             while i < best_matches.len() {
                 let (best_key, _) = best_matches[i];
-                let candidate_more_specific = self
-                    .jsx_props_relation_outcome(candidate_key, best_key)
-                    .related
-                    && !self
-                        .jsx_props_relation_outcome(best_key, candidate_key)
-                        .related;
+                let candidate_more_specific =
+                    crate::query_boundaries::checkers::jsx::props_are_assignable(
+                        self,
+                        candidate_key,
+                        best_key,
+                    ) && !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                        self,
+                        best_key,
+                        candidate_key,
+                    );
                 if candidate_more_specific {
                     best_matches.swap_remove(i);
                     continue;
                 }
 
-                let best_more_specific = self
-                    .jsx_props_relation_outcome(best_key, candidate_key)
-                    .related
-                    && !self
-                        .jsx_props_relation_outcome(candidate_key, best_key)
-                        .related;
+                let best_more_specific =
+                    crate::query_boundaries::checkers::jsx::props_are_assignable(
+                        self,
+                        best_key,
+                        candidate_key,
+                    ) && !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                        self,
+                        candidate_key,
+                        best_key,
+                    );
                 if best_more_specific {
                     candidate_is_best = false;
                     break;
@@ -905,7 +914,7 @@ impl<'a> CheckerState<'a> {
             return;
         }
         let tag_type = self.ctx.types.literal_string(tag);
-        if self.jsx_props_relation_outcome(tag_type, evaluated).related {
+        if crate::query_boundaries::checkers::jsx::props_are_assignable(self, tag_type, evaluated) {
             return;
         }
 

--- a/crates/tsz-checker/src/checkers/jsx/overloads.rs
+++ b/crates/tsz-checker/src/checkers/jsx/overloads.rs
@@ -456,9 +456,9 @@ impl<'a> CheckerState<'a> {
             // is not assignable to type parameters like `P`, so we can't just assume
             // empty attrs match when the shape can't be resolved.
             let attrs_type = self.build_attrs_object_type_from_info(&info.attrs);
-            return self
-                .jsx_props_relation_outcome(attrs_type, props_type)
-                .related;
+            return crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self, attrs_type, props_type,
+            );
         };
 
         let has_string_index = shape.string_index.is_some();
@@ -537,9 +537,9 @@ impl<'a> CheckerState<'a> {
             // and explicit-excess checks have already passed, defer to the
             // canonical assignability gate before rejecting the overload.
             let attrs_type = self.build_attrs_object_type_from_info(&info.attrs);
-            return self
-                .jsx_props_relation_outcome(attrs_type, props_type)
-                .related;
+            return crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self, attrs_type, props_type,
+            );
         }
 
         true
@@ -650,7 +650,7 @@ impl<'a> CheckerState<'a> {
     /// keeps overload matching aligned with the canonical generic-constraint
     /// path without naming any particular helper alias.
     fn jsx_attr_assignable_to_expected(&mut self, attr_type: TypeId, expected: TypeId) -> bool {
-        self.jsx_props_relation_outcome(attr_type, expected).related
+        crate::query_boundaries::checkers::jsx::props_are_assignable(self, attr_type, expected)
             || self.jsx_attr_assignable_after_referenced_constraints(attr_type, expected)
     }
 
@@ -696,11 +696,13 @@ impl<'a> CheckerState<'a> {
         }
         let restricted = self.resolve_lazy_type(restricted);
         let restricted_evaluated = self.evaluate_type_for_assignability(restricted);
-        self.jsx_props_relation_outcome(restricted_evaluated, expected)
-            .related
-            || self
-                .jsx_props_relation_outcome(restricted, expected)
-                .related
+        crate::query_boundaries::checkers::jsx::props_are_assignable(
+            self,
+            restricted_evaluated,
+            expected,
+        ) || crate::query_boundaries::checkers::jsx::props_are_assignable(
+            self, restricted, expected,
+        )
     }
 
     /// Build an object type from collected JSX attribute info.

--- a/crates/tsz-checker/src/checkers/jsx/props/attr_check_pipeline.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/attr_check_pipeline.rs
@@ -354,9 +354,11 @@ impl<'a> CheckerState<'a> {
         if crate::query_boundaries::common::contains_type_parameters(self.ctx.types, spread_type) {
             outcome.spread_covers_all = true;
         } else if !ctx.skip_prop_checks
-            && self
-                .jsx_props_relation_outcome(spread_type, ctx.props_type)
-                .related
+            && crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self,
+                spread_type,
+                ctx.props_type,
+            )
         {
             // The solver reports the spread is structurally assignable to the
             // whole props type, so all required members are satisfied — including
@@ -751,10 +753,11 @@ impl<'a> CheckerState<'a> {
             && !suppress_for_primitive_props_with_missing_ia_required
         {
             let attrs_type = self.build_jsx_provided_attrs_object_type(&outcome.provided_attrs);
-            if !self
-                .jsx_props_relation_outcome(attrs_type, ctx.props_type)
-                .related
-            {
+            if !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self,
+                attrs_type,
+                ctx.props_type,
+            ) {
                 self.report_jsx_synthesized_props_assignability_error(
                     attrs_type,
                     &opts.display_target,
@@ -833,9 +836,7 @@ impl<'a> CheckerState<'a> {
                 .spread_entries
                 .iter()
                 .any(|&(spread_type, display_spread_type, _, _)| {
-                    self
-                        .jsx_props_relation_outcome(spread_type, ctx.props_type)
-                        .related
+                    crate::query_boundaries::checkers::jsx::props_are_assignable(self, spread_type, ctx.props_type)
                         || crate::query_boundaries::checkers::jsx::spread_source_covers_readonly_wrapped_type_parameter(
                             self.ctx.types,
                             &self.ctx.definition_store,
@@ -877,10 +878,11 @@ impl<'a> CheckerState<'a> {
             && !react_alias_spread_only_contributes_children
         {
             let attrs_type = self.build_jsx_provided_attrs_object_type(&outcome.provided_attrs);
-            if !self
-                .jsx_props_relation_outcome(attrs_type, ctx.props_type)
-                .related
-            {
+            if !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self,
+                attrs_type,
+                ctx.props_type,
+            ) {
                 // tsc uses just the type parameter name here (e.g. "P"), not
                 // the full "IntrinsicAttributes & P" display target. The
                 // IntrinsicAttributes intersection check for spread

--- a/crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/generic_spread.rs
@@ -74,9 +74,11 @@ impl<'a> CheckerState<'a> {
             {
                 return false;
             }
-            !self
-                .jsx_props_relation_outcome(*actual_type, expected_type)
-                .related
+            !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self,
+                *actual_type,
+                expected_type,
+            )
         });
 
         let has_alias_string_prop_mismatch = provided_attrs.iter().any(|(name, actual_type)| {
@@ -105,9 +107,9 @@ impl<'a> CheckerState<'a> {
 
         if !has_explicit_prop_mismatch
             && !has_alias_string_prop_mismatch
-            && self
-                .jsx_props_relation_outcome(attrs_type, props_type)
-                .related
+            && crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self, attrs_type, props_type,
+            )
         {
             return false;
         }

--- a/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/resolution.rs
@@ -150,13 +150,11 @@ impl<'a> CheckerState<'a> {
                                 type_id,
                             );
                             match attr_type {
-                                Some(attr_type) => {
-                                    *attr_type == TypeId::ANY
-                                        || *attr_type == TypeId::ERROR
-                                        || self
-                                            .jsx_props_relation_outcome(*attr_type, expected)
-                                            .related
-                                }
+                                Some(attr_type) => *attr_type == TypeId::ANY
+                                    || *attr_type == TypeId::ERROR
+                                    || crate::query_boundaries::checkers::jsx::props_are_assignable(
+                                        self, *attr_type, expected,
+                                    ),
                                 None => expected != TypeId::NEVER && expected != TypeId::ERROR,
                             }
                         }
@@ -364,12 +362,15 @@ impl<'a> CheckerState<'a> {
                         .map(|type_id| self.normalize_jsx_function_context_type(type_id));
                     if attr_name == "key"
                         && expected_special_type.is_some_and(|expected_type| {
-                            !self
-                                .jsx_props_relation_outcome(TypeId::STRING, expected_type)
-                                .related
-                                && !self
-                                    .jsx_props_relation_outcome(TypeId::NUMBER, expected_type)
-                                    .related
+                            !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                                self,
+                                TypeId::STRING,
+                                expected_type,
+                            ) && !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                                self,
+                                TypeId::NUMBER,
+                                expected_type,
+                            )
                         })
                     {
                         expected_special_type = None;
@@ -452,10 +453,11 @@ impl<'a> CheckerState<'a> {
                     }
                     if let Some(expected_type) = expected_special_type {
                         if attr_data.initializer.is_none() {
-                            if !self
-                                .jsx_props_relation_outcome(TypeId::BOOLEAN_TRUE, expected_type)
-                                .related
-                            {
+                            if !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                                self,
+                                TypeId::BOOLEAN_TRUE,
+                                expected_type,
+                            ) {
                                 let target_str = self.format_type(expected_type);
                                 let message = format_message(
                                     diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
@@ -733,10 +735,11 @@ impl<'a> CheckerState<'a> {
                     if let Some(entry) = outcome.provided_attrs.last_mut() {
                         entry.1 = TypeId::BOOLEAN_TRUE;
                     }
-                    if !self
-                        .jsx_props_relation_outcome(TypeId::BOOLEAN_TRUE, expected_type)
-                        .related
-                    {
+                    if !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                        self,
+                        TypeId::BOOLEAN_TRUE,
+                        expected_type,
+                    ) {
                         let is_literal_target = crate::query_boundaries::common::is_literal_type(
                             self.ctx.types,
                             expected_type,
@@ -902,9 +905,11 @@ impl<'a> CheckerState<'a> {
                     if is_special_named_attr {
                         if actual_type != TypeId::ANY
                             && actual_type != TypeId::ERROR
-                            && !self
-                                .jsx_props_relation_outcome(actual_type, expected_type)
-                                .related
+                            && !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                                self,
+                                actual_type,
+                                expected_type,
+                            )
                         {
                             outcome.needs_special_attr_object_assignability = true;
                         }

--- a/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/union_props.rs
@@ -190,8 +190,9 @@ impl<'a> CheckerState<'a> {
                         if *attr_type == TypeId::ANY || *attr_type == TypeId::ERROR {
                             return true;
                         }
-                        self.jsx_props_relation_outcome(*attr_type, expected)
-                            .related
+                        crate::query_boundaries::checkers::jsx::props_are_assignable(
+                            self, *attr_type, expected,
+                        )
                     }
                     _ => true,
                 }
@@ -263,10 +264,9 @@ impl<'a> CheckerState<'a> {
             })
             .collect();
         let attrs_type = self.ctx.types.factory().object(properties);
-        if self
-            .jsx_props_relation_outcome(attrs_type, props_type)
-            .related
-        {
+        if crate::query_boundaries::checkers::jsx::props_are_assignable(
+            self, attrs_type, props_type,
+        ) {
             return;
         }
         self.report_jsx_synthesized_props_assignability_error(

--- a/crates/tsz-checker/src/checkers/jsx/props/validation.rs
+++ b/crates/tsz-checker/src/checkers/jsx/props/validation.rs
@@ -241,9 +241,11 @@ impl<'a> CheckerState<'a> {
             {
                 return false;
             }
-            !self
-                .jsx_props_relation_outcome(*attr_type, expected_type)
-                .related
+            !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self,
+                *attr_type,
+                expected_type,
+            )
         });
         // A spread whose source carries a deferred conditional over a type
         // parameter (e.g. `Omit`/`Overwrite` of an unresolved `T`) is an
@@ -273,9 +275,9 @@ impl<'a> CheckerState<'a> {
                     attrs_type,
                 );
             if !source_retains_explicit_object
-                && self
-                    .jsx_props_relation_outcome(attrs_type, props_type)
-                    .related
+                && crate::query_boundaries::checkers::jsx::props_are_assignable(
+                    self, attrs_type, props_type,
+                )
             {
                 return;
             }
@@ -1058,12 +1060,16 @@ impl<'a> CheckerState<'a> {
         {
             let alias_evaluated = self.evaluate_type_with_env(alias_hint);
             if alias_evaluated != TypeId::ERROR
-                && self
-                    .jsx_props_relation_outcome(alias_evaluated, normalized)
-                    .related
-                && self
-                    .jsx_props_relation_outcome(normalized, alias_evaluated)
-                    .related
+                && crate::query_boundaries::checkers::jsx::props_are_assignable(
+                    self,
+                    alias_evaluated,
+                    normalized,
+                )
+                && crate::query_boundaries::checkers::jsx::props_are_assignable(
+                    self,
+                    normalized,
+                    alias_evaluated,
+                )
             {
                 self.ctx.types.store_display_alias(normalized, alias_hint);
             }
@@ -1748,7 +1754,11 @@ impl<'a> CheckerState<'a> {
             // Build target: IntrinsicAttributes & spread_type
             let target = self.ctx.types.factory().intersection2(ia_type, spread_type);
 
-            if !self.jsx_props_relation_outcome(spread_type, target).related {
+            if !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self,
+                spread_type,
+                target,
+            ) {
                 let spread_name = self.format_type(spread_type);
                 let target_name = format!("IntrinsicAttributes & {spread_name}");
                 let message = format_message(
@@ -1882,13 +1892,15 @@ impl<'a> CheckerState<'a> {
             if evaluated != display_type && evaluated != TypeId::ERROR {
                 if let Some(alias_hint) = alias_hint {
                     let alias_evaluated = self.evaluate_type_with_env(alias_hint);
-                    if self
-                        .jsx_props_relation_outcome(alias_evaluated, evaluated)
-                        .related
-                        && self
-                            .jsx_props_relation_outcome(evaluated, alias_evaluated)
-                            .related
-                    {
+                    if crate::query_boundaries::checkers::jsx::props_are_assignable(
+                        self,
+                        alias_evaluated,
+                        evaluated,
+                    ) && crate::query_boundaries::checkers::jsx::props_are_assignable(
+                        self,
+                        evaluated,
+                        alias_evaluated,
+                    ) {
                         self.ctx.types.store_display_alias(evaluated, alias_hint);
                     }
                 }
@@ -1911,9 +1923,11 @@ impl<'a> CheckerState<'a> {
     ) -> Option<bool> {
         if !initializer_is_bare_string_literal
             || original_property_type == expected_type
-            || self
-                .jsx_props_relation_outcome(actual_type, expected_type)
-                .related
+            || crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self,
+                actual_type,
+                expected_type,
+            )
         {
             return None;
         }

--- a/crates/tsz-checker/src/checkers/jsx/spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/spread.rs
@@ -109,9 +109,11 @@ impl<'a> CheckerState<'a> {
         // normalized JSX spread path below so we can classify TS2322 vs TS2741 from
         // the apparent/object shape first.
         if !spread_has_type_params
-            && self
-                .jsx_props_relation_outcome(spread_type, props_type)
-                .related
+            && crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self,
+                spread_type,
+                props_type,
+            )
         {
             return false;
         }
@@ -197,10 +199,11 @@ impl<'a> CheckerState<'a> {
                 // so the spread's type issues are masked.
                 return false;
             }
-            if self
-                .jsx_props_relation_outcome(spread_type, props_type)
-                .related
-            {
+            if crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self,
+                spread_type,
+                props_type,
+            ) {
                 return false;
             }
             let spread_name = self.format_type(spread_source_type);
@@ -370,10 +373,11 @@ impl<'a> CheckerState<'a> {
                 prop.type_id
             };
 
-            if !self
-                .jsx_props_relation_outcome(source_type, expected_type)
-                .related
-            {
+            if !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self,
+                source_type,
+                expected_type,
+            ) {
                 // This property has a type mismatch.
                 // Check if it will be overwritten by a later explicit attribute.
                 if overridden_names.contains(prop_name.as_str()) {
@@ -414,9 +418,11 @@ impl<'a> CheckerState<'a> {
         let mut has_type_mismatch = has_unfixable_mismatch;
         if !has_type_mismatch
             && spread_has_type_params
-            && !self
-                .jsx_props_relation_outcome(resolved_spread, props_type)
-                .related
+            && !crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self,
+                resolved_spread,
+                props_type,
+            )
         {
             has_type_mismatch = true;
         }
@@ -425,9 +431,11 @@ impl<'a> CheckerState<'a> {
         // resolved spread type is assignable to the props type.
         if has_type_mismatch
             && spread_has_type_params
-            && self
-                .jsx_props_relation_outcome(resolved_spread, props_type)
-                .related
+            && crate::query_boundaries::checkers::jsx::props_are_assignable(
+                self,
+                resolved_spread,
+                props_type,
+            )
         {
             has_type_mismatch = false;
         }

--- a/crates/tsz-checker/src/tests/jsx_generic_spread_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_generic_spread_relation_routing_arch_tests.rs
@@ -12,10 +12,13 @@ fn jsx_generic_spread_assignability_uses_relation_outcome_boundary() {
         .expect("find generic JSX spread assignability reporter");
     let function = &source[function_start..];
 
-    assert_eq!(
-        function.matches("jsx_props_relation_outcome").count(),
-        2,
-        "generic JSX spread assignability decisions should route through JSX props relation outcomes"
+    assert!(
+        !function.contains("jsx_props_relation_outcome"),
+        "generic JSX spread assignability decisions should route through the JSX props boundary helper"
+    );
+    assert!(
+        function.contains("checkers::jsx::props_are_assignable("),
+        "generic JSX spread assignability should use query_boundaries::checkers::jsx::props_are_assignable"
     );
     assert!(
         !function.contains("diagnostic_relation_boolean_guard"),
@@ -37,16 +40,13 @@ fn jsx_generic_spread_validation_uses_relation_outcome_boundary() {
         .find("pub(in crate::checkers_domain::jsx) fn normalize_jsx_required_props_target")
         .expect("find next JSX validation helper");
     let function = &rest[..function_end];
-    let compact_function: String = function.chars().filter(|ch| !ch.is_whitespace()).collect();
-
     assert!(
-        function.contains("jsx_props_relation_outcome(*attr_type, expected_type)")
-            && function.contains(".related"),
-        "generic JSX spread explicit attribute mismatch must use JSX props relation outcomes"
+        !function.contains("jsx_props_relation_outcome("),
+        "generic JSX spread attrs validation should route through the JSX props boundary helper"
     );
     assert!(
-        compact_function.contains("jsx_props_relation_outcome(attrs_type,props_type).related"),
-        "generic JSX spread synthesized attrs compatibility must use JSX props relation outcomes"
+        function.matches("props_are_assignable(").count() >= 2,
+        "generic JSX spread attrs validation should use query_boundaries::checkers::jsx::props_are_assignable"
     );
     assert!(
         !function.contains("diagnostic_relation_boolean_guard"),

--- a/crates/tsz-checker/src/tests/jsx_props_resolution_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_props_resolution_relation_routing_arch_tests.rs
@@ -7,10 +7,13 @@ fn jsx_props_resolution_uses_relation_outcome_boundary() {
     let source_path = Path::new(manifest_dir).join("src/checkers/jsx/props/resolution.rs");
     let source = fs::read_to_string(source_path).expect("read JSX props resolution source");
 
-    assert_eq!(
-        source.matches("jsx_props_relation_outcome(").count(),
-        6,
-        "JSX props resolution relation probes should route through JSX props relation outcomes"
+    assert!(
+        !source.contains("jsx_props_relation_outcome("),
+        "JSX props resolution relation probes should route through the JSX props boundary helper"
+    );
+    assert!(
+        source.contains("checkers::jsx::props_are_assignable("),
+        "JSX props resolution should use query_boundaries::checkers::jsx::props_are_assignable"
     );
     assert!(
         !source.contains("assign_relation_outcome("),

--- a/crates/tsz-checker/src/tests/jsx_props_validation_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_props_validation_relation_routing_arch_tests.rs
@@ -7,10 +7,14 @@ fn jsx_props_validation_uses_relation_outcome_boundary() {
     let source_path = Path::new(manifest_dir).join("src/checkers/jsx/props/validation.rs");
     let source = fs::read_to_string(source_path).expect("read JSX props validation source");
 
-    assert_eq!(
-        source.matches("jsx_props_relation_outcome(").count(),
-        8,
-        "JSX props validation relation probes should route through JSX props relation outcomes"
+    assert!(
+        !source.contains("jsx_props_relation_outcome("),
+        "JSX props validation relation probes should route through the JSX props boundary helper"
+    );
+    assert!(
+        source.contains("jsx::props_are_assignable(")
+            || source.contains("checkers::jsx::props_are_assignable("),
+        "JSX props validation should use query_boundaries::checkers::jsx::props_are_assignable"
     );
     assert!(
         !source.contains("diagnostic_relation_boolean_guard("),
@@ -50,4 +54,39 @@ fn jsx_generic_managed_attrs_uses_jsx_props_boundary() {
         !function.contains("jsx::types_are_assignable("),
         "generic managed attrs final assignability should not use the generic JSX assignment helper"
     );
+}
+
+#[test]
+fn jsx_checker_props_boolean_probes_use_domain_boundary() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let jsx_dir = Path::new(manifest_dir).join("src/checkers/jsx");
+    let mut violations = Vec::new();
+    collect_jsx_props_relation_violations(&jsx_dir, &jsx_dir, &mut violations);
+
+    assert!(
+        violations.is_empty(),
+        "JSX checker props boolean probes should use query_boundaries::checkers::jsx::props_are_assignable; violations: {violations:?}"
+    );
+}
+
+fn collect_jsx_props_relation_violations(dir: &Path, root: &Path, violations: &mut Vec<String>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_jsx_props_relation_violations(&path, root, violations);
+            continue;
+        }
+        if path.extension().is_none_or(|ext| ext != "rs") {
+            continue;
+        }
+        let source = fs::read_to_string(&path).expect("read JSX checker source");
+        if source.contains("jsx_props_relation_outcome(") {
+            let rel = path.strip_prefix(root).unwrap_or(&path);
+            violations.push(rel.display().to_string());
+        }
+    }
 }


### PR DESCRIPTION
## Agent
AgentName: M5Refactorer

## Track
Checker/query-boundary simplification (#8225/#8227)

## Invariant
When JSX checker code needs a boolean props assignability answer, it should use the JSX domain boundary helper instead of reading `.related` from `jsx_props_relation_outcome` directly.

## Scope
- Routes JSX props boolean probes through `query_boundaries::checkers::jsx::props_are_assignable`.
- Keeps `jsx_props_relation_outcome` as the single lower-level helper behind the JSX boundary.
- Adds/updates routing ratchets so `src/checkers/jsx` cannot reintroduce direct props relation-outcome calls.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: Refactor-only relation routing cleanup; no JSX compatibility rule changes intended.

## Verification
- `scripts/safe-run.sh cargo test -p tsz-checker --lib jsx_props -- --nocapture`
- `scripts/safe-run.sh cargo test -p tsz-checker --lib jsx_generic_spread -- --nocapture`
- `scripts/safe-run.sh python3 scripts/arch/arch_guard.py`
- Clean rebase onto current `origin/main` before publish; PR CI will run the exact pushed head.

## Coordination Notes
- Non-overlapping with #12916 (`query_boundaries/common.rs`) and current open PRs.
- #12916 has been queued; this PR does not depend on waiting for its merge-group result.