### PR TITLE
perf(scanner): truncate diagnostics on snapshot restore

### DIFF
--- a/crates/tsz-scanner/src/scanner_impl.rs
+++ b/crates/tsz-scanner/src/scanner_impl.rs
@@ -105,14 +105,13 @@ pub struct ScannerSnapshot {
     pub token_invalid_separator_pos: Option<usize>,
     pub token_invalid_separator_is_consecutive: bool,
     pub regex_flag_errors: Vec<RegexFlagError>,
-    pub scanner_diagnostics: Vec<ScannerDiagnostic>,
+    pub scanner_diagnostics_len: usize,
 }
 
 /// The scanner state that holds the current position and token information.
 ///
 /// ZERO-COPY OPTIMIZATION: Source is stored as UTF-8 text directly (no Vec<char>).
-/// For ASCII-only files (99% of TypeScript), byte position == character position.
-/// Positions are byte-based internally for performance, converted when needed.
+/// Positions are byte-based internally; for ASCII-only files, byte position == character position.
 #[wasm_bindgen]
 pub struct ScannerState {
     /// The source text as UTF-8 text, shared so we don't duplicate per phase.
@@ -1066,7 +1065,7 @@ impl ScannerState {
             token_invalid_separator_pos: self.token_invalid_separator_pos,
             token_invalid_separator_is_consecutive: self.token_invalid_separator_is_consecutive,
             regex_flag_errors: self.regex_flag_errors.clone(),
-            scanner_diagnostics: self.scanner_diagnostics.clone(),
+            scanner_diagnostics_len: self.scanner_diagnostics.len(),
         }
     }
 
@@ -1083,7 +1082,8 @@ impl ScannerState {
         self.token_invalid_separator_is_consecutive =
             snapshot.token_invalid_separator_is_consecutive;
         self.regex_flag_errors = snapshot.regex_flag_errors;
-        self.scanner_diagnostics = snapshot.scanner_diagnostics;
+        self.scanner_diagnostics
+            .truncate(snapshot.scanner_diagnostics_len);
     }
 
     /// Get the interned atom for the current identifier token.

--- a/crates/tsz-scanner/src/scanner_impl/tests.rs
+++ b/crates/tsz-scanner/src/scanner_impl/tests.rs
@@ -604,6 +604,24 @@ fn scanner_snapshot_and_restore() {
     assert_eq!(next, SyntaxKind::PlusToken);
 }
 
+#[test]
+fn scanner_restore_truncates_lookahead_diagnostics() {
+    let mut scanner = ScannerState::new("0__0 0__1".to_string(), true);
+    assert_eq!(scanner.scan(), SyntaxKind::NumericLiteral);
+    let saved_len = scanner.get_scanner_diagnostics().len();
+    assert!(saved_len > 0);
+
+    let snapshot = scanner.save_state();
+    assert_eq!(scanner.scan(), SyntaxKind::NumericLiteral);
+    assert!(scanner.get_scanner_diagnostics().len() > saved_len);
+
+    scanner.restore_state(snapshot);
+    assert_eq!(scanner.get_scanner_diagnostics().len(), saved_len);
+
+    assert_eq!(scanner.scan(), SyntaxKind::NumericLiteral);
+    assert!(scanner.get_scanner_diagnostics().len() > saved_len);
+}
+
 // ── Rescan methods ────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Goal: fast

AgentName: Codex
Track: Scanner tech-debt (#13066)
Invariant: Scanner lookahead snapshots save the append-only diagnostics length; restoring a speculative scan truncates diagnostics back to that mark instead of cloning and swapping the whole diagnostics vector.
Scope: Replace `ScannerSnapshot`'s diagnostics clone with a saved length, truncate diagnostics on restore, and add a scanner regression test covering preserved pre-snapshot diagnostics plus discarded lookahead diagnostics.
Project Corpus Impact: None expected. Parser/scanner behavior is intended unchanged; this removes avoidable allocation on lookahead-heavy parse paths.

Closes #13066

## Verification
- `scripts/safe-run.sh cargo check -p tsz-scanner --all-targets`
- `scripts/safe-run.sh cargo check -p tsz-parser --all-targets`
- `scripts/safe-run.sh cargo nextest run -p tsz-scanner scanner_snapshot_and_restore scanner_restore_truncates_lookahead_diagnostics`
- `cargo fmt --check`
- `git diff --check`
- `scripts/arch/check-checker-boundaries.sh`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium

## Coordination Notes
- Reused `/Users/mohsen/code/tsz-m5-relation-cache` on a fresh branch from `origin/main`; no new worktree was created.
- Structural rule: diagnostics are append-only while scanning lookahead, so save/restore only needs the vector mark.
- No overlap with active PRs #13192, #13191, #13190, #13187, #13183, #13177, #13176, or #13163.