### PR TITLE
fix(lowering): unify interface and type-literal member collection behind one shared pipeline

### DIFF
--- a/crates/tsz-lowering/src/lower/core.rs
+++ b/crates/tsz-lowering/src/lower/core.rs
@@ -129,9 +129,9 @@ pub struct TypeLowering<'a> {
     pub(super) limit_exceeded: Rc<RefCell<bool>>,
 }
 
-pub(super) struct InterfaceParts {
+pub(super) struct ObjectTypeParts {
     // Use IndexMap for deterministic property order - this ensures
-    // the same interface produces the same TypeId on every lowering.
+    // the same object type produces the same TypeId on every lowering.
     // FxHashMap has undefined iteration order, causing non-determinism.
     pub(super) properties: IndexMap<Atom, PropertyMerge>,
     pub(super) call_signatures: Vec<CallSignature>,
@@ -139,7 +139,7 @@ pub(super) struct InterfaceParts {
     pub(super) string_index: Option<IndexSignature>,
     /// Additional string-keyed index signatures whose key type differs from
     /// `string_index.key_type`. Merged into `string_index` via key-type union
-    /// in `finish_interface_parts`, where the type interner is available.
+    /// in `finish_object_type_parts`, where the type interner is available.
     pub(super) extra_string_indices: Vec<IndexSignature>,
     pub(super) number_index: Option<IndexSignature>,
     /// True when at least one member has a computed property name that could not
@@ -176,7 +176,7 @@ pub(super) struct MethodOverloads {
     pub(super) declaration_order: u32,
 }
 
-impl InterfaceParts {
+impl ObjectTypeParts {
     /// Stride between declaration passes. Must be larger than the maximum number
     /// of properties any single interface declaration contributes.
     const DECL_ORDER_STRIDE: u32 = 10_000;
@@ -191,7 +191,9 @@ impl InterfaceParts {
             number_index: None,
             has_late_bound_members: false,
             current_pass_base: 0,
-            pass_local_counter: 0,
+            // 1-based: declaration_order 0 is the interner constructors'
+            // "unset" sentinel (they backfill it from vec order).
+            pass_local_counter: 1,
             declaration_orders: rustc_hash::FxHashMap::default(),
         }
     }
@@ -200,9 +202,11 @@ impl InterfaceParts {
     ///
     /// `forward_decl_index` is the 0-based index of the declaration in
     /// forward (source) order, so the earliest declaration gets index 0.
+    /// Pass-local orders are 1-based so no property keeps `declaration_order`
+    /// of 0, which the interner constructors treat as "unset" and backfill.
     pub(super) const fn set_declaration_pass(&mut self, forward_decl_index: usize) {
         self.current_pass_base = (forward_decl_index as u32) * Self::DECL_ORDER_STRIDE;
-        self.pass_local_counter = 0;
+        self.pass_local_counter = 1;
     }
 
     /// Get the next `declaration_order` value for a property being added in
@@ -355,13 +359,28 @@ impl InterfaceParts {
                     existing.readonly = false;
                 }
             } else {
-                // Distinct pattern: defer key-type union to finish_interface_parts
+                // Distinct pattern: defer key-type union to finish_object_type_parts
                 // where the type interner is available.
                 self.extra_string_indices.push(index);
             }
         } else {
             self.string_index = Some(index);
         }
+    }
+}
+
+/// Merge missing defaults/constraints from a subsequent declaration's type
+/// parameters into the already-collected parameters. Interface merging keeps
+/// the first declaration's parameter list but later declarations may carry the
+/// default or constraint (e.g. `Uint8Array` declares its default in
+/// lib.es5.d.ts while es2015.iterable.d.ts omits it).
+fn merge_type_param_metadata(collected: &mut [TypeParamInfo], extra: Vec<TypeParamInfo>) {
+    for (i, ep) in extra.into_iter().enumerate() {
+        let Some(cp) = collected.get_mut(i) else {
+            break;
+        };
+        cp.default = cp.default.or(ep.default);
+        cp.constraint = cp.constraint.or(ep.constraint);
     }
 }
 
@@ -563,7 +582,7 @@ impl<'a> TypeLowering<'a> {
             return (TypeId::ERROR, Vec::new());
         }
 
-        let mut parts = InterfaceParts::new();
+        let mut parts = ObjectTypeParts::new();
         let mut type_params_collected = false;
         let mut collected_params = Vec::new();
 
@@ -634,27 +653,18 @@ impl<'a> TypeLowering<'a> {
                     // declared in lib.es5.d.ts but other declarations in
                     // es2015.iterable.d.ts etc. omit it.
                     let extra = lowerer.collect_type_parameters_raw(params);
-                    for (i, ep) in extra.into_iter().enumerate() {
-                        if i < collected_params.len() {
-                            if collected_params[i].default.is_none() && ep.default.is_some() {
-                                collected_params[i].default = ep.default;
-                            }
-                            if collected_params[i].constraint.is_none() && ep.constraint.is_some() {
-                                collected_params[i].constraint = ep.constraint;
-                            }
-                        }
-                    }
+                    merge_type_param_metadata(&mut collected_params, extra);
                 }
             }
 
             // Collect members using the arena-specific lowerer
-            lowerer.collect_interface_members(&interface.members, &mut parts);
+            lowerer.collect_object_type_members(&interface.members, &mut parts);
         }
 
         // Assign declaration_order in FORWARD declaration order for diagnostics.
         self.assign_forward_declaration_order_cross_file(&mut parts, declarations);
 
-        let result = self.finish_interface_parts(parts, symbol_id);
+        let result = self.finish_object_type_parts(parts, symbol_id);
 
         if type_params_collected {
             self.pop_type_param_scope();
@@ -696,16 +706,7 @@ impl<'a> TypeLowering<'a> {
             } else {
                 // Merge missing defaults/constraints from subsequent declarations
                 let extra = lowerer.collect_type_parameters_raw(params);
-                for (i, ep) in extra.into_iter().enumerate() {
-                    if i < collected.len() {
-                        if collected[i].default.is_none() && ep.default.is_some() {
-                            collected[i].default = ep.default;
-                        }
-                        if collected[i].constraint.is_none() && ep.constraint.is_some() {
-                            collected[i].constraint = ep.constraint;
-                        }
-                    }
-                }
+                merge_type_param_metadata(&mut collected, extra);
             }
         }
 
@@ -1645,193 +1646,32 @@ impl<'a> TypeLowering<'a> {
     }
 
     /// Lower a type literal ({ x: T, y: U })
+    ///
+    /// Routes through the same member-collection pipeline as interface
+    /// lowering (`collect_object_type_members` / `finish_object_type_parts`)
+    /// so structurally equivalent `interface I { ... }` and `type T = { ... }`
+    /// produce identical types: method overloads accumulate into one member,
+    /// index signatures merge (conflicting value types poison to error,
+    /// distinct string-key patterns union their key types), and duplicate
+    /// member conflicts are detected instead of producing duplicate
+    /// properties.
     fn lower_type_literal(&self, node_idx: NodeIndex) -> TypeId {
         let node = match self.arena.get(node_idx) {
             Some(n) => n,
             None => return TypeId::ERROR,
         };
 
-        if let Some(data) = self.arena.get_type_literal(node) {
-            let mut properties = Vec::new();
-            let mut call_signatures = Vec::new();
-            let mut construct_signatures = Vec::new();
-            let mut string_index = None;
-            let mut number_index = None;
-            let mut has_late_bound_members = false;
+        let Some(data) = self.arena.get_type_literal(node) else {
+            return self.interner.object(vec![]);
+        };
 
-            for &idx in &data.members.nodes {
-                let Some(member) = self.arena.get(idx) else {
-                    continue;
-                };
-
-                if let Some(sig) = self.arena.get_signature(member) {
-                    match member.kind {
-                        k if k == syntax_kind_ext::CALL_SIGNATURE => {
-                            call_signatures.push(self.lower_call_signature(sig));
-                        }
-                        k if k == syntax_kind_ext::CONSTRUCT_SIGNATURE => {
-                            construct_signatures.push(self.lower_call_signature(sig));
-                        }
-                        k if k == syntax_kind_ext::METHOD_SIGNATURE => {
-                            if let Some(name) = self.lower_signature_name(sig.name) {
-                                let is_symbol_named =
-                                    self.lower_signature_name_is_symbol_named(sig.name);
-                                let (is_string_named, single_quoted_name) =
-                                    self.arena.string_property_name_flags(sig.name);
-                                let type_id = self.lower_method_signature(sig);
-                                properties.push(PropertyInfo {
-                                    name,
-                                    type_id,
-                                    write_type: type_id,
-                                    optional: sig.question_token,
-                                    readonly: self.arena.has_modifier(
-                                        &sig.modifiers,
-                                        tsz_scanner::SyntaxKind::ReadonlyKeyword,
-                                    ),
-                                    is_method: true,
-                                    is_class_prototype: false,
-                                    visibility: Visibility::Public,
-                                    parent_id: None,
-                                    declaration_order: 0,
-                                    is_string_named,
-                                    is_symbol_named,
-                                    single_quoted_name,
-                                });
-                            } else if self.is_unresolved_computed_property_name(sig.name) {
-                                has_late_bound_members = true;
-                            }
-                        }
-                        _ => {
-                            if let Some(prop) = self.lower_type_element(idx) {
-                                properties.push(prop);
-                            } else if self.is_unresolved_computed_property_name(sig.name) {
-                                has_late_bound_members = true;
-                            }
-                        }
-                    }
-                    continue;
-                }
-
-                if let Some(index_sig) = self.arena.get_index_signature(member)
-                    && let Some(index_info) = self.lower_index_signature(index_sig)
-                {
-                    if index_info.key_type == TypeId::NUMBER {
-                        number_index = Some(index_info);
-                    } else {
-                        string_index = Some(index_info);
-                    }
-                    continue;
-                }
-
-                // Handle accessor declarations (get/set) in type literals
-                if (member.kind == syntax_kind_ext::GET_ACCESSOR
-                    || member.kind == syntax_kind_ext::SET_ACCESSOR)
-                    && let Some(accessor) = self.arena.get_accessor(member)
-                    && let Some(name) = self.lower_signature_name(accessor.name)
-                {
-                    let is_symbol_named = self.lower_signature_name_is_symbol_named(accessor.name);
-                    let (is_string_named, single_quoted_name) =
-                        self.arena.string_property_name_flags(accessor.name);
-                    let is_getter = member.kind == syntax_kind_ext::GET_ACCESSOR;
-                    if is_getter {
-                        let getter_type = self.lower_type(accessor.type_annotation);
-                        if let Some(existing) = properties.iter_mut().find(|p| p.name == name) {
-                            existing.type_id = getter_type;
-                        } else {
-                            properties.push(PropertyInfo {
-                                name,
-                                type_id: getter_type,
-                                write_type: getter_type,
-                                optional: false,
-                                readonly: true,
-                                is_method: false,
-                                is_class_prototype: false,
-                                visibility: Visibility::Public,
-                                parent_id: None,
-                                declaration_order: 0,
-                                is_string_named,
-                                is_symbol_named,
-                                single_quoted_name,
-                            });
-                        }
-                    } else {
-                        let setter_type = accessor
-                            .parameters
-                            .nodes
-                            .first()
-                            .and_then(|&param_idx| self.arena.get(param_idx))
-                            .and_then(|param_node| self.arena.get_parameter(param_node))
-                            .map_or(TypeId::UNKNOWN, |param| {
-                                self.lower_type(param.type_annotation)
-                            });
-                        if let Some(existing) = properties.iter_mut().find(|p| p.name == name) {
-                            existing.write_type = setter_type;
-                            existing.readonly = false;
-                        } else {
-                            properties.push(PropertyInfo {
-                                name,
-                                type_id: setter_type,
-                                write_type: setter_type,
-                                optional: false,
-                                readonly: false,
-                                is_method: false,
-                                is_class_prototype: false,
-                                visibility: Visibility::Public,
-                                parent_id: None,
-                                declaration_order: 0,
-                                is_string_named,
-                                is_symbol_named,
-                                single_quoted_name,
-                            });
-                        }
-                    }
-                } else if member.is_accessor()
-                    && let Some(accessor) = self.arena.get_accessor(member)
-                    && self.is_unresolved_computed_property_name(accessor.name)
-                {
-                    has_late_bound_members = true;
-                }
-            }
-
-            if !call_signatures.is_empty() || !construct_signatures.is_empty() {
-                return self.interner.callable(CallableShape {
-                    call_signatures,
-                    construct_signatures,
-                    properties,
-                    string_index,
-                    number_index,
-                    symbol: None,
-                    is_abstract: false,
-                });
-            }
-
-            let flags = if has_late_bound_members {
-                ObjectFlags::HAS_LATE_BOUND_MEMBERS
-            } else {
-                ObjectFlags::empty()
-            };
-
-            if string_index.is_some() || number_index.is_some() {
-                if !self.index_signature_properties_compatible(
-                    &properties,
-                    string_index.as_ref(),
-                    number_index.as_ref(),
-                ) {
-                    return TypeId::ERROR;
-                }
-                return self.interner.object_with_index(ObjectShape {
-                    properties,
-                    string_index,
-                    number_index,
-                    flags,
-                    ..ObjectShape::default()
-                });
-            }
-
-            self.interner.object_with_flags(properties, flags)
-        } else {
-            self.interner.object(vec![])
-        }
+        // A type literal is a single declaration pass, so the 1-based
+        // pass-local counters already produce forward source order; the
+        // separate forward-order walk is only needed when merged interface
+        // declarations are collected in reverse.
+        let mut parts = ObjectTypeParts::new();
+        self.collect_object_type_members(&data.members, &mut parts);
+        self.finish_object_type_parts(parts, None)
     }
 
     pub fn lower_interface_declarations(&self, declarations: &[NodeIndex]) -> TypeId {
@@ -1872,7 +1712,7 @@ impl<'a> TypeLowering<'a> {
             return (TypeId::ERROR, Vec::new());
         }
 
-        let mut parts = InterfaceParts::new();
+        let mut parts = ObjectTypeParts::new();
         let mut type_params: Option<&NodeList> = None;
         let mut found = false;
 
@@ -1925,10 +1765,10 @@ impl<'a> TypeLowering<'a> {
             {
                 self.push_type_param_scope();
                 let _ = self.collect_type_parameters(params);
-                self.collect_interface_members(&interface.members, &mut parts);
+                self.collect_object_type_members(&interface.members, &mut parts);
                 self.pop_type_param_scope();
             } else {
-                self.collect_interface_members(&interface.members, &mut parts);
+                self.collect_object_type_members(&interface.members, &mut parts);
             }
         }
 
@@ -1941,7 +1781,7 @@ impl<'a> TypeLowering<'a> {
         self.assign_forward_declaration_order(&mut parts, declarations.iter().copied());
 
         (
-            self.finish_interface_parts(parts, symbol_id),
+            self.finish_object_type_parts(parts, symbol_id),
             collected_params,
         )
     }

--- a/crates/tsz-lowering/src/lower/core/signature_members.rs
+++ b/crates/tsz-lowering/src/lower/core/signature_members.rs
@@ -108,7 +108,20 @@ impl<'a> TypeLowering<'a> {
         }
     }
 
-    pub(super) fn collect_interface_members(&self, members: &NodeList, parts: &mut InterfaceParts) {
+    /// Collect object-type members (properties, methods, call/construct
+    /// signatures, index signatures, accessors) into `ObjectTypeParts`.
+    ///
+    /// This is the single member-collection pipeline shared by interface
+    /// declarations (same-arena and cross-arena merged) and type literals, so
+    /// structurally equivalent `interface I { ... }` and `type T = { ... }`
+    /// lower through identical merge rules: method-overload accumulation,
+    /// index-signature merging, duplicate-member conflict handling, and
+    /// late-bound member detection.
+    pub(super) fn collect_object_type_members(
+        &self,
+        members: &NodeList,
+        parts: &mut ObjectTypeParts,
+    ) {
         for &idx in &members.nodes {
             let Some(member) = self.arena.get(idx) else {
                 continue;
@@ -256,12 +269,31 @@ impl<'a> TypeLowering<'a> {
         }
     }
 
+    /// Assign forward `declaration_order` values (1-based) for one member list,
+    /// continuing from `counter`. Used for both interface declarations and type
+    /// literals so earlier members get lower order numbers, matching tsc's
+    /// property enumeration for diagnostics like TS2740 "missing properties:
+    /// length, pop, ...".
+    pub(super) fn assign_forward_member_order(
+        &self,
+        parts: &mut ObjectTypeParts,
+        members: impl Iterator<Item = NodeIndex>,
+        counter: &mut u32,
+    ) {
+        for idx in members {
+            if let Some(name) = self.object_member_name(idx) {
+                parts.declaration_orders.entry(name).or_insert_with(|| {
+                    *counter += 1;
+                    *counter
+                });
+            }
+        }
+    }
+
     /// Assign `declaration_order` values by iterating declarations in FORWARD order.
-    /// This gives earlier declarations lower order numbers, matching tsc's property
-    /// enumeration for diagnostics like TS2740 "missing properties: length, pop, ...".
     pub(super) fn assign_forward_declaration_order(
         &self,
-        parts: &mut InterfaceParts,
+        parts: &mut ObjectTypeParts,
         declarations: impl Iterator<Item = NodeIndex>,
     ) {
         let mut counter: u32 = 0;
@@ -272,21 +304,18 @@ impl<'a> TypeLowering<'a> {
             let Some(interface) = self.arena.get_interface(node) else {
                 continue;
             };
-            for &idx in &interface.members.nodes {
-                if let Some(name) = self.get_interface_member_name(idx) {
-                    parts.declaration_orders.entry(name).or_insert_with(|| {
-                        counter += 1;
-                        counter
-                    });
-                }
-            }
+            self.assign_forward_member_order(
+                parts,
+                interface.members.nodes.iter().copied(),
+                &mut counter,
+            );
         }
     }
 
     /// Cross-file variant of `assign_forward_declaration_order`.
     pub(super) fn assign_forward_declaration_order_cross_file(
         &self,
-        parts: &mut InterfaceParts,
+        parts: &mut ObjectTypeParts,
         declarations: &[(NodeIndex, &NodeArena)],
     ) {
         let mut counter: u32 = 0;
@@ -298,19 +327,17 @@ impl<'a> TypeLowering<'a> {
                 continue;
             };
             let lowerer = self.with_arena(decl_arena);
-            for &idx in &interface.members.nodes {
-                if let Some(name) = lowerer.get_interface_member_name(idx) {
-                    parts.declaration_orders.entry(name).or_insert_with(|| {
-                        counter += 1;
-                        counter
-                    });
-                }
-            }
+            lowerer.assign_forward_member_order(
+                parts,
+                interface.members.nodes.iter().copied(),
+                &mut counter,
+            );
         }
     }
 
-    /// Extract the property/method name from an interface member node.
-    fn get_interface_member_name(&self, idx: NodeIndex) -> Option<Atom> {
+    /// Extract the property/method name from an object-type member node
+    /// (interface member or type-literal member).
+    fn object_member_name(&self, idx: NodeIndex) -> Option<Atom> {
         let member = self.arena.get(idx)?;
         if let Some(sig) = self.arena.get_signature(member) {
             return self.lower_signature_name(sig.name);
@@ -324,9 +351,13 @@ impl<'a> TypeLowering<'a> {
         None
     }
 
-    pub(super) fn finish_interface_parts(
+    /// Build the final object/callable type from collected `ObjectTypeParts`.
+    ///
+    /// Shared by interface lowering and type-literal lowering; `symbol_id` is
+    /// `Some` only for interfaces that need symbol stamping.
+    pub(super) fn finish_object_type_parts(
         &self,
-        mut parts: InterfaceParts,
+        mut parts: ObjectTypeParts,
         symbol_id: Option<tsz_binder::SymbolId>,
     ) -> TypeId {
         // When an interface (or merged interface group) carries multiple string-keyed

--- a/crates/tsz-lowering/tests/lower_tests.rs
+++ b/crates/tsz-lowering/tests/lower_tests.rs
@@ -9,3 +9,4 @@ use tsz_solver::*;
 include!("lower_tests_parts/helpers.rs");
 include!("lower_tests_parts/fundamental_types.rs");
 include!("lower_tests_parts/object_template_and_advanced_types.rs");
+include!("lower_tests_parts/member_pipeline_parity.rs");

--- a/crates/tsz-lowering/tests/lower_tests_parts/member_pipeline_parity.rs
+++ b/crates/tsz-lowering/tests/lower_tests_parts/member_pipeline_parity.rs
@@ -1,0 +1,223 @@
+// Interface vs type-literal member-pipeline parity.
+//
+// Both forms lower through the shared `collect_object_type_members` /
+// `finish_object_type_parts` pipeline, so a structurally identical
+// `interface I { ... }` and `type T = { ... }` must intern to the same
+// `TypeId`: same method-overload merging, index-signature merging, duplicate
+// member conflict handling, accessor merging, and late-bound detection.
+
+/// Parse a source containing one interface (by name) and one type literal,
+/// returning both from a single arena so lowered `TypeId`s are comparable.
+fn parse_interface_and_type_literal(
+    source: &str,
+    interface_name: &str,
+) -> (NodeArena, Vec<NodeIndex>, NodeIndex) {
+    let arena = parse_and_take_arena(source);
+    let mut declarations = Vec::new();
+    let mut literal_idx = NodeIndex::NONE;
+    for i in 0..arena.len() {
+        let idx = NodeIndex(i as u32);
+        let Some(node) = arena.get(idx) else {
+            continue;
+        };
+        if node.kind == syntax_kind_ext::INTERFACE_DECLARATION
+            && let Some(interface) = arena.get_interface(node)
+            && let Some(name_node) = arena.get(interface.name)
+            && let Some(ident) = arena.get_identifier(name_node)
+            && ident.escaped_text == interface_name
+        {
+            declarations.push(idx);
+        }
+        if node.kind == syntax_kind_ext::TYPE_LITERAL && literal_idx == NodeIndex::NONE {
+            literal_idx = idx;
+        }
+    }
+    assert!(
+        !declarations.is_empty(),
+        "Could not find interface '{interface_name}'"
+    );
+    assert!(
+        literal_idx != NodeIndex::NONE,
+        "Could not find type literal"
+    );
+    (arena, declarations, literal_idx)
+}
+
+/// Lower both forms with one interner and assert they produce the same type.
+fn assert_interface_literal_parity(source: &str, interface_name: &str) -> (TypeInterner, TypeId) {
+    let (arena, declarations, literal_idx) =
+        parse_interface_and_type_literal(source, interface_name);
+    let interner = TypeInterner::new();
+    let lowering = TypeLowering::new(&arena, &interner);
+    let interface_type = lowering.lower_interface_declarations(&declarations);
+    let literal_type = lowering.lower_type(literal_idx);
+    assert_ne!(interface_type, TypeId::ERROR, "interface lowering failed");
+    assert_eq!(
+        interface_type, literal_type,
+        "interface vs type-literal lowering diverged for: {source}"
+    );
+    (interner, literal_type)
+}
+
+#[test]
+fn test_member_parity_properties_optional_readonly() {
+    assert_interface_literal_parity(
+        "interface Alpha { qty: number; readonly tag?: string; }
+         type AlphaLit = { qty: number; readonly tag?: string; };",
+        "Alpha",
+    );
+}
+
+#[test]
+fn test_member_parity_single_method() {
+    assert_interface_literal_parity(
+        "interface Beacon { ping(msg: string): number; }
+         type BeaconLit = { ping(msg: string): number; };",
+        "Beacon",
+    );
+}
+
+#[test]
+fn test_member_parity_generic_method() {
+    assert_interface_literal_parity(
+        "interface Wrapper { wrap<T>(value: T): T[]; }
+         type WrapperLit = { wrap<T>(value: T): T[]; };",
+        "Wrapper",
+    );
+}
+
+#[test]
+fn test_member_parity_method_overloads() {
+    let (interner, type_id) = assert_interface_literal_parity(
+        "interface Chord { play(): void; play(note: string): boolean; }
+         type ChordLit = { play(): void; play(note: string): boolean; };",
+        "Chord",
+    );
+
+    // Overloads of the same method merge into ONE property whose type carries
+    // both call signatures (previously the type-literal path produced two
+    // duplicate properties named `play`).
+    match interner.lookup(type_id).expect("type should exist") {
+        TypeData::Object(shape_id) => {
+            let shape = interner.object_shape(shape_id);
+            assert_eq!(shape.properties.len(), 1, "overloads must merge");
+            let prop = &shape.properties[0];
+            assert_eq!(interner.resolve_atom(prop.name), "play");
+            assert!(prop.is_method);
+            match interner.lookup(prop.type_id).expect("member type") {
+                TypeData::Callable(callable_id) => {
+                    let callable = interner.callable_shape(callable_id);
+                    assert_eq!(callable.call_signatures.len(), 2);
+                }
+                other => panic!("Expected Callable member, got {other:?}"),
+            }
+        }
+        other => panic!("Expected Object type, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_member_parity_call_and_construct_signatures() {
+    assert_interface_literal_parity(
+        "interface Factory { (count: number): string; new (count: number): string; ready: boolean; }
+         type FactoryLit = { (count: number): string; new (count: number): string; ready: boolean; };",
+        "Factory",
+    );
+}
+
+#[test]
+fn test_member_parity_string_and_number_index_signatures() {
+    assert_interface_literal_parity(
+        "interface Grid { [cell: string]: unknown; length: number; }
+         type GridLit = { [cell: string]: unknown; length: number; };",
+        "Grid",
+    );
+}
+
+#[test]
+fn test_member_parity_distinct_string_pattern_index_signatures() {
+    let (interner, type_id) = assert_interface_literal_parity(
+        "interface Dataset { [key: `data-${string}`]: string; [key: `aria-${string}`]: string; }
+         type DatasetLit = { [key: `data-${string}`]: string; [key: `aria-${string}`]: string; };",
+        "Dataset",
+    );
+
+    // Distinct string-keyed patterns merge by unioning the key types
+    // (previously the type-literal path kept only the LAST index signature,
+    // silently dropping the `data-${string}` pattern).
+    match interner.lookup(type_id).expect("type should exist") {
+        TypeData::ObjectWithIndex(shape_id) => {
+            let shape = interner.object_shape(shape_id);
+            let string_index = shape
+                .string_index
+                .as_ref()
+                .expect("expected merged string index signature");
+            match interner
+                .lookup(string_index.key_type)
+                .expect("key type should exist")
+            {
+                TypeData::Union(list_id) => {
+                    assert_eq!(interner.type_list(list_id).len(), 2);
+                }
+                other => panic!("Expected union of key patterns, got {other:?}"),
+            }
+        }
+        other => panic!("Expected ObjectWithIndex type, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_member_parity_duplicate_conflicting_members() {
+    assert_interface_literal_parity(
+        "interface Clash { v: string; v: number; }
+         type ClashLit = { v: string; v: number; };",
+        "Clash",
+    );
+}
+
+#[test]
+fn test_member_parity_get_set_accessors() {
+    assert_interface_literal_parity(
+        "interface Gauge { get level(): number; set level(value: number); }
+         type GaugeLit = { get level(): number; set level(value: number); };",
+        "Gauge",
+    );
+}
+
+#[test]
+fn test_member_parity_late_bound_computed_member() {
+    let (interner, type_id) = assert_interface_literal_parity(
+        "declare const marker: symbol;
+         interface Tagged { [marker]: string; }
+         type TaggedLit = { [marker]: string; };",
+        "Tagged",
+    );
+
+    match interner.lookup(type_id).expect("type should exist") {
+        TypeData::Object(shape_id) => {
+            let shape = interner.object_shape(shape_id);
+            assert!(
+                shape.flags.contains(ObjectFlags::HAS_LATE_BOUND_MEMBERS),
+                "unresolved computed member must mark the type late-bound"
+            );
+        }
+        other => panic!("Expected Object type, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_member_parity_negative_different_shapes_differ() {
+    let (arena, declarations, literal_idx) = parse_interface_and_type_literal(
+        "interface Pair { first: string; }
+         type PairLit = { first: number; };",
+        "Pair",
+    );
+    let interner = TypeInterner::new();
+    let lowering = TypeLowering::new(&arena, &interner);
+    let interface_type = lowering.lower_interface_declarations(&declarations);
+    let literal_type = lowering.lower_type(literal_idx);
+    assert_ne!(
+        interface_type, literal_type,
+        "structurally different shapes must not collapse"
+    );
+}

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -941,7 +941,9 @@ pub struct PropertyInfo {
     pub visibility: Visibility,
     /// Symbol that declared this property (for nominal identity checks)
     pub parent_id: Option<SymbolId>,
-    /// Declaration order for preserving source ordering in emit (excluded from equality/hash).
+    /// Declaration order for preserving source ordering in emit (excluded from
+    /// equality/hash). 0 means "unset": interner constructors backfill it from
+    /// insertion order.
     pub declaration_order: u32,
     /// Whether this property was declared with a string key that looks numeric
     /// (e.g. `"404"` vs `404`). Included in PartialEq/Hash because `"100"` and


### PR DESCRIPTION
Goal: hold

Fixes #13122

## Summary

`tsz-lowering` collected object members through two divergent pipelines: the `InterfaceParts`-based collector used by both interface drivers (same-arena and cross-arena merged), and a hand-rolled inline copy in `lower_type_literal` that had drifted. This PR deletes the drifted copy and routes type literals through the shared pipeline, now named `collect_object_type_members` / `finish_object_type_parts` / `ObjectTypeParts`.

## Structural rule

When an object type is declared as `interface I { M }` or `type T = { M }` with the same member list `M`, tsc computes identical members for both forms. tsz now does the same through the single shared member-collection pipeline in `tsz-lowering` (owner layer: lowering; the checker and solver consume the resulting `TypeId`s unchanged).

Drift fixed by the unification (each previously diverged in the type-literal copy only):

- **Method overloads**: same-named method signatures in a type literal produced duplicate properties; they now merge into one overloaded member, as in interfaces.
- **Index signatures**: a later index signature silently replaced an earlier one (e.g. `` [k: `data-${string}`] `` dropped when `` [k: `aria-${string}`] `` followed); distinct string-key patterns now union their key types, and same-key conflicts poison the value type, as in interfaces.
- **Duplicate members**: conflicting duplicate properties now get conflict handling instead of duplicate entries.
- **Member representation**: type-literal methods now lower to the same callable representation interfaces use, so structurally equivalent forms intern to the same `TypeId`.

Also in this PR:

- Pass-local declaration orders are 1-based (0 stays the interner's "unset" sentinel), so single-pass type literals need no separate forward-order walk — removes a per-literal member-name re-resolution from the hot path.
- `merge_type_param_metadata` extracted to dedupe the two copies of the merged-interface type-parameter default/constraint merge loop.

## Adjacent-case matrix

New `member_pipeline_parity.rs` tests assert `TypeId` equality between interface and type-literal forms (varied binder names: Alpha, Beacon, Wrapper, Chord, Factory, Grid, Dataset, Clash, Gauge, Tagged, Pair) across: plain/optional/readonly properties; single, generic, and overloaded methods; call + construct signatures; string + number index signatures; distinct string-pattern index signatures (key-type union pinned); duplicate conflicting members; get/set accessors; late-bound computed members (flag pinned); plus a negative case asserting structurally different shapes do not collapse.

## Verification

- `cargo test -p tsz-lowering` — 166 passed; the only failure (`test_template_literal_only_interpolation`) is pre-existing and reproduces on clean `origin/main` (e2320f4), unrelated to this diff (template-literal scanning, see #13067 family).
- Targeted checker suites, all green: `type_literal_method_overload_tests`, `type_literal_overload_optionality_tests`, `contextual_typing_tests`, `contextual_method_index_signature_tests`, `index_signature_argument_assignability_tests`, `ts2374_lib_merged_index_signature_tests`, `symbol_index_signature_tests`, `keyof_template_index_signature_tests`, `index_signature_type_check_probe_tests`, `function_bivariance`, `ts2636_method_bivariance_tests`, `object_literal_getter_widening_tests`, `export_equals_display_order_tests` (2 pre-existing failures there also reproduce on clean `origin/main`).
- `cargo clippy -p tsz-lowering -p tsz-solver --all-targets` — clean.
- Ready-review CI owns the broad conformance/emit suites.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude
Effort: high

https://claude.ai/code/session_0141ZwHSpjoGRB4o72ooiDKf