### PR TITLE
refactor(checker): route index-access assignability normalization through assignability boundary (#12945)

### DIFF
--- a/crates/tsz-checker/src/assignability/index_access_normalization.rs
+++ b/crates/tsz-checker/src/assignability/index_access_normalization.rs
@@ -16,14 +16,22 @@ impl<'a> CheckerState<'a> {
             return self.normalize_index_access_for_assignability(reduced, depth + 1);
         }
 
-        if crate::query_boundaries::common::is_index_access_type(self.ctx.types, ty) {
+        if crate::query_boundaries::assignability::is_index_access_for_assignability(
+            self.ctx.types,
+            ty,
+        ) {
             let evaluated = self.evaluate_type_for_assignability(ty);
             if evaluated != ty && evaluated != TypeId::ERROR {
                 return self.normalize_index_access_for_assignability(evaluated, depth + 1);
             }
         }
 
-        if let Some(members) = crate::query_boundaries::common::union_members(self.ctx.types, ty) {
+        if let Some(members) =
+            crate::query_boundaries::assignability::union_members_for_assignability(
+                self.ctx.types,
+                ty,
+            )
+        {
             let mut changed = false;
             let normalized_members: Vec<_> = members
                 .into_iter()

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -108,6 +108,9 @@ mod assignability_diagnostics_relation_routing_arch_tests;
 #[path = "tests/assignability_display_relation_routing_arch_tests.rs"]
 mod assignability_display_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/assignability_index_access_normalization_boundary_arch_tests.rs"]
+mod assignability_index_access_normalization_boundary_arch_tests;
+#[cfg(test)]
 #[path = "tests/assignability_reporter_relation_routing_arch_tests.rs"]
 mod assignability_reporter_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -731,6 +731,11 @@ pub(crate) use tsz_solver::type_queries::{
     keyof_object_properties, map_compound_members,
 };
 
+/// Indexed-access normalization shape probes; submodule keeps this file under
+/// its LOC ceiling while the assignability boundary still owns the helpers.
+mod shape;
+pub(crate) use shape::{is_index_access_for_assignability, union_members_for_assignability};
+
 pub(crate) fn classify_for_assignability_eval(
     db: &dyn TypeDatabase,
     type_id: TypeId,

--- a/crates/tsz-checker/src/query_boundaries/assignability/shape.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/shape.rs
@@ -1,0 +1,37 @@
+//! Indexed-access surface normalization shape probes.
+//!
+//! These helpers own the low-level type-shape questions asked while normalizing
+//! indexed-access surfaces *before* an assignability relation runs (the TS2322 /
+//! TS2345 pipeline). Routing them through this boundary — rather than the
+//! catch-all `query_boundaries::common` module — keeps the relation-adjacent
+//! normalization steps visibly owned by the assignability boundary, so
+//! reviewers can tell which shape probes are part of the relation pipeline from
+//! generic type queries. They delegate to the existing solver queries
+//! internally; the point is ownership and ratcheting, not new semantics.
+
+use tsz_solver::TypeId;
+use tsz_solver::construction::TypeDatabase;
+use tsz_solver::type_queries::TypeIdList;
+
+/// Detect an indexed-access type (`T[K]`) during assignability normalization.
+///
+/// Used to decide whether a surface should be driven through
+/// `evaluate_type_for_assignability` before the relation runs. Identical in
+/// behavior to the shared solver predicate; the dedicated name marks it as the
+/// assignability-pipeline entry point.
+pub(crate) fn is_index_access_for_assignability(db: &dyn TypeDatabase, ty: TypeId) -> bool {
+    tsz_solver::type_queries::is_index_access_type(db, ty)
+}
+
+/// Peel union members during assignability normalization.
+///
+/// Returns the interned member list (a zero-copy [`TypeIdList`] view) when `ty`
+/// is a union so each member can be normalized independently, or `None`
+/// otherwise. Mirrors `query_boundaries::common::union_members` but is owned by
+/// the assignability boundary for the relation-preparation path.
+pub(crate) fn union_members_for_assignability(
+    db: &dyn TypeDatabase,
+    ty: TypeId,
+) -> Option<TypeIdList> {
+    tsz_solver::type_queries::get_union_members(db, ty)
+}

--- a/crates/tsz-checker/src/tests/assignability_index_access_normalization_boundary_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/assignability_index_access_normalization_boundary_arch_tests.rs
@@ -1,0 +1,30 @@
+use std::fs;
+use std::path::Path;
+
+/// Ratchet: indexed-access assignability normalization must ask its low-level
+/// type-shape questions through the assignability boundary, not the catch-all
+/// `query_boundaries::common` module. Normalization runs inside the TS2322 /
+/// TS2345 relation pipeline, so its shape probes are relation-adjacent and
+/// belong behind `query_boundaries::assignability`.
+#[test]
+fn assignability_index_access_normalization_avoids_common_boundary() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/assignability/index_access_normalization.rs"),
+    )
+    .expect("failed to read index_access_normalization.rs");
+
+    assert!(
+        !source.contains("query_boundaries::common::"),
+        "index-access assignability normalization must use assignability boundary helpers, \
+         not query_boundaries::common"
+    );
+    assert!(
+        source.contains("query_boundaries::assignability::is_index_access_for_assignability"),
+        "normalization must detect indexed access through the named assignability boundary helper"
+    );
+    assert!(
+        source.contains("query_boundaries::assignability::union_members_for_assignability"),
+        "normalization must peel union members through the named assignability boundary helper"
+    );
+}


### PR DESCRIPTION
Closes #12945

AgentName: M5Refactorer

Track: checker architecture boundary debt (#8223)

Invariant: behavior-preserving boundary ownership refactor — no relation
semantics, failure reasons, or TS2322/TS2345 messages change. Both new helpers
delegate to the exact solver queries the `common` module used
(`is_index_access_type`, `get_union_members`).

## Structural rule

When assignability code normalizes indexed-access surfaces before relation
evaluation, index-access detection and union-member peeling must route through
`query_boundaries::assignability`, not the catch-all `query_boundaries::common`.
Normalization runs inside the TS2322/TS2345 relation pipeline, so these shape
probes are relation-adjacent and belong to the assignability boundary; this lets
reviewers distinguish relation-pipeline shape probes from generic type queries.

Owner layer: checker `query_boundaries::assignability` (checker still owns
evaluation orchestration; the solver still owns the underlying queries).

## Scope

- `crates/tsz-checker/src/assignability/index_access_normalization.rs` — route
  the two `common::` calls through the named assignability boundary helpers.
- `crates/tsz-checker/src/query_boundaries/assignability.rs` — declare the
  `shape` submodule and re-export the helpers.
- `crates/tsz-checker/src/query_boundaries/assignability/shape.rs` (new) — house
  `is_index_access_for_assignability` and `union_members_for_assignability`.
  Placed in a submodule so the boundary file stays at/under its 2000-LOC ceiling
  (it was at 1996) while still owning the helpers — splitting rather than raising
  a local ceiling, per the repo contract.
- `crates/tsz-checker/src/tests/assignability_index_access_normalization_boundary_arch_tests.rs`
  (new) + `lib.rs` registration — red-first ratchet test.

Non-goals (unchanged, per the issue): no relation failure reasons / TS2322
wording changes, no migration of the rest of `assignability_checker.rs`, no move
of normalization into the solver.

## Adjacent-case matrix

The normalization algorithm is untouched, so all adjacent cases keep their prior
behavior through the renamed (byte-identical) delegations: nested indexed access
with the depth-limit-8 guard, union-of-index-access members normalized
independently, `reduce_literal_index_access_property_types` interaction order,
evaluated vs unevaluated indexed access via `evaluate_type_for_assignability`,
ERROR/ANY short-circuits, and renamed type-parameter instantiations.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a (boundary-only ownership refactor; no semantic change, so no
  corpus row is affected)

## Verification

- `cargo build -p tsz-checker` — clean.
- `cargo test -p tsz-checker --lib assignability_index_access_normalization_avoids_common_boundary` — green.
- `cargo clippy -p tsz-checker --lib` — clean.
- `scripts/safe-run.sh python3 scripts/arch/arch_guard.py` — "Architecture
  guardrails passed" (boundary file at 2000 LOC, under the limit).
- Confirmed the 4 pre-existing `ts2322_tests::index_access_type_parameter_mismatch_elaboration`
  failures reproduce on the clean tree (inherited red baseline, tracked by
  #8432) and are unrelated to this delegation rename.

## Coordination Notes

Boundary-only slice of #8223; orthogonal to the RelationRequest adoption work in
#8227. Follows the merged precedents #12920 (assignability cache probes) and
#12921 (excess-property tail queries). The ratchet test pins the boundary so the
`common::` references cannot regress.

https://claude.ai/code/session_015tEgwqVb8gxL5S8dLhAod1

---
_Generated by [Claude Code](https://claude.ai/code/session_015tEgwqVb8gxL5S8dLhAod1)_