### PR TITLE
fix(checker,solver): two-pass overload resolution — any-source-not-related subtype pass (tsc chooseOverload parity)

### DIFF
--- a/crates/tsz-checker/src/assignability/mod.rs
+++ b/crates/tsz-checker/src/assignability/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod compound_assignment;
 mod constrained_type_param_assertion;
 mod index_access_normalization;
 mod nullish_error_targets;
+mod overload_subtype_pass;
 mod polymorphic_this_diagnostics;
 mod readonly_tuple_diagnostics;
 mod relation_outcome_helpers;

--- a/crates/tsz-checker/src/assignability/overload_subtype_pass.rs
+++ b/crates/tsz-checker/src/assignability/overload_subtype_pass.rs
@@ -1,0 +1,92 @@
+//! Overload-resolution subtype-pass relation entries (tsc `chooseOverload`
+//! with `subtypeRelation`; issue #13042).
+//!
+//! Pass 1 of overload resolution runs assignability under the solver's
+//! `AnySourceNotRelated` propagation mode: an `any` source is not related to
+//! non-`any`/`unknown` targets at every nesting level, while an `any` target
+//! still accepts everything. The mode is part of the relation cache key, so
+//! pass-1 results cannot poison the default assignable relation.
+
+use crate::query_boundaries::assignability::AssignabilityQueryInputs;
+use crate::state::{CheckerOverrideProvider, CheckerState};
+use tracing::trace;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Shared core for the overload-resolution subtype pass (tsc
+    /// `chooseOverload` with `subtypeRelation`): assignability where an `any`
+    /// source is not related to non-`any`/`unknown` targets at every nesting
+    /// level, while an `any` target still accepts everything. The mode is
+    /// part of the relation cache key, so pass-1 results cannot poison the
+    /// default assignable relation (or vice versa).
+    fn check_overload_subtype_pass_assignability(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        extra_flags: u16,
+        label: &str,
+    ) -> bool {
+        let flags = self.ctx.pack_relation_flags() | extra_flags;
+        let overrides = CheckerOverrideProvider::new(self, None);
+        let relation_result =
+            crate::query_boundaries::assignability::cached_overload_subtype_pass_assignability(
+                &AssignabilityQueryInputs {
+                    db: self.ctx.types,
+                    resolver: &self.ctx,
+                    source,
+                    target,
+                    flags,
+                    inheritance_graph: &self.ctx.inheritance_graph,
+                    sound_mode: self.ctx.sound_mode(),
+                },
+                &overrides,
+            );
+        let result = relation_result.is_related();
+
+        self.propagate_overflow_flags(
+            relation_result.depth_exceeded,
+            relation_result.iteration_exceeded,
+        );
+
+        trace!(source = source.0, target = target.0, result, "{label}");
+        result
+    }
+
+    /// Like `is_assignable_to_strict`, but under the overload-resolution
+    /// subtype pass where an `any` source is not related to concrete targets.
+    pub fn is_assignable_to_overload_subtype_pass(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        if source == target {
+            return true;
+        }
+        let (source, target) = self.prepare_assignability_inputs(source, target);
+        self.check_overload_subtype_pass_assignability(
+            source,
+            target,
+            0,
+            "is_assignable_to_overload_subtype_pass",
+        )
+    }
+
+    /// Strict-function-types variant of
+    /// [`Self::is_assignable_to_overload_subtype_pass`].
+    pub fn is_assignable_to_overload_subtype_pass_strict(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        if source == target {
+            return true;
+        }
+        let (source, target) = self.prepare_assignability_inputs(source, target);
+        self.check_overload_subtype_pass_assignability(
+            source,
+            target,
+            crate::query_boundaries::assignability::RelationFlags::STRICT_FUNCTION_TYPES,
+            "is_assignable_to_overload_subtype_pass_strict",
+        )
+    }
+}

--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -1261,6 +1261,56 @@ impl<'a> CheckerState<'a> {
         self.execute_relation_request(&request)
     }
 
+    /// Overload-resolution subtype-pass variant of
+    /// [`Self::call_adapter_compatibility_relation_outcome`]: identical
+    /// relation shape, but an `any` source is not related to concrete targets
+    /// at every nesting level (tsc `chooseOverload` with `subtypeRelation`).
+    pub(crate) fn overload_subtype_pass_compatibility_relation_outcome(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> crate::query_boundaries::assignability::RelationOutcome {
+        let (source, target) = self.prepare_assignability_inputs(source, target);
+        let request =
+            crate::query_boundaries::assignability::RelationRequest::call_adapter_compatibility(
+                source, target,
+            )
+            .with_overload_subtype_pass();
+        self.execute_relation_request(&request)
+    }
+
+    /// Overload-resolution subtype-pass variant of the bivariant-callback
+    /// relation probe used by the call adapter.
+    pub(crate) fn overload_subtype_pass_bivariant_relation_outcome(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> crate::query_boundaries::assignability::RelationOutcome {
+        let (source, target) = self.prepare_assignability_inputs(source, target);
+        let request = crate::query_boundaries::assignability::RelationRequest::bivariant_callbacks(
+            source, target,
+        )
+        .with_overload_subtype_pass();
+        self.execute_relation_request(&request)
+    }
+
+    /// Overload-resolution subtype-pass variant of the strict relation probe
+    /// used by the call adapter.
+    pub(crate) fn overload_subtype_pass_strict_relation_outcome(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> crate::query_boundaries::assignability::RelationOutcome {
+        crate::query_boundaries::assignability::RelationOutcome {
+            related: self.is_assignable_to_overload_subtype_pass_strict(source, target),
+            depth_exceeded: false,
+            iteration_exceeded: false,
+            failure: None,
+            weak_union_violation: false,
+            property_classification: None,
+        }
+    }
+
     /// Execute a diagnostic-bearing call-adapter identity fallback relation for
     /// raw checker types, preserving the canonical call-adapter identity shape.
     pub(crate) fn call_adapter_identity_relation_outcome(

--- a/crates/tsz-checker/src/checkers/call_checker/applicability.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/applicability.rs
@@ -123,7 +123,10 @@ impl<'a> CheckerState<'a> {
         self.ensure_relation_inputs_ready(arg_types);
 
         let db = self.ctx.types;
-        let mut checker = CheckerCallAssignabilityAdapter { state: self };
+        let mut checker = CheckerCallAssignabilityAdapter {
+            state: self,
+            overload_subtype_pass: false,
+        };
         resolve_call(
             db,
             &mut checker,
@@ -149,7 +152,10 @@ impl<'a> CheckerState<'a> {
         self.ensure_relation_inputs_ready(arg_types);
 
         let db = self.ctx.types;
-        let mut checker = CheckerCallAssignabilityAdapter { state: self };
+        let mut checker = CheckerCallAssignabilityAdapter {
+            state: self,
+            overload_subtype_pass: false,
+        };
         resolve_call_with_arg_sources(
             db,
             &mut checker,
@@ -203,6 +209,58 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Pass-1 ("subtype pass") variant of
+    /// `resolve_call_with_checker_adapter_maybe_arg_sources` for overload
+    /// resolution: identical argument handling, but the adapter's relation
+    /// probes treat an `any` source as not related to concrete targets at
+    /// every nesting level (tsc `chooseOverload` with `subtypeRelation`).
+    pub(crate) fn resolve_call_with_checker_adapter_subtype_pass(
+        &mut self,
+        func_type: TypeId,
+        arg_types: &[TypeId],
+        force_bivariant_callbacks: bool,
+        contextual_type: Option<TypeId>,
+        actual_this_type: Option<TypeId>,
+        arg_source_is_type_annotation: &[bool],
+        arg_source_is_readonly_annotation: &[bool],
+    ) -> tsz_solver::operations::CallWithCheckerResult {
+        self.ensure_relation_input_ready(func_type);
+        self.ensure_relation_inputs_ready(arg_types);
+
+        let db = self.ctx.types;
+        let mut checker = CheckerCallAssignabilityAdapter {
+            state: self,
+            overload_subtype_pass: true,
+        };
+        if arg_source_is_type_annotation.iter().any(|&m| m)
+            || arg_source_is_readonly_annotation.iter().any(|&m| m)
+        {
+            resolve_call_with_arg_sources(
+                db,
+                &mut checker,
+                func_type,
+                arg_types,
+                &CallArgSourceOptions {
+                    force_bivariant_callbacks,
+                    contextual_type,
+                    actual_this_type,
+                    arg_source_is_type_annotation,
+                    arg_source_is_readonly_annotation,
+                },
+            )
+        } else {
+            resolve_call(
+                db,
+                &mut checker,
+                func_type,
+                arg_types,
+                force_bivariant_callbacks,
+                contextual_type,
+                actual_this_type,
+            )
+        }
+    }
+
     pub(crate) fn resolve_new_with_checker_adapter(
         &mut self,
         type_id: TypeId,
@@ -214,7 +272,10 @@ impl<'a> CheckerState<'a> {
         self.ensure_relation_inputs_ready(arg_types);
 
         let db = self.ctx.types;
-        let mut checker = CheckerCallAssignabilityAdapter { state: self };
+        let mut checker = CheckerCallAssignabilityAdapter {
+            state: self,
+            overload_subtype_pass: false,
+        };
         resolve_new(
             db,
             &mut checker,

--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -54,6 +54,12 @@ pub(crate) struct OverloadResolution {
 
 pub(super) struct CheckerCallAssignabilityAdapter<'s, 'ctx> {
     pub(super) state: &'s mut CheckerState<'ctx>,
+    /// Overload-resolution subtype pass (tsc `chooseOverload` with
+    /// `subtypeRelation`): when set, the three relation probes below route
+    /// through the subtype-pass relation entries where an `any` source is
+    /// not related to concrete targets at every nesting level. Non-relation
+    /// adapter methods are unaffected.
+    pub(super) overload_subtype_pass: bool,
 }
 
 impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
@@ -68,7 +74,15 @@ impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
         {
             return false;
         }
-        if self
+        if self.overload_subtype_pass {
+            if self
+                .state
+                .overload_subtype_pass_compatibility_relation_outcome(source, target)
+                .related
+            {
+                return true;
+            }
+        } else if self
             .state
             .call_adapter_compatibility_relation_outcome(source, target)
             .related
@@ -94,6 +108,12 @@ impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
         {
             return false;
         }
+        if self.overload_subtype_pass {
+            return self
+                .state
+                .overload_subtype_pass_strict_relation_outcome(source, target)
+                .related;
+        }
         self.state.strict_relation_outcome(source, target).related
     }
 
@@ -107,6 +127,12 @@ impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
                 .is_some()
         {
             return false;
+        }
+        if self.overload_subtype_pass {
+            return self
+                .state
+                .overload_subtype_pass_bivariant_relation_outcome(source, target)
+                .related;
         }
         self.state
             .bivariant_callbacks_relation_outcome(source, target)

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -231,6 +231,17 @@ impl<'a> CheckerState<'a> {
         // a fallback and continue trying later overloads which might have better
         // return context inference.
         let mut no_rcs_fallback: Option<NoReturnContextFallback> = None;
+        // tsc's `chooseOverload` runs twice over the candidate list: first
+        // with the subtype relation (where an `any` argument is NOT related
+        // to concrete parameter types, at every nesting level), then with the
+        // assignable relation. A candidate that only succeeds under the
+        // assignable relation must not win immediately: a later candidate may
+        // still pass the subtype pass (e.g. a generic overload instantiated
+        // with `U = any`). The first assignable-only success is stashed here
+        // and accepted after the loop, preserving declaration order for the
+        // fallback pass. Single-signature calls keep today's behavior.
+        let overload_two_pass = signatures.len() > 1;
+        let mut assignable_pass_fallback: Option<NoReturnContextFallback> = None;
         // Mark arguments whose type comes from a type annotation (typed
         // identifier, `as`/`satisfies`/`as const`). The direct (non-overloaded)
         // call path computes the same markers so generic inference treats their
@@ -281,20 +292,48 @@ impl<'a> CheckerState<'a> {
                 } else {
                     func_type
                 };
+            // Pass 1 (subtype pass): when the candidate fails under the
+            // stricter any-source-not-related relation, roll back any
+            // speculative state from the attempt and re-resolve with the
+            // normal assignable relation. A success from that second attempt
+            // is deferred (see `assignable_pass_fallback`) instead of
+            // selected immediately.
+            let mut subtype_pass_deferred = false;
             let (mut result, instantiated_predicate, instantiated_params) = if let Some(result) =
                 self.overload_string_argument_array_parameter_mismatch(&sig, &arg_types)
             {
                 (result, None, None)
             } else {
-                self.resolve_call_with_checker_adapter_maybe_arg_sources(
-                    resolved_func_type,
-                    &arg_types,
-                    force_bivariant_callbacks,
-                    sig_contextual_type,
-                    None,
-                    &arg_source_markers,
-                    &arg_readonly_markers,
-                )
+                let mut resolution = None;
+                if overload_two_pass {
+                    let subtype_pass_snap = self.snapshot_overload_retry_state();
+                    let pass1 = self.resolve_call_with_checker_adapter_subtype_pass(
+                        resolved_func_type,
+                        &arg_types,
+                        force_bivariant_callbacks,
+                        sig_contextual_type,
+                        None,
+                        &arg_source_markers,
+                        &arg_readonly_markers,
+                    );
+                    if matches!(pass1.0, CallResult::Success(_)) {
+                        resolution = Some(pass1);
+                    } else {
+                        self.rollback_overload_retry_state(&subtype_pass_snap);
+                        subtype_pass_deferred = true;
+                    }
+                }
+                resolution.unwrap_or_else(|| {
+                    self.resolve_call_with_checker_adapter_maybe_arg_sources(
+                        resolved_func_type,
+                        &arg_types,
+                        force_bivariant_callbacks,
+                        sig_contextual_type,
+                        None,
+                        &arg_source_markers,
+                        &arg_readonly_markers,
+                    )
+                })
             };
             if let CallResult::ArgumentTypeMismatch {
                 expected,
@@ -805,6 +844,23 @@ impl<'a> CheckerState<'a> {
                         continue;
                     }
 
+                    // This candidate failed the subtype pass and only matched
+                    // under the assignable relation. Mirror tsc: keep scanning
+                    // for a later candidate that passes the subtype pass; the
+                    // first assignable-only success is preserved (declaration
+                    // order) as the pass-2 fallback accepted after the loop.
+                    if subtype_pass_deferred {
+                        if assignable_pass_fallback.is_none() {
+                            assignable_pass_fallback = Some((
+                                final_arg_types.clone(),
+                                final_return_type,
+                                selected_type_predicate.clone(),
+                                self.ctx.snapshot_full(),
+                            ));
+                        }
+                        continue;
+                    }
+
                     // Merge the node types inferred during argument collection.
                     // If we did the instantiated retry, node_types already contains the
                     // refreshed entries; otherwise merge the first-pass temp_node_types.
@@ -872,6 +928,21 @@ impl<'a> CheckerState<'a> {
         // but no later overload succeeded, accept the deferred fallback.
         if let Some((fallback_arg_types, fallback_return_type, fallback_predicate, fallback_snap)) =
             no_rcs_fallback
+        {
+            self.ctx.rollback_full(&fallback_snap);
+            self.ctx.node_types.merge(&temp_node_types);
+            return Some(OverloadResolution {
+                arg_types: fallback_arg_types,
+                result: CallResult::Success(fallback_return_type),
+                selected_type_predicate: fallback_predicate,
+            });
+        }
+
+        // No candidate passed the subtype pass: accept the first candidate
+        // (declaration order) that matched under the assignable relation,
+        // mirroring tsc's second `chooseOverload` pass.
+        if let Some((fallback_arg_types, fallback_return_type, fallback_predicate, fallback_snap)) =
+            assignable_pass_fallback
         {
             self.ctx.rollback_full(&fallback_snap);
             self.ctx.node_types.merge(&temp_node_types);

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1083,6 +1083,9 @@ mod overload_anchor_at_argument_tests;
 #[path = "tests/overload_param_relation_routing_arch_tests.rs"]
 mod overload_param_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/overload_two_pass_any_source_tests.rs"]
+mod overload_two_pass_any_source_tests;
+#[cfg(test)]
 #[path = "tests/partial_pick_indexed_access_write_tests.rs"]
 mod partial_pick_indexed_access_write_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -659,80 +659,20 @@ fn mapped_templates_structurally_assignable(
         || mapped_template_structurally_assignable(db, source_eval, target_eval)
 }
 
-/// Boundary-safe flag constants for relation policy.
-///
-/// Mirrors the solver's typed `RelationFlags` bit surface while keeping the
-/// checker-facing packed `u16` protocol quarantined to this boundary. Checker
-/// code should use these constants when constructing relation policy flags
-/// (e.g., in `pack_relation_flags`).
-pub(crate) struct RelationFlags;
-
-impl RelationFlags {
-    pub const STRICT_NULL_CHECKS: u16 = tsz_solver::RelationFlags::STRICT_NULL_CHECKS.bits() as u16;
-    pub const STRICT_FUNCTION_TYPES: u16 =
-        tsz_solver::RelationFlags::STRICT_FUNCTION_TYPES.bits() as u16;
-    pub const EXACT_OPTIONAL_PROPERTY_TYPES: u16 =
-        tsz_solver::RelationFlags::EXACT_OPTIONAL_PROPERTY_TYPES.bits() as u16;
-    pub const NO_UNCHECKED_INDEXED_ACCESS: u16 =
-        tsz_solver::RelationFlags::NO_UNCHECKED_INDEXED_ACCESS.bits() as u16;
-    pub const NO_ERASE_GENERICS: u16 = tsz_solver::RelationFlags::NO_ERASE_GENERICS.bits() as u16;
-    pub const ALLOW_BIVARIANT_REST: u16 =
-        tsz_solver::RelationFlags::ALLOW_BIVARIANT_REST.bits() as u16;
-    pub const ALLOW_ERASED_GENERIC_SIGNATURE_RETRY: u16 =
-        tsz_solver::RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY.bits() as u16;
-    pub const DISABLE_METHOD_BIVARIANCE: u16 =
-        tsz_solver::RelationFlags::DISABLE_METHOD_BIVARIANCE.bits() as u16;
-}
-
-/// Re-export of the solver's relation cache key type.
-///
-/// Used by the assignability checker to construct cache keys for memoizing
-/// subtype and assignability relation results.
-pub(crate) use tsz_solver::RelationCacheKey;
-
-/// Build a cache key for an assignability lookup.
-///
-/// Canonical, typed construction point for assignability cache keys in the
-/// checker. Callers pass a packed `u16` from `pack_relation_flags()` and
-/// this helper funnels it through the solver's typed `RelationCacheConfig`,
-/// so no call site needs to hand-roll the key's internal representation.
-///
-/// The resulting config is produced by the solver's typed `RelationPolicy`
-/// bridge, so this write path lands in the same cache slot as the solver's
-/// internal write path.
-pub(crate) const fn assignability_cache_key(
-    source: TypeId,
-    target: TypeId,
-    flags: u16,
-) -> RelationCacheKey {
-    RelationCacheKey::for_assignability(
-        source,
-        target,
-        relation_policy::from_checker_flags_u16(flags).cache_config(),
-    )
-}
-
-/// Build a cache key for a subtype lookup. See [`assignability_cache_key`].
-pub(crate) const fn subtype_cache_key(
-    source: TypeId,
-    target: TypeId,
-    flags: u16,
-) -> RelationCacheKey {
-    RelationCacheKey::for_subtype(
-        source,
-        target,
-        relation_policy::from_checker_flags_u16(flags).cache_config(),
-    )
-}
 pub(crate) use tsz_solver::type_queries::{
     AssignabilityEvalKind, ExcessPropertiesKind, get_allowed_keys, get_keyof_type,
     get_string_literal_value, get_union_members, is_keyof_type, is_type_parameter_like,
     keyof_object_properties, map_compound_members,
 };
 
-/// Indexed-access normalization shape probes; submodule keeps this file under
-/// its LOC ceiling while the assignability boundary still owns the helpers.
+/// Submodules keep this file under its LOC ceiling while the assignability
+/// boundary still owns the helpers: relation cache-key construction, the
+/// overload subtype pass, and indexed-access normalization shape probes.
+mod cache_key;
+mod overload_subtype_pass;
 mod shape;
+pub(crate) use cache_key::{RelationFlags, assignability_cache_key, subtype_cache_key};
+pub(crate) use overload_subtype_pass::cached_overload_subtype_pass_assignability;
 pub(crate) use shape::{is_index_access_for_assignability, union_members_for_assignability};
 
 pub(crate) fn classify_for_assignability_eval(
@@ -1273,6 +1213,17 @@ pub(crate) fn execute_relation<R: tsz_solver::relations::subtype::TypeResolver>(
     // override forced the failure).
     let (policy, context) =
         assignability_policy_and_context(db, inheritance_graph, solver_flags, sound_mode);
+    // The overload subtype pass rides on the typed `any`-propagation mode (not
+    // the packed `u16` flags, which are saturated). The mode participates in
+    // `RelationPolicy::cache_config`, so pass-1 results cannot share relation
+    // cache slots with the default assignable relation.
+    let policy = if request.overload_subtype_pass {
+        policy.with_any_propagation_mode(
+            tsz_solver::relations::subtype::AnyPropagationMode::AnySourceNotRelated,
+        )
+    } else {
+        policy
+    };
     let solver_outcome = query_assignability_with_failure_analysis(RelationQueryInputs {
         interner: db.as_type_database(),
         resolver,

--- a/crates/tsz-checker/src/query_boundaries/assignability/cache_key.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/cache_key.rs
@@ -1,0 +1,74 @@
+//! Relation cache-key construction for the assignability boundary.
+//!
+//! Submodule keeps the assignability boundary under its LOC ceiling while the
+//! boundary still owns cache-key policy.
+
+use tsz_solver::TypeId;
+
+use super::relation_policy;
+
+/// Boundary-safe flag constants for relation policy.
+///
+/// Mirrors the solver's typed `RelationFlags` bit surface while keeping the
+/// checker-facing packed `u16` protocol quarantined to this boundary. Checker
+/// code should use these constants when constructing relation policy flags
+/// (e.g., in `pack_relation_flags`).
+pub(crate) struct RelationFlags;
+
+impl RelationFlags {
+    pub const STRICT_NULL_CHECKS: u16 = tsz_solver::RelationFlags::STRICT_NULL_CHECKS.bits() as u16;
+    pub const STRICT_FUNCTION_TYPES: u16 =
+        tsz_solver::RelationFlags::STRICT_FUNCTION_TYPES.bits() as u16;
+    pub const EXACT_OPTIONAL_PROPERTY_TYPES: u16 =
+        tsz_solver::RelationFlags::EXACT_OPTIONAL_PROPERTY_TYPES.bits() as u16;
+    pub const NO_UNCHECKED_INDEXED_ACCESS: u16 =
+        tsz_solver::RelationFlags::NO_UNCHECKED_INDEXED_ACCESS.bits() as u16;
+    pub const NO_ERASE_GENERICS: u16 = tsz_solver::RelationFlags::NO_ERASE_GENERICS.bits() as u16;
+    pub const ALLOW_BIVARIANT_REST: u16 =
+        tsz_solver::RelationFlags::ALLOW_BIVARIANT_REST.bits() as u16;
+    pub const ALLOW_ERASED_GENERIC_SIGNATURE_RETRY: u16 =
+        tsz_solver::RelationFlags::ALLOW_ERASED_GENERIC_SIGNATURE_RETRY.bits() as u16;
+    pub const DISABLE_METHOD_BIVARIANCE: u16 =
+        tsz_solver::RelationFlags::DISABLE_METHOD_BIVARIANCE.bits() as u16;
+}
+
+/// Re-export of the solver's relation cache key type.
+///
+/// Used by the assignability checker to construct cache keys for memoizing
+/// subtype and assignability relation results.
+pub(crate) use tsz_solver::RelationCacheKey;
+
+/// Build a cache key for an assignability lookup.
+///
+/// Canonical, typed construction point for assignability cache keys in the
+/// checker. Callers pass a packed `u16` from `pack_relation_flags()` and
+/// this helper funnels it through the solver's typed `RelationCacheConfig`,
+/// so no call site needs to hand-roll the key's internal representation.
+///
+/// The resulting config is produced by the solver's typed `RelationPolicy`
+/// bridge, so this write path lands in the same cache slot as the solver's
+/// internal write path.
+pub(crate) const fn assignability_cache_key(
+    source: TypeId,
+    target: TypeId,
+    flags: u16,
+) -> RelationCacheKey {
+    RelationCacheKey::for_assignability(
+        source,
+        target,
+        relation_policy::from_checker_flags_u16(flags).cache_config(),
+    )
+}
+
+/// Build a cache key for a subtype lookup. See [`assignability_cache_key`].
+pub(crate) const fn subtype_cache_key(
+    source: TypeId,
+    target: TypeId,
+    flags: u16,
+) -> RelationCacheKey {
+    RelationCacheKey::for_subtype(
+        source,
+        target,
+        relation_policy::from_checker_flags_u16(flags).cache_config(),
+    )
+}

--- a/crates/tsz-checker/src/query_boundaries/assignability/overload_subtype_pass.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability/overload_subtype_pass.rs
@@ -1,0 +1,72 @@
+//! Overload-resolution subtype-pass assignability boundary (issue #13042).
+//!
+//! Submodule keeps the assignability boundary under its LOC ceiling while the
+//! boundary still owns the cache-key construction and relation execution.
+
+use tsz_solver::RelationCacheKey;
+
+use super::relation_policy;
+use super::{
+    AssignabilityQueryInputs, RelationQueryInputs, SolverRelationKind, is_relation_cacheable,
+};
+
+/// Overload-resolution subtype pass (tsc `chooseOverload` with
+/// `subtypeRelation`): assignability where an `any` source is not related to
+/// non-`any`/`unknown` targets at every nesting level, while an `any` target
+/// still accepts everything.
+///
+/// The pass rides on the typed `AnySourceNotRelated` propagation mode rather
+/// than the packed `u16` flag protocol (which is saturated). The mode is part
+/// of `RelationPolicy::cache_config`, so the checker-level cache key built
+/// here can never share a slot with default assignable-relation results.
+pub(crate) fn cached_overload_subtype_pass_assignability<
+    R: tsz_solver::relations::subtype::TypeResolver,
+>(
+    inputs: &AssignabilityQueryInputs<'_, R>,
+    overrides: &dyn tsz_solver::relations::compat::AssignabilityOverrideProvider,
+) -> tsz_solver::relations::relation_queries::RelationResult {
+    let policy = relation_policy::from_checker_flags_u16(inputs.flags)
+        .with_strict_subtype_checking(inputs.sound_mode)
+        .with_strict_any_propagation(inputs.sound_mode)
+        .with_any_propagation_mode(
+            tsz_solver::relations::subtype::AnyPropagationMode::AnySourceNotRelated,
+        );
+    let is_cacheable =
+        is_relation_cacheable(inputs.db.as_type_database(), inputs.source, inputs.target);
+    let cache_key =
+        RelationCacheKey::for_assignability(inputs.source, inputs.target, policy.cache_config());
+    if is_cacheable && let Some(cached) = inputs.db.lookup_assignability_cache(cache_key) {
+        return tsz_solver::relations::relation_queries::RelationResult {
+            kind: tsz_solver::relations::relation_queries::RelationKind::Assignable,
+            related: cached,
+            depth_exceeded: false,
+            iteration_exceeded: false,
+        };
+    }
+
+    let context = tsz_solver::relations::relation_queries::RelationContext {
+        query_db: Some(inputs.db),
+        inheritance_graph: Some(inputs.inheritance_graph),
+        class_check: None,
+    };
+    let relation_result = tsz_solver::relations::relation_queries::query_relation_with_overrides(
+        RelationQueryInputs {
+            interner: inputs.db.as_type_database(),
+            resolver: inputs.resolver,
+            source: inputs.source,
+            target: inputs.target,
+            kind: SolverRelationKind::Assignable,
+            policy,
+            context,
+            overrides,
+        },
+    );
+
+    if is_cacheable {
+        inputs
+            .db
+            .insert_assignability_cache(cache_key, relation_result.is_related());
+    }
+
+    relation_result
+}

--- a/crates/tsz-checker/src/query_boundaries/relation_request.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_request.rs
@@ -234,6 +234,12 @@ pub(crate) struct RelationRequest {
     pub source_is_fresh: bool,
     /// Allow targeted erased-signature retry for interface property compatibility.
     pub allow_erased_generic_signature_retry: bool,
+    /// Overload-resolution subtype pass (tsc `chooseOverload` with
+    /// `subtypeRelation`): an `any` source is not related to non-`any`/
+    /// non-`unknown` targets, at every nesting level. The boundary maps this
+    /// to the solver's `AnySourceNotRelated` propagation mode, which also
+    /// partitions the relation caches.
+    pub overload_subtype_pass: bool,
 }
 
 impl RelationRequest {
@@ -246,6 +252,7 @@ impl RelationRequest {
             missing_property_mode: MissingPropertyMode::Report,
             source_is_fresh: false,
             allow_erased_generic_signature_retry: false,
+            overload_subtype_pass: false,
         }
     }
 
@@ -715,6 +722,14 @@ impl RelationRequest {
     /// Allow a failed generic-signature inference to retry with erased signatures.
     pub(crate) const fn with_erased_generic_signature_retry(mut self) -> Self {
         self.allow_erased_generic_signature_retry = true;
+        self
+    }
+
+    /// Run this relation under the overload-resolution subtype pass, where an
+    /// `any` source is not related to non-`any`/`unknown` targets at every
+    /// nesting level (tsc `chooseOverload` with `subtypeRelation`).
+    pub(crate) const fn with_overload_subtype_pass(mut self) -> Self {
+        self.overload_subtype_pass = true;
         self
     }
 }

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_01.rs
@@ -1910,8 +1910,10 @@ fn test_relation_request_override_builders_remain_explicit() {
 /// checker-safe flag surface for request-sensitive relation policy.
 #[test]
 fn test_relation_flags_surface_covers_checker_policy_bits() {
-    let source = fs::read_to_string("src/query_boundaries/assignability.rs")
-        .expect("failed to read query_boundaries/assignability.rs");
+    // The flag surface lives in the boundary-owned `cache_key` submodule
+    // (split out of assignability.rs to satisfy the file-size ceiling).
+    let source = fs::read_to_string("src/query_boundaries/assignability/cache_key.rs")
+        .expect("failed to read query_boundaries/assignability/cache_key.rs");
 
     assert!(
         source.contains("pub(crate) struct RelationFlags;"),
@@ -1937,8 +1939,10 @@ fn test_relation_flags_surface_covers_checker_policy_bits() {
 /// `RelationFlags` bit surface, not the legacy cache-key `FLAG_*` protocol.
 #[test]
 fn test_relation_flags_surface_uses_solver_typed_flags() {
-    let source = fs::read_to_string("src/query_boundaries/assignability.rs")
-        .expect("failed to read query_boundaries/assignability.rs");
+    // The flag surface lives in the boundary-owned `cache_key` submodule
+    // (split out of assignability.rs to satisfy the file-size ceiling).
+    let source = fs::read_to_string("src/query_boundaries/assignability/cache_key.rs")
+        .expect("failed to read query_boundaries/assignability/cache_key.rs");
 
     assert!(
         source.contains("tsz_solver::RelationFlags::STRICT_NULL_CHECKS"),

--- a/crates/tsz-checker/src/tests/overload_two_pass_any_source_tests.rs
+++ b/crates/tsz-checker/src/tests/overload_two_pass_any_source_tests.rs
@@ -1,0 +1,194 @@
+//! Two-pass overload resolution with `any` arguments (issue #13042).
+//!
+//! Structural rule: tsc's `chooseOverload` runs twice — first with the
+//! subtype relation, where an `any` SOURCE is not related to concrete
+//! targets (at every nesting level), then with the assignable relation in
+//! declaration order. With an `any` argument and a mixed
+//! non-generic/generic overload set, the non-generic candidate is skipped
+//! in pass 1 and the generic one wins with `U = any`; when every candidate
+//! fails pass 1, the first assignable candidate wins in declaration order.
+//!
+//! tsz routes pass 1 through the solver's `AnySourceNotRelated` relation
+//! mode via `resolve_call_with_checker_adapter_subtype_pass`.
+//!
+//! The inferred result types are pinned through probe assignments:
+//! a probe against an incompatible concrete target errors (TS2322) when the
+//! call result is concrete and stays silent when the result is `any`.
+
+use crate::test_utils::{check_source_diagnostics, diagnostic_count};
+
+fn count(source: &str, code: u32) -> usize {
+    diagnostic_count(&check_source_diagnostics(source), code)
+}
+
+/// Mixed overload set, `any` argument: the generic candidate wins pass 1
+/// with `U = any`, so the call result is `any` (matrix case `e`).
+#[test]
+fn any_argument_prefers_generic_candidate_over_first_nongeneric() {
+    let source = r#"
+declare function grabItem(key: string): "s";
+declare function grabItem<TPick>(key: TPick, alt?: TPick): TPick;
+declare const opaque: any;
+const picked = grabItem(opaque);
+const probeNum: number = picked;
+const probeObj: { marker: number } = picked;
+"#;
+    assert_eq!(
+        count(source, 2322),
+        0,
+        "result should be `any` (generic candidate with TPick = any), not the literal \"s\""
+    );
+}
+
+/// Declaration order with the generic candidate first: pass 1 selects it
+/// directly, so the result is still `any`.
+#[test]
+fn any_argument_generic_first_declaration_order_still_any() {
+    let source = r#"
+declare function fetchSlot<TBox>(handle: TBox, fallback?: TBox): TBox;
+declare function fetchSlot(handle: string): "s";
+declare const blob: any;
+const slot = fetchSlot(blob);
+const probeNum: number = slot;
+"#;
+    assert_eq!(
+        count(source, 2322),
+        0,
+        "generic-first declaration order should also produce `any`"
+    );
+}
+
+/// All-non-generic overloads with an `any` argument: every candidate fails
+/// pass 1, and pass 2 picks the FIRST candidate in declaration order
+/// (matrix case `e2`).
+#[test]
+fn any_argument_all_nongeneric_falls_back_in_declaration_order() {
+    let source = r#"
+declare function stamp(value: string): "s";
+declare function stamp(value: number): "n";
+declare const fuzzy: any;
+const tag = stamp(fuzzy);
+const probeWrong: "n" = tag;
+"#;
+    assert_eq!(
+        count(source, 2322),
+        1,
+        "pass 2 must select the first overload in declaration order (result \"s\", not `any`/\"n\")"
+    );
+
+    let ok_source = r#"
+declare function stamp(value: string): "s";
+declare function stamp(value: number): "n";
+declare const fuzzy: any;
+const tag = stamp(fuzzy);
+const probeRight: "s" = tag;
+"#;
+    assert_eq!(count(ok_source, 2322), 0, "result should be exactly \"s\"");
+}
+
+/// When the generic candidate cannot match the call arity, the non-generic
+/// candidate still wins through the pass-2 fallback.
+#[test]
+fn any_argument_generic_arity_mismatch_keeps_nongeneric_winner() {
+    let source = r#"
+declare function routeKey(name: string): "s";
+declare function routeKey<TPair>(name: TPair, partner: TPair): TPair;
+declare const loose: any;
+const route = routeKey(loose);
+const probeWrong: "x" = route;
+"#;
+    assert_eq!(
+        count(source, 2322),
+        1,
+        "generic candidate fails arity, so the non-generic \"s\" result must win (not `any`)"
+    );
+}
+
+/// Non-`any` arguments are unaffected: the first matching overload wins as
+/// before, in both literal and numeric forms.
+#[test]
+fn concrete_arguments_keep_existing_overload_selection() {
+    let source = r#"
+declare function render(value: string): "s";
+declare function render(value: number): "n";
+const a = render("title");
+const b = render(42);
+const probeA: "s" = a;
+const probeB: "n" = b;
+"#;
+    assert_eq!(
+        count(source, 2322),
+        0,
+        "concrete arguments must keep today's overload selection"
+    );
+}
+
+/// Reduce-style overload pair with an `any` seed: the union-typed callback
+/// result flows from the generic candidate with `U = any` (matrix cases
+/// `a`/`b`).
+#[test]
+fn reduce_like_any_seed_selects_generic_candidate() {
+    let source = r#"
+interface SegmentList {
+    fold(merge: (acc: string, item: string) => string): string;
+    fold(merge: (acc: string, item: string) => string, seed: string): string;
+    fold<TAcc>(merge: (acc: TAcc, item: string) => TAcc, seed: TAcc): TAcc;
+}
+declare const segments: SegmentList;
+declare const opaqueSeed: any;
+const merged = segments.fold((acc, item) => acc[item], opaqueSeed);
+const probeNum: number = merged;
+const constant = segments.fold(() => "x", opaqueSeed);
+const probeNum2: number = constant;
+"#;
+    assert_eq!(
+        count(source, 2322),
+        0,
+        "any seed must select the generic fold (TAcc = any); result is `any`, not string"
+    );
+}
+
+/// Reduce-style call with a concrete seed keeps the string overload
+/// (matrix case `d`).
+#[test]
+fn reduce_like_concrete_seed_keeps_string_result() {
+    let source = r#"
+interface SegmentList {
+    fold(merge: (acc: string, item: string) => string): string;
+    fold(merge: (acc: string, item: string) => string, seed: string): string;
+    fold<TAcc>(merge: (acc: TAcc, item: string) => TAcc, seed: TAcc): TAcc;
+}
+declare const segments: SegmentList;
+const collapsed = segments.fold(() => "x", "start");
+const probeNum: number = collapsed;
+"#;
+    assert_eq!(
+        count(source, 2322),
+        1,
+        "concrete seed keeps the string overload; string is not assignable to number"
+    );
+}
+
+/// An explicit callback parameter annotation makes the generic candidate
+/// fail pass 1 too — the rejection applies inside the nested callback
+/// parameter comparison, not just at the top-level argument (matrix case
+/// `c`). Declaration order then selects the string overload in pass 2.
+#[test]
+fn annotated_callback_param_rejects_generic_candidate_at_nested_level() {
+    let source = r#"
+interface SegmentList {
+    fold(merge: (acc: string, item: string) => string): string;
+    fold(merge: (acc: string, item: string) => string, seed: string): string;
+    fold<TAcc>(merge: (acc: TAcc, item: string) => TAcc, seed: TAcc): TAcc;
+}
+declare const segments: SegmentList;
+declare const opaqueSeed: any;
+const joined = segments.fold((acc: string, item) => acc + item, opaqueSeed);
+const probeNum: number = joined;
+"#;
+    assert_eq!(
+        count(source, 2322),
+        1,
+        "annotated callback param must reject the generic candidate in pass 1 (nested any source); result is string"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -667,12 +667,17 @@ impl<'a> CheckerState<'a> {
                 None => &[],
             };
             let check_excess_properties = false;
+            // Keep the per-argument provider empty (no fabricated contextual
+            // `any` for callbacks), but expose the `any` callable so spread
+            // position checks know the callee imposes no parameter-arity
+            // shape: `new anyCtor(...args)` must not emit TS2556 (tsc resolves
+            // it through the any-signature path with no spread restriction).
             self.collect_call_argument_types_with_context(
                 args,
                 |_i, _arg_count| None, // No parameter type info for ANY callee
                 check_excess_properties,
                 None, // No skipping needed
-                CallableContext::none(),
+                CallableContext::new(TypeId::ANY),
             );
 
             return TypeId::ANY;

--- a/crates/tsz-checker/tests/variadic_tuple_spread_arity_ts2556_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_spread_arity_ts2556_tests.rs
@@ -334,3 +334,61 @@ fn open_ended_tuple_into_iife_all_annotated_emits_ts2556() {
         diagnostic_codes(&diags)
     );
 }
+
+// ---------------------------------------------------------------------------
+// `any` callee: no parameter-arity shape, so non-tuple spreads never overflow
+// a fixed parameter list. tsc resolves `new anyCtor(...args)` through the
+// any-signature path with no TS2556 (comlink canary, issue #13042).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn any_constructor_spread_arguments_do_not_emit_ts2556() {
+    let source = "\
+declare const makerish: any;
+declare const packedBlob: any;
+declare const packedList: any[];
+const built = new makerish(...packedBlob);
+const builtFromList = new makerish(...packedList);
+";
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        0,
+        "spread into an `any` constructor must not emit TS2556, got {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+#[test]
+fn any_callee_call_spread_arguments_do_not_emit_ts2556() {
+    let source = "\
+declare const invoker: any;
+declare const looseArgs: any[];
+const out = invoker(...looseArgs);
+";
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        0,
+        "spread into an `any` callee must not emit TS2556, got {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+#[test]
+fn known_constructor_non_tuple_spread_still_emits_ts2556() {
+    let source = "\
+declare class CrateBox {
+    constructor(width: number, label: string);
+}
+declare const loosePair: number[];
+const crated = new CrateBox(...loosePair);
+";
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        diagnostic_count(&diags, 2556),
+        1,
+        "non-tuple spread into a fixed-arity constructor keeps TS2556, got {:?}",
+        diagnostic_codes(&diags)
+    );
+}

--- a/crates/tsz-solver/src/caches/query_trace.rs
+++ b/crates/tsz-solver/src/caches/query_trace.rs
@@ -105,6 +105,7 @@ const fn relation_cache_config_trace_fields(
         CachedAnyMode::All => "all",
         CachedAnyMode::TopLevelOnlyAtTop => "top_level_only_at_top",
         CachedAnyMode::TopLevelOnlyNested => "top_level_only_nested",
+        CachedAnyMode::AnySourceNotRelated => "any_source_not_related",
     };
     RelationCacheConfigTraceFields {
         flags: config.flags.bits(),

--- a/crates/tsz-solver/src/contextual/core.rs
+++ b/crates/tsz-solver/src/contextual/core.rs
@@ -678,6 +678,15 @@ impl<'a> ContextualTypeContext<'a> {
         let Some(expected) = self.expected else {
             return false;
         };
+        // An `any` (or error) callable imposes no parameter-arity shape, so a
+        // non-tuple spread can never overflow a fixed parameter list. tsc
+        // resolves `new anyCtor(...args)` through the any-signature path with
+        // no TS2556. This mirrors the no-callable fallback probe used when no
+        // contextual callable type is available, which also accepts every
+        // position for an `any` callee.
+        if expected == TypeId::ANY || expected == TypeId::ERROR {
+            return true;
+        }
         if let Some(TypeData::Application(app_id)) = self.interner.lookup(expected) {
             let app = self.interner.type_application(app_id);
             let ctx = ContextualTypeContext::with_expected(self.interner, app.base);

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -815,6 +815,17 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         self.cache.clear();
     }
 
+    /// Toggle the overload subtype-pass mode (tsc `chooseOverload` with
+    /// `subtypeRelation`): an `any` source is not related to non-`any`/
+    /// non-`unknown` targets, at every nesting level, while an `any` target
+    /// still accepts everything.
+    pub fn set_any_source_not_related(&mut self, enabled: bool) {
+        if self.lawyer.any_source_not_related != enabled {
+            self.lawyer.set_any_source_not_related(enabled);
+            self.cache.clear();
+        }
+    }
+
     /// Get a reference to the lawyer layer for `any` propagation rules.
     pub const fn lawyer(&self) -> &AnyPropagationRules {
         &self.lawyer
@@ -1441,6 +1452,14 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             // `isSimpleTypeRelatedTo`: `if (s & TypeFlags.Any) return !(t & TypeFlags.Never);`
             if source == TypeId::ANY && target == TypeId::NEVER {
                 return Some(false);
+            }
+            // Overload subtype pass: an `any` target still accepts every
+            // source, but an `any` source is related only to `any`/`unknown`
+            // targets, mirroring tsc's `isSimpleTypeRelatedTo` for the
+            // subtype relation (a source `any` returns true only for the
+            // assignable/comparable relations).
+            if self.lawyer.any_source_not_related {
+                return Some(target == TypeId::ANY || target == TypeId::UNKNOWN);
             }
             // If legacy suppression is allowed, we still return true here.
             if self.lawyer.allow_any_suppression {

--- a/crates/tsz-solver/src/relations/lawyer.rs
+++ b/crates/tsz-solver/src/relations/lawyer.rs
@@ -151,6 +151,13 @@ pub struct AnyPropagationRules {
     /// When false, `any` is treated more strictly and structural errors
     /// are still reported even when `any` is involved.
     pub(crate) allow_any_suppression: bool,
+    /// Overload-resolution subtype pass (tsc `chooseOverload` with
+    /// `subtypeRelation`): an `any` SOURCE is not related to concrete
+    /// targets at every nesting level, while an `any`/`unknown` TARGET
+    /// still accepts everything. Takes precedence over
+    /// `allow_any_suppression` when set, because the subtype pass is a
+    /// dedicated relation mode rather than a Sound-Mode strictness knob.
+    pub(crate) any_source_not_related: bool,
 }
 
 impl AnyPropagationRules {
@@ -161,6 +168,7 @@ impl AnyPropagationRules {
     pub const fn new() -> Self {
         Self {
             allow_any_suppression: true,
+            any_source_not_related: false,
         }
     }
 
@@ -172,6 +180,7 @@ impl AnyPropagationRules {
     pub const fn strict() -> Self {
         Self {
             allow_any_suppression: false,
+            any_source_not_related: false,
         }
     }
 
@@ -180,9 +189,17 @@ impl AnyPropagationRules {
         self.allow_any_suppression = allow;
     }
 
+    /// Toggle the overload subtype-pass mode where an `any` source is not
+    /// related to concrete targets (see `any_source_not_related`).
+    pub const fn set_any_source_not_related(&mut self, enabled: bool) {
+        self.any_source_not_related = enabled;
+    }
+
     /// Return the propagation mode for `any` handling in the subtype engine.
     pub const fn any_propagation_mode(&self) -> AnyPropagationMode {
-        if self.allow_any_suppression {
+        if self.any_source_not_related {
+            AnyPropagationMode::AnySourceNotRelated
+        } else if self.allow_any_suppression {
             AnyPropagationMode::All
         } else {
             AnyPropagationMode::TopLevelOnly

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -245,6 +245,9 @@ impl RelationPolicy {
             // perspective. The `SubtypeChecker` refines this to
             // `TopLevelOnlyNested` at depth > 0 when it builds its own key.
             AnyPropagationMode::TopLevelOnly => CachedAnyMode::TopLevelOnlyAtTop,
+            // Depth-independent: the overload subtype pass behaves the same
+            // at every nesting level, so one cached mode covers all depths.
+            AnyPropagationMode::AnySourceNotRelated => CachedAnyMode::AnySourceNotRelated,
         };
         self.cache_config_with_cached_any_mode(any_mode)
     }
@@ -630,6 +633,10 @@ pub(crate) fn configured_compat_checker<'a, R: TypeResolver>(
     checker.set_inheritance_graph(context.inheritance_graph);
     checker.set_strict_subtype_checking(policy.strict_subtype_checking);
     checker.set_strict_any_propagation(policy.strict_any_propagation);
+    checker.set_any_source_not_related(matches!(
+        policy.any_propagation_mode,
+        AnyPropagationMode::AnySourceNotRelated
+    ));
     checker.set_assume_related_on_cycle(policy.assume_related_on_cycle);
     checker.set_skip_weak_type_checks(policy.skip_weak_type_checks);
     checker.set_erase_generics(policy.erase_generics);

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -183,18 +183,21 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // =========================================================================
         // Fast paths (no cycle tracking needed)
         // =========================================================================
-        let allow_any = self.any_propagation.allows_any_at_depth(self.guard.depth());
+        let allow_any_source = self
+            .any_propagation
+            .allows_any_source_at_depth(self.guard.depth());
+        let allow_any_target = self
+            .any_propagation
+            .allows_any_target_at_depth(self.guard.depth());
         let mut source = source;
         let mut target = target;
-        if !allow_any {
-            if source == TypeId::ANY {
-                // In strict mode, any doesn't match everything structurally.
-                // We demote it to STRICT_ANY so it only matches top types or itself.
-                source = TypeId::STRICT_ANY;
-            }
-            if target == TypeId::ANY {
-                target = TypeId::STRICT_ANY;
-            }
+        if !allow_any_source && source == TypeId::ANY {
+            // In strict mode, any doesn't match everything structurally.
+            // We demote it to STRICT_ANY so it only matches top types or itself.
+            source = TypeId::STRICT_ANY;
+        }
+        if !allow_any_target && target == TypeId::ANY {
+            target = TypeId::STRICT_ANY;
         }
 
         // Same type is always a subtype of itself
@@ -242,7 +245,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
         // Any is assignable to anything except never (when allowed).
         // tsc: `if (s & TypeFlags.Any) return !(t & TypeFlags.Never);`
-        if allow_any
+        if allow_any_source
             && (source == TypeId::ANY || source == TypeId::STRICT_ANY)
             && target != TypeId::NEVER
         {
@@ -250,17 +253,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
 
         // Everything is assignable to any (when allowed)
-        if allow_any && (target == TypeId::ANY || target == TypeId::STRICT_ANY) {
+        if allow_any_target && (target == TypeId::ANY || target == TypeId::STRICT_ANY) {
             return SubtypeResult::True;
         }
 
-        // If not allowing any (nested strict any / identity mode), STRICT_ANY
-        // can only match STRICT_ANY, ANY, or UNKNOWN as a top-type source.
-        // Crucially, non-any types are NOT assignable to STRICT_ANY in this mode.
+        // If not allowing any sources (nested strict any / identity mode /
+        // overload subtype pass), STRICT_ANY can only match STRICT_ANY, ANY,
+        // or UNKNOWN as a top-type source. Crucially, non-any types are NOT
+        // assignable to STRICT_ANY in the symmetric strict modes.
         // This ensures that bidirectional subtype checks used for identity (TS2403)
         // correctly reject `number <: any` at nested depths, matching tsc's
         // isTypeIdenticalTo where `any` is only identical to `any`.
-        if !allow_any
+        if !allow_any_source
             && (source == TypeId::ANY || source == TypeId::STRICT_ANY)
             && (target == TypeId::ANY || target == TypeId::STRICT_ANY || target == TypeId::UNKNOWN)
         {

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -107,13 +107,32 @@ pub enum AnyPropagationMode {
     All,
     /// `any` is treated as top/bottom only at the top-level comparison.
     TopLevelOnly,
+    /// Overload-resolution subtype pass (tsc `chooseOverload` with
+    /// `subtypeRelation`): an `any` SOURCE is not related to non-`any`/
+    /// non-`unknown` targets, at every nesting level. An `any`/`unknown`
+    /// TARGET still accepts everything, matching tsc's
+    /// `isSimpleTypeRelatedTo`, where a source `any` returns `true` only for
+    /// the assignable/comparable relations while a target `any` returns
+    /// `true` for every relation.
+    AnySourceNotRelated,
 }
 
 impl AnyPropagationMode {
+    /// Whether an `any` SOURCE may match arbitrary targets at this depth.
     #[inline]
-    pub(crate) const fn allows_any_at_depth(self, depth: u32) -> bool {
+    pub(crate) const fn allows_any_source_at_depth(self, depth: u32) -> bool {
         match self {
             Self::All => true,
+            Self::TopLevelOnly => depth == 0,
+            Self::AnySourceNotRelated => false,
+        }
+    }
+
+    /// Whether an `any` TARGET accepts arbitrary sources at this depth.
+    #[inline]
+    pub(crate) const fn allows_any_target_at_depth(self, depth: u32) -> bool {
+        match self {
+            Self::All | Self::AnySourceNotRelated => true,
             Self::TopLevelOnly => depth == 0,
         }
     }

--- a/crates/tsz-solver/src/relations/subtype/helpers.rs
+++ b/crates/tsz-solver/src/relations/subtype/helpers.rs
@@ -282,6 +282,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 CachedAnyMode::TopLevelOnlyAtTop
             }
             AnyPropagationMode::TopLevelOnly => CachedAnyMode::TopLevelOnlyNested,
+            // Depth-independent mode: same behavior at every nesting level.
+            AnyPropagationMode::AnySourceNotRelated => CachedAnyMode::AnySourceNotRelated,
         }
     }
 

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -677,8 +677,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         });
         // T<X> <: T<any> and T<any> <: T<X> are always true when
         // any-propagation is enabled; skip variance computation entirely rather
-        // than risking structural expansion.
-        let allow_any = self.any_propagation.allows_any_at_depth(self.guard.depth());
+        // than risking structural expansion. The shortcut requires `any` to be
+        // permissive on BOTH sides: under asymmetric modes (overload subtype
+        // pass) `T<any> <: T<X>` must fall through to the per-argument variance
+        // checks so an `any` source argument is rejected there.
+        let allow_any = self
+            .any_propagation
+            .allows_any_source_at_depth(self.guard.depth())
+            && self
+                .any_propagation
+                .allows_any_target_at_depth(self.guard.depth());
         if allow_any && (s_args.iter().all(|a| a.is_any()) || t_args.iter().all(|a| a.is_any())) {
             return Some(SubtypeResult::True);
         }

--- a/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
@@ -164,7 +164,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return true;
         }
         if let Some(kind) = intrinsic_kind(self.interner, source) {
-            let allow_any = self.any_propagation.allows_any_at_depth(self.guard.depth());
+            // `source` is the relation source here, so consult the
+            // source-side `any` allowance.
+            let allow_any = self
+                .any_propagation
+                .allows_any_source_at_depth(self.guard.depth());
             return match intrinsic_vs_object_super(kind, IntrinsicObjectKind::ObjectKeyword) {
                 Some(result) => result,
                 // `any` is mode-dependent for the `object` keyword.
@@ -287,7 +291,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     ///
     /// Rule #29: Function intrinsic accepts any callable type as a subtype.
     pub(crate) fn is_callable_type(&mut self, source: TypeId) -> bool {
-        let allow_any = self.any_propagation.allows_any_at_depth(self.guard.depth());
+        // `source` is the relation source (a candidate callable), so consult
+        // the source-side `any` allowance.
+        let allow_any = self
+            .any_propagation
+            .allows_any_source_at_depth(self.guard.depth());
         match source {
             TypeId::ANY if allow_any => return true,
             TypeId::NEVER | TypeId::ERROR | TypeId::FUNCTION => return true,

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -353,6 +353,12 @@ pub enum CachedAnyMode {
     TopLevelOnlyAtTop,
     /// Configured `TopLevelOnly`, currently nested (depth > 0).
     TopLevelOnlyNested,
+    /// Overload-resolution subtype pass: an `any` source is not related to
+    /// non-`any`/`unknown` targets at every depth, while an `any` target
+    /// still accepts everything. Depth-independent, so it needs no
+    /// at-top/nested split. Results computed under this mode must never
+    /// share a cache slot with the default assignable relation.
+    AnySourceNotRelated,
 }
 
 /// Canonical cache-partitioning configuration for relation queries.

--- a/crates/tsz-solver/tests/compat_tests_parts/part_03.rs
+++ b/crates/tsz-solver/tests/compat_tests_parts/part_03.rs
@@ -1401,3 +1401,108 @@ fn test_unknown_not_assignable_to_union_missing_empty_object() {
         "unknown should not be assignable to `string | null | undefined` (no `{{}}` member)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Overload subtype pass: `any` source is not related to concrete targets
+// (tsc `chooseOverload` with `subtypeRelation`; issue #13042).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_any_source_not_related_top_level() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+    checker.set_any_source_not_related(true);
+
+    assert!(
+        !checker.is_assignable(TypeId::ANY, TypeId::STRING),
+        "subtype pass: `any` source must not be related to a concrete target"
+    );
+    assert!(
+        checker.is_assignable(TypeId::STRING, TypeId::ANY),
+        "subtype pass: `any` target still accepts everything"
+    );
+    assert!(
+        checker.is_assignable(TypeId::ANY, TypeId::ANY),
+        "subtype pass: `any` is related to `any`"
+    );
+    assert!(
+        checker.is_assignable(TypeId::ANY, TypeId::UNKNOWN),
+        "subtype pass: `any` is related to `unknown`"
+    );
+    assert!(
+        !checker.is_assignable(TypeId::ANY, TypeId::NEVER),
+        "`any` is never assignable to `never`"
+    );
+}
+
+#[test]
+fn test_any_source_not_related_applies_at_nested_levels() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+    checker.set_any_source_not_related(true);
+
+    let any_array = interner.array(TypeId::ANY);
+    let string_array = interner.array(TypeId::STRING);
+
+    assert!(
+        !checker.is_assignable(any_array, string_array),
+        "subtype pass: nested `any` source (array element) must not be related"
+    );
+    assert!(
+        checker.is_assignable(string_array, any_array),
+        "subtype pass: nested `any` target still accepts everything"
+    );
+}
+
+#[test]
+fn test_any_source_not_related_inside_callback_param_comparison() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+    checker.set_strict_function_types(true);
+    checker.set_any_source_not_related(true);
+
+    let takes_string = interner.function(FunctionShape {
+        params: vec![ParamInfo::unnamed(TypeId::STRING)],
+        this_type: None,
+        return_type: TypeId::VOID,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+    let takes_any = interner.function(FunctionShape {
+        params: vec![ParamInfo::unnamed(TypeId::ANY)],
+        this_type: None,
+        return_type: TypeId::VOID,
+        type_params: Vec::new(),
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    // Contravariant parameter check compares target-param -> source-param,
+    // so the target's `any` parameter becomes a nested relation SOURCE and
+    // must be rejected by the subtype pass.
+    assert!(
+        !checker.is_assignable(takes_string, takes_any),
+        "subtype pass: `any` appearing as a nested contravariant source must be rejected"
+    );
+    // The reverse direction relates string -> any (any as nested target).
+    assert!(
+        checker.is_assignable(takes_any, takes_string),
+        "subtype pass: `any` as a nested target still accepts the parameter"
+    );
+}
+
+#[test]
+fn test_any_source_not_related_off_keeps_default_any_behavior() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+    checker.set_any_source_not_related(true);
+    checker.set_any_source_not_related(false);
+
+    assert!(
+        checker.is_assignable(TypeId::ANY, TypeId::STRING),
+        "default relation: `any` source is assignable to everything but never"
+    );
+}

--- a/crates/tsz-solver/tests/relation_cache_config_tests.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests.rs
@@ -301,6 +301,7 @@ fn any_propagation_mode_differences_produce_distinct_keys() {
         CachedAnyMode::All,
         CachedAnyMode::TopLevelOnlyAtTop,
         CachedAnyMode::TopLevelOnlyNested,
+        CachedAnyMode::AnySourceNotRelated,
     ];
     for (i, &a) in any_modes.iter().enumerate() {
         for (j, &b) in any_modes.iter().enumerate() {


### PR DESCRIPTION
Fixes #13042 (comlink canary false positives from single-pass overload resolution).

## Agent
AgentName: StudioOpus

## Track
Conformance / project corpus — compiler PR (call checker + solver relations).

## Invariant
When a call has more than one overload signature, tsc's `chooseOverload` runs twice: pass 1 with `subtypeRelation`, where an `any` SOURCE is not related to non-`any`/`unknown` targets at every nesting level (`isSimpleTypeRelatedTo` relates a source `any` only under the assignable/comparable relations, while an `any` TARGET accepts everything in every relation), then pass 2 with `assignableRelation` in declaration order; this PR changes the solver relation engine (new `AnySourceNotRelated` propagation mode) and the checker overload loop (per-candidate two-pass with declaration-order fallback). Additionally: when the callable is `any`/error it imposes no parameter-arity shape, so `new anyCtor(...args)` must not emit TS2556; this PR changes `allows_non_tuple_spread_position` and the `new`-on-`any` argument collection branch.

## Scope
- `crates/tsz-solver`: `relations/subtype/{core,cache,helpers,rules/*}.rs` (asymmetric any-propagation mode), `relations/{lawyer,compat,relation_queries}.rs`, `types.rs` (`CachedAnyMode::AnySourceNotRelated` cache partitioning), `contextual/core.rs` (any-callee spread), `caches/query_trace.rs`.
- `crates/tsz-checker`: `checkers/call_checker/{mod,applicability,overload_resolution}.rs` (pass-aware adapter + two-pass loop), `assignability/{overload_subtype_pass,relation_outcome_helpers}.rs`, `query_boundaries/{relation_request,assignability,assignability/{cache_key,overload_subtype_pass}}.rs`, `types/computation/complex.rs` (`new`-on-`any` branch), tests.
- File splits to satisfy the 2000-line ceiling: `assignability/overload_subtype_pass.rs`, `query_boundaries/assignability/{cache_key,overload_subtype_pass}.rs`; the two `RelationFlags`-surface arch-test pins follow the code motion.

## Behavior matrix (tsc 5.5 verified, renamed binders in tests)
| case | tsc | tsz before | tsz now |
|---|---|---|---|
| `arr.reduce((o, p) => o[p], anyVal)` | `any` | `string` | `any` |
| `arr.reduce(() => "x", anyVal)` | `any` | `string` | `any` |
| `arr.reduce((o: string, p) => o + p, anyVal)` | `string` (generic fails pass 1 via nested callback-param any-vs-string) | `string` | `string` |
| `arr.reduce(() => "x", "seed")` | `string` | `string` | `string` |
| mixed non-generic/generic, `any` arg | `any` (generic, `U = any`) | first non-generic | `any` |
| generic-first declaration order, `any` arg | `any` | — | `any` |
| generic candidate fails arity, `any` arg | non-generic result | — | non-generic result |
| all-non-generic, `any` arg | first overload (pass 2, declaration order) | — | first overload |
| `new anyCtor(...anyArgs)` | no error | TS2556 | no error |
| `new FixedCtor(...numberArray)` | TS2556 | TS2556 | TS2556 |

Cache-poisoning safety: the mode participates in every relation cache key (`RelationPolicy::cache_config` -> `CachedAnyMode::AnySourceNotRelated`, solver shared subtype cache via `cache_config_with_cached_any_mode`, checker-level `RelationCacheKey`, per-instance compat cache cleared on toggle), pinned by `relation_cache_config_tests`.

## Project Corpus Impact
- Row: comlink-project
- Bug family: single-pass overload resolution (any-argument candidate selection)
- Evidence: comlink canary 9 -> 7 errors (line 331 TS7053 reduce-seed selection and line 342 TS2556 any-ctor spread fixed). Zod canary 86 -> 86 (no delta). Remaining comlink line 322 TS7006 x2 is a pre-existing distinct family (speculative implicit-any leak when the reduce result flows through an implicitly-typed `let` forced by a later `Promise.resolve` chain); bisection notes posted on #13042.

## Verification
- New tests: `overload_two_pass_any_source_tests` (8 cases: full matrix, nested annotated-callback rejection, declaration-order fallback, arity fallback, concrete-arg no-change), solver `compat_tests` `any_source_not_related` family (top-level / nested array element / nested contravariant callback param / mode-off), `relation_cache_config_tests` distinct-key coverage, TS2556 any-callee tests (new ctor spread, call spread, fixed-arity negative).
- `cargo nextest run -p tsz-checker -E 'test(/overload|call_checker|reduce|call_arg|any/)'`: 911 passed / 7 failed — all 7 reproduced identically on clean origin/main (pre-existing local failures).
- `cargo nextest run -p tsz-checker -E 'test(/assignab|relation|ts2345|ts2322|callback/)'` and `'test(/spread|new_expr|construct|ts2556|ts2554|implicit_any|7006/)'`: every failure reproduced on clean origin/main.
- `cargo nextest run -p tsz-solver -E 'test(/relation|compat|subtype|lawyer|any/)'`: 1867/1867 passed.
- Architecture contract tests: 138/142; the 4 failures are the known pre-existing set (verified on origin/main).
- `python3 scripts/arch/arch_guard.py`: passed. `cargo clippy -p tsz-checker -p tsz-solver --profile ci-lint`: clean.
- `scripts/conformance/conformance.sh run --filter overload`: 62/62 passed (100%).

## Coordination Notes
- Tracking issue: #13042. Prior canary fixes in other families: #13031 (recursive conditional-branch failure elaboration), #13037 (flow-analysis recursion bound).
- The remaining comlink line-322 TS7006 pair is intentionally NOT patched here (would require an identifier/heuristic hack); findings documented on #13042 for a follow-up in the implicit-any/speculation family.
- No overlap with open PRs (only #13132, arch-test repair, different files... it touches `architecture_contract_tests_parts` — if it lands first I will rebase my two `RelationFlags`-pin updates).
