### PR TITLE
perf(parser): avoid cloning arena child lists for parent links

### DIFF
--- a/crates/tsz-parser/src/parser/node_arena/declarations.rs
+++ b/crates/tsz-parser/src/parser/node_arena/declarations.rs
@@ -12,50 +12,45 @@ use crate::parser::node::{
 impl NodeArenaInner {
     /// Add a function node
     pub fn add_function(&mut self, kind: u16, pos: u32, end: u32, data: FunctionData) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let name = data.name;
-        let type_parameters = data.type_parameters.clone();
-        let parameters = data.parameters.clone();
         let type_annotation = data.type_annotation;
         let body = data.body;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(name, parent);
+        self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
+        self.set_parent_list(&data.parameters, parent);
+        self.set_parent(type_annotation, parent);
+        self.set_parent(body, parent);
 
         let data_index = self.len_u32(self.functions.len());
         self.functions.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent_opt_list(type_parameters.as_ref(), parent);
-        self.set_parent_list(&parameters, parent);
-        self.set_parent(type_annotation, parent);
-        self.set_parent(body, parent);
 
         parent
     }
 
     /// Add a class node
     pub fn add_class(&mut self, kind: u16, pos: u32, end: u32, data: ClassData) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let name = data.name;
-        let type_parameters = data.type_parameters.clone();
-        let heritage_clauses = data.heritage_clauses.clone();
-        let members = data.members.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(name, parent);
+        self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
+        self.set_parent_opt_list(data.heritage_clauses.as_ref(), parent);
+        self.set_parent_list(&data.members, parent);
 
         let data_index = self.len_u32(self.classes.len());
         self.classes.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent_opt_list(type_parameters.as_ref(), parent);
-        self.set_parent_opt_list(heritage_clauses.as_ref(), parent);
-        self.set_parent_list(&members, parent);
 
         parent
     }
@@ -68,24 +63,21 @@ impl NodeArenaInner {
         end: u32,
         data: InterfaceData,
     ) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let name = data.name;
-        let type_parameters = data.type_parameters.clone();
-        let heritage_clauses = data.heritage_clauses.clone();
-        let members = data.members.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(name, parent);
+        self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
+        self.set_parent_opt_list(data.heritage_clauses.as_ref(), parent);
+        self.set_parent_list(&data.members, parent);
 
         let data_index = self.len_u32(self.interfaces.len());
         self.interfaces.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent_opt_list(type_parameters.as_ref(), parent);
-        self.set_parent_opt_list(heritage_clauses.as_ref(), parent);
-        self.set_parent_list(&members, parent);
 
         parent
     }
@@ -98,42 +90,40 @@ impl NodeArenaInner {
         end: u32,
         data: TypeAliasData,
     ) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let name = data.name;
-        let type_parameters = data.type_parameters.clone();
         let type_node = data.type_node;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(name, parent);
+        self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
+        self.set_parent(type_node, parent);
 
         let data_index = self.len_u32(self.type_aliases.len());
         self.type_aliases.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent_opt_list(type_parameters.as_ref(), parent);
-        self.set_parent(type_node, parent);
 
         parent
     }
 
     /// Add an enum declaration node
     pub fn add_enum(&mut self, kind: u16, pos: u32, end: u32, data: EnumData) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let name = data.name;
-        let members = data.members.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(name, parent);
+        self.set_parent_list(&data.members, parent);
 
         let data_index = self.len_u32(self.enums.len());
         self.enums.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent_list(&members, parent);
 
         parent
     }
@@ -164,20 +154,20 @@ impl NodeArenaInner {
 
     /// Add a module declaration node
     pub fn add_module(&mut self, kind: u16, pos: u32, end: u32, data: ModuleData) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let name = data.name;
         let body = data.body;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(name, parent);
+        self.set_parent(body, parent);
 
         let data_index = self.len_u32(self.modules.len());
         self.modules.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent(body, parent);
 
         parent
     }
@@ -190,16 +180,16 @@ impl NodeArenaInner {
         end: u32,
         data: ModuleBlockData,
     ) -> NodeIndex {
-        let statements = data.statements.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.statements.as_ref(), parent);
 
         let data_index = self.len_u32(self.module_blocks.len());
         self.module_blocks.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(statements.as_ref(), parent);
 
         parent
     }
@@ -218,19 +208,18 @@ impl NodeArenaInner {
         data: VariableData,
         flags: u16,
     ) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
-        let declarations = data.declarations.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent_list(&data.declarations, parent);
 
         let data_index = self.len_u32(self.variables.len());
         self.variables.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes
             .push(Node::with_data_and_flags(kind, pos, end, data_index, flags));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent_list(&declarations, parent);
 
         parent
     }

--- a/crates/tsz-parser/src/parser/node_arena/expressions.rs
+++ b/crates/tsz-parser/src/parser/node_arena/expressions.rs
@@ -88,19 +88,18 @@ impl NodeArenaInner {
         data: CallExprData,
     ) -> NodeIndex {
         let expression = data.expression;
-        let type_arguments = data.type_arguments.clone();
-        let arguments = data.arguments.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent(expression, parent);
+        self.set_parent_opt_list(data.type_arguments.as_ref(), parent);
+        self.set_parent_opt_list(data.arguments.as_ref(), parent);
 
         let data_index = self.len_u32(self.call_exprs.len());
         self.call_exprs.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        self.set_parent_opt_list(type_arguments.as_ref(), parent);
-        self.set_parent_opt_list(arguments.as_ref(), parent);
 
         parent
     }
@@ -183,15 +182,16 @@ impl NodeArenaInner {
         end: u32,
         data: LiteralExprData,
     ) -> NodeIndex {
-        let elements = data.elements.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_list(&data.elements, parent);
 
         let data_index = self.len_u32(self.literal_exprs.len());
         self.literal_exprs.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent_list(&elements, parent);
         parent
     }
 
@@ -264,17 +264,17 @@ impl NodeArenaInner {
         data: TemplateExprData,
     ) -> NodeIndex {
         let head = data.head;
-        let template_spans = data.template_spans.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent(head, parent);
+        self.set_parent_list(&data.template_spans, parent);
 
         let data_index = self.len_u32(self.template_exprs.len());
         self.template_exprs.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(head, parent);
-        self.set_parent_list(&template_spans, parent);
 
         parent
     }
@@ -312,19 +312,19 @@ impl NodeArenaInner {
         data: TaggedTemplateData,
     ) -> NodeIndex {
         let tag = data.tag;
-        let type_arguments = data.type_arguments.clone();
         let template = data.template;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent(tag, parent);
+        self.set_parent_opt_list(data.type_arguments.as_ref(), parent);
+        self.set_parent(template, parent);
 
         let data_index = self.len_u32(self.tagged_templates.len());
         self.tagged_templates.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(tag, parent);
-        self.set_parent_opt_list(type_arguments.as_ref(), parent);
-        self.set_parent(template, parent);
 
         parent
     }
@@ -338,15 +338,17 @@ impl NodeArenaInner {
         data: ExprWithTypeArgsData,
     ) -> NodeIndex {
         let expression = data.expression;
-        let type_arguments = data.type_arguments.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent(expression, parent);
+        self.set_parent_opt_list(data.type_arguments.as_ref(), parent);
+
         let data_index = self.len_u32(self.expr_with_type_args.len());
         self.expr_with_type_args.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        self.set_parent_opt_list(type_arguments.as_ref(), parent);
         parent
     }
 

--- a/crates/tsz-parser/src/parser/node_arena/imports_exports.rs
+++ b/crates/tsz-parser/src/parser/node_arena/imports_exports.rs
@@ -18,21 +18,22 @@ impl NodeArenaInner {
         end: u32,
         data: ImportDeclData,
     ) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let import_clause = data.import_clause;
         let module_specifier = data.module_specifier;
         let attributes = data.attributes;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(import_clause, parent);
+        self.set_parent(module_specifier, parent);
+        self.set_parent(attributes, parent);
 
         let data_index = self.len_u32(self.import_decls.len());
         self.import_decls.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(import_clause, parent);
-        self.set_parent(module_specifier, parent);
-        self.set_parent(attributes, parent);
         parent
     }
 
@@ -67,16 +68,17 @@ impl NodeArenaInner {
         data: NamedImportsData,
     ) -> NodeIndex {
         let name = data.name;
-        let elements = data.elements.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent(name, parent);
+        self.set_parent_list(&data.elements, parent);
 
         let data_index = self.len_u32(self.named_imports.len());
         self.named_imports.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(name, parent);
-        self.set_parent_list(&elements, parent);
         parent
     }
 
@@ -110,21 +112,22 @@ impl NodeArenaInner {
         end: u32,
         data: ExportDeclData,
     ) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let export_clause = data.export_clause;
         let module_specifier = data.module_specifier;
         let attributes = data.attributes;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(export_clause, parent);
+        self.set_parent(module_specifier, parent);
+        self.set_parent(attributes, parent);
 
         let data_index = self.len_u32(self.export_decls.len());
         self.export_decls.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(export_clause, parent);
-        self.set_parent(module_specifier, parent);
-        self.set_parent(attributes, parent);
         parent
     }
 
@@ -136,17 +139,18 @@ impl NodeArenaInner {
         end: u32,
         data: ExportAssignmentData,
     ) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let expression = data.expression;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(expression, parent);
 
         let data_index = self.len_u32(self.export_assignments.len());
         self.export_assignments.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(expression, parent);
         parent
     }
 
@@ -158,15 +162,16 @@ impl NodeArenaInner {
         end: u32,
         data: ImportAttributesData,
     ) -> NodeIndex {
-        let elements = data.elements.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_list(&data.elements, parent);
 
         let data_index = self.len_u32(self.import_attributes.len());
         self.import_attributes.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent_list(&elements, parent);
         parent
     }
 

--- a/crates/tsz-parser/src/parser/node_arena/jsx.rs
+++ b/crates/tsz-parser/src/parser/node_arena/jsx.rs
@@ -19,19 +19,19 @@ impl NodeArenaInner {
         data: JsxElementData,
     ) -> NodeIndex {
         let opening_element = data.opening_element;
-        let children = data.children.clone();
         let closing_element = data.closing_element;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent(opening_element, parent);
+        self.set_parent_list(&data.children, parent);
+        self.set_parent(closing_element, parent);
 
         let data_index = self.len_u32(self.jsx_elements.len());
         self.jsx_elements.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(opening_element, parent);
-        self.set_parent_list(&children, parent);
-        self.set_parent(closing_element, parent);
         parent
     }
 
@@ -44,19 +44,19 @@ impl NodeArenaInner {
         data: JsxOpeningData,
     ) -> NodeIndex {
         let tag_name = data.tag_name;
-        let type_arguments = data.type_arguments.clone();
         let attributes = data.attributes;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent(tag_name, parent);
+        self.set_parent_opt_list(data.type_arguments.as_ref(), parent);
+        self.set_parent(attributes, parent);
 
         let data_index = self.len_u32(self.jsx_opening.len());
         self.jsx_opening.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(tag_name, parent);
-        self.set_parent_opt_list(type_arguments.as_ref(), parent);
-        self.set_parent(attributes, parent);
         parent
     }
 
@@ -90,19 +90,19 @@ impl NodeArenaInner {
         data: JsxFragmentData,
     ) -> NodeIndex {
         let opening_fragment = data.opening_fragment;
-        let children = data.children.clone();
         let closing_fragment = data.closing_fragment;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent(opening_fragment, parent);
+        self.set_parent_list(&data.children, parent);
+        self.set_parent(closing_fragment, parent);
 
         let data_index = self.len_u32(self.jsx_fragments.len());
         self.jsx_fragments.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(opening_fragment, parent);
-        self.set_parent_list(&children, parent);
-        self.set_parent(closing_fragment, parent);
         parent
     }
 
@@ -114,16 +114,16 @@ impl NodeArenaInner {
         end: u32,
         data: JsxAttributesData,
     ) -> NodeIndex {
-        let properties = data.properties.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_list(&data.properties, parent);
 
         let data_index = self.len_u32(self.jsx_attributes.len());
         self.jsx_attributes.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_list(&properties, parent);
         parent
     }
 

--- a/crates/tsz-parser/src/parser/node_arena/members.rs
+++ b/crates/tsz-parser/src/parser/node_arena/members.rs
@@ -19,24 +19,22 @@ impl NodeArenaInner {
         end: u32,
         data: SignatureData,
     ) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let name = data.name;
-        let type_parameters = data.type_parameters.clone();
-        let parameters = data.parameters.clone();
         let type_annotation = data.type_annotation;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(name, parent);
+        self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
+        self.set_parent_opt_list(data.parameters.as_ref(), parent);
+        self.set_parent(type_annotation, parent);
 
         let data_index = self.len_u32(self.signatures.len());
         self.signatures.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent_opt_list(type_parameters.as_ref(), parent);
-        self.set_parent_opt_list(parameters.as_ref(), parent);
-        self.set_parent(type_annotation, parent);
 
         parent
     }
@@ -49,20 +47,19 @@ impl NodeArenaInner {
         end: u32,
         data: IndexSignatureData,
     ) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
-        let parameters = data.parameters.clone();
         let type_annotation = data.type_annotation;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent_list(&data.parameters, parent);
+        self.set_parent(type_annotation, parent);
 
         let data_index = self.len_u32(self.index_signatures.len());
         self.index_signatures.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent_list(&parameters, parent);
-        self.set_parent(type_annotation, parent);
 
         parent
     }
@@ -75,21 +72,22 @@ impl NodeArenaInner {
         end: u32,
         data: PropertyDeclData,
     ) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let name = data.name;
         let type_annotation = data.type_annotation;
         let initializer = data.initializer;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(name, parent);
+        self.set_parent(type_annotation, parent);
+        self.set_parent(initializer, parent);
 
         let data_index = self.len_u32(self.property_decls.len());
         self.property_decls.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent(type_annotation, parent);
-        self.set_parent(initializer, parent);
         parent
     }
 
@@ -101,25 +99,24 @@ impl NodeArenaInner {
         end: u32,
         data: MethodDeclData,
     ) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let name = data.name;
-        let type_parameters = data.type_parameters.clone();
-        let parameters = data.parameters.clone();
         let type_annotation = data.type_annotation;
         let body = data.body;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(name, parent);
+        self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
+        self.set_parent_list(&data.parameters, parent);
+        self.set_parent(type_annotation, parent);
+        self.set_parent(body, parent);
 
         let data_index = self.len_u32(self.method_decls.len());
         self.method_decls.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent_opt_list(type_parameters.as_ref(), parent);
-        self.set_parent_list(&parameters, parent);
-        self.set_parent(type_annotation, parent);
-        self.set_parent(body, parent);
         parent
     }
 
@@ -131,46 +128,43 @@ impl NodeArenaInner {
         end: u32,
         data: ConstructorData,
     ) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
-        let type_parameters = data.type_parameters.clone();
-        let parameters = data.parameters.clone();
         let body = data.body;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
+        self.set_parent_list(&data.parameters, parent);
+        self.set_parent(body, parent);
 
         let data_index = self.len_u32(self.constructors.len());
         self.constructors.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent_opt_list(type_parameters.as_ref(), parent);
-        self.set_parent_list(&parameters, parent);
-        self.set_parent(body, parent);
         parent
     }
 
     /// Add an accessor declaration node (get/set)
     pub fn add_accessor(&mut self, kind: u16, pos: u32, end: u32, data: AccessorData) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let name = data.name;
-        let type_parameters = data.type_parameters.clone();
-        let parameters = data.parameters.clone();
         let type_annotation = data.type_annotation;
         let body = data.body;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(name, parent);
+        self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
+        self.set_parent_list(&data.parameters, parent);
+        self.set_parent(type_annotation, parent);
+        self.set_parent(body, parent);
 
         let data_index = self.len_u32(self.accessors.len());
         self.accessors.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent_opt_list(type_parameters.as_ref(), parent);
-        self.set_parent_list(&parameters, parent);
-        self.set_parent(type_annotation, parent);
-        self.set_parent(body, parent);
 
         parent
     }
@@ -186,18 +180,20 @@ impl NodeArenaInner {
         let name = data.name;
         let type_annotation = data.type_annotation;
         let initializer = data.initializer;
-        let modifiers = data.modifiers.clone();
-        let data_index = self.len_u32(self.parameters.len());
-        self.parameters.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
         // Set parent pointers for children
         self.set_parent(name, parent);
         self.set_parent(type_annotation, parent);
         self.set_parent(initializer, parent);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+
+        let data_index = self.len_u32(self.parameters.len());
+        self.parameters.push(data);
+        let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
+        self.nodes.push(Node::with_data(kind, pos, end, data_index));
+        self.extended_info.push(ExtendedNodeInfo::default());
         parent
     }
 
@@ -209,22 +205,22 @@ impl NodeArenaInner {
         end: u32,
         data: TypeParameterData,
     ) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let name = data.name;
         let constraint = data.constraint;
         let default = data.default;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(name, parent);
+        self.set_parent(constraint, parent);
+        self.set_parent(default, parent);
 
         let data_index = self.len_u32(self.type_parameters.len());
         self.type_parameters.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent(constraint, parent);
-        self.set_parent(default, parent);
 
         parent
     }
@@ -250,14 +246,16 @@ impl NodeArenaInner {
 
     /// Add a heritage clause node
     pub fn add_heritage(&mut self, kind: u16, pos: u32, end: u32, data: HeritageData) -> NodeIndex {
-        let types = data.types.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_list(&data.types, parent);
+
         let data_index = self.len_u32(self.heritage_clauses.len());
         self.heritage_clauses.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent_list(&types, parent);
         parent
     }
 }

--- a/crates/tsz-parser/src/parser/node_arena/mod.rs
+++ b/crates/tsz-parser/src/parser/node_arena/mod.rs
@@ -308,19 +308,19 @@ impl NodeArenaInner {
     /// Add a source file node
     pub fn add_source_file(&mut self, pos: u32, end: u32, data: SourceFileData) -> NodeIndex {
         use super::syntax_kind_ext::SOURCE_FILE;
-        let statements = data.statements.clone();
         let end_of_file_token = data.end_of_file_token;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_list(&data.statements, parent);
+        self.set_parent(end_of_file_token, parent);
 
         let data_index = self.len_u32(self.source_files.len());
         self.source_files.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes
             .push(Node::with_data(SOURCE_FILE, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_list(&statements, parent);
-        self.set_parent(end_of_file_token, parent);
 
         parent
     }

--- a/crates/tsz-parser/src/parser/node_arena/patterns.rs
+++ b/crates/tsz-parser/src/parser/node_arena/patterns.rs
@@ -16,15 +16,16 @@ impl NodeArenaInner {
         end: u32,
         data: BindingPatternData,
     ) -> NodeIndex {
-        let elements = data.elements.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_list(&data.elements, parent);
 
         let data_index = self.len_u32(self.binding_patterns.len());
         self.binding_patterns.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent_list(&elements, parent);
         parent
     }
 
@@ -60,19 +61,20 @@ impl NodeArenaInner {
         end: u32,
         data: PropertyAssignmentData,
     ) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let name = data.name;
         let initializer = data.initializer;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(name, parent);
+        self.set_parent(initializer, parent);
 
         let data_index = self.len_u32(self.property_assignments.len());
         self.property_assignments.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent(initializer, parent);
         parent
     }
 
@@ -84,19 +86,20 @@ impl NodeArenaInner {
         end: u32,
         data: ShorthandPropertyData,
     ) -> NodeIndex {
-        let modifiers = data.modifiers.clone();
         let name = data.name;
         let object_assignment_initializer = data.object_assignment_initializer;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.modifiers.as_ref(), parent);
+        self.set_parent(name, parent);
+        self.set_parent(object_assignment_initializer, parent);
 
         let data_index = self.len_u32(self.shorthand_properties.len());
         self.shorthand_properties.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent(object_assignment_initializer, parent);
         parent
     }
 }

--- a/crates/tsz-parser/src/parser/node_arena/statements.rs
+++ b/crates/tsz-parser/src/parser/node_arena/statements.rs
@@ -11,16 +11,16 @@ use crate::parser::node::{
 impl NodeArenaInner {
     /// Add a block node
     pub fn add_block(&mut self, kind: u16, pos: u32, end: u32, data: BlockData) -> NodeIndex {
-        let statements = data.statements.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_list(&data.statements, parent);
 
         let data_index = self.len_u32(self.blocks.len());
         self.blocks.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_list(&statements, parent);
 
         parent
     }
@@ -146,15 +146,17 @@ impl NodeArenaInner {
         data: CaseClauseData,
     ) -> NodeIndex {
         let expression = data.expression;
-        let statements = data.statements.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent(expression, parent);
+        self.set_parent_list(&data.statements, parent);
+
         let data_index = self.len_u32(self.case_clauses.len());
         self.case_clauses.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        self.set_parent_list(&statements, parent);
         parent
     }
 

--- a/crates/tsz-parser/src/parser/node_arena/types.rs
+++ b/crates/tsz-parser/src/parser/node_arena/types.rs
@@ -15,15 +15,17 @@ impl NodeArenaInner {
     /// Add a type reference node
     pub fn add_type_ref(&mut self, kind: u16, pos: u32, end: u32, data: TypeRefData) -> NodeIndex {
         let type_name = data.type_name;
-        let type_arguments = data.type_arguments.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent(type_name, parent);
+        self.set_parent_opt_list(data.type_arguments.as_ref(), parent);
+
         let data_index = self.len_u32(self.type_refs.len());
         self.type_refs.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(type_name, parent);
-        self.set_parent_opt_list(type_arguments.as_ref(), parent);
         parent
     }
 
@@ -35,16 +37,16 @@ impl NodeArenaInner {
         end: u32,
         data: CompositeTypeData,
     ) -> NodeIndex {
-        let types = data.types.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_list(&data.types, parent);
 
         let data_index = self.len_u32(self.composite_types.len());
         self.composite_types.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_list(&types, parent);
 
         parent
     }
@@ -57,20 +59,19 @@ impl NodeArenaInner {
         end: u32,
         data: FunctionTypeData,
     ) -> NodeIndex {
-        let type_parameters = data.type_parameters.clone();
-        let parameters = data.parameters.clone();
         let type_annotation = data.type_annotation;
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
+        self.set_parent_list(&data.parameters, parent);
+        self.set_parent(type_annotation, parent);
 
         let data_index = self.len_u32(self.function_types.len());
         self.function_types.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent_opt_list(type_parameters.as_ref(), parent);
-        self.set_parent_list(&parameters, parent);
-        self.set_parent(type_annotation, parent);
 
         parent
     }
@@ -84,15 +85,17 @@ impl NodeArenaInner {
         data: TypeQueryData,
     ) -> NodeIndex {
         let expr_name = data.expr_name;
-        let type_arguments = data.type_arguments.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent(expr_name, parent);
+        self.set_parent_opt_list(data.type_arguments.as_ref(), parent);
+
         let data_index = self.len_u32(self.type_queries.len());
         self.type_queries.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(expr_name, parent);
-        self.set_parent_opt_list(type_arguments.as_ref(), parent);
         parent
     }
 
@@ -104,14 +107,16 @@ impl NodeArenaInner {
         end: u32,
         data: TypeLiteralData,
     ) -> NodeIndex {
-        let members = data.members.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_list(&data.members, parent);
+
         let data_index = self.len_u32(self.type_literals.len());
         self.type_literals.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent_list(&members, parent);
         parent
     }
 
@@ -142,14 +147,16 @@ impl NodeArenaInner {
         end: u32,
         data: TupleTypeData,
     ) -> NodeIndex {
-        let elements = data.elements.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent_list(&data.elements, parent);
+
         let data_index = self.len_u32(self.tuple_types.len());
         self.tuple_types.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent_list(&elements, parent);
         parent
     }
 
@@ -269,19 +276,21 @@ impl NodeArenaInner {
         let name_type = data.name_type;
         let question_token = data.question_token;
         let type_node = data.type_node;
-        let members = data.members.clone();
-        let data_index = self.len_u32(self.mapped_types.len());
-        self.mapped_types.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
         self.set_parent(readonly_token, parent);
         self.set_parent(type_parameter, parent);
         self.set_parent(name_type, parent);
         self.set_parent(question_token, parent);
         self.set_parent(type_node, parent);
-        self.set_parent_opt_list(members.as_ref(), parent);
+        self.set_parent_opt_list(data.members.as_ref(), parent);
+
+        let data_index = self.len_u32(self.mapped_types.len());
+        self.mapped_types.push(data);
+        let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
+        self.nodes.push(Node::with_data(kind, pos, end, data_index));
+        self.extended_info.push(ExtendedNodeInfo::default());
         parent
     }
 
@@ -313,15 +322,17 @@ impl NodeArenaInner {
         data: TemplateLiteralTypeData,
     ) -> NodeIndex {
         let head = data.head;
-        let template_spans = data.template_spans.clone();
+        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+
+        self.set_parent(head, parent);
+        self.set_parent_list(&data.template_spans, parent);
+
         let data_index = self.len_u32(self.template_literal_types.len());
         self.template_literal_types.push(data);
         let index = self.len_u32(self.nodes.len());
+        debug_assert_eq!(parent.0, index);
         self.nodes.push(Node::with_data(kind, pos, end, data_index));
         self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(head, parent);
-        self.set_parent_list(&template_spans, parent);
         parent
     }
 


### PR DESCRIPTION
Goal: fast

Closes #13071

AgentName: Codex

Track: tech-debt / parser allocation

Invariant: `NodeArena` constructors already know the parent node slot before they move typed node data into the arena. Parent assignment should borrow child lists from the incoming data against that reserved `NodeIndex`, then move the data exactly once, instead of cloning child lists solely to revisit them after the move.

Scope:
- Removed all `clone()` calls from `crates/tsz-parser/src/parser/node_arena/*` constructors.
- Reserved the parent node index before pushing typed data and assigned child parents from borrowed `data` fields.
- Added debug assertions that the reserved parent index still matches the actual node slot at insertion.

Project Corpus Impact: No semantic or diagnostic change expected. This reduces parser constructor allocation pressure on every project row while preserving existing parent links.

## Verification
- `scripts/safe-run.sh cargo check -p tsz-parser --all-targets`
- `scripts/safe-run.sh cargo nextest run -p tsz-parser -E 'test(test_parent_mapping) or test(node_arena)'`
- `cargo fmt --check`
- `git diff --check`
- `rg -n "clone\\(\\)" crates/tsz-parser/src/parser/node_arena -g '*.rs'` (no matches)
- `find crates/tsz-parser/src/parser/node_arena -maxdepth 1 -type f -print | sort | xargs wc -l`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium

## Coordination Notes
- Open PR scan before publish showed active work in solver/checker/emitter lanes; this PR touches only parser arena constructor modules.
- Disk guard reported low free space, so local verification was kept to parser-focused checks with hot cache reuse.
