### PR TITLE
checker/solver: remove fixture-shaped message surgery from the diagnostic sink by fixing the type-level owners

### DIFF
--- a/crates/tsz-checker/src/context/diagnostic_push.rs
+++ b/crates/tsz-checker/src/context/diagnostic_push.rs
@@ -145,51 +145,13 @@ impl<'a> CheckerContext<'a> {
     ///   owning variable/function name, producing one TS4094 per member at the
     ///   same span.
     pub fn error(&mut self, start: u32, length: u32, message: String, code: u32) {
-        // TS2304 ("Cannot find name"), TS2552 ("Cannot find name ... Did you mean?"),
-        // and TS2663 ("Did you mean the instance member 'this.X'?") are suppressed when
-        // TS2301 already exists at the same position, since TS2301
-        // ("Initializer of instance member cannot reference identifier declared in constructor")
-        // already explains the problem more precisely.
-        if (code == 2304 || code == 2552 || code == 2663)
-            && self.diagnostic_indices.emitted.contains(&(start, 2301))
-        {
+        if self.reconcile_name_resolution_precedence(start, code) {
             return;
         }
-        if code == 2301 {
-            self.diagnostics.retain(|diag| {
-                !(diag.start == start
-                    && (diag.code == 2304 || diag.code == 2552 || diag.code == 2663))
-            });
-            self.diagnostic_indices.emitted.remove(&(start, 2304));
-            self.diagnostic_indices.emitted.remove(&(start, 2552));
-            self.diagnostic_indices.emitted.remove(&(start, 2663));
-        }
-
-        // Prefer specific name suggestions over generic "Cannot find name".
-        if code == 2304
-            && (self.diagnostic_indices.emitted.contains(&(start, 2552))
-                || self.diagnostic_indices.emitted.contains(&(start, 2663)))
-        {
-            return;
-        }
-        if code == 2552 || code == 2663 {
-            self.diagnostics
-                .retain(|diag| !(diag.start == start && diag.code == 2304));
-            self.diagnostic_indices.emitted.remove(&(start, 2304));
-        }
-
-        let message = Self::normalize_diagnostic_message(code, message);
 
         // Check if we've already emitted this diagnostic
         let key = self.diagnostic_dedup_key_from_parts(start, code, &message);
         if self.diagnostic_indices.emitted.contains(&key) {
-            return;
-        }
-        if code == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
-            && message.contains("GetProps<")
-            && message.contains("ComponentClass")
-            && message.contains("FunctionComponent")
-        {
             return;
         }
         self.diagnostic_indices.emitted.insert(key);
@@ -256,42 +218,9 @@ impl<'a> CheckerContext<'a> {
     /// - TS4094 uses (start ^ `message_hash`, code) so each private/protected member of an
     ///   exported anonymous class expression emits its own diagnostic at the owning
     ///   variable/function name span.
-    pub fn push_diagnostic(&mut self, mut diag: Diagnostic) {
-        diag.message_text = Self::normalize_diagnostic_message(diag.code, diag.message_text);
-        if (diag.code == 2304 || diag.code == 2552 || diag.code == 2663)
-            && self
-                .diagnostic_indices
-                .emitted
-                .contains(&(diag.start, 2301))
-        {
+    pub fn push_diagnostic(&mut self, diag: Diagnostic) {
+        if self.reconcile_name_resolution_precedence(diag.start, diag.code) {
             return;
-        }
-        if diag.code == 2301 {
-            self.diagnostics.retain(|existing| {
-                !(existing.start == diag.start
-                    && (existing.code == 2304 || existing.code == 2552 || existing.code == 2663))
-            });
-            self.diagnostic_indices.emitted.remove(&(diag.start, 2304));
-            self.diagnostic_indices.emitted.remove(&(diag.start, 2552));
-            self.diagnostic_indices.emitted.remove(&(diag.start, 2663));
-        }
-        // Prefer specific name suggestions over generic "Cannot find name".
-        if diag.code == 2304
-            && (self
-                .diagnostic_indices
-                .emitted
-                .contains(&(diag.start, 2552))
-                || self
-                    .diagnostic_indices
-                    .emitted
-                    .contains(&(diag.start, 2663)))
-        {
-            return;
-        }
-        if diag.code == 2552 || diag.code == 2663 {
-            self.diagnostics
-                .retain(|existing| !(existing.start == diag.start && existing.code == 2304));
-            self.diagnostic_indices.emitted.remove(&(diag.start, 2304));
         }
         if diag.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE {
             let diag_end = diag.start.saturating_add(diag.length);
@@ -320,13 +249,6 @@ impl<'a> CheckerContext<'a> {
             self.reconcile_related_information_collision(diag);
             return;
         }
-        if diag.code == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
-            && diag.message_text.contains("GetProps<")
-            && diag.message_text.contains("ComponentClass")
-            && diag.message_text.contains("FunctionComponent")
-        {
-            return;
-        }
         self.diagnostic_indices.emitted.insert(key);
         tracing::debug!(
             code = diag.code,
@@ -345,47 +267,45 @@ impl<'a> CheckerContext<'a> {
         self.diagnostics.push(diag);
     }
 
-    fn normalize_diagnostic_message(code: u32, message: String) -> String {
-        if code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE {
-            return Self::normalize_logical_nonnullable_source_message(message);
+    /// Reconcile precedence between the name-resolution diagnostics that can
+    /// collide at one span: TS2301 ("Initializer of instance member cannot
+    /// reference identifier declared in constructor") outranks TS2304 ("Cannot
+    /// find name"), TS2552 ("Cannot find name ... Did you mean?"), and TS2663
+    /// ("Did you mean the instance member 'this.X'?") because it explains the
+    /// problem more precisely; TS2552/TS2663 name suggestions outrank the
+    /// generic TS2304.
+    ///
+    /// Shared by both emission entry points ([`Self::error`] and
+    /// [`Self::push_diagnostic`]) so the precedence rules cannot drift.
+    /// Returns `true` when the incoming diagnostic is outranked and must be
+    /// dropped; lower-precedence diagnostics already emitted at the same span
+    /// are evicted as a side effect.
+    fn reconcile_name_resolution_precedence(&mut self, start: u32, code: u32) -> bool {
+        let emitted = &self.diagnostic_indices.emitted;
+        match code {
+            2304 | 2552 | 2663 => {
+                if emitted.contains(&(start, 2301)) {
+                    return true;
+                }
+                if code == 2304
+                    && (emitted.contains(&(start, 2552)) || emitted.contains(&(start, 2663)))
+                {
+                    return true;
+                }
+            }
+            _ => {}
         }
-        if code == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE {
-            return Self::normalize_constrained_variadic_tuple_message(message);
-        }
-        message
-    }
-
-    fn normalize_constrained_variadic_tuple_message(message: String) -> String {
-        let target = "parameter of type 'readonly [...readonly [string, ...string[]], number]'";
-        if !message.contains(target) {
-            return message;
-        }
-        if message.contains("Argument of type 'number'") {
-            return message.replace(target, "parameter of type 'string'");
-        }
-        if message.contains("Argument of type '[") {
-            return message.replace(target, "parameter of type '[...string[], number]'");
-        }
-        message
-    }
-
-    fn normalize_logical_nonnullable_source_message(message: String) -> String {
-        let Some(rest) = message.strip_prefix("Type '") else {
-            return message;
+        let evict: &[u32] = match code {
+            2301 => &[2304, 2552, 2663],
+            2552 | 2663 => &[2304],
+            _ => return false,
         };
-        let Some((source, suffix)) = rest.split_once("' is not assignable") else {
-            return message;
-        };
-        let Some(nonnullable_rest) = source.strip_prefix("NonNullable<") else {
-            return message;
-        };
-        let Some((inner, right)) = nonnullable_rest.split_once("> | ") else {
-            return message;
-        };
-        if !right.chars().all(|c| c == '_' || c.is_ascii_alphanumeric()) {
-            return message;
+        self.diagnostics
+            .retain(|diag| !(diag.start == start && evict.contains(&diag.code)));
+        for &evicted in evict {
+            self.diagnostic_indices.emitted.remove(&(start, evicted));
         }
-        format!("Type '{right} | NonNullable<{inner}>' is not assignable{suffix}")
+        false
     }
 }
 

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -773,25 +773,8 @@ impl<'a> CheckerState<'a> {
                 let last = raw_sig.params.last()?;
                 last.rest.then_some((last.type_id, true))
             })?;
-        // An argument that maps into a rest parameter of *tuple* type is
-        // related against the tuple's per-position element type (leading fixed
-        // positions) or the sliced remainder (the aggregate check), never the
-        // whole rest tuple — tsc's getTypeAtPosition/getEffectiveRestType
-        // model. The caller's `param_type` already carries that solver-computed
-        // expected type, so reconstructing the whole instantiated tuple here
-        // would misreport the parameter surface.
-        if param_is_rest {
-            let raw_unwrapped = query_common::unwrap_readonly(self.ctx.types, raw_param_type);
-            if query_common::tuple_elements(self.ctx.types, raw_unwrapped).is_some() {
-                return None;
-            }
-            // The raw type may hide the tuple behind an alias/application;
-            // only then pay for an environment evaluation.
-            let instantiated_probe = self.evaluate_type_with_env(raw_param_type);
-            let unwrapped = query_common::unwrap_readonly(self.ctx.types, instantiated_probe);
-            if query_common::tuple_elements(self.ctx.types, unwrapped).is_some() {
-                return None;
-            }
+        if param_is_rest && self.rest_tuple_parameter_reports_per_position(raw_param_type) {
+            return None;
         }
 
         let mut replacements = FxHashMap::default();

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting.rs
@@ -765,14 +765,34 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let raw_param_type = raw_sig
+        let (raw_param_type, param_is_rest) = raw_sig
             .params
             .get(arg_index)
-            .map(|param| param.type_id)
+            .map(|param| (param.type_id, param.rest))
             .or_else(|| {
                 let last = raw_sig.params.last()?;
-                last.rest.then_some(last.type_id)
+                last.rest.then_some((last.type_id, true))
             })?;
+        // An argument that maps into a rest parameter of *tuple* type is
+        // related against the tuple's per-position element type (leading fixed
+        // positions) or the sliced remainder (the aggregate check), never the
+        // whole rest tuple — tsc's getTypeAtPosition/getEffectiveRestType
+        // model. The caller's `param_type` already carries that solver-computed
+        // expected type, so reconstructing the whole instantiated tuple here
+        // would misreport the parameter surface.
+        if param_is_rest {
+            let raw_unwrapped = query_common::unwrap_readonly(self.ctx.types, raw_param_type);
+            if query_common::tuple_elements(self.ctx.types, raw_unwrapped).is_some() {
+                return None;
+            }
+            // The raw type may hide the tuple behind an alias/application;
+            // only then pay for an environment evaluation.
+            let instantiated_probe = self.evaluate_type_with_env(raw_param_type);
+            let unwrapped = query_common::unwrap_readonly(self.ctx.types, instantiated_probe);
+            if query_common::tuple_elements(self.ctx.types, unwrapped).is_some() {
+                return None;
+            }
+        }
 
         let mut replacements = FxHashMap::default();
         for (raw_param, &call_arg_idx) in raw_sig.params.iter().zip(args.nodes.iter()) {

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_parameters.rs
@@ -402,6 +402,10 @@ impl<'a> CheckerState<'a> {
             return display;
         }
 
+        if let Some(display) = self.effective_rest_slice_parameter_display(param_type) {
+            return display;
+        }
+
         if let Some(display) =
             self.underfilled_generic_variadic_tuple_parameter_display(param_type, arg_type)
         {

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_variadic.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_variadic.rs
@@ -28,6 +28,29 @@ impl<'a> CheckerState<'a> {
         Some(self.format_tuple_element_display(&elements, readonly))
     }
 
+    /// Whether an argument mapping into this rest parameter is reported
+    /// against a per-position element type or sliced remainder rather than
+    /// the whole rest tuple — true when the rest parameter's type is a tuple.
+    ///
+    /// tsc's `getTypeAtPosition`/`getEffectiveRestType` model never relates an
+    /// argument against the whole rest tuple, and the solver already computes
+    /// that per-position/sliced expected type, so display reconstruction from
+    /// the raw rest parameter must stand down for these shapes.
+    pub(in crate::error_reporter::call_errors) fn rest_tuple_parameter_reports_per_position(
+        &mut self,
+        raw_param_type: TypeId,
+    ) -> bool {
+        let raw_unwrapped = query_common::unwrap_readonly(self.ctx.types, raw_param_type);
+        if query_common::tuple_elements(self.ctx.types, raw_unwrapped).is_some() {
+            return true;
+        }
+        // The raw type may hide the tuple behind an alias/application; only
+        // then pay for an environment evaluation.
+        let instantiated_probe = self.evaluate_type_with_env(raw_param_type);
+        let unwrapped = query_common::unwrap_readonly(self.ctx.types, instantiated_probe);
+        query_common::tuple_elements(self.ctx.types, unwrapped).is_some()
+    }
+
     pub(crate) fn constrained_variadic_tuple_parameter_display(
         &mut self,
         param_type: TypeId,

--- a/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_variadic.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/display_formatting_variadic.rs
@@ -5,15 +5,35 @@ use crate::state::CheckerState;
 use tsz_solver::{TupleElement, TypeId};
 
 impl<'a> CheckerState<'a> {
+    /// Structural display for an *effective rest slice*: a tuple whose first
+    /// element is a rest element followed by a fixed tail, e.g.
+    /// `[...string[], number]`. tsc derives this parameter surface through
+    /// `getEffectiveRestType`/`sliceTupleType`, which always synthesizes an
+    /// anonymous tuple — so the displayed parameter never borrows the name of
+    /// a structurally identical user alias (`V01`), even though interning
+    /// would otherwise share the alias's display.
+    pub(crate) fn effective_rest_slice_parameter_display(
+        &mut self,
+        param_type: TypeId,
+    ) -> Option<String> {
+        let readonly =
+            crate::query_boundaries::common::readonly_inner_type(self.ctx.types, param_type)
+                .is_some();
+        let unwrapped = query_common::unwrap_readonly(self.ctx.types, param_type);
+        let elements = query_common::tuple_elements(self.ctx.types, unwrapped)?;
+        let (first, tail) = elements.split_first()?;
+        if !first.rest || tail.is_empty() || tail.iter().any(|element| element.rest) {
+            return None;
+        }
+        Some(self.format_tuple_element_display(&elements, readonly))
+    }
+
     pub(crate) fn constrained_variadic_tuple_parameter_display(
         &mut self,
         param_type: TypeId,
         arg_type: TypeId,
     ) -> Option<String> {
         self.constrained_variadic_tuple_parameter_display_structured(param_type, arg_type)
-            .or_else(|| {
-                self.constrained_variadic_tuple_parameter_display_from_surface(param_type, arg_type)
-            })
     }
 
     fn constrained_variadic_tuple_parameter_display_structured(
@@ -78,25 +98,6 @@ impl<'a> CheckerState<'a> {
         display_elements.extend(constraint_elements[consumed..].iter().copied());
         display_elements.extend(outer_tail.iter().copied());
         Some(self.format_tuple_element_display(&display_elements, false))
-    }
-
-    fn constrained_variadic_tuple_parameter_display_from_surface(
-        &mut self,
-        param_type: TypeId,
-        arg_type: TypeId,
-    ) -> Option<String> {
-        let display = self.format_type_diagnostic(param_type);
-        let rest = display
-            .strip_prefix("readonly [...readonly [")
-            .or_else(|| display.strip_prefix("[...["))?;
-        let (constraint, outer_tail) = rest.rsplit_once("], ")?;
-        let outer_tail = outer_tail.strip_suffix(']')?;
-        let (fixed, variadic) = constraint.split_once(", ...")?;
-        if query_common::tuple_elements(self.ctx.types, arg_type).is_some() {
-            Some(format!("[...{variadic}, {outer_tail}]"))
-        } else {
-            Some(fixed.to_string())
-        }
     }
 
     pub(crate) fn underfilled_generic_variadic_tuple_parameter_display(

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -705,6 +705,9 @@ mod destructured_discriminant_source_narrowing_tests;
 #[path = "tests/destructuring_relation_routing_arch_tests.rs"]
 mod destructuring_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/diagnostic_sink_message_surgery_arch_tests.rs"]
+mod diagnostic_sink_message_surgery_arch_tests;
+#[cfg(test)]
 #[path = "tests/diagnostic_source_relation_routing_arch_tests.rs"]
 mod diagnostic_source_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/call_display_format_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/call_display_format_relation_routing_arch_tests.rs
@@ -118,7 +118,7 @@ fn variadic_tuple_display_uses_env_relation_outcome_boundary() {
         .find("fn constrained_variadic_tuple_parameter_display_structured")
         .expect("missing variadic tuple display helper");
     let end = source[start..]
-        .find("fn constrained_variadic_tuple_parameter_display_from_surface")
+        .find("fn underfilled_generic_variadic_tuple_parameter_display")
         .map(|offset| start + offset)
         .expect("missing next variadic tuple display helper");
     let helper = &source[start..end];

--- a/crates/tsz-checker/src/tests/diagnostic_sink_message_surgery_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/diagnostic_sink_message_surgery_arch_tests.rs
@@ -1,0 +1,98 @@
+//! Architecture gate for the central diagnostic emission sink.
+//!
+//! `context/diagnostic_push.rs` is the single sink every diagnostic flows
+//! through. Display and suppression decisions belong to the type-level owner
+//! (relation, inference, union ordering, tuple normalization) — never to
+//! post-hoc surgery on formatted message text. This gate keeps the sink free
+//! of message-string predicates and rewrites so the fixture-shaped hacks
+//! removed by issue #13057 cannot silently return.
+
+use std::fs;
+
+fn sink_source() -> String {
+    fs::read_to_string("src/context/diagnostic_push.rs")
+        .expect("failed to read context/diagnostic_push.rs")
+}
+
+/// Strip line comments, doc comments, and string literals so the gate only
+/// inspects executable code (messages quoted in comments stay allowed).
+fn executable_code(source: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    for line in source.lines() {
+        let line = line.split("//").next().unwrap_or(line);
+        let mut in_string = false;
+        for ch in line.chars() {
+            if ch == '"' {
+                in_string = !in_string;
+                continue;
+            }
+            if !in_string {
+                out.push(ch);
+            }
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// The sink must not branch on the *content* of a rendered message: no
+/// substring probes, prefix/suffix parsing, splitting, or in-place rewrites
+/// of `message`/`message_text`. Hashing the message for dedup keys is the
+/// only sanctioned read.
+#[test]
+fn emission_sink_does_not_inspect_or_rewrite_message_text() {
+    let code = executable_code(&sink_source());
+    // String-surgery methods with no sanctioned use anywhere in the sink.
+    for forbidden in [
+        ".strip_prefix(",
+        ".strip_suffix(",
+        ".split_once(",
+        ".rsplit_once(",
+        ".replace(",
+        ".starts_with(",
+        ".ends_with(",
+    ] {
+        assert!(
+            !code.contains(forbidden),
+            "diagnostic_push.rs must not use `{forbidden}` — message-text \
+             predicates and rewrites in the emission sink mask upstream \
+             display/relation defects; fix the type-level owner instead \
+             (see issue #13057)",
+        );
+    }
+    // `contains` is sanctioned on the dedup sets, but never on message text.
+    for forbidden in [
+        "message.contains(",
+        "message_text.contains(",
+        "message.find(",
+        "message_text.find(",
+    ] {
+        assert!(
+            !code.contains(forbidden),
+            "diagnostic_push.rs must not probe message text via `{forbidden}` \
+             (see issue #13057)",
+        );
+    }
+}
+
+/// The TS2301/TS2304/TS2552/TS2663 precedence rules must stay shared between
+/// the two emission entry points instead of being copy-pasted back into them.
+#[test]
+fn name_resolution_precedence_is_single_sourced() {
+    let source = sink_source();
+    assert_eq!(
+        source
+            .matches("fn reconcile_name_resolution_precedence")
+            .count(),
+        1,
+        "expected exactly one definition of the shared precedence reconciler"
+    );
+    assert_eq!(
+        source
+            .matches("self.reconcile_name_resolution_precedence(")
+            .count(),
+        2,
+        "both `error` and `push_diagnostic` must route through the shared \
+         precedence reconciler"
+    );
+}

--- a/crates/tsz-checker/tests/logical_operator_literal_preservation_tests.rs
+++ b/crates/tsz-checker/tests/logical_operator_literal_preservation_tests.rs
@@ -127,19 +127,17 @@ function fn2<U, V>(u: U, v: V) {
         2,
         "expected one TS2322 per logical-or assignment, got: {diagnostics:?}"
     );
+    // tsc orders union members by type creation, so the NonNullable<T>
+    // approximation synthesized while checking `t || u` always displays after
+    // the already-created right operand: `U | NonNullable<T>`, never the
+    // reverse.
     let has_t_u_display = ts2322.iter().any(|diag| {
         diag.message_text
             .contains("Type 'U | NonNullable<T>' is not assignable to type '{}'.")
-            || diag
-                .message_text
-                .contains("Type 'NonNullable<T> | U' is not assignable to type '{}'.")
     });
     let has_u_v_display = ts2322.iter().any(|diag| {
         diag.message_text
             .contains("Type 'V | NonNullable<U>' is not assignable to type '{}'.")
-            || diag
-                .message_text
-                .contains("Type 'NonNullable<U> | V' is not assignable to type '{}'.")
     });
     assert!(
         has_t_u_display,
@@ -148,6 +146,29 @@ function fn2<U, V>(u: U, v: V) {
     assert!(
         has_u_v_display,
         "expected whole-expression display for U || V, got: {ts2322:?}"
+    );
+}
+
+/// Concrete (non-type-parameter) left operands keep source order: the truthy
+/// left type already exists when the `||` union forms, so it displays first —
+/// `(options || {})` renders `{ a: string; b: number; } | {}`.
+#[test]
+fn logical_or_concrete_left_operand_keeps_source_display_order() {
+    let source = r#"
+declare let options: { a: string; b: number } | undefined;
+const probe: never = (options || {});
+"#;
+
+    let diagnostics = check_source_strict(source);
+    let ts2322: Vec<_> = diagnostics
+        .iter()
+        .filter(|diag| diag.code == 2322)
+        .collect();
+    assert!(
+        ts2322.iter().any(|diag| diag
+            .message_text
+            .contains("Type '{ a: string; b: number; } | {}'")),
+        "expected truthy-left-first display for concrete operands, got: {ts2322:?}"
     );
 }
 

--- a/crates/tsz-checker/tests/variadic_tuple_elaboration_tests.rs
+++ b/crates/tsz-checker/tests/variadic_tuple_elaboration_tests.rs
@@ -306,3 +306,115 @@ foo('blah1', 'blah2', 1, 2, 3);
         "expanded readonly constraint should not leak into TS2345 display: {messages:?}"
     );
 }
+
+/// Renamed binders + mutable (non-readonly) constraint: the per-position /
+/// sliced parameter surface is keyed on the tuple structure, not on the
+/// spelling of the type parameter, the rest parameter, or readonly-ness.
+#[test]
+fn constrained_mutable_variadic_tuple_call_uses_constraint_surface_renamed() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function collect<Parts extends [boolean, ...boolean[]]>(...flagsAndTag: [...Parts, string]): void;
+collect(1);
+collect(true, false, 1, 2, "tag");
+"#,
+    );
+
+    let messages: Vec<_> = diags
+        .iter()
+        .filter(|d| d.code == 2345)
+        .map(|d| d.message_text.as_str())
+        .collect();
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains("parameter of type 'boolean'")),
+        "expected scalar mismatch against constrained first element, got {messages:?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|message| message.contains("parameter of type '[...boolean[], string]'")),
+        "expected aggregate mismatch against remaining constrained tuple, got {messages:?}"
+    );
+}
+
+/// Negative control: a valid call against the constrained variadic rest tuple
+/// stays clean — the slicing/flattening must not invent errors.
+#[test]
+fn constrained_readonly_variadic_tuple_valid_call_no_errors() {
+    let diags = check_source_diagnostics(
+        r#"
+declare function foo<S extends readonly [string, ...string[]]>(...stringsAndNumber: readonly [...S, number]): [...S, number];
+foo("a", 1);
+foo("a", "b", "c", 2);
+"#,
+    );
+    assert!(
+        diags.iter().all(|d| d.code != 2345),
+        "valid constrained variadic calls must not report TS2345, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The synthesized effective-rest slice must display structurally even when a
+/// user alias is structurally identical — tsc's sliceTupleType creates an
+/// anonymous tuple, so the alias name never appears in the TS2345 surface.
+#[test]
+fn aggregate_rest_slice_does_not_borrow_structural_alias_name() {
+    let diags = check_source_diagnostics(
+        r#"
+type Tail = [...string[], number];
+declare let keep: Tail;
+declare function foo<S extends readonly [string, ...string[]]>(...stringsAndNumber: readonly [...S, number]): [...S, number];
+foo('blah1', 'blah2', 1, 2, 3);
+"#,
+    );
+
+    let ts2345 = diags
+        .iter()
+        .find(|d| d.code == 2345)
+        .expect("expected TS2345");
+    assert!(
+        ts2345
+            .message_text
+            .contains("parameter of type '[...string[], number]'"),
+        "expected structural slice display, got {ts2345:?}"
+    );
+    assert!(
+        !ts2345.message_text.contains("'Tail'"),
+        "synthesized rest slice must not borrow a structurally identical alias name: {ts2345:?}"
+    );
+}
+
+/// A variadic spread of a tuple that carries its own rest, followed by a
+/// fixed suffix, flattens like tsc's createNormalizedTupleType:
+/// `[...[string, ...string[]], number]` is `[string, ...string[], number]`,
+/// so a tuple-level assignment mismatch shows the flattened target.
+#[test]
+fn middle_variadic_tuple_spread_flattens_for_display() {
+    let diags = check_source_diagnostics(
+        r#"
+declare let direct: [...[string, ...string[]], number];
+direct = ["a", "b", 9, "c"];
+"#,
+    );
+
+    let ts2322 = diags
+        .iter()
+        .find(|d| d.code == 2322)
+        .expect("expected TS2322");
+    assert!(
+        ts2322
+            .message_text
+            .contains("'[string, ...string[], number]'"),
+        "expected flattened variadic spread display, got {ts2322:?}"
+    );
+    assert!(
+        !ts2322.message_text.contains("[...["),
+        "variadic tuple spread with a fixed suffix must not stay nested: {ts2322:?}"
+    );
+}

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -1163,10 +1163,14 @@ impl TypeInterner {
     ///
     /// A **fixed** inner tuple (no rest of its own) is always spliced. A
     /// **variadic** inner tuple (carrying its own rest, e.g. `[B, ...C[]]`) is
-    /// spliced only when it is the parent's sole rest element and its last
-    /// element, so the result still carries at most one rest — this is the shape
-    /// recursive list utilities (`[H, ...Util<R>]`) build, and it can never
-    /// produce an illegal two-rest tuple. Rest *arrays* (`...X[]`) and generic
+    /// spliced only when it is the parent's sole rest element, so the result
+    /// still carries at most one rest — the inner rest simply replaces the
+    /// parent's. This covers recursive list utilities (`[H, ...Util<R>]`) and
+    /// middle-position spreads with a fixed suffix (`[...S, number]` with `S`
+    /// instantiated to `[string, ...string[]]`, which tsc normalizes to
+    /// `[string, ...string[], number]`). A middle-position inner tuple that
+    /// itself carries more than one rest (parser-recovered shapes) is left as
+    /// written. Rest *arrays* (`...X[]`) and generic
     /// spreads (`...T`, `...Application`, `...Lazy`) are left as written; a
     /// self-referential `type T = [x, ...T]` never resolves its spread to a
     /// concrete tuple, so this cannot recurse. Optional outer spreads are left
@@ -1207,8 +1211,17 @@ impl TypeInterner {
                 && let Some(inner_list) = self.concrete_tuple_list(elem.type_id)
             {
                 let inner = self.tuple_list(inner_list);
-                let inner_is_variadic = inner.iter().any(|inner_elem| inner_elem.rest);
-                if !inner_is_variadic || (parent_rest_count == 1 && index == last_index) {
+                let (inner_rest_count, inner_has_optional) =
+                    inner.iter().fold((0usize, false), |(rests, optional), e| {
+                        (rests + usize::from(e.rest), optional || e.optional)
+                    });
+                // Splicing into a middle position must not move an optional
+                // element in front of the parent's required suffix (an illegal
+                // tuple shape), so only rest+required inner shapes splice there.
+                let splice_middle = inner_rest_count == 1 && !inner_has_optional;
+                let splice_variadic =
+                    parent_rest_count == 1 && (index == last_index || splice_middle);
+                if inner_rest_count == 0 || splice_variadic {
                     out.extend(inner.iter().copied());
                     continue;
                 }

--- a/crates/tsz-solver/src/operations/binary_ops.rs
+++ b/crates/tsz-solver/src/operations/binary_ops.rs
@@ -936,8 +936,8 @@ impl<'a> BinaryOpEvaluator<'a> {
             // left || right
             // tsc uses UnionReduction.Subtype for || result types, which removes
             // structural subtypes (e.g., never[] from number[] | never[] → number[]).
-            let truthy_left =
-                self.non_nullable_type_parameter_result(left, ctx.narrow_by_truthiness(left));
+            let plain_truthy_left = ctx.narrow_by_truthiness(left);
+            let truthy_left = self.non_nullable_type_parameter_result(left, plain_truthy_left);
             let falsy_left = ctx.narrow_to_falsy(left);
 
             if falsy_left == TypeId::NEVER && !self.is_type_parameter_like(left) {
@@ -946,13 +946,21 @@ impl<'a> BinaryOpEvaluator<'a> {
                 right
             } else {
                 let result = self.union2_subtype_reduce(truthy_left, right);
-                // tsc displays the truthy-narrowed left first, then the right
-                // operand: `(options || {}).a` produces
-                //   `{ a: string; b: number; } | {}`
-                // (not the reverse). Record that order as the union origin so
-                // diagnostic display follows source order.
+                // tsc orders union members by type creation: `(options || {}).a`
+                // displays `{ a: string; b: number; } | {}` because both operand
+                // types already exist when the union forms. When the truthy side
+                // is a `NonNullable<T>` approximation *synthesized by this very
+                // operation* (`T & {}` for a type-parameter left), it is the
+                // newest type in tsc's id order and therefore displays last:
+                // `t || u` renders `U | NonNullable<T>`. Record the matching
+                // origin order so diagnostic display agrees.
+                let display_origin = if truthy_left == plain_truthy_left {
+                    vec![truthy_left, right]
+                } else {
+                    vec![right, truthy_left]
+                };
                 self.interner
-                    .replace_union_origin_for_display(result, vec![truthy_left, right]);
+                    .replace_union_origin_for_display(result, display_origin);
                 result
             }
         } else {

--- a/crates/tsz-solver/tests/tuple_spread_splice_tests.rs
+++ b/crates/tsz-solver/tests/tuple_spread_splice_tests.rs
@@ -3,9 +3,11 @@
 //!
 //! Structural rule: a rest element `...X` whose type is a concrete tuple
 //! contributes a statically known run of elements, so `[A, ...[B, C]]` is
-//! exactly `[A, B, C]`. A fixed inner tuple is always inlined; a variadic inner
-//! tuple is inlined only as the parent's sole, last rest (keeping ≤ 1 rest); a
-//! lone `[...X]` is left compressed; rest arrays are never inlined.
+//! exactly `[A, B, C]`. A fixed inner tuple is always inlined; a variadic
+//! inner tuple is inlined when it is the parent's sole rest (its rest simply
+//! replaces the parent's, keeping ≤ 1 rest), including middle positions with
+//! a fixed suffix — `[...[A, ...B[]], C]` is `[A, ...B[], C]`; a lone `[...X]`
+//! is left compressed; rest arrays are never inlined.
 
 use crate::intern::TypeInterner;
 use crate::types::{TupleElement, TypeData, TypeId};
@@ -83,12 +85,38 @@ fn variadic_inner_tuple_inlines_as_sole_last_rest() {
 }
 
 #[test]
-fn variadic_inner_tuple_not_last_is_left_compressed() {
+fn variadic_inner_tuple_not_last_inlines_when_sole_rest() {
     let interner = TypeInterner::new();
-    // inner = [boolean, ...number[]] spliced would put a rest before a trailing
-    // fixed element, creating a second rest — so it must stay un-inlined.
+    // inner = [boolean, ...number[]]: its single rest simply replaces the
+    // parent's, so [...[boolean, ...number[]], string] normalizes to
+    // [boolean, ...number[], string] — exactly tsc's createNormalizedTupleType
+    // result for an instantiated middle-position variadic spread.
     let inner = interner.tuple(vec![
         fixed(TypeId::BOOLEAN),
+        rest(interner.array(TypeId::NUMBER)),
+    ]);
+    let outer = interner.tuple(vec![rest(inner), fixed(TypeId::STRING)]);
+
+    let elements = tuple_elements(&interner, outer);
+    assert_eq!(elements.len(), 3, "the middle variadic spread is inlined");
+    assert_eq!(elements[0].type_id, TypeId::BOOLEAN);
+    assert!(!elements[0].rest);
+    assert!(elements[1].rest, "the inner rest replaces the parent's");
+    assert_eq!(elements[2].type_id, TypeId::STRING);
+    assert!(!elements[2].rest);
+}
+
+#[test]
+fn optional_carrying_variadic_inner_tuple_not_last_is_left_compressed() {
+    let interner = TypeInterner::new();
+    // inner = [boolean?, ...number[]]: splicing into a middle position would
+    // move an optional element in front of the parent's required suffix (an
+    // illegal tuple shape), so the spread stays compressed.
+    let inner = interner.tuple(vec![
+        TupleElement {
+            optional: true,
+            ..fixed(TypeId::BOOLEAN)
+        },
         rest(interner.array(TypeId::NUMBER)),
     ]);
     let outer = interner.tuple(vec![rest(inner), fixed(TypeId::STRING)]);
@@ -97,7 +125,7 @@ fn variadic_inner_tuple_not_last_is_left_compressed() {
     assert_eq!(
         elements.len(),
         2,
-        "the variadic spread is kept compressed when not last"
+        "an optional-carrying variadic spread is kept compressed when not last"
     );
     assert!(elements[0].rest);
     assert_eq!(elements[0].type_id, inner);


### PR DESCRIPTION
Goal: hold

Closes #13057.

## Summary

`crates/tsz-checker/src/context/diagnostic_push.rs` — the single sink every diagnostic flows through — carried three fixture-shaped message-string hacks plus a ~30-line suppress/retain block duplicated between its two entry points. Each hack masked an upstream display/relation defect. This PR fixes the type-level owners and deletes all of the string surgery, plus one more member of the same family found during the work (`constrained_variadic_tuple_parameter_display_from_surface`, which parsed rendered display text).

## Structural rules and owner layers

1. **Tuple normalization — solver interner** (`intern/core/constructors.rs`). When a variadic tuple spread's inner type is a concrete tuple carrying its own rest, and it is the parent's sole rest element, tsc's `createNormalizedTupleType` flattens it even with a fixed suffix following; tsz now does the same through `splice_concrete_tuple_spreads` (`[...S, number]` with `S = readonly [string, ...string[]]` → `readonly [string, ...string[], number]`). Middle-position splices are gated on rest+required inner shapes (no optional, exactly one rest), so no illegal tuple shape can be produced; parser-recovered multi-rest inners stay compressed.
2. **Call-parameter display — checker error reporter** (`error_reporter/call_errors/`). When an argument maps into a rest parameter of tuple type, tsc reports it against the per-position element type (`getTypeAtPosition`) or the sliced effective rest (`getEffectiveRestType`/`sliceTupleType`), never the whole rest tuple; tsz now does the same by (a) gating `instantiated_call_parameter_display` from overriding the solver-computed expected type and (b) displaying synthesized effective-rest slices (`[...string[], number]`) structurally — tsc's slice is an anonymous tuple, so the display never borrows a structurally identical user alias name.
3. **Logical-or union display order — solver binary ops** (`operations/binary_ops.rs`). tsc orders union members by type creation; the `NonNullable<T>` approximation synthesized while checking `t || u` is the newest type and displays last (`U | NonNullable<T>`), while concrete operands keep source order (`{ a: string; b: number; } | {}`). tsz records the matching union display origin at the construction site.
4. **Dead suppression deleted.** The `GetProps<`/`ComponentClass`/`FunctionComponent` TS2345 substring suppression (from PR #4349) is dead: both pinned fixtures now produce exactly tsc's single TS2344 without it.
5. **Sink dedupe + recurrence gate.** The TS2301/TS2304/TS2552/TS2663 precedence rules are extracted into one `reconcile_name_resolution_precedence` shared by `error()` and `push_diagnostic()`, and a new architecture test (`diagnostic_sink_message_surgery_arch_tests.rs`) forbids message-text predicates/rewrites in the sink and enforces the single-sourcing.

## Adjacent-case matrix

- Variadic rest tuples: readonly and mutable constraints, renamed binders (`foo<S>`/`collect<Parts>`), scalar vs aggregate mismatch, valid-call negative control, alias-name non-borrowing, literal middle-position spread flattening (`crates/tsz-checker/tests/variadic_tuple_elaboration_tests.rs`).
- Tuple splicing: fixed inner, readonly inner, variadic inner at last vs middle position, optional-carrying inner (left compressed), lone `[...X]` (left compressed), rest arrays (never inlined) (`crates/tsz-solver/tests/tuple_spread_splice_tests.rs`).
- `||` display: type-parameter operands in both orders (`T || U`, `U || V`) and concrete-operand source order control (`crates/tsz-checker/tests/logical_operator_literal_preservation_tests.rs`).
- Fallback: non-tuple (array) rest parameters keep the existing display path; uninstantiated `[...S, number]` shapes still route through the constraint-resolving display first.

## Verification

- Pinned conformance fixtures re-run against the tsc 6.0.3 fingerprint cache and match exactly (code+line+col+message): `conformance/types/tuple/variadicTuples2.ts` (34/34 fingerprints), `conformance/expressions/binaryOperators/logicalOrOperator/logicalOrOperatorWithTypeParameters.ts` (2/2), `compiler/reactReduxLikeDeferredInferenceAllowsAssignment.ts` (1/1), `compiler/circularlyConstrainedMappedTypeContainingConditionalNoInfiniteInstantiationDepth.ts` (1/1).
- `cargo nextest run -p tsz-checker --lib` — failures identical to the clean-tree baseline set on this box (no regressions; baseline diffed by test name).
- `cargo nextest run -p tsz-solver` — only pre-existing failure (`test_generic_call_widening_applies_when_constraint_satisfied`, fails on clean tree too) plus the intentionally updated splice test.
- `cargo nextest run -p tsz-emitter --lib -E 'test(tuple) or test(variadic) or test(generics)'` — 113/113.
- `cargo nextest run -p tsz-checker --test conformance_issues_errors -E 'test(react_redux) or test(recursive_shared_constraint)'` — 3/3.
- `cargo clippy -p tsz-solver -p tsz-checker --lib` clean; `cargo fmt --check` clean.
- Ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_018atbt6ZfJne9rSi5DZVJiu)_