### PR TITLE
fix(solver): raise distributive-conditional union cap above real-world key spaces

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -93,6 +93,9 @@ path = "tests/lib_heritage_cycle_dom_tests.rs"
 name = "keyof_operand_indexed_access_validation_tests"
 path = "tests/keyof_operand_indexed_access_validation_tests.rs"
 [[test]]
+name = "large_union_conditional_distribution_tests"
+path = "tests/large_union_conditional_distribution_tests.rs"
+[[test]]
 name = "union_protected_intersection_property_tests"
 path = "tests/union_protected_intersection_property_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/jsx_component_attribute_tests_parts/part_01.rs
+++ b/crates/tsz-checker/tests/jsx_component_attribute_tests_parts/part_01.rs
@@ -560,6 +560,13 @@ fn test_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts2322() {
         !has_code(&diags, diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
         "real react16 fixture should not emit TS2322, got: {diags:?}"
     );
+    assert!(
+        !has_code(
+            &diags,
+            diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE
+        ),
+        "real react16 fixture should not emit TS2740 missing-props noise, got: {diags:?}"
+    );
 }
 
 #[test]

--- a/crates/tsz-checker/tests/large_union_conditional_distribution_tests.rs
+++ b/crates/tsz-checker/tests/large_union_conditional_distribution_tests.rs
@@ -13,7 +13,7 @@
 //!
 //! Structural rule: distributing a conditional over a union of N members must
 //! produce the same result for N just below and just above the old `100` cap.
-//! The cap now mirrors `DEFAULT_MAX_MAPPED_KEYS` (native 500) so realistic key
+//! The cap now uses the conservative mapped-key floor (250) so realistic key
 //! spaces (DOM tag maps, generated SDK surfaces, large literal enums) evaluate
 //! like `tsc` instead of bailing.
 //!

--- a/crates/tsz-checker/tests/large_union_conditional_distribution_tests.rs
+++ b/crates/tsz-checker/tests/large_union_conditional_distribution_tests.rs
@@ -1,0 +1,145 @@
+//! Regression coverage: distributive conditional types over large unions.
+//!
+//! `distribute_conditional` (and its instantiation-path twin) capped union
+//! distribution at `100` members and returned `TypeId::ERROR` past that point.
+//! For a key space larger than the cap this silently dropped the conditional's
+//! result, so a distributive `Exclude`-style conditional collapsed to `ERROR`
+//! and an intersection `Html & Pick<Svg, Exclude<keyof Svg, keyof Html>>`
+//! degraded to just `Html`. The downstream effect was a *false negative*:
+//! `Html[T]` with `T extends keyof (that intersection)` no longer saw the
+//! Svg-only keys, so the `TS2536` ("Type 'T' cannot be used to index type
+//! 'Html'") that `tsc` reports was dropped purely because the union crossed the
+//! size threshold.
+//!
+//! Structural rule: distributing a conditional over a union of N members must
+//! produce the same result for N just below and just above the old `100` cap.
+//! The cap now mirrors `DEFAULT_MAX_MAPPED_KEYS` (native 500) so realistic key
+//! spaces (DOM tag maps, generated SDK surfaces, large literal enums) evaluate
+//! like `tsc` instead of bailing.
+//!
+//! The fixtures define their own distributive conditional / mapped helpers
+//! (`Excl`, `Pck`) rather than the lib `Exclude`/`Pick` so the test is
+//! independent of lib loading (`check_source` runs without lib contexts) while
+//! exercising the exact same `distribute_conditional` path. Verified against
+//! `tsc` 6.0.3: the >100-member shapes report the same diagnostics as the
+//! <100-member shapes.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source, diagnostic_codes};
+
+fn codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    diagnostic_codes(&check_source(source, "test.ts", options))
+}
+
+fn count(source: &str, code: u32) -> usize {
+    codes(source).into_iter().filter(|&c| c == code).count()
+}
+
+/// Distributive `Exclude` and homomorphic `Pick`, defined locally so the test
+/// does not depend on lib utility types.
+const HELPERS: &str = "type Excl<T, U> = T extends U ? never : T;\n\
+                       type Pck<T, K extends keyof T> = { [P in K]: T[P] };\n";
+
+/// `interface Html` with `html` keys and `interface Svg` with the same `html`
+/// keys plus `svg_only` distinct keys, then the deprecated-`lib.dom` shape
+/// `ElMap = Html & Pck<Svg, Excl<keyof Svg, keyof Html>>`.
+///
+/// `keyof ElMap` is therefore `keyof Html | <svg-only keys>`, a strict superset
+/// of `keyof Html`, so `Html[T]` for `T extends keyof ElMap` must report TS2536.
+/// The `Excl` here distributes over `keyof Svg` (`html + svg_only` members).
+fn element_tag_map_source(html: usize, svg_only: usize) -> String {
+    let mut s = String::from(HELPERS);
+    s.push_str("interface Html {\n");
+    for i in 0..html {
+        s.push_str(&format!("  \"h{i}\": {i};\n"));
+    }
+    s.push_str("}\n");
+    s.push_str("interface Svg {\n");
+    for i in 0..html {
+        s.push_str(&format!("  \"h{i}\": {i};\n"));
+    }
+    for i in 0..svg_only {
+        s.push_str(&format!("  \"s{i}\": {i};\n"));
+    }
+    s.push_str("}\n");
+    s.push_str(
+        "type ElMap = Html & Pck<Svg, Excl<keyof Svg, keyof Html>>;\n\
+         type Q<T extends keyof ElMap> = Html[T];\n",
+    );
+    s
+}
+
+/// A literal-string union `"m0" | "m1" | ... | "m{n-1}"`.
+fn literal_union(n: usize) -> String {
+    let mut s = String::from("type Big =\n");
+    for i in 0..n {
+        s.push_str(&format!("  | \"m{i}\"\n"));
+    }
+    s.push_str(";\n");
+    s
+}
+
+#[test]
+fn small_union_reports_ts2536_through_pick_exclude() {
+    // Control: `keyof Svg` has 50 members, comfortably under the old 100 cap.
+    let src = element_tag_map_source(20, 30);
+    assert_eq!(
+        count(&src, 2536),
+        1,
+        "small key space must report the indexing TS2536: {:?}",
+        codes(&src)
+    );
+}
+
+#[test]
+fn large_union_reports_ts2536_through_pick_exclude() {
+    // `keyof Svg` has 170 members, so `Excl<keyof Svg, keyof Html>` exceeded the
+    // old `100` cap and collapsed `ElMap` down to `Html`, dropping the TS2536.
+    // It must now be reported just like the small case.
+    let src = element_tag_map_source(20, 150);
+    assert_eq!(
+        count(&src, 2536),
+        1,
+        "large key space must still report the indexing TS2536 \
+         (distribution must not collapse to ERROR): {:?}",
+        codes(&src)
+    );
+}
+
+#[test]
+fn large_union_exclude_keeps_membership_no_false_positive() {
+    // A *valid* use of a distributive conditional over a >100-member union must
+    // not invent a diagnostic: every retained member is assignable to the result.
+    let mut s = literal_union(150);
+    s.push_str("type Rest = ");
+    s.push_str("Big extends infer B ? (B extends \"m0\" ? never : B) : never;\n");
+    s.push_str("const ok: Rest = \"m149\";\n");
+    assert_eq!(
+        count(&s, 2322),
+        0,
+        "valid assignment into a distributed conditional over a large union \
+         must not error: {:?}",
+        codes(&s)
+    );
+}
+
+#[test]
+fn large_union_exclude_rejects_removed_member() {
+    // The complement: the removed member is genuinely gone from the result, so
+    // assigning it back is a real TS2322. This guards against the cap silently
+    // widening the result to `string`/the original union.
+    let mut s = String::from("type Excl<T, U> = T extends U ? never : T;\n");
+    s.push_str(&literal_union(150));
+    s.push_str("type Rest = Excl<Big, \"m0\">;\n");
+    s.push_str("const bad: Rest = \"m0\";\n");
+    assert_eq!(
+        count(&s, 2322),
+        1,
+        "assigning the excluded member back must error TS2322: {:?}",
+        codes(&s)
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -42,14 +42,11 @@ use phases::TailCallStep;
 /// invented diagnostics (false negatives such as missing **TS2536** on indexed
 /// access through such a key space).
 ///
-/// WASM keeps a smaller bound for memory safety; native CLI/server builds can
-/// afford a larger one. The values intentionally mirror `DEFAULT_MAX_MAPPED_KEYS`
-/// (the analogous "evaluate a large key space" cap), which was already raised
-/// from `100` for the same real-world reason.
-#[cfg(target_arch = "wasm32")]
+/// Keep this at the conservative mapped-key floor. `DEFAULT_MAX_MAPPED_KEYS` is
+/// target-split elsewhere, but a single cross-target conditional-distribution
+/// budget avoids making native CI eagerly materialize React-sized surfaces that
+/// the 250-budget path still defers.
 pub(crate) const MAX_CONDITIONAL_DISTRIBUTION_SIZE: usize = 250;
-#[cfg(not(target_arch = "wasm32"))]
-pub(crate) const MAX_CONDITIONAL_DISTRIBUTION_SIZE: usize = 500;
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Maximum depth for tail-recursive conditional evaluation.

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -27,6 +27,30 @@ use super::super::evaluate::TypeEvaluator;
 use crate::type_queries::get_application_base;
 use phases::TailCallStep;
 
+/// Maximum number of union members a distributive conditional type
+/// (`Exclude`, `Extract`, `NonNullable`, and any user `T extends U ? X : Y`
+/// distributed over a union) may expand before the solver bails with
+/// `TypeId::ERROR`.
+///
+/// Distribution is linear in the member count — one conditional is evaluated
+/// per member — so the dominant cost is bounded CPU/allocation rather than a
+/// combinatorial blow-up. The previous value of `100` was far below the size of
+/// real-world key spaces: filtering `keyof` over a generated API surface, a DOM
+/// tag-name map, or an SDK enum routinely produces unions of 150–500 members.
+/// When the cap was hit the conditional collapsed to `TypeId::ERROR`, which then
+/// poisoned downstream `keyof`/relation decisions and silently dropped or
+/// invented diagnostics (false negatives such as missing **TS2536** on indexed
+/// access through such a key space).
+///
+/// WASM keeps a smaller bound for memory safety; native CLI/server builds can
+/// afford a larger one. The values intentionally mirror `DEFAULT_MAX_MAPPED_KEYS`
+/// (the analogous "evaluate a large key space" cap), which was already raised
+/// from `100` for the same real-world reason.
+#[cfg(target_arch = "wasm32")]
+pub(crate) const MAX_CONDITIONAL_DISTRIBUTION_SIZE: usize = 250;
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) const MAX_CONDITIONAL_DISTRIBUTION_SIZE: usize = 500;
+
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Maximum depth for tail-recursive conditional evaluation.
     /// This allows patterns like `type Loop<T> = T extends [...infer R] ? Loop<R> : never`
@@ -1502,9 +1526,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         true_type: TypeId,
         false_type: TypeId,
     ) -> TypeId {
-        // Limit distribution to prevent OOM with large unions
-        const MAX_DISTRIBUTION_SIZE: usize = 100;
-        if members.len() > MAX_DISTRIBUTION_SIZE {
+        // Limit distribution to prevent OOM with pathologically large unions.
+        if members.len() > MAX_CONDITIONAL_DISTRIBUTION_SIZE {
             self.mark_depth_exceeded();
             return TypeId::ERROR;
         }

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -1122,21 +1122,29 @@ impl<'a> TypeInstantiator<'a> {
                         self.interner.lookup(distribution_source)
                     {
                         let members = self.interner.type_list(members);
-                        // Limit distribution to prevent OOM with large unions
-                        // (e.g., string literal unions with thousands of members)
-                        const MAX_DISTRIBUTION_SIZE: usize = 100;
-                        if members.len() > MAX_DISTRIBUTION_SIZE {
+                        // Limit distribution to prevent OOM with pathologically
+                        // large unions (e.g. string-literal unions with thousands
+                        // of members). Shares the evaluation-path cap so both
+                        // lowering routes agree on what is representable.
+                        if members.len()
+                            > crate::evaluation::evaluate_rules::conditional::MAX_CONDITIONAL_DISTRIBUTION_SIZE
+                        {
                             self.depth_exceeded = true;
                             return TypeId::ERROR;
                         }
                         let cond_type = self.interner.conditional(cond);
                         let mut results = Vec::with_capacity(members.len());
+                        // Reuse one substitution map across members: only the
+                        // distributed parameter (`info.name`) changes per step, so
+                        // overwrite that single key instead of cloning the whole
+                        // map for every member (matters now the cap allows up to
+                        // `MAX_CONDITIONAL_DISTRIBUTION_SIZE` members).
+                        let mut member_subst = self.substitution.clone();
                         for &member in members.iter() {
                             // Check depth before each distribution step
                             if self.depth_exceeded {
                                 return TypeId::ERROR;
                             }
-                            let mut member_subst = self.substitution.clone();
                             member_subst.insert(info.name, member);
                             let instantiated = if self.preserve_unsubstituted_type_params {
                                 instantiate_type_preserving(self.interner, cond_type, &member_subst)

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -51,9 +51,7 @@ TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
-TypeScript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts
 TypeScript/tests/cases/conformance/jsdoc/importTag17.ts
-TypeScript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
 # objectLiteralMemberWithoutBlock1.ts: RESOLVED. `var v = { foo(); }` parsed the
 # body-less object method but suppressed the missing-body `'{' expected` whenever
 # the next token was `;`, so the outer object-literal member loop emitted a


### PR DESCRIPTION
AgentName: Studio-manager

**Track:** Conformance / solver — mapped/keyof/inference family (scoped slice of #8432).

**Invariant:** A distributive conditional distributed over a union of N members must evaluate to the same type for N just below and just above the old `100` threshold; raising the cap must not eagerly materialize larger JSX/mapped key spaces into false required-prop diagnostics.

**Scope:** PR #12925 plus CI unblock. Keep the shared conditional-distribution cap at a single cross-target `250`, shared by the evaluator and instantiation path; add React16 JSX coverage for the false `TS2740` discovered by CI; remove the two accepted-regression ledger rows this PR now fixes. No relation, inference, parser, or emit behavior is otherwise touched.

## Summary
Distributive conditional types (`Exclude`, `Extract`, `NonNullable`, and any user `T extends U ? X : Y` distributed over a union) bailed with `TypeId::ERROR` once the union exceeded `100` members. The PR lifts that conservative ceiling to `250` and shares one solver constant between the evaluation path and the instantiation distribution loop.

CI initially showed that the native `500` cap was too eager for the current mapped/JSX required-prop surface: `contextuallyTypedJsxAttribute2.tsx` began reporting a false `TS2740` against React16 anchor props. The follow-up keeps the real-world `>100` fix, but holds the cap at the conservative 250 floor so React-sized helper chains continue to defer instead of inventing required props.

The same exact-head conformance run also proved two accepted-regression rows are now green, so the accepted-regression ledger shrinks from 9 rows to 7 rows instead of keeping stale debt.

## Structural rule
When a distributive conditional is distributed over a union of N members, `tsc` evaluates every member. tsz may still cap pathological key spaces, but crossing the old `100` threshold must not collapse a realistic `Exclude`/`Pick`/`keyof` helper chain to `ERROR` and thereby drop diagnostics.

Witnessed shape:

```ts
type ElMap = Html & Pick<Svg, Exclude<keyof Svg, keyof Html>>;
type Q<T extends keyof ElMap> = Html[T]; // tsc: TS2536
```

With `keyof Svg` > 100, the old cap collapsed `Exclude<keyof Svg, keyof Html>` to `ERROR`, degraded the intersection to just `Html`, and dropped the `TS2536` that `tsc` reports. With the final 250 cap, the 150-member regression family now behaves like the below-cap control, while the React16 JSX fixture no longer crosses into the false required-prop path.

## Owner layer
`tsz-solver`:
- `evaluation/evaluate_rules/conditional.rs::distribute_conditional`
- `instantiation/instantiate.rs` distribution lowering loop

`tsz-checker` tests:
- `large_union_conditional_distribution_tests` covers below/above-old-cap `TS2536`, retained-member, and removed-member behavior.
- `jsx_component_attribute_tests` now asserts the real React16 fixture emits neither false `TS2322` nor false `TS2740` missing-props noise.

Conformance ledger:
- Removed `destructuringParameterDeclaration2.ts` and `conditionalTypes1.ts` after focused exact-head conformance showed both now pass.

## Adjacent-case matrix
- Indexing through `Pick<…, Exclude<…>>`: small key space and 170-member key space both report exactly one `TS2536`.
- Distributive conditional over a 150-member literal union: retained members stay assignable, and the excluded member is rejected with the real `TS2322`.
- React16 `contextuallyTypedJsxAttribute2.tsx`: no false `TS2322`; no false `TS2740` required-prop diagnostic.
- Accepted-regression drift rows: `destructuringParameterDeclaration2.ts` and `conditionalTypes1.ts` pass and are removed from the ledger.

## Project Corpus Impact
- Row: n/a. This is conformance/solver strictness work, not a project-corpus row claim.
- Accepted-regression gate: 9 listed rows -> 7 listed rows.
- Bug family: keyof / indexed-access (`TS2536`) via distributive conditional truncation, with a JSX required-prop guard to keep the cap from exposing known mapped-surface debt.

Low risk: unions `<= 100` are unchanged; unions `101..=250` now compute instead of collapsing to `ERROR`; unions above `250` continue to avoid expensive eager materialization. Native ready-review CI owns broad validation.

## Verification
- `scripts/safe-run.sh --limit 70% -- ./scripts/conformance/conformance.sh run --filter contextuallyTypedJsxAttribute2 --verbose` -> 1/1 passed.
- `scripts/safe-run.sh --limit 70% -- ./scripts/conformance/conformance.sh run --filter destructuringParameterDeclaration2 --verbose` -> 1/1 passed.
- `scripts/safe-run.sh --limit 70% -- ./scripts/conformance/conformance.sh run --filter conditionalTypes1 --verbose` -> 1/1 passed.
- `scripts/safe-run.sh --limit 70% -- cargo nextest run -p tsz-checker --test large_union_conditional_distribution_tests` -> 4 passed.
- `scripts/safe-run.sh --limit 70% -- cargo nextest run -p tsz-checker --test jsx_component_attribute_tests test_contextually_typed_jsx_attribute2_react16_fixture_has_no_ts2322` -> 1 passed.
- `scripts/safe-run.sh --limit 70% -- cargo nextest run -p tsz-solver --test conditional_deferred_return_tests --test conditional_infer_tuple_numeric_key_tests` -> 8 passed.
- `cargo fmt --all --check` -> clean.
- `git diff --check` -> clean.
- `python3 scripts/conformance/query-conformance.py --dashboard` -> accepted-regression gate now lists 7 tests.

## Coordination Notes
Studio-manager took the next concrete step on PR #12925 after exact-head CI run 27177222045 failed only in `conformance-aggregate` / `CI Summary`. Root cause was the native `500` cap exposing a false React16 JSX `TS2740`, plus two now-stale accepted-regression ledger rows. This PR is ready for exact-head CI after the follow-up commit and should enter GitHub's native merge queue once the PR-head checks pass.
