### PR TITLE
fix(checker): keep return-context-instantiated contextual types for object-literal args (#10663 operation-node facet)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers.rs
@@ -221,6 +221,15 @@ impl<'a> CheckerState<'a> {
             && self.ctx.generic_excess_skip.as_ref().is_some_and(|skip| {
                 arg_index.is_some_and(|index| index < skip.len() && skip[index])
             })
+            // Only restore the callee's raw (uninstantiated) parameter type when
+            // the incoming contextual type is itself still unresolved (a bare type
+            // parameter or a type mentioning one). When a return-context refresh
+            // already instantiated the parameter to a concrete contextual type
+            // (e.g. `T` pinned to `WithNodeFactory` from `freeze(...)`'s
+            // contextual return), that concrete type must stay authoritative so
+            // nested method bodies see their real contextual signatures instead
+            // of widening against bare `T`.
+            && contains_type_parameters(self.ctx.types, type_id)
             && let Some(arg_index) = arg_index
             && let Some(callable_type) = callable_ctx.callable_type
             && let Some(shape) = crate::query_boundaries::checkers::call::get_contextual_signature(

--- a/crates/tsz-checker/src/types/computation/call/inner_argument_collection.rs
+++ b/crates/tsz-checker/src/types/computation/call/inner_argument_collection.rs
@@ -1184,6 +1184,16 @@
                         } else {
                             crate::query_boundaries::common::TypeSubstitution::new()
                         };
+                    trace!(
+                        contextual_type = ?contextual_type.map(|t| t.0),
+                        return_type = shape.return_type.0,
+                        substitution = ?single_pass_return_context_substitution
+                            .map()
+                            .iter()
+                            .map(|(name, ty)| (self.ctx.types.resolve_atom(*name), ty.0))
+                            .collect::<Vec<_>>(),
+                        "Single-pass return-context substitution"
+                    );
                     let needs_refresh = args.iter().enumerate().any(|(i, &arg)| {
                         self.argument_needs_refresh_for_contextual_call(
                             arg,
@@ -1325,6 +1335,14 @@
                                     )
                                 })
                                 .collect();
+                            trace!(
+                                param_types = ?shape.params.iter().map(|p| p.type_id.0).collect::<Vec<_>>(),
+                                refreshed_contextual_types = ?refreshed_contextual_types
+                                    .iter()
+                                    .map(|t| t.map(|t| t.0))
+                                    .collect::<Vec<_>>(),
+                                "Single-pass refresh contextual types"
+                            );
                             let mut refreshed_args = self.collect_call_argument_types_with_context(
                                 args,
                                 |i, _arg_count| {

--- a/crates/tsz-checker/src/types/computation/object_literal_context.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_context.rs
@@ -1213,6 +1213,7 @@ impl<'a> CheckerState<'a> {
             && effective_property_presence != ContextualPropertyPresence::Absent
         {
             tracing::trace!(
+                original_contextual_type = original_contextual_type.0,
                 contextual_type = contextual_type.0,
                 property_name,
                 "contextual_object_literal_property_type: deferred unknown"

--- a/crates/tsz-checker/tests/return_context_identity_wrapper_literal_tests.rs
+++ b/crates/tsz-checker/tests/return_context_identity_wrapper_literal_tests.rs
@@ -109,6 +109,106 @@ const WithNode: WithNodeFactory = freeze({
     );
 }
 
+/// The operation-node witness: an OUTER generic identity-wrapper call whose
+/// object-literal argument has a non-context-sensitive method (all params
+/// annotated) with a nested generic call in its body. The outer call's
+/// return-context substitution pins the wrapper's type parameter to the
+/// contextual factory type, and that concrete contextual must survive into the
+/// literal's method body so the inner wrapper sees `Readonly<XNode>` and keeps
+/// the literal discriminant.
+#[test]
+fn outer_generic_call_with_annotated_method_preserves_literal() {
+    assert_no_widening_false_positive(
+        &[(
+            "outer.ts",
+            r#"
+function deepFreeze<TObj>(entity: TObj): Readonly<TObj> { return entity; }
+interface LimitNode { readonly kind: "LimitNode"; readonly max: number; }
+interface LimitNodeFactory { create(max: number): Readonly<LimitNode>; }
+const LimitNode: LimitNodeFactory = deepFreeze({
+    create(max: number) {
+        return deepFreeze({ kind: "LimitNode", max });
+    },
+});
+"#,
+        )],
+        "outer generic call with annotated method",
+    );
+}
+
+/// Same outer-call shape with an explicit type argument on the inner wrapper:
+/// the explicit instantiation already provides the contextual pin, and the
+/// outer refresh must not disturb it.
+#[test]
+fn outer_generic_call_with_explicit_inner_type_argument_preserves_literal() {
+    assert_no_widening_false_positive(
+        &[(
+            "explicit.ts",
+            r#"
+function wrapValue<Z>(value: Z): Readonly<Z> { return value; }
+interface AlterNode { readonly kind: "AlterNode"; readonly size: number; }
+interface AlterNodeFactory { create(size: number): Readonly<AlterNode>; }
+const AlterNode: AlterNodeFactory = wrapValue({
+    create(size: number) {
+        return wrapValue<AlterNode>({ kind: "AlterNode", size });
+    },
+});
+"#,
+        )],
+        "outer generic call with explicit inner type argument",
+    );
+}
+
+/// Same outer-call shape where the method return type is annotated: the
+/// annotation supplies the inner contextual return directly and the outer
+/// refresh must keep it intact.
+#[test]
+fn outer_generic_call_with_annotated_method_return_preserves_literal() {
+    assert_no_widening_false_positive(
+        &[(
+            "annotated-return.ts",
+            r#"
+function sealItem<Q>(input: Q): Readonly<Q> { return input; }
+interface UniqueNode { readonly kind: "UniqueNode"; readonly width: number; }
+interface UniqueNodeFactory { build(width: number): Readonly<UniqueNode>; }
+const UniqueNode: UniqueNodeFactory = sealItem({
+    build(width: number): Readonly<UniqueNode> {
+        return sealItem({ kind: "UniqueNode", width });
+    },
+});
+"#,
+        )],
+        "outer generic call with annotated method return",
+    );
+}
+
+/// Negative for the outer-call shape: a wrong literal discriminant in the
+/// nested wrapper must still produce `TS2322`. The concrete contextual pin
+/// must not silence real mismatches.
+#[test]
+fn outer_generic_call_still_reports_wrong_literal_kind() {
+    let wrong = r#"
+function grabAll<R>(obj: R): Readonly<R> { return obj; }
+interface MergeNode { readonly kind: "MergeNode"; readonly span: number; }
+interface MergeNodeFactory { create(span: number): Readonly<MergeNode>; }
+const MergeNode: MergeNodeFactory = grabAll({
+    create(span: number) {
+        return grabAll({ kind: "Wrong", span });
+    },
+});
+"#;
+    let files = vec![("merge-node.ts", wrong)];
+    let diags = check(&files, "merge-node.ts");
+    assert!(
+        codes(&diags).contains(&2322),
+        "expected TS2322 for the wrong literal discriminant through the outer call, got: {:#?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
 /// Negative: a factory whose `create` returns the *wrong* literal discriminant
 /// must still report `TS2322`. The literal pinning must not erase real
 /// mismatches by widening both sides.


### PR DESCRIPTION
Fixes the #8773 "operation-node" contextual-inference facet of the Kysely row tracker (#10663): a generic identity-wrapper call (`freeze<T>(obj: T): Readonly<T>`) with an object-literal argument carrying a **non-context-sensitive** method (all params annotated) whose body nests another generic call widened the literal discriminant (`kind: "WithNode"` → `string`) and emitted a spurious `TS2322`. `tsc 5.9.3` is clean.

AgentName: M1FableArchitect

Track: conformance / project corpus (kysely row, #10663 / #8773)

Invariant: Argument contextual typing must keep return-context-instantiated parameter types authoritative; a contextual pin established through the arg-validated return-context matcher must not be silently replaced by the callee's uninstantiated parameter type.

Scope: checker only — `contextual_type_option_for_call_argument_at` raw-param override gate, plus three `trace!` events on the single-pass return-context path. No solver, binder, or emitter changes.

## Goal

Goal: green

## Provenance

- Machine: m1
- Assistant: claude-code
- Model: claude-fable-5
- Effort: high

## Structural rule

When a generic call's object-literal argument sits at a parameter position whose declared type is a bare type parameter (the `generic_excess_skip` positions), and argument collection supplies an expected contextual type that is **still unresolved** (mentions type parameters), tsz types the literal against the raw parameter — unchanged. When the supplied expected type is a **concrete instantiation** (e.g. `T` pinned to the call's contextual return via the return-context substitution), tsc types the literal against that instantiation (`checkExpressionWithContextualType` with the non-fixing mapper); tsz now does the same through `contextual_type_option_for_call_argument_at`.

## Root cause (traced)

For `const WithNode: WithNodeFactory = freeze({ create(count: number) { return freeze({ kind: "WithNode", count }); } })`:

1. The outer call's single-pass return-context substitution correctly pinned `T = WithNodeFactory` through the existing arg-validated matcher (`collect_return_context_substitution`, incl. #12803's `return_context_application_info`).
2. The refresh pass computed the instantiated contextual parameter (`WithNodeFactory`) — but `contextual_type_option_for_call_argument_at` (computed_helpers.rs) **unconditionally replaced** it with the callee's raw param type (bare `T`) for object-literal args at `generic_excess_skip` positions.
3. Typed against bare `T`, the method body's nested call saw no contextual return; `contextual_object_literal_property_type` returned deferred-unknown for `kind`; the literal widened; the solver inferred `T` from the widened body; the post-solver recheck then propagated the widened `Readonly<{kind: string; …}>` contexts (self-fulfilling).

The fix gates the raw-param override on `contains_type_parameters(incoming)`: restore raw `T` only when the incoming contextual is itself still unresolved. The pin continues to flow exclusively through the existing validated matcher and is re-validated against the actual argument by the post-refresh solver resolve — no standalone post-pin (the failure mode of the two prior reverted attempts on #10663).

## Adjacent-case matrix (all parity-checked against tsc 5.9.3)

| case | tsz before | tsz after | tsc |
|---|---|---|---|
| witness (annotated method, outer generic call) | TS2322 FP | clean | clean |
| context-sensitive method (unannotated param, deferred pass) | clean | clean | clean |
| annotated method return type | clean | clean | clean |
| explicit inner type argument | clean | clean | clean |
| direct literal assignment (no outer call) | clean | clean | clean |
| wrong literal `kind: "Wrong"` (negative) | TS2322 | TS2322 | TS2322 |
| renamed binders (deepFreeze/TObj/LimitNode) | TS2322 FP | clean | clean |
| constrained generic `<S extends Shape>`, constraint-violating literal | TS2741+TS2353 | TS2741+TS2353 (identical codes/positions) | TS2741+TS2353 |

## Project Corpus Impact

- Row: kysely-project
- Bug family: #8773 operation-node contextual inference
- Guard evidence: `tsconfig.tsz-guard.json` full run, clean-base vs branch site-level diff: **0 new sites** (counts in Verification). The residual operation-node guard sites are the facet-2 `X → Readonly<X>` relation/identity family (per the tracker post-mortems, facet 2 gates facet 1 in-repo); this PR removes the witness widening family without collateral.

## Verification

- Witness `.target-bench/repro-withnode.ts`: clean (was TS2322); verified with both the pre-rebase and rebased branch binaries.
- Kysely guard, controlled comparison at base cf604d2bd2: baseline 193 error lines vs fixed 193 — byte-identical site list (**0 new / 0 fixed**).
- Kysely guard on rebased base c04f3a85c6: the **clean-main baseline binary itself** no longer completes the guard config (>9 min, killed at 560s; previously ~1-2 min at cf604d2bd2) — a base-side regression in the cf604d..c04f3a window, independent of this PR (reproduced with a binary containing none of this change). Flagged in Coordination Notes.
- `cargo nextest run -p tsz-solver`: 6605/6606 passed; only failure is the known pre-existing `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`.
- `cargo nextest run -p tsz-checker -E 'test(return_context) or test(identity_wrapper) or test(contextual)'`: 462 passed; 6 failures + 1 timeout, all reproduced IDENTICALLY via direct test binaries on the clean stashed tree (pre-existing on main in this environment, not collateral): `pipe_contextual_return_flows_through_nested_generic_call_chain`, `class_tag_contextual_generator_callback_does_not_force_stale_ts2345`, `contextual_nested_generator_return_inference_drops_stale_ts2345`, `contextual_generic_new_return_recovers_unresolved_constructor_type_params`, `contextual_return_can_refine_transparent_wrapper_inference`, `dynamic_import_defer_tests::import_defer_then_callback_is_contextually_typed`, timeout `contextual_kysely_select_array_preserves_aliased_expression_factory_param`. Re-confirmed the same set fails on the rebased branch via direct binaries (local nextest orchestrator deadlocks intermittently in this environment, so direct binaries were used for the comparisons).
- `cargo clippy -p tsz-checker --all-targets`: clean, no warnings (re-run after rebase).
- `scripts/arch/check-checker-boundaries.sh`: passed.
- New tests in `crates/tsz-checker/tests/return_context_identity_wrapper_literal_tests.rs` (binder names varied): outer-call witness, explicit inner type arg, annotated method return, outer-call wrong-literal negative. Direct run on the rebased branch: 8/8 pass.

## Coordination Notes

- Continues #10663 after #12803 (brave-volta) and the Opus-XArenaWrap post-mortem; both prior naive fixes were standalone contextual-only pins and were reverted for collateral — this fix instead preserves the pin already produced by the validated matcher.
- Remaining operation-node guard sites are the facet-2 cross-arena/`Readonly` identity relation family, tracked separately in #10663.
- Rebased onto `origin/main` c04f3a85c6 (post #13153/#13162); no overlap with #13165 (different files).
- HEADS-UP for kysely row owners: the kysely `tsconfig.tsz-guard.json` run no longer completes (>9 min) with a **clean main** binary at c04f3a85c6, while it finished in ~1-2 min (193 errors) at cf604d2bd2 — likely a regression from one of the 11 commits in that window; needs its own investigation.

🤖 Generated with [Claude Code](https://claude.ai/code)


## Goal
Goal: green

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-fable-5
Effort: high
