### PR TITLE
fix(checker): infer type args through cross-module type-alias chains

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -122,7 +122,25 @@ impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
         use crate::query_boundaries::state::type_environment::application_info;
 
         let (base, args) = application_info(self.state.ctx.types, type_id)?;
-        let sym_id = self.state.ctx.resolve_type_to_symbol_id(base)?;
+        let sym_id = self.state.ctx.resolve_type_to_symbol_id(base).or_else(|| {
+            // A type-alias body imported from another module can reference a
+            // sibling type that the lowering pass left as `UnresolvedTypeName`
+            // because that name was not in scope at the alias's *use* site
+            // (it is private to the alias's defining module). Recover it
+            // through the merged binder graph so alias expansion — and the
+            // generic-call inference that depends on it — sees the real
+            // declaration instead of aborting. Without this, inference of a
+            // type argument through a cross-module alias chain
+            // (`type Opts<T> = Inner<T>`) silently fails and the argument
+            // collapses to `unknown`.
+            let atom = crate::query_boundaries::spread::unresolved_type_name_atom(
+                self.state.ctx.types,
+                base,
+            )?;
+            let name = self.state.ctx.types.resolve_atom(atom);
+            let def_id = TypeResolver::resolve_unresolved_type_name(&self.state.ctx, &name)?;
+            self.state.ctx.def_to_symbol_id_with_fallback(def_id)
+        })?;
         let (body, type_params) = self.state.type_reference_symbol_type_with_params(sym_id);
         if body == TypeId::ANY || body == TypeId::ERROR || type_params.is_empty() {
             return None;

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -46,8 +46,6 @@
 # Keep these visible as accepted-regression debt until their owning parity
 # fixes remove them from exact-head aggregate output.
 TypeScript/tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts
-TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules1.ts
-TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules2.ts
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
@@ -70,6 +68,22 @@ TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
 # failures: 0), so their entries were retired. Verify either with:
 #   scripts/conformance/conformance.sh run --test-dir <ts-6.0.3>/tests/cases \
 #     --filter <testName> --workers 1
+# declarationEmitUsingAlternativeContainingModules1.ts and
+# declarationEmitUsingAlternativeContainingModules2.ts: RESOLVED. A generic
+# function imported from another module whose parameter type is a type alias
+# whose body is itself a generic application (`type Opts<A> = Inner<A>`, the
+# `UseQueryOptions`/`UndefinedInitialQueryOptions` chain in these fixtures)
+# inferred its type argument as `unknown`, emitting a spurious TS18046 on the
+# `select` callback parameter. The constraint walker expands such alias
+# applications during call inference via `expand_type_alias_application`, but
+# the alias body's reference to a sibling type that is private to the alias's
+# defining module is lowered as `UnresolvedTypeName` (it is not in scope at the
+# use site), and that expansion path only resolved `Lazy`/`TypeQuery`/object
+# bases — so it aborted and the type argument collapsed. `expand_type_alias_
+# application` now recovers an `UnresolvedTypeName` base through the merged
+# binder graph (`resolve_unresolved_type_name`), so the alias chain expands and
+# the argument infers like tsc. Verified via the conformance runner (2/2) and
+# the minimal cross-module alias-chain witnesses.
 # objectLiteralMemberWithoutBlock1.ts: RESOLVED. `var v = { foo(); }` parsed the
 # body-less object method but suppressed the missing-body `'{' expected` whenever
 # the next token was `;`, so the outer object-literal member loop emitted a


### PR DESCRIPTION
AgentName: M4-C
**Track:** conformance / checker generic-call inference

## Invariant
When a generic function imported from another module has a parameter type that is a **type alias whose body is itself a generic application** (`type Opts<A> = Inner<A>`), and the type argument must be inferred from a call argument, the inference must expand the alias chain to reach the inner shape and infer the type argument — exactly as `tsc` does. It must not collapse the type argument to `unknown`.

## Structural rule
> When the constraint walker meets `(object-literal source, Application target)` during generic-call inference and the target application's args contain inference placeholders, it expands the alias via `expand_type_alias_application` and recurses. That helper resolved the application base through `resolve_type_to_symbol_id`, which only handles `Lazy`/`TypeQuery`/object-symbol bases. A type-alias body imported from another module references sibling, module-private types that the lowering pass leaves as `TypeData::UnresolvedTypeName` (they are not in scope at the alias's *use* site). For a single expansion level (a directly-referenced interface) this never came up, but for an alias chain (`Opts<A> = Inner<A>`) the **second** expansion (`Inner<A>`) hit an `UnresolvedTypeName` base, `expand_type_alias_application` returned `None`, the walker fell back to `evaluate_type` (which resolves the placeholder to its `unknown` constraint), and the type argument collapsed.

`expand_type_alias_application` now falls back to `resolve_unresolved_type_name` (the existing merged-binder-graph recovery already used by the type-environment evaluator) when the base is an `UnresolvedTypeName`, so the alias chain expands and the argument infers correctly.

## Scope
- Owner layer: **checker** — `crates/tsz-checker/src/checkers/call_checker/mod.rs`, `CheckerCallAssignabilityAdapter::expand_type_alias_application`.
  - When `resolve_type_to_symbol_id(base)` is `None`, extract the `UnresolvedTypeName` atom, resolve it via `TypeResolver::resolve_unresolved_type_name`, and map the recovered `DefId` to a symbol with `def_to_symbol_id_with_fallback`.
- No new user-name/file-name literals; uses binder/def-graph resolution only. No printer-output predicates. The fix is keyed purely on the alias/application structure.

### Adjacent-case matrix (verified vs `tsc`, cross-module)
| Parameter shape | before | after |
| --- | --- | --- |
| `type Opts<A> = Inner<A>` (alias → interface) | `unknown` (TS18046/TS2322) | infers correctly |
| `type Wrapper<Z> = Leaf<Z>` (alias → alias → object literal) | `unknown` | infers correctly |
| `type Outer<O> = Mid<O> = Base<O>` (3-level chain) | `unknown` | infers correctly |
| direct interface `Options<U>` (1 level) | already worked | still works |
| alias body is an object literal directly | already worked | still works |
| genuine mismatch (`number` arg vs `string` annotation) | — | still reports TS2322 (no over-widening to `any`) |
| single-file (any of the above) | already worked | still works |

## Project Corpus Impact
- Row: n/a
- Bug family: cross-module generic-call inference / accepted-regression ledger burn-down
- Evidence: Removes the `declarationEmitUsingAlternativeContainingModules1.ts` and `declarationEmitUsingAlternativeContainingModules2.ts` rows from `scripts/conformance/conformance-accepted-regressions.txt` (now pass, with a `RESOLVED` note recording the root cause). These are the TanStack-query `UseQueryReturnType` re-export fixtures; the `select` callback's `data` parameter was reported `'data' is of type 'unknown'` (TS18046) — a false positive (`tsc` compiles them clean).
- No project guard-config row is expected to flip: the change only recovers a previously-dropped inference (removing false positives), gated to `UnresolvedTypeName` bases that `resolve_type_to_symbol_id` could not already resolve.

## Verification
- `tsz-conformance --filter declarationEmitUsingAlternativeContainingModules` → **2/2 passed** (was 0/2).
- Regression smoke: 79-fixture sample across the `declarationEmit*` / `contextualTyping*` / `genericCall*` / `typeAlias*` / `reexport` families, fixed binary vs pre-fix baseline → **0 regressions** (the only 2 sample FAILs, `declarationEmitCastReusesTypeNode3/4`, fail identically on baseline — pre-existing, unrelated).
- Production correctness confirmed on minimal witnesses: inferred type is the exact `number`, not `any` (negative assignments still raise TS2322).
- `cargo clippy -p tsz-checker --lib` — clean.
- `cargo fmt -p tsz-checker -p tsz-solver --check` — clean.
- `scripts/arch/check-checker-boundaries.sh` — architecture guardrails passed.
- Relevant existing suites green: `call_resolution_regression_tests` (171), `co_contra_inference_tests` (8), `context_sensitive_callback_inference_tests` (3).

## Coordination Notes
- The two `bug`-labeled open issues (#10663, #8432) are both already `WIP`; the one non-WIP accepted-regression *issue* (#12770) was already fixed by merged PR #12721. The defect addressed here lives in the accepted-regression ledger with no standalone issue, so this PR is the claim/record rather than a relabeled issue.
- The unit-test harnesses (`check_multi_file*`) do not faithfully reproduce cross-file generic inference (they yield `r = any` where the real driver yields `r = number`), a known limitation noted in `cross_file_type_params_cache_tests`; the conformance fixtures (run via the real binary in CI, now de-listed from the ledger) are the authoritative regression guard.

https://claude.ai/code/session_01TtCNKL57WAXwCQvu5niZ1c

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtCNKL57WAXwCQvu5niZ1c)_
