### PR TITLE
perf(checker): memoize collect_lazy_def_ids over immutable type structure

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -81,6 +81,9 @@ path = "tests/closure_boundary_property_narrowing_tests.rs"
 name = "flow_property_reference_cache_tests"
 path = "tests/flow_property_reference_cache_tests.rs"
 [[test]]
+name = "lazy_def_id_cache_tests"
+path = "tests/lazy_def_id_cache_tests.rs"
+[[test]]
 name = "assignment_branch_merge_narrowing_tests"
 path = "tests/assignment_branch_merge_narrowing_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -6,7 +6,7 @@ use crate::query_boundaries::assignability::{
     get_keyof_type, get_string_literal_value, get_union_members, is_type_parameter_like,
     keyof_object_properties, map_compound_members,
 };
-use crate::query_boundaries::common::{collect_lazy_def_ids, collect_type_queries};
+use crate::query_boundaries::common::collect_type_queries;
 use crate::state::CheckerState;
 use rustc_hash::FxHashSet;
 use tsz_common::interner::Atom;
@@ -1495,7 +1495,7 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            for def_id in collect_lazy_def_ids(self.ctx.types, current) {
+            for &def_id in self.ctx.collect_lazy_def_ids_cached(current).iter() {
                 if refs_resolution_fuel_exhausted() {
                     break;
                 }

--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -83,6 +83,7 @@ class_instance_type_cache = { lifetime = "FileLocalReset", capability = "FileTyp
 class_constructor_type_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 class_chain_summary_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 env_eval_cache = { lifetime = "FileLocalReset", capability = "RelationSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
+lazy_def_ids_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "pure speed memo of the lazy-DefId set reachable from a type; recomputable on demand, reset at file-session boundary" }
 class_symbol_to_decl_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 heritage_symbol_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 base_constructor_expr_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -136,6 +136,7 @@ impl<'a> CheckerContext<'a> {
             class_constructor_type_cache: FxHashMap::default(),
             class_chain_summary_cache: RefCell::new(FxHashMap::default()),
             env_eval_cache: RefCell::new(FxHashMap::default()),
+            lazy_def_ids_cache: RefCell::new(FxHashMap::default()),
             class_symbol_to_decl_cache: RefCell::new(FxHashMap::default()),
             heritage_symbol_cache: RefCell::new(FxHashMap::default()),
             base_constructor_expr_cache: RefCell::new(FxHashMap::default()),

--- a/crates/tsz-checker/src/context/env_eval_cache.rs
+++ b/crates/tsz-checker/src/context/env_eval_cache.rs
@@ -52,17 +52,36 @@ impl<'a> CheckerContext<'a> {
         self.env_eval_cache.borrow().len() <= ENV_EVAL_SEED_PERSIST_SOFT_CAP
     }
 
+    /// Memoized `collect_lazy_def_ids`: the walk is pure over the immutable
+    /// interned type structure, so the reachable lazy-`DefId` set is cached per
+    /// `type_id` and reused across the many hot callers that re-query the same
+    /// (lib-heavy) types. Returns an `Rc` slice for cheap clone-on-hit.
+    pub(crate) fn collect_lazy_def_ids_cached(
+        &self,
+        type_id: TypeId,
+    ) -> std::rc::Rc<[tsz_solver::DefId]> {
+        if let Some(cached) = self.lazy_def_ids_cache.borrow().get(&type_id) {
+            return std::rc::Rc::clone(cached);
+        }
+        let collected: std::rc::Rc<[tsz_solver::DefId]> =
+            crate::query_boundaries::common::collect_lazy_def_ids(self.types, type_id).into();
+        self.lazy_def_ids_cache
+            .borrow_mut()
+            .insert(type_id, std::rc::Rc::clone(&collected));
+        collected
+    }
+
     fn type_mentions_def(&self, type_id: TypeId, def_id: tsz_solver::DefId) -> bool {
-        crate::query_boundaries::common::contains_lazy_def_id(self.types, type_id, def_id)
+        self.collect_lazy_def_ids_cached(type_id).contains(&def_id)
     }
 
     /// Whether `type_id` references any type-alias `DefId` flagged as
     /// unconditionally-infinite (TS2589). Such aliases are error types in tsc,
     /// so assignments involving them must not produce structural mismatches.
     pub(crate) fn type_involves_depth_poisoned_def(&self, type_id: TypeId) -> bool {
-        crate::query_boundaries::common::collect_lazy_def_ids(self.types, type_id)
-            .into_iter()
-            .any(|def_id| self.definition_store.is_depth_poisoned(def_id))
+        self.collect_lazy_def_ids_cached(type_id)
+            .iter()
+            .any(|&def_id| self.definition_store.is_depth_poisoned(def_id))
     }
 
     pub(crate) fn lookup_env_eval_cache(&self, type_id: TypeId) -> Option<EnvEvalCacheEntry> {

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -722,6 +722,15 @@ pub struct CheckerContext<'a> {
     /// limit so follow-up validation passes can still surface TS2589 from a cache hit.
     pub(crate) env_eval_cache: RefCell<FxHashMap<TypeId, EnvEvalCacheEntry>>,
 
+    /// Memoizes the set of lazy `DefId`s reachable from a type (the structural
+    /// `collect_lazy_def_ids` walk). The walk is pure over the immutable interned
+    /// type structure, but it is re-run for the same (large, lib-heavy) types
+    /// from many hot callers (alias checking, assignability, type analysis,
+    /// `lib_augmentations`, the env-eval seed/persist scan), where it dominates
+    /// `walk_referenced_types` on real lib-heavy projects. Caching the result is
+    /// a pure speed memo: identical to recomputing on demand.
+    pub(crate) lazy_def_ids_cache: RefCell<FxHashMap<TypeId, std::rc::Rc<[DefId]>>>,
+
     /// Cache class symbol -> class declaration node lookups used in inheritance queries.
     /// Stores misses as `None` to avoid repeated declaration scans on hot paths.
     pub class_symbol_to_decl_cache: RefCell<FxHashMap<SymbolId, Option<NodeIndex>>>,

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_circular.rs
@@ -440,9 +440,11 @@ impl<'a> CheckerState<'a> {
                 .any(|sym_ref| sym_ref.0 == sym_id.0);
         let has_deferred_resolution_chain_ref =
             common::is_structurally_deferred_type(self.ctx.types, resolved_type)
-                && common::collect_lazy_def_ids(self.ctx.types, resolved_type)
-                    .into_iter()
-                    .any(|def_id| {
+                && self
+                    .ctx
+                    .collect_lazy_def_ids_cached(resolved_type)
+                    .iter()
+                    .any(|&def_id| {
                         self.ctx
                             .def_to_symbol
                             .borrow()

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -41,8 +41,7 @@ impl<'a> CheckerState<'a> {
         alias_def_id: tsz_solver::def::DefId,
         type_id: TypeId,
     ) -> bool {
-        let mut pending =
-            crate::query_boundaries::common::collect_lazy_def_ids(self.ctx.types, type_id);
+        let mut pending = self.ctx.collect_lazy_def_ids_cached(type_id).to_vec();
         if pending.is_empty() {
             return true;
         }
@@ -71,10 +70,7 @@ impl<'a> CheckerState<'a> {
                 return false;
             }
 
-            pending.extend(crate::query_boundaries::common::collect_lazy_def_ids(
-                self.ctx.types,
-                body,
-            ));
+            pending.extend(self.ctx.collect_lazy_def_ids_cached(body).iter().copied());
         }
 
         true

--- a/crates/tsz-checker/src/types/queries/lib_augmentations.rs
+++ b/crates/tsz-checker/src/types/queries/lib_augmentations.rs
@@ -201,8 +201,7 @@ impl<'a> CheckerState<'a> {
         if !crate::query_boundaries::common::type_id_is_known_to_db(self.ctx.types, type_id) {
             return false;
         }
-        for def_id in crate::query_boundaries::common::collect_lazy_def_ids(self.ctx.types, type_id)
-        {
+        for &def_id in self.ctx.collect_lazy_def_ids_cached(type_id).iter() {
             let has_body_in_env = self
                 .ctx
                 .type_env

--- a/crates/tsz-checker/tests/lazy_def_id_cache_tests.rs
+++ b/crates/tsz-checker/tests/lazy_def_id_cache_tests.rs
@@ -1,0 +1,67 @@
+//! Regression tests for the memoized `collect_lazy_def_ids` walk
+//! (`CheckerContext::collect_lazy_def_ids_cached`).
+//!
+//! The lazy-`DefId` set reachable from a type is a pure function of the
+//! immutable interned type structure, so it is cached per `type_id` and reused
+//! across the many hot callers (alias-cycle checking, assignability ref
+//! resolution, `lib_augmentations`, the env-eval seed/persist scan, TS2589
+//! depth-poison detection). These tests pin that the cache preserves behavior:
+//! a recursive alias referenced from multiple assignability positions (cache
+//! hits) must still narrow assignability correctly, and depth-poisoned infinite
+//! recursion must still be tolerated rather than producing structural noise.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+/// A recursive generic alias (`Tree<T>` carries a `Lazy(Tree)` ref) used in
+/// several assignment positions. Correct-typed assignments must pass and only
+/// the genuinely mismatched one (`Tree<number>` -> `Tree<string>`) trips TS2322.
+/// If the cache aliased or dropped reachable lazy def ids, structural
+/// assignability of the recursive shape would break.
+#[test]
+fn recursive_alias_assignability_is_stable_across_occurrences() {
+    let codes = check_source_strict_codes(
+        r#"
+type Tree<T> = { value: T; children: Tree<T>[] };
+declare const a: Tree<number>;
+const ok1: Tree<number> = a;
+const ok2: { value: number; children: Tree<number>[] } = a;
+const ok3: Tree<number> = a;
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "correct recursive-alias assignments must not error, got: {codes:?}"
+    );
+
+    let mismatch = check_source_strict_codes(
+        r#"
+type Tree<T> = { value: T; children: Tree<T>[] };
+declare const a: Tree<number>;
+const bad: Tree<string> = a;
+"#,
+    );
+    assert!(
+        mismatch.contains(&2322),
+        "Tree<number> assigned to Tree<string> must trip TS2322, got: {mismatch:?}"
+    );
+}
+
+/// Two distinct recursive aliases that share a member name must stay
+/// independent through the cached lazy-def-id walk: assigning one to the other
+/// must error, exercising the cache for two different reachable lazy def sets.
+#[test]
+fn distinct_recursive_aliases_do_not_alias_in_cache() {
+    let codes = check_source_strict_codes(
+        r#"
+type ListA = { head: number; tail: ListA | null };
+type ListB = { head: string; tail: ListB | null };
+declare const a: ListA;
+const sameOk: ListA = a;
+const crossBad: ListB = a;
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "ListA assigned to ListB must trip TS2322 (distinct lazy def sets), got: {codes:?}"
+    );
+}

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -379,7 +379,7 @@ toward the `2x` target or move a red runtime/residency row toward green.
 Track these as counters or periodic audit bullets. They are more useful than
 subjective "cleanup" language.
 
-1. `CheckerContext` field count, currently pinned at `242`, plus the number of
+1. `CheckerContext` field count, currently pinned at `243`, plus the number of
    checker `source_text.contains` / file-name / rendered-message
    diagnostic decisions.
 2. Number of post-check `rewrite_*_fingerprints` passes still active.

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -14,7 +14,7 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        242,
+        243,
     ),
 ]
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -992,7 +992,7 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        242,
+        243,
     ),
 ]
 


### PR DESCRIPTION
AgentName: StudioOpus

Track: Lib-interface residency performance (#12101). Data-driven from profiling the real vite-vanilla fixture after the flow-narrowing O(n^2) family landed (#12940/#12943/#12950).

## Summary

Benchmarking the worst sub-2x row showed vite-vanilla dropped to tsz 108ms vs tsgo 77ms (was 238 vs 113), and the remaining cost is dominated by lib resolution / lazy materialization. Within that, the `collect_lazy_def_ids` / `contains_lazy_def_id` structural walk (`walk_referenced_types`) is re-run for the same large lib-heavy types from many hot callers:

- `type_analysis::core` (alias-cycle checking)
- `assignability_checker` (ref resolution)
- `lib_augmentations`
- `computed_helpers_circular`
- `env_eval_cache` seed/persist scan (`type_mentions_def`)
- TS2589 depth-poison detection (`type_involves_depth_poisoned_def`)

## Structural rule

The reachable lazy-`DefId` set is a pure function of the immutable interned type structure. Memoize it per `type_id` (`CheckerContext::collect_lazy_def_ids_cached`, returning an `Rc<[DefId]>` for cheap clone-on-hit) and route those callers through it. `contains_lazy_def_id(root, t)` becomes `collect(root).contains(t)` — both use the identical `walk_referenced_types` traversal and neither short-circuits the walk, so results are byte-identical.

## Invariant

Pure speed memo: identical results to recomputing on demand; cache key is the (immutable) `type_id`. `FileLocalReset` so it never outlives a file session. Verified behavior-identical: full local conformance shows **0 unlisted regressions** (the 3 fingerprint diffs are pre-existing accepted-regressions, unrelated to this path); recursive 91/91, circular 36/36, infinite 16/16.

## Owner layer

`tsz_checker` context + the lazy-def-id callers (`context/{mod,constructors,env_eval_cache}`, `assignability/assignability_checker`, `state/type_analysis/{core,computed_helpers_circular}`, `types/queries/lib_augmentations`). No solver change — the underlying `collect_lazy_def_ids` walk is unchanged.

## Scope

13 files. 2 regression tests in a new `lazy_def_id_cache_tests.rs`. `CheckerContext` field count 242 -> 243 (cap + lifetime manifest + ROADMAP metric bumped).

## Project Corpus Impact
- Row: vite-vanilla-ts-app (lib-heavy; local --noEmit 0.12s -> 0.08s, ~33%), plus nextjs-fresh-app / ts-essentials-project (same lib-residency path)
- Bug family: n/a (performance; behavior-preserving, byte-identical diagnostics)

## Verification

- `cargo nextest run -p tsz-checker --test lazy_def_id_cache_tests` — 2/2.
- Full local conformance (`conformance.sh run --profile release`): 0 unlisted regressions; recursive/circular/infinite 100%.
- `scripts/arch/arch_guard.py` passes (243/243 classified); `cargo clippy -p tsz-checker --tests` clean.
- Perf: vite-vanilla `--noEmit` 0.12s -> 0.08s, stable across 8 runs.

## Coordination Notes

Follows the lib-residency campaign (#12101); independent of and complements the merged flow-narrowing PRs (#12940/#12943/#12950). Touches different files (no overlap).