### PR TITLE
fix(workspace): consolidate line/col-from-offset onto tsz-common LineMap

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_completions_display.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_completions_display.rs
@@ -895,20 +895,9 @@ impl Server {
                 == Some("characterTyped");
             if is_character_typed {
                 // Compute byte offset from line/character position
-                let byte_offset = {
-                    let mut off = 0usize;
-                    let mut current_line = 0u32;
-                    for (i, ch) in source_text.char_indices() {
-                        if current_line == position.line {
-                            off = i + position.character as usize;
-                            break;
-                        }
-                        if ch == '\n' {
-                            current_line += 1;
-                        }
-                    }
-                    off
-                };
+                let byte_offset = line_map
+                    .position_to_offset(position, &source_text)
+                    .map_or(0, |offset| offset as usize);
                 // Check the position of the just-typed character (offset - 1),
                 // since the cursor is positioned after the typed character.
                 if byte_offset > 0 && Self::is_in_string_or_comment(&source_text, byte_offset - 1) {
@@ -939,20 +928,9 @@ impl Server {
                     .and_then(|v| v.as_str())
                     .and_then(|s| s.chars().next());
                 if let Some(tc) = trigger_char {
-                    let byte_offset = {
-                        let mut off = 0usize;
-                        let mut current_line = 0u32;
-                        for (i, ch) in source_text.char_indices() {
-                            if current_line == position.line {
-                                off = i + position.character as usize;
-                                break;
-                            }
-                            if ch == '\n' {
-                                current_line += 1;
-                            }
-                        }
-                        off
-                    };
+                    let byte_offset = line_map
+                        .position_to_offset(position, &source_text)
+                        .map_or(0, |offset| offset as usize);
                     let typed_pos = byte_offset.saturating_sub(1);
                     let span_start = sig_help.applicable_span_start as usize;
                     if !Self::is_trigger_syntactic_owner(&source_text, tc, typed_pos, span_start) {

--- a/crates/tsz-cli/src/driver/check_utils.rs
+++ b/crates/tsz-cli/src/driver/check_utils.rs
@@ -3,6 +3,7 @@
 //! parse diagnostic conversion, and pragma detection.
 
 use super::*;
+use tsz_common::position::LineMap;
 
 #[path = "check_utils/tslib_helpers.rs"]
 mod tslib_helpers;
@@ -940,57 +941,6 @@ pub(super) fn create_cross_file_lookup_binder_with_augmentations(
 }
 
 // --- TS directive suppression ---
-/// Length in bytes of a line break starting at `bytes[i]`, or `0` if there is
-/// no line break at that position. Recognizes `\n`, `\r`, `\r\n`, and the
-/// UTF-8 encodings of U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH
-/// SEPARATOR), matching `tsz-scanner::is_line_break` and tsc's own line
-/// break recognition.
-fn line_break_len_at(bytes: &[u8], i: usize) -> usize {
-    match bytes.get(i) {
-        Some(&b'\n') => 1,
-        Some(&b'\r') => {
-            if bytes.get(i + 1) == Some(&b'\n') {
-                2
-            } else {
-                1
-            }
-        }
-        Some(&0xE2)
-            if bytes.get(i + 1) == Some(&0x80)
-                && matches!(bytes.get(i + 2), Some(&0xA8) | Some(&0xA9)) =>
-        {
-            3
-        }
-        _ => 0,
-    }
-}
-
-/// Build a line-start table: `line_starts[i]` is the byte offset of the first char on line `i`.
-fn build_line_starts(text: &str) -> Vec<u32> {
-    let mut starts = vec![0u32];
-    let bytes = text.as_bytes();
-    let len = bytes.len();
-    let mut i = 0;
-    while i < len {
-        let lb = line_break_len_at(bytes, i);
-        if lb > 0 {
-            starts.push((i + lb) as u32);
-            i += lb;
-        } else {
-            i += 1;
-        }
-    }
-    starts
-}
-
-/// Get the 0-based line number for a byte offset.
-fn line_of_offset(line_starts: &[u32], offset: u32) -> u32 {
-    match line_starts.binary_search(&offset) {
-        Ok(exact) => exact as u32,
-        Err(insert) => insert.saturating_sub(1) as u32,
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DirectiveKind {
     ExpectError,
@@ -1051,9 +1001,9 @@ struct TsDirective {
     unused_diagnostic_length: u32,
 }
 
-/// Scan source text for `@ts-expect-error` and `@ts-ignore` directives in comments.
-fn find_ts_directives(text: &str) -> Vec<TsDirective> {
-    let line_starts = build_line_starts(text);
+/// Scan source text for `@ts-expect-error` and `@ts-ignore` directives in
+/// comments. `line_map` must be built from the same `text`.
+fn find_ts_directives(text: &str, line_map: &LineMap) -> Vec<TsDirective> {
     let mut directives = Vec::new();
 
     for comment in tsz_common::comments::get_comment_ranges(text) {
@@ -1063,18 +1013,15 @@ fn find_ts_directives(text: &str) -> Vec<TsDirective> {
         };
 
         let suppressed_line = if comment.is_multi_line {
-            let close_line = line_of_offset(&line_starts, comment.end.saturating_sub(1));
+            let close_line = line_map.line_index(comment.end.saturating_sub(1));
             close_line + 1
         } else {
-            let comment_line = line_of_offset(&line_starts, comment.pos);
+            let comment_line = line_map.line_index(comment.pos);
             comment_line + 1
         };
         let directive_start = comment.pos.saturating_add(directive_offset);
-        let directive_line = line_of_offset(&line_starts, directive_start) as usize;
-        let directive_line_start = line_starts
-            .get(directive_line)
-            .copied()
-            .unwrap_or(comment.pos);
+        let directive_line = line_map.line_index(directive_start) as usize;
+        let directive_line_start = line_map.line_start(directive_line).unwrap_or(comment.pos);
         let unused_diagnostic_start = if comment.is_multi_line && directive_line_start > comment.pos
         {
             directive_line_start
@@ -1104,12 +1051,11 @@ pub(super) fn apply_ts_directive_suppression(
     diagnostics: &mut Vec<Diagnostic>,
     preserve_declaration_jsdoc_name_diagnostics: bool,
 ) {
-    let directives = find_ts_directives(source_text);
+    let line_map = LineMap::build(source_text);
+    let directives = find_ts_directives(source_text, &line_map);
     if directives.is_empty() {
         return;
     }
-
-    let line_starts = build_line_starts(source_text);
 
     // Check for @ts-nocheck — suppresses TS2578 for unused directives.
     let has_ts_nocheck =
@@ -1132,7 +1078,7 @@ pub(super) fn apply_ts_directive_suppression(
     // syntactic diagnostics on the target line still make `@ts-expect-error`
     // used. Keep those diagnostics while recording the directive hit.
     diagnostics.retain(|diag| {
-        let diag_line = line_of_offset(&line_starts, diag.start);
+        let diag_line = line_map.line_index(diag.start);
         for (idx, directive) in directives.iter().enumerate() {
             if diag_line == directive.suppressed_line {
                 directive_used[idx] = true;

--- a/crates/tsz-cli/src/driver/check_utils/tests.rs
+++ b/crates/tsz-cli/src/driver/check_utils/tests.rs
@@ -287,11 +287,11 @@ fn ts_directive_scan_ignores_plain_template_text() {
 #[test]
 fn ts_directive_line_starts_treat_cr_as_line_break() {
     assert_eq!(
-        build_line_starts("// @ts-ignore\rlet x: string = 1;\r"),
+        line_starts_of("// @ts-ignore\rlet x: string = 1;\r"),
         vec![0, 14, 33],
     );
     assert_eq!(
-        build_line_starts("// @ts-ignore\r\nlet x: string = 1;\n"),
+        line_starts_of("// @ts-ignore\r\nlet x: string = 1;\n"),
         vec![0, 15, 34],
     );
 }
@@ -471,20 +471,34 @@ fn ts_directive_scan_keeps_triple_slash_directives() {
     assert_eq!(directives[0].suppressed_line, 1);
 }
 
+/// [`super::find_ts_directives`] with a freshly built line map, for tests
+/// that only have source text.
+fn find_ts_directives(text: &str) -> Vec<TsDirective> {
+    super::find_ts_directives(text, &LineMap::build(text))
+}
+
+/// Line-start table of the shared `LineMap`, as used by directive scanning.
+fn line_starts_of(text: &str) -> Vec<u32> {
+    let map = LineMap::build(text);
+    (0..map.line_count())
+        .map(|line| map.line_start(line).unwrap())
+        .collect()
+}
+
 #[test]
-fn build_line_starts_handles_cr_and_crlf() {
+fn line_starts_handle_cr_and_crlf() {
     // \n only
-    assert_eq!(build_line_starts("a\nb\nc"), vec![0, 2, 4]);
+    assert_eq!(line_starts_of("a\nb\nc"), vec![0, 2, 4]);
     // \r only (classic Mac line endings)
-    assert_eq!(build_line_starts("a\rb\rc"), vec![0, 2, 4]);
+    assert_eq!(line_starts_of("a\rb\rc"), vec![0, 2, 4]);
     // \r\n (Windows): one line break, not two
-    assert_eq!(build_line_starts("a\r\nb\r\nc"), vec![0, 3, 6]);
+    assert_eq!(line_starts_of("a\r\nb\r\nc"), vec![0, 3, 6]);
     // Mixed
-    assert_eq!(build_line_starts("a\nb\rc\r\nd"), vec![0, 2, 4, 7]);
+    assert_eq!(line_starts_of("a\nb\rc\r\nd"), vec![0, 2, 4, 7]);
     // U+2028 LINE SEPARATOR
-    assert_eq!(build_line_starts("a\u{2028}b"), vec![0, 4]);
+    assert_eq!(line_starts_of("a\u{2028}b"), vec![0, 4]);
     // U+2029 PARAGRAPH SEPARATOR
-    assert_eq!(build_line_starts("a\u{2029}b"), vec![0, 4]);
+    assert_eq!(line_starts_of("a\u{2029}b"), vec![0, 4]);
 }
 
 #[test]
@@ -1380,7 +1394,7 @@ fn no_check_multiple_expect_error_directives_do_not_emit_ts2578() {
 }
 
 fn check_directive_suppression(source: &str, codes_in: &[u32]) -> Vec<Diagnostic> {
-    let line_starts = build_line_starts(source);
+    let line_starts = line_starts_of(source);
     let line1_start = line_starts.get(1).copied().unwrap_or(0);
     let mut diagnostics: Vec<Diagnostic> = codes_in
         .iter()

--- a/crates/tsz-cli/src/try_tsz/mod.rs
+++ b/crates/tsz-cli/src/try_tsz/mod.rs
@@ -816,17 +816,12 @@ fn line_column_for_path_label(
 ) -> Option<(Option<u32>, Option<u32>)> {
     let path = cwd.join(label);
     let text = fs::read_to_string(path).ok()?;
-    let offset = usize::try_from(start).ok()?.min(text.len());
-    let prefix = &text[..offset];
-    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() + 1;
-    let column = prefix
-        .rsplit_once('\n')
-        .map_or(prefix.chars().count() + 1, |(_, tail)| {
-            tail.chars().count() + 1
-        });
+    // 1-based line/column with UTF-16 columns, matching how tsc reports
+    // diagnostic positions (these values are diffed against tsc output).
+    let position = tsz_common::position::LineMap::build(&text).offset_to_position(start, &text);
     Some((
-        Some(u32::try_from(line).ok()?),
-        Some(u32::try_from(column).ok()?),
+        Some(position.line.saturating_add(1)),
+        Some(position.character.saturating_add(1)),
     ))
 }
 

--- a/crates/tsz-common/src/position/mod.rs
+++ b/crates/tsz-common/src/position/mod.rs
@@ -114,15 +114,25 @@ impl LineMap {
         Self { line_starts }
     }
 
-    /// Convert a byte offset to a Position (line, character).
-    /// Character is counted in UTF-16 code units for LSP compatibility.
+    /// Get the 0-based line index containing a byte offset.
+    ///
+    /// Offsets past the end of the source are clamped to the last line. This
+    /// is the line-only counterpart of [`Self::offset_to_position`] for
+    /// callers that do not need a column (and therefore no source text).
     #[must_use]
-    pub fn offset_to_position(&self, offset: u32, source: &str) -> Position {
-        // Binary search for the line containing this offset
+    pub fn line_index(&self, offset: u32) -> u32 {
         let line = match self.line_starts.binary_search(&offset) {
             Ok(exact) => exact,
             Err(insert_point) => insert_point.saturating_sub(1),
         };
+        u32::try_from(line).unwrap_or(u32::MAX)
+    }
+
+    /// Convert a byte offset to a Position (line, character).
+    /// Character is counted in UTF-16 code units for LSP compatibility.
+    #[must_use]
+    pub fn offset_to_position(&self, offset: u32, source: &str) -> Position {
+        let line = self.line_index(offset) as usize;
 
         let line_start = usize::try_from(self.line_starts.get(line).copied().unwrap_or(0))
             .unwrap_or(usize::MAX)
@@ -157,6 +167,19 @@ impl LineMap {
             line: u32::try_from(line).unwrap_or(u32::MAX),
             character,
         }
+    }
+
+    /// Convert a byte offset to a 0-based `(line, column)` pair with the
+    /// column counted in UTF-16 code units.
+    ///
+    /// This is the unit TypeScript uses everywhere positions surface: tsc
+    /// diagnostics, source maps, LSP positions, and tsserver protocol offsets
+    /// all count UTF-16 code units. Convenience wrapper around
+    /// [`Self::offset_to_position`] for callers working with tuples.
+    #[must_use]
+    pub fn line_col_utf16(&self, offset: u32, source: &str) -> (u32, u32) {
+        let position = self.offset_to_position(offset, source);
+        (position.line, position.character)
     }
 
     /// Convert a Position (line, character) to a byte offset.

--- a/crates/tsz-common/tests/position_tests.rs
+++ b/crates/tsz-common/tests/position_tests.rs
@@ -420,3 +420,37 @@ fn test_line_map_treats_u2028_and_u2029_as_line_terminators() {
     // U+2029 sits at bytes 13..16; line3 starts at byte 16.
     assert_eq!(map.offset_to_position(16, source), Position::new(2, 0));
 }
+
+#[test]
+fn test_line_index_matches_offset_to_position_line() {
+    let source = "a\r\nbb\rc\u{2028}dd\nlast";
+    let map = LineMap::build(source);
+    for offset in 0..=u32::try_from(source.len()).unwrap() {
+        assert_eq!(
+            map.line_index(offset),
+            map.offset_to_position(offset, source).line,
+            "line_index diverged from offset_to_position at offset {offset}"
+        );
+    }
+    // Past-end offsets clamp to the last line.
+    assert_eq!(
+        map.line_index(1000),
+        u32::try_from(map.line_count()).unwrap() - 1
+    );
+}
+
+#[test]
+fn test_line_col_utf16_counts_utf16_units() {
+    // 😀 is 4 UTF-8 bytes but 2 UTF-16 code units; é is 2 bytes, 1 unit.
+    let source = "\u{1F600}\u{00E9}x\nsecond";
+    let map = LineMap::build(source);
+    assert_eq!(map.line_col_utf16(0, source), (0, 0));
+    // After the emoji (byte 4): column 2 in UTF-16 units.
+    assert_eq!(map.line_col_utf16(4, source), (0, 2));
+    // After é (byte 6): column 3.
+    assert_eq!(map.line_col_utf16(6, source), (0, 3));
+    // 'x' ends the first line at byte 7.
+    assert_eq!(map.line_col_utf16(7, source), (0, 4));
+    // Start of "second" (byte 8).
+    assert_eq!(map.line_col_utf16(8, source), (1, 0));
+}

--- a/crates/tsz-core/tests/source_map_test_utils.rs
+++ b/crates/tsz-core/tests/source_map_test_utils.rs
@@ -93,23 +93,14 @@ pub fn decode_mappings(mappings: &str) -> Vec<DecodedMapping> {
     decoded
 }
 
+/// 0-based `(line, column)` of `needle` in `text`, with UTF-16 columns —
+/// the unit source maps use, via the shared `tsz_common` line map.
 pub fn find_line_col(text: &str, needle: &str) -> (u32, u32) {
     let idx = text
         .find(needle)
         .unwrap_or_else(|| panic!("expected to find {needle} in {text}"));
-
-    let mut line = 0u32;
-    let mut col = 0u32;
-    for &b in text.as_bytes().iter().take(idx) {
-        if b == b'\n' {
-            line += 1;
-            col = 0;
-        } else {
-            col += 1;
-        }
-    }
-
-    (line, col)
+    let offset = u32::try_from(idx).expect("test fixture exceeds u32 offsets");
+    tsz_common::position::LineMap::build(text).line_col_utf16(offset, text)
 }
 
 pub fn has_mapping_for_prefixes(

--- a/crates/tsz-emitter/src/emitter/core.rs
+++ b/crates/tsz-emitter/src/emitter/core.rs
@@ -385,7 +385,7 @@ pub struct Printer<'a> {
 
     /// Precomputed line map for O(log n) line/column lookups from byte offsets.
     /// Built once when source text is set; avoids O(n^2) scanning during emission.
-    pub(crate) line_map: Option<LineMap>,
+    pub(crate) line_map: Option<LineMap<'a>>,
 
     /// Pending source position for mapping the next write.
     pub(crate) pending_source_pos: Option<SourcePosition>,

--- a/crates/tsz-emitter/src/emitter/jsx/transform.rs
+++ b/crates/tsz-emitter/src/emitter/jsx/transform.rs
@@ -657,24 +657,15 @@ impl<'a> Printer<'a> {
     /// `react-jsxdev` source metadata, which is consumed by the runtime as
     /// JavaScript string indices.
     pub(in super::super) fn source_line_col_pos(&self, pos: u32) -> (u32, u32) {
+        if let Some(line_map) = &self.line_map {
+            let (line, col) = line_map.line_col(pos);
+            return (line + 1, col + 1);
+        }
         let Some(text) = self.source_text else {
             return (1, 1);
         };
-        let pos = (pos as usize).min(text.len());
-        let mut line = 1u32;
-        let mut col = 1u32;
-        for (i, ch) in text.char_indices() {
-            if i >= pos {
-                break;
-            }
-            if ch == '\n' {
-                line += 1;
-                col = 1;
-            } else if ch != '\r' {
-                col += ch.len_utf16() as u32;
-            }
-        }
-        (line, col)
+        let (line, col) = crate::output::source_writer::compute_line_col(text, pos);
+        (line + 1, col + 1)
     }
 
     // =========================================================================

--- a/crates/tsz-emitter/src/output/source_writer.rs
+++ b/crates/tsz-emitter/src/output/source_writer.rs
@@ -844,59 +844,31 @@ impl Default for SourceWriter {
 /// Without this, computing line/column from a byte offset requires scanning
 /// from the beginning of the file, which is O(pos) per call and leads to
 /// O(n^2) total cost when emitting large files.
-pub struct LineMap {
-    /// Byte offsets of the start of each line (line 0 starts at offset 0).
-    /// `line_starts[i]` is the byte offset of the first character on line `i`.
-    line_starts: Vec<u32>,
-    /// The full source text, needed for UTF-16 column computation.
-    text: String,
+///
+/// Thin adapter over [`tsz_common::position::LineMap`] that pairs the map
+/// with the borrowed source text, so emitter call sites get `(line, column)`
+/// tuples without threading the text through every lookup. Line terminators
+/// (`\n`, `\r`, `\r\n`, U+2028, U+2029) and UTF-16 column units match tsc's
+/// scanner line map, which is what tsc uses for source map positions.
+pub struct LineMap<'a> {
+    inner: tsz_common::position::LineMap,
+    text: &'a str,
 }
 
-impl LineMap {
+impl<'a> LineMap<'a> {
     /// Build a line map from source text. O(n) in text length.
-    pub fn new(text: &str) -> Self {
-        let mut line_starts = Vec::with_capacity(text.len() / 40 + 1);
-        line_starts.push(0);
-        for (i, b) in text.as_bytes().iter().enumerate() {
-            if *b == b'\n' {
-                line_starts.push((i + 1) as u32);
-            }
-        }
+    pub fn new(text: &'a str) -> Self {
         Self {
-            line_starts,
-            text: text.to_string(),
+            inner: tsz_common::position::LineMap::build(text),
+            text,
         }
     }
 
     /// Look up (line, column) from a byte offset. O(log n) via binary search.
     /// Column counting uses UTF-16 code units for source map compatibility.
+    /// Offsets past the end of the text clamp to the end-of-file position.
     pub fn line_col(&self, pos: u32) -> (u32, u32) {
-        let pos_usize = pos as usize;
-        if pos_usize >= self.text.len() {
-            // End-of-file position
-            let line = (self.line_starts.len() - 1) as u32;
-            let line_start = *self.line_starts.last().unwrap_or(&0) as usize;
-            let col: u32 = self.text[line_start..]
-                .chars()
-                .map(|c| c.len_utf16() as u32)
-                .sum();
-            return (line, col);
-        }
-
-        // Binary search for the line containing `pos`
-        let line = match self.line_starts.binary_search(&pos) {
-            Ok(exact) => exact,
-            Err(insert) => insert - 1,
-        };
-        let line_start = self.line_starts[line] as usize;
-
-        // Compute column in UTF-16 code units
-        let col: u32 = self.text[line_start..pos_usize]
-            .chars()
-            .map(|c| c.len_utf16() as u32)
-            .sum();
-
-        (line as u32, col)
+        self.inner.line_col_utf16(pos, self.text)
     }
 
     /// Create a `SourcePosition` from a byte offset. O(log n).
@@ -906,39 +878,14 @@ impl LineMap {
     }
 }
 
-/// Compute line and column from byte offset in source text
-/// Note: Column counting uses UTF-16 code units for source map compatibility
+/// Compute line and column from byte offset in source text.
+///
+/// Column counting uses UTF-16 code units and the full tsc line terminator
+/// set, exactly like [`LineMap`]; prefer a cached [`LineMap`] when computing
+/// more than one position for the same text, since this rebuilds the line
+/// table on every call.
 pub fn compute_line_col(text: &str, pos: u32) -> (u32, u32) {
-    let pos = pos as usize;
-    if pos >= text.len() {
-        // Return end of file position
-        let line = text.matches('\n').count() as u32;
-        let last_newline = text.rfind('\n').map_or(0, |i| i + 1);
-        // Count UTF-16 code units in the last line
-        let col = text[last_newline..]
-            .chars()
-            .map(|c| c.len_utf16() as u32)
-            .sum();
-        return (line, col);
-    }
-
-    let mut line = 0u32;
-    let mut col = 0u32;
-
-    for (i, ch) in text.char_indices() {
-        if i >= pos {
-            break;
-        }
-        if ch == '\n' {
-            line += 1;
-            col = 0;
-        } else {
-            // UTF-16 code units: non-BMP characters (emojis etc.) count as 2
-            col += ch.len_utf16() as u32;
-        }
-    }
-
-    (line, col)
+    tsz_common::position::LineMap::build(text).line_col_utf16(pos, text)
 }
 
 /// Create a `SourcePosition` from a byte offset and source text

--- a/crates/tsz-emitter/tests/source_writer.rs
+++ b/crates/tsz-emitter/tests/source_writer.rs
@@ -906,3 +906,27 @@ fn source_position_copy_clone_independence() {
     assert_eq!(c.line, 2);
     assert_eq!(a.column, 3);
 }
+
+#[test]
+fn line_map_recognizes_cr_crlf_and_unicode_separators() {
+    // tsc's scanner line map treats \r, \r\n, U+2028 and U+2029 as line
+    // terminators; source map positions must match.
+    let lm = LineMap::new("a\rb\r\nc\u{2028}d");
+    assert_eq!(lm.line_col(0), (0, 0)); // 'a'
+    assert_eq!(lm.line_col(2), (1, 0)); // 'b' after \r
+    assert_eq!(lm.line_col(5), (2, 0)); // 'c' after \r\n
+    assert_eq!(lm.line_col(9), (3, 0)); // 'd' after U+2028
+}
+
+#[test]
+fn compute_line_col_matches_line_map_on_mixed_terminators() {
+    let text = "a\rb\r\nc\u{2028}d\u{2029}e\n\u{1F600}";
+    let lm = LineMap::new(text);
+    for pos in 0..=(text.len() as u32 + 2) {
+        assert_eq!(
+            compute_line_col(text, pos),
+            lm.line_col(pos),
+            "compute_line_col diverged from LineMap at byte {pos}"
+        );
+    }
+}

--- a/crates/tsz-lsp/src/formatting.rs
+++ b/crates/tsz-lsp/src/formatting.rs
@@ -585,18 +585,12 @@ impl DocumentFormattingProvider {
 
 /// Compute the end position of a document (the position immediately past the
 /// last character). Used to build a whole-document replacement range.
+///
+/// Columns are UTF-16 code units, matching the LSP protocol's position
+/// encoding.
 fn document_end_position(source: &str) -> Position {
-    let mut line: u32 = 0;
-    let mut character: u32 = 0;
-    for ch in source.chars() {
-        if ch == '\n' {
-            line += 1;
-            character = 0;
-        } else {
-            character += 1;
-        }
-    }
-    Position::new(line, character)
+    let end = u32::try_from(source.len()).unwrap_or(u32::MAX);
+    tsz_common::position::LineMap::build(source).offset_to_position(end, source)
 }
 
 #[cfg(test)]

--- a/crates/tsz-lsp/src/fourslash/parsing.rs
+++ b/crates/tsz-lsp/src/fourslash/parsing.rs
@@ -6,34 +6,42 @@ use super::Marker;
 /// The anonymous marker `/**/` gets the name `""`.
 pub(super) fn parse_markers(file: &str, source: &str) -> (String, Vec<Marker>) {
     let mut cleaned = String::with_capacity(source.len());
-    let mut markers = Vec::new();
+    // (name, byte offset in cleaned text); line/character are resolved once
+    // the cleaned text is complete.
+    let mut pending: Vec<(String, u32)> = Vec::new();
     let mut i = 0;
     let bytes = source.as_bytes();
-    let mut offset: u32 = 0;
 
     while i < bytes.len() {
         if i + 3 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
             // Check for marker pattern: /*name*/
             if let Some(end) = find_marker_end(&bytes[i + 2..]) {
-                let name_bytes = &bytes[i + 2..i + 2 + end];
-                let name = String::from_utf8_lossy(name_bytes).to_string();
-                // Calculate position from cleaned text
-                let (line, character) = offset_to_line_col(&cleaned, offset);
-                markers.push(Marker {
-                    name,
-                    file: file.to_string(),
-                    line,
-                    character,
-                    offset,
-                });
+                let name = String::from_utf8_lossy(&bytes[i + 2..i + 2 + end]).to_string();
+                pending.push((name, cleaned.len() as u32));
                 i += 2 + end + 2; // skip /*name*/
                 continue;
             }
         }
-        cleaned.push(bytes[i] as char);
-        offset += 1;
-        i += 1;
+        // Copy the full UTF-8 character so multi-byte content survives intact.
+        let ch_len = source[i..].chars().next().map_or(1, char::len_utf8);
+        cleaned.push_str(&source[i..i + ch_len]);
+        i += ch_len;
     }
+
+    let line_map = tsz_common::position::LineMap::build(&cleaned);
+    let markers = pending
+        .into_iter()
+        .map(|(name, offset)| {
+            let position = line_map.offset_to_position(offset, &cleaned);
+            Marker {
+                name,
+                file: file.to_string(),
+                line: position.line,
+                character: position.character,
+                offset,
+            }
+        })
+        .collect();
 
     (cleaned, markers)
 }
@@ -51,24 +59,6 @@ pub(crate) fn find_marker_end(bytes: &[u8]) -> Option<usize> {
         }
     }
     None
-}
-
-/// Convert byte offset to (line, character) in cleaned text.
-fn offset_to_line_col(text: &str, offset: u32) -> (u32, u32) {
-    let mut line = 0u32;
-    let mut col = 0u32;
-    for (i, ch) in text.chars().enumerate() {
-        if i as u32 == offset {
-            return (line, col);
-        }
-        if ch == '\n' {
-            line += 1;
-            col = 0;
-        } else {
-            col += 1;
-        }
-    }
-    (line, col)
 }
 
 /// Parse multi-file test content.
@@ -217,6 +207,38 @@ mod tests {
         assert_eq!(markers[1].name, "ref");
         assert_eq!(markers[1].line, 1);
         assert_eq!(markers[1].character, 0);
+    }
+
+    #[test]
+    fn test_parse_markers_preserves_non_ascii_and_reports_utf16_columns() {
+        // "héllo" contains a 2-byte é; 😀 is 4 bytes / 2 UTF-16 units.
+        let (cleaned, markers) = parse_markers(
+            "test.ts",
+            "const h\u{00E9}llo = \"\u{1F600}\";\n/*m*/h\u{00E9}llo;",
+        );
+        assert_eq!(
+            cleaned,
+            "const h\u{00E9}llo = \"\u{1F600}\";\nh\u{00E9}llo;"
+        );
+        assert_eq!(markers.len(), 1);
+        assert_eq!(markers[0].line, 1);
+        assert_eq!(markers[0].character, 0);
+        // Byte offset into the cleaned text (line 1 starts after the 22-byte
+        // first line + newline).
+        assert_eq!(markers[0].offset, 23);
+        assert_eq!(&cleaned[markers[0].offset as usize..], "h\u{00E9}llo;");
+    }
+
+    #[test]
+    fn test_parse_markers_after_non_ascii_on_same_line_counts_utf16() {
+        let (cleaned, markers) = parse_markers("test.ts", "\u{1F600} + /*m*/x");
+        assert_eq!(cleaned, "\u{1F600} + x");
+        assert_eq!(markers.len(), 1);
+        assert_eq!(markers[0].line, 0);
+        // Emoji = 2 UTF-16 units, then " + " = 3.
+        assert_eq!(markers[0].character, 5);
+        // Byte offset: emoji = 4 bytes, " + " = 3.
+        assert_eq!(markers[0].offset, 7);
     }
 
     #[test]

--- a/crates/tsz-lsp/tests/formatting_tests.rs
+++ b/crates/tsz-lsp/tests/formatting_tests.rs
@@ -672,3 +672,19 @@ fn position_to_offset(text: &str, position: Position) -> usize {
         text.len()
     );
 }
+
+#[test]
+fn test_document_end_position_counts_utf16_units() {
+    // LSP positions are UTF-16 code units: 😀 is 2 units (4 UTF-8 bytes).
+    let end = document_end_position("ab\nc\u{1F600}d");
+    assert_eq!(end, Position::new(1, 4));
+}
+
+#[test]
+fn test_document_end_position_handles_cr_and_unicode_separators() {
+    // \r, \r\n, U+2028 and U+2029 are line terminators, matching the line
+    // map used for every other LSP position in the workspace.
+    assert_eq!(document_end_position("a\rb"), Position::new(1, 1));
+    assert_eq!(document_end_position("a\r\nb"), Position::new(1, 1));
+    assert_eq!(document_end_position("a\u{2028}b"), Position::new(1, 1));
+}


### PR DESCRIPTION
Goal: hold

Fixes #13119

## Summary

Five divergent offset→line/column implementations existed across the workspace with three column units (bytes, chars, UTF-16 code units) and inconsistent line-terminator sets. This consolidates all of them onto `tsz_common::position::LineMap`, which already implements tsc's exact semantics: UTF-16 code-unit columns and the full terminator set (`\n`, `\r`, `\r\n`, U+2028, U+2029).

## Structural rule

When converting a byte offset to a line/column anywhere positions surface (diagnostics, source maps, JSX dev metadata, LSP positions, tsserver offsets), tsc counts columns in UTF-16 code units over its scanner line map; tsz does the same through `tsz_common::position::LineMap` as the single owner — no per-crate reimplementations.

## Owner layer

`tsz-common` (`position::LineMap`). Consumers (emitter, lsp, cli, core test utils) hold either a cached map or build one per text; none re-derive line/column semantics.

## Changes

- **tsz-common**: add `LineMap::line_index` (line-only query, no source text needed) and `LineMap::line_col_utf16` (tuple convenience); `offset_to_position` now reuses `line_index`.
- **tsz-emitter**: the emitter's own `LineMap` (\n-only terminators; cloned the entire source into the struct) becomes a thin borrowing adapter over the common map; `compute_line_col` delegates. Source-map positions now recognize `\r`/U+2028/U+2029 like tsc.
- **tsz-emitter (JSX dev)**: `source_line_col_pos` uses the printer's cached line map (O(log n) per element) instead of an O(n) scan per JSX element — removes O(n²) behavior on JSX-heavy files in `react-jsxdev` mode.
- **tsz-lsp**: `document_end_position` reports UTF-16 columns (LSP protocol unit; previously char counts — wrong for non-BMP). Fourslash `parse_markers` now preserves multi-byte UTF-8 (previously byte-cast each byte to a char, corrupting non-ASCII), stores byte offsets as its `Marker.offset` doc claims, and reports UTF-16 marker columns.
- **tsz-cli**: `try_tsz` diagnostic line/columns now match tsc's UTF-16 units (previously 1-based char counts, \n-only — wrong columns for non-ASCII when diffing against tsc). Directive suppression (`@ts-ignore`/`@ts-expect-error`) drops its duplicated line-start table (one shared `LineMap` build per file, previously up to two table builds). tsz_server completions no longer add UTF-16 character counts directly to byte indices when computing trigger offsets.
- **tsz-core**: source-map test helper `find_line_col` uses the shared map (previously byte columns).

## Adjacent-case matrix

- Astral-plane chars (😀, 2 UTF-16 units / 4 UTF-8 bytes), BMP multi-byte (é), and mixed lines — covered in tsz-common, tsz-emitter, tsz-lsp tests.
- Terminator matrix: `\n`, lone `\r`, `\r\n`, mixed, U+2028, U+2029 — covered in tsz-common, tsz-emitter, tsz-cli tests (`line_starts_handle_cr_and_crlf`, `compute_line_col_matches_line_map_on_mixed_terminators`, `line_map_recognizes_cr_crlf_and_unicode_separators`).
- Past-end offsets clamp to EOF position (existing + new tests).
- Fourslash markers before/after non-ASCII content on the same and following lines.

Out of scope (noted, not changed): tsz_server's `line_offset_to_byte` protocol converter (position→offset direction, owned by #13063's tsserver migration); scanner-internal line-break classification (canonical lexer definition); `SourceWriter`'s incremental output column tracking (output-side, not offset lookup).

## Verification

```
cargo nextest run -p tsz-common -p tsz-emitter -p tsz-lsp -p tsz-cli \
  -E 'test(position) or test(line_map) or test(line_col) or test(line_starts) or test(parse_markers) or test(document_end) or test(directive) or test(jsx) or test(compute_line)'
# 373 passed after rebase onto main
cargo fmt --check        # clean
cargo clippy -p tsz-common -p tsz-emitter -p tsz-lsp -p tsz-cli -p tsz-core --tests  # zero warnings
```

Pre-existing local failures in `tsz-core source_map_tests_4` (async-ES5 `end label must be available after if lowering` panic, #9330 family) reproduce identically with this change stashed and are untouched by this PR.

## Provenance

Machine: cloud
Assistant: claude-code
Model: undisclosed
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_019f8mFVNGiBcVmHLKw6Bhh9)_