### PR TITLE
fix(solver): inline concrete tuple spreads (createNormalizedTupleType)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1245,6 +1245,9 @@ mod ts2590_array_literal_identity_skip_tests;
 #[path = "tests/ts2739_alias_unfold_display_tests.rs"]
 mod ts2739_alias_unfold_display_tests;
 #[cfg(test)]
+#[path = "tests/tuple_spread_flattening_tests.rs"]
+mod tuple_spread_flattening_tests;
+#[cfg(test)]
 #[path = "tests/type_alias_computed_display_tests.rs"]
 mod type_alias_computed_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/tuple_spread_flattening_tests.rs
+++ b/crates/tsz-checker/src/tests/tuple_spread_flattening_tests.rs
@@ -1,0 +1,173 @@
+//! Regression tests for inlining concrete tuple spreads (`createNormalizedTupleType`).
+//!
+//! A rest element `...X` whose type resolves to a concrete tuple contributes a
+//! statically known run of elements, so `[A, ...[B, C]]` is exactly
+//! `[A, B, C]`. Before the fix, a spread whose operand was an **alias**
+//! (`...Aliased`), a **pending application** (`...Util<T>`), or a **readonly**
+//! tuple (`...readonly [B, C]`) stayed un-inlined, and value-position numeric
+//! reads past the fixed prefix fell back to the whole-tuple element union
+//! (`head | [tail]`) — surfacing as spurious `TS2339`/`TS2493`/`TS2322`.
+//!
+//! Per the anti-hardcoding gate, the binder names (`A`/`Head`, `Tail`, etc.)
+//! vary across cases so the tests pin the structural rule, not a spelling.
+
+use crate::test_utils::check_source_diagnostics;
+
+/// No spurious property/index/assignability diagnostics for a structurally
+/// valid program.
+fn no_access_errors(src: &str) -> bool {
+    check_source_diagnostics(src)
+        .iter()
+        .all(|d| !matches!(d.code, 2339 | 2493 | 2322 | 2740))
+}
+
+fn codes(src: &str) -> Vec<i32> {
+    let mut v: Vec<i32> = check_source_diagnostics(src)
+        .iter()
+        .map(|d| d.code as i32)
+        .collect();
+    v.sort_unstable();
+    v
+}
+
+// ── Alias spread: `[A, ...AliasTuple]` ───────────────────────────────────────
+
+#[test]
+fn alias_fixed_tuple_spread_inlines_for_value_access() {
+    // `[{ w: 3 }, ...Plain]` is `[{ w: 3 }, { x: 1 }]`; `t[1]` is `{ x: 1 }`.
+    assert!(no_access_errors(
+        r#"
+type Plain = readonly [{ x: 1 }];
+type Combined = readonly [{ w: 3 }, ...Plain];
+declare const t: Combined;
+const head: 3 = t[0].w;
+const tail: 1 = t[1].x;
+"#
+    ));
+}
+
+#[test]
+fn alias_spread_renamed_binders_behave_identically() {
+    // Renaming the alias and members must not change the outcome (§ anti-hardcoding).
+    assert!(no_access_errors(
+        r#"
+type Suffix = readonly [{ beta: 2 }, { gamma: 3 }];
+type Whole = readonly [{ alpha: 1 }, ...Suffix];
+declare const whole: Whole;
+const a: 1 = whole[0].alpha;
+const b: 2 = whole[1].beta;
+const g: 3 = whole[2].gamma;
+"#
+    ));
+}
+
+// ── readonly spread: `[A, ...readonly [B, C]]` ───────────────────────────────
+
+#[test]
+fn readonly_tuple_spread_inlines_for_value_access() {
+    assert!(no_access_errors(
+        r#"
+declare const t: readonly [{ w: 3 }, ...readonly [{ x: 1 }, { y: 2 }]];
+const x: 1 = t[1].x;
+const y: 2 = t[2].y;
+"#
+    ));
+}
+
+// ── Application spread: `[A, ...Util<T>]` ────────────────────────────────────
+
+#[test]
+fn application_tuple_spread_inlines_for_value_access() {
+    // `Id<[{ x: 1 }, { y: 2 }]>` reduces to the tuple, then spreads inline.
+    assert!(no_access_errors(
+        r#"
+type Id<X> = X extends unknown ? X : never;
+declare const t: readonly [{ w: 3 }, ...Id<readonly [{ x: 1 }, { y: 2 }]>];
+const x: 1 = t[1].x;
+const y: 2 = t[2].y;
+"#
+    ));
+}
+
+// ── The `head | tail` union regression (recursive list utility) ──────────────
+
+#[test]
+fn recursive_tuple_map_flattens_fully() {
+    // `Map<[1,2,3]> = [Head, ...Map<Rest>]` must flatten to `[1, 2, 3]`, not a
+    // nested `[1, ...[2, ...[3, ...[]]]]`. Reading `m[2]` must yield `3`.
+    assert!(no_access_errors(
+        r#"
+type MapTuple<T> = T extends readonly [infer Head, ...infer Rest]
+    ? readonly [Head, ...MapTuple<Rest>]
+    : T;
+declare const m: MapTuple<readonly [1, 2, 3]>;
+const a: 1 = m[0];
+const b: 2 = m[1];
+const c: 3 = m[2];
+"#
+    ));
+}
+
+#[test]
+fn recursive_object_tuple_map_finds_deep_property() {
+    // The original witness shape: a recursive conditional that wraps each tuple
+    // element. Element 2's `wrapped` property must be reachable.
+    assert!(no_access_errors(
+        r#"
+type Compute<V> = V extends readonly [infer H, ...infer T]
+    ? readonly [Compute<H>, ...Compute<T>]
+    : V extends object
+        ? { [K in keyof V]: Compute<V[K]> }
+        : V;
+declare const u: Compute<readonly [{ a: 1 }, { b: 2 }, { wrapped: 3 }]>;
+const w: 3 = u[2].wrapped;
+"#
+    ));
+}
+
+// ── Negative control: genuine errors must still fire ─────────────────────────
+
+#[test]
+fn wrong_element_type_after_flattening_still_errors() {
+    // `t[1]` is `{ x: 1 }`; assigning to an incompatible annotation must error.
+    assert!(
+        !codes(
+            r#"
+type Plain = readonly [{ x: 1 }];
+declare const t: readonly [{ w: 3 }, ...Plain];
+const bad: { x: 2 } = t[1];
+"#
+        )
+        .is_empty()
+    );
+}
+
+// ── Variadic preservation: rest arrays must not be over-spliced ──────────────
+
+#[test]
+fn rest_array_spread_is_preserved() {
+    // `[A, ...number[]]` stays variadic; numeric reads still resolve to the
+    // element type and length stays `number`, not a literal.
+    assert!(no_access_errors(
+        r#"
+declare const t: readonly [string, ...number[]];
+const head: string = t[0];
+const rest: number = t[5];
+"#
+    ));
+}
+
+#[test]
+fn variadic_tail_tuple_spread_keeps_single_rest() {
+    // `[A, ...[B, ...C[]]]` flattens to `[A, B, ...C[]]` — fixed prefix readable,
+    // trailing rest preserved.
+    assert!(no_access_errors(
+        r#"
+type Tail = readonly [boolean, ...number[]];
+declare const t: readonly [string, ...Tail];
+const a: string = t[0];
+const b: boolean = t[1];
+const c: number = t[7];
+"#
+    ));
+}

--- a/crates/tsz-checker/src/types/computation/access_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/access_helpers.rs
@@ -179,6 +179,10 @@ impl<'a> CheckerState<'a> {
         index_type: TypeId,
         literal_index: Option<usize>,
     ) -> TypeId {
+        // Flatten any tuple spread element whose type is an alias / pending
+        // application before the resolver-less solver query (see
+        // `flatten_tuple_spread_rests`).
+        let object_type = self.flatten_tuple_spread_rests(object_type);
         // Normalize index type for enum values
         let solver_index_type = if let Some(index) = literal_index {
             self.ctx.types.literal_number(index as f64)
@@ -209,6 +213,87 @@ impl<'a> CheckerState<'a> {
         self.ctx
             .types
             .resolve_element_access_type(object_type, solver_index_type, literal_index)
+    }
+
+    /// Resolve a tuple's spread (`rest`) element types and rebuild it so the
+    /// solver's resolver-less element-access evaluator sees a flat tuple.
+    ///
+    /// `[A, ...Alias]` / `[A, ...Util<T>]` stores the spread operand as a bare
+    /// `Lazy(DefId)` alias reference or a pending `Application`. The solver's
+    /// numeric element-access path (`tuple_fixed_slot`) only descends into a
+    /// rest element that is already a concrete `Tuple`, so an unresolved spread
+    /// made an in-bounds read fall back to the whole-tuple element union
+    /// (`head | tail`) — surfacing as false `TS2339`/`TS2493`. Type-position
+    /// indexed access (`T[1]`) already resolves these because it runs the
+    /// resolver-backed evaluator; this brings the value position to parity.
+    ///
+    /// Only tuples carrying a spread element do any work — purely fixed tuples
+    /// (the common case) and non-tuples return unchanged. Each rest element is
+    /// resolved through the same alias/application path used for the index, then
+    /// the tuple is rebuilt via `factory.tuple()`, which inlines a now-concrete
+    /// fixed-tuple spread (`createNormalizedTupleType`). `readonly` is preserved.
+    fn flatten_tuple_spread_rests(&mut self, object_type: TypeId) -> TypeId {
+        // A recursive list utility `[H, ...Util<R>]` resolves one nesting level
+        // per pass: resolving the spread exposes the next `[H, ...Util<R')]`,
+        // which `factory.tuple()` inlines, leaving a fresh spread to resolve.
+        // Iterate to a fixpoint under a bound so deep recursion fully flattens
+        // while a non-terminating alias cannot spin.
+        const MAX_FLATTEN_PASSES: usize = 64;
+        let mut current = object_type;
+        for _ in 0..MAX_FLATTEN_PASSES {
+            let next = self.flatten_tuple_spread_rests_once(current);
+            if next == current {
+                break;
+            }
+            current = next;
+        }
+        current
+    }
+
+    fn flatten_tuple_spread_rests_once(&mut self, object_type: TypeId) -> TypeId {
+        let inner = crate::query_boundaries::common::unwrap_readonly(self.ctx.types, object_type);
+        let is_readonly = inner != object_type;
+        let Some(elements) = crate::query_boundaries::common::tuple_elements(self.ctx.types, inner)
+        else {
+            return object_type;
+        };
+        if !elements.iter().any(|elem| elem.rest) {
+            return object_type;
+        }
+        let mut changed = false;
+        let mut rebuilt = Vec::with_capacity(elements.len());
+        for elem in elements {
+            if elem.rest {
+                // Resolve a bare `Lazy(DefId)` alias and reduce a pending
+                // application through the resolver-backed environment — the
+                // solver's own element-access evaluator is resolver-less and
+                // would leave the spread opaque.
+                let resolved = self.resolve_lazy_type(elem.type_id);
+                let resolved = self.evaluate_application_type(resolved);
+                if resolved != elem.type_id {
+                    changed = true;
+                }
+                rebuilt.push(tsz_solver::TupleElement {
+                    type_id: resolved,
+                    ..elem
+                });
+            } else {
+                rebuilt.push(elem);
+            }
+        }
+        if !changed {
+            return object_type;
+        }
+        // Rebuild via `factory.tuple()`, which inlines a now-concrete tuple
+        // spread (`createNormalizedTupleType`). `readonly` is re-applied so the
+        // receiver shape is unchanged apart from the splice.
+        let factory = self.ctx.types.factory();
+        let tuple = factory.tuple(rebuilt);
+        if is_readonly {
+            factory.readonly_type(tuple)
+        } else {
+            tuple
+        }
     }
 
     pub(crate) fn recover_assignment_target_type_for_errored_element_index(

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -1150,12 +1150,95 @@ impl TypeInterner {
         self.readonly_type(self.array(element))
     }
 
+    /// Splice spread elements whose type is a *concrete tuple* inline, matching
+    /// tsc's `createNormalizedTupleType`.
+    ///
+    /// A rest element `...X` where `X` resolves (through `readonly`) to a
+    /// `Tuple` contributes a statically known run of elements, so `[A, ...[B, C]]`
+    /// is exactly `[A, B, C]`. tsc always flattens these — at construction and
+    /// after instantiation — so leaving the spread un-inlined makes the
+    /// represented length, element-by-index access, relations, and display all
+    /// disagree with the flattened form (the value position would index the
+    /// whole inner tuple instead of its member).
+    ///
+    /// A **fixed** inner tuple (no rest of its own) is always spliced. A
+    /// **variadic** inner tuple (carrying its own rest, e.g. `[B, ...C[]]`) is
+    /// spliced only when it is the parent's sole rest element and its last
+    /// element, so the result still carries at most one rest — this is the shape
+    /// recursive list utilities (`[H, ...Util<R>]`) build, and it can never
+    /// produce an illegal two-rest tuple. Rest *arrays* (`...X[]`) and generic
+    /// spreads (`...T`, `...Application`, `...Lazy`) are left as written; a
+    /// self-referential `type T = [x, ...T]` never resolves its spread to a
+    /// concrete tuple, so this cannot recurse. Optional outer spreads are left
+    /// untouched. Inner elements are already normalized because every tuple is
+    /// built through this same path, so a single pass is idempotent.
+    fn splice_concrete_tuple_spreads(&self, elements: Vec<TupleElement>) -> Vec<TupleElement> {
+        // A lone `[...X]` (sole element, a rest) is left compressed: it already
+        // denotes exactly `X`, and inlining it would eagerly expand a possibly
+        // huge instantiated spread (`[...T]` with `T` a large tuple) with no
+        // structural benefit — index/length/relation queries already descend
+        // through the single rest. Splicing targets `[head, ..., ...inner]`
+        // shapes (recursive list utilities), which always carry a fixed prefix.
+        if elements.len() == 1 && elements[0].rest {
+            return elements;
+        }
+        // Single pass over the elements: count rests (needed to keep the result
+        // single-rest) and learn whether any spread is a concrete tuple worth
+        // inlining. The common case (a plain fixed tuple with no rest) bails
+        // here without a second scan.
+        let mut parent_rest_count = 0usize;
+        let mut has_spliceable = false;
+        for elem in &elements {
+            if elem.rest {
+                parent_rest_count += 1;
+                if !elem.optional && self.concrete_tuple_list(elem.type_id).is_some() {
+                    has_spliceable = true;
+                }
+            }
+        }
+        if !has_spliceable {
+            return elements;
+        }
+        let last_index = elements.len().saturating_sub(1);
+        let mut out: Vec<TupleElement> = Vec::with_capacity(elements.len());
+        for (index, elem) in elements.into_iter().enumerate() {
+            if elem.rest
+                && !elem.optional
+                && let Some(inner_list) = self.concrete_tuple_list(elem.type_id)
+            {
+                let inner = self.tuple_list(inner_list);
+                let inner_is_variadic = inner.iter().any(|inner_elem| inner_elem.rest);
+                if !inner_is_variadic || (parent_rest_count == 1 && index == last_index) {
+                    out.extend(inner.iter().copied());
+                    continue;
+                }
+            }
+            out.push(elem);
+        }
+        out
+    }
+
+    /// If `type_id` (after unwrapping `readonly`) is a `Tuple`, return its
+    /// element-list id; otherwise `None`. The list may itself be variadic — the
+    /// caller decides whether splicing it is safe.
+    fn concrete_tuple_list(&self, type_id: TypeId) -> Option<crate::types::TupleListId> {
+        let unwrapped = match self.lookup(type_id) {
+            Some(TypeData::ReadonlyType(inner)) => inner,
+            _ => type_id,
+        };
+        match self.lookup(unwrapped) {
+            Some(TypeData::Tuple(list_id)) => Some(list_id),
+            _ => None,
+        }
+    }
+
     /// Intern a tuple type.
     ///
     /// Normalizes optional element types: when exact optional properties are
     /// disabled, strips explicit `undefined` from `optional=true` union types
     /// since optionality already implies `| undefined`.
     pub fn tuple(&self, elements: Vec<TupleElement>) -> TypeId {
+        let elements = self.splice_concrete_tuple_spreads(elements);
         let elements = self.normalize_optional_tuple_elements(elements);
         // A single anonymous rest element wrapping an Array collapses to a plain array type.
         if elements.len() == 1

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -485,6 +485,9 @@ mod tuple_cardinality_tests;
 #[path = "../tests/tuple_comprehensive_tests.rs"]
 mod tuple_comprehensive_tests;
 #[cfg(test)]
+#[path = "../tests/tuple_spread_splice_tests.rs"]
+mod tuple_spread_splice_tests;
+#[cfg(test)]
 #[path = "../tests/type_parameter_comprehensive_tests.rs"]
 mod type_parameter_comprehensive_tests;
 #[cfg(test)]

--- a/crates/tsz-solver/src/operations/sequence_property.rs
+++ b/crates/tsz-solver/src/operations/sequence_property.rs
@@ -9,7 +9,24 @@
 //! diverging.
 
 use crate::construction::TypeDatabase;
-use crate::types::{TupleElement, TypeData, TypeId};
+use crate::types::{TupleElement, TupleListId, TypeData, TypeId};
+
+/// Resolve a type to a tuple element-list id, transparently unwrapping a
+/// `readonly` wrapper.
+///
+/// A spread element `...X` where `X` is a `readonly` tuple (`...readonly [a, b]`)
+/// contributes the same statically known run of elements as a mutable tuple
+/// spread, so the index walk and fixed-length count must descend through it.
+/// Without unwrapping, `tuple_fixed_slot_inner` bailed to `None` on a
+/// `ReadonlyType(Tuple)` rest element and the caller fell back to a bogus
+/// element-union (`head | readonly [tail]`) for an in-bounds numeric read.
+fn tuple_list_id_through_readonly(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TupleListId> {
+    let unwrapped = crate::type_queries::data::unwrap_readonly(db, type_id);
+    match db.lookup(unwrapped) {
+        Some(TypeData::Tuple(id)) => Some(id),
+        _ => None,
+    }
+}
 
 /// Upper bound on rest-spread recursion while walking nested variadic tuples.
 const MAX_TUPLE_SPREAD_DEPTH: usize = 64;
@@ -88,10 +105,7 @@ fn tuple_fixed_slot_inner(
             if rest_id.is_intrinsic() {
                 return None;
             }
-            let inner_list_id = match db.lookup(rest_id) {
-                Some(TypeData::Tuple(id)) => id,
-                _ => return None,
-            };
+            let inner_list_id = tuple_list_id_through_readonly(db, rest_id)?;
             let inner = db.tuple_list(inner_list_id);
             let rest_index = index.checked_sub(position)?;
             if let Some(slot) = tuple_fixed_slot_inner(db, &inner, rest_index, depth + 1) {
@@ -120,10 +134,7 @@ pub(crate) fn compute_tuple_fixed_length(db: &dyn TypeDatabase, type_id: TypeId)
     if type_id.is_intrinsic() {
         return None;
     }
-    let list_id = match db.lookup(type_id) {
-        Some(TypeData::Tuple(id)) => id,
-        _ => return None,
-    };
+    let list_id = tuple_list_id_through_readonly(db, type_id)?;
 
     let elements = db.tuple_list(list_id);
     let mut total = 0usize;
@@ -150,10 +161,8 @@ pub(crate) fn compute_tuple_fixed_length(db: &dyn TypeDatabase, type_id: TypeId)
         if rest_id.is_intrinsic() {
             return None;
         }
-        let inner_list_id = match db.lookup(rest_id) {
-            Some(TypeData::Tuple(id)) => id,
-            _ => return None, // Rest spreads a non-tuple → variable length
-        };
+        // A rest that spreads a non-tuple → variable length.
+        let inner_list_id = tuple_list_id_through_readonly(db, rest_id)?;
         let inner_elements = db.tuple_list(inner_list_id);
         let mut inner_rest_count = 0;
         for elem in inner_elements.iter() {

--- a/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
+++ b/crates/tsz-solver/tests/evaluate_application_orchestrator_tests.rs
@@ -187,15 +187,19 @@ fn evaluate_application_variadic_prepend_flattens_tail_application() {
 
     let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
     let result = evaluator.evaluate(prepend_app);
+    // `Tail<[number, boolean]> = [number, boolean] extends [infer _, ...infer R]
+    // ? R : never` drops the head, yielding `[boolean]`, so
+    // `Prepend<string, Tail<...>> = [string, ...[boolean]] = [string, boolean]`.
+    // The flattened spread inlines the resolved tail application exactly,
+    // matching `tsc`'s `createNormalizedTupleType`.
     let expected = interner.tuple(vec![
         tuple_elem(TypeId::STRING),
-        tuple_elem(TypeId::NUMBER),
         tuple_elem(TypeId::BOOLEAN),
     ]);
 
     assert_eq!(
         result, expected,
-        "Prepend<Head, Tail<Source>> must preserve exact tail arity through a rest Application"
+        "Prepend<Head, Tail<Source>> must inline the resolved tail application's exact arity"
     );
 }
 

--- a/crates/tsz-solver/tests/tuple_spread_splice_tests.rs
+++ b/crates/tsz-solver/tests/tuple_spread_splice_tests.rs
@@ -1,0 +1,140 @@
+//! Unit tests for `TypeInterner::tuple` inlining concrete tuple spreads
+//! (`createNormalizedTupleType`).
+//!
+//! Structural rule: a rest element `...X` whose type is a concrete tuple
+//! contributes a statically known run of elements, so `[A, ...[B, C]]` is
+//! exactly `[A, B, C]`. A fixed inner tuple is always inlined; a variadic inner
+//! tuple is inlined only as the parent's sole, last rest (keeping ≤ 1 rest); a
+//! lone `[...X]` is left compressed; rest arrays are never inlined.
+
+use crate::intern::TypeInterner;
+use crate::types::{TupleElement, TypeData, TypeId};
+
+fn fixed(type_id: TypeId) -> TupleElement {
+    TupleElement::fixed(type_id)
+}
+
+fn rest(type_id: TypeId) -> TupleElement {
+    TupleElement::rest(type_id)
+}
+
+fn tuple_elements(interner: &TypeInterner, type_id: TypeId) -> Vec<TupleElement> {
+    match interner.lookup(type_id) {
+        Some(TypeData::Tuple(list_id)) => interner.tuple_list(list_id).to_vec(),
+        other => panic!("expected tuple, got {other:?}"),
+    }
+}
+
+#[test]
+fn fixed_tuple_spread_is_inlined() {
+    let interner = TypeInterner::new();
+    let inner = interner.tuple(vec![fixed(TypeId::NUMBER), fixed(TypeId::BOOLEAN)]);
+    let outer = interner.tuple(vec![fixed(TypeId::STRING), rest(inner)]);
+
+    let elements = tuple_elements(&interner, outer);
+    let expected = interner.tuple(vec![
+        fixed(TypeId::STRING),
+        fixed(TypeId::NUMBER),
+        fixed(TypeId::BOOLEAN),
+    ]);
+    assert_eq!(
+        outer, expected,
+        "[string, ...[number, boolean]] = [string, number, boolean]"
+    );
+    assert_eq!(elements.len(), 3);
+    assert!(elements.iter().all(|elem| !elem.rest));
+}
+
+#[test]
+fn readonly_fixed_tuple_spread_is_inlined() {
+    let interner = TypeInterner::new();
+    let inner = interner.tuple(vec![fixed(TypeId::NUMBER)]);
+    let readonly_inner = interner.readonly_type(inner);
+    let outer = interner.tuple(vec![fixed(TypeId::STRING), rest(readonly_inner)]);
+
+    let expected = interner.tuple(vec![fixed(TypeId::STRING), fixed(TypeId::NUMBER)]);
+    assert_eq!(
+        outer, expected,
+        "readonly is unwrapped before inlining the spread"
+    );
+}
+
+#[test]
+fn variadic_inner_tuple_inlines_as_sole_last_rest() {
+    let interner = TypeInterner::new();
+    // inner = [boolean, ...number[]]
+    let inner = interner.tuple(vec![
+        fixed(TypeId::BOOLEAN),
+        rest(interner.array(TypeId::NUMBER)),
+    ]);
+    let outer = interner.tuple(vec![fixed(TypeId::STRING), rest(inner)]);
+
+    let elements = tuple_elements(&interner, outer);
+    // [string, ...[boolean, ...number[]]] = [string, boolean, ...number[]]
+    assert_eq!(elements.len(), 3);
+    assert_eq!(elements[0].type_id, TypeId::STRING);
+    assert!(!elements[0].rest);
+    assert_eq!(elements[1].type_id, TypeId::BOOLEAN);
+    assert!(!elements[1].rest);
+    assert!(
+        elements[2].rest,
+        "the inner array rest is preserved as the single trailing rest"
+    );
+}
+
+#[test]
+fn variadic_inner_tuple_not_last_is_left_compressed() {
+    let interner = TypeInterner::new();
+    // inner = [boolean, ...number[]] spliced would put a rest before a trailing
+    // fixed element, creating a second rest — so it must stay un-inlined.
+    let inner = interner.tuple(vec![
+        fixed(TypeId::BOOLEAN),
+        rest(interner.array(TypeId::NUMBER)),
+    ]);
+    let outer = interner.tuple(vec![rest(inner), fixed(TypeId::STRING)]);
+
+    let elements = tuple_elements(&interner, outer);
+    assert_eq!(
+        elements.len(),
+        2,
+        "the variadic spread is kept compressed when not last"
+    );
+    assert!(elements[0].rest);
+    assert_eq!(elements[0].type_id, inner);
+}
+
+#[test]
+fn sole_rest_spread_is_left_compressed() {
+    let interner = TypeInterner::new();
+    // A large `[...inner]` must not eagerly expand — it already denotes `inner`.
+    let inner = interner.tuple((0..512).map(|_| fixed(TypeId::NUMBER)).collect());
+    let outer = interner.tuple(vec![rest(inner)]);
+
+    let elements = tuple_elements(&interner, outer);
+    assert_eq!(elements.len(), 1);
+    assert!(elements[0].rest);
+    assert_eq!(elements[0].type_id, inner);
+}
+
+#[test]
+fn rest_array_spread_is_not_inlined() {
+    let interner = TypeInterner::new();
+    let outer = interner.tuple(vec![
+        fixed(TypeId::STRING),
+        rest(interner.array(TypeId::NUMBER)),
+    ]);
+
+    let elements = tuple_elements(&interner, outer);
+    assert_eq!(elements.len(), 2);
+    assert!(elements[1].rest);
+}
+
+#[test]
+fn empty_tuple_spread_collapses_away() {
+    let interner = TypeInterner::new();
+    let empty = interner.tuple(vec![]);
+    let outer = interner.tuple(vec![fixed(TypeId::STRING), rest(empty)]);
+
+    let expected = interner.tuple(vec![fixed(TypeId::STRING)]);
+    assert_eq!(outer, expected, "[string, ...[]] = [string]");
+}


### PR DESCRIPTION
AgentName: web-opus-tuple-spread

Track: Performance / correctness — recursive type evaluation pressure (#12271, ts-toolbelt-project row).

## Invariant
When a tuple rest element `...X` resolves (through `readonly`) to a concrete tuple, `tsc` inlines its elements: `[A, ...[B, C]]` is exactly `[A, B, C]` (`createNormalizedTupleType`). tsz now produces the same flattened representation at every consumer (length, element-by-index access, relations, display), so a value-position numeric read can never disagree with type-position indexed access.

## Structural rule
When a spread operand is a concrete tuple, `tsc` inlines it through `X`; tsz now does X through `TypeInterner::tuple` (construction), the resolver-backed `get_element_access_type` (value reads), and `sequence_property` (readonly descent). A lone `[...X]` stays compressed (it already denotes `X`) to preserve the large-spread compression invariant.

## Why it failed
A rest element holding an **alias** (`...Aliased`), a **pending application** (`...Util<T>`), or a **readonly** tuple (`...readonly [B, C]`) stayed un-inlined. The solver's resolver-less numeric element-access path (`tuple_fixed_slot`) only descended into a rest that was *already* a bare `Tuple`, so an in-bounds read fell back to the whole-tuple element union (`head | [tail]`) — surfacing as spurious **TS2339 / TS2493 / TS2322**. Recursive list utilities (`[H, ...Util<R>]`, the ts-toolbelt `List` shape) never reduced, instead building deeply nested un-flattened spreads.

## Scope (owner layer, three coordinated points)
- `crates/tsz-solver/src/intern/core/constructors.rs`: `splice_concrete_tuple_spreads` inlines a **fixed** inner tuple always, and a **variadic** inner tuple only as the parent's sole, last rest (keeps the result single-rest; never an illegal two-rest tuple). A sole `[...X]` is left compressed.
- `crates/tsz-solver/src/operations/sequence_property.rs`: numeric `tuple_fixed_slot` and `compute_tuple_fixed_length` descend through a `readonly` tuple rest via one shared `tuple_list_id_through_readonly` helper.
- `crates/tsz-checker/src/types/computation/access_helpers.rs`: `get_element_access_type` resolves alias/application rest operands through the resolver-backed environment, then rebuilds via `tuple()` (which splices), iterating to a bounded fixpoint so deep recursion fully flattens.

Literal spreads keep inlining at lowering (`fixed_tuple_spread_elements`); this brings the value position to parity with type-position indexed access.

### Adjacent-case matrix
- alias fixed-tuple spread (`[A, ...Plain]`); readonly spread (`...readonly [B, C]`); application spread (`...Id<[…]>`); recursive `[H, ...Map<R>]` flattens fully (the `head | tail` union regression); negative control (wrong element type still errors); variadic preservation (`[A, ...number[]]`, `[A, ...[B, ...C[]]]`); renamed binders (anti-hardcoding); large sole-rest stays compressed.

## Project Corpus Impact
- Row: ts-toolbelt-project
- Bug family: recursive type evaluation pressure (recursive tuple/list spread flattening)

Evidence: the synthetic `Recursive utility aliases` hotspot and ts-toolbelt `List` utilities build `[H, ...Util<R>]` tuples; un-flattened nested spreads both produce wrong types and grow the recursive representation. The splice is structural (no fixture-name fast paths), gated on concrete-tuple shape, and idempotent.

## Verification
- New unit tests: `crates/tsz-solver/tests/tuple_spread_splice_tests.rs` (7 — fixed/readonly/variadic-last/variadic-not-last/sole-rest/rest-array/empty) and `crates/tsz-checker/src/tests/tuple_spread_flattening_tests.rs` (9 — alias/readonly/application/recursive spreads, union regression, negative control, variadic preservation, renamed binders).
- `cargo test -p tsz-solver --lib` → 6595 passed (1 pre-existing unrelated failure: `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`, confirmed failing on base).
- Checker lib: no new failures vs. base (same pre-existing set).
- Corrected `evaluate_application_variadic_prepend_flattens_tail_application`: the prior expectation (`[string, number, boolean]`) leaked the dropped head; the flattened result `[string, boolean]` matches `tsc`.
- `cargo fmt` clean; `cargo clippy -p tsz-solver -p tsz-checker --lib --all-features` clean.
- Broad conformance/emit/bench left to ready-review CI per repo policy.

## Coordination Notes
Advances #12271 (ts-toolbelt recursive type evaluation pressure). Orthogonal to the in-flight constraint-validation work (#12942 `query_boundaries/checkers/generic.rs`, merged #12927): this touches tuple construction, numeric element access, and the checker element-access entry only. No diagnostic-string predicates, no user-name/file-name literals. Does not by itself flip the row — it removes a correctness/size cliff for recursive tuple utilities and brings value-position tuple reads to parity with type-position.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mrxdwi9Dzj4yJ7UPx6VZqt)_