### PR TITLE
refactor(ci): prune dead gcp suite entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -993,7 +993,7 @@ jobs:
     # Conformance shards consume the dist-fast binaries artifact and run the
     # tsz-conformance harness; they do not need unit's test outputs. Each
     # shard runs on its own self-hosted 8-vCPU runner, so concurrent fanout
-    # does not compete with the unit-archive compile for rustc capacity.
+    # does not compete with Rust build/test jobs for rustc capacity.
     name: conformance-${{ matrix.shard }}
     needs: [gate, dist-binaries]
     if: needs.gate.outputs.full_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true'

--- a/scripts/ci/ci-resources.sh
+++ b/scripts/ci/ci-resources.sh
@@ -50,7 +50,7 @@ default_cargo_build_jobs() {
   cpu_jobs="$HOST_CPUS"
   mem_mb="$(host_memory_mb)"
   case "${TSZ_CI_SUITE:-${_TSZ_CI_SUITE:-}}" in
-    unit|checker-integration|unit-archive|unit-shard)
+    unit|checker-integration)
       # Force `CARGO_BUILD_JOBS=1` on unit. Observed RSS-per-rustc on this
       # workspace's lib-test compiles (notably tsz-checker, tsz-emitter,
       # tsz-solver, tsz-core lib-test) now exceeds 16 GiB per process during

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -943,53 +943,6 @@ run_emit_shard() {
   return 0
 }
 
-run_emit_aggregate() {
-  ci_section "Emit aggregate"
-  local bucket run_key
-  bucket="${_TSZ_CI_CACHE_BUCKET:-${TSZ_CI_CACHE_BUCKET:-}}"
-  run_key="${GITHUB_SHA:-${REVISION_ID:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}}"
-  local expected_shards="${_TSZ_CI_EMIT_SHARD_COUNT:-${TSZ_CI_EMIT_SHARDS:-4}}"
-
-  if [[ -z "$bucket" || "$run_key" == "unknown" ]]; then
-    echo "error: cannot aggregate — no bucket or run key available" >&2
-    return 1
-  fi
-
-  local prefix="${bucket%/}/emit-runs/${run_key}"
-  local tmp_dir
-  tmp_dir="$(mktemp -d)"
-
-  echo "Downloading emit shard results from ${prefix}/shard-*.json ..."
-  if ! gsutil -q cp "${prefix}/shard-*.json" "$tmp_dir/" 2>/dev/null; then
-    echo "error: failed to download emit shard results from GCS" >&2
-    return 1
-  fi
-
-  local js_passed=0 js_total=0 js_skipped=0 js_timeouts=0
-  local dts_passed=0 dts_total=0 dts_skipped=0 files_count=0
-  for f in "$tmp_dir"/shard-*.json; do
-    [[ -f "$f" ]] || continue
-    files_count=$((files_count + 1))
-    local t
-    t="$(jq -r '.js_total // 0' "$f" 2>/dev/null || echo 0)"
-    [[ "$(num_or_zero "$t")" -eq 0 ]] && continue  # skip empty trailing shards (count only for files_count)
-    js_passed=$((js_passed + $(num_or_zero "$(jq -r '.js_passed'  "$f")")))
-    js_total=$((js_total   + $(num_or_zero "$(jq -r '.js_total'   "$f")")))
-    js_skipped=$((js_skipped + $(num_or_zero "$(jq -r '.js_skipped // 0' "$f")")))
-    js_timeouts=$((js_timeouts + $(num_or_zero "$(jq -r '.js_timeouts // 0' "$f")")))
-    dts_passed=$((dts_passed + $(num_or_zero "$(jq -r '.dts_passed' "$f")")))
-    dts_total=$((dts_total   + $(num_or_zero "$(jq -r '.dts_total'  "$f")")))
-    dts_skipped=$((dts_skipped + $(num_or_zero "$(jq -r '.dts_skipped // 0' "$f")")))
-  done
-
-  validate_emit_aggregate_counts "$js_passed" "$js_total" "$js_skipped" "$js_timeouts" \
-    "$dts_passed" "$dts_total" "$dts_skipped" "$files_count" "$expected_shards"
-  write_emit_metric "$METRICS_DIR/emit.json" \
-    "$js_passed" "$js_total" "$js_skipped" "$js_timeouts" \
-    "$dts_passed" "$dts_total" "$dts_skipped"
-  publish_latest_metric emit "$METRICS_DIR/emit.json"
-}
-
 run_fourslash_shard() {
   ci_section "Fourslash shard"
   local bucket run_key shard_index shard_count
@@ -1143,169 +1096,6 @@ run_fourslash_aggregate() {
   echo "Fourslash OK: ${total_passed}/${total_tests}"
 }
 
-run_emit_shards() {
-  ci_section "Emit shards"
-  mkdir -p "$LOG_DIR/emit"
-  export TSZ_BIN="$ROOT_DIR/.target/dist-fast/tsz"
-  echo "Emit shard config: shards=${SHARD_COUNT} workers_per_shard=${EMIT_WORKERS} chunk=${EMIT_CHUNK} timeout_ms=${EMIT_TIMEOUT_MS}"
-
-  for shard in $(seq 0 $((SHARD_COUNT - 1))); do
-    (
-      set +e
-      offset=$((shard * EMIT_CHUNK))
-      detail_json="$METRICS_DIR/emit-detail-${shard}.json"
-      ./scripts/emit/run.sh --skip-build --max="$EMIT_CHUNK" --offset="$offset" --concurrency="$EMIT_WORKERS" \
-        --timeout="$EMIT_TIMEOUT_MS" \
-        --json-out="$detail_json" \
-        >"$LOG_DIR/emit/shard-${shard}.log" 2>&1
-      rc="$?"
-      js_p="$(jq -r '.summary.jsPass // 0' "$detail_json" 2>/dev/null || echo 0)"
-      js_t="$(jq -r '.summary.jsTotal // 0' "$detail_json" 2>/dev/null || echo 0)"
-      js_s="$(jq -r '.summary.jsSkip // 0' "$detail_json" 2>/dev/null || echo 0)"
-      js_to="$(jq -r '.summary.jsTimeout // 0' "$detail_json" 2>/dev/null || echo 0)"
-      dts_p="$(jq -r '.summary.dtsPass // 0' "$detail_json" 2>/dev/null || echo 0)"
-      dts_t="$(jq -r '.summary.dtsTotal // 0' "$detail_json" 2>/dev/null || echo 0)"
-      dts_s="$(jq -r '.summary.dtsSkip // 0' "$detail_json" 2>/dev/null || echo 0)"
-      js_p="$(num_or_zero "$js_p")"
-      js_t="$(num_or_zero "$js_t")"
-      js_s="$(num_or_zero "$js_s")"
-      js_to="$(num_or_zero "$js_to")"
-      dts_p="$(num_or_zero "$dts_p")"
-      dts_t="$(num_or_zero "$dts_t")"
-      dts_s="$(num_or_zero "$dts_s")"
-      printf '{"shard":%s,"rc":%s,"js_passed":%s,"js_total":%s,"js_skipped":%s,"js_timeouts":%s,"dts_passed":%s,"dts_total":%s,"dts_skipped":%s}\n' \
-        "$shard" "$rc" "$js_p" "$js_t" "$js_s" "$js_to" "$dts_p" "$dts_t" "$dts_s" \
-        > "$METRICS_DIR/emit-shard-${shard}.json"
-      if [[ "$rc" -ne 0 ]]; then
-        show_log_tail "$LOG_DIR/emit/shard-${shard}.log"
-      fi
-      echo "EMIT_SHARD shard=${shard} rc=${rc} js=${js_p}/${js_t} skip=${js_s} timeout=${js_to} dts=${dts_p}/${dts_t} skip=${dts_s}"
-      exit 0
-    ) &
-  done
-  wait
-}
-
-aggregate_emit() {
-  ci_section "Aggregate emit"
-  local js_passed=0 js_total=0 js_skipped=0 js_timeouts=0 dts_passed=0 dts_total=0 dts_skipped=0 shard_count=0
-  for f in "$METRICS_DIR"/emit-shard-*.json; do
-    [[ -f "$f" ]] || continue
-    js_passed=$((js_passed + $(jq -r '.js_passed' "$f")))
-    js_total=$((js_total + $(jq -r '.js_total' "$f")))
-    js_skipped=$((js_skipped + $(jq -r '.js_skipped // 0' "$f")))
-    js_timeouts=$((js_timeouts + $(jq -r '.js_timeouts // 0' "$f")))
-    dts_passed=$((dts_passed + $(jq -r '.dts_passed' "$f")))
-    dts_total=$((dts_total + $(jq -r '.dts_total' "$f")))
-    dts_skipped=$((dts_skipped + $(jq -r '.dts_skipped // 0' "$f")))
-    shard_count=$((shard_count + 1))
-  done
-
-  echo "Emit shards: ${shard_count}/${SHARD_COUNT}"
-  echo "Emit aggregate: JS ${js_passed}/${js_total} (skip=${js_skipped}, timeout=${js_timeouts}), DTS ${dts_passed}/${dts_total} (skip=${dts_skipped})"
-
-  if [[ "$shard_count" -lt "$SHARD_COUNT" || "$js_total" -eq 0 ]]; then
-    echo "error: emit shard coverage is not trustworthy" >&2
-    show_log_tails "$LOG_DIR/emit"
-    return 1
-  fi
-
-  write_emit_metric "$METRICS_DIR/emit.json" \
-    "$js_passed" "$js_total" "$js_skipped" "$js_timeouts" \
-    "$dts_passed" "$dts_total" "$dts_skipped"
-
-  base_js="$(jq -r '.summary.jsPass // 0' scripts/emit/emit-snapshot.json)"
-  base_dts="$(jq -r '.summary.dtsPass // 0' scripts/emit/emit-snapshot.json)"
-  base_dts="$(cap_positive_baseline "$base_dts" "$TSZ_CI_DTS_ACCEPTED_FLOOR")"
-  if [[ "$base_js" -gt 0 && "$js_passed" -lt "$base_js" ]]; then
-    echo "error: emit JS regression: ${js_passed} < ${base_js}" >&2
-    show_log_tails "$LOG_DIR/emit"
-    return 1
-  fi
-  if [[ "$base_dts" -gt 0 && "$dts_passed" -lt "$base_dts" ]]; then
-    echo "error: emit DTS regression: ${dts_passed} < ${base_dts}" >&2
-    show_log_tails "$LOG_DIR/emit"
-    return 1
-  fi
-  publish_latest_metric emit "$METRICS_DIR/emit.json"
-}
-
-run_fourslash_shards() {
-  ci_section "Fourslash shards"
-  mkdir -p "$LOG_DIR/fourslash"
-  echo "Fourslash shard config: shards=${SHARD_COUNT} workers_per_shard=${FOURSLASH_WORKERS}"
-
-  for shard in $(seq 0 $((SHARD_COUNT - 1))); do
-    (
-      set +e
-      detail_json="$METRICS_DIR/fourslash-detail-${shard}.json"
-      ./scripts/fourslash/run-fourslash.sh \
-        --skip-cargo-build \
-        --skip-ts-build \
-        --shard="${shard}/${SHARD_COUNT}" \
-        --workers="$FOURSLASH_WORKERS" --memory-limit=512 \
-        --json-out="$detail_json" \
-        >"$LOG_DIR/fourslash/shard-${shard}.log" 2>&1
-      rc="$?"
-      results="$(grep -a '^Results:' "$LOG_DIR/fourslash/shard-${shard}.log" | tail -1 || true)"
-      passed="$(echo "$results" | grep -oE 'Results:[[:space:]]*[0-9]+ passed' | grep -oE '[0-9]+' | head -1 || true)"
-      total="$(echo "$results" | grep -oE 'out of [0-9]+' | grep -oE '[0-9]+' | head -1 || true)"
-      passed="$(num_or_zero "$passed")"
-      total="$(num_or_zero "$total")"
-      printf '{"shard":%s,"rc":%s,"passed":%s,"total":%s}\n' "$shard" "$rc" "$passed" "$total" \
-        > "$METRICS_DIR/fourslash-shard-${shard}.json"
-      if [[ "$rc" -ne 0 ]]; then
-        show_log_tail "$LOG_DIR/fourslash/shard-${shard}.log"
-      fi
-      echo "FOURSLASH_SHARD shard=${shard} rc=${rc} passed=${passed} total=${total}"
-      exit 0
-    ) &
-  done
-  wait
-}
-
-aggregate_fourslash() {
-  ci_section "Aggregate fourslash"
-  local total_passed=0 total_tests=0 shard_count=0
-  for f in "$METRICS_DIR"/fourslash-shard-*.json; do
-    [[ -f "$f" ]] || continue
-    total_passed=$((total_passed + $(jq -r '.passed' "$f")))
-    total_tests=$((total_tests + $(jq -r '.total' "$f")))
-    shard_count=$((shard_count + 1))
-  done
-
-  echo "Fourslash shards: ${shard_count}/${SHARD_COUNT}"
-  echo "Fourslash aggregate: ${total_passed}/${total_tests}"
-
-  if [[ "$shard_count" -lt "$SHARD_COUNT" || "$total_tests" -eq 0 ]]; then
-    echo "error: fourslash shard coverage is not trustworthy" >&2
-    show_log_tails "$LOG_DIR/fourslash"
-    return 1
-  fi
-
-  baseline="$(jq -r '.summary.passed // .passed // 0' scripts/fourslash/fourslash-snapshot.json)"
-  if [[ "$baseline" -gt 0 ]]; then
-    tolerance="$(awk "BEGIN {printf \"%d\", $baseline * 0.001 + 1}")"
-    floor=$((baseline - tolerance))
-    if [[ "$total_passed" -lt "$floor" ]]; then
-      echo "error: fourslash regression: ${total_passed} < ${baseline} (floor=${floor})" >&2
-      show_log_tails "$LOG_DIR/fourslash"
-      return 1
-    fi
-  fi
-  local pass_rate
-  pass_rate="$(awk -v p="$total_passed" -v t="$total_tests" 'BEGIN { if (t > 0) printf "%.1f", (p / t) * 100; else print "0.0" }')"
-  jq -n \
-    --arg suite "fourslash" \
-    --arg pass_rate "$pass_rate" \
-    --argjson passed "$total_passed" \
-    --argjson total "$total_tests" \
-    --argjson shards "$shard_count" \
-    '{suite:$suite, pass_rate:$pass_rate, passed:$passed, total:$total, shards:$shards}' \
-    > "$METRICS_DIR/fourslash.json"
-  publish_latest_metric fourslash "$METRICS_DIR/fourslash.json"
-}
-
 run_dist_binaries() {
   ci_section "Build dist-fast binaries"
   ci_report_memory "dist-binaries"
@@ -1317,12 +1107,6 @@ show_sccache_stats() {
   if command -v sccache >/dev/null 2>&1 && [[ -n "${RUSTC_WRAPPER:-}" ]]; then
     sccache --show-stats 2>/dev/null || true
   fi
-}
-
-run_unit_archive_only() {
-  ci_section "Build unit test archive"
-  timed build_unit_test_archive build_unit_test_archive
-  show_sccache_stats
 }
 
 run_node_harness_prep() {
@@ -1338,26 +1122,6 @@ run_lsp_e2e_smoke() {
     return 1
   fi
   node scripts/lsp/e2e-smoke.mjs "$bin"
-}
-
-run_build() {
-  ci_section "Build dist-fast binaries (upload for parallel jobs)"
-  timed build_test_binaries build_test_binaries
-  timed build_unit_test_archive build_unit_test_archive
-  # Seed scripts/node_modules so save_caches can cache it for all parallel shard jobs.
-  # Shards all start simultaneously after build completes, so if build doesn't seed it,
-  # every shard misses the cache and reinstalls npm packages independently.
-  ci_section "Seed scripts node_modules for parallel job cache"
-  if [[ ! -x scripts/node_modules/.bin/tsc ]]; then
-    if command -v npm >/dev/null 2>&1; then
-      (cd scripts && npm install --silent --include=dev)
-    else
-      echo "warn: npm not found in build image; skipping scripts/node_modules seed (shards will reinstall on cache-miss)" >&2
-    fi
-  else
-    echo "scripts/node_modules already present (cache hit)"
-  fi
-  show_sccache_stats
 }
 
 suite_needs_typescript_source() {
@@ -1389,22 +1153,13 @@ run_common_setup() {
   fi
 }
 
-run_all_suites() {
-  timed run_lint run_lint
-  timed run_unit_tests run_unit_tests
-  timed build_test_binaries build_test_binaries
-  timed build_wasm build_wasm
-  timed build_wasm_web build_wasm_web
-  timed prep_node_artifacts prep_node_artifacts
-  timed run_conformance run_conformance
-  timed run_emit_shards run_emit_shards
-  timed aggregate_emit aggregate_emit
-  timed run_fourslash_shards run_fourslash_shards
-  timed aggregate_fourslash aggregate_fourslash
-}
-
 main() {
-  local suite="${1:-${TSZ_CI_SUITE:-all}}"
+  local suite="${1:-${TSZ_CI_SUITE:-}}"
+
+  if [[ -z "$suite" ]]; then
+    echo "usage: $0 $(ci_suite_usage full)" >&2
+    return 2
+  fi
 
   if ! ci_suite_is_known full "$suite"; then
     echo "error: unknown CI suite '${suite}'" >&2
@@ -1415,17 +1170,8 @@ main() {
   run_common_setup "$suite"
 
   case "$suite" in
-    all|full)
-      run_all_suites
-      ;;
-    build)
-      run_build
-      ;;
     dist-binaries)
       run_dist_binaries
-      ;;
-    unit-archive)
-      run_unit_archive_only
       ;;
     node-harness-prep)
       run_node_harness_prep
@@ -1439,19 +1185,8 @@ main() {
     checker-integration)
       timed run_checker_integration_tests run_checker_integration_tests
       ;;
-    unit-shard)
-      timed run_unit_shard run_unit_shard
-      ;;
     lsp-e2e)
       timed run_lsp_e2e_smoke run_lsp_e2e_smoke
-      ;;
-    wasm)
-      timed build_wasm build_wasm
-      show_sccache_stats
-      ;;
-    wasm-web)
-      timed build_wasm_web build_wasm_web
-      show_sccache_stats
       ;;
     wasm-all)
       timed build_wasm_all build_wasm_all
@@ -1464,25 +1199,10 @@ main() {
     conformance-aggregate)
       timed run_conformance_aggregate run_conformance_aggregate
       ;;
-    emit)
-      timed build_test_binaries build_test_binaries
-      timed prep_node_artifacts prep_node_artifacts
-      timed run_emit_shards run_emit_shards
-      timed aggregate_emit aggregate_emit
-      ;;
-    fourslash)
-      timed build_test_binaries build_test_binaries
-      timed prep_node_artifacts prep_node_artifacts
-      timed run_fourslash_shards run_fourslash_shards
-      timed aggregate_fourslash aggregate_fourslash
-      ;;
     emit-shard)
       timed build_test_binaries build_test_binaries
       timed maybe_prep_node_artifacts maybe_prep_node_artifacts
       timed run_emit_shard run_emit_shard
-      ;;
-    emit-aggregate)
-      timed run_emit_aggregate run_emit_aggregate
       ;;
     fourslash-shard)
       timed build_test_binaries build_test_binaries

--- a/scripts/ci/gcp-summary.py
+++ b/scripts/ci/gcp-summary.py
@@ -350,7 +350,7 @@ def main() -> int:
     lines: list[str] = []
     append_env(lines, args.suite, args.exit_code)
 
-    if args.suite in {"emit", "emit-shard", "emit-aggregate"}:
+    if args.suite == "emit-shard":
         emit_summary(metrics_dir, logs_dir, lines)
     elif args.suite == "fourslash":
         fourslash_summary(metrics_dir, logs_dir, lines)

--- a/scripts/ci/suite-metadata.sh
+++ b/scripts/ci/suite-metadata.sh
@@ -1,32 +1,26 @@
 #!/usr/bin/env bash
 
 _TSZ_CI_GITHUB_SUITES=(
-  build
   dist-binaries
-  unit-archive
   node-harness-prep
   lint
   unit
-  checker-integration
-  unit-shard
   lsp-e2e
-  wasm
-  wasm-web
   wasm-all
   conformance
   conformance-aggregate
-  emit
   emit-shard
-  emit-aggregate
-  fourslash
   fourslash-shard
   fourslash-aggregate
 )
 
+_TSZ_CI_DIRECT_SUITES=(
+  checker-integration
+)
+
 _TSZ_CI_FULL_SUITES=(
-  all
-  full
   "${_TSZ_CI_GITHUB_SUITES[@]}"
+  "${_TSZ_CI_DIRECT_SUITES[@]}"
 )
 
 _TSZ_CI_CACHE_SUITES=(
@@ -78,21 +72,15 @@ ci_suite_is_known() {
 
 ci_suite_needs_group() {
   local suite="$1" group="$2"
-  case "$suite" in
-    all|full)
-      return 0
-      ;;
-  esac
-
   case "$group" in
     lint)
       [[ "$suite" == "lint" ]]
       ;;
     unit)
-      [[ "$suite" == "unit" || "$suite" == "checker-integration" || "$suite" == "unit-shard" || "$suite" == "unit-archive" ]]
+      [[ "$suite" == "unit" || "$suite" == "checker-integration" ]]
       ;;
     wasm)
-      [[ "$suite" == "wasm" || "$suite" == "wasm-web" || "$suite" == "wasm-all" ]]
+      [[ "$suite" == "wasm-all" ]]
       ;;
     node)
       [[ "$suite" == "lint" || "$suite" == conformance* || "$suite" == emit* || "$suite" == fourslash* || "$suite" == "node-harness-prep" ]]
@@ -108,7 +96,7 @@ ci_suite_needs_group() {
 
 ci_suite_needs_rust_compile() {
   case "$1" in
-    all|full|bench|build|lint|unit|checker-integration|wasm|wasm-web|wasm-all|dist-binaries|unit-archive)
+    all|full|bench|lint|unit|checker-integration|wasm-all|dist-binaries)
       return 0
       ;;
     *)
@@ -143,12 +131,12 @@ ci_suite_caches() {
       # It does not read the TypeScript corpus or install npm packages.
       echo "cargo-home"
       ;;
-    build|unit|checker-integration)
+    unit|checker-integration)
       # Full local build/unit flows may run tests that reference
       # TypeScript/src/lib and tests/cases at runtime.
       echo "cargo-home typescript-source"
       ;;
-    dist-binaries|unit-archive)
+    dist-binaries)
       # Rust compile/archive only; downstream suites restore corpus or
       # harness state when they actually need it.
       echo "cargo-home"
@@ -158,13 +146,9 @@ ci_suite_caches() {
       # and uses npm's cache for pinned tsgo/tsc installs.
       echo "cargo-home typescript-source npm"
       ;;
-    wasm|wasm-web|wasm-all)
+    wasm-all)
       # wasm-pack installs the matching wasm-bindgen CLI on demand.
       echo "cargo-home typescript-source wasm-pack-cache"
-      ;;
-    unit-shard)
-      # Downloads the nextest archive directly from GCS.
-      echo ""
       ;;
     lsp-e2e)
       # Reuses the dist-fast `tsz-lsp` binary artifact and a Node protocol
@@ -176,13 +160,9 @@ ci_suite_caches() {
       # from TypeScript source. No npm/harness restore needed.
       echo "typescript-source dist-fast-commit"
       ;;
-    conformance-aggregate|emit-aggregate|fourslash-aggregate)
+    conformance-aggregate|fourslash-aggregate)
       # Aggregates only download per-shard JSONs from GCS.
       echo ""
-      ;;
-    emit|fourslash)
-      # Full Node-driven test run: TypeScript source + harness + tsz binary.
-      echo "typescript-source npm scripts-node-modules typescript-harness typescript-node-modules dist-fast-commit"
       ;;
     emit-shard)
       # Shards get Node runtime artifacts and tsz via CI artifacts, so only
@@ -214,13 +194,10 @@ ci_suite_target_caches() {
     all|full)
       echo "cargo-target-deps cargo-target-unit cargo-target-wasm"
       ;;
-    build)
-      echo "cargo-target-deps cargo-target-unit"
-      ;;
     dist-binaries)
       echo "cargo-target-deps"
       ;;
-    unit-archive|unit|checker-integration)
+    unit|checker-integration)
       echo "cargo-target-unit"
       ;;
     lint)
@@ -228,7 +205,7 @@ ci_suite_target_caches() {
       # sccache handles cross-commit lint reuse.
       echo ""
       ;;
-    wasm|wasm-web|wasm-all)
+    wasm-all)
       echo "cargo-target-wasm"
       ;;
     *)

--- a/scripts/ci/test_gcp_full_ci_emit_metrics.py
+++ b/scripts/ci/test_gcp_full_ci_emit_metrics.py
@@ -50,19 +50,9 @@ write_emit_metric "{out}" 13401 13530 1 0 1619 1669 11862
         self.assertEqual(data["dts_skipped"], 11862)
 
     def test_single_shard_emit_publishes_latest_metric(self):
-        body = self.function_body("run_emit_shard", "\nrun_emit_aggregate() {")
+        body = self.function_body("run_emit_shard", "\nrun_fourslash_shard() {")
         validate_idx = body.index(
             'validate_emit_aggregate_counts "$js_p" "$js_t" "$js_s" "$js_to" "$dts_p" "$dts_t" "$dts_s" 1 1',
-        )
-        write_idx = body.index('write_emit_metric "$METRICS_DIR/emit.json"', validate_idx)
-        publish_idx = body.index('publish_latest_metric emit "$METRICS_DIR/emit.json"', write_idx)
-        self.assertLess(validate_idx, write_idx)
-        self.assertLess(write_idx, publish_idx)
-
-    def test_multi_shard_emit_aggregate_publishes_latest_metric(self):
-        body = self.function_body("run_emit_aggregate", "\nrun_fourslash_shard() {")
-        validate_idx = body.index(
-            'validate_emit_aggregate_counts "$js_passed" "$js_total" "$js_skipped" "$js_timeouts"',
         )
         write_idx = body.index('write_emit_metric "$METRICS_DIR/emit.json"', validate_idx)
         publish_idx = body.index('publish_latest_metric emit "$METRICS_DIR/emit.json"', write_idx)

--- a/scripts/ci/test_suite_metadata.py
+++ b/scripts/ci/test_suite_metadata.py
@@ -1,0 +1,62 @@
+"""Contract tests for CI suite metadata."""
+
+import pathlib
+import re
+import subprocess
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+CLOUDBUILD_CHECKER = ROOT / "scripts" / "cloudbuild" / "cloudbuild-checker-integration.yaml"
+
+
+def suite_names(scope: str) -> list[str]:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"source scripts/ci/suite-metadata.sh; ci_suite_names {scope}",
+        ],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+class SuiteMetadataTests(unittest.TestCase):
+    def test_github_suites_match_workflow_invocations(self):
+        workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+        invoked = set(re.findall(r"scripts/ci/github-suite\.sh\s+([A-Za-z0-9_-]+)", workflow))
+
+        self.assertEqual(set(suite_names("github")), invoked)
+
+    def test_full_suites_add_only_direct_cloudbuild_suite(self):
+        cloudbuild = CLOUDBUILD_CHECKER.read_text(encoding="utf-8")
+        direct = set(re.findall(r"scripts/ci/gcp-full-ci\.sh\s+([A-Za-z0-9_-]+)", cloudbuild))
+
+        self.assertEqual(set(suite_names("full")), set(suite_names("github")) | direct)
+        self.assertEqual(direct, {"checker-integration"})
+
+    def test_removed_local_fanout_suites_are_not_entry_points(self):
+        removed = {
+            "all",
+            "full",
+            "build",
+            "unit-archive",
+            "unit-shard",
+            "wasm",
+            "wasm-web",
+            "emit",
+            "emit-aggregate",
+            "fourslash",
+        }
+
+        self.assertTrue(removed.isdisjoint(suite_names("full")))
+        self.assertTrue(removed.isdisjoint(suite_names("github")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Goal: hold

AgentName: Codex
Track: CI infra tech-debt
Invariant: `scripts/ci/suite-metadata.sh` exposes only suites that are reachable from the GitHub workflow or direct Cloud Build checker integration; dead local fanout entries do not remain as accepted CI entry points.
Scope:
- Remove obsolete all/full/local fanout suite cases from `gcp-full-ci.sh`.
- Narrow suite metadata to live GitHub suites plus the direct `checker-integration` Cloud Build suite.
- Drop the unused emit multi-shard aggregate path and its summary branch.
- Add a suite metadata contract test that compares declared suites to workflow and Cloud Build invocations.
Project Corpus Impact: None; CI-script metadata only, no project corpus row behavior change.

Fixes #13124

## Verification
- `bash -n scripts/ci/gcp-full-ci.sh scripts/ci/suite-metadata.sh scripts/ci/github-suite.sh scripts/ci/ci-resources.sh`
- `python3 scripts/ci/test_suite_metadata.py`
- `python3 scripts/ci/test_gcp_full_ci_emit_metrics.py`
- `python3 scripts/ci/test_gcp_full_ci_conformance_artifacts.py`
- `python3 scripts/ci/test_ci_resources.py`
- `node scripts/ci/test-pr-ready-state.mjs`
- `node scripts/ci/test-cloudbuild-config-paths.mjs`
- `git diff --check`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium

## Coordination Notes
- No overlap with open compiler PRs #13177, #13176, #13175, or #13163.
- Related active PR #13178 is independent and touches only conformance option conversion.
