### PR TITLE
test(checker): recursive cross-lib Promise/PromiseLike parity gate (shared-lib-universe PR1)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -87,6 +87,9 @@ path = "tests/flow_property_reference_cache_tests.rs"
 name = "lazy_def_id_cache_tests"
 path = "tests/lazy_def_id_cache_tests.rs"
 [[test]]
+name = "recursive_lib_type_relation_tests"
+path = "tests/recursive_lib_type_relation_tests.rs"
+[[test]]
 name = "assignment_branch_merge_narrowing_tests"
 path = "tests/assignment_branch_merge_narrowing_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/recursive_lib_type_relation_tests.rs
+++ b/crates/tsz-checker/tests/recursive_lib_type_relation_tests.rs
@@ -1,0 +1,68 @@
+//! Parity invariant for the shared-lib-universe campaign.
+//!
+//! Recursive / cross-lib-file library types (`Promise<T>` ↔ `PromiseLike<T>`
+//! spanning lib.es5 + lib.es2015.promise, including nested
+//! `Promise<Promise<T>>` and chained `.then`) must resolve and relate identically whether the lib
+//! binder/arena are deep-cloned per checker (today) or shared read-only (the
+//! campaign payoff). These tests pin the structural relations that any sharing
+//! refactor must keep byte-identical — they are the green baseline re-run under
+//! both clone and shared modes.
+//!
+//! See memory `project_shared_lib_universe_campaign`. The arena-sharing
+//! experiment regressed exactly this class of cross-lib resolution
+//! (`recursiveComplicatedClasses` lost a `TS2345` on `Symbol`), so a sharing PR
+//! that keeps these green AND keeps `recursiveComplicatedClasses` is the bar.
+
+use tsz_checker::test_utils::{
+    check_source_with_libs_code_messages, load_default_lib_files, strict_checker_options,
+};
+
+/// Strict-mode diagnostic codes against the full default lib bundle (es2015+,
+/// so `Promise`/`PromiseLike`/`Awaited`/`IterableIterator` exist). Filters
+/// TS2318 missing-default-lib noise.
+fn check_source_strict_codes(source: &str) -> Vec<u32> {
+    let libs = load_default_lib_files();
+    check_source_with_libs_code_messages(source, "test.ts", strict_checker_options(), &libs)
+        .into_iter()
+        .map(|(code, _)| code)
+        .filter(|&code| code != 2318)
+        .collect()
+}
+
+/// `Promise<T>` is assignable to `PromiseLike<T>` — the canonical recursive,
+/// cross-lib-file relation (the two interfaces live in lib.es5 / lib.es2015 and
+/// reference each other through `.then`). Nested `Promise<Promise<T>>` and a
+/// user thenable assignable to `PromiseLike<T>` exercise the recursive `.then`
+/// resolution that the lib clone currently isolates per checker.
+#[test]
+fn recursive_lib_types_resolve_and_relate() {
+    let codes = check_source_strict_codes(
+        r#"
+declare const pr: Promise<number>;
+const pl: PromiseLike<number> = pr;
+declare const nested: Promise<Promise<number>>;
+const plNested: PromiseLike<Promise<number>> = nested;
+declare const t: Promise<number>;
+const back: Promise<number> = t.then((n) => n + 1).then((n) => n);
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "recursive/cross-lib Promise/PromiseLike relations must resolve cleanly, got: {codes:?}"
+    );
+}
+
+/// The relation is real, not vacuous: a mismatched type argument across the
+/// `Promise`/`PromiseLike` boundary must still trip TS2322.
+#[test]
+fn promise_like_relation_rejects_mismatched_type_argument() {
+    let codes = check_source_strict_codes(
+        r#"
+const p: PromiseLike<string> = (async () => 1)();
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "Promise<number> assigned to PromiseLike<string> must trip TS2322, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
AgentName: StudioOpus

Track: Performance / shared-immutable-lib-universe campaign (staged). This is PR1 — the parity gate established before any sharing refactor.

## Summary

The campaign goal is to bind lib.d.ts once and share it read-only across per-file checkers (like tsgo), eliminating the per-run lib clone (measured ~5ms vite / 6.7ms nextjs ≈ 7-10% of those runs; lib bootstrap ≈ 20%). It is high-blast-radius, so it is staged. This PR adds only the **parity invariant** every later PR must keep byte-identical, with no production change.

## Structural rule

Recursive, cross-lib-file library types must resolve and relate identically whether the lib binder/arena are deep-cloned per checker (today) or shared read-only (the payoff). `Promise<T> <: PromiseLike<T>` is the canonical case (the two interfaces live in different lib files and reference each other via `.then`); nested `Promise<Promise<T>>` and chained `.then` exercise the recursive resolution the per-checker clone currently isolates.

## Why this gate

An arena-sharing experiment during design regressed exactly this class — `recursiveComplicatedClasses` lost a `TS2345` (`TypeSymbol` not assignable to lib `Symbol`) — proving the lib clone is correctness-load-bearing. So these green tests + `recursiveComplicatedClasses` staying green are the bar a future sharing PR must clear.

## Invariant

No production behavior change — tests only. Uses the full default lib bundle (`load_default_lib_files` + `strict_checker_options`).

## Owner layer

`tsz_checker` tests.

## Scope

2 files, +71. New `recursive_lib_type_relation_tests.rs` (2 tests) + Cargo registration.

## Project Corpus Impact
- Row: n/a (campaign foundation; the eventual sharing PR targets vite-vanilla / nextjs-fresh-app / large-ts-repo)
- Bug family: n/a

## Verification

- `cargo nextest run -p tsz-checker --test recursive_lib_type_relation_tests` — 2/2.
- `cargo clippy -p tsz-checker --tests` clean.

## Coordination Notes

Full campaign design/critique + measured justification + the corrected understanding (the binder merge mutates the *program* binder, not the lib binder; the real sharing blocker is per-checker resolution-cache + arena resolution state) are in memory `project_shared_lib_universe_campaign`. Next PRs: resolve the parallel-bind data-race question, then isolate per-checker lib mutations into a per-file overlay, then share read-only.