### PR TITLE
perf(checker): resolve readonly lib-interface property reads via lazy fast path

### DIFF
--- a/crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs
+++ b/crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs
@@ -269,3 +269,105 @@ export {};
         "inherited member via global receiver should resolve cleanly, got {codes:?}",
     );
 }
+
+/// A `readonly` own plain property read resolves through the single-member fast
+/// path (the `readonly` modifier is write-only and does not change the read
+/// type). Proven across two distinct interfaces + member spellings
+/// (`Element.tagName`, `Node.nodeName`) so the behavior follows the shape, not a
+/// name. Before this, `readonly` members forced the receiver's full structural
+/// materialization.
+#[test]
+fn readonly_own_member_read_resolves_without_diagnostics() {
+    let codes = dom_codes(
+        r#"
+declare const el: Element;
+declare const node: Node;
+const t: string = el.tagName;
+const n: string = node.nodeName;
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "readonly own-member reads should not produce diagnostics, got {codes:?}",
+    );
+}
+
+/// A type mismatch on a `readonly` own member must still report TS2322 — the fast
+/// path resolves the real member type, it does not widen it.
+#[test]
+fn readonly_own_member_type_mismatch_still_errors() {
+    let codes = dom_codes(
+        r#"
+declare const el: Element;
+const wrong: number = el.tagName;
+export {};
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "readonly string member assigned to number should report TS2322, got {codes:?}",
+    );
+}
+
+/// Writing to a `readonly` member must still report TS2540. The readonly *write*
+/// diagnostic is decided by `check_readonly_assignment`, which re-materializes the
+/// receiver independently of the read fast path, so keeping readonly reads on the
+/// fast path does not suppress it. Proven across two interfaces so it follows the
+/// shape, not a spelling.
+#[test]
+fn readonly_member_write_still_reports_ts2540() {
+    let codes = dom_codes(
+        r#"
+declare const el: Element;
+declare const node: Node;
+el.tagName = "x";
+node.nodeName = "y";
+export {};
+"#,
+    );
+    assert_eq!(
+        codes,
+        vec![2540, 2540],
+        "writes to readonly members should each report TS2540, got {codes:?}",
+    );
+}
+
+/// A chained read through a `readonly` member that is itself typed as a simple
+/// lib interface (`Document.documentElement: HTMLElement`) resolves each link
+/// lazily and types correctly. This exercises both levers together: the readonly
+/// member resolves through the fast path AND, being a bare lib-interface
+/// reference, stays `Lazy` so the leaf `tagName` resolves without materializing
+/// `HTMLElement`.
+#[test]
+fn readonly_lib_interface_reference_member_chains_cleanly() {
+    let codes = dom_codes(
+        r#"
+declare const d: Document;
+const t: string = d.documentElement.tagName;
+export {};
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "chained read through a readonly lib-interface-reference member should resolve cleanly, got {codes:?}",
+    );
+}
+
+/// A type mismatch on the leaf of a chained `readonly` lib-interface-reference
+/// member read must still report TS2322 — keeping the intermediate readonly
+/// member lazy does not widen the leaf member type.
+#[test]
+fn readonly_lib_interface_reference_chain_leaf_mismatch_still_errors() {
+    let codes = dom_codes(
+        r#"
+declare const d: Document;
+const wrong: number = d.documentElement.tagName;
+export {};
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "string leaf assigned to number through a readonly chain should report TS2322, got {codes:?}",
+    );
+}

--- a/crates/tsz-checker/src/types/queries/lib_resolution_member.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution_member.rs
@@ -10,10 +10,12 @@
 //!
 //! Scope (intentionally narrow for soundness — anything else returns `None` and
 //! falls back to the full-materialization path):
-//! - Plain property signatures (`prop: T` / `prop?: T`) and unambiguous method
-//!   signature groups. Accessors, index signatures, call/construct signatures,
-//!   readonly writes, optional methods, and computed/symbol-named members take
-//!   the full path.
+//! - Plain property signatures (`prop: T` / `prop?: T`, including `readonly`
+//!   ones — `readonly` is write-only and does not change the read type) and
+//!   unambiguous method signature groups. Accessors, index signatures,
+//!   call/construct signatures, optional methods, and computed/symbol-named
+//!   members take the full path. Readonly *writes* (TS2540) are decided
+//!   independently in `check_readonly_assignment`, never through this read path.
 //! - A single own property declaration, or one method overload group in one
 //!   arena. Split declarations and mixed property/method members take the full
 //!   path.
@@ -289,13 +291,22 @@ impl CheckerState<'_> {
         {
             return None;
         }
-        // Readonly properties carry extra write semantics. Leave those on the
-        // full path so their exact behavior is authoritative. Optional plain
-        // properties are safe here because property access returns the read
-        // annotation type; optionality itself is tracked by full object shapes.
-        if self.has_readonly_modifier(&sig.modifiers) {
-            return None;
-        }
+        // `readonly` is a *write*-only modifier: a property read returns the
+        // declared annotation type regardless of readonly-ness, and the
+        // `PropertyAccessResult` this fast path produces carries no readonly flag
+        // (readonly is never encoded in the read result — see
+        // `tsz_solver::operations::property::PropertyAccessResult::Success`). The
+        // readonly *write* diagnostic (TS2540) is decided independently in
+        // `check_readonly_assignment`, which re-materializes the receiver and
+        // queries `property_is_readonly` (which resolves the bare `Lazy` itself),
+        // so it never depends on this read path. Resolving a readonly own plain
+        // property here is therefore byte-identical to full materialization for
+        // the read, while extending the lazy single-member fast path to the large
+        // class of `readonly` lib-interface members (e.g. `Node.nodeName`,
+        // `Element.tagName`, `HTMLElement.offsetWidth`) that previously forced the
+        // receiver's full structural materialization. Optional plain properties
+        // are likewise safe — optionality is tracked by full object shapes, not
+        // the read annotation type returned here.
 
         // Build the same hybrid-resolver TypeLowering the full lib path uses, so
         // the member annotation lowers to a byte-identical type.


### PR DESCRIPTION
AgentName: lucid-hopper-ygmyn5

Track: Performance / lazy lib-interface materialization (#12101).

## Invariant

When resolving a **value-position property read** `recv.p` whose receiver is a
bare `Lazy(DefId)` reference to an eligible simple lib interface (the existing
`lazy_lib_member_receiver_def_id` predicate: non-generic, unmerged, unaugmented,
unshadowed), and `p` is a `readonly` plain property signature, tsz resolves only
member `p` through the single-member fast path instead of materializing the
receiver's full structural shape + transitive `extends` closure. The read is
byte-identical to full materialization, and the readonly **write** diagnostic
(TS2540) is unchanged.

## Structural rule

`readonly` is a *write*-only modifier. A property **read** returns the declared
annotation type regardless of readonly-ness, and the read-side
`PropertyAccessResult::Success` carries **no** readonly flag (readonly is never
encoded in the read result). The readonly **write** diagnostic (TS2540) is
decided independently in `check_readonly_assignment`, which re-materializes the
receiver and queries `property_is_readonly` (itself resolving the bare `Lazy`),
so it never depends on this read path. The previous `has_readonly_modifier` bail
in `resolve_simple_lib_interface_property` was therefore over-conservative: it
forced full materialization of the receiver (and its heritage closure) just to
read one `readonly` member.

This generalizes the shared fast-path mechanism (it removes a special-case bail)
rather than adding a special case — the value-position counterpart slice that
follows #12117 (own-member) and #12829 (chained lib-interface-reference members).

## Owner layer

Solver-backed checker query:
`crates/tsz-checker/src/types/queries/lib_resolution_member.rs`
(`resolve_simple_lib_interface_property`). Eligibility reuses the existing
receiver predicate and `TSZ_DISABLE_LAZY_MEMBER_ACCESS` kill-switch. Readonly
*write* semantics stay in `state/state_checking/readonly.rs`, untouched.

## Scope

- `crates/tsz-checker/src/types/queries/lib_resolution_member.rs`: drop the
  `has_readonly_modifier` early-return so readonly plain-property reads use the
  single-member fast path; document why reads are byte-identical and writes
  remain on the independent path; sync the module-scope docstring.
- `crates/tsz-checker/src/tests/lazy_lib_member_access_tests.rs`: 5 new tests —
  readonly own-member read (across `Element.tagName` + `Node.nodeName`), readonly
  read type-mismatch (TS2322), readonly **write** still reports TS2540 (across two
  interfaces), chained readonly lib-interface-reference read
  (`Document.documentElement.tagName`), and chained readonly leaf mismatch.

Adjacent-case matrix: own readonly read; readonly read mismatch (TS2322);
readonly write (TS2540) preserved; chained readonly lib-interface-reference read;
chained readonly leaf mismatch; generic / augmented / shadowed receivers and
non-readonly members unchanged (existing eligibility gate + prior tests).

## Project Corpus Impact
- Row: vite-vanilla-ts-app
- Bug family: #12101 lazy lib-interface materialization

Evidence: many DOM properties are `readonly` (`Node.nodeName`, `Element.tagName`,
`HTMLElement.offsetWidth`, `Document.documentElement`, ...); each previously
forced the receiver's full structural materialization on a value-position read.
This slice keeps those reads on the lazy single-member path. No diagnostic deltas
are introduced (the `PropertyAccessResult` read result carries no readonly flag;
writes are decided independently), so accepted-regression and conformance
baselines are intended to remain unchanged.

## Verification

- `cargo nextest run -p tsz-checker --lib -E 'test(lazy_lib_member_access)'`
  → 17 passed (12 prior + 5 new).
- Byte-identity A/B: the same suite passes identically with the fast path **on**
  and with `TSZ_DISABLE_LAZY_MEMBER_ACCESS=1` (full materialization), confirming
  the readonly-read fast path and the legacy path agree.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib
  --all-features -- -D warnings` clean.
- Touched files stay well under the 2000-line limit (508 / 373).
- Broad conformance/emit left to ready-review CI per repo policy. (Local fresh
  container lacks the full lib/submodule setup, so a baseline set of
  Promise/async/Symbol/JSX unit tests fail identically with and without this
  change — verified the same failures exist on the base commit — and are
  unrelated to this diff.)

## Coordination Notes

Continues the lazy lib-interface materialization campaign (#12101; prior art
#12117 own-member, #12829 chained references, #8638 type-position refs). Confined
to the property-read fast path and gated by the existing
`TSZ_DISABLE_LAZY_MEMBER_ACCESS` kill-switch. Readonly write semantics (TS2540)
deliberately stay on the independent `check_readonly_assignment` path. No
fixture-name fast paths; eligibility is structural via the existing receiver
predicate. Does not by itself close the vite row — the intrinsic generic-method
return-type / param materialization cascade documented in #12101 remains a
separate, harder lever.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqGQVtV34hJ4szGiq89nPB)_