### PR TITLE
fix(checker,solver): converge type-param generation identity for type-level decls; ES-private nominal derivation; gate constraint-fallback

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1736,3 +1736,6 @@ path = "tests/call_argument_boolean_literal_array_display_tests.rs"
 [[test]]
 name = "type_param_pick_subset_assignability_tests"
 path = "tests/type_param_pick_subset_assignability_tests.rs"
+[[test]]
+name = "implements_type_param_generation_identity_tests"
+path = "tests/implements_type_param_generation_identity_tests.rs"

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -843,6 +843,42 @@ impl<'a> CheckerState<'a> {
         name_node: tsz_parser::parser::NodeIndex,
         info: tsz_solver::TypeParamInfo,
     ) -> tsz_solver::TypeId {
+        // Type-level declarations (class/interface/type-alias) intern their
+        // type parameters *structurally*, converging with the `tsz-lowering`
+        // scheme that builds these declarations' def bodies. Without this, the
+        // same declaration's `DB`/`TB` exist in two generations — a
+        // checker-fresh id (heritage-clause arguments, annotation scope) and a
+        // lowering-structural id (def-lowered member shapes) — and
+        // identity-sensitive relation rules (conditional `extends` equivalence,
+        // `S[T1]`-vs-`S[T2]` index-access distinctness) treat one declaration
+        // as two unrelated type parameters: false TS2416 on `implements`/
+        // `extends` members whose deferred types close over the outer params
+        // (the dominant kysely builder family).
+        //
+        // Function-like declarations keep declaration-scoped *fresh* ids:
+        // two same-named, same-constrained params of different functions are
+        // distinct in tsc (`S[K_outer]` vs `S[K_inner]` must keep erroring),
+        // and call-site relation paths reconcile method-local params through
+        // name-keyed signature unification instead of id identity.
+        if self.type_param_belongs_to_type_level_decl(name_node) {
+            let type_id = self.ctx.types.type_param(info);
+            if let Some(def_id) = self
+                .ctx
+                .binder
+                .node_symbols
+                .get(&name_node.0)
+                .and_then(|&sym_id| self.ctx.definition_store.find_def_by_symbol(sym_id.0))
+            {
+                self.ctx
+                    .definition_store
+                    .register_type_to_def(type_id, def_id);
+                self.ctx
+                    .definition_store
+                    .register_type_param_for_def(def_id, type_id);
+            }
+            return type_id;
+        }
+
         let registered_def = self
             .ctx
             .binder
@@ -891,6 +927,33 @@ impl<'a> CheckerState<'a> {
         }
 
         type_id
+    }
+
+    /// Whether `name_node` (a type-parameter's name identifier) belongs to a
+    /// type-level declaration — class, interface, or type alias — whose def
+    /// body is lowered with structurally-interned type parameters.
+    ///
+    /// The chain is `name identifier -> TypeParameter node -> declaring node`.
+    fn type_param_belongs_to_type_level_decl(
+        &self,
+        name_node: tsz_parser::parser::NodeIndex,
+    ) -> bool {
+        use tsz_parser::parser::syntax_kind_ext;
+        let Some(param_idx) = self.ctx.arena.parent_of(name_node) else {
+            return false;
+        };
+        let Some(decl_idx) = self.ctx.arena.parent_of(param_idx) else {
+            return false;
+        };
+        self.ctx.arena.get(decl_idx).is_some_and(|node| {
+            matches!(
+                node.kind,
+                k if k == syntax_kind_ext::CLASS_DECLARATION
+                    || k == syntax_kind_ext::CLASS_EXPRESSION
+                    || k == syntax_kind_ext::INTERFACE_DECLARATION
+                    || k == syntax_kind_ext::TYPE_ALIAS_DECLARATION
+            )
+        })
     }
 
     pub(super) fn empty_type_literal_satisfies_optional_mapped_constraint(

--- a/crates/tsz-checker/tests/implements_type_param_generation_identity_tests.rs
+++ b/crates/tsz-checker/tests/implements_type_param_generation_identity_tests.rs
@@ -1,0 +1,209 @@
+//! Tests for type-parameter `TypeId` generation identity across checker passes.
+//!
+//! Structural rule: every resolution of the same type-parameter declaration
+//! (class member checking, heritage-clause type-argument resolution, interface
+//! member rebuilding for the `implements` check) must converge on a single
+//! `TypeId` per `TypeParamInfo`. `tsc` identifies type parameters by symbol;
+//! `tsz` approximates that with declaration-scoped fresh `TypeId`s deduped in
+//! `intern_type_param_for_decl` — plus a *separate* structurally-interned
+//! scheme used by the lowering for class member shapes. The two schemes do
+//! not converge: trace evidence shows the impl-side member embedding
+//! lowered/structural param ids while the heritage-clause substitution
+//! produces checker-fresh ids for the same declarations. Member types
+//! embedding those ids inside *deferred* types (conditional `extends`
+//! clauses, which relate by `TypeId` identity) then fail against each other:
+//! false TS2416 on `implements` members (the dominant kysely builder family).
+//!
+//! The convergence: `intern_type_param_for_decl` interns class/interface/
+//! type-alias type parameters *structurally* (`TypeInterner::type_param`),
+//! matching the lowering's scheme, so every resolution of a type-level
+//! declaration's parameter produces one `TypeId`. Function-like declarations
+//! keep declaration-scoped fresh ids so distinct same-named, same-constrained
+//! function params stay distinct (`S[K_outer]` vs `S[K_inner]` keeps
+//! erroring). All witnesses are tsc-5.5-verified.
+//!
+//! The remaining ignored test pins a separate residue: a deferred
+//! conditional instantiated with concrete type arguments must relate to its
+//! generic origin (tsc's same-conditional-root rule), which id convergence
+//! alone does not provide.
+//!
+//! Owner layer: checker type-parameter identity
+//! (`state/type_analysis/core.rs::intern_type_param_for_decl` and the
+//! lowering's structural `type_param` interning).
+
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn count(diags: &[tsz_checker::diagnostics::Diagnostic], code: u32) -> usize {
+    diags.iter().filter(|d| d.code == code).count()
+}
+
+fn codes(diags: &[tsz_checker::diagnostics::Diagnostic]) -> Vec<(u32, String)> {
+    diags
+        .iter()
+        .map(|d| (d.code, d.message_text.clone()))
+        .collect()
+}
+
+/// Minimal kysely-shaped witness: a generic method whose deferred conditional
+/// mixes its own type param with an outer dependent-constrained interface
+/// param, reached through an interface-typed parameter of an implemented
+/// member. tsc-clean; tsz emitted a false TS2416 before the fix.
+#[test]
+fn implements_member_with_dependent_constraint_conditional_no_ts2416() {
+    let source = r#"
+interface FM<DB, TB extends keyof DB> {
+    any<RE>(expr: RE): RE extends ReadonlyArray<TB> ? number : never
+}
+interface B7<DB, TB extends keyof DB> {
+    m(lhs: FM<DB, TB>): void
+}
+class B7Impl<DB, TB extends keyof DB> implements B7<DB, TB> {
+    m(lhs: FM<DB, TB>): void {}
+}
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2416),
+        0,
+        "identical member types must relate across passes; got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Renamed binders (anti-hardcoding): interface/class params named differently
+/// from the inner interface's own params.
+#[test]
+fn implements_member_dependent_constraint_conditional_renamed_binders() {
+    let source = r#"
+interface Mod<SchemaT, TblT extends keyof SchemaT> {
+    probe<Ref>(expr: Ref): Ref extends ReadonlyArray<TblT> ? number : never
+}
+interface Host<Db2, Tb2 extends keyof Db2> {
+    member(lhs: Mod<Db2, Tb2>): void
+}
+class HostImpl<Db2, Tb2 extends keyof Db2> implements Host<Db2, Tb2> {
+    member(lhs: Mod<Db2, Tb2>): void {}
+}
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2416),
+        0,
+        "renamed-binder form must behave identically; got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Mapped-indexed alias in the constraint chain (closer to kysely's
+/// `StringReference`/`ExtractColumnType` shape), with self-recursion through
+/// a `Pick`-like local alias.
+#[test]
+fn implements_member_recursive_builder_with_mapped_indexed_alias() {
+    let source = r#"
+type LocalPick<T, K extends keyof T> = { [P in K]: T[P] }
+type AnyCol<DB, TB extends keyof DB> = { [T in TB]: keyof DB[T] }[TB] & string
+type ExtractCol<DB, TB extends keyof DB, C> = {
+    [T in TB]: C extends keyof DB[T] ? DB[T][C] : never
+}[TB]
+interface Expression<T> {
+    readonly expressionType?: T
+}
+interface EW<DB, TB extends keyof DB, T> extends Expression<T> {
+    dummy?: [DB, TB]
+}
+interface FM<DB, TB extends keyof DB> {
+    any<RE extends AnyCol<DB, TB>>(
+        expr: RE,
+    ): Exclude<ExtractCol<DB, TB, RE>, null> extends ReadonlyArray<infer I>
+        ? EW<DB, TB, I>
+        : never
+    any<T>(expr: Expression<ReadonlyArray<T>>): EW<DB, TB, T>
+}
+interface EB<DB, TB extends keyof DB> {
+    get eb(): EB<DB, TB>
+    get fn(): FM<DB, TB>
+}
+type EBSub<DB, TB extends keyof DB> = LocalPick<EB<DB, TB>, 'eb'>
+interface B7<DB, TB extends keyof DB> {
+    m(lhs: EBSub<DB, TB>): void
+}
+class B7Impl<DB, TB extends keyof DB> implements B7<DB, TB> {
+    m(lhs: EBSub<DB, TB>): void {}
+}
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2416),
+        0,
+        "recursive builder member must relate to itself; got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Unconstrained-params control (passed before the fix; must keep passing).
+#[test]
+fn implements_member_unconstrained_params_still_clean() {
+    let source = r#"
+interface FM<DB, TB> {
+    any<RE>(expr: RE): RE extends ReadonlyArray<TB> ? number : never
+}
+interface B7<DB, TB> {
+    m(lhs: FM<TB, DB>): void
+}
+class B7Impl<DB, TB> implements B7<DB, TB> {
+    m(lhs: FM<TB, DB>): void {}
+}
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(count(&diags, 2416), 0, "got: {:?}", codes(&diags));
+}
+
+/// Genuinely incompatible negative control: the impl member narrows the
+/// parameter type — must still error (TS2416).
+#[test]
+fn implements_member_genuinely_incompatible_still_ts2416() {
+    let source = r#"
+interface FM<DB, TB extends keyof DB> {
+    any<RE>(expr: RE): RE extends ReadonlyArray<TB> ? number : never
+}
+interface B7<DB, TB extends keyof DB> {
+    m(lhs: FM<DB, TB>): void
+}
+class B7Impl<DB, TB extends keyof DB> implements B7<DB, TB> {
+    m(lhs: string): void {}
+}
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2416),
+        1,
+        "narrowed impl parameter must keep failing; got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Method-bivariance control: a concretely instantiated impl parameter is
+/// accepted bivariantly by tsc (method declarations relate bivariantly);
+/// verified against `tsc 5.5` (clean).
+#[test]
+#[ignore = "pinned: relating a deferred conditional instantiated with concrete args against its generic origin still requires conditional-root identity (tsc relates same-root conditional instantiations); the generation-identity convergence fixed the generic-vs-generic family but not this concrete bivariant form"]
+fn implements_member_concrete_param_bivariant_accepted() {
+    let source = r#"
+interface FM<DB, TB extends keyof DB> {
+    any<RE>(expr: RE): RE extends ReadonlyArray<TB> ? number : never
+}
+interface B7<DB, TB extends keyof DB> {
+    m(lhs: FM<DB, TB>): void
+}
+class B7Impl<DB, TB extends keyof DB> implements B7<DB, TB> {
+    m(lhs: FM<{ a: 1 }, 'a'>): void {}
+}
+"#;
+    let diags = check_source_diagnostics(source);
+    assert_eq!(
+        count(&diags, 2416),
+        0,
+        "tsc accepts this bivariantly; got: {:?}",
+        codes(&diags)
+    );
+}

--- a/crates/tsz-solver/src/relations/compat_overrides.rs
+++ b/crates/tsz-solver/src/relations/compat_overrides.rs
@@ -243,6 +243,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             match source_prop {
                 Some(sp) => {
                     if !self.subtype.nominal_member_origin_ok(
+                        target_prop.name,
                         sp.parent_id,
                         target_prop.parent_id,
                         target_prop.visibility,

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1477,6 +1477,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // `protected` is hierarchical (shared `nominal_member_origin_ok`).
                 if t_prop.visibility != Visibility::Public {
                     if !self.nominal_member_origin_ok(
+                        t_prop.name,
                         sp.parent_id,
                         t_prop.parent_id,
                         t_prop.visibility,
@@ -1741,6 +1742,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // decided by the shared `nominal_member_origin_ok`.
                 if t_prop.visibility != Visibility::Public {
                     if !self.nominal_member_origin_ok(
+                        t_prop.name,
                         sp.parent_id,
                         t_prop.parent_id,
                         t_prop.visibility,

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -389,16 +389,25 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     }
 
     /// Decide whether a source property satisfies a *nominal* (private or
-    /// protected) target property, given the two declaring-class symbols
-    /// (`parent_id`s) and the target member's visibility.
+    /// protected) target property, given the member name, the two
+    /// declaring-class symbols (`parent_id`s), and the target member's
+    /// visibility.
     ///
-    /// - `private` requires *declaration identity*: the source property must
-    ///   originate from the exact same declaration.
+    /// - `private` (modifier) requires *declaration identity*: the source
+    ///   property must originate from the exact same declaration.
     /// - `protected` is *hierarchical*: tsc accepts the member when the source
     ///   property is declared in the target's protected-declaring class or in a
     ///   class derived from it (`isPropertyInClassDerivedFrom`). The source may
     ///   also legally widen the member from `protected` to `public`, so its own
     ///   visibility is not consulted.
+    /// - ES private identifiers (`#name`) are *hierarchical* too: tsc keys each
+    ///   `#name` slot per declaring class (escaped `__#<id>@name`), so a derived
+    ///   class redeclaring the same `#name` still carries the base class's slot
+    ///   as a separate member and remains assignable to the base. tsz's merged
+    ///   object shapes key properties by surface name, which lets the derived
+    ///   redeclaration shadow the inherited brand; the declaring-class
+    ///   derivation check restores the tsc verdict (the inherited slot is
+    ///   always present on a derived class).
     ///
     /// Falls back to declaration identity when class symbols or the inheritance
     /// graph are unavailable, preserving the previous strict nominal behavior
@@ -407,6 +416,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// nominal-brand override.
     pub(crate) fn nominal_member_origin_ok(
         &self,
+        member_name: tsz_common::interner::Atom,
         source_parent: Option<tsz_binder::SymbolId>,
         target_parent: Option<tsz_binder::SymbolId>,
         target_visibility: Visibility,
@@ -417,12 +427,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if source_parent == target_parent {
             return true;
         }
-        // `private` requires strict declaration identity, which just failed.
-        if target_visibility != Visibility::Protected {
+        // `private` (modifier) requires strict declaration identity, which just
+        // failed — unless the member is an ES private identifier (`#name`),
+        // which is a per-class slot that a derived class always inherits.
+        let is_es_private_identifier = self
+            .interner
+            .resolve_atom_ref(member_name)
+            .as_ref()
+            .starts_with('#');
+        if target_visibility != Visibility::Protected && !is_es_private_identifier {
             return false;
         }
-        // `protected`: the source's declaring class must derive from (or equal)
-        // the target's protected-declaring class.
+        // `protected` / `#name`: the source's declaring class must derive from
+        // (or equal) the target's declaring class.
         match (source_parent, target_parent, self.inheritance_graph) {
             (Some(src_class), Some(tgt_class), Some(graph)) => {
                 graph.is_derived_from(src_class, tgt_class)
@@ -512,8 +529,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // is hierarchical (a derived class may widen it to `public`). Both are
         // decided by the shared `nominal_member_origin_ok`.
         if target.visibility != Visibility::Public {
-            if !self.nominal_member_origin_ok(source.parent_id, target.parent_id, target.visibility)
-            {
+            if !self.nominal_member_origin_ok(
+                target.name,
+                source.parent_id,
+                target.parent_id,
+                target.visibility,
+            ) {
                 return SubtypeResult::False;
             }
         } else if source.visibility != Visibility::Public {
@@ -1259,6 +1280,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // identity, `protected` is hierarchical (shared helper).
                 if t_prop.visibility != Visibility::Public {
                     if !self.nominal_member_origin_ok(
+                        t_prop.name,
                         sp.parent_id,
                         t_prop.parent_id,
                         t_prop.visibility,


### PR DESCRIPTION
fix(checker,solver): converge type-parameter generation identity for type-level declarations; ES-private nominal derivation

Fixes the dominant kysely TS2416 family (48 -> 6) by giving every
class/interface/type-alias type-parameter declaration ONE canonical
`TypeId` across the checker and the lowering, plus an ES-private
nominal repair exposed by the same investigation.

AgentName: claude-fable-5-tpgi

Goal: green

Track: conformance / project-corpus (kysely canary)

Invariant: one semantic type universe — two `TypeId`s for one
type-parameter declaration violates canonical identity; relation rules
that key on type-parameter identity (`conditional extends` equivalence,
`S[T1]`-vs-`S[T2]` index-access distinctness, private-brand nominality)
must observe one id per declaration.

## Structural rules

1. When a type parameter is declared by a class, interface, or type
   alias, tsc identifies it by symbol; tsz now interns it structurally
   (`TypeInterner::type_param`) in `intern_type_param_for_decl`,
   converging with the `tsz-lowering` scheme that builds those
   declarations' def bodies. Previously the same declaration's `DB`/`TB`
   existed in two generations — checker-fresh ids (heritage-clause
   arguments, annotation scope) and lowering-structural ids (def-lowered
   member shapes) — and identity-keyed relation rules treated one
   declaration as two unrelated parameters: false TS2416 on
   `implements`/`extends` members whose deferred conditionals or
   `keyof DB[TB]` index accesses close over the outer dependent-
   constrained params. Function-like declarations keep declaration-
   scoped fresh ids so `S[K_outer]` vs `S[K_inner]` (distinct same-named
   function params) keeps erroring. Owner: checker
   `state/type_analysis/core.rs::intern_type_param_for_decl`.

2. When a derived class redeclares an ES private identifier (`#name`),
   tsc keys each slot per declaring class (`__#<id>@name`) so the
   inherited base slot remains a separate member and the derived class
   stays assignable to the base; tsz's merged object shapes key
   properties by surface name, letting the redeclaration shadow the
   inherited brand. `nominal_member_origin_ok` now accepts a `#`-named
   member when the source's declaring class derives from the target's
   declaring class (the inherited slot is always present). `private`
   modifier members keep strict declaration identity; unrelated classes
   with same-named `#` fields keep failing. Owner: solver
   `relations/subtype/rules/objects.rs` (shared by structural check,
   explain, and `CompatChecker` brand override).

## CI fix-forward: genericFunctionInference1

The first push also gated instantiation's unsubstituted-`TypeParameter`
constraint-fallback on substitution relevance. CI `conformance-aggregate`
flagged exactly one regression: `genericFunctionInference1.ts`
(fingerprint mismatch — extra false TS2345 at `pipe2(f25, f25)` with a
mis-generalized `<T extends { value: T }, T_1 extends { value: T }>`
signature; the pipe/compose higher-order regeneralization machinery
depends on the original fallback rewrite for self-constrained function
params). Local bisect attributed the regression to the gate alone, and
with the generation split removed by rule 1 the gate proved redundant:
kysely output is byte-identical without it. The gate is dropped;
`instantiate.rs` is untouched relative to main.

## Scope

- `crates/tsz-checker/src/state/type_analysis/core.rs`: structural
  interning for type-level decl params (+ helper).
- `crates/tsz-solver/src/relations/subtype/rules/objects.rs`,
  `relations/subtype/explain.rs`, `relations/compat_overrides.rs`:
  ES-private nominal derivation (signature threads the member name).
- `crates/tsz-checker/tests/implements_type_param_generation_identity_tests.rs`
  (+ Cargo.toml entry): ports #13163's pins; three pins un-ignored, one
  remains pinned (concrete bivariant conditional-root residue).

## Project Corpus Impact
- Row: kysely-project
- Bug family: contextual generics, guards, indexed/property access —
  implements/extends TS2416 false positives from type-param generation
  identity divergence

Canary table (own clean-main baselines, dist-fast, same configs as
project-compile-guard):

| Row     | main | this PR | delta |
|---------|------|---------|-------|
| kysely  | 183 (TS2416 x48) | 138 (TS2416 x6) | -45 |
| zod     | 86   | 83      | -3   |
| valibot | 1813 | 1814    | +1*  |
| msw     | 216  | 217     | +1** |
| comlink | 7    | 7       | 0    |
| ofetch  | 46   | 46      | 0    |

*valibot +1: `methods/cache/cacheAsync.ts(131,3)` — contextual class
generic inference (`new _LruCache(config)` against a
`Cache<OutputDataset<...>>` context) resolves the element to `unknown`.
Root cause: structural interning interacts with the pre-existing
instantiation constraint-fallback in this contextual flow; the earlier
gate suppressed it but regressed conformance (above), so the +1 is
accepted and tracked as a follow-up.
**msw +1: `src/core/http.ts(42,36)` — tsc 5.5 itself rejects this call
(`http.ts(42,47)` TS2345 on the neighbouring argument under the same
guard config); the new diagnostic lands on a tsc-flagged statement, not
a tsc-clean site (same self-referential `Params extends
PathParams<keyof Params>` family).

With #13163's mapped-indexed substitution applied on top, kysely drops
one further error (137).

## Verification

- Conformance: `genericFunctionInference` 2/2 (includes the CI
  regression `genericFunctionInference1`, now PASS), implementsClause
  2/2, classImplements 11/11, typeParameter 101/101, privateName
  127/127, conditionalType 17/17, indexedAccess 13/13, heritage 1/1.
- `implements_type_param_generation_identity_tests`: 5 active pass
  (witness, renamed binders, recursive mapped-indexed builder,
  unconstrained control, genuinely-incompatible negative control);
  1 pin remains ignored with an updated reason (concrete bivariant
  form needs conditional-root identity, out of scope).
- `cargo nextest run -p tsz-solver`: sole failure is the known
  pre-existing `higher_order_generic_pipe_regeneralizes...`
  local-environment failure. With the gate dropped,
  `instantiation/instantiate.rs` is byte-identical to main, and that
  test exercises only solver instantiation/relations on non-private
  members — its behavior on this branch is bitwise main behavior; the
  local failure is environmental, not a branch regression.
- Full `-p tsz-checker -p tsz-lowering` suite diffed against a clean
  baseline run at the parent commit: no new failures, 11 fixed
  (including the `enum_indexed_access` known-local-failure family,
  `deeply_nested_record_conditional...`, and
  `contextual_kysely_select_array_preserves_aliased_expression_factory_param`).
- `scripts/arch/arch_guard.py`: pass.
- `cargo clippy --profile ci-lint ... -D warnings`: pass.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: high

## Coordination Notes

- Overlap: draft #13165 (`fix/type-param-decl-identity`) attacks the same
  generation-identity family with a different design (solver-owned
  per-(file, node, info) canonical map + instantiation identity
  preservation), measured kysely 188 -> 147 (TS2416 48 -> 17) with one
  known in-family regression. This PR reaches TS2416 48 -> 6 / total
  183 -> 138 with zero new failures across the full checker+lowering
  suite. Proposal: land this first; #13165 rebases, re-measures its
  residual (axes 3/4 — cross-arena child-checker identity and
  instantiation identity preservation — remain its distinct value), and
  drops the parts this PR subsumes. I have not modified or closed
  #13165. Note its known regression
  (`pipe_preserves_self_constrained_generic_function_result`) is the
  same HOFI family that forced this PR's gate removal — evidence that
  instantiation's structural rewrite of fresh function params is
  load-bearing for pipe/compose regeneralization.
- Defect 1 of the decomposed family landed as #13156; defect 2 is
  #13163 (draft) whose mapped-indexed binder substitution waits on this
  PR: its fix exposes +4 kysely errors through the generation-identity
  defect fixed here. After this lands, #13163 rebases, re-runs kysely
  (`where`-member sites become re-checkable; measured 137 combined),
  and flips ready. Its copy of the pin file should be dropped on
  rebase (ported here, three pins un-ignored).
- Campaign context: #13031 / #13037 / #13139 / #13142 / #13145 /
  #13150 landed.
- The remaining kysely TS2416 x6 (`whereRef`/`havingRef`/`groupBy`/
  `$asTuple`/`$asScalar`/`executeTakeFirstOrThrow`), the ignored
  bivariant pin, and the valibot cacheAsync contextual-inference +1
  are follow-up candidates.
