### PR TITLE
fix(solver): permissive-instantiation gate for generic conditionals + atomic def body/params publication

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -872,6 +872,11 @@ impl<'a> CheckerContext<'a> {
 
     /// Register a generic definition body (with type parameters) in **both**
     /// type environments.
+    ///
+    /// Body and params are published to the shared `DefinitionStore` in one
+    /// atomic write so concurrent readers never observe a generic alias whose
+    /// body is visible but whose parameter list is still missing (which would
+    /// mis-instantiate every application of the alias).
     pub fn register_def_with_params_in_envs(
         &self,
         def_id: DefId,
@@ -883,9 +888,8 @@ impl<'a> CheckerContext<'a> {
             .definition_store
             .get_type_params(def_id)
             .is_none_or(|existing| existing != params);
-        self.definition_store.set_body(def_id, body);
         self.definition_store
-            .set_type_params(def_id, params.clone());
+            .set_body_with_params(def_id, body, Some(params.clone()));
         if body_changed || params_changed {
             self.clear_type_evaluation_caches_for_def(def_id);
         }

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -352,6 +352,33 @@ fn parallel_file_session_reuse_requested() -> bool {
 /// gate requires fixing the cold-start conditional/`infer` evaluation
 /// family first (then re-running the 10x byte-diff determinism loop on
 /// ts-toolbelt at full width).
+///
+/// Deep-dive 2026-06-11 (gate-lift campaign, `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK`
+/// repro on ts-toolbelt at 4 workers; 0/5 runs correct on the pre-fix binary —
+/// 3/5 livelocked >150s, 2/5 emitted false `TS2344`s): the root family is
+/// **in-flight shared-`DefinitionStore` state**. Every fresh checker
+/// re-derives def bodies into the shared store (last-writer-wins; ~6.4k
+/// re-publications with different `TypeId` forms per sequential ts-toolbelt
+/// run — benign there because each checker reads its own writes through its
+/// `TypeEnvironment` before falling back to the store, and foreign bodies are
+/// only read after their writer completed). Under parallelism, sibling
+/// workers consume bodies/params mid-rewrite, so deferred-type evaluation
+/// (`keyof`/indexed-access/conditional checks) observes half-constructed
+/// foreign forms: generic conditionals were resolved to definitive false
+/// branches (e.g. `` `${N}` extends keyof IterationMap `` while `N` is still
+/// generic -> `IterationMap['__']`), which both emits false `TS2344`s and
+/// feeds self-sustaining recursive expansions (`RangeForth` over the `'__'`
+/// sentinel tuple) whose accumulator grows fresh `TypeId`s every step —
+/// defeating every TypeId-keyed cycle guard and burning the full 2M-op
+/// per-query budget per call site (the observed livelock; 67k
+/// generic-check false-branch decisions per run vs 106 sequentially).
+/// Two structural fixes landed from this investigation (tsc-parity generic
+/// check-type deferral in conditional evaluation; atomic body+params
+/// publication), which remove the dominant false-branch storm, but
+/// write-once/session-scoped visibility experiments on the def store show
+/// several more in-flight channels (delegation buckets, lib cache,
+/// interner side-state) still leak; the gate stays until the
+/// mutation-isolation campaign makes shared def state schedule-independent.
 const fn should_use_sequential_fresh_checking(
     work_item_count: usize,
     has_large_wildcard_barrel: bool,
@@ -1147,11 +1174,16 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
         let extract_type_cache = !options.no_emit || options.emit_declarations;
         // Create shared cross-file query cache for multi-file projects.
         // Eliminates redundant type evaluations and relation checks across files.
-        let shared_query_cache = if work_items.len() > 1 {
-            Some(tsz_solver::construction::SharedQueryCache::new())
-        } else {
-            None
-        };
+        // `TSZ_EXPERIMENT_NO_SHARED_QC` is a diagnosis-only escape hatch for
+        // the parallel fresh-checking campaign: it disables the cross-file
+        // shared cache so cache-poisoning races can be isolated from other
+        // parallel-lane defects.
+        let shared_query_cache =
+            if work_items.len() > 1 && std::env::var_os("TSZ_EXPERIMENT_NO_SHARED_QC").is_none() {
+                Some(tsz_solver::construction::SharedQueryCache::new())
+            } else {
+                None
+            };
 
         let check_file_with_fresh_checker = |file_idx: usize| {
             let binder = build_checker_binder(file_idx);
@@ -1203,11 +1235,21 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
                     work_items: &work_items,
                     large_export_threshold: LARGE_WILDCARD_BARREL_EXPORTS,
                 });
-            let use_sequential_checking = should_use_sequential_fresh_checking(
-                work_items.len(),
-                has_large_wildcard_barrel,
-                has_parallel_order_sensitive_global_lib,
-            );
+            // Experiment escape hatch for the parallel fresh-checking gate
+            // lift campaign: force the rayon path regardless of the
+            // DOM-lib/barrel heuristics so livelock/determinism repros can be
+            // driven from the env without rebuilding.
+            let force_parallel_experiment =
+                std::env::var_os("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK").is_some();
+            let use_sequential_checking = if force_parallel_experiment {
+                false
+            } else {
+                should_use_sequential_fresh_checking(
+                    work_items.len(),
+                    has_large_wildcard_barrel,
+                    has_parallel_order_sensitive_global_lib,
+                )
+            };
             // T2.1.B (`PERFORMANCE_PLAN.md` §6 PR table): the sequential
             // no-emit path *can* construct one `CheckerState` and re-target
             // it across files via `CheckerContext::switch_to_file` instead

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -857,7 +857,38 @@ impl DefinitionStore {
     /// entry is created so that cross-file type resolution can find the
     /// body via `get_body`.
     pub fn set_body(&self, id: DefId, body: TypeId) {
+        self.set_body_with_params(id, body, None);
+    }
+
+    /// Publish a definition body — and optionally its type parameters —
+    /// atomically under the entry lock.
+    ///
+    /// The shared `DefinitionStore` is read concurrently by sibling parallel
+    /// file checkers while each fresh checker re-derives bodies for the defs
+    /// it touches. Body and type parameters must be written under one entry
+    /// guard: publishing the body first and the parameter list second (two
+    /// separate `get_mut` windows) let a concurrent reader observe a generic
+    /// alias whose body was visible but whose `type_params` were still
+    /// empty/stale, mis-instantiating every application of the alias
+    /// (false `TS2344` storms under parallel fresh checking; sequential
+    /// checking never interleaves a reader between the two writes).
+    pub fn set_body_with_params(
+        &self,
+        id: DefId,
+        body: TypeId,
+        params: Option<Vec<TypeParamInfo>>,
+    ) {
         if let Some(mut entry) = self.definitions.get_mut(&id) {
+            if let Some(params) = params {
+                if entry.kind == DefKind::TypeAlias
+                    && entry.type_params.is_empty()
+                    && !params.is_empty()
+                    && let Some(prev_body) = entry.body
+                {
+                    self.body_to_alias.remove(&prev_body);
+                }
+                entry.type_params = params;
+            }
             entry.body = Some(body);
 
             // Maintain body_to_alias index for non-generic type aliases.
@@ -875,7 +906,7 @@ impl DefinitionStore {
                 DefinitionInfo {
                     kind: DefKind::Interface,
                     name: Atom::default(),
-                    type_params: Vec::new(),
+                    type_params: params.unwrap_or_default(),
                     body: Some(body),
                     instance_shape: None,
                     static_shape: None,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -136,6 +136,46 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         checker
     }
 
+    /// tsc's permissive-instantiation false-branch gate (`getConditionalType`).
+    ///
+    /// When the check type is still generic, a failed relation against the
+    /// extends type is only *definitive* if it also fails under the permissive
+    /// instantiation — every named type parameter replaced by `any`
+    /// (tsc's `wildcardType`). `Exclude<keyof Params, never>` resolves its
+    /// false branch this way (`keyof any` is not assignable to `never`
+    /// regardless of `Params`), while genuinely indeterminate relations stay
+    /// deferred. Returns `true` when the false branch is definitive.
+    fn permissive_false_branch_is_definitive(
+        &mut self,
+        check_type: TypeId,
+        extends_type: TypeId,
+    ) -> bool {
+        use crate::instantiation::instantiate::{TypeSubstitution, instantiate_type};
+        let mut params = self.extract_type_params_from_type(check_type);
+        for param in self.extract_type_params_from_type(extends_type) {
+            if !params.iter().any(|existing| existing.name == param.name) {
+                params.push(param);
+            }
+        }
+        if params.is_empty() {
+            // No named parameters to widen: the failed relation already used
+            // the most permissive forms available.
+            return true;
+        }
+        let mut substitution = TypeSubstitution::new();
+        for param in &params {
+            substitution.insert(param.name, TypeId::ANY);
+        }
+        let permissive_check =
+            self.evaluate(instantiate_type(self.interner(), check_type, &substitution));
+        let permissive_extends = self.evaluate(instantiate_type(
+            self.interner(),
+            extends_type,
+            &substitution,
+        ));
+        !self.check_conditional_subtype(permissive_check, permissive_extends)
+    }
+
     /// Evaluate a conditional type: T extends U ? X : Y
     ///
     /// Algorithm:
@@ -873,6 +913,32 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     });
                 }
 
+                // Infer match failed. If the check type is still generic the
+                // failure is only definitive when it also fails under the
+                // permissive instantiation (every type parameter replaced by
+                // `any` — tsc's `getPermissiveInstantiation` gate in
+                // `getConditionalType`); otherwise instantiation could still
+                // make the pattern match, so the conditional stays deferred.
+                // The TS2589 depth-detection pass is exempt: it evaluates
+                // alias bodies with their parameters left free precisely so
+                // the recursive branch is driven and the recursion guard can
+                // observe the re-applied alias.
+                if !self.is_depth_detection_pass()
+                    && crate::type_queries::is_generic_conditional_check_type(
+                        self.interner(),
+                        check_type,
+                    )
+                    && !self.permissive_false_branch_is_definitive(check_type, extends_type)
+                {
+                    return self.interner().conditional(ConditionalType {
+                        check_type,
+                        extends_type,
+                        true_type: cond.true_type,
+                        false_type: cond.false_type,
+                        is_distributive: cond.is_distributive,
+                    });
+                }
+
                 // Infer match failed — take the false branch.
                 match self.try_dispatch_tail_call(
                     cond.false_type,
@@ -917,6 +983,26 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // T <: U -> true branch
                 cond.true_type
             } else if extends_has_type_params
+                // tsc parity (`getConditionalType`): a conditional whose
+                // effective check type is still generic — instantiable flags,
+                // or a type reference/tuple/template whose arguments are
+                // generic — only resolves to the false branch when the
+                // relation also fails under the permissive instantiation
+                // (every type parameter replaced by `any`, tsc's
+                // `getPermissiveInstantiation` gate); otherwise it stays
+                // deferred until instantiation makes the check type concrete.
+                // This also covers deferred wrappers over *unresolved*
+                // references (`keyof Lazy(D)`), which under parallel fresh
+                // checking must defer rather than yield a schedule-dependent
+                // definitive false. The TS2589 depth-detection pass is exempt
+                // so unconditionally-recursive aliases still drive their
+                // recursive branch and surface the depth error.
+                || (!self.is_depth_detection_pass()
+                    && crate::type_queries::is_generic_conditional_check_type(
+                        self.interner(),
+                        check_type,
+                    )
+                    && !self.permissive_false_branch_is_definitive(check_type, extends_type))
                 // Also check if the evaluated check_type is a direct Lazy reference
                 // (or a union/intersection of Lazy refs). Type parameters in generic
                 // function bodies are Lazy(DefId) and contains_type_parameters doesn't

--- a/crates/tsz-solver/src/type_queries/core.rs
+++ b/crates/tsz-solver/src/type_queries/core.rs
@@ -12,6 +12,84 @@ use crate::{TypeData, TypeId, TypeParamInfo};
 use super::classifiers::get_lazy_def_id;
 use super::traversal::collect_property_name_atoms_for_diagnostics;
 
+/// tsc-equivalent `isGenericType` for conditional-type branch decisions.
+///
+/// `getConditionalType` in tsc never resolves a conditional whose (effective)
+/// check type is still generic: `isGenericType` = instantiable flags
+/// (`TypeParameter` / `infer` / `this` / indexed access / `keyof` /
+/// string-mapping / deferred conditional) plus object types whose *type
+/// arguments* are generic (type references, tuples, arrays, and
+/// unions/intersections of those, and generic mapped types). Crucially it does
+/// NOT recurse through object members or function signatures — an anonymous
+/// object/function type containing a type parameter in a member position is
+/// not "generic" for deferral purposes, so `(x: T) => void extends Function`
+/// still resolves eagerly.
+///
+/// A `KeyOf` / `IndexAccess` / `StringIntrinsic` / `Conditional` node that
+/// *survived* evaluation is by construction still deferred (either its operand
+/// is generic or its reference could not be resolved yet), so those count as
+/// generic without inspecting the operand. This also keeps the decision
+/// schedule-independent under parallel fresh checking: an unresolved
+/// `keyof Lazy(D)` defers instead of feeding a definitive false branch.
+pub fn is_generic_conditional_check_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    is_generic_conditional_check_type_depth(db, type_id, 0)
+}
+
+fn is_generic_conditional_check_type_depth(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    depth: u32,
+) -> bool {
+    // Conservative cap: beyond this depth keep the current eager behavior
+    // (treat as non-generic) so pathological nesting cannot flip resolution.
+    if depth > 64 || type_id.is_intrinsic() {
+        return false;
+    }
+    match db.lookup(type_id) {
+        Some(
+            TypeData::TypeParameter(_)
+            | TypeData::Infer(_)
+            | TypeData::BoundParameter(_)
+            | TypeData::ThisType
+            | TypeData::KeyOf(_)
+            | TypeData::IndexAccess(_, _)
+            | TypeData::StringIntrinsic { .. }
+            | TypeData::Conditional(_),
+        ) => true,
+        Some(TypeData::TemplateLiteral(spans)) => db.template_list(spans).iter().any(|span| {
+            matches!(
+                span,
+                crate::types::TemplateSpan::Type(t)
+                    if is_generic_conditional_check_type_depth(db, *t, depth + 1)
+            )
+        }),
+        Some(TypeData::Application(app_id)) => {
+            let app = db.type_application(app_id);
+            app.args
+                .iter()
+                .any(|&arg| is_generic_conditional_check_type_depth(db, arg, depth + 1))
+        }
+        Some(TypeData::Tuple(elements)) => db
+            .tuple_list(elements)
+            .iter()
+            .any(|el| is_generic_conditional_check_type_depth(db, el.type_id, depth + 1)),
+        Some(TypeData::Array(elem) | TypeData::ReadonlyType(elem) | TypeData::NoInfer(elem)) => {
+            is_generic_conditional_check_type_depth(db, elem, depth + 1)
+        }
+        Some(TypeData::Union(list) | TypeData::Intersection(list)) => db
+            .type_list(list)
+            .iter()
+            .any(|&m| is_generic_conditional_check_type_depth(db, m, depth + 1)),
+        Some(TypeData::Mapped(mapped_id)) => {
+            // Generic mapped type: tsc's `isGenericMappedType` keys off a
+            // still-generic constraint (`[K in keyof T]`).
+            let mapped = db.get_mapped(mapped_id);
+            is_generic_conditional_check_type_depth(db, mapped.constraint, depth + 1)
+        }
+        _ => false,
+    }
+}
+
 pub fn get_allowed_keys(db: &dyn TypeDatabase, type_id: TypeId) -> rustc_hash::FxHashSet<String> {
     if let Some(exact) = super::data::collect_exact_literal_property_keys(db, type_id) {
         return exact.into_iter().map(|a| db.resolve_atom(a)).collect();


### PR DESCRIPTION
Goal: fast

## Summary

Two tsc-grounded fixes from the parallel-checking livelock investigation (the last characterized blocker before lifting the DOM-lib sequential gate on the ts-toolbelt metric row). Mechanism, fully traced: under parallel fresh checking, sibling workers consume `DefinitionStore` def bodies/params **mid-rewrite** (~6,400 last-writer-wins republications per run); a half-constructed foreign form makes a still-generic conditional resolve definitively-false (witness: `` `${N}` extends keyof IterationMap `` deciding false while `N` is generic, selecting the `'__'` sentinel tuple), and sentinel recursion with growing accumulator tuples mints fresh `TypeId`s every cycle — defeating every TypeId-keyed guard (67,752 eager-false decisions per livelocked run vs 106 sequential; each query burns its full budget uncached).

## Structural rules

1. **Permissive-instantiation gate** (`evaluation/evaluate_rules/conditional.rs` + `is_generic_conditional_check_type`): a failed relation with a still-generic check type resolves to the false branch only if it **also fails with every named type parameter replaced by `any`** — tsc's `getPermissiveInstantiation` semantics in `getConditionalType`; otherwise the conditional defers. (Blanket deferral without the gate broke `conditionalTypesSimplifyWhenTrivial` and a TS2589 case — both pass with it.) TS2589 depth detection exempt.
2. **Atomic body+params publication** (`DefinitionStore::set_body_with_params`, used by `register_def_with_params_in_envs`): closes the reader window where a generic alias had a visible body but missing/stale `type_params` (mis-instantiating every application).

The sequential gate itself is **not** lifted — forced-parallel still livelocks through remaining in-flight channels (delegation-bucket TypeIds, shared lib cache, interner side-state); the gate comment at `driver/check.rs:334` now documents the real blocker, the failed experiments (write-once bodies; session-scoped visibility), and the structural endgame (deterministic program-wide def materialization before parallel checking). Two campaign env knobs ride along (`TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK`, `TSZ_EXPERIMENT_NO_SHARED_QC`).

## Measured

- Forced-parallel 4-worker repro: false diagnostics (incl. wild type confusion) largely eliminated (timeouts remain — the gate stays).
- ts-toolbelt sequential (the metric): 0.66s wall / 0.86s user, 10× byte-identical (baseline 0.67/0.87 — no regression; campaign start: 1.02/1.21).
- vite/nextjs 5× byte-identical, 0 diagnostics.

## Project Corpus Impact
- Row: ts-toolbelt (metric row); prerequisite layer for the parallel-checking campaign on all DOM-lib rows
- Bug family: generic-conditional eager-false under in-flight def state

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: high

## Verification

- Full local conformance: 12583/12585 — zero new vs the accepted ledger.
- `cargo nextest run -p tsz-solver` conditional/permissive filters: 470/470; full suite failures identical to base (stash A/B). Checker `--lib` failure set exactly equal to base (60=60 by name).
- Conformance filters 100%: conditionalType 17/17, infer 87/87, genericCall 50/50, mappedType 55/55, recursiveType 23/23, jsx shard 65/65, moduleResolution 111/111.
- clippy clean; arch guards pass.
