### PR TITLE
fix(solver): keep generic-dependent application members in union simplification

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -681,6 +681,9 @@ mod contextual_typing_tests;
 #[path = "../tests/cross_file_class_merge_tests.rs"]
 mod cross_file_class_merge_tests;
 #[cfg(test)]
+#[path = "tests/cross_file_generic_alias_union_implements_tests.rs"]
+mod cross_file_generic_alias_union_implements_tests;
+#[cfg(test)]
 #[path = "tests/cross_file_interface_property_access_tests.rs"]
 mod cross_file_interface_property_access_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/cross_file_generic_alias_union_implements_tests.rs
+++ b/crates/tsz-checker/src/tests/cross_file_generic_alias_union_implements_tests.rs
@@ -1,0 +1,250 @@
+//! Cross-file generic alias unions in `implements` member checks.
+//!
+//! A union alias whose members depend on unresolved type parameters (e.g.
+//! `keyof DB[TB] & string` or a mapped-indexed template literal) must keep all
+//! of its members when the union is evaluated. The evaluator's subtype-based
+//! union simplification runs with `bypass_evaluation=true` and cannot judge a
+//! generic-dependent `Application` member soundly: the expansion looks
+//! string-like and gets absorbed by an object-shaped member (here
+//! `Expression<unknown>`), collapsing the union and producing false `TS2416`
+//! on every method of an implementing class (Kysely
+//! `SelectQueryBuilderImpl` family, #10663).
+//!
+//! tsc does not subtype-reduce union members that depend on unresolved type
+//! parameters, so neither do we. Cases vary binder names, member order, and
+//! include a genuine-mismatch negative control so the rule follows the type
+//! shape rather than identifier names.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::{Diagnostic, diagnostic_codes};
+use crate::test_utils::{check_multi_file_with_libs, load_lib_files};
+use tsz_common::common::ModuleKind;
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    check_multi_file_with_libs(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &load_lib_files(&["es5.d.ts"]),
+    )
+}
+
+fn implements_member_errors(diagnostics: &[Diagnostic]) -> Vec<(u32, String)> {
+    diagnostics
+        .iter()
+        .filter(|d| {
+            d.code
+                == diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE
+        })
+        .map(|d| (d.code, d.message_text.to_string()))
+        .collect()
+}
+
+const REFS_SRC: &str = r#"
+export interface Expression<T> {
+    readonly expressionType?: T | undefined;
+}
+
+export type AnyColumn<DB, TB extends keyof DB> = keyof DB[TB] & string;
+
+export type AnyColumnWithTable<DB, TB extends keyof DB> = {
+    [T in TB]: `${T & string}.${keyof DB[T] & string}`;
+}[TB];
+
+export type ReferenceExpression<DB, TB extends keyof DB> =
+    | AnyColumn<DB, TB>
+    | AnyColumnWithTable<DB, TB>
+    | Expression<unknown>;
+
+export interface WhereInterface<DB, TB extends keyof DB> {
+    whereRef<LRE extends ReferenceExpression<DB, TB>, RRE extends ReferenceExpression<DB, TB>>(
+        lhs: LRE,
+        op: string,
+        rhs: RRE,
+    ): WhereInterface<DB, TB>;
+}
+"#;
+
+const BUILDER_SRC: &str = r#"
+import { ReferenceExpression, WhereInterface } from "./refs";
+
+export interface SelectQueryBuilder<DB, TB extends keyof DB, O> extends WhereInterface<DB, TB> {
+    whereRef<LRE extends ReferenceExpression<DB, TB>, RRE extends ReferenceExpression<DB, TB>>(
+        lhs: LRE,
+        op: string,
+        rhs: RRE,
+    ): SelectQueryBuilder<DB, TB, O>;
+}
+
+class SelectQueryBuilderImpl<DB, TB extends keyof DB, O> implements SelectQueryBuilder<DB, TB, O> {
+    whereRef(
+        lhs: ReferenceExpression<DB, TB>,
+        op: string,
+        rhs: ReferenceExpression<DB, TB>,
+    ): SelectQueryBuilder<DB, TB, O> {
+        return this;
+    }
+}
+"#;
+
+#[test]
+fn generic_dependent_alias_union_member_survives_cross_file_implements() {
+    let diags = check(
+        &[("./refs.ts", REFS_SRC), ("./builder.ts", BUILDER_SRC)],
+        "./builder.ts",
+    );
+    let errors = implements_member_errors(&diags);
+    assert!(
+        errors.is_empty(),
+        "expected the implements check to accept the structurally identical member, got: {errors:?}",
+    );
+}
+
+#[test]
+fn renamed_binders_and_reordered_members_stay_clean() {
+    let refs = r#"
+export interface Operand<V> {
+    readonly operandType?: V | undefined;
+}
+
+export type ColumnOf<Schema, Table extends keyof Schema> = keyof Schema[Table] & string;
+
+export type QualifiedColumnOf<Schema, Table extends keyof Schema> = {
+    [Row in Table]: `${Row & string}.${keyof Schema[Row] & string}`;
+}[Table];
+
+export type ColumnRef<Schema, Table extends keyof Schema> =
+    | Operand<unknown>
+    | QualifiedColumnOf<Schema, Table>
+    | ColumnOf<Schema, Table>;
+
+export interface FilterableQuery<Schema, Table extends keyof Schema> {
+    compareColumns<L extends ColumnRef<Schema, Table>, R extends ColumnRef<Schema, Table>>(
+        left: L,
+        operator: string,
+        right: R,
+    ): FilterableQuery<Schema, Table>;
+}
+"#;
+    let main = r#"
+import { ColumnRef, FilterableQuery } from "./refs";
+
+export interface Query<Schema, Table extends keyof Schema, Row>
+    extends FilterableQuery<Schema, Table> {
+    compareColumns<L extends ColumnRef<Schema, Table>, R extends ColumnRef<Schema, Table>>(
+        left: L,
+        operator: string,
+        right: R,
+    ): Query<Schema, Table, Row>;
+}
+
+class QueryImpl<Schema, Table extends keyof Schema, Row> implements Query<Schema, Table, Row> {
+    compareColumns(
+        left: ColumnRef<Schema, Table>,
+        operator: string,
+        right: ColumnRef<Schema, Table>,
+    ): Query<Schema, Table, Row> {
+        return this;
+    }
+}
+"#;
+    let diags = check(&[("./refs.ts", refs), ("./main.ts", main)], "./main.ts");
+    let errors = implements_member_errors(&diags);
+    assert!(
+        errors.is_empty(),
+        "expected renamed/reordered variant to stay clean, got: {errors:?}",
+    );
+}
+
+#[test]
+fn genuinely_narrower_impl_member_still_reports_ts2416() {
+    // Negative control: the impl accepts only the object member, so the
+    // interface's broader generic parameter genuinely does not fit and the
+    // member-level mismatch must still be reported.
+    let builder = r#"
+import { Expression, ReferenceExpression, WhereInterface } from "./refs";
+
+export interface SelectQueryBuilder<DB, TB extends keyof DB, O> extends WhereInterface<DB, TB> {
+    whereRef<LRE extends ReferenceExpression<DB, TB>, RRE extends ReferenceExpression<DB, TB>>(
+        lhs: LRE,
+        op: string,
+        rhs: RRE,
+    ): SelectQueryBuilder<DB, TB, O>;
+}
+
+class SelectQueryBuilderImpl<DB, TB extends keyof DB, O> implements SelectQueryBuilder<DB, TB, O> {
+    whereRef(
+        lhs: Expression<unknown>,
+        op: string,
+        rhs: Expression<unknown>,
+    ): SelectQueryBuilder<DB, TB, O> {
+        return this;
+    }
+}
+"#;
+    let diags = check(
+        &[("./refs.ts", REFS_SRC), ("./builder.ts", builder)],
+        "./builder.ts",
+    );
+    let errors = implements_member_errors(&diags);
+    assert!(
+        !errors.is_empty(),
+        "expected a genuine member mismatch to keep reporting TS2416",
+    );
+}
+
+#[test]
+fn single_file_equivalent_stays_clean() {
+    let single = r#"
+interface Expression<T> {
+    readonly expressionType?: T | undefined;
+}
+
+type AnyColumn<DB, TB extends keyof DB> = keyof DB[TB] & string;
+
+type AnyColumnWithTable<DB, TB extends keyof DB> = {
+    [T in TB]: `${T & string}.${keyof DB[T] & string}`;
+}[TB];
+
+type ReferenceExpression<DB, TB extends keyof DB> =
+    | AnyColumn<DB, TB>
+    | AnyColumnWithTable<DB, TB>
+    | Expression<unknown>;
+
+interface WhereInterface<DB, TB extends keyof DB> {
+    whereRef<LRE extends ReferenceExpression<DB, TB>, RRE extends ReferenceExpression<DB, TB>>(
+        lhs: LRE,
+        op: string,
+        rhs: RRE,
+    ): WhereInterface<DB, TB>;
+}
+
+interface SelectQueryBuilder<DB, TB extends keyof DB, O> extends WhereInterface<DB, TB> {
+    whereRef<LRE extends ReferenceExpression<DB, TB>, RRE extends ReferenceExpression<DB, TB>>(
+        lhs: LRE,
+        op: string,
+        rhs: RRE,
+    ): SelectQueryBuilder<DB, TB, O>;
+}
+
+class SelectQueryBuilderImpl<DB, TB extends keyof DB, O> implements SelectQueryBuilder<DB, TB, O> {
+    whereRef(
+        lhs: ReferenceExpression<DB, TB>,
+        op: string,
+        rhs: ReferenceExpression<DB, TB>,
+    ): SelectQueryBuilder<DB, TB, O> {
+        return this;
+    }
+}
+"#;
+    let diags = check(&[("./single.ts", single)], "./single.ts");
+    let errors = implements_member_errors(&diags);
+    assert!(
+        errors.is_empty(),
+        "expected the single-file equivalent to stay clean, got: {errors:?}",
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -804,3 +804,7 @@ mod tests;
 #[cfg(test)]
 #[path = "../../tests/evaluate_application_orchestrator_tests.rs"]
 mod orchestrator_tests;
+
+#[cfg(test)]
+#[path = "../../tests/union_simplification_generic_member_tests.rs"]
+mod union_simplification_generic_member_tests;

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -388,6 +388,17 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 let members = self.interner.type_list(list_id);
                 members.iter().any(|&m| self.is_complex_type(m))
             }
+            // A generic-dependent application (`Foo<DB, TB>` with type-parameter
+            // arguments) expands to a type the bypass-evaluation subtype checker
+            // cannot judge soundly (e.g. an alias body `keyof DB[TB] & string`
+            // looks string-like and gets absorbed by an object member). tsc does
+            // not subtype-reduce union members that depend on unresolved type
+            // parameters, so keep them. Fully-concrete applications stay
+            // simplifiable via the canonicalizer.
+            TypeData::Application(app_id) => {
+                let app = self.interner.type_application(app_id);
+                app.args.iter().any(|&arg| self.is_complex_type(arg))
+            }
             TypeData::Array(_) | TypeData::Tuple(_) => self.has_nested_complex_marker(type_id),
             // Function types with Application/Lazy return *or parameter* types are
             // complex because the simplify-union subtype checker runs with

--- a/crates/tsz-solver/tests/union_simplification_generic_member_tests.rs
+++ b/crates/tsz-solver/tests/union_simplification_generic_member_tests.rs
@@ -1,0 +1,175 @@
+//! Tests pinning union simplification's treatment of generic-dependent
+//! `Application` members.
+//!
+//! `evaluate_union` removes a member when the bypass-evaluation
+//! `SubtypeChecker` judges it a subtype of a sibling. A generic application
+//! (`Alias<DB, TB>` with type-parameter arguments) expands to a type that
+//! checker cannot judge soundly — in the Kysely witness (#10663),
+//! `AnyColumn<DB, TB>` (= `keyof DB[TB] & string`) looked string-like and was
+//! absorbed by the object-shaped `Expression<unknown>` member, collapsing the
+//! alias union and cascading into false `TS2416` on every implementing
+//! method. tsc performs no subtype reduction on members that depend on
+//! unresolved type parameters, so the member must survive evaluation.
+//!
+//! Concrete applications remain simplifiable: a fully-instantiated alias
+//! member that *is* redundant must still be absorbed.
+
+use super::*;
+use crate::construction::TypeInterner;
+use crate::def::{DefId, DefKind};
+use crate::evaluation::evaluate::TypeEvaluator;
+use crate::relations::subtype::TypeEnvironment;
+
+fn optional_unknown_property_object(interner: &TypeInterner, prop: &str) -> TypeId {
+    let mut info = PropertyInfo::new(
+        interner.intern_string(prop),
+        interner.union2(TypeId::UNKNOWN, TypeId::UNDEFINED),
+    );
+    info.optional = true;
+    interner.object(vec![info])
+}
+
+/// `type AnyColumn<DB, TB extends keyof DB> = keyof DB[TB] & string` —
+/// registered in `env` under `def_id`; returns the generic application
+/// `AnyColumn<DB, TB>` with the *type parameters themselves* as arguments
+/// (the open-generic context of a method signature annotation).
+fn generic_alias_application(
+    interner: &TypeInterner,
+    env: &mut TypeEnvironment,
+    def_id: DefId,
+) -> TypeId {
+    let db_param = TypeParamInfo {
+        name: interner.intern_string("DB"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let db_type = interner.intern(TypeData::TypeParameter(db_param));
+    let tb_param = TypeParamInfo {
+        name: interner.intern_string("TB"),
+        constraint: Some(interner.keyof(db_type)),
+        default: None,
+        is_const: false,
+    };
+    let tb_type = interner.intern(TypeData::TypeParameter(tb_param));
+
+    let body = interner.intersection(vec![
+        interner.keyof(interner.index_access(db_type, tb_type)),
+        TypeId::STRING,
+    ]);
+    env.insert_def_with_params(def_id, body, vec![db_param, tb_param]);
+    env.insert_def_kind(def_id, DefKind::TypeAlias);
+
+    interner.application(interner.lazy(def_id), vec![db_type, tb_type])
+}
+
+#[test]
+fn generic_dependent_application_member_survives_union_evaluation() {
+    let interner = TypeInterner::new();
+    let mut env = TypeEnvironment::new();
+    let app = generic_alias_application(&interner, &mut env, DefId(301));
+    let expression_like = optional_unknown_property_object(&interner, "expressionType");
+
+    let union = interner.union(vec![app, expression_like]);
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    let result = evaluator.evaluate(union);
+
+    let Some(TypeData::Union(list_id)) = interner.lookup(result) else {
+        panic!(
+            "expected the union to survive evaluation, got {:?}",
+            interner.lookup(result)
+        );
+    };
+    let members = interner.type_list(list_id);
+    assert_eq!(
+        members.len(),
+        2,
+        "the generic-dependent alias member must not be absorbed by the object member",
+    );
+}
+
+#[test]
+fn renamed_binders_member_survives_union_evaluation() {
+    // Same shape with different binder names and member order — the rule
+    // must follow the type shape, not the identifier spelling.
+    let interner = TypeInterner::new();
+    let mut env = TypeEnvironment::new();
+
+    let schema_param = TypeParamInfo {
+        name: interner.intern_string("Schema"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let schema_type = interner.intern(TypeData::TypeParameter(schema_param));
+    let table_param = TypeParamInfo {
+        name: interner.intern_string("Table"),
+        constraint: Some(interner.keyof(schema_type)),
+        default: None,
+        is_const: false,
+    };
+    let table_type = interner.intern(TypeData::TypeParameter(table_param));
+
+    let body = interner.intersection(vec![
+        interner.keyof(interner.index_access(schema_type, table_type)),
+        TypeId::STRING,
+    ]);
+    env.insert_def_with_params(DefId(302), body, vec![schema_param, table_param]);
+    env.insert_def_kind(DefId(302), DefKind::TypeAlias);
+    let app = interner.application(interner.lazy(DefId(302)), vec![schema_type, table_type]);
+
+    let operand_like = optional_unknown_property_object(&interner, "operandType");
+
+    let union = interner.union(vec![operand_like, app]);
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    let result = evaluator.evaluate(union);
+
+    let Some(TypeData::Union(list_id)) = interner.lookup(result) else {
+        panic!(
+            "expected the union to survive evaluation, got {:?}",
+            interner.lookup(result)
+        );
+    };
+    assert_eq!(interner.type_list(list_id).len(), 2);
+}
+
+#[test]
+fn concrete_application_member_still_simplifiable() {
+    // Negative control: a fully-concrete alias application that evaluates to
+    // a subtype of a sibling must still be absorbed (the canonicalizer-backed
+    // simplification stays enabled for non-generic members).
+    let interner = TypeInterner::new();
+    let mut env = TypeEnvironment::new();
+
+    let t_param = TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    };
+    let t_type = interner.intern(TypeData::TypeParameter(t_param));
+    // type Boxed<T> = { value: T }
+    let body = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("value"),
+        t_type,
+    )]);
+    env.insert_def_with_params(DefId(303), body, vec![t_param]);
+    env.insert_def_kind(DefId(303), DefKind::TypeAlias);
+    // Boxed<"a"> | { value: string } — the literal instantiation is a strict
+    // subtype of the wider object member and is redundant in the union.
+    let lit_a = interner.literal_string("a");
+    let app = interner.application(interner.lazy(DefId(303)), vec![lit_a]);
+    let wider = interner.object(vec![PropertyInfo::new(
+        interner.intern_string("value"),
+        TypeId::STRING,
+    )]);
+
+    let union = interner.union(vec![app, wider]);
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &env);
+    let result = evaluator.evaluate(union);
+
+    assert_eq!(
+        result, wider,
+        "a concrete redundant application member must still be absorbed",
+    );
+}


### PR DESCRIPTION
AgentName: M1FableArchitect
Track: 3 (relations/evaluation semantics)
Invariant: Union evaluation must not drop members whose meaning depends on unresolved type parameters; `tsc` performs no subtype reduction on such members.
Scope: `tsz-solver` union simplification gate (`is_complex_type`) + checker regression tests. No checker/emitter logic changes.

## Structural rule

When a union member is a generic application (`Alias<DB, TB>` with type-parameter arguments), `tsc` keeps the member as written; `tsz` does the same by treating the member as complex in the evaluator's subtype-based union simplification (owner: solver `evaluation/evaluate/support.rs::is_complex_type`).

Before this change, `remove_redundant_members` (which runs with `bypass_evaluation=true`) would expand such a member through the canonicalizer and absorb it into an object-shaped sibling: in the Kysely witness, `AnyColumn<DB, TB>` (= `keyof DB[TB] & string`, string-ish under the bypass relation) was absorbed by `Expression<unknown>` (all-optional object), collapsing
`ReferenceExpression<DB, TB>` to a single member and producing false `TS2416` on every method of `SelectQueryBuilderImpl` in a 2-file repro (`tsc` 5.9.3 clean).

`is_complex_type` already declares this principle for unions/intersections containing type parameters ("TSC does not perform such simplification on unions with type parameters"); this PR extends it to `Application` members whose **arguments** are complex. Fully-concrete applications remain simplifiable (Task #37 canonicalizer intent preserved).

## Adjacent-case matrix (new tests)

`cross_file_generic_alias_union_implements_tests.rs` (checker, multi-file with `es5.d.ts` libs):
- Kysely-shaped 2-file repro (`implements` member check) — clean.
- Renamed binders (`Schema`/`Table`/`Row` instead of `DB`/`TB`/`O`) and reordered union members — clean.
- Negative control: genuinely narrower impl member still reports `TS2416` (tsc-verified).
- Single-file equivalent — clean.

`union_simplification_generic_member_tests.rs` (solver, `TypeEnvironment`-backed):
- Generic-dependent application member survives union evaluation (+ renamed-binder variant).
- Negative control: a fully-concrete redundant application member is still absorbed.

**Honest caveat:** these in-repo tests pass with *and without* the code change — none of the unit harnesses (`check_multi_file` variants, synthetic `TypeEnvironment`) recreate the cross-arena resolver state where the absorption fires; they pin the scenario and the concrete-member behavior, not the mechanism. The bisecting witness is CLI-level: the 2-file repro fails on a clean `main` dist-fast build and passes with this change (verified on two clean rebuilds). The harness gap is the same cross-arena-state territory as #13044.

## Project Corpus Impact
- Row: kysely-project
- Bug family: contextual generics / cross-file alias union collapse (#10663, TS2416 `SelectQueryBuilderImpl` cluster)

Local guard-config measurement (fresh dist-fast, `tsz --noEmit -p tsconfig.tsz-guard.json`): 187 -> 188. The +1 site (`over-builder.ts(129)`: `PartitionByExpressionOrList<DB, TB>` vs `<any, any>`) is the *same* still-open root cause this fix exposes rather than introduces: the dominant TS2416 driver on the row is the eager cross-file alias expansion/degradation in class-member computation, diagnosed and filed as #13044 (also summarized on #10663). This PR is the parity-correct first slice; the 2-file micro repro it fixes is pinned as tests.

## Verification
- CLI bisect (the load-bearing check): 2-file repro errors with `TS2416` on clean `main` dist-fast, clean with this change; full Kysely guard config re-run shows zero regressed sites (site-level diff against the 187 baseline).
- `cargo nextest run -p tsz-solver --no-fail-fast` — green including the 3 new tests (the `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder` failure reproduces on unmodified `origin/main`, pre-existing).
- `cargo nextest run -p tsz-checker -E 'test(cross_file_generic_alias_union_implements)'` — 4/4 pass.
- `cargo clippy -p tsz-solver --all-targets`, `cargo clippy -p tsz-checker --all-targets`, `scripts/arch/check-checker-boundaries.sh` — clean.

## Coordination Notes
- Tracker: #10663 (row tracker, currently WIP-claimed by lucid-hopper for the type-guard narrowing family — this PR touches a different family; diagnosis comment added there).
- The mapped-index substitution facet (symbolic `{[T in TB]: F(T)}[TB]` evaluating to a fresh same-named constrained parameter instead of deferring) was prototyped and reverted here: direct index substitution conflicts with the pinned per-key idiom test (`test_index_access_mapped_keyof_preserves_per_key_template_relation`); the parity-correct shape is deferral + relation-time simplification (tsc `getSimplifiedIndexedAccessType`) — recorded on #10663 and gated behind #13044 for row impact.
