### PR TITLE
fix(solver): guard recursive conditional-branch failure elaboration

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -195,6 +195,28 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source: TypeId,
         target: TypeId,
     ) -> Option<SubtypeFailureReason> {
+        // Route the public entry through the guarded path so the recursion
+        // guard brackets every elaboration, including the nested branch /
+        // member / constraint explanations that call `explain_failure_guarded`
+        // directly. Bracketing only here would leave those nested paths
+        // unguarded (see `explain_failure_guarded`).
+        self.explain_failure_guarded(source, target)
+    }
+
+    /// Guarded elaboration funnel. Every recursive elaboration path (object
+    /// members, mapped constraints, conditional branches, tuple/function
+    /// elements) routes back through this method, so applying the recursion
+    /// guard at this single point bounds the depth of mutually-recursive
+    /// conditional/mapped types. Without it, types like zod's
+    /// `ZodFormattedError<any>` -- whose conditional branches reintern to
+    /// fresh `(source, target)` pairs at every level -- recurse the explain
+    /// path until the stack overflows, even though the main relation check is
+    /// already depth-bounded.
+    fn explain_failure_guarded(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> Option<SubtypeFailureReason> {
         let pair = (source, target);
         match self.guard.enter(pair) {
             crate::recursion::RecursionResult::Entered => {}
@@ -207,12 +229,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 });
             }
         }
-        let result = self.explain_failure_guarded(source, target);
+        let result = self.explain_failure_body(source, target);
         self.guard.leave(pair);
         result
     }
 
-    fn explain_failure_guarded(
+    fn explain_failure_body(
         &mut self,
         source: TypeId,
         target: TypeId,


### PR DESCRIPTION
AgentName: StudioOpus

Track: Conformance / benchmark-canary fix-forward (zod compile crash).

Invariant: Diagnostic elaboration must terminate. The failure-explanation
path must be depth/cycle bounded exactly like the main relation check, so
mutually-recursive conditional types cannot drive the checker to a stack
overflow.

## Summary

The `zod` (3.9.7) canary compile-guard project aborts with
`fatal runtime error: stack overflow` instead of type-checking. An lldb
backtrace shows an unbounded cycle entirely inside the diagnostic
elaboration path:

```
explain_failure_inner -> explain_conditional_branch_failure -> explain_failure_inner -> ...
```

## Structural rule

When a relation between two mutually-recursive conditional types fails and
the checker elaborates *why*, each conditional branch reinterns to a fresh
`(source, target)` pair (e.g. zod's `ZodFormattedError<T>` whose array
branch is `ZodFormattedError<T[number]>[]`). tsc bounds elaboration depth;
tsz does X through the solver's `RecursionGuard`.

The recursion guard was applied only in the public `explain_failure`. But
`explain_failure_guarded` is the real funnel: every nested explanation
(object members, mapped constraints, conditional branches, tuple/function
elements) calls `explain_failure_guarded` *directly*, bypassing the guard.
The exact-pair short-circuit in `conditional_branch_reason`
(`branch_source == source && branch_target == target`) never fires for
these types because each expansion produces distinct TypeIds.

Fix: relocate the guard into `explain_failure_guarded` so every elaboration
path is depth/cycle bounded at a single point. On exhaustion the
elaboration terminates with a bounded `TypeMismatch` reason instead of
recursing forever. The main relation check was already depth-bounded, which
is why the crash only manifested on the slow diagnostic path.

Owner layer: solver (`relations/subtype/explain.rs`). No checker/emitter
changes; the printer still only reads types.

## Scope

- `crates/tsz-solver/src/relations/subtype/explain.rs`: move
  `guard.enter/leave` from `explain_failure` into `explain_failure_guarded`;
  split the former body into `explain_failure_body`.

Adjacent cases covered by the single funnel relocation: the same guard now
brackets object-member, mapped-constraint, and conditional-branch nested
explanations — not just the conditional path that surfaced the crash.

## Project Corpus Impact
- Row: zod-project
- Bug family: stack overflow in recursive conditional-type diagnostic elaboration

## Verification

- `zod` canary: pre-fix `tsz --noEmit -p tsconfig.tsz-guard.json` aborts
  (exit 134, stack overflow); post-fix type-checks to completion (exit 2,
  bounded diagnostics, 0 overflow).
- Reduced in-fixture witness: zod `ZodError.ts` + first 180 lines of
  `types.ts` (introducing `ZodType.safeParse`'s deferred `ZodError<Input>`
  return) — overflows pre-fix, terminates post-fix.
- `cargo nextest run -p tsz-solver`: explain/recursion/conditional/subtype
  suites pass (608 targeted; full suite green modulo a pre-existing
  arm64-local hashmap-ordering flake in
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`
  that reproduces with this change reverted and passes in CI `unit`).

## Coordination Notes

Out of scope (separate follow-ups, each a distinct root cause):
- The remaining 86 `zod` diagnostics are false-positive conformance bugs
  (zod is clean under tsc).
- `effect` canary also overflows, but in a *different* path —
  `tsz_checker::flow_domain::control_flow::typeof_exclusions::typeof_exclusion_mask_memoized`
  (flow-analysis recursion, not the solver explain path). Separate fix.
- `drizzle-orm` canary times out (perf, not crash).

The `zod` canary compile-guard row is the authoritative CI regression gate
for this crash.
