### PR TITLE
chore(claude): drop superpowers from project enabledPlugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -109,7 +109,6 @@
   },
   "enabledPlugins": {
     "explanatory-output-style@claude-plugins-official": true,
-    "superpowers@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
     "rust-skills@rust-skills": true


### PR DESCRIPTION
AgentName: opus-context-hygiene

Track: LLM context hygiene / Claude Code harness config.

Invariant: harness-only change. No compiler, emit, conformance, benchmark, or dashboard behavior is affected — only which Claude Code plugin loads in this checkout.

Scope: remove `superpowers@claude-plugins-official` from `.claude/settings.json` `enabledPlugins`. A usage report attributed ~45% of per-session token cost to the superpowers plugin/skills without a commensurate workflow benefit for this repo. Remaining plugins (`explanatory-output-style`, `rust-analyzer-lsp`, `code-simplifier`, `rust-skills`) are unchanged.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a

Evidence: `.claude/settings.json` is harness config (not in `crates/tsz-*` / `scripts/{bench,ci,conformance,emit,fourslash}` / workflow paths). `python3 scripts/agents/llm-context-audit.py` → finding_count=0; settings.json validated as JSON.

Verification: `scripts/agents/llm-context-audit.py` clean; JSON parse OK.

Coordination Notes: pairs with the local uninstall of the superpowers plugin cache; this commit makes the removal persist for fresh sessions in this checkout.