### PR TITLE
fix(checker): overload argument collection reads caller node types through an overlay (#13184)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1747,3 +1747,7 @@ path = "tests/deeply_nested_mapped_types_tests.rs"
 [[test]]
 name = "implements_type_param_generation_identity_tests"
 path = "tests/implements_type_param_generation_identity_tests.rs"
+
+[[test]]
+name = "overload_argument_flow_narrowing_visibility_tests"
+path = "tests/overload_argument_flow_narrowing_visibility_tests.rs"

--- a/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/assignment_ops.rs
@@ -890,6 +890,11 @@ impl<'a> CheckerState<'a> {
             "get_type_of_node_with_request must never return the DELEGATE sentinel"
         );
         if right_raw != TypeId::ERROR {
+            tracing::trace!(
+                ?right_idx,
+                ?right_raw,
+                "check_assignment_expression: publishing RHS type for flow analysis"
+            );
             self.ctx.node_types.or_insert(right_idx.0, right_raw);
         }
 

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution.rs
@@ -169,7 +169,14 @@ impl<'a> CheckerState<'a> {
         // Diagnostics produced during this pass are speculative: if no overload
         // matches, TypeScript reports the overload failure and suppresses these
         // nested callback/body diagnostics.
-        self.ctx.node_types = Default::default();
+        //
+        // Use an overlay over the caller's cached expression types rather than
+        // an empty map: speculative collection must still SEE previously
+        // computed types (flow narrowing of an argument like `obj[k]` after
+        // `obj[k] = rhs` reads the cached `rhs` type, exactly as on the
+        // non-overloaded call path), while its own writes stay isolated in the
+        // overlay layer for the selective merge below.
+        self.ctx.node_types = original_node_types.overlay();
         // Clear the contextual resolution cache once before the loop — the cache
         // is shared and needs clearing before any arg is re-evaluated, but clearing
         // it per-arg was redundant (empty after the first iteration).
@@ -364,6 +371,7 @@ impl<'a> CheckerState<'a> {
                     actual_this_type,
                     overload_snap: &overload_snap,
                     has_contextual_refresh_args: !contextual_refresh_args.is_empty(),
+                    caller_node_types: &original_node_types,
                 },
                 &mut selected_type_predicate,
             ) {
@@ -1016,7 +1024,10 @@ impl<'a> CheckerState<'a> {
             // Snapshot per-candidate diagnostic state so we can roll back on mismatch.
             let candidate_snap = self.ctx.snapshot_diagnostics();
             let candidate_ts2454_errors = self.ctx.emitted_ts2454_errors.clone();
-            self.ctx.node_types = Default::default();
+            // Per-candidate scratch layer over the caller's cached types: see
+            // the union-contextual collection above for the read-visibility
+            // rationale.
+            self.ctx.node_types = original_node_types.overlay();
             refresh_all_args(self);
             let resolved_func_type =
                 if let Some(def_id) = lazy_def_id_for_type(self.ctx.types, func_type) {
@@ -1151,7 +1162,7 @@ impl<'a> CheckerState<'a> {
                         });
                     self.ctx.restore_ts2454_state(&candidate_ts2454_errors);
                     self.clear_contextual_resolution_cache();
-                    self.ctx.node_types = Default::default();
+                    self.ctx.node_types = original_node_types.overlay();
                     refresh_all_args(self);
                     for (i, &arg_idx) in args.iter().enumerate() {
                         if self.argument_needs_refresh_for_contextual_call(
@@ -1410,7 +1421,7 @@ impl<'a> CheckerState<'a> {
                         .rollback_and_replace_diagnostics(&candidate_snap, merged);
                 }
                 self.ctx.restore_ts2454_state(&candidate_ts2454_errors);
-                self.ctx.node_types = Default::default();
+                self.ctx.node_types = original_node_types.overlay();
                 refresh_all_args(self);
 
                 // Restore const-assertion and literal-preservation context for the

--- a/crates/tsz-checker/src/checkers/call_checker/overload_resolution/contextual_retry.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/overload_resolution/contextual_retry.rs
@@ -19,6 +19,9 @@ pub(super) struct ContextualRetryInput<'s> {
     pub(super) actual_this_type: Option<TypeId>,
     pub(super) overload_snap: &'s FullSnapshot,
     pub(super) has_contextual_refresh_args: bool,
+    /// Pristine caller `node_types` snapshot; the retry's speculative
+    /// collection runs in an overlay over it (read-through, isolated writes).
+    pub(super) caller_node_types: &'s crate::context::NodeTypeCache,
 }
 
 impl<'a> CheckerState<'a> {
@@ -38,6 +41,7 @@ impl<'a> CheckerState<'a> {
             actual_this_type,
             overload_snap,
             has_contextual_refresh_args,
+            caller_node_types,
         } = input;
 
         if !matches!(result, CallResult::ArgumentTypeMismatch { .. })
@@ -101,7 +105,7 @@ impl<'a> CheckerState<'a> {
             _ => sig.return_type,
         };
         self.rollback_overload_retry_state(overload_snap);
-        self.ctx.node_types = Default::default();
+        self.ctx.node_types = caller_node_types.overlay();
         for &arg_idx in args {
             self.invalidate_expression_for_contextual_retry(arg_idx);
             self.ctx.daa_error_nodes.remove(&arg_idx.0);

--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -72,9 +72,37 @@ pub struct TypeReferenceValidationCaches {
 /// parent/child checkers. It is Arc-backed for cheap speculation snapshots:
 /// rollback stores a read snapshot and the active cache copy-on-writes only if
 /// it is mutated after the snapshot.
+///
+/// # Overlay mode
+///
+/// Speculative passes (overload-resolution argument collection) need two
+/// properties at once:
+///
+/// 1. **Read visibility**: type queries issued while collecting argument types
+///    must see every expression type the surrounding (non-speculative) check
+///    already computed — flow narrowing of an argument like `obj[k]` after
+///    `obj[k] = rhs` needs `rhs`'s cached type, exactly as on the
+///    non-overloaded call path where the cache is never masked.
+/// 2. **Write isolation**: entries produced while probing a candidate must be
+///    identifiable so the caller can keep only the winning candidate's entries.
+///
+/// [`Self::overlay`] provides both: reads fall through to a read-only `base`
+/// snapshot of the caller's entries, while writes (and removals, recorded as
+/// [`TypeId::NONE`] tombstones) stay in the overlay's own `data` layer.
+/// Bulk operations that harvest speculative results ([`Self::iter`],
+/// [`Self::merge`], [`Self::merge_owned`]) intentionally see only the overlay
+/// layer, so the existing "restore caller map, merge winner entries" restore
+/// choreography is unchanged.
 #[derive(Clone, Debug)]
 pub struct NodeTypeCache {
     data: Arc<FxHashMap<u32, TypeId>>,
+    /// Read-only fallback consulted on `data` misses. `None` for plain caches.
+    ///
+    /// Invariants:
+    /// - `base` never contains [`TypeId::NONE`].
+    /// - `data` may contain [`TypeId::NONE`] tombstones only when `base` is
+    ///   `Some`; a tombstone masks the base entry for that key.
+    base: Option<Arc<FxHashMap<u32, TypeId>>>,
 }
 
 impl NodeTypeCache {
@@ -85,6 +113,7 @@ impl NodeTypeCache {
                 capacity.min(4096),
                 Default::default(),
             )),
+            base: None,
         }
     }
 
@@ -92,12 +121,42 @@ impl NodeTypeCache {
     pub fn new() -> Self {
         Self {
             data: Arc::new(FxHashMap::default()),
+            base: None,
+        }
+    }
+
+    /// Create an empty speculative write layer whose reads fall through to
+    /// this cache's current visible entries. See the type-level docs.
+    pub fn overlay(&self) -> Self {
+        let base = if self.base.is_none() {
+            // Plain cache: share its map as the read-only base (O(1)).
+            Arc::clone(&self.data)
+        } else {
+            // Already an overlay: flatten to a single visible view so the new
+            // overlay has a NONE-free base (O(n), not hit by the overload
+            // choreography which always overlays the pristine caller map).
+            Arc::new(self.to_hash_map())
+        };
+        Self {
+            data: Arc::new(FxHashMap::default()),
+            base: Some(base),
         }
     }
 
     #[inline]
     pub fn get(&self, key: &u32) -> Option<&TypeId> {
-        self.data.get(key)
+        // Plain caches never store NONE (see `insert`), so the common
+        // non-speculative path stays a single hash lookup.
+        let Some(base) = &self.base else {
+            return self.data.get(key);
+        };
+        match self.data.get(key) {
+            // Tombstone: the entry was removed in this layer; do not fall
+            // through to the base.
+            Some(&TypeId::NONE) => None,
+            Some(value) => Some(value),
+            None => base.get(key),
+        }
     }
 
     #[inline]
@@ -105,25 +164,41 @@ impl NodeTypeCache {
         if key == u32::MAX {
             return;
         }
-        let data = Arc::make_mut(&mut self.data);
         if value == TypeId::NONE {
-            data.remove(&key);
-        } else {
-            data.insert(key, value);
+            self.remove(&key);
+            return;
         }
+        Arc::make_mut(&mut self.data).insert(key, value);
     }
 
     #[inline]
     pub fn contains_key(&self, key: &u32) -> bool {
-        self.data.contains_key(key)
+        self.get(key).is_some()
     }
 
     #[inline]
     pub fn remove(&mut self, key: &u32) -> Option<TypeId> {
-        if !self.data.contains_key(key) {
-            return None;
+        let Some(base) = &self.base else {
+            if !self.data.contains_key(key) {
+                return None;
+            }
+            tracing::trace!(key, "node_types: removing entry");
+            return Arc::make_mut(&mut self.data).remove(key);
+        };
+        let previous = match self.data.get(key) {
+            // Already tombstoned in this layer.
+            Some(&TypeId::NONE) => return None,
+            Some(&value) => value,
+            None => *base.get(key)?,
+        };
+        tracing::trace!(key, "node_types: removing entry");
+        if base.contains_key(key) {
+            // Mask the base entry instead of exposing it again.
+            Arc::make_mut(&mut self.data).insert(*key, TypeId::NONE);
+        } else {
+            Arc::make_mut(&mut self.data).remove(key);
         }
-        Arc::make_mut(&mut self.data).remove(key)
+        Some(previous)
     }
 
     #[inline]
@@ -137,25 +212,36 @@ impl NodeTypeCache {
         // that check `if let Some(&cached) = ...get(&idx.0)` would return the
         // sentinel as if it were a real type.
         if value == TypeId::NONE {
-            return self.data.get(&key).copied().unwrap_or(TypeId::NONE);
+            return self.get(&key).copied().unwrap_or(TypeId::NONE);
         }
-        *Arc::make_mut(&mut self.data).entry(key).or_insert(value)
+        if let Some(&existing) = self.get(&key) {
+            return existing;
+        }
+        Arc::make_mut(&mut self.data).insert(key, value);
+        value
     }
 
+    /// Iterate this cache's own (non-tombstone) entries. For an overlay this
+    /// is exactly the set of speculative writes — base entries are excluded by
+    /// design so harvest/merge sites keep their pre-overlay behavior.
     pub fn iter(&self) -> impl Iterator<Item = (u32, TypeId)> + '_ {
-        self.data.iter().map(|(i, t)| (*i, *t))
+        self.data
+            .iter()
+            .filter(|(_, t)| **t != TypeId::NONE)
+            .map(|(i, t)| (*i, *t))
     }
 
     pub fn clear(&mut self) {
         Arc::make_mut(&mut self.data).clear();
+        self.base = None;
     }
 
     pub fn merge(&mut self, other: &Self) {
-        Arc::make_mut(&mut self.data).extend(other.iter());
+        self.extend(other.iter());
     }
 
     pub fn merge_owned(&mut self, other: Self) {
-        Arc::make_mut(&mut self.data).extend(other.iter());
+        self.extend(other.iter());
     }
 
     pub fn extend<I: IntoIterator<Item = (u32, TypeId)>>(&mut self, iter: I) {
@@ -164,16 +250,35 @@ impl NodeTypeCache {
         }
     }
 
+    /// Number of entries in this cache's own layer (tombstones included);
+    /// base entries of an overlay are not counted. Used for cache statistics,
+    /// not for visibility decisions — use [`Self::get`]/[`Self::contains_key`]
+    /// for those.
     pub fn len(&self) -> usize {
         self.data.len()
     }
 
+    /// `true` when this cache's own layer has no entries. Like [`Self::len`],
+    /// ignores any overlay base.
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
 
+    /// Materialize the visible view (base entries overlaid with this layer's
+    /// writes, tombstoned keys excluded).
     pub fn to_hash_map(&self) -> FxHashMap<u32, TypeId> {
-        self.iter().collect()
+        let Some(base) = &self.base else {
+            return self.iter().collect();
+        };
+        let mut map: FxHashMap<u32, TypeId> = base.as_ref().clone();
+        for (key, value) in self.data.iter() {
+            if *value == TypeId::NONE {
+                map.remove(key);
+            } else {
+                map.insert(*key, *value);
+            }
+        }
+        map
     }
 }
 
@@ -372,5 +477,66 @@ mod tests {
         assert!(!Arc::ptr_eq(&parent.data, &child.data));
         assert_eq!(parent.get(&sym), Some(&TypeId::STRING));
         assert_eq!(child.get(&sym), None);
+    }
+
+    #[test]
+    fn node_type_cache_overlay_reads_through_base_and_isolates_writes() {
+        let mut caller = NodeTypeCache::new();
+        caller.insert(1, TypeId::STRING);
+
+        let mut overlay = caller.overlay();
+        // Base entries are visible through the overlay...
+        assert_eq!(overlay.get(&1), Some(&TypeId::STRING));
+        assert!(overlay.contains_key(&1));
+
+        // ...but overlay writes stay in the overlay's own layer.
+        overlay.insert(2, TypeId::NUMBER);
+        assert_eq!(overlay.get(&2), Some(&TypeId::NUMBER));
+        assert_eq!(caller.get(&2), None);
+
+        // Harvest (`iter`) yields only the overlay's own writes, so the
+        // overload-resolution "restore caller, merge winner" choreography
+        // never re-merges base entries.
+        let harvested: Vec<_> = overlay.iter().collect();
+        assert_eq!(harvested, vec![(2, TypeId::NUMBER)]);
+    }
+
+    #[test]
+    fn node_type_cache_overlay_tombstone_masks_base_entry() {
+        let mut caller = NodeTypeCache::new();
+        caller.insert(1, TypeId::STRING);
+
+        let mut overlay = caller.overlay();
+        assert_eq!(overlay.remove(&1), Some(TypeId::STRING));
+        // The base entry stays masked rather than resurfacing.
+        assert_eq!(overlay.get(&1), None);
+        assert!(!overlay.contains_key(&1));
+        // Removing again reports the entry as already gone.
+        assert_eq!(overlay.remove(&1), None);
+        // Tombstones never escape through harvest or materialization.
+        assert_eq!(overlay.iter().count(), 0);
+        assert!(overlay.to_hash_map().is_empty());
+        // A later write through the overlay overrides the tombstone.
+        overlay.insert(1, TypeId::NUMBER);
+        assert_eq!(overlay.get(&1), Some(&TypeId::NUMBER));
+        // The caller's map is untouched throughout.
+        assert_eq!(caller.get(&1), Some(&TypeId::STRING));
+    }
+
+    #[test]
+    fn node_type_cache_nested_overlay_flattens_to_visible_view() {
+        let mut caller = NodeTypeCache::new();
+        caller.insert(1, TypeId::STRING);
+
+        let mut inner = caller.overlay();
+        inner.insert(2, TypeId::NUMBER);
+        inner.remove(&1);
+
+        let nested = inner.overlay();
+        // The nested overlay sees exactly the inner overlay's visible view:
+        // the tombstoned base entry stays hidden, the inner write shows.
+        assert_eq!(nested.get(&1), None);
+        assert_eq!(nested.get(&2), Some(&TypeId::NUMBER));
+        assert_eq!(nested.to_hash_map().len(), 1);
     }
 }

--- a/crates/tsz-checker/src/context/speculation.rs
+++ b/crates/tsz-checker/src/context/speculation.rs
@@ -302,6 +302,11 @@ impl<'a> CheckerContext<'a> {
     /// Roll back to a return-type snapshot, discarding speculative diagnostics,
     /// dedup state, and cache entries added during speculation.
     fn rollback_return_type(&mut self, snap: &ReturnTypeSnapshot) {
+        tracing::trace!(
+            node_types_now = self.node_types.len(),
+            node_types_restored = snap.cache.node_types.len(),
+            "rollback_return_type: restoring node_types/flow caches"
+        );
         self.rollback_full(&snap.full);
         self.node_types.clone_from(&snap.cache.node_types);
         self.request_node_types

--- a/crates/tsz-checker/src/flow/control_flow/assignment.rs
+++ b/crates/tsz-checker/src/flow/control_flow/assignment.rs
@@ -609,6 +609,12 @@ impl<'a> FlowAnalyzer<'a> {
                     );
                 }
             }
+            if cached_rhs_type.is_none() {
+                tracing::trace!(
+                    ?rhs,
+                    "get_assigned_type: node_types MISS for rhs; trying syntactic fallback"
+                );
+            }
             let fallback_rhs_type = self.fallback_assigned_type_from_expression(rhs);
             if let Some(rhs_type) = fallback_rhs_type {
                 return self.assigned_type_respecting_access_read_surface(

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -386,6 +386,12 @@ impl<'a> FlowAnalyzer<'a> {
                     // No symbol ID - must do full check
                     self.assignment_targets_reference_node(flow.node, reference)
                 };
+                tracing::trace!(
+                    flow_node = ?flow.node,
+                    ?reference,
+                    targets_reference,
+                    "flow ASSIGNMENT considered"
+                );
                 if targets_reference {
                     // For const symbols declared via destructuring, the declared type
                     // already correctly accounts for all possible values including

--- a/crates/tsz-checker/tests/overload_argument_flow_narrowing_visibility_tests.rs
+++ b/crates/tsz-checker/tests/overload_argument_flow_narrowing_visibility_tests.rs
@@ -1,0 +1,280 @@
+//! Overload-resolution argument collection must SEE caller-computed node
+//! types (issue #13184).
+//!
+//! Rule under test:
+//!
+//! > When `obj[kSym] = rhs` (with `kSym` a `unique symbol` const) — or any
+//! > assignment whose RHS type was already computed by the surrounding
+//! > statement check — is followed by a read of the same reference in
+//! > argument position of an overloaded call, tsc narrows the read to the
+//! > assigned type while resolving the overload. tsz does the same through
+//! > `FlowAnalyzer` assignment narrowing, which requires the speculative
+//! > overload argument-collection pass to read the caller's `node_types`
+//! > entries (an overlay layer) instead of an empty scratch map.
+//!
+//! Without the overlay, the flow walk for the argument cannot resolve the
+//! assignment RHS (`handler.bind(this)` below), silently degrades to the
+//! declared type `EventHandler<Event> | null`, and every candidate rejects
+//! `null` — a false `TS2769`. Witness: msw `src/core/sse.ts` 526/537/548.
+//!
+//! The matrix below varies binder names, symbol-keyed vs named properties,
+//! and includes negative cases where narrowing must NOT apply (read before
+//! write, narrowing killed by a later `null` write).
+
+use std::sync::{Arc, OnceLock};
+
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::test_utils::{
+    check_source_with_libs_code_messages, load_lib_files, strict_checker_options,
+};
+
+fn dom_libs() -> &'static [Arc<LibFile>] {
+    static LIBS: OnceLock<Vec<Arc<LibFile>>> = OnceLock::new();
+    LIBS.get_or_init(|| {
+        load_lib_files(&[
+            "es5.d.ts",
+            "es2015.core.d.ts",
+            "es2015.symbol.d.ts",
+            "es2015.iterable.d.ts",
+            "dom.d.ts",
+        ])
+    })
+}
+
+fn check_strict_dom(source: &str) -> Vec<(u32, String)> {
+    check_source_with_libs_code_messages(source, "test.ts", strict_checker_options(), dom_libs())
+}
+
+fn ts2769_messages(source: &str) -> Vec<String> {
+    check_strict_dom(source)
+        .into_iter()
+        .filter_map(|(code, message)| (code == 2769).then_some(message))
+        .collect()
+}
+
+/// The msw `sse.ts` witness reduced: symbol-keyed element access narrowed by
+/// the immediately preceding assignment, read in argument position of an
+/// overloaded call whose first candidate is inference-bearing.
+#[test]
+fn symbol_keyed_assignment_narrows_argument_of_overloaded_call() {
+    let source = r#"
+type EventHandler<EventType extends Event> = (event: EventType) => any
+
+const kOnOpen = Symbol('kOnOpen')
+
+class Obs {
+  private [kOnOpen]: EventHandler<Event> | null = null
+
+  set onopen(handler: EventHandler<Event>) {
+    this[kOnOpen] = handler.bind(this)
+    this.addEventListener('open', this[kOnOpen])
+  }
+
+  public addEventListener<K extends keyof EventSourceEventMap>(
+    type: K,
+    listener: EventHandler<EventSourceEventMap[K]>,
+  ): void
+  public addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+  ): void
+  public addEventListener(
+    type: string,
+    listener: EventHandler<MessageEvent> | EventListenerOrEventListenerObject,
+  ): void {}
+}
+export {}
+"#;
+    let messages = ts2769_messages(source);
+    assert!(
+        messages.is_empty(),
+        "assignment narrowing must survive speculative overload argument \
+         collection; got TS2769: {messages:?}"
+    );
+}
+
+/// Renamed binders + a named (non-symbol) private property: the rule is
+/// structural, not tied to `kOnOpen`/`addEventListener` or computed keys.
+#[test]
+fn named_property_assignment_narrows_argument_with_renamed_binders() {
+    let source = r#"
+type Cb<T extends Event> = (event: T) => any
+
+class Watcher {
+  private stored: Cb<Event> | null = null
+
+  set onping(fn: Cb<Event>) {
+    this.stored = fn.bind(this)
+    this.listen('ping', this.stored)
+  }
+
+  public listen<Q extends keyof EventSourceEventMap>(
+    kind: Q,
+    callback: Cb<EventSourceEventMap[Q]>,
+  ): void
+  public listen(kind: string, callback: EventListenerOrEventListenerObject): void
+  public listen(
+    kind: string,
+    callback: Cb<MessageEvent> | EventListenerOrEventListenerObject,
+  ): void {}
+}
+export {}
+"#;
+    let messages = ts2769_messages(source);
+    assert!(
+        messages.is_empty(),
+        "named-property assignment narrowing must survive overload argument \
+         collection; got TS2769: {messages:?}"
+    );
+}
+
+/// Local variable form: `let slot: H | null = null; slot = handler.bind(t)`
+/// followed by an overloaded call reading `slot`.
+#[test]
+fn local_variable_assignment_narrows_argument_of_overloaded_call() {
+    let source = r#"
+type EventHandler<EventType extends Event> = (event: EventType) => any
+
+declare function on<K extends keyof EventSourceEventMap>(
+  type: K,
+  listener: EventHandler<EventSourceEventMap[K]>,
+): void
+declare function on(type: string, listener: EventListenerOrEventListenerObject): void
+
+function setup(handler: EventHandler<Event>, target: object) {
+  let slot: EventHandler<Event> | null = null
+  slot = handler.bind(target)
+  on('open', slot)
+}
+export {}
+"#;
+    let messages = ts2769_messages(source);
+    assert!(
+        messages.is_empty(),
+        "local-variable assignment narrowing must survive overload argument \
+         collection; got TS2769: {messages:?}"
+    );
+}
+
+/// Negative: a later `null` write kills the narrowing — both tsc and tsz
+/// report TS2769 because `null` matches no candidate.
+#[test]
+fn null_write_after_assignment_still_rejects_overloads() {
+    let source = r#"
+type EventHandler<EventType extends Event> = (event: EventType) => any
+
+const kOnOpen = Symbol('kOnOpen')
+
+class Obs {
+  private [kOnOpen]: EventHandler<Event> | null = null
+
+  set onopen(handler: EventHandler<Event>) {
+    this[kOnOpen] = handler.bind(this)
+    this[kOnOpen] = null
+    this.addEventListener('open', this[kOnOpen])
+  }
+
+  public addEventListener<K extends keyof EventSourceEventMap>(
+    type: K,
+    listener: EventHandler<EventSourceEventMap[K]>,
+  ): void
+  public addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+  ): void
+  public addEventListener(
+    type: string,
+    listener: EventHandler<MessageEvent> | EventListenerOrEventListenerObject,
+  ): void {}
+}
+export {}
+"#;
+    let messages = ts2769_messages(source);
+    assert_eq!(
+        messages.len(),
+        1,
+        "narrowing killed by a later null write must still fail overload \
+         resolution exactly once; got: {messages:?}"
+    );
+}
+
+/// Negative: reading the property BEFORE the assignment keeps the declared
+/// union, so the overloaded call must fail in both compilers.
+#[test]
+fn read_before_write_keeps_declared_type_and_rejects_overloads() {
+    let source = r#"
+type EventHandler<EventType extends Event> = (event: EventType) => any
+
+const kOnOpen = Symbol('kOnOpen')
+
+class Obs {
+  private [kOnOpen]: EventHandler<Event> | null = null
+
+  set onopen(handler: EventHandler<Event>) {
+    this.addEventListener('open', this[kOnOpen])
+    this[kOnOpen] = handler.bind(this)
+  }
+
+  public addEventListener<K extends keyof EventSourceEventMap>(
+    type: K,
+    listener: EventHandler<EventSourceEventMap[K]>,
+  ): void
+  public addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+  ): void
+  public addEventListener(
+    type: string,
+    listener: EventHandler<MessageEvent> | EventListenerOrEventListenerObject,
+  ): void {}
+}
+export {}
+"#;
+    let messages = ts2769_messages(source);
+    assert_eq!(
+        messages.len(),
+        1,
+        "a read before the write must keep the declared `| null` type and \
+         fail overload resolution exactly once; got: {messages:?}"
+    );
+}
+
+/// Concrete (non-inference-bearing) overload variant stays clean too: the
+/// first candidate takes the concrete handler type directly.
+#[test]
+fn concrete_overload_variant_stays_clean() {
+    let source = r#"
+type EventHandler<EventType extends Event> = (event: EventType) => any
+
+const kOnMessage = Symbol('kOnMessage')
+
+class Obs {
+  private [kOnMessage]: EventHandler<MessageEvent> | null = null
+
+  set onmessage(handler: EventHandler<MessageEvent>) {
+    this[kOnMessage] = handler.bind(this)
+    this.addEventListener('message', this[kOnMessage])
+  }
+
+  public addEventListener(
+    type: string,
+    listener: EventHandler<MessageEvent>,
+  ): void
+  public addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+  ): void
+  public addEventListener(
+    type: string,
+    listener: EventHandler<MessageEvent> | EventListenerOrEventListenerObject,
+  ): void {}
+}
+export {}
+"#;
+    let messages = ts2769_messages(source);
+    assert!(
+        messages.is_empty(),
+        "concrete overload variant must accept the narrowed handler; got \
+         TS2769: {messages:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes #13184 (symbol-keyed element-access narrowing lost in speculative argument checking — msw `src/core/sse.ts` 526/537/548, TS2769 ×3).

## Structural rule

When `obj[kSym] = rhs` (with `kSym` a `unique symbol` const) — or any assignment whose RHS the surrounding statement check has already typed — is followed by a read of the same reference in argument position of an overloaded call, tsc narrows the read to the assigned type while resolving the overload. tsz does the same through `FlowAnalyzer` assignment narrowing, which requires the speculative overload argument-collection pass to read the caller's `node_types` entries.

## Root cause (traced)

Overload resolution masked `ctx.node_types` with an **empty map** (`std::mem::take` + `Default::default()`) at five sites for write isolation: union-contextual collection, per-candidate collection, two pre-inference/contextual retries, and the `contextual_retry` module. During that window, the flow walk for the argument `this[kOnOpen]` matched the preceding assignment but `get_assigned_type` missed `node_types` for the RHS (`handler.bind(this)` — a call expression the syntactic fallback cannot type), so narrowing silently degraded to the declared `EventHandler&lt;Event&gt; | null` and every candidate rejected `null` → false TS2769. The published RHS type (verified via new trace points) was present in the caller map the whole time — just invisible behind the mask.

## Fix (owner: checker cache layer — no type semantics moved)

`NodeTypeCache` gains an **overlay mode**: an empty write layer whose reads fall through to a read-only snapshot of the caller's entries, with removals recorded as `TypeId::NONE` tombstones. The five masking sites install `original_node_types.overlay()` instead of an empty map, so speculative collection sees previously computed expression types — exactly like the non-overloaded call path (and tsc's single node cache) — while `iter`/`merge`/`take` harvest only the overlay's own writes, keeping the existing "restore caller, merge winner" choreography byte-identical. The plain (non-overlay) `get` path stays a single hash lookup.

## Adjacent matrix (all in `crates/tsz-checker/tests/overload_argument_flow_narrowing_visibility_tests.rs`, tsc-verified)

- symbol-keyed private property, inference-bearing first overload (the witness) — clean
- renamed binders + named (non-symbol) property (`Watcher.stored` / `listen`) — clean
- local `let slot: H | null` variable form — clean
- concrete (non-inference-bearing) overload variant — clean
- negative: later `null` write kills narrowing → exactly one TS2769 (matches tsc)
- negative: read before write keeps the declared union → exactly one TS2769 (matches tsc)

Plus 3 `NodeTypeCache` unit tests (overlay read-through/write isolation, tombstone masking, nested-overlay flattening).

## Verification

- `cargo nextest run -p tsz-checker --cargo-profile dev-fast --test overload_argument_flow_narrowing_visibility_tests` — 6/6 pass; 4 of 6 fail without the fix (verified by stashing the overlay change).
- `cargo nextest run -p tsz-checker --cargo-profile dev-fast` over all registered `overload|speculat` targets (165 tests) and `narrow|flow|assignment` targets (321 tests) — all pass.
- `cargo nextest run -p tsz-checker --lib -E 'test(/node_type_cache|symbol_type_cache/)'` — 10/10 pass.
- `cargo clippy -p tsz-checker --all-targets` and `cargo fmt --check` — clean.
- CLI parity probes vs `tsc 6.0.2 --strict --lib es2022,dom,dom.iterable`: reduced msw witness and 7 adjacent/negative variants all match tsc exit/diagnostics.
- Four pre-existing failures in `conditional_infer_tests` / `issue_9692` / `nonnull_contextual_type_arg_inference_tests` / `ts2344_infer_conditional_constraint` are environmental in this container (missing compiled TypeScript libs) and fail identically with the fix stashed.
- Broad conformance/emit suites: ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high

https://claude.ai/code/session_01EA3BFuFvbVMqa28waMVqnQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EA3BFuFvbVMqa28waMVqnQ)_