### PR TITLE
fix(parser): match tsc recovery for misplaced case clause and empty element access

### DIFF
--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -301,6 +301,13 @@ pub struct ParserState {
     /// A malformed JSX attribute list used bracket syntax in a tag head, as in
     /// `<a[foo]>`; the closing tag should be recovered by outer expression code.
     pub(crate) suppress_next_jsx_head_missing_semicolon: bool,
+    /// Set while parsing a class member recovered after a misplaced
+    /// `case`/`default` switch-clause keyword (TS1068). tsc keeps such a member
+    /// (it still emits) but does not run post-parse grammar checks on it, so the
+    /// yield-outside-generator check (TS1163) does not fire; tsz emits TS1163
+    /// eagerly in the parser, so this suppresses it for the recovered member.
+    /// Reset at the top of every `parse_class_member`.
+    pub(crate) suppress_recovered_clause_member_yield_grammar: bool,
     /// A JSX closing tag had trailing attributes (`</div {...props}>`). The
     /// tail is recovered as source-level syntax after the JSX expression.
     pub(crate) recover_jsx_closing_tag_trailing_tail: bool,
@@ -430,6 +437,7 @@ impl ParserState {
             in_jsx_attribute_initializer_element: false,
             recover_jsx_missing_attr_initializer_head: false,
             suppress_next_jsx_head_missing_semicolon: false,
+            suppress_recovered_clause_member_yield_grammar: false,
             recover_jsx_closing_tag_trailing_tail: false,
             recover_jsx_closing_tag_extra_namespace_tail: false,
             recover_jsx_invalid_namespace_head_tail: false,
@@ -485,6 +493,7 @@ impl ParserState {
         self.in_jsx_attribute_initializer_element = false;
         self.recover_jsx_missing_attr_initializer_head = false;
         self.suppress_next_jsx_head_missing_semicolon = false;
+        self.suppress_recovered_clause_member_yield_grammar = false;
         self.recover_jsx_closing_tag_trailing_tail = false;
         self.recover_jsx_closing_tag_extra_namespace_tail = false;
         self.recover_jsx_invalid_namespace_head_tail = false;
@@ -555,6 +564,25 @@ impl ParserState {
             == diagnostic_codes::OCTAL_LITERALS_ARE_NOT_ALLOWED_USE_THE_SYNTAX
             || last.code == diagnostic_codes::DECIMALS_WITH_LEADING_ZEROS_ARE_NOT_ALLOWED;
         is_leading_zero && last.start != self.token_pos()
+    }
+
+    /// Returns true when the most recent parse diagnostic was an
+    /// "element access expression should take an argument" error (TS1011) at a
+    /// position different from the current token. Like the leading-zero case,
+    /// this is orthogonal to the missing-semicolon error (TS1005) that follows
+    /// a completed postfix expression: for `x[] )` tsc reports TS1011 at the
+    /// empty subscript AND `';' expected.` at the stray close token, because its
+    /// `parseErrorAtPosition` dedups only by exact start. tsz's distance-based
+    /// suppression would otherwise drop the `';' expected.` (because the TS1011
+    /// is within a few tokens), leaving the close token to fall through to the
+    /// statement list as a spurious TS1128.
+    pub(crate) fn last_error_was_element_access_missing_argument_at_other_pos(&self) -> bool {
+        use tsz_common::diagnostics::diagnostic_codes;
+        let Some(last) = self.parse_diagnostics.last() else {
+            return false;
+        };
+        last.code == diagnostic_codes::AN_ELEMENT_ACCESS_EXPRESSION_SHOULD_TAKE_AN_ARGUMENT
+            && last.start != self.token_pos()
     }
 
     pub(crate) fn should_emit_jsx_missing_close_brace_at_semicolon(
@@ -1855,7 +1883,9 @@ impl ParserState {
                 .take(4)
                 .any(|diag| diag.start == token_pos);
             if !already_reported_here
-                && (self.should_report_error() || self.last_error_was_leading_zero_at_other_pos())
+                && (self.should_report_error()
+                    || self.last_error_was_leading_zero_at_other_pos()
+                    || self.last_error_was_element_access_missing_argument_at_other_pos())
             {
                 self.parse_error_at_current_token("';' expected.", diagnostic_codes::EXPECTED);
             }

--- a/crates/tsz-parser/src/parser/state_expressions_unary.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_unary.rs
@@ -377,10 +377,16 @@ impl ParserState {
         // Otherwise parse as an identifier (the checker will emit TS1212 in
         // strict mode for `yield` as a reserved word).
         if !self.in_generator_context() && next_is_ident_keyword_or_literal_on_same_line {
-            self.parse_error_at_current_token(
-                "A 'yield' expression is only allowed in a generator body.",
-                diagnostic_codes::A_YIELD_EXPRESSION_IS_ONLY_ALLOWED_IN_A_GENERATOR_BODY,
-            );
+            // Still parse as a yield expression (so emit is unchanged), but
+            // skip the grammar diagnostic when this subtree belongs to a class
+            // member recovered after a misplaced `case`/`default` clause: tsc
+            // keeps that member yet does not run the yield grammar check on it.
+            if !self.suppress_recovered_clause_member_yield_grammar {
+                self.parse_error_at_current_token(
+                    "A 'yield' expression is only allowed in a generator body.",
+                    diagnostic_codes::A_YIELD_EXPRESSION_IS_ONLY_ALLOWED_IN_A_GENERATOR_BODY,
+                );
+            }
             // Fall through to parse as yield expression
         } else if !self.in_generator_context() {
             // Outside a generator context and next token is not identifier/keyword/

--- a/crates/tsz-parser/src/parser/state_statements_class_members.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_members.rs
@@ -1334,6 +1334,11 @@ impl ParserState {
         use tsz_common::diagnostics::diagnostic_codes;
         let start_pos = self.token_pos();
 
+        // Clear any leftover recovered-clause yield suppression from the
+        // previous member; it is (re)armed below only for a misplaced
+        // `case`/`default` clause and must not leak into sibling members.
+        self.suppress_recovered_clause_member_yield_grammar = false;
+
         if self.is_token(SyntaxKind::SemicolonToken) {
             let end_pos = self.token_end();
             self.next_token();
@@ -1369,6 +1374,14 @@ impl ParserState {
                 diagnostic_codes::UNEXPECTED_TOKEN_A_CONSTRUCTOR_METHOD_ACCESSOR_OR_PROPERTY_WAS_EXPECTED,
             );
             self.next_token();
+            // tsc keeps the recovered clause body as a class member (it still
+            // emits, e.g. `case d = () => {...}` -> `this.d = () => {...}`) but
+            // does not run the post-parse grammar checks on it, so the
+            // yield-outside-generator check (TS1163) does not fire. tsz emits
+            // TS1163 eagerly in the parser, so suppress it while this recovered
+            // member is parsed. The flag is reset at the top of the next
+            // `parse_class_member`, scoping it to exactly this member.
+            self.suppress_recovered_clause_member_yield_grammar = true;
         }
 
         // Handle bare `#` that can't become a PrivateIdentifier.

--- a/crates/tsz-parser/tests/parser_improvement_class_member_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_class_member_recovery_tests.rs
@@ -272,3 +272,147 @@ class C {
         "Valid private names should not emit TS1127, got diagnostics: {diagnostics:?}"
     );
 }
+
+// =====================================================================
+// Misplaced `case`/`default` switch-clause keyword in a class body.
+//
+// When a class member begins with `case`/`default` followed by a property
+// name on the same line (a misplaced switch clause), tsc reports a single
+// TS1068 ("A constructor, method, accessor, or property was expected."),
+// consumes the keyword, and parses the rest as a normal class member that it
+// KEEPS (it still emits — `case d = () => {...}` -> `this.d = () => {...}`).
+// It does not, however, run the post-parse grammar checks on that recovered
+// member, so the yield-outside-generator check (TS1163) does not fire. tsz
+// emits TS1163 eagerly in the parser, so it suppresses it for the recovered
+// member while still parsing (and thus emitting) the member.
+// =====================================================================
+
+fn diagnostic_codes_of(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    let mut codes: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+/// Number of class members in the first top-level class declaration.
+fn first_class_member_count(source: &str) -> usize {
+    let (parser, root) = parse_source(source);
+    let arena = parser.get_arena();
+    let source_file = arena.get_source_file_at(root).unwrap();
+    let class_idx = source_file.statements.nodes[0];
+    let class_node = arena.get(class_idx).unwrap();
+    arena.get_class(class_node).unwrap().members.nodes.len()
+}
+
+#[test]
+fn misplaced_case_clause_with_yield_arrow_reports_only_ts1068() {
+    // The witness from `constructorWithIncompleteTypeAnnotation.ts`: a
+    // misplaced `case` clause whose initializer is a non-generator arrow with a
+    // `yield` expression. tsc reports only TS1068 — the recovered member is
+    // kept but its yield is not grammar-checked (no TS1163).
+    let source = "class Widget {\n     case  handler = () => {  yield  0; };\n    render() { return 0; }\n}\n";
+    let codes = diagnostic_codes_of(source);
+    assert_eq!(
+        codes,
+        vec![diagnostic_codes::UNEXPECTED_TOKEN_A_CONSTRUCTOR_METHOD_ACCESSOR_OR_PROPERTY_WAS_EXPECTED],
+        "misplaced `case` clause must report only TS1068, never the recovered \
+         member's TS1163; got {:?}",
+        diagnostic_codes_of(source)
+    );
+}
+
+#[test]
+fn misplaced_case_clause_keeps_recovered_member_for_emit() {
+    // tsc keeps the recovered `handler` member (it emits `this.handler = ...`),
+    // so tsz must not drop it. The class retains both the recovered member and
+    // the following `render` method.
+    let source = "class Widget {\n     case  handler = () => {  yield  0; };\n    render() { return 0; }\n}\n";
+    assert_eq!(
+        first_class_member_count(source),
+        2,
+        "the recovered `case` member must be kept alongside the following method"
+    );
+}
+
+#[test]
+fn misplaced_case_clause_with_object_literal_reports_only_ts1068() {
+    // A balanced object/array literal initializer parses as part of the kept
+    // member; only the leading TS1068 is reported.
+    let source = "class Registry {\n  case  entry = { a: 1, b: [2, 3] };\n  size() {}\n}\n";
+    assert_eq!(
+        diagnostic_codes_of(source),
+        vec![diagnostic_codes::UNEXPECTED_TOKEN_A_CONSTRUCTOR_METHOD_ACCESSOR_OR_PROPERTY_WAS_EXPECTED],
+    );
+}
+
+#[test]
+fn misplaced_case_clause_before_class_close_reports_only_ts1068() {
+    // The recovered member ends via ASI at the class close `}`; no cascading
+    // errors leak past the class body.
+    let source = "class Node_ {\n  case  next = 1 }\n";
+    assert_eq!(
+        diagnostic_codes_of(source),
+        vec![diagnostic_codes::UNEXPECTED_TOKEN_A_CONSTRUCTOR_METHOD_ACCESSOR_OR_PROPERTY_WAS_EXPECTED],
+    );
+}
+
+#[test]
+fn misplaced_default_clause_with_yield_arrow_reports_only_ts1068() {
+    // `default` shares the misplaced-switch-clause recovery with `case`.
+    let source = "class Surface {\n  default  paint = () => { yield 1; };\n  area() {}\n}\n";
+    assert_eq!(
+        diagnostic_codes_of(source),
+        vec![diagnostic_codes::UNEXPECTED_TOKEN_A_CONSTRUCTOR_METHOD_ACCESSOR_OR_PROPERTY_WAS_EXPECTED],
+    );
+}
+
+#[test]
+fn case_as_property_name_followed_by_semicolon_is_still_valid() {
+    // Negative control: `case` is a legal property name by itself (followed by
+    // `;`/`(`), so it must NOT trigger the misplaced-clause recovery. A bare
+    // `case;` property parses without any TS1068.
+    let source = "class Bag {\n  case;\n  value() {}\n}\n";
+    let codes = diagnostic_codes_of(source);
+    assert!(
+        !codes.contains(
+            &diagnostic_codes::UNEXPECTED_TOKEN_A_CONSTRUCTOR_METHOD_ACCESSOR_OR_PROPERTY_WAS_EXPECTED
+        ),
+        "`case;` as a property name must not emit TS1068; got {codes:?}"
+    );
+}
+
+#[test]
+fn non_generator_arrow_yield_still_reports_ts1163_when_attached() {
+    // Negative control: when the arrow is a normal (non-recovered) member
+    // initializer, the yield-outside-generator grammar check still fires. The
+    // suppression flag must be scoped to the recovered member only, not leak to
+    // sibling members.
+    let source = "class Live {\n  handler = () => {  yield  0; };\n  run() {}\n}\n";
+    let codes = diagnostic_codes_of(source);
+    assert!(
+        codes.contains(&diagnostic_codes::A_YIELD_EXPRESSION_IS_ONLY_ALLOWED_IN_A_GENERATOR_BODY),
+        "a genuine non-generator arrow `yield` must still report TS1163; got {codes:?}"
+    );
+}
+
+#[test]
+fn yield_suppression_does_not_leak_to_sibling_member_after_case() {
+    // The recovered `case` member suppresses its own TS1163, but the *following*
+    // genuine member's non-generator `yield` must still report TS1163 — the flag
+    // is reset per member.
+    let source = "class Mixed {\n  case  a = () => { yield 0; };\n  b = () => { yield 1; };\n}\n";
+    let codes = diagnostic_codes_of(source);
+    assert!(
+        codes.contains(&diagnostic_codes::A_YIELD_EXPRESSION_IS_ONLY_ALLOWED_IN_A_GENERATOR_BODY),
+        "the sibling member's yield must still report TS1163; got {codes:?}"
+    );
+    // Exactly one TS1163 (from the sibling `b`, not the recovered `a`).
+    let ts1163 = codes
+        .iter()
+        .filter(|&&c| c == diagnostic_codes::A_YIELD_EXPRESSION_IS_ONLY_ALLOWED_IN_A_GENERATOR_BODY)
+        .count();
+    assert_eq!(
+        ts1163, 1,
+        "only the sibling member should report TS1163; got {codes:?}"
+    );
+}

--- a/crates/tsz-parser/tests/parser_improvement_expression_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_expression_recovery_tests.rs
@@ -324,3 +324,74 @@ fn test_statement_starting_with_question_does_not_seed_conditional_condition() {
         "statement-start `?` should not become a conditional expression with a missing condition"
     );
 }
+
+// =====================================================================
+// Empty element access (`x[]`) followed by a stray close token.
+//
+// `x[]` reports TS1011 ("An element access expression should take an
+// argument."). When the completed postfix expression is then followed by a
+// stray close token that cannot start a statement (for example `)`), tsc
+// reports TS1005 ("';' expected.") at that token — its `parseErrorAtPosition`
+// dedups missing-semicolon errors by exact start only, so the nearby TS1011
+// does not suppress it. tsz's distance-based suppression would otherwise drop
+// the `';' expected.`, leaving the close token to fall through to the
+// statement list as a spurious TS1128 ("Declaration or statement expected.").
+// =====================================================================
+
+fn expression_recovery_codes(source: &str) -> Vec<u32> {
+    let (parser, _root) = parse_source(source);
+    let mut codes: Vec<u32> = parser.get_diagnostics().iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+    codes
+}
+
+#[test]
+fn empty_element_access_then_stray_paren_reports_semicolon_not_ts1128() {
+    let codes = expression_recovery_codes("probe[] )\n");
+    assert!(
+        codes.contains(&diagnostic_codes::AN_ELEMENT_ACCESS_EXPRESSION_SHOULD_TAKE_AN_ARGUMENT),
+        "empty subscript must still report TS1011; got {codes:?}"
+    );
+    assert!(
+        codes.contains(&diagnostic_codes::EXPECTED),
+        "the stray close token must report TS1005 ';' expected; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED),
+        "the stray close token must not fall through to a spurious TS1128; got {codes:?}"
+    );
+}
+
+#[test]
+fn empty_element_access_then_stray_bracket_close_reports_semicolon_not_ts1128() {
+    // `value[])` shape from the witness `...rest: string[]) {...}` reduced to
+    // statement level: empty subscript immediately followed by `)`.
+    let codes = expression_recovery_codes("value[]) \n");
+    assert!(
+        codes.contains(&diagnostic_codes::AN_ELEMENT_ACCESS_EXPRESSION_SHOULD_TAKE_AN_ARGUMENT)
+    );
+    assert!(codes.contains(&diagnostic_codes::EXPECTED));
+    assert!(!codes.contains(&diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED));
+}
+
+#[test]
+fn nonempty_element_access_then_stray_paren_unchanged() {
+    // Negative control: a non-empty subscript already completed correctly —
+    // TS1005 at the stray `)`, no TS1011, no TS1128. The fix must not perturb
+    // this path.
+    let codes = expression_recovery_codes("probe[0] )\n");
+    assert!(
+        !codes.contains(&diagnostic_codes::AN_ELEMENT_ACCESS_EXPRESSION_SHOULD_TAKE_AN_ARGUMENT)
+    );
+    assert!(codes.contains(&diagnostic_codes::EXPECTED));
+    assert!(!codes.contains(&diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED));
+}
+
+#[test]
+fn call_expression_then_stray_paren_unchanged() {
+    // Negative control: a completed call followed by a stray `)` already
+    // reports TS1005 ';' expected (no TS1011 involved).
+    let codes = expression_recovery_codes("invoke() )\n");
+    assert!(codes.contains(&diagnostic_codes::EXPECTED));
+    assert!(!codes.contains(&diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED));
+}

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -45,7 +45,26 @@
 #   exact-head aggregate and stay listed.
 # Keep these visible as accepted-regression debt until their owning parity
 # fixes remove them from exact-head aggregate output.
-TypeScript/tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts
+# constructorWithIncompleteTypeAnnotation.ts: RESOLVED. Two parser error-recovery
+# divergences in this torture file, both now matching tsc exactly (diagnostics
+# and JS emit):
+#   1. A misplaced `case`/`default` switch-clause keyword in a class body
+#      (`case d = () => { yield 0; };`) emitted a spurious TS1163
+#      ("A 'yield' expression is only allowed in a generator body."). tsc reports
+#      only TS1068, consumes the keyword, and keeps the recovered member (it still
+#      emits `this.d = () => { yield 0; }`) but does not run the post-parse grammar
+#      check on it. tsz emits TS1163 eagerly in the parser, so it now suppresses
+#      it for the recovered member (scoped per member) while still parsing and
+#      emitting the member.
+#   2. An empty element access (`x[]`, TS1011) followed by a stray close token
+#      reported TS1128 ("Declaration or statement expected.") instead of tsc's
+#      TS1005 ("';' expected."): the distance-based missing-semicolon suppression
+#      dropped the `;` error because the TS1011 was a few tokens away. tsc dedups
+#      that error by exact start only, so it reports both. The missing-semicolon
+#      path now keeps the `;` error past a different-position TS1011 (mirroring the
+#      existing leading-zero exception). Covered by
+#      parser_improvement_class_member_recovery_tests::misplaced_case_clause_* and
+#      parser_improvement_expression_recovery_tests::empty_element_access_*.
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts


### PR DESCRIPTION
AgentName: M1-A
Track: Conformance / parser error-recovery parity

Closes #12933.

**Invariant:** Match `tsc` exactly on the parser error-recovery diagnostics
**and JS emit** for
`TypeScript/tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts`.
tsz already matched ~47 of 49 fingerprints; this PR closes the remaining two
divergences, both in malformed-input recovery, without changing emit for any
other file.

## Problem & structural rule

### 1. Spurious TS1163 for a misplaced `case` switch-clause in a class body
A class member beginning with `case`/`default` followed by a property name on
the same line (a misplaced switch clause, e.g. `case d = () => { yield 0; };`)
is reported by `tsc` as a single **TS1068**. `tsc` consumes the keyword and
**keeps** the recovered member — it still emits `this.d = () => { yield 0; }` —
but does not run the post-parse grammar checks on it, so the
yield-outside-generator check (**TS1163**) does not fire. tsz emits TS1163
eagerly in the parser, so it produced a spurious TS1163.

> When a reserved switch-clause keyword (`case`/`default`) cannot begin a class
> member, `tsc` reports TS1068, keeps the recovered member (so it still emits),
> but does not grammar-check it. tsz now suppresses the eager TS1163 for the
> recovered member while still parsing/emitting it.

An earlier revision of this PR *discarded* the clause; that removed the spurious
TS1163 but also dropped `this.d` from emit (a JS-emit regression caught by CI).
The fix was corrected to **suppress the diagnostic** while keeping the member,
so emit is byte-identical to before.

### 2. TS1128 instead of TS1005 after an empty element access + stray close token
An empty element access `x[]` reports **TS1011**. When the completed postfix
expression is followed by a stray close token (e.g. `)`), `tsc` reports
**TS1005** ("';' expected.") — its `parseErrorAtPosition` dedups missing-semicolon
errors by exact start only. tsz's distance-based suppression dropped the
`';' expected` because the TS1011 was a few tokens away, leaving the stray
token to fall through to the statement list as a spurious **TS1128**.

> The missing-semicolon error after a completed postfix expression must survive a
> nearby TS1011 at a different position, mirroring the existing leading-zero
> (`00.5;`) exception and `tsc`'s exact-position dedup.

## Owner layer
- `tsz-parser`:
  - `suppress_recovered_clause_member_yield_grammar` flag (`state.rs`): set after
    the misplaced `case`/`default` TS1068, reset at the top of each
    `parse_class_member`, checked at the TS1163 emit site
    (`state_expressions_unary.rs`).
  - `last_error_was_element_access_missing_argument_at_other_pos` (`state.rs`):
    new exception alongside `last_error_was_leading_zero_at_other_pos` in the
    missing-semicolon path.

This changes only which diagnostics are emitted — no AST or emit changes — so the
emit suite is unaffected.

## Scope / adjacent matrix (verified vs `tsc` 6.0.3)
- `case`/`default` clause with non-generator arrow + `yield`, balanced
  object/array literal, no trailing `;`, clause before the class close `}` →
  all report only TS1068, **member kept**.
- suppression scoped per-member: a sibling member's genuine non-generator
  `yield` still reports TS1163.
- `case;` as a bare property name → still valid (no TS1068).
- `x[] )` / `x[])` → TS1011 + TS1005 (no TS1128); `x[0] )` and `f() )` → TS1005
  only (unchanged negative controls).

## Project Corpus Impact
- Row: n/a
- Bug family: parser error-recovery cascade (TS1163 / TS1128-vs-TS1005)
- Removes the `constructorWithIncompleteTypeAnnotation.ts` accepted-regression
  ledger entry (now passes, matching `tsc`'s 49 diagnostics and JS emit).

## Verification
- **End-to-end:** the `tsz` binary on the exact fixture reproduces `tsc@6.0.3`'s
  full 49-diagnostic fingerprint set (line, column, code, message) and emits the
  recovered `this.d = () => { yield 0; }` member, matching tsc.
- New parser unit tests (12), incl. member-retention and per-member suppression
  scoping; binder names varied.
- Full `tsz-parser` lib suite green (1415 passed, 0 failed); clippy/fmt clean.
- Rebased onto latest `main` (no conflicts).

## Coordination Notes
The two other `bug`-labeled open issues (#10663, #8432) are already `WIP`; this
defect lived only in the accepted-regression ledger, so #12933 was filed to
claim it. The remaining 4 ledger rows (mapped/conditional-inference and
relation-fuel parity) are out of scope here.

https://claude.ai/code/session_01SPktaP5TgjDqL8rktdAcXm
