### PR TITLE
perf(checker): cache package.json reads for typesVersions import redirect

### DIFF
--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -84,6 +84,7 @@ class_constructor_type_cache = { lifetime = "FileLocalReset", capability = "File
 class_chain_summary_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 env_eval_cache = { lifetime = "FileLocalReset", capability = "RelationSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 lazy_def_ids_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "pure speed memo of the lazy-DefId set reachable from a type; recomputable on demand, reset at file-session boundary" }
+package_json_cache = { lifetime = "FileLocalReset", capability = "ProgramLookupContext", reason = "memoized parsed package.json for typesVersions import redirect; process-stable within a compile, reset at file-session boundary so LSP picks up edits" }
 class_symbol_to_decl_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 heritage_symbol_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 base_constructor_expr_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -137,6 +137,7 @@ impl<'a> CheckerContext<'a> {
             class_chain_summary_cache: RefCell::new(FxHashMap::default()),
             env_eval_cache: RefCell::new(FxHashMap::default()),
             lazy_def_ids_cache: RefCell::new(FxHashMap::default()),
+            package_json_cache: RefCell::new(FxHashMap::default()),
             class_symbol_to_decl_cache: RefCell::new(FxHashMap::default()),
             heritage_symbol_cache: RefCell::new(FxHashMap::default()),
             base_constructor_expr_cache: RefCell::new(FxHashMap::default()),

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -731,6 +731,17 @@ pub struct CheckerContext<'a> {
     /// a pure speed memo: identical to recomputing on demand.
     pub(crate) lazy_def_ids_cache: RefCell<FxHashMap<TypeId, std::rc::Rc<[DefId]>>>,
 
+    /// Memoizes parsed `package.json` payloads (keyed by package-root path) for
+    /// the `typesVersions` import-redirect fallback. Without it,
+    /// `types_versions_redirected_target_index` re-reads and re-parses the same
+    /// `package.json` from disk on every import resolution — a dominant cost on
+    /// package-heavy real apps (e.g. nextjs re-resolving `react`/`next`). The
+    /// `None` slot caches "no readable/parseable package.json" so misses are not
+    /// retried. `package.json` is stable within a compile; reset at the
+    /// file-session boundary keeps the LSP picking up edits between compiles.
+    pub(crate) package_json_cache:
+        RefCell<FxHashMap<std::path::PathBuf, Option<std::rc::Rc<serde_json::Value>>>>,
+
     /// Cache class symbol -> class declaration node lookups used in inheritance queries.
     /// Stores misses as `None` to avoid repeated declaration scans on hot paths.
     pub class_symbol_to_decl_cache: RefCell<FxHashMap<SymbolId, Option<NodeIndex>>>,

--- a/crates/tsz-checker/src/context/package_resolution.rs
+++ b/crates/tsz-checker/src/context/package_resolution.rs
@@ -115,8 +115,7 @@ impl<'a> CheckerContext<'a> {
             .map(|source_file| source_file.file_name.as_str())?;
         let package_root =
             Self::node_modules_package_root_for_name(target_file_name, &package_name)?;
-        let package_json_text = std::fs::read_to_string(package_root.join("package.json")).ok()?;
-        let package_json = serde_json::from_str::<serde_json::Value>(&package_json_text).ok()?;
+        let package_json = self.cached_package_json(&package_root)?;
         let types_versions = package_json.get("typesVersions")?;
         let public_subpath = package_subpath.as_deref().unwrap_or("index");
 
@@ -141,6 +140,25 @@ impl<'a> CheckerContext<'a> {
         }
 
         None
+    }
+
+    /// Read and parse `<package_root>/package.json`, memoized per path. The file
+    /// is stable within a compile, so this collapses the repeated per-import
+    /// disk read + JSON parse to one per package root. The `None` slot caches an
+    /// unreadable/unparseable `package.json` so misses are not retried.
+    fn cached_package_json(&self, package_root: &Path) -> Option<std::rc::Rc<serde_json::Value>> {
+        let package_json_path = package_root.join("package.json");
+        if let Some(cached) = self.package_json_cache.borrow().get(&package_json_path) {
+            return cached.clone();
+        }
+        let parsed = std::fs::read_to_string(&package_json_path)
+            .ok()
+            .and_then(|text| serde_json::from_str::<serde_json::Value>(&text).ok())
+            .map(std::rc::Rc::new);
+        self.package_json_cache
+            .borrow_mut()
+            .insert(package_json_path, parsed.clone());
+        parsed
     }
 
     fn file_index_for_package_relative_path(

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -379,7 +379,7 @@ toward the `2x` target or move a red runtime/residency row toward green.
 Track these as counters or periodic audit bullets. They are more useful than
 subjective "cleanup" language.
 
-1. `CheckerContext` field count, currently pinned at `243`, plus the number of
+1. `CheckerContext` field count, currently pinned at `244`, plus the number of
    checker `source_text.contains` / file-name / rendered-message
    diagnostic decisions.
 2. Number of post-check `rewrite_*_fingerprints` passes still active.

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -14,7 +14,7 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        243,
+        244,
     ),
 ]
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -992,7 +992,7 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        243,
+        244,
     ),
 ]
 


### PR DESCRIPTION
AgentName: StudioOpus

Track: Module/package resolution performance (Campaign 5). Data-driven from profiling the real nextjs-fresh-app fixture after the flow-narrowing + lazy-def-id work landed.

## Summary

nextjs-fresh-app is the next sub-2x row after vite (tsz 83.6ms vs tsgo 77ms, down from 195 vs 116 in May). Profiling it showed `context::package_resolution` is ~7% of the run: the checker's `types_versions_redirected_target_index` fallback (for index-resolved bare imports) did `std::fs::read_to_string(<package_root>/package.json)` + a `serde_json` parse on **every** import resolution — including stage-1 precomputed `resolved_module_paths` hits — so package-heavy apps re-read the same `react`/`next` `package.json` repeatedly.

## Structural rule

`package.json` is stable within a compile, so memoize the parsed payload per package-root path (`CheckerContext::cached_package_json`), collapsing the repeated per-import disk read + parse to one per package root. The `None` slot caches an unreadable/unparseable file so misses are not retried. The typesVersions matching logic is unchanged — only the read is cached.

## Invariant

Pure speed memo: identical results to reading on demand (a read can't change mid-compile). `FileLocalReset` so a fresh checker session re-reads — the LSP picks up `package.json` edits between compiles. typesVersions parsing/matching (tested in `tsz-core`/`tsz-cli`) is untouched.

## Owner layer

`tsz_checker` context: `context/{mod,constructors,package_resolution}`. No resolver or driver change.

## Scope

7 files, +36/-5. `CheckerContext` field count 243 -> 244 (cap + lifetime manifest + ROADMAP metric bumped).

## Project Corpus Impact
- Row: nextjs-fresh-app (package-heavy; local --noEmit 0.09s -> 0.06s), plus any package-heavy real app re-resolving the same npm packages
- Bug family: n/a (performance; behavior-preserving, byte-identical diagnostics)

## Verification

- Full local conformance (`conformance.sh run --profile release`): 0 unlisted regressions (the 3 fingerprint diffs are pre-existing accepted-regressions).
- nextjs-fresh-app resolves with 0 diagnostics (unchanged) and `--noEmit` drops 0.09s -> 0.06s, stable across runs.
- `scripts/arch/arch_guard.py` passes (244/244 classified); `cargo clippy -p tsz-checker` clean.
- typesVersions resolution behavior is covered by `tsz-core` module_resolver tests + `tsz-cli` dual_package_exports tests (logic unchanged).

## Coordination Notes

Follows #13020 (merged) in the data-driven real-row campaign; touches different files (context/package_resolution vs the flow/type-analysis paths). No overlap with open PRs.