### PR TITLE
fix(solver,checker): clear msw unique-symbol member-lookup FP family (split-accessor writes, in-flight ctor caching, well-known in-guards)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/references.rs
+++ b/crates/tsz-checker/src/flow/control_flow/references.rs
@@ -526,7 +526,17 @@ impl<'a> FlowAnalyzer<'a> {
             if access.question_dot_token {
                 return None;
             }
-            let name = self.literal_atom_from_node_or_type(access.name_or_argument)?;
+            let name = self.literal_atom_from_node_or_type(access.name_or_argument);
+            tracing::trace!(
+                ?idx,
+                key = ?access.name_or_argument,
+                resolved = ?name,
+                key_type = ?self
+                    .node_types
+                    .and_then(|nt| nt.get(&access.name_or_argument.0).copied()),
+                "element-access property_reference key resolution"
+            );
+            let name = name?;
             return Some((access.expression, name));
         }
 
@@ -574,6 +584,16 @@ impl<'a> FlowAnalyzer<'a> {
 
         let node_types = self.node_types?;
         let type_id = *node_types.get(&idx.0)?;
+        // Well-known symbol keys (e.g. `Symbol.iterator in x`): members keyed
+        // by a built-in `Symbol.*` unique symbol are stored under the
+        // "[Symbol.<name>]" member name — the same syntax-derived convention
+        // computed property declarations use — not the generic
+        // "__unique_<id>" name that `literal_property_name` derives. Without
+        // this mapping, `in`-narrowing fails to match any union constituent
+        // and the guard degrades to `T & Record<__unique_N, unknown>`.
+        if let Some(atom) = self.well_known_symbol_member_atom(idx, type_id) {
+            return Some((atom, false));
+        }
         if let Some(atom) = crate::query_boundaries::type_computation::access::literal_property_name(
             self.interner,
             type_id,
@@ -585,6 +605,40 @@ impl<'a> FlowAnalyzer<'a> {
             LiteralValueKind::Number(value) => Some((self.atom_from_numeric_value(value), true)),
             LiteralValueKind::None => None,
         }
+    }
+
+    /// Member-name atom for a well-known unique-symbol key written as
+    /// `Symbol.<name>` (`Symbol.iterator`, `Symbol.asyncIterator`, …).
+    ///
+    /// Class/interface members keyed by these well-known symbols are stored
+    /// under "[Symbol.<name>]" — the same syntax-derived convention used when
+    /// the member declaration's computed property name is resolved (see
+    /// `types/type_node_property_names.rs`). The key expression must actually
+    /// carry a `unique symbol` type so a user-defined `Symbol` object with
+    /// ordinary members does not alias the well-known names.
+    fn well_known_symbol_member_atom(
+        &self,
+        idx: NodeIndex,
+        type_id: tsz_solver::TypeId,
+    ) -> Option<Atom> {
+        crate::query_boundaries::common::unique_symbol_ref(
+            self.interner.as_type_database(),
+            type_id,
+        )?;
+        let node = self.arena.get(idx)?;
+        if node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+            return None;
+        }
+        let access = self.arena.get_access_expr(node)?;
+        let base_node = self.arena.get(access.expression)?;
+        let base_ident = self.arena.get_identifier(base_node)?;
+        if base_ident.escaped_text != "Symbol" {
+            return None;
+        }
+        let name_node = self.arena.get(access.name_or_argument)?;
+        let ident = self.arena.get_identifier(name_node)?;
+        let name = format!("[Symbol.{}]", ident.escaped_text);
+        Some(self.interner.intern_string(&name))
     }
 
     pub(crate) fn literal_number_from_node_or_type(&self, idx: NodeIndex) -> Option<f64> {

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1314,6 +1314,9 @@ mod union_source_literal_target_display_tests;
 #[path = "tests/unique_symbol_assignment_ts2322_tests.rs"]
 mod unique_symbol_assignment_ts2322_tests;
 #[cfg(test)]
+#[path = "tests/unique_symbol_member_lookup_family_tests.rs"]
+mod unique_symbol_member_lookup_family_tests;
+#[cfg(test)]
 #[path = "tests/variadic_tuple_alias_display_tests.rs"]
 mod variadic_tuple_alias_display_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1324,6 +1324,23 @@ impl<'a> CheckerState<'a> {
                 .zip(self.ctx.get_existing_def_id(sym_id))
                 .is_some_and(|(ld, od)| ld == od)
         };
+        // A class symbol queried in value position while its own instance
+        // type is still being computed (`class_instance_resolution_set`
+        // contains it, e.g. a static self-reference like
+        // `readonly X = C.Y` forcing `typeof C` mid-build) yields a
+        // provisional constructor type whose construct-signature return is
+        // the Phase-0 prescan instance shape — missing computed/symbol-keyed
+        // members and heritage. Caching that would leak the partial instance
+        // into later `new C()` results (false TS7053/TS2739/TS2741). Only
+        // results that actually embed the provisional instance are dropped;
+        // healthy in-window results stay cacheable (perf on large
+        // self-referential classes).
+        let class_instance_resolution_in_flight = self
+            .ctx
+            .binder
+            .get_symbol(sym_id)
+            .is_some_and(|s| s.has_any_flags(symbol_flags::CLASS))
+            && self.ctor_result_embeds_inflight_instance(sym_id, result);
         if let Some(file_idx) = cross_file_owner_idx {
             self.ctx.cache_cross_file_symbol_type(
                 sym_id,
@@ -1332,7 +1349,8 @@ impl<'a> CheckerState<'a> {
                 type_params.clone(),
             );
         } else {
-            let result_cached_locally = if result_is_lazy_to_self
+            let result_cached_locally = if (result_is_lazy_to_self
+                || class_instance_resolution_in_flight)
                 && self
                     .ctx
                     .binder
@@ -1360,7 +1378,15 @@ impl<'a> CheckerState<'a> {
         // IMPORTANT: We use the type_params returned by compute_type_of_symbol
         // because those are the same TypeIds used when lowering the type body.
         // Calling get_type_params_for_symbol would create fresh TypeIds that don't match.
-        if use_local_symbol_state && result != TypeId::ANY && result != TypeId::ERROR {
+        if use_local_symbol_state
+            && result != TypeId::ANY
+            && result != TypeId::ERROR
+            // Do not register provisional in-flight class constructor types
+            // (see `class_instance_resolution_in_flight` above): the env entry
+            // would pin the prescan instance shape for Lazy/Application
+            // resolution even after the real instance type is finished.
+            && !class_instance_resolution_in_flight
+        {
             // For class symbols, we need to cache BOTH the constructor type (for value position)
             // and the instance type (for type position with typeof/TypeQuery resolution).
             let class_env_entry = self.ctx.binder.get_symbol(sym_id).and_then(|symbol| {

--- a/crates/tsz-checker/src/tests/unique_symbol_member_lookup_family_tests.rs
+++ b/crates/tsz-checker/src/tests/unique_symbol_member_lookup_family_tests.rs
@@ -1,0 +1,352 @@
+//! Regression coverage for the msw `unique symbol` member-lookup
+//! false-positive family (sse.ts / RequestHandler.ts canary sites).
+//!
+//! Three structural rules, one per sub-bug:
+//!
+//! 1. **Split accessors (relations)**: when relating object types, tsc
+//!    compares only property *read* types; setter/write types never
+//!    participate in assignability, subtype, or conditional-`extends`
+//!    relations (TS 4.3 divergent accessors). Owner:
+//!    `tsz_solver::relations::subtype` property compatibility, gated by
+//!    `SubtypeChecker::check_split_accessor_writes` (Sound Mode only).
+//!
+//! 2. **In-flight class constructor types (caching)**: a class constructor
+//!    type computed while the class's own instance type is still being built
+//!    (static self-reference forcing `typeof C` mid-build) embeds the
+//!    provisional prescan instance shape — missing computed/symbol-keyed
+//!    members and heritage — and must not be cached. Owner:
+//!    `CheckerState::get_type_of_symbol` result caching and
+//!    `class_constructor_type_cache` insertion.
+//!
+//! 3. **Well-known symbol `in` guards (narrowing)**: members keyed by a
+//!    built-in `Symbol.*` unique symbol are stored under the
+//!    "[Symbol.<name>]" member name, so `Symbol.iterator in x` must narrow
+//!    with that key, not the generic "__unique_<id>" name. Owner:
+//!    `FlowAnalyzer::literal_atom_and_kind_from_node_or_type`.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::Diagnostic;
+use crate::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn check_with_libs(src: &str) -> Vec<Diagnostic> {
+    let libs = load_default_lib_files();
+    check_source_with_libs(src, "test.ts", CheckerOptions::default(), &libs)
+}
+
+fn assert_clean_setup(diags: &[Diagnostic], label: &str) {
+    // Guard against vacuous passes: the witness must not have unresolved
+    // global/lib names (TS2304/TS2583/TS2584), otherwise the asserted codes
+    // could be absent merely because the types collapsed to errors.
+    assert!(
+        !diags.iter().any(|d| matches!(d.code, 2304 | 2583 | 2584)),
+        "{label}: witness has unresolved names; fix the test source: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+fn assert_no_codes(label: &str, src: &str, codes: &[u32]) {
+    let diags = check_with_libs(src);
+    assert_clean_setup(&diags, label);
+    let bad: Vec<_> = diags.iter().filter(|d| codes.contains(&d.code)).collect();
+    assert!(
+        bad.is_empty(),
+        "{label}: expected none of {codes:?}; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+fn assert_has_code(label: &str, src: &str, code: u32) {
+    let diags = check_with_libs(src);
+    assert_clean_setup(&diags, label);
+    assert!(
+        diags.iter().any(|d| d.code == code),
+        "{label}: expected TS{code}; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-bug 1: split-accessor write types must not participate in relations
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn divergent_accessor_class_assignable_to_plain_property_interface() {
+    // tsc-verified clean: read types match; the narrower setter is ignored.
+    assert_no_codes(
+        "divergent accessor → interface",
+        r#"
+type Cb = (ev: string) => void
+
+interface Sink {
+    handler: Cb | null
+}
+
+class Holder {
+    #cb: Cb | null = null
+    get handler(): Cb | null {
+        return this.#cb
+    }
+    set handler(value: Cb) {
+        this.#cb = value
+    }
+}
+
+declare const h: Holder
+const sink: Sink = h
+declare function take(s: Sink): void
+take(h)
+"#,
+        &[2322, 2345],
+    );
+}
+
+#[test]
+fn divergent_accessor_object_types_relate_through_read_types_both_directions() {
+    // tsc-verified clean in all four combinations (wt.ts witness).
+    assert_no_codes(
+        "split accessor anonymous object relations",
+        r#"
+declare const a: { get x(): string; set x(v: string) }
+const b: { get x(): string; set x(v: string | number) } = a
+declare const c: { get x(): string; set x(v: string | number) }
+const d: { get x(): string; set x(v: string) } = c
+declare const e: { x: string }
+const f: { get x(): string; set x(v: string | number) } = e
+const g: { x: string } = c
+declare const h: { get x(): string; set x(v: string) }
+const i: { readonly x: string } = h
+export {}
+"#,
+        &[2322],
+    );
+}
+
+#[test]
+fn divergent_accessor_conditional_extends_ignores_write_types() {
+    // `T extends { get x; set x(wider) }` matches on read types in tsc.
+    assert_no_codes(
+        "conditional extends with split accessor",
+        r#"
+type W<T> = T extends { get x(): string; set x(v: string | number) } ? 1 : 0
+type T1 = W<{ x: string }>
+declare const probe: T1
+const one: 1 = probe
+export {}
+"#,
+        &[2322],
+    );
+}
+
+#[test]
+fn divergent_accessor_read_type_mismatch_still_errors() {
+    // Negative control: an incompatible *read* type must keep failing.
+    assert_has_code(
+        "read type mismatch",
+        r#"
+declare const a: { get x(): number; set x(v: number | string) }
+const b: { x: string } = a
+export {}
+"#,
+        2322,
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-bug 2: provisional class constructor types must not leak via caches
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn early_new_of_class_with_static_self_ref_sees_symbol_member() {
+    // The msw ObservableEventSource shape: a method declared BEFORE the class
+    // forces the class type; the class has a static self-reference and a
+    // generic method. The `new` result must include the symbol-keyed member
+    // and satisfy the declared return type.
+    assert_no_codes(
+        "use-before-decl class with static self-ref",
+        r#"
+class Maker {
+    build(): Widget {
+        const w = new Widget()
+        w[kHandler] = (event) => {
+            console.log(event)
+        }
+        return w
+    }
+}
+
+const kHandler = Symbol('kHandler')
+
+class Widget {
+    static readonly MODE = 2
+    public readonly MODE = Widget.MODE
+    private [kHandler]: ((event: string) => void) | null = null
+    public listen<K extends string>(name: K): void {
+        console.log(name)
+    }
+}
+export {}
+"#,
+        &[7053, 7006, 2739, 2741, 2322],
+    );
+}
+
+#[test]
+fn early_new_of_extending_class_with_static_self_ref_keeps_heritage() {
+    // Same shape but with a lib base class: the `new` result must also keep
+    // inherited members (dispatchEvent) — the provisional prescan type has
+    // neither heritage nor computed members.
+    assert_no_codes(
+        "use-before-decl extending class keeps heritage",
+        r#"
+class Driver {
+    open(): Source {
+        const s = new Source()
+        s[kOnAny] = (event) => {
+            console.log(event)
+        }
+        s.dispatchEvent(new Event('ping'))
+        return s
+    }
+}
+
+const kOnAny = Symbol('kOnAny')
+
+class Source extends EventTarget {
+    static readonly OPEN = 1
+    public readonly OPEN = Source.OPEN
+    private [kOnAny]: ((event: string) => void) | null = null
+    public on<K extends string>(name: K): void {
+        console.log(name)
+    }
+}
+export {}
+"#,
+        &[7053, 7006, 2739, 2741, 2339, 2322],
+    );
+}
+
+#[test]
+fn class_declared_before_use_still_resolves_symbol_member() {
+    // Order control: class first, use after (already-working path must stay).
+    assert_no_codes(
+        "class-first order control",
+        r#"
+const kTag = Symbol('kTag')
+
+class Box {
+    static readonly N = 1
+    public readonly N = Box.N
+    private [kTag]: ((event: string) => void) | null = null
+    public touch<K extends string>(name: K): void {
+        console.log(name)
+    }
+}
+
+const b = new Box()
+b[kTag] = (event) => {
+    console.log(event)
+}
+export {}
+"#,
+        &[7053, 7006, 2739, 2741, 2322],
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-bug 3: `Symbol.iterator in x` narrowing uses the well-known member name
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn well_known_symbol_in_guard_narrows_iterable_union() {
+    // The msw RequestHandler.ts:450 shape.
+    assert_no_codes(
+        "Symbol.iterator in union",
+        r#"
+function pick(result: Iterable<number> | AsyncIterable<number>) {
+    return Symbol.iterator in result
+        ? result[Symbol.iterator]()
+        : result[Symbol.asyncIterator]()
+}
+export { pick }
+"#,
+        &[2571, 7053],
+    );
+}
+
+#[test]
+fn well_known_symbol_in_guard_narrows_user_interfaces() {
+    // Renamed-binder adjacent case with user-declared interfaces.
+    assert_no_codes(
+        "Symbol.asyncIterator in user union",
+        r#"
+interface SyncThing {
+    [Symbol.iterator](): Iterator<string>
+}
+interface AsyncThing {
+    [Symbol.asyncIterator](): AsyncIterator<string>
+}
+
+function choose(thing: SyncThing | AsyncThing) {
+    if (Symbol.asyncIterator in thing) {
+        return thing[Symbol.asyncIterator]()
+    }
+    return thing[Symbol.iterator]()
+}
+export { choose }
+"#,
+        &[2571, 7053, 2339],
+    );
+}
+
+#[test]
+fn user_unique_symbol_in_guard_still_narrows() {
+    // The generic "__unique_<id>" path must keep working for user symbols.
+    assert_no_codes(
+        "user unique symbol in guard",
+        r#"
+const kA: unique symbol = Symbol('kA')
+const kB: unique symbol = Symbol('kB')
+
+interface WithA {
+    [kA]: () => string
+}
+interface WithB {
+    [kB]: () => number
+}
+
+function read(value: WithA | WithB) {
+    if (kA in value) {
+        return value[kA]()
+    }
+    return value[kB]()
+}
+export { read }
+"#,
+        &[2571, 7053, 2339],
+    );
+}
+
+#[test]
+fn wide_symbol_key_indexing_union_still_errors() {
+    // Negative control: a non-unique `symbol`-typed key cannot index a union
+    // without a matching index signature (tsc reports TS7053 too).
+    assert_has_code(
+        "wide symbol key negative control",
+        r#"
+declare const wide: symbol
+declare const uni: Iterable<number> | AsyncIterable<number>
+const v = uni[wide]
+export { v }
+"#,
+        7053,
+    );
+}

--- a/crates/tsz-checker/src/types/class_type/constructor.rs
+++ b/crates/tsz-checker/src/types/class_type/constructor.rs
@@ -181,7 +181,7 @@ impl<'a> CheckerState<'a> {
             && request.is_empty()
             && !nested_in_foreign_class_window
             && current_sym
-                .map(|sym_id| !self.ctx.class_constructor_resolution_set.contains(&sym_id))
+                .map(|sym_id| self.constructor_cache_admissible(sym_id, result))
                 .unwrap_or(true);
         if can_use_cache {
             self.ctx

--- a/crates/tsz-checker/src/types/class_type/helpers.rs
+++ b/crates/tsz-checker/src/types/class_type/helpers.rs
@@ -97,6 +97,62 @@ pub(super) fn declaration_is_module_augmentation(
 }
 
 impl<'a> CheckerState<'a> {
+    /// Whether a just-computed constructor type for this class symbol may be
+    /// cached. Two windows forbid caching:
+    /// - the class's own constructor resolution is re-entrant
+    ///   (`class_constructor_resolution_set`), or
+    /// - the class's INSTANCE type computation is still in flight AND the
+    ///   constructor result actually embeds the provisional instance shape
+    ///   (see `ctor_result_embeds_inflight_instance`).
+    pub(super) fn constructor_cache_admissible(
+        &self,
+        sym_id: tsz_binder::SymbolId,
+        result: TypeId,
+    ) -> bool {
+        !self.ctx.class_constructor_resolution_set.contains(&sym_id)
+            && !self.ctor_result_embeds_inflight_instance(sym_id, result)
+    }
+
+    /// Constructor types computed while the class's own INSTANCE type is
+    /// still being built (`class_instance_resolution_set`, e.g. a static
+    /// self-reference forcing `typeof C` mid-build) can embed the Phase-0
+    /// prescan instance shape — missing computed/symbol-keyed members and
+    /// heritage — as their construct-signature return. Caching such a result
+    /// leaks the partial instance into every later `new C()` (false
+    /// TS7053/TS2739/TS2741). The check is narrow on purpose: results whose
+    /// construct return does NOT point at the in-flight provisional instance
+    /// (e.g. a `Lazy(DefId)` or already-final shape) stay cacheable, so heavy
+    /// self-referential classes are not recomputed per reference.
+    pub(crate) fn ctor_result_embeds_inflight_instance(
+        &self,
+        sym_id: tsz_binder::SymbolId,
+        result: TypeId,
+    ) -> bool {
+        if !self.ctx.class_instance_resolution_set.contains(&sym_id) {
+            return false;
+        }
+        let Some(decl_idx) = self
+            .ctx
+            .binder
+            .get_symbol(sym_id)
+            .and_then(|symbol| symbol.primary_declaration())
+        else {
+            // No declaration to compare against: be conservative inside the
+            // in-flight window and treat the result as provisional.
+            return true;
+        };
+        let Some(&provisional_instance) = self.ctx.class_instance_type_cache.get(&decl_idx) else {
+            return true;
+        };
+        crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, result)
+            .is_some_and(|shape| {
+                shape
+                    .construct_signatures
+                    .iter()
+                    .any(|sig| sig.return_type == provisional_instance)
+            })
+    }
+
     pub(super) fn class_member_name_is_symbol_named(&mut self, name_idx: NodeIndex) -> bool {
         self.ctx
             .arena

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -195,6 +195,15 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// be observably distinct.
     /// Default: false.
     pub strict_readonly_identity: bool,
+    /// Whether split-accessor (divergent getter/setter) properties are checked
+    /// contravariantly on their write types during property compatibility.
+    ///
+    /// `tsc` relates object properties through their *read* types only;
+    /// setter/write types never participate in assignability, subtype, or
+    /// conditional-`extends` relations (TS 4.3 divergent accessors). Sound
+    /// Mode opts back into the sound contravariant write check.
+    /// Default: false (tsc parity).
+    pub check_split_accessor_writes: bool,
     /// Whether null/undefined are treated as separate types.
     /// Default: true (strict null checks).
     pub strict_null_checks: bool,
@@ -352,6 +361,7 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             allow_bivariant_param_count: false,
             exact_optional_property_types: false,
             strict_readonly_identity: false,
+            check_split_accessor_writes: false,
             strict_null_checks: true,
             no_unchecked_indexed_access: false,
             disable_method_bivariance: false,
@@ -400,6 +410,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             allow_bivariant_param_count: false,
             exact_optional_property_types: false,
             strict_readonly_identity: false,
+            check_split_accessor_writes: false,
             strict_null_checks: true,
             no_unchecked_indexed_access: false,
             disable_method_bivariance: false,

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -1536,7 +1536,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         property_name: t_prop.name,
                     });
                 }
-                if !t_prop.readonly
+                // Sound Mode only: tsc never relates split-accessor write
+                // types (mirrors the gate in check_property_types).
+                if self.check_split_accessor_writes
+                    && !t_prop.readonly
                     && !sp.readonly
                     && (sp.has_split_accessor() || t_prop.has_split_accessor())
                 {
@@ -1794,7 +1797,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         property_name: t_prop.name,
                     });
                 }
-                if !t_prop.readonly
+                // Sound Mode only: tsc never relates split-accessor write
+                // types (mirrors the gate in check_property_types).
+                if self.check_split_accessor_writes
+                    && !t_prop.readonly
                     && !sp.readonly
                     && (sp.has_split_accessor() || t_prop.has_split_accessor())
                 {

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -758,9 +758,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return SubtypeResult::False;
         }
 
-        // Rule #26: Split Accessors - Contravariant writes
+        // Rule #26 (Sound Mode only): Split Accessors - Contravariant writes
         // For mutable target properties WITH DIFFERENT READ/WRITE TYPES, check write type compatibility
         // Target write type must be subtype of source write type (contravariance)
+        //
+        // PARITY: tsc relates object properties through their *read* types only.
+        // Setter/write types never participate in assignability, subtype, or
+        // conditional-`extends` relations (TS 4.3 divergent accessors); writes
+        // are validated at the actual write site instead. The contravariant
+        // write check below is therefore gated behind
+        // `check_split_accessor_writes`, which only Sound Mode enables.
         //
         // IMPORTANT: This contravariant check only applies to "split accessors" where the
         // property has different types for reading vs writing (e.g., getter returns `string`,
@@ -774,8 +781,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // `{ readonly x: T }` IS assignable to `{ x: T }`. When the source
         // property is readonly, its write_type is irrelevant (it may be NONE or
         // a sentinel value), so skip the write check entirely.
-        let has_split_accessor =
-            !source.readonly && (source.has_split_accessor() || target.has_split_accessor());
+        let has_split_accessor = self.check_split_accessor_writes
+            && !source.readonly
+            && (source.has_split_accessor() || target.has_split_accessor());
 
         if !target.readonly && has_split_accessor {
             let source_write = self.bind_property_receiver_this(
@@ -1311,7 +1319,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 {
                     return SubtypeResult::False;
                 }
-                if !t_prop.readonly && (sp.has_split_accessor() || t_prop.has_split_accessor()) {
+                // Sound Mode only: tsc never relates split-accessor write
+                // types (see check_property_types above for the parity rule).
+                if self.check_split_accessor_writes
+                    && !t_prop.readonly
+                    && (sp.has_split_accessor() || t_prop.has_split_accessor())
+                {
                     let source_write = self.bind_property_receiver_this(
                         source_receiver,
                         self.optional_property_write_type(sp),

--- a/crates/tsz-solver/src/sound_prototype.rs
+++ b/crates/tsz-solver/src/sound_prototype.rs
@@ -176,6 +176,7 @@ impl<'a> SoundLawyer<'a> {
         checker.allow_void_return = false; // Strict void handling
         checker.allow_bivariant_rest = false; // No bivariant rest params
         checker.disable_method_bivariance = true; // Methods are also contravariant
+        checker.check_split_accessor_writes = true; // Setter writes are contravariant
         checker.strict_null_checks = self.config.strict_null_checks;
         checker.exact_optional_property_types = self.config.exact_optional_property_types;
         checker.no_unchecked_indexed_access = self.config.no_unchecked_indexed_access;

--- a/crates/tsz-solver/tests/compat_tests_parts/part_01.rs
+++ b/crates/tsz-solver/tests/compat_tests_parts/part_01.rs
@@ -127,7 +127,7 @@ fn test_split_accessor_allows_wider_setter_in_source() {
 }
 
 #[test]
-fn test_split_accessor_rejects_wider_setter_in_target() {
+fn test_split_accessor_allows_wider_setter_in_target() {
     let interner = TypeInterner::new();
     let mut checker = CompatChecker::new(&interner);
 
@@ -164,7 +164,10 @@ fn test_split_accessor_rejects_wider_setter_in_target() {
         single_quoted_name: false,
     }]);
 
-    assert!(!checker.is_assignable(source, target));
+    // PARITY: tsc relates properties through their *read* types only; a
+    // target with a wider setter (split accessor) does not block
+    // assignability. Writes are validated at the actual write site.
+    assert!(checker.is_assignable(source, target));
 }
 
 #[test]

--- a/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/cache_agreement.rs
+++ b/crates/tsz-solver/tests/relation_policy_cache_agreement_tests/cache_agreement.rs
@@ -1894,9 +1894,12 @@ fn subtype_cache_split_accessor_variance_matches_uncached_property_policy() {
         wide_to_narrow_uncached,
         "split accessor with a wider write type should satisfy a uniform property target",
     );
+    // PARITY: tsc relates properties through their *read* types only, so the
+    // reverse direction is also related; write types are Sound Mode-only.
+    // This test's subject is cache-slot agreement, not the relation value.
     assert!(
-        !narrow_to_wide_uncached,
-        "uniform property write type should not satisfy a wider split-accessor target",
+        narrow_to_wide_uncached,
+        "uniform property should satisfy a wider split-accessor target (read types match)",
     );
 
     let wide_to_narrow_cached =

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_00.rs
@@ -1136,7 +1136,18 @@ fn test_split_accessor_variance() {
     }]);
 
     assert!(checker.is_subtype_of(wide_accessor, narrow_accessor));
-    assert!(!checker.is_subtype_of(narrow_accessor, wide_accessor));
+    // PARITY: tsc relates properties through their *read* types only; the
+    // narrower write type does not block the relation (TS 4.3 divergent
+    // accessors). Witness: `declare const a: { get x(): string; set x(v:
+    // string) }; const b: { get x(): string; set x(v: string | number) } = a`
+    // is accepted by tsc.
+    assert!(checker.is_subtype_of(narrow_accessor, wide_accessor));
+
+    // Sound Mode opts back into the contravariant write check.
+    let mut sound_checker = SubtypeChecker::new(&interner);
+    sound_checker.check_split_accessor_writes = true;
+    assert!(sound_checker.is_subtype_of(wide_accessor, narrow_accessor));
+    assert!(!sound_checker.is_subtype_of(narrow_accessor, wide_accessor));
 }
 
 #[test]

--- a/crates/tsz-solver/tests/subtype_tests_parts/part_04.rs
+++ b/crates/tsz-solver/tests/subtype_tests_parts/part_04.rs
@@ -799,8 +799,18 @@ fn test_mutable_property_split_accessor_wider_write() {
 
     // Split accessor with wider write is a subtype (can write more, reads same)
     assert!(checker.is_subtype_of(obj_split, obj_normal));
-    // Normal cannot substitute for split (narrower write type)
-    assert!(!checker.is_subtype_of(obj_normal, obj_split));
+    // PARITY: tsc relates properties through their *read* types only; the
+    // narrower write type does not block the relation (TS 4.3 divergent
+    // accessors). Witness: `declare const a: { get x(): string; set x(v:
+    // string) }; const b: { get x(): string; set x(v: string | number) } = a`
+    // is accepted by tsc.
+    assert!(checker.is_subtype_of(obj_normal, obj_split));
+
+    // Sound Mode opts back into the contravariant write check.
+    let mut sound_checker = SubtypeChecker::new(&interner);
+    sound_checker.check_split_accessor_writes = true;
+    assert!(sound_checker.is_subtype_of(obj_split, obj_normal));
+    assert!(!sound_checker.is_subtype_of(obj_normal, obj_split));
 }
 
 #[test]


### PR DESCRIPTION
Goal: green

Clear the msw unique-symbol member-lookup false-positive family (sse.ts:397 + RequestHandler.ts:450 + cascades) by fixing three distinct parity defects in solver relations, checker class-type caching, and flow narrowing.

AgentName: SymbolMemberLookupFixer
Track: project-corpus false positives (msw canary)
Invariant: tsc parity for unique-symbol member lookup, split-accessor relations, and well-known-symbol `in` guards; Sound Mode retains the contravariant write check.
Scope: solver subtype relations (split-accessor writes), checker class constructor caching, checker flow `in`-guard key derivation, tests.

## Structural rules (one per sub-bug)

1. **Split accessors (solver relations).** When relating object types, tsc compares only property *read* types; setter/write types never participate in assignability, subtype, or conditional-`extends` relations (TS 4.3 divergent accessors) — writes are validated at the write site. tsz does this through a new `SubtypeChecker::check_split_accessor_writes` flag (default `false`); only `SoundLawyer` enables it, preserving Sound Mode's contravariant write check. This cleared `ObservableEventSource -> EventSource` (witness: `{ get x(): string; set x(v: string) }` vs `{ get x(): string; set x(v: string | number) }` relate in both directions in tsc; tsz rejected three of four combinations).
2. **In-flight class constructor caching (checker).** When a class constructor type is computed while the class's own instance type is still being built (a static self-reference such as `public readonly OPEN = C.OPEN` forces `typeof C` mid-build), its construct-signature return is the Phase-0 prescan instance shape — missing computed/symbol-keyed members and heritage. tsz must not cache it: `get_type_of_symbol` now drops the placeholder instead of caching, and `class_constructor_type_cache` insertion is gated by `constructor_cache_admissible` (both windows). This cleared `source[kOnAnyMessage] = ...` TS7053 at msw sse.ts:397 plus the `Type 'Obs' is missing ... in type 'Obs'` TS2739/TS2741 self-mismatch.
3. **Well-known symbol `in` guards (checker flow).** Members keyed by built-in `Symbol.*` unique symbols are stored under the syntax-derived `"[Symbol.<name>]"` member name (the same convention computed-property declarations use), not the generic `"__unique_<id>"` name. `Symbol.iterator in x` now derives the guard atom syntactically (`well_known_symbol_member_atom`), so `Iterable | AsyncIterable` unions narrow instead of degrading to `T & Record<__unique_N, unknown>` (msw RequestHandler.ts:450, TS2571 + TS7053). The key expression must carry a `unique symbol` type, so a user-defined `Symbol` value with ordinary members cannot alias well-known names; user unique-symbol consts keep the `__unique_<symid>` path.

## Adjacent matrix
- Split accessors: class to interface, anonymous objects both directions, plain vs split, readonly target, conditional-`extends`, negative control (read-type mismatch still TS2322), Sound-Mode-on assertions.
- Ctor caching: use-before-decl + static self-ref + generic method (msw shape), same with lib heritage (`extends EventTarget`, `dispatchEvent` retained), class-declared-first order control; renamed binders throughout.
- `in` guards: lib `Iterable`/`AsyncIterable` union, user interfaces keyed by `[Symbol.iterator]`/`[Symbol.asyncIterator]`, user unique-symbol consts (positive), wide `symbol` key negative control (TS7053 in both compilers).

## Project Corpus Impact
- Row: msw
- Bug family: unique-symbol member lookup / split-accessor relations / well-known-symbol in-narrowing

### Canary table (same-tree pre/post, dist-fast, msw guard configs)

| project | origin/main | this PR | delta | notes |
|---|---|---|---|---|
| msw | 211 | 208 | **-3** | -4 family errors fixed; +1 pre-existing relation failure (sub-bug E) unmasked at sse.ts:435 now that `source` types correctly |
| zod | 54 | 48 | **-6** | `_shape`/`_def` TS2536/TS2339 family cleared (in-flight ctor caching) |
| kysely | 135 | 130 | **-5** | 31 removed / 26 added within the already-failing introspector generic-chain family (same files); attributed to the ctor-caching fix, documented below |
| comlink | 3 | 3 | 0 | |
| ofetch | 46 | 46 | 0 | |
| valibot | 1821 | 1821 | 0 | byte-identical output |


Remaining msw family errors are two separate defects (decomposition + reduced witnesses preserved):
- D (open): `this.addEventListener('open', this[kOnOpen])` after `this[kOnOpen] = handler.bind(this)` is not narrowed (sse.ts 526/537/548). Root: a speculative pass runs assignment narrowing with a `node_types` snapshot that lacks the assignment RHS; the degraded result is reused. 25-line tsc-clean witness reduced.
- E (open): `ObservableEventSource -> EventSource` relation fails only when specific other root files are co-included (4 `src/browser/*` files; combination-dependent, single files do not trigger) and elaborates as a structurally-identical `onmessage` mismatch — lib-identity/cache drift, not symbol-related (sse.ts 435/525/536/547/677). Repro: `files: [4 browser utils] + sse.ts`.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: high

- Witnesses derived by delta-debugging (tsc-clean AND tsz-fails oracle) from msw `src/core/sse.ts` and `src/core/handlers/RequestHandler.ts`.
- tsc 6.0.3 verified clean on every positive witness; negative controls error in both compilers.

## Verification
- `cargo nextest run -p tsz-checker -E 'test(/unique_symbol_member_lookup_family/)'` — 11/11 (new lib-enabled tests with unresolved-name vacuity guard).
- `cargo nextest run -p tsz-solver -E 'test(/symbol|property|index|split_accessor/)'` — green after updating tests that pinned the non-parity write check; Sound-Mode behavior asserted explicitly.
- Conformance on the final head: `uniqueSymbol` 12/12, `Accessors` 74/74, `inOperator` 5/5, `Symbol` 205/205 — all 100%, zero known failures.
- `scripts/arch/arch_guard.py` green (constructor.rs ratchet respected via `constructor_cache_admissible` helper in `class_type/helpers.rs`).
- `cargo clippy --profile ci-lint -p tsz-solver -p tsz-checker --all-targets -- -D warnings` green.
- Final-head sweep `-E 'test(/unique_symbol_member_lookup_family|symbol|computed|element_access|7053/)'`: 769 run / 4 failed; all four (`object_entries_computed_object_literal_keeps_string_any_shape`, `test_computed_unique_prefix_property_stays_string_key`, `ts2860_instanceof_lhs_not_assignable_to_symbol_hasinstance_param`, `ts2861_instanceof_symbol_hasinstance_must_return_boolean`) fail identically on origin/main sources (verified by in-tree revert) — pre-existing, untouched by this PR. Solver sweep: 1109/1109.

## Coordination Notes
- Campaign context: 8 false-positive family PRs landed; #13151/#13170 landed mid-task and this branch is rebased onto them; #13163 pending flip.
- #13151 (mid-resolution subclass ctor degradation) is adjacent to sub-bug 2 but distinct: it publishes an early partial ctor for subclass windows; this PR stops caching of in-flight self-window ctor results. Both gates compose in `constructor_cache_admissible`.
- Sub-bugs D and E are left open deliberately; follow-up issues with the reduced witnesses.


