### PR TITLE
fix(solver): gate signature-return raw-form unknown fallback on evaluation stability (#13212)

### DIFF
--- a/crates/tsz-checker/tests/ts2322_tests_parts/part_04.rs
+++ b/crates/tsz-checker/tests/ts2322_tests_parts/part_04.rs
@@ -1804,3 +1804,102 @@ fn test_ts2322_array_element_chain_independent_of_element_names() {
         "got: {chain:?}"
     );
 }
+
+// =============================================================================
+// #13212: deferred alias applications in signature-return position that
+// genuinely evaluate to `unknown` must not be vetoed by the raw-form
+// recursive-cycle fallback in `check_return_compat`. Structural rule: when a
+// `() => Alias<Args>` target return evaluates (stably) to `unknown`, tsc
+// relates the source return against `unknown` — always true. The raw fallback
+// applies only to recursion-bailed collapses.
+// =============================================================================
+
+/// Conditional alias whose both branches are `unknown`, concrete argument,
+/// nullish source return (valibot vf/vk witness).
+#[test]
+fn deferred_conditional_alias_unknown_return_accepts_undefined_source() {
+    let source = r#"
+type Wrap<T> = T extends 1 ? unknown : unknown;
+const f: () => Wrap<2> = () => undefined;
+const g: () => Wrap<2> = () => null;
+declare const h: () => void;
+const i: () => Wrap<2> = h;
+"#;
+    let diags = diagnostics_for_source(source);
+    assert!(
+        !has_diagnostic_code(&diags, 2322),
+        "deferred alias application evaluating to unknown must accept nullish/void returns: {diags:#?}"
+    );
+}
+
+/// Same shape through a pure indexed-access alias (no conditional) — the rule
+/// is about deferred applications generally, not conditionals (valibot vg).
+#[test]
+fn deferred_indexed_access_alias_unknown_return_accepts_undefined_source() {
+    let source = r#"
+type Carton<T> = { contents: T };
+type Pull<B extends Carton<unknown>> = B['contents'];
+const f: () => Pull<Carton<unknown>> = () => undefined;
+"#;
+    let diags = diagnostics_for_source(source);
+    assert!(
+        !has_diagnostic_code(&diags, 2322),
+        "indexed-access alias application evaluating to unknown must accept undefined return: {diags:#?}"
+    );
+}
+
+/// Generic-interface member position: the alias application reaches the
+/// relation through interface instantiation (valibot vq witness, renamed
+/// binders). Both the literal property and the signature-return member must
+/// relate.
+#[test]
+fn generic_interface_member_with_unknown_alias_return_accepts_object_literal() {
+    let source = r#"
+type Pick2<T> = T extends 1 ? unknown : unknown;
+interface Step<T> {
+  readonly tag: 'mark';
+  readonly go: () => Pick2<T>;
+  readonly payload: T;
+}
+function build(payload: number): Step<number> {
+  return { tag: 'mark', payload, go: () => 1 as unknown };
+}
+function buildNullish(payload: number): Step<number> {
+  return { tag: 'mark', payload, go: () => undefined };
+}
+"#;
+    let diags = diagnostics_for_source(source);
+    assert!(
+        !has_diagnostic_code(&diags, 2322),
+        "generic interface instantiation with unknown-evaluating alias return must accept: {diags:#?}"
+    );
+}
+
+/// Negative control: the same deferred-alias return shape must still reject a
+/// source whose return is genuinely incompatible with the evaluated branch.
+#[test]
+fn deferred_conditional_alias_string_return_still_rejects_number_source() {
+    let source = r#"
+type Pick3<T> = T extends 1 ? number : string;
+const f: () => Pick3<2> = () => 42;
+"#;
+    let diags = diagnostics_for_source(source);
+    assert!(
+        has_diagnostic_code(&diags, 2322),
+        "alias application evaluating to string must still reject a number return: {diags:#?}"
+    );
+}
+
+/// Positive control adjacent to the negative one: the selected branch accepts.
+#[test]
+fn deferred_conditional_alias_string_return_accepts_string_source() {
+    let source = r#"
+type Pick4<T> = T extends 1 ? number : string;
+const f: () => Pick4<2> = () => 'ok';
+"#;
+    let diags = diagnostics_for_source(source);
+    assert!(
+        !has_diagnostic_code(&diags, 2322),
+        "alias application evaluating to string must accept a string return: {diags:#?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
+++ b/crates/tsz-solver/src/evaluation/cross_eval_guard.rs
@@ -104,15 +104,31 @@ pub(crate) fn memoized_eval(
     no_unchecked_indexed_access: bool,
     compute: impl FnOnce() -> (TypeId, bool),
 ) -> Option<TypeId> {
+    memoized_eval_with_stability(type_id, no_unchecked_indexed_access, compute)
+        .map(|(result, _)| result)
+}
+
+/// Like [`memoized_eval`], but also reports whether the result is *stable*:
+/// converged without tripping any recursion/depth/budget limit.
+///
+/// A memo hit is always stable (only stable results are stored). A fresh
+/// computation reports the `memoizable` flag from `compute`. Callers that
+/// treat a collapsed result (e.g. `unknown`) as suspicious can use the flag to
+/// distinguish a genuinely evaluated answer from a recursion-bail artifact.
+pub(crate) fn memoized_eval_with_stability(
+    type_id: TypeId,
+    no_unchecked_indexed_access: bool,
+    compute: impl FnOnce() -> (TypeId, bool),
+) -> Option<(TypeId, bool)> {
     if let Some(cached) = query_memo_get(type_id, no_unchecked_indexed_access) {
-        return Some(cached);
+        return Some((cached, true));
     }
     let _cross = CrossEvalExpansionGuard::enter(type_id)?;
     let (result, memoizable) = compute();
     if memoizable {
         query_memo_put(type_id, no_unchecked_indexed_access, result);
     }
-    Some(result)
+    Some((result, memoizable))
 }
 
 /// RAII membership guard for cross-evaluator expansion of a `TypeId`.

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -272,7 +272,10 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// This prevents O(n²) behavior when the same type (e.g., a large union) is
     /// evaluated multiple times across different subtype checks.
     /// Key is (`TypeId`, `no_unchecked_indexed_access`) since that flag affects evaluation.
-    pub(crate) eval_cache: FxHashMap<(TypeId, bool), TypeId>,
+    /// Value is `(result, stable)` where `stable` records whether the evaluation
+    /// converged without tripping a recursion/depth/budget limit (see
+    /// `evaluate_type_with_stability`).
+    pub(crate) eval_cache: FxHashMap<(TypeId, bool), (TypeId, bool)>,
     /// Apparent object shapes for primitive wrapper fallback.
     ///
     /// Primitive structural subtype checks can ask for the same wrapper shape
@@ -540,7 +543,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     pub fn cache_statistics(&self) -> SubtypeCheckerCacheStatistics {
         let eval_entries = self.eval_cache.len();
         let estimated_size_bytes =
-            eval_entries.saturating_mul(std::mem::size_of::<((TypeId, bool), TypeId)>());
+            eval_entries.saturating_mul(std::mem::size_of::<((TypeId, bool), (TypeId, bool))>());
         SubtypeCheckerCacheStatistics {
             eval_entries,
             estimated_size_bytes,

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -1949,10 +1949,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Results are cached in `eval_cache` to avoid re-evaluating the same type across
     /// multiple subtype checks. This turns O(n²) evaluate calls into O(n).
     pub(crate) fn evaluate_type(&mut self, type_id: TypeId) -> TypeId {
+        self.evaluate_type_with_stability(type_id).0
+    }
+
+    /// Like [`Self::evaluate_type`], but also reports whether the evaluation is
+    /// *stable*: it converged without tripping any recursion/depth/budget limit
+    /// and without a cross-instance cycle bail.
+    ///
+    /// A stable result is the type's converged answer; an unstable one is a
+    /// recursion artifact (e.g. a self-referential application collapsed to
+    /// `unknown` by a cycle guard). Callers that special-case collapsed results
+    /// must consult the flag so a genuinely evaluated `unknown` is not treated
+    /// like a bail artifact.
+    pub(crate) fn evaluate_type_with_stability(&mut self, type_id: TypeId) -> (TypeId, bool) {
         // Fast path: intrinsic types (number, string, boolean, void, null, etc.)
         // never need evaluation. Skip cache lookup entirely.
         if type_id.is_intrinsic() {
-            return type_id;
+            return (type_id, true);
         }
         // Check local evaluation cache first.
         // Key includes no_unchecked_indexed_access since with that flag evaluation results can vary.
@@ -1969,8 +1982,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // evaluator, re-entering the same `TypeId` without any guard firing. On a
         // cross-instance cycle (`None`) leave the type unevaluated and, crucially,
         // do not record it in `eval_cache` — the in-flight ancestor owns the result.
-        let Some(result) =
-            cross_eval_guard::memoized_eval(type_id, self.no_unchecked_indexed_access, || {
+        let Some((result, stable)) = cross_eval_guard::memoized_eval_with_stability(
+            type_id,
+            self.no_unchecked_indexed_access,
+            || {
                 let mut evaluator = TypeEvaluator::with_resolver(self.interner, self.resolver);
                 evaluator.set_no_unchecked_indexed_access(self.no_unchecked_indexed_access);
                 // Pass query_db to share the application evaluation cache across
@@ -1981,11 +1996,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 }
                 let result = evaluator.evaluate(type_id);
                 (result, !evaluator.recursion_limit_hit())
-            })
-        else {
-            return type_id;
+            },
+        ) else {
+            return (type_id, false);
         };
-        self.eval_cache.insert(cache_key, result);
-        result
+        self.eval_cache.insert(cache_key, (result, stable));
+        (result, stable)
     }
 }

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
@@ -915,14 +915,26 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return SubtypeResult::True;
         }
 
-        let source_needs_raw_fallback = matches!(
-            self.interner.lookup(source_return),
-            Some(TypeData::Application(_) | TypeData::Lazy(_))
-        ) && self.evaluate_type(source_return) == TypeId::UNKNOWN;
-        let target_needs_raw_fallback = matches!(
-            self.interner.lookup(target_return),
-            Some(TypeData::Application(_) | TypeData::Lazy(_))
-        ) && self.evaluate_type(target_return) == TypeId::UNKNOWN;
+        // Recursive-application cycle guard: when a deferred `Application`/`Lazy`
+        // return collapses to `unknown` because a recursion guard bailed (e.g.
+        // self-referential iterator applications), the collapsed `unknown` is a
+        // cycle artifact, not the converged answer — relating against it would
+        // accept anything. Re-check the raw deferred forms in that case.
+        //
+        // The guard must only fire for *unstable* evaluations. A deferred alias
+        // application that genuinely evaluates to `unknown` (e.g. a conditional
+        // alias whose selected branch is `unknown`) is the converged answer:
+        // tsc relates the source against that `unknown` (everything is
+        // assignable). Vetoing it through a raw-form comparison manufactures
+        // `X is not assignable to unknown` false positives (#13212).
+        let mut unstable_unknown_collapse = |ret: TypeId| {
+            matches!(
+                self.interner.lookup(ret),
+                Some(TypeData::Application(_) | TypeData::Lazy(_))
+            ) && self.evaluate_type_with_stability(ret) == (TypeId::UNKNOWN, false)
+        };
+        let source_needs_raw_fallback = unstable_unknown_collapse(source_return);
+        let target_needs_raw_fallback = unstable_unknown_collapse(target_return);
 
         if source_needs_raw_fallback || target_needs_raw_fallback {
             let prev = self.bypass_evaluation;


### PR DESCRIPTION
Goal: green

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-fable-5
Effort: high

AgentName: M1FableArchitect
Track: valibot/kysely false-positive identity family (#13212 F1)
Invariant: when a deferred `Application`/`Lazy` signature-return evaluates **stably** to `unknown`, the relation must use the evaluated `unknown` (everything assignable), exactly like tsc; the raw-form fallback is reserved for recursion-bailed collapses.

## Scope
Root-causes the #13212 gate witness (valibot `'"transformation"' is not assignable to '"transformation"'` / `Type 'unknown' is not assignable to type 'unknown'` self-identity family).

**Refutes the canonical-interning framing for this witness**: tracing shows evaluation of `C<number>` / `C<2>` produces the canonical `TypeId::UNKNOWN(3)` — there is no fresh/duplicate intrinsic. The failure owner is `check_return_compat` (`relations/subtype/rules/functions/mod.rs`): a raw-form fallback added by `9805b5061d` ("Guard recursive iterator application subtype cycles") re-checks the relation against the **raw deferred application** with `bypass_evaluation=true` whenever the return evaluates to `unknown`, and vetoes on raw failure. It could not distinguish a genuinely converged `unknown` (`type C<T> = T extends 1 ? unknown : unknown` at `C<2>`) from a recursion-bail artifact.

Structural rule: when a signature-return target/source is a deferred alias application whose evaluation **converges** to `unknown`, tsc relates against `unknown`; tsz now does the same through `check_return_compat`, which only takes the raw-form fallback when the `unknown` collapse is *unstable* (recursion/depth/budget bail or cross-eval cycle), the artifact case the guard was introduced for.

Plumbing: `cross_eval_guard::memoized_eval_with_stability` exposes the existing `memoizable` convergence bit (memo hits are stable by construction); the `SubtypeChecker` `eval_cache` now stores `(result, stable)`; `evaluate_type_with_stability` surfaces it. No new evaluation work on any path.

Explains the triage discriminator matrix exactly:
- only signature-return position failed (`check_return_compat` is return-only); property position passed
- `() => 1` passed while `undefined`/`null`/`void`/`unknown` sources failed (raw-dispatch asymmetry of the vetoed comparison)
- raw indexed access passed (already evaluated before reaching the fallback)

## Adjacent-case matrix (new tests, `ts2322_tests_parts/part_04.rs`)
- conditional alias `unknown` return: `undefined`, `null`, `void` sources (vf/vk/vm/vn witnesses)
- pure indexed-access alias (non-conditional) `unknown` return (vg witness)
- generic-interface member instantiation, renamed binders, literal-property + signature-return members, `unknown`-cast and `undefined` sources (vq/vp witnesses)
- negative control: alias evaluating to `string` still rejects a `number` return
- positive control: alias evaluating to `string` accepts a `string` return

## Project Corpus Impact
- Row: valibot-project (also kysely-project F3)
- Bug family: canonical interning of instantiation/evaluation results (#13212)

valibot A/B (dev-fast @ 6413132985 both sides, `tsconfig.tsz-guard.json`): **1821 → 1817**, families TS2322 27→23, all other families identical; ZERO new families. `returns.ts`/`returnsAsync.ts` self-identity clusters eliminated. `args.ts` is count-neutral: the `(83,5)` per-property `~run` error re-shapes to a `(77,3)` object-level error on the same assignment, now elaborating the *real* surviving reason (`Types of property 'schema' are incompatible` — `Schema` type param vs the tuple-schema union constraint, F4-adjacent; masked defect surfaced, documented for follow-up; tsc reports 0 there before and after).

kysely 2×/side: 135 = 135, site-identical (13 "Two different types" sites unchanged — kysely F3 does **not** route through `check_return_compat`; separate root cause, stays open under #13212).
zod: 54 = 54 site-identical. comlink: 3 = 3 site-identical.

## Verification
- `/tmp/valibot-min2` repro matrix (28 configs incl. the 9-line vq gate): all 0 errors with fix (tsc 5.9.3 clean); base failed 13 of them.
- Conformance smokes (dist-fast runner, pinned-lib `TSZ_LIB_DIR`, `--tsz-binary` fix build): `conditional` 51/51, `conditionalType` 17/17, `inferTypes` 7/7, `iterator` 25/25, `generator` 98/98, `unknownType` 4/4 — the iterator/generator families are the ones the original raw fallback guarded.
- tsz-solver tests: 6608 passed; 2 failures identical on clean `origin/main` (pre-existing: `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`, `test_generic_call_widening_applies_when_constraint_satisfied`).
- tsz-checker `ts2322_tests`: 289 passed (284 on base + 5 new); 7 failures identical on clean `origin/main` (pre-existing local-env failures).
- Adjacent checker suites green: function_bivariance, function_terminal_return_flow, generator_return_type_widening, generic_return_fingerprint, large_union_conditional_distribution, recursive_conditional_alias_index, recursive_conditional_infer_depth, recursive_value_call_return, return_context_identity_wrapper_literal, async_return_promise_identity (async_return_widening has 1 pre-existing base failure).
- clippy (tsz-solver --all-targets, tsz-checker + ts2322 test target): clean. Arch guard: pass.

## Coordination Notes
- Sibling lanes: `../tsz-f1b` (no-erase signature relation, `relations/subtype/cache.rs`) and the display/F4 agent — this PR touches `rules/functions/{mod,checking}.rs`, `subtype/core.rs` (eval_cache type only), and `evaluation/cross_eval_guard.rs`; no overlap with their files.
- #13212 remains open: the big F1 clusters (TS2344×132, TS7006×114, TS2345×135) and kysely F3 do not route through this veto and need separate root-causing; the issue's "non-canonical interning" hypothesis is refuted for the gate witness (evaluation interns canonically).
