### PR TITLE
fix(solver): substitute mapped binder with its generic constraint in mapped-indexed access

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1745,5 +1745,9 @@ name = "deeply_nested_mapped_types_tests"
 path = "tests/deeply_nested_mapped_types_tests.rs"
 
 [[test]]
+name = "mapped_indexed_constraint_substitution_tests"
+path = "tests/mapped_indexed_constraint_substitution_tests.rs"
+
+[[test]]
 name = "implements_type_param_generation_identity_tests"
 path = "tests/implements_type_param_generation_identity_tests.rs"

--- a/crates/tsz-checker/tests/mapped_indexed_constraint_substitution_tests.rs
+++ b/crates/tsz-checker/tests/mapped_indexed_constraint_substitution_tests.rs
@@ -1,0 +1,241 @@
+//! Tests for indexing a *generic* mapped type by its own constraint:
+//! `{ [T in TB]: F(T) }[TB]` where `TB` is still generic.
+//!
+//! Structural rule (tsc `substituteIndexedMappedType` parity): when the
+//! object of an indexed access is a generic mapped type (its constraint
+//! still contains type variables) and the index is that constraint, the
+//! result is the template instantiated with the mapped binder replaced by
+//! the constraint — `F(TB)` — not the template over a fresh parameter
+//! `T extends TB`. The fresh-parameter form fails identity with the
+//! simplified form on the other side of a relation, producing false
+//! TS2322/TS2345/TS2416 (kysely `AnyColumn`/`AnyColumnWithTable` family).
+//!
+//! Owner layer: solver evaluation
+//! (`evaluate_rules/index_access.rs::instantiate_mapped_template_with_constraint_param`).
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn count(diags: &[tsz_checker::diagnostics::Diagnostic], code: u32) -> usize {
+    diags.iter().filter(|d| d.code == code).count()
+}
+
+fn codes(diags: &[tsz_checker::diagnostics::Diagnostic]) -> Vec<(u32, String)> {
+    diags
+        .iter()
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+/// kysely `AnyColumn` shape: `{ [T in TB]: keyof DB[T] }[TB] & string` must be
+/// mutually assignable with `keyof DB[TB] & string` in a generic context.
+#[test]
+fn keyof_template_mapped_indexed_by_constraint_both_directions() {
+    let source = r#"
+type AnyCol<DB, TB extends keyof DB> = { [T in TB]: keyof DB[T] }[TB] & string
+function h<DB, TB extends keyof DB>(a: AnyCol<DB, TB>, b: keyof DB[TB] & string) {
+    const x: keyof DB[TB] & string = a
+    const y: AnyCol<DB, TB> = b
+}
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2322),
+        0,
+        "AnyCol<DB, TB> and keyof DB[TB] & string must be mutually assignable; got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Renamed binders (anti-hardcoding): the rule must not key on `T`/`TB`/`DB`.
+#[test]
+fn keyof_template_mapped_indexed_by_constraint_renamed_binders() {
+    let source = r#"
+type Cols<Schema, Tables extends keyof Schema> = {
+    [Tbl in Tables]: keyof Schema[Tbl]
+}[Tables] &
+    string
+function probe<Schema, Tables extends keyof Schema>(
+    a: Cols<Schema, Tables>,
+    b: keyof Schema[Tables] & string,
+) {
+    const x: keyof Schema[Tables] & string = a
+    const y: Cols<Schema, Tables> = b
+}
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2322),
+        0,
+        "renamed-binder form must behave identically; got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Template-literal template (kysely `AnyColumnWithTable` shape).
+#[test]
+fn template_literal_mapped_indexed_by_constraint_both_directions() {
+    let source = r#"
+type ColT<DB, TB extends keyof DB> = {
+    [T in TB]: `${T & string}.${keyof DB[T] & string}`
+}[TB]
+function h<DB, TB extends keyof DB>(
+    a: ColT<DB, TB>,
+    b: `${TB & string}.${keyof DB[TB] & string}`,
+) {
+    const x: `${TB & string}.${keyof DB[TB] & string}` = a
+    const y: ColT<DB, TB> = b
+}
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2322),
+        0,
+        "template-literal mapped-indexed alias must collapse to the substituted form; got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Correlated-function template: `{ [K in keyof T]: (x: T[K]) => void }[keyof T]`
+/// relates to `(x: T[keyof T]) => void` (tsc simplification identity).
+#[test]
+fn function_template_mapped_indexed_by_keyof_constraint() {
+    let source = r#"
+type FnMap<T> = { [K in keyof T]: (x: T[K]) => void }[keyof T]
+function h<T>(a: FnMap<T>, b: (x: T[keyof T]) => void) {
+    const x: (x: T[keyof T]) => void = a
+    const y: FnMap<T> = b
+}
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2322),
+        0,
+        "generic mapped fn template indexed by its constraint must substitute the binder; got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Through an interface member and impl-vs-interface TS2416 (kysely witness
+/// shape, locally mocked).
+#[test]
+fn impl_vs_interface_member_using_mapped_indexed_alias_no_ts2416() {
+    let source = r#"
+type AnyCol<DB, TB extends keyof DB> = { [T in TB]: keyof DB[T] }[TB] & string
+interface Builder<DB, TB extends keyof DB> {
+    refTuple(refs: ReadonlyArray<AnyCol<DB, TB>>): keyof DB[TB] & string
+}
+class BuilderImpl<DB, TB extends keyof DB> implements Builder<DB, TB> {
+    refTuple(refs: ReadonlyArray<keyof DB[TB] & string>): AnyCol<DB, TB> {
+        return refs[0] as AnyCol<DB, TB>
+    }
+}
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2416),
+        0,
+        "impl member typed via the alias must satisfy the interface member typed via the substituted form; got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Concrete control: a fully concrete key space stays a per-key union — the
+/// collapse must not fire for literal constraints (distributive semantics).
+#[test]
+fn concrete_key_space_stays_per_key_union() {
+    let source = r#"
+type Conc = { [K in 'a' | 'b']: (x: K) => void }['a' | 'b']
+declare const c1: Conc
+const c2: ((x: 'a') => void) | ((x: 'b') => void) = c1
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2322),
+        0,
+        "concrete mapped-indexed access must remain the per-key union; got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Concrete negative control: the collapsed (non-distributive) function-of-union
+/// form is NOT a supertype of the per-key union — tsc errors here and so must we.
+#[test]
+fn concrete_key_space_collapse_shape_still_errors() {
+    let source = r#"
+type Conc = { [K in 'a' | 'b']: (x: K) => void }['a' | 'b']
+declare const c1: Conc
+const c3: (x: 'a' | 'b') => void = c1
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2322),
+        1,
+        "per-key union of functions must not be assignable to the function over the key union; got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Genuinely incompatible negative control: `AnyCol<DB, TB>` is the keys of
+/// `DB[TB]`, not `TB` itself — must still error.
+#[test]
+fn mapped_indexed_alias_not_assignable_to_unrelated_param() {
+    let source = r#"
+type AnyCol<DB, TB extends keyof DB> = { [T in TB]: keyof DB[T] }[TB] & string
+function h<DB, TB extends keyof DB>(a: AnyCol<DB, TB>) {
+    const x: TB = a
+}
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2322),
+        1,
+        "keys of DB[TB] are unrelated to TB; assignment must keep erroring; got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Infer-bearing-conditional control (mapped deferral boundary, see #13004):
+/// per-key filtering aliases like `FunctionKeys` must keep working through
+/// generic `Pick` without false diagnostics.
+#[test]
+fn function_keys_filter_through_generic_pick_still_clean() {
+    let source = r#"
+type LocalPick<T, K extends keyof T> = { [P in K]: T[P] }
+type NonUndefined<A> = A extends undefined ? never : A
+type FunctionKeys<T extends object> = {
+    [K in keyof T]-?: NonUndefined<T[K]> extends (...args: any[]) => unknown ? K : never
+}[keyof T]
+type FunctionProps<T extends object> = LocalPick<T, FunctionKeys<T>>
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        diags.len(),
+        0,
+        "generic Pick over a per-key filter alias must stay clean; got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Concrete instantiation of the filter alias still distributes per key.
+#[test]
+fn function_keys_filter_concrete_instantiation_distributes() {
+    let source = r#"
+type NonUndefined<A> = A extends undefined ? never : A
+type FunctionKeys<T extends object> = {
+    [K in keyof T]-?: NonUndefined<T[K]> extends (...args: any[]) => unknown ? K : never
+}[keyof T]
+interface Mixed {
+    go(): void
+    name: string
+}
+const k: FunctionKeys<Mixed> = 'go'
+const bad: FunctionKeys<Mixed> = 'name'
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2322),
+        1,
+        "FunctionKeys<Mixed> must be exactly 'go' ('name' rejected, 'go' accepted); got: {:?}",
+        codes(&diags)
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -90,6 +90,45 @@ impl<'a, 'b, R: TypeResolver> IndexAccessVisitor<'a, 'b, R> {
             return value_type;
         }
 
+        // tsc parity (`substituteIndexedMappedType`): indexing a *generic*
+        // mapped type `{ [T in C]: F(T) }` by its own constraint `C` (where `C`
+        // still contains type variables, e.g. a type parameter or `keyof T`)
+        // substitutes the index for the mapped binder, producing `F(C)`.
+        // Substituting a fresh `T extends C` parameter instead breaks identity
+        // with the simplified form tsc compares against: `{ [T in TB]:
+        // keyof DB[T] }[TB]` must relate to `keyof DB[TB]` in both directions.
+        // Concrete key spaces never reach here: literal-only constraints are
+        // expanded per key by `try_evaluate_mapped_template_per_concrete_key`,
+        // and the remaining non-generic constraints keep the conservative
+        // fresh-parameter behavior below.
+        //
+        // Known interaction: in whole-project checks the collapsed form is
+        // compared by `TypeId` identity against member types built from a
+        // different type-parameter generation (checker fresh ids vs lowering
+        // structural ids — see the pinned witnesses in
+        // `implements_type_param_generation_identity_tests`), which can flip
+        // order-dependent impl-vs-interface comparisons. That generation
+        // divergence is a distinct checker defect; this evaluation rule is
+        // the tsc-parity behavior.
+        if crate::type_queries::contains_type_parameters_db(
+            self.evaluator.interner(),
+            mapped.constraint,
+        ) {
+            let subst = TypeSubstitution::single(mapped.type_param.name, mapped.constraint);
+            let mut value_type = self.evaluator.evaluate(instantiate_type(
+                self.evaluator.interner(),
+                mapped.template,
+                &subst,
+            ));
+            if matches!(mapped.optional_modifier, Some(MappedModifier::Add)) {
+                value_type = self
+                    .evaluator
+                    .interner()
+                    .union2(value_type, TypeId::UNDEFINED);
+            }
+            return value_type;
+        }
+
         let constrained_key = self.evaluator.interner().type_param(TypeParamInfo {
             name: mapped.type_param.name,
             constraint: Some(mapped.constraint),

--- a/crates/tsz-solver/tests/index_access_comprehensive_tests.rs
+++ b/crates/tsz-solver/tests/index_access_comprehensive_tests.rs
@@ -757,8 +757,18 @@ fn test_index_access_mapped_with_intersection_index() {
     );
 }
 
+/// tsc parity (`substituteIndexedMappedType`): indexing a generic mapped type
+/// `{ [K in keyof T]: F(K) }` by its own still-generic constraint `keyof T`
+/// substitutes the constraint for the binder, producing `F(keyof T)` — the
+/// whole key space collapses into a single substitution. This is the
+/// documented `tsc` behavior for generic `T` (per-key expansion only happens
+/// for concrete, literal-enumerable key spaces) and is why `KeysMatching`
+/// style utilities see `T[keyof T] extends string ? keyof T : never` in
+/// generic contexts. This test previously pinned the opposite (a fresh
+/// `K extends keyof T` binder kept in the template), which broke identity
+/// with the simplified form `tsc` compares against.
 #[test]
-fn test_index_access_mapped_keyof_preserves_per_key_template_relation() {
+fn test_index_access_mapped_keyof_substitutes_constraint_for_binder() {
     let interner = TypeInterner::new();
 
     let t_param = TypeParamInfo {
@@ -804,32 +814,12 @@ fn test_index_access_mapped_keyof_preserves_per_key_template_relation() {
         false_type: TypeId::NEVER,
         is_distributive: false,
     });
-    assert_ne!(
+    assert_eq!(
         result, collapsed,
-        "mapped[keyof T] should not collapse the whole key space into a single substitution"
+        "mapped[keyof T] with a generic constraint must substitute the constraint for the \
+         binder (tsc `substituteIndexedMappedType` parity): expected \
+         `T[keyof T] extends string ? keyof T : never`"
     );
-
-    match interner.lookup(result) {
-        Some(TypeData::Conditional(cond_id)) => {
-            let cond = interner.conditional_type(cond_id);
-            match (
-                interner.lookup(cond.check_type),
-                interner.lookup(cond.true_type),
-            ) {
-                (
-                    Some(TypeData::IndexAccess(object_type, key_type)),
-                    Some(TypeData::TypeParameter(_)),
-                ) => {
-                    assert_eq!(object_type, t_type);
-                    assert_eq!(key_type, cond.true_type);
-                }
-                other => panic!(
-                    "Expected per-key conditional to keep a single key parameter, got {other:?}"
-                ),
-            }
-        }
-        other => panic!("Expected deferred conditional result, got {other:?}"),
-    }
 }
 
 #[test]


### PR DESCRIPTION
AgentName: StudioOpus
Goal: green

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: medium

Track: conformance / project-corpus false positives (kysely campaign)
Invariant: indexing a generic mapped type by its own still-generic constraint produces the template with the binder substituted by the constraint (tsc `substituteIndexedMappedType` parity), so the alias form and the hand-written substituted form relate in both directions.
Scope: `crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs` (mapped-indexed evaluation), `crates/tsz-checker` regression tests + executable pins for the dominant kysely defect.

## Summary

Follow-up to the residue documented in #13156: the kysely false-positive family decomposes into two defects. This PR fixes the mapped-binder substitution defect with a tsc-verified witness matrix, and reduces + pins the dominant defect (type-parameter generation identity) to a 10-line witness with trace-level evidence. It is DRAFT because the two defects interact: with the parity fix active, four kysely `where`-member comparisons flip from pass to fail through the *pinned* (unfixed) defect, so this should land after — or together with — the generation-identity fix.

**Defect fixed — mapped binder left as a fresh constrained parameter in `{ [T in TB]: F(T) }[TB]`.**

Structural rule: when the object of an indexed access is a *generic* mapped type `{ [T in C]: F(T) }` (its constraint `C` still contains type variables, e.g. a type parameter or `keyof T`) and the index is that constraint, tsc (`substituteIndexedMappedType`) instantiates the template with `T := C`, producing `F(C)`. tsz instead substituted a *fresh* type parameter `T' extends C`, producing `F(T')`. The fresh binder fails identity/relation against the substituted form on the other side, so tsc-clean code emitted false TS2322/TS2345, and elaborations rendered kysely's `AnyColumn`/`AnyColumnWithTable` aliases with the binder visibly unsubstituted (`keyof DB[T] & string`).

Witness (tsc 5.5 clean; tsz before: false TS2322 with `Extract<keyof DB[T], string>`, `T` free; after: clean):

```ts
type AnyCol<DB, TB extends keyof DB> = { [T in TB]: keyof DB[T] }[TB] & string
function h<DB, TB extends keyof DB>(a: AnyCol<DB, TB>, b: keyof DB[TB] & string) {
  const x: keyof DB[TB] & string = a // was: false TS2322
  const y: AnyCol<DB, TB> = b
}
```

Owner layer: solver evaluation (`instantiate_mapped_template_with_constraint_param`). Adjacent matrix (all tsc-5.5-verified, in `mapped_indexed_constraint_substitution_tests.rs`): renamed binders; template-literal template (`AnyColumnWithTable` shape); correlated function template `{ [K in keyof T]: (x: T[K]) => void }[keyof T]`; impl-vs-interface TS2416 through the alias; concrete-key-space distributivity preserved (positive + negative controls); genuinely-incompatible negative control; infer-bearing `FunctionKeys` filter through generic Pick and its concrete per-key instantiation (mapped-deferral boundary, #13004).

**Defect pinned (dominant kysely family, NOT fixed here) — type-parameter generation identity.**

Reduced from the kysely fixture by member bisection (`ExpressionBuilder` → `FunctionModule.any`) to a 10-line tsc-clean witness producing a false TS2416:

```ts
interface FM<DB, TB extends keyof DB> {
  any<RE>(expr: RE): RE extends ReadonlyArray<TB> ? number : never
}
interface B7<DB, TB extends keyof DB> { m(lhs: FM<DB, TB>): void }
class B7Impl<DB, TB extends keyof DB> implements B7<DB, TB> {
  m(lhs: FM<DB, TB>): void {}
}
```

Mechanism (verified with structured dumps at the TS2416 relation boundary): the impl-side member type embeds one generation of the class's type-parameter `TypeId`s while the base member (interface member rebuilt via `get_type_of_interface_member_simple` + instantiated with heritage-clause args) embeds another. The same declaration is minted under two id schemes — the lowering's structural `type_param` interning and the checker's `fresh_type_param`-based `intern_type_param_for_decl` — and the def-level cache (`find_type_param_for_def`) ping-pongs between the two-pass `{T, None}` / `{T, keyof DB}` infos, minting fresh ids on every `push_type_parameters` call. Identical deferred conditionals then intern differently per side and the conditional `extends`-identity relation rejects them ("Two different types with this name exist, but they are unrelated").

Adjacent matrix pinned: dependent constraint (`TB extends keyof DB`) fails; unconstrained or `TB extends string` passes; property members pass (only the method path diverges); concrete instantiations pass. Executable pins live in `implements_type_param_generation_identity_tests.rs` (`#[ignore]` with reason) plus active controls.

**Why the two interact (the +4):** with the collapse active, the four kysely `where` members (delete-query-builder 115, on-conflict-builder 118/327, update-query-builder 121) emit TS2416 with a bogus arity reason — only in the full-project compile; the standalone file closure is clean. Evaluation order decides which generation's collapsed form lands in the project-wide caches first. Root cause is the pinned generation divergence, not the substitution rule. Gating experiments (non-conditional templates; pre-eval-only collapse) either did not remove the +4 or introduced an evaluation oscillation, so the rule ships clean with the dependency documented in-code. (Historical: resolved by #13170 landing first; the +4 no longer reproduces on the rebased head.)

## Project Corpus Impact
- Row: kysely-project
- Bug family: mapped-binder substitution in mapped-indexed member instantiation

## Verification

Canaries (dist-fast, rebased branch on 6bac88fa1b vs clean 6bac88fa1b, same machine, post-#13170 re-measure):
- kysely: 135 -> 134 (-1: the `FunctionModule<DB, TB>` member-compat TS2322 at `function-module.ts:799` — the campaign target family)
- zod: 54 -> 54, comlink: 3 -> 3, msw: 211 -> 211, ofetch: 46 -> 46, valibot: 1821 -> 1821 (all flat)
- The pre-#13170 +4 `where`-member TS2416 interaction is gone: with the generation-identity fix (#13170) on main, this PR is a strict -1 on kysely with no other row movement. (Earlier draft-era numbers: 183 -> 187 on 97689e3edc.)

Correctness evidence for the fixed defect: the witness matrix flips from false TS2322/TS2345 to clean and matches `npx -p typescript@5.5 tsc --noEmit --strict` exactly, including negative controls.

- New tests (post-rebase): `cargo nextest run -p tsz-checker --test mapped_indexed_constraint_substitution_tests --test implements_type_param_generation_identity_tests` — 15/15 pass, 1 skipped (the one pin #13170 left `#[ignore]`d on main). The branch now carries main's version of the generation-identity pin file; this PR's copy was dropped in the rebase.
- `cargo nextest run -p tsz-solver -E 'test(/mapped|index|instantiat|relation|subtype/)'` — 2495/2495 pass after updating one stale pin: `test_index_access_mapped_keyof_preserves_per_key_template_relation` (from #11679) asserted the pre-parity behavior (fresh `K extends keyof T` binder kept in the template for a *generic* `keyof T` index). tsc's `substituteIndexedMappedType` collapses that key space; verified with tsc 5.5: `M<T>[keyof T]` and `T[keyof T] extends string ? keyof T : never` are mutually assignable, with an unrelated-conditional negative control. The test is renamed to `test_index_access_mapped_keyof_substitutes_constraint_for_binder` and now pins the collapsed tsc-parity form.
- `cargo nextest run -p tsz-checker -E 'test(/ts2416|implements|mapped/)'` — 774 run: 761 passed, 13 failed; the same 13 (mapped-enum display family, key-correlation pair, TS2327 elaboration family, structural-containment debt test, tuple unique-symbol keys) reproduce identically with the solver change reverted on the same head — pre-existing on main, not from this PR (verified by paired runs).
- Conformance narrow filters (re-run post-rebase on 6bac88fa1b): `tsxLibraryManagedAttributes` 1/1 PASS (mapped-deferral infer boundary guard); `mappedType` 55/55 PASS.
- `python3 scripts/arch/arch_guard.py` — passed. `cargo clippy -p tsz-solver -p tsz-checker --all-targets -- -D warnings` — clean.

## Coordination Notes

Campaign: #13031/#13037/#13139/#13142/#13145/#13150/#13153/#13156 landed; #13151 in flight. This is defect 2 from #13156's investigation; the dominant defect decomposed out of it is pinned here (generation identity) with witnesses and trace evidence for the follow-up owner. A convergence draft for `intern_type_param_for_decl` (consult the node-keyed cache for def-registered params too) stabilizes the mint ping-pong but does not flip the witness by itself — the impl-side member still embeds lowering-interned structural ids; the follow-up must unify the lowering and checker id schemes (or bridge them at the relation boundary). Landing order followed: the generation-identity fix landed as #13170; this branch was rebased onto 6bac88fa1b, the +4 interaction is confirmed gone (see canaries), and the PR is now ready.
