### PR TITLE
arch health: consolidate escape_js_string and fix stale contract test assertions

### DIFF
--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_00.rs
@@ -1031,6 +1031,15 @@ fn test_assignment_and_binding_default_assignability_use_central_gateway_helpers
         &fs::read_to_string("src/state/state_checking/class.rs")
             .expect("failed to read src/state/state_checking/class.rs for architecture guard"),
     );
+    state_checking_src.push_str(
+        &fs::read_to_string("src/state/variable_checking/for_loop.rs")
+            .expect("failed to read src/state/variable_checking/for_loop.rs for architecture guard"),
+    );
+    state_checking_src.push_str(
+        &fs::read_to_string("src/state/variable_checking/initializer_policy.rs").expect(
+            "failed to read src/state/variable_checking/initializer_policy.rs for architecture guard",
+        ),
+    );
     assert!(
         state_checking_src.contains("check_assignable_or_report(")
             || state_checking_src.contains("check_assignable_or_report_at(")

--- a/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_02.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_02.rs
@@ -320,9 +320,10 @@ fn test_diagnostic_paths_use_relation_outcome_hint() {
         .expect("failed to read assignability_diagnostics.rs");
 
     assert!(
-        source.contains("assign_relation_outcome("),
-        "check_assignable_or_report_at must obtain a RelationOutcome via the named \
-         assign_relation_outcome helper instead of re-calling the solver separately"
+        source.contains("assign_relation_outcome(")
+            || source.contains("assignability_reason_relation_outcome("),
+        "check_assignable_or_report_at must obtain a RelationOutcome via a named \
+         assignability relation outcome helper instead of re-calling the solver separately"
     );
     assert!(
         source.contains("should_skip_weak_union_error_with_hint(")

--- a/crates/tsz-common/src/source_map/mod.rs
+++ b/crates/tsz-common/src/source_map/mod.rs
@@ -555,12 +555,14 @@ pub fn escape_js_string(s: &str, quote: char) -> String {
     let bytes = s.as_bytes();
     let quote_byte = quote as u8;
 
-    // Fast path check using SIMD
+    // Fast path: return early when there is nothing to escape.
+    // All five special bytes (\, quote, \n, \r, \t, \0) must be absent.
     let has_backslash = memchr::memchr(b'\\', bytes).is_some();
     let has_quote = memchr::memchr(quote_byte, bytes).is_some();
-    let has_newline = memchr::memchr2(b'\n', b'\r', bytes).is_some();
+    let has_newline_or_cr = memchr::memchr2(b'\n', b'\r', bytes).is_some();
+    let has_tab_or_null = memchr::memchr2(b'\t', b'\0', bytes).is_some();
 
-    if !has_backslash && !has_quote && !has_newline {
+    if !has_backslash && !has_quote && !has_newline_or_cr && !has_tab_or_null {
         return s.to_string();
     }
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
@@ -3,44 +3,23 @@
 //! Type syntax emission (type references, unions, mapped types, etc.) is in `type_emission.rs`.
 
 use rustc_hash::{FxHashMap, FxHashSet};
+use tsz_common::source_map::escape_js_string;
 use tsz_parser::parser::NodeIndex;
 
 /// Escape a cooked string value for embedding in a double-quoted string literal.
 ///
-/// The scanner stores "cooked" (unescaped) text for string literals. When
-/// writing strings back into `.d.ts` output we must re-escape characters
-/// that cannot appear raw inside double-quoted string literals.
+/// Delegates to `tsz_common::source_map::escape_js_string` so there is one
+/// canonical escape implementation in the workspace.
 pub(crate) fn escape_string_for_double_quote(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 4);
-    for ch in s.chars() {
-        match ch {
-            '\\' => out.push_str("\\\\"),
-            '"' => out.push_str("\\\""),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            '\0' => out.push_str("\\0"),
-            c => out.push(c),
-        }
-    }
-    out
+    escape_js_string(s, '"')
 }
 
 /// Escape a cooked string value for embedding in a single-quoted string literal.
+///
+/// Delegates to `tsz_common::source_map::escape_js_string` so there is one
+/// canonical escape implementation in the workspace.
 pub(crate) fn escape_string_for_single_quote(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 4);
-    for ch in s.chars() {
-        match ch {
-            '\\' => out.push_str("\\\\"),
-            '\'' => out.push_str("\\'"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            '\0' => out.push_str("\\0"),
-            c => out.push(c),
-        }
-    }
-    out
+    escape_js_string(s, '\'')
 }
 
 type JsFoldedNamedExports = (

--- a/crates/tsz-emitter/src/emitter/types/printer/mod.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/mod.rs
@@ -5,6 +5,7 @@
 
 use tsz_binder::{SymbolArena, SymbolId};
 use tsz_common::interner::Atom;
+use tsz_common::source_map::escape_js_string;
 use tsz_parser::parser::node::NodeArena;
 use tsz_solver::construction::TypeInterner;
 
@@ -308,32 +309,11 @@ impl<'a> TypePrinter<'a> {
 mod symbol_resolution;
 mod type_printing;
 
-/// Escape a cooked string value for embedding in a double-quoted string literal.
-///
-/// The solver stores "cooked" (unescaped) text for string literals. When
-/// writing strings back into `.d.ts` output we must re-escape characters
-/// that cannot appear raw inside double-quoted string literals.
-fn escape_string_for_double_quote(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 4);
-    for ch in s.chars() {
-        match ch {
-            '\\' => out.push_str("\\\\"),
-            '"' => out.push_str("\\\""),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            '\0' => out.push_str("\\0"),
-            c => out.push(c),
-        }
-    }
-    out
-}
-
 /// Quote a property name with the appropriate quote style.
 /// tsc uses double quotes for numeric-like strings (e.g. "-1", "0")
 /// and for other non-identifier names.
 fn quote_property_name(name: &str) -> String {
-    format!("\"{}\"", escape_string_for_double_quote(name))
+    format!("\"{}\"", escape_js_string(name, '"'))
 }
 
 fn quote_property_name_single(name: &str) -> String {

--- a/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
@@ -2,13 +2,14 @@
 
 use tsz_binder::{Symbol, SymbolId, symbol_flags};
 use tsz_common::interner::Atom;
+use tsz_common::source_map::escape_js_string;
 use tsz_parser::parser::node::{NodeAccess, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::computation::{TypeSubstitution, instantiate_type_cached};
 use tsz_solver::types::TypeId;
 use tsz_solver::visitor;
 
-use super::{TypePrinter, escape_string_for_double_quote};
+use super::TypePrinter;
 
 impl<'a> TypePrinter<'a> {
     /// Check if a symbol is visible (exported) from the current module.
@@ -935,10 +936,7 @@ impl<'a> TypePrinter<'a> {
     pub(crate) fn print_literal(&self, literal: &tsz_solver::types::LiteralValue) -> String {
         match literal {
             tsz_solver::types::LiteralValue::String(atom) => {
-                format!(
-                    "\"{}\"",
-                    escape_string_for_double_quote(&self.resolve_atom(*atom))
-                )
+                format!("\"{}\"", escape_js_string(&self.resolve_atom(*atom), '"'))
             }
             tsz_solver::types::LiteralValue::Number(n) => {
                 let v = n.0;


### PR DESCRIPTION
AgentName: dazzling-johnson

Track: Architecture / Tech Debt

Invariant: (1) String-escaping logic for JS/TS literals has exactly one canonical implementation (`tsz_common::source_map::escape_js_string`); emitter modules delegate to it. (2) Architecture contract tests scan the correct source corpus and use current helper names.

Scope: `crates/tsz-common/src/source_map/mod.rs`, `crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs`, `crates/tsz-emitter/src/emitter/types/printer/{mod,symbol_resolution}.rs`, `crates/tsz-checker/src/tests/architecture_contract_tests_parts/part_{00,02}.rs`

## Summary

### Commit 1 — consolidate escape_js_string (partial fix for #13107)

**Bug fix**: `escape_js_string` fast-path in `tsz-common` was missing `\t` and `\0` membership checks, causing strings containing only tabs or null chars (no backslash, quote, or newline) to pass through unescaped. Fixed by adding a `memchr2(b'\t', b'\0')` guard.

**Consolidation**: Two hand-rolled 16-line escaping loops in `tsz-emitter/declaration_emitter/helpers/mod.rs` are replaced with delegation wrappers. A third exact duplicate `escape_string_for_double_quote` in `tsz-emitter/types/printer/mod.rs` and its submodule `symbol_resolution.rs` are removed; callers now use `escape_js_string` directly.

The CLI's `escape_string_double_quote` helper is intentionally left unchanged — it escapes additional control characters for filename display and is not part of the JS literal path.

### Commit 2 — fix stale architecture contract test assertions

`test_assignment_and_binding_default_assignability_use_central_gateway_helpers` scanned only five source files, missing `variable_checking/for_loop.rs` and `variable_checking/initializer_policy.rs`, which are the modules that actually contain the `check_assignable_or_report(` and `ensure_relation_input_ready(` gateway calls. Added both to the corpus.

`test_diagnostic_paths_use_relation_outcome_hint` required the literal string `assign_relation_outcome(`, but `assignability_diagnostics.rs` was refactored to use the more descriptive `assignability_reason_relation_outcome(`. The assertion now accepts either name.

After this fix, 127/129 architecture contract tests pass; the two remaining failures (`test_emitter_direct_solver_access_does_not_grow` and `test_emitter_source_text_recovery_surface_does_not_grow`) are pre-existing ceiling overages tracked separately.

## Project Corpus Impact

- Row: n/a
- Bug family: n/a — no semantic or diagnostic changes; pure structural cleanup and test corpus correctness.

## Verification

- `cargo test -p tsz-checker --lib architecture_contract_tests_src` — 127/129 pass (2 pre-existing ceiling failures unrelated to this PR)
- `cargo nextest run -p tsz-common` — 497 tests pass (includes `escape_js_string` unit tests)
- `cargo nextest run -p tsz-emitter` — 3669 tests pass (includes `string_literal_type_escapes_tab` and `fix_string_literal_escaped_tab` which catch the fast-path bug)

## Coordination Notes

- No other open dazzling-johnson PRs touch these files.
- The two remaining arch contract test failures (`test_emitter_direct_solver_access_does_not_grow`, `test_emitter_source_text_recovery_surface_does_not_grow`) require deep emitter architectural changes and will be addressed in separate PRs.