### PR TITLE
perf(checker): bound diagnostic display normalization with a per-rendered-type work budget

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -1465,6 +1465,16 @@ impl<'a> CheckerState<'a> {
             return type_id;
         }
 
+        // Inside a diagnostic display-budget scope, evaluation results are
+        // memoized and total evaluation work is fuel-bounded (issue #13040).
+        // Self-expanding application chains intern fresh types per
+        // evaluation, so the cycle set below never converges on them; the
+        // fuel guarantees rendering one type does bounded work. Outside a
+        // scope (relation/semantic paths) both are inert.
+        if let Some(cached) = crate::error_reporter::display_budget::cached_eval(type_id) {
+            return cached;
+        }
+
         thread_local! {
             static ASSIGNABILITY_EVAL_VISITING: std::cell::RefCell<FxHashSet<TypeId>> =
                 Default::default();
@@ -1476,8 +1486,16 @@ impl<'a> CheckerState<'a> {
             return type_id;
         }
 
+        if !crate::error_reporter::display_budget::try_consume_eval_fuel() {
+            ASSIGNABILITY_EVAL_VISITING.with(|visiting| visiting.borrow_mut().remove(&type_id));
+            return type_id;
+        }
+
         let result = self.evaluate_type_for_assignability_inner(type_id);
         ASSIGNABILITY_EVAL_VISITING.with(|visiting| visiting.borrow_mut().remove(&type_id));
+        // Cycle-truncated returns above are never recorded — only complete
+        // results are safe to replay for later calls in this scope.
+        crate::error_reporter::display_budget::record_eval(type_id, result);
         result
     }
 

--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -1537,14 +1537,10 @@ impl<'a> CheckerState<'a> {
         crate::error_reporter::display_budget::record_eval(type_id, result);
 
         // Memoize only clean completions: fuel-exhausted or depth-clamped
-        // evaluations are degraded forms that a later, fresher evaluation
-        // must be allowed to improve on.
-        //
-        // The stamp is recomputed here on purpose: the evaluation above
-        // routinely grows the type environments (def resolution, symbol
-        // types), and the result is valid for that *post*-evaluation state.
-        // Reusing the lookup-time stamp would file the entry under a stale
-        // stamp and the next lookup would immediately drop it.
+        // evaluations are degraded forms a fresher evaluation must improve on.
+        // The stamp is recomputed on purpose: evaluation grows the type
+        // environments, and the result is valid for that *post*-evaluation
+        // state; the lookup-time stamp would file the entry as already stale.
         if outermost
             && result != TypeId::ERROR
             && !refs_resolution_fuel_exhausted()

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -560,6 +560,12 @@ impl<'a> CheckerState<'a> {
         }
 
         DEPTH.set(depth + 1);
+        // Bound the total work spent normalizing this rendered type. The
+        // recursion below is depth-capped but not breadth-capped: each node
+        // can fan out into freshly interned children (self-expanding generic
+        // applications), so without a work budget normalization is
+        // effectively unbounded (issue #13040).
+        let _budget_scope = crate::error_reporter::display_budget::DisplayBudgetScope::enter();
         let mut visiting = FxHashSet::default();
         let result = self.normalize_assignability_display_type_inner(ty, &mut visiting, 0);
         DEPTH.set(depth);
@@ -622,6 +628,11 @@ impl<'a> CheckerState<'a> {
         // `string`.  Without this guard the else-branch evaluates the literal
         // and the widened primitive replaces the original.
         if crate::query_boundaries::common::literal_value(self.ctx.types, ty).is_some() {
+            return ty;
+        }
+        // Work budget: once the per-rendered-type visit budget is exhausted,
+        // truncate hard and display the type as-is (issue #13040).
+        if !crate::error_reporter::display_budget::try_consume_visit() {
             return ty;
         }
         let ty = self

--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -560,11 +560,9 @@ impl<'a> CheckerState<'a> {
         }
 
         DEPTH.set(depth + 1);
-        // Bound the total work spent normalizing this rendered type. The
-        // recursion below is depth-capped but not breadth-capped: each node
-        // can fan out into freshly interned children (self-expanding generic
-        // applications), so without a work budget normalization is
-        // effectively unbounded (issue #13040).
+        // The recursion below is depth-capped but not breadth-capped: each
+        // node can fan out into freshly interned children, so the work
+        // budget is what bounds it (issue #13040).
         let _budget_scope = crate::error_reporter::display_budget::DisplayBudgetScope::enter();
         let mut visiting = FxHashSet::default();
         let result = self.normalize_assignability_display_type_inner(ty, &mut visiting, 0);

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -197,6 +197,9 @@ impl<'a> CheckerState<'a> {
     }
 
     pub(crate) fn format_type_for_assignability_message(&mut self, ty: TypeId) -> String {
+        // Fail-safe work-budget scope for callers that bypass
+        // `format_type_for_diagnostic_role` (issue #13040).
+        let _budget_scope = crate::error_reporter::display_budget::DisplayBudgetScope::enter();
         let format_with_def_store = |state: &Self, type_id: TypeId| {
             let mut formatter =
                 tsz_solver::TypeFormatter::with_symbols(state.ctx.types, &state.ctx.binder.symbols)

--- a/crates/tsz-checker/src/error_reporter/display_budget.rs
+++ b/crates/tsz-checker/src/error_reporter/display_budget.rs
@@ -1,0 +1,241 @@
+//! Per-rendered-type work budget for diagnostic display normalization.
+//!
+//! Rendering one diagnostic must be bounded by the size of the displayed
+//! type — it must not re-run full type evaluation per node of an unbounded
+//! expansion (issue #13040). Self-expanding generic applications (for
+//! example `Awaited<...>` chains) intern fresh `TypeId`s on every
+//! evaluation, so per-`TypeId` cycle sets and memos never converge. The
+//! display normalization pass caps its recursion *depth*, but its *breadth*
+//! is unbounded: each node fans out into freshly interned children and calls
+//! `evaluate_type_for_assignability` again, which made diagnostic emission
+//! effectively non-terminating on large recursive application types.
+//!
+//! A [`DisplayBudgetScope`] is entered at the top of each rendered-type
+//! formatting entry point and grants a bounded amount of work:
+//!
+//! - a node-visit budget for the normalization tree
+//!   ([`try_consume_visit`]), and
+//! - an evaluation-fuel budget plus a result memo for
+//!   `evaluate_type_for_assignability` ([`try_consume_eval_fuel`],
+//!   [`cached_eval`], [`record_eval`]).
+//!
+//! When a budget is exhausted the caller returns the type unchanged — a hard
+//! truncation, like tsc's `...` elision on long type displays. Outside an
+//! active scope every helper is inert, so pure relation/semantic paths are
+//! unaffected.
+//!
+//! The limits are deliberately far above what any realistically rendered
+//! diagnostic consumes (the downstream formatter truncates nested printing
+//! long before either budget is visible), so legitimate messages are
+//! byte-identical; only pathological self-expanding normalization is cut
+//! short.
+
+use rustc_hash::FxHashMap;
+use std::cell::{Cell, RefCell};
+use tsz_solver::TypeId;
+
+/// Maximum normalization-tree node visits per rendered type.
+const DISPLAY_VISIT_BUDGET: u32 = 50_000;
+
+/// Maximum `evaluate_type_for_assignability` invocations per rendered type.
+/// Nested self-recursive evaluation steps consume fuel too, so this bounds
+/// the total evaluation work triggered by rendering one type.
+const DISPLAY_EVAL_FUEL: u32 = 8_000;
+
+struct DisplayBudget {
+    visits: u32,
+    eval_fuel: u32,
+    eval_memo: FxHashMap<TypeId, TypeId>,
+}
+
+thread_local! {
+    static ACTIVE: RefCell<Option<DisplayBudget>> = const { RefCell::new(None) };
+    // Scope nesting depth, kept outside `ACTIVE` as a plain `Cell` so the
+    // helpers below can answer "no scope active" — the common case on pure
+    // relation/semantic paths — with a single cheap thread-local read
+    // instead of a `RefCell` borrow.
+    static SCOPE_DEPTH: Cell<u32> = const { Cell::new(0) };
+}
+
+fn scope_is_active() -> bool {
+    SCOPE_DEPTH.with(|depth| depth.get() > 0)
+}
+
+/// RAII scope delimiting the rendering of one displayed type.
+///
+/// The outermost scope installs a fresh budget; nested scopes (rendering
+/// helpers re-entering one another) share it. The budget is dropped when the
+/// outermost scope exits.
+pub(crate) struct DisplayBudgetScope;
+
+impl DisplayBudgetScope {
+    pub(crate) fn enter() -> Self {
+        SCOPE_DEPTH.with(|depth| {
+            if depth.get() == 0 {
+                ACTIVE.with(|active| {
+                    *active.borrow_mut() = Some(DisplayBudget {
+                        visits: DISPLAY_VISIT_BUDGET,
+                        eval_fuel: DISPLAY_EVAL_FUEL,
+                        eval_memo: FxHashMap::default(),
+                    });
+                });
+            }
+            depth.set(depth.get() + 1);
+        });
+        Self
+    }
+}
+
+impl Drop for DisplayBudgetScope {
+    fn drop(&mut self) {
+        SCOPE_DEPTH.with(|depth| {
+            depth.set(depth.get().saturating_sub(1));
+            if depth.get() == 0 {
+                ACTIVE.with(|active| {
+                    if let Some(budget) = active.borrow_mut().take()
+                        && (budget.visits == 0 || budget.eval_fuel == 0)
+                    {
+                        tracing::debug!(
+                            visits_left = budget.visits,
+                            eval_fuel_left = budget.eval_fuel,
+                            "display normalization budget exhausted; type rendered truncated"
+                        );
+                    }
+                });
+            }
+        });
+    }
+}
+
+fn try_consume(counter: fn(&mut DisplayBudget) -> &mut u32) -> bool {
+    if !scope_is_active() {
+        return true;
+    }
+    ACTIVE.with(|active| match active.borrow_mut().as_mut() {
+        Some(budget) => {
+            let counter = counter(budget);
+            if *counter == 0 {
+                false
+            } else {
+                *counter -= 1;
+                true
+            }
+        }
+        None => true,
+    })
+}
+
+/// Consume one normalization node visit.
+///
+/// Returns `false` once the visit budget is exhausted; the caller must then
+/// return the type unchanged instead of recursing. Always `true` when no
+/// scope is active.
+pub(crate) fn try_consume_visit() -> bool {
+    try_consume(|budget| &mut budget.visits)
+}
+
+/// Consume one unit of evaluation fuel.
+///
+/// Returns `false` once the fuel is exhausted; the caller must then return
+/// the input type unevaluated. Always `true` when no scope is active.
+pub(crate) fn try_consume_eval_fuel() -> bool {
+    try_consume(|budget| &mut budget.eval_fuel)
+}
+
+/// Look up a previously recorded evaluation result within the active scope.
+pub(crate) fn cached_eval(type_id: TypeId) -> Option<TypeId> {
+    if !scope_is_active() {
+        return None;
+    }
+    ACTIVE.with(|active| {
+        active
+            .borrow()
+            .as_ref()
+            .and_then(|budget| budget.eval_memo.get(&type_id).copied())
+    })
+}
+
+/// Record a fully computed evaluation result within the active scope.
+///
+/// Only complete results may be recorded — cycle-truncated returns must not
+/// be memoized, or later non-cyclic calls would observe the truncation.
+pub(crate) fn record_eval(type_id: TypeId, result: TypeId) {
+    if !scope_is_active() {
+        return;
+    }
+    ACTIVE.with(|active| {
+        if let Some(budget) = active.borrow_mut().as_mut() {
+            budget.eval_memo.insert(type_id, result);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inert_without_scope() {
+        for _ in 0..(DISPLAY_VISIT_BUDGET + DISPLAY_EVAL_FUEL) {
+            assert!(try_consume_visit());
+            assert!(try_consume_eval_fuel());
+        }
+        assert_eq!(cached_eval(TypeId::STRING), None);
+        record_eval(TypeId::STRING, TypeId::NUMBER);
+        assert_eq!(cached_eval(TypeId::STRING), None);
+    }
+
+    #[test]
+    fn visit_budget_exhausts_and_resets_per_scope() {
+        {
+            let _scope = DisplayBudgetScope::enter();
+            for _ in 0..DISPLAY_VISIT_BUDGET {
+                assert!(try_consume_visit());
+            }
+            assert!(!try_consume_visit());
+            assert!(!try_consume_visit());
+        }
+        let _scope = DisplayBudgetScope::enter();
+        assert!(try_consume_visit());
+    }
+
+    #[test]
+    fn eval_fuel_exhausts_and_resets_per_scope() {
+        {
+            let _scope = DisplayBudgetScope::enter();
+            for _ in 0..DISPLAY_EVAL_FUEL {
+                assert!(try_consume_eval_fuel());
+            }
+            assert!(!try_consume_eval_fuel());
+        }
+        let _scope = DisplayBudgetScope::enter();
+        assert!(try_consume_eval_fuel());
+    }
+
+    #[test]
+    fn nested_scopes_share_one_budget() {
+        let _outer = DisplayBudgetScope::enter();
+        assert!(try_consume_visit());
+        {
+            let _inner = DisplayBudgetScope::enter();
+            for _ in 0..(DISPLAY_VISIT_BUDGET - 1) {
+                assert!(try_consume_visit());
+            }
+            assert!(!try_consume_visit());
+        }
+        // Inner scope exit must not reset the outer scope's budget.
+        assert!(!try_consume_visit());
+    }
+
+    #[test]
+    fn eval_memo_is_scoped() {
+        {
+            let _scope = DisplayBudgetScope::enter();
+            assert_eq!(cached_eval(TypeId::STRING), None);
+            record_eval(TypeId::STRING, TypeId::NUMBER);
+            assert_eq!(cached_eval(TypeId::STRING), Some(TypeId::NUMBER));
+        }
+        let _scope = DisplayBudgetScope::enter();
+        assert_eq!(cached_eval(TypeId::STRING), None);
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/mod.rs
@@ -30,6 +30,7 @@ mod conditional_alias_display;
 mod core;
 mod core_alias_display;
 mod core_formatting;
+pub(crate) mod display_budget;
 mod emitters;
 mod fingerprint_policy;
 mod generic_display_helpers;

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -697,6 +697,9 @@ impl<'a> CheckerState<'a> {
             );
         }
 
+        // Fail-safe work-budget scope: the recursive failure-reason tree of
+        // one diagnostic shares a single budget (issue #13040).
+        let _budget_scope = crate::error_reporter::display_budget::DisplayBudgetScope::enter();
         let source = self.recover_unknown_array_source_type_for_display(source, idx, depth);
         let (start, length) = self
             .resolve_diagnostic_anchor(idx, DiagnosticAnchorKind::Exact)

--- a/crates/tsz-checker/src/error_reporter/type_display_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/type_display_policy.rs
@@ -86,6 +86,11 @@ impl<'a> CheckerState<'a> {
         if self.ctx.diagnostics_discarded {
             return format!("[discarded #{}]", ty.0);
         }
+        // One rendered type, one work budget: bounds the display
+        // normalization and evaluation work spent producing this string so
+        // diagnostic emission stays terminating on self-expanding generic
+        // types (issue #13040).
+        let _budget_scope = crate::error_reporter::display_budget::DisplayBudgetScope::enter();
         // Only apply the indexed-access alias resolution for roles where the
         // alias would otherwise leak through unresolved (call parameters /
         // arguments / direct assignability). For declaration-emit-adjacent

--- a/crates/tsz-checker/src/error_reporter/type_display_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/type_display_policy.rs
@@ -86,10 +86,7 @@ impl<'a> CheckerState<'a> {
         if self.ctx.diagnostics_discarded {
             return format!("[discarded #{}]", ty.0);
         }
-        // One rendered type, one work budget: bounds the display
-        // normalization and evaluation work spent producing this string so
-        // diagnostic emission stays terminating on self-expanding generic
-        // types (issue #13040).
+        // One rendered type, one work budget (issue #13040).
         let _budget_scope = crate::error_reporter::display_budget::DisplayBudgetScope::enter();
         // Only apply the indexed-access alias resolution for roles where the
         // alias would otherwise leak through unresolved (call parameters /

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -714,6 +714,9 @@ mod direct_generic_return_tests;
 #[path = "tests/dispatch_tests.rs"]
 mod dispatch_tests;
 #[cfg(test)]
+#[path = "tests/display_normalization_budget_tests.rs"]
+mod display_normalization_budget_tests;
+#[cfg(test)]
 #[path = "tests/do_while_exit_narrowing_tests.rs"]
 mod do_while_exit_narrowing_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/display_normalization_budget_tests.rs
+++ b/crates/tsz-checker/src/tests/display_normalization_budget_tests.rs
@@ -1,0 +1,115 @@
+//! Tests for issue #13040: rendering one diagnostic must do bounded work.
+//!
+//! Structural rule: when a diagnostic's displayed type is a self-expanding
+//! generic (each evaluation step interns fresh `TypeId`s, so cycle sets and
+//! per-`TypeId` memos never converge), tsc renders a truncated display in
+//! bounded time; tsz does the same through the per-rendered-type display
+//! budget (`error_reporter::display_budget`), which caps normalization node
+//! visits and evaluation fuel instead of re-running full type evaluation per
+//! node of an unbounded expansion.
+//!
+//! The mechanics of the budget itself (exhaustion, scoping, memo) are unit
+//! tested in `error_reporter::display_budget`. These tests pin the observable
+//! contract: diagnostics on self-expanding generics are still emitted with
+//! the correct code, and ordinary diagnostics render byte-identical messages
+//! (the budget is far above what any realistic message consumes).
+
+use crate::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|d| d.code)
+        .collect()
+}
+
+#[test]
+fn self_expanding_generic_interface_source_still_reports_ts2322() {
+    // Every property nests a structurally fresh instantiation (`Wrap<Wrap<T>>`,
+    // `Wrap<[T]>`, `Wrap<{ v: T }>`), so display normalization can never
+    // converge by `TypeId` identity; it must terminate via the work budget.
+    let codes = codes(
+        r#"
+interface Wrap<T> {
+    one: Wrap<Wrap<T>>;
+    two: Wrap<[T]>;
+    three: Wrap<{ v: T }>;
+    value: T;
+}
+declare const w: Wrap<string>;
+const sink: number = w;
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "self-expanding interface source must still report TS2322, got: {codes:?}"
+    );
+}
+
+#[test]
+fn self_expanding_generic_alias_argument_still_reports_ts2345() {
+    // Same family through the call-argument display path (the sampled hot
+    // stack in #13040 was TS2345 emission), with renamed binders and a
+    // generic alias instead of an interface.
+    let codes = codes(
+        r#"
+type Grow<U> = {
+    left: Grow<{ a: U }>;
+    right: Grow<{ b: U }>;
+    middle: Grow<[U, U]>;
+    leaf: U;
+};
+declare const g: Grow<"seed">;
+declare function take(n: number): void;
+take(g);
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "self-expanding alias argument must still report TS2345, got: {codes:?}"
+    );
+}
+
+#[test]
+fn self_expanding_promise_chain_target_still_reports_ts2322() {
+    // Awaited-style async expansion: the negative/fallback direction where
+    // the *target* of the assignment is the self-expanding side.
+    let codes = codes(
+        r#"
+interface Chain<T> {
+    next: Chain<Promise<T>>;
+    alt: Chain<{ inner: T }>;
+    value: T;
+}
+declare const c: Chain<number>;
+declare let dst: Chain<string>;
+dst = c;
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "self-expanding target must still report TS2322, got: {codes:?}"
+    );
+}
+
+#[test]
+fn ordinary_diagnostic_messages_are_unchanged_by_the_budget() {
+    // Positive control: a small, fully convergent type must render the exact
+    // message tsc shows — the budget must be invisible for realistic types.
+    let diagnostics = check_source_diagnostics(
+        r#"
+const plain: { kind: "circle"; radius: number } = { kind: "square", radius: 1 };
+"#,
+    );
+    let messages: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == 2322)
+        .map(|d| d.message_text.as_str())
+        .collect();
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("\"square\"") && m.contains("\"circle\"")),
+        "ordinary literal mismatch display must be unaffected, got: {messages:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

Addresses #13040 (effect-project row: diagnostic display/eval churn made checking effectively non-terminating, >300x tsc; row re-measure on the bench lane should confirm before the issue closes).

## Structural rule

Rendering one diagnostic must do work bounded by the size of the displayed type. When the displayed type is a self-expanding generic (each evaluation step interns fresh `TypeId`s — `Awaited<...>`-style application chains — so cycle sets and per-`TypeId` memos never converge), tsc renders a truncated display in bounded time; tsz now does the same through a per-rendered-type work budget instead of re-running full `evaluate_type_for_assignability` per node of an unbounded expansion.

## Owner layer

Checker `error_reporter` (diagnostic display policy). No solver semantics touched; relation/semantic paths are unaffected — every budget helper is inert outside a display scope, behind a single thread-local `Cell` read.

## What changed

- New `error_reporter::display_budget`: RAII `DisplayBudgetScope` entered per rendered type at `format_type_for_diagnostic_role`, outermost `normalize_assignability_display_type`, and (fail-safe, shared nested budget) `format_type_for_assignability_message` and `render_failure_reason`. The scope grants a normalization node-visit budget (50k) plus evaluation fuel (8k) and a result memo for `evaluate_type_for_assignability`.
- `normalize_assignability_display_type_inner` consumes one visit per node; exhaustion returns the type unchanged (hard truncation, like tsc's display elision). The recursion was depth-capped (12) but breadth-unbounded — fresh interned children at every level made the tree effectively infinite.
- `evaluate_type_for_assignability` consults the scope memo, burns fuel per (nested) evaluation step, and records only complete results (cycle-truncated returns are never memoized).
- Budgets are far above what any realistic message consumes, so legitimate diagnostics render byte-identical; only pathological self-expanding normalization is cut short.

## Adjacent-case matrix

- Self-expanding generic **interface** as assignment **source** (TS2322) — covered.
- Self-expanding generic **alias** as call **argument** (TS2345, the sampled hot stack), renamed binders — covered.
- Self-expanding Promise-chain as assignment **target** (negative/fallback direction) — covered.
- Positive control: ordinary literal-mismatch TS2322 message asserted byte-exact — budget invisible on realistic types.
- Budget mechanics (exhaustion, per-scope reset, nested-scope sharing, memo scoping, inertness without scope) unit-tested in `error_reporter::display_budget`.

## Performance

- Repeated operation addressed: per-node full re-evaluation during display normalization; state is per-rendered-type (thread-local scope), key is input `TypeId`, invalidation is scope exit (memo never outlives one rendered type, so no cross-diagnostic staleness), fuel bounds total evaluation steps even when fresh interning defeats the memo.
- Hot non-display path (`evaluate_type_for_assignability` on relation paths) pays one thread-local `Cell` read when no scope is active.
- No fixture-name fast paths; no user-identifier or rendered-string predicates.

## Verification

- `cargo test -p tsz-checker --lib -- display_budget display_normalization_budget` — 9/9 pass.
- Full `cargo test -p tsz-checker --lib` failure set diffed against the base commit: byte-identical (61 pre-existing environment failures before and after; zero new failures, +9 new passing tests).
- `cargo clippy -p tsz-checker --lib --tests` — clean. `cargo fmt` — clean.
- Ready-review CI owns the conformance/emit/fourslash parity gates proving byte-identical diagnostics; effect-row termination to be confirmed by the bench lane.

## Provenance

Machine: cloud
Assistant: claude-code
Model: undisclosed (harness undercover mode)
Effort: high

https://claude.ai/code/session_01SzFqemKCKBpia8aCjf3nxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzFqemKCKBpia8aCjf3nxr)_

## Post-rebase measurement update (shepherding)

Rebased onto current main (conflicts with the discarded-diagnostics early-returns resolved as a union — both behaviors kept). On this head: display-budget tests 9/9; zod/comlink/ofetch counts byte-equal to main (54/3/46). **Measured effect row: still exceeds 900s after this change** — the budget eliminates the sampled display/eval churn class, but a further bottleneck remains beneath it; #13040 stays open with this as a necessary-but-not-sufficient step, and the row re-measure expectation in the opening paragraph should be read accordingly.
