### PR TITLE
fix(workspace): use scanner identifier predicates

### DIFF
--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -9,6 +9,7 @@ use crate::checker::diagnostics::Diagnostic;
 use crate::emitter::{ModuleKind, NewLineKind, ScriptTarget};
 use tsz_common::diagnostics::data::{diagnostic_codes, diagnostic_messages};
 use tsz_common::diagnostics::format_message;
+use tsz_scanner::{is_ecmascript_identifier_part, is_ecmascript_identifier_start};
 mod deprecation_helpers;
 mod extends;
 mod lib_offsets;
@@ -482,15 +483,12 @@ fn is_valid_identifier_or_qualified_name(s: &str) -> bool {
 }
 
 fn is_valid_identifier(s: &str) -> bool {
-    if s.is_empty() {
-        return false;
-    }
     let mut chars = s.chars();
     match chars.next() {
-        Some(c) if c.is_alphabetic() || c == '_' || c == '$' => {}
+        Some(c) if is_ecmascript_identifier_start(c) => {}
         _ => return false,
     }
-    chars.all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+    chars.all(is_ecmascript_identifier_part)
 }
 
 /// Find the byte offset of a JSON key within the source text.

--- a/crates/tsz-core/src/config/tests/options_parsing.rs
+++ b/crates/tsz-core/src/config/tests/options_parsing.rs
@@ -318,6 +318,33 @@ fn test_ts5059_emitted_for_invalid_react_namespace_value() {
 }
 
 #[test]
+fn test_jsx_identifier_options_accept_ecmascript_unicode_identifiers() {
+    let source = r#"{
+  "compilerOptions": {
+"jsx": "react",
+"jsxFactory": "élément.create",
+"reactNamespace": "日本語"
+  }
+}"#;
+    let parsed = parse_tsconfig_with_diagnostics(source, "tsconfig.json").unwrap();
+    let codes: Vec<u32> = parsed.diagnostics.iter().map(|d| d.code).collect();
+    assert!(
+        !codes.contains(
+            &diagnostic_codes::INVALID_VALUE_FOR_JSXFACTORY_IS_NOT_A_VALID_IDENTIFIER_OR_QUALIFIED_NAME,
+        ),
+        "Unicode jsxFactory should be accepted, got diagnostics: {:?}",
+        parsed.diagnostics
+    );
+    assert!(
+        !codes.contains(
+            &diagnostic_codes::INVALID_VALUE_FOR_REACTNAMESPACE_IS_NOT_A_VALID_IDENTIFIER
+        ),
+        "Unicode reactNamespace should be accepted, got diagnostics: {:?}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
 fn test_disable_size_limit_option_is_recognized() {
     let source = r#"{
   "compilerOptions": {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members.rs
@@ -8,7 +8,10 @@ use super::super::DeclarationEmitter;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_scanner::{SyntaxKind, string_to_token, token_is_reserved_word};
+use tsz_scanner::{
+    SyntaxKind, is_ecmascript_identifier_part, is_ecmascript_identifier_start, string_to_token,
+    token_is_reserved_word,
+};
 
 impl<'a> DeclarationEmitter<'a> {
     pub(in crate::declaration_emitter) fn format_object_member_type_text(
@@ -391,11 +394,11 @@ impl<'a> DeclarationEmitter<'a> {
             return false;
         };
 
-        if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
+        if !is_ecmascript_identifier_start(first) {
             return false;
         }
 
-        chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
+        chars.all(is_ecmascript_identifier_part)
     }
 
     pub(in crate::declaration_emitter) fn preferred_object_member_initializer_type_text(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members_tests.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_object_members_tests.rs
@@ -40,7 +40,17 @@ fn valid_identifiers_emit_bare_regardless_of_name_choice() {
     // Vary the spelling: plain, leading underscore, leading `$`, the
     // `__proto__` witness, and a mixed case. None are reserved words, so all
     // must be emittable bare.
-    for name in ["foo", "_x", "$bar", "__proto__", "_proto__", "fooBar123"] {
+    for name in [
+        "foo",
+        "_x",
+        "$bar",
+        "__proto__",
+        "_proto__",
+        "fooBar123",
+        "café",
+        "日本語",
+        "π2",
+    ] {
         assert!(
             DeclarationEmitter::can_emit_bare_property_name(name),
             "expected `{name}` to be emittable bare",
@@ -96,6 +106,10 @@ fn literal_text_canonicalizes_valid_identifiers_to_bare() {
     assert_eq!(
         DeclarationEmitter::format_property_name_literal_text("___proto__"),
         "___proto__",
+    );
+    assert_eq!(
+        DeclarationEmitter::format_property_name_literal_text("café"),
+        "café",
     );
 }
 

--- a/crates/tsz-emitter/tests/statements.rs
+++ b/crates/tsz-emitter/tests/statements.rs
@@ -178,6 +178,25 @@ fn es5_property_access_preserves_raw_astral_identifier_name() {
 }
 
 #[test]
+fn object_literal_unicode_property_names_emit_bare() {
+    let source = "const obj = { café: 1, 日本語: 2 };";
+    let output = parse_and_emit_strict_target(source, "unicode.ts", ScriptTarget::ES2015);
+
+    assert!(
+        output.contains("café: 1"),
+        "Unicode identifier-start property should emit bare.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("日本語: 2"),
+        "Unicode identifier-name property should emit bare.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("\"café\"") && !output.contains("\"日本語\""),
+        "Unicode identifier property names should not be quoted.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn es5_arrow_empty_block_preserves_inner_line_comment() {
     let source = "const f: () => undefined = () => {\n    // keep\n};\n";
     let output = parse_and_emit_strict_target(source, "arrow.ts", ScriptTarget::ES5);

--- a/crates/tsz-lsp/src/project/imports/position.rs
+++ b/crates/tsz-lsp/src/project/imports/position.rs
@@ -8,9 +8,13 @@ use crate::utils::find_node_at_offset;
 use tsz_common::position::{Position, Range};
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::{NodeArena, NodeIndex, syntax_kind_ext};
-use tsz_scanner::SyntaxKind;
+use tsz_scanner::{SyntaxKind, is_ecmascript_identifier_part, is_ecmascript_identifier_start};
 
 use super::super::{ImportKind, ImportTarget, Project, ProjectFile};
+
+fn identifier_span_touches_probe(start: usize, end: usize, probe: usize) -> bool {
+    (start..=end).contains(&probe)
+}
 
 impl Project {
     /// Returns `true` when `position` falls inside a `NamedImports` node —
@@ -121,45 +125,32 @@ impl Project {
     }
 
     fn identifier_text_around_offset(source_text: &str, probe_offset: usize) -> Option<String> {
-        let bytes = source_text.as_bytes();
-        if bytes.is_empty() {
-            return None;
-        }
+        let probe = probe_offset.min(source_text.len());
+        let mut current_start = None;
+        let mut current_end = 0;
 
-        let mut idx = probe_offset.min(bytes.len() - 1);
-        if !Self::is_ascii_identifier_continue(bytes[idx]) {
-            if idx > 0 && Self::is_ascii_identifier_continue(bytes[idx - 1]) {
-                idx -= 1;
-            } else {
-                return None;
+        for (idx, ch) in source_text.char_indices() {
+            let next = idx + ch.len_utf8();
+            if let Some(start) = current_start {
+                if is_ecmascript_identifier_part(ch) {
+                    current_end = next;
+                    continue;
+                }
+                if identifier_span_touches_probe(start, current_end, probe) {
+                    return Some(source_text[start..current_end].to_string());
+                }
+                current_start = None;
+            }
+
+            if is_ecmascript_identifier_start(ch) {
+                current_start = Some(idx);
+                current_end = next;
             }
         }
 
-        let mut start = idx;
-        while start > 0 && Self::is_ascii_identifier_continue(bytes[start - 1]) {
-            start -= 1;
-        }
-
-        let mut end = idx + 1;
-        while end < bytes.len() && Self::is_ascii_identifier_continue(bytes[end]) {
-            end += 1;
-        }
-
-        if start >= end || !Self::is_ascii_identifier_start(bytes[start]) {
-            return None;
-        }
-
-        source_text
-            .get(start..end)
-            .map(std::string::ToString::to_string)
-    }
-
-    const fn is_ascii_identifier_start(byte: u8) -> bool {
-        byte.is_ascii_alphabetic() || byte == b'_' || byte == b'$'
-    }
-
-    const fn is_ascii_identifier_continue(byte: u8) -> bool {
-        byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+        let start = current_start?;
+        identifier_span_touches_probe(start, current_end, probe)
+            .then(|| source_text[start..current_end].to_string())
     }
 
     pub(crate) fn identifier_at_position(
@@ -291,5 +282,31 @@ impl Project {
             module_specifier,
             kind,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Project;
+
+    #[test]
+    fn identifier_text_around_offset_accepts_unicode_identifier_start_and_part() {
+        let source = "const café = 日本語;";
+
+        let cafe_start = source.find("café").expect("café");
+        assert_eq!(
+            Project::identifier_text_around_offset(source, cafe_start),
+            Some("café".to_string())
+        );
+        assert_eq!(
+            Project::identifier_text_around_offset(source, cafe_start + "café".len()),
+            Some("café".to_string())
+        );
+
+        let japanese_mid = source.find("本").expect("日本語");
+        assert_eq!(
+            Project::identifier_text_around_offset(source, japanese_mid),
+            Some("日本語".to_string())
+        );
     }
 }

--- a/crates/tsz-lsp/src/signature_help/contextual.rs
+++ b/crates/tsz-lsp/src/signature_help/contextual.rs
@@ -1,3 +1,4 @@
+use super::unicode_identifier::identifier_before_offset;
 use super::*;
 
 impl<'a> SignatureHelpProvider<'a> {
@@ -329,12 +330,11 @@ impl<'a> SignatureHelpProvider<'a> {
             return None;
         }
         let prefix = &self.source_text[start..end];
-        let colon_candidate = prefix.rfind(':').and_then(|idx| {
-            self.identifier_before_offset(prefix, idx)
-                .map(|name| (idx, name))
-        });
+        let colon_candidate = prefix
+            .rfind(':')
+            .and_then(|idx| identifier_before_offset(prefix, idx).map(|name| (idx, name)));
         let paren_candidate = prefix.rfind('(').and_then(|idx| {
-            let name = self.identifier_before_offset(prefix, idx)?;
+            let name = identifier_before_offset(prefix, idx)?;
             if name == "function" {
                 return None;
             }
@@ -353,25 +353,6 @@ impl<'a> SignatureHelpProvider<'a> {
             (None, Some((_, pname))) => Some(pname),
             (None, None) => None,
         }
-    }
-
-    pub(super) fn identifier_before_offset(&self, text: &str, offset: usize) -> Option<String> {
-        if offset == 0 || offset > text.len() {
-            return None;
-        }
-        let bytes = text.as_bytes();
-        let mut end = offset;
-        while end > 0 && bytes[end - 1].is_ascii_whitespace() {
-            end -= 1;
-        }
-        if end == 0 {
-            return None;
-        }
-        let mut start = end;
-        while start > 0 && Self::is_ascii_identifier_byte(bytes[start - 1]) {
-            start -= 1;
-        }
-        (start < end).then(|| text[start..end].to_string())
     }
 
     pub(super) fn parameter_type_and_name_at(
@@ -1024,10 +1005,6 @@ impl<'a> SignatureHelpProvider<'a> {
                 })
                 .collect();
         }
-    }
-
-    pub(super) const fn is_ascii_identifier_byte(byte: u8) -> bool {
-        byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
     }
 
     pub(super) fn find_textual_call_trigger(

--- a/crates/tsz-lsp/src/signature_help/internal_tests.rs
+++ b/crates/tsz-lsp/src/signature_help/internal_tests.rs
@@ -182,6 +182,34 @@ fn contextual_object_member_signature_preferred_over_outer_call() {
 }
 
 #[test]
+fn contextual_object_member_signature_accepts_unicode_member_name() {
+    let source = "interface I { café(n: number, s: string): void; }\ndeclare function takesObj(i: I): void;\ntakesObj({ café: () });";
+    let (parser, root) = parse_test_source(source);
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+
+    let interner = TypeInterner::new();
+    let line_map = LineMap::build(source);
+    let provider = SignatureHelpProvider::new(
+        parser.get_arena(),
+        &binder,
+        &line_map,
+        &interner,
+        source,
+        "test.ts".to_string(),
+    );
+    let cursor_offset = source.find("café: (").expect("unicode member") + "café: (".len();
+    let position = line_map.offset_to_position(cursor_offset as u32, source);
+    let mut cache = None;
+    let help = provider
+        .get_signature_help(root, position, &mut cache)
+        .expect("unicode contextual signature help should be available");
+    let active = &help.signatures[help.active_signature as usize].label;
+    assert_eq!(active, "café(n: number, s: string): void");
+}
+
+#[test]
 fn contextual_variable_initializer_type_alias_and_function_type() {
     let source = "type Cb = () => void;\nconst cb: Cb = ();\nconst cb2: () => void = ();";
     let (parser, root) = parse_test_source(source);

--- a/crates/tsz-lsp/src/signature_help/mod.rs
+++ b/crates/tsz-lsp/src/signature_help/mod.rs
@@ -53,6 +53,7 @@ mod shapes;
 #[path = "internal_tests.rs"]
 mod signature_help_internal_tests;
 mod trigger;
+mod unicode_identifier;
 
 pub(super) use display::apply_type_param_substitution;
 use phases::TypeArgumentContext;

--- a/crates/tsz-lsp/src/signature_help/unicode_identifier.rs
+++ b/crates/tsz-lsp/src/signature_help/unicode_identifier.rs
@@ -1,0 +1,33 @@
+use tsz_scanner::{is_ecmascript_identifier_part, is_ecmascript_identifier_start};
+
+pub(super) fn identifier_before_offset(text: &str, offset: usize) -> Option<String> {
+    if offset == 0 || offset > text.len() {
+        return None;
+    }
+    let mut end = offset;
+    while let Some((idx, ch)) = previous_char_before(text, end) {
+        if !ch.is_whitespace() {
+            break;
+        }
+        end = idx;
+    }
+    if end == 0 {
+        return None;
+    }
+    let mut start = end;
+    while let Some((idx, ch)) = previous_char_before(text, start) {
+        if !is_ecmascript_identifier_part(ch) {
+            break;
+        }
+        start = idx;
+    }
+    if start >= end {
+        return None;
+    }
+    let first = text[start..end].chars().next()?;
+    is_ecmascript_identifier_start(first).then(|| text[start..end].to_string())
+}
+
+fn previous_char_before(text: &str, offset: usize) -> Option<(usize, char)> {
+    text.get(..offset)?.char_indices().next_back()
+}


### PR DESCRIPTION
Goal: hold

## Agent
AgentName: Codex

## Track
hold / tech-debt

## Invariant
ECMAScript identifier-name decisions use the scanner-owned Unicode predicates instead of crate-local ASCII copies when validating TypeScript/JavaScript identifiers.

## Scope
- Route tsconfig `jsxFactory` / `reactNamespace` identifier validation through `tsz_scanner::is_ecmascript_identifier_*`.
- Route declaration-emitter object-member bare-name decisions through the same scanner predicates.
- Make LSP offset-based identifier recovery Unicode-aware for import-position and contextual signature-help fallbacks.
- Add Unicode witnesses for config validation, DTS property-name formatting, JS object-literal emit, and LSP contextual/member recovery.

## Project Corpus Impact
None expected. This is a Hold parity/maintenance fix for Unicode identifier handling in config, emit formatting, and LSP textual fallbacks.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-core -E 'test(test_jsx_identifier_options_accept_ecmascript_unicode_identifiers)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-lsp -E 'test(identifier_text_around_offset_accepts_unicode_identifier_start_and_part) or test(contextual_object_member_signature_accepts_unicode_member_name)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter --lib -E 'test(valid_identifiers_emit_bare_regardless_of_name_choice) or test(literal_text_canonicalizes_valid_identifiers_to_bare)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter --lib -E 'test(object_literal_unicode_property_names_emit_bare)'`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-lsp --all-targets -- -D warnings`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-emitter --all-targets -- -D warnings`
- `scripts/arch/check-checker-boundaries.sh`
- `cargo fmt --check`
- `git diff --check`
- exact-head CI Summary passed for `6ef2bce83ea3ad88d4842b5b6fe95a69d7bbc0b9`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium

## Coordination Notes
- Closes #13120.
- Reused the inactive `tsz-m5-key-constraints` worktree after #13204 merged.
- No active PR overlap found for the Unicode identifier predicate centralization lane.
- A broader local emitter nextest invocation attempted to build all emitter test binaries and failed with local disk `errno=28`; reran the relevant emitter checks as targeted `--lib` filters after cache cleanup.
