### PR TITLE
fix(checker): typeof EnumDeclaration in type position returns namespace type not union

### DIFF
--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -429,6 +429,12 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         if use_flow_sensitive_query
             && let Some(&expr_type) = self.ctx.node_types.get(&type_query.expr_name.0)
             && expr_type != TypeId::ERROR
+            // Don't use a cached enum-union type as the result of `typeof EnumDeclaration`.
+            // The flow-sensitive pre-resolution caches the symbol's declared type (the union
+            // 0|1|2|3) under the identifier node, but `typeof EnumName` must resolve to the
+            // namespace type (the object with member properties). Skip the cache so the ENUM
+            // branch below can return the correct TypeQuery instead.
+            && crate::query_boundaries::common::enum_def_id(self.ctx.types, expr_type).is_none()
         {
             if let Some(type_arguments) = &type_arguments {
                 return self
@@ -451,6 +457,33 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             if let Some(escaped_name) = type_only_name {
                 self.emit_type_query_type_only_error(&escaped_name, type_query.expr_name);
                 return TypeId::ERROR;
+            }
+
+            // `typeof EnumDeclaration` must resolve to the enum namespace type (the object
+            // `{ Up: 0, Down: 1, … }`), not to the union type stored in `symbol_types`.
+            // Return the cached namespace type when available, otherwise defer via TypeQuery
+            // so the solver can resolve it on demand. This is separate from enum-member types
+            // (`Direction.Up`) and variables typed as an enum (`x: Direction`), which both
+            // carry the union/literal type and must NOT be intercepted here.
+            if sym_flags & tsz_binder::symbol_flags::ENUM != 0
+                && sym_flags & tsz_binder::symbol_flags::ENUM_MEMBER == 0
+            {
+                if let Some(&ns_type) = self.ctx.enum_namespace_types.get(&sym_id) {
+                    if let Some(type_arguments) = &type_arguments {
+                        return self.apply_instantiation_expression_type_arguments(
+                            ns_type,
+                            type_arguments,
+                        );
+                    }
+                    return ns_type;
+                }
+                let factory = self.ctx.types.factory();
+                let base = factory.type_query(tsz_solver::SymbolRef(sym_id.0));
+                if let Some(type_arguments) = &type_arguments {
+                    return self
+                        .apply_instantiation_expression_type_arguments(base, type_arguments);
+                }
+                return base;
             }
 
             if sym_flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0

--- a/crates/tsz-checker/src/types/type_node_advanced/enum_indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/enum_indexed_access.rs
@@ -20,7 +20,46 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             return None;
         }
 
-        self.ctx.enum_namespace_types.get(&sym_id).copied()
+        if let Some(&ns_type) = self.ctx.enum_namespace_types.get(&sym_id) {
+            return Some(ns_type);
+        }
+
+        // Cache miss: the enum namespace type hasn't been computed yet (it is
+        // populated lazily when `get_type_of_symbol` runs for the enum, which
+        // happens after this type-node check for inline `(typeof Enum)["K"]`
+        // expressions). Build a minimal property-existence object from the
+        // binder's export table so that the TS2339 key check below can verify
+        // whether the key actually exists on the enum namespace without
+        // requiring the full `merge_namespace_exports_into_object` path (which
+        // is only available on `CheckerState`).  The actual indexed-access
+        // return type is computed by the solver via `evaluated_indexed_type`,
+        // independently of this object.
+        let Some(exports) = symbol.exports.as_ref() else {
+            return None;
+        };
+        let factory = self.ctx.types.factory();
+        let props: Vec<tsz_solver::PropertyInfo> = exports
+            .iter()
+            .map(|(name, _)| {
+                let name_atom = self.ctx.types.intern_string(name);
+                tsz_solver::PropertyInfo {
+                    name: name_atom,
+                    type_id: tsz_solver::TypeId::ANY,
+                    write_type: tsz_solver::TypeId::ANY,
+                    optional: false,
+                    readonly: true,
+                    is_method: false,
+                    is_class_prototype: false,
+                    visibility: tsz_common::Visibility::Public,
+                    parent_id: None,
+                    declaration_order: 0,
+                    is_string_named: false,
+                    is_symbol_named: false,
+                    single_quoted_name: false,
+                }
+            })
+            .collect();
+        Some(factory.object(props))
     }
 
     fn type_surface_is_type_query_alias(&self, type_id: TypeId) -> bool {

--- a/crates/tsz-checker/src/types/type_node_advanced/enum_indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/enum_indexed_access.rs
@@ -34,9 +34,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         // is only available on `CheckerState`).  The actual indexed-access
         // return type is computed by the solver via `evaluated_indexed_type`,
         // independently of this object.
-        let Some(exports) = symbol.exports.as_ref() else {
-            return None;
-        };
+        let exports = symbol.exports.as_ref()?;
         let factory = self.ctx.types.factory();
         let props: Vec<tsz_solver::PropertyInfo> = exports
             .iter()


### PR DESCRIPTION
AgentName: dazzling-johnson

## Track
Compiler — diagnostic parity (TS2339 false positive)

## Invariant
For any enum `E`, `(typeof E)["MemberKey"]` and `{ [K in keyof typeof E]: (typeof E)[K] }` must
not emit TS2339. `typeof EnumDeclaration` in a type position resolves to the enum namespace
object type `{ Up: 0, Down: 1, … }`, never to the enum's value-domain union `0 | 1 | 2 | 3`.

## Scope
`crates/tsz-checker/src/types/type_node_advanced.rs` —
`TypeNodeChecker::get_type_from_type_query`

`crates/tsz-checker/src/types/type_node_advanced/enum_indexed_access.rs` —
`TypeNodeChecker::enum_namespace_property_object`

## Root Cause
`compute_helpers_binding` pre-resolves TYPE_QUERY identifier nodes in type alias bodies and
caches their types in `node_types[identifier_node]`. For `typeof Direction`, the identifier
`Direction` resolves to the symbol's declared type — `TypeData::Enum(def_id, union)` — which
is the value-domain union (`0 | 1 | 2 | 3`), not the namespace object.

`get_type_from_type_query` hit this cached union type in the flow-sensitive fast path and
returned it directly.  Downstream, `enum_namespace_property_object` received an `object_type`
of `TypeData::Enum` instead of a TypeQuery or namespace object, failed its guard, returned
`None`, and the indexed-access type resolver fell through to property-access on the union,
hit `PropertyNotFound`, and emitted a false TS2339 for every valid member key.

## Fix (two-part)

**Fix 1 — skip stale cache (`type_node_advanced.rs`)**
The `node_types` fast-path now has an extra guard:
`&& crate::query_boundaries::common::enum_def_id(self.ctx.types, expr_type).is_none()`

When the cached type is `TypeData::Enum`, we skip the fast path so the ENUM-declaration
branch below can run.

**Fix 2 — return namespace type for ENUM declarations (`type_node_advanced.rs`)**
Immediately after `resolve_type_query_symbol` succeeds, for symbols with the `ENUM` flag
and not `ENUM_MEMBER`, we:
- Return the cached namespace type from `enum_namespace_types` if available.
- Otherwise construct a deferred `TypeQuery(SymbolRef)` so the solver resolves the namespace
  object on demand — which returns `ANY` for missing properties instead of `PropertyNotFound`,
  safely suppressing false TS2339 during incremental elaboration.

This is structurally sound: enum-member types (`Direction.Up`) and variables typed as an enum
(`x: Direction`) carry the union/literal type and are NOT intercepted — only the enum
declaration symbol itself triggers this path.

**Fix 3 — property-existence fallback (`enum_indexed_access.rs`)**
`enum_namespace_property_object` now builds a minimal property-existence object from the
binder's export table on a cache miss. This lets the TS2339 key guard validate member names
even before the full namespace type has been materialised, without requiring the
`merge_namespace_exports_into_object` path (available only on `CheckerState`).

## Adjacent Cases Covered
- Numeric enum — direct indexed access: `obj["Up"]` → number (pre-existing)
- Numeric enum — property access: `obj.Up` → number (pre-existing)
- `(typeof Direction)["Up"]` inline → no TS2339 (NEW — was failing)
- `(typeof Mode)["Write"]` renamed member → no TS2339 (NEW — was failing)
- `DirectionObject["Up"]` (alias of `typeof Direction`) → no TS2339 (NEW — was failing)
- Mapped type `{ [K in keyof typeof Flags]: (typeof Flags)[K] }` → no TS2322 (pre-existing)
- `Direction["Up"]` where `Direction` is the VALUE type → still fires TS2339 (negative case)
- String enums, auto-incremented enums, inline mapped types — all green

## Project Corpus Impact
- Row: n/a
- Bug family: enum indexed access / typeof-enum false TS2339

Evidence: All 17 `enum_indexed_access_tests` pass (3 previously failing):
`test_numeric_enum_typeof_indexed_access_literal_member`,
`test_numeric_enum_typeof_indexed_access_literal_renamed_member`,
`test_string_enum_typeof_indexed_access_literal_member`.
All 82 `indexed_access` lib tests pass. No new failures introduced (pre-existing zod_type_query
failures confirmed unchanged by stash comparison).

## Verification
```
cargo test -p tsz-checker --test enum_indexed_access_tests
# test result: ok. 17 passed; 0 failed

cargo test -p tsz-checker --lib indexed_access
# test result: ok. 82 passed; 0 failed
```

## Coordination Notes
No overlap with open PRs. Touches only `TypeNodeChecker::get_type_from_type_query` and
`enum_namespace_property_object` — both are checker-layer helpers with no solver or emitter
side-effects. The `TypeQuery` deferred path was already used by this function for other symbol
kinds; this change adds enum declarations as an additional case following the same pattern.

## Goal
Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-4-6
Effort: high