### PR TITLE
fix(solver): thread-local evaluation fuel — removes cross-worker budget race (flaky TS2344s, parallel re-evaluation storms)

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -331,6 +331,27 @@ fn parallel_file_session_reuse_requested() -> bool {
     )
 }
 
+/// Decide whether fresh per-file checkers run sequentially instead of on the
+/// rayon pool.
+///
+/// Tiny batches stay sequential to avoid pool overhead. Large wildcard
+/// barrels (PR #5881) and DOM/webworker-lib projects (PR #7312) stay
+/// sequential because correctness and termination on type-heavy projects
+/// currently depend on checking files in deterministic order with a
+/// progressively warmed `SharedQueryCache`.
+///
+/// Investigated 2026-06 while attempting to lift the DOM gate for the
+/// ts-toolbelt row: the blocker is not (only) racing shared state. Checking
+/// `ts-toolbelt/sources/Function/AutoPath.ts` *alone* (cold caches, fully
+/// sequential) is a runaway evaluation, and `sources/Number/Greater.ts`
+/// alone emits a false `TS2344` (`'undefined'` vs the `Iteration` tuple
+/// constraint). The sequential project run masks both because earlier files
+/// warm the shared eval/relation caches before the heavy files are reached.
+/// Under parallel fresh checking, workers start those files cold, so runs
+/// nondeterministically hang or surface the false diagnostics. Lifting this
+/// gate requires fixing the cold-start conditional/`infer` evaluation
+/// family first (then re-running the 10x byte-diff determinism loop on
+/// ts-toolbelt at full width).
 const fn should_use_sequential_fresh_checking(
     work_item_count: usize,
     has_large_wildcard_barrel: bool,

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -270,20 +270,34 @@ pub struct TypeInterner {
     /// `QueryCache`, and survive across files and child checkers. Values hold
     /// no `TypeId`s, only `Variance` bitmasks and `DefId`s.
     pub(super) def_variance_masks: DashMap<DefId, SharedDefVariance, FxBuildHasher>,
-    /// Global evaluation fuel counter.
-    ///
-    /// Tracks cumulative evaluation work across ALL `TypeEvaluator` instances.
-    /// Mirrors TypeScript's `instantiationCount` which limits total type instantiation
-    /// work across the entire program check. Prevents deeply recursive type libraries
-    /// (like ts-toolbelt) from consuming unbounded memory through repeated type
-    /// instantiation that creates new `TypeIds` on each expansion.
-    ///
-    /// When this counter exceeds `MAX_EVALUATION_FUEL`, evaluators bail out early
-    /// with `TypeId::ERROR`, matching tsc's TS2589 behavior.
-    pub(super) evaluation_fuel: AtomicU32,
     /// Unique identifier scoping this interner's entries in the thread-local
     /// lookup/intern cache. See `NEXT_INTERNER_INSTANCE_ID` for context.
     pub(super) instance_id: u32,
+}
+
+thread_local! {
+    /// Per-thread evaluation fuel counter.
+    ///
+    /// Tracks cumulative evaluation work across the `TypeEvaluator` instances
+    /// of the file-check session running on this thread. Mirrors TypeScript's
+    /// `instantiationCount`, which bounds runaway type instantiation per
+    /// checked source element. Prevents deeply recursive type libraries (like
+    /// ts-toolbelt) from consuming unbounded memory through repeated type
+    /// instantiation that creates new `TypeIds` on each expansion.
+    ///
+    /// When this counter exceeds `MAX_EVALUATION_FUEL`, evaluators bail out
+    /// early with `TypeId::ERROR`, matching tsc's TS2589 behavior.
+    ///
+    /// This is thread-local rather than a process-global atomic on purpose:
+    /// each file-check session runs entirely on one worker thread and resets
+    /// the budget at session start (`reset_evaluation_fuel` from
+    /// `build_type_environment`). A process-global counter made concurrent
+    /// fresh-checker workers consume and reset each other's budget, so
+    /// whether a deep evaluation bailed to `TypeId::ERROR` depended on
+    /// sibling-worker scheduling — the source of flaky parallel-check
+    /// diagnostics (false TS2344) and uncached re-evaluation storms on
+    /// type-heavy projects.
+    static EVALUATION_FUEL: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
 }
 
 /// Entry-count snapshot for retained `TypeInterner` predicate caches.
@@ -388,7 +402,6 @@ impl TypeInterner {
             union_too_complex: AtomicBool::new(false),
             tuple_too_large: AtomicBool::new(false),
             def_variance_masks: DashMap::with_hasher(FxBuildHasher),
-            evaluation_fuel: AtomicU32::new(0),
             instance_id: NEXT_INTERNER_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
         }
     }
@@ -1237,17 +1250,21 @@ impl TypeInterner {
 
     /// Consume evaluation fuel and return whether fuel is exhausted.
     ///
-    /// This is a global budget across all `TypeEvaluator` instances. When exhausted,
-    /// the current evaluation should bail out with ERROR, but the interner remains
-    /// readable so already-computed project types do not turn into opaque `Type(N)`
-    /// placeholders in later diagnostics.
+    /// This is a per-thread budget across the `TypeEvaluator` instances of
+    /// the file-check session running on this thread (see `EVALUATION_FUEL`).
+    /// When exhausted, the current evaluation should bail out with ERROR, but
+    /// the interner remains readable so already-computed project types do not
+    /// turn into opaque `Type(N)` placeholders in later diagnostics.
     #[inline]
     pub fn consume_evaluation_fuel(&self, amount: u32) -> bool {
-        let prev = self.evaluation_fuel.fetch_add(amount, Ordering::Relaxed);
-        prev.wrapping_add(amount) > MAX_EVALUATION_FUEL
+        EVALUATION_FUEL.with(|fuel| {
+            let next = fuel.get().wrapping_add(amount);
+            fuel.set(next);
+            next > MAX_EVALUATION_FUEL
+        })
     }
 
-    /// Reset the global evaluation fuel counter.
+    /// Reset this thread's evaluation fuel counter.
     ///
     /// Called at the start of each top-level file check session. `tsc` resets
     /// its `instantiationCount` per checked source element, so the fuel limit
@@ -1256,13 +1273,14 @@ impl TypeInterner {
     /// of any multi-thousand-file program into blanket `TypeId::ERROR`.
     #[inline]
     pub fn reset_evaluation_fuel(&self) {
-        self.evaluation_fuel.store(0, Ordering::Relaxed);
+        EVALUATION_FUEL.with(|fuel| fuel.set(0));
     }
 
-    /// Check whether global evaluation fuel is exhausted without consuming any.
+    /// Check whether this thread's evaluation fuel is exhausted without
+    /// consuming any.
     #[inline]
     pub fn is_evaluation_fuel_exhausted(&self) -> bool {
-        self.evaluation_fuel.load(Ordering::Relaxed) > MAX_EVALUATION_FUEL
+        EVALUATION_FUEL.with(|fuel| fuel.get() > MAX_EVALUATION_FUEL)
     }
 
     #[inline]


### PR DESCRIPTION
Goal: fast

## Summary

`TypeInterner.evaluation_fuel` was a process-global `AtomicU32`: every `TypeEvaluator` on every rayon worker consumed from one budget, and `build_type_environment` reset it per file from whichever worker started a session — erasing sibling workers' accounting mid-flight. Under N workers, budgets exhausted ~N× early and nondeterministically: fuel-exhaustion `TypeId::ERROR` bails surfaced as flaky false TS2344s, and the "limit-hit ⇒ don't cache" gates discarded results, triggering re-evaluation storms (a gate-bypassed ts-toolbelt parallel probe burned 24+ CPU-minutes; sequential is ~1.1s). This is a live nondeterminism source in the *existing* parallel checking lane (witnessed: a 200-file synthetic at 4 workers hangs >120s on main; completes with this fix).

## Structural rule

Evaluation fuel is a per-file-session budget; a file session runs on exactly one worker. Make the counter a thread-local `Cell<u32>`: each worker's sessions meter and reset their own budget, reproducing sequential per-file semantics exactly. Single-threaded behavior is arithmetically identical.

## Measured

- ts-toolbelt fresh-parallel probe (4 workers, shared query cache off): 3 false TS2344 / 9 errors / 27.6s user → **0 errors / ~1.5s user**.
- 200-file synthetic parallel witness: main hangs >120s at 4 workers → completes.
- Sequential lanes byte-identical: ts-toolbelt 10× identical to baseline (0 errors), vite/nextjs 5× byte-identical.
- Note: this does NOT lift the DOM-lib sequential gate (`should_use_sequential_fresh_checking`) — full-width parallel ts-toolbelt still blocks on the cold-start conditional/`infer` evaluation family (deterministic single-threaded witnesses recorded in the gate's new doc comment: `Function/AutoPath.ts` standalone runaway, `Number/Greater.ts` standalone false TS2344). This fix removes the fuel-race layer beneath that work and de-flakes the existing parallel lane.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: high

## Verification

- Full local conformance: 12583/12585 — zero new vs the accepted ledger.
- `cargo nextest run -p tsz-solver` fuel suites: `test_fuel_limit_exceeded`, `test_reset_instantiation_fuel`, `test_evaluation_fuel_exhaustion_does_not_poison_interner_storage` — pass; crate suites' only failures reproduce identically on the unmodified tree (known Mac-delta family).
- ts-toolbelt row: 0 errors, byte-identical output; vite/nextjs 5× byte-identical.
- Arch guard passes.
