### PR TITLE
fix(checker): identity-aware return-context binding for shadowed type params (kysely Promise TResult2 family)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1176,6 +1176,9 @@ mod rest_parameter_relation_routing_arch_tests;
 #[path = "tests/return_context_promise_identity_tests.rs"]
 mod return_context_promise_identity_tests;
 #[cfg(test)]
+#[path = "tests/return_context_type_param_shadowing_tests.rs"]
+mod return_context_type_param_shadowing_tests;
+#[cfg(test)]
 #[path = "../tests/reverse_mapped_inference_tests.rs"]
 mod reverse_mapped_inference_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/return_context_type_param_shadowing_tests.rs
+++ b/crates/tsz-checker/src/tests/return_context_type_param_shadowing_tests.rs
@@ -1,0 +1,146 @@
+//! Return-context inference when an enclosing function's type parameter
+//! shares its name with the callee's type parameter.
+//!
+//! Structural rule: `tsc` identifies type parameters by symbol, never by
+//! name. When an `async` function `execute<T>(): Promise<T>` returns a
+//! generic call `provide<T>(..): Promise<T>`, the contextual return type
+//! (`T | PromiseLike<T> | Promise<T>`) mentions the *enclosing* `T`, which is
+//! a distinct entity from the callee's `T`. The name-keyed blocking in the
+//! return-context substitution used to refuse the legitimate binding
+//! (callee `T` := enclosing `T`) and later bind callee `T` to a lib
+//! `Promise.then` signature parameter instead, producing
+//! `Type 'Promise<TResult2>' is not assignable to type 'T'`
+//! (kysely.ts 707/717/751/776, tracker #10663).
+
+use crate::test_utils::check_source_diagnostics;
+
+fn diagnostic_summaries(source: &str) -> Vec<String> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|diagnostic| format!("TS{}: {}", diagnostic.code, diagnostic.message_text))
+        .collect()
+}
+
+#[test]
+fn async_return_of_generic_call_with_shadowed_type_param_is_clean() {
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+declare function provide<T>(p: Promise<T>): Promise<T>;
+
+async function execute<T>(callback: () => Promise<T>): Promise<T> {
+    return provide(callback());
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "same-named callee/enclosing type params must not block return-context inference; got {diags:?}"
+    );
+}
+
+#[test]
+fn async_return_of_generic_call_with_shadowed_param_async_callback_is_clean() {
+    // The kysely.ts witness shape: a generic method whose async-arrow
+    // consumer is contextually typed from the callee's parameter. The leaked
+    // `TResult2` binding used to contaminate the arrow's contextual return
+    // type, producing `Type 'T' is not assignable to type 'TResult2'`.
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+interface Runner {
+    withConnection<T>(consumer: (connection: string) => Promise<T>): Promise<T>;
+}
+
+class Builder {
+    declare readonly runner: Runner;
+
+    async run<T>(callback: (db: number) => Promise<T>): Promise<T> {
+        return this.runner.withConnection(async (connection) => {
+            return await callback(connection.length);
+        });
+    }
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "async-arrow consumer with shadowed type param must infer through the contextual Promise; got {diags:?}"
+    );
+}
+
+#[test]
+fn async_return_of_generic_call_with_renamed_type_params_is_clean() {
+    // Renamed-binder adjacents: the fix must not depend on the parameters
+    // actually colliding.
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+declare function provideA<TInner>(p: Promise<TInner>): Promise<TInner>;
+declare function provideB<T>(p: Promise<T>): Promise<T>;
+
+async function executeA<TOuter>(callback: () => Promise<TOuter>): Promise<TOuter> {
+    return provideA(callback());
+}
+
+async function executeB<TOuter>(callback: () => Promise<TOuter>): Promise<TOuter> {
+    return provideB(callback());
+}
+
+async function executeC<TResult1>(callback: () => Promise<TResult1>): Promise<TResult1> {
+    return provideA(callback());
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "renamed type-param adjacents must stay clean; got {diags:?}"
+    );
+}
+
+#[test]
+fn sync_return_of_generic_call_with_shadowed_type_param_is_clean() {
+    // Non-async fallback: the contextual type is the plain `Promise<T>`
+    // annotation rather than the async awaited union.
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+declare function provide<T>(p: Promise<T>): Promise<T>;
+
+function execute<T>(callback: () => Promise<T>): Promise<T> {
+    return provide(callback());
+}
+"#,
+    );
+    assert!(
+        diags.is_empty(),
+        "non-async shadowed type params must stay clean; got {diags:?}"
+    );
+}
+
+#[test]
+fn async_return_of_mismatched_generic_call_still_reports_ts2322() {
+    // Negative case: an actually-wrong return must still fail with tsc's
+    // diagnostic (`number` is not the enclosing `T`).
+    let diags = diagnostic_summaries(
+        r#"
+/// <reference lib="es2015.promise" />
+declare function provide<T>(p: Promise<T>): Promise<T>;
+
+async function bad<T>(callback: () => Promise<T>): Promise<T> {
+    return provide(Promise.resolve(123));
+}
+"#,
+    );
+    assert_eq!(
+        diags.len(),
+        1,
+        "concrete mismatch must still be reported exactly once; got {diags:?}"
+    );
+    assert!(
+        diags[0].starts_with("TS2322:")
+            && diags[0].contains("'number'")
+            && diags[0].contains("'T'"),
+        "expected TS2322 number-vs-T; got {diags:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/call_inference/return_context.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference/return_context.rs
@@ -25,7 +25,8 @@ impl<'a> CheckerState<'a> {
                 if tracked_type_params.contains(&tp.name)
                     && target != TypeId::UNKNOWN
                     && target != TypeId::ERROR
-                    && !self.target_contains_blocking_return_context_type_params(
+                    && !self.return_context_binding_target_blocked(
+                        referenced,
                         target,
                         tracked_type_params,
                     )
@@ -66,7 +67,8 @@ impl<'a> CheckerState<'a> {
                 && tracked_type_params.contains(&tp.name)
                 && target != TypeId::UNKNOWN
                 && target != TypeId::ERROR
-                && !self.target_contains_blocking_return_context_type_params(
+                && !self.return_context_binding_target_blocked(
+                    indexed_object,
                     target,
                     tracked_type_params,
                 )

--- a/crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference/return_context_substitution.rs
@@ -30,6 +30,49 @@ struct ReturnContextShapeSubstitutionRequest<'a> {
 }
 
 impl<'a> CheckerState<'a> {
+    /// Whether binding the tracked type parameter `source_tp` to `target`
+    /// must be refused during return-context substitution.
+    ///
+    /// `tsc` identifies type parameters by symbol, never by name. When the
+    /// contextual target is a *bare* type parameter from an enclosing
+    /// declaration that merely shares the callee parameter's name (for
+    /// example `async execute<T>(..): Promise<T>` returning
+    /// `provide<T>(..)`), the binding callee-`T` := enclosing-`T` is
+    /// legitimate and must not be refused. The previous name-keyed check
+    /// refused it and let a later structural walk bind the parameter to an
+    /// unrelated lib signature type parameter instead (for example
+    /// `Promise.then`'s `TResult2`), yielding
+    /// `Type 'Promise<TResult2>' is not assignable to type 'T'`.
+    ///
+    /// Composite targets that mention a tracked name (for example
+    /// `ReadonlyArray<T>`) keep the conservative name-keyed blocking: the
+    /// return-context substitution is merged with priority over
+    /// argument-driven inference, so admitting composite bindings here can
+    /// override correct argument inference (`freeze([arg])` against a
+    /// contextual `ReadonlyArray<T>`).
+    pub(super) fn return_context_binding_target_blocked(
+        &self,
+        source_tp: TypeId,
+        target: TypeId,
+        tracked_type_params: &FxHashSet<Atom>,
+    ) -> bool {
+        if common::contains_infer_types(self.ctx.types, target) {
+            return true;
+        }
+        // Fast path: no same-named mention at all means no possible
+        // self-reference.
+        if !common::references_any_type_param_named(self.ctx.types, target, tracked_type_params) {
+            return false;
+        }
+        if common::type_param_info(self.ctx.types, target).is_some() {
+            // A bare type parameter target blocks only when it is the very
+            // parameter being bound (identity), not a same-named parameter
+            // from another declaration scope.
+            return self.contains_type_parameter_identity_shallow(target, source_tp);
+        }
+        true
+    }
+
     fn array_or_number_index_element_type(&mut self, type_id: TypeId) -> Option<TypeId> {
         if let Some(elem) = common::array_element_type(self.ctx.types, type_id) {
             return Some(elem);
@@ -152,8 +195,7 @@ impl<'a> CheckerState<'a> {
             && tracked_type_params.contains(&tp.name)
             && target != TypeId::UNKNOWN
             && target != TypeId::ERROR
-            && !self
-                .target_contains_blocking_return_context_type_params(target, tracked_type_params)
+            && !self.return_context_binding_target_blocked(source, target, tracked_type_params)
         {
             if substitution.get(tp.name).is_none() {
                 substitution.insert(tp.name, target);
@@ -232,7 +274,8 @@ impl<'a> CheckerState<'a> {
                         && substitution.get(tp.name).is_none()
                         && target_member != TypeId::UNKNOWN
                         && target_member != TypeId::ERROR
-                        && !self.target_contains_blocking_return_context_type_params(
+                        && !self.return_context_binding_target_blocked(
+                            source_member,
                             target_member,
                             tracked_type_params,
                         )


### PR DESCRIPTION
AgentName: M1FableArchitect
Track: conformance / project corpus (kysely row, tracker #10663)
Invariant: return-context substitution must identify type parameters the way `tsc` does — by declaration identity, never by name; argument-driven inference must not be displaced by name-collision artifacts.
Scope: checker-only — `types/computation/call_inference/{return_context_substitution.rs,return_context.rs}` binding-block predicate + new test shard. No solver, emitter, or shared-helper changes (`target_contains_blocking_return_context_type_params` keeps its other three consumers untouched).

## Problem

`kysely.ts` (707,5)/(751,5) `TS2322: Type 'Promise<TResult2>' is not assignable to type 'T'` and (717,7)/(776,9) `TS2322: Type 'T' is not assignable to type 'TResult2'`. tsc 5.9.3 is clean. Minimal witness (tsz errored, tsc clean):

```ts
declare function provide<T>(p: Promise<T>): Promise<T>

async function execute<T>(callback: () => Promise<T>): Promise<T> {
  return provide(callback())
}
```

Renaming either type parameter (or making the outer function non-async) made it pass, and the same failure reproduces with both parameters named `TResult1` — a pure name-collision defect, not a Promise-specific one.

## Root cause

In an async function the return expression's contextual type is built as `T | PromiseLike<T> | Promise<T>` (`core_statement_checks.rs`). The return-context substitution (`collect_return_context_substitution`) tracks the callee's type parameters **by name** (`FxHashSet<Atom>`), and its binding-block predicate (`target_contains_blocking_return_context_type_params` → `references_any_type_param_named`) refused the legitimate binding callee-`T` := enclosing-`T` because the enclosing skolem merely shares the name. With the legitimate binding refused, the structural walk descended into the lib `Promise`/`PromiseLike` `then` signatures and the "target is a tracked type param → infer from source" branch inserted `T := TResult2` (verified by instrumentation: `rcs insert site="target_tracked_from_source" name="T" source=TResult2 target=T`). The contaminated substitution instantiated the call's return type to `Promise<TResult2>` and the consumer arrow's contextual parameter types to `TResult2`, producing both diagnostic shapes. The solver's argument-driven `resolve_generic_call` had already inferred the correct answer (`T := enclosing T`) in the same check.

## Structural rule

When a generic call's contextual return type references a *bare* type parameter of an enclosing declaration whose name equals one of the callee's type parameters, tsc treats it as an opaque foreign type and infers callee-`T` := enclosing-`T`; tsz now does the same through the checker's return-context substitution by blocking a binding only when the candidate target is the *very parameter being bound* (TypeId/declaration identity via `contains_type_parameter_identity_shallow`), not a same-named parameter from another scope.

Composite targets that mention a tracked name (e.g. `ReadonlyArray<T>`) deliberately keep the conservative name-keyed blocking: the return-context substitution merges with priority over argument inference (`merge_return_context_substitution`), and admitting composite bindings regressed `freeze([arg])` against contextual `ReadonlyArray<T>` (kysely `object-utils.ts`) during development — that variant was tested and rejected.

## Adjacent-case matrix (new tests, `return_context_type_param_shadowing_tests.rs`)

- shadowed `T`, async, direct generic call → clean (was 1 false TS2322)
- shadowed `T`, async, generic method + async-arrow consumer (kysely witness shape) → clean (was 2)
- renamed binders `TInner`/`TOuter`, `T`/`TOuter`, `TResult1`/`TInner` → clean (unchanged)
- shadowed `T`, non-async → clean (unchanged)
- negative: concrete mismatch `provide(Promise.resolve(123))` → still exactly one `TS2322: 'number' … 'T'` (tsc-matching main message)

## Project Corpus Impact
- Row: kysely-project
- Bug family: TS2322 Promise-inference `TResult2` leak (return-context type-param name shadowing); kysely guard config 188 → 183 errors (kysely.ts 707/717/751/776 cleared, plus expression-builder.ts(1398) TS2740 same-family bonus), zero new sites (`diff` of full guard outputs is removals-only).

## Verification
- `tsz --noEmit -p .target-bench/external/kysely/tsconfig.tsz-guard.json`: 188 → 183, site-level diff removals-only.
- `cargo nextest run -p tsz-checker -E 'test(return_context) or test(promise) or test(direct_generic_return) or test(shadowing)'`: pass (includes 5 new tests).
- `cargo nextest run -p tsz-solver`: 6605/6606; the single failure (`higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`) also fails on a clean `main` checkout with the solver untouched — pre-existing, unrelated (checker-only diff; solver does not depend on checker).
- `cargo clippy -p tsz-checker --all-targets`: clean.
- `scripts/arch/check-checker-boundaries.sh`: passed.

## Coordination Notes
- Slice of tracker #10663 (kysely row family map); independent of #10661 (typeof/class identity) and #8773 (builder-chain contextual generics).
- Residual same-family parity gaps left intentionally out of scope (pre-existing before this PR, tsc-clean): sync block-bodied arrow consumer (`Promise<string>` display oddity) and bare-`T` consumer requiring nested-promise unwrap; both documented in the investigation notes and unchanged by this PR.
- The remaining name-keyed `TypeSubstitution` machinery is a known broader campaign; this PR fixes the binding-block predicate only.
