### PR TITLE
refactor(checker): route excess property tail type queries

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
@@ -108,8 +108,7 @@ impl<'a> CheckerState<'a> {
         nested_target: TypeId,
         outer_intersection: TypeId,
     ) -> TypeId {
-        let Some(outer_members) =
-            tsz_solver::type_queries::get_intersection_members(self.ctx.types, outer_intersection)
+        let Some(outer_members) = query::intersection_members(self.ctx.types, outer_intersection)
         else {
             return nested_target;
         };
@@ -132,8 +131,7 @@ impl<'a> CheckerState<'a> {
     }
 
     fn single_non_undefined_member(&self, type_id: TypeId) -> Option<(TypeId, bool)> {
-        let Some(members) = tsz_solver::type_queries::get_union_members(self.ctx.types, type_id)
-        else {
+        let Some(members) = query::union_members(self.ctx.types, type_id) else {
             return (type_id != TypeId::UNDEFINED).then_some((type_id, false));
         };
         let has_undefined = members.contains(&TypeId::UNDEFINED);
@@ -147,9 +145,8 @@ impl<'a> CheckerState<'a> {
     /// Returns the `TypeId` of an enclosing intersection reachable from `target`:
     /// the type itself, its `Lazy` body, or an intersection member of a union wrapper.
     fn recover_outer_intersection_from_target(&self, target: TypeId) -> Option<TypeId> {
-        let is_intersection = |t: TypeId| {
-            tsz_solver::type_queries::get_intersection_members(self.ctx.types, t).is_some()
-        };
+        let is_intersection =
+            |t: TypeId| query::intersection_members(self.ctx.types, t).is_some();
         if is_intersection(target) {
             return Some(target);
         }
@@ -159,7 +156,7 @@ impl<'a> CheckerState<'a> {
         {
             return Some(body);
         }
-        tsz_solver::type_queries::get_union_members(self.ctx.types, target)?
+        query::union_members(self.ctx.types, target)?
             .into_iter()
             .find(|&member| is_intersection(member))
     }
@@ -175,9 +172,7 @@ impl<'a> CheckerState<'a> {
         nested_target: TypeId,
         outer_object: TypeId,
     ) -> TypeId {
-        let Some(_outer_shape) =
-            tsz_solver::type_queries::get_object_shape(self.ctx.types, outer_object)
-        else {
+        let Some(_outer_shape) = query::object_shape(self.ctx.types, outer_object) else {
             return nested_target;
         };
 
@@ -194,8 +189,7 @@ impl<'a> CheckerState<'a> {
             return nested_target;
         };
 
-        let Some(body_shape) = tsz_solver::type_queries::get_object_shape(self.ctx.types, body)
-        else {
+        let Some(body_shape) = query::object_shape(self.ctx.types, body) else {
             return nested_target;
         };
 
@@ -251,8 +245,7 @@ impl<'a> CheckerState<'a> {
         ) {
             return true;
         }
-        if let Some(members) = tsz_solver::type_queries::get_union_members(self.ctx.types, type_id)
-        {
+        if let Some(members) = query::union_members(self.ctx.types, type_id) {
             return members
                 .iter()
                 .any(|&m| self.type_directly_references_def(m, target_def_id));

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs
@@ -1238,6 +1238,26 @@ fn test_assignment_and_binding_default_assignability_use_central_gateway_helpers
 }
 
 #[test]
+fn test_excess_property_tail_routes_type_queries_through_state_boundary() {
+    let source = fs::read_to_string("src/state/state_checking/property/excess_property_tail.rs")
+        .expect("failed to read src/state/state_checking/property/excess_property_tail.rs");
+    assert!(
+        !source.contains("tsz_solver::type_queries::"),
+        "state_property_checking excess-property tail should route solver type-query access through query_boundaries::state::checking"
+    );
+    for boundary_call in [
+        "query::intersection_members(",
+        "query::union_members(",
+        "query::object_shape(",
+    ] {
+        assert!(
+            source.contains(boundary_call),
+            "excess-property tail should use {boundary_call} for solver shape queries"
+        );
+    }
+}
+
+#[test]
 fn test_type_cache_surface_excludes_application_and_mapped_eval_caches() {
     let context_src = fs::read_to_string("src/context/mod.rs")
         .expect("failed to read src/context/mod.rs for guard");


### PR DESCRIPTION
## Agent
AgentName: M5Refactorer

## Track
Checker/query-boundary simplification (#8225/#8227)

## Invariant
When excess-property tail checking needs union, intersection, or object-shape facts, checker state code should ask `query_boundaries::state::checking`; raw solver `type_queries` stay behind query boundaries.

## Scope
- Replaces direct `tsz_solver::type_queries::{get_union_members,get_intersection_members,get_object_shape}` calls in `state/state_checking/property/excess_property_tail.rs` with the existing `query` boundary aliases.
- Adds a focused architecture ratchet for the cleaned excess-property tail module.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: Refactor-only query-boundary routing cleanup; no excess-property policy change intended.

## Verification
- `scripts/safe-run.sh cargo test -p tsz-checker --lib test_excess_property_tail_routes_type_queries_through_state_boundary -- --nocapture`
- `scripts/safe-run.sh python3 scripts/arch/arch_guard.py`

## Coordination Notes
- Non-overlapping with #12916 (`query_boundaries/common.rs`), #12917 (`checkers/jsx`), and #12920 (`assignability_relation.rs` / `query_boundaries/assignability.rs`).
- A broader existing architecture contract has an unrelated pre-existing failure on this base, so this PR adds and verifies a focused ratchet for the cleaned module.