### PR TITLE
fix(checker): bound deep flow-analysis recursion to prevent stack overflow

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/condition_nullish.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_nullish.rs
@@ -1,5 +1,5 @@
 use super::FlowAnalyzer;
-use super::flow_dp::{DpMemo, DpState};
+use super::flow_dp::{DpMemo, resolve_backward_dp};
 use tsz_binder::{FlowNodeId, flow_flags};
 use tsz_parser::parser::NodeIndex;
 use tsz_scanner::SyntaxKind;
@@ -19,37 +19,47 @@ impl<'a> FlowAnalyzer<'a> {
         target: NodeIndex,
     ) -> bool {
         let mut memo: DpMemo<bool> = DpMemo::default();
-        self.excludes_null_memoized(flow_id, target, &mut memo)
+        // Back-edge / no-information element is `false` (treat the loop as not
+        // contributing a null-exclusion) so loops do not over-narrow, matching
+        // the previous recursive `DpState::InProgress` arm. Folded iteratively
+        // (see `resolve_backward_dp`) so a long antecedent chain cannot exhaust
+        // the native stack.
+        resolve_backward_dp(
+            flow_id,
+            &mut memo,
+            false,
+            |node| self.null_exclusion_antecedents(node),
+            |node, antecedent_values| self.excludes_null_fold(node, target, antecedent_values),
+        )
     }
 
-    fn excludes_null_memoized(
+    /// The antecedents the null-exclusion traversal descends into: the
+    /// non-`none` predecessors. Unlike the typeof-exclusion mask, this analysis
+    /// historically did not filter unreachable antecedents, so that behavior is
+    /// preserved here.
+    fn null_exclusion_antecedents(
+        &self,
+        flow_id: FlowNodeId,
+    ) -> smallvec::SmallVec<[FlowNodeId; 2]> {
+        let Some(flow) = self.binder.flow_nodes.get(flow_id) else {
+            return smallvec::SmallVec::new();
+        };
+        flow.antecedent
+            .iter()
+            .copied()
+            .filter(|antecedent| !antecedent.is_none())
+            .collect()
+    }
+
+    /// `true` when `flow_id` itself is a `target`-null comparison, or every one
+    /// of its antecedents excludes null. Matches the previous recursive
+    /// `compute`: a node with no antecedents that is not itself a null
+    /// comparison does not exclude null.
+    fn excludes_null_fold(
         &self,
         flow_id: FlowNodeId,
         target: NodeIndex,
-        memo: &mut DpMemo<bool>,
-    ) -> bool {
-        if flow_id.is_none() {
-            return false;
-        }
-        match memo.get(&flow_id) {
-            // Back-edge: preserve the historical fail-safe (treat the loop as
-            // not contributing a null-exclusion) so loops do not over-narrow.
-            Some(DpState::InProgress) => return false,
-            Some(DpState::Done(value)) => return *value,
-            None => {}
-        }
-        memo.insert(flow_id, DpState::InProgress);
-
-        let value = self.compute_excludes_null(flow_id, target, memo);
-        memo.insert(flow_id, DpState::Done(value));
-        value
-    }
-
-    fn compute_excludes_null(
-        &self,
-        flow_id: FlowNodeId,
-        target: NodeIndex,
-        memo: &mut DpMemo<bool>,
+        antecedent_values: &[bool],
     ) -> bool {
         let Some(flow) = self.binder.flow_nodes.get(flow_id) else {
             return false;
@@ -60,22 +70,7 @@ impl<'a> FlowAnalyzer<'a> {
             return true;
         }
 
-        let mut saw_antecedent = false;
-        // Snapshot so we can release the borrow on `flow_nodes` before
-        // recursing into siblings. Most flow nodes have one or two antecedents,
-        // so keep that snapshot stack-backed in the common case.
-        let antecedents: smallvec::SmallVec<[FlowNodeId; 2]> =
-            flow.antecedent.iter().copied().collect();
-        for antecedent in antecedents {
-            if antecedent.is_none() {
-                continue;
-            }
-            saw_antecedent = true;
-            if !self.excludes_null_memoized(antecedent, target, memo) {
-                return false;
-            }
-        }
-        saw_antecedent
+        !antecedent_values.is_empty() && antecedent_values.iter().all(|&excludes| excludes)
     }
 
     fn condition_branch_excludes_null_for_target(

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -1,8 +1,7 @@
 use crate::query_boundaries::common::QueryDatabase;
 use crate::query_boundaries::flow as flow_boundary;
 use crate::query_boundaries::flow_analysis as query;
-use crate::query_boundaries::flow_analysis::{tuple_elements_for_type, union_members_for_type};
-use crate::query_boundaries::state::checking::find_property_in_object_by_str;
+use crate::query_boundaries::flow_analysis::union_members_for_type;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
@@ -81,6 +80,7 @@ pub(crate) const fn is_session_stable_flow_cache_symbol(symbol: SymbolId) -> boo
     symbol.0 & (FLOW_CACHE_SYNTHETIC_BIT | FLOW_CACHE_PER_NODE_BIT) != FLOW_CACHE_SYNTHETIC_BIT
 }
 
+mod flow_query;
 mod flow_traversal;
 
 #[must_use]
@@ -201,13 +201,6 @@ impl CallPredicateMap {
 const FLOW_STEP_BUDGET_MIN: usize = 10_000;
 const FLOW_STEP_BUDGET_SCALE: usize = 12;
 const FLOW_STEP_BUDGET_MAX: usize = 40_000;
-
-/// Maximum nesting depth of re-entrant flow-type queries before narrowing bails
-/// to the un-narrowed declared type. Matches tsc's `flowDepth` ceiling of 2000
-/// in `getFlowTypeOfReference`: deep enough that no realistic narrowing chain is
-/// truncated, low enough that the native stack cannot overflow (each level adds
-/// one `check_flow` frame; 2000 frames stay well within the 128MB worker stack).
-const MAX_FLOW_QUERY_DEPTH: u32 = 2000;
 
 const fn flow_step_budget(flow_node_count: usize) -> usize {
     let scaled = flow_node_count.saturating_mul(FLOW_STEP_BUDGET_SCALE);
@@ -962,256 +955,6 @@ impl<'a> FlowAnalyzer<'a> {
     /// Get a reference to the flow graph.
     pub const fn flow_graph(&self) -> Option<&FlowGraph<'a>> {
         self.flow_graph.as_ref()
-    }
-
-    /// Get the narrowed type of a symbol at a specific flow node.
-    ///
-    /// This walks backwards through the flow graph, applying narrowing operations
-    /// when it encounters condition nodes.
-    pub fn get_flow_type(
-        &self,
-        reference: NodeIndex,
-        initial_type: TypeId,
-        flow_node: FlowNodeId,
-    ) -> TypeId {
-        // Short-circuit for error types: flow narrowing must not transform ERROR
-        // into a concrete type. When the declared/initial type is ERROR (e.g.,
-        // property access on an unresolved type), condition narrowing handlers
-        // like `== null` can produce `null | undefined` regardless of the input
-        // type, turning a suppressed error into a false positive diagnostic.
-        if initial_type == TypeId::ERROR {
-            return initial_type;
-        }
-        let narrowed = self.get_flow_type_uncorrelated(reference, initial_type, flow_node);
-        self.apply_correlated_destructured_narrowing(reference, initial_type, narrowed, flow_node)
-    }
-
-    fn get_flow_type_uncorrelated(
-        &self,
-        reference: NodeIndex,
-        initial_type: TypeId,
-        flow_node: FlowNodeId,
-    ) -> TypeId {
-        if flow_node.is_none() {
-            return initial_type;
-        }
-
-        // Bound re-entrant flow-query nesting. Each nested `get_flow_type`
-        // resolution adds a `check_flow` frame; without a ceiling, deeply
-        // nested narrowing in large modules overflows the native stack. tsc
-        // applies the same guard (`flowDepth === 2000` in
-        // `getFlowTypeOfReference`), returning the un-narrowed declared type
-        // rather than narrowing further. We mirror that: bail to `initial_type`.
-        let depth = self.flow_query_depth.get();
-        if depth >= MAX_FLOW_QUERY_DEPTH {
-            return initial_type;
-        }
-        self.flow_query_depth.set(depth + 1);
-        let result = self.get_flow_type_uncorrelated_inner(reference, initial_type, flow_node);
-        self.flow_query_depth.set(depth);
-        result
-    }
-
-    fn get_flow_type_uncorrelated_inner(
-        &self,
-        reference: NodeIndex,
-        initial_type: TypeId,
-        flow_node: FlowNodeId,
-    ) -> TypeId {
-        // Resolve symbol for caching purposes.
-        //
-        // Member-like references (`a.b`, `a[b]`, `this.x`) must NOT key by a bare
-        // member `SymbolId`: the binder links some member accesses (notably
-        // `this.x` on a class field) to the field symbol, which both aliases
-        // distinct receivers (`x.foo` vs `this.foo` share the field symbol) and
-        // defeats occurrence sharing for everything else. `check_flow` keys such
-        // references by their structural path instead (`flow_reference_path_symbol`),
-        // which is occurrence-stable and receiver-disjoint. Only resolve a symbol
-        // for plain identifier / `this` / `super` roots.
-        let symbol_id = self
-            .binder
-            .resolve_identifier(self.arena, reference)
-            .or_else(|| {
-                if self.is_member_like_reference(reference) {
-                    None
-                } else {
-                    self.reference_symbol(reference)
-                }
-            });
-
-        self.check_flow(
-            reference,
-            initial_type,
-            flow_node,
-            &mut Vec::new(),
-            symbol_id,
-        )
-    }
-
-    fn apply_correlated_destructured_narrowing(
-        &self,
-        reference: NodeIndex,
-        _initial_type: TypeId,
-        narrowed_type: TypeId,
-        flow_node: FlowNodeId,
-    ) -> TypeId {
-        let Some(bindings) = self.destructured_bindings else {
-            return narrowed_type;
-        };
-        let Some(sym_id) = self
-            .binder
-            .resolve_identifier(self.arena, reference)
-            .or_else(|| self.reference_symbol(reference))
-        else {
-            return narrowed_type;
-        };
-        let Some(info) = bindings.get(&sym_id) else {
-            return narrowed_type;
-        };
-        if !info.is_const {
-            return narrowed_type;
-        }
-
-        let Some(source_members) = union_members_for_type(self.interner, info.source_type) else {
-            return narrowed_type;
-        };
-
-        let siblings: Vec<_> = bindings
-            .iter()
-            .filter(|(other_sym, other_info)| {
-                **other_sym != sym_id && other_info.group_id == info.group_id && other_info.is_const
-            })
-            .map(|(other_sym, other_info)| (*other_sym, other_info))
-            .collect();
-        if siblings.is_empty() {
-            return narrowed_type;
-        }
-
-        let mut remaining_members = source_members.to_vec();
-        let original_member_count = remaining_members.len();
-
-        for (sib_sym, sib_info) in siblings {
-            let Some(sib_ref) = self.symbol_identifier_ref(sib_sym) else {
-                continue;
-            };
-            let Some(sib_initial) =
-                self.derive_binding_type_from_members(&source_members, sib_info)
-            else {
-                continue;
-            };
-
-            let sib_narrowed = self.get_flow_type_uncorrelated(sib_ref, sib_initial, flow_node);
-            if sib_narrowed == sib_initial {
-                continue;
-            }
-
-            remaining_members.retain(|&member| {
-                self.binding_type_from_member(member, sib_info)
-                    .is_none_or(|member_ty| self.types_overlap(member_ty, sib_narrowed))
-            });
-        }
-
-        if remaining_members.len() == original_member_count {
-            return narrowed_type;
-        }
-        if remaining_members.is_empty() {
-            return TypeId::NEVER;
-        }
-
-        let Some(correlated) = self.derive_binding_type_from_members(&remaining_members, info)
-        else {
-            return narrowed_type;
-        };
-
-        if correlated == narrowed_type {
-            return correlated;
-        }
-
-        self.intersect_types(correlated, narrowed_type)
-            .unwrap_or(correlated)
-    }
-
-    fn symbol_identifier_ref(&self, sym: SymbolId) -> Option<NodeIndex> {
-        symbol_first_identifier_ref(
-            self.arena,
-            self.binder,
-            self.shared_symbol_first_identifier_ref,
-            sym,
-        )
-    }
-
-    fn binding_type_from_member(
-        &self,
-        member: TypeId,
-        info: &crate::context::DestructuredBindingInfo,
-    ) -> Option<TypeId> {
-        if !info.property_name.is_empty() {
-            let mut current = member;
-            for segment in info.property_name.split('.') {
-                let prop = find_property_in_object_by_str(self.interner, current, segment)?;
-                current = prop.type_id;
-            }
-            Some(current)
-        } else if let Some(elements) = tuple_elements_for_type(self.interner, member) {
-            resolve_tuple_binding_type(
-                self.interner,
-                &elements,
-                info.element_index as usize,
-                info.is_rest,
-            )
-        } else {
-            None
-        }
-    }
-
-    fn derive_binding_type_from_members(
-        &self,
-        members: &[TypeId],
-        info: &crate::context::DestructuredBindingInfo,
-    ) -> Option<TypeId> {
-        let mut result_types = Vec::new();
-        for &member in members {
-            if let Some(member_ty) = self.binding_type_from_member(member, info) {
-                result_types.push(member_ty);
-            }
-        }
-        if result_types.is_empty() {
-            None
-        } else {
-            Some(tsz_solver::utils::union_or_single(
-                self.interner,
-                result_types,
-            ))
-        }
-    }
-
-    fn types_overlap(&self, left: TypeId, right: TypeId) -> bool {
-        left == right
-            || self.flow_assignability_related(left, right)
-            || self.flow_assignability_related(right, left)
-    }
-
-    fn intersect_types(&self, left: TypeId, right: TypeId) -> Option<TypeId> {
-        let left_members = union_members_for_type(self.interner, left);
-        let right_members = union_members_for_type(self.interner, right);
-
-        match (left_members, right_members) {
-            (Some(left_members), Some(right_members)) => {
-                let filtered: Vec<_> = left_members
-                    .iter()
-                    .filter(|member| right_members.contains(member))
-                    .copied()
-                    .collect();
-                if filtered.is_empty() {
-                    None
-                } else {
-                    Some(tsz_solver::utils::union_or_single(self.interner, filtered))
-                }
-            }
-            (Some(left_members), None) => left_members.contains(&right).then_some(right),
-            (None, Some(right_members)) => right_members.contains(&left).then_some(left),
-            (None, None) => (left == right).then_some(left),
-        }
     }
 
     /// Check if a reference is definitely assigned at a specific flow node.

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -4,7 +4,7 @@ use crate::query_boundaries::flow_analysis as query;
 use crate::query_boundaries::flow_analysis::{tuple_elements_for_type, union_members_for_type};
 use crate::query_boundaries::state::checking::find_property_in_object_by_str;
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use tsz_binder::BinderState;
 use tsz_binder::{FlowNode, FlowNodeArena, FlowNodeId, SymbolId, flow_flags};
@@ -201,6 +201,13 @@ impl CallPredicateMap {
 const FLOW_STEP_BUDGET_MIN: usize = 10_000;
 const FLOW_STEP_BUDGET_SCALE: usize = 12;
 const FLOW_STEP_BUDGET_MAX: usize = 40_000;
+
+/// Maximum nesting depth of re-entrant flow-type queries before narrowing bails
+/// to the un-narrowed declared type. Matches tsc's `flowDepth` ceiling of 2000
+/// in `getFlowTypeOfReference`: deep enough that no realistic narrowing chain is
+/// truncated, low enough that the native stack cannot overflow (each level adds
+/// one `check_flow` frame; 2000 frames stay well within the 128MB worker stack).
+const MAX_FLOW_QUERY_DEPTH: u32 = 2000;
 
 const fn flow_step_budget(flow_node_count: usize) -> usize {
     let scaled = flow_node_count.saturating_mul(FLOW_STEP_BUDGET_SCALE);
@@ -440,6 +447,15 @@ pub struct FlowAnalyzer<'a> {
     /// session-stable synthetic cache symbol, so the flow cache is shared across
     /// occurrences of the same path instead of being keyed per syntactic node.
     pub(crate) shared_flow_reference_keys: Option<&'a FlowReferenceKeyInterner>,
+    /// Current nesting depth of re-entrant flow-type queries. Narrowing one
+    /// reference can require the flow type of *another* reference (e.g. an
+    /// aliased condition or optional-chain guard), so `get_flow_type` →
+    /// `check_flow` → `get_flow_type` re-enters. `flow_step_budget` bounds the
+    /// work *within* a single traversal but not this nesting, so deeply nested
+    /// narrowing (large modules such as the `effect` canary) would otherwise
+    /// recurse until the native stack overflows. Mirrors tsc's `flowDepth`
+    /// guard in `getFlowTypeOfReference`.
+    pub(crate) flow_query_depth: Cell<u32>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -651,6 +667,7 @@ impl<'a> FlowAnalyzer<'a> {
             destructured_bindings: None,
             concrete_this_type: None,
             shared_flow_reference_keys: None,
+            flow_query_depth: Cell::new(0),
         }
     }
 
@@ -689,6 +706,7 @@ impl<'a> FlowAnalyzer<'a> {
             destructured_bindings: None,
             concrete_this_type: None,
             shared_flow_reference_keys: None,
+            flow_query_depth: Cell::new(0),
         }
     }
 
@@ -978,6 +996,28 @@ impl<'a> FlowAnalyzer<'a> {
             return initial_type;
         }
 
+        // Bound re-entrant flow-query nesting. Each nested `get_flow_type`
+        // resolution adds a `check_flow` frame; without a ceiling, deeply
+        // nested narrowing in large modules overflows the native stack. tsc
+        // applies the same guard (`flowDepth === 2000` in
+        // `getFlowTypeOfReference`), returning the un-narrowed declared type
+        // rather than narrowing further. We mirror that: bail to `initial_type`.
+        let depth = self.flow_query_depth.get();
+        if depth >= MAX_FLOW_QUERY_DEPTH {
+            return initial_type;
+        }
+        self.flow_query_depth.set(depth + 1);
+        let result = self.get_flow_type_uncorrelated_inner(reference, initial_type, flow_node);
+        self.flow_query_depth.set(depth);
+        result
+    }
+
+    fn get_flow_type_uncorrelated_inner(
+        &self,
+        reference: NodeIndex,
+        initial_type: TypeId,
+        flow_node: FlowNodeId,
+    ) -> TypeId {
         // Resolve symbol for caching purposes.
         //
         // Member-like references (`a.b`, `a[b]`, `this.x`) must NOT key by a bare

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_query.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_query.rs
@@ -1,0 +1,279 @@
+//! Public flow-type query entry points.
+//!
+//! `get_flow_type` is the boundary the rest of the checker calls to ask "what
+//! is this reference's narrowed type at this flow node?". It layers three
+//! concerns on top of the core `check_flow` traversal:
+//! - an ERROR short-circuit so suppressed errors are not narrowed into
+//!   concrete (false-positive-producing) types,
+//! - a re-entrant nesting bound (`MAX_FLOW_QUERY_DEPTH`, mirroring tsc's
+//!   `flowDepth` guard) so mutually-dependent reference queries cannot
+//!   overflow the native stack, and
+//! - correlated destructured-binding narrowing, which refines a `const`
+//!   destructured binding by what its sibling bindings' narrowing implies
+//!   about the shared source union.
+
+use super::{FlowAnalyzer, resolve_tuple_binding_type, symbol_first_identifier_ref};
+use crate::query_boundaries::flow_analysis::{tuple_elements_for_type, union_members_for_type};
+use crate::query_boundaries::state::checking::find_property_in_object_by_str;
+use tsz_binder::{FlowNodeId, SymbolId};
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
+
+/// Maximum nesting depth of re-entrant flow-type queries before narrowing bails
+/// to the un-narrowed declared type. Matches tsc's `flowDepth` ceiling of 2000
+/// in `getFlowTypeOfReference`: deep enough that no realistic narrowing chain is
+/// truncated, low enough that the native stack cannot overflow (each level adds
+/// one `check_flow` frame; 2000 frames stay well within the 128MB worker stack).
+const MAX_FLOW_QUERY_DEPTH: u32 = 2000;
+
+impl<'a> FlowAnalyzer<'a> {
+    /// Get the narrowed type of a symbol at a specific flow node.
+    ///
+    /// This walks backwards through the flow graph, applying narrowing operations
+    /// when it encounters condition nodes.
+    pub fn get_flow_type(
+        &self,
+        reference: NodeIndex,
+        initial_type: TypeId,
+        flow_node: FlowNodeId,
+    ) -> TypeId {
+        // Short-circuit for error types: flow narrowing must not transform ERROR
+        // into a concrete type. When the declared/initial type is ERROR (e.g.,
+        // property access on an unresolved type), condition narrowing handlers
+        // like `== null` can produce `null | undefined` regardless of the input
+        // type, turning a suppressed error into a false positive diagnostic.
+        if initial_type == TypeId::ERROR {
+            return initial_type;
+        }
+        let narrowed = self.get_flow_type_uncorrelated(reference, initial_type, flow_node);
+        self.apply_correlated_destructured_narrowing(reference, initial_type, narrowed, flow_node)
+    }
+
+    fn get_flow_type_uncorrelated(
+        &self,
+        reference: NodeIndex,
+        initial_type: TypeId,
+        flow_node: FlowNodeId,
+    ) -> TypeId {
+        if flow_node.is_none() {
+            return initial_type;
+        }
+
+        // Bound re-entrant flow-query nesting. Each nested `get_flow_type`
+        // resolution adds a `check_flow` frame; without a ceiling, deeply
+        // nested narrowing in large modules overflows the native stack. tsc
+        // applies the same guard (`flowDepth === 2000` in
+        // `getFlowTypeOfReference`), returning the un-narrowed declared type
+        // rather than narrowing further. We mirror that: bail to `initial_type`.
+        let depth = self.flow_query_depth.get();
+        if depth >= MAX_FLOW_QUERY_DEPTH {
+            return initial_type;
+        }
+        self.flow_query_depth.set(depth + 1);
+        let result = self.get_flow_type_uncorrelated_inner(reference, initial_type, flow_node);
+        self.flow_query_depth.set(depth);
+        result
+    }
+
+    fn get_flow_type_uncorrelated_inner(
+        &self,
+        reference: NodeIndex,
+        initial_type: TypeId,
+        flow_node: FlowNodeId,
+    ) -> TypeId {
+        // Resolve symbol for caching purposes.
+        //
+        // Member-like references (`a.b`, `a[b]`, `this.x`) must NOT key by a bare
+        // member `SymbolId`: the binder links some member accesses (notably
+        // `this.x` on a class field) to the field symbol, which both aliases
+        // distinct receivers (`x.foo` vs `this.foo` share the field symbol) and
+        // defeats occurrence sharing for everything else. `check_flow` keys such
+        // references by their structural path instead (`flow_reference_path_symbol`),
+        // which is occurrence-stable and receiver-disjoint. Only resolve a symbol
+        // for plain identifier / `this` / `super` roots.
+        let symbol_id = self
+            .binder
+            .resolve_identifier(self.arena, reference)
+            .or_else(|| {
+                if self.is_member_like_reference(reference) {
+                    None
+                } else {
+                    self.reference_symbol(reference)
+                }
+            });
+
+        self.check_flow(
+            reference,
+            initial_type,
+            flow_node,
+            &mut Vec::new(),
+            symbol_id,
+        )
+    }
+
+    fn apply_correlated_destructured_narrowing(
+        &self,
+        reference: NodeIndex,
+        _initial_type: TypeId,
+        narrowed_type: TypeId,
+        flow_node: FlowNodeId,
+    ) -> TypeId {
+        let Some(bindings) = self.destructured_bindings else {
+            return narrowed_type;
+        };
+        let Some(sym_id) = self
+            .binder
+            .resolve_identifier(self.arena, reference)
+            .or_else(|| self.reference_symbol(reference))
+        else {
+            return narrowed_type;
+        };
+        let Some(info) = bindings.get(&sym_id) else {
+            return narrowed_type;
+        };
+        if !info.is_const {
+            return narrowed_type;
+        }
+
+        let Some(source_members) = union_members_for_type(self.interner, info.source_type) else {
+            return narrowed_type;
+        };
+
+        let siblings: Vec<_> = bindings
+            .iter()
+            .filter(|(other_sym, other_info)| {
+                **other_sym != sym_id && other_info.group_id == info.group_id && other_info.is_const
+            })
+            .map(|(other_sym, other_info)| (*other_sym, other_info))
+            .collect();
+        if siblings.is_empty() {
+            return narrowed_type;
+        }
+
+        let mut remaining_members = source_members.to_vec();
+        let original_member_count = remaining_members.len();
+
+        for (sib_sym, sib_info) in siblings {
+            let Some(sib_ref) = self.symbol_identifier_ref(sib_sym) else {
+                continue;
+            };
+            let Some(sib_initial) =
+                self.derive_binding_type_from_members(&source_members, sib_info)
+            else {
+                continue;
+            };
+
+            let sib_narrowed = self.get_flow_type_uncorrelated(sib_ref, sib_initial, flow_node);
+            if sib_narrowed == sib_initial {
+                continue;
+            }
+
+            remaining_members.retain(|&member| {
+                self.binding_type_from_member(member, sib_info)
+                    .is_none_or(|member_ty| self.types_overlap(member_ty, sib_narrowed))
+            });
+        }
+
+        if remaining_members.len() == original_member_count {
+            return narrowed_type;
+        }
+        if remaining_members.is_empty() {
+            return TypeId::NEVER;
+        }
+
+        let Some(correlated) = self.derive_binding_type_from_members(&remaining_members, info)
+        else {
+            return narrowed_type;
+        };
+
+        if correlated == narrowed_type {
+            return correlated;
+        }
+
+        self.intersect_types(correlated, narrowed_type)
+            .unwrap_or(correlated)
+    }
+
+    fn symbol_identifier_ref(&self, sym: SymbolId) -> Option<NodeIndex> {
+        symbol_first_identifier_ref(
+            self.arena,
+            self.binder,
+            self.shared_symbol_first_identifier_ref,
+            sym,
+        )
+    }
+
+    fn binding_type_from_member(
+        &self,
+        member: TypeId,
+        info: &crate::context::DestructuredBindingInfo,
+    ) -> Option<TypeId> {
+        if !info.property_name.is_empty() {
+            let mut current = member;
+            for segment in info.property_name.split('.') {
+                let prop = find_property_in_object_by_str(self.interner, current, segment)?;
+                current = prop.type_id;
+            }
+            Some(current)
+        } else if let Some(elements) = tuple_elements_for_type(self.interner, member) {
+            resolve_tuple_binding_type(
+                self.interner,
+                &elements,
+                info.element_index as usize,
+                info.is_rest,
+            )
+        } else {
+            None
+        }
+    }
+
+    fn derive_binding_type_from_members(
+        &self,
+        members: &[TypeId],
+        info: &crate::context::DestructuredBindingInfo,
+    ) -> Option<TypeId> {
+        let mut result_types = Vec::new();
+        for &member in members {
+            if let Some(member_ty) = self.binding_type_from_member(member, info) {
+                result_types.push(member_ty);
+            }
+        }
+        if result_types.is_empty() {
+            None
+        } else {
+            Some(tsz_solver::utils::union_or_single(
+                self.interner,
+                result_types,
+            ))
+        }
+    }
+
+    fn types_overlap(&self, left: TypeId, right: TypeId) -> bool {
+        left == right
+            || self.flow_assignability_related(left, right)
+            || self.flow_assignability_related(right, left)
+    }
+
+    fn intersect_types(&self, left: TypeId, right: TypeId) -> Option<TypeId> {
+        let left_members = union_members_for_type(self.interner, left);
+        let right_members = union_members_for_type(self.interner, right);
+
+        match (left_members, right_members) {
+            (Some(left_members), Some(right_members)) => {
+                let filtered: Vec<_> = left_members
+                    .iter()
+                    .filter(|member| right_members.contains(member))
+                    .copied()
+                    .collect();
+                if filtered.is_empty() {
+                    None
+                } else {
+                    Some(tsz_solver::utils::union_or_single(self.interner, filtered))
+                }
+            }
+            (Some(left_members), None) => left_members.contains(&right).then_some(right),
+            (None, Some(right_members)) => right_members.contains(&left).then_some(left),
+            (None, None) => (left == right).then_some(left),
+        }
+    }
+}

--- a/crates/tsz-checker/src/flow/control_flow/flow_dp.rs
+++ b/crates/tsz-checker/src/flow/control_flow/flow_dp.rs
@@ -20,6 +20,7 @@
 //!   the asymptotic cost from exponential to linear.
 
 use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
 use tsz_binder::FlowNodeId;
 
 #[derive(Clone, Copy)]
@@ -33,3 +34,88 @@ pub(crate) enum DpState<T: Copy> {
 /// table is per-traversal, not shared across queries, so it does not need to
 /// participate in the broader checker cache plumbing.
 pub(crate) type DpMemo<T> = FxHashMap<FlowNodeId, DpState<T>>;
+
+/// Drive a backward flow-graph DP fold *iteratively* over an explicit heap
+/// stack rather than the native call stack.
+///
+/// The recursive shape (`compute(node)` folds `dp(antecedent)` for each
+/// antecedent, memoizing per node) is `O(N)` in total work but recurses to a
+/// depth equal to the longest acyclic antecedent chain. Real-world fixtures
+/// (e.g. the `effect` canary's large modules) produce antecedent chains long
+/// enough to exhaust even the 128MB checker stack, aborting the whole compile.
+/// Folding over an explicit `Vec` stack keeps the work `O(N)` while bounding
+/// native-stack depth to a constant.
+///
+/// Semantics match the previous recursion exactly:
+/// - `none` flow ids resolve to `in_progress_value` (the analysis's
+///   no-information element).
+/// - A node still `InProgress` when read by a descendant is a CFG back-edge
+///   (loop); it resolves to `in_progress_value`, so the fold treats the loop as
+///   contributing no information, identical to the recursive
+///   `DpState::InProgress` arm.
+/// - `antecedents_of` returns exactly the antecedents the recursion descended
+///   into (the analysis owns `none`/unreachable filtering).
+/// - `fold` receives the node and the resolved antecedent values in
+///   `antecedents_of` order and computes the node's own contribution combined
+///   with them. Fold operators here (AND of bools, intersection of masks) are
+///   commutative and associative, so visitation order is irrelevant.
+pub(crate) fn resolve_backward_dp<T, FAnts, FFold>(
+    root: FlowNodeId,
+    memo: &mut DpMemo<T>,
+    in_progress_value: T,
+    antecedents_of: FAnts,
+    fold: FFold,
+) -> T
+where
+    T: Copy,
+    FAnts: Fn(FlowNodeId) -> SmallVec<[FlowNodeId; 2]>,
+    FFold: Fn(FlowNodeId, &[T]) -> T,
+{
+    if root.is_none() {
+        return in_progress_value;
+    }
+
+    // `true` marks the post-visit entry: by the time it is popped, every
+    // antecedent pushed below it has already been resolved to `Done` (or left
+    // `InProgress` because it is a back-edge ancestor).
+    let mut stack: Vec<(FlowNodeId, bool)> = vec![(root, false)];
+    while let Some((node, post)) = stack.pop() {
+        if post {
+            let ants = antecedents_of(node);
+            let values: SmallVec<[T; 2]> = ants
+                .iter()
+                .map(|&a| match memo.get(&a) {
+                    Some(DpState::Done(v)) => *v,
+                    // `InProgress` (back-edge ancestor) or absent (`none`):
+                    // contribute the no-information element.
+                    _ => in_progress_value,
+                })
+                .collect();
+            let value = fold(node, &values);
+            memo.insert(node, DpState::Done(value));
+            continue;
+        }
+
+        match memo.get(&node) {
+            // Already resolved, or already scheduled (its post-entry is still
+            // below us on the stack). Either way, do not re-expand.
+            Some(_) => continue,
+            None => {}
+        }
+        memo.insert(node, DpState::InProgress);
+        stack.push((node, true));
+        for antecedent in antecedents_of(node) {
+            // Only descend into antecedents we have not seen. An `InProgress`
+            // antecedent is a back-edge ancestor; leaving it unpushed makes the
+            // post-visit read it as `in_progress_value`.
+            if matches!(memo.get(&antecedent), None) {
+                stack.push((antecedent, false));
+            }
+        }
+    }
+
+    match memo.get(&root) {
+        Some(DpState::Done(v)) => *v,
+        _ => in_progress_value,
+    }
+}

--- a/crates/tsz-checker/src/flow/control_flow/flow_dp.rs
+++ b/crates/tsz-checker/src/flow/control_flow/flow_dp.rs
@@ -96,11 +96,10 @@ where
             continue;
         }
 
-        match memo.get(&node) {
-            // Already resolved, or already scheduled (its post-entry is still
-            // below us on the stack). Either way, do not re-expand.
-            Some(_) => continue,
-            None => {}
+        // Already resolved, or already scheduled (its post-entry is still
+        // below us on the stack). Either way, do not re-expand.
+        if memo.get(&node).is_some() {
+            continue;
         }
         memo.insert(node, DpState::InProgress);
         stack.push((node, true));
@@ -108,7 +107,7 @@ where
             // Only descend into antecedents we have not seen. An `InProgress`
             // antecedent is a back-edge ancestor; leaving it unpushed makes the
             // post-visit read it as `in_progress_value`.
-            if matches!(memo.get(&antecedent), None) {
+            if memo.get(&antecedent).is_none() {
                 stack.push((antecedent, false));
             }
         }

--- a/crates/tsz-checker/src/flow/control_flow/typeof_exclusions.rs
+++ b/crates/tsz-checker/src/flow/control_flow/typeof_exclusions.rs
@@ -1,5 +1,5 @@
 use super::FlowAnalyzer;
-use super::flow_dp::{DpMemo, DpState};
+use super::flow_dp::{DpMemo, resolve_backward_dp};
 use tsz_binder::{FlowNodeId, flow_flags};
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
@@ -22,47 +22,68 @@ impl<'a> FlowAnalyzer<'a> {
     }
 
     /// Compute the bitmask of typeof-kinds excluded along every reachable path
-    /// to `flow_id`. The result is `own_mask | (intersection of antecedent
-    /// masks)`, memoized per flow node so the cost is `O(N)` rather than the
-    /// previous `O(N · 2^N)` clone-per-branch traversal.
+    /// to `flow_id`: `own_mask | (intersection of antecedent masks)`, folded
+    /// iteratively over the flow graph (see [`resolve_backward_dp`]). Each node
+    /// is computed once, so the cost is `O(N)` and the native-stack depth is
+    /// bounded regardless of how long the antecedent chain is.
     pub(crate) fn antecedent_typeof_exclusion_mask(
         &self,
         flow_id: FlowNodeId,
         target: NodeIndex,
     ) -> u8 {
         let mut memo: DpMemo<u8> = DpMemo::default();
-        self.typeof_exclusion_mask_memoized(flow_id, target, &mut memo)
+        // Back-edge / no-information element is `0` (no exclusions), so the
+        // surrounding intersection collapses and loops drive no narrowing,
+        // matching the previous recursive `DpState::InProgress` arm.
+        resolve_backward_dp(
+            flow_id,
+            &mut memo,
+            0,
+            |node| self.typeof_exclusion_antecedents(node),
+            |node, antecedent_masks| {
+                self.typeof_exclusion_mask_fold(node, target, antecedent_masks)
+            },
+        )
     }
 
-    fn typeof_exclusion_mask_memoized(
+    /// The antecedents the mask traversal descends into: non-`none`,
+    /// non-unreachable predecessors of a reachable node. An unreachable (or
+    /// missing) node contributes nothing and is not traversed past.
+    fn typeof_exclusion_antecedents(
+        &self,
+        flow_id: FlowNodeId,
+    ) -> smallvec::SmallVec<[FlowNodeId; 2]> {
+        let Some(flow) = self.binder.flow_nodes.get(flow_id) else {
+            return smallvec::SmallVec::new();
+        };
+        if flow.has_any_flags(flow_flags::UNREACHABLE) {
+            return smallvec::SmallVec::new();
+        }
+        flow.antecedent
+            .iter()
+            .copied()
+            .filter(|antecedent| {
+                !antecedent.is_none()
+                    && !self
+                        .binder
+                        .flow_nodes
+                        .get(*antecedent)
+                        .is_some_and(|antecedent_flow| {
+                            antecedent_flow.has_any_flags(flow_flags::UNREACHABLE)
+                        })
+            })
+            .collect()
+    }
+
+    /// Combine a node's own typeof-exclusion bit with the intersection of its
+    /// antecedents' masks. Matches the previous recursive `compute`: an
+    /// unreachable/missing node yields `0`, a node with no reachable
+    /// antecedents yields just its own bit, otherwise `own | intersection`.
+    fn typeof_exclusion_mask_fold(
         &self,
         flow_id: FlowNodeId,
         target: NodeIndex,
-        memo: &mut DpMemo<u8>,
-    ) -> u8 {
-        if flow_id.is_none() {
-            return 0;
-        }
-        match memo.get(&flow_id) {
-            // Back-edge: return the historical fail-safe value (no exclusions)
-            // so the surrounding intersection collapses, matching the previous
-            // `visited.contains` behavior and avoiding loop-driven narrowing.
-            Some(DpState::InProgress) => return 0,
-            Some(DpState::Done(value)) => return *value,
-            None => {}
-        }
-        memo.insert(flow_id, DpState::InProgress);
-
-        let value = self.compute_typeof_exclusion_mask(flow_id, target, memo);
-        memo.insert(flow_id, DpState::Done(value));
-        value
-    }
-
-    fn compute_typeof_exclusion_mask(
-        &self,
-        flow_id: FlowNodeId,
-        target: NodeIndex,
-        memo: &mut DpMemo<u8>,
+        antecedent_masks: &[u8],
     ) -> u8 {
         let Some(flow) = self.binder.flow_nodes.get(flow_id) else {
             return 0;
@@ -82,36 +103,10 @@ impl<'a> FlowAnalyzer<'a> {
             0
         };
 
-        if flow.antecedent.is_empty() {
-            return own;
-        }
-
-        let mut common_antecedent_mask = None;
-        // Snapshot antecedents so we can release the borrow on `flow_nodes`
-        // before recursing. Most flow nodes have one or two antecedents, so
-        // keep that snapshot stack-backed in the common case.
-        let antecedents: smallvec::SmallVec<[FlowNodeId; 2]> =
-            flow.antecedent.iter().copied().collect();
-        for antecedent in antecedents {
-            if antecedent.is_none() {
-                continue;
-            }
-            if self
-                .binder
-                .flow_nodes
-                .get(antecedent)
-                .is_some_and(|antecedent_flow| {
-                    antecedent_flow.has_any_flags(flow_flags::UNREACHABLE)
-                })
-            {
-                continue;
-            }
-            let mask = self.typeof_exclusion_mask_memoized(antecedent, target, memo);
-            common_antecedent_mask = Some(match common_antecedent_mask {
-                Some(common) => common & mask,
-                None => mask,
-            });
-        }
+        let common_antecedent_mask = antecedent_masks
+            .iter()
+            .copied()
+            .reduce(|common, mask| common & mask);
 
         own | common_antecedent_mask.unwrap_or(0)
     }


### PR DESCRIPTION
AgentName: StudioOpus

Track: Conformance / benchmark-canary fix-forward (effect compile crash).

Invariant: Flow analysis must not recurse to a depth proportional to the
input. Both the backward DP folds and re-entrant flow-type queries must be
bounded so large real-world modules cannot overflow the worker stack.

## Summary

The `effect` canary compile-guard project aborts with `fatal runtime error:
stack overflow` instead of type-checking. lldb backtraces show two distinct
input-proportional recursions in `tsz_checker::flow_domain::control_flow`:

1. `typeof_exclusion_mask_memoized` (and its sibling `excludes_null_memoized`)
   — a backward DP fold that is `O(N)` in total work but recurses once per
   antecedent, so a long acyclic antecedent chain recurses to chain length.
2. `check_flow -> get_flow_type_uncorrelated -> check_flow` — re-entrant
   flow-type queries (narrowing one reference needs another reference's flow
   type) nest without a depth bound.

## Structural rule

Flow-graph folds depend only on a node's own flags and its antecedents'
memoized results, so they must be evaluated over an explicit work stack, not
the native call stack. And re-entrant flow queries must carry a nesting
ceiling: tsc bounds this with `flowDepth === 2000` in `getFlowTypeOfReference`,
returning the un-narrowed declared type when exceeded; tsz does the same
through `MAX_FLOW_QUERY_DEPTH`.

## Scope

- `flow_dp.rs`: new `resolve_backward_dp` — a shared iterative post-order DP
  driver over an explicit stack. Preserves the recursive semantics exactly,
  including the `InProgress` back-edge -> no-information element for loops.
- `typeof_exclusions.rs`, `condition_nullish.rs`: fold through the iterative
  driver instead of recursing. Each analysis keeps its own antecedent
  filtering (the typeof mask skips unreachable antecedents; the null chain
  preserves its historical non-filtering) and its own fold operator
  (intersection of masks / AND of bools).
- `core.rs`: `flow_query_depth` (`Cell<u32>`) bounds re-entrant flow-type
  query nesting at `MAX_FLOW_QUERY_DEPTH = 2000`, mirroring tsc.
- `core/flow_query.rs`: the `get_flow_type` entry points and correlated
  destructured-binding narrowing moved verbatim out of `core.rs` to satisfy
  the arch size ratchet (1848-line cap); no behavior change.

Both bounds sit far above any realistic narrowing depth, so narrowing
behavior is unchanged for normal code; only pathological/very-large inputs
that would otherwise crash are affected.

Owner layer: checker flow domain. No solver/emitter changes.

## Project Corpus Impact
- Row: effect-project
- Bug family: stack overflow in deep flow-analysis recursion

## Verification

- `effect` canary: pre-fix `tsz --noEmit -p tsconfig.tsz-guard.json` aborts
  (exit 134, stack overflow) in `typeof_exclusion_mask_memoized`; with the DP
  driver alone it crashes one layer deeper in the re-entrant
  `check_flow`/`get_flow_type` cycle; with both bounds it no longer overflows.
- Flow DP behavior preserved: the iterative driver replicates the previous
  per-node values (intersection / AND folds are order-independent, and the
  back-edge element is unchanged).
- CI is the regression gate for narrowing/conformance (local env has stale
  lib-state failures unrelated to this change).

## Coordination Notes

`effect` no longer crashes but its remaining compile cost still exceeds the
compile-guard timeout; that is a separate flow-analysis performance matter
(re-entrant query memoization across nested flow queries) and is out of scope
for this crash fix. `drizzle-orm` canary also times out (separate). The
companion crash fix for the `zod` canary landed in #13031.
