### PR TITLE
fix(perf-counters): add cross_file_type_params cache counters to dump_string

### DIFF
--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -29,7 +29,9 @@ impl PerfCounters {
              cache hits (lib)           {:>12}\n  \
              cache hits (cross-file)    {:>12}\n  \
              misses (full work)         {:>12}\n  \
-             max recursion depth        {:>12}\n\
+             max recursion depth        {:>12}\n  \
+             type-params cache hits     {:>12}\n  \
+             type-params cache misses   {:>12}\n\
              Checker construction:\n  \
              CheckerState::new          {:>12}\n  \
              ::with_parent_cache        {:>12}\n  \
@@ -76,6 +78,8 @@ impl PerfCounters {
             snap.delegate.cache_hits_cross_file,
             snap.delegate.misses,
             snap.delegate.max_recursion_depth,
+            snap.delegate.cross_file_type_params_cache_hits,
+            snap.delegate.cross_file_type_params_cache_misses,
             snap.checker.state_constructed,
             snap.checker.with_parent_cache_constructed,
             snap.checker.file_session_resets,

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -1940,6 +1940,52 @@ mod json_tests {
     }
 
     #[test]
+    fn cross_file_type_params_cache_counters_appear_in_dump_string() {
+        // `dump_string` is empty when counters are disabled. Force them on so
+        // the text output can be inspected. The sentinel values are read back
+        // via a delta check so concurrent test runs don't interfere.
+        force_enable_perf_counters_for_tests();
+        let c = counters();
+        let before_hits = c
+            .cross_file_type_params_cache_hits
+            .load(Ordering::Relaxed);
+        let before_misses = c
+            .cross_file_type_params_cache_misses
+            .load(Ordering::Relaxed);
+        c.cross_file_type_params_cache_hits
+            .fetch_add(99, Ordering::Relaxed);
+        c.cross_file_type_params_cache_misses
+            .fetch_add(77, Ordering::Relaxed);
+        let dump = PerfCounters::dump_string();
+        assert!(
+            !dump.is_empty(),
+            "dump_string must be non-empty when counters are enabled"
+        );
+        assert!(
+            dump.contains("type-params cache hits"),
+            "dump_string must include 'type-params cache hits' label, got:\n{dump}"
+        );
+        assert!(
+            dump.contains("type-params cache misses"),
+            "dump_string must include 'type-params cache misses' label, got:\n{dump}"
+        );
+        let hits_after = c
+            .cross_file_type_params_cache_hits
+            .load(Ordering::Relaxed);
+        let misses_after = c
+            .cross_file_type_params_cache_misses
+            .load(Ordering::Relaxed);
+        assert!(
+            hits_after >= before_hits + 99,
+            "hits counter not bumped (before={before_hits}, after={hits_after})"
+        );
+        assert!(
+            misses_after >= before_misses + 77,
+            "misses counter not bumped (before={before_misses}, after={misses_after})"
+        );
+    }
+
+    #[test]
     fn write_json_to_writes_valid_json_with_atomic_rename() {
         let dir = std::env::temp_dir();
         let path = dir.join(format!("tsz-perf-counter-snap-{}.json", std::process::id()));


### PR DESCRIPTION
AgentName: dazzling-johnson

## Track
T2.2 (cross-file performance substrate)

## Invariant
`PerfCounters::dump_string()` must surface every counter that appears in `DelegateCounters` and the JSON snapshot.

## Closing: superseded by #13144

PR #13144 (lsp/core/common/cli: 4 tech-debt fixes) includes this same perf-counter display fix as its Commit 3, with identical scope (`crates/tsz-common/src/perf_counters/dump.rs`). That PR is CI-passing on all heavy checks. Closing this standalone PR to avoid a conflicting merge.

## Project Corpus Impact
- Row: n/a
- Bug family: n/a

## Coordination Notes
- Superseded by #13144 commit 3 (identical fix).