### PR TITLE
feat(emitter): binder-backed import value-usage facts for JS-emit elision

### DIFF
--- a/crates/tsz-cli/src/driver/emit.rs
+++ b/crates/tsz-cli/src/driver/emit.rs
@@ -255,6 +255,10 @@ pub(crate) fn emit_outputs(
             continue;
         }
 
+        // Per-file binder, built on first use and shared by the JS
+        // import-elision facts and the declaration emitter.
+        let mut file_binder: Option<tsz_binder::BinderState> = None;
+
         // Skip JS input files whose output path would collide with a TS file's
         // output (tsc's "emit blocked" behavior for --allowJs).
         let is_js_input = input_path
@@ -456,12 +460,13 @@ pub(crate) fn emit_outputs(
                 && !printer_options.verbatim_module_syntax
                 && tsz_emitter::import_value_usage::file_has_import_declarations(&file.arena)
             {
-                let binder =
-                    tsz::parallel::create_binder_from_bound_file(file, context.program, file_idx);
+                let binder = file_binder.get_or_insert_with(|| {
+                    tsz::parallel::create_binder_from_bound_file(file, context.program, file_idx)
+                });
                 printer_options.import_usage_facts = Some(std::sync::Arc::new(
                     tsz_emitter::import_value_usage::compute_import_value_usage_facts(
                         &file.arena,
-                        &binder,
+                        binder,
                         tsz_emitter::import_value_usage::ImportValueUsageInputs {
                             external_const_enum_bindings: Some(
                                 &printer_options.external_const_enum_bindings,
@@ -576,9 +581,11 @@ pub(crate) fn emit_outputs(
                 let file_path = PathBuf::from(&file.file_name);
                 let type_cache = context.type_caches.get(&file_path).cloned();
 
-                // Reconstruct BinderState for this file to enable usage analysis
-                let binder =
-                    tsz::parallel::create_binder_from_bound_file(file, context.program, file_idx);
+                // Per-file BinderState (shared with the JS import-elision
+                // facts when both emits run) to enable usage analysis.
+                let binder = &*file_binder.get_or_insert_with(|| {
+                    tsz::parallel::create_binder_from_bound_file(file, context.program, file_idx)
+                });
 
                 // Create emitter with type information and binder
                 let mut emitter = if let Some(ref cache) = type_cache {
@@ -587,7 +594,7 @@ pub(crate) fn emit_outputs(
                         &file.arena,
                         cache_view,
                         &context.program.type_interner,
-                        &binder,
+                        binder,
                     );
                     // Set current arena and file path for foreign symbol tracking
                     emitter.set_current_arena(
@@ -610,7 +617,7 @@ pub(crate) fn emit_outputs(
                     let mut emitter = DeclarationEmitter::new(&file.arena);
                     // Still set binder and current file context without cache for
                     // declaration paths that consult program-level export facts.
-                    emitter.set_binder(Some(&binder));
+                    emitter.set_binder(Some(binder));
                     emitter.set_current_arena(
                         std::sync::Arc::clone(&file.arena),
                         file.file_name.clone(),
@@ -637,7 +644,7 @@ pub(crate) fn emit_outputs(
                 // exported-surface overload pre-scan so the emitter doesn't
                 // need to discover overloads incrementally during the walk.
                 let summary = tsz_binder::DeclarationSummary::from_binder(
-                    &binder,
+                    binder,
                     &file.arena,
                     &file.file_name,
                     file.source_file,
@@ -685,7 +692,7 @@ pub(crate) fn emit_outputs(
 
                     let mut analyzer = UsageAnalyzer::new(
                         &file.arena,
-                        &binder,
+                        binder,
                         &cache_view,
                         &context.program.type_interner,
                         std::sync::Arc::clone(&file.arena),

--- a/crates/tsz-cli/src/driver/emit.rs
+++ b/crates/tsz-cli/src/driver/emit.rs
@@ -447,6 +447,31 @@ pub(crate) fn emit_outputs(
                 &declaration_const_enum_exports,
             );
 
+            // Binder-backed import-elision facts: compute per-binding
+            // value-usage facts from the file's binder so import elision
+            // follows symbol references instead of the text-scan heuristics.
+            // Skipped where elision never applies (JS sources,
+            // --verbatimModuleSyntax) and for files without imports.
+            if !is_js_input
+                && !printer_options.verbatim_module_syntax
+                && tsz_emitter::import_value_usage::file_has_import_declarations(&file.arena)
+            {
+                let binder =
+                    tsz::parallel::create_binder_from_bound_file(file, context.program, file_idx);
+                printer_options.import_usage_facts = Some(std::sync::Arc::new(
+                    tsz_emitter::import_value_usage::compute_import_value_usage_facts(
+                        &file.arena,
+                        &binder,
+                        tsz_emitter::import_value_usage::ImportValueUsageInputs {
+                            external_const_enum_bindings: Some(
+                                &printer_options.external_const_enum_bindings,
+                            ),
+                            type_only_nodes: Some(printer_options.type_only_nodes.as_ref()),
+                        },
+                    ),
+                ));
+            }
+
             // Run the lowering pass to generate transform directives
             let module_none_out_file =
                 js_bundle_path.is_some() && matches!(printer_options.module, ModuleKind::None);

--- a/crates/tsz-cli/src/driver/emit.rs
+++ b/crates/tsz-cli/src/driver/emit.rs
@@ -458,16 +458,18 @@ pub(crate) fn emit_outputs(
             // --verbatimModuleSyntax) and for files without imports.
             if !is_js_input
                 && !printer_options.verbatim_module_syntax
-                && tsz_emitter::import_value_usage::file_has_import_declarations(&file.arena)
+                && tsz_emitter::passes::import_value_usage::file_has_import_declarations(
+                    &file.arena,
+                )
             {
                 let binder = file_binder.get_or_insert_with(|| {
                     tsz::parallel::create_binder_from_bound_file(file, context.program, file_idx)
                 });
                 printer_options.import_usage_facts = Some(std::sync::Arc::new(
-                    tsz_emitter::import_value_usage::compute_import_value_usage_facts(
+                    tsz_emitter::passes::import_value_usage::compute_import_value_usage_facts(
                         &file.arena,
                         binder,
-                        tsz_emitter::import_value_usage::ImportValueUsageInputs {
+                        tsz_emitter::passes::import_value_usage::ImportValueUsageInputs {
                             external_const_enum_bindings: Some(
                                 &printer_options.external_const_enum_bindings,
                             ),

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -232,7 +232,7 @@ pub struct PrinterOptions {
     /// import-elision decision sites consult these facts instead of the
     /// text-based heuristics in `crate::import_usage`. Binder-less callers
     /// (transpile-style emit) leave this `None` and keep the text fallback.
-    pub import_usage_facts: Option<Arc<crate::import_value_usage::ImportValueUsageFacts>>,
+    pub import_usage_facts: Option<Arc<crate::passes::import_value_usage::ImportValueUsageFacts>>,
 }
 
 impl Default for PrinterOptions {

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -228,6 +228,11 @@ pub struct PrinterOptions {
     /// True when jsx was explicitly set to "preserve" (not the unset default).
     /// Used by rewriteRelativeImportExtensions to add preserveJsx arg.
     pub jsx_preserve_explicit: bool,
+    /// Binder-backed per-import-binding value-usage facts. When set, the
+    /// import-elision decision sites consult these facts instead of the
+    /// text-based heuristics in `crate::import_usage`. Binder-less callers
+    /// (transpile-style emit) leave this `None` and keep the text fallback.
+    pub import_usage_facts: Option<Arc<crate::import_value_usage::ImportValueUsageFacts>>,
 }
 
 impl Default for PrinterOptions {
@@ -273,6 +278,7 @@ impl Default for PrinterOptions {
             verbatim_module_syntax: false,
             rewrite_relative_import_extensions: false,
             jsx_preserve_explicit: false,
+            import_usage_facts: None,
         }
     }
 }

--- a/crates/tsz-emitter/src/emitter/module_emission/imports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/imports.rs
@@ -52,40 +52,9 @@ impl<'a> Printer<'a> {
             return false;
         }
 
-        let mut names = Vec::new();
-        if clause.name.is_some() {
-            let default_name = self.get_identifier_text_idx(clause.name);
-            if !default_name.is_empty() {
-                names.push((clause.name, default_name));
-            }
-        }
-        if clause.named_bindings.is_some()
-            && let Some(bindings_node) = self.arena.get(clause.named_bindings)
-            && let Some(named_imports) = self.arena.get_named_imports(bindings_node)
-        {
-            if named_imports.name.is_some() && named_imports.elements.nodes.is_empty() {
-                let ns_name = self.get_identifier_text_idx(named_imports.name);
-                if !ns_name.is_empty() {
-                    names.push((named_imports.name, ns_name));
-                }
-            } else {
-                for &spec_idx in &named_imports.elements.nodes {
-                    let Some(spec_node) = self.arena.get(spec_idx) else {
-                        continue;
-                    };
-                    let Some(spec) = self.arena.get_specifier(spec_node) else {
-                        continue;
-                    };
-                    if spec.is_type_only {
-                        continue;
-                    }
-                    let local_name = self.get_identifier_text_idx(spec.name);
-                    if !local_name.is_empty() {
-                        names.push((spec.name, local_name));
-                    }
-                }
-            }
-        }
+        let names = crate::transforms::emit_utils::collect_import_clause_value_binding_names(
+            self.arena, clause,
+        );
         if names.is_empty() {
             return !self.import_clause_is_empty_named_import(clause);
         }
@@ -424,31 +393,6 @@ impl<'a> Printer<'a> {
             && self.async_return_type_uses_imported_promise_constructor(&[local_name])
     }
 
-    /// Whether the default binding of an import clause is referenced as a
-    /// value in the rest of the file. Mirrors `filter_value_specs_by_usage`
-    /// for the default binding so that an unused default beside a used named
-    /// or namespace binding is elided (matching tsc).
-    fn default_binding_has_value_usage(
-        &self,
-        import_node: &Node,
-        default_name_idx: NodeIndex,
-    ) -> bool {
-        self.import_binding_has_value_usage(import_node, default_name_idx)
-    }
-
-    /// Whether the namespace binding of an import clause (`import * as ns`) is
-    /// referenced as a value in the rest of the file. Mirrors
-    /// `default_binding_has_value_usage` for the namespace binding so that an
-    /// unused namespace beside a surviving default or named binding is elided
-    /// (matching tsc).
-    fn namespace_binding_has_value_usage(
-        &self,
-        import_node: &Node,
-        namespace_name_idx: NodeIndex,
-    ) -> bool {
-        self.import_binding_has_value_usage(import_node, namespace_name_idx)
-    }
-
     /// Filter named import specifiers to only those with value-level usage
     /// in the rest of the file.
     fn filter_value_specs_by_usage(
@@ -484,15 +428,6 @@ impl<'a> Printer<'a> {
                 self.import_binding_has_value_usage(import_node, spec.name)
             })
             .collect()
-    }
-
-    fn default_import_has_value_usage_after_node(
-        &self,
-        import_node: &Node,
-        _import_data: &tsz_parser::parser::node::ImportDeclData,
-        name_idx: NodeIndex,
-    ) -> bool {
-        self.import_binding_has_value_usage(import_node, name_idx)
     }
 
     /// Check if an import-equals declaration's identifier is used after the import.
@@ -756,7 +691,7 @@ impl<'a> Printer<'a> {
                 && !self.ctx.options.verbatim_module_syntax
                 && !self.is_jsx_factory_import_clause(clause)
             {
-                self.default_import_has_value_usage_after_node(node, import, clause.name)
+                self.import_binding_has_value_usage(node, clause.name)
             } else {
                 true
             };
@@ -780,7 +715,7 @@ impl<'a> Printer<'a> {
                         && !preserve_invalid_module_syntax
                         && !self.is_jsx_factory_import_clause(clause);
                     if !gate_namespace
-                        || self.namespace_binding_has_value_usage(node, named_imports.name)
+                        || self.import_binding_has_value_usage(node, named_imports.name)
                     {
                         namespace_name = Some(named_imports.name);
                     }
@@ -817,7 +752,7 @@ impl<'a> Printer<'a> {
             && !self.source_is_js_file
             && !self.ctx.options.verbatim_module_syntax
             && !self.is_jsx_factory_import_clause(clause)
-            && !self.default_binding_has_value_usage(node, clause.name)
+            && !self.import_binding_has_value_usage(node, clause.name)
         {
             has_default = false;
         }

--- a/crates/tsz-emitter/src/emitter/module_emission/imports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/imports.rs
@@ -20,6 +20,24 @@ impl<'a> Printer<'a> {
                 })
     }
 
+    /// Binder-backed value-usage fact for one import-binding name node.
+    /// `None` when facts are unavailable for this binding; callers fall back
+    /// to the text-based heuristics in `crate::import_usage`.
+    pub(in crate::emitter) fn binding_value_used_fact(&self, name_idx: NodeIndex) -> Option<bool> {
+        self.ctx
+            .options
+            .import_usage_facts
+            .as_ref()?
+            .binding_value_used(name_idx)
+    }
+
+    /// Gate for the per-binding usage-based elision paths: active when
+    /// binder-backed facts are present, or in text-heuristic mode when the
+    /// checker provided no type-only marks (--noCheck-style emit).
+    pub(in crate::emitter) fn import_usage_gate_active(&self) -> bool {
+        self.ctx.options.import_usage_facts.is_some() || self.ctx.options.type_only_nodes.is_empty()
+    }
+
     pub(in crate::emitter) fn import_has_value_usage_after_node(
         &self,
         node: &Node,
@@ -38,7 +56,7 @@ impl<'a> Printer<'a> {
         if clause.name.is_some() {
             let default_name = self.get_identifier_text_idx(clause.name);
             if !default_name.is_empty() {
-                names.push(default_name);
+                names.push((clause.name, default_name));
             }
         }
         if clause.named_bindings.is_some()
@@ -48,7 +66,7 @@ impl<'a> Printer<'a> {
             if named_imports.name.is_some() && named_imports.elements.nodes.is_empty() {
                 let ns_name = self.get_identifier_text_idx(named_imports.name);
                 if !ns_name.is_empty() {
-                    names.push(ns_name);
+                    names.push((named_imports.name, ns_name));
                 }
             } else {
                 for &spec_idx in &named_imports.elements.nodes {
@@ -63,7 +81,7 @@ impl<'a> Printer<'a> {
                     }
                     let local_name = self.get_identifier_text_idx(spec.name);
                     if !local_name.is_empty() {
-                        names.push(local_name);
+                        names.push((spec.name, local_name));
                     }
                 }
             }
@@ -71,6 +89,24 @@ impl<'a> Printer<'a> {
         if names.is_empty() {
             return !self.import_clause_is_empty_named_import(clause);
         }
+
+        // Binder-backed facts: authoritative for the pure value-usage
+        // question when every binding is covered. JSX-factory, decorator
+        // metadata, and ES5 Promise-constructor cases stay below because
+        // they are implicit usages the reference scan does not model.
+        let mut facts_settled = false;
+        if self.ctx.options.import_usage_facts.is_some() {
+            let mut all_known = true;
+            for (name_idx, _) in &names {
+                match self.binding_value_used_fact(*name_idx) {
+                    Some(true) => return true,
+                    Some(false) => {}
+                    None => all_known = false,
+                }
+            }
+            facts_settled = all_known;
+        }
+
         let Some(source_text) = self.source_text else {
             return true;
         };
@@ -83,23 +119,25 @@ impl<'a> Printer<'a> {
         };
         let haystack =
             Self::source_excluding_import_decl(source_text, node, import_decl, self.arena);
-        // Strip type-only content from the haystack so that identifiers
-        // appearing only in type positions (type annotations, declare lines,
-        // other import/export type statements, etc.) don't count as value usages.
-        let value_haystack = crate::import_usage::strip_type_only_content(&haystack);
-        let value_haystack = crate::import_usage::strip_qualified_accesses_for_names(
-            &value_haystack,
-            &self.ctx.options.external_const_enum_bindings,
-        );
-        let appears_in_value_haystack = names.iter().any(|name| {
-            crate::import_usage::contains_identifier_value_occurrence(&value_haystack, name)
-        });
-        if appears_in_value_haystack {
-            return true;
+        if !facts_settled {
+            // Strip type-only content from the haystack so that identifiers
+            // appearing only in type positions (type annotations, declare lines,
+            // other import/export type statements, etc.) don't count as value usages.
+            let value_haystack = crate::import_usage::strip_type_only_content(&haystack);
+            let value_haystack = crate::import_usage::strip_qualified_accesses_for_names(
+                &value_haystack,
+                &self.ctx.options.external_const_enum_bindings,
+            );
+            let appears_in_value_haystack = names.iter().any(|(_, name)| {
+                crate::import_usage::contains_identifier_value_occurrence(&value_haystack, name)
+            });
+            if appears_in_value_haystack {
+                return true;
+            }
         }
         if names
             .iter()
-            .any(|name| self.is_classic_jsx_factory_root(name))
+            .any(|(_, name)| self.is_classic_jsx_factory_root(name))
         {
             return true;
         }
@@ -110,13 +148,16 @@ impl<'a> Printer<'a> {
         // type annotation in the unstripped haystack references one of our
         // imported names.
         if self.ctx.options.emit_decorator_metadata
-            && names.iter().any(|name| {
+            && names.iter().any(|(_, name)| {
                 crate::import_usage::name_appears_in_decorator_metadata_type(&haystack, name)
             })
         {
             return true;
         }
-        self.ctx.target_es5 && self.async_return_type_uses_imported_promise_constructor(&names)
+        self.ctx.target_es5
+            && self.async_return_type_uses_imported_promise_constructor(
+                &names.into_iter().map(|(_, name)| name).collect::<Vec<_>>(),
+            )
     }
 
     fn import_clause_is_namespace_only(
@@ -321,6 +362,68 @@ impl<'a> Printer<'a> {
             .any(|root| root == name)
     }
 
+    /// Whether one import-clause binding (default, namespace, or named
+    /// specifier local name) is referenced as a value in the rest of the
+    /// file. Consults the binder-backed facts when present; otherwise falls
+    /// back to the text-based scan of the whole module with the import
+    /// declaration whited out (issue #3597: ES imports are module-scoped, so
+    /// a use BEFORE the import is still a real value use).
+    ///
+    /// `--emitDecoratorMetadata` and ES5 async Promise-constructor usages are
+    /// implicit references neither path models, so they are checked in both
+    /// modes.
+    fn import_binding_has_value_usage(&self, import_node: &Node, name_idx: NodeIndex) -> bool {
+        let local_name = self.get_identifier_text_idx(name_idx);
+        if local_name.is_empty() {
+            return true;
+        }
+        let fact = self.binding_value_used_fact(name_idx);
+        if fact == Some(true) {
+            return true;
+        }
+        let needs_haystack = fact.is_none() || self.ctx.options.emit_decorator_metadata;
+        if needs_haystack {
+            let Some(source_text) = self.source_text else {
+                return true;
+            };
+            let Some(import_data) = self.arena.get_import_decl(import_node) else {
+                return true;
+            };
+            let haystack = Self::source_excluding_import_decl(
+                source_text,
+                import_node,
+                import_data,
+                self.arena,
+            );
+            if fact.is_none() {
+                let value_haystack = crate::import_usage::strip_type_only_content(&haystack);
+                let value_haystack = crate::import_usage::strip_qualified_accesses_for_names(
+                    &value_haystack,
+                    &self.ctx.options.external_const_enum_bindings,
+                );
+                if crate::import_usage::contains_identifier_value_occurrence(
+                    &value_haystack,
+                    &local_name,
+                ) {
+                    return true;
+                }
+            }
+            // Under `--emitDecoratorMetadata`, decorated-member type
+            // annotations are *value* references; preserve the binding whose
+            // name appears in such an annotation.
+            if self.ctx.options.emit_decorator_metadata
+                && crate::import_usage::name_appears_in_decorator_metadata_type(
+                    &haystack,
+                    &local_name,
+                )
+            {
+                return true;
+            }
+        }
+        self.ctx.target_es5
+            && self.async_return_type_uses_imported_promise_constructor(&[local_name])
+    }
+
     /// Whether the default binding of an import clause is referenced as a
     /// value in the rest of the file. Mirrors `filter_value_specs_by_usage`
     /// for the default binding so that an unused default beside a used named
@@ -330,105 +433,35 @@ impl<'a> Printer<'a> {
         import_node: &Node,
         default_name_idx: NodeIndex,
     ) -> bool {
-        let local_name = self.get_identifier_text_idx(default_name_idx);
-        if local_name.is_empty() {
-            return true;
-        }
-        let Some(source_text) = self.source_text else {
-            return true;
-        };
-        let Some(import_data) = self.arena.get_import_decl(import_node) else {
-            return true;
-        };
-        // Issue #3597: ES import declarations are module-scoped; a top-level
-        // use BEFORE the import is still a real value use. Scan the entire
-        // source with the import declaration's text whited out.
-        let haystack =
-            Self::source_excluding_import_decl(source_text, import_node, import_data, self.arena);
-        let value_haystack = crate::import_usage::strip_type_only_content(&haystack);
-        let value_haystack = crate::import_usage::strip_qualified_accesses_for_names(
-            &value_haystack,
-            &self.ctx.options.external_const_enum_bindings,
-        );
-        if crate::import_usage::contains_identifier_value_occurrence(&value_haystack, &local_name) {
-            return true;
-        }
-        // Under `--emitDecoratorMetadata`, decorated-member type
-        // annotations are *value* references; preserve the default whose
-        // name appears in such an annotation.
-        if self.ctx.options.emit_decorator_metadata
-            && crate::import_usage::name_appears_in_decorator_metadata_type(&haystack, &local_name)
-        {
-            return true;
-        }
-        self.ctx.target_es5
-            && self.async_return_type_uses_imported_promise_constructor(&[local_name])
+        self.import_binding_has_value_usage(import_node, default_name_idx)
     }
 
     /// Whether the namespace binding of an import clause (`import * as ns`) is
     /// referenced as a value in the rest of the file. Mirrors
     /// `default_binding_has_value_usage` for the namespace binding so that an
     /// unused namespace beside a surviving default or named binding is elided
-    /// (matching tsc). The full module is scanned (issue #3597) so a use BEFORE
-    /// the import still keeps the binding.
+    /// (matching tsc).
     fn namespace_binding_has_value_usage(
         &self,
         import_node: &Node,
         namespace_name_idx: NodeIndex,
     ) -> bool {
-        let local_name = self.get_identifier_text_idx(namespace_name_idx);
-        if local_name.is_empty() {
-            return true;
-        }
-        let Some(source_text) = self.source_text else {
-            return true;
-        };
-        let Some(import_data) = self.arena.get_import_decl(import_node) else {
-            return true;
-        };
-        let haystack =
-            Self::source_excluding_import_decl(source_text, import_node, import_data, self.arena);
-        let value_haystack = crate::import_usage::strip_type_only_content(&haystack);
-        let value_haystack = crate::import_usage::strip_qualified_accesses_for_names(
-            &value_haystack,
-            &self.ctx.options.external_const_enum_bindings,
-        );
-        if crate::import_usage::contains_identifier_value_occurrence(&value_haystack, &local_name) {
-            return true;
-        }
-        // Under `--emitDecoratorMetadata`, decorated-member type annotations are
-        // *value* references; preserve the namespace whose name appears there.
-        if self.ctx.options.emit_decorator_metadata
-            && crate::import_usage::name_appears_in_decorator_metadata_type(&haystack, &local_name)
-        {
-            return true;
-        }
-        self.ctx.target_es5
-            && self.async_return_type_uses_imported_promise_constructor(&[local_name])
+        self.import_binding_has_value_usage(import_node, namespace_name_idx)
     }
 
     /// Filter named import specifiers to only those with value-level usage
-    /// in the rest of the file. Used in --noCheck mode.
+    /// in the rest of the file.
     fn filter_value_specs_by_usage(
         &self,
         import_node: &Node,
         specs: &[NodeIndex],
     ) -> Vec<NodeIndex> {
-        let Some(source_text) = self.source_text else {
+        if self.source_text.is_none() && self.ctx.options.import_usage_facts.is_none() {
             return specs.to_vec();
-        };
-        let Some(import_data) = self.arena.get_import_decl(import_node) else {
+        }
+        if self.arena.get_import_decl(import_node).is_none() {
             return specs.to_vec();
-        };
-        // Issue #3597: scan the entire module so a use BEFORE the import
-        // still keeps the binding alive.
-        let haystack =
-            Self::source_excluding_import_decl(source_text, import_node, import_data, self.arena);
-        let value_haystack = crate::import_usage::strip_type_only_content(&haystack);
-        let value_haystack = crate::import_usage::strip_qualified_accesses_for_names(
-            &value_haystack,
-            &self.ctx.options.external_const_enum_bindings,
-        );
+        }
         let jsx_factory_roots = self.classic_jsx_factory_roots();
 
         specs
@@ -448,22 +481,7 @@ impl<'a> Printer<'a> {
                 if jsx_factory_roots.iter().any(|root| root == &local_name) {
                     return true;
                 }
-                if crate::import_usage::contains_identifier_value_occurrence(
-                    &value_haystack,
-                    &local_name,
-                ) {
-                    return true;
-                }
-                // Under `--emitDecoratorMetadata`, decorated-member type
-                // annotations are *value* references; preserve specs whose
-                // name appears in such an annotation.
-                self.ctx.options.emit_decorator_metadata
-                    && crate::import_usage::name_appears_in_decorator_metadata_type(
-                        &haystack,
-                        &local_name,
-                    )
-                    || (self.ctx.target_es5
-                        && self.async_return_type_uses_imported_promise_constructor(&[local_name]))
+                self.import_binding_has_value_usage(import_node, spec.name)
             })
             .collect()
     }
@@ -471,33 +489,10 @@ impl<'a> Printer<'a> {
     fn default_import_has_value_usage_after_node(
         &self,
         import_node: &Node,
-        import_data: &tsz_parser::parser::node::ImportDeclData,
+        _import_data: &tsz_parser::parser::node::ImportDeclData,
         name_idx: NodeIndex,
     ) -> bool {
-        let name = self.get_identifier_text_idx(name_idx);
-        if name.is_empty() {
-            return true;
-        }
-        let Some(source_text) = self.source_text else {
-            return true;
-        };
-        // Issue #3597: scan the entire module so a use BEFORE the import
-        // still keeps the default binding alive.
-        let haystack =
-            Self::source_excluding_import_decl(source_text, import_node, import_data, self.arena);
-        let value_haystack = crate::import_usage::strip_type_only_content(&haystack);
-        let value_haystack = crate::import_usage::strip_qualified_accesses_for_names(
-            &value_haystack,
-            &self.ctx.options.external_const_enum_bindings,
-        );
-
-        if crate::import_usage::contains_identifier_value_occurrence(&value_haystack, &name)
-            || (self.ctx.options.emit_decorator_metadata
-                && crate::import_usage::name_appears_in_decorator_metadata_type(&haystack, &name))
-        {
-            return true;
-        }
-        self.ctx.target_es5 && self.async_return_type_uses_imported_promise_constructor(&[name])
+        self.import_binding_has_value_usage(import_node, name_idx)
     }
 
     /// Check if an import-equals declaration's identifier is used after the import.
@@ -513,6 +508,9 @@ impl<'a> Printer<'a> {
         let name = self.get_identifier_text_idx(import_data.import_clause);
         if name.is_empty() {
             return true;
+        }
+        if let Some(used) = self.binding_value_used_fact(import_data.import_clause) {
+            return used;
         }
         let Some(source_text) = self.source_text else {
             return true;
@@ -592,6 +590,9 @@ impl<'a> Printer<'a> {
         let name = self.get_identifier_text_idx(import_data.import_clause);
         if name.is_empty() {
             return true;
+        }
+        if let Some(used) = self.binding_value_used_fact(import_data.import_clause) {
+            return used;
         }
         let Some(source_text) = self.source_text else {
             return true;
@@ -750,7 +751,7 @@ impl<'a> Printer<'a> {
         if clause.name.is_some() {
             has_default = if preserve_invalid_module_syntax {
                 true
-            } else if self.ctx.options.type_only_nodes.is_empty()
+            } else if self.import_usage_gate_active()
                 && !self.source_is_js_file
                 && !self.ctx.options.verbatim_module_syntax
                 && !self.is_jsx_factory_import_clause(clause)
@@ -773,7 +774,7 @@ impl<'a> Printer<'a> {
                     // binding beside a surviving default (`import Foo, * as ns`)
                     // is elided. JSX-factory namespace names are exempt because
                     // they are referenced implicitly by JSX elements.
-                    let gate_namespace = self.ctx.options.type_only_nodes.is_empty()
+                    let gate_namespace = self.import_usage_gate_active()
                         && !self.source_is_js_file
                         && !self.ctx.options.verbatim_module_syntax
                         && !preserve_invalid_module_syntax
@@ -787,7 +788,7 @@ impl<'a> Printer<'a> {
                     value_specs = self.collect_value_specifiers(&named_imports.elements);
                     // In --noCheck mode (type_only_nodes empty), apply text-based
                     // heuristic to elide individual named specifiers unused as values.
-                    if self.ctx.options.type_only_nodes.is_empty()
+                    if self.import_usage_gate_active()
                         && !self.source_is_js_file
                         && !self.ctx.options.verbatim_module_syntax
                         && !preserve_invalid_module_syntax
@@ -812,7 +813,7 @@ impl<'a> Printer<'a> {
         // because their name is referenced implicitly by JSX elements.
         if has_default
             && has_named
-            && self.ctx.options.type_only_nodes.is_empty()
+            && self.import_usage_gate_active()
             && !self.source_is_js_file
             && !self.ctx.options.verbatim_module_syntax
             && !self.is_jsx_factory_import_clause(clause)
@@ -956,7 +957,7 @@ impl<'a> Printer<'a> {
                     has_value_binding = true;
                 } else {
                     let mut value_specs = self.collect_value_specifiers(&named_imports.elements);
-                    if self.ctx.options.type_only_nodes.is_empty()
+                    if self.import_usage_gate_active()
                         && !self.source_is_js_file
                         && !self.ctx.options.verbatim_module_syntax
                     {
@@ -1031,7 +1032,7 @@ impl<'a> Printer<'a> {
             && named_imports.name.is_none()
         {
             let mut value_specs = self.collect_value_specifiers(&named_imports.elements);
-            if self.ctx.options.type_only_nodes.is_empty()
+            if self.import_usage_gate_active()
                 && !self.source_is_js_file
                 && !self.ctx.options.verbatim_module_syntax
             {
@@ -1135,7 +1136,7 @@ impl<'a> Printer<'a> {
         }
 
         let mut value_specs = self.collect_value_specifiers(&named_imports.elements);
-        if self.ctx.options.type_only_nodes.is_empty()
+        if self.import_usage_gate_active()
             && !self.source_is_js_file
             && !self.ctx.options.verbatim_module_syntax
         {
@@ -1210,7 +1211,7 @@ impl<'a> Printer<'a> {
             return true;
         }
         let mut value_specs = self.collect_value_specifiers(&named_imports.elements);
-        if self.ctx.options.type_only_nodes.is_empty()
+        if self.import_usage_gate_active()
             && !self.source_is_js_file
             && !self.ctx.options.verbatim_module_syntax
         {

--- a/crates/tsz-emitter/src/import_value_usage.rs
+++ b/crates/tsz-emitter/src/import_value_usage.rs
@@ -126,12 +126,12 @@ enum ReferenceTarget {
 }
 
 /// Invoke `apply` with the binding index of every binding matched by
-/// `target`. Free function (rather than a `UsageScan` method) so callers can
-/// mutate sibling `UsageScan` fields from `apply`.
+/// `target` among the same-named `candidates`. Free function (rather than a
+/// `UsageScan` method) so callers can mutate sibling `UsageScan` fields from
+/// `apply`.
 fn for_each_matching_binding(
     target: ReferenceTarget,
-    name: &str,
-    by_name: &FxHashMap<String, Vec<usize>>,
+    candidates: &[usize],
     bindings: &[Binding],
     mut apply: impl FnMut(usize, &Binding),
 ) {
@@ -140,7 +140,7 @@ fn for_each_matching_binding(
         ReferenceTarget::Binding(idx) => apply(idx, &bindings[idx]),
         ReferenceTarget::AllSameName | ReferenceTarget::SameNameWithUnknownSymbol => {
             let unknown_only = matches!(target, ReferenceTarget::SameNameWithUnknownSymbol);
-            for &idx in by_name.get(name).map_or(&[][..], Vec::as_slice) {
+            for &idx in candidates {
                 if !unknown_only || bindings[idx].symbol.is_none() {
                     apply(idx, &bindings[idx]);
                 }
@@ -253,13 +253,19 @@ impl<'a> UsageScan<'a> {
             return;
         }
         // For `import A = ...` the clause IS the alias identifier node.
+        let Some(name) = self
+            .arena
+            .get_identifier_at(import.import_clause)
+            .map(|ident| ident.escaped_text.clone())
+            .filter(|name| !name.is_empty())
+        else {
+            return;
+        };
         let exported = self
             .arena
             .has_modifier(&import.modifiers, SyntaxKind::ExportKeyword)
             || self.import_equals_is_export_declaration_clause(decl_idx);
-        let Some(binding_idx) = self.add_binding(import.import_clause, exported) else {
-            return;
-        };
+        let binding_idx = self.add_named_binding(import.import_clause, name, exported);
         self.alias_decl_to_binding.insert(decl_idx, binding_idx);
     }
 
@@ -270,14 +276,6 @@ impl<'a> UsageScan<'a> {
             .parent_of(decl_idx)
             .and_then(|p| self.arena.get(p))
             .is_some_and(|p| p.kind == syntax_kind_ext::EXPORT_DECLARATION)
-    }
-
-    fn add_binding(&mut self, name_idx: NodeIndex, exported_import_equals: bool) -> Option<usize> {
-        let name = self.arena.get_identifier_at(name_idx)?.escaped_text.clone();
-        if name.is_empty() {
-            return None;
-        }
-        Some(self.add_named_binding(name_idx, name, exported_import_equals))
     }
 
     fn add_named_binding(
@@ -319,9 +317,12 @@ impl<'a> UsageScan<'a> {
                 continue;
             };
             let name = ident.escaped_text.as_str();
-            if name.is_empty() || !self.by_name.contains_key(name) {
+            if name.is_empty() {
                 continue;
             }
+            let Some(candidates) = self.by_name.get(name) else {
+                continue;
+            };
             // Skip the binding declarations themselves.
             if self.binding_name_nodes.contains(&node_idx) {
                 continue;
@@ -329,25 +330,18 @@ impl<'a> UsageScan<'a> {
             match self.classify_reference(node_idx, name) {
                 ReferencePosition::NotAReference | ReferencePosition::Erased => {}
                 ReferencePosition::Value => {
-                    let target = self.resolve_reference_target(node_idx, name);
+                    let target = self.resolve_reference_target(node_idx, candidates);
                     let value_used = &mut self.value_used;
-                    for_each_matching_binding(
-                        target,
-                        name,
-                        &self.by_name,
-                        &self.bindings,
-                        |_, binding| {
-                            value_used.insert(binding.name_node);
-                        },
-                    );
+                    for_each_matching_binding(target, candidates, &self.bindings, |_, binding| {
+                        value_used.insert(binding.name_node);
+                    });
                 }
                 ReferencePosition::ImportEqualsRhs(alias_decl) => {
-                    let target = self.resolve_reference_target(node_idx, name);
+                    let target = self.resolve_reference_target(node_idx, candidates);
                     let alias_edges = &mut self.alias_edges;
                     for_each_matching_binding(
                         target,
-                        name,
-                        &self.by_name,
+                        candidates,
                         &self.bindings,
                         |binding_idx, _| {
                             alias_edges.push((alias_decl, binding_idx));
@@ -358,12 +352,17 @@ impl<'a> UsageScan<'a> {
         }
     }
 
-    /// Resolve a reference to the binding population it can denote.
+    /// Resolve a reference to the binding population it can denote, among
+    /// the same-named `candidates`.
     ///
     /// Uses shadow-aware scope resolution; when the reference cannot be
     /// resolved (or a binding's own symbol is unknown), same-named bindings
     /// conservatively match so the import is preserved.
-    fn resolve_reference_target(&self, ref_idx: NodeIndex, name: &str) -> ReferenceTarget {
+    fn resolve_reference_target(
+        &self,
+        ref_idx: NodeIndex,
+        candidates: &[usize],
+    ) -> ReferenceTarget {
         // Scope resolution first: `node_symbols` keys *declaration* sites
         // (e.g. `export default expr` maps to the default-export symbol), so
         // it is only a fallback for references the scope walk cannot reach.
@@ -379,11 +378,10 @@ impl<'a> UsageScan<'a> {
                 // The reference resolved to a different symbol (a shadowing
                 // local). Only same-named bindings whose own symbol is
                 // unknown still conservatively match.
-                if self.by_name.get(name).is_some_and(|candidates| {
-                    candidates
-                        .iter()
-                        .any(|&idx| self.bindings[idx].symbol.is_none())
-                }) {
+                if candidates
+                    .iter()
+                    .any(|&idx| self.bindings[idx].symbol.is_none())
+                {
                     ReferenceTarget::SameNameWithUnknownSymbol
                 } else {
                     ReferenceTarget::None
@@ -721,6 +719,9 @@ impl<'a> UsageScan<'a> {
             }
             current = self.arena.parent_of(idx);
         }
+        // Unknown context — including a walk cut short by the step bound —
+        // conservatively counts as a value usage (over-preserve, never elide
+        // a runtime-required import).
         ReferencePosition::Value
     }
 

--- a/crates/tsz-emitter/src/import_value_usage.rs
+++ b/crates/tsz-emitter/src/import_value_usage.rs
@@ -1,0 +1,737 @@
+//! Binder-backed per-import-binding value-usage facts for JS-emit import
+//! elision.
+//!
+//! tsc decides import elision through checker alias-reference marking: an
+//! import binding survives JS emit only when it is referenced in at least one
+//! *value* position. tsz historically approximated that question by scanning
+//! raw source text (`crate::import_usage`), which is a standing parity-risk
+//! surface (multi-line generics, strings, shadowing, identifiers named like
+//! keywords).
+//!
+//! This module computes the same per-binding facts once per file from
+//! `BinderState` symbol resolution plus a syntactic position classification of
+//! every identifier reference. The facts are threaded into emit through
+//! `PrinterOptions::import_usage_facts` (the same channel as
+//! `type_only_nodes`) and consumed by the elision decision sites in
+//! `emitter/module_emission/imports.rs` and `lowering/import_usage.rs` as
+//! table lookups. Binder-less paths (transpile-style emit, direct `Printer`
+//! construction) leave the facts unset and keep the conservative text-based
+//! fallback.
+//!
+//! Classification policy: only positions that are *provably* erased at
+//! runtime (type annotations, `typeof` type queries, interface/type-alias
+//! bodies, `implements` clauses, ambient declarations) are treated as
+//! non-value. Unknown or unresolvable references conservatively count as
+//! value usages so the failure mode is over-preserving an import, never
+//! eliding one that is required at runtime.
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use tsz_binder::{BinderState, SymbolId};
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::NodeArena;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_scanner::SyntaxKind;
+
+/// Per-file, per-import-binding value-usage facts.
+///
+/// Keys are the *binding name* identifier nodes of import declarations: the
+/// default-import name, the namespace-import name, each named-import
+/// specifier's local name, and the alias identifier of
+/// `import X = ...` declarations.
+#[derive(Debug, Default, Clone)]
+pub struct ImportValueUsageFacts {
+    /// Every import-binding name node that was analyzed.
+    known_bindings: FxHashSet<NodeIndex>,
+    /// The subset of `known_bindings` referenced in at least one value
+    /// position.
+    value_used: FxHashSet<NodeIndex>,
+}
+
+impl ImportValueUsageFacts {
+    /// Whether the import binding declared by `name_idx` is referenced in a
+    /// value position somewhere in the file.
+    ///
+    /// Returns `None` when `name_idx` is not a binding this analysis knows
+    /// about (callers should fall back to their conservative path).
+    #[must_use]
+    pub fn binding_value_used(&self, name_idx: NodeIndex) -> Option<bool> {
+        self.known_bindings
+            .contains(&name_idx)
+            .then(|| self.value_used.contains(&name_idx))
+    }
+}
+
+/// Inputs that mirror the policy the text-based decision sites already apply.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ImportValueUsageInputs<'a> {
+    /// Local binding names that refer to external const enums. Qualified
+    /// accesses through these bindings (`E.Member`, `E["Member"]`) are inlined
+    /// during emit and therefore do not keep the binding alive.
+    pub external_const_enum_bindings: Option<&'a FxHashSet<String>>,
+    /// Specifier nodes the checker marked as type-only (re-exports of
+    /// interfaces/type aliases etc.). Export specifiers in this set do not
+    /// count as value references.
+    pub type_only_nodes: Option<&'a FxHashSet<NodeIndex>>,
+}
+
+/// Returns true when the file contains any import declaration whose elision
+/// decision the facts can own. Lets callers skip binder construction for
+/// files without imports.
+#[must_use]
+pub fn file_has_import_declarations(arena: &NodeArena) -> bool {
+    arena.nodes.iter().any(|node| {
+        node.kind == syntax_kind_ext::IMPORT_DECLARATION
+            || node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+    })
+}
+
+/// How an identifier occurrence relates to runtime code.
+enum ReferencePosition {
+    /// Not a reference at all (declaration name, member name, label, ...).
+    NotAReference,
+    /// A reference that is erased from JS output (type annotation, `typeof`
+    /// query, interface body, ambient declaration, ...).
+    Erased,
+    /// A runtime value reference.
+    Value,
+    /// The root of the entity name on the right-hand side of
+    /// `import A = X.Y;` — a value reference only if the alias itself
+    /// survives emit. `0` is the `IMPORT_EQUALS_DECLARATION` node.
+    ImportEqualsRhs(NodeIndex),
+}
+
+struct Binding {
+    /// The binding's local-name identifier node.
+    name_node: NodeIndex,
+    /// The binder symbol for the binding, when known.
+    symbol: Option<SymbolId>,
+    /// Whether this is an `import A = ...` alias carrying an `export`
+    /// modifier (always emitted, so its RHS reference is always live).
+    exported_import_equals: bool,
+}
+
+struct UsageScan<'a> {
+    arena: &'a NodeArena,
+    binder: &'a BinderState,
+    bindings: Vec<Binding>,
+    /// Binding indices grouped by local name for the identifier pre-filter.
+    by_name: FxHashMap<String, Vec<usize>>,
+    /// Binding index by binder symbol for shadow-aware matching.
+    by_symbol: FxHashMap<SymbolId, usize>,
+    value_used: FxHashSet<NodeIndex>,
+    /// `import A = X.Y;` edges: alias declaration node -> binding indices
+    /// referenced by its right-hand side.
+    alias_edges: Vec<(NodeIndex, usize)>,
+    /// Alias declaration node -> binding index of the alias itself.
+    alias_decl_to_binding: FxHashMap<NodeIndex, usize>,
+    external_const_enum_bindings: Option<&'a FxHashSet<String>>,
+    type_only_nodes: Option<&'a FxHashSet<NodeIndex>>,
+}
+
+/// Compute per-import-binding value-usage facts for one source file.
+///
+/// `binder` must be the binder for `arena`'s file (per-file binders built by
+/// the CLI driver or a directly-bound `BinderState` in tests).
+#[must_use]
+pub fn compute_import_value_usage_facts(
+    arena: &NodeArena,
+    binder: &BinderState,
+    inputs: ImportValueUsageInputs<'_>,
+) -> ImportValueUsageFacts {
+    let mut scan = UsageScan {
+        arena,
+        binder,
+        bindings: Vec::new(),
+        by_name: FxHashMap::default(),
+        by_symbol: FxHashMap::default(),
+        value_used: FxHashSet::default(),
+        alias_edges: Vec::new(),
+        alias_decl_to_binding: FxHashMap::default(),
+        external_const_enum_bindings: inputs.external_const_enum_bindings,
+        type_only_nodes: inputs.type_only_nodes,
+    };
+    scan.collect_bindings();
+    if scan.bindings.is_empty() {
+        return ImportValueUsageFacts::default();
+    }
+    scan.scan_references();
+    scan.propagate_alias_edges();
+
+    ImportValueUsageFacts {
+        known_bindings: scan.bindings.iter().map(|b| b.name_node).collect(),
+        value_used: scan.value_used,
+    }
+}
+
+impl<'a> UsageScan<'a> {
+    // =========================================================================
+    // Binding collection
+    // =========================================================================
+
+    fn collect_bindings(&mut self) {
+        for idx in 0..self.arena.nodes.len() {
+            let node_idx = NodeIndex(idx as u32);
+            let Some(node) = self.arena.get(node_idx) else {
+                continue;
+            };
+            if node.kind == syntax_kind_ext::IMPORT_DECLARATION {
+                self.collect_import_declaration_bindings(node_idx);
+            } else if node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION {
+                self.collect_import_equals_binding(node_idx);
+            }
+        }
+    }
+
+    fn collect_import_declaration_bindings(&mut self, decl_idx: NodeIndex) {
+        let Some(import) = self.arena.get_import_decl_at(decl_idx) else {
+            return;
+        };
+        let Some(clause) = self.arena.get_import_clause_at(import.import_clause) else {
+            return;
+        };
+        if clause.is_type_only {
+            // `import type` clauses are elided unconditionally; the decision
+            // sites never ask about them.
+            return;
+        }
+        if clause.name.is_some() {
+            self.add_binding(clause.name, false);
+        }
+        if clause.named_bindings.is_none() {
+            return;
+        }
+        if let Some(named) = self.arena.get_named_imports_at(clause.named_bindings) {
+            if named.name.is_some() && named.elements.nodes.is_empty() {
+                self.add_binding(named.name, false);
+            } else {
+                for &spec_idx in &named.elements.nodes {
+                    let Some(spec) = self.arena.get_specifier_at(spec_idx) else {
+                        continue;
+                    };
+                    if spec.is_type_only {
+                        continue;
+                    }
+                    self.add_binding(spec.name, false);
+                }
+            }
+        }
+    }
+
+    fn collect_import_equals_binding(&mut self, decl_idx: NodeIndex) {
+        let Some(import) = self.arena.get_import_decl_at(decl_idx) else {
+            return;
+        };
+        if import.is_type_only || import.import_clause.is_none() {
+            return;
+        }
+        // For `import A = ...` the clause IS the alias identifier node.
+        let exported = self
+            .arena
+            .has_modifier(&import.modifiers, SyntaxKind::ExportKeyword)
+            || self.import_equals_is_export_declaration_clause(decl_idx);
+        let Some(binding_idx) = self.add_binding(import.import_clause, exported) else {
+            return;
+        };
+        self.alias_decl_to_binding.insert(decl_idx, binding_idx);
+    }
+
+    /// `export import A = X` parses with the `export` keyword on an enclosing
+    /// `EXPORT_DECLARATION` in some recovery shapes; treat that as exported.
+    fn import_equals_is_export_declaration_clause(&self, decl_idx: NodeIndex) -> bool {
+        self.arena
+            .parent_of(decl_idx)
+            .and_then(|p| self.arena.get(p))
+            .is_some_and(|p| p.kind == syntax_kind_ext::EXPORT_DECLARATION)
+    }
+
+    fn add_binding(&mut self, name_idx: NodeIndex, exported_import_equals: bool) -> Option<usize> {
+        let name = self.arena.get_identifier_at(name_idx)?.escaped_text.clone();
+        if name.is_empty() {
+            return None;
+        }
+        let symbol = self.binder.get_node_symbol(name_idx);
+        let binding_idx = self.bindings.len();
+        if let Some(sym) = symbol {
+            self.by_symbol.insert(sym, binding_idx);
+        }
+        self.by_name.entry(name).or_default().push(binding_idx);
+        self.bindings.push(Binding {
+            name_node: name_idx,
+            symbol,
+            exported_import_equals,
+        });
+        Some(binding_idx)
+    }
+
+    // =========================================================================
+    // Reference scan
+    // =========================================================================
+
+    fn scan_references(&mut self) {
+        for idx in 0..self.arena.nodes.len() {
+            let node_idx = NodeIndex(idx as u32);
+            let Some(node) = self.arena.get(node_idx) else {
+                continue;
+            };
+            if node.kind != SyntaxKind::Identifier as u16 {
+                continue;
+            }
+            let Some(ident) = self.arena.get_identifier(node) else {
+                continue;
+            };
+            if ident.escaped_text.is_empty() || !self.by_name.contains_key(&ident.escaped_text) {
+                continue;
+            }
+            // Skip the binding declarations themselves.
+            if self
+                .bindings
+                .iter()
+                .any(|binding| binding.name_node == node_idx)
+            {
+                continue;
+            }
+            let name = ident.escaped_text.clone();
+            match self.classify_reference(node_idx, &name) {
+                ReferencePosition::NotAReference | ReferencePosition::Erased => {}
+                ReferencePosition::Value => {
+                    self.record_value_reference(node_idx, &name);
+                }
+                ReferencePosition::ImportEqualsRhs(alias_decl) => {
+                    self.record_alias_rhs_reference(node_idx, &name, alias_decl);
+                }
+            }
+        }
+    }
+
+    fn record_value_reference(&mut self, ref_idx: NodeIndex, name: &str) {
+        for binding_idx in self.matching_bindings(ref_idx, name) {
+            let name_node = self.bindings[binding_idx].name_node;
+            self.value_used.insert(name_node);
+        }
+    }
+
+    fn record_alias_rhs_reference(
+        &mut self,
+        ref_idx: NodeIndex,
+        name: &str,
+        alias_decl: NodeIndex,
+    ) {
+        for binding_idx in self.matching_bindings(ref_idx, name) {
+            self.alias_edges.push((alias_decl, binding_idx));
+        }
+    }
+
+    /// Resolve a reference to the import bindings it can denote.
+    ///
+    /// Uses shadow-aware scope resolution; when the reference cannot be
+    /// resolved (or the binding's own symbol is unknown), every same-named
+    /// binding matches so the import is conservatively preserved.
+    fn matching_bindings(&self, ref_idx: NodeIndex, name: &str) -> Vec<usize> {
+        let Some(candidates) = self.by_name.get(name) else {
+            return Vec::new();
+        };
+        // Scope resolution first: `node_symbols` keys *declaration* sites
+        // (e.g. `export default expr` maps to the default-export symbol), so
+        // it is only a fallback for references the scope walk cannot reach.
+        let resolved = self
+            .binder
+            .resolve_identifier_with_filter(self.arena, ref_idx, &[], |_| true)
+            .or_else(|| self.binder.get_node_symbol(ref_idx));
+        match resolved {
+            Some(sym) => {
+                if let Some(&binding_idx) = self.by_symbol.get(&sym) {
+                    return vec![binding_idx];
+                }
+                // The reference resolved to a different symbol. Only trust the
+                // mismatch (i.e. treat it as a shadowing local) when every
+                // same-named binding has a known symbol to compare against.
+                if candidates
+                    .iter()
+                    .all(|&idx| self.bindings[idx].symbol.is_some())
+                {
+                    return Vec::new();
+                }
+                candidates
+                    .iter()
+                    .copied()
+                    .filter(|&idx| self.bindings[idx].symbol.is_none())
+                    .collect()
+            }
+            // Unresolvable reference: conservatively match every same-named
+            // binding so the import is preserved.
+            None => candidates.clone(),
+        }
+    }
+
+    // =========================================================================
+    // Position classification
+    // =========================================================================
+
+    fn classify_reference(&self, ref_idx: NodeIndex, name: &str) -> ReferencePosition {
+        let Some(parent_idx) = self.arena.parent_of(ref_idx) else {
+            return ReferencePosition::NotAReference;
+        };
+        let Some(parent) = self.arena.get(parent_idx) else {
+            return ReferencePosition::NotAReference;
+        };
+
+        if let Some(position) = self.classify_by_parent(ref_idx, parent_idx, parent.kind, name) {
+            return position;
+        }
+
+        self.classify_by_ancestors(ref_idx)
+    }
+
+    /// Immediate-parent classification: positions where the identifier is a
+    /// name being *introduced or labeled* rather than a reference, plus the
+    /// import/export-specific reference shapes.
+    #[allow(clippy::too_many_lines)]
+    fn classify_by_parent(
+        &self,
+        ref_idx: NodeIndex,
+        parent_idx: NodeIndex,
+        parent_kind: u16,
+        name: &str,
+    ) -> Option<ReferencePosition> {
+        use ReferencePosition::{NotAReference, Value};
+        match parent_kind {
+            // `obj.prop` — the property name is not a scope reference.
+            // (`obj[expr]` element-access arguments ARE references and fall
+            // through to the default classification.)
+            syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION => {
+                let access = self.arena.get_access_expr_at(parent_idx)?;
+                if access.name_or_argument == ref_idx {
+                    return Some(NotAReference);
+                }
+                // The receiver of a qualified access through an external
+                // const enum binding is inlined away during emit.
+                if access.expression == ref_idx && self.is_external_const_enum_binding(name) {
+                    return Some(NotAReference);
+                }
+                None
+            }
+            syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION => {
+                let access = self.arena.get_access_expr_at(parent_idx)?;
+                if access.expression == ref_idx && self.is_external_const_enum_binding(name) {
+                    return Some(NotAReference);
+                }
+                None
+            }
+            // `A.B` in entity-name position: only the leftmost identifier is a
+            // scope reference.
+            syntax_kind_ext::QUALIFIED_NAME => {
+                let qualified = self.arena.get_qualified_name_at(parent_idx)?;
+                if qualified.right == ref_idx {
+                    return Some(NotAReference);
+                }
+                None
+            }
+            // `{ name: value }` — the (non-computed) key is not a reference.
+            syntax_kind_ext::PROPERTY_ASSIGNMENT => {
+                let prop = self.arena.get_property_assignment_at(parent_idx)?;
+                (prop.name == ref_idx).then_some(NotAReference)
+            }
+            // (`{ name }` shorthand property assignments fall through to the
+            // wildcard: the shorthand name IS a reference in value position.)
+            // Destructuring: `{ key: localName }` — `key` is not a reference
+            // and `localName` is a declaration. Initializers are references.
+            syntax_kind_ext::BINDING_ELEMENT => {
+                let element = self.arena.get_binding_element_at(parent_idx)?;
+                (element.property_name == ref_idx || element.name == ref_idx)
+                    .then_some(NotAReference)
+            }
+            // Declaration names introduce bindings; they are not references.
+            syntax_kind_ext::VARIABLE_DECLARATION => {
+                let decl = self.arena.get_variable_declaration_at(parent_idx)?;
+                (decl.name == ref_idx).then_some(NotAReference)
+            }
+            syntax_kind_ext::PARAMETER => {
+                let param = self.arena.get_parameter_at(parent_idx)?;
+                (param.name == ref_idx).then_some(NotAReference)
+            }
+            syntax_kind_ext::FUNCTION_DECLARATION | syntax_kind_ext::FUNCTION_EXPRESSION => {
+                let func = self.arena.get_function_at(parent_idx)?;
+                (func.name == ref_idx).then_some(NotAReference)
+            }
+            syntax_kind_ext::CLASS_DECLARATION | syntax_kind_ext::CLASS_EXPRESSION => {
+                let class = self.arena.get_class_at(parent_idx)?;
+                (class.name == ref_idx).then_some(NotAReference)
+            }
+            syntax_kind_ext::INTERFACE_DECLARATION => {
+                let interface = self.arena.get_interface_at(parent_idx)?;
+                (interface.name == ref_idx).then_some(NotAReference)
+            }
+            syntax_kind_ext::TYPE_ALIAS_DECLARATION => {
+                let alias = self.arena.get_type_alias_at(parent_idx)?;
+                (alias.name == ref_idx).then_some(NotAReference)
+            }
+            syntax_kind_ext::ENUM_DECLARATION => {
+                let enum_decl = self.arena.get_enum_at(parent_idx)?;
+                (enum_decl.name == ref_idx).then_some(NotAReference)
+            }
+            syntax_kind_ext::MODULE_DECLARATION => {
+                let module = self.arena.get_module_at(parent_idx)?;
+                (module.name == ref_idx).then_some(NotAReference)
+            }
+            syntax_kind_ext::TYPE_PARAMETER => {
+                let type_param = self.arena.get_type_parameter_at(parent_idx)?;
+                (type_param.name == ref_idx).then_some(NotAReference)
+            }
+            // Member names (non-computed) are not references.
+            syntax_kind_ext::PROPERTY_DECLARATION => {
+                let prop = self.arena.get_property_decl_at(parent_idx)?;
+                (prop.name == ref_idx).then_some(NotAReference)
+            }
+            syntax_kind_ext::METHOD_DECLARATION => {
+                let method = self.arena.get_method_decl_at(parent_idx)?;
+                (method.name == ref_idx).then_some(NotAReference)
+            }
+            syntax_kind_ext::GET_ACCESSOR | syntax_kind_ext::SET_ACCESSOR => {
+                let accessor = self.arena.get_accessor_at(parent_idx)?;
+                (accessor.name == ref_idx).then_some(NotAReference)
+            }
+            syntax_kind_ext::PROPERTY_SIGNATURE | syntax_kind_ext::METHOD_SIGNATURE => {
+                let signature = self.arena.get_signature_at(parent_idx)?;
+                (signature.name == ref_idx).then_some(NotAReference)
+            }
+            syntax_kind_ext::ENUM_MEMBER => {
+                let member = self.arena.get_enum_member_at(parent_idx)?;
+                (member.name == ref_idx).then_some(NotAReference)
+            }
+            // Statement labels, JSX namespaced/closing-tag names, and the
+            // identifiers inside import binding constructs (e.g. the `a` in
+            // `import { a as b }`) are never symbol references.
+            syntax_kind_ext::LABELED_STATEMENT
+            | syntax_kind_ext::BREAK_STATEMENT
+            | syntax_kind_ext::CONTINUE_STATEMENT
+            | syntax_kind_ext::JSX_NAMESPACED_NAME
+            | syntax_kind_ext::JSX_CLOSING_ELEMENT
+            | syntax_kind_ext::IMPORT_CLAUSE
+            | syntax_kind_ext::NAMESPACE_IMPORT
+            | syntax_kind_ext::IMPORT_SPECIFIER
+            | syntax_kind_ext::NAMESPACE_EXPORT => Some(NotAReference),
+            // JSX attribute names are not references.
+            syntax_kind_ext::JSX_ATTRIBUTE => {
+                let attribute = self.arena.get_jsx_attribute_at(parent_idx)?;
+                (attribute.name == ref_idx).then_some(NotAReference)
+            }
+            // JSX tags: lower-case identifier tags are intrinsic elements,
+            // not references; everything else references the component value.
+            syntax_kind_ext::JSX_OPENING_ELEMENT | syntax_kind_ext::JSX_SELF_CLOSING_ELEMENT => {
+                if name.chars().next().is_some_and(char::is_lowercase) {
+                    Some(NotAReference)
+                } else {
+                    Some(Value)
+                }
+            }
+            // `import A = X;` — the RHS root is a deferred reference that is
+            // live only when the alias survives emit. The alias name itself
+            // was filtered out as a binding declaration before this point.
+            // (Qualified RHS roots — `import A = X.Y;` — reach the
+            // import-equals node through the ancestor walk instead.)
+            syntax_kind_ext::IMPORT_EQUALS_DECLARATION => {
+                Some(self.classify_import_equals_rhs(parent_idx))
+            }
+            // Export specifiers: `export { local }` / `export { local as out }`
+            // reference `local` as a value unless the export is type-only.
+            syntax_kind_ext::EXPORT_SPECIFIER => {
+                Some(self.classify_export_specifier(ref_idx, parent_idx))
+            }
+            _ => None,
+        }
+    }
+
+    /// References on the right-hand side of `import A = ...` are live only
+    /// when the alias itself survives emit; type-only aliases are erased
+    /// unconditionally.
+    fn classify_import_equals_rhs(&self, decl_idx: NodeIndex) -> ReferencePosition {
+        if self
+            .arena
+            .get_import_decl_at(decl_idx)
+            .is_some_and(|import| import.is_type_only)
+        {
+            return ReferencePosition::Erased;
+        }
+        ReferencePosition::ImportEqualsRhs(decl_idx)
+    }
+
+    fn classify_export_specifier(
+        &self,
+        ref_idx: NodeIndex,
+        spec_idx: NodeIndex,
+    ) -> ReferencePosition {
+        let Some(spec) = self.arena.get_specifier_at(spec_idx) else {
+            return ReferencePosition::NotAReference;
+        };
+        if spec.is_type_only
+            || self
+                .type_only_nodes
+                .is_some_and(|set| set.contains(&spec_idx))
+        {
+            return ReferencePosition::NotAReference;
+        }
+        // The local (referenced) side is `property_name` when present
+        // (`export { local as out }`), otherwise `name` (`export { local }`).
+        let local_side = if spec.property_name.is_some() {
+            spec.property_name
+        } else {
+            spec.name
+        };
+        if local_side != ref_idx {
+            return ReferencePosition::NotAReference;
+        }
+        // Re-exports from another module (`export { x } from "m"`) do not
+        // reference local bindings; find the enclosing export declaration.
+        let mut current = self.arena.parent_of(spec_idx);
+        let mut steps = 0usize;
+        while let Some(idx) = current {
+            if idx.is_none() || steps > 8 {
+                break;
+            }
+            steps += 1;
+            let Some(node) = self.arena.get(idx) else {
+                break;
+            };
+            if node.kind == syntax_kind_ext::EXPORT_DECLARATION {
+                let Some(export) = self.arena.get_export_decl_at(idx) else {
+                    break;
+                };
+                if export.is_type_only || export.module_specifier.is_some() {
+                    return ReferencePosition::NotAReference;
+                }
+                return ReferencePosition::Value;
+            }
+            current = self.arena.parent_of(idx);
+        }
+        ReferencePosition::Value
+    }
+
+    /// Ancestor classification: erased (type/ambient) context vs runtime
+    /// value context. Unknown shapes default to value context so the failure
+    /// mode is preserving the import.
+    fn classify_by_ancestors(&self, ref_idx: NodeIndex) -> ReferencePosition {
+        let mut current = self.arena.parent_of(ref_idx);
+        // Generous bound; AST depth is far smaller in practice.
+        let mut steps = 0usize;
+        while let Some(idx) = current {
+            if idx.is_none() || steps > 4096 {
+                break;
+            }
+            steps += 1;
+            let Some(node) = self.arena.get(idx) else {
+                break;
+            };
+            // Any type-node ancestor (TypeReference, TypeQuery, ImportType,
+            // mapped/conditional/etc.) erases the reference from JS output.
+            // `typeof x` in a *type* position is TYPE_QUERY (erased); the
+            // runtime `typeof x` is TYPE_OF_EXPRESSION (a value ancestor).
+            if node.is_type_node() {
+                return ReferencePosition::Erased;
+            }
+            match node.kind {
+                syntax_kind_ext::INTERFACE_DECLARATION
+                | syntax_kind_ext::TYPE_ALIAS_DECLARATION => {
+                    return ReferencePosition::Erased;
+                }
+                // The left root of a qualified `import A = X.Y;` right-hand
+                // side (the QUALIFIED_NAME right sides were already filtered
+                // out as non-references).
+                syntax_kind_ext::IMPORT_EQUALS_DECLARATION => {
+                    return self.classify_import_equals_rhs(idx);
+                }
+                // `implements` clauses are type-only; `extends` on classes is
+                // a runtime expression (interface `extends` is unreachable
+                // here because the interface ancestor matches first).
+                syntax_kind_ext::HERITAGE_CLAUSE => {
+                    if let Some(heritage) = self.arena.get_heritage_clause_at(idx)
+                        && heritage.token == SyntaxKind::ImplementsKeyword as u16
+                    {
+                        return ReferencePosition::Erased;
+                    }
+                }
+                // Ambient declarations never produce runtime references.
+                syntax_kind_ext::VARIABLE_STATEMENT => {
+                    if let Some(var_stmt) = self.arena.get_variable_at(idx)
+                        && self.arena.is_declare(&var_stmt.modifiers)
+                    {
+                        return ReferencePosition::Erased;
+                    }
+                }
+                syntax_kind_ext::FUNCTION_DECLARATION => {
+                    if let Some(func) = self.arena.get_function_at(idx)
+                        && self.arena.is_declare(&func.modifiers)
+                    {
+                        return ReferencePosition::Erased;
+                    }
+                }
+                syntax_kind_ext::CLASS_DECLARATION => {
+                    if let Some(class) = self.arena.get_class_at(idx)
+                        && self.arena.is_declare(&class.modifiers)
+                    {
+                        return ReferencePosition::Erased;
+                    }
+                }
+                syntax_kind_ext::ENUM_DECLARATION => {
+                    if let Some(enum_decl) = self.arena.get_enum_at(idx)
+                        && self.arena.is_declare(&enum_decl.modifiers)
+                    {
+                        return ReferencePosition::Erased;
+                    }
+                }
+                syntax_kind_ext::MODULE_DECLARATION => {
+                    if let Some(module) = self.arena.get_module_at(idx)
+                        && self.arena.is_declare(&module.modifiers)
+                    {
+                        return ReferencePosition::Erased;
+                    }
+                }
+                _ => {}
+            }
+            current = self.arena.parent_of(idx);
+        }
+        ReferencePosition::Value
+    }
+
+    fn is_external_const_enum_binding(&self, name: &str) -> bool {
+        self.external_const_enum_bindings
+            .is_some_and(|set| set.contains(name))
+    }
+
+    // =========================================================================
+    // Alias-edge fixpoint
+    // =========================================================================
+
+    /// `import A = X.Y;` keeps `X` alive only when `A` itself survives emit
+    /// (value-used or exported). Aliases can chain, so iterate to fixpoint.
+    fn propagate_alias_edges(&mut self) {
+        if self.alias_edges.is_empty() {
+            return;
+        }
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for &(alias_decl, target_binding) in &self.alias_edges {
+                let alias_live = match self.alias_decl_to_binding.get(&alias_decl) {
+                    Some(&alias_binding) => {
+                        let alias = &self.bindings[alias_binding];
+                        alias.exported_import_equals || self.value_used.contains(&alias.name_node)
+                    }
+                    // The alias declaration was not collected as a binding
+                    // (type-only or malformed); conservatively treat the
+                    // reference as live.
+                    None => true,
+                };
+                if alias_live {
+                    let target = self.bindings[target_binding].name_node;
+                    if self.value_used.insert(target) {
+                        changed = true;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "../tests/import_value_usage.rs"]
+mod tests;

--- a/crates/tsz-emitter/src/import_value_usage.rs
+++ b/crates/tsz-emitter/src/import_value_usage.rs
@@ -110,10 +110,51 @@ struct Binding {
     exported_import_equals: bool,
 }
 
+/// Which import bindings a resolved reference denotes.
+#[derive(Clone, Copy)]
+enum ReferenceTarget {
+    /// A shadowing local or unrelated symbol: no binding matches.
+    None,
+    /// Resolved to exactly this binding.
+    Binding(usize),
+    /// Unresolvable reference: every same-named binding conservatively
+    /// matches so the import is preserved.
+    AllSameName,
+    /// Resolved to a foreign symbol: only same-named bindings whose own
+    /// symbol is unknown conservatively match.
+    SameNameWithUnknownSymbol,
+}
+
+/// Invoke `apply` with the binding index of every binding matched by
+/// `target`. Free function (rather than a `UsageScan` method) so callers can
+/// mutate sibling `UsageScan` fields from `apply`.
+fn for_each_matching_binding(
+    target: ReferenceTarget,
+    name: &str,
+    by_name: &FxHashMap<String, Vec<usize>>,
+    bindings: &[Binding],
+    mut apply: impl FnMut(usize, &Binding),
+) {
+    match target {
+        ReferenceTarget::None => {}
+        ReferenceTarget::Binding(idx) => apply(idx, &bindings[idx]),
+        ReferenceTarget::AllSameName | ReferenceTarget::SameNameWithUnknownSymbol => {
+            let unknown_only = matches!(target, ReferenceTarget::SameNameWithUnknownSymbol);
+            for &idx in by_name.get(name).map_or(&[][..], Vec::as_slice) {
+                if !unknown_only || bindings[idx].symbol.is_none() {
+                    apply(idx, &bindings[idx]);
+                }
+            }
+        }
+    }
+}
+
 struct UsageScan<'a> {
     arena: &'a NodeArena,
     binder: &'a BinderState,
     bindings: Vec<Binding>,
+    /// All binding name nodes, for skipping the declarations themselves.
+    binding_name_nodes: FxHashSet<NodeIndex>,
     /// Binding indices grouped by local name for the identifier pre-filter.
     by_name: FxHashMap<String, Vec<usize>>,
     /// Binding index by binder symbol for shadow-aware matching.
@@ -142,6 +183,7 @@ pub fn compute_import_value_usage_facts(
         arena,
         binder,
         bindings: Vec::new(),
+        binding_name_nodes: FxHashSet::default(),
         by_name: FxHashMap::default(),
         by_symbol: FxHashMap::default(),
         value_used: FxHashSet::default(),
@@ -158,7 +200,7 @@ pub fn compute_import_value_usage_facts(
     scan.propagate_alias_edges();
 
     ImportValueUsageFacts {
-        known_bindings: scan.bindings.iter().map(|b| b.name_node).collect(),
+        known_bindings: scan.binding_name_nodes,
         value_used: scan.value_used,
     }
 }
@@ -254,6 +296,7 @@ impl<'a> UsageScan<'a> {
         if let Some(sym) = symbol {
             self.by_symbol.insert(sym, binding_idx);
         }
+        self.binding_name_nodes.insert(name_idx);
         self.by_name.entry(name).or_default().push(binding_idx);
         self.bindings.push(Binding {
             name_node: name_idx,
@@ -268,68 +311,64 @@ impl<'a> UsageScan<'a> {
     // =========================================================================
 
     fn scan_references(&mut self) {
-        for idx in 0..self.arena.nodes.len() {
+        let arena = self.arena;
+        for idx in 0..arena.nodes.len() {
             let node_idx = NodeIndex(idx as u32);
-            let Some(node) = self.arena.get(node_idx) else {
+            let Some(node) = arena.get(node_idx) else {
                 continue;
             };
             if node.kind != SyntaxKind::Identifier as u16 {
                 continue;
             }
-            let Some(ident) = self.arena.get_identifier(node) else {
+            let Some(ident) = arena.get_identifier(node) else {
                 continue;
             };
-            if ident.escaped_text.is_empty() || !self.by_name.contains_key(&ident.escaped_text) {
+            let name = ident.escaped_text.as_str();
+            if name.is_empty() || !self.by_name.contains_key(name) {
                 continue;
             }
             // Skip the binding declarations themselves.
-            if self
-                .bindings
-                .iter()
-                .any(|binding| binding.name_node == node_idx)
-            {
+            if self.binding_name_nodes.contains(&node_idx) {
                 continue;
             }
-            let name = ident.escaped_text.clone();
-            match self.classify_reference(node_idx, &name) {
+            match self.classify_reference(node_idx, name) {
                 ReferencePosition::NotAReference | ReferencePosition::Erased => {}
                 ReferencePosition::Value => {
-                    self.record_value_reference(node_idx, &name);
+                    let target = self.resolve_reference_target(node_idx, name);
+                    let value_used = &mut self.value_used;
+                    for_each_matching_binding(
+                        target,
+                        name,
+                        &self.by_name,
+                        &self.bindings,
+                        |_, binding| {
+                            value_used.insert(binding.name_node);
+                        },
+                    );
                 }
                 ReferencePosition::ImportEqualsRhs(alias_decl) => {
-                    self.record_alias_rhs_reference(node_idx, &name, alias_decl);
+                    let target = self.resolve_reference_target(node_idx, name);
+                    let alias_edges = &mut self.alias_edges;
+                    for_each_matching_binding(
+                        target,
+                        name,
+                        &self.by_name,
+                        &self.bindings,
+                        |binding_idx, _| {
+                            alias_edges.push((alias_decl, binding_idx));
+                        },
+                    );
                 }
             }
         }
     }
 
-    fn record_value_reference(&mut self, ref_idx: NodeIndex, name: &str) {
-        for binding_idx in self.matching_bindings(ref_idx, name) {
-            let name_node = self.bindings[binding_idx].name_node;
-            self.value_used.insert(name_node);
-        }
-    }
-
-    fn record_alias_rhs_reference(
-        &mut self,
-        ref_idx: NodeIndex,
-        name: &str,
-        alias_decl: NodeIndex,
-    ) {
-        for binding_idx in self.matching_bindings(ref_idx, name) {
-            self.alias_edges.push((alias_decl, binding_idx));
-        }
-    }
-
-    /// Resolve a reference to the import bindings it can denote.
+    /// Resolve a reference to the binding population it can denote.
     ///
     /// Uses shadow-aware scope resolution; when the reference cannot be
-    /// resolved (or the binding's own symbol is unknown), every same-named
-    /// binding matches so the import is conservatively preserved.
-    fn matching_bindings(&self, ref_idx: NodeIndex, name: &str) -> Vec<usize> {
-        let Some(candidates) = self.by_name.get(name) else {
-            return Vec::new();
-        };
+    /// resolved (or a binding's own symbol is unknown), same-named bindings
+    /// conservatively match so the import is preserved.
+    fn resolve_reference_target(&self, ref_idx: NodeIndex, name: &str) -> ReferenceTarget {
         // Scope resolution first: `node_symbols` keys *declaration* sites
         // (e.g. `export default expr` maps to the default-export symbol), so
         // it is only a fallback for references the scope walk cannot reach.
@@ -340,26 +379,24 @@ impl<'a> UsageScan<'a> {
         match resolved {
             Some(sym) => {
                 if let Some(&binding_idx) = self.by_symbol.get(&sym) {
-                    return vec![binding_idx];
+                    return ReferenceTarget::Binding(binding_idx);
                 }
-                // The reference resolved to a different symbol. Only trust the
-                // mismatch (i.e. treat it as a shadowing local) when every
-                // same-named binding has a known symbol to compare against.
-                if candidates
-                    .iter()
-                    .all(|&idx| self.bindings[idx].symbol.is_some())
-                {
-                    return Vec::new();
+                // The reference resolved to a different symbol (a shadowing
+                // local). Only same-named bindings whose own symbol is
+                // unknown still conservatively match.
+                if self.by_name.get(name).is_some_and(|candidates| {
+                    candidates
+                        .iter()
+                        .any(|&idx| self.bindings[idx].symbol.is_none())
+                }) {
+                    ReferenceTarget::SameNameWithUnknownSymbol
+                } else {
+                    ReferenceTarget::None
                 }
-                candidates
-                    .iter()
-                    .copied()
-                    .filter(|&idx| self.bindings[idx].symbol.is_none())
-                    .collect()
             }
             // Unresolvable reference: conservatively match every same-named
             // binding so the import is preserved.
-            None => candidates.clone(),
+            None => ReferenceTarget::AllSameName,
         }
     }
 

--- a/crates/tsz-emitter/src/import_value_usage.rs
+++ b/crates/tsz-emitter/src/import_value_usage.rs
@@ -236,26 +236,12 @@ impl<'a> UsageScan<'a> {
             // sites never ask about them.
             return;
         }
-        if clause.name.is_some() {
-            self.add_binding(clause.name, false);
-        }
-        if clause.named_bindings.is_none() {
-            return;
-        }
-        if let Some(named) = self.arena.get_named_imports_at(clause.named_bindings) {
-            if named.name.is_some() && named.elements.nodes.is_empty() {
-                self.add_binding(named.name, false);
-            } else {
-                for &spec_idx in &named.elements.nodes {
-                    let Some(spec) = self.arena.get_specifier_at(spec_idx) else {
-                        continue;
-                    };
-                    if spec.is_type_only {
-                        continue;
-                    }
-                    self.add_binding(spec.name, false);
-                }
-            }
+        for (name_idx, name) in
+            crate::transforms::emit_utils::collect_import_clause_value_binding_names(
+                self.arena, clause,
+            )
+        {
+            self.add_named_binding(name_idx, name, false);
         }
     }
 
@@ -291,6 +277,15 @@ impl<'a> UsageScan<'a> {
         if name.is_empty() {
             return None;
         }
+        Some(self.add_named_binding(name_idx, name, exported_import_equals))
+    }
+
+    fn add_named_binding(
+        &mut self,
+        name_idx: NodeIndex,
+        name: String,
+        exported_import_equals: bool,
+    ) -> usize {
         let symbol = self.binder.get_node_symbol(name_idx);
         let binding_idx = self.bindings.len();
         if let Some(sym) = symbol {
@@ -303,7 +298,7 @@ impl<'a> UsageScan<'a> {
             symbol,
             exported_import_equals,
         });
-        Some(binding_idx)
+        binding_idx
     }
 
     // =========================================================================

--- a/crates/tsz-emitter/src/lib.rs
+++ b/crates/tsz-emitter/src/lib.rs
@@ -17,7 +17,6 @@ pub mod declaration_emitter;
 pub mod emitter;
 pub mod enums;
 pub mod import_usage;
-pub mod import_value_usage;
 pub(crate) mod jsx_pragmas;
 
 /// tsc emits this exact string when recursive DTS expansion reaches its depth limit.
@@ -29,6 +28,7 @@ pub(crate) const MAX_RECURSIVE_EXPANSION: u32 = 10;
 pub(crate) const MAX_RECURSIVE_INTERSECTION_EXPANSION: u32 = 5;
 pub mod lowering;
 pub mod output;
+pub mod passes;
 pub mod safe_slice;
 pub mod transforms;
 pub mod type_cache_view;

--- a/crates/tsz-emitter/src/lib.rs
+++ b/crates/tsz-emitter/src/lib.rs
@@ -17,6 +17,7 @@ pub mod declaration_emitter;
 pub mod emitter;
 pub mod enums;
 pub mod import_usage;
+pub mod import_value_usage;
 pub(crate) mod jsx_pragmas;
 
 /// tsc emits this exact string when recursive DTS expansion reaches its depth limit.

--- a/crates/tsz-emitter/src/lowering/import_usage.rs
+++ b/crates/tsz-emitter/src/lowering/import_usage.rs
@@ -230,40 +230,7 @@ impl<'a> LoweringPass<'a> {
         node: &Node,
         clause: &tsz_parser::parser::node::ImportClauseData,
     ) -> bool {
-        let mut names = Vec::new();
-        if clause.name.is_some() {
-            let default_name = emit_utils::identifier_text_or_empty(self.arena, clause.name);
-            if !default_name.is_empty() {
-                names.push((clause.name, default_name));
-            }
-        }
-        if clause.named_bindings.is_some()
-            && let Some(bindings_node) = self.arena.get(clause.named_bindings)
-            && let Some(named_imports) = self.arena.get_named_imports(bindings_node)
-        {
-            if named_imports.name.is_some() && named_imports.elements.nodes.is_empty() {
-                let ns_name = emit_utils::identifier_text_or_empty(self.arena, named_imports.name);
-                if !ns_name.is_empty() {
-                    names.push((named_imports.name, ns_name));
-                }
-            } else {
-                for &spec_idx in &named_imports.elements.nodes {
-                    let Some(spec_node) = self.arena.get(spec_idx) else {
-                        continue;
-                    };
-                    let Some(spec) = self.arena.get_specifier(spec_node) else {
-                        continue;
-                    };
-                    if spec.is_type_only {
-                        continue;
-                    }
-                    let local_name = emit_utils::identifier_text_or_empty(self.arena, spec.name);
-                    if !local_name.is_empty() {
-                        names.push((spec.name, local_name));
-                    }
-                }
-            }
-        }
+        let names = emit_utils::collect_import_clause_value_binding_names(self.arena, clause);
         if names.is_empty() {
             return true;
         }

--- a/crates/tsz-emitter/src/lowering/import_usage.rs
+++ b/crates/tsz-emitter/src/lowering/import_usage.rs
@@ -251,7 +251,6 @@ impl<'a> LoweringPass<'a> {
             }
             facts_settled = all_known;
         }
-        let names: Vec<String> = names.into_iter().map(|(_, name)| name).collect();
 
         let Some(source_text) = self.current_source_text else {
             return true;
@@ -296,7 +295,7 @@ impl<'a> LoweringPass<'a> {
                 &value_haystack,
                 &self.ctx.options.external_const_enum_bindings,
             );
-            if names.iter().any(|name| {
+            if names.iter().any(|(_, name)| {
                 crate::import_usage::contains_identifier_occurrence(&value_haystack, name)
             }) {
                 return true;
@@ -306,13 +305,16 @@ impl<'a> LoweringPass<'a> {
         // members become *value* references via `__metadata("design:type", X)`.
         // Don't elide imports whose binding appears in such an annotation.
         if self.ctx.options.emit_decorator_metadata
-            && names.iter().any(|name| {
+            && names.iter().any(|(_, name)| {
                 crate::import_usage::name_appears_in_decorator_metadata_type(haystack, name)
             })
         {
             return true;
         }
-        self.ctx.target_es5 && self.async_return_type_uses_imported_promise_constructor(&names)
+        self.ctx.target_es5
+            && self.async_return_type_uses_imported_promise_constructor(
+                &names.into_iter().map(|(_, name)| name).collect::<Vec<_>>(),
+            )
     }
 
     fn named_imports_have_value_usage(

--- a/crates/tsz-emitter/src/lowering/import_usage.rs
+++ b/crates/tsz-emitter/src/lowering/import_usage.rs
@@ -214,6 +214,17 @@ impl<'a> LoweringPass<'a> {
         usage
     }
 
+    /// Binder-backed value-usage fact for one import-binding name node.
+    /// `None` when facts are unavailable for this binding; callers fall back
+    /// to the text-based heuristics.
+    fn binding_value_used_fact(&self, name_idx: NodeIndex) -> Option<bool> {
+        self.ctx
+            .options
+            .import_usage_facts
+            .as_ref()?
+            .binding_value_used(name_idx)
+    }
+
     pub(super) fn import_has_value_usage_after_node(
         &self,
         node: &Node,
@@ -223,7 +234,7 @@ impl<'a> LoweringPass<'a> {
         if clause.name.is_some() {
             let default_name = emit_utils::identifier_text_or_empty(self.arena, clause.name);
             if !default_name.is_empty() {
-                names.push(default_name);
+                names.push((clause.name, default_name));
             }
         }
         if clause.named_bindings.is_some()
@@ -233,7 +244,7 @@ impl<'a> LoweringPass<'a> {
             if named_imports.name.is_some() && named_imports.elements.nodes.is_empty() {
                 let ns_name = emit_utils::identifier_text_or_empty(self.arena, named_imports.name);
                 if !ns_name.is_empty() {
-                    names.push(ns_name);
+                    names.push((named_imports.name, ns_name));
                 }
             } else {
                 for &spec_idx in &named_imports.elements.nodes {
@@ -248,7 +259,7 @@ impl<'a> LoweringPass<'a> {
                     }
                     let local_name = emit_utils::identifier_text_or_empty(self.arena, spec.name);
                     if !local_name.is_empty() {
-                        names.push(local_name);
+                        names.push((spec.name, local_name));
                     }
                 }
             }
@@ -256,6 +267,25 @@ impl<'a> LoweringPass<'a> {
         if names.is_empty() {
             return true;
         }
+
+        // Binder-backed facts: authoritative for the pure value-usage
+        // question when every binding is covered. Decorator-metadata and ES5
+        // Promise-constructor usages are implicit references the reference
+        // scan does not model, so they are still checked below.
+        let mut facts_settled = false;
+        if self.ctx.options.import_usage_facts.is_some() {
+            let mut all_known = true;
+            for (name_idx, _) in &names {
+                match self.binding_value_used_fact(*name_idx) {
+                    Some(true) => return true,
+                    Some(false) => {}
+                    None => all_known = false,
+                }
+            }
+            facts_settled = all_known;
+        }
+        let names: Vec<String> = names.into_iter().map(|(_, name)| name).collect();
+
         let Some(source_text) = self.current_source_text else {
             return true;
         };
@@ -290,19 +320,20 @@ impl<'a> LoweringPass<'a> {
             }
         }
         let haystack = &source_text[start..];
-        // Strip type-only content so identifiers in type positions
-        // (type aliases, interfaces, type annotations, etc.) don't
-        // cause unnecessary helper emission.
-        let value_haystack = crate::import_usage::strip_type_only_content(haystack);
-        let value_haystack = crate::import_usage::strip_qualified_accesses_for_names(
-            &value_haystack,
-            &self.ctx.options.external_const_enum_bindings,
-        );
-        if names
-            .iter()
-            .any(|name| crate::import_usage::contains_identifier_occurrence(&value_haystack, name))
-        {
-            return true;
+        if !facts_settled {
+            // Strip type-only content so identifiers in type positions
+            // (type aliases, interfaces, type annotations, etc.) don't
+            // cause unnecessary helper emission.
+            let value_haystack = crate::import_usage::strip_type_only_content(haystack);
+            let value_haystack = crate::import_usage::strip_qualified_accesses_for_names(
+                &value_haystack,
+                &self.ctx.options.external_const_enum_bindings,
+            );
+            if names.iter().any(|name| {
+                crate::import_usage::contains_identifier_occurrence(&value_haystack, name)
+            }) {
+                return true;
+            }
         }
         // Under `--emitDecoratorMetadata`, type annotations on decorated class
         // members become *value* references via `__metadata("design:type", X)`.
@@ -347,17 +378,24 @@ impl<'a> LoweringPass<'a> {
             {
                 return true;
             }
+            let fact = self.binding_value_used_fact(spec.name);
+            if fact == Some(true) {
+                return true;
+            }
             let Some(source_text) = self.current_source_text else {
                 return true;
             };
             let haystack = self.source_after_import_statement(node, source_text);
-            let value_haystack = crate::import_usage::strip_type_only_content(haystack);
-            let value_haystack = crate::import_usage::strip_qualified_accesses_for_names(
-                &value_haystack,
-                &self.ctx.options.external_const_enum_bindings,
-            );
-            if crate::import_usage::contains_identifier_occurrence(&value_haystack, &local_name) {
-                return true;
+            if fact.is_none() {
+                let value_haystack = crate::import_usage::strip_type_only_content(haystack);
+                let value_haystack = crate::import_usage::strip_qualified_accesses_for_names(
+                    &value_haystack,
+                    &self.ctx.options.external_const_enum_bindings,
+                );
+                if crate::import_usage::contains_identifier_occurrence(&value_haystack, &local_name)
+                {
+                    return true;
+                }
             }
             if self.ctx.options.emit_decorator_metadata
                 && crate::import_usage::name_appears_in_decorator_metadata_type(

--- a/crates/tsz-emitter/src/passes/import_value_usage.rs
+++ b/crates/tsz-emitter/src/passes/import_value_usage.rs
@@ -766,5 +766,5 @@ impl<'a> UsageScan<'a> {
 }
 
 #[cfg(test)]
-#[path = "../tests/import_value_usage.rs"]
+#[path = "../../tests/import_value_usage.rs"]
 mod tests;

--- a/crates/tsz-emitter/src/passes/import_value_usage.rs
+++ b/crates/tsz-emitter/src/passes/import_value_usage.rs
@@ -474,8 +474,8 @@ impl<'a> UsageScan<'a> {
 
     /// Immediate-parent classification: positions where the identifier is a
     /// name being *introduced or labeled* rather than a reference, plus the
-    /// import/export-specific reference shapes.
-    #[allow(clippy::too_many_lines)]
+    /// import/export-specific reference shapes. The two halves cover disjoint
+    /// parent kinds.
     fn classify_by_parent(
         &self,
         ref_idx: NodeIndex,
@@ -483,7 +483,22 @@ impl<'a> UsageScan<'a> {
         parent_kind: u16,
         name: &str,
     ) -> Option<ReferencePosition> {
-        use ReferencePosition::{NotAReference, Value};
+        self.classify_name_position(ref_idx, parent_idx, parent_kind, name)
+            .or_else(|| {
+                self.classify_import_export_position(ref_idx, parent_idx, parent_kind, name)
+            })
+    }
+
+    /// Declaration, member, and access-name positions: places where the
+    /// identifier introduces or labels a name instead of referencing one.
+    fn classify_name_position(
+        &self,
+        ref_idx: NodeIndex,
+        parent_idx: NodeIndex,
+        parent_kind: u16,
+        name: &str,
+    ) -> Option<ReferencePosition> {
+        use ReferencePosition::NotAReference;
         match parent_kind {
             // `obj.prop` — the property name is not a scope reference.
             // (`obj[expr]` element-access arguments ARE references and fall
@@ -588,6 +603,21 @@ impl<'a> UsageScan<'a> {
                 let member = self.arena.get_enum_member_at(parent_idx)?;
                 (member.name == ref_idx).then_some(NotAReference)
             }
+            _ => None,
+        }
+    }
+
+    /// Label, JSX, and import/export-construct positions, including the
+    /// import-equals and export-specifier reference shapes.
+    fn classify_import_export_position(
+        &self,
+        ref_idx: NodeIndex,
+        parent_idx: NodeIndex,
+        parent_kind: u16,
+        name: &str,
+    ) -> Option<ReferencePosition> {
+        use ReferencePosition::{NotAReference, Value};
+        match parent_kind {
             // Statement labels, JSX namespaced/closing-tag names, and the
             // identifiers inside import binding constructs (e.g. the `a` in
             // `import { a as b }`) are never symbol references.

--- a/crates/tsz-emitter/src/passes/import_value_usage.rs
+++ b/crates/tsz-emitter/src/passes/import_value_usage.rs
@@ -26,7 +26,7 @@
 //! eliding one that is required at runtime.
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use tsz_binder::{BinderState, SymbolId};
+use tsz_binder::{BinderState, SymbolId, symbol_flags};
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::syntax_kind_ext;
@@ -108,6 +108,11 @@ struct Binding {
     /// Whether this is an `import A = ...` alias carrying an `export`
     /// modifier (always emitted, so its RHS reference is always live).
     exported_import_equals: bool,
+    /// For `import A = ...` aliases, the AST parent of the declaration.
+    /// Duplicate same-named aliases in one container resolve to a single
+    /// declaration, but the emitter's duplicate suppression decides which
+    /// one survives, so a value use must keep all of them alive.
+    import_equals_container: Option<NodeIndex>,
 }
 
 /// Which import bindings a resolved reference denotes.
@@ -137,7 +142,22 @@ fn for_each_matching_binding(
 ) {
     match target {
         ReferenceTarget::None => {}
-        ReferenceTarget::Binding(idx) => apply(idx, &bindings[idx]),
+        // Duplicate same-named `import A = ...` aliases in one container
+        // resolve to a single declaration, but the emitter's duplicate
+        // suppression decides which one survives, so a value use keeps every
+        // sibling alias alive.
+        ReferenceTarget::Binding(idx) => {
+            apply(idx, &bindings[idx]);
+            if let Some(container) = bindings[idx].import_equals_container {
+                for &candidate in candidates {
+                    if candidate != idx
+                        && bindings[candidate].import_equals_container == Some(container)
+                    {
+                        apply(candidate, &bindings[candidate]);
+                    }
+                }
+            }
+        }
         ReferenceTarget::AllSameName | ReferenceTarget::SameNameWithUnknownSymbol => {
             let unknown_only = matches!(target, ReferenceTarget::SameNameWithUnknownSymbol);
             for &idx in candidates {
@@ -241,7 +261,7 @@ impl<'a> UsageScan<'a> {
                 self.arena, clause,
             )
         {
-            self.add_named_binding(name_idx, name, false);
+            self.add_named_binding(name_idx, name, false, None);
         }
     }
 
@@ -265,7 +285,17 @@ impl<'a> UsageScan<'a> {
             .arena
             .has_modifier(&import.modifiers, SyntaxKind::ExportKeyword)
             || self.import_equals_is_export_declaration_clause(decl_idx);
-        let binding_idx = self.add_named_binding(import.import_clause, name, exported);
+        let container = self.arena.parent_of(decl_idx).filter(|idx| idx.is_some());
+        let binding_idx = self.add_named_binding(import.import_clause, name, exported, container);
+        // Some binder paths key the alias symbol on the declaration node
+        // rather than the alias identifier; backfill so shadow-aware
+        // matching can recognize references to this alias.
+        if self.bindings[binding_idx].symbol.is_none()
+            && let Some(sym) = self.binder.get_node_symbol(decl_idx)
+        {
+            self.bindings[binding_idx].symbol = Some(sym);
+            self.by_symbol.insert(sym, binding_idx);
+        }
         self.alias_decl_to_binding.insert(decl_idx, binding_idx);
     }
 
@@ -283,6 +313,7 @@ impl<'a> UsageScan<'a> {
         name_idx: NodeIndex,
         name: String,
         exported_import_equals: bool,
+        import_equals_container: Option<NodeIndex>,
     ) -> usize {
         let symbol = self.binder.get_node_symbol(name_idx);
         let binding_idx = self.bindings.len();
@@ -295,6 +326,7 @@ impl<'a> UsageScan<'a> {
             name_node: name_idx,
             symbol,
             exported_import_equals,
+            import_equals_container,
         });
         binding_idx
     }
@@ -363,21 +395,35 @@ impl<'a> UsageScan<'a> {
         ref_idx: NodeIndex,
         candidates: &[usize],
     ) -> ReferenceTarget {
-        // Scope resolution first: `node_symbols` keys *declaration* sites
-        // (e.g. `export default expr` maps to the default-export symbol), so
-        // it is only a fallback for references the scope walk cannot reach.
+        // Scope resolution, accepting only symbols that can answer a *value*
+        // reference: one of our import bindings, or a genuine value-space
+        // shadow. Pure type-space symbols (type parameters, interfaces, type
+        // aliases) and foreign alias symbols (e.g. the alias a re-export
+        // specifier declares for the same name) are resolver hits that do NOT
+        // shadow value references, so the walk continues past them.
+        // `node_symbols` keys *declaration* sites (e.g. `export default expr`
+        // maps to the default-export symbol), so it is only a fallback for
+        // references the scope walk cannot reach.
         let resolved = self
             .binder
-            .resolve_identifier_with_filter(self.arena, ref_idx, &[], |_| true)
+            .resolve_identifier_with_filter(self.arena, ref_idx, &[], |sym| {
+                self.by_symbol.contains_key(&sym) || self.is_value_shadow_symbol(sym)
+            })
             .or_else(|| self.binder.get_node_symbol(ref_idx));
         match resolved {
             Some(sym) => {
                 if let Some(&binding_idx) = self.by_symbol.get(&sym) {
                     return ReferenceTarget::Binding(binding_idx);
                 }
-                // The reference resolved to a different symbol (a shadowing
-                // local). Only same-named bindings whose own symbol is
-                // unknown still conservatively match.
+                if !self.is_value_shadow_symbol(sym) {
+                    // Resolver artifact (a foreign alias or a type-space
+                    // symbol reached through the `node_symbols` fallback):
+                    // shadowing is unproven, conservatively preserve.
+                    return ReferenceTarget::AllSameName;
+                }
+                // The reference resolved to a genuine value shadow. Only
+                // same-named bindings whose own symbol is unknown still
+                // conservatively match.
                 if candidates
                     .iter()
                     .any(|&idx| self.bindings[idx].symbol.is_none())
@@ -391,6 +437,20 @@ impl<'a> UsageScan<'a> {
             // binding so the import is preserved.
             None => ReferenceTarget::AllSameName,
         }
+    }
+
+    /// Whether `sym` is a value-space, non-alias binding — the only kind of
+    /// symbol that can shadow an import for a value reference.
+    ///
+    /// Namespace/module symbols are excluded: a namespace sharing an import's
+    /// name *merges or collides* with it (e.g. the enclosing `namespace A.M`
+    /// whose body declares `import M = ...`) rather than shadowing it, so
+    /// resolving to one proves nothing about the import's liveness.
+    fn is_value_shadow_symbol(&self, sym: SymbolId) -> bool {
+        const SHADOW: u32 = symbol_flags::VALUE & !symbol_flags::MODULE;
+        self.binder.get_symbol(sym).is_some_and(|symbol| {
+            symbol.flags & SHADOW != 0 && symbol.flags & symbol_flags::ALIAS == 0
+        })
     }
 
     // =========================================================================

--- a/crates/tsz-emitter/src/passes/mod.rs
+++ b/crates/tsz-emitter/src/passes/mod.rs
@@ -1,0 +1,3 @@
+//! Analysis passes that compute per-file facts consumed by emit.
+
+pub mod import_value_usage;

--- a/crates/tsz-emitter/src/transforms/emit_utils.rs
+++ b/crates/tsz-emitter/src/transforms/emit_utils.rs
@@ -170,6 +170,47 @@ pub(crate) fn identifier_text_or_empty(arena: &NodeArena, idx: NodeIndex) -> Str
     identifier_text(arena, idx).unwrap_or_default()
 }
 
+/// Collect the runtime (non-type-only) bindings of an import clause as
+/// `(name node, name)` pairs: the default name, the namespace name, and each
+/// named specifier's local name. Shared by the printer's and the lowering
+/// pass's import value-usage decision sites.
+pub(crate) fn collect_import_clause_value_binding_names(
+    arena: &NodeArena,
+    clause: &tsz_parser::parser::node::ImportClauseData,
+) -> Vec<(NodeIndex, String)> {
+    let mut names = Vec::new();
+    let mut push = |name_idx: NodeIndex| {
+        let name = identifier_text_or_empty(arena, name_idx);
+        if !name.is_empty() {
+            names.push((name_idx, name));
+        }
+    };
+    if clause.name.is_some() {
+        push(clause.name);
+    }
+    if clause.named_bindings.is_some()
+        && let Some(bindings_node) = arena.get(clause.named_bindings)
+        && let Some(named_imports) = arena.get_named_imports(bindings_node)
+    {
+        if named_imports.name.is_some() && named_imports.elements.nodes.is_empty() {
+            push(named_imports.name);
+        } else {
+            for &spec_idx in &named_imports.elements.nodes {
+                let Some(spec_node) = arena.get(spec_idx) else {
+                    continue;
+                };
+                let Some(spec) = arena.get_specifier(spec_node) else {
+                    continue;
+                };
+                if !spec.is_type_only {
+                    push(spec.name);
+                }
+            }
+        }
+    }
+    names
+}
+
 /// Returns true when an expression evaluated from a function parameter can
 /// allocate a downlevel optional-chain/nullish temp in the function body.
 pub(crate) fn parameter_expression_generates_downlevel_temp(

--- a/crates/tsz-emitter/tests/import_value_usage.rs
+++ b/crates/tsz-emitter/tests/import_value_usage.rs
@@ -1,0 +1,389 @@
+//! Tests for the binder-backed import value-usage facts.
+//!
+//! The adjacent-case matrix mirrors the elision families the text-based
+//! scanner historically mis-handled: keyword-named locals, multi-line type
+//! annotations, shadowing, use-before-import, `typeof` type queries vs
+//! runtime `typeof`, export re-exports, `import =` alias chains, and
+//! external const-enum qualified accesses. Binder names vary across tests on
+//! purpose (anti-hardcoding gate).
+
+use super::{ImportValueUsageInputs, compute_import_value_usage_facts};
+use crate::emitter::{ModuleKind, Printer, PrinterOptions};
+use rustc_hash::FxHashSet;
+use std::sync::Arc;
+use tsz_binder::BinderState;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_parser::parser::{NodeIndex, ParserState};
+use tsz_scanner::SyntaxKind;
+
+fn parse_and_bind(source: &str) -> (ParserState, NodeIndex, BinderState) {
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+    (parser, root, binder)
+}
+
+/// Find the import-binding name node for `name` (specifier local name,
+/// default/namespace clause name, or `import X = ...` alias).
+fn binding_name_node(parser: &ParserState, name: &str) -> NodeIndex {
+    for idx in 0..parser.arena.nodes.len() {
+        let node_idx = NodeIndex(idx as u32);
+        let Some(node) = parser.arena.get(node_idx) else {
+            continue;
+        };
+        if node.kind != SyntaxKind::Identifier as u16 {
+            continue;
+        }
+        let Some(ident) = parser.arena.get_identifier(node) else {
+            continue;
+        };
+        if ident.escaped_text != name {
+            continue;
+        }
+        let Some(parent_idx) = parser.arena.parent_of(node_idx) else {
+            continue;
+        };
+        let Some(parent) = parser.arena.get(parent_idx) else {
+            continue;
+        };
+        match parent.kind {
+            syntax_kind_ext::IMPORT_SPECIFIER => {
+                if parser
+                    .arena
+                    .get_specifier(parent)
+                    .is_some_and(|spec| spec.name == node_idx)
+                {
+                    return node_idx;
+                }
+            }
+            syntax_kind_ext::IMPORT_CLAUSE | syntax_kind_ext::NAMESPACE_IMPORT => {
+                return node_idx;
+            }
+            syntax_kind_ext::NAMED_IMPORTS => {
+                if parser
+                    .arena
+                    .get_named_imports(parent)
+                    .is_some_and(|named| named.name == node_idx)
+                {
+                    return node_idx;
+                }
+            }
+            syntax_kind_ext::IMPORT_EQUALS_DECLARATION => {
+                if parser
+                    .arena
+                    .get_import_decl(parent)
+                    .is_some_and(|import| import.import_clause == node_idx)
+                {
+                    return node_idx;
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("no import binding named `{name}` in test source");
+}
+
+/// Compute facts and return whether the binding named `name` is value-used.
+fn binding_used(source: &str, name: &str) -> bool {
+    binding_used_with_inputs(source, name, ImportValueUsageInputs::default())
+}
+
+fn binding_used_with_inputs(source: &str, name: &str, inputs: ImportValueUsageInputs<'_>) -> bool {
+    let (parser, _root, binder) = parse_and_bind(source);
+    let facts = compute_import_value_usage_facts(&parser.arena, &binder, inputs);
+    let name_node = binding_name_node(&parser, name);
+    facts
+        .binding_value_used(name_node)
+        .expect("binding should be known to the facts")
+}
+
+// =============================================================================
+// Positive cases: bindings that must stay alive
+// =============================================================================
+
+#[test]
+fn call_expression_is_value_usage() {
+    assert!(binding_used(
+        "import { alpha } from \"./m\";\nalpha();\n",
+        "alpha"
+    ));
+}
+
+#[test]
+fn keyword_named_local_does_not_hide_usage() {
+    // The text scanner whites out lines starting with `type `, so the
+    // assignment `type = gamma;` (a variable named `type`) hid the use of
+    // `gamma` and the import was falsely elided.
+    assert!(binding_used(
+        "import { gamma } from \"./m\";\nlet type = 5;\ntype = gamma;\n",
+        "gamma"
+    ));
+}
+
+#[test]
+fn use_before_import_is_value_usage() {
+    assert!(binding_used(
+        "boot();\nimport { boot } from \"./m\";\n",
+        "boot"
+    ));
+}
+
+#[test]
+fn runtime_typeof_is_value_usage() {
+    assert!(binding_used(
+        "import { conf } from \"./m\";\nconsole.log(typeof conf);\n",
+        "conf"
+    ));
+}
+
+#[test]
+fn local_export_is_value_usage() {
+    assert!(binding_used(
+        "import { item } from \"./m\";\nexport { item };\n",
+        "item"
+    ));
+}
+
+#[test]
+fn renamed_local_export_is_value_usage() {
+    assert!(binding_used(
+        "import { item } from \"./m\";\nexport { item as out };\n",
+        "item"
+    ));
+}
+
+#[test]
+fn export_default_is_value_usage() {
+    assert!(binding_used(
+        "import { picked } from \"./m\";\nexport default picked;\n",
+        "picked"
+    ));
+}
+
+#[test]
+fn class_extends_is_value_usage() {
+    assert!(binding_used(
+        "import { Base } from \"./m\";\nclass Sub extends Base {}\n",
+        "Base"
+    ));
+}
+
+#[test]
+fn decorator_is_value_usage() {
+    assert!(binding_used(
+        "import { dec } from \"./m\";\n@dec\nclass Decorated {}\n",
+        "dec"
+    ));
+}
+
+#[test]
+fn shorthand_property_is_value_usage() {
+    assert!(binding_used(
+        "import { short } from \"./m\";\nconst bag = { short };\n",
+        "short"
+    ));
+}
+
+#[test]
+fn default_import_value_usage() {
+    assert!(binding_used(
+        "import widget from \"./m\";\nwidget.run();\n",
+        "widget"
+    ));
+}
+
+#[test]
+fn namespace_import_value_usage() {
+    assert!(binding_used(
+        "import * as ns from \"./m\";\nns.go();\n",
+        "ns"
+    ));
+}
+
+#[test]
+fn import_equals_chain_keeps_root_alive() {
+    let source = "import lib = require(\"./lib\");\nimport sub = lib.child;\nsub();\n";
+    assert!(binding_used(source, "sub"));
+    assert!(binding_used(source, "lib"));
+}
+
+#[test]
+fn exported_import_equals_keeps_root_alive() {
+    let source = "import lib = require(\"./lib\");\nexport import sub = lib.child;\n";
+    assert!(binding_used(source, "lib"));
+}
+
+// =============================================================================
+// Negative cases: bindings tsc elides
+// =============================================================================
+
+#[test]
+fn type_annotation_only_is_not_value_usage() {
+    assert!(!binding_used(
+        "import { Beta } from \"./m\";\nlet holder: Beta;\n",
+        "Beta"
+    ));
+}
+
+#[test]
+fn multi_line_generic_annotation_is_not_value_usage() {
+    // The per-line text stripper cannot follow annotations that span lines;
+    // the AST walk can.
+    assert!(!binding_used(
+        "import { Delta } from \"./m\";\nconst v: Map<\n    Delta,\n    string\n> = new Map();\n",
+        "Delta"
+    ));
+}
+
+#[test]
+fn shadowed_reference_is_not_value_usage() {
+    assert!(!binding_used(
+        "import { omega } from \"./m\";\nfunction f(omega: number) {\n    return omega + 1;\n}\n",
+        "omega"
+    ));
+}
+
+#[test]
+fn typeof_type_query_is_not_value_usage() {
+    assert!(!binding_used(
+        "import { conf } from \"./m\";\ntype Conf = typeof conf;\n",
+        "conf"
+    ));
+}
+
+#[test]
+fn type_only_export_clause_is_not_value_usage() {
+    assert!(!binding_used(
+        "import { item } from \"./m\";\nexport type { item };\n",
+        "item"
+    ));
+}
+
+#[test]
+fn reexport_from_other_module_is_not_value_usage() {
+    assert!(!binding_used(
+        "import { thing } from \"./m\";\nexport { thing } from \"./other\";\n",
+        "thing"
+    ));
+}
+
+#[test]
+fn property_name_positions_are_not_value_usage() {
+    assert!(!binding_used(
+        "import { prop } from \"./m\";\nconst holder = { prop: 1 };\nholder.prop;\n",
+        "prop"
+    ));
+}
+
+#[test]
+fn implements_clause_is_not_value_usage() {
+    assert!(!binding_used(
+        "import { Contract } from \"./m\";\nclass Impl implements Contract {}\n",
+        "Contract"
+    ));
+}
+
+#[test]
+fn interface_body_reference_is_not_value_usage() {
+    assert!(!binding_used(
+        "import { Shape } from \"./m\";\ninterface Box {\n    inner: Shape;\n}\n",
+        "Shape"
+    ));
+}
+
+#[test]
+fn ambient_declaration_is_not_value_usage() {
+    assert!(!binding_used(
+        "import { Kind } from \"./m\";\ndeclare const probe: Kind;\n",
+        "Kind"
+    ));
+}
+
+#[test]
+fn unused_import_equals_chain_is_not_value_usage() {
+    let source = "import lib = require(\"./lib\");\nimport sub = lib.child;\n";
+    assert!(!binding_used(source, "sub"));
+    assert!(!binding_used(source, "lib"));
+}
+
+#[test]
+fn unused_specifier_beside_used_one() {
+    let source = "import { used, unused } from \"./m\";\nused();\n";
+    assert!(binding_used(source, "used"));
+    assert!(!binding_used(source, "unused"));
+}
+
+#[test]
+fn external_const_enum_qualified_access_is_not_value_usage() {
+    let mut const_enums = FxHashSet::default();
+    const_enums.insert("Palette".to_string());
+    let inputs = ImportValueUsageInputs {
+        external_const_enum_bindings: Some(&const_enums),
+        type_only_nodes: None,
+    };
+    assert!(!binding_used_with_inputs(
+        "import { Palette } from \"./m\";\nconst c = Palette.Red;\n",
+        "Palette",
+        inputs,
+    ));
+    // A bare (non-qualified) use still keeps the binding.
+    assert!(binding_used_with_inputs(
+        "import { Palette } from \"./m\";\nconst c = Palette;\n",
+        "Palette",
+        inputs,
+    ));
+}
+
+// =============================================================================
+// End-to-end: facts threaded through the printer
+// =============================================================================
+
+fn emit_with_facts(source: &str, module: ModuleKind) -> String {
+    let (parser, root, binder) = parse_and_bind(source);
+    let facts =
+        compute_import_value_usage_facts(&parser.arena, &binder, ImportValueUsageInputs::default());
+    let options = PrinterOptions {
+        module,
+        import_usage_facts: Some(Arc::new(facts)),
+        ..Default::default()
+    };
+    let mut printer = Printer::with_options(&parser.arena, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn es_emit_keeps_import_used_through_keyword_named_local() {
+    let source = "import { used, unused } from \"./m\";\nlet type = 1;\ntype = used;\n";
+    let output = emit_with_facts(source, ModuleKind::ESNext);
+    assert!(
+        output.contains("used"),
+        "binding referenced through a keyword-named local must survive.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("unused"),
+        "unreferenced specifier must be elided.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn cjs_emit_elides_import_without_value_usage() {
+    let source = "import { Marker } from \"./m\";\nlet probe: Marker;\nprobe;\n";
+    let output = emit_with_facts(source, ModuleKind::CommonJS);
+    assert!(
+        !output.contains("require(\"./m\")"),
+        "type-only-used import must not emit a require.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn cjs_emit_keeps_import_with_value_usage() {
+    let source = "import { runner } from \"./m\";\nrunner();\n";
+    let output = emit_with_facts(source, ModuleKind::CommonJS);
+    assert!(
+        output.contains("require(\"./m\")"),
+        "value-used import must emit a require.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/tests/import_value_usage.rs
+++ b/crates/tsz-emitter/tests/import_value_usage.rs
@@ -387,3 +387,106 @@ fn cjs_emit_keeps_import_with_value_usage() {
         "value-used import must emit a require.\nOutput:\n{output}"
     );
 }
+
+// =============================================================================
+// Resolver-artifact cases: symbols that cannot shadow a value binding
+// =============================================================================
+
+/// A generic's type parameter sharing the import's name shadows it in type
+/// space only; value references in the body still hit the import
+/// (`declarationEmitRetainedAnnotationRetainsImportInOutput`).
+#[test]
+fn type_parameter_shadow_does_not_hide_value_usage() {
+    assert!(binding_used(
+        "import * as NS from \"./m\";\nexport const run = <NS>(i: () => NS): NS => NS.go(i);\n",
+        "NS"
+    ));
+}
+
+/// A re-export specifier (`export { x as out } from "mod"`) does not
+/// introduce a local binding; bare references still hit the same-named
+/// import (`es6ExportEqualsInterop`).
+#[test]
+fn reexport_specifier_does_not_hide_value_usage() {
+    assert!(binding_used(
+        "import { a as out } from \"./m\";\nout;\nexport { b as out } from \"./other\";\n",
+        "out"
+    ));
+}
+
+/// Find every import-equals alias named `name`, in source order.
+fn import_equals_alias_nodes(parser: &ParserState, name: &str) -> Vec<NodeIndex> {
+    let mut nodes = Vec::new();
+    for idx in 0..parser.arena.nodes.len() {
+        let node_idx = NodeIndex(idx as u32);
+        let Some(node) = parser.arena.get(node_idx) else {
+            continue;
+        };
+        if node.kind != SyntaxKind::Identifier as u16 {
+            continue;
+        }
+        if parser
+            .arena
+            .get_identifier(node)
+            .is_none_or(|ident| ident.escaped_text != name)
+        {
+            continue;
+        }
+        let Some(parent_idx) = parser.arena.parent_of(node_idx) else {
+            continue;
+        };
+        let Some(parent) = parser.arena.get(parent_idx) else {
+            continue;
+        };
+        if parent.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
+            && parser
+                .arena
+                .get_import_decl(parent)
+                .is_some_and(|import| import.import_clause == node_idx)
+        {
+            nodes.push(node_idx);
+        }
+    }
+    nodes
+}
+
+/// Same-named namespace aliases must not pollute each other: a value use in
+/// one namespace keeps only that namespace's alias alive (`importStatements`).
+#[test]
+fn same_named_namespace_aliases_are_isolated() {
+    let source = "namespace Root {\n    export class Thing {}\n}\nnamespace UserA {\n    import w = Root;\n    export const t = new w.Thing();\n}\nnamespace UserB {\n    import w = Root;\n    var m: typeof w;\n    var p: w.Thing;\n}\n";
+    let (parser, _root, binder) = parse_and_bind(source);
+    let facts =
+        compute_import_value_usage_facts(&parser.arena, &binder, ImportValueUsageInputs::default());
+    let aliases = import_equals_alias_nodes(&parser, "w");
+    assert_eq!(aliases.len(), 2, "expected two `w` aliases");
+    assert_eq!(
+        facts.binding_value_used(aliases[0]),
+        Some(true),
+        "UserA's alias is value-used"
+    );
+    assert_eq!(
+        facts.binding_value_used(aliases[1]),
+        Some(false),
+        "UserB's alias is type-only-used and must not be polluted by UserA's"
+    );
+}
+
+/// Duplicate alias declarations (an error case tsc still emits) merge into
+/// one binder symbol; a value use must keep every same-named alias binding
+/// alive so the emitter's own duplicate suppression picks the survivor
+/// (`moduleSharesNameWithImportDeclarationInsideIt3`).
+#[test]
+fn duplicate_aliases_share_value_usage() {
+    let source = "namespace Z {\n    export namespace M {\n        export function bar() { return \"\"; }\n    }\n    export interface I { }\n}\nnamespace A.M {\n    import M = Z.M;\n    import M = Z.I;\n    export function bar() {\n    }\n    M.bar();\n}\n";
+    let (parser, _root, binder) = parse_and_bind(source);
+    let facts =
+        compute_import_value_usage_facts(&parser.arena, &binder, ImportValueUsageInputs::default());
+    let aliases = import_equals_alias_nodes(&parser, "M");
+    assert_eq!(aliases.len(), 2, "expected two `M` aliases");
+    assert_eq!(
+        facts.binding_value_used(aliases[0]),
+        Some(true),
+        "first duplicate alias must stay alive"
+    );
+}


### PR DESCRIPTION
Goal: hold

Closes #13054 (the usage-computation piece: binder-backed per-binding facts now own the JS-emit import-elision decision in the CLI pipeline; the text scanner remains only as the binder-less fallback, and its deletion is the follow-up once the remaining binder-less consumers are wired).

## Summary

JS-emit import elision ("is this import binding referenced as a value?") was decided by scanning raw source text (`crates/tsz-emitter/src/import_usage.rs`), a standing parity-bug family — confirmed false elision when a variable named `type` appears (`type = x;` lines are whited out, hiding real uses of `x`, producing runtime-broken output), over-preservation on multi-line generic annotations, and an O(imports × file-size) cost paid twice (lowering + printing) per file.

**Failure family**: module/export schedule — import elision decisions in JS emit.

**Structural rule**: when an import binding has at least one identifier reference that (a) resolves to the binding's symbol under shadow-aware scope resolution and (b) sits in a runtime value position, tsc keeps the binding in JS emit; tsz now answers this through per-file `ImportValueUsageFacts` computed once from `BinderState` + a syntactic position classification, threaded to emit via `PrinterOptions::import_usage_facts` (the same channel as `type_only_nodes`).

**Output owner**: the facts module (`tsz_emitter::import_value_usage`) owns the value-usage question; the decision sites in `emitter/module_emission/imports.rs` and `lowering/import_usage.rs` consume it as table lookups. No semantic validation enters the emitter (the module only reads binder symbols + AST positions, mirroring the in-crate `declaration_emitter/usage_analyzer.rs` precedent), and no output surgery is involved — decisions are made before writing.

## What changed

- New `crates/tsz-emitter/src/import_value_usage.rs`: collects import bindings (default, namespace, named specifiers, `import =` aliases), classifies every candidate identifier reference (declaration/member/label positions vs erased type/ambient contexts vs value positions), resolves through the binder with conservative fall-back-to-preserve on unresolved references, and propagates `import A = X.Y` alias-edge liveness to a fixpoint. Conservative by construction: unknown shapes classify as value (over-preserve, never false-elide).
- Decision sites consult facts first; the text heuristics remain only for binder-less callers (transpile-style emit, direct `Printer` construction). JSX-factory, `emitDecoratorMetadata`, and ES5 async Promise-constructor implicit usages remain site-owned checks in both modes.
- The three duplicated default/namespace/single-binding text scans collapsed into one `import_binding_has_value_usage` helper; the clause-binding walk is shared via `emit_utils::collect_import_clause_value_binding_names` across printer, lowering, and the facts module.
- CLI driver computes facts per emitted file, reusing one per-file `BinderState` across JS facts and declaration emit; files without imports, JS sources, and `verbatimModuleSyntax` skip the computation.

## Adjacent-case matrix (unit-tested, binder names varied)

- positive: call use; keyword-named local (`let type = 5; type = x;`); use-before-import; runtime `typeof`; `export { x }` / `export { x as y }` / `export default x`; class `extends`; decorators; shorthand object property; default/namespace bindings; used `import =` chains; `export import` chains.
- negative: type-annotation-only; multi-line generic annotation; shadowed parameter; `typeof` type query; `export type { x }`; re-export from another module; property-name positions; `implements`; interface bodies; ambient `declare`; unused `import =` chains; unused specifier beside used one; external-const-enum qualified access (bare use still preserves).
- end-to-end (built CLI): keyword-named-local witness emits the import in both CJS and ESM; multi-line-annotation case elides; mixed default+named elides only the unused side; decorator-metadata preserves the annotated import and elides the sibling; JSX classic factory namespace import preserved; import-equals chain used/unused both match tsc.

## Performance

Facts are computed once per file: one O(nodes) kind scan + per-matching-identifier scope resolution, replacing per-import whole-file copies (`source_excluding_import_decl` + `strip_type_only_content`, previously O(imports × file-size), paid again at lowering). The per-file binder is shared with declaration emit instead of constructed twice.

## Verification

- `cargo nextest run -p tsz-emitter import_value_usage` — 30/30 new unit tests.
- `cargo nextest run -p tsz-emitter` — 4247 passed; the 2 failures (`declaration_emitter::tests::enum_template_and_advanced::take_diagnostics_*`) reproduce on the merge-base, pre-existing.
- `cargo nextest run -p tsz-cli -E 'test(/emit|import|elision|module/)'` — failures identical to merge-base (pre-existing, verified by stashing).
- `cargo clippy -p tsz-emitter -p tsz-cli --all-targets` — clean.
- CLI witness checks above run against the built binary on the rebased head.
- Broad emit/conformance suites: ready-review CI owns them (no TypeScript submodule in this environment).

## Provenance

Machine: cloud
Assistant: claude-code
Model: undisclosed (Claude Code undercover mode)
Effort: high

https://claude.ai/code/session_01TTPZQrcgMXYjXtDegZbAot

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTPZQrcgMXYjXtDegZbAot)_