### PR TITLE
fix(solver): keep tuple rest elements in spread-operand form through evaluator rebuild (recursive-generic tuple-rest false TS2344/TS2322 family)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1149,6 +1149,9 @@ mod recursive_path_default_type_param_tests;
 #[path = "tests/recursive_tuple_alias_diagnostic_display_tests.rs"]
 mod recursive_tuple_alias_diagnostic_display_tests;
 #[cfg(test)]
+#[path = "tests/recursive_tuple_rest_cycle_tests.rs"]
+mod recursive_tuple_rest_cycle_tests;
+#[cfg(test)]
 #[path = "tests/ref_type_params_cache_tests.rs"]
 mod ref_type_params_cache_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/recursive_tuple_rest_cycle_tests.rs
+++ b/crates/tsz-checker/src/tests/recursive_tuple_rest_cycle_tests.rs
@@ -1,0 +1,210 @@
+//! Regression tests for recursive generic interfaces with tuple-rest members.
+//!
+//! Structural rule: when a self-recursive generic interface has a member tuple
+//! containing a concrete array rest (e.g. `items: [Self<T>, ...number[]]`),
+//! the evaluator's tuple rebuild must keep the rest element's `type_id` in its
+//! spread-operand (array) form. Before the fix, the rebuild unwrapped
+//! `...number[]` to `number`, so `check_tuple_subtype` compared `number`
+//! against `number[]` and rejected relations tsc accepts — surfacing as a
+//! false `TS2344` on the constraint path and a false `TS2322` on the
+//! assignability path (valibot `BaseIssue<TInput>.issues` family).
+//!
+//! Per the anti-hardcoding gate, binder names vary across cases so the tests
+//! pin the structural rule, not a spelling.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn codes(src: &str) -> Vec<u32> {
+    let mut v: Vec<u32> = check_source_diagnostics(src)
+        .iter()
+        .map(|d| d.code)
+        .collect();
+    v.sort_unstable();
+    v
+}
+
+// ── Witness: constraint-satisfaction path (TS2344) ──────────────────────────
+
+#[test]
+fn recursive_tuple_rest_constraint_path_accepts_narrower_arg() {
+    // tsc: clean. The cycle on `Box<string> <: Box<unknown>` is assumed
+    // related; the `...Box<T>[]` rest compares array-to-array.
+    assert_eq!(
+        codes(
+            r#"
+interface Box<T> {
+  items: [Box<T>, ...Box<T>[]];
+}
+type Use<X extends Box<unknown>> = X;
+type P = Use<Box<string>>;
+"#
+        ),
+        Vec::<u32>::new()
+    );
+}
+
+// ── Witness: plain assignability path (TS2322) ──────────────────────────────
+
+#[test]
+fn recursive_tuple_rest_assignability_accepts_narrower_arg() {
+    assert_eq!(
+        codes(
+            r#"
+interface Node2<T> {
+  kids: [Node2<T>, ...Node2<T>[]];
+}
+declare const ns: Node2<string>;
+const nu: Node2<unknown> = ns;
+"#
+        ),
+        Vec::<u32>::new()
+    );
+}
+
+// ── Concrete array rest beside a recursive fixed element ────────────────────
+
+#[test]
+fn recursive_fixed_element_with_concrete_array_rest_accepted() {
+    // The rest array's element is concrete (no type parameter); the fixed
+    // element re-enters the in-progress relation. tsc: clean.
+    assert_eq!(
+        codes(
+            r#"
+interface Chain<T> {
+  links: [Chain<T>, ...number[]];
+}
+declare const cs: Chain<string>;
+const cu: Chain<unknown> = cs;
+"#
+        ),
+        Vec::<u32>::new()
+    );
+}
+
+// ── Valibot shape: optional + readonly + `| undefined` wrapper ──────────────
+
+#[test]
+fn valibot_shaped_optional_readonly_tuple_rest_accepted() {
+    assert_eq!(
+        codes(
+            r#"
+interface Issue<T> {
+  readonly kind: string;
+  readonly issues?: [Issue<T>, ...Issue<T>[]] | undefined;
+}
+type Msg<X extends Issue<unknown>> = X;
+type P = Msg<Issue<string>>;
+declare const i: Issue<string>;
+const j: Issue<unknown> = i;
+"#
+        ),
+        Vec::<u32>::new()
+    );
+}
+
+// ── NEGATIVE control: tsc also rejects (must stay rejected) ─────────────────
+
+#[test]
+fn directly_witnessed_param_mismatch_still_rejected() {
+    // `value: T` pins the variance, so `Crate<string>` is NOT assignable to
+    // `Crate<number>` (tsc: TS2322), while `Crate<unknown>` stays accepted.
+    let src_fail = r#"
+interface Crate<T> { value: T; parts: [Crate<T>, ...number[]]; }
+declare const cs: Crate<string>;
+const cn: Crate<number> = cs;
+"#;
+    assert_eq!(codes(src_fail), vec![2322]);
+
+    let src_ok = r#"
+interface Crate<T> { value: T; parts: [Crate<T>, ...number[]]; }
+declare const cs: Crate<string>;
+const cu: Crate<unknown> = cs;
+"#;
+    assert_eq!(codes(src_ok), Vec::<u32>::new());
+}
+
+// ── Alias-wrapped constraint ────────────────────────────────────────────────
+
+#[test]
+fn alias_wrapped_recursive_tuple_rest_constraint_accepted() {
+    assert_eq!(
+        codes(
+            r#"
+interface Wrap<T> {
+  parts: [Wrap<T>, ...string[]];
+}
+type Alias<T> = Wrap<T>;
+type Need<X extends Alias<unknown>> = X;
+type Q = Need<Alias<boolean>>;
+"#
+        ),
+        Vec::<u32>::new()
+    );
+}
+
+// ── Controls: tuple without rest / rest-only array form ─────────────────────
+
+#[test]
+fn closed_tuple_without_rest_control_accepted() {
+    assert_eq!(
+        codes(
+            r#"
+interface Pair<T> { items: [Pair<T>, Pair<T>]; }
+declare const ps: Pair<string>;
+const pu: Pair<unknown> = ps;
+"#
+        ),
+        Vec::<u32>::new()
+    );
+}
+
+#[test]
+fn rest_only_tuple_control_accepted() {
+    assert_eq!(
+        codes(
+            r#"
+interface Many<T> { items: [...Many<T>[]]; }
+declare const ms: Many<string>;
+const mu: Many<unknown> = ms;
+"#
+        ),
+        Vec::<u32>::new()
+    );
+}
+
+// ── Union-of-arrays rest (evaluator union distribution arm) ─────────────────
+
+#[test]
+fn union_array_rest_beside_recursive_element_accepted() {
+    // tsc: clean. Exercises the union-spread distribution arm of the tuple
+    // evaluator, which must also keep array members in spread-operand form.
+    assert_eq!(
+        codes(
+            r#"
+type Mix = number[] | string[];
+interface Pack<T> { entries: [Pack<T>, ...Mix]; }
+declare const ps: Pack<string>;
+const pu: Pack<unknown> = ps;
+"#
+        ),
+        Vec::<u32>::new()
+    );
+}
+
+// ── Nested application argument ─────────────────────────────────────────────
+
+#[test]
+fn nested_application_argument_accepted() {
+    assert_eq!(
+        codes(
+            r#"
+interface Deep<T> {
+  items: [Deep<T>, ...Deep<T>[]];
+}
+type Use<X extends Deep<unknown>> = X;
+type R = Use<Deep<Deep<string>>>;
+"#
+        ),
+        Vec::<u32>::new()
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -1495,22 +1495,6 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     }
                     changed = true;
                     continue;
-                } else if let Some(TypeData::Array(element_type)) = self.interner.lookup(evaluated)
-                {
-                    // Rest element evaluating to an array stays as rest
-                    let rest_element = TupleElement {
-                        type_id: element_type,
-                        name: elem.name,
-                        optional: elem.optional,
-                        rest: true,
-                    };
-                    for alternative in &mut alternatives {
-                        alternative.push(rest_element);
-                    }
-                    if element_type != elem.type_id {
-                        changed = true;
-                    }
-                    continue;
                 } else if let Some(TypeData::Union(list_id)) = self.interner.lookup(evaluated) {
                     let members = self.interner.type_list(list_id);
                     let mut spread_alternatives: Vec<Vec<TupleElement>> =
@@ -1523,9 +1507,16 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                                 spread_alternatives
                                     .push(self.interner.tuple_list(inner_list_id).to_vec());
                             }
-                            Some(TypeData::Array(element_type)) => {
+                            Some(TypeData::Array(_)) => {
+                                // Keep the array form: a rest `TupleElement`'s
+                                // `type_id` holds the spread operand (`E[]` for
+                                // `...E[]`), matching the type-node lowering,
+                                // the instantiator, and `expand_tuple_rest`.
+                                // Unwrapping to the element type here corrupts
+                                // the rebuilt tuple and makes the relation
+                                // checker compare `E` against `E[]`.
                                 spread_alternatives.push(vec![TupleElement {
-                                    type_id: element_type,
+                                    type_id: member_inner,
                                     name: elem.name,
                                     optional: elem.optional,
                                     rest: true,
@@ -1575,6 +1566,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 }
             }
 
+            // Default: keep the (evaluated) type as-is. For rest elements this
+            // preserves the spread-operand form (`E[]` for `...E[]`) that the
+            // type-node lowering, the instantiator, and `expand_tuple_rest`
+            // all assume; an earlier version unwrapped array rests to their
+            // element type here, corrupting every evaluated tuple with a
+            // concrete array rest (`[Box<T>, ...number[]]` became
+            // `[Box<T>, ...number]`) and breaking recursive-generic relations.
             let next_element = TupleElement {
                 type_id: evaluated,
                 name: elem.name,

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -986,6 +986,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
         self.guard.leave(pair);
 
+        tracing::trace!(
+            src = source.0,
+            tgt = target.0,
+            ?result,
+            "check_subtype dispatch result"
+        );
+
         // Cache definitive results for cross-checker memoization.
         // Skip context-dependent results (see lookup guard above).
         if can_use_shared_relation_cache && let Some(db) = self.query_db {
@@ -1014,11 +1021,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// compares Application type arguments before assuming related.
     /// In normal mode, delegates to `cycle_result` (coinductive assumption).
     fn result_on_cycle(&self, source: TypeId, target: TypeId) -> SubtypeResult {
-        if self.identity_cycle_check {
+        let result = if self.identity_cycle_check {
             self.identity_cycle_result(source, target)
         } else {
             self.cycle_result()
-        }
+        };
+        tracing::trace!(
+            src = source.0,
+            tgt = target.0,
+            ?result,
+            "relation cycle hit"
+        );
+        result
     }
 
     /// Identity-mode cycle result: check Application type arguments at cycle points.

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -386,6 +386,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
             if let Some(def_id) = def_id {
                 let variances = self.resolve_application_variances(def_id);
+                tracing::trace!(
+                    ?def_id,
+                    ?variances,
+                    s_args = ?s_app.args,
+                    t_args = ?t_app.args,
+                    "app-vs-app variance fast path"
+                );
                 if let Some(variances) = variances {
                     // Ensure variance count matches arg count (may differ with defaults)
                     if variances.len() == s_app.args.len() {
@@ -526,9 +533,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             let visiting_rev = self.def_guard.is_visiting(&(def_pair.1, def_pair.0));
             // Check for cycles before expansion
             if visiting || visiting_rev {
-                return if self
-                    .application_cycle_with_concrete_differing_args_is_unsound(&s_app, &t_app)
-                {
+                let unsound =
+                    self.application_cycle_with_concrete_differing_args_is_unsound(&s_app, &t_app);
+                tracing::trace!(
+                    ?def_pair,
+                    unsound,
+                    s_args = ?s_app.args,
+                    t_args = ?t_app.args,
+                    "app-vs-app def-pair cycle"
+                );
+                return if unsound {
                     SubtypeResult::False
                 } else {
                     self.cycle_result()

--- a/crates/tsz-solver/src/relations/subtype/rules/tuples.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/tuples.rs
@@ -44,6 +44,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         source: &[TupleElement],
         target: &[TupleElement],
     ) -> SubtypeResult {
+        tracing::trace!(?source, ?target, "check_tuple_subtype enter");
         // Fast path: [...S] <: [...T] when both are single-rest-element tuples.
         // tsc treats these as equivalent to S <: T for assignability.
         // This handles variadic tuple identity: [...U] <: [...T] when U extends T.


### PR DESCRIPTION
Fixes the largest false-positive family in the benchmark-canary corpus: recursive generic interfaces with tuple-rest members (valibot `BaseIssue<TInput>.issues?: [BaseIssue<TInput>, ...BaseIssue<TInput>[]]`).

AgentName: StudioOpus

Track: conformance (project-corpus false-positive triage, family #1)

Invariant: a rest `TupleElement.type_id` always holds the spread operand (`E[]` for `...E[]`) — the convention shared by the type-node lowering, the instantiator, `expand_tuple_rest`, and `check_tuple_subtype`.

Scope: `tsz-solver` evaluator (`evaluation/evaluate/support.rs::visit_tuple`); trace-level diagnostics events in the subtype relation (`cache.rs`, `rules/generics.rs`, `rules/tuples.rs`); new checker regression tests.

## Structural rule

When a tuple type contains any element that needs evaluation (e.g. a self-recursive `Application` like `Box<T>`), the evaluator rebuilds the tuple. The rebuild's array-rest arm stored the **unwrapped element type** (`number` for `...number[]`), violating the spread-operand convention. `check_tuple_subtype` then compared the source rest's stored type (`number`) against `array(expand_tuple_rest(target_rest).variadic)` (`number[]`) and returned `False`, so `Box<string> <: Box<unknown>` failed on **both** the constraint path (TS2344 "does not satisfy the constraint") and plain assignability (TS2322), plus cascaded TS2345/TS2394/TS2430.

When a self-recursive generic interface contains a tuple-with-rest member, tsc relates `Box<string> <: Box<unknown>` by assuming the in-progress relation on cycle re-entry; tsz does the same through the solver once the evaluator preserves the rest convention — the fixed-element re-entry already resolves `CycleDetected`, and the rest-element compare becomes array-to-array. The fix deletes the corrupting unwrap arm (the default fall-through already stores the evaluated operand) and fixes the same violation in the union-of-arrays spread-distribution arm.

Note: the triage hypothesis ("constraint-entry lacks the cycle assumption") was disproven during root-cause tracing — both relation entries fail identically; the owner is the evaluator's tuple rebuild, not the relation configuration.

## Adjacent-case matrix (new tests, renamed binders)

`crates/tsz-checker/src/tests/recursive_tuple_rest_cycle_tests.rs`:
- witness: constraint path (`Use<Box<string>>` with `X extends Box<unknown>`) — clean
- witness: assignability path — clean
- concrete array rest beside recursive fixed element (`[Chain<T>, ...number[]]`) — clean
- valibot shape (optional + readonly + `| undefined`) — clean
- NEGATIVE control: `value: T` member pins variance; `Crate<string> -> Crate<number>` still TS2322 (tsc parity), `-> Crate<unknown>` clean
- alias-wrapped constraint — clean
- controls: closed tuple without rest, rest-only tuple — clean
- union-of-arrays rest (`[Pack<T>, ...Mix]`, `Mix = number[] | string[]`) — clean (exercises the union distribution arm)
- nested application argument (`Use<Deep<Deep<string>>>`) — clean

All verified clean against `tsc 5.5 --strict`.

## Project Corpus Impact
- Row: valibot-project
- Bug family: recursive-tuple-rest constraint-path cycle assumption

## Verification
- tsz unit: `recursive_tuple_rest_cycle_tests` 10/10 pass; checker families `tuple`/`ts2344`/`constraint`/`generic` — only failures are 17 pre-existing local failures that reproduce identically on clean main (verified per-test against a main-state build; main CI green); `ts2344` family fully green (33/33).
- Canary raw `error TS` lines (dist-fast, tsconfig.tsz-guard.json): valibot 2452 -> 1813 (-639; TS2344 579 -> 78, TS2322 117 -> 21, TS2345 118 -> 113, TS2430 34 -> 32, TS2394 2 -> 1; +1 TS2578 "unused @ts-expect-error" where the false error under a directive disappeared); zod 86 -> 86; comlink 7 -> 7; kysely 188 -> 188. No canary increased.
- tsc 5.5 ground truth on the same valibot config: 1515 errors, all module-resolution/config noise (TS5097/TS2307), zero semantic errors — remaining tsz semantic diagnostics are smaller pre-existing families (positions shifted finer on the same calls, e.g. base64.ts(100,19) -> (100,35)).
- `python3 scripts/arch/arch_guard.py`: passed.
- clippy ci-lint on tsz-solver + tsz-checker: clean (see CI).

## Coordination Notes
- Campaign context: #13031 (recursive conditional-branch elaboration guard), #13037, #13139 (two-pass overload resolution) landed; this is triage family #1 from the benchmark-canary corpus.
- The secondary symptom from triage (object-literal failure elaboration reporting per-property TS2322 for matching properties) was expected to be largely cascade; canary deltas quantify what remains — follow-up if nonzero.
