### PR TITLE
perf(checker): share flow narrowing cache across property reference occurrences

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -75,6 +75,9 @@ path = "tests/variadic_tuple_spread_arity_ts2556_tests.rs"
 name = "closure_boundary_property_narrowing_tests"
 path = "tests/closure_boundary_property_narrowing_tests.rs"
 [[test]]
+name = "flow_property_reference_cache_tests"
+path = "tests/flow_property_reference_cache_tests.rs"
+[[test]]
 name = "assignment_branch_merge_narrowing_tests"
 path = "tests/assignment_branch_merge_narrowing_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -57,6 +57,7 @@ flow_worklist = { lifetime = "WorkerReusable", capability = "FlowSessionState", 
 flow_in_worklist = { lifetime = "WorkerReusable", capability = "FlowSessionState", reason = "scratch allocation that can be cleared and reused by one worker between file sessions" }
 flow_visited = { lifetime = "WorkerReusable", capability = "FlowSessionState", reason = "scratch allocation that can be cleared and reused by one worker between file sessions" }
 flow_results = { lifetime = "WorkerReusable", capability = "FlowSessionState", reason = "scratch allocation that can be cleared and reused by one worker between file sessions" }
+flow_reference_keys = { lifetime = "WorkerReusable", capability = "FlowSessionState", reason = "per-run structural reference-path interner shared across file sessions within one worker; run-local ids are dropped on cross-run snapshot so persisted paths cannot alias" }
 narrowing_cache = { lifetime = "FileLocalReset", capability = "FlowSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 narrowable_identifier_cache = { lifetime = "FileLocalReset", capability = "FlowSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 flow_switch_reference_cache = { lifetime = "FileLocalReset", capability = "FlowSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -104,6 +104,7 @@ impl<'a> CheckerContext<'a> {
                 128,
                 Default::default(),
             )),
+            flow_reference_keys: RefCell::new(FxHashMap::default()),
             narrowable_identifier_cache: RefCell::new(
                 crate::context::NarrowableIdentifierCache::with_capacity(arena.nodes.len()),
             ),

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -1563,7 +1563,18 @@ impl<'a> CheckerContext<'a> {
             boxed_types,
             boxed_def_ids,
             well_known_symbol_names: type_env.snapshot_well_known_symbol_names(),
-            flow_analysis_cache: self.flow_analysis_cache.into_inner(),
+            // Drop structural reference-path entries: their ids are assigned by
+            // the per-run `flow_reference_keys` interner, so persisting them
+            // across runs could alias a different path to the same id. They are
+            // pure memo entries and are cheaply recomputed; real-symbol and
+            // per-node keys are program-stable and kept.
+            flow_analysis_cache: {
+                let mut cache = self.flow_analysis_cache.into_inner();
+                cache.retain(|(_, symbol, _), _| {
+                    crate::control_flow::is_session_stable_flow_cache_symbol(*symbol)
+                });
+                cache
+            },
             class_instance_type_to_decl: self.class_instance_type_to_decl,
             class_instance_type_cache: self.class_instance_type_cache,
             class_constructor_type_cache: self.class_constructor_type_cache,

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -575,6 +575,13 @@ pub struct CheckerContext<'a> {
     pub flow_analysis_cache:
         RefCell<FxHashMap<(tsz_binder::FlowNodeId, tsz_binder::SymbolId, TypeId), TypeId>>,
 
+    /// Interner that gives property/element reference *paths* (`a.b`) a
+    /// session-stable synthetic cache symbol, so `flow_analysis_cache` is shared
+    /// across occurrences of the same path instead of keyed per syntactic node
+    /// (avoids O(N²) re-walks of the flow graph). Append-only and rebuildable;
+    /// its structural-keyed cache entries are dropped on incremental save.
+    pub flow_reference_keys: RefCell<FxHashMap<Vec<u32>, u32>>,
+
     /// Reusable buffers for flow analysis to avoid frequent heap allocations in `check_flow`.
     pub flow_worklist: RefCell<VecDeque<(tsz_binder::FlowNodeId, TypeId)>>,
     pub flow_in_worklist: RefCell<FxHashSet<tsz_binder::FlowNodeId>>,

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -19,6 +19,55 @@ use tsz_solver::{ParamInfo, TupleElement, TypeId, TypePredicate};
 type FlowCache = FxHashMap<(FlowNodeId, SymbolId, TypeId), TypeId>;
 type ReferenceMatchCache = RefCell<FxHashMap<(u32, u32), bool>>;
 type ReferenceSymbolCache = RefCell<FxHashMap<u32, Option<SymbolId>>>;
+/// Session-scoped interner mapping a structural reference *path*
+/// (`[base_symbol_id, prop_atom, ...]`) to a sequential id. See
+/// [`FlowAnalyzer::flow_reference_path_symbol`].
+pub(crate) type FlowReferenceKeyInterner = RefCell<FxHashMap<Vec<u32>, u32>>;
+
+// Flow-cache symbol space partition. The `SymbolId` slot of a `FlowCache` key
+// must distinguish three disjoint kinds of reference so distinct references can
+// never alias:
+// - real binder symbols keep bit 31 clear;
+// - structural reference *paths* (`a.b`) set bit 31, clear bit 30, and carry an
+//   interned id in the low 30 bits (occurrence-independent, interned per run);
+// - the per-syntactic-node fallback (`f().x`) sets bits 31 and 30 and carries
+//   the node index in the low 30 bits (program-stable across runs).
+/// Bit 31: any synthetic (non-binder) flow-cache symbol.
+const FLOW_CACHE_SYNTHETIC_BIT: u32 = 0x8000_0000;
+/// Bit 30: per-node fallback (vs. structural path) within the synthetic space.
+const FLOW_CACHE_PER_NODE_BIT: u32 = 0x4000_0000;
+/// Low 30 bits carrying the interned id or node index.
+const FLOW_CACHE_PAYLOAD_MASK: u32 = 0x3FFF_FFFF;
+
+/// Synthetic cache symbol for an interned structural reference-path `id`.
+/// `id` must be `< FLOW_CACHE_PER_NODE_BIT` (enforced by the caller).
+pub(crate) const fn structural_flow_cache_symbol(id: u32) -> SymbolId {
+    SymbolId(FLOW_CACHE_SYNTHETIC_BIT | id)
+}
+
+/// Largest exclusive bound for a structural-path id before its bit would
+/// collide with the per-node fallback space.
+pub(crate) const FLOW_CACHE_STRUCTURAL_ID_LIMIT: u32 = FLOW_CACHE_PER_NODE_BIT;
+
+/// Per-syntactic-node fallback cache symbol for a reference `node`.
+pub(crate) const fn per_node_flow_cache_symbol(node: NodeIndex) -> SymbolId {
+    SymbolId(
+        FLOW_CACHE_SYNTHETIC_BIT | FLOW_CACHE_PER_NODE_BIT | (node.0 & FLOW_CACHE_PAYLOAD_MASK),
+    )
+}
+
+/// True when `symbol` is a real binder symbol (bit 31 clear), i.e. not in the
+/// synthetic flow-cache space.
+pub(crate) const fn is_real_binder_symbol(symbol: SymbolId) -> bool {
+    symbol.0 & FLOW_CACHE_SYNTHETIC_BIT == 0
+}
+
+/// True when a flow-cache entry keyed by `symbol` is stable across runs and so
+/// safe to persist on incremental save. Real binder symbols and per-node keys
+/// qualify; structural-path keys are interned per run and must be dropped.
+pub(crate) const fn is_session_stable_flow_cache_symbol(symbol: SymbolId) -> bool {
+    symbol.0 & (FLOW_CACHE_SYNTHETIC_BIT | FLOW_CACHE_PER_NODE_BIT) != FLOW_CACHE_SYNTHETIC_BIT
+}
 
 mod flow_traversal;
 
@@ -375,6 +424,10 @@ pub struct FlowAnalyzer<'a> {
     pub(crate) destructured_bindings:
         Option<&'a FxHashMap<SymbolId, crate::context::DestructuredBindingInfo>>,
     pub(crate) concrete_this_type: Option<TypeId>,
+    /// Optional shared interner that gives property/element reference paths a
+    /// session-stable synthetic cache symbol, so the flow cache is shared across
+    /// occurrences of the same path instead of being keyed per syntactic node.
+    pub(crate) shared_flow_reference_keys: Option<&'a FlowReferenceKeyInterner>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -585,6 +638,7 @@ impl<'a> FlowAnalyzer<'a> {
             shared_symbol_first_identifier_ref: None,
             destructured_bindings: None,
             concrete_this_type: None,
+            shared_flow_reference_keys: None,
         }
     }
 
@@ -622,7 +676,22 @@ impl<'a> FlowAnalyzer<'a> {
             shared_symbol_first_identifier_ref: None,
             destructured_bindings: None,
             concrete_this_type: None,
+            shared_flow_reference_keys: None,
         }
+    }
+
+    /// Set a shared interner for property/element reference-path cache keys.
+    ///
+    /// Without it, references that do not resolve to a single symbol (e.g.
+    /// `a.b`) fall back to a per-syntactic-node synthetic cache symbol, so each
+    /// occurrence re-walks the whole flow graph (O(N²) over N occurrences). With
+    /// it, every occurrence of the same path shares cache entries (O(N)).
+    pub const fn with_flow_reference_keys(
+        mut self,
+        interner: &'a FlowReferenceKeyInterner,
+    ) -> Self {
+        self.shared_flow_reference_keys = Some(interner);
+        self
     }
 
     /// Set the flow analysis cache to avoid redundant graph traversals.

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -72,10 +72,12 @@ impl<'a> FlowAnalyzer<'a> {
             .is_some_and(|sid| self.is_control_flow_typed_any_symbol(sid));
         let skip_cache_for_control_flow_typed_any = control_flow_typed_any_symbol;
 
-        // Use a synthetic cache symbol for references that don't resolve to a symbol
-        // (for example complex/property references). This enables cache reuse while
-        // keeping symbol-backed keys disjoint.
-        let cache_symbol = symbol_id.unwrap_or(SymbolId(reference.0.wrapping_add(1) | 0x8000_0000));
+        // Select the cache symbol (disjoint spaces — see `core.rs`): real binder
+        // symbol → structural path key (shared across occurrences) → per-node
+        // fallback for anything non-pathy (e.g. `f().x`).
+        let cache_symbol = symbol_id
+            .or_else(|| self.flow_reference_path_symbol(reference))
+            .unwrap_or_else(|| super::per_node_flow_cache_symbol(reference));
 
         // Initialize worklist with the entry point
         worklist.push_back((flow_id, initial_type));

--- a/crates/tsz-checker/src/flow/control_flow/mod.rs
+++ b/crates/tsz-checker/src/flow/control_flow/mod.rs
@@ -38,6 +38,8 @@ pub(crate) mod var_utils;
 mod zod_literal_helpers;
 
 pub(crate) use self::core::{
-    CallPredicateMap, PredicateSignature, PropertyKey, symbol_first_identifier_ref,
+    CallPredicateMap, FLOW_CACHE_STRUCTURAL_ID_LIMIT, PredicateSignature, PropertyKey,
+    is_real_binder_symbol, is_session_stable_flow_cache_symbol, structural_flow_cache_symbol,
+    symbol_first_identifier_ref,
 };
 pub use self::core::{FlowAnalyzer, FlowGraph};

--- a/crates/tsz-checker/src/flow/control_flow/references.rs
+++ b/crates/tsz-checker/src/flow/control_flow/references.rs
@@ -267,6 +267,59 @@ impl<'a> FlowAnalyzer<'a> {
         false
     }
 
+    /// Map a property/element reference *path* to a session-stable synthetic
+    /// cache [`SymbolId`], so every syntactic occurrence of the same path shares
+    /// flow-cache entries instead of re-walking the flow graph per occurrence.
+    ///
+    /// Returns `None` when the reference is not a stable narrowable path (e.g.
+    /// `f().x`, or a base that does not resolve to a symbol); callers then fall
+    /// back to the per-node synthetic key, preserving prior behavior.
+    ///
+    /// The structural key is `[base_symbol_id, prop_atom_0, prop_atom_1, ...]`:
+    /// position 0 is always a base `SymbolId` and the rest are always property
+    /// `Atom`s, so two distinct paths can never collide. The id is folded into a
+    /// synthetic symbol via [`super::structural_flow_cache_symbol`], keyed
+    /// disjointly from real and per-node symbols (see the symbol-space partition
+    /// in `core.rs`).
+    pub(crate) fn flow_reference_path_symbol(&self, reference: NodeIndex) -> Option<SymbolId> {
+        let interner = self.shared_flow_reference_keys?;
+        // Require at least one property hop (a bare identifier already carries a
+        // resolved `SymbolId`); walk the rest of the path base-first.
+        let (base, prop) = self.property_reference(reference)?;
+        let mut key = Vec::new();
+        self.collect_flow_reference_path(base, &mut key)?;
+        key.push(prop.0);
+        let mut map = interner.borrow_mut();
+        let next = map.len() as u32;
+        let id = *map.entry(key).or_insert(next);
+        if id >= super::FLOW_CACHE_STRUCTURAL_ID_LIMIT {
+            // Structural-key space exhausted (pathologically many distinct paths);
+            // fall back to the per-node key rather than risk aliasing.
+            return None;
+        }
+        Some(super::structural_flow_cache_symbol(id))
+    }
+
+    /// Append the base-first structural key of `reference` to `out`.
+    ///
+    /// Recurses through property/element hops, then resolves the leaf base to
+    /// its real binder `SymbolId` at position 0.
+    fn collect_flow_reference_path(&self, reference: NodeIndex, out: &mut Vec<u32>) -> Option<()> {
+        if let Some((base, prop)) = self.property_reference(reference) {
+            self.collect_flow_reference_path(base, out)?;
+            out.push(prop.0);
+            return Some(());
+        }
+        let sym = self.reference_symbol(reference)?;
+        // The leaf must be a real binder symbol; refuse if a synthetic value ever
+        // leaked in, rather than risk crossing key spaces.
+        if !super::is_real_binder_symbol(sym) {
+            return None;
+        }
+        out.push(sym.0);
+        Some(())
+    }
+
     pub(crate) fn property_reference(&self, idx: NodeIndex) -> Option<(NodeIndex, Atom)> {
         let idx = self.skip_parenthesized(idx);
         let node = self.arena.get(idx)?;

--- a/crates/tsz-checker/src/flow/flow_analysis/definite.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/definite.rs
@@ -225,6 +225,7 @@ impl<'a> CheckerState<'a> {
             &self.ctx.node_types,
         )
         .with_flow_cache(&self.ctx.flow_analysis_cache)
+        .with_flow_reference_keys(&self.ctx.flow_reference_keys)
         .with_switch_reference_cache(&self.ctx.flow_switch_reference_cache)
         .with_numeric_atom_cache(&self.ctx.flow_numeric_atom_cache)
         .with_reference_match_cache(&self.ctx.flow_reference_match_cache)

--- a/crates/tsz-checker/src/flow/flow_analysis/usage.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/usage.rs
@@ -1380,6 +1380,7 @@ impl<'a> CheckerState<'a> {
             &self.ctx.node_types,
         )
         .with_flow_cache(&self.ctx.flow_analysis_cache)
+        .with_flow_reference_keys(&self.ctx.flow_reference_keys)
         .with_reference_match_cache(&self.ctx.flow_reference_match_cache)
         .with_type_environment(&self.ctx.type_environment)
         .with_checker_context(&self.ctx)

--- a/crates/tsz-checker/src/types/computation/identifier_flow.rs
+++ b/crates/tsz-checker/src/types/computation/identifier_flow.rs
@@ -599,6 +599,7 @@ impl<'a> CheckerState<'a> {
             &self.ctx.node_types,
         )
         .with_flow_cache(&self.ctx.flow_analysis_cache)
+        .with_flow_reference_keys(&self.ctx.flow_reference_keys)
         .with_switch_reference_cache(&self.ctx.flow_switch_reference_cache)
         .with_numeric_atom_cache(&self.ctx.flow_numeric_atom_cache)
         .with_reference_match_cache(&self.ctx.flow_reference_match_cache)

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -209,6 +209,7 @@ impl<'a> CheckerState<'a> {
             &self.ctx.node_types,
         )
         .with_flow_cache(&self.ctx.flow_analysis_cache)
+        .with_flow_reference_keys(&self.ctx.flow_reference_keys)
         .with_switch_reference_cache(&self.ctx.flow_switch_reference_cache)
         .with_numeric_atom_cache(&self.ctx.flow_numeric_atom_cache)
         .with_reference_match_cache(&self.ctx.flow_reference_match_cache)

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -583,6 +583,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         &self.ctx.node_types,
                     )
                     .with_flow_cache(&self.ctx.flow_analysis_cache)
+                    .with_flow_reference_keys(&self.ctx.flow_reference_keys)
                     .with_switch_reference_cache(&self.ctx.flow_switch_reference_cache)
                     .with_numeric_atom_cache(&self.ctx.flow_numeric_atom_cache)
                     .with_reference_match_cache(&self.ctx.flow_reference_match_cache)

--- a/crates/tsz-checker/tests/flow_property_reference_cache_tests.rs
+++ b/crates/tsz-checker/tests/flow_property_reference_cache_tests.rs
@@ -1,0 +1,128 @@
+//! Regression tests for the structural flow-cache key used by property and
+//! element reference narrowing.
+//!
+//! Property/element references (`x.a`, `x["a"]`) do not resolve to a single
+//! `SymbolId`, so the flow analyzer keys their narrowing cache on a structural
+//! reference *path* — `[base_symbol_id, prop_atom, ...]` — interned to a
+//! synthetic cache symbol. This lets every syntactic occurrence of the same
+//! path share cache entries (turning the previous O(N²) per-occurrence flow
+//! re-walk into O(N)).
+//!
+//! Correctness hinges on the key never aliasing two *different* references.
+//! These tests would fail if the structural key dropped the base symbol (so
+//! `a.v` and `b.v` collided), dropped the property (so `o.a` and `o.b`
+//! collided), or corrupted the narrowed type across repeated reads of the same
+//! path.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+/// Two distinct bases (`first` vs `second`) that share property names must
+/// narrow independently: narrowing `first.kind` must not leak into
+/// `second.kind`. Binder names are deliberately varied from the usual `x`/`y`.
+#[test]
+fn distinct_bases_with_shared_property_narrow_independently() {
+    let codes = check_source_strict_codes(
+        r#"
+type Shape = { kind: "a"; av: number } | { kind: "b"; bv: string };
+function check(first: Shape, second: Shape) {
+  if (first.kind === "a") {
+    const n: number = first.av;
+  }
+  if (second.kind === "b") {
+    const s: string = second.bv;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "distinct bases sharing a property name must narrow independently, got: {codes:?}"
+    );
+}
+
+/// The structural key must include the property: narrowing `box.left` must not
+/// be reused for the *different* property `box.right` on the same base, so the
+/// still-optional `box.right` keeps `number | undefined` and trips TS2322.
+#[test]
+fn distinct_properties_on_same_base_do_not_share_narrowing() {
+    let codes = check_source_strict_codes(
+        r#"
+function pick(box: { left?: number; right?: number }) {
+  if (box.left !== undefined) {
+    const x: number = box.left;
+  }
+  const y: number = box.right;
+}
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "narrowing box.left must not leak to box.right, expected TS2322, got: {codes:?}"
+    );
+}
+
+/// Repeated reads of the *same* narrowed path must keep the narrowed type. A
+/// shared structural key is read once per occurrence; a corrupted cache entry
+/// would surface as `av` no longer existing on the un-narrowed union.
+#[test]
+fn repeated_reads_of_same_path_keep_narrowing() {
+    let codes = check_source_strict_codes(
+        r#"
+type Shape = { kind: "a"; av: number } | { kind: "b"; bv: string };
+function many(value: Shape) {
+  if (value.kind === "a") {
+    const a1: number = value.av;
+    const a2: number = value.av;
+    const a3: number = value.av;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "repeated reads of value.av must stay narrowed, got: {codes:?}"
+    );
+}
+
+/// Deeper paths (`outer.inner.kind`) must also stay distinct per full path:
+/// narrowing `left.inner.kind` must not affect `right.inner.kind`.
+#[test]
+fn distinct_bases_with_shared_nested_path_narrow_independently() {
+    let codes = check_source_strict_codes(
+        r#"
+type Inner = { kind: "a"; av: number } | { kind: "b"; bv: string };
+function check(left: { inner: Inner }, right: { inner: Inner }) {
+  if (left.inner.kind === "a") {
+    const n: number = left.inner.av;
+  }
+  if (right.inner.kind === "b") {
+    const s: string = right.inner.bv;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "nested paths under distinct bases must narrow independently, got: {codes:?}"
+    );
+}
+
+/// Element-access (`obj["a"]`) and property-access (`obj.a`) denote the same
+/// reference, so narrowing through one is observed through the other — the
+/// structural key treats them identically.
+#[test]
+fn element_access_and_property_access_share_one_path() {
+    let codes = check_source_strict_codes(
+        r#"
+function f(obj: { a?: { b: number } }) {
+  if (obj["a"]) {
+    const v: number = obj.a.b;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "obj[\"a\"] and obj.a are the same reference and must share narrowing, got: {codes:?}"
+    );
+}

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -379,7 +379,7 @@ toward the `2x` target or move a red runtime/residency row toward green.
 Track these as counters or periodic audit bullets. They are more useful than
 subjective "cleanup" language.
 
-1. `CheckerContext` field count, currently pinned at `241`, plus the number of
+1. `CheckerContext` field count, currently pinned at `242`, plus the number of
    checker `source_text.contains` / file-name / rendered-message
    diagnostic decisions.
 2. Number of post-check `rewrite_*_fingerprints` passes still active.

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -14,7 +14,7 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        241,
+        242,
     ),
 ]
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -672,7 +672,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "flow"
         / "control_flow"
         / "core.rs",
-        1823,
+        1824,
     ),
     (
         "Solver boundary: type_queries/flow.rs size ratchet",
@@ -992,7 +992,7 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        241,
+        242,
     ),
 ]
 


### PR DESCRIPTION
AgentName: web-opus-flow-cache

Track: Inference / control-flow analysis performance (relates to #8773, the Kysely project row).

## Summary

Property/element references (`a.b`, `a["b"]`) do not resolve to a single `SymbolId`, so the control-flow narrowing cache (`flow_analysis_cache`) keyed them on a **per-syntactic-node** synthetic symbol (`reference.0 | 0x8000_0000`). Each syntactic occurrence of the same path therefore got a distinct cache key and re-walked the entire flow graph back to the binding. N reads of a reference cost **O(N²)** — and property access dominates real, relation-heavy code (builder/query chains, the Kysely row).

Identifier reads were already O(N) because their cache key is the resolved `SymbolId`, shared across occurrences. This PR extends the same sharing to property/element paths.

## Structural rule

When narrowing a reference, `tsc` keys its flow cache by a structural reference *key* (`getFlowCacheKey`), so every occurrence of the same path shares results. tsz now does the same: a property/element path gets a session-stable structural cache symbol built from `[base_symbol_id, prop_atom_0, ...]` (position 0 is always a base symbol, the rest always property atoms → distinct paths can never collide), interned per session and folded into a synthetic id. Non-path references (`f().x`) keep the per-node fallback.

Owner layer: `tsz_checker` control-flow analysis (`flow/control_flow/{core,references,flow_traversal}`).

## Invariant

Behavior is unchanged — the narrowed types computed are identical; only the cache *key* becomes shareable (pure-memo). The synthetic `SymbolId` space is partitioned into three disjoint kinds (real binder symbol / structural path / per-node fallback), centralized behind named constants and helpers in `flow/control_flow/core.rs`. Structural-path ids are interned per run, so those entries are dropped from the flow cache on incremental save (`is_session_stable_flow_cache_symbol`) to avoid cross-run id aliasing; real-symbol and per-node keys are program-stable and kept.

## Scope

- `flow/control_flow/core.rs`: symbol-space constants + helpers, `FlowReferenceKeyInterner`, `FlowAnalyzer` field/builder.
- `flow/control_flow/references.rs`: `flow_reference_path_symbol` / `collect_flow_reference_path`.
- `flow/control_flow/core/flow_traversal.rs`: cache-symbol selection.
- `context/{mod,constructors,core}.rs`: session-scoped interner field + incremental-save filter.
- 5 `FlowAnalyzer` build sites wired with `.with_flow_reference_keys(...)`.
- New `flow_property_reference_cache_tests` (distinct bases, distinct properties, deep paths, element-vs-property equivalence, repeated reads).

## Project Corpus Impact
- Row: kysely-project (and any property-access-heavy project row; #8773)
- Bug family: control-flow narrowing perf — O(N²) per-occurrence property-reference flow re-walk

## Verification

- Micro-benchmark, 300 reads of a narrowable reference at module scope (debug `tsz`):
  - `base.a` (property): **6.84s → 0.75s**; parameter `base.a`: 6.75s → 0.73s — now identical to identifier reads (`base`: 0.75s).
  - Confirmed O(N) scaling (was super-linear).
- Behavior parity: identical diagnostics before/after on a battery of contextual-generic builder-chain and narrowing fixtures.
- `cargo test -p tsz-checker` across ~20 narrowing/flow/type-guard/optional-chain/property-access/discriminant targets (250+ tests): all green, including the new regression suite.
- `cargo clippy -p tsz-checker --tests` and `cargo fmt` clean.

## Coordination Notes

Keeps #8773 open: this fixes a dominant per-reference flow-analysis cost on the Kysely row, but does not by itself flip the row (other families remain). No conformance baseline changes expected (pure-memo cache-key change). Ready-review CI owns the broad conformance/emit suites.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TznP2EhUgpaUUeWcBvPM13)_