### PR TITLE
refactor(lsp): centralize full-provider checker bootstrap

### DIFF
--- a/crates/tsz-lsp/src/hover/contextual.rs
+++ b/crates/tsz-lsp/src/hover/contextual.rs
@@ -49,26 +49,7 @@ impl<'a> HoverProvider<'a> {
             .get_identifier_text(prop_assign.name)
             .map(std::string::ToString::to_string)?;
 
-        let compiler_options = self.checker_options();
-        let mut checker = if let Some(cache) = type_cache.take() {
-            CheckerState::with_cache(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                cache,
-                compiler_options,
-            )
-        } else {
-            CheckerState::new(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                compiler_options,
-            )
-        };
-        self.apply_lib_contexts(&mut checker);
+        let mut checker = self.checker_with_cache(type_cache);
 
         let contextual_type_idx =
             self.contextual_type_for_object_literal(object_literal_idx, prop_assign_idx);
@@ -897,15 +878,8 @@ impl<'a> HoverProvider<'a> {
             .get_identifier_text(access.name_or_argument)
             .map(str::to_string)?;
 
-        let compiler_options = self.checker_options();
-        let mut checker = CheckerState::new(
-            self.arena,
-            self.binder,
-            self.interner,
-            self.file_name.clone(),
-            compiler_options,
-        );
-        self.apply_lib_contexts(&mut checker);
+        let mut empty_type_cache = None;
+        let mut checker = self.checker_with_cache(&mut empty_type_cache);
 
         let expr_type_id = checker.get_type_of_node(access.expression);
         let member_type_id = self
@@ -963,15 +937,8 @@ impl<'a> HoverProvider<'a> {
                 .iter()
                 .position(|&idx| idx == fn_expr_idx)?;
 
-            let compiler_options = self.checker_options();
-            let mut checker = CheckerState::new(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                compiler_options,
-            );
-            self.apply_lib_contexts(&mut checker);
+            let mut empty_type_cache = None;
+            let mut checker = self.checker_with_cache(&mut empty_type_cache);
             let callee_type_id = checker.get_type_of_node(call.expression);
             if let Some(function_shape_id) =
                 tsz_solver::visitor::function_shape_id(self.interner, callee_type_id)

--- a/crates/tsz-lsp/src/hover/core.rs
+++ b/crates/tsz-lsp/src/hover/core.rs
@@ -137,26 +137,7 @@ impl<'a> HoverProvider<'a> {
         let symbol = self.binder.symbols.get(symbol_id)?;
 
         // 3. Compute Type Information
-        let compiler_options = self.checker_options();
-        let mut checker = if let Some(cache) = type_cache.take() {
-            CheckerState::with_cache(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                cache,
-                compiler_options,
-            )
-        } else {
-            CheckerState::new(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                compiler_options,
-            )
-        };
-        self.apply_lib_contexts(&mut checker);
+        let mut checker = self.checker_with_cache(type_cache);
 
         let decl_node_idx = self.find_best_declaration(symbol, node_idx);
 
@@ -280,27 +261,7 @@ impl<'a> HoverProvider<'a> {
             return None;
         }
 
-        let compiler_options = self.checker_options();
-
-        let mut checker = if let Some(cache) = type_cache.take() {
-            CheckerState::with_cache(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                cache,
-                compiler_options,
-            )
-        } else {
-            CheckerState::new(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                compiler_options,
-            )
-        };
-        self.apply_lib_contexts(&mut checker);
+        let mut checker = self.checker_with_cache(type_cache);
 
         let name = self
             .arena
@@ -1380,14 +1341,8 @@ impl<'a> HoverProvider<'a> {
         symbol: &tsz_binder::Symbol,
         decl_node_idx: NodeIndex,
     ) -> Option<String> {
-        let mut checker = CheckerState::new(
-            self.arena,
-            self.binder,
-            self.interner,
-            self.file_name.clone(),
-            self.checker_options(),
-        );
-        self.apply_lib_contexts(&mut checker);
+        let mut empty_type_cache = None;
+        let mut checker = self.checker_with_cache(&mut empty_type_cache);
 
         let type_id = if decl_node_idx.is_some()
             && symbol.flags

--- a/crates/tsz-lsp/src/provider_macro/mod.rs
+++ b/crates/tsz-lsp/src/provider_macro/mod.rs
@@ -240,6 +240,33 @@ macro_rules! define_lsp_provider {
                     checker.ctx.set_lib_contexts(self.lib_contexts.to_vec());
                 }
             }
+
+            fn checker_with_cache(
+                &self,
+                type_cache: &mut Option<tsz_checker::TypeCache>,
+            ) -> tsz_checker::CheckerState<'a> {
+                let checker_options = self.checker_options();
+                let mut checker = if let Some(cache) = type_cache.take() {
+                    tsz_checker::CheckerState::with_cache(
+                        self.arena,
+                        self.binder,
+                        self.interner,
+                        self.file_name.clone(),
+                        cache,
+                        checker_options,
+                    )
+                } else {
+                    tsz_checker::CheckerState::new(
+                        self.arena,
+                        self.binder,
+                        self.interner,
+                        self.file_name.clone(),
+                        checker_options,
+                    )
+                };
+                self.apply_lib_contexts(&mut checker);
+                checker
+            }
         }
     };
 }

--- a/crates/tsz-lsp/src/signature_help/contextual.rs
+++ b/crates/tsz-lsp/src/signature_help/contextual.rs
@@ -1,5 +1,6 @@
 use super::unicode_identifier::identifier_before_offset;
 use super::*;
+use tsz_checker::state::CheckerState;
 
 impl<'a> SignatureHelpProvider<'a> {
     pub(super) fn signature_help_for_contextual_variable_initializer(
@@ -89,26 +90,7 @@ impl<'a> SignatureHelpProvider<'a> {
             })
             .unwrap_or_else(|| var_name.clone());
 
-        let compiler_options = self.checker_options();
-        let mut checker = if let Some(cache) = type_cache.take() {
-            CheckerState::with_cache(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                cache,
-                compiler_options,
-            )
-        } else {
-            CheckerState::new(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                compiler_options,
-            )
-        };
-        self.apply_lib_contexts(&mut checker);
+        let mut checker = self.checker_with_cache(type_cache);
 
         let contextual_type = checker.get_type_of_node(decl.type_annotation);
         let contextual_type = checker.resolve_lazy_type(contextual_type);
@@ -1073,26 +1055,7 @@ impl<'a> SignatureHelpProvider<'a> {
         let mut walker = crate::resolver::ScopeWalker::new(self.arena, self.binder);
         let symbol_id = walker.resolve_node(root, callee_expr)?;
 
-        let compiler_options = self.checker_options();
-        let mut checker = if let Some(cache) = type_cache.take() {
-            CheckerState::with_cache(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                cache,
-                compiler_options,
-            )
-        } else {
-            CheckerState::new(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                compiler_options,
-            )
-        };
-        self.apply_lib_contexts(&mut checker);
+        let mut checker = self.checker_with_cache(type_cache);
 
         let docs = self.signature_documentation_for_symbol(root, symbol_id, trigger.call_kind);
         let callee_type = checker.get_type_of_symbol(symbol_id);
@@ -1208,26 +1171,7 @@ impl<'a> SignatureHelpProvider<'a> {
         let mut walker = crate::resolver::ScopeWalker::new(self.arena, self.binder);
         let symbol_id = walker.resolve_node(root, callee_expr)?;
 
-        let compiler_options = self.checker_options();
-        let mut checker = if let Some(cache) = type_cache.take() {
-            CheckerState::with_cache(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                cache,
-                compiler_options,
-            )
-        } else {
-            CheckerState::new(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                compiler_options,
-            )
-        };
-        self.apply_lib_contexts(&mut checker);
+        let mut checker = self.checker_with_cache(type_cache);
 
         let docs = self.signature_documentation_for_symbol(root, symbol_id, trigger.call_kind);
         let callee_type = checker.get_type_of_symbol(symbol_id);

--- a/crates/tsz-lsp/src/signature_help/mod.rs
+++ b/crates/tsz-lsp/src/signature_help/mod.rs
@@ -26,7 +26,6 @@ use crate::jsdoc::{JsdocTag, ParsedJsdoc, inline_param_jsdocs, jsdoc_for_node, p
 use crate::resolver::{ScopeCache, ScopeCacheStats};
 use crate::utils::find_node_at_or_before_offset;
 use tsz_binder::symbol_flags;
-use tsz_checker::state::CheckerState;
 use tsz_common::position::Position;
 use tsz_parser::parser::node::{CallExprData, NodeAccess};
 use tsz_parser::{
@@ -303,26 +302,7 @@ impl<'a> SignatureHelpProvider<'a> {
         };
 
         // 6. Create checker with persistent cache if available
-        let compiler_options = self.checker_options();
-        let mut checker = if let Some(cache) = type_cache.take() {
-            CheckerState::with_cache(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                cache,
-                compiler_options,
-            )
-        } else {
-            CheckerState::new(
-                self.arena,
-                self.binder,
-                self.interner,
-                self.file_name.clone(),
-                compiler_options,
-            )
-        };
-        self.apply_lib_contexts(&mut checker);
+        let mut checker = self.checker_with_cache(type_cache);
 
         let access_docs = if call_kind == CallKind::Call {
             self.signature_documentation_for_property_access(root, callee_expr)

--- a/crates/tsz-lsp/src/signature_help/selection.rs
+++ b/crates/tsz-lsp/src/signature_help/selection.rs
@@ -1,4 +1,5 @@
 use super::*;
+use tsz_checker::state::CheckerState;
 
 impl<'a> SignatureHelpProvider<'a> {
     pub(super) fn tuple_union_variants(text: &str) -> Vec<String> {

--- a/crates/tsz-lsp/src/signature_help/shapes.rs
+++ b/crates/tsz-lsp/src/signature_help/shapes.rs
@@ -1,4 +1,5 @@
 use super::*;
+use tsz_checker::state::CheckerState;
 
 impl<'a> SignatureHelpProvider<'a> {
     pub(super) fn get_signatures_from_type(


### PR DESCRIPTION
Goal: hold

## AgentName
Codex

## Track
hold / LSP provider parity maintenance

## Invariant
Full LSP providers construct `CheckerState` through the macro-generated provider bootstrap so type-cache reuse, strict checker options, sound-mode options, and lib contexts stay aligned across hover and signature-help paths.

## Scope
- Added a shared `checker_with_cache` helper to the `define_lsp_provider!(full ...)` tier.
- Replaced duplicated hover and signature-help checker construction blocks with the shared helper.
- Made child-module `CheckerState` type imports explicit where they were previously inherited through parent-module scope.

## Project Corpus Impact
None. This is LSP provider bootstrap refactoring only; it does not change parser, binder, checker, solver, emitter, or project-row behavior.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-lsp -E 'test(test_hover_global_from_lib_uses_lib_context_type) or test(test_hover_contextually_typed_function_expression_parameter) or test(test_hover_property_initializer_parameter_uses_contextual_annotation) or test(textual_nested_incomplete_call_prefers_inner_callee) or test(contextual_object_member_signature_preferred_over_outer_call) or test(generic_inference_uses_argument_literal_for_signature_display) or test(test_signature_help_simple)'`
- `CARGO_INCREMENTAL=0 scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-lsp --all-targets -- -D warnings`
- `git diff --check`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium

## Coordination Notes
Closes #13116. Verified no overlapping open PR targets this LSP provider bootstrap slice.
