### PR TITLE
fix(bench/ci): per-sha binary snapshots and CPU-share timeout evidence for sound perf measurement

### DIFF
--- a/.agents/skills/tsz-performance-engineering/SKILL.md
+++ b/.agents/skills/tsz-performance-engineering/SKILL.md
@@ -33,10 +33,18 @@ python3 scripts/perf/migration_callsite_counts.py --json
 python3 scripts/perf/query-perf-counters.py --json <artifact> --baseline <baseline>
 scripts/safe-run.sh ./scripts/bench/perf-hotspots.sh --quick --json-file /tmp/hotspots.json
 scripts/safe-run.sh ./scripts/bench/bench-vs-tsgo.sh --filter '<row>' --json-file /tmp/bench.json
+scripts/bench/measure-tsz.sh --timeout 420 --json-file /tmp/m.json -- --noEmit -p <tsconfig>
 ```
 
 Use focused compile guard or `cargo nextest run -E 'test(...)'` when shortest.
 Do not run full conformance, emit, fourslash, or broad project suites locally.
+
+For ad-hoc timing or perf bisects on shared boxes, use
+`scripts/bench/measure-tsz.sh`: it snapshots the binary to an immutable
+hash-verified copy (never time the live `dist-fast/` path — sibling sessions
+overwrite it) and records process CPU time next to wall time, so wall-only
+timeouts under CPU contention are reported as unmeasured instead of slow.
+See `references/perf-mistakes.md` and issue #13174.
 
 ## Cache Checklist
 

--- a/.agents/skills/tsz-performance-engineering/references/perf-mistakes.md
+++ b/.agents/skills/tsz-performance-engineering/references/perf-mistakes.md
@@ -50,6 +50,16 @@ is not a timing target yet.
 - **Micro wins overclaimed**: preallocation, clone removal, and formatting
   fixes are valuable only when tied to a hot path or row movement. Keep claims
   proportional.
+- **Measuring a live shared binary**: on shared boxes, a sibling session can
+  overwrite `dist-fast/tsz` mid-run, so the binary you measured may not be the
+  sha you built (#13174 was a phantom regression from exactly this). Measure
+  through `scripts/bench/measure-tsz.sh`, which snapshots the binary to an
+  immutable hash-verified copy first; never time the live build-output path.
+- **Wall-only timeouts under load**: a run needing 14s of CPU exceeds a 420s
+  wall timeout at a <4% CPU share with zero code regression. Record process
+  CPU time next to wall time; a low-CPU-share wall timeout is unmeasured, not
+  slow. `measure-tsz.sh`, `run-with-timeout.sh`, and the project compile guard
+  classify this automatically.
 - **Stale coordination state**: old WIP text, issue notes, or PR labels may be
   stale. Use current PR head, row state, and fresh signed comments before
   taking ownership or publishing results.
@@ -66,6 +76,8 @@ is not a timing target yet.
 - `scripts/bench/project-rows.mjs`: source of truth for required/canary rows
   and compatibility metadata.
 - `scripts/bench/row-utils.mjs`: what counts as a complete green row.
+- `scripts/bench/measure-tsz.sh`: sound single-binary timing on shared boxes
+  (immutable binary snapshot + CPU-share timeout classification).
 - `scripts/bench/perf-hotspots.sh`: narrow hotspot suite for quick perf signal.
 - `scripts/bench/bench-vs-tsgo.sh`: filtered TSZ vs `tsgo` project timing.
 - `scripts/bench/tsgo-winner-report.mjs`: rows where `tsgo` is currently

--- a/scripts/bench/lib/measure-protocol.sh
+++ b/scripts/bench/lib/measure-protocol.sh
@@ -1,0 +1,235 @@
+# shellcheck shell=bash
+# Shared perf-measurement protocol primitives (issue #13174).
+#
+# Sourced (never executed) by scripts/bench/run-with-timeout.sh,
+# scripts/bench/measure-tsz.sh, scripts/ci/project-compile-guard.sh, and
+# scripts/bench/test-measure-protocol.mjs so the measurement protocol has a
+# single, unit-tested definition.
+#
+# The protocol exists because two measurement hazards produced a false perf
+# regression report on a shared box:
+#   1. Measuring a live shared binary path (e.g. dist-fast/tsz) that a sibling
+#      session can overwrite mid-run. Fix: snapshot the binary to an immutable
+#      content-addressed path, verify the copy's hash, and measure the copy.
+#   2. Trusting wall-clock timeouts under CPU contention. A run that needs 14s
+#      of CPU exceeds any wall timeout at a <4% CPU share with zero code
+#      regression. Fix: record process CPU time alongside wall time and treat
+#      low-CPU-share wall timeouts as unmeasured, not slow.
+
+# Default contention threshold: a timed-out process that consumed less than
+# this percentage of one CPU during the wall-timeout window is classified as
+# contended (unmeasured) rather than slow. Healthy CPU-bound compiles sit near
+# or above 100%; observed contended runs sit below ~22%.
+TSZ_MEASURE_DEFAULT_MIN_CPU_SHARE_PCT=25
+
+# Stable sha256 of a file (Linux sha256sum / macOS shasum). Mirrors
+# sha256_of_file in scripts/ci/lib/project-compile-fingerprint.sh, which must
+# stay self-contained for its own unit test.
+tsz_sha256_of_file() {
+  sha256sum "$1" 2>/dev/null | awk '{print $1}' \
+    || shasum -a 256 "$1" 2>/dev/null | awk '{print $1}' || true
+}
+
+# Copy a binary to an immutable content-addressed path and verify the copy.
+#
+#   tsz_snapshot_binary <source_binary> <snapshot_dir>
+#
+# Prints "<snapshot_path> <sha256>" on success. The snapshot name embeds the
+# content hash, so concurrent sessions sharing <snapshot_dir> converge on the
+# same file and a later rebuild of the source can never mutate an existing
+# snapshot. The copy is hashed after the copy and compared against the hash
+# read before the copy; a mismatch means the source was overwritten mid-copy
+# (the live-binary hazard this exists to catch), so the copy is retried.
+tsz_snapshot_binary() {
+  local src="$1" dest_dir="$2"
+  local attempt h_src h_copy dest tmp
+
+  if [ ! -f "$src" ]; then
+    echo "tsz_snapshot_binary: source binary not found: $src" >&2
+    return 1
+  fi
+  mkdir -p "$dest_dir" || return 1
+
+  for attempt in 1 2 3; do
+    h_src="$(tsz_sha256_of_file "$src")"
+    if [ -z "$h_src" ]; then
+      echo "tsz_snapshot_binary: no sha256 tool available (need sha256sum or shasum)" >&2
+      return 1
+    fi
+    dest="$dest_dir/$(basename "$src").${h_src:0:16}"
+
+    if [ -f "$dest" ] && [ "$(tsz_sha256_of_file "$dest")" = "$h_src" ]; then
+      printf '%s %s\n' "$dest" "$h_src"
+      return 0
+    fi
+
+    tmp="${dest}.tmp.$$"
+    cp "$src" "$tmp" 2>/dev/null || {
+      rm -f "$tmp"
+      echo "tsz_snapshot_binary: copy failed: $src -> $tmp" >&2
+      return 1
+    }
+    h_copy="$(tsz_sha256_of_file "$tmp")"
+    if [ "$h_copy" = "$h_src" ]; then
+      chmod +x "$tmp"
+      mv -f "$tmp" "$dest"
+      printf '%s %s\n' "$dest" "$h_src"
+      return 0
+    fi
+
+    # Source mutated between the hash read and the copy: retry against the
+    # new content rather than blessing a torn snapshot.
+    rm -f "$tmp"
+    echo "tsz_snapshot_binary: source changed mid-copy (attempt $attempt), retrying: $src" >&2
+  done
+
+  echo "tsz_snapshot_binary: source kept changing during snapshot; refusing to measure a moving binary: $src" >&2
+  return 1
+}
+
+# Remove stale snapshots in <snapshot_dir> for <source_binary>, keeping only
+# <keep_path>. Bounds disk use to one snapshot per binary name.
+tsz_prune_binary_snapshots() {
+  local src_base dest_dir keep
+  src_base="$(basename "$1")"
+  dest_dir="$2"
+  keep="$3"
+  [ -d "$dest_dir" ] || return 0
+  local f
+  for f in "$dest_dir/$src_base".*; do
+    [ -e "$f" ] || continue
+    [ "$f" = "$keep" ] || rm -f "$f"
+  done
+}
+
+# awk function shared by the cputime helpers: parse a ps(1) TIME value into
+# seconds. Handles Linux "[dd-]hh:mm:ss" and macOS "mm:ss.cc" / "hh:mm:ss.cc".
+_TSZ_CPUTIME_AWK_FN='
+function cputime_secs(t,  days, dp, parts, n, i, secs) {
+  days = 0
+  if (t ~ /-/) {
+    split(t, dp, "-")
+    days = dp[1]
+    t = dp[2]
+  }
+  n = split(t, parts, ":")
+  secs = 0
+  for (i = 1; i <= n; i += 1) {
+    secs = secs * 60 + parts[i]
+  }
+  return days * 86400 + secs
+}
+'
+
+# Parse one ps TIME string to seconds (printed with two decimals).
+tsz_cputime_to_seconds() {
+  awk -v t="$1" "${_TSZ_CPUTIME_AWK_FN} BEGIN { printf \"%.2f\", cputime_secs(t) }"
+}
+
+# Total CPU seconds consumed by <pid> and its descendants, summed over the
+# live process tree (same tree walk as the compile guard's RSS sampler).
+# Thread CPU time is included in each process's TIME. Prints a number with
+# two decimals, or nothing if ps fails.
+tsz_process_tree_cpu_seconds() {
+  local root_pid="$1"
+
+  ps -e -o pid=,ppid=,time= 2>/dev/null | awk -v root="$root_pid" "${_TSZ_CPUTIME_AWK_FN}"'
+    {
+      pid[NR] = $1
+      ppid[NR] = $2
+      cpu[NR] = cputime_secs($3)
+      count = NR
+    }
+    END {
+      if (count == 0) exit 1
+      live[root] = 1
+      changed = 1
+      while (changed) {
+        changed = 0
+        for (i = 1; i <= count; i += 1) {
+          if (live[ppid[i]] && !live[pid[i]]) {
+            live[pid[i]] = 1
+            changed = 1
+          }
+        }
+      }
+      total = 0
+      for (i = 1; i <= count; i += 1) {
+        if (live[pid[i]]) total += cpu[i]
+      }
+      printf "%.2f", total
+    }
+  '
+}
+
+# Start a wall-timeout watchdog for <pid>: after <timeout_secs> it samples the
+# process tree's CPU seconds into <cpu_file> and SIGKILLs <pid>. Prints the
+# watchdog pid. <cpu_file> must not exist beforehand; its existence afterwards
+# marks that the watchdog fired, and its content is the CPU evidence for
+# classifying the timeout. Sampling before the kill is the protocol-critical
+# ordering: a dead process tree has no CPU time left to read.
+tsz_start_timeout_watchdog() {
+  local timeout_secs="$1" pid="$2" cpu_file="$3"
+  (
+    sleep "$timeout_secs"
+    tsz_process_tree_cpu_seconds "$pid" > "$cpu_file" 2>/dev/null || true
+    kill -KILL "$pid" 2>/dev/null || true
+  ) &
+  echo $!
+}
+
+# CPU share percentage: 100 * cpu_seconds / wall_seconds, rounded to an
+# integer. Prints nothing when either input is empty or wall is not positive.
+tsz_cpu_share_pct() {
+  local cpu="$1" wall="$2"
+  [ -n "$cpu" ] && [ -n "$wall" ] || return 0
+  awk -v c="$cpu" -v w="$wall" 'BEGIN {
+    if (w + 0 <= 0) exit 0
+    printf "%d", (c * 100 / w) + 0.5
+  }'
+}
+
+# True (exit 0) when a wall timeout is contention-confirmed: CPU evidence
+# exists and the CPU share is below the threshold. An unknown CPU sample is
+# NOT contended -- callers must not silently discard a timeout without
+# evidence.
+#
+#   tsz_timeout_is_contended <wall_seconds> <cpu_seconds> <min_share_pct>
+tsz_timeout_is_contended() {
+  local wall="$1" cpu="$2" min_pct="${3:-$TSZ_MEASURE_DEFAULT_MIN_CPU_SHARE_PCT}"
+  local share
+  share="$(tsz_cpu_share_pct "$cpu" "$wall")"
+  [ -n "$share" ] && [ "$share" -lt "$min_pct" ]
+}
+
+# True (exit 0) when a wall timeout is confirmed CPU-bound, i.e. genuinely
+# slow: CPU evidence exists and the share is at or above the threshold. This
+# is NOT the negation of tsz_timeout_is_contended -- a timeout with no CPU
+# sample is neither contended nor CPU-bound, just unmeasured. Persisting an
+# unmeasured timeout (e.g. into a result cache) requires this to be true.
+#
+#   tsz_timeout_is_cpu_bound <wall_seconds> <cpu_seconds> <min_share_pct>
+tsz_timeout_is_cpu_bound() {
+  local wall="$1" cpu="$2" min_pct="${3:-$TSZ_MEASURE_DEFAULT_MIN_CPU_SHARE_PCT}"
+  local share
+  share="$(tsz_cpu_share_pct "$cpu" "$wall")"
+  [ -n "$share" ] && [ "$share" -ge "$min_pct" ]
+}
+
+# One-line classification of a wall timeout for logs and diagnostics.
+#
+#   tsz_timeout_contention_note <wall_seconds> <cpu_seconds> <min_share_pct>
+tsz_timeout_contention_note() {
+  local wall="$1" cpu="$2" min_pct="${3:-$TSZ_MEASURE_DEFAULT_MIN_CPU_SHARE_PCT}"
+  local share
+  share="$(tsz_cpu_share_pct "$cpu" "$wall")"
+  if [ -z "$share" ]; then
+    printf 'wall timeout after %ss; process CPU time unavailable -- treat as unmeasured unless CPU evidence exists\n' "$wall"
+  elif [ "$share" -lt "$min_pct" ]; then
+    printf 'wall timeout after %ss with only %ss process CPU (~%s%% CPU share, threshold %s%%): likely CPU contention -- treat as unmeasured, not slow\n' \
+      "$wall" "$cpu" "$share" "$min_pct"
+  else
+    printf 'wall timeout after %ss with %ss process CPU (~%s%% CPU share): CPU-bound timeout\n' \
+      "$wall" "$cpu" "$share"
+  fi
+}

--- a/scripts/bench/measure-tsz.sh
+++ b/scripts/bench/measure-tsz.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Sound perf measurement for a tsz binary on shared boxes (issue #13174).
+#
+# Implements the measurement protocol from scripts/bench/lib/measure-protocol.sh:
+#   1. Never measure a live shared binary path: the binary is snapshotted to an
+#      immutable content-addressed copy (hash-verified) and the copy is run, so
+#      a sibling session rebuilding dist-fast/ mid-run cannot poison the
+#      measurement.
+#   2. Never trust wall time alone: each run records process CPU time next to
+#      wall time. A wall timeout whose CPU share is below the contention
+#      threshold is classified unmeasured-contention, not slow.
+#
+# Usage:
+#   scripts/bench/measure-tsz.sh [options] -- <tsz args...>
+#
+# Options:
+#   --bin PATH            binary to measure (default: $CARGO_TARGET_DIR or
+#                         .target, + /dist-fast/tsz)
+#   --timeout SECS        wall timeout per run (default: 420)
+#   --runs N              repetitions (default: 1)
+#   --min-cpu-share PCT   contention threshold percent (default: 25)
+#   --snapshot-dir DIR    snapshot location (default: $TMPDIR/tsz-measure-snapshots)
+#   --json-file FILE      also write a JSON result artifact
+#   --label NAME          free-form label recorded in the artifact
+#
+# Exit codes:
+#   0    every run was measured (the child's own exit code is data, not failure)
+#   124  at least one CPU-bound (genuine) timeout and no unmeasured run
+#   125  at least one run was unmeasured (contention / missing CPU evidence)
+#   2    usage or setup error
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=scripts/bench/lib/measure-protocol.sh
+source "$SCRIPT_DIR/lib/measure-protocol.sh"
+
+usage() {
+  # Print the header comment block (everything between the shebang and the
+  # first non-comment line) so the docs above stay the single source of truth.
+  awk 'NR > 1 { if (!/^#/) exit; sub(/^# ?/, ""); print }' "${BASH_SOURCE[0]}"
+}
+
+DEFAULT_TARGET_DIR="${CARGO_TARGET_DIR:-$PROJECT_ROOT/.target}"
+BIN="$DEFAULT_TARGET_DIR/dist-fast/tsz"
+TIMEOUT_SECS=420
+RUNS=1
+MIN_CPU_SHARE_PCT="$TSZ_MEASURE_DEFAULT_MIN_CPU_SHARE_PCT"
+SNAPSHOT_DIR="${TSZ_MEASURE_SNAPSHOT_DIR:-${TMPDIR:-/tmp}/tsz-measure-snapshots}"
+JSON_FILE=""
+LABEL=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --bin) BIN="$2"; shift 2 ;;
+    --timeout) TIMEOUT_SECS="$2"; shift 2 ;;
+    --runs) RUNS="$2"; shift 2 ;;
+    --min-cpu-share) MIN_CPU_SHARE_PCT="$2"; shift 2 ;;
+    --snapshot-dir) SNAPSHOT_DIR="$2"; shift 2 ;;
+    --json-file) JSON_FILE="$2"; shift 2 ;;
+    --label) LABEL="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    --) shift; break ;;
+    *) echo "measure-tsz: unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [ "$#" -eq 0 ]; then
+  echo "measure-tsz: no command arguments after --" >&2
+  usage >&2
+  exit 2
+fi
+if ! [[ "$TIMEOUT_SECS" =~ ^[0-9]+$ ]] || [ "$TIMEOUT_SECS" -le 0 ]; then
+  echo "measure-tsz: --timeout must be a positive integer: $TIMEOUT_SECS" >&2
+  exit 2
+fi
+if ! [[ "$RUNS" =~ ^[0-9]+$ ]] || [ "$RUNS" -le 0 ]; then
+  echo "measure-tsz: --runs must be a positive integer: $RUNS" >&2
+  exit 2
+fi
+
+now_seconds() {
+  if [ -n "${EPOCHREALTIME:-}" ]; then
+    printf '%s' "${EPOCHREALTIME/,/.}"
+  else
+    date +%s
+  fi
+}
+
+# Parse the children line of bash's `times` builtin ("0m0.012s 0m0.004s")
+# into "user sys" seconds.
+times_children_seconds() {
+  { times; } | sed -n '2p' | awk '{
+    for (i = 1; i <= 2; i += 1) {
+      gsub(/s$/, "", $i)
+      split($i, p, "m")
+      out[i] = p[1] * 60 + p[2]
+    }
+    printf "%.3f %.3f", out[1], out[2]
+  }'
+}
+
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
+GIT_SHA="$(git -C "$PROJECT_ROOT" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
+if [ "$GIT_SHA" != "unknown" ] && [ -n "$(git -C "$PROJECT_ROOT" status --porcelain 2>/dev/null | head -1)" ]; then
+  GIT_SHA="${GIT_SHA}-dirty"
+fi
+
+snapshot_out="$(tsz_snapshot_binary "$BIN" "$SNAPSHOT_DIR")" || exit 2
+read -r SNAPSHOT_BIN BIN_SHA256 <<< "$snapshot_out"
+tsz_prune_binary_snapshots "$BIN" "$SNAPSHOT_DIR" "$SNAPSHOT_BIN"
+
+OUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tsz-measure.XXXXXX")"
+
+echo "measure-tsz: git $GIT_SHA"
+echo "measure-tsz: source binary  $BIN"
+echo "measure-tsz: snapshot       $SNAPSHOT_BIN"
+echo "measure-tsz: sha256         $BIN_SHA256"
+echo "measure-tsz: timeout ${TIMEOUT_SECS}s, runs $RUNS, contention threshold ${MIN_CPU_SHARE_PCT}%"
+
+RUN_ROWS=()
+N_MEASURED=0
+N_TIMEOUT_CPU_BOUND=0
+N_UNMEASURED=0
+
+for run in $(seq 1 "$RUNS"); do
+  log="$OUT_DIR/run-${run}.log"
+  cpu_file="$OUT_DIR/run-${run}.cpu"
+  rm -f "$cpu_file"
+
+  read -r u_before s_before <<< "$(times_children_seconds)"
+  t0="$(now_seconds)"
+
+  "$SNAPSHOT_BIN" "$@" > "$log" 2>&1 &
+  pid=$!
+  watchdog_pid="$(tsz_start_timeout_watchdog "$TIMEOUT_SECS" "$pid" "$cpu_file")"
+
+  rc=0
+  wait "$pid" 2>/dev/null || rc=$?
+  kill "$watchdog_pid" 2>/dev/null || true
+  wait "$watchdog_pid" 2>/dev/null || true
+
+  t1="$(now_seconds)"
+  read -r u_after s_after <<< "$(times_children_seconds)"
+  wall="$(awk -v a="$t0" -v b="$t1" 'BEGIN { printf "%.2f", b - a }')"
+
+  cpu_user="" cpu_sys="" cpu_total="" classification="" note=""
+  if [ "$rc" -eq 137 ] && [ -e "$cpu_file" ]; then
+    rc=124
+    cpu_total="$(cat "$cpu_file" 2>/dev/null || true)"
+    note="$(tsz_timeout_contention_note "$TIMEOUT_SECS" "$cpu_total" "$MIN_CPU_SHARE_PCT")"
+    if [ -z "$cpu_total" ]; then
+      classification="unmeasured-no-cpu-sample"
+      N_UNMEASURED=$((N_UNMEASURED + 1))
+    elif tsz_timeout_is_contended "$TIMEOUT_SECS" "$cpu_total" "$MIN_CPU_SHARE_PCT"; then
+      classification="unmeasured-contention"
+      N_UNMEASURED=$((N_UNMEASURED + 1))
+    else
+      classification="timeout-cpu-bound"
+      N_TIMEOUT_CPU_BOUND=$((N_TIMEOUT_CPU_BOUND + 1))
+    fi
+  else
+    cpu_user="$(awk -v a="$u_before" -v b="$u_after" 'BEGIN { printf "%.3f", b - a }')"
+    cpu_sys="$(awk -v a="$s_before" -v b="$s_after" 'BEGIN { printf "%.3f", b - a }')"
+    cpu_total="$(awk -v u="$cpu_user" -v s="$cpu_sys" 'BEGIN { printf "%.3f", u + s }')"
+    classification="measured"
+    N_MEASURED=$((N_MEASURED + 1))
+  fi
+  share="$(tsz_cpu_share_pct "$cpu_total" "$wall")"
+  if [ "$classification" = "measured" ] && [ -n "$share" ] && [ "$share" -lt "$MIN_CPU_SHARE_PCT" ]; then
+    note="completed under CPU contention (~${share}% CPU share): wall time unreliable, use cpu_s"
+  fi
+
+  echo "measure-tsz: run ${run}/${RUNS}: ${classification} exit=${rc} wall=${wall}s cpu=${cpu_total:-?}s share=${share:-?}% log=$log"
+  [ -n "$note" ] && echo "measure-tsz:   ${note}"
+
+  RUN_ROWS+=("$(printf '{"run":%s,"classification":"%s","exit_code":%s,"wall_s":%s,"cpu_s":%s,"cpu_user_s":%s,"cpu_sys_s":%s,"cpu_share_pct":%s,"log":"%s"}' \
+    "$run" "$classification" "$rc" "$wall" \
+    "${cpu_total:-null}" "${cpu_user:-null}" "${cpu_sys:-null}" "${share:-null}" \
+    "$(json_escape "$log")")")
+done
+
+if [ -n "$JSON_FILE" ]; then
+  cmd_json=""
+  for arg in "$@"; do
+    cmd_json="${cmd_json:+$cmd_json,}\"$(json_escape "$arg")\""
+  done
+  runs_json="$(IFS=,; printf '%s' "${RUN_ROWS[*]}")"
+  printf '{"protocol":"snapshot+cpu-share/v1","label":"%s","git_sha":"%s","binary":{"source":"%s","snapshot":"%s","sha256":"%s"},"timeout_s":%s,"min_cpu_share_pct":%s,"command":[%s],"runs":[%s],"summary":{"measured":%s,"timeout_cpu_bound":%s,"unmeasured":%s}}\n' \
+    "$(json_escape "$LABEL")" "$GIT_SHA" \
+    "$(json_escape "$BIN")" "$(json_escape "$SNAPSHOT_BIN")" "$BIN_SHA256" \
+    "$TIMEOUT_SECS" "$MIN_CPU_SHARE_PCT" "$cmd_json" "$runs_json" \
+    "$N_MEASURED" "$N_TIMEOUT_CPU_BOUND" "$N_UNMEASURED" > "$JSON_FILE"
+  echo "measure-tsz: JSON written to $JSON_FILE"
+fi
+
+if [ "$N_UNMEASURED" -gt 0 ]; then
+  echo "measure-tsz: result UNMEASURED -- do not report these wall times as a regression" >&2
+  exit 125
+fi
+if [ "$N_TIMEOUT_CPU_BOUND" -gt 0 ]; then
+  exit 124
+fi
+exit 0

--- a/scripts/bench/run-with-timeout.sh
+++ b/scripts/bench/run-with-timeout.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/bench/lib/measure-protocol.sh
+source "$SCRIPT_DIR/lib/measure-protocol.sh"
+
 if [ "$#" -lt 2 ]; then
   echo "usage: $0 <seconds> [--] <command...>" >&2
   exit 2
@@ -24,11 +28,13 @@ fi
 "$@" &
 pid=$!
 
-(
-  sleep "$timeout_secs"
-  kill -KILL "$pid" 2>/dev/null || true
-) &
-watchdog_pid=$!
+# The watchdog samples the process tree's CPU time immediately before the
+# kill. On timeout this is the evidence that distinguishes a CPU-bound
+# (genuinely slow) run from one starved by CPU contention, whose wall time is
+# meaningless (issue #13174). The sample file doubles as the timed-out marker.
+cpu_file="$(mktemp)"
+rm -f "$cpu_file"
+watchdog_pid="$(tsz_start_timeout_watchdog "$timeout_secs" "$pid" "$cpu_file")"
 
 exit_code=0
 wait "$pid" 2>/dev/null || exit_code=$?
@@ -37,6 +43,13 @@ kill "$watchdog_pid" 2>/dev/null || true
 wait "$watchdog_pid" 2>/dev/null || true
 
 if [ "$exit_code" -eq 137 ]; then
+  if [ -e "$cpu_file" ]; then
+    cpu_secs="$(cat "$cpu_file" 2>/dev/null || true)"
+    echo "run-with-timeout: $(tsz_timeout_contention_note "$timeout_secs" "$cpu_secs" \
+      "${RUN_WITH_TIMEOUT_MIN_CPU_SHARE_PCT:-$TSZ_MEASURE_DEFAULT_MIN_CPU_SHARE_PCT}")" >&2
+  fi
+  rm -f "$cpu_file"
   exit 124
 fi
+rm -f "$cpu_file"
 exit "$exit_code"

--- a/scripts/bench/test-measure-protocol.mjs
+++ b/scripts/bench/test-measure-protocol.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// Unit tests for scripts/bench/lib/measure-protocol.sh (issue #13174):
+// per-sha binary snapshotting and CPU-share timeout classification. These
+// primitives are what keep perf measurements sound on shared boxes, so each
+// contract is pinned here:
+//   - ps TIME parsing across Linux/macOS formats,
+//   - snapshot immutability against source overwrites,
+//   - contention classification thresholds.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const lib = path.join(dirname, "lib", "measure-protocol.sh");
+
+function runLib(script) {
+  const result = spawnSync("bash", ["-c", `set -euo pipefail; source '${lib}'; ${script}`], {
+    encoding: "utf8",
+  });
+  return result;
+}
+
+function libStdout(script) {
+  const result = runLib(script);
+  assert.equal(result.status, 0, `lib call failed: ${script}\nstderr: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+// --- tsz_cputime_to_seconds: every ps TIME shape seen on Linux and macOS ---
+const parseCases = [
+  ["0:00.05", "0.05"], // macOS mm:ss.cc
+  ["12:34.56", "754.56"], // macOS mm:ss.cc with minutes
+  ["00:00:05", "5.00"], // Linux hh:mm:ss
+  ["1:02:03", "3723.00"], // Linux h:mm:ss
+  ["2-00:00:10", "172810.00"], // Linux dd-hh:mm:ss
+];
+for (const [input, expected] of parseCases) {
+  assert.equal(
+    libStdout(`tsz_cputime_to_seconds '${input}'`),
+    expected,
+    `tsz_cputime_to_seconds(${input})`,
+  );
+}
+
+// --- tsz_process_tree_cpu_seconds: returns a number for a live process ---
+{
+  const out = libStdout("tsz_process_tree_cpu_seconds $$");
+  assert.match(out, /^\d+\.\d{2}$/, `tree cpu sample should be numeric, got: ${out}`);
+}
+
+// --- tsz_cpu_share_pct ---
+assert.equal(libStdout("tsz_cpu_share_pct 14 420"), "3");
+assert.equal(libStdout("tsz_cpu_share_pct 415 420"), "99");
+assert.equal(libStdout("tsz_cpu_share_pct 840 420"), "200"); // multi-threaded > 100%
+assert.equal(libStdout("tsz_cpu_share_pct '' 420"), ""); // unknown cpu -> no share
+assert.equal(libStdout("tsz_cpu_share_pct 14 0"), ""); // degenerate wall -> no share
+
+// --- tsz_timeout_is_contended ---
+function contended(args) {
+  return runLib(`tsz_timeout_is_contended ${args}`).status === 0;
+}
+assert.equal(contended("420 14 25"), true, "3% share is contended");
+assert.equal(contended("420 415 25"), false, "99% share is not contended");
+assert.equal(contended("420 '' 25"), false, "unknown cpu must NOT be contention-confirmed");
+assert.equal(contended("420 100 25"), true, "24% share is below the 25% threshold");
+assert.equal(contended("420 105 25"), false, "25% share is at the threshold");
+
+// --- tsz_timeout_is_cpu_bound: NOT the negation of is_contended ---
+function cpuBound(args) {
+  return runLib(`tsz_timeout_is_cpu_bound ${args}`).status === 0;
+}
+assert.equal(cpuBound("420 415 25"), true, "99% share is CPU-bound");
+assert.equal(cpuBound("420 14 25"), false, "3% share is not CPU-bound");
+assert.equal(
+  cpuBound("420 '' 25"),
+  false,
+  "no CPU sample is neither contended nor CPU-bound -- unmeasured",
+);
+
+// --- tsz_timeout_contention_note ---
+{
+  const note = libStdout("tsz_timeout_contention_note 420 14 25");
+  assert.match(note, /likely CPU contention/, note);
+  assert.match(note, /unmeasured, not slow/, note);
+}
+{
+  const note = libStdout("tsz_timeout_contention_note 420 415 25");
+  assert.match(note, /CPU-bound timeout/, note);
+  assert.doesNotMatch(note, /contention/, note);
+}
+{
+  const note = libStdout("tsz_timeout_contention_note 420 '' 25");
+  assert.match(note, /CPU time unavailable/, note);
+  assert.match(note, /unmeasured/, note);
+}
+
+// --- tsz_snapshot_binary: immutable, content-addressed, mid-run-safe ---
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-measure-protocol-"));
+try {
+  const src = path.join(tmpDir, "fake-tsz");
+  const snapDir = path.join(tmpDir, "snapshots");
+  fs.writeFileSync(src, "#!/bin/sh\necho v1\n", { mode: 0o755 });
+
+  const first = libStdout(`tsz_snapshot_binary '${src}' '${snapDir}'`).split(/\s+/);
+  assert.equal(first.length, 2, "prints '<path> <sha256>'");
+  const [snapPath, snapHash] = first;
+  assert.notEqual(snapPath, src, "snapshot must not be the live path");
+  assert.match(snapHash, /^[0-9a-f]{64}$/);
+  assert.ok(snapPath.includes(snapHash.slice(0, 16)), "snapshot path is content-addressed");
+  const v1Content = fs.readFileSync(snapPath, "utf8");
+
+  // Same content -> same snapshot path (idempotent, concurrent-session safe).
+  const again = libStdout(`tsz_snapshot_binary '${src}' '${snapDir}'`).split(/\s+/);
+  assert.deepEqual(again, first, "re-snapshot of identical content reuses the path");
+
+  // Overwriting the live binary (the sibling-session hazard) must not touch
+  // the existing snapshot, and a new snapshot lands at a new path.
+  fs.writeFileSync(src, "#!/bin/sh\necho v2\n", { mode: 0o755 });
+  const second = libStdout(`tsz_snapshot_binary '${src}' '${snapDir}'`).split(/\s+/);
+  assert.notEqual(second[0], snapPath, "new content gets a new snapshot path");
+  assert.notEqual(second[1], snapHash, "new content gets a new hash");
+  assert.equal(
+    fs.readFileSync(snapPath, "utf8"),
+    v1Content,
+    "the v1 snapshot is immutable after the source was overwritten",
+  );
+
+  // Pruning keeps only the snapshot being measured.
+  libStdout(`tsz_prune_binary_snapshots '${src}' '${snapDir}' '${second[0]}'`);
+  const remaining = fs.readdirSync(snapDir);
+  assert.deepEqual(remaining, [path.basename(second[0])], "prune keeps exactly the live snapshot");
+
+  // Missing source fails loudly.
+  const missing = runLib(`tsz_snapshot_binary '${tmpDir}/does-not-exist' '${snapDir}'`);
+  assert.notEqual(missing.status, 0, "missing source must fail");
+  assert.match(missing.stderr, /not found/);
+} finally {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+console.log("measure-protocol tests passed");

--- a/scripts/bench/test-measure-tsz.mjs
+++ b/scripts/bench/test-measure-tsz.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// End-to-end tests for scripts/bench/measure-tsz.sh (issue #13174): the
+// protocol runner must snapshot the binary before measuring, report wall and
+// CPU time per run, and classify wall timeouts by CPU share so contended runs
+// surface as unmeasured (exit 125) instead of as a phantom regression.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const measure = path.join(dirname, "measure-tsz.sh");
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-measure-tsz-"));
+const snapDir = path.join(tmpDir, "snapshots");
+
+function writeFakeBin(name, body) {
+  const p = path.join(tmpDir, name);
+  fs.writeFileSync(p, `#!/bin/sh\n${body}\n`, { mode: 0o755 });
+  return p;
+}
+
+function runMeasure(args) {
+  return spawnSync("bash", [measure, "--snapshot-dir", snapDir, ...args], {
+    encoding: "utf8",
+  });
+}
+
+try {
+  // --- measured run: JSON artifact, snapshot isolation, child exit preserved as data ---
+  {
+    const bin = writeFakeBin("fake-ok", "echo diagnostics; exit 3");
+    const jsonFile = path.join(tmpDir, "ok.json");
+    const result = runMeasure([
+      "--bin", bin,
+      "--timeout", "30",
+      "--runs", "2",
+      "--json-file", jsonFile,
+      "--label", "ok-case",
+      "--", "--noEmit", "-p", "x.json",
+    ]);
+    assert.equal(result.status, 0, `measured run should exit 0: ${result.stderr}\n${result.stdout}`);
+
+    const artifact = JSON.parse(fs.readFileSync(jsonFile, "utf8"));
+    assert.equal(artifact.protocol, "snapshot+cpu-share/v1");
+    assert.equal(artifact.label, "ok-case");
+    assert.match(artifact.binary.sha256, /^[0-9a-f]{64}$/);
+    assert.notEqual(artifact.binary.snapshot, bin, "must measure the snapshot, not the live path");
+    assert.deepEqual(artifact.command, ["--noEmit", "-p", "x.json"]);
+    assert.equal(artifact.runs.length, 2);
+    for (const run of artifact.runs) {
+      assert.equal(run.classification, "measured");
+      assert.equal(run.exit_code, 3, "the child's own exit code is data, not failure");
+      assert.equal(typeof run.wall_s, "number");
+      assert.equal(typeof run.cpu_s, "number");
+    }
+    assert.deepEqual(artifact.summary, { measured: 2, timeout_cpu_bound: 0, unmeasured: 0 });
+
+    // The hazard from the issue: the live binary is overwritten after the
+    // snapshot. The snapshot recorded in the artifact must still be the
+    // original content.
+    fs.writeFileSync(bin, "#!/bin/sh\nexit 99\n", { mode: 0o755 });
+    const snapshotRun = spawnSync(artifact.binary.snapshot, [], { encoding: "utf8" });
+    assert.equal(snapshotRun.status, 3, "snapshot must be immune to live-path overwrites");
+  }
+
+  // --- idle timeout: contended, unmeasured, exit 125 ---
+  {
+    const bin = writeFakeBin("fake-idle", "sleep 30");
+    const jsonFile = path.join(tmpDir, "idle.json");
+    const result = runMeasure(["--bin", bin, "--timeout", "1", "--json-file", jsonFile, "--", "x"]);
+    assert.equal(result.status, 125, `contended timeout should exit 125: ${result.stdout}`);
+    assert.match(result.stderr, /UNMEASURED/, result.stderr);
+
+    const artifact = JSON.parse(fs.readFileSync(jsonFile, "utf8"));
+    assert.match(artifact.runs[0].classification, /^unmeasured-/);
+    assert.equal(artifact.summary.unmeasured, 1);
+  }
+
+  // --- busy timeout: CPU-bound, genuine slowness, exit 124 ---
+  {
+    const bin = writeFakeBin("fake-busy", "while :; do :; done");
+    const jsonFile = path.join(tmpDir, "busy.json");
+    const result = runMeasure(["--bin", bin, "--timeout", "3", "--json-file", jsonFile, "--", "x"]);
+    assert.equal(result.status, 124, `cpu-bound timeout should exit 124: ${result.stdout}`);
+
+    const artifact = JSON.parse(fs.readFileSync(jsonFile, "utf8"));
+    assert.equal(artifact.runs[0].classification, "timeout-cpu-bound");
+    assert.equal(artifact.runs[0].exit_code, 124);
+    assert.equal(artifact.summary.timeout_cpu_bound, 1);
+  }
+
+  // --- usage errors ---
+  {
+    const noCommand = runMeasure(["--bin", "/bin/sh"]);
+    assert.equal(noCommand.status, 2, "missing -- command must be a usage error");
+    const missingBin = runMeasure(["--bin", path.join(tmpDir, "absent"), "--", "x"]);
+    assert.equal(missingBin.status, 2, "missing binary must be a setup error");
+  }
+} finally {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+console.log("measure-tsz tests passed");

--- a/scripts/bench/test-timeout-runner.mjs
+++ b/scripts/bench/test-timeout-runner.mjs
@@ -11,8 +11,39 @@ const success = spawnSync("bash", [runner, "2", "--", "node", "-e", "process.exi
   encoding: "utf8",
 });
 assert.equal(success.status, 7, "runner should preserve child exit status");
+assert.doesNotMatch(
+  success.stderr,
+  /run-with-timeout:/,
+  "completed runs should not emit a timeout note",
+);
 
-const timeout = spawnSync("bash", [runner, "1", "--", "node", "-e", "setTimeout(() => {}, 5000)"], {
-  encoding: "utf8",
-});
-assert.equal(timeout.status, 124, "runner should map killed timeout to exit 124");
+// A sleeping child consumes ~no CPU during the timeout window: the runner must
+// flag the kill as likely CPU contention / unmeasured rather than implying the
+// command was genuinely slow (issue #13174).
+const idleTimeout = spawnSync(
+  "bash",
+  [runner, "1", "--", "node", "-e", "setTimeout(() => {}, 5000)"],
+  { encoding: "utf8" },
+);
+assert.equal(idleTimeout.status, 124, "runner should map killed timeout to exit 124");
+assert.match(idleTimeout.stderr, /run-with-timeout: wall timeout after 1s/, idleTimeout.stderr);
+assert.match(
+  idleTimeout.stderr,
+  /likely CPU contention|CPU time unavailable/,
+  `idle timeout must not be reported as CPU-bound: ${idleTimeout.stderr}`,
+);
+
+// A busy-looping child is genuinely CPU-bound: the note must say so and must
+// not suggest contention.
+const busyTimeout = spawnSync(
+  "bash",
+  [runner, "3", "--", "node", "-e", "const t = Date.now(); while (Date.now() - t < 20000) {}"],
+  { encoding: "utf8" },
+);
+assert.equal(busyTimeout.status, 124, "busy timeout still exits 124");
+assert.match(
+  busyTimeout.stderr,
+  /CPU-bound timeout/,
+  `busy timeout should be classified CPU-bound: ${busyTimeout.stderr}`,
+);
+assert.doesNotMatch(busyTimeout.stderr, /contention/, busyTimeout.stderr);

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -402,6 +402,8 @@ run_lint() {
   node scripts/bench/test-readme-perf-svg.mjs || return $?
   node scripts/bench/test-reduction-backlog.mjs || return $?
   node scripts/bench/test-timeout-runner.mjs || return $?
+  node scripts/bench/test-measure-protocol.mjs || return $?
+  node scripts/bench/test-measure-tsz.mjs || return $?
   node scripts/bench/test-check-artifact-readiness.mjs || return $?
   node scripts/bench/test-bench-readiness-banner.mjs || return $?
   node scripts/bench/test-ci-health-benchmark-readiness.mjs || return $?

--- a/scripts/ci/project-compile-guard.sh
+++ b/scripts/ci/project-compile-guard.sh
@@ -17,6 +17,7 @@ PROJECT_COMPATIBILITY_SUMMARY="${TSZ_PROJECT_COMPILE_COMPATIBILITY_SUMMARY:-$FIX
 RESULT_CACHE_DIR="${TSZ_PROJECT_COMPILE_RESULT_CACHE_DIR:-$FIXTURE_ROOT/.result-cache}"
 FAILURES=0
 LAST_PEAK_RSS_BYTES=0
+LAST_TIMEOUT_CPU_SECONDS=""
 TYPE_CHALLENGES_SOLUTIONS_MANIFEST_WRITTEN=0
 
 fail() {
@@ -66,6 +67,12 @@ validate_project_compatibility_artifact_paths() {
   fi
 }
 
+# Measurement-protocol primitives: binary snapshotting and CPU-share evidence
+# for wall timeouts (issue #13174).
+# shellcheck source=scripts/bench/lib/measure-protocol.sh
+source "$ROOT_DIR/scripts/bench/lib/measure-protocol.sh"
+MIN_CPU_SHARE_PCT="${TSZ_PROJECT_COMPILE_MIN_CPU_SHARE_PCT:-$TSZ_MEASURE_DEFAULT_MIN_CPU_SHARE_PCT}"
+
 # shellcheck source=scripts/bench/project-fixtures.sh
 source "$ROOT_DIR/scripts/bench/project-fixtures.sh"
 tsz_sync_project_row_groups
@@ -83,10 +90,25 @@ fi
 # shellcheck source=scripts/ci/lib/project-compile-fingerprint.sh
 source "$ROOT_DIR/scripts/ci/lib/project-compile-fingerprint.sh"
 
-# Compute tsz binary hash once at startup for all per-project fingerprints.
-_TSZ_BINARY_HASH="$(sha256_of_file "$TSZ_BIN")"
-
 mkdir -p "$FIXTURE_ROOT"
+
+# Snapshot the tsz binary to an immutable content-addressed copy and run that
+# copy for every project. TSZ_BIN often points at a live shared build output
+# (dist-fast/tsz) that a sibling session can overwrite mid-run; measuring the
+# live path would attribute a foreign binary's results to this run's binary
+# hash. The snapshot is hash-verified, so _TSZ_BINARY_HASH is the hash of the
+# binary that actually ran. Disable with TSZ_PROJECT_COMPILE_SNAPSHOT_BIN=0
+# when TSZ_BIN is already an immutable path.
+if [[ "${TSZ_PROJECT_COMPILE_SNAPSHOT_BIN:-1}" == "1" ]]; then
+  _snapshot_out="$(tsz_snapshot_binary "$TSZ_BIN" "$FIXTURE_ROOT/.bin-snapshot")" \
+    || fail "could not snapshot tsz binary for measurement: $TSZ_BIN"
+  read -r TSZ_RUN_BIN _TSZ_BINARY_HASH <<< "$_snapshot_out"
+  tsz_prune_binary_snapshots "$TSZ_BIN" "$FIXTURE_ROOT/.bin-snapshot" "$TSZ_RUN_BIN"
+else
+  TSZ_RUN_BIN="$TSZ_BIN"
+  # Compute tsz binary hash once at startup for all per-project fingerprints.
+  _TSZ_BINARY_HASH="$(sha256_of_file "$TSZ_BIN")"
+fi
 mkdir -p "$RESULT_CACHE_DIR"
 validate_project_compatibility_artifact_paths
 rm -f "$FIXTURE_ROOT/type-challenges-readiness-pairing.json"
@@ -100,19 +122,21 @@ run_with_timeout() {
   # Empty (not "0") is the "no positive sample yet" sentinel so the
   # record-time reason logic can distinguish it from a deliberate zero.
   LAST_PEAK_RSS_BYTES=""
+  # CPU seconds the process tree consumed before a wall-timeout kill; empty
+  # when the run did not time out or no sample could be taken. Callers use it
+  # to distinguish CPU-bound timeouts from CPU-contention false timeouts.
+  LAST_TIMEOUT_CPU_SECONDS=""
   "$@" &
   local pid=$!
-  local timeout_file
-  timeout_file="$(mktemp)"
-  rm -f "$timeout_file"
+  # The watchdog writes the pre-kill CPU sample here; the file's existence is
+  # the timed-out marker and its content the contention evidence (#13174).
+  local cpu_time_file
+  cpu_time_file="$(mktemp)"
+  rm -f "$cpu_time_file"
   local rss_file=""
   local rss_monitor_pid=""
-  (
-    sleep "$timeout_secs"
-    touch "$timeout_file"
-    kill -9 "$pid" 2>/dev/null || true
-  ) &
-  local watchdog_pid=$!
+  local watchdog_pid
+  watchdog_pid="$(tsz_start_timeout_watchdog "$timeout_secs" "$pid" "$cpu_time_file")"
   if measure_peak_rss_enabled; then
     rss_file=$(mktemp)
     : > "$rss_file"
@@ -135,10 +159,11 @@ run_with_timeout() {
   wait "$pid" 2>/dev/null || exit_code=$?
 
   local timed_out=0
-  if [ -e "$timeout_file" ]; then
+  if [ -e "$cpu_time_file" ]; then
     timed_out=1
+    LAST_TIMEOUT_CPU_SECONDS="$(cat "$cpu_time_file" 2>/dev/null || true)"
   fi
-  rm -f "$timeout_file"
+  rm -f "$cpu_time_file"
 
   kill "$watchdog_pid" 2>/dev/null || true
   wait "$watchdog_pid" 2>/dev/null || true
@@ -565,18 +590,27 @@ check_project() {
   file_count="$(count_ts_files "$src_dir")"
 
   echo "::group::${name}"
-  echo "Running: $TSZ_BIN --noEmit -p $tsconfig"
-  local rc=0 exit_class="" diagnostic_delta=""
+  echo "Running: $TSZ_RUN_BIN --noEmit -p $tsconfig"
+  local rc=0 exit_class="" diagnostic_delta="" timeout_unmeasured=0
   run_with_timeout "$PROJECT_TIMEOUT" \
     env \
       TSZ_USE_EMBEDDED_LIBS=1 \
       RUST_MIN_STACK="${TSZ_RUST_MIN_STACK:-536870912}" \
-      "$TSZ_BIN" --noEmit -p "$tsconfig" >"$log" 2>&1 || rc=$?
+      "$TSZ_RUN_BIN" --noEmit -p "$tsconfig" >"$log" 2>&1 || rc=$?
 
   if [[ "$rc" -ne 0 ]]; then
     FAILURES=$((FAILURES + 1))
     exit_class="$(project_failure_class "$([[ "$rc" -eq 124 ]] && echo "timeout" || echo "nonzero exit")" "$rc")"
     diagnostic_delta="$(diagnostic_lines_from_file "tsz" "$log")"
+    local timeout_note=""
+    if [[ "$rc" -eq 124 ]]; then
+      timeout_note="$(tsz_timeout_contention_note "$PROJECT_TIMEOUT" \
+        "$LAST_TIMEOUT_CPU_SECONDS" "$MIN_CPU_SHARE_PCT")"
+      diagnostic_delta="tsz: ${timeout_note}"$'\n'"$diagnostic_delta"
+      if ! tsz_timeout_is_cpu_bound "$PROJECT_TIMEOUT" "$LAST_TIMEOUT_CPU_SECONDS" "$MIN_CPU_SHARE_PCT"; then
+        timeout_unmeasured=1
+      fi
+    fi
     record_project_compatibility \
       "$name" \
       "$exit_class" \
@@ -590,7 +624,7 @@ check_project() {
       "$src_dir" \
       "$tsc_exit_codes"
     if [[ "$rc" -eq 124 ]]; then
-      echo "error: ${name} timed out after ${PROJECT_TIMEOUT}s" >&2
+      echo "error: ${name} ${timeout_note}" >&2
     else
       echo "error: ${name} failed with exit code ${rc}" >&2
     fi
@@ -605,8 +639,14 @@ check_project() {
     echo "${name} compiled successfully."
     echo "::endgroup::"
   fi
-  [[ -n "$_cache_file" ]] && \
+  # A timeout without confirmed CPU-bound evidence (contention, or no CPU
+  # sample at all) is unmeasured, not a result: caching it would persist a
+  # possibly-false failure for as long as the fingerprint stays stable.
+  if [[ "$timeout_unmeasured" == "1" ]]; then
+    echo "::warning::${name} timeout lacks CPU-bound evidence (contention or missing sample); result not cached"
+  elif [[ -n "$_cache_file" ]]; then
     write_compile_cache "$_fp" "$rc" "$file_count" "$exit_class" "$diagnostic_delta" "$_cache_file"
+  fi
   return 0
 }
 


### PR DESCRIPTION
Closes #13174.

Goal: fast

## Summary

Issue #13174 refuted a reported kysely-guard ">9min regression" (the range actually contained a 2.7x speedup) and named two measurement hazards that produced the false report on a shared box:

1. **Live shared binary**: `~/.cache/tsz-target/dist-fast/tsz` was overwritten mid-measurement by a sibling session, so the measured binary was not the built sha.
2. **Wall-only timeouts under load**: a run needing ~14s of CPU exceeds a 420s wall timeout at a <4% CPU share with zero code regression.

This PR turns the issue's protocol recommendation into enforced tooling so the whole hazard class cannot recur — not a kysely-specific patch. Rule: *a perf measurement is valid only if (a) the executed binary is an immutable, hash-verified copy and (b) a wall timeout is attributed to slowness only with CPU-bound evidence; otherwise it is unmeasured.* Owner: bench/CI measurement tooling (no compiler-semantics change).

## Changes

- **`scripts/bench/lib/measure-protocol.sh`** (new, shared, unit-tested): hash-verified content-addressed binary snapshots with mid-copy mutation detection + retry; process-tree CPU sampling handling Linux/macOS `ps` TIME formats; CPU-share computation; `tsz_timeout_is_contended` / `tsz_timeout_is_cpu_bound` (deliberately not negations of each other — a sample-less timeout is neither, it is unmeasured); shared timeout watchdog that samples CPU evidence *before* the kill.
- **`scripts/bench/measure-tsz.sh`** (new): agent-facing protocol runner for ad-hoc timing and perf bisects. Snapshots the binary, records wall/user/sys per run, writes a JSON artifact, exits 125 for unmeasured timeouts vs 124 for confirmed CPU-bound ones.
- **`scripts/bench/run-with-timeout.sh`**: on timeout, prints the CPU-share classification to stderr so a contended kill is never read as slowness. Exit-code contract unchanged (124).
- **`scripts/ci/project-compile-guard.sh`**: snapshots `TSZ_BIN` at startup, so the executed binary is guaranteed to match `_TSZ_BINARY_HASH` for the whole run (previously the hash was taken once and the live path executed — a mid-run overwrite silently mis-attributed every fingerprint); timeout diagnostics now carry CPU evidence; timeouts without CPU-bound confirmation are **not** written to the result cache (an unmeasured failure must not persist across runs). Structured `exit_class` vocabulary unchanged; opt-out via `TSZ_PROJECT_COMPILE_SNAPSHOT_BIN=0`.
- **Tests** wired into the gcp-full-ci lint block: `test-measure-protocol.mjs` (snapshot immutability against source overwrites, ps TIME parsing matrix, threshold asymmetry), `test-measure-tsz.mjs` (end-to-end measured / contended / CPU-bound / usage-error), extended `test-timeout-runner.mjs` (idle timeout flags contention; busy-loop timeout reports CPU-bound).
- **Docs**: `tsz-performance-engineering` skill + `perf-mistakes.md` name the two hazards and point at the tool.

Adjacent-case matrix: measured run (child exit code preserved as data), contended timeout, CPU-bound timeout, sample-less timeout, snapshot reuse (same content → same path), source overwritten after snapshot, source mutating mid-copy (retry), missing binary/usage errors.

Deferred (documented, out of scope here): extending the closed `exit_class` vocabulary with an unmeasured-timeout class (downstream dashboard consumers), wiring the protocol into `bench-vs-tsgo-results.sh`'s own timing loop and `precommit-microbench`.

## Verification

- `node scripts/bench/test-measure-protocol.mjs`
- `node scripts/bench/test-measure-tsz.mjs`
- `node scripts/bench/test-timeout-runner.mjs`
- `node scripts/ci/test-project-compile-guard-fingerprint.mjs`
- `node scripts/ci/test-project-compile-guard-rss-sentinel.mjs`
- `node scripts/ci/test-project-compile-guard-readiness-artifacts.mjs` (passes; needs signing-neutral git config in this sandbox)
- Guard end-to-end smoke: stub `TSZ_BIN` + no-match filter → exit 0, snapshot created under `<fixture-root>/.bin-snapshot/`
- `bash -n` on all four shell files
- CI: lint block runs all of the above; project-compile-guard job exercises the snapshot path on real rows

## Provenance

Machine: cloud
Assistant: claude-code
Model: undisclosed
Effort: high

https://claude.ai/code/session_013vvarpaTFwAjengVX83JQi

---
_Generated by [Claude Code](https://claude.ai/code/session_013vvarpaTFwAjengVX83JQi)_