### PR TITLE
fix(cli): expose typesVersions compiler version option

### DIFF
--- a/crates/tsz-cli/src/commands/args.rs
+++ b/crates/tsz-cli/src/commands/args.rs
@@ -720,7 +720,9 @@ pub struct CliArgs {
     /// Override the compiler version used for typesVersions resolution
     /// (or set `TSZ_TYPES_VERSIONS_COMPILER_VERSION`).
     #[arg(
-        long = "typesVersions",
+        long = "typesVersionsCompilerVersion",
+        alias = "types-versions-compiler-version",
+        alias = "typesVersions",
         alias = "types-versions",
         value_name = "VERSION",
         hide = true

--- a/crates/tsz-cli/src/driver/plan.rs
+++ b/crates/tsz-cli/src/driver/plan.rs
@@ -1220,6 +1220,31 @@ mod tests {
     }
 
     #[test]
+    fn apply_cli_overrides_types_versions_compiler_version_sets_option() {
+        let mut options = ResolvedCompilerOptions::default();
+        let args =
+            CliArgs::try_parse_from(["tsz", "--typesVersionsCompilerVersion", "5.6.1"]).unwrap();
+        apply_cli_overrides(&mut options, &args).unwrap();
+        assert_eq!(
+            options.types_versions_compiler_version.as_deref(),
+            Some("5.6.1")
+        );
+    }
+
+    #[test]
+    fn apply_cli_overrides_types_versions_compiler_version_uses_env_fallback() {
+        let mut options = ResolvedCompilerOptions::default();
+        let args = CliArgs::try_parse_from(["tsz"]).unwrap();
+        crate::driver::with_types_versions_env(Some(" 5.5.4 "), || {
+            apply_cli_overrides(&mut options, &args).unwrap();
+        });
+        assert_eq!(
+            options.types_versions_compiler_version.as_deref(),
+            Some("5.5.4")
+        );
+    }
+
+    #[test]
     fn apply_cli_overrides_strict_expands_flags() {
         let mut options = ResolvedCompilerOptions::default();
         let args = CliArgs::try_parse_from(["tsz", "--strict"]).unwrap();

--- a/crates/tsz-cli/src/driver/resolution/package_resolution.rs
+++ b/crates/tsz-cli/src/driver/resolution/package_resolution.rs
@@ -37,8 +37,9 @@ pub(crate) struct PackageJson {
 // `exports_imports` module). Keep only the CLI-specific compiler-version
 // plumbing here.
 
-// NOTE: Keep this in sync with the TypeScript version this compiler targets.
-// TODO: Make this configurable once CLI plumbing is available.
+// Default used when neither tsconfig `typesVersionsCompilerVersion`, CLI
+// `--typesVersionsCompilerVersion`, nor `TSZ_TYPES_VERSIONS_COMPILER_VERSION`
+// provides a non-empty override.
 pub(crate) const TYPES_VERSIONS_COMPILER_VERSION_FALLBACK: SemVer =
     tsz_common::module_resolution::types_versions::DEFAULT_COMPILER_VERSION;
 


### PR DESCRIPTION
Goal: green

Closes #13006

AgentName: Codex

Track: tech-debt / CLI package-resolution config

Invariant: `typesVersions` resolution must derive its compiler-version selector from explicit configuration when supplied. The fallback is only the default when tsconfig, CLI, and environment overrides are absent or empty.

Scope:
- Added the explicit hidden CLI spelling `--typesVersionsCompilerVersion` with kebab-case alias while preserving the older `--typesVersions` aliases.
- Replaced the stale hardcoded-config TODO with the actual fallback contract.
- Added `apply_cli_overrides` coverage for the explicit CLI option and environment fallback trimming.

Project Corpus Impact: No default behavior change. Projects that need a `typesVersions` selector override can now use the explicit CLI spelling that matches the config field.

## Verification
- `scripts/safe-run.sh cargo check -p tsz-cli --all-targets`
- `scripts/safe-run.sh cargo nextest run -p tsz-cli -E 'test(apply_cli_overrides_types_versions_compiler_version)'`
- `cargo fmt --check`
- `git diff --check`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium

## Coordination Notes
- Open PR scan before publish showed active work in checker/solver/emitter lanes; this PR touches only CLI argument/config plumbing and CLI plan tests.
- Disk was critically low during verification; recovered by deleting current-worktree Cargo incremental scratch only, preserving compiled dependency artifacts.
