### PR TITLE
fix(ci): metadata summary must not mirror stale metadata-gate failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1311,6 +1311,14 @@ jobs:
               runs.sort(key=lambda run: run.get("created_at", ""), reverse=True)
               accepted_summary_names = ("CI Summary",) if required_summary else ("CI Summary", "CI Light Summary")
               accepted_summary_label = "CI Summary" if required_summary else "CI Summary or CI Light Summary"
+              # Metadata gates are re-validated by THIS metadata run (the
+              # summary above already failed hard if this run's pr-body-gate
+              # failed), so a previous failure caused ONLY by those gates must
+              # not be mirrored: that would deadlock body fixes — the edited
+              # event that repairs the body would forever mirror the stale
+              # gate failure it just fixed. Suite-job failures still mirror
+              # as failures.
+              metadata_gate_jobs = {"pr-body-gate", "CI Summary", "CI Light Summary"}
               for run in runs:
                   jobs = github_json(f"/repos/{repository}/actions/runs/{run['id']}/jobs?per_page=100").get("jobs", [])
                   summaries = [job for job in jobs if job.get("name") in accepted_summary_names]
@@ -1324,7 +1332,22 @@ jobs:
                   if conclusion == "success":
                       print(f"Metadata-only CI mirrors successful {summary_name} from run {run['id']}: {url}")
                       return
-                  print(f"Previous {summary_name} for this head was {conclusion or 'missing'} in run {run['id']}: {url}")
+                  suite_failures = [
+                      job.get("name")
+                      for job in jobs
+                      if job.get("name") not in metadata_gate_jobs
+                      and job.get("conclusion") not in (None, "success", "skipped", "neutral")
+                  ]
+                  if conclusion == "cancelled" and not suite_failures:
+                      print(f"Previous {summary_name} in run {run['id']} was cancelled (superseded) with no suite failures; scanning older runs.")
+                      continue
+                  if not suite_failures:
+                      print(
+                          f"Previous {summary_name} in run {run['id']} failed only on metadata gates; "
+                          f"this metadata run re-validated the PR body, so the suite verdict stands green: {url}"
+                      )
+                      return
+                  print(f"Previous {summary_name} for this head was {conclusion or 'missing'} in run {run['id']} with suite failures {suite_failures}: {url}")
                   sys.exit(1)
               print(f"Metadata-only CI could not find a previous {accepted_summary_label} for head {head_sha}.")
               sys.exit(1)


### PR DESCRIPTION
Goal: hold

## Summary

PRs get stuck after a body fix: the `edited` metadata run's `ci-summary` mirrors the previous suite run's verdict, and when that verdict failed **only** on `pr-body-gate` (or its own summary job), the mirror reproduces the stale failure forever. The very event that repairs the body re-publishes the failure it just fixed; only a manual `gh run rerun --failed` of the old suite run breaks the loop. This deadlock was hit four times in one day while shepherding campaign PRs (#13177, #13183 most recently). A `cancelled` (superseded) previous summary likewise hard-failed instead of consulting older runs.

## Structural rule

The metadata run re-validates the current body itself: `pr-body-gate` runs on `edited` events, and `ci-summary` already exits 1 before mirroring if THIS run's gate failed. Therefore a previous summary failure with **no suite-job failures** carries no information the metadata run hasn't re-checked, and must mirror as green. Previous runs with real suite-job failures still mirror as failures, unchanged.

## Scope

`.github/workflows/ci.yml`, `mirror_previous_required_summary` only:
- previous summary failed + zero non-metadata job failures → mirror green (explanatory log);
- previous summary cancelled + zero suite failures → continue scanning older runs;
- previous summary failed with suite failures → exit 1 (unchanged), now logging which jobs.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: medium

## Verification

- YAML validated (ruby YAML.load_file).
- The embedded summary python block compiles (extracted + `compile()`).
- Behavior table reasoned through all four prior-summary states (success / metadata-only failure / suite failure / cancelled); the deadlock scenario (#13183: pr-body-gate failure → body fixed → edited event) now resolves to green-mirror instead of stale-failure mirror.
- This change only affects metadata-only (`edited`) runs' summary verdicts; suite runs are untouched.

## Coordination Notes

Born from the canary fix-forward campaign (11 PRs landed) where every body-format fix required manual rerun surgery. Complements, not replaces, the `pr-body-gate` contract from #13157.
