### PR TITLE
feat(lsp): surface JSDoc @typedef/@callback in document symbols (#13010)

### DIFF
--- a/crates/tsz-lsp/src/symbols/document_symbols.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols.rs
@@ -22,6 +22,7 @@ use tsz_scanner::SyntaxKind;
 
 mod expando;
 mod imports;
+mod jsdoc;
 mod model;
 mod support;
 
@@ -249,10 +250,11 @@ impl<'a> DocumentSymbolProvider<'a> {
                     // declarations merge into a single nested nav
                     // entry (matches tsc's `mergeChildren`).
                     merge_same_name_modules(&mut symbols);
-                    // JS files can declare types via JSDoc
-                    // `@typedef` tags on any top-level statement.
-                    // Scan them so they surface as `type` nav entries.
-                    Self::apply_jsdoc_typedefs(&sf.statements.nodes, &mut symbols);
+                    // Files can declare types via JSDoc `@typedef` /
+                    // `@callback` tags. Scan the file's JSDoc comments and
+                    // surface each alias as a `type` nav entry, matching
+                    // tsserver's navigation tree.
+                    self.apply_jsdoc_typedefs(&sf.comments, &mut symbols);
                 }
                 symbols
             }
@@ -1563,12 +1565,24 @@ impl<'a> DocumentSymbolProvider<'a> {
         }
     }
 
-    /// Walk top-level statements for `@typedef` / `@callback` JSDoc tags and surface
-    /// their names as `type` nav entries. Stub until JSDoc AST nodes flow through the parser.
-    const fn apply_jsdoc_typedefs(_statements: &[NodeIndex], _symbols: &mut [DocumentSymbolEntry]) {
-        // TODO: when the parser exposes JSDoc nodes, walk them for
-        // `@typedef T` and append `DocumentSymbolEntry { name: T, kind:
-        // SymbolKind::Struct }` entries. Until then this is a no-op.
+    /// Scan the file's JSDoc comments for `@typedef` / `@callback` tags and
+    /// surface their names as `type` nav entries, inserting each in source
+    /// order relative to the syntactic top-level symbols.
+    ///
+    /// tsz does not lower JSDoc into AST nodes — the binder and checker both
+    /// read tags directly from the cached comment ranges — so this mirrors that
+    /// model rather than waiting on a JSDoc parser (see [`jsdoc`]).
+    fn apply_jsdoc_typedefs(
+        &self,
+        comments: &[tsz_common::comments::CommentRange],
+        symbols: &mut Vec<DocumentSymbolEntry>,
+    ) {
+        for entry in jsdoc::collect_jsdoc_type_aliases(comments, self.source_text, self.line_map) {
+            let target = entry.selection_range.start;
+            let insert_at = symbols
+                .partition_point(|existing| jsdoc::position_le(existing.range.start, target));
+            symbols.insert(insert_at, entry);
+        }
     }
 
     /// Post-process: scan top-level expression statements for
@@ -1954,3 +1968,7 @@ impl<'a> DocumentSymbolProvider<'a> {
 #[cfg(test)]
 #[path = "../../tests/document_symbols_tests.rs"]
 mod document_symbols_tests;
+
+#[cfg(test)]
+#[path = "../../tests/document_symbols_jsdoc_tests.rs"]
+mod document_symbols_jsdoc_tests;

--- a/crates/tsz-lsp/src/symbols/document_symbols/jsdoc.rs
+++ b/crates/tsz-lsp/src/symbols/document_symbols/jsdoc.rs
@@ -1,0 +1,367 @@
+//! JSDoc `@typedef` / `@callback` document-symbol collection.
+//!
+//! tsz does not parse JSDoc into structured AST nodes; the binder and checker
+//! both discover JSDoc tags by scanning the raw comment ranges cached on
+//! [`tsz_parser::parser::node::SourceFileData`] (`comments`) and parsing the
+//! tag text directly (see `tsz_checker`'s `parse_jsdoc_typedefs` and the
+//! binder's `core_jsdoc`). Document symbols follow the same model: tsserver's
+//! navigation tree surfaces every `@typedef` and `@callback` declaration as a
+//! `type` leaf (`ScriptElementKind.typeElement`), regardless of whether the
+//! host file is JS or TS, so this scanner walks the file's JSDoc comments and
+//! produces one [`DocumentSymbolEntry`] per type-alias name.
+//!
+//! Name extraction mirrors the checker's tag grammar, including the
+//! type-then-name form (`@typedef {T}` with the name on a later line) and the
+//! object-wrapper form (`@typedef {{ ... }} Name`), by tracking brace depth
+//! across lines. Because the underlying tag node is unavailable, ranges are
+//! computed from byte offsets into the raw comment text: the selection range
+//! covers the name identifier and the full range spans from the `@` tag marker
+//! to the end of the name.
+//!
+//! Scope: only the two `type`-kinded type-alias tags are handled here.
+//! tsserver's `isJSDocTypeAlias` also covers `@enum`, but tsc surfaces that
+//! with a distinct `ScriptElementKind` (`enum`) and pairs it with the host
+//! object declaration's members, so it is deliberately left to a separate
+//! change rather than folded in as a third `type` leaf.
+
+use tsz_common::comments::{CommentRange, is_jsdoc_comment};
+use tsz_common::position::{LineMap, Position, Range};
+
+use super::model::{DocumentSymbolEntry, SymbolKind};
+
+/// Walk the file's JSDoc comments and emit a `type` document-symbol entry for
+/// every `@typedef` / `@callback` declaration, in source order.
+pub(super) fn collect_jsdoc_type_aliases(
+    comments: &[CommentRange],
+    source: &str,
+    line_map: &LineMap,
+) -> Vec<DocumentSymbolEntry> {
+    // Cheap reject: avoid scanning every comment when the file cannot contain a
+    // type-alias tag at all. Mirrors the checker's pre-scan in `jsdoc::lookup`.
+    if comments.is_empty() || (!source.contains("@typedef") && !source.contains("@callback")) {
+        return Vec::new();
+    }
+
+    let mut entries = Vec::new();
+    for comment in comments {
+        if !is_jsdoc_comment(comment, source) {
+            continue;
+        }
+        scan_comment(comment, source, line_map, &mut entries);
+    }
+    entries
+}
+
+/// Parser state while walking the lines of a single JSDoc comment.
+enum Mode {
+    /// Looking for a fresh `@typedef` / `@callback` tag at the start of a line.
+    Scan,
+    /// Inside a `@typedef`'s brace-delimited type expression that has not yet
+    /// closed; `depth` is the current unbalanced `{` count and `tag_abs` is the
+    /// absolute byte offset of the owning `@typedef` marker.
+    InType { depth: usize, tag_abs: usize },
+    /// The `@typedef`'s type expression closed with no trailing name on its
+    /// line; the name is the next bare token on a following content line.
+    ExpectName { tag_abs: usize },
+}
+
+fn scan_comment(
+    comment: &CommentRange,
+    source: &str,
+    line_map: &LineMap,
+    out: &mut Vec<DocumentSymbolEntry>,
+) {
+    let raw = comment.get_text(source);
+    let comment_base = comment.pos as usize;
+    let mut mode = Mode::Scan;
+
+    let mut line_start = 0usize;
+    for line in raw.split_inclusive('\n') {
+        let abs_line_start = comment_base + line_start;
+        line_start += line.len();
+
+        let (skipped, content) = strip_jsdoc_line_decoration(line);
+        let content_abs = abs_line_start + skipped;
+
+        match mode {
+            Mode::InType { depth, tag_abs } => match advance_braces(content, depth) {
+                BraceScan::Open { depth } => {
+                    mode = Mode::InType { depth, tag_abs };
+                }
+                BraceScan::Closed { residual } => {
+                    mode = finish_typedef_after_type(
+                        content,
+                        content_abs,
+                        residual,
+                        tag_abs,
+                        source,
+                        line_map,
+                        out,
+                    );
+                }
+            },
+            Mode::ExpectName { tag_abs } => {
+                let trimmed = content.trim_start();
+                if trimmed.is_empty() {
+                    // Blank continuation line; keep waiting for the name.
+                    mode = Mode::ExpectName { tag_abs };
+                } else if trimmed.starts_with('@') {
+                    // A new tag terminates the pending typedef without a name;
+                    // re-dispatch this line as a fresh tag.
+                    mode = scan_tag_line(content, content_abs, source, line_map, out);
+                } else {
+                    push_name_token(content, content_abs, tag_abs, source, line_map, out);
+                    mode = Mode::Scan;
+                }
+            }
+            Mode::Scan => {
+                mode = scan_tag_line(content, content_abs, source, line_map, out);
+            }
+        }
+    }
+}
+
+/// Dispatch a line that may begin a `@typedef` / `@callback` tag. Returns the
+/// mode to continue scanning subsequent lines with.
+fn scan_tag_line(
+    content: &str,
+    content_abs: usize,
+    source: &str,
+    line_map: &LineMap,
+    out: &mut Vec<DocumentSymbolEntry>,
+) -> Mode {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with('@') {
+        return Mode::Scan;
+    }
+    // Account for whitespace skipped by `trim_start` so offsets stay accurate.
+    let lead = content.len() - trimmed.len();
+    let tag_abs = content_abs + lead;
+
+    if let Some(rest) = strip_tag(trimmed, "typedef") {
+        let rest_abs = tag_abs + "@typedef".len();
+        return begin_typedef(rest, rest_abs, tag_abs, source, line_map, out);
+    }
+    if let Some(rest) = strip_tag(trimmed, "callback") {
+        let rest_abs = tag_abs + "@callback".len();
+        // A callback's name must appear on the tag line itself.
+        push_name_token(rest, rest_abs, tag_abs, source, line_map, out);
+    }
+    Mode::Scan
+}
+
+/// Handle the body of a `@typedef` tag once the `@typedef` marker is consumed.
+/// `rest` is the text after `@typedef`; `rest_abs` its absolute offset.
+fn begin_typedef(
+    rest: &str,
+    rest_abs: usize,
+    tag_abs: usize,
+    source: &str,
+    line_map: &LineMap,
+    out: &mut Vec<DocumentSymbolEntry>,
+) -> Mode {
+    let lead = rest.len() - rest.trim_start().len();
+    let trimmed = &rest[lead..];
+    if trimmed.starts_with('{') {
+        let brace_abs = rest_abs + lead;
+        match advance_braces(trimmed, 0) {
+            BraceScan::Open { depth } => Mode::InType { depth, tag_abs },
+            BraceScan::Closed { residual } => finish_typedef_after_type(
+                trimmed, brace_abs, residual, tag_abs, source, line_map, out,
+            ),
+        }
+    } else {
+        // `@typedef Name` — no type expression; the name is on this line.
+        push_name_token(rest, rest_abs, tag_abs, source, line_map, out);
+        Mode::Scan
+    }
+}
+
+/// After a typedef's type expression closes (`residual` is the byte index just
+/// past the closing brace within `content`), capture a same-line trailing name
+/// if present, otherwise wait for it on a following line.
+fn finish_typedef_after_type(
+    content: &str,
+    content_abs: usize,
+    residual: Option<usize>,
+    tag_abs: usize,
+    source: &str,
+    line_map: &LineMap,
+    out: &mut Vec<DocumentSymbolEntry>,
+) -> Mode {
+    let Some(residual) = residual else {
+        return Mode::ExpectName { tag_abs };
+    };
+    let after = &content[residual..];
+    let after_trimmed = after.trim_start();
+    if after_trimmed.is_empty() || after_trimmed.starts_with('@') {
+        return Mode::ExpectName { tag_abs };
+    }
+    push_name_token(
+        after,
+        content_abs + residual,
+        tag_abs,
+        source,
+        line_map,
+        out,
+    );
+    Mode::Scan
+}
+
+/// Result of scanning a (partial) brace-delimited type expression on one line.
+enum BraceScan {
+    /// The expression is still open after this line; `depth` braces remain.
+    Open { depth: usize },
+    /// The expression closed; `residual` is the byte index just past the
+    /// closing `}` within the scanned slice, or `None` when it ended the slice.
+    Closed { residual: Option<usize> },
+}
+
+/// Scan `s` from byte index `start`, updating an existing brace `depth`. Quotes
+/// (`'`, `"`, `` ` ``) are honored so braces inside string literals in a type
+/// expression do not unbalance the count, matching the checker's
+/// `parse_jsdoc_curly_type_expr`.
+fn advance_braces(s: &str, mut depth: usize) -> BraceScan {
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+    for (idx, ch) in s.char_indices() {
+        if let Some(active) = quote {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == active {
+                quote = None;
+            }
+            continue;
+        }
+        match ch {
+            '"' | '\'' | '`' => quote = Some(ch),
+            '{' => depth += 1,
+            '}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    let next = idx + ch.len_utf8();
+                    return BraceScan::Closed {
+                        residual: (next < s.len()).then_some(next),
+                    };
+                }
+            }
+            _ => {}
+        }
+    }
+    BraceScan::Open { depth }
+}
+
+/// Extract the first whitespace-delimited identifier from `text` and, if it is
+/// a valid type-alias name, push a `type` entry for it. `text_abs` is the
+/// absolute byte offset of `text[0]`; `tag_abs` is the offset of the owning
+/// `@typedef` / `@callback` marker (used for the enclosing range).
+fn push_name_token(
+    text: &str,
+    text_abs: usize,
+    tag_abs: usize,
+    source: &str,
+    line_map: &LineMap,
+    out: &mut Vec<DocumentSymbolEntry>,
+) {
+    let lead = text.len() - text.trim_start().len();
+    let rest = &text[lead..];
+    if rest.is_empty() || rest.starts_with('@') {
+        return;
+    }
+    let Some(token) = rest.split_whitespace().next() else {
+        return;
+    };
+    let name = normalize_name(token);
+    if !is_valid_type_alias_name(name) {
+        return;
+    }
+
+    let name_abs = text_abs + lead;
+    let name_end = name_abs + name.len();
+    let selection = byte_range(line_map, source, name_abs, name_end);
+    let range = byte_range(line_map, source, tag_abs.min(name_abs), name_end);
+
+    out.push(DocumentSymbolEntry {
+        name: name.to_string(),
+        detail: None,
+        kind: SymbolKind::Struct,
+        kind_modifiers: String::new(),
+        range,
+        selection_range: selection,
+        container_name: None,
+        children: Vec::new(),
+    });
+}
+
+/// Strip a JSDoc tag prefix (`@typedef`, `@callback`) when `line` begins with
+/// it followed by a tag boundary. Returns the remainder after the tag name.
+fn strip_tag<'a>(line: &'a str, tag: &str) -> Option<&'a str> {
+    let rest = line.strip_prefix('@')?.strip_prefix(tag)?;
+    match rest.chars().next() {
+        None => Some(rest),
+        Some(c) if !c.is_ascii_alphanumeric() && c != '_' => Some(rest),
+        Some(_) => None,
+    }
+}
+
+/// Strip leading whitespace and a single JSDoc line decoration (`/**`, `/*`, or
+/// `*`) plus following whitespace, returning the bytes skipped and the content.
+fn strip_jsdoc_line_decoration(line: &str) -> (usize, &str) {
+    let after_ws = line.trim_start();
+    let undecorated = after_ws
+        .strip_prefix("/**")
+        .or_else(|| after_ws.strip_prefix("/*"))
+        .or_else(|| after_ws.strip_prefix('*'))
+        .unwrap_or(after_ws);
+    let content = undecorated.trim_start();
+    (line.len() - content.len(), content)
+}
+
+/// Normalize a raw name token to the bare alias name: drop a trailing comma /
+/// semicolon, a glued comment terminator (`*/`), and any generic parameter list
+/// (`Name<T>` → `Name`). Mirrors the checker's `normalize_jsdoc_typedef_name`.
+fn normalize_name(token: &str) -> &str {
+    let punctuation = |c| c == ',' || c == ';';
+    let mut name = token.trim_end_matches(punctuation);
+    if let Some(stripped) = name.strip_suffix("*/") {
+        name = stripped;
+    }
+    if let Some(angle) = name.find('<') {
+        name = &name[..angle];
+    }
+    // The `*/` / generic truncation can re-expose a trailing separator.
+    name.trim_end_matches(punctuation)
+}
+
+/// A type-alias name is an identifier optionally containing `.` (namespaced
+/// callback names) — matching the checker's callback-name validation and
+/// rejecting type-expression fragments such as `{Object}`.
+fn is_valid_type_alias_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+        return false;
+    }
+    name.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$' || c == '.')
+}
+
+/// Build an LSP [`Range`] spanning the byte interval `[start, end)`.
+fn byte_range(line_map: &LineMap, source: &str, start: usize, end: usize) -> Range {
+    let start = u32::try_from(start).unwrap_or(u32::MAX);
+    let end = u32::try_from(end).unwrap_or(u32::MAX);
+    Range::new(
+        line_map.offset_to_position(start, source),
+        line_map.offset_to_position(end, source),
+    )
+}
+
+/// Whether `a` is at or before `b` in source order. Used by the caller to
+/// insert type-alias entries into the top-level symbol list in source order.
+pub(super) const fn position_le(a: Position, b: Position) -> bool {
+    a.line < b.line || (a.line == b.line && a.character <= b.character)
+}

--- a/crates/tsz-lsp/tests/document_symbols_jsdoc_tests.rs
+++ b/crates/tsz-lsp/tests/document_symbols_jsdoc_tests.rs
@@ -1,0 +1,159 @@
+//! Document-symbol coverage for JSDoc `@typedef` / `@callback` type aliases.
+//!
+//! These exercise `jsdoc::collect_jsdoc_type_aliases` through the public
+//! `DocumentSymbolProvider` surface, mirroring the harness in
+//! `document_symbols_tests.rs`.
+
+use super::*;
+use tsz_common::position::LineMap;
+
+fn parse_jsdoc_source(source: &str) -> (tsz_parser::ParserState, tsz_parser::parser::NodeIndex) {
+    let mut parser = tsz_parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    (parser, root)
+}
+
+fn symbols_for(source: &str) -> Vec<DocumentSymbol> {
+    let (parser, root) = parse_jsdoc_source(source);
+    let line_map = LineMap::build(source);
+    let provider = DocumentSymbolProvider::new(parser.get_arena(), &line_map, source);
+    provider.get_document_symbols(root)
+}
+
+/// The text covered by `selection_range` must be exactly the symbol's name —
+/// this validates that the byte-offset → position math is correct.
+fn assert_selection_matches_name(source: &str, symbol: &DocumentSymbol) {
+    let line_map = LineMap::build(source);
+    let start = line_map
+        .position_to_offset(symbol.selection_range.start, source)
+        .expect("selection start maps to an offset");
+    let end = line_map
+        .position_to_offset(symbol.selection_range.end, source)
+        .expect("selection end maps to an offset");
+    let slice = &source[start as usize..end as usize];
+    assert_eq!(
+        slice, symbol.name,
+        "selection_range should cover the name token"
+    );
+}
+
+#[test]
+fn typedef_with_braced_type_surfaces_as_type() {
+    let source = "/** @typedef {number} Meters */\n";
+    let symbols = symbols_for(source);
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0].name, "Meters");
+    assert_eq!(symbols[0].kind, SymbolKind::Struct);
+    assert_eq!(symbols[0].kind.to_script_element_kind(), "type");
+    assert_selection_matches_name(source, &symbols[0]);
+}
+
+#[test]
+fn callback_surfaces_as_type() {
+    let source = "/**\n * @callback OnClick\n * @param {number} x\n */\n";
+    let symbols = symbols_for(source);
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0].name, "OnClick");
+    assert_eq!(symbols[0].kind, SymbolKind::Struct);
+    assert_selection_matches_name(source, &symbols[0]);
+}
+
+#[test]
+fn typedef_without_type_uses_trailing_name() {
+    // `@typedef Name` with the shape described via @property tags.
+    let source = "/**\n * @typedef Point\n * @property {number} x\n * @property {number} y\n */\n";
+    let symbols = symbols_for(source);
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0].name, "Point");
+    assert_selection_matches_name(source, &symbols[0]);
+}
+
+#[test]
+fn generic_typedef_name_drops_type_parameters() {
+    let source = "/** @typedef {Array<T>} Box<T> */\n";
+    let symbols = symbols_for(source);
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0].name, "Box");
+    assert_selection_matches_name(source, &symbols[0]);
+}
+
+#[test]
+fn typedef_type_then_name_on_following_line() {
+    let source = "/**\n * @typedef {{ a: number, b: string }}\n * NamedShape\n */\n";
+    let symbols = symbols_for(source);
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0].name, "NamedShape");
+    assert_selection_matches_name(source, &symbols[0]);
+}
+
+#[test]
+fn object_wrapper_typedef_spanning_lines() {
+    let source = "/**\n * @typedef {{\n *   a: number,\n *   b: string,\n * }} Wrapped\n */\n";
+    let symbols = symbols_for(source);
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0].name, "Wrapped");
+    assert_selection_matches_name(source, &symbols[0]);
+}
+
+#[test]
+fn multiple_typedefs_in_one_comment() {
+    let source = "/**\n * @typedef {number} A\n * @typedef {string} B\n */\n";
+    let symbols = symbols_for(source);
+    let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, ["A", "B"]);
+    assert!(symbols.iter().all(|s| s.kind == SymbolKind::Struct));
+}
+
+#[test]
+fn typedef_inserted_in_source_order_with_declarations() {
+    let source = "/** @typedef {number} Id */\nconst x = 1;\nfunction f() {}\n";
+    let symbols = symbols_for(source);
+    let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, ["Id", "x", "f"]);
+    assert_eq!(symbols[0].kind, SymbolKind::Struct);
+}
+
+#[test]
+fn typedef_after_declaration_keeps_source_order() {
+    let source = "const x = 1;\n/** @typedef {number} Id */\nfunction f() {}\n";
+    let symbols = symbols_for(source);
+    let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, ["x", "Id", "f"]);
+}
+
+#[test]
+fn non_type_alias_tags_do_not_surface() {
+    // A doc comment with only @param / @returns must not create symbols.
+    let source =
+        "/**\n * @param {number} x\n * @returns {number}\n */\nfunction f(x) { return x; }\n";
+    let symbols = symbols_for(source);
+    let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, ["f"]);
+}
+
+#[test]
+fn typedef_lookalike_in_string_is_ignored() {
+    // `@typedef` appearing in a string literal is not a comment, so no symbol.
+    let source = "const s = \"@typedef {number} Nope\";\n";
+    let symbols = symbols_for(source);
+    let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, ["s"]);
+}
+
+#[test]
+fn single_line_block_comment_is_not_jsdoc() {
+    // `/* ... */` (single asterisk) is not a JSDoc comment.
+    let source = "/* @typedef {number} Nope */\nconst x = 1;\n";
+    let symbols = symbols_for(source);
+    let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, ["x"]);
+}
+
+#[test]
+fn typedef_with_trailing_comment_terminator_glued_to_name() {
+    let source = "/** @typedef {number} Glued*/\n";
+    let symbols = symbols_for(source);
+    assert_eq!(symbols.len(), 1);
+    assert_eq!(symbols[0].name, "Glued");
+    assert_selection_matches_name(source, &symbols[0]);
+}


### PR DESCRIPTION
Resolves #13010.

AgentName: claude/confident-hawking-hvm43n

Track: Track 10 — Guardrails, Tooling, Architecture (LSP navigation tech-debt)

## Summary

Replaces the no-op `apply_jsdoc_typedefs` stub in
`crates/tsz-lsp/src/symbols/document_symbols.rs` (the TODO at the old
`:1569`) with a real JSDoc-aware document-symbol traversal. `@typedef` and
`@callback` declarations now surface as `type` nav entries, matching
tsserver's navigation tree.

## Structural rule

When a JSDoc comment declares a type alias, `tsc` surfaces it in the
navigation tree as a `type` leaf (`ScriptElementKind.typeElement`); `tsz`
now does the same through the LSP document-symbol provider.

The TODO's premise — "when the parser exposes JSDoc nodes" — does not match
how tsz models JSDoc. tsz never lowers JSDoc into AST nodes: the binder
(`crates/tsz-binder/src/state/core_jsdoc.rs`) and the checker
(`crates/tsz-checker/src/jsdoc/parsing.rs::parse_jsdoc_typedefs`) both
discover tags by scanning the raw comment ranges cached on
`SourceFileData::comments` and parsing the tag text directly. The fix
follows that established, per-crate pattern rather than waiting on a JSDoc
parser that does not exist.

Owner layer: `tsz-lsp` (document-symbol provider). No checker/solver/binder
internals are touched; this is pure syntactic name extraction for an
outline, not a type algorithm.

## Invariant

Document symbols match tsserver's navigation tree for JSDoc type aliases:
each `@typedef` / `@callback` becomes one `type` leaf, in source order
relative to the syntactic top-level symbols. Existing (non-JSDoc) symbol
output is unchanged.

## Scope

- `crates/tsz-lsp/src/symbols/document_symbols/jsdoc.rs` (new): a
  line-by-line state machine (`Scan` / `InType` / `ExpectName`) that mirrors
  the checker's tag grammar — braced type (`@typedef {T} Name`), bare name
  (`@typedef Name`), type-then-name on a later line, the `{{ ... }}` object
  wrapper spanning lines, and generic-suffix stripping (`Name<T>` → `Name`).
  Brace tracking is quote-aware. Ranges come from byte offsets into the raw
  comment text: the selection range covers the name identifier; the full
  range spans from the `@` marker to the end of the name.
- `crates/tsz-lsp/src/symbols/document_symbols.rs`: drop the stub; call the
  new collector with `sf.comments`; insert each alias entry in source order
  via `partition_point`.
- `crates/tsz-lsp/tests/document_symbols_jsdoc_tests.rs` (new): 13 tests.

Adjacent-case matrix: braced / unbraced / generic / type-then-name /
multi-line object-wrapper typedefs; `@callback`; two typedefs in one
comment; source-order insertion before and after sibling declarations;
negatives — `@typedef` look-alike inside a string literal, single-asterisk
`/* */` block comments (not JSDoc), and comments with only `@param` /
`@returns`.

`@enum` (also covered by tsserver's `isJSDocTypeAlias`) is intentionally
out of scope: `tsc` surfaces it with a distinct `ScriptElementKind` and
pairs it with the host object's members, so it belongs to a separate change
rather than being folded in as a third `type` leaf. This is documented in
the new module.

No anti-hardcoding concerns: dispatch is by JSDoc tag text and brace
structure, not by identifier/file-name strings or rendered diagnostic text.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a

LSP-only navigation change; no project-corpus row exercises document
symbols, and no semantic/inference/emit path is touched. Evidence: the
diff is confined to `crates/tsz-lsp/src/symbols/document_symbols*` and a new
LSP test file.

## Verification

- `cargo test -p tsz-lsp --lib document_symbols` — 124 passed, 0 failed
  (111 pre-existing + 13 new JSDoc tests).
- `cargo test -p tsz-lsp --lib` — 4009 passed, 0 failed, 1 ignored.
- `cargo clippy -p tsz-lsp --tests` — clean.
- Rebased on latest `main` (`4fc0cbd`); clean rebase, no conflicts; all
  files under the 2000-line cap.

## Coordination Notes

- No overlap with open PRs: this touches only
  `crates/tsz-lsp/src/symbols/document_symbols*`. Independent of the JSDoc
  emit/checker work in flight.
- Builds on top of the merged `NodeArena` `Arc` clone (#13033); the provider
  reads the arena through `Deref`, so it is unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GM4SAfuxJyDwpVBr63tW2G)_