### PR TITLE
fix(checker,solver): boxed-type DefId identity collision corrupted shared def store + publication census infra

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -861,6 +861,7 @@ impl<'a> CheckerContext<'a> {
     }
 
     /// Register a non-generic definition body in **both** type environments.
+    #[track_caller]
     pub fn register_def_in_envs(&self, def_id: DefId, body: TypeId) {
         let body_changed = self.definition_store.get_body(def_id) != Some(body);
         self.definition_store.set_body(def_id, body);
@@ -877,6 +878,7 @@ impl<'a> CheckerContext<'a> {
     /// atomic write so concurrent readers never observe a generic alias whose
     /// body is visible but whose parameter list is still missing (which would
     /// mis-instantiate every application of the alias).
+    #[track_caller]
     pub fn register_def_with_params_in_envs(
         &self,
         def_id: DefId,
@@ -905,6 +907,7 @@ impl<'a> CheckerContext<'a> {
     /// Register a definition body in **both** type environments, choosing
     /// `insert_def` or `insert_def_with_params` based on whether `params` is
     /// empty.
+    #[track_caller]
     pub fn register_def_auto_params_in_envs(
         &self,
         def_id: DefId,

--- a/crates/tsz-checker/src/types/queries/lib_augmentations.rs
+++ b/crates/tsz-checker/src/types/queries/lib_augmentations.rs
@@ -10,6 +10,16 @@ use super::lib_resolution::{
     augmentation_def_id_from_node, no_value_resolver, resolve_augmentation_node,
 };
 
+/// Mutation-isolation campaign prototype gate: the `finalize` variant of the
+/// `TSZ_EXPERIMENT_LIB_DEF_PUBLISH_ONCE` experiment freezes each lib def's
+/// shared-store body at its finalized publication point.
+fn lib_def_freeze_at_finalize_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("TSZ_EXPERIMENT_LIB_DEF_PUBLISH_ONCE").is_ok_and(|v| v == "finalize")
+    })
+}
+
 impl<'a> CheckerState<'a> {
     /// Lower augmentation declarations from a given arena and return the resulting `TypeId`.
     ///
@@ -182,6 +192,12 @@ impl<'a> CheckerState<'a> {
         let type_params = self.ctx.get_def_type_params(def_id).unwrap_or_default();
         self.ctx
             .register_def_auto_params_in_envs(def_id, ty, type_params);
+        // Mutation-isolation campaign prototype (`finalize` variant): freeze
+        // the shared-store body at the finalized publication point so later
+        // checkers' re-finalizations cannot republish a different form.
+        if lib_def_freeze_at_finalize_enabled() {
+            self.ctx.definition_store.mark_publish_once(def_id);
+        }
     }
 
     /// Wrapper around `register_finalized_lib_body` that no-ops unless the

--- a/crates/tsz-checker/src/types/type_checking/global.rs
+++ b/crates/tsz-checker/src/types/type_checking/global.rs
@@ -369,17 +369,40 @@ impl<'a> CheckerState<'a> {
         let mut boxed_def_entries: smallvec::SmallVec<
             [(IntrinsicKind, TypeId, tsz_solver::DefId); 16],
         > = smallvec::SmallVec::new();
+        // Resolve each per-lib-context SymbolId to a DefId and verify the
+        // def actually names this builtin. Per-lib SymbolIds are
+        // binder-relative; `get_lib_def_id` resolves them through
+        // context-agnostic indexes (raw symbol id, with every lib def sharing
+        // the same sentinel decl file index), so a later lib context's
+        // `String` symbol id can collide with an unrelated def from an
+        // earlier lib binder (e.g. `alert`). Registering — and worse,
+        // `insert_def`-publishing — the boxed body onto that unrelated def
+        // corrupts the shared `DefinitionStore` body for that def (a
+        // last-writer-wins in-flight channel the parallel-checking campaign
+        // must eliminate). On mismatch, route through the canonical
+        // name-keyed lib def resolution instead.
+        let boxed_def_for = |checker: &Self, name: &str, sym_id: tsz_binder::SymbolId| {
+            let def_id = checker.ctx.get_lib_def_id(sym_id);
+            let name_matches = checker
+                .ctx
+                .definition_store
+                .get(def_id)
+                .is_some_and(|info| checker.ctx.types.resolve_atom(info.name) == name);
+            if name_matches {
+                def_id
+            } else {
+                checker.ctx.get_canonical_lib_def_id(name, sym_id)
+            }
+        };
         for &(name, type_opt, kind) in boxed_names {
             let Some(ty) = type_opt else { continue };
             for ctx in self.ctx.lib_contexts.iter() {
                 if let Some(sym_id) = ctx.binder.file_locals.get(name) {
-                    let def_id = self.ctx.get_lib_def_id(sym_id);
-                    boxed_def_entries.push((kind, ty, def_id));
+                    boxed_def_entries.push((kind, ty, boxed_def_for(self, name, sym_id)));
                 }
             }
             if let Some(sym_id) = self.ctx.binder.file_locals.get(name) {
-                let def_id = self.ctx.get_lib_def_id(sym_id);
-                boxed_def_entries.push((kind, ty, def_id));
+                boxed_def_entries.push((kind, ty, boxed_def_for(self, name, sym_id)));
             }
         }
         for &(kind, _ty, def_id) in &boxed_def_entries {

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -971,6 +971,26 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
             ),
         );
         shared_store.init_file_locks(program.files.len());
+        // Mutation-isolation campaign prototype: keep lib interface bodies
+        // immutable in the shared store after first materialization
+        // (first-writer-wins). Sequential checking order makes the first
+        // writer deterministic; the experiment measures republication
+        // suppression + diagnostic parity for this def class before the
+        // campaign promotes it to a pre-materialization pass.
+        // Two variants: `first` (default) freezes every lib interface def at
+        // its first body write; `finalize` lets the checker freeze each def
+        // at its finalized-body publication point instead (see
+        // `register_finalized_lib_body`).
+        match std::env::var("TSZ_EXPERIMENT_LIB_DEF_PUBLISH_ONCE") {
+            Ok(value) if value == "finalize" => {
+                tracing::info!("publish-once experiment: freeze-at-finalize variant");
+            }
+            Ok(_) => {
+                let marked = shared_store.mark_non_program_interface_defs_publish_once();
+                tracing::info!(marked, "publish-once experiment: lib interface defs marked");
+            }
+            Err(_) => {}
+        }
         program_context.shared_definition_store = Some(shared_store);
     }
 
@@ -1799,6 +1819,41 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
     } else {
         None
     };
+
+    // Mutation-isolation campaign census dump (env-gated, see
+    // `tsz_solver::def::publication_census`). The driver owns name
+    // resolution (shared `TypeInterner` atoms, program file table) and
+    // file IO; when `TSZ_DEF_PUBLICATION_CENSUS` names a path the report
+    // is written there, otherwise it goes to the tracing stream.
+    if let Some(report) = tsz_solver::def::publication_census::dump_to_string(
+        &|atom| program.type_interner.resolve_atom(atom),
+        &|file_id| {
+            program
+                .files
+                .get(file_id as usize)
+                .map_or_else(|| format!("<file#{file_id}>"), |f| f.file_name.clone())
+        },
+        &|type_id| {
+            tsz_solver::def::publication_census::describe_type_shallow(
+                &program.type_interner,
+                type_id,
+            )
+        },
+    ) {
+        let dest = std::env::var("TSZ_DEF_PUBLICATION_CENSUS").unwrap_or_default();
+        if dest.contains('/') {
+            if let Err(err) = std::fs::write(&dest, &report) {
+                tracing::warn!(
+                    target: "def_publication_census",
+                    %err,
+                    path = %dest,
+                    "failed to write census report"
+                );
+            }
+        } else {
+            tracing::info!(target: "def_publication_census", "\n{report}");
+        }
+    }
 
     CollectDiagnosticsResult {
         diagnostics,

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -19,6 +19,7 @@ mod definition_info;
 
 pub use content_addressed::ContentAddressedDefIds;
 
+use super::publication_census;
 #[cfg(test)]
 use crate::types::ObjectFlags;
 use crate::types::{ObjectShape, PropertyInfo, TypeId, TypeParamInfo};
@@ -364,6 +365,16 @@ pub struct DefinitionStore {
     /// matching tsc's collapse of the alias to the error type.
     depth_poisoned_defs: DefDashSet<DefId>,
 
+    /// Mutation-isolation campaign prototype: defs whose shared-store body is
+    /// **published once** — after the first body materialization, later
+    /// publications carrying a *different* body form are dropped instead of
+    /// overwriting (first-writer-wins instead of last-writer-wins). Used to
+    /// measure whether a def class can be pre-materialized and kept immutable
+    /// during per-file checking without diagnostic drift. Populated only when
+    /// the `TSZ_EXPERIMENT_LIB_DEF_PUBLISH_ONCE` experiment is enabled by the
+    /// driver; empty (and skipped via a cheap `is_empty` gate) otherwise.
+    publish_once_defs: DefDashSet<DefId>,
+
     /// Reverse index: `file_id` -> `Vec<DefId>` for per-file definition lookups.
     ///
     /// Populated during `register()` when the `DefinitionInfo` has a `file_id`.
@@ -623,6 +634,7 @@ impl DefinitionStore {
             computed_alias_bodies: DefDashSet::default(),
             directly_named_alias_bodies: DefDashSet::default(),
             depth_poisoned_defs: DefDashSet::default(),
+            publish_once_defs: DefDashSet::default(),
             shape_to_def: DefDashMap::default(),
             file_to_defs: DefDashMap::with_capacity_and_hasher(file_capacity, Default::default()),
             class_to_constructor: DefDashMap::with_capacity_and_hasher(
@@ -856,6 +868,7 @@ impl DefinitionStore {
     /// `get_or_create_def_id` without a full `register` call), a minimal
     /// entry is created so that cross-file type resolution can find the
     /// body via `get_body`.
+    #[track_caller]
     pub fn set_body(&self, id: DefId, body: TypeId) {
         self.set_body_with_params(id, body, None);
     }
@@ -872,12 +885,58 @@ impl DefinitionStore {
     /// empty/stale, mis-instantiating every application of the alias
     /// (false `TS2344` storms under parallel fresh checking; sequential
     /// checking never interleaves a reader between the two writes).
+    #[track_caller]
     pub fn set_body_with_params(
         &self,
         id: DefId,
         body: TypeId,
         params: Option<Vec<TypeParamInfo>>,
     ) {
+        // Mutation-isolation prototype: defs marked publish-once keep their
+        // first published body; a later attempt to overwrite it with a
+        // *different* body form is dropped (the shared store stays immutable
+        // for that def after first materialization). Identical republication
+        // is allowed through (it is a no-op write).
+        let suppressed = !self.publish_once_defs.is_empty()
+            && self.publish_once_defs.contains(&id)
+            && self
+                .definitions
+                .get(&id)
+                .and_then(|entry| entry.body)
+                .is_some_and(|prev| prev != body);
+        // Mutation-isolation campaign census (env-gated, see
+        // `publication_census`): classify this publication against the
+        // pre-write entry state with caller attribution.
+        if publication_census::census_enabled() {
+            let caller = std::panic::Location::caller();
+            let (outcome, kind, name, file_id) = match self.definitions.get(&id) {
+                Some(entry) => {
+                    let params_changed = params
+                        .as_ref()
+                        .is_some_and(|new_params| *new_params != entry.type_params);
+                    (
+                        if suppressed {
+                            publication_census::PublicationOutcome::SuppressedDifferentBody
+                        } else {
+                            publication_census::classify(entry.body, body, params_changed, true)
+                        },
+                        Some(entry.kind),
+                        entry.name,
+                        entry.file_id,
+                    )
+                }
+                None => (
+                    publication_census::classify(None, body, false, false),
+                    None,
+                    Atom::NONE,
+                    None,
+                ),
+            };
+            publication_census::record_publication(id, kind, name, file_id, body, outcome, caller);
+        }
+        if suppressed {
+            return;
+        }
         if let Some(mut entry) = self.definitions.get_mut(&id) {
             if let Some(params) = params {
                 if entry.kind == DefKind::TypeAlias
@@ -927,6 +986,39 @@ impl DefinitionStore {
             );
             self.bump_generation();
         }
+    }
+
+    /// Mutation-isolation campaign prototype: mark every **interface**
+    /// definition that does not originate from a program source file (lib
+    /// binder symbols carry the binder's "no declaration file" sentinel
+    /// index) as publish-once. After each such def's first body
+    /// materialization, later publications with a different body form are
+    /// dropped, keeping the shared store immutable for the class while
+    /// per-file checkers continue to use their own `TypeEnvironment` bodies.
+    ///
+    /// Returns the number of definitions marked. Driver-invoked only when the
+    /// `TSZ_EXPERIMENT_LIB_DEF_PUBLISH_ONCE` experiment is enabled.
+    pub fn mark_non_program_interface_defs_publish_once(&self) -> usize {
+        /// `tsz_binder` symbols without a program declaration file (every
+        /// lib-binder symbol) carry `u32::MAX` as `decl_file_idx`.
+        const NON_PROGRAM_FILE_SENTINEL: u32 = u32::MAX;
+        let mut marked = 0usize;
+        for entry in &self.definitions {
+            let info = entry.value();
+            if info.kind == DefKind::Interface && info.file_id == Some(NON_PROGRAM_FILE_SENTINEL) {
+                self.publish_once_defs.insert(*entry.key());
+                marked += 1;
+            }
+        }
+        marked
+    }
+
+    /// Mutation-isolation campaign prototype: mark a single def publish-once
+    /// **after** its current body, so the form just published becomes the
+    /// frozen one (used to freeze at the *finalized* lib-body publication
+    /// point rather than at the first partial materialization).
+    pub fn mark_publish_once(&self, id: DefId) {
+        self.publish_once_defs.insert(id);
     }
 
     /// Mark a type-alias `DefId` as having an unconditionally-infinite

--- a/crates/tsz-solver/src/def/mod.rs
+++ b/crates/tsz-solver/src/def/mod.rs
@@ -7,6 +7,7 @@
 
 mod core;
 pub mod incremental;
+pub mod publication_census;
 pub mod resolver;
 
 pub use self::core::*;

--- a/crates/tsz-solver/src/def/publication_census.rs
+++ b/crates/tsz-solver/src/def/publication_census.rs
@@ -1,0 +1,400 @@
+//! Env-gated census of `DefinitionStore` body publications.
+//!
+//! The mutation-isolation campaign (lifting the sequential fresh-checking
+//! gate in the CLI driver) needs the shared `DefinitionStore` to become
+//! immutable during parallel file checking. Today every per-file checker
+//! re-derives and republishes def bodies into the shared store
+//! (last-writer-wins), and sibling workers can observe bodies mid-rewrite.
+//!
+//! This module measures that republication traffic so the campaign can decide
+//! which def classes must be pre-materialized before the parallel phase:
+//!
+//! - **who**: which `DefId`s (kind, name, file) get republished,
+//! - **from where**: which call paths publish (via `#[track_caller]`
+//!   attribution on [`super::DefinitionStore::set_body_with_params`]),
+//! - **what changes**: first publication vs byte-identical republication vs
+//!   a *different* body `TypeId` (the dangerous class — checker-relative
+//!   forms are not interchangeable across checkers).
+//!
+//! Gated by the `TSZ_DEF_PUBLICATION_CENSUS` environment variable; when unset
+//! the only cost on the publication path is one `OnceLock<bool>` load.
+//! Recording takes a global mutex, which is acceptable at observed volumes
+//! (~10^3..10^4 publications per project run). Output is rendered by
+//! [`dump_to_string`]; the CLI driver owns file IO and name resolution.
+
+use super::{DefId, DefKind};
+use crate::intern::TypeInterner;
+use crate::types::{TypeData, TypeId};
+use rustc_hash::FxHashMap;
+use std::panic::Location;
+use std::sync::{Mutex, OnceLock};
+use tsz_common::interner::Atom;
+
+/// Cheap global gate: census recording is enabled iff
+/// `TSZ_DEF_PUBLICATION_CENSUS` is set in the environment.
+#[inline]
+pub fn census_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("TSZ_DEF_PUBLICATION_CENSUS").is_some())
+}
+
+/// How a single `set_body_with_params` call related to the existing entry.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum PublicationOutcome {
+    /// Entry existed with no body yet: the first real publication.
+    First,
+    /// No entry existed; a minimal entry was minted (cross-file delegation).
+    MintedMinimal,
+    /// Republication with the identical body `TypeId` (and unchanged params).
+    SameBody,
+    /// Republication with the identical body `TypeId` but a different
+    /// type-parameter list.
+    SameBodyParamsChanged,
+    /// Republication with a *different* body `TypeId` — the class that makes
+    /// the shared store schedule-dependent under parallel checking.
+    DifferentBody,
+    /// Different body `TypeId` *and* a different type-parameter list.
+    DifferentBodyParamsChanged,
+    /// A different-body publication that was *dropped* because the def is
+    /// marked publish-once (mutation-isolation prototype): the store kept
+    /// the first materialized form.
+    SuppressedDifferentBody,
+}
+
+impl PublicationOutcome {
+    const ALL: [Self; 7] = [
+        Self::First,
+        Self::MintedMinimal,
+        Self::SameBody,
+        Self::SameBodyParamsChanged,
+        Self::DifferentBody,
+        Self::DifferentBodyParamsChanged,
+        Self::SuppressedDifferentBody,
+    ];
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::First => "first",
+            Self::MintedMinimal => "minted-minimal",
+            Self::SameBody => "same-body",
+            Self::SameBodyParamsChanged => "same-body+params-changed",
+            Self::DifferentBody => "different-body",
+            Self::DifferentBodyParamsChanged => "different-body+params-changed",
+            Self::SuppressedDifferentBody => "suppressed-different-body",
+        }
+    }
+
+    const fn is_different_body(self) -> bool {
+        matches!(self, Self::DifferentBody | Self::DifferentBodyParamsChanged)
+    }
+}
+
+/// Per-`DefId` aggregate.
+struct DefCensus {
+    name: Atom,
+    kind: Option<DefKind>,
+    file_id: Option<u32>,
+    publications: u64,
+    different_body: u64,
+    /// Distinct body `TypeId`s observed (deduped, capped).
+    bodies: Vec<TypeId>,
+    /// True once the distinct-body list overflowed [`MAX_TRACKED_BODIES`].
+    bodies_overflowed: bool,
+}
+
+const MAX_TRACKED_BODIES: usize = 16;
+
+#[derive(Default)]
+struct CensusState {
+    /// (caller file, caller line, outcome) -> count.
+    by_site: FxHashMap<(&'static str, u32, PublicationOutcome), u64>,
+    by_def: FxHashMap<DefId, DefCensus>,
+}
+
+fn state() -> &'static Mutex<CensusState> {
+    static STATE: OnceLock<Mutex<CensusState>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(CensusState::default()))
+}
+
+/// Record one body publication. Call only when [`census_enabled`] is true.
+///
+/// `prev_body` is the entry body before this write (`None` for both the
+/// `First` and `MintedMinimal` outcomes, disambiguated by `outcome`).
+pub fn record_publication(
+    def_id: DefId,
+    kind: Option<DefKind>,
+    name: Atom,
+    file_id: Option<u32>,
+    new_body: TypeId,
+    outcome: PublicationOutcome,
+    caller: &'static Location<'static>,
+) {
+    let Ok(mut state) = state().lock() else {
+        return;
+    };
+    *state
+        .by_site
+        .entry((caller.file(), caller.line(), outcome))
+        .or_insert(0) += 1;
+    let entry = state.by_def.entry(def_id).or_insert_with(|| DefCensus {
+        name,
+        kind,
+        file_id,
+        publications: 0,
+        different_body: 0,
+        bodies: Vec::new(),
+        bodies_overflowed: false,
+    });
+    // Later publications may carry richer metadata (a minted-minimal entry
+    // gets a real kind/name once registered); keep the best-known values.
+    if entry.kind.is_none() {
+        entry.kind = kind;
+    }
+    if entry.name.is_none() && !name.is_none() {
+        entry.name = name;
+    }
+    if entry.file_id.is_none() {
+        entry.file_id = file_id;
+    }
+    entry.publications += 1;
+    if outcome.is_different_body() {
+        entry.different_body += 1;
+    }
+    if !entry.bodies.contains(&new_body) {
+        if entry.bodies.len() < MAX_TRACKED_BODIES {
+            entry.bodies.push(new_body);
+        } else {
+            entry.bodies_overflowed = true;
+        }
+    }
+}
+
+/// Classify a publication against the pre-write entry state.
+pub fn classify(
+    prev_body: Option<TypeId>,
+    new_body: TypeId,
+    params_changed: bool,
+    entry_existed: bool,
+) -> PublicationOutcome {
+    match prev_body {
+        None if !entry_existed => PublicationOutcome::MintedMinimal,
+        None => PublicationOutcome::First,
+        Some(prev) if prev == new_body => {
+            if params_changed {
+                PublicationOutcome::SameBodyParamsChanged
+            } else {
+                PublicationOutcome::SameBody
+            }
+        }
+        Some(_) => {
+            if params_changed {
+                PublicationOutcome::DifferentBodyParamsChanged
+            } else {
+                PublicationOutcome::DifferentBody
+            }
+        }
+    }
+}
+
+const fn kind_label(kind: Option<DefKind>) -> &'static str {
+    match kind {
+        Some(DefKind::TypeAlias) => "type-alias",
+        Some(DefKind::Interface) => "interface",
+        Some(DefKind::Class) => "class",
+        Some(DefKind::ClassConstructor) => "class-constructor",
+        Some(DefKind::Enum) => "enum",
+        Some(DefKind::Namespace) => "namespace",
+        Some(DefKind::Function) => "function",
+        Some(DefKind::Variable) => "variable",
+        None => "unknown",
+    }
+}
+
+/// Shallow one-level description of a type for census body-form reports:
+/// expands object/function shapes to property names and signature skeletons
+/// so "what differs between republished body forms" is visible without a
+/// full formatter context. Diagnostics tooling only.
+pub fn describe_type_shallow(interner: &TypeInterner, id: TypeId) -> String {
+    let Some(data) = interner.lookup(id) else {
+        return "<not interned>".to_string();
+    };
+    match data {
+        TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
+            let shape = interner.object_shape(shape_id);
+            let props: Vec<String> = shape
+                .properties
+                .iter()
+                .take(8)
+                .map(|p| format!("{}:{}", interner.resolve_atom(p.name), p.type_id.0))
+                .collect();
+            format!(
+                "{data:?} flags={:?} symbol={:?} props[{}]={{{}{}}} sidx={:?} nidx={:?}",
+                shape.flags,
+                shape.symbol,
+                shape.properties.len(),
+                props.join(", "),
+                if shape.properties.len() > 8 {
+                    ", …"
+                } else {
+                    ""
+                },
+                shape.string_index.as_ref().map(|i| i.value_type.0),
+                shape.number_index.as_ref().map(|i| i.value_type.0),
+            )
+        }
+        TypeData::Function(shape_id) => {
+            let shape = interner.function_shape(shape_id);
+            format!(
+                "{data:?} tparams={} params={:?} ret={} method={}",
+                shape.type_params.len(),
+                shape.params.iter().map(|p| p.type_id.0).collect::<Vec<_>>(),
+                shape.return_type.0,
+                shape.is_method,
+            )
+        }
+        other => format!("{other:?}"),
+    }
+}
+
+/// Render the census as a human-readable report and clear the accumulated
+/// state. Returns `None` when the census is disabled or empty.
+///
+/// `resolve_name` maps a def-name [`Atom`] to a string; `resolve_file` maps a
+/// binder file index to a display name. Both are supplied by the caller (the
+/// CLI driver) because the store does not own a string interner.
+pub fn dump_to_string(
+    resolve_name: &dyn Fn(Atom) -> String,
+    resolve_file: &dyn Fn(u32) -> String,
+    describe_type: &dyn Fn(TypeId) -> String,
+) -> Option<String> {
+    if !census_enabled() {
+        return None;
+    }
+    let mut state = state().lock().ok()?;
+    if state.by_site.is_empty() && state.by_def.is_empty() {
+        return None;
+    }
+    let state = std::mem::take(&mut *state);
+
+    let mut out = String::from("=== DefinitionStore body publication census ===\n");
+
+    // ---- Totals by outcome ----
+    let mut totals: FxHashMap<PublicationOutcome, u64> = FxHashMap::default();
+    for (&(_, _, outcome), &count) in &state.by_site {
+        *totals.entry(outcome).or_insert(0) += count;
+    }
+    let grand_total: u64 = totals.values().sum();
+    out.push_str(&format!("total publications: {grand_total}\n"));
+    for outcome in PublicationOutcome::ALL {
+        let count = totals.get(&outcome).copied().unwrap_or(0);
+        if count > 0 {
+            out.push_str(&format!("  {:<32} {count}\n", outcome.label()));
+        }
+    }
+
+    // ---- By call site x outcome ----
+    out.push_str("\n--- publications by call site ---\n");
+    let mut sites: Vec<_> = state
+        .by_site
+        .iter()
+        .map(|(&(file, line, outcome), &count)| (file, line, outcome, count))
+        .collect();
+    sites.sort_by(|a, b| b.3.cmp(&a.3).then(a.0.cmp(b.0)).then(a.1.cmp(&b.1)));
+    for (file, line, outcome, count) in sites {
+        out.push_str(&format!(
+            "  {count:>8}  {:<32} {file}:{line}\n",
+            outcome.label()
+        ));
+    }
+
+    // ---- By def kind x file ----
+    out.push_str("\n--- different-body republications by def kind ---\n");
+    let mut by_kind: FxHashMap<&'static str, (u64, u64, u64)> = FxHashMap::default();
+    for census in state.by_def.values() {
+        let slot = by_kind.entry(kind_label(census.kind)).or_insert((0, 0, 0));
+        slot.0 += census.publications;
+        slot.1 += census.different_body;
+        if census.different_body > 0 {
+            slot.2 += 1;
+        }
+    }
+    let mut kinds: Vec<_> = by_kind.into_iter().collect();
+    kinds.sort_by_key(|entry| std::cmp::Reverse(entry.1.1));
+    out.push_str(&format!(
+        "  {:<18} {:>10} {:>12} {:>10}\n",
+        "kind", "pubs", "diff-body", "defs"
+    ));
+    for (kind, (pubs, diff, defs)) in kinds {
+        out.push_str(&format!("  {kind:<18} {pubs:>10} {diff:>12} {defs:>10}\n"));
+    }
+
+    // ---- Different-body republications by file ----
+    out.push_str("\n--- different-body republications by file ---\n");
+    let mut by_file: FxHashMap<Option<u32>, u64> = FxHashMap::default();
+    for census in state.by_def.values() {
+        if census.different_body > 0 {
+            *by_file.entry(census.file_id).or_insert(0) += census.different_body;
+        }
+    }
+    let mut files: Vec<_> = by_file.into_iter().collect();
+    files.sort_by_key(|entry| std::cmp::Reverse(entry.1));
+    for (file_id, count) in files.into_iter().take(40) {
+        let name = file_id.map_or_else(|| "<no file>".to_string(), resolve_file);
+        out.push_str(&format!("  {count:>8}  {name}\n"));
+    }
+
+    // ---- Top republished defs ----
+    out.push_str("\n--- top defs by different-body republication ---\n");
+    let mut defs: Vec<_> = state
+        .by_def
+        .iter()
+        .filter(|(_, c)| c.different_body > 0)
+        .collect();
+    defs.sort_by_key(|entry| std::cmp::Reverse(entry.1.different_body));
+    out.push_str(&format!(
+        "  {:<10} {:>6} {:>10} {:>8}  {:<18} {:<28} {}\n",
+        "def", "pubs", "diff-body", "bodies", "kind", "name", "file"
+    ));
+    let mut body_details = String::new();
+    for (rank, (def_id, census)) in defs.iter().take(12).enumerate() {
+        let name = resolve_name(census.name);
+        body_details.push_str(&format!(
+            "\n[{rank}] def #{} {} ({}) — {} distinct bodies{}\n",
+            def_id.0,
+            name,
+            kind_label(census.kind),
+            census.bodies.len(),
+            if census.bodies_overflowed { "+" } else { "" },
+        ));
+        for body in &census.bodies {
+            let desc = describe_type(*body);
+            let desc: String = desc.chars().take(400).collect();
+            body_details.push_str(&format!("    {} = {desc}\n", body.0));
+        }
+    }
+    for (def_id, census) in defs.into_iter().take(60) {
+        let name = resolve_name(census.name);
+        let file = census
+            .file_id
+            .map_or_else(|| "<no file>".to_string(), resolve_file);
+        let bodies = if census.bodies_overflowed {
+            format!("{}+", census.bodies.len())
+        } else {
+            census.bodies.len().to_string()
+        };
+        out.push_str(&format!(
+            "  {:<10} {:>6} {:>10} {:>8}  {:<18} {:<28} {file}\n",
+            format!("#{}", def_id.0),
+            census.publications,
+            census.different_body,
+            bodies,
+            kind_label(census.kind),
+            name,
+        ));
+    }
+
+    out.push_str("\n--- distinct body forms for top republished defs ---\n");
+    out.push_str(&body_details);
+
+    Some(out)
+}


### PR DESCRIPTION
Goal: fast

## Summary

Foundation slice of the mutation-isolation campaign (the path to lifting the DOM-lib sequential checking gate), with a latent correctness bug fixed. A publication census of the shared `DefinitionStore` (65,402 `set_body` publications on ts-toolbelt; instrumentation included as `def/publication_census.rs`) found that **75% of different-body republications (4,836) were a DefId identity collision**, not re-derivation: boxed-type registration resolves per-lib-context `SymbolId`s through context-agnostic indexes (raw symbol id, with every lib def sharing the `u32::MAX` decl-file sentinel so the composite key degenerates), and `get_existing_def_id`'s name guard self-confirms against the *first* lib binder owning that raw id — so `String`/`Number`/`Symbol`/`Function` interface bodies were published onto **unrelated lib defs** (`alert`, `blur`, `moveBy`, `requestIdleCallback`): garbage in the shared store that parallel siblings would consume.

## Structural rule

Boxed-type def resolution must verify symbol identity by name against the owning lib context (with a canonical fallback), never trust a raw-`SymbolId`-keyed cross-context probe whose composite key has degenerated. Misdirected publications: **4,836 → 0**.

Also included (env-gated experiment knobs + census instrumentation, default-off): the publish-once "finalize" freeze experiment, which validated the campaign's central assumption — *finalized* lib bodies are interchangeable across checkers (byte-identical on three rows; the "first"-write freeze variant is unsound, proven by a false TS2339, and is documented as such). Census taxonomy + the staged campaign plan are recorded in the session memory and the gate comment trail.

## Project Corpus Impact
- Row: foundation for lifting the sequential gate on all DOM-lib rows (ts-toolbelt metric path); rows verified byte-identical today
- Bug family: DefId identity collision in boxed-type registration (shared-store corruption)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: high

## Verification

- Full local conformance: 12583/12585 — zero new vs the accepted ledger.
- ts-toolbelt 0.65–0.66s wall / 0.84–0.86s user (no regression vs the 0.66/0.86 metric); ts-toolbelt/vite/next-app byte-identical diagnostics.
- `cargo nextest run -p tsz-solver`: 6616/6618 (2 pre-existing); checker `--lib` failure set identical to base (60=60, stash A/B).
- Conformance filters 100%: conditionalType 17/17, infer 87/87, mappedType 55/55, moduleResolution 111/111, jsx shard 65/65.
- clippy clean; arch guards pass.
