### PR TITLE
fix(solver): relate alias return types through genuine unknown evaluations (#13212 F1)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -366,6 +366,9 @@ mod rest_parameter_tests;
 #[path = "../tests/rest_tuple_contextual_typing_tests.rs"]
 mod rest_tuple_contextual_typing_tests;
 #[cfg(test)]
+#[path = "tests/return_alias_unknown_eval_assignability_tests.rs"]
+mod return_alias_unknown_eval_assignability_tests;
+#[cfg(test)]
 #[path = "tests/return_relation_routing_arch_tests.rs"]
 mod return_relation_routing_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/return_alias_unknown_eval_assignability_tests.rs
+++ b/crates/tsz-checker/src/tests/return_alias_unknown_eval_assignability_tests.rs
@@ -1,0 +1,177 @@
+//! Signature-return aliases that legitimately evaluate to `unknown` must
+//! relate through their evaluated form (issue #13212, valibot F1 family).
+//!
+//! Structural rule: when a function return type is an alias `Application` /
+//! `Lazy` reference whose evaluation genuinely produces `unknown`, tsc
+//! relates the evaluated form (`unknown` relates to `unknown`); tsz does the
+//! same through `check_return_compat`, taking the raw-form fallback only
+//! when the referenced body is missing or still an `unknown` placeholder.
+//! Additionally, results computed under `bypass_evaluation` are never
+//! persisted in the shared relation cache, so a raw-mode comparison cannot
+//! poison later full-evaluation checks of the same `(source, target)` pair
+//! (the `'x' is not assignable to 'x'` sibling-member false positives).
+
+use tsz_common::options::checker::CheckerOptions;
+
+fn diags_strict(source: &str) -> Vec<crate::diagnostics::Diagnostic> {
+    let opts = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    crate::test_utils::check_source(source, "test.ts", opts)
+}
+
+fn assert_clean(source: &str) {
+    let diags = diags_strict(source);
+    assert!(
+        diags.is_empty(),
+        "Expected no diagnostics (tsc-clean); got: {diags:?}"
+    );
+}
+
+/// The valibot gate repro: a conditional alias whose branches are both
+/// `unknown`, referenced in signature-return position of a generic
+/// interface member. Both the `run` member and the sibling literal member
+/// `kind` must relate (the latter regressed via relation-cache poisoning).
+#[test]
+fn conditional_alias_unknown_return_in_generic_interface_member() {
+    assert_clean(
+        r#"
+type C<T> = T extends 1 ? unknown : unknown;
+interface A<T> {
+  readonly kind: 'transformation';
+  readonly run: () => C<T>;
+  readonly x: T;
+}
+function make(x: number): A<number> {
+  return { kind: 'transformation', x, run: () => 1 as unknown };
+}
+"#,
+    );
+}
+
+/// Same shape with renamed binders and a different discriminant literal.
+#[test]
+fn conditional_alias_unknown_return_renamed_binders() {
+    assert_clean(
+        r#"
+type Indirection<Z> = Z extends 9 ? unknown : unknown;
+interface Holder<Q> {
+  readonly tag: 'holder';
+  readonly cb: () => Indirection<Q>;
+  readonly val: Q;
+}
+const h: Holder<string> = { tag: 'holder', cb: () => 'x' as unknown, val: 'ok' };
+"#,
+    );
+}
+
+/// Bare function-type positions (no interface): `() => unknown` must be
+/// assignable to `() => C<number>` when `C<number>` evaluates to `unknown`.
+#[test]
+fn conditional_alias_unknown_return_in_function_return_position() {
+    assert_clean(
+        r#"
+type C<T> = T extends 1 ? unknown : unknown;
+function make(): () => C<number> {
+  return () => 1 as unknown;
+}
+"#,
+    );
+}
+
+/// Unit-type and nullish sources against an unknown-evaluating alias target
+/// (the issue's adjacent matrix: `undefined`/`null`/`void` sources failed,
+/// `1` passed — all must pass).
+#[test]
+fn unit_and_nullish_sources_against_unknown_evaluating_alias_target() {
+    assert_clean(
+        r#"
+type Cond<T> = T extends 1 ? unknown : unknown;
+const f1: () => Cond<2> = () => undefined;
+const f2: () => Cond<2> = () => null;
+const f3: () => Cond<2> = () => {};
+const f4: () => Cond<2> = () => 1;
+"#,
+    );
+}
+
+/// Pure indexed-access alias (not conditional-specific): an alias whose body
+/// is an indexed access producing `unknown` in signature-return position.
+#[test]
+fn indexed_access_alias_unknown_return_in_interface_member() {
+    assert_clean(
+        r#"
+interface BaseSchema { types: { output: unknown } }
+type Get<B extends BaseSchema> = B['types']['output'];
+interface Wrapper<S extends BaseSchema> {
+  readonly tag: 'wrap';
+  readonly run: () => Get<S>;
+}
+function mk(): Wrapper<BaseSchema> {
+  return { tag: 'wrap', run: () => 0 as unknown };
+}
+"#,
+    );
+}
+
+/// Negative case: an alias that evaluates to `string` must still reject a
+/// number-returning source — skipping the raw fallback must not mask real
+/// mismatches in the evaluated relation.
+#[test]
+fn alias_evaluating_to_string_still_rejects_number_source() {
+    let diags = diags_strict(
+        r#"
+type Pick1<T> = T extends 1 ? string : string;
+function bad(): () => Pick1<number> {
+  return () => 42;
+}
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "Expected TS2322 for number source vs string-evaluating alias; got: {diags:?}"
+    );
+}
+
+/// Negative case: the unknown-evaluating alias as the SOURCE return type is
+/// still not assignable to a concrete target return type (`unknown` is only
+/// assignable to `unknown`/`any`).
+#[test]
+fn unknown_evaluating_alias_source_still_rejected_against_string_target() {
+    let diags = diags_strict(
+        r#"
+type U<T> = T extends 1 ? unknown : unknown;
+function bad(): () => string {
+  return (() => 0 as unknown) as () => U<number>;
+}
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| {
+            d.code == 2322
+                && (d
+                    .message_text
+                    .contains("'unknown' is not assignable to type 'string'")
+                    || d.related_information.iter().any(|r| {
+                        r.message_text
+                            .contains("'unknown' is not assignable to type 'string'")
+                    }))
+        }),
+        "Expected TS2322 elaborating unknown vs string; got: {diags:?}"
+    );
+}
+
+/// Property position (already-passing control from the issue's adjacent
+/// matrix) stays clean alongside the signature-return fix.
+#[test]
+fn unknown_evaluating_alias_in_property_position_stays_clean() {
+    assert_clean(
+        r#"
+type C<T> = T extends 1 ? unknown : unknown;
+interface P<T> { p: C<T> }
+const v: P<number> = { p: 1 as unknown };
+"#,
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -457,9 +457,22 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // (correctness-preserving: the result is recomputed later), never
         // produces a wrong answer. Captures `lazy_failures_at_entry` and
         // `weak_sensitivity_at_entry` from the enclosing scope by name.
+        //
+        // Results computed under `bypass_evaluation` are also never written:
+        // that mode compares raw alias/meta forms without expanding them, so
+        // its answers can differ from full-evaluation answers for the same
+        // pair, and the flag-agnostic `RelationCacheKey` cannot tell the two
+        // modes apart. Persisting a raw-mode `False` (e.g. `unknown` vs an
+        // alias application that evaluates to `unknown`) would poison every
+        // later full-evaluation check of the same pair, from any raw-mode
+        // entry point (`check_return_compat`'s placeholder fallback, the
+        // evaluator's union/intersection simplification). Reads stay shared:
+        // a full-evaluation answer is the more precise result for the same
+        // relation, so serving it to a bypass-mode query is sound.
         macro_rules! cache_definitive {
             ($db:expr, $key:expr, $result:expr) => {
-                if lazy_resolve_failure_count() == lazy_failures_at_entry
+                if !self.bypass_evaluation
+                    && lazy_resolve_failure_count() == lazy_failures_at_entry
                     && weak_type_sensitivity_count() == weak_sensitivity_at_entry
                 {
                     match $result {

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
@@ -915,16 +915,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return SubtypeResult::True;
         }
 
-        let source_needs_raw_fallback = matches!(
-            self.interner.lookup(source_return),
-            Some(TypeData::Application(_) | TypeData::Lazy(_))
-        ) && self.evaluate_type(source_return) == TypeId::UNKNOWN;
-        let target_needs_raw_fallback = matches!(
-            self.interner.lookup(target_return),
-            Some(TypeData::Application(_) | TypeData::Lazy(_))
-        ) && self.evaluate_type(target_return) == TypeId::UNKNOWN;
+        let needs_raw_fallback = self.return_type_needs_raw_fallback(source_return)
+            || self.return_type_needs_raw_fallback(target_return);
 
-        if source_needs_raw_fallback || target_needs_raw_fallback {
+        if needs_raw_fallback {
             let prev = self.bypass_evaluation;
             self.bypass_evaluation = true;
             let raw_result = self.check_subtype(source_return, target_return);
@@ -943,6 +937,57 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         } else {
             self.check_subtype(source_return, target_return)
         }
+    }
+
+    /// Whether a return type must be compared in its raw alias form by
+    /// [`Self::check_return_compat`]: an `Application`/`Lazy` reference whose
+    /// evaluation produced `unknown` as a placeholder for a missing body,
+    /// rather than as a genuine evaluation result.
+    ///
+    /// A reference the resolver maps to a real body (e.g. `C<number>` where
+    /// `type C<T> = T extends 1 ? unknown : unknown`) makes the evaluator's
+    /// `unknown` answer authoritative: the relation must compare the
+    /// evaluated form (`unknown` relates to `unknown`), not the raw alias
+    /// shape. Only an unresolvable reference — no defining `DefId`, no
+    /// registered body, an `unknown` placeholder body (cross-file body not
+    /// yet registered), or a self-referential `Lazy` wrapper — justifies the
+    /// raw-form fallback.
+    ///
+    /// Detecting a placeholder also records an undetermined-result event
+    /// (`note_lazy_resolve_failure`): any relation result derived from the
+    /// raw comparison is schedule-dependent and must not be memoized as
+    /// definitive in the shared relation cache.
+    fn return_type_needs_raw_fallback(&mut self, return_type: TypeId) -> bool {
+        // Single interner lookup yields both the alias-shape gate and the
+        // defining `DefId` (this runs for every function-pair return check).
+        let def_id = match self.interner.lookup(return_type) {
+            Some(TypeData::Lazy(def_id)) => Some(def_id),
+            Some(TypeData::Application(app_id)) => {
+                let base = self.interner.type_application(app_id).base;
+                crate::visitor::lazy_def_id(self.interner, base)
+            }
+            _ => return false,
+        };
+        if self.evaluate_type(return_type) != TypeId::UNKNOWN {
+            return false;
+        }
+        let is_placeholder = match def_id {
+            Some(def_id) => match self.resolver.resolve_lazy(def_id, self.interner) {
+                Some(body) => {
+                    body == TypeId::UNKNOWN
+                        || matches!(
+                            self.interner.lookup(body),
+                            Some(TypeData::Lazy(body_def)) if body_def == def_id
+                        )
+                }
+                None => true,
+            },
+            None => true,
+        };
+        if is_placeholder {
+            crate::relations::subtype::cache::note_lazy_resolve_failure();
+        }
+        is_placeholder
     }
 
     pub(crate) fn instantiate_function_shape(


### PR DESCRIPTION
Goal: green

Fixes the F1 gate repro of #13212 (valibot row, `unknown ≰ unknown` / `'transformation' ≰ 'transformation'` false positives).

## Structural rule

When a function return type is an `Application`/`Lazy` alias reference whose evaluation genuinely produces `unknown` (e.g. `type C<T> = T extends 1 ? unknown : unknown` in signature-return position), tsc relates the evaluated form; tsz does the same through `check_return_compat`, taking the raw-form `bypass_evaluation` fallback only when the `unknown` evaluation is a placeholder for an unresolved body. Owner layer: solver relations (`relations/subtype`).

## Root cause

Two compounding defects, both witnessed on a 4-line repro (tsc 5.9.3 clean, tsz emitted 2 errors):

1. `check_return_compat`'s raw-form fallback treated **every** `unknown` evaluation of an alias return type as a failed-resolution sentinel and compared the raw forms under `bypass_evaluation`, rejecting `unknown -> C<number>` with `Type 'unknown' is not assignable to type 'unknown'`.
2. That bypass-mode `False` was persisted in the **shared relation cache**, whose flag-agnostic `RelationCacheKey` cannot distinguish raw-mode from full-evaluation answers — poisoning every later full-evaluation check of the same pair. This is what produced the impossible sibling-member failures (`'transformation' ≰ 'transformation'`), and is the same poisoning class behind the kysely "Two different types with this name exist" family.

## Fix

- `return_type_needs_raw_fallback` (relations/subtype/rules/functions/mod.rs): the fallback fires only when the reference is an unresolved placeholder — no defining `DefId`, no registered body, an `unknown` placeholder body (cross-file body not yet registered), or a self-referential `Lazy` wrapper. A resolvable body makes the evaluator's `unknown` answer authoritative. Placeholder detection records `note_lazy_resolve_failure()` so the surrounding relation results are not memoized as definitive (the cache-write asymmetry flagged as a latent neighbor in #12951).
- `cache_definitive!` (relations/subtype/cache.rs): never write shared relation-cache entries computed under `bypass_evaluation`, from any raw-mode entry point (return-compat fallback, evaluator union/intersection simplification). Reads stay shared — a full-evaluation answer is the more precise result for the same relation.

## Adjacent-case matrix (new regression tests, all matching tsc)

- Conditional alias to `unknown` in generic-interface member return position (the gate repro, including the sibling literal member) — clean.
- Same shape with renamed binders/discriminants; bare function-type positions — clean.
- Pure indexed-access alias (`B['types']['output']`) in return position — not conditional-specific — clean.
- `undefined`/`null`/`{}`/`1` sources against an unknown-evaluating alias target — clean (previously the nullish sources failed).
- Property position control — stays clean.
- Negative: alias evaluating to `string` vs number-returning source still emits TS2322; unknown-evaluating alias as *source* against `() => string` still emits TS2322 with the correct `unknown ≰ string` elaboration.

Fallback behavior for genuinely unresolved cross-file placeholder bodies is preserved (the helper returns `true` exactly for the placeholder shapes the fallback was built for).

## Verification

- `cargo test -p tsz-checker --lib return_alias_unknown_eval` — 8/8 new regression tests pass.
- `cargo test -p tsz-solver --lib relations` — 1353/1353 pass.
- Full `cargo test -p tsz-checker --lib` and `-p tsz-solver --lib`: failure sets byte-identical to base `main` (pre-existing failures only; the `source_option_bag_tests` module is order-dependent on both trees — 0/4 when module-filtered on base and on this branch alike).
- Repro matrix (gate repro + 9 adjacent cases) verified against the built CLI; negatives still error.
- Rebased on current `main` (`eacc8fc`), zero conflicts; ready-review CI owns the broad conformance/emit suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high

https://claude.ai/code/session_01F54FcGcSyWofoE3585kB7P

---
_Generated by [Claude Code](https://claude.ai/code/session_01F54FcGcSyWofoE3585kB7P)_