### PR TITLE
perf(checker): delegation-tree memo for completed cross-arena sentinel results fixes drizzle-orm livelock

### DIFF
--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -647,6 +647,10 @@ impl<'a> CheckerContext<'a> {
         ctx.symbol_instance_types = parent.symbol_instance_types.clone();
         ctx.enum_namespace_types = parent.enum_namespace_types.clone();
 
+        // Note: the clone shares (does not copy) the embedded session memo of
+        // completed cross-arena delegation results via its internal `Arc`:
+        // child writes must be visible to the parent and to sibling children
+        // within the same file-check session.
         ctx.lib_delegation_cache = parent.lib_delegation_cache.clone();
         // Skip the deep `HashMap::clone` for caches that are empty on the
         // parent: `ctx` was just constructed via `Self::base(...)` so its

--- a/crates/tsz-checker/src/context/cross_file_delegation_cache.rs
+++ b/crates/tsz-checker/src/context/cross_file_delegation_cache.rs
@@ -9,6 +9,10 @@ use tsz_solver::{TypeId, TypeParamInfo};
 pub struct CrossFileDelegationCache {
     symbol_types: FxHashMap<SymbolId, (TypeId, Vec<TypeParamInfo>)>,
     declaration_node_types: Arc<dashmap::DashMap<(usize, NodeIndex, u8), TypeId>>,
+    /// Session memo of completed cross-arena delegation results; shared
+    /// (via `Arc` clone in `with_parent_cache`) with every transient child
+    /// checker in the same file-check session. See [`CrossArenaSessionMemo`].
+    session_memo: Arc<CrossArenaSessionMemo>,
 }
 
 impl Default for CrossFileDelegationCache {
@@ -16,6 +20,7 @@ impl Default for CrossFileDelegationCache {
         Self {
             symbol_types: FxHashMap::default(),
             declaration_node_types: Arc::new(dashmap::DashMap::new()),
+            session_memo: Arc::new(CrossArenaSessionMemo::default()),
         }
     }
 }
@@ -27,9 +32,14 @@ impl CrossFileDelegationCache {
     pub fn clear(&mut self) {
         self.symbol_types.clear();
         self.declaration_node_types.clear();
+        // Replace rather than clear: transient child checkers from the
+        // prior session may still hold Arc clones of the old memo.
+        self.session_memo = Arc::new(CrossArenaSessionMemo::default());
     }
 
-    /// Clears only the file-local `symbol_types` cache.
+    /// Clears only the file-local `symbol_types` cache (and the file-session
+    /// delegation memo, which may hold contextual sentinel outcomes that must
+    /// not leak into the next file's session).
     ///
     /// `declaration_node_types` is keyed by `(arena_ptr, NodeIndex, mode)`.  Each
     /// [`NodeArena`] is a distinct heap object, so its pointer value is unique per
@@ -40,6 +50,13 @@ impl CrossFileDelegationCache {
     #[inline]
     pub fn clear_file_local(&mut self) {
         self.symbol_types.clear();
+        self.session_memo = Arc::new(CrossArenaSessionMemo::default());
+    }
+
+    /// Session memo of completed cross-arena delegation results.
+    #[inline]
+    pub fn session_memo(&self) -> &CrossArenaSessionMemo {
+        &self.session_memo
     }
 
     #[inline]
@@ -98,5 +115,95 @@ impl CrossFileDelegationCache {
     #[inline]
     fn arena_ptr(arena: &NodeArena) -> usize {
         arena as *const NodeArena as usize
+    }
+}
+
+/// Memo of *completed* cross-arena delegation results, scoped to one
+/// outermost delegation tree.
+///
+/// Structural rule: when the same `(owner file, symbol)` cross-arena
+/// delegation is requested repeatedly inside one delegation tree, `tsc`
+/// computes the symbol's type once per program; `tsz`
+/// re-ran the full child-checker pipeline per type-reference occurrence
+/// whenever the completed result was a sentinel (`ERROR`/`UNKNOWN`),
+/// because the shared `DefinitionStore` cross-file buckets intentionally
+/// refuse sentinel writes (an *in-progress* sentinel must not poison
+/// other checkers). That recomputation is the drizzle-orm livelock
+/// (issue #13041): one alias such as `SelectedFields` re-ran thousands
+/// of full delegations, all completing with the same `ERROR`.
+///
+/// This memo records *completed sentinel* outcomes only (`ERROR`/`UNKNOWN`
+/// symbol results; completed-`None` class-instance/interface results),
+/// keyed by `(owner_file_idx, raw symbol id, context fingerprint)`. The
+/// first two components are the same global key shape the canonical
+/// `DefinitionStore` cross-file buckets use: the raw `SymbolId` is
+/// interpreted in the owner file's binder, so the pair is unambiguous
+/// program-wide. The fingerprint is an order-independent hash of the
+/// requesting checker's in-progress resolution sets
+/// (`symbol_resolution_set`, `class_instance_resolution_set`,
+/// `class_constructor_resolution_set`) — the mutable context a delegated
+/// computation's cycle detection can observe. A completed sentinel is
+/// replayed only for a repeat under the *identical* in-progress context,
+/// where the baseline recomputation is the same deterministic function
+/// and reproduces it. Successful results intentionally stay on the gated
+/// shared-store buckets, which model requester stability; memoizing them
+/// here (or replaying sentinels across *different* contexts) changed
+/// elaboration output on the valibot and kysely canaries.
+///
+/// Scope and invalidation: one `Arc` lives on the top-level file checker
+/// and is shared (not cloned) with every transient child checker via
+/// `with_parent_cache`. Each memo-consuming delegation entry point clears
+/// the maps when it begins a **new outermost tree**
+/// ([`clear_for_new_delegation_tree`](Self::clear_for_new_delegation_tree)
+/// at cross-arena depth 0), so completed sentinel outcomes are replayed
+/// only *within* the delegation tree whose in-progress context produced
+/// them — repeats across statements/trees recompute exactly as before
+/// (zero diagnostic delta on completing canaries), while the
+/// combinatorial re-resolution *inside* one tree (the livelock) collapses
+/// to one computation per `(file, symbol)`. All other delegation inputs
+/// (arenas, binders, merged libs, compiler options) are immutable for the
+/// session, so no further invalidation is needed.
+///
+/// In-progress guard returns (cross-arena depth, per-checker recursion
+/// budget) are *not* completed results and must never be written here.
+#[derive(Default)]
+pub struct CrossArenaSessionMemo {
+    /// Set on every insert; lets `clear_for_new_delegation_tree` skip the
+    /// per-shard map clears (the overwhelmingly common case: most outermost
+    /// delegations never produce a sentinel completion).
+    dirty: std::sync::atomic::AtomicBool,
+    /// `delegate_cross_arena_symbol_resolution` completed sentinel results,
+    /// keyed by `(owner_file_idx, raw symbol id, context fingerprint)`.
+    pub symbol: dashmap::DashMap<(u32, u32, u64), (TypeId, Vec<TypeParamInfo>)>,
+    /// `delegate_cross_arena_class_instance_type` completed negative results
+    /// (`None` or sentinel-typed = completed without a usable instance type).
+    pub class_instance: dashmap::DashMap<(u32, u32, u64), Option<(TypeId, Vec<TypeParamInfo>)>>,
+    /// `delegate_cross_arena_interface_type` completed-`None` child-checker
+    /// results (completed with `UNKNOWN`/`ERROR`).
+    pub interface: dashmap::DashMap<(u32, u32, u64), Option<TypeId>>,
+}
+
+impl CrossArenaSessionMemo {
+    /// Mark the memo non-empty. Call after every insert into any bucket.
+    #[inline]
+    pub fn mark_dirty(&self) {
+        self.dirty.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Drop all entries before starting a new outermost delegation tree.
+    ///
+    /// Completed sentinel outcomes may depend on the in-progress resolution
+    /// context of the tree that computed them; replaying them in a *later*
+    /// tree (whose baseline recomputation could succeed) would change
+    /// diagnostics. Call at every memo-consuming delegation entry point
+    /// when the cross-arena depth is 0. Costs one relaxed atomic load when
+    /// the memo is already empty.
+    #[inline]
+    pub fn clear_for_new_delegation_tree(&self) {
+        if self.dirty.swap(false, std::sync::atomic::Ordering::Relaxed) {
+            self.symbol.clear();
+            self.class_instance.clear();
+            self.interface.clear();
+        }
     }
 }

--- a/crates/tsz-checker/src/context/cross_file_delegation_cache.rs
+++ b/crates/tsz-checker/src/context/cross_file_delegation_cache.rs
@@ -166,6 +166,11 @@ impl CrossFileDelegationCache {
 ///
 /// In-progress guard returns (cross-arena depth, per-checker recursion
 /// budget) are *not* completed results and must never be written here.
+/// Memo key: `(owner_file_idx, raw symbol id, in-progress-context fingerprint)`.
+type SessionMemoKey = (u32, u32, u64);
+/// Completed symbol-resolution payload: resolved type plus captured type params.
+type ResolvedSymbolType = (TypeId, Vec<TypeParamInfo>);
+
 #[derive(Default)]
 pub struct CrossArenaSessionMemo {
     /// Set on every insert; lets `clear_for_new_delegation_tree` skip the
@@ -174,13 +179,13 @@ pub struct CrossArenaSessionMemo {
     dirty: std::sync::atomic::AtomicBool,
     /// `delegate_cross_arena_symbol_resolution` completed sentinel results,
     /// keyed by `(owner_file_idx, raw symbol id, context fingerprint)`.
-    pub symbol: dashmap::DashMap<(u32, u32, u64), (TypeId, Vec<TypeParamInfo>)>,
+    pub symbol: dashmap::DashMap<SessionMemoKey, ResolvedSymbolType>,
     /// `delegate_cross_arena_class_instance_type` completed negative results
     /// (`None` or sentinel-typed = completed without a usable instance type).
-    pub class_instance: dashmap::DashMap<(u32, u32, u64), Option<(TypeId, Vec<TypeParamInfo>)>>,
+    pub class_instance: dashmap::DashMap<SessionMemoKey, Option<ResolvedSymbolType>>,
     /// `delegate_cross_arena_interface_type` completed-`None` child-checker
     /// results (completed with `UNKNOWN`/`ERROR`).
-    pub interface: dashmap::DashMap<(u32, u32, u64), Option<TypeId>>,
+    pub interface: dashmap::DashMap<SessionMemoKey, Option<TypeId>>,
 }
 
 impl CrossArenaSessionMemo {

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -475,6 +475,9 @@ impl<'a> CheckerContext<'a> {
         self.symbol_instance_types =
             crate::context::SymbolTypeCache::with_capacity(binder.symbols.len());
         self.enum_namespace_types.clear();
+        // Also replaces the embedded session memo of completed cross-arena
+        // delegation results (file-session-scoped; may hold contextual
+        // sentinel outcomes that must not leak into the next file).
         self.lib_delegation_cache.clear();
         self.var_decl_types.clear();
         self.merged_value_types.clear();

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -17,7 +17,7 @@ pub use caches::{
 pub(crate) use compiler_options::is_declaration_file_name;
 pub(crate) use compiler_options::is_js_file_name;
 pub(crate) use compiler_options::should_resolve_jsdoc_for_file;
-pub use cross_file_delegation_cache::CrossFileDelegationCache;
+pub use cross_file_delegation_cache::{CrossArenaSessionMemo, CrossFileDelegationCache};
 pub use cross_file_type_params_cache::{
     CrossFileTypeParamsCacheStatistics, cross_file_type_params_cache_statistics,
 };

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -6,9 +6,7 @@ use crate::state_type_analysis::cross_file_direct::is_direct_lowering_source_fil
 use crate::symbols_domain::name_text::expression_name_text_in_arena;
 use crate::types_domain::queries::lib_resolution::keyword_syntax_to_type_id;
 use tsz_binder::{SymbolId, symbol_flags};
-use tsz_common::perf_counters::{
-    CrossArenaAliasShortcutOutcome, CrossArenaSymbolMissKind, CrossArenaSymbolMissSource,
-};
+use tsz_common::perf_counters::{CrossArenaSymbolMissKind, CrossArenaSymbolMissSource};
 use tsz_parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
@@ -127,236 +125,30 @@ impl<'a> CheckerState<'a> {
         self.get_symbol_globally(sym_id)
     }
 
-    pub(crate) fn try_resolve_cross_arena_named_alias_without_child(
-        &mut self,
-        sym_id: SymbolId,
-    ) -> Option<(TypeId, Vec<tsz_solver::TypeParamInfo>)> {
-        use CrossArenaAliasShortcutOutcome as AliasOutcome;
-
-        let (module_name, import_name, alias_source_file_idx) = {
-            let Some(symbol) = self.get_cross_file_symbol(sym_id) else {
-                tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                    AliasOutcome::MissingSymbol,
-                );
-                return None;
-            };
-            if symbol.flags & symbol_flags::ALIAS == 0 {
-                tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                    AliasOutcome::NotAlias,
-                );
-                return None;
-            }
-            let Some(module_name) = symbol.import_module.clone() else {
-                tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                    AliasOutcome::MissingModule,
-                );
-                return None;
-            };
-            let Some(import_name) = symbol.import_name.clone() else {
-                tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                    AliasOutcome::MissingImportName,
-                );
-                return None;
-            };
-            if import_name == "*" {
-                tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                    AliasOutcome::NamespaceImport,
-                );
-                return None;
-            }
-            if import_name == "default" {
-                tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                    AliasOutcome::DefaultImport,
-                );
-                return None;
-            }
-            let Some(alias_source_file_idx) = (symbol.decl_file_idx != u32::MAX)
-                .then_some(symbol.decl_file_idx as usize)
-                .or_else(|| self.ctx.resolve_symbol_file_index(sym_id))
-            else {
-                tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                    AliasOutcome::MissingAliasFile,
-                );
-                return None;
-            };
-            (module_name, import_name, alias_source_file_idx)
-        };
-
-        let alias_cache_file_idx = self
-            .ctx
-            .resolve_symbol_file_index(sym_id)
-            .unwrap_or(alias_source_file_idx);
-        let Some(target_sym_id) = self.resolve_cross_file_export_from_file(
-            &module_name,
-            &import_name,
-            Some(alias_source_file_idx),
-        ) else {
-            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                AliasOutcome::MissingTarget,
-            );
-            return None;
-        };
-        if target_sym_id == sym_id {
-            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                AliasOutcome::SelfTarget,
-            );
-            return None;
+    /// Order-independent hash of the in-progress resolution sets a delegated
+    /// computation's cycle detection can observe. Used as the context
+    /// component of the cross-arena sentinel memo key: a completed sentinel
+    /// is replayable only under the identical in-progress context.
+    fn cross_arena_context_fingerprint(&self) -> u64 {
+        #[inline]
+        fn mix(value: u64) -> u64 {
+            // splitmix64 finalizer
+            let mut z = value.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^ (z >> 31)
         }
-
-        let Some(target_flags) = self
-            .get_cross_file_symbol(target_sym_id)
-            .map(|symbol| symbol.flags)
-        else {
-            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                AliasOutcome::MissingTargetSymbol,
-            );
-            return None;
-        };
-        if target_flags & symbol_flags::ALIAS != 0 {
-            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                AliasOutcome::TargetAlias,
-            );
-            return None;
+        let mut acc: u64 = 0;
+        for s in &self.ctx.symbol_resolution_set {
+            acc ^= mix(u64::from(s.0));
         }
-
-        let target_binder = self
-            .ctx
-            .resolve_symbol_file_index(target_sym_id)
-            .and_then(|file_idx| self.ctx.get_binder_for_file(file_idx))
-            .unwrap_or(self.ctx.binder);
-        if self
-            .ctx
-            .alias_partner_for(target_binder, target_sym_id)
-            .is_some()
-        {
-            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                AliasOutcome::AliasPartner,
-            );
-            return None;
+        for s in &self.ctx.class_instance_resolution_set {
+            acc ^= mix(u64::from(s.0) | (1 << 40));
         }
-
-        let target_is_interface_value_merge = target_flags & symbol_flags::INTERFACE != 0
-            && target_flags & (symbol_flags::VARIABLE | symbol_flags::FUNCTION) != 0;
-        if target_is_interface_value_merge {
-            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                AliasOutcome::InterfaceValueMerge,
-            );
-            return None;
+        for s in &self.ctx.class_constructor_resolution_set {
+            acc ^= mix(u64::from(s.0) | (1 << 41));
         }
-
-        let target_file_idx = self
-            .ctx
-            .resolve_symbol_file_index(target_sym_id)
-            .or_else(|| {
-                self.ctx
-                    .resolve_import_target_from_file(alias_source_file_idx, &module_name)
-            });
-        if let Some(file_idx) = target_file_idx {
-            self.ctx
-                .register_symbol_file_target(target_sym_id, file_idx);
-        }
-        let (mut result, params) = if target_flags & symbol_flags::TYPE_ALIAS != 0 {
-            target_file_idx
-                .and_then(|file_idx| {
-                    self.ctx
-                        .cached_cross_file_symbol_type(target_sym_id, file_idx as u32)
-                })
-                .or_else(|| {
-                    let resolved = self.direct_source_file_type_alias_result(
-                        target_sym_id,
-                        target_file_idx,
-                        true,
-                    )?;
-                    if let Some(file_idx) = target_file_idx {
-                        self.ctx.cache_cross_file_symbol_type(
-                            target_sym_id,
-                            file_idx as u32,
-                            resolved.0,
-                            resolved.1.clone(),
-                        );
-                    }
-                    Some(resolved)
-                })
-                .unwrap_or_else(|| {
-                    let resolved = self.type_reference_symbol_type_with_params(target_sym_id);
-                    if let Some(file_idx) = target_file_idx {
-                        self.ctx.cache_cross_file_symbol_type(
-                            target_sym_id,
-                            file_idx as u32,
-                            resolved.0,
-                            resolved.1.clone(),
-                        );
-                    }
-                    resolved
-                })
-        } else {
-            (self.get_type_of_symbol(target_sym_id), Vec::new())
-        };
-        result = self.apply_module_augmentations(&module_name, &import_name, result);
-        if result == TypeId::ERROR {
-            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                AliasOutcome::ErrorResult,
-            );
-            return None;
-        }
-        if result == TypeId::UNKNOWN {
-            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
-                AliasOutcome::UnknownResult,
-            );
-            return None;
-        }
-
-        self.ctx.symbol_types.insert(sym_id, result);
-        self.ctx.cache_cross_file_symbol_type(
-            sym_id,
-            alias_cache_file_idx as u32,
-            result,
-            params.clone(),
-        );
-        tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(AliasOutcome::Success);
-
-        Some((result, params))
-    }
-
-    fn cached_symbol_arena_or_cross_file_symbol_type(
-        &self,
-        sym_id: SymbolId,
-        file_idx: usize,
-        source_cache_scope: u64,
-        symbol_type_cache_from_symbol_arena: bool,
-    ) -> Option<(TypeId, Vec<tsz_solver::TypeParamInfo>)> {
-        let file_idx = file_idx as u32;
-        if !symbol_type_cache_from_symbol_arena {
-            return self.ctx.cached_cross_file_symbol_type(sym_id, file_idx);
-        }
-
-        self.ctx
-            .cached_stable_source_file_symbol_arena_type(sym_id, file_idx, source_cache_scope)
-    }
-
-    pub(super) fn cache_symbol_arena_or_cross_file_symbol_type(
-        &self,
-        sym_id: SymbolId,
-        file_idx: usize,
-        source_cache_scope: u64,
-        symbol_type_cache_from_symbol_arena: bool,
-        type_id: TypeId,
-        type_params: Vec<tsz_solver::TypeParamInfo>,
-    ) {
-        let file_idx = file_idx as u32;
-        if !symbol_type_cache_from_symbol_arena {
-            self.ctx
-                .cache_cross_file_symbol_type(sym_id, file_idx, type_id, type_params);
-            return;
-        }
-
-        self.ctx.cache_stable_source_file_symbol_arena_type(
-            sym_id,
-            file_idx,
-            source_cache_scope,
-            type_id,
-            type_params,
-        );
+        acc
     }
 
     /// Delegate symbol resolution to a checker using the correct arena.
@@ -581,6 +373,15 @@ impl<'a> CheckerState<'a> {
             || delegate_arena.is_some_and(|arena| !std::ptr::eq(arena, self.ctx.arena));
 
         if should_delegate {
+            // Session-memo key: the owner file of the delegated symbol. Uses
+            // the same `(owner_file_idx, raw SymbolId)` key shape as the
+            // canonical DefinitionStore cross-file buckets (the raw id is
+            // interpreted in the owner binder), independent of the stable
+            // shared-cache eligibility gate below.
+            let memo_file_idx = cross_file_idx
+                .or_else(|| delegate_arena.and_then(|arena| self.ctx.get_file_idx_for_arena(arena)))
+                .map(|idx| idx as u32);
+
             let symbol_type_cache_file_idx = self.symbol_arena_symbol_type_cache_file_idx(
                 needs_cross_file_delegation,
                 cross_file_idx,
@@ -609,6 +410,49 @@ impl<'a> CheckerState<'a> {
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             }
             let _delegate_depth_guard = tsz_common::perf_counters::enter_delegate();
+
+            // Delegation-tree memo of completed sentinel outcomes the shared
+            // store refuses: replay the first completion instead of
+            // re-running the full child checker per type-reference
+            // occurrence inside this tree (issue #13041). At depth 0 this
+            // call roots a new tree, so stale entries from the previous
+            // tree's in-progress context are dropped first.
+            if !Self::is_in_cross_arena_delegation() {
+                self.ctx
+                    .lib_delegation_cache
+                    .session_memo()
+                    .clear_for_new_delegation_tree();
+            }
+            let memo_context_fp = memo_file_idx
+                .is_some()
+                .then(|| self.cross_arena_context_fingerprint());
+            if let Some(file_idx) = memo_file_idx
+                && let Some(fp) = memo_context_fp
+                && let Some(hit) = self
+                    .ctx
+                    .lib_delegation_cache
+                    .session_memo()
+                    .symbol
+                    .get(&(file_idx, sym_id.0, fp))
+            {
+                let (cached_type, cached_params) = hit.clone();
+                drop(hit);
+                if cached_type != TypeId::ERROR && cached_type != TypeId::UNKNOWN {
+                    self.ctx.symbol_types.insert(sym_id, cached_type);
+                } else if needs_cross_file_delegation {
+                    // Mirror the full-work path's child merge-back: for
+                    // cross-file delegations the child's
+                    // `symbol_types[sym] = ERROR` is merged into the
+                    // requesting checker (`entry_or_insert`), and later
+                    // `get_type_of_symbol` lookups short-circuit on it.
+                    self.ctx.symbol_types.entry_or_insert(sym_id, cached_type);
+                }
+                if let Some(p) = perf {
+                    p.delegate_cross_arena_cache_hits_cross_file
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
+                return Some((cached_type, cached_params));
+            }
 
             if symbol_type_cache_file_idx.is_none()
                 && !needs_cross_file_delegation
@@ -1126,6 +970,24 @@ impl<'a> CheckerState<'a> {
                 );
             }
 
+            // Record completed *sentinel* results in the session memo so
+            // repeats within this file-check session replay them instead of
+            // re-running the child checker (issue #13041's livelock was
+            // exclusively repeated identical ERROR completions). Non-sentinel
+            // results stay on the gated shared-store caches above, which
+            // already model requester stability; memoizing them here changed
+            // elaboration output on the valibot/kysely canaries. In-progress
+            // guard returns above never reach this write.
+            if let Some(file_idx) = memo_file_idx
+                && let Some(fp) = memo_context_fp
+                && matches!(result, TypeId::ERROR | TypeId::UNKNOWN)
+            {
+                let memo = self.ctx.lib_delegation_cache.session_memo();
+                memo.symbol
+                    .insert((file_idx, sym_id.0, fp), (result, result_params.clone()));
+                memo.mark_dirty();
+            }
+
             self.ctx.leave_recursion();
             Self::leave_cross_arena_delegation();
             return Some((result, result_params));
@@ -1203,6 +1065,33 @@ impl<'a> CheckerState<'a> {
         {
             tsz_common::perf_counters::record_delegate_cross_arena_cache_hit_cross_file();
             return Some((cached_type, cached_params));
+        }
+
+        // Delegation-tree memo of completed `None`/sentinel outcomes the
+        // shared bucket refuses to store (issue #13041: repeated full
+        // child-checker recomputation). Non-sentinel results stay on the
+        // shared bucket above. At depth 0 this call roots a new tree, so
+        // stale entries from the previous tree's context are dropped first.
+        if !Self::is_in_cross_arena_delegation() {
+            self.ctx
+                .lib_delegation_cache
+                .session_memo()
+                .clear_for_new_delegation_tree();
+        }
+        let memo_context_fp = query_file_idx
+            .is_some()
+            .then(|| self.cross_arena_context_fingerprint());
+        if let Some(file_idx) = query_file_idx
+            && let Some(fp) = memo_context_fp
+            && let Some(hit) = self
+                .ctx
+                .lib_delegation_cache
+                .session_memo()
+                .class_instance
+                .get(&(file_idx as u32, sym_id.0, fp))
+        {
+            tsz_common::perf_counters::record_delegate_cross_arena_cache_hit_cross_file();
+            return hit.clone();
         }
 
         if !Self::enter_cross_arena_delegation() {
@@ -1293,6 +1182,23 @@ impl<'a> CheckerState<'a> {
             self.cache_shared_actual_lib_class_delegation(shared_name, *type_id);
         }
 
+        // Record only completed `None`/sentinel outcomes in the session
+        // memo; non-sentinel results already write through to the shared
+        // class-instance bucket above, which models requester stability.
+        // In-progress guard returns above never reach here.
+        let completed_negative = result
+            .as_ref()
+            .is_none_or(|(type_id, _)| matches!(*type_id, TypeId::ERROR | TypeId::UNKNOWN));
+        if completed_negative
+            && let Some(file_idx) = query_file_idx
+            && let Some(fp) = memo_context_fp
+        {
+            let memo = self.ctx.lib_delegation_cache.session_memo();
+            memo.class_instance
+                .insert((file_idx as u32, sym_id.0, fp), result.clone());
+            memo.mark_dirty();
+        }
+
         self.ctx.leave_recursion();
         Self::leave_cross_arena_delegation();
 
@@ -1351,6 +1257,35 @@ impl<'a> CheckerState<'a> {
                 .definition_store
                 .register_type_to_def(cached_type, def_id);
             return Some(cached_type);
+        }
+
+        // Delegation-tree memo of completed `None` (UNKNOWN/ERROR)
+        // child-checker outcomes the shared bucket refuses to store (issue
+        // #13041). Successful results stay on the shared interface bucket
+        // above. At depth 0 this call roots a new tree, so stale entries
+        // from the previous tree's context are dropped first.
+        if !Self::is_in_cross_arena_delegation() {
+            self.ctx
+                .lib_delegation_cache
+                .session_memo()
+                .clear_for_new_delegation_tree();
+        }
+        let memo_context_fp = query_file_idx
+            .is_some()
+            .then(|| self.cross_arena_context_fingerprint());
+        if let Some(file_idx) = query_file_idx
+            && let Some(fp) = memo_context_fp
+            && let Some(hit) = self
+                .ctx
+                .lib_delegation_cache
+                .session_memo()
+                .interface
+                .get(&(file_idx as u32, sym_id.0, fp))
+        {
+            let cached = *hit;
+            drop(hit);
+            tsz_common::perf_counters::record_delegate_cross_arena_cache_hit_cross_file();
+            return cached;
         }
         let delegate_binder = if let Some(file_idx) = delegate_file_idx {
             self.ctx
@@ -1476,7 +1411,7 @@ impl<'a> CheckerState<'a> {
         self.ctx.leave_recursion();
         Self::leave_cross_arena_delegation();
 
-        if result != TypeId::UNKNOWN && result != TypeId::ERROR {
+        let outcome = if result != TypeId::UNKNOWN && result != TypeId::ERROR {
             // Register instance type → DefId so the TypeFormatter can display
             // the interface name (e.g., "Date") instead of the structural form.
             // This mirrors the class registration in symbol_types.rs.
@@ -1491,7 +1426,23 @@ impl<'a> CheckerState<'a> {
             Some(result)
         } else {
             None
+        };
+
+        // Record only the completed-`None` (UNKNOWN/ERROR) child-checker
+        // outcome in the session memo; successful results were written to
+        // the shared interface bucket above. In-progress guard returns
+        // never reach here.
+        if outcome.is_none()
+            && let Some(file_idx) = query_file_idx
+            && let Some(fp) = memo_context_fp
+        {
+            let memo = self.ctx.lib_delegation_cache.session_memo();
+            memo.interface
+                .insert((file_idx as u32, sym_id.0, fp), outcome);
+            memo.mark_dirty();
         }
+
+        outcome
     }
 
     pub(crate) fn delegate_cross_arena_interface_member_simple_type(

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -131,7 +131,7 @@ impl<'a> CheckerState<'a> {
     /// is replayable only under the identical in-progress context.
     fn cross_arena_context_fingerprint(&self) -> u64 {
         #[inline]
-        fn mix(value: u64) -> u64 {
+        const fn mix(value: u64) -> u64 {
             // splitmix64 finalizer
             let mut z = value.wrapping_add(0x9E37_79B9_7F4A_7C15);
             z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_alias_shortcut.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_alias_shortcut.rs
@@ -1,0 +1,243 @@
+//! Cross-arena alias shortcut and the symbol-arena/cross-file symbol-type
+//! cache key plumbing used by `delegate_cross_arena_symbol_resolution`.
+//!
+//! Split out of `cross_file.rs` (2000-line shard cap).
+
+use crate::state::CheckerState;
+use tsz_binder::{SymbolId, symbol_flags};
+use tsz_common::perf_counters::CrossArenaAliasShortcutOutcome;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    pub(crate) fn try_resolve_cross_arena_named_alias_without_child(
+        &mut self,
+        sym_id: SymbolId,
+    ) -> Option<(TypeId, Vec<tsz_solver::TypeParamInfo>)> {
+        use CrossArenaAliasShortcutOutcome as AliasOutcome;
+
+        let (module_name, import_name, alias_source_file_idx) = {
+            let Some(symbol) = self.get_cross_file_symbol(sym_id) else {
+                tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                    AliasOutcome::MissingSymbol,
+                );
+                return None;
+            };
+            if symbol.flags & symbol_flags::ALIAS == 0 {
+                tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                    AliasOutcome::NotAlias,
+                );
+                return None;
+            }
+            let Some(module_name) = symbol.import_module.clone() else {
+                tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                    AliasOutcome::MissingModule,
+                );
+                return None;
+            };
+            let Some(import_name) = symbol.import_name.clone() else {
+                tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                    AliasOutcome::MissingImportName,
+                );
+                return None;
+            };
+            if import_name == "*" {
+                tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                    AliasOutcome::NamespaceImport,
+                );
+                return None;
+            }
+            if import_name == "default" {
+                tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                    AliasOutcome::DefaultImport,
+                );
+                return None;
+            }
+            let Some(alias_source_file_idx) = (symbol.decl_file_idx != u32::MAX)
+                .then_some(symbol.decl_file_idx as usize)
+                .or_else(|| self.ctx.resolve_symbol_file_index(sym_id))
+            else {
+                tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                    AliasOutcome::MissingAliasFile,
+                );
+                return None;
+            };
+            (module_name, import_name, alias_source_file_idx)
+        };
+
+        let alias_cache_file_idx = self
+            .ctx
+            .resolve_symbol_file_index(sym_id)
+            .unwrap_or(alias_source_file_idx);
+        let Some(target_sym_id) = self.resolve_cross_file_export_from_file(
+            &module_name,
+            &import_name,
+            Some(alias_source_file_idx),
+        ) else {
+            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                AliasOutcome::MissingTarget,
+            );
+            return None;
+        };
+        if target_sym_id == sym_id {
+            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                AliasOutcome::SelfTarget,
+            );
+            return None;
+        }
+
+        let Some(target_flags) = self
+            .get_cross_file_symbol(target_sym_id)
+            .map(|symbol| symbol.flags)
+        else {
+            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                AliasOutcome::MissingTargetSymbol,
+            );
+            return None;
+        };
+        if target_flags & symbol_flags::ALIAS != 0 {
+            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                AliasOutcome::TargetAlias,
+            );
+            return None;
+        }
+
+        let target_binder = self
+            .ctx
+            .resolve_symbol_file_index(target_sym_id)
+            .and_then(|file_idx| self.ctx.get_binder_for_file(file_idx))
+            .unwrap_or(self.ctx.binder);
+        if self
+            .ctx
+            .alias_partner_for(target_binder, target_sym_id)
+            .is_some()
+        {
+            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                AliasOutcome::AliasPartner,
+            );
+            return None;
+        }
+
+        let target_is_interface_value_merge = target_flags & symbol_flags::INTERFACE != 0
+            && target_flags & (symbol_flags::VARIABLE | symbol_flags::FUNCTION) != 0;
+        if target_is_interface_value_merge {
+            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                AliasOutcome::InterfaceValueMerge,
+            );
+            return None;
+        }
+
+        let target_file_idx = self
+            .ctx
+            .resolve_symbol_file_index(target_sym_id)
+            .or_else(|| {
+                self.ctx
+                    .resolve_import_target_from_file(alias_source_file_idx, &module_name)
+            });
+        if let Some(file_idx) = target_file_idx {
+            self.ctx
+                .register_symbol_file_target(target_sym_id, file_idx);
+        }
+        let (mut result, params) = if target_flags & symbol_flags::TYPE_ALIAS != 0 {
+            target_file_idx
+                .and_then(|file_idx| {
+                    self.ctx
+                        .cached_cross_file_symbol_type(target_sym_id, file_idx as u32)
+                })
+                .or_else(|| {
+                    let resolved = self.direct_source_file_type_alias_result(
+                        target_sym_id,
+                        target_file_idx,
+                        true,
+                    )?;
+                    if let Some(file_idx) = target_file_idx {
+                        self.ctx.cache_cross_file_symbol_type(
+                            target_sym_id,
+                            file_idx as u32,
+                            resolved.0,
+                            resolved.1.clone(),
+                        );
+                    }
+                    Some(resolved)
+                })
+                .unwrap_or_else(|| {
+                    let resolved = self.type_reference_symbol_type_with_params(target_sym_id);
+                    if let Some(file_idx) = target_file_idx {
+                        self.ctx.cache_cross_file_symbol_type(
+                            target_sym_id,
+                            file_idx as u32,
+                            resolved.0,
+                            resolved.1.clone(),
+                        );
+                    }
+                    resolved
+                })
+        } else {
+            (self.get_type_of_symbol(target_sym_id), Vec::new())
+        };
+        result = self.apply_module_augmentations(&module_name, &import_name, result);
+        if result == TypeId::ERROR {
+            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                AliasOutcome::ErrorResult,
+            );
+            return None;
+        }
+        if result == TypeId::UNKNOWN {
+            tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
+                AliasOutcome::UnknownResult,
+            );
+            return None;
+        }
+
+        self.ctx.symbol_types.insert(sym_id, result);
+        self.ctx.cache_cross_file_symbol_type(
+            sym_id,
+            alias_cache_file_idx as u32,
+            result,
+            params.clone(),
+        );
+        tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(AliasOutcome::Success);
+
+        Some((result, params))
+    }
+
+    pub(super) fn cached_symbol_arena_or_cross_file_symbol_type(
+        &self,
+        sym_id: SymbolId,
+        file_idx: usize,
+        source_cache_scope: u64,
+        symbol_type_cache_from_symbol_arena: bool,
+    ) -> Option<(TypeId, Vec<tsz_solver::TypeParamInfo>)> {
+        let file_idx = file_idx as u32;
+        if !symbol_type_cache_from_symbol_arena {
+            return self.ctx.cached_cross_file_symbol_type(sym_id, file_idx);
+        }
+
+        self.ctx
+            .cached_stable_source_file_symbol_arena_type(sym_id, file_idx, source_cache_scope)
+    }
+
+    pub(super) fn cache_symbol_arena_or_cross_file_symbol_type(
+        &self,
+        sym_id: SymbolId,
+        file_idx: usize,
+        source_cache_scope: u64,
+        symbol_type_cache_from_symbol_arena: bool,
+        type_id: TypeId,
+        type_params: Vec<tsz_solver::TypeParamInfo>,
+    ) {
+        let file_idx = file_idx as u32;
+        if !symbol_type_cache_from_symbol_arena {
+            self.ctx
+                .cache_cross_file_symbol_type(sym_id, file_idx, type_id, type_params);
+            return;
+        }
+
+        self.ctx.cache_stable_source_file_symbol_arena_type(
+            sym_id,
+            file_idx,
+            source_cache_scope,
+            type_id,
+            type_params,
+        );
+    }
+}

--- a/crates/tsz-checker/src/state/type_analysis/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/mod.rs
@@ -15,6 +15,7 @@ mod core;
 mod core_type_query;
 pub(crate) mod cross_file;
 mod cross_file_alias_cycle;
+mod cross_file_alias_shortcut;
 mod cross_file_cache;
 mod cross_file_delegation;
 pub(crate) mod cross_file_direct;


### PR DESCRIPTION
Fixes #13041 — drizzle-orm benchmark-canary CPU livelock (tsc 2.24s; tsz pegged one core >900s with zero diagnostics emitted). With this PR the fixture completes in ~6.5 minutes; the >900s livelock is gone.

AgentName: StudioOpus

Track: performance / project-corpus runtime blocker (drizzle-orm row)

Invariant: the memoization is semantics-preserving. The new `CrossArenaSessionMemo` (embedded in `CrossFileDelegationCache`) records only *completed sentinel* cross-arena delegation outcomes — never in-progress guard returns, never successful results:
- Cache key: `(owner_file_idx: u32, raw SymbolId: u32, context_fingerprint: u64)`. The first two components are the same global key shape the canonical `DefinitionStore` cross-file buckets use (raw `SymbolId` interpreted in the owner file's binder). The fingerprint is an order-independent splitmix64/XOR hash of the requesting checker's in-progress resolution sets (`symbol_resolution_set`, `class_instance_resolution_set`, `class_constructor_resolution_set`) — the mutable context a delegated computation's cycle detection can observe. A completed sentinel is replayed only for a repeat under the *identical* in-progress context, where the recomputation is the same deterministic function and reproduces it.
- Scope/invalidation: one `Arc` per top-level file checker, shared (not cloned) with transient child checkers via `with_parent_cache`; cleared whenever a memo-consuming delegation entry point roots a **new outermost delegation tree** (cross-arena depth 0; one relaxed atomic when the memo is empty), and replaced on `reset_for_next_file`/`clear_file_local`. All other delegation inputs (arenas, binders, merged libs, compiler options) are immutable per session, so no further invalidation exists or is needed.
- Sentinel discipline: shared `DefinitionStore` buckets refuse `ERROR`/`UNKNOWN` writes because an in-progress sentinel must not poison other checkers; the memo distinguishes *completed* sentinels and replays them only within the producing tree+context. On a cross-file hit, the child merge-back side effect (`symbol_types entry_or_insert` of the sentinel) is mirrored.
- Why not memoize successes or replay across contexts: both were tried and changed elaboration output on the valibot/kysely canaries (+1 to +25 errors). The shipped form showed no delta beyond the canaries' own pre-existing run-to-run nondeterminism (see Verification).

Scope: `crates/tsz-checker` only — `context/cross_file_delegation_cache.rs` (new `CrossArenaSessionMemo`), `context/{constructors,file_session_reset,mod}.rs` wiring comments, the three `delegate_cross_arena_*` functions in `state/type_analysis/cross_file.rs`, and a mechanical split of the alias-shortcut/cache-key helpers into `state/type_analysis/cross_file_alias_shortcut.rs` (2000-line shard cap). No solver, binder, emitter, or diagnostic-path changes.

## Structural rule

When the same `(owner file, symbol)` cross-arena delegation repeats inside one delegation tree under the identical in-progress context and its completed result is a sentinel, `tsc` computes a symbol's type once per program; `tsz` re-ran the full child-checker pipeline (child `CheckerState` + cross-file state copy + nested delegation tree) at every type-reference occurrence, because completed sentinel results were uncacheable everywhere. tsz now replays the completed outcome through the delegation-tree memo owned by the checker's cross-file delegation layer.

Diagnosis (10s `sample` of the pegged process, matching the issue's two samples, plus targeted tracing): the worker sat in `check_class_declaration -> get_class_instance_type_inner -> base_instance_type_from_expression -> type_reference_symbol_type -> delegate_cross_arena_{symbol,class_instance,interface}_type -> get_type_of_interface -> recurse`; `lookup_any_file_key` (1,392 leaf samples) and `core::fmt`/`format_inner` (~1,600) were hot only because the delegation trees re-ran. Tracing proved every repeated full-work delegation completed with `result = TypeId::ERROR` (e.g. `SelectedFields`: 2,693 identical recomputations in a 73-file subset; depth-guard early returns were 60 of 3,908 events). The issue's fix-directions 2/3 (file-key interning, export-resolution memo) were not needed: those leaves shrink proportionally once the recomputation collapses.

## Project Corpus Impact
- Row: drizzle-orm-project
- Bug family: cross-arena class/interface type recomputation livelock

## Verification

drizzle-orm fixture (448 files, `tsz --noEmit -p tsconfig.tsz-guard.json`, dist-fast, same machine):

| metric | before (origin/main cf604d2bd2) | after |
| --- | --- | --- |
| wall time | timeout >300s (issue: >900s, killed) | 388-392s (two runs, completes; rc=2 with ~4,200 diagnostics) |
| peak RSS | 751 MB at kill | 751-754 MB |
| diagnostics | none emitted | completes (~4,200; red row, see caveat) |

73-file pg-core subset (attribution mode): total time 38.1s -> 19.0s; delegation full-work misses 6,715 -> 798; diagnostics byte-identical.

Canary error counts, own baseline binary (cf604d2bd2) vs this PR, same cwd:

| canary | baseline | this PR | delta |
| --- | --- | --- | --- |
| zod | 86 | 86 | 0 |
| comlink | 7 | 7 | 0 |
| msw | 215 (x2 runs) | 215 (x2 runs) | 0 |
| ofetch | 46 | 46 | 0 |
| ts-rest | 31 | 31 | 0 |
| kysely | 193 (wobbles 188-193 run-to-run) | 193 | 0 |
| valibot | 1813/1814 (wobbles run-to-run) | 1814 | 0 (matching base run is error-for-error identical) |
| effect | timeout >900s on main | still times out at 900s (rc=124; pre-existing, different bottleneck — my caches did not unlock it) | n/a |

Caveat: kysely, valibot, and drizzle diagnostics are run-to-run nondeterministic *with the same binary* (pre-existing; parallel file order feeds order-dependent cross-file results on red rows). The deltas above are within that envelope; the strict-variant experiments that exceeded it (success memoization, cross-context sentinel replay) were rejected.

- `cargo nextest run -p tsz-checker -E 'test(/cross_file|cross_arena|interface|heritage|class/)'`: 1847 run / 1823 passed / 24 failed on this branch — failure set byte-identical to origin/main (cf604d2bd2) under the same filter (all 24 pre-existing; zero novel failures)
- `python3 scripts/arch/arch_guard.py`: passes.
- clippy (ci-lint) on tsz-checker: test-profile build compiles clean under the workspace deny set (clippy::correctness/perf/complexity/style enforced at build time); `python3 scripts/arch/arch_guard.py` passes on the final head
- vite/nextjs fixtures: not present under `.target/project-compile-guard` in this checkout — skipped (noted).

## Coordination Notes

Fixes #13041. Campaign context: #13031, #13037, #13139, #13142, #13145 landed before this branch. Remaining known follow-ups on the drizzle row are parity bugs, not runtime blockers: (a) cross-file type aliases whose bodies reference import aliases complete with `ERROR` through the child-checker path (`direct_source_file_type_alias` rejects `local_alias_symbol` bodies; `tsc` compiles this fixture clean in 2.24s) — fixing that family would make these results cacheable in the canonical buckets and is the next big lever; (b) run-to-run diagnostic nondeterminism under parallel checking on red rows; (c) drizzle at ~390s still far from tsc's 2.24s — the remaining hot loop is the per-(context,tree) recomputation of the same ERROR aliases, bounded but still dominant.
