### PR TITLE
fix(solver): defer distributive conditionals with unresolved Lazy check refs (zod stripPath family) — BLOCKED

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/property.rs
+++ b/crates/tsz-checker/src/state/state_checking/property.rs
@@ -396,7 +396,7 @@ impl<'a> CheckerState<'a> {
                 let mut uncertain = false;
 
                 for &member in &members {
-                    let resolved_member = self.resolve_type_for_property_access(member);
+                    let resolved_member = self.excess_member_for_property_probe(member);
                     if self.target_index_signature_accepts_source_property_with_env(
                         resolved_member,
                         source_prop,

--- a/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
+++ b/crates/tsz-checker/src/state/state_checking/property/excess_property_tail.rs
@@ -1,4 +1,25 @@
 impl<'a> CheckerState<'a> {
+    /// Resolve an intersection member for excess-property probing.
+    ///
+    /// A deferred conditional member (e.g. a distributive conditional whose
+    /// check type was an unresolved `Lazy` semantic ref at interning time)
+    /// hides its eventual properties from raw lookups. Evaluate it through
+    /// the checker's `TypeEnvironment` so distribution runs before property
+    /// probing; otherwise every source property looks excess and a false
+    /// TS2353 preempts the real mismatch.
+    pub(super) fn excess_member_for_property_probe(&mut self, member: TypeId) -> TypeId {
+        let resolved_member = self.resolve_type_for_property_access(member);
+        if crate::query_boundaries::common::has_deferred_conditional_member(
+            self.ctx.types,
+            resolved_member,
+        ) {
+            let evaluated = self.evaluate_type_with_env(resolved_member);
+            self.resolve_type_for_property_access(evaluated)
+        } else {
+            resolved_member
+        }
+    }
+
     fn excess_property_union_target(&self, target: TypeId, resolved_target: TypeId) -> TypeId {
         if query::union_members(self.ctx.types, resolved_target).is_some() {
             return resolved_target;

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -273,6 +273,31 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 );
             }
 
+            // A distributive conditional cannot be decided while its check type
+            // is an unresolved semantic ref (`Lazy(DefId)`): the ref may resolve
+            // to a union, which must distribute member-by-member (tsc resolves
+            // the check type before deciding distribution in
+            // `getConditionalType`). Committing a branch here would bake the
+            // non-distributed instantiation (e.g. `Pick<A | B, keyof (A | B)>`
+            // instead of `Pick<A, keyof A> | Pick<B, keyof B>`) into shared
+            // caches that later resolver-capable evaluations reuse. When the
+            // active resolver cannot resolve the ref, defer so a
+            // resolver-capable evaluation (checker `TypeEnvironment`) decides
+            // distribution. When the ref does resolve here, keep the
+            // established commit path: the with-resolver `evaluate` above has
+            // already folded resolvable refs, so reaching this point with a
+            // still-`Lazy` check means the surrounding evaluation pipeline
+            // owns the distribution decision.
+            if cond.is_distributive
+                && let Some(TypeData::Lazy(def_id)) = self.interner().lookup(check_type)
+                && self
+                    .resolver()
+                    .resolve_lazy(def_id, self.interner())
+                    .is_none()
+            {
+                return self.interner().conditional(*cond);
+            }
+
             if let Some(TypeData::Infer(info)) = self.interner().lookup(extends_type) {
                 // A bare `infer X` extends clause always matches, so tsc takes the
                 // true branch with `X` bound to the check type. Normal evaluation


### PR DESCRIPTION
Goal: green

AgentName: M1FableArchitect

## Provenance
- Machine: m1
- Assistant: claude-code
- Model: claude-fable-5
- Effort: high

Track: zod benchmark row — Bug 2 (object-literal literal preservation vs computed stripPath/Pick intersection)
Invariant: distributive conditional types must not commit a non-distributed branch while their check type is an unresolved `Lazy(DefId)` semantic ref; tsc resolves the check type before deciding distribution (`getConditionalType`).
Scope: solver `evaluation/evaluate_rules/conditional.rs` (deferral arm in Step 1) + checker `state_checking/property{,/excess_property_tail}.rs` (evaluate deferred-conditional intersection members through `TypeEnvironment` before excess-property probing).

## STATUS: BLOCKED DRAFT — DO NOT MERGE

The change is parity-correct at the owner and fixes the entire cross-file witness family, but enabling distribution surfaces two pre-existing downstream defect families that the old wrong-commit masked, regressing the real zod guard row 54 -> 76. Kept as a draft to preserve the root-cause analysis, witnesses, and measured A/B data for the follow-up campaign.

## Root cause (trace-proven)
`IssueData = stripPath<ZodIssueOptionalMessage> & { path?: ... }` where `stripPath<T> = T extends any ? Pick<T, Exclude<keyof T, "path">> : never` (distributive).

1. In a resolver-less/early evaluation, `evaluate_conditional` sees `check_eval = Lazy(DefId)` (the union alias is not resolvable in that context), which is not a `Union`, so no distribution happens; `Lazy extends any` = true commits the true branch with `T` = the unresolved union.
2. `Pick<A|B, Exclude<keyof (A|B), "path">>` then evaluates to a single merged object: only keys common to all members survive (`minimum`/`maximum` destroyed), optionality dropped, property values left as raw `A["k"] | B["k"]` index accesses. Trace witness: `evaluate_conditional check_key=Some(Lazy(2575))` (commits) vs `check_key=Some(Union(...))` (distributes) for the same conditional in the same run.
3. That wrong shape is baked into the `addIssue`/`addIssueToContext` parameter type. The deciding failure at the call site is the Lawyer's excess-property check: source `minimum` is flagged excess because the merged target destroyed the key (information loss is irrecoverable downstream — see "Rejected alternatives").

Structural rule: when `<distributive conditional has an unresolved Lazy check ref>`, tsc resolves the ref before the distribution decision; tsz now defers through the solver evaluator so a resolver-capable evaluation owns distribution.

## Witnesses (all green with this change, tsc-parity)
- /tmp/zodx cross-file family: original class-method repro, free-function (tc-m4), non-generic class (tc-m5), direct generic call (tc-m6), annotated-const props (tc-m7), TS2322 variable form (tc-m8).
- 16-member zod-mirror (tc-12) incl. parseUtil-style spread (tc-12b).
- Controls stay green: plain-literal interfaces, as-const typeof, direct annotation, keyof-typeof (tc6), user-written index-access probes.
- Negative controls unchanged: wrong literal (`flavor: "w"`) still errors (TS2322, matching tsc).

## KNOWN BLOCKING REGRESSIONS (measured, dist-fast A/B vs own base @ 0657bcc9c1)
zod guard row 54 -> 76:
1. NEW TS2590 at `src/helpers/parseUtil.ts(96,16)`: once `IssueData` is the distributed 16-member union, intersection-of-unions cross-product normalization (`intern/normalize.rs` 100k cap) trips. Deterministic even with `types.ts` as the single entry (then the ONLY delta).
2. +22 `addIssue` TS2345 resurrect ONLY in full-include multi-checker ordering: contextual extraction over the deferred conditional fails when the `DefId` is not resolvable in the consuming checker's `TypeEnvironment` (cross-checker DefId resolution gap, #12299-adjacent). Single-entry run does NOT show these.

Both are pre-existing defects masked by the wrong-commit shape; each needs its own campaign before this lands:
- (a) intersection-of-unions product reduction in `intern/normalize.rs`,
- (b) cross-checker DefId resolution for deferred conditionals (multi-file ordering).

## Rejected alternatives (measured)
- Eager distribution when the resolver can resolve (fix1): same regressions + TS2353-vs-TS2322 diagnostic identity drift in the adjacency matrix.
- Relation-layer reduction of deferred concrete-key IndexAccess targets (fix4): corpus-neutral (zod 54->54, kysely 143->143 site-identical) but does not flip any witness — the deciding edge is the Lawyer EPC, not the judge. Dropped as dead weight.
- Lawyer EPC suppression when the target key set is unreliable (fix5): flips all witnesses green and is corpus-clean (zod 54->54, kysely 143->143 site-identical, 2 runs), BUT provably trades false positives for false negatives: `bogus: 1` (tsc TS2353) and `minimum: "wrong-type"` (tsc TS2322) both went silent. The key/type information is destroyed in the merged shape; no EPC-side recovery exists. Violates the no-cosmetic-suppression gate; rejected.

## Project Corpus Impact
- Row: zod-project
- Bug family: object-literal contextual literal preservation vs computed Pick/intersection (zod Bug 2 — stripPath distributive-conditional non-distribution)
- Evidence: zod guard 54 -> 76 with this change (blocking); kysely guard 143 -> 143 site-identical, stable over 2 runs/side. Note: the ~22 addIssue TS2345 sites this slice originally gated were already cleared on main by #13173 + #13175 (row 86 -> 54 across those PRs).

## Verification
- cargo clippy -p tsz-solver -p tsz-checker --no-deps: clean.
- scripts/arch/check-checker-boundaries.sh: clean (property.rs kept at its 1480-line ratchet by relocating the helper into property/excess_property_tail.rs).
- Witness matrix above on dist-fast builds; zod + kysely guard A/B site-diffs as listed.
- No nextest run on this machine (orchestrator hang); focused suites deferred to CI.

## Coordination Notes
- Sibling kysely lanes (../tsz-f1-newexpr generic-call inference, ../tsz-oneshots narrowing) untouched; no file overlap (solver conditional evaluation + checker EPC probing only).
- Follow-up owners wanted for campaigns (a) and (b) above; this draft should stay open as the campaign anchor or be superseded with findings preserved.
- Full investigation notes: /tmp/zod2-findings.md on m1; repro inventory under /tmp/zodx and /tmp/zod2-matrix.
