### PR TITLE
fix(emitter): use Unicode-aware identifier predicates in for-loop recovery

### DIFF
--- a/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
+++ b/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
@@ -147,7 +147,11 @@ impl<'a> Printer<'a> {
         })
     }
 
-    fn invalid_let_of_array_for_header(&self, node: &Node, loop_stmt: &LoopData) -> Option<String> {
+    fn invalid_let_of_array_for_header(
+        &self,
+        node: &Node,
+        loop_stmt: &LoopData,
+    ) -> Option<String> {
         if loop_stmt.initializer.is_some()
             || loop_stmt.condition.is_some()
             || loop_stmt.incrementor.is_some()
@@ -352,16 +356,17 @@ mod tests {
 
     #[test]
     fn typed_for_body_call_recovery_accepts_unicode_identifiers() {
-        // `é` (U+00E9) and `日` (U+65E5) are valid ECMAScript identifier-start
-        // characters; the recovery must treat them as identifier chars, not bail
-        // out with an ASCII-only check.
-        let output = emit_es5("for (let r\u{00e9}sum\u{00e9}: Type) { donn\u{00e9}es(r\u{00e9}sum\u{00e9}); }");
+        let output = emit_es5(
+            "for (let r\u{e9}sum\u{e9}: Type) { donn\u{e9}es(r\u{e9}sum\u{e9}); }",
+        );
         assert!(
-            output.contains("r\u{00e9}sum\u{00e9}"),
+            output.contains("r\u{e9}sum\u{e9}"),
             "Unicode binding identifier should be preserved in recovery.\nOutput:\n{output}"
         );
 
-        let output2 = emit_es5("for (let \u{65e5}\u{672c}\u{8a9e}: T) { \u{51e6}\u{7406}(\u{65e5}\u{672c}\u{8a9e}); }");
+        let output2 = emit_es5(
+            "for (let \u{65e5}\u{672c}\u{8a9e}: T) { \u{51e6}\u{7406}(\u{65e5}\u{672c}\u{8a9e}); }",
+        );
         assert!(
             output2.contains("\u{65e5}\u{672c}\u{8a9e}"),
             "CJK binding identifier should be preserved in recovery.\nOutput:\n{output2}"

--- a/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
+++ b/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
@@ -147,11 +147,7 @@ impl<'a> Printer<'a> {
         })
     }
 
-    fn invalid_let_of_array_for_header(
-        &self,
-        node: &Node,
-        loop_stmt: &LoopData,
-    ) -> Option<String> {
+    fn invalid_let_of_array_for_header(&self, node: &Node, loop_stmt: &LoopData) -> Option<String> {
         if loop_stmt.initializer.is_some()
             || loop_stmt.condition.is_some()
             || loop_stmt.incrementor.is_some()
@@ -357,14 +353,16 @@ mod tests {
     #[test]
     fn typed_for_body_call_recovery_accepts_unicode_identifiers() {
         // \u{e9} and \u{65e5} are valid ECMAScript identifier-start chars.
-        let output = emit_es5("for (let r\u{e9}sum\u{e9}: Type) { donn\u{e9}es(r\u{e9}sum\u{e9}); }");
+        let output =
+            emit_es5("for (let r\u{e9}sum\u{e9}: Type) { donn\u{e9}es(r\u{e9}sum\u{e9}); }");
         assert!(
             output.contains("r\u{e9}sum\u{e9}"),
             "Unicode binding identifier should be preserved in recovery.\nOutput:\n{output}"
         );
 
-        let output2 =
-            emit_es5("for (let \u{65e5}\u{672c}\u{8a9e}: T) { \u{51e6}\u{7406}(\u{65e5}\u{672c}\u{8a9e}); }");
+        let output2 = emit_es5(
+            "for (let \u{65e5}\u{672c}\u{8a9e}: T) { \u{51e6}\u{7406}(\u{65e5}\u{672c}\u{8a9e}); }",
+        );
         assert!(
             output2.contains("\u{65e5}\u{672c}\u{8a9e}"),
             "CJK binding identifier should be preserved in recovery.\nOutput:\n{output2}"

--- a/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
+++ b/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
@@ -356,17 +356,15 @@ mod tests {
 
     #[test]
     fn typed_for_body_call_recovery_accepts_unicode_identifiers() {
-        let output = emit_es5(
-            "for (let r\u{e9}sum\u{e9}: Type) { donn\u{e9}es(r\u{e9}sum\u{e9}); }",
-        );
+        // \u{e9} and \u{65e5} are valid ECMAScript identifier-start chars.
+        let output = emit_es5("for (let r\u{e9}sum\u{e9}: Type) { donn\u{e9}es(r\u{e9}sum\u{e9}); }");
         assert!(
             output.contains("r\u{e9}sum\u{e9}"),
             "Unicode binding identifier should be preserved in recovery.\nOutput:\n{output}"
         );
 
-        let output2 = emit_es5(
-            "for (let \u{65e5}\u{672c}\u{8a9e}: T) { \u{51e6}\u{7406}(\u{65e5}\u{672c}\u{8a9e}); }",
-        );
+        let output2 =
+            emit_es5("for (let \u{65e5}\u{672c}\u{8a9e}: T) { \u{51e6}\u{7406}(\u{65e5}\u{672c}\u{8a9e}); }");
         assert!(
             output2.contains("\u{65e5}\u{672c}\u{8a9e}"),
             "CJK binding identifier should be preserved in recovery.\nOutput:\n{output2}"

--- a/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
+++ b/crates/tsz-emitter/src/emitter/statements/for_recovery.rs
@@ -1,7 +1,7 @@
 use super::super::Printer;
 use tsz_parser::parser::node::{LoopData, Node};
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_scanner::SyntaxKind;
+use tsz_scanner::{SyntaxKind, is_ecmascript_identifier_part, is_ecmascript_identifier_start};
 
 struct RecoveredTypedForBodyCall {
     keyword: String,
@@ -231,12 +231,12 @@ fn parse_single_identifier_call(text: &str) -> Option<(&str, &str)> {
     }
 }
 
-const fn is_identifier_start(ch: char) -> bool {
-    ch == '_' || ch == '$' || ch.is_ascii_alphabetic()
+fn is_identifier_start(ch: char) -> bool {
+    is_ecmascript_identifier_start(ch)
 }
 
-const fn is_identifier_part(ch: char) -> bool {
-    is_identifier_start(ch) || ch.is_ascii_digit()
+fn is_identifier_part(ch: char) -> bool {
+    is_ecmascript_identifier_part(ch)
 }
 
 fn is_keyword_followed_by(text: &str, first: &str, second: &str) -> bool {
@@ -347,6 +347,24 @@ mod tests {
         assert!(
             output.contains("for (var x;;) {"),
             "Valid `for` loops should continue through the normal printer path.\nOutput:\n{output}"
+        );
+    }
+
+    #[test]
+    fn typed_for_body_call_recovery_accepts_unicode_identifiers() {
+        // `é` (U+00E9) and `日` (U+65E5) are valid ECMAScript identifier-start
+        // characters; the recovery must treat them as identifier chars, not bail
+        // out with an ASCII-only check.
+        let output = emit_es5("for (let r\u{00e9}sum\u{00e9}: Type) { donn\u{00e9}es(r\u{00e9}sum\u{00e9}); }");
+        assert!(
+            output.contains("r\u{00e9}sum\u{00e9}"),
+            "Unicode binding identifier should be preserved in recovery.\nOutput:\n{output}"
+        );
+
+        let output2 = emit_es5("for (let \u{65e5}\u{672c}\u{8a9e}: T) { \u{51e6}\u{7406}(\u{65e5}\u{672c}\u{8a9e}); }");
+        assert!(
+            output2.contains("\u{65e5}\u{672c}\u{8a9e}"),
+            "CJK binding identifier should be preserved in recovery.\nOutput:\n{output2}"
         );
     }
 }


### PR DESCRIPTION
When a typed `for`-loop header uses a Unicode binding identifier — e.g.
`for (let résumé: Type)` or `for (let 日本語: T)` — the source-backed recovery
path (`typed_for_body_call_recovery`) parses the binding name with
`parse_source_identifier`. That helper previously used two `const fn` ASCII-only
predicates (`is_ascii_alphabetic`, `is_ascii_digit`) that fail on any
non-ASCII identifier character. The ECMAScript spec permits Unicode
identifier-start and identifier-part characters (e.g. U+00E9 `é`, U+65E5 `日`)
in all identifier positions; tsc's recovered output uses the source text
verbatim, so tsz must treat the same code points as valid identifiers.

Replace the two local predicates with the scanner's existing
`is_ecmascript_identifier_start` / `is_ecmascript_identifier_part`, which
already use the full Unicode tables for lexing. Add two regression tests
covering Latin-extended (`résumé`, `données`) and CJK (`日本語`, `処理`) binding
identifiers.

## Goal
Goal: hold

## Verification
- `cargo nextest run -p tsz-emitter -- for_recovery` (all 5 tests pass, including the two new Unicode cases)
- Confirm: `for (let résumé: Type) { données(résumé); }` emits `for (let résumé, { données }; (résumé); )\n    ;`

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-sonnet-4-6
Effort: low

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnFn9XJHofLMBGbQgGU7JL)_