### PR TITLE
test(arch): repair two stale architecture contract test assertions

### DIFF
--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs
@@ -1031,6 +1031,19 @@ fn test_assignment_and_binding_default_assignability_use_central_gateway_helpers
         &fs::read_to_string("src/state/state_checking/class.rs")
             .expect("failed to read src/state/state_checking/class.rs for architecture guard"),
     );
+    // for_loop.rs and initializer_policy.rs were extracted from core.rs/state_checking as
+    // separate modules; include them so the gateway assertions below cover all
+    // variable-checking assignability call sites.
+    state_checking_src.push_str(
+        &fs::read_to_string("src/state/variable_checking/for_loop.rs").expect(
+            "failed to read src/state/variable_checking/for_loop.rs for architecture guard",
+        ),
+    );
+    state_checking_src.push_str(
+        &fs::read_to_string("src/state/variable_checking/initializer_policy.rs").expect(
+            "failed to read src/state/variable_checking/initializer_policy.rs for architecture guard",
+        ),
+    );
     assert!(
         state_checking_src.contains("check_assignable_or_report(")
             || state_checking_src.contains("check_assignable_or_report_at(")

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_02.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_02.rs
@@ -310,19 +310,27 @@ fn test_assignability_checker_has_execute_relation_request() {
 /// Note: per `test_assignability_diagnostics_route_through_relation_outcome_helpers`
 /// (`part_03.rs`), diagnostic files must NOT build `RelationRequest::*` directly;
 /// they must go through the named `*_relation_outcome` helpers in
-/// `assignability_relation.rs`. The named helpers internally build the
-/// `RelationRequest::assign(`/etc. and call `execute_relation_request(`, so
-/// the assertions here verify those helper invocations rather than the raw
-/// request builder.
+/// `assignability_relation.rs` or `relation_outcome_helpers.rs`. The named helpers
+/// internally build the `RelationRequest::assign(`/etc. and call
+/// `execute_relation_request(`, so the assertions here verify those helper
+/// invocations rather than the raw request builder.
+///
+/// `assignability_reason_relation_outcome` (in `relation_outcome_helpers.rs`) is the
+/// current canonical helper for the `check_assignable_or_report_at` family; it
+/// supersedes the older `assign_relation_outcome` entry-point by adding pre-evaluation
+/// guards (variance fast-path, deferred keyof accepts). Both satisfy the arch contract.
 #[test]
 fn test_diagnostic_paths_use_relation_outcome_hint() {
     let source = fs::read_to_string("src/assignability/assignability_diagnostics.rs")
         .expect("failed to read assignability_diagnostics.rs");
 
     assert!(
-        source.contains("assign_relation_outcome("),
-        "check_assignable_or_report_at must obtain a RelationOutcome via the named \
-         assign_relation_outcome helper instead of re-calling the solver separately"
+        source.contains("assign_relation_outcome(")
+            || source.contains("assignability_reason_relation_outcome("),
+        "check_assignable_or_report_at must obtain a RelationOutcome via a named \
+         relation-outcome helper (assign_relation_outcome or \
+         assignability_reason_relation_outcome) instead of re-calling the solver \
+         separately"
     );
     assert!(
         source.contains("should_skip_weak_union_error_with_hint(")


### PR DESCRIPTION
AgentName: dazzling-johnson

## Track
Track 10 / Architecture

## Invariant
Architecture contract tests accurately reflect the module structure they guard.

## Scope
- `crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs`
- `crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_02.rs`

## Closing: superseded by #13143

PR #13143 (arch health: consolidate escape_js_string and fix stale contract test assertions) includes these same two architecture contract test fixes as its Commit 2. That PR is green and ahead of this branch, so this PR is redundant. Closing to avoid conflicting merges.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a

## Verification
- Covered by #13143's CI run

## Coordination Notes
- Superseded by #13143 commit 2 (identical fixes).