### PR TITLE
docs: document exact PR-body fields enforced by project-corpus-pr-body CI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -89,6 +89,17 @@ Hard rules:
 - Do not add `[codex]` to PR titles.
 - PR bodies must include: `AgentName`, `Track`, `Invariant`, `Scope`,
   `Project Corpus Impact`, `Verification`, and `Coordination Notes`.
+- The `project-corpus-pr-body` CI job greps the remote body for exact field
+  formats; match them or the job fails:
+  - Always include a plain signature line `AgentName: <stable agent name>`
+    (no Markdown heading, value must be non-empty).
+  - When the PR touches semantic, benchmark, or dashboard paths
+    (`crates/tsz-*`, `crates/tsz-website`, `scripts/{bench,ci,conformance,emit,fourslash}`,
+    `.github/workflows/{bench,ci}.yml`), the body must also contain the literal
+    heading `## Project Corpus Impact` followed by `- Row: <project row or n/a>`
+    and `- Bug family: <family or n/a>` lines, each with a non-empty value.
+  - Docs/skill/harness-only PRs still need `AgentName:`; use `Row: n/a` and
+    `Bug family: n/a` with a concrete evidence line when those paths change.
 - Verify remote PR bodies after create/material edit:
   `gh pr view <n> --json body`.
 - Drain owned PRs before starting unrelated work. Do not park stale draft PRs.


### PR DESCRIPTION
AgentName: zen-dijkstra

Track: tooling/guardrail — documentation of CI-enforced PR-body contract.

Invariant: `.claude/CLAUDE.md` PR-body guidance must match what the
`project-corpus-pr-body` CI job actually greps for, so PRs authored against the
contract pass the gate.

Scope: `.claude/CLAUDE.md` only.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a
- Evidence: agent-instruction-only; no compiler, emit, or benchmark path touched.

Verification:
- `python3 scripts/agents/llm-context-audit.py` → `llm_context_audit_status=pass`, `finding_count=0`.
- Reviewed `.github/workflows/ci.yml` `project-corpus-pr-body` job to confirm the
  documented field formats (`AgentName:` plain signature, `## Project Corpus
  Impact` heading, `- Row:`, `- Bug family:`) match the grep patterns and the
  semantic-path trigger list.

Coordination Notes: No overlap with compiler lanes; docs-only. Ready for review.

### Why
The `project-corpus-pr-body` job fails ready PRs that omit a plain `AgentName:`
signature, and fails semantic/benchmark/dashboard PRs that omit the literal
`## Project Corpus Impact` heading with `- Row:` and `- Bug family:` lines.
CLAUDE.md previously named these sections without their enforced formats or the
path trigger, so a PR could follow the instructions and still fail CI. This adds
the exact formats and the path list that activates the requirement.

https://claude.ai/code/session_01AQaPAWdgpWRZ28NVPNUh9d

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQaPAWdgpWRZ28NVPNUh9d)_