### PR TITLE
refactor(checker): centralize key constraint helpers

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/key_constraints.rs
+++ b/crates/tsz-checker/src/query_boundaries/key_constraints.rs
@@ -13,3 +13,234 @@ pub(crate) fn is_symbol_only_key_constraint(db: &dyn TypeDatabase, type_id: Type
                 .all(|&member| is_symbol_only_key_constraint(db, member))
     })
 }
+
+pub(crate) fn is_generic_index_type(db: &dyn TypeDatabase, index_type: TypeId) -> bool {
+    super::common::is_type_parameter(db, index_type)
+        || super::common::keyof_inner_type(db, index_type).is_some()
+        || super::common::is_index_access_type(db, index_type)
+        || super::common::is_conditional_type(db, index_type)
+        || super::common::is_generic_application(db, index_type)
+        || super::common::union_members(db, index_type).is_some_and(|members| {
+            members
+                .iter()
+                .any(|&member| is_generic_index_type(db, member))
+        })
+        || intersection_has_generic_index(db, index_type)
+}
+
+pub(crate) fn intersection_has_generic_index(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    super::common::intersection_members(db, type_id).is_some_and(|members| {
+        members
+            .iter()
+            .any(|&member| is_generic_index_type(db, member))
+    })
+}
+
+pub(crate) fn index_resolves_to_keyof_of_receiver<F>(
+    db: &dyn TypeDatabase,
+    index_type: TypeId,
+    evaluated_receiver: TypeId,
+    evaluate: &mut F,
+) -> bool
+where
+    F: FnMut(TypeId) -> TypeId,
+{
+    if let Some(members) = super::common::intersection_members(db, index_type) {
+        return members.iter().copied().any(|member| {
+            index_resolves_to_keyof_of_receiver(db, member, evaluated_receiver, evaluate)
+        });
+    }
+    if let Some(inner) = super::common::keyof_inner_type(db, index_type) {
+        return evaluate(inner) == evaluated_receiver;
+    }
+    if let Some(param_info) = super::common::type_param_info(db, index_type)
+        && let Some(constraint) = param_info.constraint
+        && let Some(inner) = super::common::keyof_inner_type(db, constraint)
+    {
+        return evaluate(inner) == evaluated_receiver;
+    }
+    false
+}
+
+pub(crate) fn is_valid_index_for_type_param<F>(
+    db: &dyn TypeDatabase,
+    index_type: TypeId,
+    type_param: TypeId,
+    evaluate: &mut F,
+) -> bool
+where
+    F: FnMut(TypeId) -> TypeId,
+{
+    if let Some(members) = super::common::intersection_members(db, index_type) {
+        return members
+            .iter()
+            .copied()
+            .any(|member| is_valid_index_for_type_param(db, member, type_param, evaluate));
+    }
+    if super::common::is_generic_application(db, index_type) {
+        let evaluated = evaluate(index_type);
+        if evaluated != index_type && evaluated != TypeId::ERROR {
+            return is_valid_index_for_type_param(db, evaluated, type_param, evaluate);
+        }
+    }
+    if let Some(keyof_inner) = super::common::keyof_inner_type(db, index_type) {
+        return same_type_param_identity(db, keyof_inner, type_param)
+            || super::common::type_param_info(db, type_param)
+                .and_then(|param| param.constraint)
+                .is_some_and(|constraint| same_type_param_identity(db, constraint, keyof_inner));
+    }
+    if let Some(param_info) = super::common::type_param_info(db, index_type)
+        && let Some(constraint) = param_info.constraint
+        && let Some(keyof_inner) = super::common::keyof_inner_type(db, constraint)
+    {
+        return same_type_param_identity(db, keyof_inner, type_param)
+            || super::common::type_param_info(db, type_param)
+                .and_then(|param| param.constraint)
+                .is_some_and(|constraint| same_type_param_identity(db, constraint, keyof_inner));
+    }
+    false
+}
+
+pub(crate) fn same_type_param_identity(db: &dyn TypeDatabase, left: TypeId, right: TypeId) -> bool {
+    left == right
+        || super::common::type_param_info(db, left)
+            .zip(super::common::type_param_info(db, right))
+            .is_some_and(|(l, r)| l.name == r.name)
+}
+
+pub(crate) fn type_contains_same_type_param_identity<F>(
+    db: &dyn TypeDatabase,
+    ty: TypeId,
+    type_param: TypeId,
+    evaluate: &mut F,
+) -> bool
+where
+    F: FnMut(TypeId) -> TypeId,
+{
+    if same_type_param_identity(db, ty, type_param) {
+        return true;
+    }
+    if let Some(inner) = super::common::keyof_inner_type(db, ty)
+        && type_contains_same_type_param_identity(db, inner, type_param, evaluate)
+    {
+        return true;
+    }
+    if let Some((object_type, index_type)) = super::common::index_access_types(db, ty)
+        && (type_contains_same_type_param_identity(db, object_type, type_param, evaluate)
+            || type_contains_same_type_param_identity(db, index_type, type_param, evaluate))
+    {
+        return true;
+    }
+    if let Some(members) = super::common::union_members(db, ty)
+        && members
+            .iter()
+            .any(|&member| type_contains_same_type_param_identity(db, member, type_param, evaluate))
+    {
+        return true;
+    }
+    if let Some(members) = super::common::intersection_members(db, ty)
+        && members
+            .iter()
+            .any(|&member| type_contains_same_type_param_identity(db, member, type_param, evaluate))
+    {
+        return true;
+    }
+    if let Some(param_info) = super::common::type_param_info(db, ty)
+        && let Some(constraint) = param_info.constraint
+        && type_contains_same_type_param_identity(db, constraint, type_param, evaluate)
+    {
+        return true;
+    }
+    if super::common::is_generic_application(db, ty) {
+        let evaluated = evaluate(ty);
+        if evaluated != ty
+            && evaluated != TypeId::ERROR
+            && type_contains_same_type_param_identity(db, evaluated, type_param, evaluate)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+pub(crate) fn generic_index_mentions_transformed_current_type_param<F>(
+    db: &dyn TypeDatabase,
+    index_type: TypeId,
+    type_param: TypeId,
+    evaluate: &mut F,
+) -> bool
+where
+    F: FnMut(TypeId) -> TypeId,
+{
+    if let Some(keyof_inner) = super::common::keyof_inner_type(db, index_type) {
+        return !same_type_param_identity(db, keyof_inner, type_param)
+            && type_contains_same_type_param_identity(db, keyof_inner, type_param, evaluate);
+    }
+    if let Some(param_info) = super::common::type_param_info(db, index_type)
+        && let Some(constraint) = param_info.constraint
+    {
+        return generic_index_mentions_transformed_current_type_param(
+            db, constraint, type_param, evaluate,
+        );
+    }
+    if let Some(members) = super::common::union_members(db, index_type) {
+        return members.iter().any(|&member| {
+            generic_index_mentions_transformed_current_type_param(db, member, type_param, evaluate)
+        });
+    }
+    if let Some(members) = super::common::intersection_members(db, index_type) {
+        return members.iter().any(|&member| {
+            generic_index_mentions_transformed_current_type_param(db, member, type_param, evaluate)
+        });
+    }
+    if super::common::is_generic_application(db, index_type) {
+        let evaluated = evaluate(index_type);
+        if evaluated != index_type && evaluated != TypeId::ERROR {
+            return generic_index_mentions_transformed_current_type_param(
+                db, evaluated, type_param, evaluate,
+            );
+        }
+    }
+    false
+}
+
+pub(crate) fn keyof_source_type_param(
+    db: &dyn TypeDatabase,
+    index_type: TypeId,
+    type_param: TypeId,
+) -> Option<TypeId> {
+    if let Some(keyof_inner) = super::common::keyof_inner_type(db, index_type)
+        && super::common::is_type_parameter(db, keyof_inner)
+        && keyof_inner != type_param
+    {
+        return Some(keyof_inner);
+    }
+    if let Some(param_info) = super::common::type_param_info(db, index_type)
+        && let Some(constraint) = param_info.constraint
+        && let Some(keyof_inner) = super::common::keyof_inner_type(db, constraint)
+        && super::common::is_type_parameter(db, keyof_inner)
+        && keyof_inner != type_param
+    {
+        return Some(keyof_inner);
+    }
+    None
+}
+
+pub(crate) fn is_generic_key_space(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    if super::common::keyof_inner_type(db, type_id).is_some()
+        || super::common::is_type_parameter(db, type_id)
+    {
+        return true;
+    }
+    if let Some(members) = super::common::union_members(db, type_id) {
+        return members
+            .iter()
+            .all(|&member| is_generic_key_space(db, member));
+    }
+    if let Some(members) = super::common::intersection_members(db, type_id) {
+        return members
+            .iter()
+            .all(|&member| is_generic_key_space(db, member));
+    }
+    false
+}

--- a/crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs
@@ -63,6 +63,59 @@ fn indexed_access_key_space_helpers_use_relation_outcome_boundary() {
 }
 
 #[test]
+fn generic_index_policy_helpers_use_key_constraints_boundary() {
+    let source_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("src/types/computation/access_helpers.rs");
+    let source = fs::read_to_string(&source_path).expect("read access helper source");
+
+    let helper_names = [
+        "is_generic_index_type",
+        "intersection_has_generic_index",
+        "index_resolves_to_keyof_of_receiver",
+        "is_valid_index_for_type_param",
+        "same_type_param_identity",
+        "type_contains_same_type_param_identity",
+        "generic_index_mentions_transformed_current_type_param",
+        "keyof_source_type_param",
+        "is_generic_key_space",
+    ];
+
+    for helper_name in helper_names {
+        let signature = if helper_name == "index_resolves_to_keyof_of_receiver"
+            || helper_name == "same_type_param_identity"
+            || helper_name == "type_contains_same_type_param_identity"
+        {
+            format!("fn {helper_name}")
+        } else {
+            format!("pub(crate) fn {helper_name}")
+        };
+        let helper_start = source
+            .find(&signature)
+            .unwrap_or_else(|| panic!("find generic index policy helper signature: {signature}"));
+        let helper = &source[helper_start..];
+        let helper_end = [
+            helper.find("\n    fn "),
+            helper.find("\n    pub(crate) fn "),
+        ]
+        .into_iter()
+        .flatten()
+        .filter(|&idx| idx > 0)
+        .min()
+        .unwrap_or(helper.len());
+        let helper_body = &helper[..helper_end];
+
+        assert!(
+            !helper_body.contains("query_boundaries::common::"),
+            "{helper_name} should route key/index shape policy through query_boundaries::key_constraints"
+        );
+        assert!(
+            helper_body.contains("query_boundaries::key_constraints::"),
+            "{helper_name} should call the key_constraints query boundary"
+        );
+    }
+}
+
+#[test]
 fn indexed_access_type_checking_helpers_use_relation_outcome_boundary() {
     let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("src/types/type_checking/indexed_access/indexed_access_helpers.rs");

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -502,18 +502,7 @@ impl<'a> CheckerState<'a> {
     /// conditional types, and intersections containing any of the above
     /// (e.g., `keyof Boxified<T> & string` from for-in variable typing).
     pub(crate) fn is_generic_index_type(&self, index_type: TypeId) -> bool {
-        crate::query_boundaries::common::is_type_parameter(self.ctx.types, index_type)
-            || crate::query_boundaries::common::keyof_inner_type(self.ctx.types, index_type)
-                .is_some()
-            || crate::query_boundaries::common::is_index_access_type(self.ctx.types, index_type)
-            || crate::query_boundaries::common::is_conditional_type(self.ctx.types, index_type)
-            || crate::query_boundaries::common::is_generic_application(self.ctx.types, index_type)
-            || query::union_members(self.ctx.types, index_type).is_some_and(|members| {
-                members
-                    .iter()
-                    .any(|&member| self.is_generic_index_type(member))
-            })
-            || self.intersection_has_generic_index(index_type)
+        crate::query_boundaries::key_constraints::is_generic_index_type(self.ctx.types, index_type)
     }
 
     /// Check if an intersection type contains a generic index member.
@@ -522,13 +511,10 @@ impl<'a> CheckerState<'a> {
     /// which is an intersection. This helper recursively checks whether any
     /// member of the intersection is a generic index type.
     pub(crate) fn intersection_has_generic_index(&self, type_id: TypeId) -> bool {
-        if let Some(members) =
-            crate::query_boundaries::common::intersection_members(self.ctx.types, type_id)
-        {
-            members.iter().any(|&m| self.is_generic_index_type(m))
-        } else {
-            false
-        }
+        crate::query_boundaries::key_constraints::intersection_has_generic_index(
+            self.ctx.types,
+            type_id,
+        )
     }
 
     /// Preserve deferred indexed-access identity for generic write targets whose
@@ -656,27 +642,13 @@ impl<'a> CheckerState<'a> {
         index_type: TypeId,
         evaluated_receiver: TypeId,
     ) -> bool {
-        if let Some(members) =
-            crate::query_boundaries::common::intersection_members(self.ctx.types, index_type)
-        {
-            return members.iter().copied().any(|member| {
-                self.index_resolves_to_keyof_of_receiver(member, evaluated_receiver)
-            });
-        }
-        if let Some(inner) =
-            crate::query_boundaries::common::keyof_inner_type(self.ctx.types, index_type)
-        {
-            return self.evaluate_type_with_env(inner) == evaluated_receiver;
-        }
-        if let Some(param_info) =
-            crate::query_boundaries::common::type_param_info(self.ctx.types, index_type)
-            && let Some(constraint) = param_info.constraint
-            && let Some(inner) =
-                crate::query_boundaries::common::keyof_inner_type(self.ctx.types, constraint)
-        {
-            return self.evaluate_type_with_env(inner) == evaluated_receiver;
-        }
-        false
+        let types = self.ctx.types;
+        crate::query_boundaries::key_constraints::index_resolves_to_keyof_of_receiver(
+            types,
+            index_type,
+            evaluated_receiver,
+            &mut |ty| self.evaluate_type_with_env(ty),
+        )
     }
 
     /// Check if an index type is known to be a valid key for a given type parameter.
@@ -689,46 +661,13 @@ impl<'a> CheckerState<'a> {
         index_type: TypeId,
         type_param: TypeId,
     ) -> bool {
-        if let Some(members) =
-            crate::query_boundaries::common::intersection_members(self.ctx.types, index_type)
-        {
-            return members
-                .iter()
-                .copied()
-                .any(|member| self.is_valid_index_for_type_param(member, type_param));
-        }
-        if crate::query_boundaries::common::is_generic_application(self.ctx.types, index_type) {
-            let evaluated = self.evaluate_type_with_env(index_type);
-            if evaluated != index_type && evaluated != TypeId::ERROR {
-                return self.is_valid_index_for_type_param(evaluated, type_param);
-            }
-        }
-        // Direct keyof T
-        if let Some(keyof_inner) =
-            crate::query_boundaries::common::keyof_inner_type(self.ctx.types, index_type)
-        {
-            return self.same_type_param_identity(keyof_inner, type_param)
-                || crate::query_boundaries::common::type_param_info(self.ctx.types, type_param)
-                    .and_then(|param| param.constraint)
-                    .is_some_and(|constraint| {
-                        self.same_type_param_identity(constraint, keyof_inner)
-                    });
-        }
-        // K extends keyof T (type param whose constraint is keyof T)
-        if let Some(param_info) =
-            crate::query_boundaries::common::type_param_info(self.ctx.types, index_type)
-            && let Some(constraint) = param_info.constraint
-            && let Some(keyof_inner) =
-                crate::query_boundaries::common::keyof_inner_type(self.ctx.types, constraint)
-        {
-            return self.same_type_param_identity(keyof_inner, type_param)
-                || crate::query_boundaries::common::type_param_info(self.ctx.types, type_param)
-                    .and_then(|param| param.constraint)
-                    .is_some_and(|constraint| {
-                        self.same_type_param_identity(constraint, keyof_inner)
-                    });
-        }
-        false
+        let types = self.ctx.types;
+        crate::query_boundaries::key_constraints::is_valid_index_for_type_param(
+            types,
+            index_type,
+            type_param,
+            &mut |ty| self.evaluate_type_with_env(ty),
+        )
     }
 
     pub(crate) fn constraint_keyof_write_target_for_type_param(
@@ -779,70 +718,21 @@ impl<'a> CheckerState<'a> {
     }
 
     fn same_type_param_identity(&self, left: TypeId, right: TypeId) -> bool {
-        left == right
-            || crate::query_boundaries::common::type_param_info(self.ctx.types, left)
-                .zip(crate::query_boundaries::common::type_param_info(
-                    self.ctx.types,
-                    right,
-                ))
-                .is_some_and(|(l, r)| l.name == r.name)
+        crate::query_boundaries::key_constraints::same_type_param_identity(
+            self.ctx.types,
+            left,
+            right,
+        )
     }
 
     fn type_contains_same_type_param_identity(&mut self, ty: TypeId, type_param: TypeId) -> bool {
-        if self.same_type_param_identity(ty, type_param) {
-            return true;
-        }
-
-        if let Some(inner) = crate::query_boundaries::common::keyof_inner_type(self.ctx.types, ty)
-            && self.type_contains_same_type_param_identity(inner, type_param)
-        {
-            return true;
-        }
-
-        if let Some((object_type, index_type)) =
-            crate::query_boundaries::common::index_access_types(self.ctx.types, ty)
-            && (self.type_contains_same_type_param_identity(object_type, type_param)
-                || self.type_contains_same_type_param_identity(index_type, type_param))
-        {
-            return true;
-        }
-
-        if let Some(members) = crate::query_boundaries::common::union_members(self.ctx.types, ty)
-            && members
-                .iter()
-                .any(|&member| self.type_contains_same_type_param_identity(member, type_param))
-        {
-            return true;
-        }
-
-        if let Some(members) =
-            crate::query_boundaries::common::intersection_members(self.ctx.types, ty)
-            && members
-                .iter()
-                .any(|&member| self.type_contains_same_type_param_identity(member, type_param))
-        {
-            return true;
-        }
-
-        if let Some(param_info) =
-            crate::query_boundaries::common::type_param_info(self.ctx.types, ty)
-            && let Some(constraint) = param_info.constraint
-            && self.type_contains_same_type_param_identity(constraint, type_param)
-        {
-            return true;
-        }
-
-        if crate::query_boundaries::common::is_generic_application(self.ctx.types, ty) {
-            let evaluated = self.evaluate_type_with_env(ty);
-            if evaluated != ty
-                && evaluated != TypeId::ERROR
-                && self.type_contains_same_type_param_identity(evaluated, type_param)
-            {
-                return true;
-            }
-        }
-
-        false
+        let types = self.ctx.types;
+        crate::query_boundaries::key_constraints::type_contains_same_type_param_identity(
+            types,
+            ty,
+            type_param,
+            &mut |candidate| self.evaluate_type_with_env(candidate),
+        )
     }
 
     pub(crate) fn generic_index_mentions_transformed_current_type_param(
@@ -850,46 +740,13 @@ impl<'a> CheckerState<'a> {
         index_type: TypeId,
         type_param: TypeId,
     ) -> bool {
-        if let Some(keyof_inner) =
-            crate::query_boundaries::common::keyof_inner_type(self.ctx.types, index_type)
-        {
-            return !self.same_type_param_identity(keyof_inner, type_param)
-                && self.type_contains_same_type_param_identity(keyof_inner, type_param);
-        }
-
-        if let Some(param_info) =
-            crate::query_boundaries::common::type_param_info(self.ctx.types, index_type)
-            && let Some(constraint) = param_info.constraint
-        {
-            return self
-                .generic_index_mentions_transformed_current_type_param(constraint, type_param);
-        }
-
-        if let Some(members) =
-            crate::query_boundaries::common::union_members(self.ctx.types, index_type)
-        {
-            return members.iter().any(|&member| {
-                self.generic_index_mentions_transformed_current_type_param(member, type_param)
-            });
-        }
-
-        if let Some(members) =
-            crate::query_boundaries::common::intersection_members(self.ctx.types, index_type)
-        {
-            return members.iter().any(|&member| {
-                self.generic_index_mentions_transformed_current_type_param(member, type_param)
-            });
-        }
-
-        if crate::query_boundaries::common::is_generic_application(self.ctx.types, index_type) {
-            let evaluated = self.evaluate_type_with_env(index_type);
-            if evaluated != index_type && evaluated != TypeId::ERROR {
-                return self
-                    .generic_index_mentions_transformed_current_type_param(evaluated, type_param);
-            }
-        }
-
-        false
+        let types = self.ctx.types;
+        crate::query_boundaries::key_constraints::generic_index_mentions_transformed_current_type_param(
+            types,
+            index_type,
+            type_param,
+            &mut |ty| self.evaluate_type_with_env(ty),
+        )
     }
 
     /// Return the type parameter source when `index_type` is `keyof S` or `K extends keyof S`
@@ -903,26 +760,11 @@ impl<'a> CheckerState<'a> {
         index_type: TypeId,
         type_param: TypeId,
     ) -> Option<TypeId> {
-        if let Some(keyof_inner) =
-            crate::query_boundaries::common::keyof_inner_type(self.ctx.types, index_type)
-            && crate::query_boundaries::common::is_type_parameter(self.ctx.types, keyof_inner)
-            && keyof_inner != type_param
-        {
-            return Some(keyof_inner);
-        }
-
-        if let Some(param_info) =
-            crate::query_boundaries::common::type_param_info(self.ctx.types, index_type)
-            && let Some(constraint) = param_info.constraint
-            && let Some(keyof_inner) =
-                crate::query_boundaries::common::keyof_inner_type(self.ctx.types, constraint)
-            && crate::query_boundaries::common::is_type_parameter(self.ctx.types, keyof_inner)
-            && keyof_inner != type_param
-        {
-            return Some(keyof_inner);
-        }
-
-        None
+        crate::query_boundaries::key_constraints::keyof_source_type_param(
+            self.ctx.types,
+            index_type,
+            type_param,
+        )
     }
 
     /// Check whether `object_param[keyof key_source]` is valid because the
@@ -980,29 +822,7 @@ impl<'a> CheckerState<'a> {
     }
 
     pub(crate) fn is_generic_key_space(&self, type_id: TypeId) -> bool {
-        if crate::query_boundaries::common::keyof_inner_type(self.ctx.types, type_id).is_some()
-            || crate::query_boundaries::common::is_type_parameter(self.ctx.types, type_id)
-        {
-            return true;
-        }
-
-        if let Some(members) =
-            crate::query_boundaries::common::union_members(self.ctx.types, type_id)
-        {
-            return members
-                .iter()
-                .all(|&member| self.is_generic_key_space(member));
-        }
-
-        if let Some(members) =
-            crate::query_boundaries::common::intersection_members(self.ctx.types, type_id)
-        {
-            return members
-                .iter()
-                .all(|&member| self.is_generic_key_space(member));
-        }
-
-        false
+        crate::query_boundaries::key_constraints::is_generic_key_space(self.ctx.types, type_id)
     }
 
     /// When `index_node` is a `symbol`-typed identifier, follow its import


### PR DESCRIPTION
## Agent
AgentName: M5Refactorer

## Track
Checker architecture cleanup; query-boundary refactor-only PR.

## Invariant
When access-helper code needs to classify generic index/keyof constraints, checker orchestration should route through the key-constraints query boundary instead of recursively probing solver/common type shape helpers inline.

## Scope
- Adds key/index constraint helper APIs under `query_boundaries::key_constraints`.
- Converts `types/computation/access_helpers.rs` generic index/keyof policy helpers into thin delegates.
- Adds an architecture ratchet for generic index policy helper routing.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: refactor-only checker boundary cleanup; no project-row behavior path changed intentionally.

## Verification
- `scripts/safe-run.sh cargo test -p tsz-checker --lib generic_index_policy_helpers_use_key_constraints_boundary -- --nocapture`
- `scripts/safe-run.sh python3 scripts/arch/arch_guard.py`
- `git diff --check`
- `ReadLints` on edited checker/test files

## Coordination Notes
- `#12917` and `#12920` were merged before this PR was published.
- Branch was refreshed onto current `origin/main` after those merges.
- `scripts/agents/ensure-agent-labels.sh --audit` currently reports unrelated open PR `#12922` missing an agent label; this PR uses the same checker/tech-debt labels as the prior M5 cleanup PRs and carries AgentName in the body.