### PR TITLE
refactor(ci): centralize gate path classifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
           else
             echo "active_suite_found=false" >> "$GITHUB_OUTPUT"
           fi
+      - uses: actions/checkout@v4
       - id: gate
         env:
           GH_TOKEN: ${{ github.token }}
@@ -100,12 +101,6 @@ jobs:
           arch_tool_only=false
           compiler_checks_required=true
           unit_packages=""
-          # Single source of truth for "this path touches compiler/runtime
-          # CI inputs". Used in two places: the initial PR-diff classifier
-          # (sets compiler_checks_required) and the skip-main-CI logic
-          # (decides whether heavy gates are required for cached PRs).
-          # Keeping one copy prevents the two sites from drifting apart.
-          COMPILER_PATH_PATTERN='^(Cargo\.(lock|toml)|\.cargo/|rust-toolchain|\.github/workflows/(ci|bench)\.yml|crates/clippy\.toml|crates/(conformance|tsz-(binder|checker|cli|common|core|emitter|lowering|lsp|parser|scanner|solver|wasm))(/|$)|benches/|tests/|TypeScript/|scripts/(conformance|emit|fourslash|tsc|dts|snapshot)|scripts/ci/lib/[^/]+\.sh|scripts/ci/(ci-resources|gcp-full-ci|github-suite|gcp-cache|suite-metadata|build-dist|dist|wasm)[^/]*\.sh)'
           if [[ "${{ github.event_name }}" == "merge_group" ]]; then
             # Native merge queue validates a GitHub-owned synthetic merge
             # commit. Run the same Cloud Run-backed compiler suite here so
@@ -181,18 +176,15 @@ jobs:
                 if [[ "$page" -gt 30 ]]; then break; fi
               done
               if [[ -n "$all_paths" ]]; then
-                non_docs=$(printf '%s\n' "$all_paths" \
-                  | grep -vE '(^|/)[^/]+\.md$|^(LICENSE|CHANGELOG|CONTRIBUTING|CODE_OF_CONDUCT)([.-][^/]*)?$|^docs/|^\.gitignore$|^\.editorconfig$' \
-                  || true)
-                if [[ -z "$non_docs" ]]; then
+                path_classification=$(printf '%s\n' "$all_paths" | node scripts/ci/gate-path-classifier.mjs)
+                docs_only=$(printf '%s' "$path_classification" | jq -r '.docsOnly')
+                if [[ "$docs_only" == "true" ]]; then
                   echo "PR diff is docs-only — skipping CI jobs:"
-                  printf '  %s\n' $(printf '%s\n' "$all_paths" | sort -u)
+                  printf '%s' "$path_classification" | jq -r '.paths[]' | sed 's/^/  /'
                   should_run=false
                 fi
-                compiler_paths=$(printf '%s\n' "$all_paths" \
-                  | grep -E "$COMPILER_PATH_PATTERN" \
-                  || true)
-                if [[ -z "$compiler_paths" ]]; then
+                compiler_checks_required=$(printf '%s' "$path_classification" | jq -r '.compilerChecksRequired')
+                if [[ "$compiler_checks_required" != "true" ]]; then
                   compiler_checks_required=false
                   echo "PR diff has no compiler/runtime paths; compiler suites are skipped and not required by CI Summary."
                 fi
@@ -203,16 +195,11 @@ jobs:
             # jobs with a cheap bash syntax smoke job below. CI workflow edits,
             # Cargo files, Rust crates, JS helpers, and non-bench shell scripts
             # still take the normal path.
-            if [[ "$should_run" == "true" && -n "${all_paths:-}" ]]; then
-              bench_shell_paths=$(printf '%s\n' "$all_paths" \
-                | grep -E '^scripts/bench/[^/]+\.sh$' \
-                || true)
-              non_bench_shell_paths=$(printf '%s\n' "$all_paths" \
-                | grep -vE '(^|/)[^/]+\.md$|^(LICENSE|CHANGELOG|CONTRIBUTING|CODE_OF_CONDUCT)([.-][^/]*)?$|^docs/|^\.gitignore$|^\.editorconfig$|^scripts/bench/[^/]+\.sh$' \
-                || true)
-              if [[ -n "$bench_shell_paths" && -z "$non_bench_shell_paths" ]]; then
+            if [[ "$should_run" == "true" && -n "${path_classification:-}" ]]; then
+              bench_shell_only_classified=$(printf '%s' "$path_classification" | jq -r '.benchShellOnly')
+              if [[ "$bench_shell_only_classified" == "true" ]]; then
                 echo "PR diff only changes bench shell scripts/docs — running bench shell smoke only:"
-                printf '%s\n' "$bench_shell_paths" | sort -u | sed 's/^/  /'
+                printf '%s' "$path_classification" | jq -r '.benchShellPaths[]' | sed 's/^/  /'
                 should_run=false
                 full_run=false
                 bench_shell_only=true
@@ -223,16 +210,11 @@ jobs:
             # jobs with a cheap Python smoke job below. CI workflow edits, Cargo
             # files, Rust crates, shell scripts, and non-perf scripts still take
             # the normal path.
-            if [[ "$should_run" == "true" && -n "${all_paths:-}" ]]; then
-              perf_tool_paths=$(printf '%s\n' "$all_paths" \
-                | grep -E '^scripts/perf/[^/]+\.py$' \
-                || true)
-              non_perf_tool_paths=$(printf '%s\n' "$all_paths" \
-                | grep -vE '(^|/)[^/]+\.md$|^(LICENSE|CHANGELOG|CONTRIBUTING|CODE_OF_CONDUCT)([.-][^/]*)?$|^docs/|^\.gitignore$|^\.editorconfig$|^scripts/perf/[^/]+\.py$' \
-                || true)
-              if [[ -n "$perf_tool_paths" && -z "$non_perf_tool_paths" ]]; then
+            if [[ "$should_run" == "true" && -n "${path_classification:-}" ]]; then
+              perf_tool_only_classified=$(printf '%s' "$path_classification" | jq -r '.perfToolOnly')
+              if [[ "$perf_tool_only_classified" == "true" ]]; then
                 echo "PR diff only changes perf Python tools/docs — running perf tool smoke only:"
-                printf '%s\n' "$perf_tool_paths" | sort -u | sed 's/^/  /'
+                printf '%s' "$path_classification" | jq -r '.perfToolPaths[]' | sed 's/^/  /'
                 should_run=false
                 full_run=false
                 perf_tool_only=true
@@ -243,16 +225,11 @@ jobs:
             # jobs with a cheap Python smoke job below. CI workflow edits, Cargo
             # files, Rust crates, shell scripts, and non-arch scripts still take
             # the normal path.
-            if [[ "$should_run" == "true" && -n "${all_paths:-}" ]]; then
-              arch_tool_paths=$(printf '%s\n' "$all_paths" \
-                | grep -E '^scripts/arch/[^/]+\.py$' \
-                || true)
-              non_arch_tool_paths=$(printf '%s\n' "$all_paths" \
-                | grep -vE '(^|/)[^/]+\.md$|^(LICENSE|CHANGELOG|CONTRIBUTING|CODE_OF_CONDUCT)([.-][^/]*)?$|^docs/|^\.gitignore$|^\.editorconfig$|^scripts/arch/[^/]+\.py$' \
-                || true)
-              if [[ -n "$arch_tool_paths" && -z "$non_arch_tool_paths" ]]; then
+            if [[ "$should_run" == "true" && -n "${path_classification:-}" ]]; then
+              arch_tool_only_classified=$(printf '%s' "$path_classification" | jq -r '.archToolOnly')
+              if [[ "$arch_tool_only_classified" == "true" ]]; then
                 echo "PR diff only changes arch Python tools/docs — running arch tool smoke only:"
-                printf '%s\n' "$arch_tool_paths" | sort -u | sed 's/^/  /'
+                printf '%s' "$path_classification" | jq -r '.archToolPaths[]' | sed 's/^/  /'
                 should_run=false
                 full_run=false
                 arch_tool_only=true
@@ -279,44 +256,14 @@ jobs:
             # regardless, so compile breakage in any crate still surfaces fast.
             if [[ "$should_run" == "true" \
                   && "${{ github.event.pull_request.draft }}" == "true" \
-                  && -n "$all_paths" ]]; then
-              # Paths that force the full unit suite even on drafts.
-              blast_paths=$(printf '%s\n' "$all_paths" \
-                | grep -E '^(Cargo\.(lock|toml)|\.cargo/|rust-toolchain|scripts/ci/|\.github/workflows/|crates/[^/]+/(Cargo\.toml|build\.rs))' \
-                || true)
-              # Source under crates/<X>/, excluding the blast paths above.
-              crate_paths=$(printf '%s\n' "$all_paths" \
-                | grep -E '^crates/[^/]+/(src|tests|benches|examples)/' \
-                || true)
-              # Catch-all: anything else (root files, scripts/, TypeScript/, etc.)
-              # not yet classified.
-              other_paths=$(printf '%s\n' "$all_paths" \
-                | grep -vE '(^|/)[^/]+\.md$|^(LICENSE|CHANGELOG|CONTRIBUTING|CODE_OF_CONDUCT)([.-][^/]*)?$|^docs/|^\.gitignore$|^\.editorconfig$|^crates/[^/]+/(src|tests|benches|examples)/|^Cargo\.(lock|toml)$|^\.cargo/|^rust-toolchain|^scripts/ci/|^\.github/workflows/|^crates/[^/]+/(Cargo\.toml|build\.rs)$' \
-                || true)
-              if [[ -z "$blast_paths" && -z "$other_paths" && -n "$crate_paths" ]]; then
-                # Extract distinct crate names from the matching paths.
-                touched_crates=$(printf '%s\n' "$crate_paths" \
-                  | sed -E 's|^crates/([^/]+)/.*|\1|' \
-                  | sort -u)
-                known_unit_crates="tsz-common tsz-scanner tsz-parser tsz-binder tsz-solver tsz-checker tsz-emitter tsz-lsp tsz-core"
-                all_known=true
-                for crate in $touched_crates; do
-                  case " $known_unit_crates " in
-                    *" $crate "*) ;;
-                    *) all_known=false; break;;
-                  esac
-                done
-                if [[ "$all_known" == "true" ]]; then
-                  unit_packages=$(printf '%s' "$touched_crates" | tr '\n' ' ' | sed 's/ *$//')
-                  echo "P4 draft fast-fail: narrowing unit to: ${unit_packages}"
-                  printf '  touched: %s\n' $(printf '%s\n' "$crate_paths" | sort -u)
-                fi
+                  && -n "${path_classification:-}" ]]; then
+              unit_packages=$(printf '%s' "$path_classification" | jq -r '.draftUnitNarrow.unitPackages | join(" ")')
+              if [[ -n "$unit_packages" ]]; then
+                echo "P4 draft fast-fail: narrowing unit to: ${unit_packages}"
+                printf '%s' "$path_classification" | jq -r '.draftUnitNarrow.cratePaths[]' | sed 's/^/  touched: /'
               fi
               if [[ -z "$unit_packages" ]]; then
-                reasons=""
-                [[ -n "$blast_paths" ]] && reasons+="blast-radius paths touched; "
-                [[ -n "$other_paths" ]] && reasons+="unclassified paths touched; "
-                [[ -z "$crate_paths" && -z "$reasons" ]] && reasons="no crate source changes"
+                reasons=$(printf '%s' "$path_classification" | jq -r '.draftUnitNarrow.reason')
                 echo "P4 draft fast-fail: NOT narrowing (${reasons:-no eligible crates})"
               fi
             fi
@@ -387,6 +334,7 @@ jobs:
               fi
 
               pr_changed_paths=""
+              pr_changed_path_classification=""
               page=1
               while :; do
                 page_paths=$(gh api \
@@ -395,21 +343,21 @@ jobs:
                   2>/dev/null || true)
                 if [[ -z "$page_paths" ]]; then break; fi
                 pr_changed_paths+="${page_paths}"$'\n'
-                cache_paths=$(printf '%s\n' "$page_paths" \
-                  | grep -E '^(Cargo\.lock|Cargo\.toml|\.cargo/config\.toml)$' \
-                  || true)
-                if [[ -n "$cache_paths" ]]; then
-                  echo "PR #${pr_number} changed CI cache-key inputs; running main CI to refresh shared Rust caches:"
-                  printf '  %s\n' $(printf '%s\n' "$cache_paths" | sort -u)
-                  cache_key_changed=true
-                  rust_cache_refresh=true
-                  break
-                fi
                 count=$(printf '%s\n' "$page_paths" | wc -l | tr -d ' ')
                 if [[ "$count" -lt 100 ]]; then break; fi
                 page=$((page + 1))
                 if [[ "$page" -gt 30 ]]; then break; fi
               done
+              if [[ -n "$pr_changed_paths" ]]; then
+                pr_changed_path_classification=$(printf '%s\n' "$pr_changed_paths" | node scripts/ci/gate-path-classifier.mjs)
+                cache_paths=$(printf '%s' "$pr_changed_path_classification" | jq -r '.cacheKeyInputPaths[]')
+                if [[ -n "$cache_paths" ]]; then
+                  echo "PR #${pr_number} changed CI cache-key inputs; running main CI to refresh shared Rust caches:"
+                  printf '%s\n' "$cache_paths" | sed 's/^/  /'
+                  cache_key_changed=true
+                  rust_cache_refresh=true
+                fi
+              fi
             fi
             if [[ -n "$pr_number" && "$cache_key_changed" != "true" && "${main_skip_allowed:-true}" == "true" ]]; then
               pr_head_sha=$(gh api "repos/${{ github.repository }}/pulls/${pr_number}" \
@@ -438,8 +386,8 @@ jobs:
                     --jq '[.jobs[] | select(.name == "CI Summary" and .conclusion == "success")] | length' \
                     2>/dev/null || echo "0")
                   if [[ "${required_summary_passed}" -gt 0 ]]; then
-                    compiler_paths_on_pr=$(printf '%s\n' "${pr_changed_paths:-}" \
-                      | grep -E "$COMPILER_PATH_PATTERN" \
+                    compiler_paths_on_pr=$(printf '%s' "${pr_changed_path_classification:-}" \
+                      | jq -r '.compilerPaths[]?' \
                       || true)
                     if [[ -n "$compiler_paths_on_pr" ]]; then
                       heavy_checks_passed=$(gh api \

--- a/scripts/ci/gate-path-classifier.mjs
+++ b/scripts/ci/gate-path-classifier.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+export const KNOWN_UNIT_CRATES = [
+  "tsz-common",
+  "tsz-scanner",
+  "tsz-parser",
+  "tsz-binder",
+  "tsz-solver",
+  "tsz-checker",
+  "tsz-emitter",
+  "tsz-lsp",
+  "tsz-core",
+];
+
+const DOCS_ONLY_PATTERN =
+  /(^|\/)[^/]+\.md$|^(LICENSE|CHANGELOG|CONTRIBUTING|CODE_OF_CONDUCT)([.-][^/]*)?$|^docs\/|^\.gitignore$|^\.editorconfig$/;
+
+const COMPILER_PATH_PATTERN =
+  /^(Cargo\.(lock|toml)|\.cargo\/|rust-toolchain|\.github\/workflows\/(ci|bench)\.yml|crates\/clippy\.toml|crates\/(conformance|tsz-(binder|checker|cli|common|core|emitter|lowering|lsp|parser|scanner|solver|wasm))(\/|$)|benches\/|tests\/|TypeScript\/|scripts\/(conformance|emit|fourslash|tsc|dts|snapshot)|scripts\/ci\/gate-path-classifier\.mjs|scripts\/ci\/lib\/[^/]+\.sh|scripts\/ci\/(ci-resources|gcp-full-ci|github-suite|gcp-cache|suite-metadata|build-dist|dist|wasm)[^/]*\.sh)/;
+
+const BENCH_SHELL_PATTERN = /^scripts\/bench\/[^/]+\.sh$/;
+const PERF_TOOL_PATTERN = /^scripts\/perf\/[^/]+\.py$/;
+const ARCH_TOOL_PATTERN = /^scripts\/arch\/[^/]+\.py$/;
+const CACHE_KEY_INPUT_PATTERN = /^(Cargo\.lock|Cargo\.toml|\.cargo\/config\.toml)$/;
+
+const DRAFT_BLAST_PATTERN =
+  /^(Cargo\.(lock|toml)|\.cargo\/|rust-toolchain|scripts\/ci\/|\.github\/workflows\/|crates\/[^/]+\/(Cargo\.toml|build\.rs))/;
+const CRATE_SOURCE_PATTERN = /^crates\/[^/]+\/(src|tests|benches|examples)\//;
+
+function sortedUnique(values) {
+  return [...new Set(values.filter((value) => value.length > 0))].sort();
+}
+
+function crateNameForSourcePath(path) {
+  const match = /^crates\/([^/]+)\//.exec(path);
+  return match?.[1] ?? "";
+}
+
+function classifyDraftUnitNarrowing(paths) {
+  const blastPaths = paths.filter((path) => DRAFT_BLAST_PATTERN.test(path));
+  const cratePaths = paths.filter((path) => CRATE_SOURCE_PATTERN.test(path));
+  const otherPaths = paths.filter((path) => (
+    !DOCS_ONLY_PATTERN.test(path)
+      && !CRATE_SOURCE_PATTERN.test(path)
+      && !DRAFT_BLAST_PATTERN.test(path)
+  ));
+  const touchedCrates = sortedUnique(cratePaths.map(crateNameForSourcePath));
+  const knownCrates = new Set(KNOWN_UNIT_CRATES);
+  const unknownCrates = touchedCrates.filter((crate) => !knownCrates.has(crate));
+  const canNarrow = blastPaths.length === 0
+    && otherPaths.length === 0
+    && cratePaths.length > 0
+    && unknownCrates.length === 0;
+
+  const reasons = [];
+  if (blastPaths.length > 0) reasons.push("blast-radius paths touched");
+  if (otherPaths.length > 0) reasons.push("unclassified paths touched");
+  if (unknownCrates.length > 0) reasons.push("non-unit crate paths touched");
+  if (cratePaths.length === 0 && reasons.length === 0) reasons.push("no crate source changes");
+
+  return {
+    canNarrow,
+    unitPackages: canNarrow ? touchedCrates : [],
+    touchedCrates,
+    unknownCrates,
+    blastPaths: sortedUnique(blastPaths),
+    cratePaths: sortedUnique(cratePaths),
+    otherPaths: sortedUnique(otherPaths),
+    reason: reasons.join("; "),
+  };
+}
+
+export function normalizePathList(input) {
+  if (Array.isArray(input)) {
+    return sortedUnique(input.map((path) => String(path)));
+  }
+  return sortedUnique(String(input).split(/\r?\n/));
+}
+
+export function classifyGatePaths(input) {
+  const paths = normalizePathList(input);
+  const nonDocsPaths = paths.filter((path) => !DOCS_ONLY_PATTERN.test(path));
+  const compilerPaths = paths.filter((path) => COMPILER_PATH_PATTERN.test(path));
+  const benchShellPaths = paths.filter((path) => BENCH_SHELL_PATTERN.test(path));
+  const nonBenchShellPaths = paths.filter((path) => (
+    !DOCS_ONLY_PATTERN.test(path) && !BENCH_SHELL_PATTERN.test(path)
+  ));
+  const perfToolPaths = paths.filter((path) => PERF_TOOL_PATTERN.test(path));
+  const nonPerfToolPaths = paths.filter((path) => (
+    !DOCS_ONLY_PATTERN.test(path) && !PERF_TOOL_PATTERN.test(path)
+  ));
+  const archToolPaths = paths.filter((path) => ARCH_TOOL_PATTERN.test(path));
+  const nonArchToolPaths = paths.filter((path) => (
+    !DOCS_ONLY_PATTERN.test(path) && !ARCH_TOOL_PATTERN.test(path)
+  ));
+
+  return {
+    paths,
+    docsOnly: paths.length > 0 && nonDocsPaths.length === 0,
+    nonDocsPaths: sortedUnique(nonDocsPaths),
+    compilerChecksRequired: compilerPaths.length > 0,
+    compilerPaths: sortedUnique(compilerPaths),
+    benchShellOnly: benchShellPaths.length > 0 && nonBenchShellPaths.length === 0,
+    benchShellPaths: sortedUnique(benchShellPaths),
+    nonBenchShellPaths: sortedUnique(nonBenchShellPaths),
+    perfToolOnly: perfToolPaths.length > 0 && nonPerfToolPaths.length === 0,
+    perfToolPaths: sortedUnique(perfToolPaths),
+    nonPerfToolPaths: sortedUnique(nonPerfToolPaths),
+    archToolOnly: archToolPaths.length > 0 && nonArchToolPaths.length === 0,
+    archToolPaths: sortedUnique(archToolPaths),
+    nonArchToolPaths: sortedUnique(nonArchToolPaths),
+    cacheKeyInputPaths: sortedUnique(paths.filter((path) => CACHE_KEY_INPUT_PATTERN.test(path))),
+    draftUnitNarrow: classifyDraftUnitNarrowing(paths),
+  };
+}
+
+function usage() {
+  return `usage: node scripts/ci/gate-path-classifier.mjs [--file PATH]\n\nReads newline-delimited paths from stdin by default and writes JSON.`;
+}
+
+function readInput(args) {
+  const fileIndex = args.indexOf("--file");
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(`${usage()}\n`);
+    process.exit(0);
+  }
+  if (fileIndex >= 0) {
+    const file = args[fileIndex + 1];
+    if (!file) {
+      throw new Error("--file requires a path");
+    }
+    return fs.readFileSync(file, "utf8");
+  }
+  return fs.readFileSync(0, "utf8");
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const classification = classifyGatePaths(readInput(process.argv.slice(2)));
+    process.stdout.write(`${JSON.stringify(classification, null, 2)}\n`);
+  } catch (error) {
+    process.stderr.write(`gate-path-classifier: ${error.message}\n`);
+    process.exit(2);
+  }
+}

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -415,6 +415,7 @@ run_lint() {
   node scripts/ci/test-project-compile-guard-fingerprint.mjs || return $?
   node scripts/ci/test-project-compile-guard-rss-sentinel.mjs || return $?
   node scripts/ci/test-type-challenges-semantic-families.mjs || return $?
+  node scripts/ci/test-gate-path-classifier.mjs || return $?
   node scripts/ci/test-pr-ready-state.mjs || return $?
   node scripts/ci/test-refresh-green-prs.mjs || return $?
   node scripts/ci/test-check-stale-ci-runs.mjs || return $?

--- a/scripts/ci/test-gate-path-classifier.mjs
+++ b/scripts/ci/test-gate-path-classifier.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { classifyGatePaths, normalizePathList } from "./gate-path-classifier.mjs";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.join(SCRIPT_DIR, "gate-path-classifier.mjs");
+
+function classify(paths) {
+  return classifyGatePaths(paths.join("\n"));
+}
+
+assert.deepEqual(normalizePathList("docs/a.md\n\ndocs/a.md\r\nREADME.md\n"), [
+  "README.md",
+  "docs/a.md",
+]);
+
+assert.equal(classify(["docs/usage.md", "README.md", "LICENSE"]).docsOnly, true);
+assert.equal(classify(["docs/usage.md", "src/lib.rs"]).docsOnly, false);
+
+assert.equal(
+  classify(["crates/tsz-wasm/src/lib.rs"]).compilerChecksRequired,
+  true,
+  "wasm crate changes must require compiler CI",
+);
+assert.equal(
+  classify([".github/workflows/bench.yml"]).compilerChecksRequired,
+  true,
+  "bench workflow changes must require compiler CI",
+);
+assert.equal(
+  classify(["scripts/ci/gate-path-classifier.mjs"]).compilerChecksRequired,
+  true,
+  "the gate classifier itself must require compiler CI",
+);
+assert.equal(
+  classify(["scripts/ci/ci-resources.sh"]).compilerChecksRequired,
+  true,
+  "CI resource sizing changes must require compiler CI",
+);
+assert.equal(classify(["docs/usage.md"]).compilerChecksRequired, false);
+
+{
+  const result = classify(["scripts/bench/build-fixture.sh", "docs/bench.md"]);
+  assert.equal(result.benchShellOnly, true);
+  assert.deepEqual(result.benchShellPaths, ["scripts/bench/build-fixture.sh"]);
+}
+
+assert.equal(
+  classify(["scripts/bench/build-fixture.sh", "crates/tsz-checker/src/lib.rs"]).benchShellOnly,
+  false,
+);
+assert.equal(classify(["scripts/perf/collect.py", "docs/perf.md"]).perfToolOnly, true);
+assert.equal(classify(["scripts/arch/guard.py", "docs/arch.md"]).archToolOnly, true);
+
+{
+  const result = classify([
+    "crates/tsz-solver/src/relations.rs",
+    "crates/tsz-checker/tests/checker.rs",
+    "docs/checker.md",
+  ]);
+  assert.equal(result.draftUnitNarrow.canNarrow, true);
+  assert.deepEqual(result.draftUnitNarrow.unitPackages, ["tsz-checker", "tsz-solver"]);
+}
+
+{
+  const result = classify(["crates/tsz-cli/src/main.rs"]);
+  assert.equal(result.draftUnitNarrow.canNarrow, false);
+  assert.match(result.draftUnitNarrow.reason, /non-unit crate paths touched/);
+}
+
+{
+  const result = classify(["scripts/ci/gcp-full-ci.sh"]);
+  assert.equal(result.draftUnitNarrow.canNarrow, false);
+  assert.match(result.draftUnitNarrow.reason, /blast-radius paths touched/);
+}
+
+{
+  const result = classify(["Cargo.lock", ".cargo/config.toml", ".cargo/other.toml"]);
+  assert.deepEqual(result.cacheKeyInputPaths, [".cargo/config.toml", "Cargo.lock"]);
+}
+
+const cli = spawnSync(process.execPath, [SCRIPT], {
+  input: "docs/readme.md\n.github/workflows/bench.yml\n",
+  encoding: "utf8",
+});
+assert.equal(cli.status, 0, cli.stderr);
+assert.equal(JSON.parse(cli.stdout).compilerChecksRequired, true);
+
+console.log("test-gate-path-classifier: ok");

--- a/scripts/ci/test-pr-ready-state.mjs
+++ b/scripts/ci/test-pr-ready-state.mjs
@@ -11,6 +11,7 @@ const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
 const SCRIPT = path.join(ROOT, "scripts", "ci", "check-pr-ready-state.mjs");
 const CI_WORKFLOW = path.join(ROOT, ".github", "workflows", "ci.yml");
+const GATE_CLASSIFIER = path.join(ROOT, "scripts", "ci", "gate-path-classifier.mjs");
 
 function readyPr(overrides = {}) {
   return {
@@ -132,6 +133,7 @@ assert.equal(passingDraft.status, 0, passingDraft.stderr);
 assert.match(passingDraft.stdout, /Ready-state WIP check passed/);
 
 const ciWorkflow = fs.readFileSync(CI_WORKFLOW, "utf8");
+const gateClassifier = fs.readFileSync(GATE_CLASSIFIER, "utf8");
 assert.match(
   ciWorkflow,
   /pull_request:\s*\n\s*types:\s*\[[^\]]*\bedited\b[^\]]*\]/,
@@ -160,13 +162,19 @@ assert.match(
 
 assert.match(
   ciWorkflow,
-  /scripts\/ci\/\(ci-resources\|gcp-full-ci\|github-suite\|gcp-cache\|suite-metadata\|build-dist\|dist\|wasm\)/,
+  /node scripts\/ci\/gate-path-classifier\.mjs/,
+  "CI gate should use the shared path classifier instead of inline path regex copies",
+);
+
+assert.match(
+  gateClassifier,
+  /ci-resources\|gcp-full-ci\|github-suite\|gcp-cache\|suite-metadata\|build-dist\|dist\|wasm/,
   "ci-resources.sh changes must require compiler CI because they size dist/unit/wasm jobs",
 );
 
 assert.match(
-  ciWorkflow,
-  /\\.github\/workflows\/\(ci\|bench\)\\.yml/,
+  gateClassifier,
+  /\.github\\\/workflows\\\/\(ci\|bench\)\\\.yml/,
   "CI workflow changes must require compiler CI because they route native merge queue and Cloud Run jobs",
 );
 


### PR DESCRIPTION
Goal: hold

AgentName: Codex
Track: CI gate tech-debt (#13125)
Invariant: CI gate path classes are owned by `scripts/ci/gate-path-classifier.mjs`; PR and main-push gate checks consume the same classifier output for docs-only, compiler-required, bench/perf/arch tool-only, draft unit narrowing, and cache-key input decisions.
Scope: Extract the duplicated `ci.yml` path predicates into a tested Node helper, update the workflow gate to consume that JSON, and add coverage for the `tsz-wasm` and `.github/workflows/bench.yml` drift called out in the issue.
Project Corpus Impact: None. This only changes CI routing; it makes compiler-gate selection more conservative for classifier-script edits and preserves existing docs/tool-only fast paths.

Closes #13125

## Verification
- `node --check scripts/ci/gate-path-classifier.mjs && node --check scripts/ci/test-gate-path-classifier.mjs && node scripts/ci/test-gate-path-classifier.mjs`
- `node scripts/ci/test-pr-ready-state.mjs`
- `bash -n scripts/ci/gcp-full-ci.sh`
- `git diff --check`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium

## Coordination Notes
- Reused `/Users/mohsen/code/tsz-m5-relation-cache` because disk guard reported low free space.
- No overlap with active compiler PRs #13183, #13177, #13176, or #13163; this slice is CI infra only.