### PR TITLE
fix(checker): reject contravariant callback property in fresh object-literal args (#12918)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -138,6 +138,9 @@ path = "tests/block_body_callback_literal_widening_tests.rs"
 name = "extract_alias_distributive_mapped_tests"
 path = "tests/extract_alias_distributive_mapped_tests.rs"
 [[test]]
+name = "fresh_object_literal_arg_callback_param_variance_tests"
+path = "tests/fresh_object_literal_arg_callback_param_variance_tests.rs"
+[[test]]
 name = "generic_multi_prop_object_literal_tests"
 path = "tests/generic_multi_prop_object_literal_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/computation/call/inner.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner.rs
@@ -936,7 +936,7 @@ impl<'a> CheckerState<'a> {
                 Some(expected),
             ))
         {
-            let fresh_subtype = assign_query::is_fresh_subtype_of(self.ctx.types, actual, expected);
+            let fresh_subtype = self.fresh_object_literal_argument_recovers(actual, expected);
             let recover_object_literal =
                 fresh_subtype
                     && !self.object_literal_has_computed_property_names(arg_idx)

--- a/crates/tsz-checker/src/types/computation/call/mod.rs
+++ b/crates/tsz-checker/src/types/computation/call/mod.rs
@@ -48,6 +48,37 @@ struct CallFinalizationCtx<'a> {
 }
 
 impl<'a> CheckerState<'a> {
+    /// Decide whether a fresh object-literal argument that the call checker
+    /// flagged as an argument-type mismatch should be *recovered* — i.e. treated
+    /// as assignable with only excess-property checking applied — after its type
+    /// is recomputed under the expected contextual type.
+    ///
+    /// Recovery requires the refreshed literal to be genuinely assignable to the
+    /// expected parameter type. The historical gate consulted only
+    /// `is_fresh_subtype_of` (the raw subtype relation), but that relation
+    /// compares object-literal function-typed *property* members bivariantly
+    /// (it honors the member `is_method` hint), so it silently accepts a
+    /// contravariantly-incompatible callback property — e.g.
+    /// `{ f: (x: Dog) => void }` supplied for a parameter of type
+    /// `{ f: (x: Animal) => void }` under `strictFunctionTypes`, which `tsc`
+    /// rejects (TS2322). Property-position function members are owed the strict
+    /// contravariant parameter check, so the canonical assignability relation
+    /// must also hold before the mismatch is recovered. This keeps the recovery
+    /// for genuinely-assignable literals (e.g. callbacks whose parameters were
+    /// only resolved by the contextual refresh) while no longer masking real
+    /// parameter-variance failures.
+    pub(crate) fn fresh_object_literal_argument_recovers(
+        &mut self,
+        actual: TypeId,
+        expected: TypeId,
+    ) -> bool {
+        crate::query_boundaries::assignability::is_fresh_subtype_of(
+            self.ctx.types,
+            actual,
+            expected,
+        ) && self.call_arg_relation_outcome(actual, expected).related
+    }
+
     pub(crate) fn assertion_predicate_for_call(
         &mut self,
         call_idx: NodeIndex,
@@ -981,7 +1012,7 @@ impl<'a> CheckerState<'a> {
                 Some(expected),
             ))
         {
-            let fresh_subtype = assign_query::is_fresh_subtype_of(self.ctx.types, actual, expected);
+            let fresh_subtype = self.fresh_object_literal_argument_recovers(actual, expected);
             let recover_object_literal =
                 fresh_subtype
                     && !self.object_literal_has_computed_property_names(arg_idx)

--- a/crates/tsz-checker/tests/fresh_object_literal_arg_callback_param_variance_tests.rs
+++ b/crates/tsz-checker/tests/fresh_object_literal_arg_callback_param_variance_tests.rs
@@ -1,0 +1,167 @@
+//! Regression coverage for the fresh-object-literal call-argument recovery gate.
+//!
+//! A fresh object literal passed as a call argument whose function-typed
+//! *property* member has a contravariantly-incompatible parameter must be
+//! rejected under `strictFunctionTypes`, exactly as `tsc` does (TS2322 on the
+//! property), and exactly as the same literal is rejected in assignment, return,
+//! array-element, and `satisfies` positions. The call path used to recover such
+//! arguments through `is_fresh_subtype_of` alone — the raw subtype relation
+//! compares property-position function members bivariantly — so a real
+//! parameter-variance mismatch was silently accepted only in argument position.
+//!
+//! Binder names are varied across cases so the behavior cannot key off any
+//! particular identifier.
+
+use tsz_checker::test_utils::{check_source_strict, diagnostic_codes};
+
+const TS2322: u32 = 2322;
+const TS2345: u32 = 2345;
+
+fn assert_has_code(source: &str, code: u32) {
+    let diags = check_source_strict(source);
+    assert!(
+        diags.iter().any(|diag| diag.code == code),
+        "expected TS{code}, got {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+fn assert_clean(source: &str) {
+    let diags = check_source_strict(source);
+    assert!(
+        diags.is_empty(),
+        "expected no diagnostics, got {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+// --- Negative cases: the mismatch must surface (was a false negative) ---
+
+#[test]
+fn fresh_object_literal_arg_rejects_contravariant_callback_param() {
+    // `(p: Square) => void` is not assignable to `(p: Shape) => void`.
+    let source = r#"
+interface Shape { kind: string; }
+interface Square extends Shape { side: number; }
+declare function render(opts: { draw: (p: Shape) => void }): void;
+render({ draw: (p: Square) => {} });
+"#;
+    assert_has_code(source, TS2322);
+}
+
+#[test]
+fn fresh_object_literal_arg_rejects_unrelated_callback_param() {
+    let source = r#"
+interface Shape { kind: string; }
+declare function render(opts: { draw: (p: Shape) => void }): void;
+render({ draw: (p: number) => {} });
+"#;
+    assert_has_code(source, TS2322);
+}
+
+#[test]
+fn nested_fresh_object_literal_arg_rejects_contravariant_callback_param() {
+    let source = r#"
+interface Node1 { id: string; }
+interface Leaf extends Node1 { value: number; }
+declare function mount(cfg: { inner: { visit: (n: Node1) => void } }): void;
+mount({ inner: { visit: (n: Leaf) => {} } });
+"#;
+    assert_has_code(source, TS2322);
+}
+
+#[test]
+fn spread_fresh_object_literal_arg_rejects_contravariant_callback_param() {
+    // The spread member carries the narrower annotated signature; the merged
+    // fresh literal must still be rejected (TS2345 on the whole argument).
+    let source = r#"
+interface Animal2 { name: string; }
+interface Cat extends Animal2 { whiskers: number; }
+declare function adopt(o: { feed: (a: Animal2) => void }): void;
+const partial = { feed: (a: Cat) => {} };
+adopt({ ...partial });
+"#;
+    assert_has_code(source, TS2345);
+}
+
+#[test]
+fn multiple_args_each_fresh_literal_is_checked() {
+    let source = r#"
+interface Base1 { tag: string; }
+interface Derived1 extends Base1 { extra: number; }
+declare function pair(
+    a: { on: (x: Base1) => void },
+    b: { on: (x: Base1) => void },
+): void;
+pair({ on: (x: Base1) => {} }, { on: (x: Derived1) => {} });
+"#;
+    assert_has_code(source, TS2322);
+}
+
+// --- Positive controls: legitimate recoveries must stay clean ---
+
+#[test]
+fn fresh_object_literal_arg_accepts_exact_callback() {
+    let source = r#"
+interface Evt { type: string; }
+declare function listen(o: { handler: (e: Evt) => void }): void;
+listen({ handler: (e: Evt) => {} });
+"#;
+    assert_clean(source);
+}
+
+#[test]
+fn fresh_object_literal_arg_accepts_wider_callback_param() {
+    // A wider parameter (`{}`) is sound for a `(e: Evt) => void` slot.
+    let source = r#"
+interface Evt { type: string; }
+declare function listen(o: { handler: (e: Evt) => void }): void;
+listen({ handler: (e: {}) => {} });
+"#;
+    assert_clean(source);
+}
+
+#[test]
+fn fresh_object_literal_arg_accepts_unannotated_callback_param() {
+    // The parameter type is supplied only by the contextual refresh — this is
+    // exactly the recovery the gate must preserve.
+    let source = r#"
+interface Evt { type: string; }
+declare function listen(o: { handler: (e: Evt) => void }): void;
+listen({ handler: (e) => { e.type; } });
+"#;
+    assert_clean(source);
+}
+
+#[test]
+fn fresh_object_literal_arg_accepts_method_target_bivariance() {
+    // A method-signature *target* is bivariant, matching tsc: a narrower
+    // parameter is accepted.
+    let source = r#"
+interface Shape { kind: string; }
+interface Square extends Shape { side: number; }
+declare function render(opts: { draw(p: Shape): void }): void;
+render({ draw: (p: Square) => {} });
+"#;
+    assert_clean(source);
+}
+
+#[test]
+fn generic_call_object_literal_callback_inference_stays_clean() {
+    let source = r#"
+declare function run<T, U>(o: { items: T[]; map: (x: T) => U }): U[];
+const out = run({ items: [1, 2, 3], map: (x) => x.toFixed() });
+"#;
+    assert_clean(source);
+}
+
+#[test]
+fn fresh_object_literal_arg_accepts_covariant_callback_return() {
+    let source = r#"
+interface Shape { kind: string; }
+interface Square extends Shape { side: number; }
+declare function make(o: { build: () => Shape }): void;
+make({ build: (): Square => ({ kind: "s", side: 1 }) });
+"#;
+    assert_clean(source);
+}


### PR DESCRIPTION
AgentName: lucid-hopper

Fixes #12918.

**Track:** conformance / soundness parity (false negative)
**Invariant:** `tsz` matches `tsc` exactly. A fresh object-literal call argument whose function-typed *property* member has a contravariantly-incompatible parameter is rejected (`TS2322`) under `strictFunctionTypes`, exactly as in assignment / return / array-element / `satisfies` positions and for non-fresh variable arguments.

## Structural rule

> When a fresh object-literal argument has a function-typed **property** member whose parameter is contravariantly incompatible with the parameter type, `tsc` rejects it (`TS2322` at the property) under `strictFunctionTypes`. Property-position function members are owed the strict contravariant parameter check; the call-argument mismatch-recovery must require the canonical call-argument assignability relation to hold (not merely the bivariant subtype relation) before recovering.

`When a fresh object-literal call argument carries a function-typed property whose parameter is contravariantly incompatible with the parameter type, tsc reports TS2322; tsz now does the same through the checker call-recovery gate routing the decision through call_arg_relation_outcome (the canonical TS2345/TS2322 call-argument relation boundary).`

## Root cause / owner layer

Owner layer: checker call-argument AST orchestration (`crates/tsz-checker/src/types/computation/call/{inner,mod}.rs`). No solver/relation semantics changed; the checker simply asks the solver the *right* question.

When the call checker reports `CallResult::ArgumentTypeMismatch` for a fresh object-literal argument in a non-generic call, a recovery block recomputes the argument type under the expected contextual type and, if the refreshed literal is a *fresh subtype* of the parameter, treats the call as a success (running only excess-property checking). The gate consulted **`is_fresh_subtype_of`** (the raw subtype relation) alone — that relation compares object-literal function-typed **property** members *bivariantly* (it honors the member `is_method` hint), so it accepts `{ f: (x: Dog) => void }` for `{ f: (x: Animal) => void }` because the one-directional `Dog <: Animal` holds. The canonical call-argument relation (`call_arg_relation_outcome`) correctly rejects it, but was never consulted, so a genuine mismatch was masked **only** in argument position. Traced ground truth for the repro: `actual = { f: (x: Dog) => void }` (unmasked), `is_fresh_subtype_of = true`, strict call-arg relation = `false`.

Fix: a shared `fresh_object_literal_argument_recovers` helper requires **both** `is_fresh_subtype_of` and `call_arg_relation_outcome(...).related`. Recovery is preserved for genuinely-assignable literals (e.g. callbacks whose parameters are only resolved by the contextual refresh).

## Adjacent-case matrix (verified vs `tsc` 6.0.3; binder names varied)

Now reject (were false negatives): direct fresh literal arg, spread literal arg, nested object-literal arg, one-of-several args. Still reject as before: assignment (`TS2322`), non-fresh variable arg (`TS2345`), unrelated-param literal (`TS2322`), return / array-element / `satisfies` positions. Stay clean (recovery preserved): exact callback, wider (sound) callback param, unannotated callback param resolved by contextual refresh, method-signature target (bivariant), generic-call callback inference, covariant callback return.

## Project Corpus Impact

- Row: n/a (removes a false negative; cannot regress a green row by adding a missing error that `tsc` also emits).
- Bug family: callback/function-property parameter variance in fresh object-literal arguments (`false-negative`).

This strictly surfaces errors `tsc` already emits in argument position; no relation/inference behavior changes for accepted code.

## Verification

- New `crates/tsz-checker/tests/fresh_object_literal_arg_callback_param_variance_tests.rs` (11 cases): 5 negative (direct/nested/spread/multi-arg/unrelated-param) + 6 positive controls (exact/wider/unannotated/method-target/generic/covariant-return). All green.
- Built `tsz` end-to-end: the repro matrix (direct, nested, spread, return, array, `satisfies`, method-target, generic) matches `tsc` 6.0.3 exactly (codes + positions + elaboration).
- Zero new failures across ~28 adjacent integration targets (contextual/callback/object-literal/excess-property/ts2322/bivariance) and `tsz-checker --lib`; the residual failures are byte-identical to a clean `main` baseline (confirmed by stashed diff).
- `cargo clippy -p tsz-checker --tests`, `cargo fmt --check`, and `scripts/arch/arch_guard.py` clean. The recovery gate routes through the `call_arg_relation_outcome` outcome boundary, satisfying `relation_routing_residual_arch_tests::production_checker_relation_truth_uses_outcome_boundaries` (no raw `is_assignable_to` in production code).
- `/simplify` reviewed (reuse / simplification / efficiency / altitude): converged with no changes — helper is the right boundary and altitude, the conjunction is non-redundant, ordering is short-circuit-optimal.

## Coordination Notes

Created and claimed #12918 (`WIP`). Discovered via differential testing; the open `bug` issues were all already `WIP` with in-flight PRs. Out of scope (separate, pre-existing core-relation campaign): `allow_bivariant = source.is_method || target.is_method` in `crates/tsz-solver/src/relations/subtype/rules/objects.rs` should be `target.is_method` per `tsc`, which makes a **method-shorthand source** vs **property target** mismatch missed in all positions; documented in #12918, not addressed here to keep this change contained and regression-free.

https://claude.ai/code/session_01T4ygAZE4Akm5wy7amfdyih

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4ygAZE4Akm5wy7amfdyih)_