### PR TITLE
refactor(checker): route assignability display shape queries through diagnostics boundary (#12947)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -45,7 +45,7 @@ impl<'a> CheckerState<'a> {
         ty: TypeId,
         name: tsz_common::interner::Atom,
     ) -> Option<tsz_solver::PropertyInfo> {
-        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, ty)
+        crate::query_boundaries::diagnostics::object_shape_for_type(self.ctx.types, ty)
             .and_then(|shape| {
                 shape
                     .properties
@@ -54,7 +54,7 @@ impl<'a> CheckerState<'a> {
                     .cloned()
             })
             .or_else(|| {
-                crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, ty)
+                crate::query_boundaries::diagnostics::callable_shape_for_type(self.ctx.types, ty)
                     .and_then(|shape| {
                         shape
                             .properties
@@ -223,10 +223,10 @@ impl<'a> CheckerState<'a> {
             })
         };
 
-        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, target_type)
+        crate::query_boundaries::diagnostics::object_shape_for_type(self.ctx.types, target_type)
             .and_then(|shape| find_missing(&shape.properties))
             .or_else(|| {
-                crate::query_boundaries::common::callable_shape_for_type(
+                crate::query_boundaries::diagnostics::callable_shape_for_type(
                     self.ctx.types,
                     target_type,
                 )
@@ -446,17 +446,18 @@ impl<'a> CheckerState<'a> {
         }
 
         let has_callable_shape = |this: &mut Self, ty: TypeId| {
-            crate::query_boundaries::common::function_shape_for_type(this.ctx.types, ty).is_some()
-                || crate::query_boundaries::common::callable_shape_for_type(this.ctx.types, ty)
+            crate::query_boundaries::diagnostics::function_shape_for_type(this.ctx.types, ty)
+                .is_some()
+                || crate::query_boundaries::diagnostics::callable_shape_for_type(this.ctx.types, ty)
                     .is_some()
                 || {
                     let evaluated = this.evaluate_type_with_env(ty);
-                    crate::query_boundaries::common::function_shape_for_type(
+                    crate::query_boundaries::diagnostics::function_shape_for_type(
                         this.ctx.types,
                         evaluated,
                     )
                     .is_some()
-                        || crate::query_boundaries::common::callable_shape_for_type(
+                        || crate::query_boundaries::diagnostics::callable_shape_for_type(
                             this.ctx.types,
                             evaluated,
                         )
@@ -648,7 +649,7 @@ impl<'a> CheckerState<'a> {
                     if self.ctx.diagnostics.len() > diags_before {
                         return;
                     }
-                    if crate::query_boundaries::common::union_members(self.ctx.types, source)
+                    if crate::query_boundaries::diagnostics::union_members(self.ctx.types, source)
                         .is_none()
                     {
                         return;
@@ -819,7 +820,7 @@ impl<'a> CheckerState<'a> {
         let source_eval = self.evaluate_type_for_assignability(source);
         let target_eval = self.evaluate_type_for_assignability(target);
         let Some(members) =
-            crate::query_boundaries::common::union_members(self.ctx.types, source_eval)
+            crate::query_boundaries::diagnostics::union_members(self.ctx.types, source_eval)
         else {
             return source;
         };
@@ -915,7 +916,7 @@ impl<'a> CheckerState<'a> {
                 }
                 // JSDoc typedef lazy aliases must not trigger this rewrite.
                 let alias = state.ctx.types.get_display_alias(ty)?;
-                crate::query_boundaries::common::application_info(state.ctx.types, alias)?;
+                crate::query_boundaries::diagnostics::application_info(state.ctx.types, alias)?;
                 let mut formatter = state
                     .ctx
                     .create_diagnostic_type_formatter()
@@ -982,8 +983,11 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        crate::query_boundaries::common::literal_value(self.ctx.types, source)?;
-        match crate::query_boundaries::common::widen_literal_to_primitive(self.ctx.types, source) {
+        crate::query_boundaries::diagnostics::literal_value(self.ctx.types, source)?;
+        match crate::query_boundaries::diagnostics::widen_literal_to_primitive(
+            self.ctx.types,
+            source,
+        ) {
             TypeId::BOOLEAN => Some("boolean".to_string()),
             TypeId::STRING => Some("string".to_string()),
             TypeId::NUMBER => Some("number".to_string()),
@@ -1002,12 +1006,12 @@ impl<'a> CheckerState<'a> {
 
     fn type_is_generic_keyof(&mut self, type_id: TypeId) -> bool {
         let Some(operand) =
-            crate::query_boundaries::common::keyof_inner_type(self.ctx.types, type_id)
+            crate::query_boundaries::diagnostics::keyof_inner_type(self.ctx.types, type_id)
         else {
             return false;
         };
-        crate::query_boundaries::common::contains_type_parameters(self.ctx.types, operand)
-            || crate::query_boundaries::common::contains_type_parameters(
+        crate::query_boundaries::diagnostics::contains_type_parameters(self.ctx.types, operand)
+            || crate::query_boundaries::diagnostics::contains_type_parameters(
                 self.ctx.types,
                 self.evaluate_type_for_assignability(operand),
             )
@@ -1232,10 +1236,13 @@ impl<'a> CheckerState<'a> {
         source_display: String,
     ) -> String {
         let target_is_constructor_like =
-            crate::query_boundaries::common::function_shape_for_type(self.ctx.types, target)
+            crate::query_boundaries::diagnostics::function_shape_for_type(self.ctx.types, target)
                 .is_some_and(|shape| shape.is_constructor)
-                || crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, target)
-                    .is_some_and(|shape| !shape.construct_signatures.is_empty());
+                || crate::query_boundaries::diagnostics::callable_shape_for_type(
+                    self.ctx.types,
+                    target,
+                )
+                .is_some_and(|shape| !shape.construct_signatures.is_empty());
         let evaluated_source = self.evaluate_type_for_assignability(source);
         let source_has_display_props =
             self.type_or_evaluated_has_display_properties(source, evaluated_source);
@@ -1277,8 +1284,9 @@ impl<'a> CheckerState<'a> {
         // properties contain fresh types — their outer canonical properties are object types
         // (not literals), so they correctly fall through to the widening path.
         let source_is_array =
-            crate::query_boundaries::common::array_element_type(self.ctx.types, source).is_some()
-                || crate::query_boundaries::common::array_element_type(
+            crate::query_boundaries::diagnostics::array_element_type(self.ctx.types, source)
+                .is_some()
+                || crate::query_boundaries::diagnostics::array_element_type(
                     self.ctx.types,
                     evaluated_source,
                 )
@@ -1305,15 +1313,17 @@ impl<'a> CheckerState<'a> {
         let is_intersection_source = [source, self.evaluate_type_for_assignability(source)]
             .into_iter()
             .any(|candidate| {
-                crate::query_boundaries::common::is_intersection_type(self.ctx.types, candidate)
-                    && self.ctx.types.get_display_properties(candidate).is_some()
+                crate::query_boundaries::diagnostics::is_intersection_type(
+                    self.ctx.types,
+                    candidate,
+                ) && self.ctx.types.get_display_properties(candidate).is_some()
             });
         if is_intersection_source && self.target_has_literal_typed_properties(target) {
             return source_display;
         }
 
         let evaluated = self.evaluate_type_for_assignability(source);
-        let widened = crate::query_boundaries::common::widen_type(self.ctx.types, evaluated);
+        let widened = crate::query_boundaries::diagnostics::widen_type(self.ctx.types, evaluated);
         let widened = self.widen_function_like_display_type(widened);
         let widened_display = self
             .format_type_for_diagnostic_role(widened, DiagnosticTypeDisplayRole::WidenedDiagnostic);
@@ -1346,23 +1356,23 @@ impl<'a> CheckerState<'a> {
         }
         let db = self.ctx.types;
         let recurse = |child: TypeId, visiting: &mut rustc_hash::FxHashSet<TypeId>| -> bool {
-            crate::query_boundaries::common::is_literal_type(db, child)
+            crate::query_boundaries::diagnostics::is_literal_type(db, child)
                 || self.source_carries_canonical_literal_member_inner(child, visiting, depth + 1)
         };
 
-        if let Some(shape) = crate::query_boundaries::common::object_shape_for_type(db, ty) {
+        if let Some(shape) = crate::query_boundaries::diagnostics::object_shape_for_type(db, ty) {
             return shape
                 .properties
                 .iter()
                 .any(|p| recurse(p.type_id, visiting));
         }
-        if let Some(elem) = crate::query_boundaries::common::array_element_type(db, ty) {
+        if let Some(elem) = crate::query_boundaries::diagnostics::array_element_type(db, ty) {
             return recurse(elem, visiting);
         }
-        if let Some(elements) = crate::query_boundaries::common::tuple_elements(db, ty) {
+        if let Some(elements) = crate::query_boundaries::diagnostics::tuple_elements(db, ty) {
             return elements.iter().any(|e| recurse(e.type_id, visiting));
         }
-        if let Some(members) = crate::query_boundaries::common::union_members(db, ty) {
+        if let Some(members) = crate::query_boundaries::diagnostics::union_members(db, ty) {
             return members.iter().any(|&m| recurse(m, visiting));
         }
         false
@@ -1377,7 +1387,7 @@ impl<'a> CheckerState<'a> {
         // which the text-based member-literal widener mistakes for an object member and
         // widens (`... : 2` → `... : number`, `... : "no"` → `... : string`). tsc renders
         // deferred conditional branches verbatim, so never text-widen a conditional target.
-        if crate::query_boundaries::common::is_conditional_type(self.ctx.types, target) {
+        if crate::query_boundaries::diagnostics::is_conditional_type(self.ctx.types, target) {
             return target_display;
         }
         let evaluated = self.evaluate_type_for_assignability(target);
@@ -1413,7 +1423,7 @@ impl<'a> CheckerState<'a> {
             return target_display;
         }
 
-        let widened = crate::query_boundaries::common::widen_type(self.ctx.types, evaluated);
+        let widened = crate::query_boundaries::diagnostics::widen_type(self.ctx.types, evaluated);
         let widened = self.widen_function_like_display_type(widened);
         let widened_display = self
             .format_type_for_diagnostic_role(widened, DiagnosticTypeDisplayRole::WidenedDiagnostic);
@@ -1434,12 +1444,12 @@ impl<'a> CheckerState<'a> {
         ty: TypeId,
     ) -> bool {
         // Direct Application: Application(Lazy(Foo), [args])
-        if crate::query_boundaries::common::is_generic_application(db, ty) {
+        if crate::query_boundaries::diagnostics::is_generic_application(db, ty) {
             return true;
         }
         // Evaluated Application: concrete Object that carries display_alias → Application
         if let Some(alias) = db.get_display_alias(ty)
-            && crate::query_boundaries::common::is_generic_application(db, alias)
+            && crate::query_boundaries::diagnostics::is_generic_application(db, alias)
         {
             return true;
         }
@@ -1452,19 +1462,23 @@ impl<'a> CheckerState<'a> {
     /// `"hello" | "world"`, but widens to `string` when the target expects `boolean`.
     fn target_has_literal_typed_properties(&mut self, target: TypeId) -> bool {
         let target = self.evaluate_type_for_assignability(target);
-        let shape = crate::query_boundaries::common::object_shape_for_type(self.ctx.types, target)
-            .or_else(|| {
-                // For intersection/union targets, check members.
-                crate::query_boundaries::common::intersection_members(self.ctx.types, target)
+        let shape =
+            crate::query_boundaries::diagnostics::object_shape_for_type(self.ctx.types, target)
+                .or_else(|| {
+                    // For intersection/union targets, check members.
+                    crate::query_boundaries::diagnostics::intersection_members(
+                        self.ctx.types,
+                        target,
+                    )
                     .and_then(|members| {
                         members.iter().find_map(|&m| {
-                            crate::query_boundaries::common::object_shape_for_type(
+                            crate::query_boundaries::diagnostics::object_shape_for_type(
                                 self.ctx.types,
                                 m,
                             )
                         })
                     })
-            });
+                });
         let Some(shape) = shape else {
             return false;
         };
@@ -1653,7 +1667,7 @@ impl<'a> CheckerState<'a> {
         let src_callable = is_callable_application_type(self.ctx.types, source);
         let tgt_callable = is_callable_application_type(self.ctx.types, target);
         let has_type_params =
-            crate::query_boundaries::common::contains_type_parameters(self.ctx.types, source);
+            crate::query_boundaries::diagnostics::contains_type_parameters(self.ctx.types, source);
         let both_have_own_sig_params = has_own_signature_type_params(self.ctx.types, source)
             && has_own_signature_type_params(self.ctx.types, target);
         if src_callable && tgt_callable && has_type_params && !both_have_own_sig_params {

--- a/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
@@ -55,7 +55,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         let declared_type = self.get_type_of_symbol(sym_id);
-        crate::query_boundaries::common::is_type_parameter(self.ctx.types, declared_type)
+        crate::query_boundaries::diagnostics::is_type_parameter(self.ctx.types, declared_type)
             .then(|| annotation.to_string())
     }
 
@@ -317,13 +317,14 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let def_id = crate::query_boundaries::common::lazy_def_id(self.ctx.types, base)?;
+        let def_id = crate::query_boundaries::diagnostics::lazy_def_id(self.ctx.types, base)?;
         let def = self.ctx.definition_store.get(def_id)?;
         if def.kind != tsz_solver::def::DefKind::TypeAlias {
             return None;
         }
         let body = def.body?;
-        if let Some(param) = crate::query_boundaries::common::type_param_info(self.ctx.types, body)
+        if let Some(param) =
+            crate::query_boundaries::diagnostics::type_param_info(self.ctx.types, body)
         {
             let arg_idx = def
                 .type_params
@@ -333,7 +334,7 @@ impl<'a> CheckerState<'a> {
         }
 
         let (next_base, body_args) =
-            crate::query_boundaries::common::application_info(self.ctx.types, body)?;
+            crate::query_boundaries::diagnostics::application_info(self.ctx.types, body)?;
         if next_base == base {
             return None;
         }
@@ -364,7 +365,7 @@ impl<'a> CheckerState<'a> {
         if alias_args.len() < type_params.len() {
             return None;
         }
-        let substitution = crate::query_boundaries::common::TypeSubstitution::from_args(
+        let substitution = crate::query_boundaries::diagnostics::TypeSubstitution::from_args(
             self.ctx.types,
             type_params,
             &alias_args[..type_params.len()],
@@ -373,7 +374,7 @@ impl<'a> CheckerState<'a> {
             body_args
                 .iter()
                 .map(|&arg| {
-                    crate::query_boundaries::common::instantiate_type(
+                    crate::query_boundaries::diagnostics::instantiate_type(
                         self.ctx.types,
                         arg,
                         &substitution,
@@ -398,16 +399,16 @@ impl<'a> CheckerState<'a> {
         &self,
         ty: TypeId,
     ) -> bool {
-        use crate::query_boundaries::common;
+        use crate::query_boundaries::diagnostics;
         // Fast path: most formatted types carry no display alias, so this single
         // map lookup short-circuits before the type-kind classification below.
         let Some(alias) = self.ctx.types.get_display_alias(ty) else {
             return false;
         };
-        if common::is_conditional_type(self.ctx.types, ty)
-            || common::is_index_access_type(self.ctx.types, ty)
-            || common::is_mapped_type(self.ctx.types, ty)
-            || common::is_generic_application(self.ctx.types, ty)
+        if diagnostics::is_conditional_type(self.ctx.types, ty)
+            || diagnostics::is_index_access_type(self.ctx.types, ty)
+            || diagnostics::is_mapped_type(self.ctx.types, ty)
+            || diagnostics::is_generic_application(self.ctx.types, ty)
         {
             return false;
         }

--- a/crates/tsz-checker/src/error_reporter/assignability_enum_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_enum_display.rs
@@ -8,7 +8,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         ty: TypeId,
     ) -> Option<String> {
-        let members = crate::query_boundaries::common::union_members(self.ctx.types, ty)?;
+        let members = crate::query_boundaries::diagnostics::union_members(self.ctx.types, ty)?;
         if members.len() < 2 {
             return None;
         }
@@ -99,7 +99,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         ty: TypeId,
     ) -> Option<(tsz_binder::SymbolId, tsz_binder::SymbolId)> {
-        let def_id = crate::query_boundaries::common::enum_def_id(self.ctx.types, ty)?;
+        let def_id = crate::query_boundaries::diagnostics::enum_def_id(self.ctx.types, ty)?;
         let sym_id = self.ctx.def_to_symbol_id_with_fallback(def_id)?;
         let symbol = self.ctx.binder.get_symbol(sym_id)?;
         symbol

--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -22,7 +22,8 @@ impl<'a> CheckerState<'a> {
         depth: u32,
     ) -> TypeId {
         if depth != 0
-            || crate::query_boundaries::common::array_element_type(self.ctx.types, source).is_none()
+            || crate::query_boundaries::diagnostics::array_element_type(self.ctx.types, source)
+                .is_none()
         {
             return source;
         }
@@ -53,16 +54,14 @@ impl<'a> CheckerState<'a> {
                 return source;
             }
 
-            let element_type =
-                crate::query_boundaries::common::array_element_type(self.ctx.types, first_arg_type)
-                    .or_else(|| {
-                        tsz_solver::operations::get_iterator_info(
-                            self.ctx.types,
-                            first_arg_type,
-                            false,
-                        )
-                        .map(|info| info.yield_type)
-                    });
+            let element_type = crate::query_boundaries::diagnostics::array_element_type(
+                self.ctx.types,
+                first_arg_type,
+            )
+            .or_else(|| {
+                tsz_solver::operations::get_iterator_info(self.ctx.types, first_arg_type, false)
+                    .map(|info| info.yield_type)
+            });
             let Some(element_type) = element_type else {
                 return source;
             };
@@ -157,22 +156,22 @@ impl<'a> CheckerState<'a> {
                 let (pos, end) = self.get_node_span(anchor_idx).unwrap_or((0, 0));
                 self.normalized_anchor_span(anchor_idx, pos, end.saturating_sub(pos))
             });
-        let source_is_function_like = crate::query_boundaries::common::callable_shape_for_type(
+        let source_is_function_like = crate::query_boundaries::diagnostics::callable_shape_for_type(
             self.ctx.types,
             source_for_display,
         )
         .is_some()
-            || crate::query_boundaries::common::function_shape_for_type(
+            || crate::query_boundaries::diagnostics::function_shape_for_type(
                 self.ctx.types,
                 source_for_display,
             )
             .is_some();
-        let target_is_function_like = crate::query_boundaries::common::callable_shape_for_type(
+        let target_is_function_like = crate::query_boundaries::diagnostics::callable_shape_for_type(
             self.ctx.types,
             target_for_display,
         )
         .is_some()
-            || crate::query_boundaries::common::function_shape_for_type(
+            || crate::query_boundaries::diagnostics::function_shape_for_type(
                 self.ctx.types,
                 target_for_display,
             )
@@ -675,9 +674,9 @@ impl<'a> CheckerState<'a> {
         source: TypeId,
         target: TypeId,
     ) -> Option<Vec<tsz_common::interner::Atom>> {
-        use crate::query_boundaries::common::{IndexKind, IndexSignatureResolver};
+        use crate::query_boundaries::diagnostics::{IndexKind, IndexSignatureResolver};
 
-        if crate::query_boundaries::common::is_type_parameter_like(self.ctx.types, source) {
+        if crate::query_boundaries::diagnostics::is_type_parameter_like(self.ctx.types, source) {
             return None;
         }
 
@@ -722,17 +721,23 @@ impl<'a> CheckerState<'a> {
             ]
             .into_iter()
             .find(|candidate| {
-                crate::query_boundaries::common::object_shape_for_type(self.ctx.types, *candidate)
-                    .is_some()
+                crate::query_boundaries::diagnostics::object_shape_for_type(
+                    self.ctx.types,
+                    *candidate,
+                )
+                .is_some()
             })?
         };
 
         let source_shape = {
             source_candidates.iter().copied().find_map(|candidate| {
-                crate::query_boundaries::common::object_shape_for_type(self.ctx.types, candidate)
+                crate::query_boundaries::diagnostics::object_shape_for_type(
+                    self.ctx.types,
+                    candidate,
+                )
             })
         };
-        let target_shape = crate::query_boundaries::common::object_shape_for_type(
+        let target_shape = crate::query_boundaries::diagnostics::object_shape_for_type(
             self.ctx.types,
             target_with_shape,
         )?;
@@ -804,10 +809,10 @@ impl<'a> CheckerState<'a> {
             })
         };
 
-        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, target_type)
+        crate::query_boundaries::diagnostics::object_shape_for_type(self.ctx.types, target_type)
             .and_then(|shape| find_member(&shape.properties))
             .or_else(|| {
-                crate::query_boundaries::common::callable_shape_for_type(
+                crate::query_boundaries::diagnostics::callable_shape_for_type(
                     self.ctx.types,
                     target_type,
                 )
@@ -932,13 +937,13 @@ impl<'a> CheckerState<'a> {
         // type's symbol, meaning it was declared directly on the target type (not
         // inherited). tsc lists own properties before inherited ones in TS2739/TS2741.
         let target_symbol =
-            crate::query_boundaries::common::get_object_symbol(self.ctx.types, target_type);
+            crate::query_boundaries::diagnostics::get_object_symbol(self.ctx.types, target_type);
         let mut property_ranks: FxHashMap<tsz_common::interner::Atom, (u32, usize, bool)> =
             FxHashMap::default();
 
         let mut collect_ranks = |ty: TypeId, tgt_sym: Option<tsz_binder::SymbolId>| {
             if let Some(shape) =
-                crate::query_boundaries::common::object_shape_for_type(self.ctx.types, ty)
+                crate::query_boundaries::diagnostics::object_shape_for_type(self.ctx.types, ty)
             {
                 for (index, prop) in shape.properties.iter().enumerate() {
                     let is_own = tgt_sym.is_some() && prop.parent_id == tgt_sym;
@@ -950,7 +955,7 @@ impl<'a> CheckerState<'a> {
                 }
             }
             if let Some(shape) =
-                crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, ty)
+                crate::query_boundaries::diagnostics::callable_shape_for_type(self.ctx.types, ty)
             {
                 for (index, prop) in shape.properties.iter().enumerate() {
                     let is_own = tgt_sym.is_some() && prop.parent_id == tgt_sym;

--- a/crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_keyof_alias_display.rs
@@ -14,7 +14,7 @@ impl<'a> CheckerState<'a> {
     /// the `keyof { ... }` spelling. A named interface / class / alias fails this
     /// predicate and keeps its `keyof Name` form.
     pub(in crate::error_reporter) fn keyof_operand_is_anonymous(&self, operand: TypeId) -> bool {
-        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, operand)
+        crate::query_boundaries::diagnostics::object_shape_for_type(self.ctx.types, operand)
             .is_some_and(|shape| shape.symbol.is_none())
             && self.lookup_type_alias_name_for_display(operand).is_none()
     }
@@ -30,7 +30,8 @@ impl<'a> CheckerState<'a> {
         &mut self,
         ty: TypeId,
     ) -> bool {
-        let Some(operand) = crate::query_boundaries::common::keyof_inner_type(self.ctx.types, ty)
+        let Some(operand) =
+            crate::query_boundaries::diagnostics::keyof_inner_type(self.ctx.types, ty)
         else {
             return false;
         };
@@ -62,7 +63,7 @@ impl<'a> CheckerState<'a> {
         // `self.ctx.types` taken by `union_members` / `intersection_members` is
         // released before the `&mut self` recursive call below.
         if let Some(members) =
-            crate::query_boundaries::common::union_members(self.ctx.types, operand)
+            crate::query_boundaries::diagnostics::union_members(self.ctx.types, operand)
         {
             let members: Vec<TypeId> = members.iter().copied().collect();
             return members
@@ -70,7 +71,7 @@ impl<'a> CheckerState<'a> {
                 .any(|member| self.keyof_operand_yields_concrete_literal_keyset(member));
         }
         if let Some(members) =
-            crate::query_boundaries::common::intersection_members(self.ctx.types, operand)
+            crate::query_boundaries::diagnostics::intersection_members(self.ctx.types, operand)
         {
             let members: Vec<TypeId> = members.iter().copied().collect();
             return !members.is_empty()
@@ -80,16 +81,17 @@ impl<'a> CheckerState<'a> {
         }
         // A direct object operand exposes its shape; otherwise resolve a
         // non-generic alias to its body first so the shape becomes visible.
-        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, operand)
+        crate::query_boundaries::diagnostics::object_shape_for_type(self.ctx.types, operand)
             .or_else(|| {
-                let def_id = crate::query_boundaries::common::lazy_def_id(self.ctx.types, operand)?;
+                let def_id =
+                    crate::query_boundaries::diagnostics::lazy_def_id(self.ctx.types, operand)?;
                 let body = self.ctx.type_env.borrow().get_def(def_id).or_else(|| {
                     self.ctx
                         .definition_store
                         .get(def_id)
                         .and_then(|def| def.body)
                 })?;
-                crate::query_boundaries::common::object_shape_for_type(self.ctx.types, body)
+                crate::query_boundaries::diagnostics::object_shape_for_type(self.ctx.types, body)
             })
             .is_some_and(|shape| shape.string_index.is_none() && shape.number_index.is_none())
     }
@@ -118,7 +120,7 @@ impl<'a> CheckerState<'a> {
                     return None;
                 }
                 let body = def.body?;
-                crate::query_boundaries::common::keyof_inner_type(self.ctx.types, body)?;
+                crate::query_boundaries::diagnostics::keyof_inner_type(self.ctx.types, body)?;
                 let evaluated = self.evaluate_type_for_assignability(body);
                 (evaluated == ty || self.are_mutually_assignable(evaluated, ty)).then_some(def_id)
             })
@@ -134,12 +136,12 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         let body = def.body?;
-        let inner = crate::query_boundaries::common::keyof_inner_type(self.ctx.types, body)?;
+        let inner = crate::query_boundaries::diagnostics::keyof_inner_type(self.ctx.types, body)?;
         if let Some(alias_name) = self.lookup_type_alias_name_for_display(inner) {
             return Some(format!("keyof {alias_name}"));
         }
         if let Some(shape) =
-            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, inner)
+            crate::query_boundaries::diagnostics::object_shape_for_type(self.ctx.types, inner)
             && let Some(sym_id) = shape.symbol
             && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
         {
@@ -335,11 +337,12 @@ impl<'a> CheckerState<'a> {
     /// so an unrelated global `union -> keyof Name` display alias on a shared
     /// literal cannot repaint a reduced key. Returns `None` for any other shape.
     fn finite_literal_keyset_display(&mut self, ty: TypeId) -> Option<String> {
-        if let Some(value) = crate::query_boundaries::common::literal_value(self.ctx.types, ty) {
+        if let Some(value) = crate::query_boundaries::diagnostics::literal_value(self.ctx.types, ty)
+        {
             return self.literal_key_display(value);
         }
         let members: Vec<TypeId> =
-            crate::query_boundaries::common::union_members(self.ctx.types, ty)?
+            crate::query_boundaries::diagnostics::union_members(self.ctx.types, ty)?
                 .iter()
                 .copied()
                 .collect();
@@ -348,7 +351,8 @@ impl<'a> CheckerState<'a> {
         }
         let mut parts = Vec::with_capacity(members.len());
         for member in members {
-            let value = crate::query_boundaries::common::literal_value(self.ctx.types, member)?;
+            let value =
+                crate::query_boundaries::diagnostics::literal_value(self.ctx.types, member)?;
             parts.push(self.literal_key_display(value)?);
         }
         Some(parts.join(" | "))

--- a/crates/tsz-checker/src/error_reporter/conditional_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/conditional_alias_display.rs
@@ -31,7 +31,7 @@ impl<'a> CheckerState<'a> {
         &mut self,
         ty: TypeId,
     ) -> Option<String> {
-        if let Some(def_id) = crate::query_boundaries::common::lazy_def_id(self.ctx.types, ty)
+        if let Some(def_id) = crate::query_boundaries::diagnostics::lazy_def_id(self.ctx.types, ty)
             && let Some(def) = self.ctx.definition_store.get(def_id)
             && def.kind == tsz_solver::def::DefKind::TypeAlias
             && def.type_params.is_empty()
@@ -56,7 +56,8 @@ impl<'a> CheckerState<'a> {
         // when the conditional reduces to a concrete type (e.g. `unknown` once the
         // constraint is applied) — tsc renders `ReturnType<T[M]>`, not `unknown`.
         // Decline before evaluating so the deferred application keeps its name.
-        if crate::query_boundaries::common::contains_type_parameters(self.ctx.types, candidate) {
+        if crate::query_boundaries::diagnostics::contains_type_parameters(self.ctx.types, candidate)
+        {
             return None;
         }
 
@@ -69,7 +70,7 @@ impl<'a> CheckerState<'a> {
         // alias name for unions and leave them to the separate union-ordering
         // work. Single object/tuple/array/primitive reductions have no such
         // ambiguity and match `tsc` exactly.
-        if crate::query_boundaries::common::is_union_type(self.ctx.types, evaluated) {
+        if crate::query_boundaries::diagnostics::is_union_type(self.ctx.types, evaluated) {
             return None;
         }
         // When the reduced shape is registered against a *non-generic* type alias

--- a/crates/tsz-checker/src/error_reporter/core_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core_alias_display.rs
@@ -33,15 +33,17 @@ impl<'a> CheckerState<'a> {
         // Restricting to object/function/callable/union/intersection types avoids
         // regressions like `number` -> `TypeOfInfinity`.
         let is_object =
-            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, ty).is_some();
+            crate::query_boundaries::diagnostics::object_shape_for_type(self.ctx.types, ty)
+                .is_some();
         let is_union = if !is_object {
-            crate::query_boundaries::common::union_members(self.ctx.types, ty).is_some()
+            crate::query_boundaries::diagnostics::union_members(self.ctx.types, ty).is_some()
         } else {
             false
         };
         let is_function = if !is_object && !is_union {
-            crate::query_boundaries::common::function_shape_for_type(self.ctx.types, ty).is_some()
-                || crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, ty)
+            crate::query_boundaries::diagnostics::function_shape_for_type(self.ctx.types, ty)
+                .is_some()
+                || crate::query_boundaries::diagnostics::callable_shape_for_type(self.ctx.types, ty)
                     .is_some()
         } else {
             false
@@ -54,13 +56,13 @@ impl<'a> CheckerState<'a> {
         // Application like B<string>), let the formatter handle it - using the
         // raw alias name would lose the type arguments.
         if self.ctx.types.get_display_alias(ty).is_some_and(|alias| {
-            crate::query_boundaries::common::type_application(self.ctx.types, alias).is_some()
+            crate::query_boundaries::diagnostics::type_application(self.ctx.types, alias).is_some()
         }) {
             return None;
         }
         if let Some(alias) = self.ctx.types.get_display_alias(ty)
             && let Some(def_id) =
-                crate::query_boundaries::common::lazy_def_id(self.ctx.types, alias)
+                crate::query_boundaries::diagnostics::lazy_def_id(self.ctx.types, alias)
             && let Some(def) = self.ctx.definition_store.get(def_id)
             && def.kind == tsz_solver::def::DefKind::TypeAlias
             && def.type_params.is_empty()
@@ -74,7 +76,8 @@ impl<'a> CheckerState<'a> {
         // For intersection types (e.g., typeof X & Function), expand to the full
         // type representation rather than using the alias name. This matches tsc's
         // behavior in assignability messages for complex intersection types.
-        if crate::query_boundaries::common::intersection_members(self.ctx.types, ty).is_some() {
+        if crate::query_boundaries::diagnostics::intersection_members(self.ctx.types, ty).is_some()
+        {
             return None;
         }
 
@@ -94,7 +97,7 @@ impl<'a> CheckerState<'a> {
         // `type T = typeof value` aliases display as the resolved value type
         // in assignment diagnostics. Do not repaint that resolved body as `T`.
         if def.body.is_some_and(|body| {
-            crate::query_boundaries::common::is_type_query_type(self.ctx.types, body)
+            crate::query_boundaries::diagnostics::is_type_query_type(self.ctx.types, body)
         }) || self.type_alias_definition_body_is_type_query(&def)
         {
             return None;
@@ -129,10 +132,14 @@ impl<'a> CheckerState<'a> {
         if !cond.is_distributive {
             return None;
         }
-        let param_info = crate::query_boundaries::common::type_param_info(db, cond.check_type)?;
+        let param_info =
+            crate::query_boundaries::diagnostics::type_param_info(db, cond.check_type)?;
         let branches_are_concrete =
-            !crate::query_boundaries::common::contains_type_parameters(db, cond.true_type)
-                && !crate::query_boundaries::common::contains_type_parameters(db, cond.false_type);
+            !crate::query_boundaries::diagnostics::contains_type_parameters(db, cond.true_type)
+                && !crate::query_boundaries::diagnostics::contains_type_parameters(
+                    db,
+                    cond.false_type,
+                );
         if !branches_are_concrete {
             return None;
         }
@@ -147,8 +154,9 @@ impl<'a> CheckerState<'a> {
         ) {
             return None;
         }
-        let extends_members = crate::query_boundaries::common::union_members(db, cond.extends_type)
-            .unwrap_or_else(|| vec![cond.extends_type].into());
+        let extends_members =
+            crate::query_boundaries::diagnostics::union_members(db, cond.extends_type)
+                .unwrap_or_else(|| vec![cond.extends_type].into());
         let has_overlap = extends_members.iter().any(|&m| {
             crate::query_boundaries::assignability::is_fresh_subtype_of(db, m, constraint)
         });

--- a/crates/tsz-checker/src/error_reporter/literal_alias_rewrites.rs
+++ b/crates/tsz-checker/src/error_reporter/literal_alias_rewrites.rs
@@ -51,7 +51,9 @@ impl<'a> CheckerState<'a> {
             .ctx
             .types
             .get_display_alias(source)
-            .and_then(|alias| crate::query_boundaries::common::lazy_def_id(self.ctx.types, alias))
+            .and_then(|alias| {
+                crate::query_boundaries::diagnostics::lazy_def_id(self.ctx.types, alias)
+            })
             .and_then(|def_id| self.ctx.definition_store.get(def_id))
             .is_some_and(|def| {
                 def.kind == tsz_solver::def::DefKind::TypeAlias && def.type_params.is_empty()
@@ -59,15 +61,17 @@ impl<'a> CheckerState<'a> {
         {
             return false;
         }
-        let application = crate::query_boundaries::common::application_info(self.ctx.types, source)
-            .or_else(|| {
-                let alias = self.ctx.types.get_display_alias(source)?;
-                crate::query_boundaries::common::application_info(self.ctx.types, alias)
-            });
+        let application =
+            crate::query_boundaries::diagnostics::application_info(self.ctx.types, source).or_else(
+                || {
+                    let alias = self.ctx.types.get_display_alias(source)?;
+                    crate::query_boundaries::diagnostics::application_info(self.ctx.types, alias)
+                },
+            );
         let Some((base, _)) = application else {
             return false;
         };
-        let Some(def_id) = crate::query_boundaries::common::lazy_def_id(self.ctx.types, base)
+        let Some(def_id) = crate::query_boundaries::diagnostics::lazy_def_id(self.ctx.types, base)
         else {
             return false;
         };

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -589,22 +589,25 @@ impl<'a> CheckerState<'a> {
             })
             .or_else(|| {
                 target_candidates.iter().find_map(|&candidate| {
-                    crate::query_boundaries::common::get_object_symbol(self.ctx.types, candidate)
-                        .or_else(|| {
-                            crate::query_boundaries::common::object_shape_for_type(
-                                self.ctx.types,
-                                candidate,
-                            )
-                            .and_then(|shape| {
-                                shape.properties.iter().find_map(|prop| {
-                                    prop.parent_id.filter(|sym| {
-                                        self.ctx.binder.get_symbol(*sym).is_some_and(|symbol| {
-                                            symbol.has_any_flags(tsz_binder::symbol_flags::CLASS)
-                                        })
+                    crate::query_boundaries::diagnostics::get_object_symbol(
+                        self.ctx.types,
+                        candidate,
+                    )
+                    .or_else(|| {
+                        crate::query_boundaries::common::object_shape_for_type(
+                            self.ctx.types,
+                            candidate,
+                        )
+                        .and_then(|shape| {
+                            shape.properties.iter().find_map(|prop| {
+                                prop.parent_id.filter(|sym| {
+                                    self.ctx.binder.get_symbol(*sym).is_some_and(|symbol| {
+                                        symbol.has_any_flags(tsz_binder::symbol_flags::CLASS)
                                     })
                                 })
                             })
                         })
+                    })
                 })
             })?;
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -726,6 +726,9 @@ mod enum_relation_routing_arch_tests;
 #[path = "tests/enum_residual_narrowing_tests.rs"]
 mod enum_residual_narrowing_tests;
 #[cfg(test)]
+#[path = "tests/error_reporter_assignability_display_boundary_arch_tests.rs"]
+mod error_reporter_assignability_display_boundary_arch_tests;
+#[cfg(test)]
 #[path = "tests/excess_prop_object_union_display_tests.rs"]
 mod excess_prop_object_union_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -1420,13 +1420,6 @@ pub(crate) fn get_noinfer_inner(db: &dyn TypeDatabase, type_id: TypeId) -> Optio
     tsz_solver::type_queries::get_noinfer_inner(db, type_id)
 }
 
-pub(crate) fn get_object_symbol(
-    db: &dyn TypeDatabase,
-    type_id: TypeId,
-) -> Option<tsz_binder::SymbolId> {
-    tsz_solver::type_queries::get_object_symbol(db, type_id)
-}
-
 pub(crate) fn get_private_brand_name(db: &dyn TypeDatabase, type_id: TypeId) -> Option<String> {
     tsz_solver::type_queries::get_private_brand_name(db, type_id)
 }

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -19,7 +19,27 @@ pub(crate) use super::common::{
     type_parameter_constraint, union_list_id, union_members, widen_literal_to_primitive,
     widen_type_deep,
 };
+// Display-only type-shape predicates routed off the catch-all `common` boundary
+// so `error_reporter/` presentation code depends on `diagnostics` exclusively
+// (issue #12947). These remain defined in `common` for non-display callers; the
+// re-export keeps a single import surface for diagnostic render policy.
+pub(crate) use super::common::{
+    IndexKind, IndexSignatureResolver, is_conditional_type, is_generic_application,
+    is_literal_type, is_mapped_type, is_type_parameter, is_type_parameter_like, is_type_query_type,
+    is_union_type, widen_type,
+};
 pub(crate) use tsz_solver::type_queries::AssignmentNumericDisplayChildren;
+
+/// Resolve the binder symbol backing an object type, for diagnostic
+/// elaboration (spelling suggestions, missing-property anchors). Used only by
+/// `error_reporter/` presentation code, so it is owned by the diagnostics
+/// boundary rather than the catch-all `common` boundary (issue #12947).
+pub(crate) fn get_object_symbol(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<tsz_binder::SymbolId> {
+    tsz_solver::type_queries::get_object_symbol(db, type_id)
+}
 
 pub(crate) fn assignment_numeric_display_children(
     db: &dyn tsz_solver::construction::TypeDatabase,

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_04.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_04.rs
@@ -49,6 +49,7 @@ fn test_display_diagnostic_helpers_have_domain_boundary() {
         "is_unresolved_for_display",
         "type_may_display_iterator_protocol",
         "function_signature_has_typeof",
+        "get_object_symbol",
     ] {
         assert!(
             !common_source.contains(&format!("fn {helper}(")),

--- a/crates/tsz-checker/src/tests/error_reporter_assignability_display_boundary_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/error_reporter_assignability_display_boundary_arch_tests.rs
@@ -1,0 +1,61 @@
+use std::fs;
+use std::path::Path;
+
+/// Display-only assignability/alias `error_reporter` modules must obtain their
+/// type-shape facts through `query_boundaries::diagnostics`, never the catch-all
+/// `query_boundaries::common` boundary (issue #12947, slice 1). Routing render
+/// policy through a single domain boundary keeps diagnostic shape queries
+/// distinguishable from generic type queries and prevents reintroducing
+/// formatted-string predicates against `common`.
+#[test]
+fn error_reporter_assignability_display_avoids_common_boundary() {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for file in [
+        "src/error_reporter/assignability.rs",
+        "src/error_reporter/assignability_helpers.rs",
+        "src/error_reporter/assignability_alias_display.rs",
+        "src/error_reporter/assignability_keyof_alias_display.rs",
+        "src/error_reporter/assignability_enum_display.rs",
+        "src/error_reporter/conditional_alias_display.rs",
+        "src/error_reporter/core_alias_display.rs",
+        "src/error_reporter/literal_alias_rewrites.rs",
+    ] {
+        let source = fs::read_to_string(manifest.join(file))
+            .unwrap_or_else(|err| panic!("failed to read {file}: {err}"));
+        assert!(
+            !source.contains("query_boundaries::common"),
+            "{file} must route display shape queries through query_boundaries::diagnostics, \
+             not query_boundaries::common"
+        );
+    }
+}
+
+/// The display-shape predicates routed off `common` for slice 1 must remain
+/// reachable through the `diagnostics` boundary, so the migrated modules keep a
+/// single import surface for diagnostic render policy.
+#[test]
+fn diagnostics_boundary_reexports_routed_display_helpers() {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let diagnostics = fs::read_to_string(manifest.join("src/query_boundaries/diagnostics.rs"))
+        .expect("failed to read query_boundaries/diagnostics.rs");
+
+    for helper in [
+        "is_conditional_type",
+        "is_generic_application",
+        "is_literal_type",
+        "is_mapped_type",
+        "is_type_parameter",
+        "is_type_parameter_like",
+        "is_type_query_type",
+        "is_union_type",
+        "widen_type",
+        "IndexKind",
+        "IndexSignatureResolver",
+    ] {
+        assert!(
+            diagnostics.contains(helper),
+            "{helper} must remain available through query_boundaries::diagnostics for \
+             error_reporter display routing"
+        );
+    }
+}


### PR DESCRIPTION
Closes #12947 (slice 1).

AgentName: M5Refactorer

Track: checker architecture boundary debt (#8223). Related precedent #12916
(display helpers moved to `query_boundaries::diagnostics`).

## Invariant

Behavior-preserving boundary-ownership refactor. No relation semantics, failure
reasons, diagnostic codes, or message text change. Every routed query resolves
to the identical underlying function, so diagnostics are byte-identical.

## Structural rule

When `error_reporter` code needs a type-shape fact purely for diagnostic
presentation (widening hints, alias peeling, keyof/index display, callable
shape summaries, conditional/mapped/union detection), it must call
`query_boundaries::diagnostics::*`, not `query_boundaries::common::*`. This
keeps diagnostic render policy behind a single domain boundary so relation-
adjacent display probes are distinguishable from generic type queries and a
formatted-string predicate cannot be reintroduced against `common`.

Owner layer: checker `query_boundaries::diagnostics` (the solver still owns the
underlying queries; `common` still defines the shared predicates).

## Scope

Slice 1 of the #12947 plan — the assignability + alias-display group:

- `query_boundaries/diagnostics.rs`: re-export the shared display-shape
  predicates used by the migrated modules — `is_conditional_type`,
  `is_generic_application`, `is_literal_type`, `is_mapped_type`,
  `is_type_parameter`, `is_type_parameter_like`, `is_type_query_type`,
  `is_union_type`, `widen_type`, plus the `IndexKind` / `IndexSignatureResolver`
  index helpers. These stay defined in `common` for their many non-display
  callers; only the import surface moves. **`get_object_symbol` is physically
  moved** into `diagnostics` and removed from `common` — its only callers are
  `error_reporter` display code, so the diagnostics boundary now owns it.
- `error_reporter/`: route `common::` → `diagnostics::` in `assignability.rs`,
  `assignability_helpers.rs`, `assignability_alias_display.rs`,
  `assignability_keyof_alias_display.rs`, `assignability_enum_display.rs`,
  `conditional_alias_display.rs`, `core_alias_display.rs`,
  `literal_alias_rewrites.rs`, and the one `get_object_symbol` caller in
  `render_failure.rs`.
- Ratchets: new `error_reporter_assignability_display_boundary_arch_tests`
  (red-first) pins the eight migrated modules off `common` and asserts the
  routed helpers stay reachable through `diagnostics`; the `part_04`
  domain-boundary inventory now also locks `get_object_symbol`'s ownership in
  `diagnostics`.

Non-goals (per the issue): the remaining slices (`call_errors/*`,
`core/diagnostic_source*`) are left for follow-up; no message text, diagnostic
code, or relation-outcome change; no move of `error_reporter` into the solver.

## Adjacent-case matrix

The routed queries are identical functions, so all display branches keep prior
behavior: keyof/indexed-access alias display, enum/alias assignability display,
conditional-alias reduction display, literal-alias rewrites, callable-shape
summaries, index-signature missing-property elaboration, and renamed-alias
wrappers. No `contains`/`starts_with` over formatted type strings is introduced.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a (boundary-only ownership refactor; no semantic change, so no
  corpus row is affected)

Evidence: behavior-preserving re-export/move; the migrated call sites resolve to
the same underlying solver queries.

## Verification

- `cargo build -p tsz-checker` — clean.
- `cargo clippy -p tsz-checker --lib --tests` — clean.
- `cargo test -p tsz-checker --lib` boundary tests green:
  `error_reporter_assignability_display_avoids_common_boundary`,
  `diagnostics_boundary_reexports_routed_display_helpers`,
  `test_display_diagnostic_helpers_have_domain_boundary`.
- `scripts/arch/arch_guard.py` — "Architecture guardrails passed."
- The 8 migrated modules contain zero `query_boundaries::common` references.
- Pre-existing `zod_type_query_regression_tests` failures reproduce on the clean
  base tree (inherited red baseline, #8432) and are unrelated to this routing
  change.
- Broad conformance/emit/bench left to ready-review CI per repo policy.

## Coordination Notes

Boundary-only slice of #8223; follows the merged precedents #12916 (display
helper ownership) and #12954 (assignability index-access normalization). Routed
predicates that are genuinely shared (used widely outside `error_reporter`)
stay defined in `common` and are only re-exported, which is the correct depth;
only the truly display-only `get_object_symbol` is moved. Orthogonal to the
RelationRequest adoption work in #8227 — no relation-outcome paths touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEyKZUvzs7pzSmBuGQ3iLy)_