### PR TITLE
fix(checker): TS2790 delete legality keys off the declared property, not the flow-narrowed receiver

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -696,6 +696,9 @@ mod cross_file_type_param_decl_identity_tests;
 #[path = "../tests/cross_file_type_params_cache_tests.rs"]
 mod cross_file_type_params_cache_tests;
 #[cfg(test)]
+#[path = "tests/cross_module_generic_interface_heritage_tests.rs"]
+mod cross_module_generic_interface_heritage_tests;
+#[cfg(test)]
 #[path = "tests/destructured_discriminant_source_narrowing_tests.rs"]
 mod destructured_discriminant_source_narrowing_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/cross_module_generic_interface_heritage_tests.rs
+++ b/crates/tsz-checker/src/tests/cross_module_generic_interface_heritage_tests.rs
@@ -1,0 +1,287 @@
+//! Cross-module *generic* interface heritage member resolution, and `delete`
+//! legality (TS2790) against the *declared* property rather than the
+//! flow-narrowed receiver.
+//!
+//! Structural rules:
+//! - When a generic interface declared in another program module is
+//!   referenced by name, `tsc` resolves it in its declaring module —
+//!   including `extends` heritage — so inherited members must resolve
+//!   (TS2339 pins, witnessed by the ofetch project row's
+//!   `ResolvedFetchOptions<R>` / `FetchResponse<T>` cascades).
+//! - `delete obj.prop` is legal when the *declared* property is optional (or
+//!   its declared type includes `undefined`). tsz's truthiness/`in`
+//!   narrowing intersects the receiver with a synthetic required slot, which
+//!   must not turn a declared-optional property into a TS2790.
+//!
+//! Binder names are varied across cases so no identifier is load-bearing.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::{Diagnostic, diagnostic_codes};
+use crate::test_utils::check_multi_file_with_global_index;
+use tsz_common::common::ModuleKind;
+
+fn check(types_src: &str, main_src: &str) -> Vec<Diagnostic> {
+    check_multi_file_with_global_index(
+        &[("./defs.ts", types_src), ("./main.ts", main_src)],
+        "./main.ts",
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn family_errors(diagnostics: &[Diagnostic]) -> Vec<(u32, u32, String)> {
+    diagnostics
+        .iter()
+        .filter(|d| {
+            d.code == diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE
+                || d.code == diagnostic_codes::THE_OPERAND_OF_A_DELETE_OPERATOR_MUST_BE_OPTIONAL
+        })
+        .map(|d| (d.code, d.start, d.message_text.to_string()))
+        .collect()
+}
+
+fn assert_clean(diagnostics: &[Diagnostic]) {
+    let relevant = family_errors(diagnostics);
+    assert!(
+        relevant.is_empty(),
+        "expected inherited members of the imported generic interface to resolve, got: {relevant:?}",
+    );
+}
+
+/// Core witness: imported generic interface extending a generic base,
+/// referenced with default type args; inherited member access must resolve.
+///
+/// NOTE: the unit harness checks only the entry file, so *parameter*
+/// annotations (lowered to `Application(Lazy(def), args)` without entering
+/// the checker's type-reference resolution) hit a separate, pre-existing
+/// single-entry resolution gap. These tests pin the type-reference consumer
+/// (`declare const` annotations); the parameter-annotation form is covered
+/// end-to-end by the ofetch project row and CLI witnesses.
+#[test]
+fn imported_generic_interface_inherited_member_resolves() {
+    let diags = check(
+        r#"
+export interface Stem<R extends string = string> {
+  payload?: string;
+  mode?: "half" | undefined;
+}
+export interface Wrap<R extends string = string> extends Stem<R> {
+  labels: number;
+}
+"#,
+        r#"
+import type { Wrap } from "./defs";
+declare const w: Wrap;
+w.labels;
+w.payload;
+w.mode;
+"#,
+    );
+    assert_clean(&diags);
+}
+
+/// Explicit type argument instead of defaults.
+#[test]
+fn imported_generic_interface_explicit_args_inherited_member_resolves() {
+    let diags = check(
+        r#"
+export interface Root<K extends string = string> { item?: K; }
+export interface Leaf<K extends string = string> extends Root<K> { own: number; }
+"#,
+        r#"
+import type { Leaf } from "./defs";
+declare const l: Leaf<"a" | "b">;
+l.own;
+l.item;
+"#,
+    );
+    assert_clean(&diags);
+}
+
+/// Member access through a containing object property (the ofetch shape:
+/// `context.options.body`), with truthiness + `in` + `delete` narrowing flows.
+#[test]
+fn imported_generic_interface_member_after_narrowing_flows() {
+    let diags = check(
+        r#"
+export interface CoreOpts<R extends string = string, T = any> {
+  payload?: string;
+  selector?: Record<string, any>;
+  mode?: "half" | undefined;
+  budget?: number;
+}
+export interface FullOpts<R extends string = string, T = any> extends CoreOpts<R, T> {
+  labels: Headers;
+}
+export interface Carrier {
+  target: string | Request;
+  options: FullOpts;
+}
+"#,
+        r#"
+import type { Carrier } from "./defs";
+export function go(carrier: Carrier) {
+  if (typeof carrier.target === "string") {
+    if (carrier.options.selector) {
+      delete carrier.options.selector;
+    }
+    if ("selector" in carrier.options) {
+      delete carrier.options.selector;
+    }
+  }
+  if (carrier.options.payload) {
+    if (!("mode" in carrier.options)) {
+      carrier.options.mode = "half";
+    }
+  }
+  if (carrier.options.budget) {
+    carrier.options.budget.toFixed();
+  }
+}
+"#,
+    );
+    assert_clean(&diags);
+}
+
+/// Same-file control: the cross-module delegation must not disturb the
+/// already-working local path.
+#[test]
+fn same_file_generic_interface_heritage_still_resolves() {
+    let diags = check(
+        r#"export const unrelated = 1;"#,
+        r#"
+interface Inner<Q extends string = string> {
+  data?: string;
+  flag?: boolean;
+}
+interface Outer<Q extends string = string> extends Inner<Q> {
+  tags: Headers;
+}
+export function go(o: Outer) {
+  if (o.data) {
+    o.data.toUpperCase();
+  }
+  o.flag;
+  o.tags;
+}
+"#,
+    );
+    assert_clean(&diags);
+}
+
+/// Concrete (non-generic) imported interface control — already worked before
+/// the delegation fix and must keep working.
+#[test]
+fn imported_concrete_interface_inherited_member_resolves() {
+    let diags = check(
+        r#"
+export interface Floor { area?: number; }
+export interface Room extends Floor { door: string; }
+"#,
+        r#"
+import type { Room } from "./defs";
+export function go(r: Room) {
+  r.door;
+  r.area;
+}
+"#,
+    );
+    assert_clean(&diags);
+}
+
+/// Negative control: a genuinely missing member still reports TS2339.
+#[test]
+fn imported_generic_interface_missing_member_still_errors() {
+    let diags = check(
+        r#"
+export interface Seed<V = any> { kernel?: V; }
+export interface Plant<V = any> extends Seed<V> { stem: string; }
+"#,
+        r#"
+import type { Plant } from "./defs";
+declare const p: Plant;
+p.stem;
+p.kernel;
+p.absent;
+"#,
+    );
+    let property_errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE)
+        .collect();
+    assert_eq!(
+        property_errors.len(),
+        1,
+        "expected exactly one TS2339 for the genuinely missing member, got: {:?}",
+        family_errors(&diags),
+    );
+    assert!(
+        property_errors[0].message_text.contains("'absent'"),
+        "the surviving TS2339 must be for the missing member, got: {:?}",
+        property_errors[0].message_text,
+    );
+}
+
+/// `delete` on a declared-optional property stays legal even when a
+/// truthiness or `in` guard narrowed the receiver (tsz's narrowing promotes
+/// the slot to required in a synthetic intersection; tsc checks the declared
+/// property symbol, so no TS2790).
+#[test]
+fn delete_of_declared_optional_property_after_guard_is_legal() {
+    let diags = check(
+        r#"
+export interface Knobs<R extends string = string> {
+  filter?: Record<string, any>;
+  extras?: Record<string, any>;
+}
+"#,
+        r#"
+import type { Knobs } from "./defs";
+interface Holder { cfg: Knobs }
+export function go(h: Holder) {
+  if (h.cfg.filter) {
+    delete h.cfg.filter;
+  }
+  if ("extras" in h.cfg) {
+    delete h.cfg.extras;
+  }
+}
+"#,
+    );
+    let delete_errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::THE_OPERAND_OF_A_DELETE_OPERATOR_MUST_BE_OPTIONAL)
+        .collect();
+    assert!(
+        delete_errors.is_empty(),
+        "declared-optional properties stay deletable after narrowing, got: {delete_errors:?}",
+    );
+}
+
+/// Positive TS2790 control: deleting a genuinely required property still
+/// errors — the declared-type re-check must not swallow real violations.
+#[test]
+fn delete_of_required_property_still_errors() {
+    let diags = check(
+        r#"export interface Fixed { anchor: number; }"#,
+        r#"
+import type { Fixed } from "./defs";
+export function go(f: Fixed) {
+  delete f.anchor;
+}
+"#,
+    );
+    let delete_errors: Vec<_> = diags
+        .iter()
+        .filter(|d| d.code == diagnostic_codes::THE_OPERAND_OF_A_DELETE_OPERATOR_MUST_BE_OPTIONAL)
+        .collect();
+    assert_eq!(
+        delete_errors.len(),
+        1,
+        "deleting a required property must still report TS2790, got: {:?}",
+        family_errors(&diags),
+    );
+}

--- a/crates/tsz-checker/src/types/computation/delete_optionality.rs
+++ b/crates/tsz-checker/src/types/computation/delete_optionality.rs
@@ -1,0 +1,144 @@
+//! TS2790: `delete` operand optionality checking.
+//!
+//! In `strictNullChecks`, `delete obj.prop` is only legal when the property
+//! is optional (or, with `exactOptionalPropertyTypes` disabled, when its
+//! declared type includes `undefined`). `tsc` resolves the deleted
+//! property's *declared* symbol and checks its declared type — flow
+//! narrowing of the receiver is irrelevant. tsz's truthiness/`in` narrowing
+//! intersects the receiver with a synthetic required slot, so a
+//! declared-optional property can look required at the delete site; the
+//! check therefore re-validates against the un-narrowed (write-context)
+//! receiver before reporting.
+
+use crate::context::TypingRequest;
+use crate::query_boundaries::common::PropertyAccessResult;
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Report TS2790 when the operand of a `delete` expression is a
+    /// non-optional property whose declared type does not include
+    /// `undefined`.
+    ///
+    /// `operand_type` is the (possibly narrowed) type already computed for
+    /// the operand expression; `operand_idx` is the property/element access
+    /// node (parentheses already skipped by the caller).
+    pub(crate) fn check_delete_operand_optionality(
+        &mut self,
+        operand_idx: NodeIndex,
+        operand_type: TypeId,
+    ) {
+        let Some(operand_node) = self.ctx.arena.get(operand_idx) else {
+            return;
+        };
+        if operand_node.kind != syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            && operand_node.kind != syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        {
+            return;
+        }
+        let Some(access) = self.ctx.arena.get_access_expr(operand_node) else {
+            return;
+        };
+
+        let prop_name = self
+            .ctx
+            .arena
+            .get_identifier_at(access.name_or_argument)
+            .map(|ident| ident.escaped_text.clone())
+            .or_else(|| self.get_literal_string_from_node(access.name_or_argument))
+            .or_else(|| {
+                self.get_literal_index_from_node(access.name_or_argument)
+                    .map(|idx| idx.to_string())
+            });
+        let Some(prop_name) = prop_name else {
+            return;
+        };
+
+        let mut object_type = self.get_type_of_node(access.expression);
+        let uses_optional_chain_base = access.question_dot_token
+            || crate::computation::access::is_optional_chain(self.ctx.arena, access.expression);
+        if uses_optional_chain_base {
+            let (non_nullish, _) = self.split_nullish_type(object_type);
+            if let Some(non_nullish) = non_nullish {
+                object_type = non_nullish;
+            }
+        }
+
+        if object_type == TypeId::ANY
+            || object_type == TypeId::UNKNOWN
+            || object_type == TypeId::ERROR
+            || object_type == TypeId::NEVER
+        {
+            return;
+        }
+
+        let property_result = self.resolve_property_access_with_env(object_type, &prop_name);
+        let (prop_type, from_idx_sig) = match property_result {
+            PropertyAccessResult::Success {
+                type_id,
+                from_index_signature,
+                ..
+            } => {
+                let prop_type = if uses_optional_chain_base
+                    || operand_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+                {
+                    type_id
+                } else {
+                    operand_type
+                };
+                (prop_type, from_index_signature)
+            }
+            _ => (operand_type, false),
+        };
+
+        if prop_type == TypeId::ANY
+            || prop_type == TypeId::UNKNOWN
+            || prop_type == TypeId::NEVER
+            || prop_type == TypeId::ERROR
+        {
+            return;
+        }
+
+        let is_mapped =
+            crate::query_boundaries::common::is_mapped_type(self.ctx.types, object_type);
+        if from_idx_sig || is_mapped {
+            return;
+        }
+
+        let is_optional = self.is_property_optional(object_type, &prop_name);
+        let type_includes_undefined =
+            crate::query_boundaries::class_type::type_includes_undefined(self.ctx.types, prop_type);
+        if is_optional || type_includes_undefined {
+            return;
+        }
+
+        // The narrowed receiver says "required"; re-check against the
+        // declared (un-narrowed, write-context) receiver. tsc keys TS2790 off
+        // the declared property symbol, so truthiness/`in` narrowing that
+        // promoted the slot to required must not produce the error.
+        let declared_object = self
+            .get_type_of_node_with_request(access.expression, &TypingRequest::for_write_context());
+        let declared_object = self.evaluate_type_with_resolution(declared_object);
+        let declared_deletable = declared_object != object_type
+            && (self.is_property_optional(declared_object, &prop_name)
+                || matches!(
+                    self.resolve_property_access_with_env(declared_object, &prop_name),
+                    PropertyAccessResult::Success { type_id, .. }
+                        if crate::query_boundaries::class_type::type_includes_undefined(
+                            self.ctx.types,
+                            type_id,
+                        )
+                ));
+        if declared_deletable {
+            return;
+        }
+
+        self.error_at_node(
+            operand_idx,
+            crate::diagnostics::diagnostic_messages::THE_OPERAND_OF_A_DELETE_OPERATOR_MUST_BE_OPTIONAL,
+            crate::diagnostics::diagnostic_codes::THE_OPERAND_OF_A_DELETE_OPERATOR_MUST_BE_OPTIONAL,
+        );
+    }
+}

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -707,94 +707,9 @@ impl<'a> CheckerState<'a> {
                 // With exactOptionalPropertyTypes disabled, properties whose declared type
                 // includes `undefined` are also treated as deletable.
                 // tsc also exempts: any/unknown/never property types, index signature properties.
-                if !has_readonly_delete_error
-                    && self.ctx.compiler_options.strict_null_checks
-                    && let Some(operand_node) = self.ctx.arena.get(operand_idx)
-                    && (operand_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-                        || operand_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION)
-                    && let Some(access) = self.ctx.arena.get_access_expr(operand_node)
-                {
-                    use crate::query_boundaries::common::PropertyAccessResult;
-
-                    let prop_name = self
-                        .ctx
-                        .arena
-                        .get_identifier_at(access.name_or_argument)
-                        .map(|ident| ident.escaped_text.clone())
-                        .or_else(|| self.get_literal_string_from_node(access.name_or_argument))
-                        .or_else(|| {
-                            self.get_literal_index_from_node(access.name_or_argument)
-                                .map(|idx| idx.to_string())
-                        });
-
-                    if let Some(prop_name) = prop_name {
-                        let mut object_type = self.get_type_of_node(access.expression);
-                        let uses_optional_chain_base = access.question_dot_token
-                            || crate::computation::access::is_optional_chain(
-                                self.ctx.arena,
-                                access.expression,
-                            );
-                        if uses_optional_chain_base {
-                            let (non_nullish, _) = self.split_nullish_type(object_type);
-                            if let Some(non_nullish) = non_nullish {
-                                object_type = non_nullish;
-                            }
-                        }
-
-                        if object_type != TypeId::ANY
-                            && object_type != TypeId::UNKNOWN
-                            && object_type != TypeId::ERROR
-                            && object_type != TypeId::NEVER
-                        {
-                            let property_result =
-                                self.resolve_property_access_with_env(object_type, &prop_name);
-                            let (prop_type, from_idx_sig) = match property_result {
-                                PropertyAccessResult::Success {
-                                    type_id,
-                                    from_index_signature,
-                                    ..
-                                } => {
-                                    let prop_type = if uses_optional_chain_base
-                                        || operand_node.kind
-                                            == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
-                                    {
-                                        type_id
-                                    } else {
-                                        operand_type
-                                    };
-                                    (prop_type, from_index_signature)
-                                }
-                                _ => (operand_type, false),
-                            };
-
-                            if prop_type != TypeId::ANY
-                                && prop_type != TypeId::UNKNOWN
-                                && prop_type != TypeId::NEVER
-                                && prop_type != TypeId::ERROR
-                            {
-                                let is_mapped = crate::query_boundaries::common::is_mapped_type(
-                                    self.ctx.types,
-                                    object_type,
-                                );
-                                if !from_idx_sig && !is_mapped {
-                                    let is_optional =
-                                        self.is_property_optional(object_type, &prop_name);
-                                    let type_includes_undefined =
-                                        crate::query_boundaries::class_type::type_includes_undefined(
-                                            self.ctx.types,
-                                            prop_type,
-                                        );
-                                    if !is_optional && !type_includes_undefined {
-                                        self.error_at_node(
-                                            operand_idx,
-                                            crate::diagnostics::diagnostic_messages::THE_OPERAND_OF_A_DELETE_OPERATOR_MUST_BE_OPTIONAL,
-                                            crate::diagnostics::diagnostic_codes::THE_OPERAND_OF_A_DELETE_OPERATOR_MUST_BE_OPTIONAL,
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
+                // See `delete_optionality.rs` for the structural rule.
+                if !has_readonly_delete_error && self.ctx.compiler_options.strict_null_checks {
+                    self.check_delete_operand_optionality(operand_idx, operand_type);
                 }
 
                 TypeId::BOOLEAN

--- a/crates/tsz-checker/src/types/computation/mod.rs
+++ b/crates/tsz-checker/src/types/computation/mod.rs
@@ -46,6 +46,7 @@ mod complex_contextual_new;
 pub(crate) mod complex_js_constructor;
 pub(crate) mod complex_new_target;
 pub(crate) mod contextual;
+pub(crate) mod delete_optionality;
 pub(crate) mod expression_guards;
 pub(crate) mod generic_new_inference;
 pub mod helpers;


### PR DESCRIPTION
AgentName: dazzling-johnson

Track: Project corpus — ofetch false-positive paydown (imported-generic-interface member-lookup campaign)

Invariant: `delete obj.prop` is legal whenever the *declared* property is optional (or its declared type includes `undefined`); flow narrowing of the receiver must not change `delete` legality. When a truthiness or `in` guard narrows a receiver, tsz intersects it with a synthetic required slot — TS2790 must not key off that narrowed shape.

Scope:
- `crates/tsz-checker/src/types/computation/delete_optionality.rs` (new) — TS2790 check extracted from `helpers.rs` (which would otherwise cross the 2000-line cap) and extended with a declared-receiver re-check.
- `crates/tsz-checker/src/types/computation/helpers.rs` — delete-check block replaced with a call.
- `crates/tsz-checker/src/tests/cross_module_generic_interface_heritage_tests.rs` (new) + `lib.rs` registration — TS2790 fix pins plus cross-module generic-interface heritage member-resolution pins (renamed binders throughout).

## Summary

Structural rule (fixed here): When `<receiver narrowed by truthiness/`in` guard>.prop` is deleted and the declared property is optional, tsc reports nothing; tsz now matches by re-validating the would-be TS2790 against the un-narrowed (write-context) receiver type through the checker's `TypingRequest::for_write_context()` path. Genuinely required properties still error (negative control pinned).

Witness (was a false TS2790, now clean; tsc-clean verified with 5.9.3):

```ts
interface RO { query?: Record<string, any> }
declare const o: RO;
if ("query" in o) { delete o.query; }   // tsz previously: TS2790
if (o.query) { delete o.query; }        // tsz previously: TS2790
```

Adjacent matrix in the new test file: in-guard delete, truthy-guard delete, renamed binders, cross-file and same-file interfaces, required-property delete still errors (TS2790 positive control), genuinely missing member still errors (TS2339 negative control).

### Campaign findings: the ofetch TS2339 family (investigated, not yet fixed — root cause documented)

The dominant ofetch family (~22 false TS2339 on `ResolvedFetchOptions<R>` / `FetchResponse<T>` members) was re-triaged from scratch. The prior "in/delete-narrowing intersection" hypothesis is wrong in mechanism — narrowing is incidental. Confirmed structural rule:

> When a *generic* interface declared in another program module (with an `extends` clause) is referenced from an importing file, tsc resolves it in its declaring module including heritage. tsz's `type_reference_symbol_type_with_params` INTERFACE branch lowers the foreign declarations locally; `merge_interface_heritage_types` reads only `self.ctx.arena` (a no-op for foreign decls), and the `merge_lib_interface_heritage` fallback resolves the bare name through the importing file's locals — hitting the *import alias* (which has no interface declarations) — so every inherited member is silently dropped. Minimal witness: two files, `export interface Base<R> { body?: string }` + `export interface RO<R> extends Base<R> { own: number }`, `import type { RO }`, `declare const r: RO; r.body` → false TS2339 (own members resolve; inherited do not; same-file and non-generic-derived forms are unaffected).

Two candidate fixes were built and measured against fresh per-project baselines; both were rejected on canary evidence and are documented here so the next iteration starts from data:

| approach | ofetch | kysely | valibot | msw | ts-rest | verdict |
| --- | --- | --- | --- | --- | --- | --- |
| delegate all cross-module interfaces to declaring checker | −15 | +12 | +409 | +1 | +7 | rejected (identity churn project-wide) |
| delegate only foreign-decl-has-`extends` (+def body registration) | −1 | +8 | −8 | +1 | 0 | rejected (eval-cache ordering blocks the cascade; kysely churn) |
| ship TS2790 fix only (this PR) | 0 | 0 | 0 | 0 | 0 | shipped |

Remaining blocker for the family: the receiver's `Application(Lazy(def), args)` is evaluated (and its failure cached in the env/application eval caches) *before* any heritage-merged body is registered for the def; later registration does not invalidate those caches. A durable fix needs def-body registration ordering / cache-invalidation work in the solver-env boundary, not another merge call-site. The TS2339 declare-const pins in the new test file hold the currently-working forms; the broken parameter-annotation form is documented in the test module docs and reproduced by the ofetch row.

## Project Corpus Impact

- Row: ofetch (46 → 46 on this PR; family root-caused with rejected-fix canary data for the next iteration)
- Bug family: false TS2790 on delete of declared-optional property after truthiness/`in` narrowing; cross-module generic-interface heritage member drop (documented)

Goal: hold

## Verification

- `cargo nextest run -p tsz-checker -E 'test(cross_module_generic_interface_heritage) or test(delete)'` → 19 passed.
- Conformance narrow filters: `deleteOperator` 8/8, `inOperator` 5/5, `delete` substring 13/13 — all pass, 0 known failures.
- Canary rows (dist-fast, fresh per-binary baselines on this base, pre → post): ofetch 46→46, kysely 135→135, msw 211→211, valibot 1821→1821, ts-rest 31→31, comlink 3→3, zod 54→54, effect 0→0, ts-toolbelt 0→0, drizzle-orm 5338→5338.
- CLI witnesses: same-file in-guard delete TS2790 false positive (m1) now clean and tsc-parity-verified (tsc 5.9.3 exit 0).
- Focused checker suites (`cross_file|narrowing|property|delete|heritage`, 2154 tests): 4 failures, all reproduced on clean main (pre-existing; verified by reverse-applying the fix).
- `python3 scripts/arch/arch_guard.py` → passed. `cargo clippy --profile ci-lint -p tsz-checker --all-targets` → clean.

## Coordination Notes

- Campaign status: 8 PRs landed previously; #13151/#13170 were queued at task start and have since landed (this branch is rebuilt on top of current main, post-merge, with fresh baselines).
- Parallel agents own the ofetch TS5097 export-from family and the unique-symbol-members family — no file overlap with this PR.
- The cross-module generic-interface heritage family (the remaining ~9–22 ofetch TS2339s, incl. the transitive `Omit<...>` base drop) stays open; this PR's Summary carries the confirmed structural rule, minimal witnesses, and the canary data for both rejected fixes so the next owner does not repeat them.

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: high
