### PR TITLE
perf(checker): roll decision-only relation requests out to all 87 proven .related-only probe sites

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_relation.rs
+++ b/crates/tsz-checker/src/assignability/assignability_relation.rs
@@ -386,41 +386,44 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Execute an env-aware generic type-argument constraint relation while
-    /// preserving the canonical TS2344 request shape.
+    /// preserving the canonical TS2344 request shape. Decision-only: every
+    /// caller reads only `outcome.related`, so failure analysis is skipped.
     pub(crate) fn type_arg_constraint_relation_outcome_with_env(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> RelationOutcome {
-        self.relation_outcome_with_env(source, target, RelationRequest::type_arg_constraint)
+        self.relation_outcome_with_env(source, target, |source, target| {
+            RelationRequest::type_arg_constraint(source, target).with_decision_only()
+        })
     }
 
     /// Execute an env-aware generic argument suppression relation while
-    /// preserving the canonical suppression request shape.
+    /// preserving the canonical suppression request shape. Decision-only:
+    /// every caller reads only `outcome.related`, so failure analysis is
+    /// skipped.
     pub(crate) fn generic_argument_suppression_relation_outcome_with_env(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> RelationOutcome {
-        self.relation_outcome_with_env(
-            source,
-            target,
-            RelationRequest::generic_argument_suppression,
-        )
+        self.relation_outcome_with_env(source, target, |source, target| {
+            RelationRequest::generic_argument_suppression(source, target).with_decision_only()
+        })
     }
 
     /// Execute an env-aware constructor-inference constraint relation while
     /// preserving the canonical constructor-inference request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so failure
+    /// analysis is skipped.
     pub(crate) fn constructor_inference_constraint_relation_outcome_with_env(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> RelationOutcome {
-        self.relation_outcome_with_env(
-            source,
-            target,
-            RelationRequest::constructor_inference_constraint,
-        )
+        self.relation_outcome_with_env(source, target, |source, target| {
+            RelationRequest::constructor_inference_constraint(source, target).with_decision_only()
+        })
     }
 
     /// Execute a diagnostic-bearing call-argument relation for raw checker
@@ -438,39 +441,47 @@ impl<'a> CheckerState<'a> {
 
     /// Execute a diagnostic-bearing call-argument relation using the current
     /// `TypeEnvironment`, preserving env-aware relation semantics while keeping
-    /// call diagnostics on the canonical TS2345 request shape.
+    /// call diagnostics on the canonical TS2345 request shape. Decision-only:
+    /// every caller reads only `outcome.related`, so failure analysis is
+    /// skipped.
     pub(crate) fn call_arg_relation_outcome_with_env(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> RelationOutcome {
-        self.relation_outcome_with_env(source, target, RelationRequest::call_arg)
+        self.relation_outcome_with_env(source, target, |source, target| {
+            RelationRequest::call_arg(source, target).with_decision_only()
+        })
     }
 
     /// Execute a diagnostic-bearing round-2 contextual substitution relation
     /// using the current `TypeEnvironment`, preserving env-aware relation
     /// semantics while keeping call-inference refinement on its named request.
+    /// Decision-only: every caller reads only `outcome.related`, so failure
+    /// analysis is skipped.
     pub(crate) fn round2_contextual_substitution_relation_outcome_with_env(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> RelationOutcome {
-        self.relation_outcome_with_env(
-            source,
-            target,
-            RelationRequest::round2_contextual_substitution,
-        )
+        self.relation_outcome_with_env(source, target, |source, target| {
+            RelationRequest::round2_contextual_substitution(source, target).with_decision_only()
+        })
     }
 
     /// Execute a diagnostic-bearing return relation using the current
     /// `TypeEnvironment`, preserving env-aware relation semantics while keeping
-    /// return diagnostics on the canonical return request shape.
+    /// return diagnostics on the canonical return request shape. Decision-only:
+    /// every caller reads only `outcome.related`, so failure analysis is
+    /// skipped.
     pub(crate) fn return_relation_outcome_with_env(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> RelationOutcome {
-        self.relation_outcome_with_env(source, target, RelationRequest::return_stmt)
+        self.relation_outcome_with_env(source, target, |source, target| {
+            RelationRequest::return_stmt(source, target).with_decision_only()
+        })
     }
 
     /// Execute a diagnostic-bearing bivariant-callback relation for raw

--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -41,6 +41,8 @@ impl<'a> CheckerState<'a> {
 
     /// Execute a diagnostic-bearing type-comparability relation for raw
     /// checker types, preserving the canonical comparability request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn type_comparability_relation_outcome(
         &mut self,
         source: TypeId,
@@ -49,12 +51,15 @@ impl<'a> CheckerState<'a> {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request = crate::query_boundaries::assignability::RelationRequest::type_comparability(
             source, target,
-        );
+        )
+        .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a callable-source to union-arm return relation for raw checker
     /// types, preserving the canonical callable-union return request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn callable_union_return_relation_outcome(
         &mut self,
         source: TypeId,
@@ -64,12 +69,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::callable_union_return(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a callable-source to union-arm parameter relation for raw checker
     /// types, preserving the canonical callable-union parameter request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn callable_union_parameter_relation_outcome(
         &mut self,
         source: TypeId,
@@ -79,12 +87,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::callable_union_parameter(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a type-predicate-to-parameter relation for raw checker types,
     /// preserving the canonical type-predicate parameter request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn type_predicate_parameter_relation_outcome(
         &mut self,
         source: TypeId,
@@ -94,12 +105,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::type_predicate_parameter(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing JSX children relation for raw checker types,
     /// preserving the canonical JSX children request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn jsx_children_relation_outcome(
         &mut self,
         source: TypeId,
@@ -107,12 +121,15 @@ impl<'a> CheckerState<'a> {
     ) -> crate::query_boundaries::assignability::RelationOutcome {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request =
-            crate::query_boundaries::assignability::RelationRequest::jsx_children(source, target);
+            crate::query_boundaries::assignability::RelationRequest::jsx_children(source, target)
+                .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing JSX props relation for raw checker types,
     /// preserving the canonical JSX props request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn jsx_props_relation_outcome(
         &mut self,
         source: TypeId,
@@ -120,12 +137,15 @@ impl<'a> CheckerState<'a> {
     ) -> crate::query_boundaries::assignability::RelationOutcome {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request =
-            crate::query_boundaries::assignability::RelationRequest::jsx_props(source, target);
+            crate::query_boundaries::assignability::RelationRequest::jsx_props(source, target)
+                .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing JSX element-type relation for raw checker
     /// types, preserving the canonical `JSX.ElementType` request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn jsx_element_type_relation_outcome(
         &mut self,
         source: TypeId,
@@ -134,12 +154,15 @@ impl<'a> CheckerState<'a> {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request = crate::query_boundaries::assignability::RelationRequest::jsx_element_type(
             source, target,
-        );
+        )
+        .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing `for...in` LHS relation for raw checker
     /// types, preserving the canonical `for...in` LHS request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn for_in_lhs_relation_outcome(
         &mut self,
         source: TypeId,
@@ -147,7 +170,8 @@ impl<'a> CheckerState<'a> {
     ) -> crate::query_boundaries::assignability::RelationOutcome {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request =
-            crate::query_boundaries::assignability::RelationRequest::for_in_lhs(source, target);
+            crate::query_boundaries::assignability::RelationRequest::for_in_lhs(source, target)
+                .with_decision_only();
         self.execute_relation_request(&request)
     }
 
@@ -166,6 +190,8 @@ impl<'a> CheckerState<'a> {
 
     /// Execute a diagnostic-bearing rest-parameter array relation for raw
     /// checker types, preserving the canonical rest-parameter request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn rest_parameter_relation_outcome(
         &mut self,
         source: TypeId,
@@ -173,12 +199,15 @@ impl<'a> CheckerState<'a> {
     ) -> crate::query_boundaries::assignability::RelationOutcome {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request =
-            crate::query_boundaries::assignability::RelationRequest::rest_parameter(source, target);
+            crate::query_boundaries::assignability::RelationRequest::rest_parameter(source, target)
+                .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing import-attributes relation for raw
     /// checker types, preserving the canonical import-attributes request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn import_attributes_relation_outcome(
         &mut self,
         source: TypeId,
@@ -187,26 +216,33 @@ impl<'a> CheckerState<'a> {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request = crate::query_boundaries::assignability::RelationRequest::import_attributes(
             source, target,
-        );
+        )
+        .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing computed enum-member relation for raw
     /// checker types, preserving the canonical computed-enum request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn computed_enum_member_relation_outcome(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> crate::query_boundaries::assignability::RelationOutcome {
         let (source, target) = self.prepare_assignability_inputs(source, target);
-        let request = crate::query_boundaries::assignability::RelationRequest::computed_enum_member(
-            source, target,
-        );
+        let request =
+            crate::query_boundaries::assignability::RelationRequest::computed_enum_member(
+                source, target,
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing numeric-enum assignment relation for raw
     /// checker types, preserving the canonical numeric-enum assignment request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn numeric_enum_assignment_relation_outcome(
         &mut self,
         source: TypeId,
@@ -216,12 +252,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::numeric_enum_assignment(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing type-parameter default relation for raw
     /// checker types, preserving the canonical default-constraint request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn type_parameter_default_relation_outcome(
         &mut self,
         source: TypeId,
@@ -231,12 +270,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::type_parameter_default(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing index-signature relation for raw checker
     /// types, preserving the canonical index-signature request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn index_signature_relation_outcome(
         &mut self,
         source: TypeId,
@@ -245,12 +287,15 @@ impl<'a> CheckerState<'a> {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request = crate::query_boundaries::assignability::RelationRequest::index_signature(
             source, target,
-        );
+        )
+        .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing decorator-callee relation for raw checker
     /// types, preserving the canonical decorator-callee request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn decorator_callee_relation_outcome(
         &mut self,
         source: TypeId,
@@ -259,12 +304,15 @@ impl<'a> CheckerState<'a> {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request = crate::query_boundaries::assignability::RelationRequest::decorator_callee(
             source, target,
-        );
+        )
+        .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing JSDoc type-constraint relation for raw
     /// checker types, preserving the canonical JSDoc constraint request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn jsdoc_type_constraint_relation_outcome(
         &mut self,
         source: TypeId,
@@ -274,7 +322,8 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::jsdoc_type_constraint(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
@@ -316,6 +365,8 @@ impl<'a> CheckerState<'a> {
 
     /// Execute a diagnostic-bearing merged-interface constraint relation for
     /// raw checker types, preserving the canonical merged-interface request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn merged_interface_constraint_relation_outcome(
         &mut self,
         source: TypeId,
@@ -325,12 +376,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::merged_interface_constraint(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing recursive heritage property relation for
     /// raw checker types, preserving the canonical recursive-heritage request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn recursive_heritage_property_relation_outcome(
         &mut self,
         source: TypeId,
@@ -340,7 +394,8 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::recursive_heritage_property(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
@@ -364,6 +419,8 @@ impl<'a> CheckerState<'a> {
 
     /// Execute a diagnostic-bearing syntax-instantiated constraint relation
     /// for raw checker types, preserving the canonical syntax request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn syntax_instantiated_constraint_relation_outcome(
         &mut self,
         source: TypeId,
@@ -373,12 +430,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::syntax_instantiated_constraint(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing generic type-argument constraint relation
     /// for raw checker types, preserving the canonical TS2344 request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn type_arg_constraint_relation_outcome(
         &mut self,
         source: TypeId,
@@ -406,7 +466,8 @@ impl<'a> CheckerState<'a> {
 
         let request = crate::query_boundaries::assignability::RelationRequest::type_arg_constraint(
             source, target,
-        );
+        )
+        .with_decision_only();
         let outcome = self.execute_relation_request(&request);
         if outcome.related && !outcome.depth_exceeded && !outcome.iteration_exceeded {
             self.ctx
@@ -430,6 +491,8 @@ impl<'a> CheckerState<'a> {
 
     /// Execute a diagnostic-bearing mapped-key constraint relation for raw
     /// checker types, preserving the canonical mapped-key request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn mapped_key_constraint_relation_outcome(
         &mut self,
         source: TypeId,
@@ -439,12 +502,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::mapped_key_constraint(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing indexed-access constraint key relation for
     /// raw checker types, preserving the canonical key-space request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn indexed_access_constraint_key_relation_outcome(
         &mut self,
         source: TypeId,
@@ -454,12 +520,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::indexed_access_constraint_key(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing indexed-access key-space relation for raw
     /// checker types, preserving the canonical indexed-access request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn indexed_access_key_space_relation_outcome(
         &mut self,
         source: TypeId,
@@ -469,13 +538,16 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::indexed_access_key_space(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing conditional constraint component relation
     /// for raw checker types, preserving the canonical conditional request
     /// shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn conditional_constraint_component_relation_outcome(
         &mut self,
         source: TypeId,
@@ -485,13 +557,16 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::conditional_constraint_component(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing conditional true-base constraint relation
     /// for raw checker types, preserving the canonical true-base request
     /// shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn conditional_true_base_constraint_relation_outcome(
         &mut self,
         source: TypeId,
@@ -501,13 +576,16 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::conditional_true_base_constraint(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing conditional true-branch constraint relation
     /// for raw checker types, preserving the canonical true-branch request
     /// shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn conditional_true_branch_constraint_relation_outcome(
         &mut self,
         source: TypeId,
@@ -517,13 +595,16 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::conditional_true_branch_constraint(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing required mapped constraint relation for
     /// raw checker types, preserving the canonical required-mapped request
     /// shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn required_mapped_constraint_relation_outcome(
         &mut self,
         source: TypeId,
@@ -533,12 +614,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::required_mapped_constraint(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing infer-result constraint relation for raw
     /// checker types, preserving the canonical infer-result request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn infer_result_constraint_relation_outcome(
         &mut self,
         source: TypeId,
@@ -548,7 +632,8 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::infer_result_constraint(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
@@ -565,6 +650,8 @@ impl<'a> CheckerState<'a> {
     /// Execute a diagnostic-bearing generic constraint property relation for
     /// raw checker types, preserving the canonical generic-constraint request
     /// shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn generic_constraint_property_relation_outcome(
         &mut self,
         source: TypeId,
@@ -574,12 +661,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::generic_constraint_property(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing property-index-key relation for raw
     /// checker types, preserving the canonical property-index-key request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn property_index_key_relation_outcome(
         &mut self,
         source: TypeId,
@@ -588,54 +678,69 @@ impl<'a> CheckerState<'a> {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request = crate::query_boundaries::assignability::RelationRequest::property_index_key(
             source, target,
-        );
+        )
+        .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing nullish-error-target relation for raw
     /// checker types, preserving the canonical nullish-target request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn nullish_error_target_relation_outcome(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> crate::query_boundaries::assignability::RelationOutcome {
         let (source, target) = self.prepare_assignability_inputs(source, target);
-        let request = crate::query_boundaries::assignability::RelationRequest::nullish_error_target(
-            source, target,
-        );
+        let request =
+            crate::query_boundaries::assignability::RelationRequest::nullish_error_target(
+                source, target,
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing duplicate-identifier relation for raw
     /// checker types, preserving the canonical duplicate-identifier request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn duplicate_identifier_relation_outcome(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> crate::query_boundaries::assignability::RelationOutcome {
         let (source, target) = self.prepare_assignability_inputs(source, target);
-        let request = crate::query_boundaries::assignability::RelationRequest::duplicate_identifier(
-            source, target,
-        );
+        let request =
+            crate::query_boundaries::assignability::RelationRequest::duplicate_identifier(
+                source, target,
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing variable-initializer relation for raw
     /// checker types, preserving the canonical initializer request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn variable_initializer_relation_outcome(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> crate::query_boundaries::assignability::RelationOutcome {
         let (source, target) = self.prepare_assignability_inputs(source, target);
-        let request = crate::query_boundaries::assignability::RelationRequest::variable_initializer(
-            source, target,
-        );
+        let request =
+            crate::query_boundaries::assignability::RelationRequest::variable_initializer(
+                source, target,
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing contextual binding-default identifier
     /// relation for raw checker types, preserving the canonical identifier request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn identifier_binding_default_relation_outcome(
         &mut self,
         source: TypeId,
@@ -645,12 +750,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::identifier_binding_default(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing `keyof` suppression relation for raw
     /// checker types, preserving the canonical `keyof` suppression request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn keyof_diagnostic_suppression_relation_outcome(
         &mut self,
         source: TypeId,
@@ -660,12 +768,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::keyof_diagnostic_suppression(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing display-narrowing relation for raw
     /// checker types, preserving the canonical diagnostic-source request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn diagnostic_source_narrowing_relation_outcome(
         &mut self,
         source: TypeId,
@@ -675,12 +786,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::diagnostic_source_narrowing(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing overlap/comparability relation for raw
     /// checker types, preserving the canonical diagnostic-overlap request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn diagnostic_overlap_relation_outcome(
         &mut self,
         source: TypeId,
@@ -689,7 +803,8 @@ impl<'a> CheckerState<'a> {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request = crate::query_boundaries::assignability::RelationRequest::diagnostic_overlap(
             source, target,
-        );
+        )
+        .with_decision_only();
         self.execute_relation_request(&request)
     }
 
@@ -710,6 +825,8 @@ impl<'a> CheckerState<'a> {
         self.diagnostic_relation_outcome(source, constraint)
     }
 
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn broad_mapped_index_signature_display_relation_outcome(
         &mut self,
         source: TypeId,
@@ -719,7 +836,8 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::broad_mapped_index_signature_display(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
@@ -738,6 +856,8 @@ impl<'a> CheckerState<'a> {
 
     /// Execute a diagnostic-bearing polymorphic `this` receiver relation for raw
     /// checker types, preserving the canonical receiver request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn polymorphic_this_receiver_relation_outcome(
         &mut self,
         source: TypeId,
@@ -747,12 +867,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::polymorphic_this_receiver(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing class-extends index relation for raw
     /// checker types, preserving the canonical class extends request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn class_extends_index_value_relation_outcome(
         &mut self,
         source: TypeId,
@@ -762,12 +885,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::class_extends_index_value(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing class-implements index relation for raw
     /// checker types, preserving the canonical class index request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn class_implements_index_value_relation_outcome(
         &mut self,
         source: TypeId,
@@ -777,12 +903,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::class_implements_index_value(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing class-implements whole-type relation for
     /// raw checker types, preserving the canonical class implements request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn class_implements_whole_type_relation_outcome(
         &mut self,
         source: TypeId,
@@ -792,12 +921,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::class_implements_whole_type(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing class static-side relation for raw checker
     /// types, preserving the canonical class static-side request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn class_static_side_relation_outcome(
         &mut self,
         source: TypeId,
@@ -806,12 +938,15 @@ impl<'a> CheckerState<'a> {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request = crate::query_boundaries::assignability::RelationRequest::class_static_side(
             source, target,
-        );
+        )
+        .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing interface-heritage index relation for raw
     /// checker types, preserving the canonical heritage index request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn interface_heritage_index_value_relation_outcome(
         &mut self,
         source: TypeId,
@@ -821,12 +956,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::interface_heritage_index_value(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing interface-heritage generic-method relation
     /// for raw checker types, preserving the canonical heritage method request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn interface_heritage_generic_method_relation_outcome(
         &mut self,
         source: TypeId,
@@ -836,12 +974,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::interface_heritage_generic_method(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing interface-heritage property/index relation
     /// for raw checker types, preserving the canonical heritage index request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn interface_heritage_property_index_relation_outcome(
         &mut self,
         source: TypeId,
@@ -851,12 +992,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::interface_heritage_property_index(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing JSDoc heritage constraint relation for raw
     /// checker types, preserving the canonical JSDoc heritage request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn jsdoc_heritage_constraint_relation_outcome(
         &mut self,
         source: TypeId,
@@ -866,12 +1010,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::jsdoc_heritage_constraint(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing missing-property read relation for raw
     /// checker types, preserving the canonical missing-property request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn missing_property_read_relation_outcome(
         &mut self,
         source: TypeId,
@@ -881,12 +1028,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::missing_property_read(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing missing-property write relation for raw
     /// checker types, preserving the canonical missing-property request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn missing_property_write_relation_outcome(
         &mut self,
         source: TypeId,
@@ -896,13 +1046,16 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::missing_property_write(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing concrete remapped mapped missing-property
     /// relation for raw checker types, preserving the canonical
     /// remapped-mapped request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn concrete_remapped_mapped_missing_property_relation_outcome(
         &mut self,
         source: TypeId,
@@ -912,12 +1065,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::concrete_remapped_mapped_missing_property(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing exact-optional source filtering relation
     /// for raw checker types, preserving the canonical exact-optional request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn exact_optional_source_filter_relation_outcome(
         &mut self,
         source: TypeId,
@@ -927,12 +1083,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::exact_optional_source_filter(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing union excess-property fallback relation for
     /// raw checker types, preserving the canonical union excess request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn union_excess_required_property_relation_outcome(
         &mut self,
         source: TypeId,
@@ -942,12 +1101,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::union_excess_required_property(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing array-literal contextual-collapse relation
     /// for raw checker types, preserving the contextual-collapse request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn array_literal_contextual_collapse_relation_outcome(
         &mut self,
         source: TypeId,
@@ -957,7 +1119,8 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::array_literal_contextual_collapse(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
@@ -974,6 +1137,8 @@ impl<'a> CheckerState<'a> {
 
     /// Execute a diagnostic-bearing JSX render-fallback relation for raw
     /// checker types, preserving the canonical JSX fallback request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn jsx_render_fallback_relation_outcome(
         &mut self,
         source: TypeId,
@@ -982,13 +1147,16 @@ impl<'a> CheckerState<'a> {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request = crate::query_boundaries::assignability::RelationRequest::jsx_render_fallback(
             source, target,
-        );
+        )
+        .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing object-literal mapped contextual key
     /// relation for raw checker types, preserving the canonical mapped-key
     /// request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn object_literal_mapped_contextual_key_relation_outcome(
         &mut self,
         source: TypeId,
@@ -998,12 +1166,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::object_literal_mapped_contextual_key(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing object-literal computed-key relation for
     /// raw checker types, preserving the canonical computed-key request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn object_literal_computed_key_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1013,13 +1184,16 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::object_literal_computed_key(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing object-literal JSDoc declared-property
     /// relation for raw checker types, preserving the canonical declared
     /// property request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn object_literal_jsdoc_declared_property_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1029,12 +1203,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::object_literal_jsdoc_declared_property(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing contextual symbol-index value relation for
     /// raw checker types, preserving the canonical symbol-index request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn contextual_symbol_index_value_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1044,12 +1221,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::contextual_symbol_index_value(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing `in`-operator key relation for raw
     /// checker types, preserving the canonical key request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn in_operator_key_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1058,12 +1238,15 @@ impl<'a> CheckerState<'a> {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request = crate::query_boundaries::assignability::RelationRequest::in_operator_key(
             source, target,
-        );
+        )
+        .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing `in`-operator primitive-constraint
     /// relation for raw checker types, preserving the canonical TS2638 request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn in_operator_primitive_constraint_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1073,12 +1256,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::in_operator_primitive_constraint(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing compound-assignment relation for raw
     /// checker types, preserving the canonical assignment-operation request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn compound_assignment_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1087,12 +1273,15 @@ impl<'a> CheckerState<'a> {
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let request = crate::query_boundaries::assignability::RelationRequest::compound_assignment(
             source, target,
-        );
+        )
+        .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing generic element-write relation for raw
     /// checker types, preserving the canonical deferred write-target request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn generic_element_write_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1102,12 +1291,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::generic_element_write(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing property receiver element-display relation
     /// for raw checker types, preserving the canonical receiver-display request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn property_receiver_element_display_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1117,12 +1309,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::property_receiver_element_display(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing property receiver index-value relation for
     /// raw checker types, preserving the canonical receiver-display request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn property_receiver_index_value_display_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1132,12 +1327,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::property_receiver_index_value_display(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing element-access numeric-index relation for
     /// raw checker types, preserving the canonical TS7015 request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn element_access_number_index_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1147,12 +1345,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::element_access_number_index(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing element-access method-suggestion relation
     /// for raw checker types, preserving the canonical suggestion request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn element_access_method_suggestion_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1162,12 +1363,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::element_access_method_suggestion(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing call-elaboration mutual relation for raw
     /// checker types, preserving the canonical call-elaboration request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn call_elaboration_mutual_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1177,40 +1381,51 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::call_elaboration_mutual(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing call-display overlap relation for raw
     /// checker types, preserving the canonical display-overlap request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn call_display_overlap_relation_outcome(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> crate::query_boundaries::assignability::RelationOutcome {
         let (source, target) = self.prepare_assignability_inputs(source, target);
-        let request = crate::query_boundaries::assignability::RelationRequest::call_display_overlap(
-            source, target,
-        );
+        let request =
+            crate::query_boundaries::assignability::RelationRequest::call_display_overlap(
+                source, target,
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing call-checker generator-yield relation for
     /// raw checker types, preserving the canonical generator-yield request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn call_generator_yield_relation_outcome(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> crate::query_boundaries::assignability::RelationOutcome {
         let (source, target) = self.prepare_assignability_inputs(source, target);
-        let request = crate::query_boundaries::assignability::RelationRequest::call_generator_yield(
-            source, target,
-        );
+        let request =
+            crate::query_boundaries::assignability::RelationRequest::call_generator_yield(
+                source, target,
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing `IteratorResult` value relation for raw
     /// checker types, preserving the canonical iterator-result-value request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn iterator_result_value_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1220,12 +1435,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::iterator_result_value(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing round-2 contextual substitution relation
     /// for raw checker types, preserving the canonical substitution request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn round2_contextual_substitution_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1235,13 +1453,16 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::round2_contextual_substitution(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing constructor-inference constraint relation
     /// for raw checker types, preserving the canonical constructor-inference
     /// request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn constructor_inference_constraint_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1251,12 +1472,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::constructor_inference_constraint(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing call-adapter compatibility relation for
     /// raw checker types, preserving the canonical call-adapter request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn call_adapter_compatibility_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1266,7 +1490,8 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::call_adapter_compatibility(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
@@ -1274,6 +1499,8 @@ impl<'a> CheckerState<'a> {
     /// [`Self::call_adapter_compatibility_relation_outcome`]: identical
     /// relation shape, but an `any` source is not related to concrete targets
     /// at every nesting level (tsc `chooseOverload` with `subtypeRelation`).
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn overload_subtype_pass_compatibility_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1284,12 +1511,15 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::assignability::RelationRequest::call_adapter_compatibility(
                 source, target,
             )
-            .with_overload_subtype_pass();
+            .with_overload_subtype_pass()
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Overload-resolution subtype-pass variant of the bivariant-callback
     /// relation probe used by the call adapter.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn overload_subtype_pass_bivariant_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1299,7 +1529,8 @@ impl<'a> CheckerState<'a> {
         let request = crate::query_boundaries::assignability::RelationRequest::bivariant_callbacks(
             source, target,
         )
-        .with_overload_subtype_pass();
+        .with_overload_subtype_pass()
+        .with_decision_only();
         self.execute_relation_request(&request)
     }
 
@@ -1322,6 +1553,8 @@ impl<'a> CheckerState<'a> {
 
     /// Execute a diagnostic-bearing call-adapter identity fallback relation for
     /// raw checker types, preserving the canonical call-adapter identity shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn call_adapter_identity_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1331,12 +1564,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::call_adapter_identity(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing overload implementation parameter relation
     /// for raw checker types, preserving the canonical overload request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn overload_implementation_parameter_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1346,12 +1582,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::overload_implementation_parameter(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing binary arithmetic number relation for raw
     /// checker types, preserving the canonical arithmetic operand request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn binary_arithmetic_number_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1361,12 +1600,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::binary_arithmetic_number(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing private member access relation for raw
     /// checker types, preserving the canonical private member request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn private_member_access_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1376,12 +1618,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::private_member_access(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a diagnostic-bearing function-type relation for raw checker
     /// types, preserving the canonical function-type request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn function_type_compatibility_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1391,12 +1636,15 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::function_type_compatibility(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 
     /// Execute a namespace-module property mismatch relation for raw checker
     /// types, preserving the canonical downgrade request shape.
+    /// Decision-only: every caller reads only `outcome.related`, so the
+    /// boundary skips failure analysis and property classification.
     pub(crate) fn namespace_property_mismatch_relation_outcome(
         &mut self,
         source: TypeId,
@@ -1406,7 +1654,8 @@ impl<'a> CheckerState<'a> {
         let request =
             crate::query_boundaries::assignability::RelationRequest::namespace_property_mismatch(
                 source, target,
-            );
+            )
+            .with_decision_only();
         self.execute_relation_request(&request)
     }
 


### PR DESCRIPTION
Goal: fast

## Summary

Rollout of #13186's decision-only relation pattern: a rigorous audit of every `*_relation_outcome` helper and `execute_relation` consumer in tsz-checker, converting the **87 sites whose callers provably read only `.related`** to `RelationRequest::with_decision_only()` — the identical configured decision pass with the same caches, skipping `explain_failure`, weak-union analysis, and property classification. Every conversion carries call-chain evidence (paren-matched scan of all non-test sources + manual review of every outcome-binding site); helpers whose `failure`/`weak_union_violation`/`property_classification` fields are consumed anywhere downstream (TS2322 elaboration, satisfies weak-union gate, return-drift analysis, call-arg weak-union skip, destructuring, bivariant callbacks, excess-value mapped checks, property-mismatch weak-union) are left on full analysis. Overflow flags (`depth_exceeded`/`iteration_exceeded` → TS2321/TS2859) are preserved by the decision pass — verified at the type-arg success-cache and callable-type-argument consumers specifically. Each converted helper carries a "Decision-only" doc sentence so future field-readers are flagged at review.

## Measured

- Structural counters: property-classification calls **156→0** (zodmin-full), **74→0** (ts-toolbelt); zodmin-full interner calls **3.47M→3.16M (−8.7%)**.
- Green rows unchanged (ts-toolbelt 0.57–0.59s, zodmin 0.95s — failed probes are rare there); the wall payoff lands on failure-probe-heavy programs (the large-ts-repo class #13186 measured at −43% on its probe slice).
- Diagnostics byte-identical: ts-toolbelt, zodmin clean+full, vite, nextjs.

## Project Corpus Impact
- Row: large-ts-repo class (failure-elaboration-heavy); ts-toolbelt/zodmin verified neutral
- Bug family: n/a (behavior-preserving; presentation-work elision)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: medium

## Verification

- Full local conformance: 12583/12585 — zero new vs the accepted ledger.
- Conformance A/B (same runner, binary swapped): assignmentCompat 128, elaborat 3, errorMessage 6, conditionalType 17, jsx 298 — per-test PASS/FAIL byte-identical.
- `cargo nextest run -p tsz-checker --lib`: failure set identical to main (stash A/B). Solver untouched (diff is 2 checker files).
- clippy clean; arch guards pass; both files under the 2000-line ceiling.
