### PR TITLE
fix(jsdoc): resolve inline import() type queries under resolution-mode

### DIFF
--- a/crates/tsz-checker/src/jsdoc/mod.rs
+++ b/crates/tsz-checker/src/jsdoc/mod.rs
@@ -46,5 +46,6 @@ pub(crate) mod params_comment_retrieval;
 pub(crate) mod params_generic_instantiation;
 pub(crate) mod params_type_strings;
 pub(crate) mod parsing;
+pub(crate) mod parsing_import_attributes;
 pub(crate) mod resolution;
 pub(crate) mod types;

--- a/crates/tsz-checker/src/jsdoc/parsing.rs
+++ b/crates/tsz-checker/src/jsdoc/parsing.rs
@@ -451,6 +451,8 @@ impl<'a> CheckerState<'a> {
         let close_quote = rest.find(quote)?;
         let module_specifier = rest[..close_quote].trim().to_string();
         let after_quote = rest[close_quote + quote.len_utf8()..].trim_start();
+        // Skip an inline import-attributes argument (`, { ... }`) before `)`.
+        let after_quote = Self::skip_jsdoc_import_attributes_argument(after_quote);
         let after_quote = after_quote.strip_prefix(')')?.trim_start();
         if after_quote.is_empty() {
             return Some((module_specifier, None));

--- a/crates/tsz-checker/src/jsdoc/parsing_import_attributes.rs
+++ b/crates/tsz-checker/src/jsdoc/parsing_import_attributes.rs
@@ -1,0 +1,108 @@
+//! JSDoc `import(...)` resolution-mode attribute parsing for `CheckerState`.
+//!
+//! Split out of `jsdoc/parsing.rs` to keep that file within its size budget.
+//! These helpers let JSDoc `import("m", { with: { "resolution-mode": ... } }).X`
+//! type queries parse and resolve under the requested ESM/CJS condition, the
+//! inline counterpart to the `@import ... with { ... }` tag form.
+
+use crate::state::CheckerState;
+
+impl<'a> CheckerState<'a> {
+    /// Skip an optional `, { ... }` import-attributes argument that may follow
+    /// the module specifier inside an `import("m"<here>)` type expression,
+    /// returning the slice starting at the closing `)`. When no such argument
+    /// is present the input is returned unchanged.
+    pub(super) fn skip_jsdoc_import_attributes_argument(after_quote: &str) -> &str {
+        let Some(after_comma) = after_quote.strip_prefix(',') else {
+            return after_quote;
+        };
+        let after_comma = after_comma.trim_start();
+        if !after_comma.starts_with('{') {
+            return after_quote;
+        }
+        let bytes = after_comma.as_bytes();
+        let mut depth = 0usize;
+        for (idx, &b) in bytes.iter().enumerate() {
+            match b {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return after_comma[idx + 1..].trim_start();
+                    }
+                }
+                _ => {}
+            }
+        }
+        // Unbalanced braces: leave the original input untouched so the caller's
+        // `)` expectation fails cleanly rather than silently mis-parsing.
+        after_quote
+    }
+
+    /// Read the `resolution-mode` import attribute out of an
+    /// `import("m", { with: { "resolution-mode": "import" } }).Member` type
+    /// expression. Returns the resolver override, or `None` when absent.
+    pub(super) fn jsdoc_import_type_resolution_mode(
+        type_expr: &str,
+    ) -> Option<crate::context::ResolutionModeOverride> {
+        use crate::context::ResolutionModeOverride;
+
+        let attr_idx = type_expr.find("resolution-mode")?;
+        let after = type_expr[attr_idx + "resolution-mode".len()..]
+            .trim_start()
+            .trim_start_matches(['"', '\'']);
+        let after = after.trim_start().strip_prefix(':')?.trim_start();
+        let quote = after.chars().next().filter(|&c| c == '"' || c == '\'')?;
+        let value = after[quote.len_utf8()..].split(quote).next()?;
+        match value {
+            "import" => Some(ResolutionModeOverride::Import),
+            "require" => Some(ResolutionModeOverride::Require),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::state::CheckerState;
+
+    #[test]
+    fn import_type_tolerates_resolution_mode_attributes_argument() {
+        // The inline `import("m", { ... }).Member` type carries an attributes
+        // argument; `parse_jsdoc_import_type` must skip it and still recover the
+        // specifier and member name.
+        assert_eq!(
+            CheckerState::parse_jsdoc_import_type(
+                r#"import("foo", { with: { "resolution-mode": "import" } }).Member"#
+            ),
+            Some(("foo".to_string(), Some("Member".to_string())))
+        );
+        assert_eq!(
+            CheckerState::parse_jsdoc_import_type(
+                r#"import("foo", { with: { "resolution-mode": "require" } })"#
+            ),
+            Some(("foo".to_string(), None))
+        );
+    }
+
+    #[test]
+    fn import_type_reads_resolution_mode_override() {
+        use crate::context::ResolutionModeOverride;
+        assert_eq!(
+            CheckerState::jsdoc_import_type_resolution_mode(
+                r#"import("foo", { with: { "resolution-mode": "import" } }).Member"#
+            ),
+            Some(ResolutionModeOverride::Import)
+        );
+        assert_eq!(
+            CheckerState::jsdoc_import_type_resolution_mode(
+                r#"import("foo", { with: { "resolution-mode": "require" } }).Member"#
+            ),
+            Some(ResolutionModeOverride::Require)
+        );
+        assert_eq!(
+            CheckerState::jsdoc_import_type_resolution_mode(r#"import("foo").Member"#),
+            None
+        );
+    }
+}

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -236,10 +236,14 @@ impl<'a> CheckerState<'a> {
         type_expr: &str,
     ) -> Option<TypeId> {
         let (module_specifier, member_name) = Self::parse_jsdoc_import_type(type_expr)?;
+        let resolution_mode = Self::jsdoc_import_type_resolution_mode(type_expr);
 
         if let Some(member_name) = member_name {
-            if let Some(sym_id) = self.resolve_jsdoc_import_member(&module_specifier, &member_name)
-            {
+            if let Some(sym_id) = self.resolve_jsdoc_import_member_with_mode(
+                &module_specifier,
+                &member_name,
+                resolution_mode,
+            ) {
                 let resolved = self.resolve_jsdoc_symbol_type(sym_id);
                 if resolved != TypeId::ERROR && resolved != TypeId::UNKNOWN {
                     return Some(resolved);

--- a/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
+++ b/crates/tsz-checker/src/types/utilities/contextual_parameters.rs
@@ -220,10 +220,24 @@ impl<'a> CheckerState<'a> {
         module_specifier: &str,
         member_name: &str,
     ) -> Option<SymbolId> {
-        self.resolve_cross_file_export_from_file(
+        self.resolve_jsdoc_import_member_with_mode(module_specifier, member_name, None)
+    }
+
+    /// Like [`Self::resolve_jsdoc_import_member`] but honors an explicit
+    /// `resolution-mode` override carried by a JSDoc `@import ... with { ... }`
+    /// tag, so the member is looked up against the ESM/CJS conditional export
+    /// `tsc` would resolve for that mode.
+    pub(crate) fn resolve_jsdoc_import_member_with_mode(
+        &self,
+        module_specifier: &str,
+        member_name: &str,
+        resolution_mode: Option<crate::context::ResolutionModeOverride>,
+    ) -> Option<SymbolId> {
+        self.resolve_cross_file_export_from_file_with_mode(
             module_specifier,
             member_name,
             Some(self.ctx.current_file_idx),
+            resolution_mode,
         )
         // Avoid raw binder fallback here: it returns unscoped SymbolIds without
         // file-target registration, which can alias-collide across binders.

--- a/crates/tsz-cli/src/driver/resolution/discovery.rs
+++ b/crates/tsz-cli/src/driver/resolution/discovery.rs
@@ -369,7 +369,7 @@ pub(crate) fn collect_jsdoc_module_requests(
             requests.extend(
                 specifiers
                     .into_iter()
-                    .map(|specifier| (specifier, ImportKind::EsmImport, None)),
+                    .map(|(specifier, mode)| (specifier, ImportKind::EsmImport, mode)),
             );
         }
         // `@import ... from "..."` tags, parsed per content line.
@@ -401,7 +401,10 @@ const fn is_identifier_part_byte(byte: u8) -> bool {
 /// `out`. Requires a word boundary before `import` so identifiers ending in
 /// `import` (e.g. `reimport(`) are not matched. Whitespace between `(` and the
 /// string literal is tolerated.
-pub(crate) fn push_jsdoc_import_call_specifiers(text: &str, out: &mut Vec<String>) {
+pub(crate) fn push_jsdoc_import_call_specifiers(
+    text: &str,
+    out: &mut Vec<(String, Option<tsz::module_resolver::ImportingModuleKind>)>,
+) {
     let bytes = text.as_bytes();
     let mut search_from = 0usize;
     while let Some(rel) = text[search_from..].find("import(") {
@@ -436,8 +439,17 @@ pub(crate) fn push_jsdoc_import_call_specifiers(text: &str, out: &mut Vec<String
             break;
         }
         let specifier = &text[spec_start..cursor];
+        // Read an optional `, { with: { "resolution-mode": ... } }` argument up
+        // to the call's closing paren (the attribute object holds no `)`) so the
+        // inline `import("m", { ... }).X` type query resolves under the requested
+        // ESM/CJS condition, like its `@import` tag form.
+        let after_spec = &text[cursor + 1..];
+        let mode = after_spec.find(')').and_then(|paren| {
+            tsz_common::parse_jsdoc_resolution_mode_attribute_clause(&after_spec[..paren])
+                .map(tsz::module_resolver::ImportingModuleKind::from)
+        });
         if !specifier.is_empty() {
-            out.push(specifier.to_string());
+            out.push((specifier.to_string(), mode));
         }
         search_from = cursor + 1;
     }

--- a/crates/tsz-cli/src/driver/resolution_tests.rs
+++ b/crates/tsz-cli/src/driver/resolution_tests.rs
@@ -1910,7 +1910,9 @@ mod jsdoc_import_type_specifier_collection_tests {
     fn jsdoc_import_specifiers(text: &str) -> Vec<String> {
         let mut out = Vec::new();
         push_jsdoc_import_call_specifiers(text, &mut out);
-        out
+        out.into_iter()
+            .map(|(specifier, _mode)| specifier)
+            .collect()
     }
 
     #[test]
@@ -1944,6 +1946,26 @@ mod jsdoc_import_type_specifier_collection_tests {
     fn push_ignores_unquoted_and_unterminated() {
         assert!(jsdoc_import_specifiers("import(foo)").is_empty());
         assert!(jsdoc_import_specifiers("import('unterminated").is_empty());
+    }
+
+    #[test]
+    fn push_parses_inline_import_resolution_mode_attribute() {
+        use tsz::module_resolver::ImportingModuleKind;
+        let collect = |text: &str| {
+            let mut out = Vec::new();
+            push_jsdoc_import_call_specifiers(text, &mut out);
+            out
+        };
+        assert_eq!(
+            collect(r#"import("pkg", { with: { "resolution-mode": "import" } }).Foo"#),
+            [("pkg".to_string(), Some(ImportingModuleKind::Esm))]
+        );
+        assert_eq!(
+            collect(r#"import('pkg', { with: { 'resolution-mode': 'require' } }).Foo"#),
+            [("pkg".to_string(), Some(ImportingModuleKind::CommonJs))]
+        );
+        // A bare inline import type query carries no override.
+        assert_eq!(collect(r#"import("pkg").Foo"#), [("pkg".to_string(), None)]);
     }
 
     #[test]


### PR DESCRIPTION
AgentName: M1-Opus
Track: Conformance (JSDoc / module resolution)
Invariant: Match `tsc` exactly — a JSDoc `import(...)` type query with a `resolution-mode` attribute resolves its member against the same ESM/CJS conditional export `tsc` selects.

## Summary
Follow-up to #12931 (rebased onto `d70b1e1`). #12931 fixed the JSDoc `@import`
*tag* form with `resolution-mode` and **explicitly deferred** the inline
`import("m", { with: { "resolution-mode": ... } }).X` type query. This PR
completes that deferred piece.

The inline form still resolved the specifier under the importing file's *default*
condition, so an override pointing at a different package `exports` condition
silently failed — e.g. an `import`-mode member referenced from a CJS `.js` file
never resolved (only the default `require`-mode member did), dropping a genuine
diagnostic.

Witness (built `tsz`, `.js` + `@types/foo` with `import`→`index.d.mts`/`require`→`index.d.cts`):
`@returns { import("foo", { with: { "resolution-mode": "import" } }).Import }` →
`return 1` now correctly reports `TS2322: '1' not assignable to '"module"'`; the
`require` form independently reports `'"script"'`. Before this PR the `import`
form emitted nothing.

## Structural rule
> When a JSDoc `import(...)` type query carries a `resolution-mode` attribute,
> resolve the specifier under that override (`import` → ESM, `require` → CJS) and
> read the member from the resulting file. Fall back to the default-mode
> resolution when absent — matching the `@import` tag form and `tsc`.

## Owner layer & threading
- **Driver** (`resolution/discovery.rs`): `push_jsdoc_import_call_specifiers`
  now reads the inline call's `with { ... }` argument (reusing
  `tsz_common::parse_jsdoc_resolution_mode_attribute_clause`) and returns the
  `ImportingModuleKind`, so `collect_jsdoc_module_requests` emits a per-mode
  module request and both `exports` conditions are resolved.
- **Checker** (`jsdoc/parsing.rs`, `jsdoc/resolution/name_resolution.rs`,
  `types/utilities/contextual_parameters.rs`): `parse_jsdoc_import_type`
  tolerates the trailing attributes argument; `resolve_jsdoc_import_type_reference`
  threads the parsed mode through a new `resolve_jsdoc_import_member_with_mode`,
  which routes to main's `resolve_cross_file_export_from_file_with_mode`.
- The attribute helpers live in a new `jsdoc/parsing_import_attributes.rs` so
  `jsdoc/parsing.rs` stays within its 2000-line architecture budget.

## Anti-hardcoding
No identifier/file-name/printer-output predicates; the override is a structural
module-resolution condition threaded through the existing mode-aware resolver.

## Scope
JSDoc `import(...)` type queries carrying a `with { ... }` attribute. The no-mode
path for every other JSDoc import resolution is unchanged; `@import` tag handling
(owned by #12931) is untouched and stays green.

## Project Corpus Impact
- Row: n/a
- Bug family: jsdoc-import-resolution-mode (conformance; importTag17 itself is
  already resolved by #12931 — this completes the deferred inline form)

## Verification
- Built `tsz`: inline `import`/`require` mode queries both report the expected
  `TS2322`s; `importTag17` (tag form) stays green; bare `import("m").X` unchanged.
- Unit tests: driver `push_parses_inline_import_resolution_mode_attribute`;
  checker `import_type_tolerates_resolution_mode_attributes_argument`,
  `import_type_reads_resolution_mode_override`.
- `cargo test -p tsz-checker --test import_attributes_resolution_mode_tests`
  (23 passed), `cargo test -p tsz-checker --lib jsdoc::` (128 passed),
  `cargo test -p tsz-cli --lib jsdoc_import_type_specifier_collection_tests`
  (10 passed), `scripts/arch/arch_guard.py` passed,
  `cargo clippy -p tsz-checker -p tsz-cli` clean.

## Coordination Notes
Rebased onto current `main` after #12931 landed the `@import` tag fix and removed
`importTag17` from the accepted-regression ledger. Per @mohsen1's review note,
reduced to just the inline-`import(...)` follow-up #12931 deferred, reusing main's
`resolve_cross_file_export_from_file_with_mode`. No ledger change (importTag17
already resolved on main).

https://claude.ai/code/session_01Mv4vSe11pbw65wWt7EntFE
