### PR TITLE
refactor(checker): route type-parameter-constraint elaboration through a named relation outcome and repair the relation-routing ratchet (#12949)

### DIFF
--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -684,20 +684,15 @@ impl<'a> CheckerState<'a> {
         self.execute_relation_request(&request)
     }
 
-    /// Whether a source is assignable to a bare type parameter's constraint,
-    /// shaped as a `RelationOutcome` for the "could be instantiated with an
-    /// arbitrary type which could be unrelated to" related-information
-    /// elaboration (TS2322/TS2345 family).
+    /// Whether a source satisfies a bare type parameter's constraint, shaped as a
+    /// `RelationOutcome` for the "could be instantiated with an arbitrary type
+    /// which could be unrelated to" related-information elaboration.
     ///
-    /// This intentionally mirrors the checker's compat-aware assignability
-    /// decision (`diagnostic_relation_outcome` → `is_assignable_to`) rather than
-    /// the strict solver relation used by the `execute_relation_request` helpers:
-    /// the related-info must be suppressed in exactly the cases where the source
-    /// would in fact satisfy the constraint, including the checker-side variance
-    /// and index-access fast paths that the strict relation does not replicate.
-    /// Keeping the call site on a named, grep-distinct outcome boundary lets the
-    /// residual relation-routing ratchet forbid raw boolean guards in diagnostic
-    /// elaboration without changing parity.
+    /// Routes through `diagnostic_relation_outcome` (the compat-aware
+    /// `is_assignable_to` path), not the strict `execute_relation_request` path,
+    /// so the related-info is suppressed in exactly the cases where the source
+    /// would satisfy the constraint — preserving parity while keeping the call
+    /// site off a raw boolean guard.
     pub(crate) fn type_parameter_constraint_elaboration_relation_outcome(
         &mut self,
         source: TypeId,

--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -684,6 +684,28 @@ impl<'a> CheckerState<'a> {
         self.execute_relation_request(&request)
     }
 
+    /// Whether a source is assignable to a bare type parameter's constraint,
+    /// shaped as a `RelationOutcome` for the "could be instantiated with an
+    /// arbitrary type which could be unrelated to" related-information
+    /// elaboration (TS2322/TS2345 family).
+    ///
+    /// This intentionally mirrors the checker's compat-aware assignability
+    /// decision (`diagnostic_relation_outcome` → `is_assignable_to`) rather than
+    /// the strict solver relation used by the `execute_relation_request` helpers:
+    /// the related-info must be suppressed in exactly the cases where the source
+    /// would in fact satisfy the constraint, including the checker-side variance
+    /// and index-access fast paths that the strict relation does not replicate.
+    /// Keeping the call site on a named, grep-distinct outcome boundary lets the
+    /// residual relation-routing ratchet forbid raw boolean guards in diagnostic
+    /// elaboration without changing parity.
+    pub(crate) fn type_parameter_constraint_elaboration_relation_outcome(
+        &mut self,
+        source: TypeId,
+        constraint: TypeId,
+    ) -> crate::query_boundaries::assignability::RelationOutcome {
+        self.diagnostic_relation_outcome(source, constraint)
+    }
+
     pub(crate) fn broad_mapped_index_signature_display_relation_outcome(
         &mut self,
         source: TypeId,

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1198,7 +1198,9 @@ impl<'a> CheckerState<'a> {
         )?;
         if constraint == TypeId::ANY
             || constraint == TypeId::UNKNOWN
-            || self.diagnostic_relation_boolean_guard(source, constraint)
+            || self
+                .type_parameter_constraint_elaboration_relation_outcome(source, constraint)
+                .related
         {
             return None;
         }

--- a/crates/tsz-checker/src/tests/assignability_diagnostics_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/assignability_diagnostics_relation_routing_arch_tests.rs
@@ -106,14 +106,17 @@ fn assignability_diagnostics_routes_top_level_mismatch_probes_through_relation_o
         .map(|offset| numeric_enum_start + offset)
         .expect("missing next assignability diagnostics helper");
     let numeric_enum_helper = &root_source[numeric_enum_start..numeric_enum_end];
+    let numeric_enum_compact: String = numeric_enum_helper
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect();
     assert!(
-        numeric_enum_helper.contains(
-            "numeric_enum_assignment_relation_outcome(source_literal, structural_target)"
-        ),
+        numeric_enum_compact
+            .contains("numeric_enum_assignment_relation_outcome(source_literal,structural_target"),
         "numeric enum assignment override should use the numeric-enum assignment RelationOutcome"
     );
     assert!(
-        !numeric_enum_helper.contains("assign_relation_outcome(source_literal, structural_target)"),
+        !numeric_enum_compact.contains("assign_relation_outcome(source_literal,structural_target"),
         "numeric enum assignment override should not use the generic assign request"
     );
     let default_reporter_start = root_source

--- a/crates/tsz-checker/src/tests/call_elaboration_mutual_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_elaboration_mutual_relation_routing_arch_tests.rs
@@ -178,9 +178,15 @@ fn call_elaboration_object_array_helpers_use_relation_outcome_boundary() {
         "object/array call elaboration helper probes should route through call_arg_relation_outcome"
     );
     assert_eq!(
-        helpers.matches("assign_relation_outcome(").count(),
+        helpers
+            .matches("variable_initializer_relation_outcome(")
+            .count(),
         1,
-        "tail helper region should keep only the variable-initializer assignability probe as a generic assignment request"
+        "tail helper region should route the variable-initializer assignability probe through the named variable-initializer relation outcome"
+    );
+    assert!(
+        !helpers.contains("assign_relation_outcome("),
+        "object/array call elaboration helpers should not regress to generic assign relation outcomes"
     );
     assert!(
         !helpers.contains("diagnostic_relation_boolean_guard("),

--- a/crates/tsz-checker/src/tests/index_signature_property_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/index_signature_property_relation_routing_arch_tests.rs
@@ -56,11 +56,15 @@ fn union_excess_unresolved_member_matching_uses_relation_outcome() {
     let compact_block: String = block.chars().filter(|ch| !ch.is_whitespace()).collect();
 
     assert!(
-        compact_block.contains("assign_relation_outcome(")
+        compact_block.contains("union_excess_required_property_relation_outcome(")
             && compact_block.contains("source_prop.type_id")
             && compact_block.contains("target_prop.type_id")
             && compact_block.contains(".related"),
-        "union excess fallback member matching should route property compatibility through relation outcomes"
+        "union excess fallback member matching should route property compatibility through the union-excess relation outcome"
+    );
+    assert!(
+        !block.contains("assign_relation_outcome("),
+        "union excess fallback member matching should not regress to generic assignment request routing"
     );
     assert!(
         !block.contains("diagnostic_relation_boolean_guard"),

--- a/crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/indexed_access_constraint_relation_routing_arch_tests.rs
@@ -139,7 +139,7 @@ fn indexed_access_type_checking_helpers_use_relation_outcome_boundary() {
         helpers
             .matches("indexed_access_key_space_relation_outcome(")
             .count(),
-        10,
+        11,
         "indexed-access helper key-space probes should route through the named RelationRequest"
     );
     assert!(

--- a/crates/tsz-checker/src/tests/interface_index_conflict_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/interface_index_conflict_relation_routing_arch_tests.rs
@@ -8,10 +8,10 @@ fn interface_index_conflicts_use_relation_outcome_boundary() {
         .expect("read class checker compatibility source");
 
     let helper = source
-        .split("Different bases provide conflicting index signatures.")
+        .split("Conflicting index signatures from different bases")
         .nth(1)
         .expect("find inherited interface index-signature conflict block")
-        .split("The later base's index signature conflicts")
+        .split("incorrectly extends interface")
         .next()
         .expect("slice relation decision block");
     let compact: String = helper.chars().filter(|c| !c.is_whitespace()).collect();

--- a/crates/tsz-checker/src/tests/jsdoc_import_type_constraints_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsdoc_import_type_constraints_relation_routing_arch_tests.rs
@@ -17,9 +17,13 @@ fn jsdoc_import_type_constraints_use_relation_outcome_boundary() {
         .expect("slice helper body before scope restoration");
 
     assert!(
-        helper.contains("assign_relation_outcome(type_arg, constraint)")
+        helper.contains("jsdoc_type_constraint_relation_outcome(type_arg, constraint)")
             && helper.contains(".related"),
         "JSDoc import type constraint diagnostics should use the shared relation outcome boundary"
+    );
+    assert!(
+        !helper.contains("assign_relation_outcome("),
+        "JSDoc import type constraint diagnostics should not regress to the generic assign request"
     );
     assert!(
         !helper.contains("diagnostic_relation_boolean_guard"),

--- a/crates/tsz-checker/src/tests/jsx_component_props_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_component_props_relation_routing_arch_tests.rs
@@ -15,13 +15,9 @@ fn jsx_component_props_tag_relations_use_relation_outcome_boundary() {
     let compact_helpers: String = helpers.chars().filter(|ch| !ch.is_whitespace()).collect();
 
     assert_eq!(
-        helpers.matches("jsx_props_relation_outcome").count(),
+        helpers.matches("props_are_assignable").count(),
         6,
-        "JSX component prop tag relation checks should route through jsx_props_relation_outcome"
-    );
-    assert!(
-        helpers.contains(".related"),
-        "JSX component prop tag relation checks should use the relation outcome decision"
+        "JSX component prop tag relation checks should route through the props_are_assignable boundary"
     );
     assert!(
         !compact_helpers.contains("assign_relation_outcome(tag_literal,key_type)")

--- a/crates/tsz-checker/src/tests/jsx_overload_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_overload_relation_routing_arch_tests.rs
@@ -14,13 +14,9 @@ fn jsx_overload_matching_uses_relation_outcome_boundary() {
     let helpers = &source[start..end];
 
     assert_eq!(
-        helpers.matches("jsx_props_relation_outcome").count(),
+        helpers.matches("props_are_assignable").count(),
         5,
-        "JSX overload relation checks should route through jsx_props_relation_outcome"
-    );
-    assert!(
-        helpers.contains(".related"),
-        "JSX overload relation checks should use the relation outcome decision"
+        "JSX overload relation checks should route through the props_are_assignable boundary"
     );
     assert!(
         !helpers.contains("diagnostic_relation_boolean_guard"),

--- a/crates/tsz-checker/src/tests/jsx_react_alias_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_react_alias_relation_routing_arch_tests.rs
@@ -17,9 +17,9 @@ fn jsx_react_props_alias_storage_uses_relation_outcome_boundary() {
     let function = &source[function_start..function_end];
 
     assert_eq!(
-        function.matches("jsx_props_relation_outcome").count(),
+        function.matches("props_are_assignable").count(),
         2,
-        "JSX props display-alias storage should route both compatibility decisions through JSX props relation outcomes"
+        "JSX props display-alias storage should route both compatibility decisions through the props_are_assignable boundary"
     );
     assert!(
         !function.contains("assign_relation_outcome"),

--- a/crates/tsz-checker/src/tests/jsx_spread_assignability_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_spread_assignability_relation_routing_arch_tests.rs
@@ -17,9 +17,9 @@ fn jsx_spread_whole_type_assignability_uses_relation_outcome_boundary() {
     let prefix = &source[function_start..shape_branch_end];
 
     assert_eq!(
-        prefix.matches("jsx_props_relation_outcome").count(),
+        prefix.matches("props_are_assignable").count(),
         2,
-        "early JSX spread whole-type compatibility decisions should route through JSX props relation outcomes"
+        "early JSX spread whole-type compatibility decisions should route through the props_are_assignable boundary"
     );
     assert!(
         !prefix.contains("diagnostic_relation_boolean_guard"),
@@ -43,9 +43,9 @@ fn jsx_spread_property_mismatch_uses_relation_outcome_boundary() {
     let branch = &source[start..end];
 
     assert_eq!(
-        branch.matches("jsx_props_relation_outcome").count(),
+        branch.matches("props_are_assignable").count(),
         3,
-        "JSX spread property and generic whole-type mismatch probes should route through JSX props relation outcomes"
+        "JSX spread property and generic whole-type mismatch probes should route through the props_are_assignable boundary"
     );
     assert!(
         !branch.contains("diagnostic_relation_boolean_guard"),

--- a/crates/tsz-checker/src/tests/jsx_union_props_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/jsx_union_props_relation_routing_arch_tests.rs
@@ -17,9 +17,9 @@ fn jsx_union_props_diagnostics_use_relation_outcome_boundary() {
     let function = &source[function_start..function_end];
 
     assert_eq!(
-        function.matches("jsx_props_relation_outcome").count(),
+        function.matches("props_are_assignable").count(),
         2,
-        "JSX union props compatibility decisions should route through JSX props relation outcomes"
+        "JSX union props compatibility decisions should route through the props_are_assignable boundary"
     );
     assert!(
         !function.contains("diagnostic_relation_boolean_guard"),

--- a/crates/tsz-checker/src/tests/relation_routing_residual_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/relation_routing_residual_arch_tests.rs
@@ -12,6 +12,15 @@ const RAW_RELATION_PATTERNS: &[&str] = &[
     ".is_subtype_of(",
     ".assign_relation_outcome(",
     ".assign_relation_outcome_with_env(",
+    // Boolean relation guards are the assignability boundary's own primitives;
+    // diagnostic-bearing checker paths must wrap them in a named
+    // `*_relation_outcome` helper rather than probe them directly.
+    ".diagnostic_relation_boolean_guard(",
+    ".diagnostic_relation_boolean_guard_with_env(",
+    ".diagnostic_relation_boolean_guard_bivariant(",
+    ".diagnostic_relation_boolean_guard_strict(",
+    ".diagnostic_relation_boolean_guard_no_erase_generics(",
+    ".diagnostic_relation_boolean_guard_no_weak_checks(",
 ];
 
 fn rust_sources_under(dir: &Path) -> Vec<PathBuf> {
@@ -109,6 +118,29 @@ fn relation_outcome_with_env_fast_path_uses_named_diagnostic_guard() {
     assert!(
         !compact.contains("self.is_assignable_to_with_env(source,target)"),
         "relation_outcome_with_env should not embed a raw env-aware assignability fast path"
+    );
+}
+
+#[test]
+fn type_parameter_constraint_elaboration_uses_named_outcome_helper() {
+    let source = fs::read_to_string("src/error_reporter/assignability.rs")
+        .expect("failed to read error reporter assignability source");
+    let body = function_body_between(
+        &source,
+        "fn unrelated_type_parameter_target_related_info(",
+        "fn type_or_evaluated_has_display_properties(",
+    );
+    let compact: String = body.chars().filter(|ch| !ch.is_whitespace()).collect();
+
+    assert!(
+        compact
+            .contains(".type_parameter_constraint_elaboration_relation_outcome(source,constraint)"),
+        "the arbitrary-type related-info should gate on the named constraint-elaboration \
+         outcome helper"
+    );
+    assert!(
+        !compact.contains(".diagnostic_relation_boolean_guard("),
+        "the arbitrary-type related-info should not probe a raw diagnostic boolean guard"
     );
 }
 

--- a/crates/tsz-checker/src/tests/relation_routing_residual_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/relation_routing_residual_arch_tests.rs
@@ -45,6 +45,11 @@ fn collect_rust_sources(dir: &Path, sources: &mut Vec<PathBuf>) {
 
 fn allowed_raw_relation(relative_path: &str, line: &str) -> bool {
     if relative_path.starts_with("src/assignability/") {
+        // The assignability boundary owns these primitives — `is_*` relations,
+        // `is_subtype_of`, and the `diagnostic_relation_boolean_guard*` family —
+        // and composes them into the named `*_relation_outcome` helpers. Only the
+        // generic `assign_relation_outcome*` requests must still be wrapped in a
+        // domain-named outcome before a diagnostic decision consumes them.
         return !line.contains(".assign_relation_outcome(")
             && !line.contains(".assign_relation_outcome_with_env(");
     }


### PR DESCRIPTION
AgentName: M5Refactorer

Closes part of #12949 (RelationRequest residual module matrix; #8227 follow-up).

## Summary

Two related pieces of the relation-routing campaign:

1. **Residual migration.** `unrelated_type_parameter_target_related_info` in
   `error_reporter/assignability.rs` decided whether to attach the
   "could be instantiated with an arbitrary type which could be unrelated to"
   related-information by probing a raw `diagnostic_relation_boolean_guard`.
   It now routes through a new domain-named
   `type_parameter_constraint_elaboration_relation_outcome` helper that returns a
   `RelationOutcome`. The helper delegates to `diagnostic_relation_outcome`
   (the compat-aware `is_assignable_to` path), so the decision is **byte-for-byte
   behavior-identical** — it stays on the checker assignability semantics rather
   than the strict solver relation, which is required for parity here.

2. **Ratchet hardening.** The residual ratchet
   (`relation_routing_residual_arch_tests::production_checker_relation_truth_uses_outcome_boundaries`)
   now forbids the **whole** `diagnostic_relation_boolean_guard*` family in
   diagnostic-bearing checker code outside the assignability boundary, closing
   the class rather than the single witness. The assignability-boundary allow
   branch is documented (it owns those primitives and composes them into the
   named `*_relation_outcome` helpers).

3. **Ratchet repair.** The `src/tests/*relation_routing_arch_tests` suite — the
   templates #12949 references — had drifted stale after earlier boundary
   refactors (#12917 routed JSX/assignability probes through
   `props_are_assignable`; other call sites moved to
   `variable_initializer_relation_outcome`,
   `union_excess_required_property_relation_outcome`,
   `jsdoc_type_constraint_relation_outcome`; some helper bodies were reformatted
   or their comment markers moved). Each assertion is updated to the current
   named boundary, negatives are tightened to also forbid the generic
   `assign_relation_outcome` request, and moved markers are re-pointed. No
   production behavior change — only the ratchet expectations.

## Structural rule

When a checker path chooses TS2322/TS2345-family diagnostic elaboration based on
a relation decision, it must consume a named `*_relation_outcome` helper, not a
raw `diagnostic_relation_boolean_guard*` / `assign_relation_outcome*` probe. tsc
attaches the arbitrary-type related-info exactly when the source is not
assignable to the bare type-parameter constraint; tsz now makes that decision
through `type_parameter_constraint_elaboration_relation_outcome` (owner:
solver-backed `query_boundaries::assignability` gateway via the checker
assignability helpers).

## Track

Checker architecture boundary debt (#8227 RelationRequest adoption).

## Invariant

Behavior-preserving. The migrated call delegates to the same `is_assignable_to`
decision as before; the rest is test-only ratchet maintenance.

## Scope

- `crates/tsz-checker/src/assignability/relation_outcome_helpers.rs` (new helper)
- `crates/tsz-checker/src/error_reporter/assignability.rs` (call-site migration)
- `crates/tsz-checker/src/tests/relation_routing_residual_arch_tests.rs`
  (broadened pattern family + new focused test + allowlist comment)
- `crates/tsz-checker/src/tests/*relation_routing_arch_tests.rs` (stale-test repair)

## Project Corpus Impact

- Row: n/a
- Bug family: n/a (behavior-preserving refactor + arch-test maintenance; no
  TS2322/TS2345 diagnostic shift — the migrated path delegates to the identical
  `is_assignable_to` decision)

## Verification

- `cargo test -p tsz-checker --lib '_relation_routing'` → 178 passed; 0 failed
  (was 12 failing on main due to pre-existing drift).
- `cargo test -p tsz-checker --lib test_relation_request_property_policy_is_executed` → ok.
- `cargo clippy -p tsz-checker --all-targets` → clean.
- New focused ratchet `type_parameter_constraint_elaboration_uses_named_outcome_helper`
  passes.

## Coordination Notes

The repaired arch tests live in the checker **lib** test target, which the CI
unit-checker-integration job does not currently execute (it runs only
`--test` integration binaries); this PR restores them to green so the
#12949 verification command and local developer runs are trustworthy again.
The migration itself is parity-safe and unrelated to that gating gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_016C6o1sCLLP4cR4k1Nxor2h)_