### PR TITLE
refactor(checker): centralize assignability cache probe

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -2,10 +2,10 @@
 
 use crate::query_boundaries::assignability::{
     AssignabilityQueryInputs, RelationOutcome, RelationRequest, are_types_overlapping_with_env,
-    assignability_cache_key, check_application_variance_assignability, get_allowed_keys,
-    get_keyof_type, get_string_literal_value, get_union_members,
-    intersection_source_has_target_constituent, is_assignable_bivariant_with_resolver,
-    is_assignable_with_overrides, is_relation_cacheable, object_shape_for_type,
+    assignability_cache_key, cached_assignability_with_overrides,
+    check_application_variance_assignability, get_allowed_keys, get_keyof_type,
+    get_string_literal_value, get_union_members, intersection_source_has_target_constituent,
+    is_assignable_bivariant_with_resolver, is_relation_cacheable, object_shape_for_type,
 };
 use crate::query_boundaries::common::{
     has_call_signatures, has_construct_signatures, intersection_members, is_empty_object_type,
@@ -33,18 +33,10 @@ impl<'a> CheckerState<'a> {
         extra_flags: u16,
         label: &str,
     ) -> bool {
-        let is_cacheable = is_relation_cacheable(self.ctx.types, source, target);
         let flags = self.ctx.pack_relation_flags() | extra_flags;
 
-        if is_cacheable {
-            let cache_key = assignability_cache_key(source, target, flags);
-            if let Some(cached) = self.ctx.types.lookup_assignability_cache(cache_key) {
-                return cached;
-            }
-        }
-
         let overrides = CheckerOverrideProvider::new(self, None);
-        let relation_result = is_assignable_with_overrides(
+        let relation_result = cached_assignability_with_overrides(
             &AssignabilityQueryInputs {
                 db: self.ctx.types,
                 resolver: &self.ctx,
@@ -62,11 +54,6 @@ impl<'a> CheckerState<'a> {
             relation_result.depth_exceeded,
             relation_result.iteration_exceeded,
         );
-
-        if is_cacheable {
-            let cache_key = assignability_cache_key(source, target, flags);
-            self.ctx.types.insert_assignability_cache(cache_key, result);
-        }
 
         trace!(source = source.0, target = target.0, result, "{label}");
         result
@@ -1823,7 +1810,7 @@ impl<'a> CheckerState<'a> {
             let env = self.ctx.type_env.borrow();
             let flags = self.ctx.pack_relation_flags();
             let overrides = CheckerOverrideProvider::new(self, Some(&*env));
-            let relation_result = is_assignable_with_overrides(
+            let relation_result = cached_assignability_with_overrides(
                 &AssignabilityQueryInputs {
                     db: self.ctx.types,
                     resolver: &*env,

--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -2,10 +2,10 @@
 
 use crate::query_boundaries::assignability::{
     AssignabilityQueryInputs, RelationOutcome, RelationRequest, are_types_overlapping_with_env,
-    assignability_cache_key, cached_assignability_with_overrides,
+    cached_assignability_with_overrides, cached_bivariant_assignability_with_resolver,
     check_application_variance_assignability, get_allowed_keys, get_keyof_type,
     get_string_literal_value, get_union_members, intersection_source_has_target_constituent,
-    is_assignable_bivariant_with_resolver, is_relation_cacheable, object_shape_for_type,
+    object_shape_for_type,
 };
 use crate::query_boundaries::common::{
     has_call_signatures, has_construct_signatures, intersection_members, is_empty_object_type,
@@ -1904,11 +1904,6 @@ impl<'a> CheckerState<'a> {
         let source = self.evaluate_type_for_assignability(source);
         let target = self.evaluate_type_for_assignability(target);
 
-        // Check relation cache for non-inference types
-        // Construct RelationCacheKey with Lawyer-layer flags to prevent cache poisoning
-        // Note: Use ORIGINAL types for cache key, not evaluated types
-        let is_cacheable = is_relation_cacheable(self.ctx.types, source, target);
-
         // For bivariant checks, we strip the strict_function_types flag
         // so the cache key is distinct from regular assignability checks.
         // `extra_flags` lets callers force additional policy (e.g.
@@ -1917,19 +1912,9 @@ impl<'a> CheckerState<'a> {
             & !crate::query_boundaries::assignability::RelationFlags::STRICT_FUNCTION_TYPES)
             | extra_flags;
 
-        if is_cacheable {
-            // Note: For assignability checks, we use AnyPropagationMode::All (0)
-            // since the checker doesn't track depth like SubtypeChecker does
-            let cache_key = assignability_cache_key(source, target, flags);
-
-            if let Some(cached) = self.ctx.types.lookup_assignability_cache(cache_key) {
-                return cached;
-            }
-        }
-
         let env = self.ctx.type_env.borrow();
         // Preserve existing behavior: bivariant path does not use checker overrides.
-        let relation_result = is_assignable_bivariant_with_resolver(
+        let relation_result = cached_bivariant_assignability_with_resolver(
             self.ctx.types,
             &*env,
             source,
@@ -1943,14 +1928,6 @@ impl<'a> CheckerState<'a> {
             relation_result.iteration_exceeded,
         );
         let result = relation_result.is_related();
-
-        // Cache the result for non-inference types
-        // Use ORIGINAL types for cache key (not evaluated types)
-        if is_cacheable {
-            let cache_key = assignability_cache_key(source, target, flags);
-
-            self.ctx.types.insert_assignability_cache(cache_key, result);
-        }
 
         trace!(
             source = source.0,

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -1038,6 +1038,48 @@ pub(crate) fn is_assignable_bivariant_with_resolver<
     )
 }
 
+pub(crate) fn cached_bivariant_assignability_with_resolver<
+    R: tsz_solver::relations::subtype::TypeResolver,
+>(
+    db: &dyn QueryDatabase,
+    resolver: &R,
+    source: TypeId,
+    target: TypeId,
+    flags: u16,
+    inheritance_graph: &InheritanceGraph,
+    sound_mode: bool,
+) -> tsz_solver::relations::relation_queries::RelationResult {
+    let is_cacheable = is_relation_cacheable(db.as_type_database(), source, target);
+    if is_cacheable {
+        let cache_key = assignability_cache_key(source, target, flags);
+        if let Some(cached) = db.lookup_assignability_cache(cache_key) {
+            return tsz_solver::relations::relation_queries::RelationResult {
+                kind: tsz_solver::relations::relation_queries::RelationKind::AssignableBivariantCallbacks,
+                related: cached,
+                depth_exceeded: false,
+                iteration_exceeded: false,
+            };
+        }
+    }
+
+    let relation_result = is_assignable_bivariant_with_resolver(
+        db,
+        resolver,
+        source,
+        target,
+        flags,
+        inheritance_graph,
+        sound_mode,
+    );
+
+    if is_cacheable {
+        let cache_key = assignability_cache_key(source, target, flags);
+        db.insert_assignability_cache(cache_key, relation_result.is_related());
+    }
+
+    relation_result
+}
+
 pub(crate) fn is_subtype_with_resolver<R: tsz_solver::relations::subtype::TypeResolver>(
     db: &dyn QueryDatabase,
     resolver: &R,

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -918,6 +918,44 @@ pub(crate) fn is_assignable_with_overrides<R: tsz_solver::relations::subtype::Ty
     })
 }
 
+/// Execute an assignability relation through the boundary-owned checker cache.
+///
+/// Checker callers provide prepared relation inputs and the override provider,
+/// but the cacheability predicate, cache key construction, lookup, relation
+/// execution, and insert stay together here so cache policy cannot drift across
+/// call sites.
+pub(crate) fn cached_assignability_with_overrides<
+    R: tsz_solver::relations::subtype::TypeResolver,
+>(
+    inputs: &AssignabilityQueryInputs<'_, R>,
+    overrides: &dyn tsz_solver::relations::compat::AssignabilityOverrideProvider,
+) -> tsz_solver::relations::relation_queries::RelationResult {
+    let is_cacheable =
+        is_relation_cacheable(inputs.db.as_type_database(), inputs.source, inputs.target);
+    if is_cacheable {
+        let cache_key = assignability_cache_key(inputs.source, inputs.target, inputs.flags);
+        if let Some(cached) = inputs.db.lookup_assignability_cache(cache_key) {
+            return tsz_solver::relations::relation_queries::RelationResult {
+                kind: tsz_solver::relations::relation_queries::RelationKind::Assignable,
+                related: cached,
+                depth_exceeded: false,
+                iteration_exceeded: false,
+            };
+        }
+    }
+
+    let relation_result = is_assignable_with_overrides(inputs, overrides);
+
+    if is_cacheable {
+        let cache_key = assignability_cache_key(inputs.source, inputs.target, inputs.flags);
+        inputs
+            .db
+            .insert_assignability_cache(cache_key, relation_result.is_related());
+    }
+
+    relation_result
+}
+
 /// Like `is_assignable_with_overrides` but skips weak type checks (TS2559).
 ///
 /// This matches tsc's `isTypeAssignableTo` behavior, which does NOT

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs
@@ -667,8 +667,12 @@ fn test_def_symbol_bridge_writes_route_through_dual_env_helper() {
 
 #[test]
 fn test_assignability_checker_routes_relation_queries_through_query_boundaries() {
-    let assignability_source = fs::read_to_string("src/assignability/assignability_checker.rs")
+    let mut assignability_source = fs::read_to_string("src/assignability/assignability_checker.rs")
         .expect("failed to read src/assignability/assignability_checker.rs for architecture guard");
+    assignability_source.push_str(
+        &fs::read_to_string("src/assignability/assignability_relation.rs")
+            .expect("failed to read src/assignability/assignability_relation.rs"),
+    );
     let subtype_source = fs::read_to_string("src/assignability/subtype_identity_checker.rs")
         .expect(
             "failed to read src/assignability/subtype_identity_checker.rs for architecture guard",
@@ -691,8 +695,8 @@ fn test_assignability_checker_routes_relation_queries_through_query_boundaries()
 
     // Assignability helpers live in assignability_checker
     assert!(
-        assignability_source.contains("is_assignable_with_overrides("),
-        "assignability_checker should use query_boundaries::assignability::is_assignable_with_overrides"
+        assignability_source.contains("cached_assignability_with_overrides("),
+        "assignability_checker should use query_boundaries::assignability::cached_assignability_with_overrides"
     );
     assert!(
         assignability_source.contains("is_assignable_bivariant_with_resolver("),
@@ -708,6 +712,33 @@ fn test_assignability_checker_routes_relation_queries_through_query_boundaries()
         subtype_source.contains("is_redeclaration_identical_with_resolver("),
         "subtype_identity_checker should use query_boundaries::assignability::is_redeclaration_identical_with_resolver"
     );
+}
+
+#[test]
+fn test_assignability_cached_relation_uses_boundary_owned_cache_probe() {
+    let source = fs::read_to_string("src/assignability/assignability_relation.rs")
+        .expect("failed to read src/assignability/assignability_relation.rs");
+    let helper_body = source
+        .split("fn check_assignability_cached(")
+        .nth(1)
+        .and_then(|tail| tail.split("fn namespace_source_has_matching_property_mismatch").next())
+        .expect("failed to locate check_assignability_cached body");
+
+    assert!(
+        helper_body.contains("cached_assignability_with_overrides("),
+        "check_assignability_cached should delegate cache lookup, relation execution, and cache insert to query_boundaries::assignability"
+    );
+    for forbidden in [
+        "assignability_cache_key(",
+        "is_relation_cacheable(",
+        "lookup_assignability_cache(",
+        "insert_assignability_cache(",
+    ] {
+        assert!(
+            !helper_body.contains(forbidden),
+            "check_assignability_cached should not own relation-cache internals: found {forbidden}"
+        );
+    }
 }
 
 #[test]

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs
@@ -699,8 +699,8 @@ fn test_assignability_checker_routes_relation_queries_through_query_boundaries()
         "assignability_checker should use query_boundaries::assignability::cached_assignability_with_overrides"
     );
     assert!(
-        assignability_source.contains("is_assignable_bivariant_with_resolver("),
-        "assignability_checker should use query_boundaries::assignability::is_assignable_bivariant_with_resolver"
+        assignability_source.contains("cached_bivariant_assignability_with_resolver("),
+        "assignability_checker should use query_boundaries::assignability::cached_bivariant_assignability_with_resolver"
     );
 
     // Subtype/redecl/union helpers live in subtype_identity_checker
@@ -737,6 +737,33 @@ fn test_assignability_cached_relation_uses_boundary_owned_cache_probe() {
         assert!(
             !helper_body.contains(forbidden),
             "check_assignability_cached should not own relation-cache internals: found {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn test_bivariant_assignability_relation_uses_boundary_owned_cache_probe() {
+    let source = fs::read_to_string("src/assignability/assignability_relation.rs")
+        .expect("failed to read src/assignability/assignability_relation.rs");
+    let helper_body = source
+        .split("fn is_assignable_to_bivariant_with_extra_flags(")
+        .nth(1)
+        .and_then(|tail| tail.split("pub fn are_types_overlapping").next())
+        .expect("failed to locate is_assignable_to_bivariant_with_extra_flags body");
+
+    assert!(
+        helper_body.contains("cached_bivariant_assignability_with_resolver("),
+        "bivariant assignability should delegate cache lookup, relation execution, and cache insert to query_boundaries::assignability"
+    );
+    for forbidden in [
+        "assignability_cache_key(",
+        "is_relation_cacheable(",
+        "lookup_assignability_cache(",
+        "insert_assignability_cache(",
+    ] {
+        assert!(
+            !helper_body.contains(forbidden),
+            "bivariant assignability should not own relation-cache internals: found {forbidden}"
         );
     }
 }


### PR DESCRIPTION
## Agent
AgentName: M5Refactorer

## Track
Checker/query-boundary simplification (#8225/#8227)

## Invariant
When checker code runs normal or bivariant assignability relations, cacheability, key construction, lookup, relation execution, and insertion should remain inside `query_boundaries::assignability` instead of being repeated in checker orchestration.

## Scope
- Adds `cached_assignability_with_overrides` to `query_boundaries::assignability`.
- Adds `cached_bivariant_assignability_with_resolver` for the bivariant callback relation policy.
- Routes normal and bivariant assignability relation callers in `assignability_relation.rs` through boundary-owned cached helpers.
- Adds architecture ratchets forbidding local cache sandwiches in both relation paths.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: Refactor-only relation cache ownership cleanup; no relation policy change intended.

## Verification
- `scripts/safe-run.sh cargo test -p tsz-checker --lib test_assignability_cached_relation_uses_boundary_owned_cache_probe -- --nocapture`
- `scripts/safe-run.sh cargo test -p tsz-checker --lib test_bivariant_assignability_relation_uses_boundary_owned_cache_probe -- --nocapture`
- `scripts/safe-run.sh cargo test -p tsz-checker --lib test_assignability_checker_routes_relation_queries_through_query_boundaries -- --nocapture`
- `scripts/safe-run.sh python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Non-overlapping with #12916 (`query_boundaries/common.rs`) and #12917 (`checkers/jsx`).
- Display helper cleanup is intentionally deferred until #12916 lands because it already owns the first `common.rs` diagnostic-helper extraction.