### PR TITLE
perf(checker): eliminate remaining O(n^2) flow narrowing on member access and optional chains

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -49,6 +49,18 @@ pub(crate) const fn structural_flow_cache_symbol(id: u32) -> SymbolId {
 /// collide with the per-node fallback space.
 pub(crate) const FLOW_CACHE_STRUCTURAL_ID_LIMIT: u32 = FLOW_CACHE_PER_NODE_BIT;
 
+// Reserved *base* components for `this` / `super` reference paths, which carry
+// no binder symbol. These occupy position 0 of a structural key
+// (`[base, prop_atom_0, ...]`). Real bases push a binder `SymbolId` whose bit 31
+// is clear (`is_real_binder_symbol`), so reserving values with bit 31 set keeps
+// `this.x` / `super.x` paths disjoint from every `symbol#k.x` path at position 0
+// and from each other. They are key payload, not cache symbols, and never reach
+// `structural_flow_cache_symbol`.
+/// Structural-key base component for a `this` receiver.
+pub(crate) const FLOW_CACHE_THIS_BASE_KEY: u32 = FLOW_CACHE_SYNTHETIC_BIT;
+/// Structural-key base component for a `super` receiver.
+pub(crate) const FLOW_CACHE_SUPER_BASE_KEY: u32 = FLOW_CACHE_SYNTHETIC_BIT | 1;
+
 /// Per-syntactic-node fallback cache symbol for a reference `node`.
 pub(crate) const fn per_node_flow_cache_symbol(node: NodeIndex) -> SymbolId {
     SymbolId(
@@ -967,13 +979,25 @@ impl<'a> FlowAnalyzer<'a> {
         }
 
         // Resolve symbol for caching purposes.
-        // Fallback to reference_symbol for non-identifier references (e.g. some
-        // qualified/member references) so repeated flow queries can share cache
-        // entries instead of using per-node synthetic symbols.
+        //
+        // Member-like references (`a.b`, `a[b]`, `this.x`) must NOT key by a bare
+        // member `SymbolId`: the binder links some member accesses (notably
+        // `this.x` on a class field) to the field symbol, which both aliases
+        // distinct receivers (`x.foo` vs `this.foo` share the field symbol) and
+        // defeats occurrence sharing for everything else. `check_flow` keys such
+        // references by their structural path instead (`flow_reference_path_symbol`),
+        // which is occurrence-stable and receiver-disjoint. Only resolve a symbol
+        // for plain identifier / `this` / `super` roots.
         let symbol_id = self
             .binder
             .resolve_identifier(self.arena, reference)
-            .or_else(|| self.reference_symbol(reference));
+            .or_else(|| {
+                if self.is_member_like_reference(reference) {
+                    None
+                } else {
+                    self.reference_symbol(reference)
+                }
+            });
 
         self.check_flow(
             reference,

--- a/crates/tsz-checker/src/flow/control_flow/mod.rs
+++ b/crates/tsz-checker/src/flow/control_flow/mod.rs
@@ -38,8 +38,8 @@ pub(crate) mod var_utils;
 mod zod_literal_helpers;
 
 pub(crate) use self::core::{
-    CallPredicateMap, FLOW_CACHE_STRUCTURAL_ID_LIMIT, PredicateSignature, PropertyKey,
-    is_real_binder_symbol, is_session_stable_flow_cache_symbol, structural_flow_cache_symbol,
-    symbol_first_identifier_ref,
+    CallPredicateMap, FLOW_CACHE_STRUCTURAL_ID_LIMIT, FLOW_CACHE_SUPER_BASE_KEY,
+    FLOW_CACHE_THIS_BASE_KEY, PredicateSignature, PropertyKey, is_real_binder_symbol,
+    is_session_stable_flow_cache_symbol, structural_flow_cache_symbol, symbol_first_identifier_ref,
 };
 pub use self::core::{FlowAnalyzer, FlowGraph};

--- a/crates/tsz-checker/src/flow/control_flow/references.rs
+++ b/crates/tsz-checker/src/flow/control_flow/references.rs
@@ -281,14 +281,74 @@ impl<'a> FlowAnalyzer<'a> {
     /// synthetic symbol via [`super::structural_flow_cache_symbol`], keyed
     /// disjointly from real and per-node symbols (see the symbol-space partition
     /// in `core.rs`).
+    /// Decompose one member-access hop for the structural cache key, tolerating
+    /// optional-chain `?.` (which `property_reference` rejects). Reports the
+    /// receiver, the property/literal-index atom, and whether the hop was
+    /// optional. Optionality is folded into the key so a mixed `o?.a` / `o.a`
+    /// program keys them distinctly (they could narrow differently and must not
+    /// share), while repeated reads of the *same* optional path still share and
+    /// stay O(n). Entity-name element indices (`obj[key]`) return `None` here, as
+    /// in `property_reference`, and fall back to the per-node walk.
+    fn member_access_key_parts(&self, idx: NodeIndex) -> Option<(NodeIndex, Atom, bool)> {
+        let idx = self.skip_parenthesized(idx);
+        let node = self.arena.get(idx)?;
+
+        if node.kind == syntax_kind_ext::NON_NULL_EXPRESSION {
+            let unary = self.arena.get_unary_expr_ex(node)?;
+            return self.member_access_key_parts(unary.expression);
+        }
+        if node.kind == syntax_kind_ext::TYPE_ASSERTION
+            || node.kind == syntax_kind_ext::AS_EXPRESSION
+            || node.kind == syntax_kind_ext::SATISFIES_EXPRESSION
+        {
+            let assertion = self.arena.get_type_assertion(node)?;
+            return self.member_access_key_parts(assertion.expression);
+        }
+        if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            let access = self.arena.get_access_expr(node)?;
+            let ident = self.arena.get_identifier_at(access.name_or_argument)?;
+            let name = self.interner.intern_string(&ident.escaped_text);
+            return Some((access.expression, name, access.question_dot_token));
+        }
+        if node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
+            let access = self.arena.get_access_expr(node)?;
+            let name = self.literal_atom_from_node_or_type(access.name_or_argument)?;
+            return Some((access.expression, name, access.question_dot_token));
+        }
+        if node.kind == syntax_kind_ext::QUALIFIED_NAME {
+            let qn = self.arena.get_qualified_name(node)?;
+            let ident = self.arena.get_identifier_at(qn.right)?;
+            let name = self.interner.intern_string(&ident.escaped_text);
+            return Some((qn.left, name, false));
+        }
+        None
+    }
+
     pub(crate) fn flow_reference_path_symbol(&self, reference: NodeIndex) -> Option<SymbolId> {
         let interner = self.shared_flow_reference_keys?;
-        // Require at least one property hop (a bare identifier already carries a
-        // resolved `SymbolId`); walk the rest of the path base-first.
-        let (base, prop) = self.property_reference(reference)?;
         let mut key = Vec::new();
-        self.collect_flow_reference_path(base, &mut key)?;
-        key.push(prop.0);
+        if let Some((base, prop, optional)) = self.member_access_key_parts(reference) {
+            // Property/element path (`a.b`, `this.x`, `o?.a`): walk base-first.
+            self.collect_flow_reference_path(base, &mut key)?;
+            key.push(prop.0);
+            key.push(u32::from(optional));
+        } else {
+            // Bare `this` / `super`: no binder symbol and no property hop, but a
+            // stable receiver within its flow scope. Without an occurrence-stable
+            // key they fall back to a per-node symbol and re-walk the flow graph
+            // per read (O(n^2) for `this`-heavy method bodies). Intern a base-only
+            // key so repeated bare reads share flow-cache entries. Bare
+            // identifiers already carry a resolved `SymbolId` and never reach here.
+            let leaf = self.skip_parenthesized(reference);
+            let node = self.arena.get(leaf)?;
+            if node.kind == SyntaxKind::ThisKeyword as u16 {
+                key.push(super::FLOW_CACHE_THIS_BASE_KEY);
+            } else if node.kind == SyntaxKind::SuperKeyword as u16 {
+                key.push(super::FLOW_CACHE_SUPER_BASE_KEY);
+            } else {
+                return None;
+            }
+        }
         let mut map = interner.borrow_mut();
         let next = map.len() as u32;
         let id = *map.entry(key).or_insert(next);
@@ -302,13 +362,29 @@ impl<'a> FlowAnalyzer<'a> {
 
     /// Append the base-first structural key of `reference` to `out`.
     ///
-    /// Recurses through property/element hops, then resolves the leaf base to
-    /// its real binder `SymbolId` at position 0.
+    /// Recurses through property/element hops (each contributing a property atom
+    /// plus an optional-chain flag), then resolves the leaf base to its real
+    /// binder `SymbolId` (or `this`/`super` sentinel) at position 0.
     fn collect_flow_reference_path(&self, reference: NodeIndex, out: &mut Vec<u32>) -> Option<()> {
-        if let Some((base, prop)) = self.property_reference(reference) {
+        if let Some((base, prop, optional)) = self.member_access_key_parts(reference) {
             self.collect_flow_reference_path(base, out)?;
             out.push(prop.0);
+            out.push(u32::from(optional));
             return Some(());
+        }
+        // `this` / `super` carry no binder symbol but are valid narrowable bases
+        // (`this.x`, `super.x`). Reserve disjoint base components so their paths
+        // share flow-cache entries across occurrences within one container.
+        let leaf = self.skip_parenthesized(reference);
+        if let Some(node) = self.arena.get(leaf) {
+            if node.kind == SyntaxKind::ThisKeyword as u16 {
+                out.push(super::FLOW_CACHE_THIS_BASE_KEY);
+                return Some(());
+            }
+            if node.kind == SyntaxKind::SuperKeyword as u16 {
+                out.push(super::FLOW_CACHE_SUPER_BASE_KEY);
+                return Some(());
+            }
         }
         let sym = self.reference_symbol(reference)?;
         // The leaf must be a real binder symbol; refuse if a synthetic value ever
@@ -318,6 +394,104 @@ impl<'a> FlowAnalyzer<'a> {
         }
         out.push(sym.0);
         Some(())
+    }
+
+    /// True when `idx` is a narrowable member-access reference: a property or
+    /// element access whose receiver chain bottoms out in an identifier, `this`,
+    /// or `super`, where every element-access index is a string/number literal
+    /// or an entity-name expression.
+    ///
+    /// Faithful mirror of tsc's `isNarrowableReference` (over `isDottedName`).
+    /// Non-reference receivers (fresh object literals, call results) and
+    /// non-narrowable element indices (`arr[i % 3]`, `arr[f()]`) return `false`:
+    /// such accesses cannot match any control-flow antecedent, so a flow walk
+    /// over them only ever returns the declared type and can be skipped. Note
+    /// this is broader than the *structural-cache* path (`property_reference`,
+    /// which keys only literal indices): an entity-name-indexed access like
+    /// `obj[key]` is narrowable (tsc narrows it) even though it has no stable
+    /// structural key, so it must not be skipped — it falls back to the per-node
+    /// walk.
+    pub(crate) fn is_narrowable_member_reference(&self, idx: NodeIndex) -> bool {
+        let leaf = self.skip_parenthesized(idx);
+        let Some(node) = self.arena.get(leaf) else {
+            return false;
+        };
+        // Only property/element accesses reach the member-access skip; bare
+        // identifiers, `this`, and `super` are handled by the identifier path.
+        if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            && node.kind != syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        {
+            return false;
+        }
+        self.reference_is_narrowable(leaf)
+    }
+
+    fn reference_is_narrowable(&self, idx: NodeIndex) -> bool {
+        let idx = self.skip_parenthesized(idx);
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+        if node.kind == SyntaxKind::Identifier as u16
+            || node.kind == SyntaxKind::ThisKeyword as u16
+            || node.kind == SyntaxKind::SuperKeyword as u16
+            || node.kind == syntax_kind_ext::QUALIFIED_NAME
+            // `import.meta` / `new.target`: symbol-less meta-property roots that
+            // `is_matching_reference` already treats as stable references, so
+            // member accesses over them (`import.meta.env.FOO`) are narrowable.
+            || node.kind == syntax_kind_ext::META_PROPERTY
+            || node.kind == SyntaxKind::ImportKeyword as u16
+        {
+            return true;
+        }
+        if node.kind == syntax_kind_ext::NON_NULL_EXPRESSION {
+            return self
+                .arena
+                .get_unary_expr_ex(node)
+                .is_some_and(|u| self.reference_is_narrowable(u.expression));
+        }
+        if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            let Some(access) = self.arena.get_access_expr(node) else {
+                return false;
+            };
+            return !access.question_dot_token && self.reference_is_narrowable(access.expression);
+        }
+        if node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION {
+            let Some(access) = self.arena.get_access_expr(node) else {
+                return false;
+            };
+            return !access.question_dot_token
+                && self.element_index_is_narrowable(access.name_or_argument)
+                && self.reference_is_narrowable(access.expression);
+        }
+        false
+    }
+
+    /// An element-access index is narrowable when it is a string/number literal
+    /// or an entity-name expression (`obj[key]`, `obj[ns.key]`), matching tsc.
+    fn element_index_is_narrowable(&self, idx: NodeIndex) -> bool {
+        if self.literal_atom_from_node_or_type(idx).is_some() {
+            return true;
+        }
+        self.argument_is_entity_name(idx)
+    }
+
+    fn argument_is_entity_name(&self, idx: NodeIndex) -> bool {
+        let idx = self.skip_parenthesized(idx);
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+        if node.kind == SyntaxKind::Identifier as u16
+            || node.kind == SyntaxKind::ThisKeyword as u16
+            || node.kind == syntax_kind_ext::QUALIFIED_NAME
+        {
+            return true;
+        }
+        if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return self.arena.get_access_expr(node).is_some_and(|a| {
+                !a.question_dot_token && self.argument_is_entity_name(a.expression)
+            });
+        }
+        false
     }
 
     pub(crate) fn property_reference(&self, idx: NodeIndex) -> Option<(NodeIndex, Atom)> {

--- a/crates/tsz-checker/src/flow/flow_analysis/definite.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/definite.rs
@@ -244,6 +244,21 @@ impl<'a> CheckerState<'a> {
         .with_symbol_first_identifier_ref(&self.ctx.symbol_flow_memo.first_identifier_ref)
         .with_destructured_bindings(&self.ctx.destructured_bindings);
 
+        // Non-narrowable member accesses cannot match any control-flow
+        // antecedent, so the flow walk can only return the declared type. tsc
+        // runs `getFlowTypeOfReference` only for narrowable references; skipping
+        // them here avoids an O(n^2) re-walk per access (fresh/call-result
+        // receivers, dynamic element indices). Narrowable accesses (`d.a.b`,
+        // `this.x`, `arr[0]`) fall through to the walk, where the structural
+        // reference-path cache keeps repeated occurrences O(1).
+        if let Some(node) = self.ctx.arena.get(idx)
+            && (node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+                || node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
+            && !analyzer.is_narrowable_member_reference(idx)
+        {
+            return declared_type;
+        }
+
         // Strip `undefined` from the initial type for parameters with default values.
         // Matches tsc's getInitialType: a parameter like `x: string | undefined = "val"`
         // starts as `string` (not `string | undefined`) because the default guarantees it.

--- a/crates/tsz-checker/tests/flow_property_reference_cache_tests.rs
+++ b/crates/tsz-checker/tests/flow_property_reference_cache_tests.rs
@@ -126,3 +126,226 @@ function f(obj: { a?: { b: number } }) {
         "obj[\"a\"] and obj.a are the same reference and must share narrowing, got: {codes:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// `this` / `super` bases and non-narrowable member accesses.
+//
+// `this` and `super` carry no binder symbol, so before they were given a
+// reserved structural base component their flow narrowing fell back to a
+// per-node cache key and re-walked the flow graph per read (O(n^2) for
+// `this`-heavy method bodies). Non-reference member accesses (call results,
+// fresh object literals, dynamic element indices) are not references at all:
+// tsc never narrows them, so the flow walk is skipped entirely. These tests
+// pin both the narrowing that must be preserved and the narrowing that must
+// not appear.
+// ---------------------------------------------------------------------------
+
+/// `this.foo` narrows like any other reference, and a `this` base must not
+/// alias a same-named property on an unrelated receiver.
+#[test]
+fn this_member_narrows_and_is_receiver_disjoint() {
+    let codes = check_source_strict_codes(
+        r#"
+type Shape = { kind: "a"; av: number } | { kind: "b"; bv: string };
+class Holder {
+  shape: Shape = { kind: "a", av: 1 };
+  inspect(other: Shape) {
+    if (this.shape.kind === "a") {
+      const n: number = this.shape.av;
+    }
+    if (other.kind === "b") {
+      const s: string = other.bv;
+    }
+  }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "this.shape and a same-named param property must narrow independently, got: {codes:?}"
+    );
+}
+
+/// Repeated reads of `this.value` must keep the narrowed type — the O(n^2) fix
+/// must not corrupt the shared narrowing across occurrences.
+#[test]
+fn repeated_this_reads_keep_narrowing() {
+    let codes = check_source_strict_codes(
+        r#"
+class Box {
+  value: string | number = 0;
+  use() {
+    if (typeof this.value === "string") {
+      const a: string = this.value;
+      const b: string = this.value;
+      const c: string = this.value;
+    }
+  }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "repeated this.value reads must stay narrowed to string, got: {codes:?}"
+    );
+}
+
+/// Assigning to `this.field` narrows subsequent reads (assignment flow).
+#[test]
+fn this_member_assignment_narrows() {
+    let codes = check_source_strict_codes(
+        r#"
+class Box {
+  field: string | number = 0;
+  set() {
+    this.field = "hi";
+    const s: string = this.field;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "this.field must narrow to string after assignment, got: {codes:?}"
+    );
+}
+
+/// Call results are not references: tsc does not narrow `f().v` across the
+/// guard (each call is a fresh value), so the inner read keeps `number |
+/// undefined` and trips TS2322. Skipping the flow walk must preserve this.
+#[test]
+fn call_result_member_is_not_narrowed() {
+    let codes = check_source_strict_codes(
+        r#"
+declare function make(): { v: number | undefined };
+function use() {
+  if (make().v !== undefined) {
+    const x: number = make().v;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "call-result member access must not narrow (tsc parity), expected TS2322, got: {codes:?}"
+    );
+}
+
+/// A fresh object literal receiver is not a reference and must not narrow.
+#[test]
+fn fresh_object_literal_member_is_not_narrowed() {
+    let codes = check_source_strict_codes(
+        r#"
+function use(seed: number | undefined) {
+  if (({ v: seed }).v !== undefined) {
+    const x: number = ({ v: seed }).v;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "fresh-object-literal member access must not narrow, expected TS2322, got: {codes:?}"
+    );
+}
+
+/// `tsc`'s `isNarrowableReference` allows element-access indices that are
+/// string/number literals OR entity-name expressions, but not computed
+/// expressions. Mirror all three: `arr[i % 3]` (computed) does not narrow and
+/// trips TS2322, while `arr[0]` (literal) and `arr[i]` (entity-name index) do
+/// narrow. The entity-name case guards against over-skipping: `obj[key]` is
+/// narrowable even though it has no stable structural cache key.
+#[test]
+fn element_index_narrowability_matches_tsc() {
+    let computed = check_source_strict_codes(
+        r#"
+declare const arr: (number | undefined)[];
+declare const i: number;
+function use() {
+  if (arr[i % 3] !== undefined) {
+    const x: number = arr[i % 3];
+  }
+}
+"#,
+    );
+    assert!(
+        computed.contains(&2322),
+        "arr[i % 3] with a computed index must not narrow, expected TS2322, got: {computed:?}"
+    );
+
+    let literal = check_source_strict_codes(
+        r#"
+declare const arr: (number | undefined)[];
+function use() {
+  if (arr[0] !== undefined) {
+    const x: number = arr[0];
+  }
+}
+"#,
+    );
+    assert!(
+        literal.is_empty(),
+        "arr[0] with a literal index must narrow, got: {literal:?}"
+    );
+
+    let entity = check_source_strict_codes(
+        r#"
+declare const arr: (number | undefined)[];
+declare const i: number;
+function use() {
+  if (arr[i] !== undefined) {
+    const x: number = arr[i];
+  }
+}
+"#,
+    );
+    assert!(
+        entity.is_empty(),
+        "arr[i] with an entity-name index must narrow (it is narrowable in tsc), got: {entity:?}"
+    );
+}
+
+/// Optional-chain references (`o?.inner?.kind`) are narrowable and their cache
+/// key folds the `?.` flag, so repeated reads of the same optional path share
+/// (O(n)) while staying correctly narrowed. The structural key must keep the
+/// optionality so a mixed `o.a` / `o?.a` program never cross-contaminates.
+#[test]
+fn optional_chain_member_narrows_and_repeats() {
+    let codes = check_source_strict_codes(
+        r#"
+type Shape = { kind: "a"; av: number } | { kind: "b"; bv: string };
+function inspect(o: { inner?: Shape }) {
+  if (o.inner?.kind === "a") {
+    const a1: number = o.inner.av;
+    const a2: number = o.inner.av;
+    const a3: number = o.inner.av;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "optional-chain narrowing of o.inner must survive repeated reads, got: {codes:?}"
+    );
+}
+
+/// Member accesses over the `import.meta` meta-property root are narrowable:
+/// `is_matching_reference` treats `import.meta` as a stable reference, so the
+/// skip predicate must not classify `import.meta.x` as non-narrowable.
+#[test]
+fn import_meta_member_is_narrowable() {
+    let codes = check_source_strict_codes(
+        r#"
+interface ImportMeta { value?: { n: number } }
+export function read() {
+  if (import.meta.value) {
+    const n: number = import.meta.value.n;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "import.meta.value member access must narrow, got: {codes:?}"
+    );
+}

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -672,7 +672,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "flow"
         / "control_flow"
         / "core.rs",
-        1824,
+        1848,
     ),
     (
         "Solver boundary: type_queries/flow.rs size ratchet",


### PR DESCRIPTION
AgentName: StudioOpus

Track: Inference / control-flow analysis performance. Follow-up to #12940 closing every remaining member-access and optional-chain flow-narrowing O(n^2).

## Summary

#12940 made member-reference flow narrowing O(n) only when the reference bottoms out in a real binder symbol (`d.a.b`, `arr[0]`). Profiling found the remaining shapes still re-walking the flow graph per occurrence — **O(n^2)** on member-heavy real code:

| shape | before | after |
| --- | ---: | ---: |
| `this.foo` (×2000) | 7.48s | **0.03s** |
| `o?.a?.b?.c` (×1600) | 8.2x | **1.3x (O(n))** |
| `g().x` / `({...}).x` | 3.2–3.6s | **0.04s** |
| `arr[i % 3]` | 3.25s | **0.05s** |
| 10k-line file, ~20k accesses | timeout-class | **0.14s** |

The last row directly attacks the `large-ts-repo` exit-124.

## Structural rule

tsc runs `getFlowTypeOfReference` only for **narrowable references** (`isNarrowableReference`), keyed by a structural reference key so occurrences share. tsz now matches this:

1. **`this`/`super`** get reserved structural base components (bit 31 set, disjoint from real symbol ids); member-like refs no longer key by a bare member symbol.
2. **Optional chains** fold each hop's `?.` flag into the structural key — repeated `o?.a?.b` share (O(n)); mixed `o.a`/`o?.a` key distinctly (no cross-contamination).
3. **Non-narrowable accesses** (call results, fresh literals, computed indices) are skipped — they cannot match any antecedent.

The skip predicate faithfully mirrors `isNarrowableReference`/`isDottedName`: a chain bottoming out in identifier/`this`/`super`/`import.meta`, with element indices that are literal OR entity-name. Entity-name-indexed (`obj[key]`) and meta-property (`import.meta.env.X`) accesses stay narrowable.

## Invariant

Byte-identical to tsc. Full local conformance: **0 unlisted regressions** (the only fingerprint diffs are pre-existing accepted-regressions unrelated to flow narrowing). Narrowing preserved for `this`/member/entity-index/`import.meta`/optional-chain refs; computed-index / call-result / fresh-literal accesses correctly stay un-narrowed (TS2322). The structural key stays injective and receiver-disjoint; structural ids remain dropped on cross-run snapshot (per #12940). No new `CheckerContext` field.

## Owner layer

`tsz_checker` control-flow analysis: `flow/control_flow/{core,references,mod}` (cache-symbol selection + structural path + narrowability predicate), `flow/flow_analysis/definite.rs` (non-narrowable skip).

## Scope

6 files, +452/-16. 8 regression tests in `flow_property_reference_cache_tests.rs` (this/super, entity-index, optional-chain, import.meta, non-reference skips). `core.rs` ratchet 1824 -> 1848 for the reserved base-key constants.

## Project Corpus Impact
- Row: large-ts-repo (exit-124 timeout class), plus member/this-heavy required rows (vite-vanilla-ts-app, nextjs-fresh-app, ts-essentials-project)
- Bug family: n/a (performance; behavior-preserving, byte-identical diagnostics)

## Verification

- `cargo nextest run -p tsz-checker --test flow_property_reference_cache_tests` — 13/13.
- Full local conformance (`conformance.sh run --profile release`): 0 unlisted regressions; importMeta 3/3; Access 442/442; narrowing/controlFlow/thisType/discriminant/optionalChain all green.
- `scripts/arch/arch_guard.py` passes; `cargo clippy -p tsz-checker --tests` clean.
- Perf: table above (local release `--noEmit`, warm, min of repeated runs).

## Coordination Notes

Builds on #12940 (merged). Folds in the optional-chain fix (originally a separate branch) since it is the same cohesive flow-narrowing family and this PR was re-pushed for the import.meta parity fix. Independent of lib-residency #12943 (merged).