### PR TITLE
refactor(checker): ratchet common.rs helper surface + move display-widening to diagnostics (#12948)

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/spread.rs
@@ -266,7 +266,9 @@ impl<'a> CheckerState<'a> {
                 // diagnostics.
                 let spread_name = {
                     let mut props: Vec<_> = spread_shape.properties.to_vec();
-                    crate::query_boundaries::common::normalize_display_property_order(&mut props);
+                    crate::query_boundaries::diagnostics::normalize_display_property_order(
+                        &mut props,
+                    );
                     let fields: Vec<String> = props
                         .iter()
                         .map(|p| {

--- a/crates/tsz-checker/src/classes/class_abstract_checker.rs
+++ b/crates/tsz-checker/src/classes/class_abstract_checker.rs
@@ -551,14 +551,14 @@ impl<'a> CheckerState<'a> {
     /// evaluated — concrete sub-structures are preserved verbatim so this
     /// cannot widen or re-order object properties.
     ///
-    /// Delegates to the solver via `query_boundaries::common::deep_reduce_for_display`
+    /// Delegates to the solver via `query_boundaries::diagnostics::deep_reduce_for_display`
     /// so the walker stays on the correct side of the checker/solver contract.
     pub(crate) fn simplify_heritage_instance_type_for_display(
         &mut self,
         instance_type: TypeId,
     ) -> TypeId {
         match self.ctx.type_env.try_borrow() {
-            Ok(env) => crate::query_boundaries::common::deep_reduce_for_display(
+            Ok(env) => crate::query_boundaries::diagnostics::deep_reduce_for_display(
                 self.ctx.types,
                 &*env,
                 instance_type,

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -1682,7 +1682,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let display_type = crate::query_boundaries::common::widen_argument_type_for_display(
+        let display_type = crate::query_boundaries::diagnostics::widen_argument_type_for_display(
             self.ctx.types,
             arg_type,
         );
@@ -1952,7 +1952,7 @@ impl<'a> CheckerState<'a> {
                 direct_arg_type
             }
         } else {
-            crate::query_boundaries::common::widen_argument_type_for_display(
+            crate::query_boundaries::diagnostics::widen_argument_type_for_display(
                 self.ctx.types,
                 arg_type,
             )

--- a/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/error_emission.rs
@@ -205,7 +205,7 @@ impl<'a> CheckerState<'a> {
         // `boolean[]` against a `boolean` parameter. The decision is structural;
         // the output string is plain rendering (no rendered-text decision, §25).
         if param_type == TypeId::BOOLEAN
-            && crate::query_boundaries::common::boolean_literal_array_display_type(
+            && crate::query_boundaries::diagnostics::boolean_literal_array_display_type(
                 self.ctx.types,
                 arg_type,
             )

--- a/crates/tsz-checker/src/error_reporter/core/diagnostic_source/generic_source_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/diagnostic_source/generic_source_display.rs
@@ -23,7 +23,7 @@ impl<'a> CheckerState<'a> {
         if !has_constrained_type_param {
             return None;
         }
-        let reduced = crate::query_boundaries::common::get_base_constraint_for_display(
+        let reduced = crate::query_boundaries::diagnostics::get_base_constraint_for_display(
             self.ctx.types.as_type_database(),
             source,
         );

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -1323,7 +1323,7 @@ impl<'a> CheckerState<'a> {
         // the source's base constraint is nullable.  Example:
         //   source `T & U` where constraints are `string | ... | undefined`
         //   target `string | null` must stay `string | null` (not `string`).
-        let other_base = crate::query_boundaries::common::get_base_constraint_for_display(
+        let other_base = crate::query_boundaries::diagnostics::get_base_constraint_for_display(
             self.ctx.types.as_type_database(),
             other,
         );

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -13,6 +13,7 @@ use crate::diagnostics::{
 use crate::error_reporter::assignability::is_object_prototype_method;
 use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
 use crate::query_boundaries::common as query_common;
+use crate::query_boundaries::diagnostics;
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
 use tsz_parser::parser::NodeIndex;
@@ -370,7 +371,7 @@ impl<'a> CheckerState<'a> {
                 }
                 let source_display_type =
                     self.widen_display_property_literals_for_related_info(source);
-                let source_display_type = query_common::widen_argument_type_for_display(
+                let source_display_type = diagnostics::widen_argument_type_for_display(
                     self.ctx.types,
                     source_display_type,
                 );

--- a/crates/tsz-checker/src/error_reporter/property_receiver_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/property_receiver_formatting.rs
@@ -304,7 +304,7 @@ impl<'a> CheckerState<'a> {
 
         let mut parts = Vec::new();
         let mut properties = shape.properties.clone();
-        crate::query_boundaries::common::normalize_display_property_order(&mut properties);
+        crate::query_boundaries::diagnostics::normalize_display_property_order(&mut properties);
         for prop in properties {
             let name = self.ctx.types.resolve_atom(prop.name);
             let readonly = if prop.readonly { "readonly " } else { "" };

--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -37,11 +37,11 @@ impl<'a> CheckerState<'a> {
         // so the widened shape is actually rendered — `format_type_diagnostic`
         // would fall back to display aliases stored on shared TypeIds and
         // re-introduce the original literal form inside fn return types.
-        let prev_display = crate::query_boundaries::common::display_widen_for_redeclaration(
+        let prev_display = crate::query_boundaries::diagnostics::display_widen_for_redeclaration(
             self.ctx.types,
             prev_type,
         );
-        let current_display = crate::query_boundaries::common::display_widen_for_redeclaration(
+        let current_display = crate::query_boundaries::diagnostics::display_widen_for_redeclaration(
             self.ctx.types,
             current_type,
         );

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -153,6 +153,9 @@ mod class_namespace_static_relation_routing_arch_tests;
 #[path = "../tests/class_property_typed_const_initializer_tests.rs"]
 mod class_property_typed_const_initializer_tests;
 #[cfg(test)]
+#[path = "tests/common_boundary_export_ratchets.rs"]
+mod common_boundary_export_ratchets;
+#[cfg(test)]
 #[path = "../tests/constructor_overload_excess_property_tests.rs"]
 mod constructor_overload_excess_property_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -28,23 +28,6 @@ pub(crate) use super::construct_signatures::construct_signatures_for_type;
 pub(crate) use super::generic_instantiation::{instantiate_generic, instantiate_type};
 pub(crate) use super::type_rewrite::replace_type_queries_and_lazies_with;
 
-/// Thin wrapper around `tsz_solver::deep_reduce_for_display`.
-///
-/// Deeply reduce meta-type applications (e.g. `InstanceType<typeof Foo>`)
-/// that appear inside `type_id` so the solver's type printer renders the
-/// concrete form that `tsc` shows in heritage diagnostics. The generic
-/// `TypeEvaluator` only visits the top-level node; this boundary helper
-/// walks composite wrappers (`Intersection`, `Union`, `Object`) and
-/// evaluates the inner `Application` / `Conditional` leaves using the
-/// caller-supplied `TypeResolver`.
-pub(crate) fn deep_reduce_for_display<R: TypeResolver>(
-    db: &dyn TypeDatabase,
-    resolver: &R,
-    type_id: TypeId,
-) -> TypeId {
-    tsz_solver::deep_reduce_for_display(db, resolver, type_id)
-}
-
 pub(crate) fn callable_shape_for_type(
     db: &dyn TypeDatabase,
     type_id: TypeId,
@@ -282,10 +265,6 @@ pub(crate) fn object_shape_for_type(
     tsz_solver::type_queries::get_object_shape(db, type_id)
 }
 
-pub(crate) fn normalize_display_property_order(props: &mut [tsz_solver::PropertyInfo]) {
-    tsz_solver::normalize_display_property_order(props)
-}
-
 pub(crate) fn array_element_type(db: &dyn TypeDatabase, type_id: TypeId) -> Option<TypeId> {
     tsz_solver::type_queries::get_array_element_type(db, type_id)
 }
@@ -489,14 +468,6 @@ pub(crate) fn widen_type(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
 /// display correctly (e.g., `string | false` instead of `string | boolean`).
 pub(crate) fn widen_type_for_display(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
     widening::widen_type_for_display(db, type_id)
-}
-
-/// Widen a type for call-argument diagnostic display: widens boolean
-/// literals inside compound shapes (tuples/objects) so TS2345 source-type
-/// renders match tsc, e.g. `[number, number, boolean, boolean]` instead of
-/// `[number, number, false, true]`. Function param types are still skipped.
-pub(crate) fn widen_argument_type_for_display(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
-    widening::widen_argument_type_for_display(db, type_id)
 }
 
 /// Extract the element type from a rest-argument array/tuple type.
@@ -1018,12 +989,6 @@ pub(crate) fn widen_literal_to_primitive(db: &dyn TypeDatabase, type_id: TypeId)
     tsz_solver::type_queries::widen_literal_to_primitive(db, type_id)
 }
 
-pub(crate) fn boolean_literal_array_display_type(
-    db: &dyn TypeDatabase,
-    type_id: TypeId,
-) -> Option<TypeId> {
-    tsz_solver::type_queries::boolean_literal_array_display_type(db, type_id)
-}
 pub(crate) use tsz_solver::type_queries::ContextualLiteralAllowKind;
 
 pub(crate) fn classify_for_contextual_literal(
@@ -1348,18 +1313,6 @@ pub(crate) fn get_application_lazy_def_id(
 
 pub(crate) fn get_base_constraint_of_type(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
     tsz_solver::type_queries::get_base_constraint_of_type(db, type_id)
-}
-
-/// Recursively reduce a type to its base constraint for display purposes.
-///
-/// Handles type parameters, intersections, and unions: for an intersection
-/// like `T & U` where the members have constraints, returns the intersection
-/// of the constraints (further simplified via the interner). This matches
-/// tsc's `getBaseConstraintOfType` for instantiable intersections and is used
-/// in error messages to display the reduced form instead of the raw generic
-/// intersection.
-pub(crate) fn get_base_constraint_for_display(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
-    tsz_solver::type_queries::get_base_constraint_for_display(db, type_id)
 }
 
 pub(crate) fn get_call_signatures(
@@ -1716,16 +1669,6 @@ pub(crate) fn evaluate_type(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
 
 pub(crate) fn widen_type_deep(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
     widening::widen_type_deep(db, type_id)
-}
-
-/// Display-widen a type for TS2403 redeclaration messages.
-///
-/// Thin boundary wrapper over `tsz_solver::operations::widening::display_widen_for_redeclaration`.
-/// See the solver definition for semantics — preserves top-level literal /
-/// literal-union types while deep-widening fresh literals nested inside
-/// compound shapes.
-pub(crate) fn display_widen_for_redeclaration(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
-    widening::display_widen_for_redeclaration(db, type_id)
 }
 
 pub(crate) fn string_intrinsic_components(

--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -555,6 +555,73 @@ pub(crate) fn preserves_named_application_base(
         )
 }
 
+// ── Display widening / reduction ──
+//
+// These helpers encode diagnostic *display* policy: how a semantic type is
+// widened or reduced purely so the printer renders the form `tsc` shows in a
+// message. They are domain-owned here (not in `query_boundaries::common`) per
+// the boundary ratchet — display rendering is a `diagnostics` concern.
+
+/// Deeply reduce meta-type applications (e.g. `InstanceType<typeof Foo>`)
+/// that appear inside `type_id` so the solver's type printer renders the
+/// concrete form that `tsc` shows in heritage diagnostics. The generic
+/// `TypeEvaluator` only visits the top-level node; this boundary helper
+/// walks composite wrappers (`Intersection`, `Union`, `Object`) and
+/// evaluates the inner `Application` / `Conditional` leaves using the
+/// caller-supplied `TypeResolver`.
+pub(crate) fn deep_reduce_for_display<R: TypeResolver>(
+    db: &dyn TypeDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> TypeId {
+    tsz_solver::deep_reduce_for_display(db, resolver, type_id)
+}
+
+/// Normalize the property order of an object shape for diagnostic display so
+/// rendered members match `tsc`'s ordering.
+pub(crate) fn normalize_display_property_order(props: &mut [tsz_solver::PropertyInfo]) {
+    tsz_solver::normalize_display_property_order(props)
+}
+
+/// Widen a type for call-argument diagnostic display: widens boolean
+/// literals inside compound shapes (tuples/objects) so TS2345 source-type
+/// renders match tsc, e.g. `[number, number, boolean, boolean]` instead of
+/// `[number, number, false, true]`. Function param types are still skipped.
+pub(crate) fn widen_argument_type_for_display(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    tsz_solver::operations::widening::widen_argument_type_for_display(db, type_id)
+}
+
+/// Display the boolean-literal-array element form (`boolean[]` rather than the
+/// `(true | false)[]` fresh form) for argument-mismatch diagnostics.
+pub(crate) fn boolean_literal_array_display_type(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    tsz_solver::type_queries::boolean_literal_array_display_type(db, type_id)
+}
+
+/// Recursively reduce a type to its base constraint for display purposes.
+///
+/// Handles type parameters, intersections, and unions: for an intersection
+/// like `T & U` where the members have constraints, returns the intersection
+/// of the constraints (further simplified via the interner). This matches
+/// tsc's `getBaseConstraintOfType` for instantiable intersections and is used
+/// in error messages to display the reduced form instead of the raw generic
+/// intersection.
+pub(crate) fn get_base_constraint_for_display(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    tsz_solver::type_queries::get_base_constraint_for_display(db, type_id)
+}
+
+/// Display-widen a type for TS2403 redeclaration messages.
+///
+/// Thin boundary wrapper over `tsz_solver::operations::widening::display_widen_for_redeclaration`.
+/// See the solver definition for semantics — preserves top-level literal /
+/// literal-union types while deep-widening fresh literals nested inside
+/// compound shapes.
+pub(crate) fn display_widen_for_redeclaration(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
+    tsz_solver::operations::widening::display_widen_for_redeclaration(db, type_id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tsz-checker/src/tests/common_boundary_export_ratchets.rs
+++ b/crates/tsz-checker/src/tests/common_boundary_export_ratchets.rs
@@ -1,0 +1,397 @@
+//! Ratchet tests for the `query_boundaries::common` migration quarantine.
+//!
+//! `query_boundaries/common.rs` is the historical default import for any
+//! checker code needing a semantic type fact. Domain modules (`diagnostics`,
+//! `type_predicates`, `key_constraints`, `assignability`, `state::checking`,
+//! ...) now own slices of that surface, but nothing structurally prevents a
+//! new domain-specific helper from landing back in `common.rs` during a parity
+//! fix. Without a ratchet the quarantine refills faster than the domain slices
+//! drain it (see issue #12948, parent #8225 / #8223).
+//!
+//! These tests pin the exact set of `pub(crate) fn` definitions allowed to live
+//! in `common.rs`. Adding *or* removing a definition forces an explicit edit to
+//! [`ALLOWED_COMMON_PUB_CRATE_FNS`], which surfaces in review. Helpers that have
+//! already been migrated to a domain owner are additionally guarded against
+//! reappearing in `common.rs`.
+//!
+//! ## Regenerating the allowlist
+//!
+//! After an intentional change to the `common.rs` function surface, regenerate
+//! the sorted list with:
+//!
+//! ```bash
+//! grep -oE '^\s*pub\(crate\) fn [a-z_0-9]+' \
+//!     crates/tsz-checker/src/query_boundaries/common.rs \
+//!     | sed -E 's/.*fn //' | sort -u | awk '{printf "    \"%s\",\n", $0}'
+//! ```
+//!
+//! and paste the result into [`ALLOWED_COMMON_PUB_CRATE_FNS`]. A removal is the
+//! desired direction (the quarantine draining); an addition should be reviewed
+//! against the structural rule that a domain-specific semantic policy helper
+//! belongs in its named domain boundary module, not `common.rs`.
+
+use std::collections::BTreeSet;
+use std::fs;
+
+const COMMON_PATH: &str = "src/query_boundaries/common.rs";
+const DIAGNOSTICS_PATH: &str = "src/query_boundaries/diagnostics.rs";
+
+/// Snapshot of every `pub(crate) fn` defined in `common.rs`. Sorted and unique.
+/// Regenerate with the command documented in the module header.
+const ALLOWED_COMMON_PUB_CRATE_FNS: &[&str] = &[
+    "application_id",
+    "application_info",
+    "apply_contextual_type",
+    "are_same_base_literal_kind",
+    "array_applicable_type",
+    "array_element_type",
+    "call_signatures_for_type",
+    "callable_shape_for_type",
+    "callable_shape_for_type_extended",
+    "callable_shape_id",
+    "classify_for_augmentation",
+    "classify_for_contextual_literal",
+    "classify_for_evaluation",
+    "classify_for_interface_merge",
+    "classify_for_literal_value",
+    "classify_for_predicate_signature",
+    "classify_for_traversal",
+    "classify_for_type_resolution",
+    "classify_literal_type",
+    "classify_namespace_member",
+    "classify_promise_type",
+    "classify_type_query",
+    "collect_all_types",
+    "collect_callable_property_types",
+    "collect_enum_def_ids",
+    "collect_lazy_def_ids",
+    "collect_referenced_types",
+    "collect_type_queries",
+    "constraint_references_type_param_in_resolution_path",
+    "construct_return_type_for_type",
+    "contains_application_in_structure",
+    "contains_conditional_type",
+    "contains_error_type",
+    "contains_error_type_in_args",
+    "contains_free_type_parameters",
+    "contains_generic_indexed_access_surface",
+    "contains_generic_type_parameters",
+    "contains_infer_types",
+    "contains_keyof_type",
+    "contains_lazy_def_id",
+    "contains_lazy_or_recursive",
+    "contains_never_type",
+    "contains_this_type",
+    "contains_type_by_id",
+    "contains_type_parameter_named",
+    "contains_type_parameter_named_shallow",
+    "contains_type_parameters",
+    "create_string_literal_type",
+    "enum_components",
+    "enum_def_id",
+    "enum_member_type",
+    "evaluate_type",
+    "extract_contextual_type_params",
+    "find_matching_property",
+    "find_property_by_str",
+    "find_property_in_object",
+    "find_property_in_object_by_str",
+    "function_shape_for_type",
+    "function_shape_id",
+    "get_application_base",
+    "get_application_lazy_def_id",
+    "get_base_constraint_of_type",
+    "get_base_type_for_comparison",
+    "get_call_signatures",
+    "get_callable_shape_for_type",
+    "get_conditional_type_id",
+    "get_construct_return_type_union",
+    "get_construct_signatures",
+    "get_fixed_tuple_length",
+    "get_indexed_access_type",
+    "get_invalid_index_type_member",
+    "get_iterator_info",
+    "get_merged_object_shape_for_type",
+    "get_noinfer_inner",
+    "get_object_symbol",
+    "get_private_brand_name",
+    "get_private_field_name",
+    "get_readonly_inner",
+    "get_tuple_element_type_union",
+    "get_type_query_symbol_ref",
+    "has_call_signatures",
+    "has_construct_signatures",
+    "has_deferred_conditional_member",
+    "has_function_shape",
+    "has_late_bound_members",
+    "has_nonpublic_property",
+    "has_property_by_str",
+    "has_unresolved_type_parameters",
+    "homomorphic_mapped_source",
+    "index_access_parts",
+    "index_access_types",
+    "instantiate_function_shape",
+    "instantiate_function_with_type_args",
+    "instantiate_shape_to_defaults",
+    "instantiate_type_preserving_meta",
+    "instantiate_type_with_depth_status",
+    "intersect_constructor_returns",
+    "intersection_list_id",
+    "intersection_members",
+    "is_array_or_tuple_type",
+    "is_array_type",
+    "is_bare_infer_placeholder",
+    "is_bigint_type",
+    "is_boolean_type",
+    "is_callable_type",
+    "is_conditional_type",
+    "is_constructor_like_type",
+    "is_empty_object_type",
+    "is_enum_type",
+    "is_error_type",
+    "is_evaluable_meta_type",
+    "is_fresh_object_type",
+    "is_function_type",
+    "is_generic_application",
+    "is_generic_application_with_type_params",
+    "is_generic_mapped_application",
+    "is_generic_mapped_type",
+    "is_generic_type",
+    "is_homomorphic_mapped_type_context",
+    "is_index_access_type",
+    "is_infer_type",
+    "is_intersection_type",
+    "is_keyof_type",
+    "is_lazy_type",
+    "is_literal_or_primitive_or_compound_of_those",
+    "is_literal_type",
+    "is_literal_type_through_type_constraints",
+    "is_mapped_type",
+    "is_mapped_type_with_readonly_modifier",
+    "is_module_namespace_type",
+    "is_nullish_type",
+    "is_number_literal",
+    "is_number_type",
+    "is_object_like_type",
+    "is_only_null_or_undefined",
+    "is_plain_object_type",
+    "is_primitive_or_literal_compound",
+    "is_primitive_type",
+    "is_readonly_tuple_fixed_element",
+    "is_spread_marker_tuple",
+    "is_string_intrinsic_type",
+    "is_string_literal",
+    "is_string_type",
+    "is_structurally_deferred_type",
+    "is_symbol_or_unique_symbol",
+    "is_symbol_type",
+    "is_template_literal_type",
+    "is_this_type",
+    "is_tuple_like_type",
+    "is_tuple_type",
+    "is_type_deeply_any",
+    "is_type_parameter",
+    "is_type_parameter_like",
+    "is_type_parameter_or_intersection_with_type_parameter",
+    "is_type_query_type",
+    "is_union_type",
+    "is_unique_symbol_type",
+    "is_unit_type",
+    "is_unresolved_inference_result",
+    "is_valid_mapped_type_key_type",
+    "keyof_inner_type",
+    "keyof_object_properties",
+    "lazy_def_id",
+    "literal_value",
+    "map_compound_members_if_changed",
+    "mapped_type_id",
+    "mapped_type_info",
+    "needs_evaluation_for_merge",
+    "new_binary_op_evaluator",
+    "no_infer_inner_type",
+    "normalize_object_union_members_for_write_target",
+    "number_literal_value",
+    "numeric_literal_index_valid_for_object",
+    "object_shape_for_type",
+    "object_shape_id",
+    "object_symbol",
+    "object_with_index_shape_id",
+    "params_to_tuple_elements",
+    "raw_property_type",
+    "readonly_inner_type",
+    "references_any_type_param_named",
+    "remove_nullish",
+    "remove_undefined",
+    "resolve_default_type_args",
+    "rest_argument_element_type",
+    "return_type_for_type",
+    "sanitize_callable_shape_binding_pattern_params",
+    "sanitize_params_at_positions",
+    "should_preserve_application_for_inference",
+    "split_nullish_type",
+    "string_intrinsic_components",
+    "string_literal_value",
+    "stringify_literal_type",
+    "substitute_this_type",
+    "substitute_this_type_at_return_position",
+    "tuple_elements",
+    "tuple_leading_fixed_count_before_trailing",
+    "tuple_list_id",
+    "type_application",
+    "type_contains_string_literal",
+    "type_contains_undefined",
+    "type_has_displayable_name",
+    "type_has_readonly_members",
+    "type_id_is_known_to_db",
+    "type_is_conditional_type_result_with_unresolved_inference",
+    "type_param_info",
+    "type_parameter_constraint",
+    "type_parameter_default",
+    "type_parameter_has_conditional_constraint",
+    "type_parameter_has_mapped_constraint",
+    "type_query_symbol",
+    "type_shape_symbol",
+    "types_are_comparable_for_assertion",
+    "union_contains_tuple",
+    "union_list_id",
+    "union_members",
+    "union_with_undefined",
+    "unique_symbol_ref",
+    "unpack_tuple_rest_parameter",
+    "unwrap_readonly",
+    "unwrap_readonly_or_noinfer",
+    "walk_referenced_types",
+    "widen_callable_literal_return_types",
+    "widen_freshness",
+    "widen_function_literal_return_type",
+    "widen_literal_to_primitive",
+    "widen_literal_type",
+    "widen_type",
+    "widen_type_deep",
+    "widen_type_for_display",
+];
+
+/// Display-widening helpers whose definition now lives in `diagnostics`
+/// (the #12948 migration slice).
+const DISPLAY_WIDENING_IN_DIAGNOSTICS: &[&str] = &[
+    "deep_reduce_for_display",
+    "normalize_display_property_order",
+    "widen_argument_type_for_display",
+    "boolean_literal_array_display_type",
+    "get_base_constraint_for_display",
+    "display_widen_for_redeclaration",
+];
+
+/// Display / compiler-managed predicates migrated to `diagnostics` and
+/// `type_predicates` by #12916.
+const MIGRATED_OUT_OF_COMMON_12916: &[&str] = &[
+    "is_compiler_managed_type",
+    "indexed_access_alias_body",
+    "is_unresolved_for_display",
+    "type_may_display_iterator_protocol",
+    "function_signature_has_typeof",
+];
+
+/// All helpers that have been migrated out of `common.rs` to a named domain
+/// owner and must not reappear as a `common.rs` definition. Derived from the
+/// per-campaign slices so the two lists cannot drift apart.
+fn migrated_out_of_common() -> Vec<&'static str> {
+    MIGRATED_OUT_OF_COMMON_12916
+        .iter()
+        .chain(DISPLAY_WIDENING_IN_DIAGNOSTICS)
+        .copied()
+        .collect()
+}
+
+/// Whether `source` defines a free function named `name`, in either the plain
+/// `fn name(` or generic `fn name<` form. Matches the bare-`fn` convention used
+/// by the sibling architecture-contract tests.
+fn defines_fn(source: &str, name: &str) -> bool {
+    source.contains(&format!("fn {name}(")) || source.contains(&format!("fn {name}<"))
+}
+
+/// Extract the names of every `pub(crate) fn` defined at the top level of a
+/// source file (handles both plain and generic `fn name<...>` forms).
+fn extract_pub_crate_fns(source: &str) -> BTreeSet<String> {
+    const MARKER: &str = "pub(crate) fn ";
+    let mut names = BTreeSet::new();
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        let Some(rest) = trimmed.strip_prefix(MARKER) else {
+            continue;
+        };
+        let name: String = rest
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if !name.is_empty() {
+            names.insert(name);
+        }
+    }
+    names
+}
+
+#[test]
+fn common_pub_crate_fn_surface_matches_allowlist() {
+    let source =
+        fs::read_to_string(COMMON_PATH).expect("failed to read query_boundaries/common.rs");
+    let actual = extract_pub_crate_fns(&source);
+    let allowed: BTreeSet<String> = ALLOWED_COMMON_PUB_CRATE_FNS
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+
+    let added: Vec<&String> = actual.difference(&allowed).collect();
+    let removed: Vec<&String> = allowed.difference(&actual).collect();
+
+    assert!(
+        added.is_empty(),
+        "new pub(crate) fn definitions landed in query_boundaries/common.rs without review: {added:?}. \
+         A domain-specific semantic policy helper belongs in its named domain boundary module \
+         (diagnostics / type_predicates / key_constraints / assignability / ...), not common.rs. \
+         If this is an intentional cross-domain primitive, add it to ALLOWED_COMMON_PUB_CRATE_FNS \
+         in src/tests/common_boundary_export_ratchets.rs (see the regeneration command in that file)."
+    );
+    assert!(
+        removed.is_empty(),
+        "pub(crate) fn definitions were removed from query_boundaries/common.rs but the ratchet \
+         allowlist still lists them: {removed:?}. Regenerate ALLOWED_COMMON_PUB_CRATE_FNS in \
+         src/tests/common_boundary_export_ratchets.rs so the quarantine snapshot stays accurate."
+    );
+}
+
+#[test]
+fn migrated_helpers_do_not_reappear_in_common() {
+    let source =
+        fs::read_to_string(COMMON_PATH).expect("failed to read query_boundaries/common.rs");
+    let mut violations = Vec::new();
+    for name in migrated_out_of_common() {
+        if defines_fn(&source, name) {
+            violations.push(name);
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "helpers already migrated to a domain boundary reappeared as definitions in \
+         query_boundaries/common.rs: {violations:?}. Keep their definition in the owning domain \
+         module and route callers there."
+    );
+}
+
+#[test]
+fn display_widening_cluster_is_owned_by_diagnostics() {
+    let common =
+        fs::read_to_string(COMMON_PATH).expect("failed to read query_boundaries/common.rs");
+    let diagnostics = fs::read_to_string(DIAGNOSTICS_PATH)
+        .expect("failed to read query_boundaries/diagnostics.rs");
+    for name in DISPLAY_WIDENING_IN_DIAGNOSTICS {
+        assert!(
+            defines_fn(&diagnostics, name),
+            "query_boundaries::diagnostics must own the display-widening helper {name}"
+        );
+        assert!(
+            !defines_fn(&common, name),
+            "display-widening helper {name} must not be defined in common.rs"
+        );
+    }
+}

--- a/crates/tsz-checker/src/types/computation/binary_support.rs
+++ b/crates/tsz-checker/src/types/computation/binary_support.rs
@@ -1477,7 +1477,7 @@ impl<'a> CheckerState<'a> {
         // primitive (`boolean`, not `true`) against this non-literal target, matching
         // tsc. The target uses the constraint formatter, which renders the canonical
         // key union structurally (tsc strips its `PropertyKey` alias on this surface).
-        let display_source = crate::query_boundaries::common::widen_argument_type_for_display(
+        let display_source = crate::query_boundaries::diagnostics::widen_argument_type_for_display(
             self.ctx.types,
             key_type,
         );

--- a/crates/tsz-checker/src/types/computation/call_result.rs
+++ b/crates/tsz-checker/src/types/computation/call_result.rs
@@ -3,6 +3,7 @@
 use crate::query_boundaries::assignability as assign_query;
 use crate::query_boundaries::common;
 use crate::query_boundaries::common::CallResult;
+use crate::query_boundaries::diagnostics;
 use crate::query_boundaries::type_computation::core as expr_ops;
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
@@ -286,11 +287,12 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        let display_arg_type = common::widen_argument_type_for_display(self.ctx.types, arg_type);
+        let display_arg_type =
+            diagnostics::widen_argument_type_for_display(self.ctx.types, arg_type);
         // Widen a fresh boolean-literal array element to `boolean` structurally
         // (`true[]`/`false[]` -> `boolean[]`) instead of patching the rendered text.
         let display_arg_type =
-            common::boolean_literal_array_display_type(self.ctx.types, display_arg_type)
+            diagnostics::boolean_literal_array_display_type(self.ctx.types, display_arg_type)
                 .unwrap_or(display_arg_type);
         let mut actual_display = self.format_type_diagnostic(display_arg_type);
         let mut target_display = self
@@ -703,7 +705,8 @@ impl<'a> CheckerState<'a> {
                 return expected;
             }
         }
-        let actual_display_type = common::widen_argument_type_for_display(self.ctx.types, actual);
+        let actual_display_type =
+            diagnostics::widen_argument_type_for_display(self.ctx.types, actual);
         if !common::is_primitive_type(self.ctx.types, actual_display_type) {
             return expected;
         }

--- a/crates/tsz-checker/src/types/computation/object_literal_support.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_support.rs
@@ -372,7 +372,7 @@ impl<'a> CheckerState<'a> {
                 let mut branch_props: Vec<PropertyInfo> = branch.into_values().collect();
                 branch_props.sort_by_key(|p| p.declaration_order);
                 let mut display_props = branch_props.clone();
-                crate::query_boundaries::common::normalize_display_property_order(
+                crate::query_boundaries::diagnostics::normalize_display_property_order(
                     &mut display_props,
                 );
                 let obj = self
@@ -394,7 +394,7 @@ impl<'a> CheckerState<'a> {
             {
                 if has_spread {
                     let mut display_props = properties.clone();
-                    crate::query_boundaries::common::normalize_display_property_order(
+                    crate::query_boundaries::diagnostics::normalize_display_property_order(
                         &mut display_props,
                     );
                     let type_id = self
@@ -430,7 +430,7 @@ impl<'a> CheckerState<'a> {
                                 display_prop
                             })
                             .collect();
-                        crate::query_boundaries::common::normalize_display_property_order(
+                        crate::query_boundaries::diagnostics::normalize_display_property_order(
                             &mut display_props,
                         );
                         self.ctx
@@ -535,7 +535,7 @@ impl<'a> CheckerState<'a> {
                 let display_props = if has_spread {
                     shape.mark_preserve_declaration_order();
                     let mut display_props = shape.properties.clone();
-                    crate::query_boundaries::common::normalize_display_property_order(
+                    crate::query_boundaries::diagnostics::normalize_display_property_order(
                         &mut display_props,
                     );
                     Some(display_props)


### PR DESCRIPTION
## Summary

Implements both phases of #12948 (ratchet `query_boundaries::common` domain-owned
helper placement, parent #8225 / #8223).

**Phase 1 — inventory ratchet.** New checker test
`crates/tsz-checker/src/tests/common_boundary_export_ratchets.rs` pins the exact
set of `pub(crate) fn` definitions allowed to live in `common.rs`. Adding *or*
removing a definition now forces an explicit, reviewable edit to the allowlist,
so the migration quarantine cannot silently refill during parity fixes. A
reappearance guard additionally blocks already-migrated helpers (#12916 +
this slice) from being redefined in `common.rs`. The module header documents the
one-line regeneration command for the allowlist.

**Phase 2 — first migration slice.** The display-widening cluster moves from
`common.rs` to its domain owner `query_boundaries::diagnostics`:
`deep_reduce_for_display`, `normalize_display_property_order`,
`widen_argument_type_for_display`, `boolean_literal_array_display_type`,
`get_base_constraint_for_display`, `display_widen_for_redeclaration`. All call
sites are routed through the diagnostics boundary. `common.rs` drops from 1834 to
1777 lines.

## Structural rule

When a helper expresses a domain-specific semantic policy — here, *diagnostic
display* widening/reduction (how a type is widened or reduced purely so the
printer renders the form `tsc` shows in a message) — it must be **defined** in
its named domain boundary module (`diagnostics`), not in the `common.rs`
migration quarantine. Behavior is unchanged: the relocated functions are
identical thin wrappers over the same solver entry points; only their module
home and the caller import paths changed.

## Owner layer

`tsz_checker::query_boundaries` — `diagnostics` (display policy) vs `common`
(cross-domain primitives awaiting solver ownership). No solver/checker semantic
behavior changes.

## Adjacent matrix

- Plain `fn` and generic `fn name<…>` definition forms both handled by the
  ratchet scanner and the reappearance/ownership guards (`deep_reduce_for_display`
  is the generic case).
- Callers updated across all consumers: `error_reporter` (call-error display,
  redeclaration display, base-constraint display, property-receiver formatting,
  fingerprint policy), `types::computation` (call_result, binary_support,
  object_literal_support), `checkers::jsx::spread`, `classes`.
- Allowlist equality is bidirectional, so the snapshot stays accurate as the
  quarantine drains in follow-on slices.

## Verification

- `cargo test -p tsz-checker --lib common_boundary_export_ratchets` — 3/3 pass.
- `cargo test -p tsz-checker --lib test_display_diagnostic_helpers_have_domain_boundary`
  and `compiler_managed_name_predicate_has_domain_boundary` — pass (existing
  boundary tests unaffected).
- `cargo test -p tsz-checker --lib redeclaration display_widen` — pass (behavior
  unchanged for the moved helpers).
- `cargo clippy -p tsz-checker --lib --tests` — clean.
- `python3 scripts/arch/arch_guard.py` — guardrails pass.
- Rebased on `origin/main` (`c259b63`), no conflicts.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a
- Evidence: refactor-only; pure relocation of identical thin-wrapper helpers plus
  a new test-only ratchet. No semantic, emit, or diagnostic output changes; the
  full local emit/JS baseline corpus is unaffected (no checker decision paths
  altered).

## Coordination Notes

- Does not touch the `contains_conditional_type` / `is_generic_mapped_type`
  recursive-content cluster claimed by #8225, to avoid duplicate PRs.
- Follow-on Phase 2 slices (object-member probes, callable shape, key/index
  surface) remain available; the ratchet now forces them to land in their domain
  owner.

AgentName: web-opus-boundary-ratchet
Track: checker architecture / query_boundaries
Invariant: no behavior change; domain-owned helper placement enforced by ratchet
Scope: crates/tsz-checker/src/query_boundaries/{common,diagnostics}.rs, ~17 caller sites, new ratchet test, lib.rs registration

https://claude.ai/code/session_01K3iPZgEz87i187LFHjHkJk

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3iPZgEz87i187LFHjHkJk)_