### PR TITLE
fix(binder,cli): lib-global heritage survives root-file order via program_globals on cross-file lookup binders

### DIFF
--- a/crates/tsz-binder/src/binding/accessors_flow.rs
+++ b/crates/tsz-binder/src/binding/accessors_flow.rs
@@ -110,6 +110,14 @@ impl BinderState {
             return Some(sym_id);
         }
 
+        // Cross-file lookup binders keep `file_locals` per-file and carry the
+        // hoisted program-wide globals separately; consult them after the
+        // per-file miss so a lib global resolves the same way it would in a
+        // per-file checking binder.
+        if let Some(sym_id) = self.program_globals.get(name) {
+            return Some(sym_id);
+        }
+
         // Fast path: If lib symbols are merged, they're all in file_locals already
         if self.lib_symbols_merged {
             return None;
@@ -136,6 +144,12 @@ impl BinderState {
     ) -> Option<SymbolId> {
         // First check file_locals (includes merged lib symbols when lib_symbols_merged is true)
         if let Some(sym_id) = self.file_locals.get(name) {
+            return Some(sym_id);
+        }
+
+        // See `get_global_type`: cross-file lookup binders carry hoisted
+        // program-wide globals separately from per-file `file_locals`.
+        if let Some(sym_id) = self.program_globals.get(name) {
             return Some(sym_id);
         }
 

--- a/crates/tsz-binder/src/binding/accessors_flow.rs
+++ b/crates/tsz-binder/src/binding/accessors_flow.rs
@@ -103,18 +103,25 @@ impl BinderState {
     /// 1. Local `file_locals` (for user-defined globals or merged lib symbols)
     /// 2. Lib binders (only when `lib_symbols_merged` is false)
     ///
+    /// Resolve a name against the program-wide LIB globals carried by
+    /// cross-file lookup binders (`MergedProgram::lib_globals`).
+    ///
+    /// This is a dedicated accessor, NOT folded into `get_global_type*`:
+    /// many checker paths depend on those returning `None` on a cross-file
+    /// binder (e.g. JSX element-type resolution treats an unresolved global
+    /// as "use the namespace declared by the program's files"); a blanket
+    /// fallback there regresses multi-file JSX programs. Callers that
+    /// specifically resolve declaration heritage bases (`extends Request`)
+    /// through cross-arena delegation chain this explicitly so heritage does
+    /// not depend on root-file order.
+    pub fn program_global_type(&self, name: &str) -> Option<SymbolId> {
+        self.program_globals.get(name)
+    }
+
     /// Returns the `SymbolId` if found, None otherwise.
     pub fn get_global_type(&self, name: &str) -> Option<SymbolId> {
         // First check file_locals (includes merged lib symbols when lib_symbols_merged is true)
         if let Some(sym_id) = self.file_locals.get(name) {
-            return Some(sym_id);
-        }
-
-        // Cross-file lookup binders keep `file_locals` per-file and carry the
-        // hoisted program-wide globals separately; consult them after the
-        // per-file miss so a lib global resolves the same way it would in a
-        // per-file checking binder.
-        if let Some(sym_id) = self.program_globals.get(name) {
             return Some(sym_id);
         }
 
@@ -144,12 +151,6 @@ impl BinderState {
     ) -> Option<SymbolId> {
         // First check file_locals (includes merged lib symbols when lib_symbols_merged is true)
         if let Some(sym_id) = self.file_locals.get(name) {
-            return Some(sym_id);
-        }
-
-        // See `get_global_type`: cross-file lookup binders carry hoisted
-        // program-wide globals separately from per-file `file_locals`.
-        if let Some(sym_id) = self.program_globals.get(name) {
             return Some(sym_id);
         }
 

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -118,6 +118,7 @@ impl BinderState {
             current_scope: SymbolTable::new(),
             scope_stack: Vec::with_capacity(16),
             file_locals: SymbolTable::new(),
+            program_globals: SymbolTable::new(),
             expando_properties: Arc::new(FxHashMap::default()),
             declared_modules: Arc::new(FxHashSet::default()),
             is_external_module: false,
@@ -187,6 +188,7 @@ impl BinderState {
         self.current_scope.clear();
         self.scope_stack.clear();
         self.file_locals.clear();
+        self.program_globals.clear();
         Arc::make_mut(&mut self.expando_properties).clear();
         Arc::make_mut(&mut self.declared_modules).clear();
         self.is_external_module = false;
@@ -357,6 +359,7 @@ impl BinderState {
             current_scope: SymbolTable::new(),
             scope_stack: Vec::new(),
             file_locals,
+            program_globals: SymbolTable::new(),
             expando_properties: Arc::new(FxHashMap::default()),
             declared_modules: Arc::new(FxHashSet::default()),
             is_external_module: false,
@@ -482,6 +485,7 @@ impl BinderState {
             current_scope: SymbolTable::new(),
             scope_stack: Vec::new(),
             file_locals,
+            program_globals: SymbolTable::new(),
             expando_properties,
             declared_modules: Arc::new(FxHashSet::default()),
             is_external_module: false,

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -306,6 +306,29 @@ pub struct BinderState {
     pub(crate) scope_stack: Vec<SymbolTable>,
     /// File-level locals (for module resolution)
     pub file_locals: SymbolTable,
+    /// Program-wide global symbols (lib globals plus script-file globals),
+    /// shared across reconstructed binders via the `SymbolTable`'s internal
+    /// `Arc` (O(1) clone).
+    ///
+    /// Per-file checking binders fold these directly into `file_locals`
+    /// (`MergedProgram::build_merged_file_locals`), so this table stays empty
+    /// for them. Cross-file lookup binders keep `file_locals` to per-file
+    /// entries (ownership scans iterate that map), so the explicit
+    /// global-type accessors (`get_global_type`, `get_global_type_with_libs`)
+    /// consult this table after a `file_locals` miss. Without it, a binder
+    /// with `lib_symbols_merged == true` but unhoisted globals silently fails
+    /// to resolve lib globals (e.g. an `extends Error` heritage base) when a
+    /// file's types are computed through cross-arena delegation — making
+    /// check results depend on root-file order.
+    ///
+    /// Scope-chain identifier resolution (`resolve_identifier*`,
+    /// `resolve_name_with_filter`) deliberately does NOT consult this table:
+    /// those walks can run against cross-arena nodes whose declaring-file
+    /// locals are not in this binder's `file_locals`, and a program-global
+    /// hit there would shadow the declaring file's own local (e.g. a user
+    /// `interface EventSource` shadowing DOM's `EventSource`).
+    #[serde(default)]
+    pub program_globals: SymbolTable,
     /// Expando property assignments: maps identifier name → set of property names
     /// that were assigned via `X.prop = value` patterns (single-level property access).
     /// Used to suppress false TS2339 errors on read-side property accesses.

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -306,9 +306,14 @@ pub struct BinderState {
     pub(crate) scope_stack: Vec<SymbolTable>,
     /// File-level locals (for module resolution)
     pub file_locals: SymbolTable,
-    /// Program-wide global symbols (lib globals plus script-file globals),
-    /// shared across reconstructed binders via the `SymbolTable`'s internal
-    /// `Arc` (O(1) clone).
+    /// Lib-origin global symbols of the program, shared across reconstructed
+    /// binders via the `SymbolTable`'s internal `Arc` (O(1) clone).
+    ///
+    /// Deliberately lib-only (`MergedProgram::lib_globals`): script-file
+    /// globals (e.g. a program's own `JSX` namespace) must keep resolving
+    /// through the per-file cross-file path with their original symbol
+    /// identity; a program-wide fallback for them shadows/re-identifies those
+    /// declarations and regresses multi-file JSX programs.
     ///
     /// Per-file checking binders fold these directly into `file_locals`
     /// (`MergedProgram::build_merged_file_locals`), so this table stays empty

--- a/crates/tsz-binder/src/state/resolution.rs
+++ b/crates/tsz-binder/src/state/resolution.rs
@@ -158,6 +158,14 @@ impl BinderState {
                 break 'resolve Some(sym_id);
             }
 
+            // NOTE: scope-chain resolution deliberately does NOT consult
+            // `BinderState::program_globals`. Identifier resolution can run
+            // against cross-arena nodes whose declaring-file locals are not
+            // in this binder's `file_locals`; a program-global hit here would
+            // shadow the declaring file's own local (e.g. a user `interface
+            // EventSource` shadowing DOM's `EventSource`). Only the explicit
+            // global-type accessors (`get_global_type*`) consult that table.
+
             // Chained lookup: check lib binders for global symbols
             // This enables resolving console, Array, Object, etc. from lib.d.ts
             for (i, lib_binder) in self.lib_binders.iter().enumerate() {

--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -130,6 +130,12 @@ impl<'a> CheckerState<'a> {
                         })
                     })
             })
+            // Cross-file lookup binders do not fold lib globals into
+            // `file_locals`; without this explicit fallback, a lib heritage
+            // base (`extends Request`) silently fails to resolve when the
+            // declaring file is checked through cross-arena delegation,
+            // making results depend on root-file order.
+            .or_else(|| self.ctx.binder.program_global_type(normalized))
     }
 
     /// Get the type of an interface declaration.

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -923,6 +923,14 @@ pub(super) fn create_cross_file_lookup_binder_with_augmentations(
     binder.lib_binders = program.lib_binders.clone();
     binder.lib_symbol_ids = program.lib_symbol_ids.clone();
     binder.lib_type_namespace = Arc::new(program.build_lib_type_namespace(file_idx));
+    // Cross-file lookup binders deliberately keep `file_locals` per-file
+    // (ownership scans iterate that map), so carry the hoisted program-wide
+    // globals separately. Without this, a global name (e.g. an
+    // `extends Request` heritage base) silently fails to resolve when a
+    // file's types are computed through cross-arena delegation — making
+    // check results depend on root-file order. `SymbolTable` is internally
+    // `Arc`-backed, so this clone is an O(1) refcount bump.
+    binder.program_globals = program.globals.clone();
 
     binder
 }

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -924,13 +924,17 @@ pub(super) fn create_cross_file_lookup_binder_with_augmentations(
     binder.lib_symbol_ids = program.lib_symbol_ids.clone();
     binder.lib_type_namespace = Arc::new(program.build_lib_type_namespace(file_idx));
     // Cross-file lookup binders deliberately keep `file_locals` per-file
-    // (ownership scans iterate that map), so carry the hoisted program-wide
-    // globals separately. Without this, a global name (e.g. an
-    // `extends Request` heritage base) silently fails to resolve when a
-    // file's types are computed through cross-arena delegation — making
-    // check results depend on root-file order. `SymbolTable` is internally
-    // `Arc`-backed, so this clone is an O(1) refcount bump.
-    binder.program_globals = program.globals.clone();
+    // (ownership scans iterate that map), so carry the hoisted LIB globals
+    // separately. Without this, a lib-global name (e.g. an `extends Request`
+    // heritage base) silently fails to resolve when a file's types are
+    // computed through cross-arena delegation — making check results depend
+    // on root-file order. Lib-origin names only: script-file globals (e.g. a
+    // program's own `JSX` namespace) must keep resolving through the
+    // per-file cross-file path with their original symbol identity, or this
+    // fallback shadows/re-identifies them (multi-file JSX conformance
+    // regressions). `SymbolTable` is internally `Arc`-backed, so this clone
+    // is an O(1) refcount bump.
+    binder.program_globals = program.lib_globals.clone();
 
     binder
 }

--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -47,6 +47,9 @@ mod dual_package_exports_tests;
 #[path = "../tests/fs_tests.rs"]
 mod fs_tests;
 #[cfg(test)]
+#[path = "../tests/lib_heritage_import_order_cli_tests.rs"]
+mod lib_heritage_import_order_cli_tests;
+#[cfg(test)]
 #[path = "../tests/lib_shadow_cli_tests.rs"]
 mod lib_shadow_cli_tests;
 #[cfg(test)]

--- a/crates/tsz-cli/tests/lib_heritage_import_order_cli_tests.rs
+++ b/crates/tsz-cli/tests/lib_heritage_import_order_cli_tests.rs
@@ -1,0 +1,244 @@
+//! Root-file-order independence for lib-global heritage across modules.
+//!
+//! Structural rule: when `interface X extends <lib global>` (e.g. `Request`,
+//! `Error`, `Response`) is declared in one module and consumed through an
+//! import in another, tsc resolves the heritage base identically regardless
+//! of the order the root files are listed; tsz does the same through the
+//! cross-file lookup binder's `program_globals` table (the hoisted
+//! program-wide globals carried separately from per-file `file_locals`).
+//!
+//! Before that table existed, a module first reached as an IMPORT of an
+//! earlier-checked root file (instead of as an earlier root file itself)
+//! lost its lib heritage: the reconstructed cross-file binder had
+//! `lib_symbols_merged == true` but only per-file `file_locals`, so the
+//! heritage base name failed to resolve and members inherited from the lib
+//! global produced false TS2339s (msw/ofetch/valibot/comlink/kysely corpus
+//! family).
+
+use crate::args::CliArgs;
+use clap::Parser;
+
+/// Compile `files` (written into one temp dir) with the given root-file
+/// order and return the diagnostic codes.
+fn compile_in_order(files: &[(&str, &str)], root_order: &[&str]) -> Vec<u32> {
+    let dir = tempfile::tempdir().expect("temp dir");
+    for (name, contents) in files {
+        std::fs::write(dir.path().join(name), contents).expect("write repro file");
+    }
+
+    let mut argv: Vec<&str> = vec![
+        "tsz",
+        "--ignoreConfig",
+        "--noEmit",
+        "--strict",
+        "--target",
+        "es2022",
+        "--lib",
+        "es2022,dom,dom.iterable",
+    ];
+    argv.extend_from_slice(root_order);
+
+    let args = CliArgs::try_parse_from(argv).expect("parse args");
+    let result = crate::driver::compile(&args, dir.path()).expect("compile should succeed");
+    result.diagnostics.iter().map(|diag| diag.code).collect()
+}
+
+/// Assert both root-file orders produce no diagnostics.
+fn assert_clean_both_orders(files: &[(&str, &str)]) {
+    let names: Vec<&str> = files.iter().map(|(name, _)| *name).collect();
+    let forward = compile_in_order(files, &names);
+    assert!(
+        forward.is_empty(),
+        "expected clean check in forward root order {names:?}, got codes: {forward:?}"
+    );
+    let reversed: Vec<&str> = names.iter().rev().copied().collect();
+    let backward = compile_in_order(files, &reversed);
+    assert!(
+        backward.is_empty(),
+        "expected clean check in reversed root order {reversed:?}, got codes: {backward:?}"
+    );
+}
+
+#[test]
+fn imported_interface_extending_request_keeps_lib_heritage_in_both_root_orders() {
+    // Consumer listed FIRST is the regression: the declaring module is first
+    // reached as an import, through the cross-file lookup binder.
+    assert_clean_both_orders(&[
+        (
+            "reader.ts",
+            r#"
+import type { TightFetchInput } from './shapes';
+export function pullHeaders(input: TightFetchInput): Headers {
+    input.describe();
+    return input.headers;
+}
+"#,
+        ),
+        (
+            "shapes.ts",
+            r#"
+export interface TightFetchInput extends Request {
+    describe(): void;
+}
+"#,
+        ),
+    ]);
+}
+
+#[test]
+fn three_file_import_chain_keeps_lib_heritage_in_both_root_orders() {
+    assert_clean_both_orders(&[
+        (
+            "entry.ts",
+            r#"
+import type { Wrapped } from './middle';
+export function follow(w: Wrapped): string {
+    w.inner.label();
+    return w.inner.url;
+}
+"#,
+        ),
+        (
+            "middle.ts",
+            r#"
+export interface Wrapped {
+    inner: import('./bottom').TaggedReq;
+}
+"#,
+        ),
+        (
+            "bottom.ts",
+            r#"
+export interface TaggedReq extends Request {
+    label(): string;
+}
+"#,
+        ),
+    ]);
+}
+
+#[test]
+fn imported_interface_extending_error_keeps_lib_heritage_in_both_root_orders() {
+    assert_clean_both_orders(&[
+        (
+            "render.ts",
+            r#"
+import type { DomainFault } from './faults';
+export function explain(fault: DomainFault): string {
+    return fault.hint + fault.message;
+}
+"#,
+        ),
+        (
+            "faults.ts",
+            r#"
+export interface DomainFault extends Error {
+    hint: string;
+}
+"#,
+        ),
+    ]);
+}
+
+#[test]
+fn imported_interface_extending_response_keeps_lib_heritage_in_both_root_orders() {
+    assert_clean_both_orders(&[
+        (
+            "inspect.ts",
+            r#"
+import type { ParsedRes } from './payloads';
+export function code(res: ParsedRes): number {
+    void res.payload;
+    return res.status;
+}
+"#,
+        ),
+        (
+            "payloads.ts",
+            r#"
+export interface ParsedRes extends Response {
+    payload: unknown;
+}
+"#,
+        ),
+    ]);
+}
+
+#[test]
+fn imported_omit_of_lib_global_resolves_in_both_root_orders() {
+    assert_clean_both_orders(&[
+        (
+            "apply.ts",
+            r#"
+import type { LooseInit } from './aliases';
+export function take(init: LooseInit): Headers {
+    return init.headers;
+}
+"#,
+        ),
+        (
+            "aliases.ts",
+            r#"
+export type LooseInit = Omit<Request, 'method'> & { method?: string };
+"#,
+        ),
+    ]);
+}
+
+#[test]
+fn imported_interface_without_heritage_stays_clean_in_both_root_orders() {
+    assert_clean_both_orders(&[
+        (
+            "consume.ts",
+            r#"
+import type { Bare } from './bare';
+export function ident(b: Bare): number {
+    return b.id;
+}
+"#,
+        ),
+        (
+            "bare.ts",
+            r#"
+export interface Bare {
+    id: number;
+}
+"#,
+        ),
+    ]);
+}
+
+#[test]
+fn missing_member_on_lib_extending_interface_errors_in_both_root_orders() {
+    let files: &[(&str, &str)] = &[
+        (
+            "misuse.ts",
+            r#"
+import type { TightFetchInput } from './shapes';
+export function broken(input: TightFetchInput): void {
+    input.definitelyNotAMember();
+}
+"#,
+        ),
+        (
+            "shapes.ts",
+            r#"
+export interface TightFetchInput extends Request {
+    describe(): void;
+}
+"#,
+        ),
+    ];
+    let forward = compile_in_order(files, &["misuse.ts", "shapes.ts"]);
+    assert_eq!(
+        forward,
+        vec![2339],
+        "negative control must report exactly TS2339 in forward order"
+    );
+    let backward = compile_in_order(files, &["shapes.ts", "misuse.ts"]);
+    assert_eq!(
+        backward,
+        vec![2339],
+        "negative control must report exactly TS2339 in reversed order"
+    );
+}

--- a/crates/tsz-core/src/parallel/core/bind_result_reducer.rs
+++ b/crates/tsz-core/src/parallel/core/bind_result_reducer.rs
@@ -1447,6 +1447,31 @@ impl BindResultReducer {
         // filtering by `entry_sym_id == sym_id` use this to do a point lookup.
         let sym_to_decl_indices = build_sym_to_decl_indices(&self.declaration_arenas);
 
+        // Lib-origin subset of the program globals (see `MergedProgram::lib_globals`).
+        // Built once here so per-binder installation stays an O(1) table clone.
+        //
+        // Module/namespace-flagged symbols (e.g. the global `JSX` namespace)
+        // are excluded even when lib-origin: their per-file augmentation and
+        // merge identity is owned by the cross-file resolution path, and
+        // serving them from a program-wide fallback re-identifies them
+        // (witnessed as multi-file JSX conformance regressions). The flag
+        // check must happen here, against the program-wide symbol arena —
+        // a cross-file lookup binder cannot resolve these ids to symbols.
+        let lib_globals = {
+            let mut table = SymbolTable::with_capacity(self.globals.len());
+            for (name, &sym_id) in self.globals.iter() {
+                if !self.global_lib_symbol_ids.contains(&sym_id) {
+                    continue;
+                }
+                let flags = self.global_symbols.get(sym_id).map_or(0, |sym| sym.flags);
+                if flags & tsz_binder::symbol_flags::MODULE != 0 {
+                    continue;
+                }
+                table.set(name.clone(), sym_id);
+            }
+            table
+        };
+
         MergedProgram {
             files: self.files,
             symbols: self.global_symbols,
@@ -1455,6 +1480,7 @@ impl BindResultReducer {
             sym_to_decl_indices: Arc::new(sym_to_decl_indices),
             cross_file_node_symbols: Arc::new(self.cross_file_node_symbols),
             globals: self.globals,
+            lib_globals,
             file_locals: self.file_locals_list,
             declared_modules: Arc::new(self.declared_modules),
             shorthand_ambient_modules: Arc::new(self.shorthand_ambient_modules),

--- a/crates/tsz-core/src/parallel/core/merge_support.rs
+++ b/crates/tsz-core/src/parallel/core/merge_support.rs
@@ -368,6 +368,14 @@ pub struct MergedProgram {
     pub cross_file_node_symbols: Arc<CrossFileNodeSymbols>,
     /// Global symbol table (exports from all files)
     pub globals: SymbolTable,
+    /// Lib-origin subset of `globals` (names whose `SymbolId` is in
+    /// `lib_symbol_ids`), computed once at merge time so cross-file lookup
+    /// binders can install it with an O(1) clone. Script-file globals (e.g. a
+    /// test's own `JSX` namespace) are deliberately excluded: those must keep
+    /// resolving through the per-file cross-file path with their original
+    /// symbol identity, or program-global lookups shadow/re-identify them
+    /// (witnessed as multi-file JSX conformance regressions).
+    pub lib_globals: SymbolTable,
     /// Per-file symbol tables (file-local symbols, symbol IDs remapped)
     pub file_locals: Vec<SymbolTable>,
     /// Ambient module declarations across all files


### PR DESCRIPTION
AgentName: StudioOpus

Track: project-corpus false-positive reduction (triage family #2: program-composition lib-heritage drop, import-order dependent)

Invariant: root-file order must not change check results.

Scope: `crates/tsz-binder` (new `BinderState.program_globals` table consulted by the explicit global-type accessors), `crates/tsz-cli` (populate the table in the cross-file lookup binder builder; regression tests). No checker/solver/emitter semantics touched.

## Structural rule

When `interface X extends <lib global>` (`Request`, `Error`, `Response`, ...) is declared in one module and that module is first reached as an IMPORT of an earlier-checked root file (instead of as an earlier root file itself), tsc resolves the heritage base identically regardless of root-file order; tsz does the same through the binder layer: the cross-file lookup binder carries the hoisted program-wide globals in `BinderState.program_globals` (O(1) `Arc`-backed clone of `MergedProgram.globals`), and the explicit global-type accessors (`get_global_type`, `get_global_type_with_libs`) consult it after the per-file `file_locals` miss and before the `lib_symbols_merged` fast path concludes the name is absent.

Owner layer: binder (name-based global resolution); the CLI driver populates the table at cross-file binder reconstruction (`create_cross_file_lookup_binder_with_augmentations`). Per-file checking binders are unaffected: their `file_locals` already fold globals via `build_merged_file_locals`, so the table stays empty and the probe is a no-op there. tsz-core's parallel path likewise already merges globals into per-file `file_locals`.

Two deliberate exclusions (both empirically verified, see Verification):
- `file_locals` is NOT widened: ownership scans (`resolve_in_all_binders`) iterate that map to attribute symbols to files; folding globals in would make every binder claim every global.
- Scope-chain identifier resolution (`resolve_identifier*`, `resolve_name_with_filter`) does NOT consult the table: those walks can run against cross-arena nodes whose declaring-file locals are not in the active binder's `file_locals`, and a program-global hit there shadows the declaring file's own local. Witness: comlink declares `interface EventSource` (shadowing DOM's) and `Endpoint extends EventSource`; with scope-chain probes enabled the comlink row regressed 7 -> 8 (false TS2339 on `Endpoint.addEventListener`); with accessor-only probes it stays at 7.

## Witness

`decl.ts`: `export interface StrictReq extends Request { extra(): void }`; `consumer.ts` imports it and reads `req.headers` (lib `es2022,dom,dom.iterable`, strict).

- Pre-fix: `tsz --noEmit consumer.ts decl.ts` -> false `TS2339: Property 'headers' does not exist on type 'StrictReq'`; reversed root order clean. tsc clean both ways.
- Post-fix: clean in both orders; the wrong-member negative control still reports exactly TS2339 in both orders.

## Adjacent-case matrix (all verified in BOTH root orders; binder names varied)

| case | result |
|------|--------|
| 2-file `extends Request`, member from lib base | clean / clean |
| 3-file import chain (lib-extending interface at the bottom, `import('./bottom').T` in the middle) | clean / clean |
| `extends Error` | clean / clean |
| `extends Response` | clean / clean |
| `Omit<Request, 'method'>` in the imported module | clean / clean |
| no-heritage control | clean / clean |
| wrong member on lib-extending interface (negative) | exactly TS2339 / exactly TS2339 |

Locked in as 7 in-process driver tests: `crates/tsz-cli/tests/lib_heritage_import_order_cli_tests.rs` (the `extends Request` forward-order test fails without the fix).

## Project Corpus Impact

- Row: msw-project, ofetch-project, valibot-project, comlink-project (also zod, kysely canaries)
- Bug family: program-composition lib-heritage drop (import-order dependent)

Canary deltas (dist-fast, `--noEmit -p <row>/tsconfig.tsz-guard.json`, `error TS` line counts; PRE measured on a clean origin/main dist-fast build of the same workspace):

| row | pre (main) | post (fix) | delta |
|-----|-----|------|-------|
| msw | 220 | 216 | -4 |
| ofetch | 46 | 43 | -3 |
| valibot | 1813 | 1811 | -2 |
| comlink | 7 | 7 | 0 |
| zod | 86 | 93 | +7 |
| kysely | 188 | 188 | 0 |

zod +7 investigated: composition is +16 / -9 lines. 14 of the 16 new lines are one family — `TS2344 ... does not satisfy the constraint 'ZodType<any, any, any>'` — where the constraint (alias `ZodTypeAny`) now MATERIALIZES through cross-arena lowering (pre-fix the lib names inside `ZodType`'s members, e.g. `Awaited`/`Promise` returns, failed to resolve on this path, so the constraint stayed degraded and the relation passed vacuously; 4 bogus TS2554 arity errors from the same degradation disappear post-fix). The residual failure is the pre-existing cross-arena interface-lowering degradation (the same family #12299 addressed for the LibContext path), now exposed instead of masked. tsc reports 0 on zod either way, so this is FP-count movement within the same root family, not a new wrong rule.

## Verification

- New regression tests: 7/7 pass (`cargo nextest run -p tsz-cli -E 'test(/lib_heritage_import_order/)'`).
- `cargo nextest run -p tsz-binder`: 539/539 passed.
- `cargo nextest run -p tsz-checker -E 'test(/heritage|lib|interface|extends|cross_file|global/)'`: 1609 run, 18 failed — failing-test set byte-identical to clean origin/main (verified by running the same filter on detached `origin/main` in the same workspace; all 18 pre-existing).
- `python3 scripts/arch/arch_guard.py`: passed.
- `cargo clippy -p tsz-binder -p tsz-cli --profile ci-lint --all-targets`: clean.
- Performance: population is one `Arc`-backed `SymbolTable` clone per cross-file lookup binder (O(1)); the accessor probe is a single hash lookup on the miss path only and a guaranteed-empty-table no-op for per-file checking binders.

## Coordination Notes

- Campaign: #13031 / #13037 / #13139 / #13142 landed; this PR is triage family #2 (~540 FPs across msw/ofetch/valibot/comlink/kysely; this fix removes the import-order-dependent subset reachable through `get_global_type*`).
- Relates to #12299: that fixed the LibContext path for DOM heritage drops; this fixes the program-file (cross-file lookup binder) path for name-based global resolution. The remaining cross-arena lowering degradation (zod TS2344 family above, kysely residue) needs the deeper delegation/shared-lib-universe work and is intentionally out of scope.
- kysely FP tracking: #10663.



## Update: fallback scoped to heritage resolution (addresses conformance gate)

The first head's blanket `get_global_type*` fallback regressed 6 multi-file JSX
conformance tests: checker paths (JSX element-type resolution) legitimately
depend on those accessors returning `None` on a cross-file lookup binder, and a
program-wide hit re-identifies symbols. The same mechanism caused the zod +7
noted above.

Now narrowed at three layers: `MergedProgram::lib_globals` (lib-origin,
non-module subset built once at merge), a dedicated
`BinderState::program_global_type` accessor (the general accessors are reverted
to previous behavior), and a single chained fallback in
`resolve_interface_heritage_symbol_by_name` — the exact site where
`extends Request` fails under cross-arena delegation.

Verification (current head): all 6 regressed JSX tests pass via the
conformance filter; the order-independence witness holds in both root orders;
7/7 CLI heritage tests; arch guard + clippy clean. Canary deltas vs main:
msw 220→216, comlink 7→7, **zod 86→86 (the +7 no longer occurs)**, ofetch
unchanged (its 3 lines required non-heritage lookups; left for a
separately-validated adoption of the scoped accessor).
