### PR TITLE
refactor(emitter): centralize identifier text lookup

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/function_analysis.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/function_analysis.rs
@@ -1403,13 +1403,7 @@ impl<'a> DeclarationEmitter<'a> {
 
     /// Get the text of an identifier node.
     pub(crate) fn get_identifier_text(&self, idx: NodeIndex) -> Option<String> {
-        let node = self.arena.get(idx)?;
-        if node.kind != SyntaxKind::Identifier as u16 {
-            return None;
-        }
-        self.arena
-            .get_identifier(node)
-            .map(|id| id.escaped_text.clone())
+        self.arena.identifier_text(idx).map(str::to_owned)
     }
 
     /// Format a literal value as an initializer string for `const` declarations in .d.ts.

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
@@ -1918,10 +1918,7 @@ fn type_reference_identifier_name(source_arena: &NodeArena, type_idx: NodeIndex)
 }
 
 fn identifier_text(source_arena: &NodeArena, idx: NodeIndex) -> Option<String> {
-    source_arena
-        .get(idx)
-        .and_then(|node| source_arena.get_identifier(node))
-        .map(|ident| ident.escaped_text.clone())
+    source_arena.identifier_text(idx).map(str::to_owned)
 }
 
 fn callable_function_from_symbol_decl(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_mapped_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_mapped_inference.rs
@@ -931,10 +931,7 @@ fn type_reference_identifier_name(source_arena: &NodeArena, type_idx: NodeIndex)
 }
 
 fn identifier_text(source_arena: &NodeArena, idx: NodeIndex) -> Option<String> {
-    source_arena
-        .get(idx)
-        .and_then(|node| source_arena.get_identifier(node))
-        .map(|ident| ident.escaped_text.clone())
+    source_arena.identifier_text(idx).map(str::to_owned)
 }
 
 fn callable_function_from_symbol_decl(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_object_args.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_object_args.rs
@@ -1236,10 +1236,7 @@ impl<'a> DeclarationEmitter<'a> {
 }
 
 fn identifier_text(source_arena: &NodeArena, idx: NodeIndex) -> Option<String> {
-    source_arena
-        .get(idx)
-        .and_then(|node| source_arena.get_identifier(node))
-        .map(|ident| ident.escaped_text.clone())
+    source_arena.identifier_text(idx).map(str::to_owned)
 }
 
 #[cfg(test)]

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_text.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_text.rs
@@ -15,10 +15,7 @@ impl<'a> DeclarationEmitter<'a> {
         arena: &NodeArena,
         idx: NodeIndex,
     ) -> Option<String> {
-        let node = arena.get(idx)?;
-        arena
-            .get_identifier(node)
-            .map(|ident| ident.escaped_text.clone())
+        arena.identifier_text(idx).map(str::to_owned)
     }
 
     pub(in crate::declaration_emitter) fn property_name_text_from_arena(

--- a/crates/tsz-emitter/src/emitter/binding_patterns.rs
+++ b/crates/tsz-emitter/src/emitter/binding_patterns.rs
@@ -1335,16 +1335,7 @@ impl<'a> Printer<'a> {
 
     /// Get the text of an identifier node.
     pub(super) fn get_identifier_text(&self, idx: NodeIndex) -> String {
-        if idx.is_none() {
-            return String::new();
-        }
-        let Some(node) = self.arena.get(idx) else {
-            return String::new();
-        };
-        if let Some(ident) = self.arena.get_identifier(node) {
-            return ident.escaped_text.clone();
-        }
-        String::new()
+        self.arena.identifier_text_owned(idx).unwrap_or_default()
     }
 
     // =========================================================================

--- a/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
@@ -1445,10 +1445,7 @@ impl<'a> Printer<'a> {
 
         let node = self.arena.get(name_idx)?;
         if node.kind == SyntaxKind::Identifier as u16 {
-            return self
-                .arena
-                .get_identifier(node)
-                .map(|id| id.escaped_text.clone());
+            return self.arena.identifier_text_owned(name_idx);
         }
 
         if node.kind == syntax_kind_ext::QUALIFIED_NAME

--- a/crates/tsz-emitter/src/emitter/module_emission/core/module_analysis.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/module_analysis.rs
@@ -674,7 +674,7 @@ impl<'a> Printer<'a> {
     fn identifier_text_of(&self, node: &Node) -> Option<&str> {
         self.arena
             .get_identifier(node)
-            .map(|id| id.escaped_text.as_str())
+            .map(|id| self.arena.resolve_identifier_text(id))
     }
 
     /// Check if an expression is a CJS module pattern.

--- a/crates/tsz-emitter/src/lowering/helpers.rs
+++ b/crates/tsz-emitter/src/lowering/helpers.rs
@@ -950,17 +950,7 @@ impl<'a> LoweringPass<'a> {
     }
 
     pub(super) fn get_identifier_text_ref(&self, idx: NodeIndex) -> Option<&str> {
-        if idx.is_none() {
-            return None;
-        }
-
-        let node = self.arena.get(idx)?;
-        if node.kind != SyntaxKind::Identifier as u16 {
-            return None;
-        }
-
-        let ident = self.arena.get_identifier(node)?;
-        Some(&ident.escaped_text)
+        self.arena.identifier_text(idx)
     }
 
     pub(super) fn resolve_class_expr_binding_name(&self, class_idx: NodeIndex) -> Option<&str> {

--- a/crates/tsz-emitter/src/transforms/es_decorators_node_utils.rs
+++ b/crates/tsz-emitter/src/transforms/es_decorators_node_utils.rs
@@ -394,14 +394,7 @@ impl<'a> TC39DecoratorEmitter<'a> {
     }
 
     pub(super) fn get_identifier_text(&self, idx: NodeIndex) -> Option<String> {
-        let node = self.arena.get(idx)?;
-        if node.kind == SyntaxKind::Identifier as u16 {
-            self.arena
-                .get_identifier(node)
-                .map(|id| id.escaped_text.clone())
-        } else {
-            None
-        }
+        self.arena.identifier_text(idx).map(str::to_owned)
     }
 
     pub(super) fn node_text(&self, idx: NodeIndex) -> String {

--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -176,20 +176,29 @@ impl NodeArenaInner {
         ident.atom == tsz_common::interner::Atom::NONE && ident.escaped_text.is_empty()
     }
 
-    /// Get the owned text of an `Identifier` node. Returns `None` for any
-    /// other kind, including `PrivateIdentifier` — mirrors the common
+    /// Get the borrowed text of an `Identifier` node. Returns `None` for any
+    /// other kind, including `PrivateIdentifier` -- mirrors the common
     /// caller-side pattern that pre-filters on `SyntaxKind::Identifier`
-    /// before extracting `escaped_text`.
+    /// before extracting identifier text.
     #[inline]
     #[must_use]
-    pub fn identifier_text_owned(&self, index: NodeIndex) -> Option<String> {
+    pub fn identifier_text(&self, index: NodeIndex) -> Option<&str> {
         use tsz_scanner::SyntaxKind;
         let node = self.get(index)?;
         if node.kind == SyntaxKind::Identifier as u16 {
-            self.get_identifier(node).map(|id| id.escaped_text.clone())
+            self.get_identifier(node)
+                .map(|id| self.resolve_identifier_text(id))
         } else {
             None
         }
+    }
+
+    /// Get the owned text of an `Identifier` node. Returns `None` for any
+    /// other kind, including `PrivateIdentifier`.
+    #[inline]
+    #[must_use]
+    pub fn identifier_text_owned(&self, index: NodeIndex) -> Option<String> {
+        self.identifier_text(index).map(str::to_owned)
     }
 
     /// Get literal data for a node.

--- a/crates/tsz-parser/src/parser/node_view.rs
+++ b/crates/tsz-parser/src/parser/node_view.rs
@@ -245,7 +245,7 @@ impl NodeAccess for NodeArena {
     fn get_identifier_text(&self, index: NodeIndex) -> Option<&str> {
         let node = self.get(index)?;
         let data = self.get_identifier(node)?;
-        // Use atom for O(1) lookup if available, otherwise fall back to escaped_text
+        // Use the parser-owned text resolver so stale atoms cannot corrupt display text.
         Some(self.resolve_identifier_text(data))
     }
 


### PR DESCRIPTION
Goal: hold

AgentName: Codex
Track: Emitter tech-debt (#13106)
Invariant: Identifier text used by emit/lowering/DTS helpers comes from the parser-owned `NodeArena::identifier_text` resolver; emitter code no longer hand-rolls its own `escaped_text` clone paths for these helper surfaces.
Scope: Add a borrowed parser helper beside `identifier_text_owned`, route emitter/DTS helper wrappers through it, and keep owned `String` conversion explicit at call boundaries that still need ownership.
Project Corpus Impact: None expected. This is an output-helper refactor with behavior intended unchanged; it reduces hot-path allocation drift and preserves parser-owned identifier text resolution.

Closes #13106

## Verification
- `scripts/safe-run.sh cargo check -p tsz-emitter --all-targets`
- `scripts/safe-run.sh cargo nextest run -p tsz-parser resolve_identifier_text`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter generic_call_literal generic_call_mapped_inference type_inference_source_object_args`
- `cargo fmt --check`
- `git diff --check`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium

## Coordination Notes
- Reused `/Users/mohsen/code/tsz-m5-relation-cache` because disk is tight and no new worktree was needed.
- No semantic validation or output surgery added; identifier text resolution remains parser-owned and emit/DTS callers only consume it.
- No overlap with active PRs #13191, #13190, #13187, #13183, #13177, #13176, or #13163.