### PR TITLE
fix(solver): infer new-expression class type args from the contextual instance (tsc inferTypes direction) for parameterless-generic constructors

### DIFF
--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -701,7 +701,29 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 ) && with_resolve_visited(|visited| {
                     self.type_contains_placeholder(return_type_with_placeholders, &var_map, visited)
                 });
-                if return_is_union_with_placeholder {
+                // Construct signatures whose declared parameters reference
+                // NONE of the signature's type parameters also use the
+                // reversed (tsc) direction: `new C(...)` with a contextual
+                // instance type runs
+                // inferTypes(contextualType, instanceTypeWithPlaceholders), so
+                // structural matching (heritage members, same-base nested
+                // applications) records CANDIDATES for the class type
+                // parameters. The original direction only produces upper
+                // bounds, leaving parameters that appear solely in member
+                // signatures unconstrained — they then fall back to
+                // constraint/`unknown` even though the contextual type
+                // determines them (e.g. `class Impl<A,B> implements I<A,B>`
+                // with a non-generic constructor, returned where `I<A,B>` is
+                // expected). When any parameter mentions a type parameter
+                // (placeholder instantiation changed it, e.g. React's
+                // `new (props: P) => Component<P, S>`), argument inference
+                // owns those variables and the original direction is kept.
+                let constructor_params_lack_type_params =
+                    func.is_constructor
+                        && func.params.iter().zip(instantiated_params.iter()).all(
+                            |(original, instantiated)| original.type_id == instantiated.type_id,
+                        );
+                if return_is_union_with_placeholder || constructor_params_lack_type_params {
                     self.constrain_types(
                         &mut infer_ctx,
                         &var_map,


### PR DESCRIPTION
Goal: green

AgentName: M1FableArchitect
Track: kysely row (#10663) — family F1(a): new-expression class type-arg inference
Invariant: `new C(...)` with a contextual instance type infers class type parameters from the contextual structure (tsc `inferTypes(contextualType, returnType)` candidates); failed inference falls back to constraint/`unknown`, never to harvested member types.
Scope: one gate change (plus comment) in `crates/tsz-solver/src/operations/generic_call/resolve.rs` contextual return seeding, gated on `func.is_constructor && <no declared parameter mentions a signature type parameter>`.

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-fable-5
Effort: high

## Structural rule
When resolving a generic **construct signature whose declared parameters reference none of the signature's type parameters** with a contextual type, tsc runs return-context inference as `inferTypes(contextualType -> returnType)` -- the placeholder-instantiated instance type is the inference TARGET, so structural matching (heritage members, same-base nested applications like the methods' `I<A,B,C>` returns) records **candidates** for the class type parameters. tsz previously used the reversed direction for non-union return types, which can only record **upper bounds** (the placeholders sit on the source side of the walk); type parameters appearing only in member signatures got nothing and fell back to constraint/`unknown` even though the contextual type determines them. Owner: solver, `generic_call/resolve.rs` (return-context seeding). Construct signatures whose parameters do mention type parameters (e.g. React's `new (props: P) => Component<P, S>`) and non-constructor calls keep the existing direction -- argument inference owns those variables (an earlier broad `is_constructor` gate regressed 2 JSX class-component lib tests; the narrowed gate restores them).

Witness (kysely `select-query-builder` shape, single-file, tsc-clean):
`class BuilderImpl<DB, TB extends keyof DB, O> implements Builder<DB, TB, O>` with a non-generic constructor; `return new BuilderImpl({...})` inside a method whose return annotation is `Builder<DB, TB, O>` → tsz inferred `BuilderImpl<unknown, never, O>` (displayed via the separate display-zip defect as `BuilderImpl<O | undefined, true, Builder<unknown, never, O>>`) → false TS2322. tsc infers `BuilderImpl<DB, TB, O>` → clean.

## Adjacent-case matrix (all verified vs tsc 5.9.3)
| case | tsc | tsz before | tsz after |
|---|---|---|---|
| base repro (union w/ function arm) | clean | TS2322 zip | clean |
| renamed binders (`MakerImpl<Zed,Qua,Res>`) | clean | TS2322 zip (rotated) | clean |
| union object-arm instead of function-arm | clean | TS2322 zip | clean |
| union arm removed (control) | clean | clean | clean |
| explicit type args at new-site (control) | clean | clean | clean |
| genuinely wrong ctor arg (`new Impl(42)`) | TS2345 | TS2345 | TS2345 |
| construct-site in free generic fn | clean | TS2322 zip ×2 | clean |
| useless context (`const p: 123 = new Impl(...)`) | `BuilderImpl<unknown, never, unknown>` | same display | same display (exact tsc parity) |

## Project Corpus Impact
- Row: kysely-project
- Bug family: F1 new-expression class type-arg inference (#10663 triage map)

Kysely guard (`tsconfig.tsz-guard-mssql.json`, 3 runs per side, same fixture/commit):
- base (both 6bac88fa1b and rebased e37153488c, same dev-fast profile): 142 / 142 / 142
- fix: **134 / 134 / 134** (byte-identical error output across runs and across the pre/post-rebase fix builds)
- The row's ±9 run-to-run flicker set (helpers/`RawBuilder<unknown>` ×4, introspector `Kysely<any>` ×2, `ControlledTransaction`, set-operation-parser ×2 — all F1 inference-fallback shapes per the #10663 triage map) is **eliminated**; both sides now deterministic, and historically the row flickered 135↔142.
- Site-level: fix output is a **strict subset of the best-known 135 baseline** (zero new sites; also removes `column-definition-node.ts(89)`). The one site present vs the 142-run (`kysely.ts(163)`) is in the 135 baseline (known F4 family member).
- Remaining `select-query-builder` cluster (43) is F1(b) — non-generic impl method vs generic interface method relation (#13044 family) — plus the display sub-defect below; unchanged by design.

Other rows (A/B, site-level):
- comlink: 3 → 3, same locations.
- zod 54→54, ofetch 46→46, ts-rest 31→31.
- msw 211→210: removes false positive `sse.ts(134)` `'"[streaming]"' not assignable to 'BodyInit'` (tsc-clean).
- valibot 1821→1828, both sides run-to-run stable: +8 sites are the known F3 same-alias-identity fingerprint (`'"validation"' is not assignable to type '"validation"'`, ulid/uuid.ts — no new-expressions at those sites; order/cache sensitivity of the existing F3 defect), −1 site (`map.ts(116)` TS2490), plus same-site display-order shuffles. Guard CI is exit-class based for these rows.

## Display sub-defect found (separate follow-up, not fixed here)
The "zipped" diagnostic text itself is a display-owner defect: `crates/tsz-checker/src/error_reporter/core_formatting.rs` (~704-758) reconstructs `Name<args>` for an instance object by sorting its **properties by name** and taking the first N property types as type args. Probe with correct inference (`DB, TB, O` in the application) still displays `BuilderImpl<true, Builder<DB, TB, O>, O | undefined>` where tsc prints `BuilderImpl<DB, TB, O>`. This keeps the remaining F1(b) messages odd-looking but does not affect semantics; will be filed/fixed under the display owner.

## Verification
- Adjacent-case matrix above (tsc 5.9.3 cross-checked, including negative + explicit-args controls).
- Kysely guard 3×/side + flicker measurement (above); comlink/zod/msw/ofetch/ts-rest/valibot A/B (above).
- tsz-solver + tsz-checker suites via direct test binaries (nextest orchestrator unavailable on this machine), per-name A/B vs base (origin/main e37153488c rebuilt locally in both states):
  - tsz-solver lib (6601 passed): identical failure-name sets both sides (2 pre-existing machine-delta failures, both reproduced on unmodified base: `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`, `test_generic_call_widening_applies_when_constraint_satisfied`).
  - tsz-checker lib (~6500 tests): per-name delta = 1 fix-side name (`delegate_cross_arena_source_option_bag_with_sibling_alias_lowers_directly_via_cross_file_index`) which passes in isolation and whose sibling family member flaked on the base run (global perf-counter race under --test-threads=8); the remaining 266 failures are the known pre-existing Mac-delta set, identical names both sides.
  - 26 targeted integration binaries (new/constructor/generic/contextual/inference/promise/kysely families incl. `kysely_callback_context_tests`, `generic_call_inference_tests`, `new_expression_regression_tests`, `async_return_widening_tests`): identical failure-name sets both sides (9 pre-existing, all reproduced on unmodified base).
  - 3 stems (`constructor_accessibility`, `constructor_overload_excess_property_tests`, `new_expression_source_display_tests`) had no local binaries on either side (disk-pressure prune); ready-review CI owns the broad suites.
- `cargo clippy -p tsz-solver`: clean (0 warnings/errors).
- `scripts/arch/check-checker-boundaries.sh`: passed (guardrails + checker field-lifetime inventory).
- Row runtime (same dev-fast profile): kysely guard ~11.6s user (base) vs ~13s user (fix), roughly +10% on this row from the added contextual structural walk; correctness-motivated, CI bench owns the verdict.

## Coordination Notes
- Base for review: origin/main e37153488c (rebased over #13175/#13181 which landed mid-session).
- F1(b) (no-erase generic-method relation, #13044 family) and the display-zip defect are intentionally out of scope; they own the remaining select-query-builder cluster.
- The F3/order-sensitivity that moves valibot sites is the same defect family already mapped on #10663 (deferred `Omit` identity); coordinate with that campaign before chasing the ulid/uuid sites.

