### PR TITLE
fix(checker): resolve cross-file generic-alias call params for inference

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -36,6 +36,9 @@ stacker = "0.1.23"
 name = "cross_file_delegation_lookup_consolidation_tests"
 path = "tests/cross_file_delegation_lookup_consolidation_tests.rs"
 [[test]]
+name = "cross_file_generic_alias_call_inference_tests"
+path = "tests/cross_file_generic_alias_call_inference_tests.rs"
+[[test]]
 name = "keyof_source_display_tests"
 path = "tests/keyof_source_display_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -122,26 +122,32 @@ impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
         use crate::query_boundaries::state::type_environment::application_info;
 
         let (base, args) = application_info(self.state.ctx.types, type_id)?;
-        let sym_id = self.state.ctx.resolve_type_to_symbol_id(base).or_else(|| {
-            // A type-alias body imported from another module can reference a
-            // sibling type that the lowering pass left as `UnresolvedTypeName`
-            // because that name was not in scope at the alias's *use* site
-            // (it is private to the alias's defining module). Recover it
-            // through the merged binder graph so alias expansion — and the
-            // generic-call inference that depends on it — sees the real
-            // declaration instead of aborting. Without this, inference of a
-            // type argument through a cross-module alias chain
-            // (`type Opts<T> = Inner<T>`) silently fails and the argument
-            // collapses to `unknown`.
-            let atom = crate::query_boundaries::spread::unresolved_type_name_atom(
-                self.state.ctx.types,
-                base,
-            )?;
-            let name = self.state.ctx.types.resolve_atom(atom);
-            let def_id = TypeResolver::resolve_unresolved_type_name(&self.state.ctx, &name)?;
-            self.state.ctx.def_to_symbol_id_with_fallback(def_id)
-        })?;
-        let (body, type_params) = self.state.type_reference_symbol_type_with_params(sym_id);
+
+        // Resolve the generic base to its open body and type parameters. The
+        // primary path maps the base to a `SymbolId` and resolves through the
+        // checker's symbol-type machinery (which also performs heritage merging
+        // for interfaces). That mapping is unavailable when the base is a bare
+        // reference produced while lowering a *cross-file* alias body — e.g.
+        // `type W<T> = Opts<T>` imported from another module: expanding `W<P>`
+        // yields `Opts<P>`, but the nested `Opts` reference survives as an
+        // `UnresolvedTypeName` (or a `DefId`/`TypeQuery`) with no symbol
+        // registered in the calling file's context. In that case resolve the
+        // base to a `DefId` directly and read the open body from the type
+        // resolver, mirroring the evaluator's application-base resolution.
+        // Without this, inference against a generic call signature whose
+        // parameter type is an imported alias-of-a-generic stalls (the type
+        // parameters never receive candidates), producing spurious `unknown`
+        // inferences and downstream `TS18046` diagnostics.
+        let (body, type_params) = match self.state.ctx.resolve_type_to_symbol_id(base) {
+            Some(sym_id) => self.state.type_reference_symbol_type_with_params(sym_id),
+            None => {
+                let def_id = self.resolve_application_base_def_id(base)?;
+                let body =
+                    TypeResolver::resolve_lazy(&self.state.ctx, def_id, self.state.ctx.types)?;
+                let type_params = TypeResolver::get_lazy_type_params(&self.state.ctx, def_id)?;
+                (body, type_params)
+            }
+        };
         if body == TypeId::ANY || body == TypeId::ERROR || type_params.is_empty() {
             return None;
         }
@@ -191,6 +197,22 @@ impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
 
     fn next_inference_placeholder_id(&mut self) -> u64 {
         self.state.ctx.next_inference_placeholder_id()
+    }
+}
+
+impl CheckerCallAssignabilityAdapter<'_, '_> {
+    /// Resolve the base of a generic type application to its defining `DefId`,
+    /// covering the bare reference forms that survive cross-file alias-body
+    /// lowering: `Lazy(DefId)`, `TypeQuery`, and `UnresolvedTypeName`. Mirrors
+    /// the evaluator's application-base resolution (`evaluation::evaluate`) so
+    /// placeholder-preserving alias expansion can proceed even when the base
+    /// has no `SymbolId` mapping in the calling file's checker context.
+    fn resolve_application_base_def_id(&self, base: TypeId) -> Option<tsz_solver::DefId> {
+        crate::query_boundaries::checkers::call::resolve_application_base_def_id(
+            self.state.ctx.types,
+            &self.state.ctx,
+            base,
+        )
     }
 }
 

--- a/crates/tsz-checker/src/query_boundaries/checkers/call.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/call.rs
@@ -166,6 +166,31 @@ pub(crate) fn stable_call_recovery_return_type(
     candidate
 }
 
+/// Resolve an application base to the declaration identity used for generic
+/// call inference.
+///
+/// Cross-file alias lowering can leave application bases in any of the same
+/// reference forms that evaluator normalization accepts. Keep that solver-shape
+/// decoding behind this boundary so call checking only asks for the declaration
+/// identity it needs.
+pub(crate) fn resolve_application_base_def_id<R: TypeResolver>(
+    db: &dyn TypeDatabase,
+    resolver: &R,
+    base: TypeId,
+) -> Option<tsz_solver::DefId> {
+    lazy_def_id_for_type(db, base)
+        .or_else(|| {
+            tsz_solver::type_queries::get_type_query_symbol_ref(db, base)
+                .and_then(|sym_ref| resolver.symbol_to_def_id(sym_ref))
+        })
+        .or_else(|| {
+            tsz_solver::visitor::unresolved_type_name_atom(db, base).and_then(|atom| {
+                let name = db.resolve_atom(atom);
+                resolver.resolve_unresolved_type_name(&name)
+            })
+        })
+}
+
 /// Get the construct signature of a type, preferring a generic one.
 /// Used for two-pass inference in `new` expressions where the construct
 /// signature may have type parameters that need to be inferred.

--- a/crates/tsz-checker/tests/cross_file_generic_alias_call_inference_tests.rs
+++ b/crates/tsz-checker/tests/cross_file_generic_alias_call_inference_tests.rs
@@ -1,0 +1,128 @@
+//! Cross-file generic-alias call-parameter inference (refs #12937).
+//!
+//! Structural rule: when a generic call signature's parameter type is a
+//! generic type alias declared in another file (`type W<T> = Opts<T>`,
+//! re-exported through `useQuery`), the constraint walker must expand the
+//! application `W<P>` (P = inference placeholder) to its body so the
+//! signature's type parameters receive candidates from the call arguments.
+//!
+//! Before the fix, expanding `W<P>` produced `Opts<P>` whose nested `Opts`
+//! reference — lowered as part of the cross-file alias body — survived as an
+//! `UnresolvedTypeName` with no `SymbolId` in the calling file's context.
+//! `expand_type_alias_application` returned `None`, the placeholder never
+//! reached `queryFn: () => T`, and `T` collapsed to `unknown`. That made the
+//! context-sensitive `select` callback parameter `unknown` and raised a
+//! spurious `TS18046` on `data.slice(...)` where `tsc` reports nothing.
+//!
+//! The matrix varies the alias shape (plain alias, homomorphic mapped wrapper,
+//! intersection wrapper, and the combination) and the binder names, so the fix
+//! is exercised structurally rather than for one fixture.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file_with_global_index;
+use tsz_common::common::ModuleKind;
+use tsz_common::diagnostics::Diagnostic;
+
+fn opts() -> CheckerOptions {
+    CheckerOptions {
+        module: ModuleKind::CommonJS,
+        strict: true,
+        ..CheckerOptions::default()
+    }
+}
+
+const MAIN: &str = r#"
+    import { useQuery } from "./dep";
+    const getEntries = (): number[] => [1];
+    export const r = useQuery({
+        queryFn: getEntries,
+        select: (data) => data.slice(0, 1),
+    });
+"#;
+
+fn check(dep: &str) -> Vec<Diagnostic> {
+    check_multi_file_with_global_index(&[("main.ts", MAIN), ("dep.ts", dep)], "main.ts", opts())
+}
+
+fn assert_no_implicit_any(dep: &str, label: &str) {
+    let diags = check(dep);
+    let ts18046: Vec<_> = diags.iter().filter(|d| d.code == 18046).collect();
+    assert!(
+        ts18046.is_empty(),
+        "[{label}] expected no TS18046 (data inferred from queryFn through the imported \
+         generic alias), got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn plain_generic_alias_parameter() {
+    assert_no_implicit_any(
+        r#"
+        interface Opts<TFn = unknown> { queryFn?: () => TFn; select?: (d: TFn) => unknown; }
+        type W<TFn = unknown> = Opts<TFn>;
+        export declare function useQuery<TFn = unknown>(options: W<TFn>): TFn;
+        "#,
+        "plain-alias",
+    );
+}
+
+#[test]
+fn homomorphic_mapped_alias_parameter() {
+    assert_no_implicit_any(
+        r#"
+        interface Opts<TFn = unknown> { queryFn?: () => TFn; select?: (d: TFn) => unknown; }
+        type Mapped<TFn = unknown> = { [K in keyof Opts<TFn>]: Opts<TFn>[K] };
+        export declare function useQuery<TFn = unknown>(options: Mapped<TFn>): TFn;
+        "#,
+        "mapped-alias",
+    );
+}
+
+#[test]
+fn intersection_alias_parameter() {
+    assert_no_implicit_any(
+        r#"
+        interface Opts<TFn = unknown> { queryFn?: () => TFn; select?: (d: TFn) => unknown; }
+        type Wrapped<TFn = unknown> = Opts<TFn> & { initialData?: undefined };
+        export declare function useQuery<TFn = unknown>(options: Wrapped<TFn>): TFn;
+        "#,
+        "intersection-alias",
+    );
+}
+
+#[test]
+fn mapped_and_intersection_alias_parameter() {
+    // The real-world `@tanstack/vue-query` shape: a homomorphic mapped type
+    // intersected with an extra member, all behind one imported alias.
+    assert_no_implicit_any(
+        r#"
+        interface Opts<TFn = unknown> { queryFn?: () => TFn; select?: (d: TFn) => unknown; }
+        type Mapped<TFn = unknown> = { [K in keyof Opts<TFn>]: Opts<TFn>[K] };
+        type Wrapped<TFn = unknown> = Mapped<TFn> & { initialData?: undefined };
+        export declare function useQuery<TFn = unknown>(options: Wrapped<TFn>): TFn;
+        "#,
+        "mapped+intersection-alias",
+    );
+}
+
+#[test]
+fn renamed_binders_still_infer() {
+    // Vary the binder names so the fix cannot depend on any identifier text.
+    assert_no_implicit_any(
+        r#"
+        interface QueryConfig<Payload = unknown> {
+            queryFn?: () => Payload;
+            select?: (d: Payload) => unknown;
+        }
+        type ConfigAlias<Payload = unknown> = QueryConfig<Payload> & { initialData?: undefined };
+        export declare function useQuery<Payload = unknown>(
+            options: ConfigAlias<Payload>,
+        ): Payload;
+        "#,
+        "renamed-binders",
+    );
+}


### PR DESCRIPTION
## Agent
AgentName: Studio-manager

Original contributor identity: web-opus-xfile-alias.

## Track
Conformance / M4-C semantic campaign: cross-file generic-alias call inference follow-up coverage.

## Invariant
When a generic call signature's parameter type is a generic type alias defined in another file, `tsc` infers the signature type parameters from call arguments through the imported alias body; this PR broadens the checker call-inference alias-expansion fallback so tsz can resolve bare `Lazy`, `TypeQuery`, and `UnresolvedTypeName` bases without collapsing callback parameters to `unknown`.

## Scope
- `crates/tsz-checker/src/checkers/call_checker/mod.rs`: replace the narrow post-#12929 unresolved-name-to-symbol fallback with direct fallback resolution of bare application bases to `DefId`, while preserving the primary `SymbolId` path for interface heritage merging.
- `crates/tsz-checker/tests/cross_file_generic_alias_call_inference_tests.rs`: adjacent coverage for plain, mapped, intersection, combined, and renamed-binder generic-alias call shapes.
- `crates/tsz-checker/Cargo.toml`: registers the focused checker test target.

## Project Corpus Impact
- Row: n/a
- Bug family: cross-file generic-alias inference false positive / accepted-regression strictness
- Evidence: #12929 already retired the accepted-regression ledger rows on `main`; this rebased branch now keeps only additive checker fallback coverage and tests. No named required project row is claimed, but exact-head CI must still cover `project-compile-guard`, `project-compile-canary`, and conformance aggregate before queueing.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test cross_file_generic_alias_call_inference_tests` (5 passed)
- `cargo fmt --check`
- `python3 scripts/conformance/check-accepted-regression-growth.py --integrity-only`
- `git diff --check`
- Required before queue: fresh PR-head `CI Summary` success for head `c21e73a48a`.

## Coordination Notes
- Rebased onto `origin/main` after #12929 landed and removed the duplicate accepted-regression ledger change.
- Auto-merge remains disabled until the new exact-head CI passes; Studio-manager owns queue coordination for this PR.
