### PR TITLE
perf(parser): O(1)-cloneable NodeArena via Arc<NodeArenaInner> — cuts per-run lib clone 91%

### DIFF
--- a/crates/tsz-parser/src/parser/node.rs
+++ b/crates/tsz-parser/src/parser/node.rs
@@ -220,7 +220,7 @@ pub struct LiteralData {
     pub value: Option<f64>,
     /// `serde(default)` keeps deserialise back-compat with older outputs
     /// that elided this field. We dropped `skip_serializing_if` because
-    /// the lib-snapshot pipeline serializes `NodeArena` via bincode, and
+    /// the lib-snapshot pipeline serializes `NodeArena, NodeArenaInner` via bincode, and
     /// bincode's positional format desyncs on conditionally-elided
     /// fields. Always emitting a 1-byte bool adds <0.1% to JSON IPC
     /// payloads and is invisible in binary. See
@@ -1120,7 +1120,7 @@ pub(crate) struct NodeArenaPoolLengths {
 /// Arena for thin nodes with typed data pools.
 /// Provides O(1) allocation and cache-efficient storage.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct NodeArena {
+pub struct NodeArenaInner {
     /// The thin node headers (16 bytes each)
     pub nodes: Vec<Node>,
 
@@ -1260,6 +1260,91 @@ pub struct NodeArena {
     pub extended_info: Vec<ExtendedNodeInfo>,
 }
 
+/// Cheap-to-clone wrapper around the parse-immutable node arena.
+///
+/// The parser builds the arena through `DerefMut` (`Arc::make_mut`, free at
+/// refcount 1 during construction). Once built and shared — e.g. deep-cloned
+/// per checker by `clone_lib_files_for_checker` — the heavy typed pools are
+/// `Arc`-shared read-only, so cloning a `NodeArena` is an `Arc` bump instead of
+/// a deep copy of every pool. The distinct outer `Arc<NodeArenaInner>` identity
+/// is preserved per clone, so arena-pointer comparisons (lib-origin / current-
+/// file discriminators) behave exactly as with the prior deep clone.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct NodeArena {
+    inner: std::sync::Arc<NodeArenaInner>,
+}
+
+impl std::ops::Deref for NodeArena {
+    type Target = NodeArenaInner;
+    #[inline]
+    fn deref(&self) -> &NodeArenaInner {
+        &self.inner
+    }
+}
+
+impl std::ops::DerefMut for NodeArena {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut NodeArenaInner {
+        std::sync::Arc::make_mut(&mut self.inner)
+    }
+}
+
+impl NodeArena {
+    /// Construct an empty arena.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: std::sync::Arc::new(NodeArenaInner::new()),
+        }
+    }
+
+    /// Construct an arena with pool capacity pre-reserved for `capacity` nodes.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: std::sync::Arc::new(NodeArenaInner::with_capacity(capacity)),
+        }
+    }
+}
+
+/// Generate inherent `NodeArena` allocation wrappers that delegate to the inner
+/// arena via `Arc::make_mut`.
+///
+/// These shadow the `Deref`-reachable `NodeArenaInner` methods of the same name
+/// so that the parser's `self.arena.add_x(self.token_end())` calls resolve to a
+/// real inherent method (a two-phase-borrow receiver) rather than an explicit
+/// `DerefMut::deref_mut` call — preserving the two-phase borrow that lets an
+/// argument read `self` while the receiver is mutably borrowed. `make_mut` is
+/// free at refcount 1 (the parse-build case).
+macro_rules! delegate_arena_alloc {
+    ($($name:ident($($arg:ident: $ty:ty),* $(,)?));+ $(;)?) => {
+        impl NodeArena {
+            $(
+                #[inline]
+                pub fn $name(&mut self, $($arg: $ty),*) -> NodeIndex {
+                    std::sync::Arc::make_mut(&mut self.inner).$name($($arg),*)
+                }
+            )+
+        }
+    };
+}
+
+delegate_arena_alloc! {
+    add_token(kind: u16, pos: u32, end: u32);
+    add_block(kind: u16, pos: u32, end: u32, data: BlockData);
+    add_type_ref(kind: u16, pos: u32, end: u32, data: TypeRefData);
+    add_source_file(pos: u32, end: u32, data: SourceFileData);
+    add_binary_expr(kind: u16, pos: u32, end: u32, data: BinaryExprData);
+    add_jsx_opening(kind: u16, pos: u32, end: u32, data: JsxOpeningData);
+    add_expr_statement(kind: u16, pos: u32, end: u32, data: ExprStatementData);
+    add_variable_declaration(kind: u16, pos: u32, end: u32, data: VariableDeclarationData);
+    add_identifier(kind: u16, pos: u32, end: u32, data: IdentifierData);
+    add_expr_with_type_args(kind: u16, pos: u32, end: u32, data: ExprWithTypeArgsData);
+    add_computed_property(kind: u16, pos: u32, end: u32, data: ComputedPropertyData);
+    add_call_expr(kind: u16, pos: u32, end: u32, data: CallExprData);
+    create_modifier(kind: tsz_scanner::SyntaxKind, pos: u32);
+}
+
 /// Generate `pool_checkpoint` and `restore_pool_checkpoint` on `NodeArena`
 /// from a single canonical field list. Adding a new pool requires updating
 /// the field list here and in `NodeArenaPoolLengths`.
@@ -1286,7 +1371,7 @@ macro_rules! impl_pool_checkpoints {
     };
 }
 
-impl NodeArena {
+impl NodeArenaInner {
     impl_pool_checkpoints!(
         identifiers,
         qualified_names,

--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -18,11 +18,11 @@ use super::node::{
     JsxClosingData, JsxElementData, JsxExpressionData, JsxFragmentData, JsxNamespacedNameData,
     JsxOpeningData, JsxSpreadAttributeData, JsxTextData, JumpData, LabeledData, LiteralData,
     LiteralExprData, LiteralTypeData, LoopData, MappedTypeData, MethodDeclData, ModuleBlockData,
-    ModuleData, NamedImportsData, NamedTupleMemberData, Node, NodeArena, ParameterData,
-    ParenthesizedData, PropertyAssignmentData, PropertyDeclData, QualifiedNameData, ReturnData,
-    ShorthandPropertyData, SignatureData, SourceFileData, SpecifierData, SpreadData, SwitchData,
-    TaggedTemplateData, TemplateExprData, TemplateLiteralTypeData, TemplateSpanData, TryData,
-    TupleTypeData, TypeAliasData, TypeAssertionData, TypeLiteralData, TypeOperatorData,
+    ModuleData, NamedImportsData, NamedTupleMemberData, Node, NodeArena, NodeArenaInner,
+    ParameterData, ParenthesizedData, PropertyAssignmentData, PropertyDeclData, QualifiedNameData,
+    ReturnData, ShorthandPropertyData, SignatureData, SourceFileData, SpecifierData, SpreadData,
+    SwitchData, TaggedTemplateData, TemplateExprData, TemplateLiteralTypeData, TemplateSpanData,
+    TryData, TupleTypeData, TypeAliasData, TypeAssertionData, TypeLiteralData, TypeOperatorData,
     TypeParameterData, TypePredicateData, TypeQueryData, TypeRefData, UnaryExprData,
     UnaryExprDataEx, VariableData, VariableDeclarationData, WrappedTypeData,
 };
@@ -38,7 +38,7 @@ use super::syntax_kind_ext::{
     TYPE_PREDICATE, VARIABLE_DECLARATION, VARIABLE_DECLARATION_LIST, VARIABLE_STATEMENT,
 };
 
-impl NodeArena {
+impl NodeArenaInner {
     /// Get a thin node by index
     #[inline]
     #[must_use]

--- a/crates/tsz-parser/src/parser/node_access_typed_getters.rs
+++ b/crates/tsz-parser/src/parser/node_access_typed_getters.rs
@@ -7,13 +7,13 @@ use super::node::{
     ArrayTypeData, BindingElementData, BindingPatternData, CompositeTypeData, ComputedPropertyData,
     ConditionalTypeData, ExprWithTypeArgsData, FunctionTypeData, HeritageData, IndexSignatureData,
     IndexedAccessTypeData, InferTypeData, LiteralTypeData, MappedTypeData, NamedTupleMemberData,
-    Node, NodeArena, ParenthesizedData, ShorthandPropertyData, SignatureData, SpreadData,
+    Node, NodeArenaInner, ParenthesizedData, ShorthandPropertyData, SignatureData, SpreadData,
     TaggedTemplateData, TemplateExprData, TemplateLiteralTypeData, TemplateSpanData, TupleTypeData,
     TypeLiteralData, TypeOperatorData, TypeParameterData, TypePredicateData, TypeQueryData,
     WrappedTypeData,
 };
 
-impl NodeArena {
+impl NodeArenaInner {
     /// Get signature data (call, construct, method, property signatures).
     #[inline]
     #[must_use]

--- a/crates/tsz-parser/src/parser/node_arena/declarations.rs
+++ b/crates/tsz-parser/src/parser/node_arena/declarations.rs
@@ -5,11 +5,11 @@
 use crate::parser::base::NodeIndex;
 use crate::parser::node::{
     ClassData, EnumData, EnumMemberData, ExtendedNodeInfo, FunctionData, InterfaceData,
-    ModuleBlockData, ModuleData, Node, NodeArena, TypeAliasData, VariableData,
+    ModuleBlockData, ModuleData, Node, NodeArenaInner, TypeAliasData, VariableData,
     VariableDeclarationData,
 };
 
-impl NodeArena {
+impl NodeArenaInner {
     /// Add a function node
     pub fn add_function(&mut self, kind: u16, pos: u32, end: u32, data: FunctionData) -> NodeIndex {
         let modifiers = data.modifiers.clone();

--- a/crates/tsz-parser/src/parser/node_arena/expressions.rs
+++ b/crates/tsz-parser/src/parser/node_arena/expressions.rs
@@ -5,12 +5,12 @@
 use crate::parser::base::NodeIndex;
 use crate::parser::node::{
     AccessExprData, BinaryExprData, CallExprData, ComputedPropertyData, ConditionalExprData,
-    ExprWithTypeArgsData, ExtendedNodeInfo, LiteralExprData, Node, NodeArena, ParenthesizedData,
-    QualifiedNameData, SpreadData, TaggedTemplateData, TemplateExprData, TemplateSpanData,
-    TypeAssertionData, UnaryExprData, UnaryExprDataEx,
+    ExprWithTypeArgsData, ExtendedNodeInfo, LiteralExprData, Node, NodeArenaInner,
+    ParenthesizedData, QualifiedNameData, SpreadData, TaggedTemplateData, TemplateExprData,
+    TemplateSpanData, TypeAssertionData, UnaryExprData, UnaryExprDataEx,
 };
 
-impl NodeArena {
+impl NodeArenaInner {
     /// Add a qualified name node
     pub fn add_qualified_name(
         &mut self,

--- a/crates/tsz-parser/src/parser/node_arena/imports_exports.rs
+++ b/crates/tsz-parser/src/parser/node_arena/imports_exports.rs
@@ -5,11 +5,11 @@
 use crate::parser::base::NodeIndex;
 use crate::parser::node::{
     ExportAssignmentData, ExportDeclData, ExtendedNodeInfo, ImportAttributeData,
-    ImportAttributesData, ImportClauseData, ImportDeclData, NamedImportsData, Node, NodeArena,
+    ImportAttributesData, ImportClauseData, ImportDeclData, NamedImportsData, Node, NodeArenaInner,
     SpecifierData,
 };
 
-impl NodeArena {
+impl NodeArenaInner {
     /// Add an import declaration node
     pub fn add_import_decl(
         &mut self,

--- a/crates/tsz-parser/src/parser/node_arena/jsx.rs
+++ b/crates/tsz-parser/src/parser/node_arena/jsx.rs
@@ -6,10 +6,10 @@ use crate::parser::base::NodeIndex;
 use crate::parser::node::{
     ExtendedNodeInfo, JsxAttributeData, JsxAttributesData, JsxClosingData, JsxElementData,
     JsxExpressionData, JsxFragmentData, JsxNamespacedNameData, JsxOpeningData,
-    JsxSpreadAttributeData, JsxTextData, Node, NodeArena,
+    JsxSpreadAttributeData, JsxTextData, Node, NodeArenaInner,
 };
 
-impl NodeArena {
+impl NodeArenaInner {
     /// Add a JSX element node
     pub fn add_jsx_element(
         &mut self,

--- a/crates/tsz-parser/src/parser/node_arena/members.rs
+++ b/crates/tsz-parser/src/parser/node_arena/members.rs
@@ -6,11 +6,11 @@
 use crate::parser::base::NodeIndex;
 use crate::parser::node::{
     AccessorData, ConstructorData, DecoratorData, ExtendedNodeInfo, HeritageData,
-    IndexSignatureData, MethodDeclData, Node, NodeArena, ParameterData, PropertyDeclData,
+    IndexSignatureData, MethodDeclData, Node, NodeArenaInner, ParameterData, PropertyDeclData,
     SignatureData, TypeParameterData,
 };
 
-impl NodeArena {
+impl NodeArenaInner {
     /// Add a signature node (property/method signature)
     pub fn add_signature(
         &mut self,

--- a/crates/tsz-parser/src/parser/node_arena/mod.rs
+++ b/crates/tsz-parser/src/parser/node_arena/mod.rs
@@ -32,11 +32,13 @@ mod statements;
 mod types;
 
 use super::base::{NodeIndex, NodeList};
-use super::node::{ExtendedNodeInfo, IdentifierData, LiteralData, Node, NodeArena, SourceFileData};
+use super::node::{
+    ExtendedNodeInfo, IdentifierData, LiteralData, Node, NodeArenaInner, SourceFileData,
+};
 
 use tsz_common::interner::{Atom, Interner};
 
-impl NodeArena {
+impl NodeArenaInner {
     /// Maximum pre-allocation to avoid capacity overflow in huge files.
     const MAX_NODE_PREALLOC: usize = 5_000_000;
 
@@ -326,6 +328,7 @@ impl NodeArena {
 
 #[cfg(test)]
 mod tests {
+    use super::super::node::NodeArena;
     use super::*;
 
     #[test]

--- a/crates/tsz-parser/src/parser/node_arena/patterns.rs
+++ b/crates/tsz-parser/src/parser/node_arena/patterns.rs
@@ -3,11 +3,11 @@
 
 use crate::parser::base::NodeIndex;
 use crate::parser::node::{
-    BindingElementData, BindingPatternData, ExtendedNodeInfo, Node, NodeArena,
+    BindingElementData, BindingPatternData, ExtendedNodeInfo, Node, NodeArenaInner,
     PropertyAssignmentData, ShorthandPropertyData,
 };
 
-impl NodeArena {
+impl NodeArenaInner {
     /// Add a binding pattern node
     pub fn add_binding_pattern(
         &mut self,

--- a/crates/tsz-parser/src/parser/node_arena/statements.rs
+++ b/crates/tsz-parser/src/parser/node_arena/statements.rs
@@ -4,11 +4,11 @@
 use crate::parser::base::NodeIndex;
 use crate::parser::node::{
     BlockData, CaseClauseData, CatchClauseData, ExprStatementData, ExtendedNodeInfo, ForInOfData,
-    IfStatementData, JumpData, LabeledData, LoopData, Node, NodeArena, ReturnData, SwitchData,
+    IfStatementData, JumpData, LabeledData, LoopData, Node, NodeArenaInner, ReturnData, SwitchData,
     TryData, WithData,
 };
 
-impl NodeArena {
+impl NodeArenaInner {
     /// Add a block node
     pub fn add_block(&mut self, kind: u16, pos: u32, end: u32, data: BlockData) -> NodeIndex {
         let statements = data.statements.clone();

--- a/crates/tsz-parser/src/parser/node_arena/types.rs
+++ b/crates/tsz-parser/src/parser/node_arena/types.rs
@@ -7,11 +7,11 @@ use crate::parser::base::NodeIndex;
 use crate::parser::node::{
     ArrayTypeData, CompositeTypeData, ConditionalTypeData, ExtendedNodeInfo, FunctionTypeData,
     IndexedAccessTypeData, InferTypeData, LiteralTypeData, MappedTypeData, NamedTupleMemberData,
-    Node, NodeArena, TemplateLiteralTypeData, TupleTypeData, TypeLiteralData, TypeOperatorData,
-    TypePredicateData, TypeQueryData, TypeRefData, WrappedTypeData,
+    Node, NodeArenaInner, TemplateLiteralTypeData, TupleTypeData, TypeLiteralData,
+    TypeOperatorData, TypePredicateData, TypeQueryData, TypeRefData, WrappedTypeData,
 };
 
-impl NodeArena {
+impl NodeArenaInner {
     /// Add a type reference node
     pub fn add_type_ref(&mut self, kind: u16, pos: u32, end: u32, data: TypeRefData) -> NodeIndex {
         let type_name = data.type_name;

--- a/crates/tsz-parser/src/parser/node_children.rs
+++ b/crates/tsz-parser/src/parser/node_children.rs
@@ -7,7 +7,7 @@
 //! patterns, JSX, signatures, source files).
 
 use super::base::{NodeIndex, NodeList};
-use super::node::{Node, NodeArena};
+use super::node::{Node, NodeArenaInner};
 use super::syntax_kind_ext::{
     ARRAY_BINDING_PATTERN, ARRAY_LITERAL_EXPRESSION, ARRAY_TYPE, ARROW_FUNCTION, AS_EXPRESSION,
     AWAIT_EXPRESSION, BINARY_EXPRESSION, BINDING_ELEMENT, BLOCK, BREAK_STATEMENT, CALL_EXPRESSION,
@@ -38,7 +38,7 @@ use super::syntax_kind_ext::{
     YIELD_EXPRESSION,
 };
 
-impl NodeArena {
+impl NodeArenaInner {
     #[inline]
     pub(crate) fn add_opt_child(children: &mut Vec<NodeIndex>, idx: NodeIndex) {
         if idx.is_some() {

--- a/crates/tsz-parser/src/parser/node_modifiers.rs
+++ b/crates/tsz-parser/src/parser/node_modifiers.rs
@@ -6,11 +6,11 @@
 //! and lowering crates.
 
 use super::base::{NodeIndex, NodeList};
-use super::node::NodeArena;
+use super::node::NodeArenaInner;
 use tsz_common::Visibility;
 use tsz_scanner::SyntaxKind;
 
-impl NodeArena {
+impl NodeArenaInner {
     /// Check whether a modifier list contains a modifier of the given kind.
     ///
     /// This is the single source of truth for the "scan modifiers for a kind"

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -150,7 +150,7 @@ impl ParserState {
                     name,
                     type_parameters: None,
                     heritage_clauses: None,
-                    members: self.make_node_list(vec![]),
+                    members: Self::make_node_list(vec![]),
                 },
             );
         }
@@ -187,10 +187,10 @@ impl ParserState {
                     clause_end,
                     crate::parser::node::HeritageData {
                         token: SyntaxKind::ExtendsKeyword as u16,
-                        types: self.make_node_list(vec![]),
+                        types: Self::make_node_list(vec![]),
                     },
                 );
-                return self.make_node_list(vec![clause]);
+                return Self::make_node_list(vec![clause]);
             }
 
             let mut types = Vec::new();
@@ -209,10 +209,10 @@ impl ParserState {
                 clause_end,
                 crate::parser::node::HeritageData {
                     token: SyntaxKind::ExtendsKeyword as u16,
-                    types: self.make_node_list(types),
+                    types: Self::make_node_list(types),
                 },
             );
-            self.make_node_list(vec![clause])
+            Self::make_node_list(vec![clause])
         });
 
         // TS1176: Interface declaration cannot have 'implements' clause.
@@ -355,7 +355,7 @@ impl ParserState {
             }
         }
 
-        self.make_node_list(members)
+        Self::make_node_list(members)
     }
 
     /// Parse a single type member (property signature, method signature, call signature, construct signature)
@@ -602,7 +602,7 @@ impl ParserState {
             let mod_idx = self
                 .arena
                 .create_modifier(SyntaxKind::ReadonlyKeyword, start_pos);
-            self.make_node_list(vec![mod_idx])
+            Self::make_node_list(vec![mod_idx])
         })
     }
 
@@ -719,7 +719,7 @@ impl ParserState {
             self.parse_expected(SyntaxKind::CloseParenToken);
             parameters
         } else {
-            self.make_node_list(vec![])
+            Self::make_node_list(vec![])
         };
 
         // TS1005: call signatures cannot be optional — emit "';' expected." at '?'
@@ -777,7 +777,7 @@ impl ParserState {
             self.parse_expected(SyntaxKind::CloseParenToken);
             parameters
         } else {
-            self.make_node_list(vec![])
+            Self::make_node_list(vec![])
         };
 
         // TS1005: construct signatures cannot be optional — emit "';' expected." at '?'
@@ -862,7 +862,7 @@ impl ParserState {
                 end_pos,
                 crate::parser::node::IndexSignatureData {
                     modifiers,
-                    parameters: self.make_node_list(vec![]),
+                    parameters: Self::make_node_list(vec![]),
                     type_annotation,
                 },
             );
@@ -1079,7 +1079,7 @@ impl ParserState {
                 modifiers: if param_modifiers.is_empty() {
                     None
                 } else {
-                    Some(self.make_node_list(param_modifiers))
+                    Some(Self::make_node_list(param_modifiers))
                 },
                 dot_dot_dot_token,
                 name: param_name,
@@ -1096,7 +1096,7 @@ impl ParserState {
             end_pos,
             crate::parser::node::IndexSignatureData {
                 modifiers,
-                parameters: self.make_node_list(vec![param_node]),
+                parameters: Self::make_node_list(vec![param_node]),
                 type_annotation,
             },
         )
@@ -1135,7 +1135,7 @@ impl ParserState {
                 modifiers: None,
                 name,
                 type_parameters: None,
-                parameters: self.make_node_list(vec![]),
+                parameters: Self::make_node_list(vec![]),
                 type_annotation,
                 body,
             },
@@ -1350,7 +1350,7 @@ impl ParserState {
         let members = if has_open_brace {
             self.parse_enum_members()
         } else {
-            self.make_node_list(Vec::new())
+            Self::make_node_list(Vec::new())
         };
 
         if has_open_brace {
@@ -1534,7 +1534,7 @@ impl ParserState {
             }
         }
 
-        self.make_node_list(members)
+        Self::make_node_list(members)
     }
 
     // =========================================================================
@@ -1572,7 +1572,7 @@ impl ParserState {
 
         let node = match self.token() {
             SyntaxKind::FunctionKeyword => {
-                let modifiers = Some(self.make_node_list(vec![declare_modifier]));
+                let modifiers = Some(Self::make_node_list(vec![declare_modifier]));
                 self.parse_function_declaration_with_async(false, modifiers)
             }
             SyntaxKind::ClassKeyword => self.parse_declare_class(start_pos, declare_modifier),
@@ -1581,15 +1581,15 @@ impl ParserState {
                 self.parse_declare_abstract_class(start_pos, declare_modifier)
             }
             SyntaxKind::InterfaceKeyword => {
-                let modifiers = Some(self.make_node_list(vec![declare_modifier]));
+                let modifiers = Some(Self::make_node_list(vec![declare_modifier]));
                 self.parse_interface_declaration_with_modifiers(start_pos, modifiers)
             }
             SyntaxKind::TypeKeyword => {
-                let modifiers = Some(self.make_node_list(vec![declare_modifier]));
+                let modifiers = Some(Self::make_node_list(vec![declare_modifier]));
                 self.parse_type_alias_declaration_with_modifiers(start_pos, modifiers)
             }
             SyntaxKind::EnumKeyword => {
-                let modifiers = Some(self.make_node_list(vec![declare_modifier]));
+                let modifiers = Some(Self::make_node_list(vec![declare_modifier]));
                 self.parse_enum_declaration_with_modifiers(start_pos, modifiers)
             }
             SyntaxKind::NamespaceKeyword
@@ -1598,7 +1598,7 @@ impl ParserState {
                 self.parse_declare_module_with_modifiers(start_pos, all_modifiers)
             }
             SyntaxKind::VarKeyword | SyntaxKind::LetKeyword => {
-                let modifiers = self.make_node_list(vec![declare_modifier]);
+                let modifiers = Self::make_node_list(vec![declare_modifier]);
                 self.parse_variable_statement_with_modifiers(Some(start_pos), Some(modifiers))
             }
             SyntaxKind::ConstKeyword => {
@@ -1606,13 +1606,13 @@ impl ParserState {
                 if self.look_ahead_is_const_enum() {
                     self.parse_const_enum_declaration(start_pos, vec![declare_modifier])
                 } else {
-                    let modifiers = self.make_node_list(vec![declare_modifier]);
+                    let modifiers = Self::make_node_list(vec![declare_modifier]);
                     self.parse_variable_statement_with_modifiers(Some(start_pos), Some(modifiers))
                 }
             }
             SyntaxKind::UsingKeyword => {
                 // declare using
-                let modifiers = self.make_node_list(vec![declare_modifier]);
+                let modifiers = Self::make_node_list(vec![declare_modifier]);
                 self.parse_variable_statement_with_modifiers(Some(start_pos), Some(modifiers))
             }
             SyntaxKind::ImportKeyword => {
@@ -1625,7 +1625,7 @@ impl ParserState {
                     diagnostic_codes::A_MODIFIER_CANNOT_BE_USED_WITH_AN_IMPORT_DECLARATION,
                 );
 
-                let modifiers = Some(self.make_node_list(all_modifiers));
+                let modifiers = Some(Self::make_node_list(all_modifiers));
                 if self.look_ahead_is_import_equals() {
                     self.parse_import_equals_declaration_with_modifiers(start_pos, modifiers)
                 } else {
@@ -1634,7 +1634,7 @@ impl ParserState {
             }
             SyntaxKind::AwaitKeyword => {
                 // declare await using
-                let modifiers = self.make_node_list(vec![declare_modifier]);
+                let modifiers = Self::make_node_list(vec![declare_modifier]);
                 self.parse_variable_statement_with_modifiers(Some(start_pos), Some(modifiers))
             }
             SyntaxKind::ExportKeyword => {
@@ -1648,7 +1648,7 @@ impl ParserState {
                     export_start,
                     export_end,
                 );
-                let modifiers = self.make_node_list(vec![declare_modifier, export_modifier]);
+                let modifiers = Self::make_node_list(vec![declare_modifier, export_modifier]);
                 // TS1029: 'export' modifier must precede 'declare' modifier.
                 // Skip for `declare export as namespace` (valid UMD pattern) and
                 // `declare export = expr` (export assignment — TS1120 handles it).
@@ -1757,7 +1757,7 @@ impl ParserState {
                 }
                 // Pass the declare modifier to the function
                 self.parse_expected(SyntaxKind::AsyncKeyword);
-                let modifiers = Some(self.make_node_list(vec![declare_modifier]));
+                let modifiers = Some(Self::make_node_list(vec![declare_modifier]));
                 self.parse_function_declaration_with_async(true, modifiers)
             }
             _ => {

--- a/crates/tsz-parser/src/parser/state_declarations_exports.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_exports.rs
@@ -82,7 +82,7 @@ impl ParserState {
                 start_pos,
                 start_pos + keyword_text_len(SyntaxKind::ExportKeyword),
             );
-            let modifiers = Some(self.make_node_list(vec![export_modifier]));
+            let modifiers = Some(Self::make_node_list(vec![export_modifier]));
             return self.parse_import_declaration_with_modifiers(start_pos, modifiers);
         }
 
@@ -630,7 +630,7 @@ impl ParserState {
             end_pos,
             NamedImportsData {
                 name: NodeIndex::NONE, // Not a namespace export
-                elements: self.make_node_list(elements),
+                elements: Self::make_node_list(elements),
             },
         )
     }
@@ -1170,7 +1170,7 @@ impl ParserState {
             start_pos,
             end_pos,
             BlockData {
-                statements: self.make_node_list(Vec::new()),
+                statements: Self::make_node_list(Vec::new()),
                 multi_line: true,
             },
         )
@@ -1181,7 +1181,7 @@ impl ParserState {
         let (declaration_keyword, flags) =
             self.parse_for_variable_declaration_declaration_keyword();
         let declarations = self.parse_for_variable_declarations(declaration_keyword);
-        let declarations_list = self.make_node_list(declarations);
+        let declarations_list = Self::make_node_list(declarations);
         let end_pos = self.token_end();
 
         self.arena.add_variable_with_flags(
@@ -1776,7 +1776,7 @@ impl ParserState {
             start_pos,
             case_block_end,
             BlockData {
-                statements: self.make_node_list(clauses),
+                statements: Self::make_node_list(clauses),
                 multi_line: true,
             },
         );

--- a/crates/tsz-parser/src/parser/state_declarations_modules.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_modules.rs
@@ -203,7 +203,7 @@ impl ParserState {
         // Skip module/namespace/global keyword
         let is_global = self.is_token(SyntaxKind::GlobalKeyword);
         let is_namespace_keyword = self.is_token(SyntaxKind::NamespaceKeyword);
-        let modifiers = Some(self.make_node_list(modifiers_vec));
+        let modifiers = Some(Self::make_node_list(modifiers_vec));
         let name = if is_global {
             let name_start = self.token_pos();
             let name_end = self.token_end();
@@ -715,7 +715,7 @@ impl ParserState {
         self.parse_expected(SyntaxKind::CloseBraceToken);
         let end_pos = self.token_end();
 
-        let node_list = self.make_node_list(elements);
+        let node_list = Self::make_node_list(elements);
         self.arena.add_import_attributes(
             syntax_kind_ext::IMPORT_ATTRIBUTES,
             start_pos,
@@ -950,7 +950,7 @@ impl ParserState {
             end_pos,
             NamedImportsData {
                 name,
-                elements: self.make_node_list(Vec::new()),
+                elements: Self::make_node_list(Vec::new()),
             },
         )
     }
@@ -1115,7 +1115,7 @@ impl ParserState {
             end_pos,
             NamedImportsData {
                 name: NodeIndex::NONE, // Not a namespace import
-                elements: self.make_node_list(elements),
+                elements: Self::make_node_list(elements),
             },
         )
     }

--- a/crates/tsz-parser/src/parser/state_exports_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_exports_recovery.rs
@@ -83,7 +83,7 @@ impl ParserState {
                     start_pos,
                     start_pos + 6,
                 );
-                let modifiers = self.make_node_list(vec![export_node]);
+                let modifiers = Self::make_node_list(vec![export_node]);
                 self.parse_variable_statement_with_modifiers(Some(start_pos), Some(modifiers))
             }
             SyntaxKind::ConstKeyword => self.parse_export_const_or_variable(),
@@ -102,7 +102,7 @@ impl ParserState {
                         start_pos,
                         start_pos + keyword_text_len(SyntaxKind::ExportKeyword),
                     );
-                    let modifiers = Some(self.make_node_list(vec![export_modifier]));
+                    let modifiers = Some(Self::make_node_list(vec![export_modifier]));
                     self.parse_import_declaration_with_modifiers(start_pos, modifiers)
                 }
             }
@@ -157,7 +157,7 @@ impl ParserState {
                             second_export_pos,
                             second_export_end,
                         );
-                        let modifiers = Some(self.make_node_list(vec![export_modifier]));
+                        let modifiers = Some(Self::make_node_list(vec![export_modifier]));
                         self.parse_class_declaration_with_modifiers(second_export_pos, modifiers)
                     } else {
                         self.parse_exported_declaration(start_pos)
@@ -335,7 +335,7 @@ impl ParserState {
             let async_modifier =
                 self.arena
                     .add_token(SyntaxKind::AsyncKeyword as u16, async_start, async_end);
-            let modifiers = Some(self.make_node_list(vec![async_modifier]));
+            let modifiers = Some(Self::make_node_list(vec![async_modifier]));
             match self.token() {
                 SyntaxKind::ClassKeyword => {
                     self.parse_class_declaration_with_modifiers(async_start_pos, modifiers)
@@ -387,7 +387,7 @@ impl ParserState {
                 export_start,
                 export_end,
             );
-            let modifiers = self.make_node_list(vec![export_node]);
+            let modifiers = Self::make_node_list(vec![export_node]);
             self.parse_variable_statement_with_modifiers(Some(export_start), Some(modifiers))
         }
     }

--- a/crates/tsz-parser/src/parser/state_expressions_arrow.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_arrow.rs
@@ -754,7 +754,7 @@ impl ParserState {
                     initializer: NodeIndex::NONE,
                 },
             );
-            self.make_node_list(vec![param])
+            Self::make_node_list(vec![param])
         };
 
         // Parse optional return type annotation (supports type predicates: x is T)

--- a/crates/tsz-parser/src/parser/state_expressions_call_member.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_call_member.rs
@@ -277,7 +277,7 @@ impl ParserState {
                             CallExprData {
                                 expression: expr,
                                 type_arguments: Some(type_args),
-                                arguments: Some(self.make_node_list(Vec::new())),
+                                arguments: Some(Self::make_node_list(Vec::new())),
                             },
                         );
                         let optional_chain_flag =

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -274,7 +274,7 @@ impl ParserState {
             end_pos,
             crate::parser::node::BindingPatternData {
                 elements: {
-                    let mut list = self.make_node_list(elements);
+                    let mut list = Self::make_node_list(elements);
                     list.has_trailing_comma = has_trailing_comma;
                     list
                 },
@@ -455,7 +455,7 @@ impl ParserState {
             start_pos,
             end_pos,
             crate::parser::node::BindingPatternData {
-                elements: self.make_node_list(elements),
+                elements: Self::make_node_list(elements),
             },
         )
     }
@@ -1053,7 +1053,7 @@ impl ParserState {
         if let Some(opt) = options {
             args.push(opt);
         }
-        let arguments = self.make_node_list(args);
+        let arguments = Self::make_node_list(args);
 
         self.arena.add_call_expr(
             syntax_kind_ext::CALL_EXPRESSION,
@@ -1146,7 +1146,7 @@ impl ParserState {
             }
         };
 
-        (end_pos, self.make_node_list(spans))
+        (end_pos, Self::make_node_list(spans))
     }
 
     fn parse_template_expression_span(&mut self) -> (u32, NodeIndex, bool) {
@@ -1638,7 +1638,7 @@ impl ParserState {
             start_pos,
             end_pos,
             LiteralExprData {
-                elements: self.make_node_list(elements),
+                elements: Self::make_node_list(elements),
                 multi_line: false,
             },
         )

--- a/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
@@ -536,9 +536,9 @@ impl ParserState {
             // They belong to the enclosing context (e.g., object literal list).
             // This prevents `get e,` from consuming `,` as a parameter delimiter
             // and cascading errors into subsequent properties.
-            self.make_node_list(vec![])
+            Self::make_node_list(vec![])
         } else if self.is_token(SyntaxKind::CloseParenToken) {
-            self.make_node_list(vec![])
+            Self::make_node_list(vec![])
         } else if self.is_token(SyntaxKind::CommaToken) {
             use tsz_common::diagnostics::{diagnostic_codes, diagnostic_messages};
             self.parse_error_at_current_token(
@@ -546,7 +546,7 @@ impl ParserState {
                 diagnostic_codes::PARAMETER_DECLARATION_EXPECTED,
             );
             self.next_token();
-            self.make_node_list(vec![])
+            Self::make_node_list(vec![])
         } else {
             use tsz_common::diagnostics::diagnostic_codes;
             // Report error at the accessor name, matching tsc behavior
@@ -650,9 +650,9 @@ impl ParserState {
         let parameters = if !had_open_paren {
             // If ( was missing entirely, don't consume following tokens as parameters.
             // They belong to the enclosing context (e.g., object literal list).
-            self.make_node_list(vec![])
+            Self::make_node_list(vec![])
         } else if self.is_token(SyntaxKind::CloseParenToken) {
-            self.make_node_list(vec![])
+            Self::make_node_list(vec![])
         } else {
             self.parse_parameter_list()
         };
@@ -729,7 +729,7 @@ impl ParserState {
             let mod_idx = self
                 .arena
                 .create_modifier(SyntaxKind::AsyncKeyword, start_pos);
-            self.make_node_list(vec![mod_idx])
+            Self::make_node_list(vec![mod_idx])
         });
 
         // Check for generator after async: async *foo()
@@ -780,7 +780,7 @@ impl ParserState {
                 self.parse_expected(SyntaxKind::CloseParenToken);
                 params
             } else {
-                self.make_node_list(vec![])
+                Self::make_node_list(vec![])
             };
 
             let saved_flags = self.context_flags;
@@ -892,7 +892,7 @@ impl ParserState {
             use tsz_common::diagnostics::diagnostic_codes;
             self.parse_error_at_current_token("'(' expected.", diagnostic_codes::EXPECTED);
             body_already_consumed_by_recovery = self.recover_from_missing_method_open_paren();
-            self.make_node_list(vec![])
+            Self::make_node_list(vec![])
         };
 
         let type_annotation = if self.parse_optional(SyntaxKind::ColonToken) {
@@ -974,7 +974,7 @@ impl ParserState {
             let mod_idx = self
                 .arena
                 .create_modifier(SyntaxKind::AsyncKeyword, start_pos);
-            self.make_node_list(vec![mod_idx])
+            Self::make_node_list(vec![mod_idx])
         });
 
         let end_pos = self.token_end();

--- a/crates/tsz-parser/src/parser/state_expressions_literals_object.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_object.rs
@@ -112,7 +112,7 @@ impl ParserState {
             start_pos,
             end_pos,
             LiteralExprData {
-                elements: self.make_node_list(properties),
+                elements: Self::make_node_list(properties),
                 multi_line: false,
             },
         )

--- a/crates/tsz-parser/src/parser/state_expressions_tail.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_tail.rs
@@ -237,7 +237,7 @@ impl ParserState {
             }
         }
 
-        self.make_node_list(args)
+        Self::make_node_list(args)
     }
 
     // Returns true for statement-only keywords that should stop argument parsing

--- a/crates/tsz-parser/src/parser/state_import_attributes.rs
+++ b/crates/tsz-parser/src/parser/state_import_attributes.rs
@@ -148,7 +148,7 @@ impl ParserState {
             start_pos,
             end_pos,
             LiteralExprData {
-                elements: self.make_node_list(properties),
+                elements: Self::make_node_list(properties),
                 multi_line: false,
             },
         )
@@ -258,7 +258,7 @@ impl ParserState {
             start_pos,
             end_pos,
             LiteralExprData {
-                elements: self.make_node_list(properties),
+                elements: Self::make_node_list(properties),
                 multi_line: false,
             },
         )

--- a/crates/tsz-parser/src/parser/state_recovery_helpers.rs
+++ b/crates/tsz-parser/src/parser/state_recovery_helpers.rs
@@ -626,8 +626,7 @@ impl ParserState {
     }
 
     /// Create a `NodeList` from a Vec of `NodeIndex`
-    pub(crate) const fn make_node_list(&self, nodes: Vec<NodeIndex>) -> NodeList {
-        let _ = self;
+    pub(crate) const fn make_node_list(nodes: Vec<NodeIndex>) -> NodeList {
         NodeList {
             nodes,
             pos: 0,

--- a/crates/tsz-parser/src/parser/state_statements.rs
+++ b/crates/tsz-parser/src/parser/state_statements.rs
@@ -522,7 +522,7 @@ impl ParserState {
             }
         }
 
-        self.make_node_list(statements)
+        Self::make_node_list(statements)
     }
 
     /// Parse list of statements (for blocks, function bodies, etc.).
@@ -712,7 +712,7 @@ impl ParserState {
         }
 
         self.statement_list_depth -= 1;
-        self.make_node_list(statements)
+        Self::make_node_list(statements)
     }
 
     fn recover_orphan_case_assignment_before_if(&mut self) -> bool {
@@ -1039,7 +1039,7 @@ impl ParserState {
             self.parse_expected(SyntaxKind::CloseBraceToken);
             stmts
         } else {
-            self.make_node_list(Vec::new())
+            Self::make_node_list(Vec::new())
         };
         let end_pos = self.token_end();
 
@@ -1089,7 +1089,7 @@ impl ParserState {
             end_pos,
             VariableData {
                 modifiers,
-                declarations: self.make_node_list(vec![declaration_list]),
+                declarations: Self::make_node_list(vec![declaration_list]),
                 recovered_typeof_member_calls: Vec::new(),
             },
         )
@@ -1850,7 +1850,7 @@ impl ParserState {
             end_pos,
             VariableData {
                 modifiers: None,
-                declarations: self.make_node_list(declarations),
+                declarations: Self::make_node_list(declarations),
                 recovered_typeof_member_calls,
             },
             flags,

--- a/crates/tsz-parser/src/parser/state_statements_class.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class.rs
@@ -653,7 +653,7 @@ impl ParserState {
             }
         }
 
-        self.make_node_list(params)
+        Self::make_node_list(params)
     }
 
     /// Check if current token is a valid parameter modifier
@@ -835,7 +835,7 @@ impl ParserState {
         if modifiers.is_empty() {
             None
         } else {
-            Some(self.make_node_list(modifiers))
+            Some(Self::make_node_list(modifiers))
         }
     }
 
@@ -947,7 +947,7 @@ impl ParserState {
                 );
                 nodes.extend(decorators.nodes);
                 nodes.extend(param_modifiers.nodes);
-                Some(self.make_node_list(nodes))
+                Some(Self::make_node_list(nodes))
             }
         };
 

--- a/crates/tsz-parser/src/parser/state_statements_class_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_declarations.rs
@@ -31,7 +31,7 @@ impl ParserState {
                     name: NodeIndex::NONE,
                     type_parameters: None,
                     heritage_clauses: None,
-                    members: self.make_node_list(Vec::new()),
+                    members: Self::make_node_list(Vec::new()),
                 },
             );
         }
@@ -64,7 +64,7 @@ impl ParserState {
 
         let (type_parameters, heritage_clauses, members) =
             if recover_reserved_class_name_as_statement {
-                (None, None, self.make_node_list(Vec::new()))
+                (None, None, Self::make_node_list(Vec::new()))
             } else {
                 let type_parameters = self
                     .is_token(SyntaxKind::LessThanToken)
@@ -75,7 +75,7 @@ impl ParserState {
                     self.next_token();
                     self.non_block_close_brace_statement_errors_remaining =
                         CLASS_DOT_RECOVERY_STRAY_CLOSE_BRACE_COUNT;
-                    self.make_node_list(Vec::new())
+                    Self::make_node_list(Vec::new())
                 } else {
                     let class_saved_flags = self.context_flags;
                     self.context_flags |= CONTEXT_FLAG_IN_CLASS;
@@ -137,7 +137,7 @@ impl ParserState {
 
         let (type_parameters, heritage_clauses, members) =
             if recover_reserved_class_name_as_statement {
-                (None, None, self.make_node_list(Vec::new()))
+                (None, None, Self::make_node_list(Vec::new()))
             } else {
                 let type_parameters = self
                     .is_token(SyntaxKind::LessThanToken)
@@ -148,7 +148,7 @@ impl ParserState {
                     self.next_token();
                     self.non_block_close_brace_statement_errors_remaining =
                         CLASS_DOT_RECOVERY_STRAY_CLOSE_BRACE_COUNT;
-                    self.make_node_list(Vec::new())
+                    Self::make_node_list(Vec::new())
                 } else {
                     let class_saved_flags = self.context_flags;
                     self.context_flags |= CONTEXT_FLAG_IN_CLASS;
@@ -221,7 +221,7 @@ impl ParserState {
             start_pos,
             end_pos,
             ClassData {
-                modifiers: Some(self.make_node_list(vec![abstract_modifier])),
+                modifiers: Some(Self::make_node_list(vec![abstract_modifier])),
                 name,
                 type_parameters,
                 heritage_clauses,
@@ -269,7 +269,7 @@ impl ParserState {
                 tsz_common::diagnostics::diagnostic_codes::EXPRESSION_EXPECTED,
             );
             self.recover_parenthesized_class_declaration_tail();
-            self.make_node_list(Vec::new())
+            Self::make_node_list(Vec::new())
         } else {
             // Preserve existing fallback behavior for other malformed class bodies.
             let saved_flags = self.context_flags;
@@ -286,7 +286,7 @@ impl ParserState {
             start_pos,
             end_pos,
             ClassData {
-                modifiers: Some(self.make_node_list(vec![declare_modifier])),
+                modifiers: Some(Self::make_node_list(vec![declare_modifier])),
                 name,
                 type_parameters,
                 heritage_clauses,
@@ -342,7 +342,7 @@ impl ParserState {
                 tsz_common::diagnostics::diagnostic_codes::EXPRESSION_EXPECTED,
             );
             self.recover_parenthesized_class_declaration_tail();
-            self.make_node_list(Vec::new())
+            Self::make_node_list(Vec::new())
         } else {
             let saved_flags = self.context_flags;
             self.context_flags |= CONTEXT_FLAG_AMBIENT | CONTEXT_FLAG_IN_CLASS;
@@ -358,7 +358,10 @@ impl ParserState {
             start_pos,
             end_pos,
             ClassData {
-                modifiers: Some(self.make_node_list(vec![declare_modifier, abstract_modifier])),
+                modifiers: Some(Self::make_node_list(vec![
+                    declare_modifier,
+                    abstract_modifier,
+                ])),
                 name,
                 type_parameters,
                 heritage_clauses,
@@ -498,7 +501,7 @@ impl ParserState {
                 );
                 let mut nodes = decorators.map(|list| list.nodes).unwrap_or_default();
                 nodes.push(default_modifier);
-                let modifiers = Some(self.make_node_list(nodes));
+                let modifiers = Some(Self::make_node_list(nodes));
 
                 match self.token() {
                     SyntaxKind::ClassKeyword => {
@@ -603,7 +606,7 @@ impl ParserState {
         if decorators.is_empty() {
             None
         } else {
-            Some(self.make_node_list(decorators))
+            Some(Self::make_node_list(decorators))
         }
     }
 
@@ -797,9 +800,9 @@ impl ParserState {
             // Add abstract modifier to decorator list
             let mut nodes: Vec<NodeIndex> = dec_list.nodes;
             nodes.push(abstract_modifier);
-            Some(self.make_node_list(nodes))
+            Some(Self::make_node_list(nodes))
         } else {
-            Some(self.make_node_list(vec![abstract_modifier]))
+            Some(Self::make_node_list(vec![abstract_modifier]))
         };
 
         self.arena.add_class(
@@ -845,7 +848,7 @@ impl ParserState {
         if clauses.is_empty() {
             None
         } else {
-            Some(self.make_node_list(clauses))
+            Some(Self::make_node_list(clauses))
         }
     }
 
@@ -895,7 +898,7 @@ impl ParserState {
                 end_pos,
                 crate::parser::node::HeritageData {
                     token: SyntaxKind::ExtendsKeyword as u16,
-                    types: self.make_node_list(Vec::new()),
+                    types: Self::make_node_list(Vec::new()),
                 },
             ));
         }
@@ -940,7 +943,7 @@ impl ParserState {
             end_pos,
             crate::parser::node::HeritageData {
                 token: SyntaxKind::ExtendsKeyword as u16,
-                types: self.make_node_list(type_refs),
+                types: Self::make_node_list(type_refs),
             },
         ))
     }
@@ -1013,7 +1016,7 @@ impl ParserState {
             end_pos,
             crate::parser::node::HeritageData {
                 token: SyntaxKind::ImplementsKeyword as u16,
-                types: self.make_node_list(types),
+                types: Self::make_node_list(types),
             },
         ))
     }
@@ -1275,7 +1278,7 @@ impl ParserState {
                         end_pos,
                         crate::parser::node::CallExprData {
                             expression: expr,
-                            type_arguments: Some(self.make_node_list(type_args)),
+                            type_arguments: Some(Self::make_node_list(type_args)),
                             arguments: Some(args),
                         },
                     ))
@@ -1286,7 +1289,7 @@ impl ParserState {
                         self.token_end(),
                         crate::parser::node::ExprWithTypeArgsData {
                             expression: expr,
-                            type_arguments: Some(self.make_node_list(type_args)),
+                            type_arguments: Some(Self::make_node_list(type_args)),
                         },
                     ))
                 }
@@ -1328,6 +1331,6 @@ impl ParserState {
         }
         let end_pos = self.token_end();
         self.parse_expected(SyntaxKind::CloseParenToken);
-        (end_pos, self.make_node_list(args))
+        (end_pos, Self::make_node_list(args))
     }
 }

--- a/crates/tsz-parser/src/parser/state_statements_class_member_methods.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_member_methods.rs
@@ -54,7 +54,7 @@ impl ParserState {
         } else {
             self.parse_error_at_current_token("'(' expected.", diagnostic_codes::EXPECTED);
             body_already_consumed_by_recovery = self.recover_from_missing_method_open_paren();
-            self.make_node_list(vec![])
+            Self::make_node_list(vec![])
         };
 
         let type_annotation = if self.parse_optional(SyntaxKind::ColonToken) {
@@ -74,7 +74,7 @@ impl ParserState {
                 self.token_pos(),
                 self.token_pos(),
                 node::BlockData {
-                    statements: self.make_node_list(Vec::new()),
+                    statements: Self::make_node_list(Vec::new()),
                     multi_line: false,
                 },
             )

--- a/crates/tsz-parser/src/parser/state_statements_class_members.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_members.rs
@@ -523,7 +523,7 @@ impl ParserState {
                     // Don't continue parsing modifiers (e.g., don't process 'export' in 'var export foo')
                     let var_modifier = self.arena.create_modifier(var_token, start_pos);
                     modifiers.push(var_modifier);
-                    return Some(self.make_node_list(modifiers));
+                    return Some(Self::make_node_list(modifiers));
                 }
                 // `in` / `out` are variance modifiers that only apply to type
                 // parameters (of class/interface/type alias). When they appear on a
@@ -548,7 +548,7 @@ impl ParserState {
         if modifiers.is_empty() {
             None
         } else {
-            Some(self.make_node_list(modifiers))
+            Some(Self::make_node_list(modifiers))
         }
     }
 
@@ -778,7 +778,7 @@ impl ParserState {
 
         self.parse_expected(SyntaxKind::OpenParenToken);
         let parameters = if self.is_token(SyntaxKind::CloseParenToken) {
-            self.make_node_list(vec![])
+            Self::make_node_list(vec![])
         } else if self.is_token(SyntaxKind::CommaToken) {
             // `get x(,)` — comma can't start a parameter declaration.
             // tsc emits TS1138 "Parameter declaration expected" here,
@@ -790,7 +790,7 @@ impl ParserState {
             );
             // Skip the comma and continue parsing to recover
             self.next_token();
-            self.make_node_list(vec![])
+            Self::make_node_list(vec![])
         } else {
             use tsz_common::diagnostics::diagnostic_codes;
             // Report error at the accessor name, matching tsc behavior
@@ -1046,7 +1046,7 @@ impl ParserState {
 
         self.parse_expected(SyntaxKind::OpenParenToken);
         let parameters = if self.is_token(SyntaxKind::CloseParenToken) {
-            self.make_node_list(vec![])
+            Self::make_node_list(vec![])
         } else {
             self.parse_parameter_list()
         };
@@ -1252,7 +1252,7 @@ impl ParserState {
             }
         }
 
-        self.make_node_list(members)
+        Self::make_node_list(members)
     }
 
     fn class_member_list_outer_declaration_recovery_close_pos(&mut self) -> Option<u32> {

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -101,32 +101,34 @@ impl ParserState {
                 self.parse_expected(SyntaxKind::AsyncKeyword);
                 self.parse_function_declaration_with_async(
                     true,
-                    Some(self.make_node_list(modifiers)),
+                    Some(Self::make_node_list(modifiers)),
                 )
             }
-            SyntaxKind::FunctionKeyword => self
-                .parse_function_declaration_with_async(false, Some(self.make_node_list(modifiers))),
+            SyntaxKind::FunctionKeyword => self.parse_function_declaration_with_async(
+                false,
+                Some(Self::make_node_list(modifiers)),
+            ),
             SyntaxKind::ClassKeyword => self.parse_class_declaration_with_modifiers(
                 start_pos,
-                Some(self.make_node_list(modifiers)),
+                Some(Self::make_node_list(modifiers)),
             ),
             SyntaxKind::InterfaceKeyword => self.parse_interface_declaration_with_modifiers(
                 start_pos,
-                Some(self.make_node_list(modifiers)),
+                Some(Self::make_node_list(modifiers)),
             ),
             SyntaxKind::TypeKeyword => self.parse_type_alias_declaration_with_modifiers(
                 start_pos,
-                Some(self.make_node_list(modifiers)),
+                Some(Self::make_node_list(modifiers)),
             ),
             SyntaxKind::EnumKeyword => self.parse_enum_declaration_with_modifiers(
                 start_pos,
-                Some(self.make_node_list(modifiers)),
+                Some(Self::make_node_list(modifiers)),
             ),
             SyntaxKind::NamespaceKeyword
             | SyntaxKind::ModuleKeyword
             | SyntaxKind::GlobalKeyword => self.parse_module_declaration_with_modifiers(
                 start_pos,
-                Some(self.make_node_list(modifiers)),
+                Some(Self::make_node_list(modifiers)),
             ),
             SyntaxKind::VarKeyword
             | SyntaxKind::LetKeyword
@@ -134,18 +136,18 @@ impl ParserState {
             | SyntaxKind::UsingKeyword
             | SyntaxKind::AwaitKeyword => self.parse_variable_statement_with_modifiers(
                 Some(start_pos),
-                Some(self.make_node_list(modifiers)),
+                Some(Self::make_node_list(modifiers)),
             ),
             SyntaxKind::ImportKeyword => {
                 if self.look_ahead_is_import_equals() {
                     self.parse_import_equals_declaration_with_modifiers(
                         start_pos,
-                        Some(self.make_node_list(modifiers)),
+                        Some(Self::make_node_list(modifiers)),
                     )
                 } else {
                     self.parse_import_declaration_with_modifiers(
                         start_pos,
-                        Some(self.make_node_list(modifiers)),
+                        Some(Self::make_node_list(modifiers)),
                     )
                 }
             }
@@ -788,7 +790,7 @@ impl ParserState {
                 .add_token(SyntaxKind::ConstKeyword as u16, const_start, const_end);
         modifiers.push(const_modifier);
 
-        let modifiers = Some(self.make_node_list(modifiers));
+        let modifiers = Some(Self::make_node_list(modifiers));
         self.parse_enum_declaration_with_modifiers(start_pos, modifiers)
     }
 

--- a/crates/tsz-parser/src/parser/state_switch_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_switch_recovery.rs
@@ -118,7 +118,7 @@ impl ParserState {
             clause_end,
             CaseClauseData {
                 expression: clause_expr,
-                statements: self.make_node_list(statements),
+                statements: Self::make_node_list(statements),
             },
         )
     }
@@ -158,7 +158,7 @@ impl ParserState {
             clause_end,
             CaseClauseData {
                 expression: NodeIndex::NONE,
-                statements: self.make_node_list(statements),
+                statements: Self::make_node_list(statements),
             },
         )
     }

--- a/crates/tsz-parser/src/parser/state_type_parameters.rs
+++ b/crates/tsz-parser/src/parser/state_type_parameters.rs
@@ -66,7 +66,7 @@ impl ParserState {
 
         self.parse_expected_greater_than();
 
-        let mut list = self.make_node_list(params);
+        let mut list = Self::make_node_list(params);
         list.has_trailing_comma = has_trailing_comma;
         list
     }
@@ -258,7 +258,7 @@ impl ParserState {
         if modifiers.is_empty() {
             None
         } else {
-            Some(self.make_node_list(modifiers))
+            Some(Self::make_node_list(modifiers))
         }
     }
 

--- a/crates/tsz-parser/src/parser/state_types.rs
+++ b/crates/tsz-parser/src/parser/state_types.rs
@@ -399,7 +399,7 @@ impl ParserState {
             start_pos,
             end_pos,
             crate::parser::node::CompositeTypeData {
-                types: self.make_node_list(types),
+                types: Self::make_node_list(types),
             },
         )
     }
@@ -443,7 +443,7 @@ impl ParserState {
             start_pos,
             end_pos,
             crate::parser::node::CompositeTypeData {
-                types: self.make_node_list(types),
+                types: Self::make_node_list(types),
             },
         )
     }
@@ -651,7 +651,7 @@ impl ParserState {
         let mut is_constructor = false;
         let mut constructor_return_type = NodeIndex::NONE;
         let mut starting_param_index: u32 = 0;
-        let mut parameters = self.make_node_list(Vec::new());
+        let mut parameters = Self::make_node_list(Vec::new());
 
         if self.is_token(SyntaxKind::OpenParenToken) {
             self.parse_expected(SyntaxKind::OpenParenToken);
@@ -752,7 +752,7 @@ impl ParserState {
             }
         }
 
-        self.make_node_list(params)
+        Self::make_node_list(params)
     }
 
     fn parse_jsdoc_legacy_function_parameter(&mut self, index: u32) -> NodeIndex {
@@ -1070,7 +1070,7 @@ impl ParserState {
                     start_pos,
                     q_end,
                     crate::parser::node::CompositeTypeData {
-                        types: self.make_node_list(vec![base_type, null_token]),
+                        types: Self::make_node_list(vec![base_type, null_token]),
                     },
                 );
                 // Recurse to handle `T?[]` (postfix ? followed by array suffix)

--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -394,7 +394,7 @@ impl ParserState {
             start_pos,
             end_pos,
             crate::parser::node::TupleTypeData {
-                elements: self.make_node_list(elements),
+                elements: Self::make_node_list(elements),
             },
         );
 
@@ -803,7 +803,7 @@ impl ParserState {
                 end_pos,
                 crate::parser::node::TemplateLiteralTypeData {
                     head,
-                    template_spans: self.make_node_list(vec![]),
+                    template_spans: Self::make_node_list(vec![]),
                 },
             );
         }
@@ -890,7 +890,7 @@ impl ParserState {
             end_pos,
             crate::parser::node::TemplateLiteralTypeData {
                 head,
-                template_spans: self.make_node_list(spans),
+                template_spans: Self::make_node_list(spans),
             },
         )
     }
@@ -1138,7 +1138,7 @@ impl ParserState {
         let members = if extra_members.is_empty() {
             None
         } else {
-            Some(self.make_node_list(extra_members))
+            Some(Self::make_node_list(extra_members))
         };
 
         self.arena.add_mapped_type(
@@ -1320,7 +1320,7 @@ impl ParserState {
         let members = if prior_members.is_empty() {
             None
         } else {
-            Some(self.make_node_list(prior_members))
+            Some(Self::make_node_list(prior_members))
         };
 
         self.arena.add_mapped_type(
@@ -1397,7 +1397,7 @@ impl ParserState {
             start_pos,
             end_pos,
             crate::parser::node::TypeLiteralData {
-                members: self.make_node_list(members),
+                members: Self::make_node_list(members),
             },
         )
     }
@@ -1451,7 +1451,7 @@ impl ParserState {
         }
 
         self.parse_expected_greater_than();
-        let mut list = self.make_node_list(args);
+        let mut list = Self::make_node_list(args);
         list.has_trailing_comma = has_trailing_comma;
         list
     }
@@ -1591,7 +1591,7 @@ impl ParserState {
                 self.restore_speculation_checkpoint(checkpoint);
                 return None;
             }
-            return Some(self.make_node_list(Vec::new()));
+            return Some(Self::make_node_list(Vec::new()));
         }
 
         let mut args = Vec::new();
@@ -1645,7 +1645,7 @@ impl ParserState {
             // Check if the following token indicates these were type arguments
             // (call, tagged template, or instantiation expression)
             if self.can_follow_type_arguments_in_expression() {
-                let mut list = self.make_node_list(args);
+                let mut list = Self::make_node_list(args);
                 list.has_trailing_comma = has_trailing_comma;
                 return Some(list);
             }

--- a/crates/tsz-parser/src/parser/state_types_jsx.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx.rs
@@ -372,7 +372,7 @@ impl ParserState {
             }
         }
 
-        self.make_node_list(params)
+        Self::make_node_list(params)
     }
 
     /// Parse a keyword as an identifier (for type keywords like string, number, etc.)
@@ -555,7 +555,7 @@ impl ParserState {
 
     /// Get node count
     #[must_use]
-    pub const fn get_node_count(&self) -> usize {
+    pub fn get_node_count(&self) -> usize {
         self.arena.len()
     }
 

--- a/crates/tsz-parser/src/parser/state_types_jsx_elements.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx_elements.rs
@@ -1017,7 +1017,7 @@ impl ParserState {
                 start_pos,
                 end_pos,
                 crate::parser::node::JsxAttributesData {
-                    properties: self.make_node_list(properties),
+                    properties: Self::make_node_list(properties),
                 },
             ),
             aborted_for_outer_recovery,
@@ -1383,7 +1383,7 @@ impl ParserState {
             }
         }
 
-        self.make_node_list(children)
+        Self::make_node_list(children)
     }
 
     /// Parse JSX text content.

--- a/crates/tsz-parser/src/parser/state_variable_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_variable_declarations.rs
@@ -408,7 +408,7 @@ impl ParserState {
         {
             self.next_token();
             let end_pos = self.token_full_start();
-            let empty_statements = self.make_node_list(Vec::new());
+            let empty_statements = Self::make_node_list(Vec::new());
             let body = self.arena.add_block(
                 syntax_kind_ext::BLOCK,
                 end_pos,
@@ -429,7 +429,7 @@ impl ParserState {
                     asterisk_token,
                     name,
                     type_parameters: None,
-                    parameters: self.make_node_list(Vec::new()),
+                    parameters: Self::make_node_list(Vec::new()),
                     type_annotation: NodeIndex::NONE,
                     body,
                     equals_greater_than_token: false,
@@ -493,7 +493,7 @@ impl ParserState {
         if reserved_parameter_yielded_to_statement {
             self.context_flags = saved_flags;
             let end_pos = self.token_full_start();
-            let empty_statements = self.make_node_list(Vec::new());
+            let empty_statements = Self::make_node_list(Vec::new());
             let body = self.arena.add_block(
                 syntax_kind_ext::BLOCK,
                 end_pos,


### PR DESCRIPTION
AgentName: StudioOpus

Track: shared-lib-universe campaign payoff. Cuts the per-run lib clone that is ~7-10% of DOM-heavy rows, behavior-neutrally.

## Summary

`clone_lib_files_for_checker` (via `load_checker_libs`) deep-copies every lib `NodeArena` once per compile: measured **5.04ms vite / 6.70ms nextjs** (perf-tools `checker_lib_clone_elapsed_ms_total`). This PR makes that clone **O(1)** (an `Arc` bump), dropping it to **0.457ms (-91%) / 0.476ms (-93%)** with byte-identical behavior.

## Structural rule

Sharing the lib arena read-only is **unsafe** — ~25 `Arc::ptr_eq(arena)`/`std::ptr::eq(arena, …)` lib-origin and current-file discriminators (lib_queries.rs, promise_checker.rs, type_node_resolution.rs, …) read arena *identity*. Sharing flips them and silently drops diagnostics (`recursiveComplicatedClasses` loses `TS2345`). So instead of sharing, **keep the clone's distinct outer identity** (every `ptr_eq` behaves exactly as before) but make the clone cheap: `NodeArena { inner: Arc<NodeArenaInner> }` with the ~75 typed pools behind the `Arc`. Reads via `Deref` (compiler hoists the indirection — wall time unchanged); parser mutates via `DerefMut → Arc::make_mut` (free at refcount 1 during build).

## Invariant

Behavior-neutral, byte-identical to `tsc` and to prior tsz. The distinct per-clone `Arc<NodeArena>` pointer preserves all arena-identity comparisons; serde `Arc` is transparent so the lib snapshot round-trips without a format bump.

## Owner layer

`tsz_parser` (NodeArena + parser construction). No checker/solver semantic change — the 406 consumer files read through `Deref` unchanged (consumer side is read-only; 0 external `&mut NodeArena`).

## Scope

39 files, +269/-178. Core: `node.rs` (wrapper + `delegate_arena_alloc!` macro for 13 alloc methods). `make_node_list` became a free fn (it ignored `&self`). Rest is mechanical `self.make_node_list` → `Self::make_node_list`.

## Project Corpus Impact
- Row: vite-vanilla-ts-live / next-app-live (clone 5–6.7ms → ~0.46ms; wall time unchanged, no read-overhead regression)
- Bug family: n/a (performance; behavior-preserving)

## Verification

- Full local conformance (`conformance.sh run --profile release`): **12582/12585, 0 new regressions** (the 3 are pre-existing accepted Mac-delta: deeplyNestedMappedTypes, intersectionsOfLargeUnions, propTypeValidatorInference).
- Witness `recursiveComplicatedClasses` keeps `TS2345` (1/1).
- vite/nextjs: 0 diagnostics unchanged; wall-time min 0.07s/0.06s (no regression); clone `checker_lib_clone_elapsed_ms` 5.04→0.457 / 6.70→0.476.
- `cargo clippy -p tsz-parser -p tsz-core` clean; `scripts/arch/arch_guard.py` passes.

## Coordination Notes

Follows the merged campaign parity gate #13027 and the mechanism investigation in memory `project_shared_lib_universe_campaign`. This is the behavior-neutral cheap-clone path (preferred over the delicate 25-site pointer-free-identity migration, which would also work but risks parity flips). The arena is now O(1)-cloneable, so a future full read-only share is no longer required for the clone-cost win.