### PR TITLE
perf(checker): prove indexed object-map branch constraints structurally

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -169,6 +169,17 @@ impl<'a> CheckerState<'a> {
                 return true;
             }
             let value = self.resolve_lazy_type(value);
+            if query::indexed_object_map_value_structurally_satisfies_constraint(
+                self.ctx.types.as_type_database(),
+                value,
+                constraint,
+            ) || query::indexed_object_map_value_structurally_satisfies_constraint(
+                self.ctx.types.as_type_database(),
+                value,
+                constraint_evaluated,
+            ) {
+                return true;
+            }
             let value_evaluated = self.evaluate_type_for_assignability(value);
             self.conditional_constraint_component_relation_outcome(value, constraint)
                 .related

--- a/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/generic.rs
@@ -44,6 +44,31 @@ pub(crate) fn index_access_components(
     tsz_solver::type_queries::get_index_access_types(db, type_id)
 }
 
+/// Returns true when an indexed object-map branch value is structurally known
+/// to satisfy `constraint` without evaluating the branch.
+///
+/// This covers branch maps like `{ 1: Source & Constraint, 0: never }[Key]`:
+/// every selected value is either `never` or an intersection that includes the
+/// required constraint as one constituent, so the indexed result is a subtype
+/// of the constraint regardless of `Key`.
+pub(crate) fn indexed_object_map_value_structurally_satisfies_constraint(
+    db: &dyn TypeDatabase,
+    value: TypeId,
+    constraint: TypeId,
+) -> bool {
+    if value == TypeId::NEVER || value == constraint {
+        return true;
+    }
+    crate::query_boundaries::common::intersection_members(db, value).is_some_and(|members| {
+        members.iter().copied().any(|member| {
+            member == constraint
+                || indexed_object_map_value_structurally_satisfies_constraint(
+                    db, member, constraint,
+                )
+        })
+    })
+}
+
 pub(crate) fn contains_index_access_with_type_parameter_object(
     db: &dyn TypeDatabase,
     type_id: TypeId,
@@ -926,6 +951,36 @@ mod tests {
         db.store_display_alias(evaluated, keyof);
 
         assert!(!constraint_has_keyof_surface(&db, evaluated));
+    }
+
+    #[test]
+    fn indexed_object_map_value_accepts_intersection_containing_constraint() {
+        let db = TypeInterner::new();
+        let value = db.intersection(vec![TypeId::OBJECT, TypeId::STRING]);
+
+        assert!(indexed_object_map_value_structurally_satisfies_constraint(
+            &db,
+            value,
+            TypeId::STRING,
+        ));
+    }
+
+    #[test]
+    fn indexed_object_map_value_rejects_intersection_without_constraint() {
+        let db = TypeInterner::new();
+        let param = db.type_param(tsz_solver::TypeParamInfo {
+            name: db.intern_string("Item"),
+            constraint: None,
+            default: None,
+            is_const: false,
+        });
+        let value = db.intersection(vec![param, TypeId::NUMBER]);
+
+        assert!(!indexed_object_map_value_structurally_satisfies_constraint(
+            &db,
+            value,
+            TypeId::STRING,
+        ));
     }
 
     #[test]

--- a/crates/tsz-checker/src/tests/conditional_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/conditional_constraint_relation_routing_arch_tests.rs
@@ -62,3 +62,33 @@ fn conditional_filter_helper_uses_relation_outcome_boundary() {
         "the true and extends relation probes should route through the conditional constraint component request helper"
     );
 }
+
+#[test]
+fn indexed_object_map_branch_uses_structural_value_proof_before_evaluation() {
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src/checkers/generic_checker/conditional_constraint_helpers.rs");
+    let source =
+        fs::read_to_string(&source_path).expect("read conditional constraint helper source");
+
+    let function_start = source
+        .find("fn indexed_object_map_branch_satisfies_constraint_uncached")
+        .expect("find indexed object-map branch helper");
+    let rest = &source[function_start..];
+    let function_end = rest
+        .find("\n    fn tuple_value_satisfies_tuple_constraint")
+        .expect("find next helper");
+    let function = &rest[..function_end];
+
+    let structural_probe = function
+        .find("indexed_object_map_value_structurally_satisfies_constraint")
+        .expect("indexed object-map values should have a structural proof");
+    let eager_evaluation = function
+        .find("let value_evaluated = self.evaluate_type_for_assignability(value)")
+        .expect("find eager value evaluation");
+
+    assert!(
+        structural_probe < eager_evaluation,
+        "indexed object-map branches should prove values of the form never or X & C \
+         structurally before evaluating heavy branch values"
+    );
+}

--- a/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
+++ b/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
@@ -242,6 +242,29 @@ type C<T> = {0: C<Missing>}[0];
 }
 
 #[test]
+fn indexed_object_map_intersection_branch_satisfies_constraint() {
+    let diags = check_source_diagnostics(
+        r#"
+type Switch<Value, Narrow> = Value extends Narrow ? "hit" : "miss";
+type Project<Payload, Narrow> = {
+    hit: Payload & Narrow,
+    miss: never,
+}[Switch<Payload, Narrow>];
+type NeedText<Result extends string> = Result;
+type Output<Thing, Parts, Separator> =
+    NeedText<Project<{ thing: Thing, parts: Parts, separator: Separator }, string>>;
+"#,
+    );
+
+    assert_eq!(
+        diagnostic_count(&diags, 2344),
+        0,
+        "Indexed object-map values of the form never or X & string should satisfy \
+         a string constraint without eager branch evaluation; got: {diags:#?}"
+    );
+}
+
+#[test]
 fn boolean_dispatch_index_alias_uses_declared_key_subset() {
     let diags = check_source_diagnostics(
         r#"


### PR DESCRIPTION
## Agent
AgentName: Studio-B

## Track
Track 10 benchmark blocker — semantic campaign (alias-body constraint validation)

## Invariant
When every indexed object-map branch value is `never` or `X & C`, the indexed result is assignable to constraint `C` regardless of the index key; tsz proves this structurally through `query_boundaries::checkers::generic::indexed_object_map_value_structurally_satisfies_constraint` before evaluating heavy branch values in `indexed_object_map_branch_satisfies_constraint_uncached`.

## Scope
- `crates/tsz-checker/src/query_boundaries/checkers/generic.rs`: structural predicate for never / intersection-containing-constraint branch values
- `crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs`: call predicate before `evaluate_type_for_assignability(value)`
- Focused architecture and behavioral tests in `conditional_constraint_relation_routing_arch_tests.rs`, `ref_type_params_cache_tests.rs`, and query-boundary unit tests

## Project Corpus Impact
- Row: ts-toolbelt-project
- Bug family: recursive alias-body constraint validation hotspot (Select-like indexed object-map branches)
- Evidence: targets repeated ExecPath → Select<UnionOf<...>, string> constraint proof path identified by perf-counter attribution; avoids eager branch evaluation when branch map values are structurally never or Payload & string

## Verification
- `cargo nextest run -p tsz-checker --lib indexed_object_map_branch_uses_structural_value_proof_before_evaluation indexed_object_map_value_accepts_intersection_containing_constraint indexed_object_map_value_rejects_intersection_without_constraint indexed_object_map_intersection_branch_satisfies_constraint`
- CI: checker unit tests + project-corpus guard rows

## Coordination Notes
- Follows merged #12927 (type-arg constraint relation cache) on the same ts-toolbelt hotspot lane
- No hardcoded ts-toolbelt names; predicate is structural on object-map branch value shapes
- Adjacent negative fallback covered at query-boundary unit level (Item & number vs string); broader generic TS2344 deferral for wrong intersections remains a separate follow-up