### PR TITLE
scanner: expose Unicode ECMAScript identifier predicates; unify property-name quoting

### DIFF
--- a/crates/tsz-checker/src/checkers/jsx/spread.rs
+++ b/crates/tsz-checker/src/checkers/jsx/spread.rs
@@ -6,6 +6,7 @@ use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::{is_ecmascript_identifier_part, is_ecmascript_identifier_start};
 use tsz_solver::TypeId;
 
 pub(crate) struct SpreadCheckOpts<'a> {
@@ -24,14 +25,13 @@ pub(crate) struct SpreadCheckOpts<'a> {
     pub(crate) merged_attrs_display: Option<&'a str>,
 }
 
-/// Local mirror of `tsz_solver::diagnostics::format::needs_property_name_quotes`.
-/// The solver helper is private to its module, so duplicate the small predicate
-/// here for the JSX spread structural display below. Keeps the rule in lockstep
-/// with the solver's printer: numeric-only names and bracketed computed keys
-/// stay unquoted; identifier-shaped names (alphanumeric / `_` / `$` only) stay
-/// unquoted; everything else (including `data-*` and `aria-*` JSX attributes,
-/// which are common on HTML-attribute prop types) needs quoting so the
-/// rendered type stays syntactically valid TypeScript.
+/// Returns `true` if `name` must be quoted in a rendered JSX/TS property type display.
+///
+/// Uses the scanner's Unicode ECMAScript identifier tables so that Unicode property
+/// names (e.g. `café`, `naïve`) that are valid JS identifiers are not incorrectly quoted.
+/// Numeric names and bracketed computed keys stay unquoted; everything else (including
+/// `data-*` and `aria-*` JSX attributes) needs quoting so the rendered type stays
+/// syntactically valid TypeScript.
 fn jsx_property_name_needs_quotes(name: &str) -> bool {
     if name.is_empty() {
         return true;
@@ -48,10 +48,11 @@ fn jsx_property_name_needs_quotes(name: &str) -> bool {
     {
         return false;
     }
+    // Check if it's a valid ECMAScript identifier (Unicode-aware, matching the scanner)
     let mut chars = name.chars();
     match chars.next() {
-        Some(first) if first.is_ascii_alphabetic() || first == '_' || first == '$' => {
-            !chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
+        Some(first) if is_ecmascript_identifier_start(first) => {
+            !chars.all(is_ecmascript_identifier_part)
         }
         _ => true,
     }

--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -12,7 +12,7 @@ use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_scanner::SyntaxKind;
+use tsz_scanner::{SyntaxKind, is_ecmascript_identifier_part, is_ecmascript_identifier_start};
 use tsz_solver::TypeId;
 
 struct OverloadCompatCtx<'a> {
@@ -57,11 +57,11 @@ fn needs_property_name_quotes(name: &str) -> bool {
     if name.chars().all(|ch| ch.is_ascii_digit()) {
         return false;
     }
-    // Check if it's a valid identifier
+    // Check if it's a valid ECMAScript identifier (Unicode-aware, matching the scanner)
     let mut chars = name.chars();
     match chars.next() {
-        Some(first) if first.is_ascii_alphabetic() || first == '_' || first == '$' => {
-            !chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
+        Some(first) if is_ecmascript_identifier_start(first) => {
+            !chars.all(is_ecmascript_identifier_part)
         }
         _ => true,
     }

--- a/crates/tsz-scanner/src/lib.rs
+++ b/crates/tsz-scanner/src/lib.rs
@@ -590,7 +590,7 @@ pub fn token_is_trivia(token: SyntaxKind) -> bool {
 // =============================================================================
 
 /// Returns `true` if `ch` is valid as the **first** character of an ECMAScript
-/// identifier (ID_Start per Unicode + `_` and `$`).
+/// identifier (`ID_Start` per Unicode + `_` and `$`).
 ///
 /// Uses the same Unicode tables as the scanner so that checker/emitter decisions
 /// about whether a property name needs quoting stay in sync with what the
@@ -601,7 +601,7 @@ pub fn is_ecmascript_identifier_start(ch: char) -> bool {
 }
 
 /// Returns `true` if `ch` is valid as a **continuation** character of an ECMAScript
-/// identifier (ID_Continue per Unicode + `_`, `$`, ZWNJ U+200C, ZWJ U+200D).
+/// identifier (`ID_Continue` per Unicode + `_`, `$`, ZWNJ U+200C, ZWJ U+200D).
 ///
 /// Uses the same Unicode tables as the scanner so that checker/emitter decisions
 /// about whether a property name needs quoting stay in sync with what the

--- a/crates/tsz-scanner/src/lib.rs
+++ b/crates/tsz-scanner/src/lib.rs
@@ -586,6 +586,32 @@ pub fn token_is_trivia(token: SyntaxKind) -> bool {
 }
 
 // =============================================================================
+// ECMAScript Identifier Predicates
+// =============================================================================
+
+/// Returns `true` if `ch` is valid as the **first** character of an ECMAScript
+/// identifier (ID_Start per Unicode + `_` and `$`).
+///
+/// Uses the same Unicode tables as the scanner so that checker/emitter decisions
+/// about whether a property name needs quoting stay in sync with what the
+/// scanner accepts as an identifier.
+#[must_use]
+pub fn is_ecmascript_identifier_start(ch: char) -> bool {
+    scanner_impl::is_identifier_start(ch as u32)
+}
+
+/// Returns `true` if `ch` is valid as a **continuation** character of an ECMAScript
+/// identifier (ID_Continue per Unicode + `_`, `$`, ZWNJ U+200C, ZWJ U+200D).
+///
+/// Uses the same Unicode tables as the scanner so that checker/emitter decisions
+/// about whether a property name needs quoting stay in sync with what the
+/// scanner accepts as an identifier.
+#[must_use]
+pub fn is_ecmascript_identifier_part(ch: char) -> bool {
+    scanner_impl::is_identifier_part(ch as u32)
+}
+
+// =============================================================================
 // Keyword Text Mapping
 // =============================================================================
 

--- a/crates/tsz-solver/src/diagnostics/format/property_names.rs
+++ b/crates/tsz-solver/src/diagnostics/format/property_names.rs
@@ -2,6 +2,8 @@
 
 use std::borrow::Cow;
 
+use tsz_scanner::{is_ecmascript_identifier_part, is_ecmascript_identifier_start};
+
 /// Format the property-name slot used by excess-property diagnostics.
 ///
 /// The full diagnostic already wraps this value in single quotes. For property
@@ -34,10 +36,12 @@ pub(crate) fn needs_property_name_quotes(name: &str) -> bool {
     if crate::utils::is_numeric_literal_name(name) {
         return false;
     }
+    // Unicode-aware ECMAScript identifier check: delegates to the scanner tables
+    // so that property names like `café` or `naïve` are not incorrectly quoted.
     let mut chars = name.chars();
     match chars.next() {
-        Some(first) if first.is_ascii_alphabetic() || first == '_' || first == '$' => {
-            !chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
+        Some(first) if is_ecmascript_identifier_start(first) => {
+            !chars.all(is_ecmascript_identifier_part)
         }
         _ => true,
     }

--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
@@ -172,6 +172,19 @@ fn needs_property_name_quotes_edge_cases() {
 }
 
 #[test]
+fn needs_property_name_quotes_unicode_identifiers() {
+    // Unicode identifier-start characters must NOT be quoted (ECMAScript parity)
+    assert!(!super::needs_property_name_quotes("café"));
+    assert!(!super::needs_property_name_quotes("naïve"));
+    assert!(!super::needs_property_name_quotes("α"));
+    assert!(!super::needs_property_name_quotes("αβγ"));
+    assert!(!super::needs_property_name_quotes("日本語"));
+    // Non-identifier Unicode still needs quotes
+    assert!(super::needs_property_name_quotes("data-id"));
+    assert!(super::needs_property_name_quotes("aria-label"));
+}
+
+#[test]
 fn needs_property_name_quotes_canonical_numeric_forms() {
     // Canonical JS-numeric forms (matching `Number.prototype.toString()`
     // round-trip) are displayed without quotes by tsc in object literal


### PR DESCRIPTION
AgentName: dazzling-johnson
Track: 10 (Guardrails, Tooling, Residency, Performance Readiness)
Invariant: Property-name quoting decisions use a single Unicode-aware predicate matching the scanner's ECMAScript identifier tables; no ASCII-only duplicates.
Scope: `crates/tsz-scanner/src/lib.rs`, `crates/tsz-solver/src/diagnostics/format/property_names.rs`, `crates/tsz-checker/src/classes/class_checker.rs`, `crates/tsz-checker/src/checkers/jsx/spread.rs`

## Summary

Before this change, three separate ASCII-only copies of `needs_property_name_quotes`
existed in solver, class-checker, and JSX-spread — each using
`is_ascii_alphabetic` / `is_ascii_alphanumeric`. This caused Unicode property
names such as `café`, `naïve`, `α`, `日本語` to be incorrectly quoted in
diagnostics and DTS output, diverging from `tsc` which uses ECMAScript
Unicode identifier rules (XID_Start / XID_Continue).

### Structural rule
When a property name is a valid ECMAScript identifier start+continue sequence,
`tsc` displays it unquoted; `tsz` now routes through
`tsz_scanner::is_ecmascript_identifier_{start,part}` which delegates to the
existing `scanner_impl` Unicode tables (`unicode_ident::is_xid_start` / `is_xid_continue`).

### Owner layer
- `tsz-scanner` owns identifier character classification (Unicode ECMAScript rules).
- `tsz-solver::diagnostics::format` owns type-display quoting decisions.
- `tsz-checker` classes and JSX consume the canonical predicates instead of
  duplicating logic.

## Changes

- **`tsz-scanner/src/lib.rs`**: Adds public `is_ecmascript_identifier_start(ch: char) -> bool`
  and `is_ecmascript_identifier_part(ch: char) -> bool` that wrap the private
  `scanner_impl` helpers.
- **`tsz-solver/src/diagnostics/format/property_names.rs`**: Replaces ASCII-only
  `is_ascii_alphabetic` / `is_ascii_alphanumeric` with the new canonical predicates.
- **`tsz-checker/src/classes/class_checker.rs`**: Same replacement in `needs_property_name_quotes`.
- **`tsz-checker/src/checkers/jsx/spread.rs`**: Same replacement in `jsx_property_name_needs_quotes`.
- **`tsz-solver/src/diagnostics/format/tests_parts/part_02.rs`**: Adds
  `needs_property_name_quotes_unicode_identifiers` test covering `café`, `naïve`,
  `α`, `αβγ`, `日本語` (should not quote), and `data-id`, `aria-label` (must quote).

## Project Corpus Impact

- Row: n/a
- Bug family: property-name quoting parity for Unicode identifiers

Unicode identifier property names appear in user-authored TypeScript with non-ASCII
names; the fix aligns display output with tsc without touching any conformance baselines.

## Verification

- `cargo build -p tsz-scanner -p tsz-solver -p tsz-checker` — clean compile
- `cargo nextest run -p tsz-solver -E 'test(needs_property_name_quotes)'` — 5/5 pass including the new Unicode test

## Coordination Notes

Companion to dead-code PRs #13133 and #13134 (same Track 10 cleanup campaign).
No conformance baselines touched. No architectural boundary changes. Builds on
the existing `unicode_ident` dependency already present in `tsz-scanner`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MhrLdFnnML31Bw2XNBMJox)_