### PR TITLE
test(binder): pin shared-lib-binder immutability through lib merge + document the concurrency contract

### DIFF
--- a/crates/tsz-binder/src/state/lib_merge.rs
+++ b/crates/tsz-binder/src/state/lib_merge.rs
@@ -142,6 +142,15 @@ impl BinderState {
     /// # Panics
     ///
     /// Panics if either resolution cache lock is poisoned.
+    /// Concurrency contract (the shared-lib-universe data-race answer): this
+    /// merge mutates ONLY `self` (the program binder) — every `Arc::make_mut`
+    /// below targets `self`'s own fields, free at refcount 1 during a
+    /// per-file bind. The lib contexts are read immutably, so lib binders and
+    /// arenas held at refcount > 1 (a shared read-only lib set, or sibling
+    /// rayon workers binding concurrently) are never copy-on-write poisoned
+    /// and never race: sharing the bound lib set across workers is sound with
+    /// respect to this merge. Pinned by
+    /// `lib_merge_reads_shared_lib_binder_immutably_at_refcount_above_one`.
     pub fn merge_lib_contexts_into_binder(&mut self, lib_contexts: &[LibContext]) {
         // Merging lib contexts remaps SymbolIds; clear both caches so callers
         // don't receive stale ids from prior binding passes.

--- a/crates/tsz-binder/src/state/tests/semantic_defs_extended.rs
+++ b/crates/tsz-binder/src/state/tests/semantic_defs_extended.rs
@@ -1157,3 +1157,76 @@ fn merge_cross_file_does_not_downgrade_type_param_count() {
 // =============================================================================
 // Stable Identity Tests: All Declaration Families
 // =============================================================================
+
+#[test]
+fn lib_merge_reads_shared_lib_binder_immutably_at_refcount_above_one() {
+    // The shared-lib-universe invariant (and the parallel-checking
+    // mutation-isolation campaign's foundation): merging lib contexts into a
+    // program binder mutates ONLY the program binder (`self`); the lib
+    // binder/arena are read immutably. Holding the lib `Arc`s at refcount > 1
+    // (the future shared-read-only configuration) must therefore leave every
+    // `Arc`-backed merge-phase field of the LIB binder pointer-identical —
+    // proving no `Arc::make_mut` copy-on-write fires against shared lib state
+    // during a program-bind merge, and that the merge is race-free to run
+    // while other holders read the same lib binder.
+    let lib_source = r"
+interface ZetaIterable<T> { next(): T; }
+declare var zetaGlobal: ZetaIterable<number>;
+declare namespace ZetaSpace { interface Inner {} }
+";
+    let mut lib_parser = ParserState::new("lib.zeta.d.ts".to_string(), lib_source.to_string());
+    let lib_root = lib_parser.parse_source_file();
+    let mut lib_binder = BinderState::new();
+    lib_binder.bind_source_file(lib_parser.get_arena(), lib_root);
+
+    let lib_binder = std::sync::Arc::new(lib_binder);
+    let lib_arena = std::sync::Arc::new(lib_parser.get_arena().clone());
+    // Extra holders: refcount > 1, exactly like a shared read-only lib set.
+    let binder_holder = std::sync::Arc::clone(&lib_binder);
+    let arena_holder = std::sync::Arc::clone(&lib_arena);
+
+    // Snapshot the Arc-backed merge-phase fields of the LIB binder (the six
+    // targets of `Arc::make_mut` in `merge_lib_contexts_into_binder`, which
+    // must only ever fire on the PROGRAM binder's own fields).
+    let before = (
+        std::sync::Arc::as_ptr(&lib_binder.lib_type_namespace),
+        std::sync::Arc::as_ptr(&lib_binder.declaration_arenas),
+        std::sync::Arc::as_ptr(&lib_binder.symbol_arenas),
+        std::sync::Arc::as_ptr(&lib_binder.lib_symbol_ids),
+        std::sync::Arc::as_ptr(&lib_binder.lib_symbol_reverse_remap),
+        std::sync::Arc::as_ptr(&lib_binder.semantic_defs),
+    );
+
+    let lib_ctx = super::LibContext {
+        arena: std::sync::Arc::clone(&lib_arena),
+        binder: std::sync::Arc::clone(&lib_binder),
+    };
+
+    let user_source = "const renamedProbe = zetaGlobal.next();";
+    let mut user_parser = ParserState::new("test.ts".to_string(), user_source.to_string());
+    let user_root = user_parser.parse_source_file();
+    let mut main_binder = BinderState::new();
+    main_binder.bind_source_file(user_parser.get_arena(), user_root);
+    main_binder.merge_lib_contexts_into_binder(&[lib_ctx]);
+
+    let after = (
+        std::sync::Arc::as_ptr(&lib_binder.lib_type_namespace),
+        std::sync::Arc::as_ptr(&lib_binder.declaration_arenas),
+        std::sync::Arc::as_ptr(&lib_binder.symbol_arenas),
+        std::sync::Arc::as_ptr(&lib_binder.lib_symbol_ids),
+        std::sync::Arc::as_ptr(&lib_binder.lib_symbol_reverse_remap),
+        std::sync::Arc::as_ptr(&lib_binder.semantic_defs),
+    );
+    assert_eq!(
+        before, after,
+        "merge_lib_contexts_into_binder must not copy-on-write any Arc-backed \
+         merge-phase field of a shared (refcount>1) lib binder"
+    );
+    // The program binder did absorb the lib symbols (the merge ran for real).
+    assert!(
+        main_binder.file_locals.get("ZetaIterable").is_some(),
+        "merge must remap lib symbols into the program binder"
+    );
+    drop(binder_holder);
+    drop(arena_holder);
+}


### PR DESCRIPTION
Goal: fast

## Summary

Pins the foundation invariant of the shared-lib-universe / parallel-checking campaigns: `merge_lib_contexts_into_binder` mutates **only the program binder** — all six `Arc::make_mut` sites target `self`'s fields, and lib contexts are read immutably. The new tsz-binder test holds the lib binder/arena `Arc`s at refcount > 1 (the shared read-only configuration) through a real merge and asserts pointer identity on all six `Arc`-backed merge-phase fields of the **lib** binder (`lib_type_namespace`, `declaration_arenas`, `symbol_arenas`, `lib_symbol_ids`, `lib_symbol_reverse_remap`, `semantic_defs`), plus that the merge genuinely remapped lib symbols into the program binder. The concurrency contract — why sharing a bound lib set across workers is sound with respect to this merge (the long-open data-race question for the read-only lib share) — is now documented on the function itself, citing the pin.

Test-only + docs; zero behavior change. Guards future regressions where a refactor accidentally makes the merge write through shared lib state (which would silently convert the planned shared-lib configuration into cross-checker corruption).

## Project Corpus Impact
- Row: n/a (invariant pin for the parallel-checking / shared-lib campaigns)
- Bug family: n/a

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: medium

## Verification

- New test fails if any merge-phase `Arc::make_mut` ever fires against shared lib state (asserts six-field pointer identity at refcount > 1) and asserts the merge's positive effect (lib symbols remapped).
- `cargo nextest run -p tsz-binder`: 540/540.
- clippy clean; arch guards pass. No compiler-path changes.
