### PR TITLE
fix(solver): non-destructive interner-limit degradation + per-file evaluation fuel — kills the cross-file re-inference storm

### DIFF
--- a/crates/tsz-checker/src/context/cross_file_query.rs
+++ b/crates/tsz-checker/src/context/cross_file_query.rs
@@ -205,7 +205,10 @@ impl<'a> CheckerContext<'a> {
         file_idx: u32,
         secondary: u32,
         args_hash: u64,
-    ) -> Option<(tsz_solver::TypeId, Vec<tsz_solver::TypeParamInfo>)> {
+    ) -> Option<(
+        tsz_solver::TypeId,
+        std::sync::Arc<Vec<tsz_solver::TypeParamInfo>>,
+    )> {
         if !self.share_owner_symbol_type_results {
             record_cross_file_cache_miss_cause(CrossFileCacheMissCause::GateOff);
             return None;
@@ -228,6 +231,15 @@ impl<'a> CheckerContext<'a> {
             return None;
         }
         if !type_id_is_known_to_db(self.types, cached_type) {
+            tracing::trace!(
+                target: "cross_file_cache",
+                sym_id = sym_id.0,
+                file_idx,
+                secondary,
+                args_hash,
+                type_id = cached_type.0,
+                "symbol bucket entry rejected: TypeId not interned in reader's db"
+            );
             record_cross_file_cache_miss_cause(CrossFileCacheMissCause::TypeIdNotInterned);
             return None;
         }
@@ -246,7 +258,10 @@ impl<'a> CheckerContext<'a> {
         &self,
         sym_id: SymbolId,
         file_idx: u32,
-    ) -> Option<(tsz_solver::TypeId, Vec<tsz_solver::TypeParamInfo>)> {
+    ) -> Option<(
+        tsz_solver::TypeId,
+        std::sync::Arc<Vec<tsz_solver::TypeParamInfo>>,
+    )> {
         self.cached_symbol_type_entry(sym_id, file_idx, 0, 0)
     }
 
@@ -262,7 +277,10 @@ impl<'a> CheckerContext<'a> {
         file_idx: u32,
         scope: u64,
         requester_file_idx: u32,
-    ) -> Option<(tsz_solver::TypeId, Vec<tsz_solver::TypeParamInfo>)> {
+    ) -> Option<(
+        tsz_solver::TypeId,
+        std::sync::Arc<Vec<tsz_solver::TypeParamInfo>>,
+    )> {
         self.cached_symbol_type_entry(
             sym_id,
             file_idx,
@@ -283,7 +301,10 @@ impl<'a> CheckerContext<'a> {
         sym_id: SymbolId,
         file_idx: u32,
         scope: u64,
-    ) -> Option<(tsz_solver::TypeId, Vec<tsz_solver::TypeParamInfo>)> {
+    ) -> Option<(
+        tsz_solver::TypeId,
+        std::sync::Arc<Vec<tsz_solver::TypeParamInfo>>,
+    )> {
         self.cached_symbol_type_entry(sym_id, file_idx, 0, scope)
     }
 
@@ -555,7 +576,10 @@ impl<'a> CheckerContext<'a> {
         &self,
         sym_id: SymbolId,
         file_idx: u32,
-    ) -> Option<(tsz_solver::TypeId, Vec<tsz_solver::TypeParamInfo>)> {
+    ) -> Option<(
+        tsz_solver::TypeId,
+        std::sync::Arc<Vec<tsz_solver::TypeParamInfo>>,
+    )> {
         if !self.share_owner_symbol_type_results {
             record_cross_file_cache_miss_cause(CrossFileCacheMissCause::GateOff);
             return None;

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
@@ -669,7 +669,7 @@ impl<'a> CheckerState<'a> {
                 // which only searches the *current* arena and returns None
                 // for cross-file classes — so the constructor type leaks
                 // into the instance position.
-                if let Some(cached) = self
+                if let Some((cached_type, cached_params)) = self
                     .ctx
                     .cached_cross_file_symbol_type(sym_id, file_idx as u32)
                 {
@@ -681,7 +681,7 @@ impl<'a> CheckerState<'a> {
                     {
                         self.ctx.symbol_instance_types.insert(sym_id, inst_type);
                     }
-                    return cached;
+                    return (cached_type, cached_params.as_ref().clone());
                 }
                 // Found class in another file's arena. Create a child checker
                 // with that arena and directly compute the class type.

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -978,6 +978,9 @@ impl<'a> CheckerState<'a> {
             // already model requester stability; memoizing them here changed
             // elaboration output on the valibot/kysely canaries. In-progress
             // guard returns above never reach this write.
+            if matches!(result, TypeId::ERROR | TypeId::UNKNOWN) {
+                tsz_common::perf_counters::record_delegate_cross_arena_full_work_sentinel_result();
+            }
             if let Some(file_idx) = memo_file_idx
                 && let Some(fp) = memo_context_fp
                 && matches!(result, TypeId::ERROR | TypeId::UNKNOWN)
@@ -1064,7 +1067,7 @@ impl<'a> CheckerState<'a> {
                 .cached_cross_file_class_instance_type(sym_id, file_idx as u32)
         {
             tsz_common::perf_counters::record_delegate_cross_arena_cache_hit_cross_file();
-            return Some((cached_type, cached_params));
+            return Some((cached_type, cached_params.as_ref().clone()));
         }
 
         // Delegation-tree memo of completed `None`/sentinel outcomes the

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_alias_shortcut.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_alias_shortcut.rs
@@ -143,6 +143,7 @@ impl<'a> CheckerState<'a> {
                     self.ctx
                         .cached_cross_file_symbol_type(target_sym_id, file_idx as u32)
                 })
+                .map(|(cached_type, cached_params)| (cached_type, cached_params.as_ref().clone()))
                 .or_else(|| {
                     let resolved = self.direct_source_file_type_alias_result(
                         target_sym_id,
@@ -208,12 +209,16 @@ impl<'a> CheckerState<'a> {
         symbol_type_cache_from_symbol_arena: bool,
     ) -> Option<(TypeId, Vec<tsz_solver::TypeParamInfo>)> {
         let file_idx = file_idx as u32;
-        if !symbol_type_cache_from_symbol_arena {
-            return self.ctx.cached_cross_file_symbol_type(sym_id, file_idx);
-        }
-
-        self.ctx
-            .cached_stable_source_file_symbol_arena_type(sym_id, file_idx, source_cache_scope)
+        let cached = if symbol_type_cache_from_symbol_arena {
+            self.ctx.cached_stable_source_file_symbol_arena_type(
+                sym_id,
+                file_idx,
+                source_cache_scope,
+            )
+        } else {
+            self.ctx.cached_cross_file_symbol_type(sym_id, file_idx)
+        };
+        cached.map(|(cached_type, cached_params)| (cached_type, cached_params.as_ref().clone()))
     }
 
     pub(super) fn cache_symbol_arena_or_cross_file_symbol_type(

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_functions_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_functions_tests.rs
@@ -336,7 +336,7 @@ fn delegate_explicit_cross_file_source_function_lowers_annotated_signature() {
     assert_eq!(shape.return_type, TypeId::STRING);
     assert_eq!(
         state.ctx.cached_cross_file_symbol_type(summarize_sym, 1),
-        Some((ty, params)),
+        Some((ty, std::sync::Arc::new(params))),
         "explicit cross-file function result should be cached by file target",
     );
 }
@@ -403,7 +403,7 @@ fn delegate_explicit_cross_file_source_const_arrow_lowers_type_predicate() {
     assert_ne!(predicate.type_id, Some(TypeId::ERROR));
     assert_eq!(
         state.ctx.cached_cross_file_symbol_type(guard_sym, 1),
-        Some((ty, params)),
+        Some((ty, std::sync::Arc::new(params))),
         "explicit cross-file const arrow result should be cached by file target",
     );
 }

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_tests.rs
@@ -789,7 +789,7 @@ fn delegate_source_file_type_alias_caches_generic_params() {
         state
             .ctx
             .cached_stable_source_file_symbol_arena_type(leaf_sym, target_file_idx, scope),
-        Some((ty, params)),
+        Some((ty, std::sync::Arc::new(params))),
         "stable source-file symbol-arena cache hits must preserve generic params",
     );
     assert_eq!(
@@ -850,7 +850,7 @@ fn assert_explicit_cross_file_source_alias_lowers(alias_name: &str, source: &str
     );
     assert_eq!(
         state.ctx.cached_cross_file_symbol_type(alias_sym, 1),
-        Some((ty, params)),
+        Some((ty, std::sync::Arc::new(params))),
         "explicit cross-file alias result should be cached by file target",
     );
 }

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -1246,6 +1246,12 @@ impl<'a> CheckerState<'a> {
         // fresh budget for Application type evaluations. Without this, a complex
         // file (react16.d.ts) would exhaust the fuel and starve subsequent files.
         self.ctx.eval_session.reset_instantiation_fuel();
+        // Likewise reset the interner's global evaluation fuel: `tsc` resets
+        // `instantiationCount` per checked source element, so the budget must
+        // bound per-file runaway evaluation. Left cumulative, a
+        // multi-thousand-file program exhausts it early and every later
+        // file's evaluations collapse to `TypeId::ERROR`.
+        self.ctx.types.reset_evaluation_fuel();
 
         // Collect unique symbols from user code only (node_symbols).
         // Lib symbols from file_locals are NOT included here — they are resolved

--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -29,6 +29,7 @@ impl PerfCounters {
              cache hits (lib)           {:>12}\n  \
              cache hits (cross-file)    {:>12}\n  \
              misses (full work)         {:>12}\n  \
+             full-work sentinel results {:>12}\n  \
              max recursion depth        {:>12}\n  \
              xfile type-params hits     {:>12}\n  \
              xfile type-params misses   {:>12}\n\
@@ -77,6 +78,7 @@ impl PerfCounters {
             snap.delegate.cache_hits_lib,
             snap.delegate.cache_hits_cross_file,
             snap.delegate.misses,
+            snap.delegate.full_work_sentinel_results,
             snap.delegate.max_recursion_depth,
             snap.delegate.cross_file_type_params_cache_hits,
             snap.delegate.cross_file_type_params_cache_misses,
@@ -129,6 +131,7 @@ impl PerfCounters {
             + &Self::dump_compute_type_of_symbol_interface_simple_object_type_reference_reject_residues(
                 &snap.compute_type_of_symbol_interface_simple_object_type_reference_reject_residues,
             )
+            + &Self::dump_cross_file_cache_miss_causes(&snap.cross_file_cache_miss_causes)
             + &Self::dump_cross_arena_symbol_miss_classification()
             + &Self::dump_cross_arena_alias_shortcut_outcomes()
             + &Self::dump_direct_cross_file_interface_lowering_outcomes()
@@ -379,6 +382,24 @@ impl PerfCounters {
                 row.property.as_deref().unwrap_or("<unknown>"),
                 row.count,
             ));
+        }
+        out
+    }
+
+    /// Why canonical cross-file query bucket reads returned `None` (see
+    /// `CrossFileCacheMissCause`). `bucket_empty` is the expected first-miss
+    /// case; a large `sentinel_error_unknown` count means completed
+    /// `ERROR`/`UNKNOWN` answers are being recomputed instead of replayed.
+    fn dump_cross_file_cache_miss_causes(causes: &[NamedCount]) -> String {
+        let total: u64 = causes.iter().map(|c| c.count).sum();
+        if total == 0 {
+            return String::new();
+        }
+        let mut out = String::from("\nCross-file query bucket miss causes:\n");
+        for cause in causes {
+            if cause.count > 0 {
+                out.push_str(&format!("  {:<28} {:>12}\n", cause.name, cause.count));
+            }
         }
         out
     }

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -8,6 +8,11 @@ pub struct PerfCounters {
     pub delegate_cross_arena_cache_hits_lib: AtomicU64,
     pub delegate_cross_arena_cache_hits_cross_file: AtomicU64,
     pub delegate_cross_arena_misses: AtomicU64,
+    /// Of `delegate_cross_arena_misses` (full child-checker work), how many
+    /// completed with a sentinel (`ERROR`/`UNKNOWN`) result. Sentinels are
+    /// refused by the shared cross-file buckets, so a large count here means
+    /// the same failed resolutions are being recomputed per delegation tree.
+    pub delegate_cross_arena_full_work_sentinel_results: AtomicU64,
     /// T2.2 cross-file type-parameter memo: hits and misses on the
     /// `extract_type_params_from_decl` slow-path memoization. A hit means
     /// the slow-path's `with_parent_cache_attributed(..., TypeEnvironmentCore)`
@@ -191,6 +196,7 @@ impl PerfCounters {
             delegate_cross_arena_cache_hits_lib: AtomicU64::new(0),
             delegate_cross_arena_cache_hits_cross_file: AtomicU64::new(0),
             delegate_cross_arena_misses: AtomicU64::new(0),
+            delegate_cross_arena_full_work_sentinel_results: AtomicU64::new(0),
             cross_file_type_params_cache_hits: AtomicU64::new(0),
             cross_file_type_params_cache_misses: AtomicU64::new(0),
             delegate_max_recursion_depth: AtomicU64::new(0),
@@ -785,6 +791,19 @@ pub fn record_delegate_cross_arena_miss() {
     let c = counters();
     c.delegate_cross_arena_calls.fetch_add(1, Ordering::Relaxed);
     c.delegate_cross_arena_misses
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record that a full-work cross-arena delegation (a miss that ran a child
+/// checker) completed with a sentinel (`ERROR`/`UNKNOWN`) result that the
+/// shared cross-file buckets refuse to store.
+#[inline]
+pub fn record_delegate_cross_arena_full_work_sentinel_result() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .delegate_cross_arena_full_work_sentinel_results
         .fetch_add(1, Ordering::Relaxed);
 }
 

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -299,6 +299,9 @@ pub struct DelegateCounters {
     pub cache_hits_lib: u64,
     pub cache_hits_cross_file: u64,
     pub misses: u64,
+    /// Of `misses` (full child-checker work), completions whose result was a
+    /// sentinel (`ERROR`/`UNKNOWN`) the shared cross-file buckets refuse.
+    pub full_work_sentinel_results: u64,
     pub max_recursion_depth: u64,
     /// T2.2 typed-query memo: hits on the cross-file type-parameter cache.
     pub cross_file_type_params_cache_hits: u64,
@@ -506,6 +509,9 @@ impl PerfCounters {
                 cache_hits_lib: load(&c.delegate_cross_arena_cache_hits_lib),
                 cache_hits_cross_file: load(&c.delegate_cross_arena_cache_hits_cross_file),
                 misses: load(&c.delegate_cross_arena_misses),
+                full_work_sentinel_results: load(
+                    &c.delegate_cross_arena_full_work_sentinel_results,
+                ),
                 max_recursion_depth: load(&c.delegate_max_recursion_depth),
                 cross_file_type_params_cache_hits: load(&c.cross_file_type_params_cache_hits),
                 cross_file_type_params_cache_misses: load(&c.cross_file_type_params_cache_misses),

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -363,6 +363,7 @@ mod json_tests {
                 "cache_hits_lib",
                 "cache_hits_cross_file",
                 "misses",
+                "full_work_sentinel_results",
                 "max_recursion_depth",
                 "cross_file_type_params_cache_hits",
                 "cross_file_type_params_cache_misses",

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -546,6 +546,13 @@ pub trait TypeDatabase:
     fn is_evaluation_fuel_exhausted(&self) -> bool {
         false
     }
+
+    /// Reset the global evaluation fuel counter at a top-level check
+    /// boundary (per file-check session). Mirrors `tsc` resetting
+    /// `instantiationCount` per checked source element: the budget bounds
+    /// per-check runaway, not cumulative whole-program work. Default no-op
+    /// for databases without a fuel counter.
+    fn reset_evaluation_fuel(&self) {}
 }
 
 impl TypePredicateCache for TypeInterner {
@@ -1029,6 +1036,10 @@ impl TypeDatabase for TypeInterner {
 
     fn is_evaluation_fuel_exhausted(&self) -> bool {
         Self::is_evaluation_fuel_exhausted(self)
+    }
+
+    fn reset_evaluation_fuel(&self) {
+        Self::reset_evaluation_fuel(self);
     }
 }
 

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1352,6 +1352,10 @@ impl TypeDatabase for QueryCache<'_> {
     fn is_evaluation_fuel_exhausted(&self) -> bool {
         self.interner.is_evaluation_fuel_exhausted()
     }
+
+    fn reset_evaluation_fuel(&self) {
+        self.interner.reset_evaluation_fuel();
+    }
 }
 
 /// Implement `TypeResolver` for `QueryCache` with noop resolution.

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -919,6 +919,10 @@ impl DefinitionStore {
     }
 
     /// Look up a previously resolved cross-file query result.
+    ///
+    /// Returns the shared `Arc` over the cached type-params so per-hit reads
+    /// are O(1) (no `Vec<TypeParamInfo>` deep clone). Callers that need an
+    /// owned `Vec` clone at their own boundary.
     pub fn get_resolved_cross_file_query(
         &self,
         kind: u8,
@@ -926,12 +930,12 @@ impl DefinitionStore {
         primary: u32,
         secondary: u32,
         args_hash: u64,
-    ) -> Option<(TypeId, Vec<TypeParamInfo>)> {
+    ) -> Option<(TypeId, Arc<Vec<TypeParamInfo>>)> {
         self.resolved_cross_file_queries
             .get(&(kind, file_idx, primary, secondary, args_hash))
             .map(|entry| {
                 let (type_id, params) = entry.value();
-                (*type_id, params.as_ref().clone())
+                (*type_id, Arc::clone(params))
             })
     }
 

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -72,24 +72,28 @@ pub(crate) const TEMPLATE_LITERAL_EXPANSION_LIMIT: usize = 100_000;
 
 /// Maximum number of interned types before the interner returns `TypeId::ERROR`.
 ///
-/// Native and WASM currently share the same 500k policy. The circuit breaker
-/// was introduced with matching values on both cfg branches; there is no
-/// separate native memory budget yet. Keep both constants visible so any future
-/// target-specific change is reviewed explicitly.
-///
 /// Prevents OOM on pathological inputs (e.g., DOM types + module augmentation
 /// that create millions of intermediate types via heritage merging and
 /// function shape instantiation). With roughly 200-300 bytes per interned entry
-/// (DashMap overhead, `Arc`, shapes), 500k types is roughly a 100-150MB
-/// interner budget before fallback.
+/// (DashMap overhead, `Arc`, shapes), 8M types is roughly a 1.6-2.4GB
+/// interner budget before fallback; WASM keeps the historical 500k
+/// (~100-150MB) because the 32-bit heap cannot host a multi-GB interner.
 ///
-/// When the count is exceeded, new non-intrinsic interning poisons the interner
-/// and returns `TypeId::ERROR`. Already-computed ids remain readable for later
-/// diagnostics.
+/// The native value is sized for legitimate large programs, not as a working
+/// budget: a 1.2k-file slice of the `large-ts-repo` benchmark (with aws-sdk
+/// dependency surface) legitimately interns >500k unique types, and the full
+/// 12k-file row needs several million. The old shared 500k cap made the cap a
+/// *semantic* cliff on real projects rather than a pathological-input guard.
+///
+/// When the count is exceeded, new non-intrinsic interning poisons the
+/// interner and returns `TypeId::ERROR`. Already-computed ids remain readable
+/// (`lookup` and existing-key `intern` still succeed) so later diagnostics,
+/// relations, and shared cross-file caches keep working; only *new* type
+/// construction degrades to `ERROR`.
 #[cfg(target_arch = "wasm32")]
 pub(crate) const MAX_INTERNED_TYPES: usize = 500_000;
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) const MAX_INTERNED_TYPES: usize = 500_000;
+pub(crate) const MAX_INTERNED_TYPES: usize = 8_000_000;
 
 /// Maximum cumulative evaluation fuel across all `TypeEvaluator` instances.
 ///
@@ -832,9 +836,11 @@ impl TypeInterner {
     /// before falling through to the `DashMap` lookup.
     #[inline]
     pub fn intern(&self, key: TypeData) -> TypeId {
-        if self.poisoned.load(std::sync::atomic::Ordering::Relaxed) {
-            return TypeId::ERROR;
-        }
+        // NOTE: a poisoned interner (type-count limit) is handled in
+        // `intern_slow` *after* the existing-key read paths, so already
+        // interned keys keep resolving to their existing ids. Only new
+        // allocations degrade to `TypeId::ERROR`.
+        //
         // T2.4 instrumentation. Semantics:
         //   intern_calls   = number of non-poisoned `intern()` entries
         //   intern_hits    = returned an existing `TypeId` (intrinsic, TL
@@ -960,18 +966,14 @@ impl TypeInterner {
         hash: u64,
         pc: Option<&'static tsz_common::perf_counters::PerfCounters>,
     ) -> TypeId {
-        // Circuit breaker 1: type count limit. Returning `TypeId::ERROR` here
-        // intentionally does not credit a hit or miss — the residual
-        // `calls - hits - misses` exposes circuit-breaker activations.
-        if self.interned_type_limit_exceeded() {
-            return self.poison_due_to_interned_type_limit();
-        }
-
         let shard_idx = (hash as usize) & (SHARD_COUNT - 1);
         let shard = &self.shards[shard_idx];
         let inner = shard.get_inner();
 
-        // Try to get existing ID (lock-free read)
+        // Try to get existing ID (lock-free read). This runs even when the
+        // interner is poisoned: already-interned keys must keep resolving to
+        // their existing ids so program semantics and shared caches survive
+        // a type-count-limit event (only *new* types degrade to ERROR).
         if let Some(entry) = inner.key_to_index.get(&key) {
             let local_index = *entry.value();
             if let Some(c) = pc {
@@ -979,6 +981,13 @@ impl TypeInterner {
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             }
             return self.make_id(local_index, shard_idx as u32);
+        }
+
+        // Circuit breaker 1: type count limit. Returning `TypeId::ERROR` here
+        // intentionally does not credit a hit or miss — the residual
+        // `calls - hits - misses` exposes circuit-breaker activations.
+        if self.interned_type_limit_exceeded() {
+            return self.poison_due_to_interned_type_limit();
         }
 
         // Allocate new index
@@ -1052,9 +1061,10 @@ impl TypeInterner {
     /// mode) is detected and treated as a miss.
     #[inline]
     pub fn lookup(&self, id: TypeId) -> Option<TypeData> {
-        if self.poisoned.load(std::sync::atomic::Ordering::Relaxed) {
-            return None;
-        }
+        // Intentionally NOT gated on `poisoned`: already-interned ids must
+        // remain readable after a type-count-limit event so previously
+        // computed program types (and the cross-file caches that hold their
+        // ids) do not collapse to opaque misses. Only new interning degrades.
         if id.is_intrinsic() || id.is_error() {
             return self.get_intrinsic_key(id);
         }
@@ -1235,6 +1245,18 @@ impl TypeInterner {
     pub fn consume_evaluation_fuel(&self, amount: u32) -> bool {
         let prev = self.evaluation_fuel.fetch_add(amount, Ordering::Relaxed);
         prev.wrapping_add(amount) > MAX_EVALUATION_FUEL
+    }
+
+    /// Reset the global evaluation fuel counter.
+    ///
+    /// Called at the start of each top-level file check session. `tsc` resets
+    /// its `instantiationCount` per checked source element, so the fuel limit
+    /// must bound *per-check* runaway instantiation rather than accumulate
+    /// across the whole program — a cumulative budget starves the tail files
+    /// of any multi-thousand-file program into blanket `TypeId::ERROR`.
+    #[inline]
+    pub fn reset_evaluation_fuel(&self) {
+        self.evaluation_fuel.store(0, Ordering::Relaxed);
     }
 
     /// Check whether global evaluation fuel is exhausted without consuming any.

--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::caches::db::TypeDatabase;
 
 #[test]
 fn interned_type_limit_fallback_poison_returns_error() {
@@ -18,6 +19,37 @@ fn interned_type_limit_fallback_poison_returns_error() {
     );
     assert_eq!(interner.poison_due_to_interned_type_limit(), TypeId::ERROR);
     assert!(interner.poisoned.load(Ordering::Relaxed));
+}
+
+#[test]
+fn poisoned_interner_keeps_existing_types_readable_and_rejects_new_ones() {
+    let interner = TypeInterner::new();
+
+    // Intern a couple of structurally distinct types before the limit hits.
+    let pre_limit_union = TypeDatabase::union2(&interner, TypeId::STRING, TypeId::NUMBER);
+    let pre_limit_data = interner
+        .lookup(pre_limit_union)
+        .expect("freshly interned type must be readable");
+
+    // Simulate crossing the type-count limit.
+    interner
+        .alloc_counter
+        .store((MAX_INTERNED_TYPES + 1) as u32, Ordering::Relaxed);
+    assert_eq!(interner.poison_due_to_interned_type_limit(), TypeId::ERROR);
+    assert!(interner.poisoned.load(Ordering::Relaxed));
+
+    // Already-interned ids stay readable: graceful degradation must not
+    // collapse previously computed program types (or the shared cross-file
+    // caches holding their ids) into opaque misses.
+    assert_eq!(interner.lookup(pre_limit_union), Some(pre_limit_data));
+
+    // Re-interning an existing key resolves to the existing id.
+    let reinterned = TypeDatabase::union2(&interner, TypeId::STRING, TypeId::NUMBER);
+    assert_eq!(reinterned, pre_limit_union);
+
+    // Brand-new structural keys degrade to ERROR.
+    let fresh = TypeDatabase::union2(&interner, TypeId::BOOLEAN, TypeId::NUMBER);
+    assert_eq!(fresh, TypeId::ERROR);
 }
 
 #[test]

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -29,7 +29,7 @@ TRAIT_METHOD_COUNT_CHECKS = [
         "Solver boundary: TypeDatabase method count (#8205)",
         ROOT / "crates" / "tsz-solver" / "src" / "caches" / "db.rs",
         "TypeDatabase",
-        79,
+        80,
     ),
 ]
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -764,7 +764,7 @@ FILE_LINE_LIMIT_CHECKS = [
         / "state"
         / "type_environment"
         / "core.rs",
-        1461,
+        1463,
     ),
     (
         "Conformance boundary: conformance runner size ratchet",
@@ -1007,7 +1007,7 @@ TRAIT_METHOD_COUNT_CHECKS = [
         "Solver boundary: TypeDatabase method count (#8205)",
         ROOT / "crates" / "tsz-solver" / "src" / "caches" / "db.rs",
         "TypeDatabase",
-        79,
+        80,
     ),
 ]
 


### PR DESCRIPTION
Goal: fast

## Summary

The `large-ts-repo` row's cross-arena re-inference storm (the post-#13164 dominant cost; row DNF at 61min/1 core/23.5GB vs tsgo 25.6s) traces to **interner self-poisoning**, not cache keying: `MAX_INTERNED_TYPES = 500_000` while a 1,191-file slice of the row legitimately interns ~2M unique types. On poisoning, `lookup()` returned `None` and `intern()` returned `ERROR` **for already-interned keys too** (contradicting the mechanism's own doc), so cross-file result buckets rejected 85,805 reads as `type_id_not_interned` and 58,758 child-checker runs completed only to produce unstorable ERROR/UNKNOWN sentinels — every importer re-inferred imported function bodies from scratch. A second cliff of the same family: `MAX_EVALUATION_FUEL = 2M` was cumulative program-wide and never reset (tsc resets `instantiationCount` per checked source element).

## Structural rule

Resource-limit degradation must be non-destructive: crossing the interned-type limit stops *new* structural keys (degrade to `ERROR`) but already-interned ids stay readable and re-interning an existing key resolves to its existing id — so previously computed program types and the shared cross-file caches holding their ids survive. Evaluation fuel is a per-file budget, reset in `build_type_environment` beside the existing session-fuel reset.

Changes: native interned-type cap 500k→8M (WASM keeps 500k); poison-safe `lookup`/`intern_slow` (existing-key read precedes the limit check); `TypeDatabase::reset_evaluation_fuel` called per file; `get_resolved_cross_file_query` returns the stored `Arc<Vec<TypeParamInfo>>` instead of deep-cloning per cache hit; new perf counters (full-work sentinel results, cross-file bucket miss causes) that located this.

## Measured (1,191-file row slice probe)

| | before | after |
|---|---|---|
| cross-file bucket rejects | 85,805 | **0** |
| sentinel full-work child runs | 58,758 | 4,378 |
| delegate calls / full-work misses | 613,661 / 192,898 | 101,711 / 11,660 |
| interned types | 500,101 (capped, poisoned) | 1,971,462 (real demand) |
| zodmin witness | 2.71s | 2.43s, diagnostics byte-identical |
| zodmin30 | 4.29s | 3.66s, byte-identical |

The full 12k-file row still DNFs at a 900s cap — necessary, not sufficient: the next dominant levers (diagnostic rendering inside discarded delegation children; 33.6M symbol-file-target overlay copies; the 1-core sequential fallback) are profiled and recorded for follow-up.

Semantic note: programs that previously exceeded 500k interned types received ERROR-collapsed types and the diagnostics that follow from them; they now get real types (the probe slice goes 60→64 diagnostics — the corrected behavior). Sub-cap programs are bitwise unchanged.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: high

## Verification

- Full local conformance on this branch: 12583/12585 — zero new vs the accepted ledger (and `intersectionsOfLargeUnions` keeps passing post-#13164).
- `cargo nextest run -p tsz-solver`: 6,610/6,611 (1 pre-existing); new test `poisoned_interner_keeps_existing_types_readable_and_rejects_new_ones` pins the non-destructive degradation (fails on main). tsz-common 500/500; tsz-checker `--lib` failure set byte-identical to HEAD (pre-existing Mac deltas, stash A/B verified).
- Conformance filters: moduleResolution 111/111, exportAssignment 32/32, recursive 91/91, conditionalType 17/17, depth 55/55, mappedType 55/55, instantiation 3/3.
- Witness diagnostics byte-identical (zodmin, zodmin30).
- Arch guard passes (TypeDatabase cap 79→80 for `reset_evaluation_fuel`, per #8205 protocol; core.rs ratchet 1461→1463).
