### PR TITLE
refactor(common): share extension stripping and JS escaping

### DIFF
--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -13,6 +13,7 @@ use crate::control_flow::FlowGraph;
 use crate::module_resolution::build_file_name_index;
 use tsz_binder::symbols::StableLocation;
 use tsz_binder::{BinderState, SymbolId};
+use tsz_common::file_extensions::strip_known_extension;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeArena;
 use tsz_solver::TypeId;
@@ -433,7 +434,7 @@ impl<'a> CheckerContext<'a> {
             for sf in &arena.source_files {
                 let file_name = &sf.file_name;
                 // Strip .ts/.tsx/.d.ts/.js/.jsx extension to get the module specifier
-                let specifier = Self::strip_ts_extension(file_name);
+                let specifier = strip_known_extension(file_name);
                 // Use just the filename component (without directory path) to match tsc's
                 // diagnostic display. tsc shows `import("a").F` not `import("/full/path/a").F`.
                 let basename = specifier
@@ -457,7 +458,7 @@ impl<'a> CheckerContext<'a> {
         let mut paths: Vec<(u32, String)> = Vec::new();
         for (idx, arena) in arenas.iter().enumerate() {
             for sf in &arena.source_files {
-                let specifier = Self::strip_ts_extension(&sf.file_name);
+                let specifier = strip_known_extension(&sf.file_name);
                 paths.push((idx as u32, specifier.to_string()));
             }
         }
@@ -544,20 +545,6 @@ impl<'a> CheckerContext<'a> {
             Some(last_slash) => first[..=last_slash].to_string(),
             None => String::new(),
         }
-    }
-
-    /// Strip TypeScript/JavaScript extension from a file path to get the module specifier.
-    fn strip_ts_extension(path: &str) -> &str {
-        // Check extensions in order: longer extensions first to avoid partial matches
-        for ext in &[
-            ".d.ts", ".d.tsx", ".d.mts", ".d.cts", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx",
-            ".mjs", ".cjs",
-        ] {
-            if let Some(stripped) = path.strip_suffix(ext) {
-                return stripped;
-            }
-        }
-        path
     }
 
     /// Pre-populate `global_declared_modules` from skeleton-derived data.

--- a/crates/tsz-checker/src/context/package_resolution.rs
+++ b/crates/tsz-checker/src/context/package_resolution.rs
@@ -1,5 +1,6 @@
 use std::path::{Component, Path, PathBuf};
 
+use tsz_common::file_extensions::strip_known_extension;
 use tsz_common::module_resolution::types_versions;
 
 use crate::module_resolution::{
@@ -167,13 +168,13 @@ impl<'a> CheckerContext<'a> {
         target: &str,
     ) -> Option<usize> {
         let target = Self::normalize_package_relative_path(target);
-        let target = Self::strip_resolution_extension(&target);
+        let target = strip_known_extension(&target).to_string();
         let arenas = self.all_arenas.as_ref()?;
         arenas.iter().enumerate().find_map(|(idx, arena)| {
             let file_name = arena.source_files.first()?.file_name.as_str();
             let relative = Path::new(file_name).strip_prefix(package_root).ok()?;
             let relative = Self::normalize_package_relative_path(&relative.to_string_lossy());
-            let relative = Self::strip_resolution_extension(&relative);
+            let relative = strip_known_extension(&relative).to_string();
             (relative == target || relative == format!("{target}/index")).then_some(idx)
         })
     }
@@ -241,17 +242,5 @@ impl<'a> CheckerContext<'a> {
             .trim_start_matches("./")
             .trim_start_matches('/')
             .to_string()
-    }
-
-    fn strip_resolution_extension(path: &str) -> String {
-        for ext in [
-            ".d.ts", ".d.tsx", ".d.mts", ".d.cts", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx",
-            ".mjs", ".cjs",
-        ] {
-            if let Some(stripped) = path.strip_suffix(ext) {
-                return stripped.to_string();
-            }
-        }
-        path.to_string()
     }
 }

--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -6,6 +6,7 @@ use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
 use crate::query_boundaries::common as query;
 use crate::state::CheckerState;
 use crate::symbols_domain::alias_cycle::AliasCycleTracker;
+use tsz_common::file_extensions::strip_known_extension;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
@@ -1714,7 +1715,7 @@ impl<'a> CheckerState<'a> {
                 // Normalize module specifier: TSC displays resolved module names
                 // without the relative path prefix (e.g., "./b" → "b").
                 let display_name = module_name.strip_prefix("./").unwrap_or(&module_name);
-                let display_name = strip_property_namespace_module_extension(display_name);
+                let display_name = strip_known_extension(display_name);
                 let type_str = format!("typeof import(\"{display_name}\")");
                 let (code, message) = if let Some(ref suggestion) = suggestion {
                     (
@@ -1816,18 +1817,6 @@ impl<'a> CheckerState<'a> {
 }
 
 include!("properties/diagnostic_methods_tail.rs");
-
-fn strip_property_namespace_module_extension(module_name: &str) -> &str {
-    const EXTS: &[&str] = &[
-        ".d.ts", ".d.mts", ".d.cts", ".js", ".ts", ".jsx", ".tsx", ".mjs", ".cjs", ".mts", ".cts",
-    ];
-    for ext in EXTS {
-        if let Some(stripped) = module_name.strip_suffix(ext) {
-            return stripped;
-        }
-    }
-    module_name
-}
 
 /// Match tsc's `^(?:EventTarget|Node|(?:HTML[a-zA-Z]*)?Element)$` regex used by
 /// `containerSeemsToBeEmptyDomElement` to detect DOM element-like type names.

--- a/crates/tsz-checker/src/module_resolution.rs
+++ b/crates/tsz-checker/src/module_resolution.rs
@@ -39,23 +39,12 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use std::path::{Component, Path};
 use std::sync::Arc;
 
+use tsz_common::file_extensions::strip_known_extension as strip_ts_extension;
 use tsz_parser::parser::node::NodeArena;
 
 // ---------------------------------------------------------------------------
 // Extension tables
 // ---------------------------------------------------------------------------
-
-/// TypeScript/JavaScript file extensions in *stripping* order.
-///
-/// `.d.ts` (and friends) must appear before `.ts` so that stripping peels the
-/// whole `.d.ts` suffix instead of leaving a `.d` artifact in the stem. This
-/// ordering is correct for [`strip_ts_extension`] but is **not** the order in
-/// which resolution candidates should be tried — use [`RESOLUTION_EXTENSIONS`]
-/// for that.
-const TS_EXTENSIONS: &[&str] = &[
-    ".d.ts", ".d.tsx", ".d.mts", ".d.cts", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs",
-    ".cjs",
-];
 
 /// File extensions in `tsc` resolution-candidate priority order, mirroring
 /// TypeScript's `allSupportedExtensions`:
@@ -78,9 +67,10 @@ const TS_EXTENSIONS: &[&str] = &[
 /// triple-slash directive resolver in `state_checking::directive` follows the
 /// same shared order.
 ///
-/// This is intentionally distinct from [`TS_EXTENSIONS`], which is ordered
-/// declaration-first purely so suffix *stripping* works. There is no real
-/// `.d.tsx` file in TypeScript, so it is absent here.
+/// This is intentionally distinct from the shared `strip_known_extension`
+/// stripping helper, which is ordered declaration-first purely so suffix
+/// stripping works. There is no real `.d.tsx` file in TypeScript, so it is
+/// absent here.
 const RESOLUTION_EXTENSIONS: &[&str] = tsz_common::file_extensions::TSC_TS_JS_RESOLUTION_EXTENSIONS;
 
 /// `tsc` resolution priority of a concrete file path: the position of its
@@ -117,18 +107,6 @@ fn target_resolution_priority(target: &IndexedTarget<'_>) -> usize {
 const ARBITRARY_EXT_TAILS: &[&str] = &[
     ".d.ts", ".d.tsx", ".d.mts", ".d.cts", ".d.js", ".d.jsx", ".d.mjs", ".d.cjs", ".d.json",
 ];
-
-/// Strip a known TS/JS extension from the end of `path`. Returns `path`
-/// unchanged if no known extension is present. Always returns a borrow of the
-/// input — no allocation.
-fn strip_ts_extension(path: &str) -> &str {
-    for ext in TS_EXTENSIONS {
-        if let Some(stripped) = path.strip_suffix(ext) {
-            return stripped;
-        }
-    }
-    path
-}
 
 /// Detect `<base>.d.<ext>.ts` files. These are treated specially (see the
 /// `ARBITRARY_EXT_TAILS` documentation).

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
@@ -1831,17 +1831,4 @@ impl<'a> CheckerState<'a> {
             .trim_start_matches("./")
             .to_string()
     }
-
-    fn strip_ts_extensions(&self, path: &str) -> String {
-        for ext in [
-            ".d.ts", ".d.tsx", ".d.mts", ".d.cts", ".tsx", ".ts", ".mts", ".cts", ".jsx", ".js",
-            ".mjs", ".cjs",
-        ] {
-            if let Some(path) = path.strip_suffix(ext) {
-                return path.to_string();
-            }
-        }
-
-        path.to_string()
-    }
 }

--- a/crates/tsz-checker/tests/module_resolution.rs
+++ b/crates/tsz-checker/tests/module_resolution.rs
@@ -11,7 +11,7 @@ fn test_strip_ts_extension() {
     assert_eq!(strip_ts_extension("foo.js"), "foo");
     assert_eq!(strip_ts_extension("foo.jsx"), "foo");
     assert_eq!(strip_ts_extension("foo.d.ts"), "foo");
-    assert_eq!(strip_ts_extension("foo.d.tsx"), "foo");
+    assert_eq!(strip_ts_extension("foo.d.tsx"), "foo.d");
     assert_eq!(strip_ts_extension("foo.mts"), "foo");
     assert_eq!(strip_ts_extension("foo.cts"), "foo");
     assert_eq!(strip_ts_extension("foo.mjs"), "foo");
@@ -39,7 +39,8 @@ fn test_strip_ts_extension_no_match() {
 fn test_strip_dts_before_ts() {
     // .d.ts must be stripped as a whole, not just .ts leaving ".d".
     assert_eq!(strip_ts_extension("types.d.ts"), "types");
-    assert_eq!(strip_ts_extension("globals.d.tsx"), "globals");
+    // .d.tsx is a TSX source file, not a declaration extension.
+    assert_eq!(strip_ts_extension("globals.d.tsx"), "globals.d");
 }
 
 // ===========================================================================

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_imports.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_imports.rs
@@ -17,6 +17,7 @@ use tsz::lsp::Project;
 use tsz::lsp::code_actions::{CodeActionProvider, CodeFixRegistry, ImportCandidate};
 use tsz::lsp::position::LineMap;
 use tsz::parser::ParserState;
+use tsz_common::file_extensions::strip_known_extension;
 
 impl Server {
     pub(super) fn best_import_module_specifier_for_name(
@@ -632,16 +633,7 @@ impl Server {
             return specifier.to_string();
         }
 
-        for ext in [
-            ".d.ts", ".d.mts", ".d.cts", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs",
-            ".cjs",
-        ] {
-            if let Some(stripped) = specifier.strip_suffix(ext) {
-                return stripped.to_string();
-            }
-        }
-
-        specifier.to_string()
+        strip_known_extension(specifier).to_string()
     }
 
     pub(super) fn verbatim_commonjs_auto_import_codefix_action(
@@ -1471,15 +1463,9 @@ impl Server {
         };
         let rest = tail.strip_prefix(&package).unwrap_or_default();
 
-        let mut normalized_rest = rest.to_string();
-        for ext in [
-            ".d.ts", ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs",
-        ] {
-            if normalized_rest.ends_with(ext) {
-                let new_len = normalized_rest.len().saturating_sub(ext.len());
-                normalized_rest.truncate(new_len);
-                break;
-            }
+        let mut normalized_rest = strip_known_extension(rest).to_string();
+        if normalized_rest.is_empty() {
+            normalized_rest = rest.to_string();
         }
         if normalized_rest.ends_with("/index") {
             let new_len = normalized_rest.len().saturating_sub("/index".len());
@@ -1546,5 +1532,26 @@ impl Server {
         }
 
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Server;
+
+    #[test]
+    fn normalize_commonjs_module_specifier_uses_shared_extension_rules() {
+        assert_eq!(
+            Server::normalize_commonjs_module_specifier("./types.d.cts"),
+            "./types"
+        );
+        assert_eq!(
+            Server::normalize_commonjs_module_specifier("./types.d.tsx"),
+            "./types.d"
+        );
+        assert_eq!(
+            Server::normalize_commonjs_module_specifier("react/index.d.ts"),
+            "react/index.d.ts"
+        );
     }
 }

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_completions_auto_imports.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_completions_auto_imports.rs
@@ -5,6 +5,7 @@ use rustc_hash::FxHashSet;
 use std::path::Path;
 use tsz::lsp::completions::{CompletionItem, CompletionItemKind, sort_priority};
 use tsz::lsp::jsdoc::{inline_links, jsdoc_for_node, parse_jsdoc};
+use tsz_common::file_extensions::strip_known_extension;
 
 impl Server {
     pub(super) fn is_ts_like_file(path: &str) -> bool {
@@ -612,10 +613,6 @@ impl Server {
     }
 
     pub(super) fn normalize_completion_source_for_match(source: &str) -> String {
-        const SOURCE_SUFFIXES: [&str; 11] = [
-            ".d.ts", ".d.mts", ".d.cts", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs",
-            ".cjs",
-        ];
         let mut normalized = source
             .trim()
             .trim_matches('\"')
@@ -624,13 +621,9 @@ impl Server {
         if let Some(stripped) = normalized.strip_prefix("node:") {
             normalized = stripped.to_string();
         }
-        for suffix in SOURCE_SUFFIXES {
-            if let Some(base) = normalized.strip_suffix(suffix)
-                && !base.is_empty()
-            {
-                normalized = base.to_string();
-                break;
-            }
+        let stripped = strip_known_extension(&normalized);
+        if !stripped.is_empty() {
+            normalized = stripped.to_string();
         }
         if let Some(base) = normalized.strip_suffix("/index")
             && !base.is_empty()
@@ -1376,5 +1369,30 @@ impl Server {
             tsz::lsp::completions::CompletionItemKind::Constructor => "constructor",
             tsz::lsp::completions::CompletionItemKind::Alias => "alias",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Server;
+
+    #[test]
+    fn normalize_completion_source_for_match_uses_shared_extension_rules() {
+        assert_eq!(
+            Server::normalize_completion_source_for_match("'node:fs'"),
+            "fs"
+        );
+        assert_eq!(
+            Server::normalize_completion_source_for_match("\"pkg/types.d.cts\""),
+            "pkg/types"
+        );
+        assert_eq!(
+            Server::normalize_completion_source_for_match("pkg/types.d.tsx"),
+            "pkg/types.d"
+        );
+        assert_eq!(
+            Server::normalize_completion_source_for_match("pkg/index.d.ts"),
+            "pkg"
+        );
     }
 }

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -11,6 +11,7 @@ use tsz::lsp::references::FindReferences;
 use tsz::lsp::rename::RenameProvider;
 use tsz::lsp::symbols::document_symbols::DocumentSymbolProvider;
 use tsz::parser::node::NodeAccess;
+use tsz_common::source_map::escape_js_string;
 use tsz_solver::construction::TypeInterner;
 
 #[path = "handlers_info_definition.rs"]
@@ -173,36 +174,6 @@ fn has_export_modifier(
             .get(m_idx)
             .is_some_and(|m| m.kind == SyntaxKind::ExportKeyword as u16)
     })
-}
-
-/// Mirror tsc's `escapeString(s, '"')` — replace control characters
-/// and backslash/double-quote with their JS escape sequences, and
-/// encode non-printable high chars as `\uNNNN`. Used on the filename
-/// stem before wrapping it in double quotes for external-module
-/// navbar/navtree root entries, so a filename like `my fil<TAB>e`
-/// renders as `"my fil\te"` rather than embedding a literal tab.
-fn escape_string_double_quote(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '\\' => out.push_str("\\\\"),
-            '"' => out.push_str("\\\""),
-            '\t' => out.push_str("\\t"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\x08' => out.push_str("\\b"),
-            '\x0c' => out.push_str("\\f"),
-            '\x0b' => out.push_str("\\v"),
-            '\u{2028}' => out.push_str("\\u2028"),
-            '\u{2029}' => out.push_str("\\u2029"),
-            '\u{0085}' => out.push_str("\\u0085"),
-            c if (c as u32) < 0x20 => {
-                out.push_str(&format!("\\u{:04X}", c as u32));
-            }
-            c => out.push(c),
-        }
-    }
-    out
 }
 
 /// Sort a navtree/navbar symbol slice in-place, recursively sorting each
@@ -1539,7 +1510,7 @@ impl Server {
                 // quoting. Mirrors that so control characters render as
                 // their escape sequences (\t, \n, \\…).
                 (
-                    format!("\"{}\"", escape_string_double_quote(&basename)),
+                    format!("\"{}\"", escape_js_string(&basename, '"')),
                     "module",
                 )
             } else {
@@ -1745,7 +1716,7 @@ impl Server {
                     .unwrap_or("")
                     .to_string();
                 (
-                    format!("\"{}\"", escape_string_double_quote(&basename)),
+                    format!("\"{}\"", escape_js_string(&basename, '"')),
                     "module",
                 )
             } else {

--- a/crates/tsz-common/src/file_extensions.rs
+++ b/crates/tsz-common/src/file_extensions.rs
@@ -337,6 +337,7 @@ mod tests {
         assert_eq!(strip_known_extension("foo.ts"), "foo");
         assert_eq!(strip_known_extension("foo.js"), "foo");
         assert_eq!(strip_known_extension("foo.d.ts"), "foo");
+        assert_eq!(strip_known_extension("foo.d.tsx"), "foo.d");
         assert_eq!(strip_known_extension("foo"), "foo");
         assert_eq!(strip_known_extension("foo.json"), "foo.json");
     }

--- a/crates/tsz-common/src/source_map/mod.rs
+++ b/crates/tsz-common/src/source_map/mod.rs
@@ -548,57 +548,50 @@ pub fn escape_json(s: &str) -> String {
     result
 }
 
-/// Escape a JavaScript string literal (single or double quoted)
-/// SIMD-optimized with memchr for bulk scanning
+/// Escape a JavaScript string literal (single or double quoted).
 #[must_use]
 pub fn escape_js_string(s: &str, quote: char) -> String {
     let bytes = s.as_bytes();
     let quote_byte = quote as u8;
 
     // Fast path: return early when there is nothing to escape.
-    // All five special bytes (\, quote, \n, \r, \t, \0) must be absent.
+    // All JS string-sensitive bytes/chars must be absent.
     let has_backslash = memchr::memchr(b'\\', bytes).is_some();
     let has_quote = memchr::memchr(quote_byte, bytes).is_some();
     let has_newline_or_cr = memchr::memchr2(b'\n', b'\r', bytes).is_some();
-    let has_tab_or_null = memchr::memchr2(b'\t', b'\0', bytes).is_some();
+    let has_control = bytes.iter().any(|&byte| byte < 0x20);
+    let has_js_line_separator =
+        s.contains('\u{2028}') || s.contains('\u{2029}') || s.contains('\u{0085}');
 
-    if !has_backslash && !has_quote && !has_newline_or_cr && !has_tab_or_null {
+    if !has_backslash && !has_quote && !has_newline_or_cr && !has_control && !has_js_line_separator
+    {
         return s.to_string();
     }
 
     let mut result = String::with_capacity(s.len() + 16);
-    let mut start = 0;
 
-    for (i, &byte) in bytes.iter().enumerate() {
-        let escape = match byte {
-            b'\\' => Some("\\\\"),
-            b'\n' => Some("\\n"),
-            b'\r' => Some("\\r"),
-            b'\t' => Some("\\t"),
-            b'\0' => Some("\\0"),
-            b if b == quote_byte => {
-                if i > start {
-                    result.push_str(&s[start..i]);
-                }
+    for c in s.chars() {
+        match c {
+            '\\' => result.push_str("\\\\"),
+            '\n' => result.push_str("\\n"),
+            '\r' => result.push_str("\\r"),
+            '\t' => result.push_str("\\t"),
+            '\0' => result.push_str("\\0"),
+            '\x08' => result.push_str("\\b"),
+            '\x0c' => result.push_str("\\f"),
+            '\x0b' => result.push_str("\\v"),
+            '\u{2028}' => result.push_str("\\u2028"),
+            '\u{2029}' => result.push_str("\\u2029"),
+            '\u{0085}' => result.push_str("\\u0085"),
+            c if c == quote => {
                 result.push('\\');
                 result.push(quote);
-                start = i + 1;
-                continue;
             }
-            _ => None,
-        };
-
-        if let Some(escaped) = escape {
-            if i > start {
-                result.push_str(&s[start..i]);
+            c if (c as u32) < 0x20 => {
+                let _ = write!(&mut result, "\\u{:04X}", c as u32);
             }
-            result.push_str(escaped);
-            start = i + 1;
+            c => result.push(c),
         }
-    }
-
-    if start < s.len() {
-        result.push_str(&s[start..]);
     }
 
     result

--- a/crates/tsz-common/tests/source_map.rs
+++ b/crates/tsz-common/tests/source_map.rs
@@ -221,6 +221,15 @@ fn escape_js_string_newlines() {
     assert_eq!(escape_js_string("a\rb", '\''), r"a\rb");
 }
 
+#[test]
+fn escape_js_string_control_and_js_line_separators() {
+    assert_eq!(escape_js_string("\x08\x0c\x0b\x01", '"'), r"\b\f\v\u0001");
+    assert_eq!(
+        escape_js_string("\u{2028}\u{2029}\u{0085}", '"'),
+        r"\u2028\u2029\u0085"
+    );
+}
+
 // =============================================================================
 // SourceMapGenerator edge cases
 // =============================================================================

--- a/crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/imports_and_modules.rs
@@ -785,8 +785,8 @@ impl<'a> DeclarationEmitter<'a> {
         let current_dir = current.parent().unwrap_or(std::path::Path::new(""));
         let joined = current_dir.join(spec);
         let normalized = Self::normalize_path_text(&joined);
-        let current_no_ext = self.strip_ts_extensions(current_path);
-        let normalized_no_ext = self.strip_ts_extensions(&normalized);
+        let current_no_ext = self.strip_module_path_extension(current_path);
+        let normalized_no_ext = self.strip_module_path_extension(&normalized);
         if normalized_no_ext == current_no_ext {
             return true;
         }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
@@ -685,8 +685,9 @@ impl<'a> DeclarationEmitter<'a> {
         self.arena_to_path
             .iter()
             .filter_map(|(&arena_addr, source_path)| {
-                let relative = self
-                    .strip_ts_extensions(&self.calculate_relative_path(current_path, source_path));
+                let relative = self.strip_module_path_extension(
+                    &self.calculate_relative_path(current_path, source_path),
+                );
                 if relative != module_specifier
                     && relative
                         .strip_suffix("/index")

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_check.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_check.rs
@@ -1150,8 +1150,9 @@ impl<'a> DeclarationEmitter<'a> {
             };
 
             let source = diagnostic_source.to_str()?;
-            let mut from_path =
-                self.strip_ts_extensions(&self.calculate_relative_path(current_file_path, source));
+            let mut from_path = self.strip_module_path_extension(
+                &self.calculate_relative_path(current_file_path, source),
+            );
             if from_path.ends_with("/index") {
                 from_path.truncate(from_path.len() - "/index".len());
             }
@@ -1629,7 +1630,7 @@ impl<'a> DeclarationEmitter<'a> {
                 .is_none_or(|spec| spec.contains('/'))
         {
             references.push((
-                self.strip_ts_extensions(&self.calculate_relative_path(file, &source_path)),
+                self.strip_module_path_extension(&self.calculate_relative_path(file, &source_path)),
                 symbol.escaped_name.clone(),
             ));
         }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_export_paths.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_export_paths.rs
@@ -86,7 +86,7 @@ impl<'a> DeclarationEmitter<'a> {
                 let matches = if module_specifier.starts_with('.')
                     || module_specifier.starts_with('/')
                 {
-                    let relative = self.strip_ts_extensions(
+                    let relative = self.strip_module_path_extension(
                         &self.calculate_relative_path(current_path, module_path),
                     );
                     relative == module_specifier
@@ -138,7 +138,9 @@ impl<'a> DeclarationEmitter<'a> {
         };
         let subpath = parts.join("/");
 
-        let normalized = self.strip_ts_extensions(module_path).replace('\\', "/");
+        let normalized = self
+            .strip_module_path_extension(module_path)
+            .replace('\\', "/");
         if subpath.is_empty() {
             return normalized.ends_with(&format!("/{package_name}/src/index"))
                 || normalized.ends_with(&format!("/{package_name}/index"));

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
@@ -196,7 +196,7 @@ impl<'a> DeclarationEmitter<'a> {
                 .find_map(|(module_path, exports)| {
                     let candidate =
                         if module_specifier.starts_with('.') || module_specifier.starts_with('/') {
-                            Some(self.strip_ts_extensions(
+                            Some(self.strip_module_path_extension(
                                 &self.calculate_relative_path(current_path, module_path),
                             ))
                         } else {
@@ -582,7 +582,7 @@ impl<'a> DeclarationEmitter<'a> {
                 let source_path = self.arena_to_path.get(&arena_addr)?;
                 let candidate =
                     if module_specifier.starts_with('.') || module_specifier.starts_with('/') {
-                        self.strip_ts_extensions(
+                        self.strip_module_path_extension(
                             &self.calculate_relative_path(current_path, source_path),
                         )
                     } else {
@@ -681,7 +681,7 @@ impl<'a> DeclarationEmitter<'a> {
                     let candidate = if module_specifier.starts_with('.')
                         || module_specifier.starts_with('/')
                     {
-                        Some(self.strip_ts_extensions(
+                        Some(self.strip_module_path_extension(
                             &self.calculate_relative_path(current_file_path, module_path),
                         ))
                     } else {
@@ -843,7 +843,7 @@ impl<'a> DeclarationEmitter<'a> {
                 .into_iter()
                 .next()
             {
-                let mut from_path = self.strip_ts_extensions(
+                let mut from_path = self.strip_module_path_extension(
                     &self.calculate_relative_path(current_file_path, module_path),
                 );
                 if from_path.ends_with("/index") {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_symbols.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_symbols.rs
@@ -420,7 +420,7 @@ impl<'a> DeclarationEmitter<'a> {
                             .into_iter()
                             .max_by_key(|path| path.len())
                         {
-                            let mut from_path = self.strip_ts_extensions(
+                            let mut from_path = self.strip_module_path_extension(
                                 &self.calculate_relative_path(current_file_path, module_path),
                             );
                             if from_path.ends_with("/index") {
@@ -430,7 +430,7 @@ impl<'a> DeclarationEmitter<'a> {
                         }
 
                         let source_path_for_diag = source_path.clone();
-                        let mut from_path = self.strip_ts_extensions(
+                        let mut from_path = self.strip_module_path_extension(
                             &self.calculate_relative_path(current_file_path, &source_path_for_diag),
                         );
                         if from_path.ends_with("/index") {
@@ -532,8 +532,9 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         }
 
-        let mut from_path =
-            self.strip_ts_extensions(&self.calculate_relative_path(current_file_path, source_path));
+        let mut from_path = self.strip_module_path_extension(
+            &self.calculate_relative_path(current_file_path, source_path),
+        );
         if from_path.ends_with("/index") {
             from_path.truncate(from_path.len() - "/index".len());
         }
@@ -586,8 +587,9 @@ impl<'a> DeclarationEmitter<'a> {
             .into_iter()
             .max_by_key(|path| path.len())
         {
-            let mut from_path = self
-                .strip_ts_extensions(&self.calculate_relative_path(current_file_path, module_path));
+            let mut from_path = self.strip_module_path_extension(
+                &self.calculate_relative_path(current_file_path, module_path),
+            );
             if from_path.ends_with("/index") {
                 from_path.truncate(from_path.len() - "/index".len());
             }
@@ -608,8 +610,9 @@ impl<'a> DeclarationEmitter<'a> {
         // Prefer the deepest matching package root so symlinked package trees
         // keep their full path instead of collapsing to the top-level package.
         let package_root = package_roots.into_iter().max_by_key(|root| root.len())?;
-        let mut from_path = self
-            .strip_ts_extensions(&self.calculate_relative_path(current_file_path, &package_root));
+        let mut from_path = self.strip_module_path_extension(
+            &self.calculate_relative_path(current_file_path, &package_root),
+        );
         if from_path.ends_with("/index") {
             from_path.truncate(from_path.len() - "/index".len());
         }
@@ -744,7 +747,7 @@ impl<'a> DeclarationEmitter<'a> {
         let Some(source_relative) = source_relative else {
             return false;
         };
-        let source_relative_stripped = self.strip_ts_extensions(source_relative);
+        let source_relative_stripped = self.strip_module_path_extension(source_relative);
 
         for (module_path, exports) in binder.module_exports.iter() {
             if module_path == source_path || !module_path.starts_with(package_root_str.as_ref()) {
@@ -788,7 +791,7 @@ impl<'a> DeclarationEmitter<'a> {
                         .filter(|c| !matches!(c, std::path::Component::CurDir))
                         .collect();
                     let resolved_str = resolved.to_string_lossy();
-                    let resolved_stripped = self.strip_ts_extensions(&resolved_str);
+                    let resolved_stripped = self.strip_module_path_extension(&resolved_str);
                     let resolved_stripped = resolved_stripped
                         .strip_prefix("./")
                         .unwrap_or(&resolved_stripped);
@@ -905,7 +908,7 @@ impl<'a> DeclarationEmitter<'a> {
                     return None;
                 }
 
-                let mut from_path = self.strip_ts_extensions(
+                let mut from_path = self.strip_module_path_extension(
                     &self.calculate_relative_path(current_file_path, module_path),
                 );
                 if from_path.ends_with("/index") {
@@ -1099,7 +1102,7 @@ impl<'a> DeclarationEmitter<'a> {
         // against the raw specifier.  ESM `.d.ts` files use `.js` extensions
         // in re-exports (`from './foo.js'`), so we normalise both sides by
         // stripping the specifier's extension too.
-        let specifier_normalized = self.strip_ts_extensions(module_specifier);
+        let specifier_normalized = self.strip_module_path_extension(module_specifier);
         let effective_specifier = if specifier_normalized != module_specifier {
             specifier_normalized.as_str()
         } else {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
@@ -588,8 +588,8 @@ impl<'a> DeclarationEmitter<'a> {
             return text.to_string();
         }
 
-        let rel_path =
-            self.strip_ts_extensions(&self.calculate_relative_path(current_path, source_path));
+        let rel_path = self
+            .strip_module_path_extension(&self.calculate_relative_path(current_path, source_path));
         let Some(source_file) = self.arena_source_file(source_arena) else {
             return text.to_string();
         };

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_imported_calls.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_imported_calls.rs
@@ -249,7 +249,7 @@ impl<'a> DeclarationEmitter<'a> {
         self.types_versions_root_reexport_target(package_root)
             .map(|target| {
                 let target = target.to_string_lossy().replace('\\', "/");
-                let target = self.strip_ts_extensions(&target);
+                let target = self.strip_module_path_extension(&target);
                 target.ends_with(&format!("/{subpath}"))
                     || target.ends_with(&format!("/{subpath}/index"))
             })

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_public_packages.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_public_packages.rs
@@ -158,7 +158,8 @@ impl<'a> DeclarationEmitter<'a> {
                 continue;
             }
             let rel = file.strip_prefix(package_root).ok()?;
-            let mut subpath = self.strip_ts_extensions(&rel.to_string_lossy().replace('\\', "/"));
+            let mut subpath =
+                self.strip_module_path_extension(&rel.to_string_lossy().replace('\\', "/"));
             if subpath.ends_with("/index") {
                 subpath.truncate(subpath.len() - "/index".len());
             }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing_paths.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing_paths.rs
@@ -5,6 +5,7 @@ use rustc_hash::FxHashMap;
 use std::sync::Arc;
 use tracing::debug;
 use tsz_binder::{BinderState, SymbolId, symbol_flags};
+use tsz_common::file_extensions::strip_known_extension;
 use tsz_parser::parser::node::NodeArena;
 
 impl<'a> DeclarationEmitter<'a> {
@@ -130,7 +131,7 @@ impl<'a> DeclarationEmitter<'a> {
                 module_path.clone()
             } else {
                 let rel_path = self.calculate_relative_path(current_path, module_path);
-                self.strip_ts_extensions(&rel_path)
+                self.strip_module_path_extension(&rel_path)
             };
 
             candidates.push(module_specifier);
@@ -142,7 +143,7 @@ impl<'a> DeclarationEmitter<'a> {
             }
 
             for (source_module, _) in source_modules {
-                let normalized_source_module = self.strip_ts_extensions(source_module);
+                let normalized_source_module = self.strip_module_path_extension(source_module);
                 let effective_source_module = if normalized_source_module != source_module.as_str()
                 {
                     normalized_source_module.as_str()
@@ -180,7 +181,7 @@ impl<'a> DeclarationEmitter<'a> {
                     package_specifier
                 } else {
                     let rel_path = self.calculate_relative_path(current_path, module_path);
-                    self.strip_ts_extensions(&rel_path)
+                    self.strip_module_path_extension(&rel_path)
                 };
 
                 candidates.push(module_specifier);
@@ -228,7 +229,7 @@ impl<'a> DeclarationEmitter<'a> {
                         let arena_addr = std::sync::Arc::as_ptr(source_arena) as usize;
                         if let Some(source_path) = self.arena_to_path.get(&arena_addr) {
                             let rel = self.calculate_relative_path(current_path, source_path);
-                            let stripped = self.strip_ts_extensions(&rel);
+                            let stripped = self.strip_module_path_extension(&rel);
                             if alias_symbol.import_module.as_deref() == Some(&stripped)
                                 || alias_symbol.import_module.as_deref()
                                     == Some(source_path.as_str())
@@ -395,7 +396,7 @@ impl<'a> DeclarationEmitter<'a> {
             }
 
             let rel_path = self.calculate_relative_path(current_path, source_path);
-            Some(self.strip_ts_extensions(&rel_path))
+            Some(self.strip_module_path_extension(&rel_path))
         };
 
         if let Some(ambient_path) = self.check_ambient_module(sym_id, binder) {
@@ -746,7 +747,7 @@ impl<'a> DeclarationEmitter<'a> {
                             self.reverse_export_specifier_for_runtime_path(&package_root, &runtime)
                         })
                         .or_else(|| {
-                            let mut relative_path = self.strip_ts_extensions(&relative);
+                            let mut relative_path = self.strip_module_path_extension(&relative);
                             if relative_path.ends_with("/index") {
                                 relative_path.truncate(relative_path.len() - "/index".len());
                             } else if relative_path == "index" {
@@ -840,7 +841,7 @@ impl<'a> DeclarationEmitter<'a> {
             .or_else(|| {
                 let mut specifier_parts = package_relative_parts;
                 if let Some(last) = specifier_parts.last_mut() {
-                    *last = self.strip_ts_extensions(last);
+                    *last = self.strip_module_path_extension(last);
                 }
                 if specifier_parts.last().is_some_and(|part| part == "index") {
                     specifier_parts.pop();
@@ -913,7 +914,7 @@ impl<'a> DeclarationEmitter<'a> {
         let subpath = self
             .reverse_export_specifier_for_runtime_path(package_root, &runtime_relative_path)
             .or_else(|| {
-                let mut relative_path = self.strip_ts_extensions(&relative);
+                let mut relative_path = self.strip_module_path_extension(&relative);
                 if relative_path.ends_with("/index") {
                     relative_path.truncate(relative_path.len() - "/index".len());
                 } else if relative_path == "index" {
@@ -971,7 +972,7 @@ impl<'a> DeclarationEmitter<'a> {
         let package_json = serde_json::from_str::<serde_json::Value>(&package_json_text).ok()?;
         let types_versions = package_json.get("typesVersions")?.as_object()?;
         let normalized_relative =
-            Self::normalize_package_relative_path(&self.strip_ts_extensions(relative_path));
+            Self::normalize_package_relative_path(&self.strip_module_path_extension(relative_path));
 
         let mut candidates = Vec::new();
         for mappings in types_versions
@@ -1015,7 +1016,7 @@ impl<'a> DeclarationEmitter<'a> {
         relative_path: &str,
     ) -> Option<String> {
         let normalized_target =
-            Self::normalize_package_relative_path(&self.strip_ts_extensions(target));
+            Self::normalize_package_relative_path(&self.strip_module_path_extension(target));
         if let Some((target_prefix, target_suffix)) = normalized_target.split_once('*') {
             if !relative_path.starts_with(target_prefix) || !relative_path.ends_with(target_suffix)
             {
@@ -1055,7 +1056,7 @@ impl<'a> DeclarationEmitter<'a> {
             return false;
         };
         let relative_path =
-            Self::normalize_package_relative_path(&self.strip_ts_extensions(relative_path));
+            Self::normalize_package_relative_path(&self.strip_module_path_extension(relative_path));
 
         for mappings in types_versions
             .values()
@@ -1090,7 +1091,7 @@ impl<'a> DeclarationEmitter<'a> {
                         continue;
                     };
                     let reexport_path = reexport_path.to_string_lossy().replace('\\', "/");
-                    let reexport_path = self.strip_ts_extensions(&reexport_path);
+                    let reexport_path = self.strip_module_path_extension(&reexport_path);
                     if reexport_path.ends_with(&format!("/{relative_path}")) {
                         return true;
                     }
@@ -1315,24 +1316,16 @@ impl<'a> DeclarationEmitter<'a> {
             .to_string()
     }
 
-    /// Strip TypeScript file extensions from a path.
+    /// Strip an import-path extension using the shared TS/JS rules.
     ///
-    /// Converts "../utils.ts" -> "../utils"
-    pub(crate) fn strip_ts_extensions(&self, path: &str) -> String {
+    /// Arbitrary-extension declaration files (`foo.d.css.ts`) keep the user
+    /// specifier form (`foo.css`) before falling back to the shared helper.
+    pub(crate) fn strip_module_path_extension(&self, path: &str) -> String {
         if let Some((base, ext)) = Self::arbitrary_extension_declaration_user_parts(path) {
             return format!("{base}.{ext}");
         }
 
-        // Remove TypeScript and JavaScript source/declaration extensions.
-        for ext in [
-            ".d.ts", ".d.tsx", ".d.mts", ".d.cts", ".tsx", ".ts", ".mts", ".cts", ".jsx", ".js",
-            ".mjs", ".cjs",
-        ] {
-            if let Some(path) = path.strip_suffix(ext) {
-                return path.to_string();
-            }
-        }
-        path.to_string()
+        strip_known_extension(path).to_string()
     }
 
     fn arbitrary_extension_declaration_user_parts(path: &str) -> Option<(&str, &str)> {
@@ -1360,7 +1353,7 @@ impl<'a> DeclarationEmitter<'a> {
     ) -> std::path::PathBuf {
         use std::path::Component;
 
-        std::path::Path::new(&self.strip_ts_extensions(path))
+        std::path::Path::new(&self.strip_module_path_extension(path))
             .components()
             .filter(|component| !matches!(component, Component::CurDir))
             .collect()

--- a/crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs
@@ -1144,35 +1144,41 @@ fn check_call_expression_return_type_portability_skip_when_disabled() {
 // ── TS2883 portability check: symlinked-monorepo nested package ─────
 
 /// Build an empty `DeclarationEmitter` whose only purpose is exercising the
-/// path-shape helpers (`strip_ts_extensions`, `calculate_relative_path`).
+/// path-shape helpers (`strip_module_path_extension`, `calculate_relative_path`).
 fn make_path_only_emitter<'a>(parser: &'a ParserState) -> DeclarationEmitter<'a> {
     DeclarationEmitter::new(&parser.arena)
 }
 
 #[test]
-fn strip_ts_extensions_restores_arbitrary_extension_declaration_user_form() {
+fn strip_module_path_extension_restores_arbitrary_extension_declaration_user_form() {
     let (parser, _root) = parse_test_source("");
     let emitter = make_path_only_emitter(&parser);
 
-    assert_eq!(emitter.strip_ts_extensions("./foo.d.html.ts"), "./foo.html");
     assert_eq!(
-        emitter.strip_ts_extensions("../styles.d.css.ts"),
+        emitter.strip_module_path_extension("./foo.d.html.ts"),
+        "./foo.html"
+    );
+    assert_eq!(
+        emitter.strip_module_path_extension("../styles.d.css.ts"),
         "../styles.css"
     );
     assert_eq!(
-        emitter.strip_ts_extensions("components/Button.d.svelte.ts"),
+        emitter.strip_module_path_extension("components/Button.d.svelte.ts"),
         "components/Button.svelte"
     );
 }
 
 #[test]
-fn strip_ts_extensions_leaves_regular_ts_js_declaration_shapes_on_normal_path() {
+fn strip_module_path_extension_leaves_regular_ts_js_declaration_shapes_on_normal_path() {
     let (parser, _root) = parse_test_source("");
     let emitter = make_path_only_emitter(&parser);
 
-    assert_eq!(emitter.strip_ts_extensions("./foo.d.ts"), "./foo");
-    assert_eq!(emitter.strip_ts_extensions("./foo.d.mts"), "./foo");
-    assert_eq!(emitter.strip_ts_extensions("./foo.d.js.ts"), "./foo.d.js");
+    assert_eq!(emitter.strip_module_path_extension("./foo.d.ts"), "./foo");
+    assert_eq!(emitter.strip_module_path_extension("./foo.d.mts"), "./foo");
+    assert_eq!(
+        emitter.strip_module_path_extension("./foo.d.js.ts"),
+        "./foo.d.js"
+    );
 }
 
 #[test]

--- a/crates/tsz-lsp/src/completions/import_paths.rs
+++ b/crates/tsz-lsp/src/completions/import_paths.rs
@@ -8,7 +8,9 @@
 //! This is separate from string literal completions which handle
 //! string arguments in function calls.
 
-use tsz_common::file_extensions::{KNOWN_MODULE_EXTENSIONS, strip_known_extension};
+use tsz_common::file_extensions::{
+    KNOWN_MODULE_EXTENSIONS, strip_known_extension as strip_ts_extension,
+};
 
 use super::{CompletionItem, CompletionItemKind, sort_priority};
 
@@ -115,17 +117,6 @@ fn is_importable_file(path: &str) -> bool {
     KNOWN_MODULE_EXTENSIONS
         .iter()
         .any(|ext| path.ends_with(ext))
-}
-
-/// Strip TypeScript/JavaScript extensions from a path for module specifiers.
-///
-/// Delegates to [`tsz_common::file_extensions::strip_known_extension`] which
-/// handles declaration extensions (`.d.ts`, `.d.mts`, `.d.cts`) correctly —
-/// longest suffix first — so `"types.d.ts"` → `"types"` while
-/// `"types.d.tsx"` → `"types.d"` (`.tsx` is a source extension, not a
-/// declaration extension, so only `.tsx` is stripped).
-fn strip_ts_extension(path: &str) -> &str {
-    strip_known_extension(path)
 }
 
 /// Compute a relative path from `from_dir` to `to_file`.

--- a/crates/tsz-lsp/src/project/module_specifiers.rs
+++ b/crates/tsz-lsp/src/project/module_specifiers.rs
@@ -14,7 +14,6 @@ use tsz_parser::parser::node::NodeAccess;
 
 use super::{ImportSpecifierPreference, Project};
 
-use tsz_common::file_extensions::TS_FAMILY_EXTENSIONS as TS_EXTENSION_SUFFIXES;
 use tsz_common::file_extensions::TSC_TS_RESOLUTION_EXTENSIONS_BARE as TS_EXTENSION_CANDIDATES;
 
 mod helpers;
@@ -757,8 +756,8 @@ impl Project {
             return None;
         }
 
-        let from_path = strip_ts_extension(&normalize_path(Path::new(from_file)));
-        let target_path = strip_ts_extension(&normalize_path(Path::new(target_file)));
+        let from_path = strip_ts_path_extension(&normalize_path(Path::new(from_file)));
+        let target_path = strip_ts_path_extension(&normalize_path(Path::new(target_file)));
         let style = self.relative_import_style(from_file);
         let mut best_spec: Option<String> = None;
 
@@ -1028,7 +1027,7 @@ impl Project {
         let from_dir = Path::new(from_file)
             .parent()
             .unwrap_or_else(|| Path::new(""));
-        let target_path = strip_ts_extension(Path::new(target_file));
+        let target_path = strip_ts_path_extension(Path::new(target_file));
         let relative = relative_path(from_dir, &target_path);
 
         let mut spec = path_to_string(&relative).replace('\\', "/");

--- a/crates/tsz-lsp/src/project/module_specifiers/helpers.rs
+++ b/crates/tsz-lsp/src/project/module_specifiers/helpers.rs
@@ -1,4 +1,7 @@
 use super::*;
+use tsz_common::file_extensions::{
+    strip_known_extension, strip_ts_extension as strip_ts_specifier_extension,
+};
 
 /// Rank a [`SpecifierCandidateSet`] into a deduplicated, ordered list of
 /// import specifier strings, applying the caller's `pref` policy.
@@ -122,27 +125,28 @@ pub(super) fn normalize_path(path: &Path) -> PathBuf {
     normalized
 }
 
-pub(super) fn strip_ts_extension(path: &Path) -> PathBuf {
+fn strip_path_file_extension(path: &Path, strip: fn(&str) -> &str) -> PathBuf {
     let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
         return path.to_path_buf();
     };
 
-    for suffix in TS_EXTENSION_SUFFIXES {
-        if let Some(base_name) = file_name.strip_suffix(suffix) {
-            if base_name.is_empty() {
-                return path.to_path_buf();
-            }
-            let mut base = PathBuf::new();
-            if let Some(parent) = path.parent() {
-                base.push(parent);
-            }
-            base.push(base_name);
-            return base;
-        }
+    let base_name = strip(file_name);
+    if base_name == file_name || base_name.is_empty() {
+        return path.to_path_buf();
     }
 
-    path.to_path_buf()
+    let mut base = PathBuf::new();
+    if let Some(parent) = path.parent() {
+        base.push(parent);
+    }
+    base.push(base_name);
+    base
 }
+
+pub(super) fn strip_ts_path_extension(path: &Path) -> PathBuf {
+    strip_path_file_extension(path, strip_ts_specifier_extension)
+}
+
 pub(super) fn split_node_modules_package_path(package_path: &str) -> Option<(String, String)> {
     let mut segments = package_path.split('/');
     let first = segments.next()?;
@@ -813,28 +817,7 @@ pub(super) fn resolve_path_mapping_target(
 }
 
 pub(super) fn strip_js_ts_extension(path: &Path) -> PathBuf {
-    const SOURCE_SUFFIXES: [&str; 11] = [
-        ".d.ts", ".d.mts", ".d.cts", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs",
-    ];
-    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
-        return path.to_path_buf();
-    };
-
-    for suffix in SOURCE_SUFFIXES {
-        if let Some(base_name) = file_name.strip_suffix(suffix) {
-            if base_name.is_empty() {
-                return path.to_path_buf();
-            }
-            let mut base = PathBuf::new();
-            if let Some(parent) = path.parent() {
-                base.push(parent);
-            }
-            base.push(base_name);
-            return base;
-        }
-    }
-
-    path.to_path_buf()
+    strip_path_file_extension(path, strip_known_extension)
 }
 
 /// Returns the runtime (emit) extension for a source file path, preserving
@@ -870,4 +853,37 @@ pub(super) fn has_source_extension(path: &str) -> bool {
         || normalized.ends_with(".jsx")
         || normalized.ends_with(".mjs")
         || normalized.ends_with(".cjs")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_ts_path_extension_uses_shared_ts_family_rules() {
+        assert_eq!(
+            strip_ts_path_extension(Path::new("src/types.d.cts")),
+            PathBuf::from("src/types")
+        );
+        assert_eq!(
+            strip_ts_path_extension(Path::new("src/types.d.tsx")),
+            PathBuf::from("src/types.d")
+        );
+        assert_eq!(
+            strip_ts_path_extension(Path::new("src/runtime.mjs")),
+            PathBuf::from("src/runtime.mjs")
+        );
+    }
+
+    #[test]
+    fn strip_js_ts_extension_uses_shared_known_extension_rules() {
+        assert_eq!(
+            strip_js_ts_extension(Path::new("src/runtime.mjs")),
+            PathBuf::from("src/runtime")
+        );
+        assert_eq!(
+            strip_js_ts_extension(Path::new("src/types.d.tsx")),
+            PathBuf::from("src/types.d")
+        );
+    }
 }


### PR DESCRIPTION
Goal: hold

## AgentName
Codex

## Track
hold / cross-crate helper hygiene

## Invariant
JS string escaping and TS/JS module-extension stripping have one canonical implementation in `tsz-common`; callers may keep domain-specific wrappers only when they add policy such as declaration-emitter arbitrary-extension restoration.

## Scope
- Expanded `tsz_common::source_map::escape_js_string` to cover the control characters and JS line separators previously handled by local server helpers.
- Replaced checker, CLI server, LSP, and emitter extension-stripping copies with `tsz_common::file_extensions::strip_known_extension` or `strip_ts_extension` where appropriate.
- Kept the declaration emitter's arbitrary-extension declaration path policy, but renamed it away from the old duplicated helper name and delegated its normal path to the shared helper.
- Added focused tests for `.d.cts` / `.d.tsx` stripping and common JS escaping behavior.

## Project Corpus Impact
None expected. This is shared helper consolidation for module-specifier display/resolution normalization and server display escaping; no project-row fixture behavior is intentionally changed beyond removing local extension-list divergence.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-common -E 'test(escape_js_string_control_and_js_line_separators) or test(strip_known_extension_drops_both_families)'`
- `scripts/safe-run.sh cargo check -p tsz-lsp`
- `scripts/safe-run.sh cargo check -p tsz-emitter`
- Attempted `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib -E 'test(test_strip_ts_extension) or test(test_strip_dts_before_ts)'`; blocked by local disk ENOSPC while linking the `tsz-checker` lib test binary.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium

## Coordination Notes
Closes #13107. Verified the old local helper-name audit now finds only the canonical common `strip_ts_extension` implementation plus test names; broader cross-crate coverage is left to PR CI. Metadata CI was refreshed after exact-head full CI passed so branch protection sees the required `CI Summary` check.

