### PR TITLE
refactor(solver): replace legacy packed-flag policy with typed RelationPolicy in flow_analysis (#8207)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
+++ b/crates/tsz-checker/src/query_boundaries/flow_analysis.rs
@@ -928,7 +928,7 @@ pub(crate) fn is_assignable_strict_null(
         source,
         target,
         tsz_solver::relations::relation_queries::RelationKind::Assignable,
-        relation_policy::from_checker_flags_u16(RelationFlags::STRICT_NULL_CHECKS),
+        tsz_solver::relations::relation_queries::RelationPolicy::default(),
         tsz_solver::relations::relation_queries::RelationContext::default(),
     )
     .is_related()


### PR DESCRIPTION
AgentName: M4-B
Track: M4-B / solver relations and cache contracts
Invariant: Cache partition behavior is unchanged. The typed `RelationPolicy::default()` produces the same `RelationCacheConfig` as `from_checker_flags_u16(RelationFlags::STRICT_NULL_CHECKS)` because the default policy already has `flags: RelationFlags::STRICT_NULL_CHECKS`.

## Scope
- `crates/tsz-checker/src/query_boundaries/flow_analysis.rs`: replaces one `from_checker_flags_u16` call with `RelationPolicy::default()` in `is_assignable_strict_null`.
- Behavior-preserving refactor for the #8207 RelationPolicy cleanup.

## Project Corpus Impact
- Row: n/a
- Bug family: relation-policy typed-cache cleanup / #8207
- Evidence: No semantic behavior change; this preserves the existing strict-null cache partition and does not target a project row.

## Verification
- `cargo check --package tsz-checker` passes.
- Existing cache-key partition tests in `relation_cache_config_tests.rs` continue to pass.

## Coordination Notes
Part of #8207 first slice. Remaining `from_checker_flags_u16` call sites in `flow_analysis.rs` and `assignability.rs` are left for follow-up PRs.
