### PR TITLE
refactor(conformance): share directive tsconfig conversion

### DIFF
--- a/crates/conformance/src/bin/generate-tsc-cache-tsserver.rs
+++ b/crates/conformance/src/bin/generate-tsc-cache-tsserver.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant};
-use tsz_conformance::compiler_options::canonical_option_name;
+use tsz_conformance::compiler_options::directives_to_tsconfig;
 use walkdir::WalkDir;
 
 /// Timeout for reading tsserver responses (in seconds)
@@ -411,135 +411,6 @@ fn discover_tests(test_dir: &str, max: usize) -> Result<Vec<PathBuf>> {
     Ok(files)
 }
 
-/// Test harness-specific directives that should NOT be passed to tsconfig.json
-/// These are handled by the test infrastructure, not the TypeScript compiler
-const HARNESS_ONLY_DIRECTIVES: &[&str] = &[
-    "filename",
-    "allowNonTsExtensions",
-    "useCaseSensitiveFileNames",
-    "baselineFile",
-    "noErrorTruncation",
-    "suppressOutputPathCheck",
-    "noImplicitReferences",
-    "currentDirectory",
-    "traceResolution",
-    "symlink",
-    "link",
-    "noTypesAndSymbols",
-    "fullEmitPaths",
-    "noCheck",
-    "nocheck",
-    "reportDiagnostics",
-    "captureSuggestions",
-    "typeScriptVersion",
-    "skip",
-];
-
-/// List-type compiler options that accept comma-separated values
-const LIST_OPTIONS: &[&str] = &[
-    "lib",
-    "types",
-    "typeRoots",
-    "rootDirs",
-    "moduleSuffixes",
-    "customConditions",
-];
-
-/// Convert test directive options to tsconfig compiler options JSON
-///
-/// Handles:
-/// - Boolean options (true/false)
-/// - List options (comma-separated values like @lib: es6,dom)
-/// - String/enum options (target, module, etc.)
-/// - Filters out test harness-specific directives
-fn convert_options_to_tsconfig(
-    options: &std::collections::HashMap<String, String>,
-) -> serde_json::Value {
-    let mut opts = serde_json::Map::new();
-    let mut strict_explicit = false;
-
-    for (key, value) in options {
-        let key_lower = key.to_lowercase();
-        if HARNESS_ONLY_DIRECTIVES
-            .iter()
-            .any(|&d| d.to_lowercase() == key_lower)
-        {
-            continue;
-        }
-
-        if key_lower == "strict" {
-            strict_explicit = true;
-        }
-
-        let canonical_key = canonical_option_name(&key_lower);
-        let json_value = if value == "true" {
-            serde_json::Value::Bool(true)
-        } else if value == "false" {
-            serde_json::Value::Bool(false)
-        } else if LIST_OPTIONS
-            .iter()
-            .any(|&opt| opt.to_lowercase() == key_lower)
-        {
-            // For typeRoots: strip leading '/' from virtual absolute paths (e.g.
-            // "/types" → "types").  Tests use absolute paths as virtual FS roots;
-            // files are written at {test_dir}/{path}, so relative paths are needed.
-            let is_type_roots = key_lower == "typeroots";
-            let items: Vec<serde_json::Value> = value
-                .split(',')
-                .map(|s| {
-                    let s = s.trim();
-                    let s = if is_type_roots {
-                        s.trim_start_matches('/')
-                    } else {
-                        s
-                    };
-                    serde_json::Value::String(s.to_string())
-                })
-                .collect();
-            serde_json::Value::Array(items)
-        } else {
-            // For non-list options, take only the first comma-separated value
-            let effective_value = value.split(',').next().unwrap_or(value).trim();
-            if let Ok(num) = effective_value.parse::<i64>() {
-                serde_json::Value::Number(num.into())
-            } else {
-                serde_json::Value::String(effective_value.to_string())
-            }
-        };
-
-        opts.insert(canonical_key.to_string(), json_value);
-    }
-
-    // Mirror TypeScript harness behavior by leaving `strict` absent unless the
-    // test explicitly requested it.
-    //
-    // Mirror TypeScript strict-family defaulting behavior when `strict` is specified.
-    if strict_explicit {
-        if let Some(serde_json::Value::Bool(strict)) = opts.get("strict") {
-            let strict = *strict;
-            for key in [
-                "noImplicitAny",
-                "noImplicitThis",
-                "strictNullChecks",
-                "strictFunctionTypes",
-                "strictBindCallApply",
-                "strictPropertyInitialization",
-                "useUnknownInCatchVariables",
-                "alwaysStrict",
-            ] {
-                opts.entry(key.to_string())
-                    .or_insert(serde_json::Value::Bool(strict));
-            }
-        }
-    }
-
-    // Keep compilerOptions ordering deterministic so TS5023/TS5025 line/column
-    // locations are stable across cache generation runs.
-    opts.sort_keys();
-
-    serde_json::Value::Object(opts)
-}
-
 fn process_test_file(
     client: &mut TsServerClient,
     path: &Path,
@@ -619,7 +490,7 @@ fn process_test_file(
     if !has_tsconfig_file {
         let tsconfig_path = test_dir.join("tsconfig.json");
         let tsconfig_content = serde_json::json!({
-            "compilerOptions": convert_options_to_tsconfig(&options),
+            "compilerOptions": directives_to_tsconfig(&options),
             "include": ["*.ts", "*.tsx", "**/*.ts", "**/*.tsx"],
             "exclude": ["node_modules"]
         });

--- a/crates/conformance/src/compiler_options.rs
+++ b/crates/conformance/src/compiler_options.rs
@@ -11,8 +11,6 @@ const HARNESS_ONLY_DIRECTIVES: &[&str] = &[
     "noImplicitReferences",
     "noErrorTruncation",
     "noTypesAndSymbols",
-    "sourcemap",
-    "sourceMap",
     "suppressOutputPathCheck",
     "symlink",
     "link",
@@ -337,5 +335,36 @@ mod tests {
         let opts = value.as_object().expect("compilerOptions object");
 
         assert_eq!(opts.get("noCheck"), Some(&serde_json::Value::Bool(true)));
+    }
+
+    #[test]
+    fn shared_converter_preserves_source_map_compiler_options() {
+        let options = HashMap::from([
+            ("sourceMap".to_string(), "true".to_string()),
+            ("inlineSourceMap".to_string(), "false".to_string()),
+            ("inlineSources".to_string(), "true".to_string()),
+            ("mapRoot".to_string(), "/generated".to_string()),
+            ("sourceRoot".to_string(), "/src".to_string()),
+        ]);
+        let value = directives_to_tsconfig(&options);
+        let opts = value.as_object().expect("compilerOptions object");
+
+        assert_eq!(opts.get("sourceMap"), Some(&serde_json::Value::Bool(true)));
+        assert_eq!(
+            opts.get("inlineSourceMap"),
+            Some(&serde_json::Value::Bool(false))
+        );
+        assert_eq!(
+            opts.get("inlineSources"),
+            Some(&serde_json::Value::Bool(true))
+        );
+        assert_eq!(
+            opts.get("mapRoot"),
+            Some(&serde_json::Value::String("/generated".to_string()))
+        );
+        assert_eq!(
+            opts.get("sourceRoot"),
+            Some(&serde_json::Value::String("/src".to_string()))
+        );
     }
 }

--- a/crates/conformance/src/compiler_options.rs
+++ b/crates/conformance/src/compiler_options.rs
@@ -1,4 +1,37 @@
-//! Shared compiler option name helpers for conformance tooling.
+//! Shared compiler option helpers for conformance tooling.
+
+use std::collections::HashMap;
+
+const HARNESS_ONLY_DIRECTIVES: &[&str] = &[
+    "allowNonTsExtensions",
+    "baselineFile",
+    "currentDirectory",
+    "filename",
+    "fullEmitPaths",
+    "noImplicitReferences",
+    "noErrorTruncation",
+    "noTypesAndSymbols",
+    "sourcemap",
+    "sourceMap",
+    "suppressOutputPathCheck",
+    "symlink",
+    "link",
+    "traceResolution",
+    "useCaseSensitiveFileNames",
+    "reportDiagnostics",
+    "captureSuggestions",
+    "typeScriptVersion",
+    "skip",
+];
+
+const LIST_OPTIONS: &[&str] = &[
+    "lib",
+    "types",
+    "typeRoots",
+    "rootDirs",
+    "moduleSuffixes",
+    "customConditions",
+];
 
 /// Map lowercase compiler option names to canonical camelCase.
 ///
@@ -135,9 +168,92 @@ pub fn canonical_option_name(key_lower: &str) -> &str {
     }
 }
 
+/// Convert TypeScript test-harness directive options into a `tsconfig`
+/// `compilerOptions` object.
+///
+/// The conformance runner and both TSC cache generators must share this exact
+/// conversion so cached TSC baselines and live tsz diagnostics see the same
+/// option shape.
+pub fn directives_to_tsconfig(options: &HashMap<String, String>) -> serde_json::Value {
+    let mut opts = serde_json::Map::new();
+    let mut strict_explicit = false;
+
+    for (key, value) in options {
+        let key_lower = key.to_lowercase();
+        if HARNESS_ONLY_DIRECTIVES
+            .iter()
+            .any(|directive| directive.eq_ignore_ascii_case(&key_lower))
+        {
+            continue;
+        }
+
+        if key_lower == "strict" {
+            strict_explicit = true;
+        }
+
+        let tsconfig_key = canonical_option_name(&key_lower);
+        let json_value = if value == "true" {
+            serde_json::Value::Bool(true)
+        } else if value == "false" {
+            serde_json::Value::Bool(false)
+        } else if LIST_OPTIONS
+            .iter()
+            .any(|option| option.eq_ignore_ascii_case(&key_lower))
+        {
+            let is_type_roots = key_lower == "typeroots";
+            let items = value
+                .split(',')
+                .map(|item| {
+                    let item = item.trim();
+                    let item = if is_type_roots {
+                        item.trim_start_matches('/')
+                    } else {
+                        item
+                    };
+                    serde_json::Value::String(item.to_string())
+                })
+                .collect();
+            serde_json::Value::Array(items)
+        } else {
+            let effective_value = value.split(',').next().unwrap_or(value).trim();
+            if let Ok(num) = effective_value.parse::<i64>() {
+                serde_json::Value::Number(num.into())
+            } else {
+                serde_json::Value::String(effective_value.to_string())
+            }
+        };
+
+        opts.insert(tsconfig_key.to_string(), json_value);
+    }
+
+    if strict_explicit {
+        if let Some(serde_json::Value::Bool(strict)) = opts.get("strict") {
+            let strict = *strict;
+            for key in [
+                "alwaysStrict",
+                "noImplicitAny",
+                "noImplicitThis",
+                "strictNullChecks",
+                "strictFunctionTypes",
+                "strictBindCallApply",
+                "strictPropertyInitialization",
+                "useUnknownInCatchVariables",
+            ] {
+                opts.entry(key.to_string())
+                    .or_insert(serde_json::Value::Bool(strict));
+            }
+        }
+    }
+
+    opts.sort_keys();
+
+    serde_json::Value::Object(opts)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::canonical_option_name;
+    use super::{canonical_option_name, directives_to_tsconfig};
+    use std::collections::HashMap;
 
     #[test]
     fn canonicalizes_camel_case_options() {
@@ -171,5 +287,55 @@ mod tests {
     #[test]
     fn leaves_unknown_options_lowercase() {
         assert_eq!(canonical_option_name("notarealoption"), "notarealoption");
+    }
+
+    #[test]
+    fn shared_converter_canonicalizes_and_filters_options() {
+        let options = HashMap::from([
+            ("moduleresolution".to_string(), "node16".to_string()),
+            ("captureSuggestions".to_string(), "true".to_string()),
+            ("lib".to_string(), "es6, dom".to_string()),
+            ("typeroots".to_string(), "/types, /more-types".to_string()),
+        ]);
+
+        let value = directives_to_tsconfig(&options);
+        let opts = value.as_object().expect("compilerOptions object");
+
+        assert_eq!(
+            opts.get("moduleResolution"),
+            Some(&serde_json::Value::String("node16".to_string()))
+        );
+        assert!(!opts.contains_key("captureSuggestions"));
+        assert_eq!(opts.get("lib"), Some(&serde_json::json!(["es6", "dom"])));
+        assert_eq!(
+            opts.get("typeRoots"),
+            Some(&serde_json::json!(["types", "more-types"]))
+        );
+    }
+
+    #[test]
+    fn shared_converter_expands_explicit_strict_false() {
+        let options = HashMap::from([("strict".to_string(), "false".to_string())]);
+        let value = directives_to_tsconfig(&options);
+        let opts = value.as_object().expect("compilerOptions object");
+
+        assert_eq!(opts.get("strict"), Some(&serde_json::Value::Bool(false)));
+        assert_eq!(
+            opts.get("strictPropertyInitialization"),
+            Some(&serde_json::Value::Bool(false))
+        );
+        assert_eq!(
+            opts.get("alwaysStrict"),
+            Some(&serde_json::Value::Bool(false))
+        );
+    }
+
+    #[test]
+    fn shared_converter_preserves_no_check_compiler_option() {
+        let options = HashMap::from([("nocheck".to_string(), "true".to_string())]);
+        let value = directives_to_tsconfig(&options);
+        let opts = value.as_object().expect("compilerOptions object");
+
+        assert_eq!(opts.get("noCheck"), Some(&serde_json::Value::Bool(true)));
     }
 }

--- a/crates/conformance/src/test_parser.rs
+++ b/crates/conformance/src/test_parser.rs
@@ -143,9 +143,9 @@ pub fn should_skip_test(directives: &TestDirectives) -> Option<&'static str> {
 /// module=System, TS5095 for moduleResolution=bundler) because the runner
 /// produced diagnostics from non-first variants that had no cache counterpart.
 pub fn expand_option_variants(options: &HashMap<String, String>) -> Vec<HashMap<String, String>> {
-    // The cache generator takes only the first comma-separated value for all
-    // non-list options (see convert_options_to_tsconfig line 628).  The runner
-    // must do the same to produce matching diagnostic sets.
+    // The shared tsconfig converter takes only the first comma-separated value
+    // for all non-list options. The runner must do the same to produce matching
+    // diagnostic sets.
     //
     // Boolean options like "alwaysstrict" and "nolib" are also NOT expanded:
     // the cache generator passes the raw multi-value string (e.g. "true, false")

--- a/crates/conformance/src/tsz_wrapper.rs
+++ b/crates/conformance/src/tsz_wrapper.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides a simple API to compile TypeScript code and extract error codes.
 
-use crate::compiler_options::canonical_option_name;
+use crate::compiler_options::directives_to_tsconfig;
 use crate::tsc_results::DiagnosticFingerprint;
 use std::collections::HashMap;
 use std::path::Path;
@@ -1157,37 +1157,6 @@ fn normalize_ts2883_node_modules_message(path: &str) -> String {
     )
 }
 
-/// Test harness-specific directives that should NOT be passed to tsconfig.json
-const HARNESS_ONLY_DIRECTIVES: &[&str] = &[
-    "filename",
-    "allowNonTsExtensions",
-    "useCaseSensitiveFileNames",
-    "baselineFile",
-    "noErrorTruncation",
-    "suppressOutputPathCheck",
-    "noImplicitReferences",
-    "currentDirectory",
-    "traceResolution",
-    "symlink",
-    "link",
-    "noTypesAndSymbols",
-    "fullEmitPaths",
-    "reportDiagnostics",
-    "captureSuggestions",
-    "typeScriptVersion",
-    "skip",
-];
-
-/// List-type compiler options that accept comma-separated values
-const LIST_OPTIONS: &[&str] = &[
-    "lib",
-    "types",
-    "typeRoots",
-    "rootDirs",
-    "moduleSuffixes",
-    "customConditions",
-];
-
 fn no_types_and_symbols_enabled(options: &HashMap<String, String>) -> bool {
     options
         .get("noTypesAndSymbols")
@@ -1248,125 +1217,16 @@ fn declaration_file_linked_into_node_modules(
     })
 }
 
-/// Convert test directive options to tsconfig compiler options
+/// Convert test directive options to tsconfig compiler options.
 ///
-/// Handles:
-/// - Boolean options (true/false)
-/// - List options (comma-separated values like @lib: es6,dom)
-/// - String/enum options (target, module, etc.)
-/// - Filters out test harness-specific directives
-///
-/// `key_order` is kept for compatibility with call sites, but conversion output
-/// is normalized to match cache generation.
+/// `key_order` is kept for compatibility with call sites. The actual conversion
+/// is shared with the cache generators so runner/cache option shapes cannot
+/// drift.
 fn convert_options_to_tsconfig(
     options: &HashMap<String, String>,
     _key_order: &[String],
 ) -> serde_json::Value {
-    let mut opts = serde_json::Map::new();
-    let mut strict_explicit = false;
-
-    for (key, value) in options {
-        // Skip test harness-specific directives
-        let key_lower = key.to_lowercase();
-        if HARNESS_ONLY_DIRECTIVES
-            .iter()
-            .any(|&d| d.to_lowercase() == key_lower)
-        {
-            continue;
-        }
-
-        if key_lower == "strict" {
-            strict_explicit = true;
-        }
-
-        // Use canonical_option_name to match the casing the TSC cache generator used.
-        // Options NOT in the map stay lowercase, causing tsz to emit TS5025 (matching
-        // TSC's behavior when it receives lowercase option names).
-        let tsconfig_key = canonical_option_name(&key_lower);
-        let json_value = if value == "true" {
-            serde_json::Value::Bool(true)
-        } else if value == "false" {
-            serde_json::Value::Bool(false)
-        } else if LIST_OPTIONS
-            .iter()
-            .any(|&opt| opt.to_lowercase() == key_lower)
-        {
-            // Parse comma-separated list
-            // For typeRoots: strip leading '/' from virtual absolute paths (e.g. "/types" → "types")
-            // The conformance runner places virtual absolute paths at {temp_dir}/{path},
-            // so we need relative paths for typeRoots to resolve correctly.
-            let is_type_roots = key_lower == "typeroots";
-            let items: Vec<serde_json::Value> = value
-                .split(',')
-                .map(|s| {
-                    let s = s.trim();
-                    let s = if is_type_roots {
-                        s.trim_start_matches('/')
-                    } else {
-                        s
-                    };
-                    serde_json::Value::String(s.to_string())
-                })
-                .collect();
-            serde_json::Value::Array(items)
-        } else {
-            // For non-list options, take only the first comma-separated value
-            // to match the cache generator behavior.
-            let effective_value = value.split(',').next().unwrap_or(value).trim();
-            // NOTE: Do NOT convert effective_value "true"/"false" to Bool here.
-            // The cache generator keeps split results as strings (e.g.,
-            // "strictNullChecks": "true"), which triggers TS5024 in tsc.
-            // We must produce the same tsconfig to match expected diagnostics.
-            if let Ok(num) = effective_value.parse::<i64>() {
-                // Handle numeric options (e.g., maxNodeModuleJsDepth)
-                serde_json::Value::Number(num.into())
-            } else {
-                serde_json::Value::String(effective_value.to_string())
-            }
-        };
-
-        opts.insert(tsconfig_key.to_string(), json_value);
-    }
-
-    // Mirror TypeScript harness behavior by leaving `strict` absent unless the
-    // test explicitly requested it. The cached TSC baselines include strict-mode
-    // diagnostics for many tests without `@strict`, so forcing `strict: false`
-    // here suppresses real expected errors like TS2564.
-    //
-    // Mirror TypeScript strict-family defaulting behavior when `strict` is specified.
-    // tsz's config parser handles `strict: true` → sub-options expansion, but the
-    // conformance test runner strips source pragmas before writing test files, so
-    // tsz can only read options from the tsconfig. We must expand strict here to
-    // ensure tsz gets the correct sub-options.
-    //
-    // Only expand when the test explicitly set `@strict`.
-    if strict_explicit {
-        if let Some(serde_json::Value::Bool(strict_val)) = opts.get("strict").cloned() {
-            // Expand strict sub-options for both strict: true and strict: false.
-            // The tsc cache generator writes these explicitly in both directions.
-            // NOTE: alwaysStrict must be included in automatic expansion.
-            // When strict=false expands to include alwaysStrict=false, tsc 6.0 emits TS5107
-            // (deprecation warning) which suppresses all file-level errors, matching test expectations.
-            for key in [
-                "alwaysStrict",
-                "noImplicitAny",
-                "noImplicitThis",
-                "strictNullChecks",
-                "strictFunctionTypes",
-                "strictBindCallApply",
-                "strictPropertyInitialization",
-                "useUnknownInCatchVariables",
-            ] {
-                opts.entry(key.to_string())
-                    .or_insert(serde_json::Value::Bool(strict_val));
-            }
-        }
-    }
-
-    // Sort properties alphabetically for deterministic tsconfig output.
-    opts.sort_keys();
-
-    serde_json::Value::Object(opts)
+    directives_to_tsconfig(options)
 }
 
 fn copy_tsconfig_to_root_if_needed(


### PR DESCRIPTION
Goal: hold

AgentName: Codex
Track: conformance infra tech-debt
Invariant: The conformance runner and TSC cache generators derive `compilerOptions` from test directives through one shared converter, so cache generation and live runner paths cannot drift for the same directive set.
Scope:
- Move directive-to-`tsconfig` conversion into `crates/conformance/src/compiler_options.rs`.
- Route `tsz_wrapper` and `generate-tsc-cache-tsserver` through the shared converter.
- Preserve `noCheck` and source-map directives as real compiler options with shared converter tests.
Project Corpus Impact: None; conformance tooling only, no project corpus row behavior change.

Fixes #13126

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-conformance compiler_options`
- `scripts/safe-run.sh cargo nextest run -p tsz-conformance convert_options`
- `scripts/safe-run.sh cargo check -p tsz-conformance --all-targets`
- `git diff --check`
- Not run locally: focused source-map conformance filters; this reused worktree does not have `TypeScript/tests/cases`. Exact-head CI owns full conformance.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium

## Coordination Notes
- No file overlap with open PRs #13177, #13176, #13175, or #13163 at branch start.
- Reused inactive worktree `/Users/mohsen/code/tsz-m5-relation-cache`; previous branch there was already merged.
- Prior head `ebc2492a937c0d158b6e403bc82e1770064daa00` failed `conformance-aggregate` because the new shared converter incorrectly filtered `sourceMap` directives; head `e03a61770f` restores them.
