### PR TITLE
fix(test): TS2411 — exactOptionalPropertyTypes optional prop is exactly T, no error

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_checks_tests.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_checks_tests.rs
@@ -178,6 +178,10 @@ class C {
 
 #[test]
 fn ts2411_exact_optional_property_types_excludes_optional_declared_string() {
+    // With exactOptionalPropertyTypes, `foo?: string` is exactly `string` (no undefined
+    // widening), so it is assignable to the `string` index and produces no TS2411. Only
+    // `bar?: string | undefined`, whose annotation explicitly carries `undefined`, conflicts
+    // with the `string` index type. Verified against tsc 6.0.2.
     let diags = check_with_options(
         r#"
 interface Test {
@@ -207,6 +211,9 @@ interface Test {
 
 #[test]
 fn ts2411_exact_optional_property_types_with_renamed_optional() {
+    // Same rule with different names: `count?: number` is exactly `number` under EOP and
+    // raises no TS2411, while `value?: number | undefined` carries explicit `undefined` and
+    // conflicts with the `number` index type. Verified against tsc 6.0.2.
     let diags = check_with_options(
         r#"
 interface MyMap {

--- a/crates/tsz-checker/src/state/state_checking_members/index_signature_type_helpers.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/index_signature_type_helpers.rs
@@ -4,6 +4,12 @@ use tsz_solver::TypeId;
 impl<'a> CheckerState<'a> {
     /// Returns `base_type | undefined` for optional props under strict-null-checks, unless
     /// `exactOptionalPropertyTypes` is on — EOP means `p?: T` is exactly `T`, not `T | undefined`.
+    ///
+    /// This mirrors `tsc`'s `getNonMissingTypeOfSymbol`: an optional property's type is read with
+    /// the synthetic "missing" marker stripped, so under `exactOptionalPropertyTypes` a `p?: T`
+    /// property contributes exactly `T` to the index-signature (TS2411) check. Any *explicit*
+    /// `undefined` written in the annotation (`p?: T | undefined`) is preserved, so it still
+    /// participates in the check.
     pub(crate) fn index_sig_optional_type(&self, base_type: TypeId, optional: bool) -> TypeId {
         if optional && self.ctx.strict_null_checks() && !self.ctx.exact_optional_property_types() {
             self.ctx.types.union2(base_type, TypeId::UNDEFINED)

--- a/crates/tsz-checker/tests/optional_property_subtype_compatibility_tests.rs
+++ b/crates/tsz-checker/tests/optional_property_subtype_compatibility_tests.rs
@@ -8,7 +8,10 @@
 //! it does not make an absent property count as present.
 
 use crate::context::CheckerOptions;
-use crate::test_utils::{check_source_codes, check_with_options, has_diagnostic_code};
+use crate::test_utils::{
+    check_source_codes, check_source_with_libs, check_source_with_libs_code_messages,
+    check_with_options, has_diagnostic_code, load_lib_files,
+};
 
 // ── Standard mode ────────────────────────────────────────────────────────────
 
@@ -179,8 +182,15 @@ type Expected = { foo: string; bar?: boolean; baz?: any };
 const innerProps = { foo: string.isRequired, bar: bool, baz: any };
 const assign: Validator<Expected> = shape(innerProps).isRequired;
 "#;
+    let lib_files = load_lib_files(&["es5.d.ts"]);
+    let messages = check_source_with_libs_code_messages(
+        source,
+        "test.ts",
+        CheckerOptions::default(),
+        &lib_files,
+    );
     assert!(
-        check_source_codes(source).is_empty(),
-        "expected prop-types shape inference to match the declared props shape"
+        messages.is_empty(),
+        "expected prop-types shape inference to match the declared props shape. Got: {messages:?}"
     );
 }

--- a/crates/tsz-checker/tests/optional_property_subtype_compatibility_tests.rs
+++ b/crates/tsz-checker/tests/optional_property_subtype_compatibility_tests.rs
@@ -9,8 +9,8 @@
 
 use crate::context::CheckerOptions;
 use crate::test_utils::{
-    check_source_codes, check_source_with_libs, check_source_with_libs_code_messages,
-    check_with_options, has_diagnostic_code, load_lib_files,
+    check_source_codes, check_source_with_libs_code_messages, check_with_options,
+    has_diagnostic_code, load_lib_files,
 };
 
 // ── Standard mode ────────────────────────────────────────────────────────────

--- a/crates/tsz-checker/tests/ts2411_tests.rs
+++ b/crates/tsz-checker/tests/ts2411_tests.rs
@@ -372,6 +372,11 @@ export {};
 
 #[test]
 fn ts2411_interface_optional_property_exact_optional_no_undefined_widening() {
+    // With exactOptionalPropertyTypes, `optional?: string` is exactly `string` (the optional
+    // marker is "missing", not `undefined`), so it is assignable to the `string` index type and
+    // tsc reports NO TS2411. Without EOP the same property reads as `string | undefined` and
+    // does conflict — that case is covered by ts2411_interface_optional_property_vs_string_index.
+    // Verified against tsc 6.0.2: `--strict --exactOptionalPropertyTypes` reports no error here.
     let source = r#"
 interface ExactOptional {
     [key: string]: string;
@@ -389,8 +394,8 @@ export {};
         },
     ));
     assert!(
-        diagnostics.iter().any(|d| d.0 == 2411),
-        "Exact optional property types still read optional properties as possibly undefined for index compatibility, got: {diagnostics:?}"
+        !diagnostics.iter().any(|d| d.0 == 2411),
+        "exactOptionalPropertyTypes makes optional?: string exactly string, assignable to the string index — no TS2411 expected, got: {diagnostics:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

A pre-existing test, `ts2411_interface_optional_property_exact_optional_no_undefined_widening`, asserted non-`tsc` behavior and has been failing on `main`. It expected `optional?: string` against a `string` index signature to produce **TS2411** under `exactOptionalPropertyTypes`. That contradicts `tsc`.

This PR corrects the test to match `tsc`, documents the rule on the `index_sig_optional_type` helper and its two sibling internal tests. **No checker logic change** — the helper already implements the correct behavior; only the test's expectation was wrong.

Also includes a test-infra fix: `prop_types_shape_inference_matches_expected_props` now loads ES5 lib files so `Exclude`/`Pick`/`Partial` resolve.

## Ground truth (verified against tsc 6.0.2)

```ts
interface ExactOptional { [key: string]: string; optional?: string; }
```

| Case | flags | tsc |
|------|-------|-----|
| `optional?: string` vs `string` index | `--strict --exactOptionalPropertyTypes` | **no error** |
| `optional?: string` vs `string` index | `--strict` | **TS2411** (`string \| undefined`) |
| `bar?: string \| undefined` vs `string` index | `--strict --exactOptionalPropertyTypes` | **TS2411** (explicit `undefined`) |

## Structural Rule

When checking TS2411, an optional property `p?: T` contributes `T | undefined` under strict null checks, **except** under `exactOptionalPropertyTypes`, where it contributes exactly `T`. This mirrors `tsc`'s `getNonMissingTypeOfSymbol` = `removeMissingType(getTypeOfSymbol(sym), isOptional)`: the synthetic "missing" marker is stripped, but any *explicit* `undefined` in the annotation survives and still participates in the check.

Owner layer: `state_checking_members/index_signature_type_helpers.rs` (checker-side optional widening for the TS2411 path; logic unchanged, behavior already correct).

Adjacent matrix (all match tsc):
- `p?: T` vs `[s:string]: T`, EOP on → no error
- `p?: T` vs `[s:string]: T`, EOP off (strict) → TS2411
- `p?: T | undefined` vs `[s:string]: T`, EOP on → TS2411
- `p: T` vs `[s:string]: T` → no error
- `p?: T` vs `[s:string]: T | undefined` → no error

## Verification

```
cargo nextest run -p tsz-checker --lib \
  -E 'test(/ts2411/) or test(/index_signature_checks/) or test(/optional_property/)'
# 85/85 pass
```

Goal: hold

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
