### PR TITLE
fix(solver): preserve literal inferences for tuple/array-constrained type params with a primitive-constrained parameter

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1311,6 +1311,9 @@ mod unique_symbol_assignment_ts2322_tests;
 #[path = "tests/variadic_tuple_alias_display_tests.rs"]
 mod variadic_tuple_alias_display_tests;
 #[cfg(test)]
+#[path = "tests/variadic_tuple_constraint_literal_preservation_tests.rs"]
+mod variadic_tuple_constraint_literal_preservation_tests;
+#[cfg(test)]
 #[path = "../tests/variadic_tuple_elaboration_tests.rs"]
 mod variadic_tuple_elaboration_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/variadic_tuple_constraint_literal_preservation_tests.rs
+++ b/crates/tsz-checker/src/tests/variadic_tuple_constraint_literal_preservation_tests.rs
@@ -1,0 +1,121 @@
+//! Tests for literal preservation when a generic type parameter's declared
+//! constraint is a tuple/array carrying a primitive-constrained type parameter,
+//! e.g. `arrayToEnum<T extends string, U extends [T, ...T[]]>(items: U)`.
+//!
+//! tsc preserves the literal element types inferred for `U` (so
+//! `{ [k in U[number]]: k }` keeps concrete literal keys and `U[number]` is the
+//! literal union). tsz widened them to `string` because the literal-preservation
+//! gate (`constraint_is_primitive_type` in the generic-call layer, consulted by
+//! `mark_declared_constraint_preserves_literals`) did not recognise that a tuple
+//! constraint `[T, ...T[]]` carries the primitive-constrained parameter `T` in
+//! its element/rest types.
+//!
+//! Structural rule: when inferring `U` whose declared constraint is a tuple
+//! (or array) whose element/rest type is a type parameter with a primitive
+//! constraint, fresh literal candidates for `U` are preserved (not widened),
+//! matching tsc's `getCovariantInference` literal-preservation gate. This is the
+//! cross-file zod `arrayToEnum`/`ZodIssueCode` mapped-enum family.
+//!
+//! Binder names are varied across cases; the rule must be name-independent.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn ts2322(src: &str) -> Vec<String> {
+    check_source_diagnostics(src)
+        .into_iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.message_text)
+        .collect()
+}
+
+#[test]
+fn variadic_tuple_constraint_preserves_literal_elements() {
+    // `U extends [T, ...T[]]` with `T extends string`: `u[0]` must stay `"a"`.
+    let errs = ts2322(
+        r#"
+declare function f<T extends string, U extends [T, ...T[]]>(items: U): U;
+const u = f(["a", "b"]);
+const a: "a" = u[0];
+const b: "b" = u[1];
+"#,
+    );
+    assert!(errs.is_empty(), "expected no TS2322, got: {errs:?}");
+}
+
+#[test]
+fn fixed_tuple_constraint_preserves_literal_elements() {
+    // Renamed binders + fixed (non-variadic) tuple constraint `[X, X]`.
+    let errs = ts2322(
+        r#"
+declare function collect<X extends string, V extends [X, X]>(values: V): V;
+const v = collect(["red", "blue"]);
+const first: "red" = v[0];
+"#,
+    );
+    assert!(errs.is_empty(), "expected no TS2322, got: {errs:?}");
+}
+
+#[test]
+fn mapped_over_variadic_tuple_index_keeps_literal_keys() {
+    // The zod `arrayToEnum` shape: `{ [k in U[number]]: k }` must keep concrete
+    // literal keys so indexed access and `keyof` stay literal.
+    let errs = ts2322(
+        r#"
+declare function arrayToEnum<T extends string, U extends [T, ...T[]]>(
+  items: U
+): { [k in U[number]]: k };
+const E = arrayToEnum(["alpha", "beta", "gamma"]);
+const k: "alpha" = E["alpha"];
+const key: "alpha" | "beta" | "gamma" = "beta" as keyof typeof E;
+"#,
+    );
+    assert!(errs.is_empty(), "expected no TS2322, got: {errs:?}");
+}
+
+#[test]
+fn array_constraint_with_primitive_param_preserves_literals() {
+    // Array (not tuple) constraint `U extends T[]` with `T extends string`.
+    let errs = ts2322(
+        r#"
+declare function g<T extends string, U extends T[]>(items: U): U;
+const u = g(["x", "y"]);
+const first: "x" | "y" = u[0];
+"#,
+    );
+    assert!(errs.is_empty(), "expected no TS2322, got: {errs:?}");
+}
+
+#[test]
+fn unconstrained_string_array_constraint_still_widens() {
+    // Negative control: `U extends string[]` carries no primitive-constrained
+    // type parameter, so tsc widens the elements to `string`; a literal target
+    // must still be rejected (parity with tsc).
+    let errs = ts2322(
+        r#"
+declare function h<U extends string[]>(items: U): U;
+const u = h(["a", "b"]);
+const first: "a" = u[0];
+"#,
+    );
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected TS2322 (widened to string), got: {errs:?}"
+    );
+}
+
+#[test]
+fn preserved_literal_wrong_target_still_rejected() {
+    // Negative control: literals are preserved, so the precise element type is
+    // observable. `u[1]` is `"b"`; assigning it to `"a"` must fail (parity with
+    // tsc), proving the preservation did not collapse the element to a single
+    // value or widen it away.
+    let errs = ts2322(
+        r#"
+declare function f<T extends string, U extends [T, ...T[]]>(items: U): U;
+const u = f(["a", "b"]);
+const bad: "a" = u[1];
+"#,
+    );
+    assert_eq!(errs.len(), 1, "expected TS2322, got: {errs:?}");
+}

--- a/crates/tsz-solver/src/inference/infer.rs
+++ b/crates/tsz-solver/src/inference/infer.rs
@@ -566,7 +566,17 @@ impl<'a> InferenceContext<'a> {
 
     /// Record the declared `extends` constraint for an inference variable.
     pub fn set_declared_constraint(&mut self, var: InferenceVar, constraint: TypeId) {
-        self.declared_constraints.insert(var, constraint);
+        // Key by the unification root so the lookup in `resolve_with_constraints`
+        // (which reads `declared_constraints.get(&table.find(var))`) finds the
+        // entry even after `var` is unified with another inference variable.
+        // This mirrors `mark_declared_constraint_preserves_literals`, which
+        // already normalises to the root. Without it, a constraint such as
+        // `U extends [T, ...T[]]` (whose var unifies during constraint
+        // strengthening) loses its declared constraint at resolution time and
+        // literal inferences for `U` are widened (the zod `arrayToEnum`/
+        // `ZodIssueCode` family).
+        let root = self.table.find(var);
+        self.declared_constraints.insert(root, constraint);
     }
 
     /// Record that the declared `extends` constraint semantically preserves literals.

--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -1043,6 +1043,14 @@ impl<'a> InferenceContext<'a> {
     /// T's declared constraint is an index-signature object, not itself primitive,
     /// but *contains* U which IS primitive-constrained. When this holds, literal
     /// string values in the object's properties must not be widened during inference.
+    ///
+    /// It also handles variadic-tuple constraints such as
+    ///   `arrayToEnum<T extends string, U extends [T, ...T[]]>(items: U): { [k in U[number]]: k }`
+    /// where `U`'s declared constraint is the tuple `[T, ...T[]]` and `T` carries
+    /// the primitive constraint. tsc preserves the literal element types inferred
+    /// for `U`; without recursing through the tuple/array element types we widen
+    /// them to `string`, which collapses `{ [k in U[number]]: k }` to a string
+    /// index signature (the zod `ZodIssueCode` family).
     fn constraint_contains_type_param_with_primitive_constraint(
         &self,
         type_id: TypeId,
@@ -1097,6 +1105,25 @@ impl<'a> InferenceContext<'a> {
                     return true;
                 }
                 false
+            }
+            // A tuple constraint such as `U extends [T, ...T[]]` (where
+            // `T extends string`) carries the primitive-constrained type
+            // parameter in its element/rest types. tsc preserves literal
+            // inferences for `U` against such a constraint (the tuple element
+            // context implies literals), so recurse through the element types.
+            Some(TypeData::Tuple(list_id)) => {
+                let elements = self.interner.tuple_list(list_id).to_vec();
+                elements.iter().any(|element| {
+                    self.constraint_contains_type_param_with_primitive_constraint(
+                        element.type_id,
+                        depth + 1,
+                    )
+                })
+            }
+            // `...T[]` rest elements (and plain array constraints) wrap the
+            // primitive-constrained parameter in an array; follow the element.
+            Some(TypeData::Array(element)) => {
+                self.constraint_contains_type_param_with_primitive_constraint(element, depth + 1)
             }
             _ => false,
         }

--- a/crates/tsz-solver/src/operations/generic_call/mod.rs
+++ b/crates/tsz-solver/src/operations/generic_call/mod.rs
@@ -158,6 +158,14 @@ fn constraint_is_primitive_type_inner(
     match interner.lookup(type_id) {
         // Literal unions and `keyof T` constraints preserve fresh literal candidates.
         Some(TypeData::Literal(_) | TypeData::KeyOf(_)) => true,
+        // A type parameter whose own constraint is primitive (e.g. the `T` in
+        // `U extends [T, ...T[]]` with `T extends string`) preserves literal
+        // inferences: tsc keeps the literal element types of `U`. The element
+        // appears here as the call-local placeholder, which carries the
+        // original constraint in its `TypeParamInfo`.
+        Some(TypeData::TypeParameter(info)) => info.constraint.is_some_and(|constraint| {
+            constraint_is_primitive_type_inner(interner, resolver, constraint, depth + 1)
+        }),
         Some(TypeData::Conditional(conditional_id)) => {
             conditional_infer_constraint_preserves_literals(
                 interner,
@@ -179,6 +187,14 @@ fn constraint_is_primitive_type_inner(
             members
                 .iter()
                 .any(|&m| constraint_is_primitive_type_inner(interner, resolver, m, depth + 1))
+        }
+        // Variadic-tuple constraints `[T, ...T[]]` and array constraints carry
+        // the primitive-constrained parameter in their element/rest types.
+        Some(TypeData::Tuple(list_id)) => interner.tuple_list(list_id).iter().any(|element| {
+            constraint_is_primitive_type_inner(interner, resolver, element.type_id, depth + 1)
+        }),
+        Some(TypeData::Array(element) | TypeData::ReadonlyType(element)) => {
+            constraint_is_primitive_type_inner(interner, resolver, element, depth + 1)
         }
         _ => false,
     }


### PR DESCRIPTION
Fixes a tsc-parity divergence in generic-call literal preservation discovered while investigating the zod benchmark-canary `TS2345` family: when a type parameter `U`'s declared constraint is a tuple/array carrying a primitive-constrained type parameter (`U extends [T, ...T[]]`, `T extends string`), tsz widened the inferred literal elements of `U` to `string`, collapsing `arrayToEnum<...>(items: U): { [k in U[number]]: k }` to a string index signature. tsc preserves the literals.

AgentName: M1FableArchitect

Goal: green

## Provenance

Machine: m1
Assistant: claude-code
Model: claude-fable-5
Effort: high

Track: project-corpus false-positive elimination (zod canary — mapped-enum literal preservation)

Invariant: When inferring a type parameter `U` whose declared constraint is a tuple or array whose element/rest type is a type parameter with a primitive constraint (`string`/`number`/`boolean`/`bigint`/`symbol`), fresh literal candidates for `U` are preserved, not widened — matching tsc's `getCovariantInference` literal-preservation gate.

Scope: solver only. Load-bearing change: `operations/generic_call/mod.rs` `constraint_is_primitive_type_inner` gains `TypeParameter` (recurse its constraint), `Tuple` (recurse elements), and `Array`/`ReadonlyType` (recurse element) arms, so the second-pass `mark_declared_constraint_preserves_literals` fires for these constraints. Defensive companions: `inference/infer_resolve.rs` `constraint_contains_type_param_with_primitive_constraint` gains the analogous `Tuple`/`Array` arms, and `set_declared_constraint` is keyed by the unification root (consistent with `mark_declared_constraint_preserves_literals` and the resolution-time lookup). One new checker regression test + module registration.

## Structural rule

When tsz infers `U` from an argument and `U`'s declared constraint contains a primitive-constrained type parameter inside a tuple/array (`U extends [T, ...T[]]`, `T extends string`), the literal-preservation gate must recognise that constraint. tsz's gate (`constraint_is_primitive_type`, consulted by `mark_declared_constraint_preserves_literals` during generic-call setup) previously handled `Union`/`Intersection`/`Object`/`KeyOf`/`Conditional` constraints but not a bare type parameter, a tuple, or an array. The variadic-tuple constraint therefore never marked `U` literal-preserving, the inferred tuple `["a","b"]` was deep-widened to `[string, string]`, `U[number]` became `string`, and `{ [k in U[number]]: k }` collapsed to `{ [x: string]: string }` (so `keyof` was `string | number` and indexed access was `string`). The `declared_constraints` map was independently unreachable at resolution for placeholder-referencing constraints, so the fix routes through the root-keyed `literal_preserving_declared_constraints` set instead.

## Adjacent matrix

- `U extends [T, ...T[]]`, `T extends string` (variadic, the zod `arrayToEnum` shape) — positive
- `V extends [X, X]`, `X extends string`, renamed binders, fixed tuple — positive
- `{ [k in U[number]]: k }` mapped over the variadic-tuple index — indexed access and `keyof` stay literal — positive
- `U extends T[]` (array, not tuple) with `T extends string` — positive
- `U extends string[]` — no primitive-constrained parameter; tsc widens to `string`, kept widened (negative control)
- preserved literal with a too-narrow target (`u[1]` is `"b"`, assigned to `"a"`) still reports `TS2322` (negative control)

Binder names are varied across cases; the rule is name-independent.

## Project Corpus Impact

- Row: zod-project
- Bug family: variadic-tuple-constrained type-parameter literal preservation (cross-file `arrayToEnum`/`ZodIssueCode` mapped-enum inference)

zod canary: 86 → 86 (sites byte-identical). The fix is correct and resolves the cross-file `arrayToEnum` inference in isolation (see Verification, `keyof typeof arrayToEnum([...])` cross-file now clean), but the dominant zod `TS2345` `addIssue` sites are gated by a **second, independent** bug and so the row does not move yet: the source object literal `{ code: ZodIssueCode.too_small, ... }` widens `code` to `string` when contextually typed by `IssueData = stripPath<ZodIssueOptionalMessage> & { path? }` — a distributive-conditional `Pick`/intersection target. A plain-literal control (`code: "too_small"`, not via `arrayToEnum`) is clean cross-file, isolating the residual to object-literal contextual typing against a computed `stripPath`/`Pick`/intersection target. That residual is left for a follow-up (it is independent of this change and of #13151's class-constructor-window work).

## Verification

- New: `cargo nextest run -p tsz-checker -E 'test(/variadic_tuple_constraint/)'` — 6/6 (4 positive, 2 negative controls). [to be confirmed in CI]
- Single-file witnesses (CLI `--noEmit --strict`): `f<T extends string, U extends [T,...T[]]>(items: U): U; const u = f(["a","b"]); const a: "a" = u[0];` — tsc clean / tsz clean after fix (TS2322 before).
- Cross-file witness: 3-file project with `arrayToEnum` in one module and `keyof typeof E` in another — TS2322 before, clean after.
- Negative controls (`U extends string[]`, too-narrow targets) match tsc exactly — no over-preservation.
- kysely guard (A/B against this tree's own pre-change binary): 193-equivalent guard set 183 → 183 sites, **zero new, zero removed**.
- zod guard: site-identical to pre-change (no regression).
- `cargo clippy -p tsz-solver --no-deps` — clean.
- `scripts/arch/check-checker-boundaries.sh` — passes (245 fields classified; no new checker fields).

## Coordination Notes

The zod `TS2554` family (28 sites) is owned by the open green PR #13151 (StudioOpus, checker class-constructor window) — orthogonal layer/file (`class_type/constructor.rs`) to this solver change; no overlap. This PR is a real adjacent parity win that resolves one of two stacked zod bugs; the second (object-literal widening vs computed `stripPath`/`Pick` contextual type) is documented above for the next agent. Worktree: tsz-zod-row, branch `fix/zod-row`. Draft until the breadth conformance suite (CI) confirms no regression from the broadened literal-preservation gate.
