### PR TITLE
perf(checker,solver): stamp-guarded result memo for evaluate_type_for_assignability + no-op-aware generation bumps

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -1456,11 +1456,38 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Session-state stamp for the [`crate::context::AssignabilityEvalMemo`].
+    ///
+    /// `None` when either type environment is currently mutably borrowed; the
+    /// memo is skipped entirely for such re-entrant calls.
+    fn assignability_eval_memo_stamp(&self) -> Option<crate::context::AssignabilityEvalStamp> {
+        let env_generation = self.ctx.type_env.try_borrow().ok()?.generation();
+        let environment_generation = self.ctx.type_environment.try_borrow().ok()?.generation();
+        Some((
+            env_generation,
+            environment_generation,
+            self.ctx.symbol_types.version(),
+            self.ctx.symbol_instance_types.version(),
+        ))
+    }
+
     /// Evaluate a type for assignability checking.
     ///
     /// Determines if the type needs evaluation (applications, env-dependent types)
     /// and performs the appropriate evaluation.
+    ///
+    /// Outermost calls are memoized per checker session: the recursive
+    /// normalization below is deterministic while the type environments and
+    /// symbol-type caches are unchanged, and constraint validation re-requests
+    /// the same `TypeId`s heavily (~94% repeated outermost calls on the
+    /// ts-toolbelt project row, issue #8356). Nested calls are never served
+    /// from or written to the memo so the cycle-guard semantics (re-entered
+    /// types evaluate to themselves) are preserved exactly.
     pub(crate) fn evaluate_type_for_assignability(&mut self, type_id: TypeId) -> TypeId {
+        use crate::state_domain::type_environment::lazy::{
+            global_resolution_fuel_exhausted, refs_resolution_fuel_exhausted,
+        };
+
         if type_id.is_intrinsic() {
             return type_id;
         }
@@ -1468,6 +1495,18 @@ impl<'a> CheckerState<'a> {
         thread_local! {
             static ASSIGNABILITY_EVAL_VISITING: std::cell::RefCell<FxHashSet<TypeId>> =
                 Default::default();
+        }
+
+        let outermost = ASSIGNABILITY_EVAL_VISITING.with(|visiting| visiting.borrow().is_empty());
+        if outermost
+            && let Some(stamp) = self.assignability_eval_memo_stamp()
+            && let Some(memoized) = self
+                .ctx
+                .type_reference_validation_caches
+                .assignability_eval_memo
+                .get(stamp, type_id)
+        {
+            return memoized;
         }
 
         let entered =
@@ -1478,6 +1517,28 @@ impl<'a> CheckerState<'a> {
 
         let result = self.evaluate_type_for_assignability_inner(type_id);
         ASSIGNABILITY_EVAL_VISITING.with(|visiting| visiting.borrow_mut().remove(&type_id));
+
+        // Memoize only clean completions: fuel-exhausted or depth-clamped
+        // evaluations are degraded forms that a later, fresher evaluation
+        // must be allowed to improve on.
+        //
+        // The stamp is recomputed here on purpose: the evaluation above
+        // routinely grows the type environments (def resolution, symbol
+        // types), and the result is valid for that *post*-evaluation state.
+        // Reusing the lookup-time stamp would file the entry under a stale
+        // stamp and the next lookup would immediately drop it.
+        if outermost
+            && result != TypeId::ERROR
+            && !refs_resolution_fuel_exhausted()
+            && !global_resolution_fuel_exhausted()
+            && !self.ctx.depth_exceeded.get()
+            && let Some(stamp) = self.assignability_eval_memo_stamp()
+        {
+            self.ctx
+                .type_reference_validation_caches
+                .assignability_eval_memo
+                .insert(stamp, type_id, result);
+        }
         result
     }
 

--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -64,6 +64,9 @@ pub struct TypeReferenceValidationCaches {
     pub type_param_default_constraint: FxHashSet<(u32, TypeId, TypeId)>,
     /// Synthetic type-node surfaces cached for the active checker file.
     pub type_node_surface: TypeNodeSurfaceCaches,
+    /// Stamp-guarded result memo for `evaluate_type_for_assignability`.
+    /// See [`AssignabilityEvalMemo`].
+    pub assignability_eval_memo: AssignabilityEvalMemo,
 }
 
 /// Sparse cache for node-index-keyed `TypeId` lookups.
@@ -350,6 +353,10 @@ impl Default for NarrowableIdentifierCache {
 #[derive(Clone, Debug)]
 pub struct SymbolTypeCache {
     data: Arc<FxHashMap<SymbolId, TypeId>>,
+    /// Monotonic mutation counter. Consumers (the assignability evaluation
+    /// memo) treat a version change as "any previously observed symbol type
+    /// may have changed"; reads never bump it.
+    version: u64,
 }
 
 impl SymbolTypeCache {
@@ -360,6 +367,7 @@ impl SymbolTypeCache {
                 capacity.min(4096),
                 Default::default(),
             )),
+            version: 0,
         }
     }
 
@@ -367,7 +375,15 @@ impl SymbolTypeCache {
     pub fn new() -> Self {
         Self {
             data: Arc::new(FxHashMap::default()),
+            version: 0,
         }
+    }
+
+    /// Monotonic counter bumped on every mutation that can change a lookup
+    /// result. Consumed by `CheckerContext::assignability_eval_memo` stamps.
+    #[inline]
+    pub const fn version(&self) -> u64 {
+        self.version
     }
 
     #[inline]
@@ -377,11 +393,22 @@ impl SymbolTypeCache {
 
     #[inline]
     pub fn insert(&mut self, key: SymbolId, value: TypeId) {
-        let data = Arc::make_mut(&mut self.data);
+        // No-op writes (same value, or removing an absent entry) leave every
+        // lookup result unchanged, so they must not bump the version: version
+        // consumers would needlessly drop their memoized state.
+        let existing = self.data.get(&key).copied();
         if value == TypeId::NONE {
-            data.remove(&key);
+            if existing.is_none() {
+                return;
+            }
+            self.version += 1;
+            Arc::make_mut(&mut self.data).remove(&key);
         } else {
-            data.insert(key, value);
+            if existing == Some(value) {
+                return;
+            }
+            self.version += 1;
+            Arc::make_mut(&mut self.data).insert(key, value);
         }
     }
 
@@ -395,6 +422,7 @@ impl SymbolTypeCache {
         if !self.data.contains_key(key) {
             return None;
         }
+        self.version += 1;
         Arc::make_mut(&mut self.data).remove(key)
     }
 
@@ -406,6 +434,9 @@ impl SymbolTypeCache {
         // with `value == NONE` would silently break that.
         if value == TypeId::NONE {
             return self.data.get(&key).copied().unwrap_or(TypeId::NONE);
+        }
+        if !self.data.contains_key(&key) {
+            self.version += 1;
         }
         *Arc::make_mut(&mut self.data).entry(key).or_insert(value)
     }
@@ -429,12 +460,78 @@ impl SymbolTypeCache {
     }
 
     pub fn extend(&mut self, other: Self) {
+        if other.data.is_empty() {
+            return;
+        }
+        let changes = other.data.iter().any(|(symbol_id, &type_id)| {
+            type_id != TypeId::NONE && self.data.get(symbol_id) != Some(&type_id)
+        });
+        if !changes {
+            return;
+        }
+        self.version += 1;
         let data = Arc::make_mut(&mut self.data);
         for (&symbol_id, &type_id) in other.data.iter() {
             if type_id != TypeId::NONE {
                 data.insert(symbol_id, type_id);
             }
         }
+    }
+}
+
+/// Session-state stamp guarding [`AssignabilityEvalMemo`] entries.
+///
+/// Captures the generations of the two checker `TypeEnvironment`s — `type_env`
+/// (relation/evaluation bindings) and `type_environment` (flow-narrowing
+/// bindings) are independently mutated, so both generations are needed; each
+/// already folds in the shared `DefinitionStore` generation — plus the
+/// mutation versions of the symbol-type caches. Evaluating a type for
+/// assignability is deterministic while none of these change: every mutable
+/// input the evaluation consults (def/type-env bindings, resolved symbol
+/// types, class instance types) bumps one of the components.
+pub type AssignabilityEvalStamp = (u64, u64, u64, u64);
+
+/// Result memo for `evaluate_type_for_assignability`.
+///
+/// That evaluation is a recursive normalization pipeline with only a cycle
+/// guard; constraint validation and relation preparation re-run it for the
+/// same `TypeId`s thousands of times per file (measured ~94% repeated
+/// outermost calls on the ts-toolbelt project row, issue #8356). Entries are
+/// only written for outermost, fuel-clean evaluations and are dropped
+/// wholesale whenever the session stamp moves, so a hit always returns
+/// exactly what a fresh evaluation under the current environment would.
+#[derive(Debug, Default)]
+pub struct AssignabilityEvalMemo {
+    stamp: Option<AssignabilityEvalStamp>,
+    entries: FxHashMap<TypeId, TypeId>,
+}
+
+impl AssignabilityEvalMemo {
+    fn roll_to(&mut self, stamp: AssignabilityEvalStamp) {
+        if self.stamp != Some(stamp) {
+            self.entries.clear();
+            self.stamp = Some(stamp);
+        }
+    }
+
+    /// Look up a memoized evaluation result valid for `stamp`.
+    pub fn get(&mut self, stamp: AssignabilityEvalStamp, type_id: TypeId) -> Option<TypeId> {
+        self.roll_to(stamp);
+        self.entries.get(&type_id).copied()
+    }
+
+    /// Record an evaluation result computed under `stamp`.
+    pub fn insert(&mut self, stamp: AssignabilityEvalStamp, type_id: TypeId, result: TypeId) {
+        self.roll_to(stamp);
+        self.entries.insert(type_id, result);
+    }
+
+    /// Drop all entries and forget the stamp. Required between file sessions:
+    /// a fresh file's environment can restart at a previously seen generation,
+    /// which would otherwise collide with the prior file's stamp.
+    pub fn clear(&mut self) {
+        self.stamp = None;
+        self.entries.clear();
     }
 }
 

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -301,6 +301,9 @@ impl<'a> CheckerContext<'a> {
         self.type_reference_validation_caches
             .type_node_surface
             .clear();
+        self.type_reference_validation_caches
+            .assignability_eval_memo
+            .clear();
         self.in_conditional_extends_depth = 0;
         self.typeof_param_scope.clear();
         self.type_param_constraint_excluded_params.clear();

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -11,8 +11,8 @@ mod cross_file_delegation_cache;
 mod cross_file_type_params_cache;
 pub use cache_statistics::CheckerContextCacheStatistics;
 pub use caches::{
-    NarrowableIdentifierCache, NodeTypeCache, SymbolTypeCache, TypeNodeSurfaceCaches,
-    TypeReferenceValidationCaches,
+    AssignabilityEvalMemo, AssignabilityEvalStamp, NarrowableIdentifierCache, NodeTypeCache,
+    SymbolTypeCache, TypeNodeSurfaceCaches, TypeReferenceValidationCaches,
 };
 pub(crate) use compiler_options::is_declaration_file_name;
 pub(crate) use compiler_options::is_js_file_name;

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -108,6 +108,9 @@ mod assignability_diagnostics_relation_routing_arch_tests;
 #[path = "tests/assignability_display_relation_routing_arch_tests.rs"]
 mod assignability_display_relation_routing_arch_tests;
 #[cfg(test)]
+#[path = "tests/assignability_eval_memo_tests.rs"]
+mod assignability_eval_memo_tests;
+#[cfg(test)]
 #[path = "tests/assignability_index_access_normalization_boundary_arch_tests.rs"]
 mod assignability_index_access_normalization_boundary_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/assignability_eval_memo_tests.rs
+++ b/crates/tsz-checker/src/tests/assignability_eval_memo_tests.rs
@@ -1,0 +1,162 @@
+//! Tests for the stamp-guarded `evaluate_type_for_assignability` result memo
+//! (issue #8356).
+//!
+//! The memo must be semantically invisible: repeated constraint validation of
+//! the same types may skip recomputation, but diagnostics (including repeated
+//! TS2344 at distinct sites) and recursive-alias evaluation results must be
+//! byte-identical to the unmemoized pipeline. Entries are dropped whenever the
+//! session stamp (type-environment generations + symbol-type cache versions)
+//! moves, so a hit can never observe a stale environment.
+
+use crate::context::{AssignabilityEvalMemo, SymbolTypeCache};
+use crate::test_utils::check_source_codes;
+use tsz_binder::SymbolId;
+use tsz_solver::TypeId;
+
+// ---------------------------------------------------------------------------
+// Memo container semantics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn memo_serves_entries_under_unchanged_stamp() {
+    let mut memo = AssignabilityEvalMemo::default();
+    let stamp = (1, 1, 0, 0);
+    memo.insert(stamp, TypeId::STRING, TypeId::NUMBER);
+    assert_eq!(memo.get(stamp, TypeId::STRING), Some(TypeId::NUMBER));
+}
+
+#[test]
+fn memo_drops_entries_when_any_stamp_component_moves() {
+    for moved in [(2, 1, 0, 0), (1, 2, 0, 0), (1, 1, 1, 0), (1, 1, 0, 1)] {
+        let mut memo = AssignabilityEvalMemo::default();
+        memo.insert((1, 1, 0, 0), TypeId::STRING, TypeId::NUMBER);
+        assert_eq!(
+            memo.get(moved, TypeId::STRING),
+            None,
+            "stamp {moved:?} must invalidate"
+        );
+        // The memo re-stamps on the miss; fresh entries are valid again.
+        memo.insert(moved, TypeId::STRING, TypeId::BOOLEAN);
+        assert_eq!(memo.get(moved, TypeId::STRING), Some(TypeId::BOOLEAN));
+    }
+}
+
+#[test]
+fn symbol_type_cache_version_tracks_mutations_not_reads() {
+    let mut cache = SymbolTypeCache::new();
+    let v0 = cache.version();
+    assert!(cache.get(&SymbolId(7)).is_none());
+    assert_eq!(cache.version(), v0, "reads must not bump the version");
+
+    cache.insert(SymbolId(7), TypeId::STRING);
+    let v1 = cache.version();
+    assert!(v1 > v0, "insert must bump the version");
+
+    // entry_or_insert on an existing key changes nothing observable.
+    cache.entry_or_insert(SymbolId(7), TypeId::NUMBER);
+    assert_eq!(cache.version(), v1);
+
+    cache.entry_or_insert(SymbolId(8), TypeId::NUMBER);
+    assert!(cache.version() > v1, "new-key entry_or_insert must bump");
+
+    let v2 = cache.version();
+    assert!(cache.remove(&SymbolId(99)).is_none());
+    assert_eq!(cache.version(), v2, "absent remove must not bump");
+    cache.remove(&SymbolId(7));
+    assert!(cache.version() > v2, "present remove must bump");
+}
+
+// ---------------------------------------------------------------------------
+// Recursive type-level iteration (the ts-toolbelt loop idiom) stays clean
+// under heavy repeated constraint validation.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn recursive_indexed_object_map_loop_alias_stays_clean() {
+    let codes = check_source_codes(
+        r#"
+type Next<I extends number[]> = [...I, 0];
+type Loop<N extends number, I extends number[] = []> = {
+    0: Loop<N, Next<I>>;
+    1: I["length"];
+}[I["length"] extends N ? 1 : 0];
+type Three = Loop<3>;
+const ok: 3 = null as unknown as Three;
+"#,
+    );
+    assert!(codes.is_empty(), "expected clean check, got: {codes:?}");
+}
+
+#[test]
+fn recursive_indexed_object_map_loop_alias_stays_clean_renamed_binders() {
+    let codes = check_source_codes(
+        r#"
+type Step<Acc extends number[]> = [...Acc, 0];
+type Iterate<Target extends number, Acc extends number[] = []> = {
+    0: Iterate<Target, Step<Acc>>;
+    1: Acc["length"];
+}[Acc["length"] extends Target ? 1 : 0];
+type Result = Iterate<2>;
+const ok: 2 = null as unknown as Result;
+"#,
+    );
+    assert!(codes.is_empty(), "expected clean check, got: {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Repeated violations must each still report: a memoized evaluation result
+// must not swallow per-site TS2344 diagnostics.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repeated_constraint_violations_report_at_every_site() {
+    let codes = check_source_codes(
+        r#"
+type OnlyString<S extends string> = S;
+type BadA = OnlyString<number>;
+type BadB = OnlyString<number>;
+type BadC = OnlyString<{ value: number }>;
+"#,
+    );
+    let ts2344 = codes.iter().filter(|&&code| code == 2344).count();
+    assert_eq!(
+        ts2344, 3,
+        "expected TS2344 at all three sites, got: {codes:?}"
+    );
+}
+
+#[test]
+fn repeated_constraint_violations_report_at_every_site_renamed_binders() {
+    let codes = check_source_codes(
+        r#"
+type Keyish<Name extends string> = Name;
+type FirstUse = Keyish<42>;
+type SecondUse = Keyish<42>;
+"#,
+    );
+    let ts2344 = codes.iter().filter(|&&code| code == 2344).count();
+    assert_eq!(ts2344, 2, "expected TS2344 at both sites, got: {codes:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Mixed valid/invalid repeats of the same generic target: the memoized result
+// for the valid argument must not leak onto the invalid one or vice versa.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn valid_and_invalid_arguments_keep_independent_outcomes() {
+    let codes = check_source_codes(
+        r#"
+type Pick1<S extends string> = S;
+type Good = Pick1<"a">;
+type Bad = Pick1<1>;
+type GoodAgain = Pick1<"a">;
+type BadAgain = Pick1<1>;
+"#,
+    );
+    let ts2344 = codes.iter().filter(|&&code| code == 2344).count();
+    assert_eq!(
+        ts2344, 2,
+        "expected TS2344 exactly at the two invalid sites, got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -742,6 +742,12 @@ impl DefinitionStore {
     /// using the symbol's raw id and its `decl_file_idx`. The composite key ensures
     /// that the same `SymbolId(u32)` from different binders maps to different `DefIds`.
     pub fn register_symbol_mapping(&self, symbol_id: u32, file_idx: u32, def_id: DefId) {
+        // Re-registering the identical mapping changes nothing a reader can
+        // observe (the file-agnostic index keeps the first DefId anyway), so
+        // skip the generation bump for it.
+        if self.lookup_by_symbol(symbol_id, file_idx) == Some(def_id) {
+            return;
+        }
         self.register_symbol_file_mapping(symbol_id, file_idx, def_id);
         // Also maintain the file-agnostic index (keeps the first registered DefId).
         self.insert_symbol_only_mapping(symbol_id, def_id);
@@ -832,6 +838,21 @@ impl DefinitionStore {
         self.definitions.get(&id).and_then(|r| r.body)
     }
 
+    /// Whether `id` already publishes exactly `body` (and, when given,
+    /// exactly `params`). Comparison runs under the entry guard without
+    /// cloning, so no-op republication checks stay cheap on hot paths.
+    pub fn body_and_params_published(
+        &self,
+        id: DefId,
+        body: TypeId,
+        params: Option<&[TypeParamInfo]>,
+    ) -> bool {
+        self.definitions.get(&id).is_some_and(|entry| {
+            entry.body == Some(body)
+                && params.is_none_or(|params| entry.type_params.as_slice() == params)
+        })
+    }
+
     /// Get parent class `DefId` for a class.
     pub fn get_extends(&self, id: DefId) -> Option<DefId> {
         self.definitions.get(&id).and_then(|r| r.extends)
@@ -879,6 +900,16 @@ impl DefinitionStore {
         params: Option<Vec<TypeParamInfo>>,
     ) {
         if let Some(mut entry) = self.definitions.get_mut(&id) {
+            // Identical republication is a no-op: nothing a reader can
+            // observe changes, so consumers keyed on `generation()` must not
+            // see a bump for it.
+            if entry.body == Some(body)
+                && params
+                    .as_ref()
+                    .is_none_or(|params| &entry.type_params == params)
+            {
+                return;
+            }
             if let Some(params) = params {
                 if entry.kind == DefKind::TypeAlias
                     && entry.type_params.is_empty()

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -614,7 +614,10 @@ impl TypeEnvironment {
     /// Called by the checker when performing relation checks inside a class
     /// scope so the solver can resolve `this` type references during
     /// subtype/identity comparisons.
-    pub const fn set_this_type(&mut self, this_type: Option<TypeId>) {
+    pub fn set_this_type(&mut self, this_type: Option<TypeId>) {
+        if self.this_type == this_type {
+            return;
+        }
         self.this_type = this_type;
         self.bump_generation();
     }
@@ -633,7 +636,14 @@ impl TypeEnvironment {
     }
 
     /// Register a symbol's resolved type.
+    ///
+    /// Re-inserting the mapping a symbol already has is a no-op and does not
+    /// bump the generation: no later resolve call can return a different
+    /// type because of it (see [`Self::generation`] consumers).
     pub fn insert(&mut self, symbol: SymbolRef, type_id: TypeId) {
+        if self.types.get(&symbol.0) == Some(&type_id) {
+            return;
+        }
         self.types.insert(symbol.0, type_id);
         self.bump_generation();
     }
@@ -721,12 +731,20 @@ impl TypeEnvironment {
     }
 
     /// Register a symbol's resolved type with type parameters.
+    ///
+    /// Same no-op rule as [`Self::insert`]: an identical re-registration does
+    /// not bump the generation.
     pub fn insert_with_params(
         &mut self,
         symbol: SymbolRef,
         type_id: TypeId,
         params: Vec<TypeParamInfo>,
     ) {
+        if self.types.get(&symbol.0) == Some(&type_id)
+            && (params.is_empty() || self.type_params.get(&symbol.0) == Some(&params))
+        {
+            return;
+        }
         self.types.insert(symbol.0, type_id);
         if !params.is_empty() {
             self.type_params.insert(symbol.0, params);
@@ -759,12 +777,7 @@ impl TypeEnvironment {
     /// `DefinitionStore` (if set) so cross-file delegation results are
     /// visible to parent checkers without explicit merge-back.
     pub fn insert_def(&mut self, def_id: DefId, type_id: TypeId) {
-        self.def_types.insert(def_id.0, type_id);
-        // Write through to shared store for cross-checker visibility.
-        if let Some(ref store) = self.definition_store {
-            store.set_body(def_id, type_id);
-        }
-        self.bump_generation();
+        self.insert_def_with_params(def_id, type_id, Vec::new());
     }
 
     /// Get a class `DefId`'s registered instance type.
@@ -801,6 +814,21 @@ impl TypeEnvironment {
         type_id: TypeId,
         params: Vec<TypeParamInfo>,
     ) {
+        // Identical re-registration is a no-op (see `Self::insert`); checked
+        // against both the local map and the shared store so the write-through
+        // below is never skipped while either view is stale.
+        if self.def_types.get(&def_id.0) == Some(&type_id)
+            && (params.is_empty() || self.def_type_params.get(&def_id.0) == Some(&params))
+            && self.definition_store.as_ref().is_none_or(|store| {
+                store.body_and_params_published(
+                    def_id,
+                    type_id,
+                    (!params.is_empty()).then_some(params.as_slice()),
+                )
+            })
+        {
+            return;
+        }
         self.def_types.insert(def_id.0, type_id);
         if !params.is_empty() {
             self.def_type_params.insert(def_id.0, params.clone());


### PR DESCRIPTION
Goal: fast

## Summary

Claims issue #8356 (ts-toolbelt project row runtime). The dominant repeated operation on the row today is no longer child-checker delegation (the 2026-05 slices cleared most of it) but `evaluate_type_for_assignability`: a recursive normalization pipeline with only a cycle guard and **no result memo**, re-run for the same `TypeId`s by TS2344 constraint validation, relation preparation, and diagnostic display. Issue #13040 (effect row) independently names the same operation ("called at EVERY level, NO result cache").

Structural rule: when the checker's type environments and symbol-type caches are unchanged, evaluating the same `TypeId` for assignability is deterministic; tsz now serves the repeat from a stamp-guarded memo instead of re-running the whole evaluation tree, through the checker session cache layer (`CheckerContext`), the same owner as the existing `type_reference_validation_caches`.

Measured on the ts-toolbelt row (instrumented run): 420K total `evaluate_type_for_assignability` calls collapse to 11.2K outermost calls, of which **94% repeat an already-evaluated `TypeId`** (10,549 repeats vs 658 distinct).

## Changes

1. **`AssignabilityEvalMemo`** (`tsz-checker/src/context/caches.rs`): per-checker `TypeId -> TypeId` memo for outermost `evaluate_type_for_assignability` calls, guarded by a session stamp `(type_env generation, type_environment generation, symbol_types version, symbol_instance_types version)`. Entries drop wholesale whenever the stamp moves, so a hit always equals a fresh evaluation under the current environment.
   - Only **outermost** calls are served/written: nested calls keep the cycle-guard semantics (re-entered types evaluate to themselves) bit-for-bit.
   - No insertion when refs/global resolution fuel is exhausted or the relation depth clamp tripped — degraded results must stay improvable.
   - Cleared in `reset_for_next_file` (a fresh file's environment can restart at a previously seen generation).
2. **No-op-aware generation/version bumps** (solver `TypeEnvironment`, `DefinitionStore`; checker `SymbolTypeCache`): re-registering an identical mapping no longer bumps `generation()`/`version()`. This follows the documented contract ("bump whenever a later resolve call can return a different type") and stops identical re-inserts from continuously invalidating every generation-keyed consumer (the new memo and existing solver caches keyed on `resolver_generation`).

## Adjacent-case matrix (tests in `assignability_eval_memo_tests.rs`)

- recursive indexed-object-map loop aliases (the ts-toolbelt iteration idiom), two binder-name variants — clean;
- repeated TS2344 violations at distinct sites still report at every site (3-site and 2-site variants, renamed binders);
- interleaved valid/invalid arguments to the same generic target keep independent outcomes;
- memo container: stamp moves on any component invalidate; `SymbolTypeCache` version bumps on mutation only, never on reads/no-ops.

## Performance

ts-toolbelt project row (242 files, dist-fast, 4-core cloud runner, embedded libs; medians of 3):

| Metric | before | after |
| --- | --- | --- |
| Check phase | 1.55-1.62 s | 1.33-1.34 s (-16%) |
| Total | 1.95-2.04 s | 1.75-1.76 s (-13%) |
| Worst alias body validation (`__Flatten`) | 218 ms | 23 ms (-89%) |

zod row: Check 7.09-7.28 s -> 6.74 s (-5%). utility-types: unchanged (already 0.1 s).

Diagnostics byte-identical before/after on ts-toolbelt (0), zod (66 lines, exit 2), utility-types (0).

Cache key: input `TypeId` per checker session; invalidation: environment-generation stamp + per-file clear; fuel: degraded (fuel-exhausted/depth-clamped) results are never cached; residency: bounded by distinct `TypeId`s evaluated per file session, dropped on every stamp move and file reset.

## Verification

- `cargo nextest run -p tsz-checker --lib assignability_eval_memo` — 8/8 pass
- `cargo nextest run -p tsz-checker --lib` — 6461 passed; the 60 failures are byte-identical to clean main's pre-existing local set (diffed both directions: empty)
- `cargo nextest run -p tsz-solver --lib` — 6607 passed; the 2 failures also fail on clean main
- `cargo clippy -p tsz-checker -p tsz-solver` — 0 warnings; `cargo fmt --check` clean; `python3 scripts/arch/arch_guard.py` passes
- ts-toolbelt / zod / utility-types project rows: byte-identical diagnostics, timings above
- ready-review CI: conformance aggregate, emit, fourslash own the broad suites

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high

Closes nothing; #8356 stays open as the row tracker.

https://claude.ai/code/session_017hQqhav3NNhFYaDaiZKjNg

---
_Generated by [Claude Code](https://claude.ai/code/session_017hQqhav3NNhFYaDaiZKjNg)_