### PR TITLE
perf(checker,solver): decision-only relation probes + render gate for discarded delegation diagnostics — row probe −43%

### DIFF
--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -278,8 +278,10 @@ impl<'a> CheckerState<'a> {
         self.execute_relation_request(&request)
     }
 
-    /// Execute a diagnostic-bearing explicit alias constraint relation for raw
-    /// checker types, preserving the canonical explicit-alias request shape.
+    /// Execute an explicit alias constraint relation for raw checker types,
+    /// preserving the canonical explicit-alias request shape. Decision-only:
+    /// the sole consumer reads `outcome.related`, so failure analysis is
+    /// skipped.
     pub(crate) fn explicit_alias_constraint_relation_outcome(
         &mut self,
         source: TypeId,
@@ -289,12 +291,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::explicit_alias_constraint(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
-    /// Execute a diagnostic-bearing array-like constraint element relation for
-    /// raw checker types, preserving the canonical array-like request shape.
+    /// Execute an array-like constraint element relation for raw checker
+    /// types, preserving the canonical array-like request shape.
+    /// Decision-only: the sole consumer reads `outcome.related`, so failure
+    /// analysis is skipped.
     pub(crate) fn array_like_constraint_element_relation_outcome(
         &mut self,
         source: TypeId,
@@ -304,7 +309,8 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::array_like_constraint_element(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
@@ -338,8 +344,10 @@ impl<'a> CheckerState<'a> {
         self.execute_relation_request(&request)
     }
 
-    /// Execute a diagnostic-bearing base-union constraint relation for raw
-    /// checker types, preserving the canonical union-constraint request shape.
+    /// Execute a base-union constraint relation for raw checker types,
+    /// preserving the canonical union-constraint request shape. Decision-only:
+    /// the sole consumer reads `outcome.related`, so failure analysis is
+    /// skipped.
     pub(crate) fn union_constraint_member_relation_outcome(
         &mut self,
         source: TypeId,
@@ -349,7 +357,8 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::union_constraint_member(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 

--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -108,6 +108,7 @@ destructured_bindings = { lifetime = "FileLocalReset", capability = "FileTypeCac
 next_binding_group_id = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 destructured_binding_sources = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 has_parse_errors = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
+diagnostics_discarded = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "construction-time mode flag for transient delegation children whose diagnostics the parent discards; gates presentation-only rendering work" }
 has_syntax_parse_errors = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
 syntax_parse_error_positions = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
 has_real_syntax_errors = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -167,6 +167,7 @@ impl<'a> CheckerContext<'a> {
             all_parse_error_positions: Vec::new(),
             nullable_type_parse_error_positions: Vec::new(),
             diagnostics: Vec::new(),
+            diagnostics_discarded: false,
             diagnostic_indices: DiagnosticIndices::default(),
             no_overload_call_nodes: FxHashSet::default(),
             callback_return_type_errors: Vec::new(),
@@ -753,6 +754,11 @@ impl<'a> CheckerContext<'a> {
         // the child's DefId(1) means a different thing than the parent's DefId(1).
         ctx.definition_store = Arc::clone(&parent.definition_store);
         ctx.share_owner_symbol_type_results = parent.share_owner_symbol_type_results;
+
+        // A child of a discarded-diagnostics checker is itself discarded: the
+        // whole delegation subtree's diagnostics are dropped at teardown, so
+        // none of its descendants should pay for diagnostic presentation.
+        ctx.diagnostics_discarded = parent.diagnostics_discarded;
 
         ctx
     }

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -869,6 +869,19 @@ pub struct CheckerContext<'a> {
     /// Excludes `!T` / `T!` errors which should not trigger widening.
     pub nullable_type_parse_error_positions: Vec<u32>,
     pub diagnostics: Vec<Diagnostic>,
+    /// Whether this context's `diagnostics` are never surfaced to the user.
+    ///
+    /// Set for transient cross-arena delegation child checkers (the parent
+    /// consumes only the delegated symbol's type and drops the child's
+    /// diagnostics at teardown) and inherited by their descendants via
+    /// [`Self::with_parent_cache`]. When set, the expensive diagnostic
+    /// *presentation* work — solver failure-reason elaboration
+    /// (`explain_failure`), diagnostic type formatting, and related-info
+    /// chains — is skipped; diagnostics are still recorded with the correct
+    /// code and span so child-internal counting/dedup predicates keep
+    /// working. This flag must never change which checks run or what types
+    /// are computed.
+    pub diagnostics_discarded: bool,
     pub(crate) diagnostic_indices: DiagnosticIndices,
     /// Call-expression nodes that resolved to TS2769 during the current
     /// speculative context. Used so overload resolution can reject outer

--- a/crates/tsz-checker/src/error_reporter/render_failure.rs
+++ b/crates/tsz-checker/src/error_reporter/render_failure.rs
@@ -670,6 +670,33 @@ impl<'a> CheckerState<'a> {
     ) -> Diagnostic {
         use crate::query_boundaries::common::SubtypeFailureReason;
 
+        // Discarded-diagnostics children (transient cross-arena delegation
+        // subtrees) never surface their diagnostics: keep the code and span
+        // (so child-internal counting/dedup predicates behave the same) but
+        // skip the expensive presentation work — diagnostic type formatting,
+        // nested-reason elaboration, and related-info chains. The placeholder
+        // message embeds the type ids so distinct failures keep distinct
+        // message-hash dedup keys, mirroring distinct rendered messages.
+        if self.ctx.diagnostics_discarded {
+            let (start, length) = self
+                .resolve_diagnostic_anchor(idx, DiagnosticAnchorKind::Exact)
+                .map(|anchor| (anchor.start, anchor.length))
+                .unwrap_or_else(|| {
+                    let (pos, end) = self.get_node_span(idx).unwrap_or((0, 0));
+                    self.normalized_anchor_span(idx, pos, end.saturating_sub(pos))
+                });
+            return Diagnostic::error(
+                self.ctx.file_name.clone(),
+                start,
+                length,
+                format!(
+                    "[discarded diagnostic: type '#{}' is not assignable to type '#{}']",
+                    source.0, target.0
+                ),
+                reason.diagnostic_code(),
+            );
+        }
+
         let source = self.recover_unknown_array_source_type_for_display(source, idx, depth);
         let (start, length) = self
             .resolve_diagnostic_anchor(idx, DiagnosticAnchorKind::Exact)

--- a/crates/tsz-checker/src/error_reporter/type_display_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/type_display_policy.rs
@@ -79,6 +79,13 @@ impl<'a> CheckerState<'a> {
         ty: TypeId,
         role: DiagnosticTypeDisplayRole,
     ) -> String {
+        // Discarded-diagnostics children never surface their messages: skip
+        // the role-specific display policy and the type formatter entirely.
+        // The placeholder embeds the type id so different types still format
+        // to different strings (message-hash dedup keys stay distinct).
+        if self.ctx.diagnostics_discarded {
+            return format!("[discarded #{}]", ty.0);
+        }
         // Only apply the indexed-access alias resolution for roles where the
         // alias would otherwise leak through unresolved (call parameters /
         // arguments / direct assignability). For declaration-emit-adjacent

--- a/crates/tsz-checker/src/query_boundaries/assignability.rs
+++ b/crates/tsz-checker/src/query_boundaries/assignability.rs
@@ -1224,7 +1224,7 @@ pub(crate) fn execute_relation<R: tsz_solver::relations::subtype::TypeResolver>(
     } else {
         policy
     };
-    let solver_outcome = query_assignability_with_failure_analysis(RelationQueryInputs {
+    let inputs = RelationQueryInputs {
         interner: db.as_type_database(),
         resolver,
         source: request.source,
@@ -1233,7 +1233,14 @@ pub(crate) fn execute_relation<R: tsz_solver::relations::subtype::TypeResolver>(
         policy,
         context,
         overrides,
-    });
+    };
+    let solver_outcome = if request.decision_only {
+        // The caller reads only the pass/fail bit: run the identical decision
+        // pass but skip the failure-reason walk on failure.
+        tsz_solver::relations::relation_queries::query_assignability_decision_only(inputs)
+    } else {
+        query_assignability_with_failure_analysis(inputs)
+    };
 
     let related = solver_outcome.result.is_related();
     let depth_exceeded = solver_outcome.result.depth_exceeded;
@@ -1260,11 +1267,12 @@ pub(crate) fn execute_relation<R: tsz_solver::relations::subtype::TypeResolver>(
         None => (false, None),
     };
 
-    let property_classification = if request.requires_property_classification() {
-        classify_object_properties(db.as_type_database(), request.source, request.target)
-    } else {
-        None
-    };
+    let property_classification =
+        if !request.decision_only && request.requires_property_classification() {
+            classify_object_properties(db.as_type_database(), request.source, request.target)
+        } else {
+            None
+        };
 
     // Suppress ExcessProperty failure when the target has structural features
     // that make EPC inapplicable.

--- a/crates/tsz-checker/src/query_boundaries/relation_request.rs
+++ b/crates/tsz-checker/src/query_boundaries/relation_request.rs
@@ -240,6 +240,12 @@ pub(crate) struct RelationRequest {
     /// to the solver's `AnySourceNotRelated` propagation mode, which also
     /// partitions the relation caches.
     pub overload_subtype_pass: bool,
+    /// The caller consumes only `RelationOutcome::related` (plus the overflow
+    /// flags). The boundary runs the identical decision pass but skips the
+    /// structured failure analysis (`explain_failure`, weak-union detection)
+    /// and property classification, which would otherwise re-traverse the
+    /// failing relation graph just to populate fields the caller drops.
+    pub decision_only: bool,
 }
 
 impl RelationRequest {
@@ -253,6 +259,7 @@ impl RelationRequest {
             source_is_fresh: false,
             allow_erased_generic_signature_retry: false,
             overload_subtype_pass: false,
+            decision_only: false,
         }
     }
 
@@ -730,6 +737,16 @@ impl RelationRequest {
     /// nesting level (tsc `chooseOverload` with `subtypeRelation`).
     pub(crate) const fn with_overload_subtype_pass(mut self) -> Self {
         self.overload_subtype_pass = true;
+        self
+    }
+
+    /// Mark this request as decision-only: the caller reads only
+    /// `RelationOutcome::related` (and the overflow flags), so the boundary
+    /// must not spend time deriving structured failure reasons, weak-union
+    /// detection, or property classification on failure. The decision itself
+    /// is byte-identical to the full request.
+    pub(crate) const fn with_decision_only(mut self) -> Self {
+        self.decision_only = true;
         self
     }
 }

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -767,6 +767,11 @@ impl<'a> CheckerState<'a> {
                 self, // Share parent's cache to fix Cache Isolation Bug
                 tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaSymbol,
             ));
+            // The parent consumes only the delegated symbol's type; the
+            // child's diagnostics are dropped at teardown. Skip diagnostic
+            // presentation work (failure elaboration, type formatting) in
+            // this subtree.
+            checker.ctx.diagnostics_discarded = true;
             // Copy lib contexts for global symbol resolution (Array, Promise, etc.)
             checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
             // Copy all cross-file state: arenas, binders, all 6 global indices,
@@ -1140,6 +1145,8 @@ impl<'a> CheckerState<'a> {
             self,
             tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaClass,
         ));
+        // Transient delegation child: diagnostics are discarded at teardown.
+        checker.ctx.diagnostics_discarded = true;
         checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
         checker.ctx.current_file_idx = query_file_idx
             .or(delegate_file_idx)
@@ -1351,6 +1358,8 @@ impl<'a> CheckerState<'a> {
             self,
             tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaInterface,
         ));
+        // Transient delegation child: diagnostics are discarded at teardown.
+        checker.ctx.diagnostics_discarded = true;
         checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
         checker.ctx.copy_cross_file_state_from(&self.ctx);
         self.ctx.copy_symbol_file_targets_to_attributed(
@@ -1578,6 +1587,8 @@ impl<'a> CheckerState<'a> {
             self,
             tsz_common::perf_counters::CheckerCreationReason::DelegateCrossArenaOther,
         ));
+        // Transient delegation child: diagnostics are discarded at teardown.
+        checker.ctx.diagnostics_discarded = true;
         checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
         checker.ctx.copy_cross_file_state_from(&self.ctx);
         self.ctx.copy_symbol_file_targets_to_attributed(

--- a/crates/tsz-checker/src/state/type_resolution/cross_file_constructors.rs
+++ b/crates/tsz-checker/src/state/type_resolution/cross_file_constructors.rs
@@ -50,6 +50,8 @@ impl<'a> CheckerState<'a> {
             self,
             CheckerCreationReason::DelegateCrossArenaOther,
         ));
+        // Transient delegation child: diagnostics are discarded at teardown.
+        checker.ctx.diagnostics_discarded = true;
         checker.ctx.lib_contexts = self.ctx.lib_contexts.clone();
         checker.ctx.copy_cross_file_state_from(&self.ctx);
         self.ctx.copy_symbol_file_targets_to_attributed(

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -385,6 +385,35 @@ pub struct AssignabilityQueryOutcome {
 /// `AssignableBivariantCallbacks`) carry structured failure analysis; other
 /// kinds must use [`query_relation_with_overrides`].
 pub fn query_assignability_with_failure_analysis<'a, R, P>(
+    inputs: RelationQueryInputs<'a, R, P>,
+) -> AssignabilityQueryOutcome
+where
+    R: TypeResolver,
+    P: AssignabilityOverrideProvider + ?Sized,
+{
+    query_assignability_inner(inputs, true)
+}
+
+/// Decision-only variant of [`query_assignability_with_failure_analysis`]:
+/// runs the *identical* configured decision pass (same policy, overrides, and
+/// relation caches) but never derives the structured failure analysis.
+///
+/// For callers that consume only the pass/fail bit (constraint-satisfaction
+/// probes and similar), the failure-reason walk (`explain_failure` +
+/// `is_weak_union_violation`) is pure waste — on large type-level programs it
+/// re-traverses the failing relation graph per probe. The returned
+/// `analysis` is always `None`.
+pub fn query_assignability_decision_only<'a, R, P>(
+    inputs: RelationQueryInputs<'a, R, P>,
+) -> AssignabilityQueryOutcome
+where
+    R: TypeResolver,
+    P: AssignabilityOverrideProvider + ?Sized,
+{
+    query_assignability_inner(inputs, false)
+}
+
+fn query_assignability_inner<'a, R, P>(
     RelationQueryInputs {
         interner,
         resolver,
@@ -395,6 +424,7 @@ pub fn query_assignability_with_failure_analysis<'a, R, P>(
         context,
         overrides,
     }: RelationQueryInputs<'a, R, P>,
+    collect_analysis: bool,
 ) -> AssignabilityQueryOutcome
 where
     R: TypeResolver,
@@ -433,7 +463,7 @@ where
     // The failure analysis runs on the same `checker`, so its relation cache is
     // already warm with the decision's sub-results: the structural reason walk
     // observes the identical outcomes the decision did and cannot contradict it.
-    let analysis = (!related).then(|| AssignabilityFailureAnalysis {
+    let analysis = (!related && collect_analysis).then(|| AssignabilityFailureAnalysis {
         weak_union_violation: checker.is_weak_union_violation(source, target),
         failure_reason: checker.explain_failure(source, target),
     });

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -14,7 +14,7 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        248,
+        249,
     ),
 ]
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -992,7 +992,7 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        248,
+        249,
     ),
 ]
 


### PR DESCRIPTION
Goal: fast

## Summary

On the `large-ts-repo` row, transient cross-arena delegation children fully render type-mismatch diagnostic chains — elaboration, type formatting — for diagnostics the parent **discards** (only the symbol's type is consumed; verified: zero production consumers of child diagnostics). At the ~140s mark of a row run, 2,034/2,034 busy-thread samples sat under `explain_failure` for constraint probes whose callers read only `.related`. Two fixes:

1. **Decision-only relation requests**: `RelationRequest::with_decision_only()` routes to a new solver `query_assignability_decision_only` — the identical configured decision pass with the same caches, skipping `explain_failure` + weak-union analysis + property classification. Applied to three witnessed `.related`-only probe helpers (explicit-alias constraint, union-constraint member, array-like element). This speeds *real* checking too.
2. **Discarded-diagnostics render gate**: a `diagnostics_discarded` construction-time flag on the five `DelegateCrossArena*` child sites (inherited by descendants) gates *presentation only*: failure rendering returns a cheap code+span diagnostic with a TypeId-distinct placeholder, and role formatting short-circuits. Deliberately NOT gated: `analyze_assignability_failure` and emission control flow — reason shape drives emit/skip branches and diagnostic counts can influence overload selection under speculation; only string work is elided.

## Measured

- Row probe slice (packages/shared reconstruction): **273s → 156s wall (−43%)**, diagnostics **byte-identical (64/64)**; render/explain frames drop 1670 → 32 mentions; new dominant stack is raw solver evaluation.
- Quiet-machine A/B on this rebased branch vs main: zodmin 0.98s vs 1.06s (byte-identical), ts-toolbelt identical wall/user (byte-identical) — no regression anywhere.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: high

## Verification

- Full local conformance on the rebased branch: 12583/12585 — zero new vs the accepted ledger.
- `cargo nextest run -p tsz-checker --lib`: failure set byte-identical to HEAD (stash A/B).
- Conformance filters: assignmentCompat 128/128, elaborat 3/3, errorMessage 6/6, jsx shard 65/65.
- No placeholder text reaches user-facing output (asserted on probe/row/witness outputs).
- Arch guards pass (field cap 248→249 + lifetimes manifest entry for the flag).

Known follow-up: audit remaining `*_relation_outcome` helpers whose consumers read only `.related` (cheap wins of the same shape); within discarded children, message-hash dedup can theoretically collapse same-span diagnostics differently (child-internal only).
