### PR TITLE
refactor(checker): extract mode-aware cross-file export resolver to own file

### DIFF
--- a/crates/tsz-binder/src/state/core_jsdoc.rs
+++ b/crates/tsz-binder/src/state/core_jsdoc.rs
@@ -66,6 +66,26 @@ impl BinderState {
         results
     }
 
+    /// Extract the `resolution-mode` override from a JSDoc `@import` tag body.
+    ///
+    /// The tag body is everything after `@import`, e.g.
+    /// `{ Foo } from "pkg" with { "resolution-mode": "import" }`. Only the
+    /// portion after the (last, unquoted) `from` keyword can carry an import
+    /// attribute clause, so the scan starts there to avoid matching a `with`
+    /// that appears inside an imported binding name. Returns `None` when no
+    /// valid `resolution-mode` attribute is present.
+    pub(super) fn parse_jsdoc_import_resolution_mode(
+        rest: &str,
+    ) -> Option<tsz_common::ImportResolutionMode> {
+        // Cheap reject: an attribute clause requires a `with`/`assert` keyword,
+        // so skip the quote-aware `from` scan for the common no-attribute tag.
+        if !rest.contains("with") && !rest.contains("assert") {
+            return None;
+        }
+        let from_idx = Self::find_jsdoc_import_from_keyword(rest)?;
+        tsz_common::parse_jsdoc_resolution_mode_attribute_clause(&rest[from_idx + 4..])
+    }
+
     pub(super) fn find_jsdoc_import_from_keyword(rest: &str) -> Option<usize> {
         let mut quote = None;
         let mut escaped = false;
@@ -358,15 +378,17 @@ impl BinderState {
                 {
                     continue;
                 }
-                let has_attributes = rest.contains(" with ");
+                // A `with { "resolution-mode": ... }` attribute selects which
+                // package `exports`/`imports` condition the specifier resolves
+                // through. Record it on the alias so the checker resolves the
+                // member from the correct target file (e.g. an ESM `.d.mts` vs a
+                // CommonJS `.d.cts`), matching tsc.
+                let resolution_mode = Self::parse_jsdoc_import_resolution_mode(rest);
                 for (local_name, specifier, import_name) in Self::parse_jsdoc_import_tag(rest) {
                     if local_name.is_empty() || specifier.is_empty() {
                         continue;
                     }
                     self.file_import_sources.push(specifier.clone());
-                    if has_attributes {
-                        continue;
-                    }
                     // Do not redeclare a name that already has an alias in this
                     // scope (runtime ES import or earlier JSDoc `@import`). The
                     // type-only JSDoc binding must not override the existing
@@ -390,6 +412,7 @@ impl BinderState {
                         sym.is_type_only = true;
                         sym.import_module = Some(specifier.clone());
                         sym.import_name = Some(import_name);
+                        sym.import_resolution_mode = resolution_mode;
                     }
                 }
             }

--- a/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
+++ b/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
@@ -409,6 +409,60 @@ class C {}
 }
 
 #[test]
+fn jsdoc_import_tag_records_resolution_mode_attribute() {
+    // A JSDoc `@import` carrying a `with { "resolution-mode": ... }` attribute
+    // must still bind the alias (it was previously dropped entirely) and record
+    // the override so the checker resolves the member through the requested
+    // package condition. Vary the binder name so the behavior is structural,
+    // not keyed to a specific identifier.
+    let source = r#"
+/**
+ * @import { Esm as ImpAlias } from "pkg" with { "resolution-mode": "import" }
+ * @import { Cjs as ReqAlias } from "pkg" with { 'resolution-mode': 'require' }
+ * @import { Plain } from "pkg"
+ */
+class C {}
+"#;
+    let mut parser = ParserState::new("b.js".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let lookup = |name: &str| {
+        let sym_id = binder
+            .file_locals
+            .get(name)
+            .unwrap_or_else(|| panic!("expected JSDoc import alias {name}"));
+        binder
+            .symbols
+            .get(sym_id)
+            .unwrap_or_else(|| panic!("expected symbol data for {name}"))
+    };
+
+    let imp = lookup("ImpAlias");
+    assert_ne!(imp.flags & symbol_flags::ALIAS, 0);
+    assert!(imp.is_type_only);
+    assert_eq!(imp.import_module.as_deref(), Some("pkg"));
+    assert_eq!(imp.import_name.as_deref(), Some("Esm"));
+    assert_eq!(
+        imp.import_resolution_mode,
+        Some(tsz_common::ImportResolutionMode::Import)
+    );
+
+    let req = lookup("ReqAlias");
+    assert_eq!(req.import_name.as_deref(), Some("Cjs"));
+    assert_eq!(
+        req.import_resolution_mode,
+        Some(tsz_common::ImportResolutionMode::Require)
+    );
+
+    // No attribute clause → no override.
+    let plain = lookup("Plain");
+    assert_eq!(plain.import_resolution_mode, None);
+}
+
+#[test]
 fn export_as_namespace_records_current_file_namespace_metadata() {
     let source = r"
 export var x: number;

--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -292,6 +292,14 @@ pub struct Symbol {
     /// Original export name for imports with renamed imports (e.g., 'foo' for `import { foo as bar }`)
     /// If None, the import name matches the `escaped_name`.
     pub import_name: Option<String>,
+    /// Explicit `resolution-mode` override for this import alias, when one was
+    /// declared via an import attribute (`with { "resolution-mode": ... }`).
+    ///
+    /// Currently set for JSDoc `@import` aliases that carry an attribute clause.
+    /// `None` means the specifier resolves through the importing file's own
+    /// inferred module mode. The checker maps this onto the resolution request
+    /// so package `exports`/`imports` conditions pick the right target file.
+    pub import_resolution_mode: Option<tsz_common::ImportResolutionMode>,
     /// Whether this symbol is a UMD namespace export (`export as namespace Foo`).
     /// UMD exports are ALIAS symbols that should be globally visible across files,
     /// unlike regular import aliases which are file-local.
@@ -320,6 +328,7 @@ impl Symbol {
             decl_file_idx: u32::MAX,
             import_module: None,
             import_name: None,
+            import_resolution_mode: None,
             is_umd_export: false,
         }
     }

--- a/crates/tsz-checker/src/context/aliases.rs
+++ b/crates/tsz-checker/src/context/aliases.rs
@@ -23,6 +23,15 @@ pub enum ResolutionModeOverride {
     Require,
 }
 
+impl From<tsz_common::ImportResolutionMode> for ResolutionModeOverride {
+    fn from(mode: tsz_common::ImportResolutionMode) -> Self {
+        match mode {
+            tsz_common::ImportResolutionMode::Import => Self::Import,
+            tsz_common::ImportResolutionMode::Require => Self::Require,
+        }
+    }
+}
+
 /// Syntactic request kind used by the driver when resolving a module specifier.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ResolutionRequestKind {

--- a/crates/tsz-checker/src/state/type_resolution/cross_file_export.rs
+++ b/crates/tsz-checker/src/state/type_resolution/cross_file_export.rs
@@ -1,0 +1,163 @@
+//! Mode-aware cross-file export resolution for `CheckerState`.
+//!
+//! Houses `resolve_cross_file_export_from_file_with_mode`, the export-lookup
+//! kernel that honors an explicit `resolution-mode` override when picking the
+//! target file. The thin default-mode wrappers
+//! (`resolve_cross_file_export` / `resolve_cross_file_export_from_file`) live in
+//! `type_resolution/module.rs` and delegate here.
+
+use crate::state::CheckerState;
+
+impl<'a> CheckerState<'a> {
+    /// Like `resolve_cross_file_export_from_file` but honors an explicit
+    /// `resolution-mode` override when picking the target file. This routes a
+    /// specifier through the requested package `exports`/`imports` condition
+    /// (ESM `import` vs CommonJS `require`) so, e.g., a JSDoc
+    /// `@import { X } from "pkg" with { "resolution-mode": "import" }` resolves
+    /// `X` from the package's ESM-condition declaration file even when the
+    /// importing file is CommonJS. With `None` the behavior is identical to the
+    /// default-mode entry point.
+    pub(crate) fn resolve_cross_file_export_from_file_with_mode(
+        &self,
+        module_specifier: &str,
+        export_name: &str,
+        source_file_idx: Option<usize>,
+        resolution_mode_override: Option<crate::context::ResolutionModeOverride>,
+    ) -> Option<tsz_binder::SymbolId> {
+        // First, try to resolve the module specifier to a target file index.
+        // When source_file_idx is provided, resolve from that file's perspective
+        // (for following re-export chains where specifiers are relative to the
+        // declaring file, not the current file). `resolve_import_target_from_file_with_mode`
+        // falls back to the default-mode resolution when the override is `None`,
+        // so this single call covers both the default and mode-overridden paths.
+        let from_file = source_file_idx.unwrap_or(self.ctx.current_file_idx);
+        let target_file_idx = self.ctx.resolve_import_target_from_file_with_mode(
+            from_file,
+            module_specifier,
+            resolution_mode_override,
+        );
+
+        let Some(target_file_idx) = target_file_idx else {
+            if let Some((sym_id, binder_idx)) =
+                self.resolve_ambient_module_export(module_specifier, export_name)
+            {
+                // Record cross-file origin so delegate_cross_arena_symbol_resolution
+                // can find the correct arena/binder for this symbol.
+                if !self.ctx.has_symbol_file_index(sym_id) {
+                    self.ctx.register_symbol_file_target(sym_id, binder_idx);
+                }
+                return Some(sym_id);
+            }
+            return None;
+        };
+
+        // Get the target file's binder
+        let target_binder = self.ctx.get_binder_for_file(target_file_idx)?;
+
+        // Resolve the target file's canonical module key (source file path)
+        let target_arena = self.ctx.get_arena_for_file(target_file_idx as u32);
+        let target_file_name = target_arena.source_files.first()?.file_name.clone();
+
+        // Helper: record the cross-file origin so delegate_cross_arena_symbol_resolution
+        // can find the correct arena for this SymbolId.
+        let record_and_return = |sym_id: tsz_binder::SymbolId| -> Option<tsz_binder::SymbolId> {
+            self.ctx
+                .register_symbol_file_target(sym_id, target_file_idx);
+            Some(sym_id)
+        };
+
+        let is_reexport_alias = |sym_id: tsz_binder::SymbolId| {
+            target_binder
+                .get_symbol(sym_id)
+                .is_some_and(|symbol| symbol.import_module.is_some())
+        };
+
+        if let Some(exports_table) = self
+            .ctx
+            .module_exports_for_module(target_binder, &target_file_name)
+            && let Some(sym_id) =
+                self.resolve_export_from_table(target_binder, exports_table, export_name)
+            && !is_reexport_alias(sym_id)
+        {
+            return record_and_return(sym_id);
+        }
+
+        if let Some(exports_table) = self
+            .ctx
+            .module_exports_for_module(target_binder, module_specifier)
+            && let Some(sym_id) =
+                self.resolve_export_from_table(target_binder, exports_table, export_name)
+            && !is_reexport_alias(sym_id)
+        {
+            return record_and_return(sym_id);
+        }
+
+        let augmentation_export =
+            self.resolve_module_augmentation_export_for_file(target_file_idx, export_name);
+        if let Some((sym_id, augmenting_file_idx)) = augmentation_export
+            && self.module_augmentation_export_preempts_reexport_alias(sym_id, augmenting_file_idx)
+        {
+            self.ctx
+                .register_symbol_file_target(sym_id, augmenting_file_idx);
+            return Some(sym_id);
+        }
+
+        if let Some(source_binder) = self.ctx.get_binder_for_file(from_file)
+            && let Some((sym_id, _is_type_only)) =
+                source_binder.resolve_import_with_reexports_type_only(module_specifier, export_name)
+        {
+            return record_and_return(sym_id);
+        }
+
+        // Prefer the binder's type-aware export resolver so interface/type-only
+        // exports reached through `import("./x").T` behave the same way as
+        // regular type-node resolution.
+        if let Some((sym_id, _is_type_only)) =
+            target_binder.resolve_import_with_reexports_type_only(&target_file_name, export_name)
+        {
+            return record_and_return(sym_id);
+        }
+
+        // Follow re-export chains (wildcard and named re-exports) BEFORE
+        // falling back to file_locals. file_locals may contain merged globals
+        // that shadow the actual re-exported symbols.
+        let mut visited = rustc_hash::FxHashSet::default();
+        if let Some((sym_id, actual_file_idx)) =
+            self.resolve_export_in_file(target_file_idx, export_name, &mut visited)
+        {
+            self.ctx
+                .register_symbol_file_target(sym_id, actual_file_idx);
+            return Some(sym_id);
+        }
+
+        if let Some((sym_id, augmenting_file_idx)) = augmentation_export {
+            self.ctx
+                .register_symbol_file_target(sym_id, augmenting_file_idx);
+            return Some(sym_id);
+        }
+
+        // Last resort: check file_locals (for script files or binding edge cases
+        // where module_exports wasn't populated).
+        //
+        // IMPORTANT: Only use file_locals as a fallback when module_exports is
+        // empty or unavailable AND the target file is a script (not an external
+        // module). For real ES modules — files with `import`/`export` syntax or
+        // module file extensions like `.mts`/`.cts` — `file_locals` may hold
+        // imported aliases (`import x from "./other"`) that are NOT part of the
+        // module's public surface. Returning those here would let
+        // `import * as ns from "./self"` see the file's local imports through
+        // `ns.x`, which `tsc` rejects with TS2339 (issue #3585).
+        let has_module_exports = self
+            .ctx
+            .module_exports_for_module(target_binder, &target_file_name)
+            .is_some_and(|e| !e.is_empty());
+        if !target_binder.is_external_module
+            && !has_module_exports
+            && let Some(sym_id) = target_binder.file_locals.get(export_name)
+        {
+            return record_and_return(sym_id);
+        }
+
+        None
+    }
+}

--- a/crates/tsz-checker/src/state/type_resolution/mod.rs
+++ b/crates/tsz-checker/src/state/type_resolution/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod constructors;
 mod constructors_tests;
 pub mod core;
 pub(crate) mod cross_file_constructors;
+pub(crate) mod cross_file_export;
 pub(crate) mod import_type;
 pub(crate) mod judge;
 pub(crate) mod mixin_constraints;

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -97,7 +97,7 @@ impl<'a> CheckerState<'a> {
         candidates
     }
 
-    fn resolve_module_augmentation_export_for_file(
+    pub(crate) fn resolve_module_augmentation_export_for_file(
         &self,
         file_idx: usize,
         export_name: &str,
@@ -191,7 +191,7 @@ impl<'a> CheckerState<'a> {
         resolved
     }
 
-    fn module_augmentation_export_preempts_reexport_alias(
+    pub(crate) fn module_augmentation_export_preempts_reexport_alias(
         &self,
         sym_id: tsz_binder::SymbolId,
         augmenting_file_idx: usize,
@@ -609,158 +609,6 @@ impl<'a> CheckerState<'a> {
         )
     }
 
-    /// Like [`resolve_cross_file_export_from_file`] but honors an explicit
-    /// `resolution-mode` override when picking the target file. This routes a
-    /// specifier through the requested package `exports`/`imports` condition
-    /// (ESM `import` vs CommonJS `require`) so, e.g., a JSDoc
-    /// `@import { X } from "pkg" with { "resolution-mode": "import" }` resolves
-    /// `X` from the package's ESM-condition declaration file even when the
-    /// importing file is CommonJS. With `None` the behavior is identical to the
-    /// default-mode entry point.
-    pub(crate) fn resolve_cross_file_export_from_file_with_mode(
-        &self,
-        module_specifier: &str,
-        export_name: &str,
-        source_file_idx: Option<usize>,
-        resolution_mode_override: Option<crate::context::ResolutionModeOverride>,
-    ) -> Option<tsz_binder::SymbolId> {
-        // First, try to resolve the module specifier to a target file index.
-        // When source_file_idx is provided, resolve from that file's perspective
-        // (for following re-export chains where specifiers are relative to the
-        // declaring file, not the current file). `resolve_import_target_from_file_with_mode`
-        // falls back to the default-mode resolution when the override is `None`,
-        // so this single call covers both the default and mode-overridden paths.
-        let from_file = source_file_idx.unwrap_or(self.ctx.current_file_idx);
-        let target_file_idx = self.ctx.resolve_import_target_from_file_with_mode(
-            from_file,
-            module_specifier,
-            resolution_mode_override,
-        );
-
-        let Some(target_file_idx) = target_file_idx else {
-            if let Some((sym_id, binder_idx)) =
-                self.resolve_ambient_module_export(module_specifier, export_name)
-            {
-                // Record cross-file origin so delegate_cross_arena_symbol_resolution
-                // can find the correct arena/binder for this symbol.
-                if !self.ctx.has_symbol_file_index(sym_id) {
-                    self.ctx.register_symbol_file_target(sym_id, binder_idx);
-                }
-                return Some(sym_id);
-            }
-            return None;
-        };
-
-        // Get the target file's binder
-        let target_binder = self.ctx.get_binder_for_file(target_file_idx)?;
-
-        // Resolve the target file's canonical module key (source file path)
-        let target_arena = self.ctx.get_arena_for_file(target_file_idx as u32);
-        let target_file_name = target_arena.source_files.first()?.file_name.clone();
-
-        // Helper: record the cross-file origin so delegate_cross_arena_symbol_resolution
-        // can find the correct arena for this SymbolId.
-        let record_and_return = |sym_id: tsz_binder::SymbolId| -> Option<tsz_binder::SymbolId> {
-            self.ctx
-                .register_symbol_file_target(sym_id, target_file_idx);
-            Some(sym_id)
-        };
-
-        let is_reexport_alias = |sym_id: tsz_binder::SymbolId| {
-            target_binder
-                .get_symbol(sym_id)
-                .is_some_and(|symbol| symbol.import_module.is_some())
-        };
-
-        if let Some(exports_table) = self
-            .ctx
-            .module_exports_for_module(target_binder, &target_file_name)
-            && let Some(sym_id) =
-                self.resolve_export_from_table(target_binder, exports_table, export_name)
-            && !is_reexport_alias(sym_id)
-        {
-            return record_and_return(sym_id);
-        }
-
-        if let Some(exports_table) = self
-            .ctx
-            .module_exports_for_module(target_binder, module_specifier)
-            && let Some(sym_id) =
-                self.resolve_export_from_table(target_binder, exports_table, export_name)
-            && !is_reexport_alias(sym_id)
-        {
-            return record_and_return(sym_id);
-        }
-
-        let augmentation_export =
-            self.resolve_module_augmentation_export_for_file(target_file_idx, export_name);
-        if let Some((sym_id, augmenting_file_idx)) = augmentation_export
-            && self.module_augmentation_export_preempts_reexport_alias(sym_id, augmenting_file_idx)
-        {
-            self.ctx
-                .register_symbol_file_target(sym_id, augmenting_file_idx);
-            return Some(sym_id);
-        }
-
-        if let Some(source_binder) = self.ctx.get_binder_for_file(from_file)
-            && let Some((sym_id, _is_type_only)) =
-                source_binder.resolve_import_with_reexports_type_only(module_specifier, export_name)
-        {
-            return record_and_return(sym_id);
-        }
-
-        // Prefer the binder's type-aware export resolver so interface/type-only
-        // exports reached through `import("./x").T` behave the same way as
-        // regular type-node resolution.
-        if let Some((sym_id, _is_type_only)) =
-            target_binder.resolve_import_with_reexports_type_only(&target_file_name, export_name)
-        {
-            return record_and_return(sym_id);
-        }
-
-        // Follow re-export chains (wildcard and named re-exports) BEFORE
-        // falling back to file_locals. file_locals may contain merged globals
-        // that shadow the actual re-exported symbols.
-        let mut visited = rustc_hash::FxHashSet::default();
-        if let Some((sym_id, actual_file_idx)) =
-            self.resolve_export_in_file(target_file_idx, export_name, &mut visited)
-        {
-            self.ctx
-                .register_symbol_file_target(sym_id, actual_file_idx);
-            return Some(sym_id);
-        }
-
-        if let Some((sym_id, augmenting_file_idx)) = augmentation_export {
-            self.ctx
-                .register_symbol_file_target(sym_id, augmenting_file_idx);
-            return Some(sym_id);
-        }
-
-        // Last resort: check file_locals (for script files or binding edge cases
-        // where module_exports wasn't populated).
-        //
-        // IMPORTANT: Only use file_locals as a fallback when module_exports is
-        // empty or unavailable AND the target file is a script (not an external
-        // module). For real ES modules — files with `import`/`export` syntax or
-        // module file extensions like `.mts`/`.cts` — `file_locals` may hold
-        // imported aliases (`import x from "./other"`) that are NOT part of the
-        // module's public surface. Returning those here would let
-        // `import * as ns from "./self"` see the file's local imports through
-        // `ns.x`, which `tsc` rejects with TS2339 (issue #3585).
-        let has_module_exports = self
-            .ctx
-            .module_exports_for_module(target_binder, &target_file_name)
-            .is_some_and(|e| !e.is_empty());
-        if !target_binder.is_external_module
-            && !has_module_exports
-            && let Some(sym_id) = target_binder.file_locals.get(export_name)
-        {
-            return record_and_return(sym_id);
-        }
-
-        None
-    }
-
     pub(crate) fn resolve_export_from_table(
         &self,
         binder: &tsz_binder::BinderState,
@@ -839,7 +687,7 @@ impl<'a> CheckerState<'a> {
         None
     }
 
-    fn resolve_ambient_module_export(
+    pub(crate) fn resolve_ambient_module_export(
         &self,
         module_specifier: &str,
         export_name: &str,

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -601,17 +601,41 @@ impl<'a> CheckerState<'a> {
         export_name: &str,
         source_file_idx: Option<usize>,
     ) -> Option<tsz_binder::SymbolId> {
+        self.resolve_cross_file_export_from_file_with_mode(
+            module_specifier,
+            export_name,
+            source_file_idx,
+            None,
+        )
+    }
+
+    /// Like [`resolve_cross_file_export_from_file`] but honors an explicit
+    /// `resolution-mode` override when picking the target file. This routes a
+    /// specifier through the requested package `exports`/`imports` condition
+    /// (ESM `import` vs CommonJS `require`) so, e.g., a JSDoc
+    /// `@import { X } from "pkg" with { "resolution-mode": "import" }` resolves
+    /// `X` from the package's ESM-condition declaration file even when the
+    /// importing file is CommonJS. With `None` the behavior is identical to the
+    /// default-mode entry point.
+    pub(crate) fn resolve_cross_file_export_from_file_with_mode(
+        &self,
+        module_specifier: &str,
+        export_name: &str,
+        source_file_idx: Option<usize>,
+        resolution_mode_override: Option<crate::context::ResolutionModeOverride>,
+    ) -> Option<tsz_binder::SymbolId> {
         // First, try to resolve the module specifier to a target file index.
         // When source_file_idx is provided, resolve from that file's perspective
         // (for following re-export chains where specifiers are relative to the
-        // declaring file, not the current file).
+        // declaring file, not the current file). `resolve_import_target_from_file_with_mode`
+        // falls back to the default-mode resolution when the override is `None`,
+        // so this single call covers both the default and mode-overridden paths.
         let from_file = source_file_idx.unwrap_or(self.ctx.current_file_idx);
-        let target_file_idx = if let Some(from_file) = source_file_idx {
-            self.ctx
-                .resolve_import_target_from_file(from_file, module_specifier)
-        } else {
-            self.ctx.resolve_import_target(module_specifier)
-        };
+        let target_file_idx = self.ctx.resolve_import_target_from_file_with_mode(
+            from_file,
+            module_specifier,
+            resolution_mode_override,
+        );
 
         let Some(target_file_idx) = target_file_idx else {
             if let Some((sym_id, binder_idx)) =

--- a/crates/tsz-checker/src/types/queries/lib_aliases.rs
+++ b/crates/tsz-checker/src/types/queries/lib_aliases.rs
@@ -132,6 +132,12 @@ impl<'a> CheckerState<'a> {
                 .import_name
                 .as_deref()
                 .unwrap_or(&symbol.escaped_name);
+            // An explicit `resolution-mode` (from a JSDoc `@import ... with
+            // { "resolution-mode": ... }` attribute) routes the specifier
+            // through the requested package condition so members resolve from
+            // the matching ESM/CJS declaration file, mirroring tsc.
+            let resolution_mode_override: Option<crate::context::ResolutionModeOverride> =
+                symbol.import_resolution_mode.map(Into::into);
             if export_name == "default"
                 && self.ctx.compiler_options.module.is_node_module()
                 && self.ctx.file_is_esm == Some(true)
@@ -159,10 +165,11 @@ impl<'a> CheckerState<'a> {
                     export_name,
                     visited_aliases,
                 );
-                if let Some(target_sym_id) = self.resolve_cross_file_export_from_file(
+                if let Some(target_sym_id) = self.resolve_cross_file_export_from_file_with_mode(
                     module_name,
                     export_name,
                     Some(source_file_idx),
+                    resolution_mode_override,
                 ) {
                     let resolved_target =
                         if self.symbol_is_namespace_only_tracked(target_sym_id, visited_aliases) {
@@ -286,10 +293,11 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .resolve_symbol_file_index_stable(sym_id)
                 .unwrap_or(self.ctx.current_file_idx);
-            if let Some(target_idx) = self
-                .ctx
-                .resolve_import_target_from_file(source_file_idx, module_name)
-                && let Some(target_binder) = self.ctx.get_binder_for_file(target_idx)
+            if let Some(target_idx) = self.ctx.resolve_import_target_from_file_with_mode(
+                source_file_idx,
+                module_name,
+                resolution_mode_override,
+            ) && let Some(target_binder) = self.ctx.get_binder_for_file(target_idx)
             {
                 let target_arena = self.ctx.get_arena_for_file(target_idx as u32);
                 if let Some(file_name) = target_arena.source_files.first().map(|f| &f.file_name) {

--- a/crates/tsz-cli/src/driver/resolution/discovery.rs
+++ b/crates/tsz-cli/src/driver/resolution/discovery.rs
@@ -381,7 +381,8 @@ pub(crate) fn collect_jsdoc_module_requests(
                     continue;
                 };
                 if let Some(specifier) = parse_jsdoc_import_module_specifier(rest) {
-                    requests.push((specifier, ImportKind::EsmImport, None));
+                    let resolution_mode = parse_jsdoc_import_tag_resolution_mode(rest);
+                    requests.push((specifier, ImportKind::EsmImport, resolution_mode));
                 }
             }
         }
@@ -492,6 +493,25 @@ pub(crate) fn parse_jsdoc_import_module_specifier(rest: &str) -> Option<String> 
     }
 
     None
+}
+
+/// Parse the `resolution-mode` override from a JSDoc `@import` tag body.
+///
+/// `rest` is everything after `@import`, e.g.
+/// `{ Foo } from "pkg" with { "resolution-mode": "import" }`. The attribute
+/// clause can only appear after the (last, unquoted) `from` keyword, so the
+/// scan starts there to avoid matching a `with`/`assert` inside a binding name.
+/// Shares the clause grammar with the binder via `tsz_common`.
+pub(crate) fn parse_jsdoc_import_tag_resolution_mode(
+    rest: &str,
+) -> Option<tsz::module_resolver::ImportingModuleKind> {
+    // Cheap reject: an attribute clause requires a `with`/`assert` keyword.
+    if !rest.contains("with") && !rest.contains("assert") {
+        return None;
+    }
+    let from_idx = find_jsdoc_import_from_keyword(rest)?;
+    tsz_common::parse_jsdoc_resolution_mode_attribute_clause(&rest[from_idx + 4..])
+        .map(tsz::module_resolver::ImportingModuleKind::from)
 }
 
 pub(crate) fn find_jsdoc_import_from_keyword(rest: &str) -> Option<usize> {

--- a/crates/tsz-cli/src/driver/resolution_tests.rs
+++ b/crates/tsz-cli/src/driver/resolution_tests.rs
@@ -1153,6 +1153,41 @@ const value = "x";
 }
 
 #[test]
+fn test_collect_jsdoc_import_tag_parses_resolution_mode() {
+    use tsz::module_resolver::ImportingModuleKind;
+    let text = r#"
+// @ts-check
+/** @import { Esm } from "pkg" with { "resolution-mode": "import" } */
+/** @import { Cjs } from "pkg" with { 'resolution-mode': 'require' } */
+/** @import { Plain } from "pkg" */
+/** @type {Esm} */
+const value = "x";
+"#;
+    let path = Path::new("test.js");
+    let requests = collect_module_requests_from_text(path, text);
+
+    // All three target "pkg"; the attribute clause drives the per-request mode.
+    let modes: Vec<Option<ImportingModuleKind>> = requests
+        .iter()
+        .filter(|(specifier, _, _, _)| specifier == "pkg")
+        .map(|(_, _, mode, _)| *mode)
+        .collect();
+
+    assert!(
+        modes.contains(&Some(ImportingModuleKind::Esm)),
+        "expected an ESM-mode request for the `resolution-mode: import` tag, got: {modes:?}"
+    );
+    assert!(
+        modes.contains(&Some(ImportingModuleKind::CommonJs)),
+        "expected a CommonJS-mode request for the `resolution-mode: require` tag, got: {modes:?}"
+    );
+    assert!(
+        modes.contains(&None),
+        "expected a mode-less request for the plain `@import` tag, got: {modes:?}"
+    );
+}
+
+#[test]
 fn test_collect_module_specifiers_require_has_correct_kind() {
     use tsz::module_resolver::ImportKind;
     let text = r#"const data = require("./data.json");"#;

--- a/crates/tsz-common/src/common/mod.rs
+++ b/crates/tsz-common/src/common/mod.rs
@@ -276,6 +276,101 @@ pub enum ModuleKind {
     Preserve = 200,
 }
 
+/// Explicit module-resolution mode requested for an individual import.
+///
+/// This mirrors the `resolution-mode` value of an import attribute
+/// (`import ... with { "resolution-mode": "import" | "require" }`) or a JSDoc
+/// `@import`/`import(...)` type reference. It selects which `package.json`
+/// `exports`/`imports` condition (`import` vs `require`) a specifier resolves
+/// through, independent of the importing file's own module format.
+///
+/// Lives in `tsz-common` so both the binder (which records the mode on JSDoc
+/// `@import` alias symbols) and the checker (which resolves through it) can
+/// share one representation without depending on each other.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum ImportResolutionMode {
+    /// Resolve through the ESM (`import`) condition.
+    Import,
+    /// Resolve through the CommonJS (`require`) condition.
+    Require,
+}
+
+impl ImportResolutionMode {
+    /// Parse a `resolution-mode` attribute value (`"import"`/`"require"`).
+    ///
+    /// The argument should already have surrounding quotes stripped. Returns
+    /// `None` for any value other than the two valid spellings, matching the
+    /// grammar tsc enforces with TS1453.
+    #[must_use]
+    pub fn from_attribute_value(value: &str) -> Option<Self> {
+        match value {
+            "import" => Some(Self::Import),
+            "require" => Some(Self::Require),
+            _ => None,
+        }
+    }
+}
+
+/// Parse a `with { "resolution-mode": "import" | "require" }` (or legacy
+/// `assert { ... }`) import-attribute clause out of `text`.
+///
+/// `text` should be the portion of an import / JSDoc `@import` tag *after* the
+/// module specifier — e.g. the text following `from "pkg"`. The attribute
+/// keyword (`with`/`assert`) must appear at a word boundary so an identifier
+/// such as a binding named `within` is not matched. The key and value may be
+/// quoted (single or double) or bare. Returns `None` when no valid
+/// `resolution-mode` attribute is present.
+///
+/// Shared by the binder (which records the mode on JSDoc `@import` alias
+/// symbols) and the CLI driver (which emits a per-mode module request) so the
+/// JSDoc attribute grammar has a single source of truth.
+#[must_use]
+pub fn parse_jsdoc_resolution_mode_attribute_clause(text: &str) -> Option<ImportResolutionMode> {
+    const fn is_word_byte(b: u8) -> bool {
+        b == b'_' || b == b'$' || b.is_ascii_alphanumeric()
+    }
+    let bytes = text.as_bytes();
+
+    // Locate the attribute keyword (`with`/`assert`) at a word boundary.
+    let mut search = 0usize;
+    let body_start = loop {
+        let rel = [text[search..].find("with"), text[search..].find("assert")]
+            .into_iter()
+            .flatten()
+            .min()?;
+        let abs = search + rel;
+        let keyword_len = if text[abs..].starts_with("with") {
+            4
+        } else {
+            6
+        };
+        let prev_is_word = abs.checked_sub(1).is_some_and(|i| is_word_byte(bytes[i]));
+        let next_is_word = bytes
+            .get(abs + keyword_len)
+            .is_some_and(|&b| is_word_byte(b));
+        if !prev_is_word && !next_is_word {
+            break abs + keyword_len;
+        }
+        search = abs + keyword_len;
+    };
+
+    let brace_open = text[body_start..].find('{')? + body_start;
+    let brace_close = text[brace_open..].find('}')? + brace_open;
+    let body = &text[brace_open + 1..brace_close];
+
+    let colon = body.find(':')?;
+    let key = body[..colon].trim().trim_matches(|c| c == '"' || c == '\'');
+    if key != "resolution-mode" {
+        return None;
+    }
+    let value = body[colon + 1..]
+        .trim()
+        .trim_end_matches(',')
+        .trim()
+        .trim_matches(|c| c == '"' || c == '\'');
+    ImportResolutionMode::from_attribute_value(value)
+}
+
 impl ModuleKind {
     /// Parse a TypeScript compiler option module value.
     ///

--- a/crates/tsz-common/src/lib.rs
+++ b/crates/tsz-common/src/lib.rs
@@ -15,7 +15,10 @@ pub use interner::{Atom, Interner, ShardedInterner};
 
 // Common types - Shared constants to break circular dependencies
 pub mod common;
-pub use common::{ModuleKind, NewLineKind, ScriptTarget, Visibility};
+pub use common::{
+    ImportResolutionMode, ModuleKind, NewLineKind, ScriptTarget, Visibility,
+    parse_jsdoc_resolution_mode_attribute_clause,
+};
 
 // Span - Source location tracking (byte offsets)
 pub mod span;

--- a/crates/tsz-core/src/module_resolver/request_types.rs
+++ b/crates/tsz-core/src/module_resolver/request_types.rs
@@ -335,6 +335,15 @@ pub enum ImportingModuleKind {
     CommonJs,
 }
 
+impl From<tsz_common::ImportResolutionMode> for ImportingModuleKind {
+    fn from(mode: tsz_common::ImportResolutionMode) -> Self {
+        match mode {
+            tsz_common::ImportResolutionMode::Import => Self::Esm,
+            tsz_common::ImportResolutionMode::Require => Self::CommonJs,
+        }
+    }
+}
+
 impl ImportingModuleKind {
     /// Return the package.json exports/imports condition string for this module kind.
     ///

--- a/crates/tsz-core/src/parallel/lib_snapshot.rs
+++ b/crates/tsz-core/src/parallel/lib_snapshot.rs
@@ -57,7 +57,7 @@ use tsz_parser::parser::node::NodeArena;
 
 /// Magic header. Trailing byte is the format version. Bump on layout
 /// changes that break round-trip.
-const SNAPSHOT_MAGIC: &[u8; 8] = b"TSZSNAP\x04";
+const SNAPSHOT_MAGIC: &[u8; 8] = b"TSZSNAP\x05";
 
 /// Environment variable that controls the lib snapshot cache.
 const ENV_VAR: &str = "TSZ_LIB_CACHE";

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -51,7 +51,19 @@ TypeScript/tests/cases/compiler/declarationEmitUsingAlternativeContainingModules
 TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
-TypeScript/tests/cases/conformance/jsdoc/importTag17.ts
+# importTag17.ts: RESOLVED. A JSDoc `@import { X } from "pkg" with
+# { "resolution-mode": "import" | "require" }` dropped its attribute clause: the
+# binder skipped creating the alias whenever a `with` clause was present, and the
+# driver collected the JSDoc import without the resolution-mode override, so the
+# specifier only resolved through the importing file's default condition. The
+# import-only member then never resolved (only the default-condition member did),
+# losing one of the two expected TS2322s. The binder now records the
+# `resolution-mode` on the alias (`Symbol::import_resolution_mode`), the driver
+# emits a per-mode module request so both package `exports` conditions are
+# resolved, and alias resolution routes the member through
+# `resolve_import_target_from_file_with_mode`, matching tsc. Covered by
+# `jsdoc_import_tag_records_resolution_mode_attribute` (binder) and
+# `test_collect_jsdoc_import_tag_parses_resolution_mode` (driver).
 # objectLiteralMemberWithoutBlock1.ts: RESOLVED. `var v = { foo(); }` parsed the
 # body-less object method but suppressed the missing-body `'{' expected` whenever
 # the next token was `;`, so the outer object-literal member loop emitted a


### PR DESCRIPTION
AgentName: Studio-manager
Track: M1 / checker JSDoc module resolution and architecture cleanup
Invariant: When a JSDoc `@import` carries a `resolution-mode` attribute, `tsc` resolves the imported member through the requested package `exports` condition; tsz does the same by preserving the mode through binder/driver state and checker type-resolution queries.

## Scope
- Threads JSDoc `@import` `resolution-mode` through shared `ImportResolutionMode` parsing, binder alias state, CLI module requests, and mode-aware checker alias resolution.
- Extracts the mode-aware cross-file export resolver from `type_resolution/module.rs` into `type_resolution/cross_file_export.rs` so the module file stays within the architecture size ratchet.
- Leaves default-mode wrappers and no-attribute import behavior on the existing path.

## Project Corpus Impact
- Row: n/a
- Bug family: jsdoc-resolution-mode / conformance accepted-regression burn-down
- Evidence: removes the `importTag17` accepted-regression entry and keeps the change in conformance/checker/driver ownership rather than a project-row-specific path.

## Verification
- PR-head CI Summary pass on run 27184668647 before metadata refresh.
- Current PR-head CI was rerunning; metadata body update addresses the `project-corpus-pr-body` failure.
- Commit evidence includes binder, driver, and existing import-attribute resolution-mode coverage.

## Coordination Notes
- Studio-manager adopted the unowned PR for metadata, canonical labeling, queue readiness, and final merge verification.
- #12932 is the follow-up inline `import(...)` type-query case; this PR's advertised architecture extraction is kept separate from that inline follow-up.
