### PR TITLE
refactor(solver): delete dead SubtypeTracer / DynSubtypeTracer mechanism

### DIFF
--- a/crates/tsz-solver/src/diagnostics/core.rs
+++ b/crates/tsz-solver/src/diagnostics/core.rs
@@ -1,82 +1,12 @@
 //! Core implementation for solver diagnostics.
 //!
-//! Contains tracer pattern, failure reasons, lazy diagnostics, diagnostic codes,
+//! Contains failure reasons, lazy diagnostics, diagnostic codes,
 //! and core diagnostic data types. Re-exported from the parent `diagnostics` module.
 
 use crate::types::{TypeId, Visibility};
 use std::sync::Arc;
 use tsz_binder::SymbolId;
 use tsz_common::interner::Atom;
-
-// =============================================================================
-// Tracer Pattern: Zero-Cost Diagnostic Abstraction
-// =============================================================================
-
-/// A trait for tracing subtype check failures.
-///
-/// This trait enables the same subtype checking logic to be used for both
-/// fast boolean checks and detailed diagnostics.
-///
-/// The key insight is that failure reasons are constructed lazily via a closure,
-/// so fast-path implementations can skip the allocation entirely while diagnostic
-/// implementations collect detailed information.
-///
-/// # Example
-///
-/// ```text
-/// fn check_subtype_with_tracer<T: SubtypeTracer>(
-///     source: TypeId,
-///     target: TypeId,
-///     tracer: &mut T,
-/// ) -> bool {
-///     if source == target {
-///         return true;
-///     }
-///     tracer.on_mismatch(|| SubtypeFailureReason::TypeMismatch { source, target })
-/// }
-/// ```
-pub trait SubtypeTracer {
-    /// Called when a subtype mismatch is detected.
-    ///
-    /// The `reason` closure is only called if the tracer needs to collect
-    /// the failure reason, allowing fast-path implementations to skip
-    /// allocation entirely.
-    ///
-    /// # Returns
-    ///
-    /// - `true` if checking should continue (for collecting more nested failures)
-    /// - `false` if checking should stop immediately (fast path)
-    ///
-    /// # Type Parameters
-    ///
-    /// The `reason` parameter is a closure that constructs the failure reason.
-    /// It's wrapped in `FnOnce` so it's only called when needed.
-    fn on_mismatch(&mut self, reason: impl FnOnce() -> SubtypeFailureReason) -> bool;
-}
-
-/// Object-safe version of `SubtypeTracer` for dynamic dispatch.
-///
-/// This trait is dyn-compatible and can be used as `&mut dyn DynSubtypeTracer`.
-/// It has a simpler signature that takes the reason directly rather than a closure.
-pub trait DynSubtypeTracer {
-    /// Called when a subtype mismatch is detected.
-    ///
-    /// Unlike `SubtypeTracer::on_mismatch`, this takes the reason directly
-    /// rather than a closure. This makes it object-safe (dyn-compatible).
-    ///
-    /// # Returns
-    ///
-    /// - `true` if checking should continue (for collecting more nested failures)
-    /// - `false` if checking should stop immediately (fast path)
-    fn on_mismatch_dyn(&mut self, reason: SubtypeFailureReason) -> bool;
-}
-
-/// Blanket implementation for all `SubtypeTracer` types.
-impl<T: SubtypeTracer> DynSubtypeTracer for T {
-    fn on_mismatch_dyn(&mut self, reason: SubtypeFailureReason) -> bool {
-        self.on_mismatch(|| reason)
-    }
-}
 
 /// Detailed reason for a subtype check failure.
 ///

--- a/crates/tsz-solver/src/diagnostics/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/mod.rs
@@ -2,8 +2,6 @@
 //!
 //! This module defines the core data types for type checking diagnostics:
 //!
-//! - **Tracer pattern** (`SubtypeTracer`, `DynSubtypeTracer`): Zero-cost
-//!   abstraction for tracing subtype check failures without logic drift.
 //! - **Failure reasons** (`SubtypeFailureReason`): Structured enum capturing all the
 //!   ways a subtype check can fail.
 //! - **Lazy diagnostics** (`PendingDiagnostic`, `DiagnosticArg`): Deferred formatting

--- a/crates/tsz-solver/src/recursion.rs
+++ b/crates/tsz-solver/src/recursion.rs
@@ -55,7 +55,7 @@ use std::hash::Hash;
 pub enum RecursionProfile {
     /// Subtype checking: deep structural comparison of recursive types.
     ///
-    /// Used by `SubtypeChecker` and `SubtypeTracer`.
+    /// Used by `SubtypeChecker`.
     /// Needs the deepest depth limit because structural comparison of
     /// recursive types can legitimately nest deeply before a cycle is found.
     ///

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -14,6 +14,8 @@ use std::sync::Arc;
 use crate::caches::db::QueryDatabase;
 use crate::construction::TypeDatabase;
 use crate::def::DefId;
+#[cfg(test)]
+use crate::diagnostics::SubtypeFailureReason;
 use crate::objects::{PropertyCollectionResult, collect_properties};
 use crate::operations::AssignabilityChecker;
 #[cfg(test)]

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -8,14 +8,12 @@
 //! - Cycle detection for recursive types (coinductive)
 //! - Set-theoretic operations for unions and intersections
 //! - `TypeResolver` trait for lazy symbol resolution
-//! - Tracer pattern for zero-cost diagnostic abstraction
 
 use std::sync::Arc;
 
 use crate::caches::db::QueryDatabase;
 use crate::construction::TypeDatabase;
 use crate::def::DefId;
-use crate::diagnostics::{DynSubtypeTracer, SubtypeFailureReason};
 use crate::objects::{PropertyCollectionResult, collect_properties};
 use crate::operations::AssignabilityChecker;
 #[cfg(test)]
@@ -279,10 +277,6 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// thousands of times. Cache the shape once per checker so those
     /// checks avoid rebuilding method signatures and property vectors.
     pub(crate) apparent_primitive_shapes: [Option<Arc<ObjectShape>>; 5],
-    /// Optional tracer for collecting subtype failure diagnostics.
-    /// When `Some`, enables detailed failure reason collection for error messages.
-    /// When `None`, disables tracing for maximum performance (default).
-    pub tracer: Option<&'a mut dyn DynSubtypeTracer>,
     /// When true (default), non-generic functions may be compared to generic functions
     /// by erasing the target's type parameters to their constraints. This matches tsc's
     /// default `eraseGenerics` behavior for structural type comparison.
@@ -378,7 +372,6 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             allow_erased_generic_signature_retry: false,
             eval_cache: FxHashMap::default(),
             apparent_primitive_shapes: std::array::from_fn(|_| None),
-            tracer: None,
             type_param_equivalences: Vec::new(),
         }
     }
@@ -427,7 +420,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             allow_erased_generic_signature_retry: false,
             eval_cache: FxHashMap::default(),
             apparent_primitive_shapes: std::array::from_fn(|_| None),
-            tracer: None,
             type_param_equivalences: Vec::new(),
         }
     }
@@ -514,10 +506,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 continue;
             };
 
-            let saved_tracer = self.tracer.take();
             let compatible =
                 self.check_property_compatibility(source_prop, target_prop, None, None);
-            self.tracer = saved_tracer;
 
             if compatible.is_false() {
                 return true;

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -134,14 +134,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     {
                         return SubtypeResult::True;
                     }
-                    if let Some(tracer) = &mut self.tracer
-                        && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                            source_type: source,
-                            target_type: target,
-                        })
-                    {
-                        return SubtypeResult::False;
-                    }
                     return SubtypeResult::False;
                 }
                 let result = self.check_object_with_index_subtype(
@@ -238,15 +230,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             let member_list = self.interner.type_list(members);
             for &member in member_list.iter() {
                 if !self.check_subtype(member, target).is_true() {
-                    // Trace: No union member matches target
-                    if let Some(tracer) = &mut self.tracer
-                        && !tracer.on_mismatch_dyn(SubtypeFailureReason::NoUnionMemberMatches {
-                            source_type: source,
-                            target_union_members: vec![target],
-                        })
-                    {
-                        return SubtypeResult::False;
-                    }
                     return SubtypeResult::False;
                 }
             }
@@ -500,15 +483,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 }
             }
 
-            // Trace: Source is not a subtype of any union member
-            if let Some(tracer) = &mut self.tracer
-                && !tracer.on_mismatch_dyn(SubtypeFailureReason::NoUnionMemberMatches {
-                    source_type: source,
-                    target_union_members: member_list.iter().copied().collect(),
-                })
-            {
-                return SubtypeResult::False;
-            }
             return SubtypeResult::False;
         }
 
@@ -631,27 +605,24 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if let Some(members) = intersection_list_id(self.interner, target) {
             let member_list = self.interner.type_list(members);
 
-            // Keep diagnostic precision when collecting mismatch reasons via tracer.
-            if self.tracer.is_none() {
-                // Fast path: check the shared intersection merge cache first to
-                // skip the O(N) eligibility scan for repeated constraint checks.
-                let cached = self
-                    .query_db
-                    .and_then(|db| db.lookup_intersection_merge(target));
-                let merged_target = if let Some(cached_result) = cached {
-                    cached_result
-                } else if self.can_use_object_intersection_fast_path(&member_list) {
-                    self.build_object_intersection_target(target)
-                } else {
-                    // Not eligible; cache the negative result to avoid re-scanning.
-                    if let Some(db) = self.query_db {
-                        db.insert_intersection_merge(target, None);
-                    }
-                    None
-                };
-                if let Some(merged) = merged_target {
-                    return self.check_subtype(source, merged);
+            // Fast path: check the shared intersection merge cache first to
+            // skip the O(N) eligibility scan for repeated constraint checks.
+            let cached = self
+                .query_db
+                .and_then(|db| db.lookup_intersection_merge(target));
+            let merged_target = if let Some(cached_result) = cached {
+                cached_result
+            } else if self.can_use_object_intersection_fast_path(&member_list) {
+                self.build_object_intersection_target(target)
+            } else {
+                // Not eligible; cache the negative result to avoid re-scanning.
+                if let Some(db) = self.query_db {
+                    db.insert_intersection_merge(target, None);
                 }
+                None
+            };
+            if let Some(merged) = merged_target {
+                return self.check_subtype(source, merged);
             }
 
             // When checking source <: each intersection member, temporarily disable
@@ -741,15 +712,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // Note: When the type parameter is the SOURCE (e.g., T <: string), we check
             // against its constraint. But as TARGET, we return False.
 
-            // Trace: Concrete type not assignable to type parameter
-            if let Some(tracer) = &mut self.tracer
-                && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                    source_type: source,
-                    target_type: target,
-                })
-            {
-                return SubtypeResult::False;
-            }
             return SubtypeResult::False;
         }
 
@@ -796,15 +758,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // (check_generic_index_access_subtype) after the visitor dispatch can
             // resolve the access by distributing over K's constraint literals.
             if index_access_parts(self.interner, target).is_none() {
-                // Trace: Intrinsic type mismatch (boxed primitive check failed)
-                if let Some(tracer) = &mut self.tracer
-                    && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                        source_type: source,
-                        target_type: target,
-                    })
-                {
-                    return SubtypeResult::False;
-                }
                 return SubtypeResult::False;
             }
         }
@@ -823,15 +776,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             if s_lit == t_lit {
                 return SubtypeResult::True;
             }
-            // Trace: Literal type mismatch
-            if let Some(tracer) = &mut self.tracer
-                && !tracer.on_mismatch_dyn(SubtypeFailureReason::LiteralTypeMismatch {
-                    source_type: source,
-                    target_type: target,
-                })
-            {
-                return SubtypeResult::False;
-            }
             return SubtypeResult::False;
         }
 
@@ -845,15 +789,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if intrinsic_kind(self.interner, target) == Some(IntrinsicKind::Object) {
             if self.is_object_keyword_type(source) {
                 return SubtypeResult::True;
-            }
-            // Trace: Source is not object-compatible
-            if let Some(tracer) = &mut self.tracer
-                && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                    source_type: source,
-                    target_type: target,
-                })
-            {
-                return SubtypeResult::False;
             }
             return SubtypeResult::False;
         }
@@ -895,15 +830,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             if is_function_structural && source_is_object {
                 // Fall through to structural object-to-object comparison below
             } else {
-                // Trace: Source is not function-compatible
-                if let Some(tracer) = &mut self.tracer
-                    && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                        source_type: source,
-                        target_type: target,
-                    })
-                {
-                    return SubtypeResult::False;
-                }
                 return SubtypeResult::False;
             }
         }
@@ -928,14 +854,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 return SubtypeResult::True;
             }
 
-            if let Some(tracer) = &mut self.tracer
-                && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                    source_type: source,
-                    target_type: target,
-                })
-            {
-                return SubtypeResult::False;
-            }
             return SubtypeResult::False;
         }
 
@@ -1355,14 +1273,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 && crate::type_queries::is_literal_enum_member(self.interner, source)
                 && crate::type_queries::is_literal_enum_member(self.interner, target)
             {
-                if let Some(tracer) = &mut self.tracer
-                    && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                        source_type: source,
-                        target_type: target,
-                    })
-                {
-                    return SubtypeResult::False;
-                }
                 return SubtypeResult::False;
             }
 
@@ -1382,15 +1292,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             }
 
             // Different enums are NOT compatible (nominal typing)
-            // Trace: Enum nominal mismatch
-            if let Some(tracer) = &mut self.tracer
-                && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                    source_type: source,
-                    target_type: target,
-                })
-            {
-                return SubtypeResult::False;
-            }
             return SubtypeResult::False;
         }
 
@@ -1622,14 +1523,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     );
                 }
                 // FunctionShape has no properties - not assignable to non-empty object
-                if let Some(tracer) = &mut self.tracer
-                    && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                        source_type: source,
-                        target_type: target,
-                    })
-                {
-                    return SubtypeResult::False;
-                }
                 return SubtypeResult::False;
             }
             if let Some(t_shape_id) = object_with_index_shape_id(self.interner, target) {
@@ -1648,14 +1541,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     );
                 }
                 // FunctionShape has no properties - not assignable to non-empty indexed object
-                if let Some(tracer) = &mut self.tracer
-                    && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                        source_type: source,
-                        target_type: target,
-                    })
-                {
-                    return SubtypeResult::False;
-                }
                 return SubtypeResult::False;
             }
         }
@@ -1717,15 +1602,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 {
                     return result;
                 }
-                // Trace: Array/tuple not compatible with object
-                if let Some(tracer) = &mut self.tracer
-                    && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                        source_type: source,
-                        target_type: target,
-                    })
-                {
-                    return SubtypeResult::False;
-                }
                 return SubtypeResult::False;
             }
             if let Some(t_shape_id) = object_with_index_shape_id(self.interner, target) {
@@ -1736,34 +1612,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     // types with a string index signature requirement, e.g.
                     // `number[] <: { [x: string]: unknown }` is false.
                     if t_shape.string_index.is_some() {
-                        if let Some(tracer) = &mut self.tracer
-                            && !tracer.on_mismatch_dyn(
-                                SubtypeFailureReason::MissingIndexSignature {
-                                    index_kind: "string",
-                                },
-                            )
-                        {
-                            return SubtypeResult::False;
-                        }
                         return SubtypeResult::False;
                     }
                     if let Some(ref num_idx) = t_shape.number_index {
                         let elem_type =
                             array_element_type(self.interner, source).unwrap_or(TypeId::ANY);
                         if !self.check_subtype(elem_type, num_idx.value_type).is_true() {
-                            // Trace: Array element type mismatch with index signature
-                            if let Some(tracer) = &mut self.tracer
-                                && !tracer.on_mismatch_dyn(
-                                    SubtypeFailureReason::IndexSignatureMismatch {
-                                        index_kind: "number",
-                                        source_value_type: elem_type,
-                                        target_value_type: num_idx.value_type,
-                                        nested_reason: None,
-                                    },
-                                )
-                            {
-                                return SubtypeResult::False;
-                            }
                             return SubtypeResult::False;
                         }
                     }
@@ -1793,15 +1647,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     )
                 {
                     return SubtypeResult::True;
-                }
-                // Trace: Array/tuple not compatible with indexed object with non-empty properties
-                if let Some(tracer) = &mut self.tracer
-                    && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                        source_type: source,
-                        target_type: target,
-                    })
-                {
-                    return SubtypeResult::False;
                 }
                 return SubtypeResult::False;
             }
@@ -1869,17 +1714,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     return SubtypeResult::True;
                 }
             }
-        }
-
-        // Trace: Generic fallback type mismatch (no specific reason matched above)
-        if result == SubtypeResult::False
-            && let Some(tracer) = &mut self.tracer
-            && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                source_type: source,
-                target_type: target,
-            })
-        {
-            return SubtypeResult::False;
         }
 
         result

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -946,24 +946,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // `(x?: T)` and `(x?: T | undefined)` compare as equivalent.
                 let (s_effective, t_effective) = self.effective_param_type_pair(s_param, t_param);
                 if !self.are_parameters_compatible_impl(s_effective, t_effective, is_method) {
-                    // Trace: Parameter type mismatch
-                    if let Some(tracer) = &mut self.tracer
-                        && !tracer.on_mismatch_dyn(
-                            crate::diagnostics::SubtypeFailureReason::ParameterTypeMismatch {
-                                param_index: i,
-                                source_param: s_effective,
-                                target_param: t_effective,
-                                // Tracer emission is the fast-path; the
-                                // inner reason isn't computed here to
-                                // avoid recursive explain on every
-                                // failed subtype check. Callers that
-                                // need it use the explain path.
-                                inner_reason: None,
-                            },
-                        )
-                    {
-                        return SubtypeResult::False;
-                    }
                     return SubtypeResult::False;
                 }
             }

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -514,32 +514,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if target.visibility != Visibility::Public {
             if !self.nominal_member_origin_ok(source.parent_id, target.parent_id, target.visibility)
             {
-                // Trace: Property nominal mismatch
-                if let Some(tracer) = &mut self.tracer
-                    && !tracer.on_mismatch_dyn(
-                        crate::diagnostics::SubtypeFailureReason::PropertyNominalMismatch {
-                            property_name: source.name,
-                        },
-                    )
-                {
-                    return SubtypeResult::False;
-                }
                 return SubtypeResult::False;
             }
         } else if source.visibility != Visibility::Public {
             // Cannot assign private/protected source to public target
-            // Trace: Property visibility mismatch
-            if let Some(tracer) = &mut self.tracer
-                && !tracer.on_mismatch_dyn(
-                    crate::diagnostics::SubtypeFailureReason::PropertyVisibilityMismatch {
-                        property_name: source.name,
-                        source_visibility: source.visibility,
-                        target_visibility: target.visibility,
-                    },
-                )
-            {
-                return SubtypeResult::False;
-            }
             return SubtypeResult::False;
         }
 
@@ -609,15 +587,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // types already failed, that type-incompatibility reason takes precedence
         // (matching tsc), so return it unchanged instead of overwriting it.
         if result.is_true() && source.optional && !target.optional {
-            if let Some(tracer) = &mut self.tracer
-                && !tracer.on_mismatch_dyn(
-                    crate::diagnostics::SubtypeFailureReason::OptionalPropertyRequired {
-                        property_name: source.name,
-                    },
-                )
-            {
-                return SubtypeResult::False;
-            }
             return SubtypeResult::False;
         }
         result

--- a/crates/tsz-solver/src/relations/subtype/visitor.rs
+++ b/crates/tsz-solver/src/relations/subtype/visitor.rs
@@ -6,7 +6,6 @@
 
 use crate::def::DefId;
 use crate::def::resolver::TypeResolver;
-use crate::diagnostics::SubtypeFailureReason;
 use crate::relations::subtype::{SubtypeChecker, SubtypeResult};
 use crate::types::{
     CallSignature, CallableShape, CallableShapeId, ConditionalTypeId, FunctionShapeId,
@@ -217,15 +216,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                 SubtypeResult::False
             };
         }
-        // Trace: Literal doesn't match target
-        if let Some(tracer) = &mut self.checker.tracer
-            && !tracer.on_mismatch_dyn(SubtypeFailureReason::LiteralTypeMismatch {
-                source_type: self.source,
-                target_type: self.target,
-            })
-        {
-            return SubtypeResult::False;
-        }
         SubtypeResult::False
     }
 
@@ -241,15 +231,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                 .check_array_interface_subtype(element_type, self.target)
             {
                 return result;
-            }
-            // Trace: Array source doesn't match non-array target
-            if let Some(tracer) = &mut self.checker.tracer
-                && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                    source_type: self.source,
-                    target_type: self.target,
-                })
-            {
-                return SubtypeResult::False;
             }
             SubtypeResult::False
         }
@@ -284,15 +265,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                 return SubtypeResult::True;
             }
 
-            // Trace: Tuple source doesn't match non-tuple/non-array target
-            if let Some(tracer) = &mut self.checker.tracer
-                && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                    source_type: self.source,
-                    target_type: self.target,
-                })
-            {
-                return SubtypeResult::False;
-            }
             SubtypeResult::False
         }
     }
@@ -302,15 +274,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
         let member_list = self.checker.interner.type_list(TypeListId(list_id));
         for &member in member_list.iter() {
             if !self.checker.check_subtype(member, self.target).is_true() {
-                // Trace: No union member matches target
-                if let Some(tracer) = &mut self.checker.tracer
-                    && !tracer.on_mismatch_dyn(SubtypeFailureReason::NoUnionMemberMatches {
-                        source_type: self.source,
-                        target_union_members: vec![self.target],
-                    })
-                {
-                    return SubtypeResult::False;
-                }
                 return SubtypeResult::False;
             }
         }
@@ -517,15 +480,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
             }
         }
 
-        // Trace: No intersection member matches target
-        if let Some(tracer) = &mut self.checker.tracer
-            && !tracer.on_mismatch_dyn(SubtypeFailureReason::NoIntersectionMemberMatches {
-                source_type: self.source,
-                target_type: self.target,
-            })
-        {
-            return SubtypeResult::False;
-        }
         SubtypeResult::False
     }
 
@@ -706,15 +660,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                 Some(self.target),
             )
         } else {
-            // Trace: Object source doesn't match non-object target
-            if let Some(tracer) = &mut self.checker.tracer
-                && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                    source_type: self.source,
-                    target_type: self.target,
-                })
-            {
-                return SubtypeResult::False;
-            }
             SubtypeResult::False
         }
     }
@@ -756,15 +701,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                 self.target,
             )
         } else {
-            // Trace: ObjectWithIndex source doesn't match non-object target
-            if let Some(tracer) = &mut self.checker.tracer
-                && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                    source_type: self.source,
-                    target_type: self.target,
-                })
-            {
-                return SubtypeResult::False;
-            }
             SubtypeResult::False
         }
     }
@@ -789,15 +725,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
             // Avoid expanding and comparing every `Function` interface member.
             SubtypeResult::True
         } else {
-            // Trace: Function source doesn't match non-function target
-            if let Some(tracer) = &mut self.checker.tracer
-                && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                    source_type: self.source,
-                    target_type: self.target,
-                })
-            {
-                return SubtypeResult::False;
-            }
             SubtypeResult::False
         }
     }
@@ -868,15 +795,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                 Some(self.target),
             )
         } else {
-            // Trace: Callable source doesn't match non-callable/non-object target
-            if let Some(tracer) = &mut self.checker.tracer
-                && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                    source_type: self.source,
-                    target_type: self.target,
-                })
-            {
-                return SubtypeResult::False;
-            }
             SubtypeResult::False
         }
     }
@@ -936,22 +854,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                 .checker
                 .index_accesses_have_distinct_type_param_keys(key_type, t_idx)
             {
-                // Surface tsc's full TS2322 + TS5075 chain via a dedicated
-                // failure reason. Falls back to the generic TypeMismatch
-                // shape when the target key is not a type parameter we
-                // can carry constraint info for.
-                let reason = self
-                    .checker
-                    .index_access_distinct_type_param_keys_failure_reason(key_type, t_idx)
-                    .unwrap_or(SubtypeFailureReason::TypeMismatch {
-                        source_type: self.source,
-                        target_type: self.target,
-                    });
-                if let Some(tracer) = &mut self.checker.tracer
-                    && !tracer.on_mismatch_dyn(reason)
-                {
-                    return SubtypeResult::False;
-                }
                 return SubtypeResult::False;
             }
 
@@ -983,14 +885,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
         // If target is not an IndexAccess, we cannot prove subtyping.
         // Note: If S[I] could have been simplified to a concrete type that matches the target,
         // evaluate_type() in the caller (check_subtype) would have already handled it.
-        if let Some(tracer) = &mut self.checker.tracer
-            && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                source_type: self.source,
-                target_type: self.target,
-            })
-        {
-            return SubtypeResult::False;
-        }
         SubtypeResult::False
     }
     fn visit_template_literal(&mut self, template_id: u32) -> Self::Output {
@@ -1025,15 +919,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
                 .check_template_assignable_to_template(s_id, t_template_id);
         }
 
-        // Trace: Template literal doesn't match target
-        if let Some(tracer) = &mut self.checker.tracer
-            && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                source_type: self.source,
-                target_type: self.target,
-            })
-        {
-            return SubtypeResult::False;
-        }
         SubtypeResult::False
     }
     fn visit_type_query(&mut self, symbol_ref: u32) -> Self::Output {
@@ -1112,15 +997,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
             return SubtypeResult::True;
         }
 
-        // Trace: keyof doesn't match target
-        if let Some(tracer) = &mut self.checker.tracer
-            && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                source_type: self.source,
-                target_type: self.target,
-            })
-        {
-            return SubtypeResult::False;
-        }
         SubtypeResult::False
     }
     fn visit_this_type(&mut self) -> Self::Output {
@@ -1145,14 +1021,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
         // In most cases, check_subtype_inner's apparent_primitive_shape_for_type
         // would have resolved 'this' to its containing class/interface.
         // If that didn't happen or didn't result in 'True', we return False.
-        if let Some(tracer) = &mut self.checker.tracer
-            && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                source_type: self.source,
-                target_type: self.target,
-            })
-        {
-            return SubtypeResult::False;
-        }
         SubtypeResult::False
     }
     fn visit_infer(&mut self, param_info: &TypeParamInfo) -> Self::Output {
@@ -1180,15 +1048,6 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for SubtypeVisitor<'a, 'b, R> {
             return SubtypeResult::True;
         }
 
-        // Trace: unique symbol doesn't match target
-        if let Some(tracer) = &mut self.checker.tracer
-            && !tracer.on_mismatch_dyn(SubtypeFailureReason::TypeMismatch {
-                source_type: self.source,
-                target_type: self.target,
-            })
-        {
-            return SubtypeResult::False;
-        }
         SubtypeResult::False
     }
     fn visit_module_namespace(&mut self, _symbol_ref: u32) -> Self::Output {


### PR DESCRIPTION
## Summary

`SubtypeTracer` / `DynSubtypeTracer` was an "explain slow" diagnostic
hook. The `pub tracer: Option<&'a mut dyn DynSubtypeTracer>` field on
`SubtypeChecker` was always `None` — `SubtypeChecker::with_tracer(...)` was
never called from any production path — so every guarded branch was dead code
threading an unreachable pointer through the hot subtype-checking loop.

Deleted across 8 files (−457 lines, zero behavior change):

| File | Removed |
|---|---|
| `diagnostics/core.rs` | `SubtypeTracer` trait, `DynSubtypeTracer` blanket impl, 72 lines |
| `diagnostics/mod.rs` | stale doc reference |
| `recursion.rs` | stale doc reference |
| `relations/subtype/core.rs` | `tracer` field, 2 constructor sites, save/restore pattern |
| `relations/subtype/core_dispatch.rs` | 17 dead `if let Some(tracer)` blocks; `if self.tracer.is_none()` guard (always true) replaced by unconditional fast-path |
| `relations/subtype/visitor.rs` | 15 dead `if let Some(tracer)` blocks |
| `relations/subtype/rules/objects.rs` | 3 dead tracer blocks |
| `relations/subtype/rules/functions/checking.rs` | 1 dead tracer block |

## Structural rule

When a field is always `None` and no production caller ever sets it, every
guard on that field is dead. The right fix is deletion, not documentation.

## Owner layer

solver (`tsz-solver`) — no checker, binder, or emitter changes.

## Adjacent matrix

- Positive: `SubtypeFailureReason` enum is kept (used by relation-failure
  diagnostics; unrelated to the tracer).
- Negative: `SubtypeTracer` / `DynSubtypeTracer` traits fully deleted;
  any future "explain slow" tooling must be redesigned from scratch.
- Fast-path guard `if self.tracer.is_none() { ... }` in `core_dispatch.rs`
  was always true; body is now unconditional (behavior unchanged).

## Verification

`cargo build -p tsz-solver` passes with zero errors and zero warnings.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a

Pure dead-code deletion. No diagnostic behavior changed.

AgentName: dazzling-johnson
Track: 10 (Guardrails, Tooling, Residency, Performance Readiness)
Invariant: subtype-checking hot path carries no always-None tracer overhead
Scope: tsz-solver diagnostics/core.rs, relations/subtype/{core,core_dispatch,visitor,rules/*}
Coordination Notes: Closes tech-debt issue #13093. No overlap with open PRs.

https://claude.ai/code/session_018o2n2SbHEdBhDfzx9uesxU

---
_Generated by [Claude Code](https://claude.ai/code/session_018o2n2SbHEdBhDfzx9uesxU)_