### PR TITLE
fix(emit): drop redundant outer parens from reused declaration type text

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
@@ -49,6 +49,7 @@ impl<'a> DeclarationEmitter<'a> {
             .map(|type_text| {
                 Self::unwrap_return_type_zero_arg_import_type(&type_text).unwrap_or(type_text)
             })
+            .map(|type_text| Self::strip_redundant_outer_type_parentheses(&type_text))
     }
 
     pub(in crate::declaration_emitter) fn unwrap_return_type_zero_arg_import_type(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_parts/part4.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_parts/part4.rs
@@ -1,6 +1,28 @@
 use super::*;
 
 impl<'a> DeclarationEmitter<'a> {
+    /// Removes redundant parentheses that wrap an *entire* reused
+    /// type-annotation text. `tsc`'s declaration printer never parenthesizes
+    /// the outermost type, so a callee return annotation written as `(T)`,
+    /// `((T))`, or `(  T  )` must surface as `T` when reused as an inferred
+    /// declaration type.
+    ///
+    /// Only fully-enclosing outer parentheses are removed (via the shared,
+    /// quote-/escape-aware [`Self::strip_balanced_outer_parens`] scanner).
+    /// Parentheses that are merely an operand of a larger type (`(A | B)[]`,
+    /// `Array<(A | B)>`) do not wrap the whole text and are left untouched, and
+    /// disjoint groups such as `(A) | (B)` are preserved because the leading `(`
+    /// does not pair with the trailing `)`.
+    pub(in crate::declaration_emitter) fn strip_redundant_outer_type_parentheses(
+        type_text: &str,
+    ) -> String {
+        let mut current = type_text.trim();
+        while let Some(inner) = Self::strip_balanced_outer_parens(current) {
+            current = inner.trim();
+        }
+        current.to_string()
+    }
+
     pub(in crate::declaration_emitter) fn format_reused_call_structural_return_type_text(
         &self,
         type_text: &str,
@@ -147,5 +169,50 @@ impl<'a> DeclarationEmitter<'a> {
         } else {
             format!("{{ {inner}; }}")
         }
+    }
+}
+
+#[cfg(test)]
+mod strip_outer_parentheses_tests {
+    use crate::declaration_emitter::DeclarationEmitter;
+
+    fn strip(text: &str) -> String {
+        DeclarationEmitter::strip_redundant_outer_type_parentheses(text)
+    }
+
+    #[test]
+    fn removes_fully_enclosing_outer_parentheses() {
+        assert_eq!(strip("(Cond<string>)"), "Cond<string>");
+        assert_eq!(strip("((Cond<string>))"), "Cond<string>");
+        assert_eq!(strip("(  Cond<string>  )"), "Cond<string>");
+        assert_eq!(strip("(() => void)"), "() => void");
+        assert_eq!(strip("(A | B)"), "A | B");
+    }
+
+    #[test]
+    fn leaves_unparenthesized_text_unchanged() {
+        assert_eq!(strip("Cond<string>"), "Cond<string>");
+        assert_eq!(strip("() => void"), "() => void");
+        assert_eq!(strip("A | B"), "A | B");
+    }
+
+    #[test]
+    fn preserves_parentheses_that_do_not_wrap_the_whole_type() {
+        // Operand parentheses inside a larger type are not the outermost wrap.
+        assert_eq!(strip("(() => void)[]"), "(() => void)[]");
+        assert_eq!(strip("(A | B)[]"), "(A | B)[]");
+        assert_eq!(strip("Array<(A | B)>"), "Array<(A | B)>");
+        assert_eq!(strip("(A & B) & C"), "(A & B) & C");
+        // Disjoint groups: the leading `(` does not pair with the trailing `)`.
+        assert_eq!(strip("(A) | (B)"), "(A) | (B)");
+    }
+
+    #[test]
+    fn ignores_parentheses_inside_string_and_import_segments() {
+        // Literal-type strings and import specifiers may contain parens that must
+        // not skew the enclosing-pair detection.
+        assert_eq!(strip("(import(\"./m\").Foo)"), "import(\"./m\").Foo");
+        assert_eq!(strip("\"(\" | \")\""), "\"(\" | \")\"");
+        assert_eq!(strip("(\"(\" | \")\")"), "\"(\" | \")\"");
     }
 }

--- a/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/fix_verification_returned.rs
@@ -932,3 +932,94 @@ export const viaFn = make("x");
         "conditional alias body must not be expanded inline, got: {output}"
     );
 }
+
+// `tsc`'s declaration printer never parenthesizes the outermost synthesized
+// type, so a reused call-return annotation written as `(Alias<T>)`, `((Alias))`,
+// or `(  Alias  )` must surface as `Alias<args>` without the redundant outer
+// parentheses or interior whitespace. This covers the conditional-alias
+// preservation path and the plain alias-reuse path alike.
+#[test]
+fn fix_inferred_call_return_strips_redundant_outer_parentheses() {
+    // Conditional-alias preservation path: redundant outer parens dropped.
+    let single = emit_dts_with_usage_analysis(
+        r#"
+export type Cond<T> = T extends string ? { s: T } : { n: T };
+declare function make<T>(t: T): (Cond<T>);
+export const a = make("x");
+"#,
+    );
+    assert!(
+        single.contains("export declare const a: Cond<string>;"),
+        "single redundant paren must be stripped, got: {single}"
+    );
+
+    // Nested redundant parens are stripped fully.
+    let double = emit_dts_with_usage_analysis(
+        r#"
+export type Cond<T> = T extends string ? { s: T } : { n: T };
+declare function make<T>(t: T): ((Cond<T>));
+export const b = make("x");
+"#,
+    );
+    assert!(
+        double.contains("export declare const b: Cond<string>;"),
+        "nested redundant parens must be stripped, got: {double}"
+    );
+
+    // Interior whitespace inside the redundant parens is normalized away.
+    let spaced = emit_dts_with_usage_analysis(
+        r#"
+export type Cond<T> = T extends string ? { s: T } : { n: T };
+declare function make<T>(t: T): (  Cond<T>  );
+export const c = make("x");
+"#,
+    );
+    assert!(
+        spaced.contains("export declare const c: Cond<string>;"),
+        "redundant parens with interior whitespace must be stripped, got: {spaced}"
+    );
+
+    // Plain (non-conditional) alias reuse path: same normalization.
+    let plain = emit_dts_with_usage_analysis(
+        r#"
+export type Plain<T> = { value: T };
+declare function make<T>(t: T): (Plain<T>);
+export const d = make("x");
+"#,
+    );
+    assert!(
+        plain.contains("export declare const d: Plain<string>;"),
+        "plain alias reuse must strip redundant parens, got: {plain}"
+    );
+}
+
+// Parentheses that wrap only an *operand* of a larger reused type carry
+// precedence and must be preserved, while a fully-enclosing wrap around the
+// whole inferred type is still removed.
+#[test]
+fn fix_inferred_call_return_keeps_semantically_required_parentheses() {
+    // A whole-type function reference loses its redundant outer wrap...
+    let whole_fn = emit_dts_with_usage_analysis(
+        r#"
+declare function make(): (() => void);
+export const e = make();
+"#,
+    );
+    assert!(
+        whole_fn.contains("export declare const e: () => void;"),
+        "outer wrap around a whole function type must be stripped, got: {whole_fn}"
+    );
+
+    // ...but a parenthesized union/function operand inside an array keeps its
+    // parentheses because they are not the outermost wrap.
+    let arr = emit_dts_with_usage_analysis(
+        r#"
+declare function make(): (() => void)[];
+export const f = make();
+"#,
+    );
+    assert!(
+        arr.contains("export declare const f: (() => void)[];"),
+        "operand parentheses inside an array must be preserved, got: {arr}"
+    );
+}


### PR DESCRIPTION
## Summary

Declaration emit reconstructs an inferred `const`/`var` type from a callee's
return **annotation** by slicing and substituting source text (the
`call_expression_reused_type_text` family). When that annotation is wrapped in
redundant parentheses, the parens — and any interior whitespace — leaked into
the emitted `.d.ts`:

| callee return annotation | tsz (before) | tsc / tsz (after) |
|---|---|---|
| `(Cond<T>)` | `const a: (Cond<string>)` | `const a: Cond<string>` |
| `((Cond<T>))` | `const b: ((Cond<string>))` | `const b: Cond<string>` |
| `(  Cond<T>  )` | `const c: (  Cond<string>  )` | `const c: Cond<string>` |
| `(Plain<T>)` (non-conditional) | `const d: (Plain<string>)` | `const d: Plain<string>` |

`tsc`'s declaration printer never parenthesizes the **outermost** synthesized
type, so these are real parity divergences spanning both the conditional-alias
preservation path and the plain alias-reuse path.

## Structural rule

When declaration emit reuses a callee's return-annotation text as the whole
inferred type of an exported `const`/`var`, `tsc` emits the type with no
redundant outermost parentheses; tsz must strip a fully-enclosing outer paren
wrap from the reconstructed text through the emitter's reused-call-return text
boundary.

## Fix

A small shared helper `strip_redundant_outer_type_parentheses` (in
`type_inference_parts/part4.rs`) peels fully-enclosing outer parentheses by
delegating to the existing quote-/escape-aware `strip_balanced_outer_parens`
scanner, then trims. It is applied once, as the final `.map` step in
`call_expression_reused_type_text` — the single chokepoint every reused
const/var call-return type text flows through (consumed by `variable_decl`,
`exports`, `portability_check`, and `type_inference_expression_literals`).

Operand parentheses that carry precedence are intentionally preserved because
they do not wrap the whole text: `(() => void)[]`, `(A | B)[]`,
`Array<(A | B)>`, and disjoint groups like `(A) | (B)`.

## Owner layer

Emitter (declaration emit text reconstruction). No semantic validation, no
checker/solver changes, no output surgery of already-emitted text — the
normalization happens on the reused-type text before it is committed as a
declaration annotation, and reuses the canonical balanced-paren scanner rather
than introducing a second one.

## Adjacent-case matrix

- Stripped: `(T)`, `((T))`, `(  T  )`, `(() => void)`, `(A | B)`, conditional
  alias `(Cond<T>)`, plain alias `(Plain<T>)`.
- Preserved: `(() => void)[]`, `(A | B)[]`, `Array<(A | B)>`, `(A & B) & C`,
  `(A) | (B)`, and parens inside string-literal / `import(...)` segments.
- Unchanged: bare `Cond<string>`, `() => void`, `A | B` (helper is a no-op).

Known follow-up (out of scope here): function/method/arrow **return-type**
inference reuses sibling text producers that leak the same redundant parens;
those paths are a separate producer family and are tracked for a later pass so
this change stays a focused, low-risk const/var fix.

## Project Corpus Impact
- Row: n/a
- Bug family: declaration-emit redundant outer parentheses on reused conditional/plain alias type text

## Verification
- New unit tests for the helper (`strip_outer_parentheses_tests`, 4 tests) and
  end-to-end emit regression tests
  (`fix_inferred_call_return_strips_redundant_outer_parentheses`,
  `fix_inferred_call_return_keeps_semantically_required_parentheses`).
- `cargo test -p tsz-emitter --lib`: 3656 passed, 0 failed.
- `cargo test -p tsz-emitter --tests`: 0 failures.
- `cargo clippy -p tsz-emitter --lib`: clean. `cargo fmt`: clean.

## Coordination Notes
Addresses the declaration-emit / conditional-alias parity class tracked by
#12770. Stripping is a no-op on any output that is already tsc-correct (tsc
never emits redundant outer parens), so currently-passing baselines are
unaffected; only previously-divergent reuse cases change.

AgentName: web-opus48-emit
Track: emit / declaration parity
Invariant: declaration emit matches tsc — the outermost synthesized type is never parenthesized
Scope: crates/tsz-emitter reused call-return type text reconstruction

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYbnoHB23VFzbFEgCjxtmm)_