### PR TITLE
fix(checker,solver): lib-def identity-collision audit (7 families) + atomic def publication; finalize-freeze/defer as gated experiments

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -708,6 +708,31 @@ impl<'a> CheckerContext<'a> {
         }
     }
 
+    /// Resolve a lib symbol's `DefId`, verifying the def actually names
+    /// `expected_name`.
+    ///
+    /// Raw `SymbolId`s are binder-relative, and every lib-binder symbol
+    /// shares the `u32::MAX` declaration-file sentinel, so the raw-id
+    /// resolution in [`get_lib_def_id`](Self::get_lib_def_id) can answer with
+    /// a colliding def registered by a *different* lib binder for an
+    /// unrelated name (and `get_existing_def_id`'s name guard self-confirms
+    /// the collision because it derives the name from the first lib binder
+    /// owning the raw id). When the caller knows which name the symbol must
+    /// bind, verify the resolved def against it and, on mismatch, route
+    /// through the canonical name-keyed lib def resolution instead.
+    pub fn lib_def_id_verified(&self, expected_name: &str, sym_id: SymbolId) -> DefId {
+        let def_id = self.get_lib_def_id(sym_id);
+        if self
+            .definition_store
+            .get(def_id)
+            .is_some_and(|info| self.types.resolve_atom(info.name) == expected_name)
+        {
+            def_id
+        } else {
+            self.get_canonical_lib_def_id(expected_name, sym_id)
+        }
+    }
+
     /// Cache type parameters for a canonical lib symbol (without body registration).
     ///
     /// Combines [`get_canonical_lib_def_id`] + [`insert_def_type_params`] into a
@@ -729,24 +754,40 @@ impl<'a> CheckerContext<'a> {
 
     /// Register a lib type's DefId, type parameters, and body in one step.
     ///
-    /// Combines `get_lib_def_id` + `insert_def_type_params` +
+    /// Combines name-verified def resolution + `insert_def_type_params` +
     /// `register_def_auto_params_in_envs` into a single call, eliminating the
     /// repeated three-step pattern in `resolve_lib_type_by_name` (interface and
     /// type-alias branches) and `resolve_lib_type_with_params`.
     ///
+    /// `expected_name` is the bare name the resolved type binds (for
+    /// namespace-qualified lib types, the export name). The def resolution is
+    /// name-verified because this function *publishes* `body` into the shared
+    /// `DefinitionStore`: a raw-`SymbolId` resolution that collides across lib
+    /// binders would publish the body onto an unrelated def (the misdirected
+    /// write family the boxed-type identity fix closed).
+    ///
     /// Returns the `DefId` for subsequent use (e.g., creating `Lazy(DefId)`).
     pub fn register_lib_def_resolved(
         &self,
+        expected_name: &str,
         sym_id: SymbolId,
         body: TypeId,
         params: Vec<tsz_solver::TypeParamInfo>,
     ) -> DefId {
-        let def_id = self.get_lib_def_id(sym_id);
+        let def_id = self.get_or_create_def_id_for_symbol_name(sym_id, expected_name);
         self.insert_def_type_params(def_id, params.clone());
         self.register_def_auto_params_in_envs(def_id, body, params);
 
-        if let Some(symbol) = self.binder.get_symbol(sym_id) {
-            let canonical_def_id = self.get_canonical_lib_def_id(&symbol.escaped_name, sym_id);
+        // Mirror onto the canonical name-keyed def when it differs, but only
+        // when the main binder's symbol at this raw id actually names
+        // `expected_name` — otherwise the raw id belongs to an unrelated
+        // main-binder symbol and the mirror would target a colliding def.
+        if self
+            .binder
+            .get_symbol(sym_id)
+            .is_some_and(|symbol| symbol.escaped_name == expected_name)
+        {
+            let canonical_def_id = self.get_canonical_lib_def_id(expected_name, sym_id);
             if canonical_def_id != def_id {
                 let canonical_params = self.get_def_type_params(def_id).unwrap_or_default();
                 self.insert_def_type_params(canonical_def_id, canonical_params.clone());

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -22,6 +22,14 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 use tsz_solver::TypeParamInfo;
 
+/// Opt-in switch for the finalized-lib-def freeze (mutation-isolation
+/// experiment). Default OFF until augmentation-aware invalidation lands.
+pub(super) fn lib_def_freeze_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| std::env::var("TSZ_ENABLE_LIB_DEF_FREEZE").is_ok_and(|v| v == "1"))
+}
+
 impl<'a> CheckerState<'a> {
     pub(crate) fn resolve_actual_lib_name_to_def_id_for_lowering(
         &self,
@@ -36,6 +44,28 @@ impl<'a> CheckerState<'a> {
             .global_augmentations
             .get(name)
             .is_some_and(|v| !v.is_empty())
+    }
+
+    /// Whether ANY file in the program declares a global augmentation for
+    /// `name`. The lib-def freeze must be gated program-wide, not on the
+    /// current checker's binder: a non-augmenting file can resolve (and would
+    /// otherwise freeze) a lib name before the augmenting file's
+    /// `declare global` merge runs, pinning the pre-augmentation form into the
+    /// shared store (witness: importMeta.ts). When the cross-file binder set
+    /// is unavailable, conservatively report `true` so the freeze stays off.
+    pub(crate) fn any_program_file_augments_lib_name(&self, name: &str) -> bool {
+        if self.lib_name_has_local_augmentation(name) {
+            return true;
+        }
+        let Some(binders) = self.ctx.all_binders.as_ref() else {
+            return true;
+        };
+        binders.iter().any(|binder| {
+            binder
+                .global_augmentations
+                .get(name)
+                .is_some_and(|v| !v.is_empty())
+        })
     }
 
     fn lib_name_depends_on_builtin_iterator_return(name: &str) -> bool {

--- a/crates/tsz-checker/src/types/queries/lib_augmentations.rs
+++ b/crates/tsz-checker/src/types/queries/lib_augmentations.rs
@@ -10,14 +10,14 @@ use super::lib_resolution::{
     augmentation_def_id_from_node, no_value_resolver, resolve_augmentation_node,
 };
 
-/// Mutation-isolation campaign prototype gate: the `finalize` variant of the
-/// `TSZ_EXPERIMENT_LIB_DEF_PUBLISH_ONCE` experiment freezes each lib def's
-/// shared-store body at its finalized publication point.
-fn lib_def_freeze_at_finalize_enabled() -> bool {
+/// Mutation-isolation campaign: freeze each lib def's shared-store body at
+/// its *finalized* publication point (heritage-merged + augmented), so later
+/// checkers' re-finalizations cannot republish a different (checker-relative)
+/// form. Default-on; `TSZ_DISABLE_LIB_DEF_FREEZE=1` is the kill switch for
+/// A/B parity measurement.
+pub(crate) fn lib_def_finalize_freeze_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| {
-        std::env::var("TSZ_EXPERIMENT_LIB_DEF_PUBLISH_ONCE").is_ok_and(|v| v == "finalize")
-    })
+    *ENABLED.get_or_init(|| !std::env::var("TSZ_DISABLE_LIB_DEF_FREEZE").is_ok_and(|v| v == "1"))
 }
 
 impl<'a> CheckerState<'a> {
@@ -190,12 +190,46 @@ impl<'a> CheckerState<'a> {
             return;
         }
         let type_params = self.ctx.get_def_type_params(def_id).unwrap_or_default();
+        // Publish through the store's finalize entry point first: it bypasses
+        // the deferred-publication drop (the finalized form must replace any
+        // earlier intermediate form), and the env registration below then
+        // write-throughs the identical body (a no-op same-body publication).
+        self.ctx.definition_store.set_body_finalized(
+            def_id,
+            ty,
+            (!type_params.is_empty()).then(|| type_params.clone()),
+        );
         self.ctx
             .register_def_auto_params_in_envs(def_id, ty, type_params);
-        // Mutation-isolation campaign prototype (`finalize` variant): freeze
-        // the shared-store body at the finalized publication point so later
-        // checkers' re-finalizations cannot republish a different form.
-        if lib_def_freeze_at_finalize_enabled() {
+    }
+
+    /// Mutation-isolation campaign: freeze `name`'s lib def body in the
+    /// shared store after a **cleanly completed** resolution (not
+    /// heritage-incomplete, not locally augmented), so later checkers'
+    /// re-finalizations cannot republish a different (checker-relative) form.
+    ///
+    /// Freezing must only happen at clean completion: the incomplete-heritage
+    /// recovery path (#12299) intentionally re-resolves the name and
+    /// *overwrites* the def body with the flattened form — freezing the
+    /// incomplete body would suppress that recovery and drop inherited
+    /// members (false `TS2339`).
+    pub(crate) fn freeze_finalized_lib_def(&mut self, name: &str) {
+        if !lib_def_finalize_freeze_enabled() {
+            return;
+        }
+        // Declaration emit is out of scope for the freeze: emit nameability
+        // analysis (TS7056 and friends) is sensitive to which checker's lib
+        // body TypeId the shared store carries, and freezing the first
+        // checker's form regresses tsc parity there. The campaign target is
+        // the checking pipeline (parallel gate-lift); the emit lane keeps
+        // last-writer-wins semantics until emit type identity is owned.
+        if self.ctx.emit_declarations() {
+            return;
+        }
+        let name_atom = self.ctx.types.intern_string(name);
+        if let Some(defs) = self.ctx.definition_store.find_defs_by_name(name_atom)
+            && let Some(&def_id) = defs.first()
+        {
             self.ctx.definition_store.mark_publish_once(def_id);
         }
     }

--- a/crates/tsz-checker/src/types/queries/lib_namespace_direct.rs
+++ b/crates/tsz-checker/src/types/queries/lib_namespace_direct.rs
@@ -163,7 +163,14 @@ impl<'a> CheckerState<'a> {
             if let Some(namespace) = namespace
                 && let Some(sym_id) = self.resolve_lib_namespace_export_symbol(namespace, type_name)
             {
-                return Some(self.ctx.get_lib_def_id(sym_id));
+                // Namespace-export SymbolIds are relative to the lib binder
+                // owning the export table; resolve the def name-verified so a
+                // raw-id collision with another lib binder cannot answer with
+                // an unrelated def.
+                return Some(
+                    self.ctx
+                        .get_or_create_def_id_for_symbol_name(sym_id, type_name),
+                );
             }
             self.resolve_actual_lib_name_to_def_id_for_lowering(type_name)
                 .or_else(|| self.resolve_entity_name_text_to_def_id_for_lowering(type_name))
@@ -198,7 +205,12 @@ impl<'a> CheckerState<'a> {
             ty = self.merge_lib_interface_heritage(ty, cache_name).0;
         }
 
-        self.ctx.register_lib_def_resolved(sym_id, ty, params);
+        // For namespace-qualified lib types the def is registered under the
+        // bare export name (the symbol's escaped name), not the dotted cache
+        // key.
+        let bare_name = cache_name.rsplit('.').next().unwrap_or(cache_name);
+        self.ctx
+            .register_lib_def_resolved(bare_name, sym_id, ty, params);
         self.ensure_relation_input_ready(ty);
         self.ctx
             .lib_type_resolution_cache
@@ -303,7 +315,9 @@ impl<'a> CheckerState<'a> {
                         && let Some(sym_id) =
                             self.resolve_lib_namespace_export_symbol(namespace, &name)
                     {
-                        return Some(self.ctx.get_lib_def_id(sym_id));
+                        // Name-verified: see the namespace-export resolver in
+                        // `resolve_lib_interface_type_by_symbol` above.
+                        return Some(self.ctx.get_or_create_def_id_for_symbol_name(sym_id, &name));
                     }
                     self.resolve_actual_lib_name_to_def_id_for_lowering(&name)
                         .or_else(|| self.resolve_entity_name_text_to_def_id_for_lowering(&name))

--- a/crates/tsz-checker/src/types/queries/lib_resolution.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution.rs
@@ -213,11 +213,15 @@ pub(crate) fn lib_def_id_from_node(
     fallback_arena: &NodeArena,
 ) -> Option<tsz_solver::DefId> {
     let sym_id = resolve_lib_node_in_arenas(binder, node_idx, decl_arenas, fallback_arena)?;
-    if binder
+    if let Some(symbol) = binder
         .get_symbol_with_libs(sym_id, &[])
-        .is_some_and(|symbol| symbol.has_any_flags(tsz_binder::symbol_flags::TYPE_PARAMETER))
+        .filter(|symbol| symbol.has_any_flags(tsz_binder::symbol_flags::TYPE_PARAMETER))
     {
-        return Some(ctx.get_lib_def_id(sym_id));
+        // The owning binder says this is a type parameter; resolve the def
+        // name-verified against that binder's symbol name so a raw-id
+        // collision with another lib binder cannot answer with an unrelated
+        // def.
+        return Some(ctx.get_or_create_def_id_for_symbol_name(sym_id, &symbol.escaped_name));
     }
 
     if let Some(name) = entity_name_text_from_decl_arenas(node_idx, decl_arenas, fallback_arena) {
@@ -233,6 +237,11 @@ pub(crate) fn lib_def_id_from_node(
         return Some(ctx.get_canonical_lib_def_id(expected_name, sym_id));
     }
 
+    // No syntactic name available; verify against the owning binder's symbol
+    // name instead of trusting the raw-id resolution.
+    if let Some(symbol) = binder.get_symbol_with_libs(sym_id, &[]) {
+        return Some(ctx.get_or_create_def_id_for_symbol_name(sym_id, &symbol.escaped_name));
+    }
     Some(ctx.get_lib_def_id(sym_id))
 }
 
@@ -250,14 +259,13 @@ pub(crate) fn lib_def_id_from_node_in_lib_contexts(
 ) -> Option<tsz_solver::DefId> {
     let sym_id =
         resolve_lib_node_in_lib_contexts(node_idx, decl_arenas, fallback_arena, lib_contexts)?;
-    if lib_contexts.iter().any(|ctx| {
-        ctx.binder
-            .get_symbol_with_libs(sym_id, &[])
-            .is_some_and(|symbol| symbol.has_any_flags(tsz_binder::symbol_flags::TYPE_PARAMETER))
-    }) {
-        return Some(ctx.get_lib_def_id(sym_id));
-    }
-
+    // NOTE: `resolve_lib_node_in_lib_contexts` only resolves through lib
+    // `file_locals` (name-keyed), which never hold type parameters. The old
+    // type-parameter probe here checked the raw SymbolId against *every* lib
+    // binder, so it could only fire on a raw-id collision with an unrelated
+    // binder's type-parameter symbol — and then resolved the def through the
+    // same context-agnostic raw-id path (the lib-def identity-collision
+    // family). Resolve by syntactic name instead.
     let name = entity_name_text_from_decl_arenas(node_idx, decl_arenas, fallback_arena)?;
     let expected_name = name
         .strip_prefix("globalThis.")
@@ -304,6 +312,11 @@ pub(crate) fn augmentation_def_id_from_node(
             .next()
             .unwrap_or(&name);
         Some(ctx.get_or_create_def_id_for_symbol_name(sym_id, expected_name))
+    } else if let Some(symbol) = binder.get_symbol_with_libs(sym_id, &[]) {
+        // No syntactic name; verify against the owning binder's symbol name
+        // instead of trusting the raw-id resolution (lib-def identity
+        // collision family).
+        Some(ctx.get_or_create_def_id_for_symbol_name(sym_id, &symbol.escaped_name))
     } else {
         Some(ctx.get_lib_def_id(sym_id))
     }
@@ -1222,6 +1235,33 @@ impl<'a> CheckerState<'a> {
 
         // `name` resolved completely; clear any in-progress / stale incomplete marker.
         clear_lib_resolution_mark(name);
+
+        // Mutation-isolation campaign: the body finalized above is the
+        // program-wide form for this lib def — freeze it so later checkers'
+        // re-finalizations (checker-relative TypeIds of the byte-identical
+        // semantic form) cannot republish a different body into the shared
+        // store. Only on clean completion (the heritage-incomplete recovery
+        // above must stay able to overwrite), and only for names without
+        // user-side augmentations (an augmented body is relative to the
+        // augmenting file set, so the program-wide form is owned by the
+        // augmentation-merging path, not this one). Unlike the shared-cache
+        // gate below, builtin-merged names (Array, `Intl.*`,
+        // iterator-return-dependent interfaces) are still frozen: within one
+        // program their finalized bodies are option-stable, and per-file
+        // checkers keep using their own `TypeEnvironment` bodies for local
+        // resolution.
+        // OPT-IN (TSZ_ENABLE_LIB_DEF_FREEZE=1): freezing still regresses the
+        // declare-global augmentation class even with the program-wide name
+        // gate (witness: importMeta.ts gains a spurious TS2345 — a def
+        // RELATED to the augmented name gets pinned through a channel the
+        // name gate does not cover). The mutation-isolation campaign needs
+        // augmentation-aware freeze invalidation before this can default on.
+        if super::lib::lib_def_freeze_enabled()
+            && lib_type_id.is_some()
+            && !self.any_program_file_augments_lib_name(name)
+        {
+            self.freeze_finalized_lib_def(name);
+        }
 
         // Generic lib interfaces had their type params cached above.
         self.ctx

--- a/crates/tsz-checker/src/types/queries/lib_resolution_selected.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution_selected.rs
@@ -59,7 +59,7 @@ pub(crate) fn register_selected_lib_def_resolved(
     params: Vec<TypeParamInfo>,
 ) -> DefId {
     if !selected_from_lib_context {
-        return ctx.register_lib_def_resolved(sym_id, ty, params);
+        return ctx.register_lib_def_resolved(name, sym_id, ty, params);
     }
 
     let def_id = ctx.get_canonical_lib_def_id(name, sym_id);

--- a/crates/tsz-checker/src/types/queries/lib_scoped_heritage.rs
+++ b/crates/tsz-checker/src/types/queries/lib_scoped_heritage.rs
@@ -72,11 +72,15 @@ impl<'a> CheckerState<'a> {
 
             let class_name = class_symbol.escaped_name.as_str();
             let return_base_sym = self.resolve_lib_symbol_by_name(class_name)?;
+            // `resolve_lib_symbol_by_name` can answer with a SymbolId from a
+            // lib binder other than the first raw-id owner; resolve the def
+            // name-verified so the Lazy heritage target cannot collide with
+            // an unrelated def.
             let return_base = self
                 .ctx
                 .types
                 .factory()
-                .lazy(self.ctx.get_lib_def_id(return_base_sym));
+                .lazy(self.ctx.lib_def_id_verified(class_name, return_base_sym));
             let type_params = self.collect_scoped_lib_class_type_params(
                 base.arena,
                 class_symbol.primary_declaration()?,

--- a/crates/tsz-checker/src/types/type_checking/global.rs
+++ b/crates/tsz-checker/src/types/type_checking/global.rs
@@ -381,28 +381,15 @@ impl<'a> CheckerState<'a> {
         // last-writer-wins in-flight channel the parallel-checking campaign
         // must eliminate). On mismatch, route through the canonical
         // name-keyed lib def resolution instead.
-        let boxed_def_for = |checker: &Self, name: &str, sym_id: tsz_binder::SymbolId| {
-            let def_id = checker.ctx.get_lib_def_id(sym_id);
-            let name_matches = checker
-                .ctx
-                .definition_store
-                .get(def_id)
-                .is_some_and(|info| checker.ctx.types.resolve_atom(info.name) == name);
-            if name_matches {
-                def_id
-            } else {
-                checker.ctx.get_canonical_lib_def_id(name, sym_id)
-            }
-        };
         for &(name, type_opt, kind) in boxed_names {
             let Some(ty) = type_opt else { continue };
             for ctx in self.ctx.lib_contexts.iter() {
                 if let Some(sym_id) = ctx.binder.file_locals.get(name) {
-                    boxed_def_entries.push((kind, ty, boxed_def_for(self, name, sym_id)));
+                    boxed_def_entries.push((kind, ty, self.ctx.lib_def_id_verified(name, sym_id)));
                 }
             }
             if let Some(sym_id) = self.ctx.binder.file_locals.get(name) {
-                boxed_def_entries.push((kind, ty, boxed_def_for(self, name, sym_id)));
+                boxed_def_entries.push((kind, ty, self.ctx.lib_def_id_verified(name, sym_id)));
             }
         }
         for &(kind, _ty, def_id) in &boxed_def_entries {
@@ -411,14 +398,18 @@ impl<'a> CheckerState<'a> {
 
         // Register ThisType marker DefIds so ThisTypeMarkerExtractor can identify
         // ThisType<T> applications when the base type is Lazy(DefId).
+        // Name-verified resolution (`lib_def_id_verified`): a raw per-lib
+        // SymbolId collision would register an *unrelated* def as the
+        // ThisType marker (same identity-collision family as the boxed-type
+        // registration fix above).
         for ctx in self.ctx.lib_contexts.iter() {
             if let Some(sym_id) = ctx.binder.file_locals.get("ThisType") {
-                let def_id = self.ctx.get_lib_def_id(sym_id);
+                let def_id = self.ctx.lib_def_id_verified("ThisType", sym_id);
                 self.ctx.types.register_this_type_def_id(def_id);
             }
         }
         if let Some(sym_id) = self.ctx.binder.file_locals.get("ThisType") {
-            let def_id = self.ctx.get_lib_def_id(sym_id);
+            let def_id = self.ctx.lib_def_id_verified("ThisType", sym_id);
             self.ctx.types.register_this_type_def_id(def_id);
         }
 
@@ -525,16 +516,19 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // Name-verified (`lib_def_id_verified`): a raw per-lib SymbolId
+        // collision would mark an unrelated def as the Function interface,
+        // corrupting `T extends Function` constraint checks.
         for ctx in self.ctx.lib_contexts.iter() {
             if let Some(sym_id) = ctx.binder.file_locals.get("Function") {
-                let def_id = self.ctx.get_lib_def_id(sym_id);
+                let def_id = self.ctx.lib_def_id_verified("Function", sym_id);
                 self.ctx
                     .types
                     .register_boxed_def_id(IntrinsicKind::Function, def_id);
             }
         }
         if let Some(sym_id) = self.ctx.binder.file_locals.get("Function") {
-            let def_id = self.ctx.get_lib_def_id(sym_id);
+            let def_id = self.ctx.lib_def_id_verified("Function", sym_id);
             self.ctx
                 .types
                 .register_boxed_def_id(IntrinsicKind::Function, def_id);

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -971,25 +971,31 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
             ),
         );
         shared_store.init_file_locks(program.files.len());
-        // Mutation-isolation campaign prototype: keep lib interface bodies
-        // immutable in the shared store after first materialization
-        // (first-writer-wins). Sequential checking order makes the first
-        // writer deterministic; the experiment measures republication
-        // suppression + diagnostic parity for this def class before the
-        // campaign promotes it to a pre-materialization pass.
-        // Two variants: `first` (default) freezes every lib interface def at
-        // its first body write; `finalize` lets the checker freeze each def
-        // at its finalized-body publication point instead (see
-        // `register_finalized_lib_body`).
-        match std::env::var("TSZ_EXPERIMENT_LIB_DEF_PUBLISH_ONCE") {
-            Ok(value) if value == "finalize" => {
-                tracing::info!("publish-once experiment: freeze-at-finalize variant");
-            }
-            Ok(_) => {
-                let marked = shared_store.mark_non_program_interface_defs_publish_once();
-                tracing::info!(marked, "publish-once experiment: lib interface defs marked");
-            }
-            Err(_) => {}
+        // Mutation-isolation campaign: lib interface defs are materialized
+        // once per program (prime checker + first-demand finalization under
+        // deterministic sequential order) and frozen at their finalized
+        // publication point (`freeze_finalized_lib_def`, default-on; kill
+        // switch `TSZ_DISABLE_LIB_DEF_FREEZE=1`). Deferred publication
+        // (default-on; kill switch `TSZ_DISABLE_LIB_DEF_DEFER_PUBLISH=1`)
+        // additionally drops the pre-finalize intermediate-stage overwrites
+        // so the shared store only observes `first form -> finalized form`
+        // for the class; per-file checkers keep refining through their own
+        // `TypeEnvironment` bodies.
+        //
+        // Declaration emit is out of scope (`!options.emit_declarations`,
+        // mirrored by `freeze_finalized_lib_def`): emit nameability analysis
+        // (TS7056 and friends) is sensitive to which checker's lib body
+        // TypeId the shared store carries.
+        // OPT-IN (TSZ_ENABLE_LIB_DEF_DEFER_PUBLISH=1): like the finalized-def
+        // freeze, deferred publication independently regresses the
+        // declare-global augmentation class (witness: importMeta.ts spurious
+        // TS2345) — pre-finalize forms it drops are load-bearing for
+        // augmented names. Needs augmentation-aware routing before default-on.
+        let defer_disabled = options.emit_declarations
+            || !std::env::var("TSZ_ENABLE_LIB_DEF_DEFER_PUBLISH").is_ok_and(|v| v == "1");
+        if !defer_disabled {
+            let marked = shared_store.mark_non_program_interface_defs_deferred();
+            tracing::debug!(marked, "lib interface defs marked deferred-publication");
         }
         program_context.shared_definition_store = Some(shared_store);
     }
@@ -1001,6 +1007,18 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
     // file checks. Tiny no-emit batches use the sequential reused-checker
     // path; that real checker primes itself before checking the first file, so
     // a separate prime checker would duplicate the same setup.
+    //
+    // Mutation-isolation campaign: this hook is also the once-per-program
+    // finalized lib-body materialization pre-pass. The prime checker resolves
+    // the boxed builtins (String/Number/Boolean/Object/Function/...) and the
+    // Array protocol through `resolve_lib_type_by_name`, which registers each
+    // def's *finalized* body (heritage-merged + augmented) and — default-on
+    // (`freeze_finalized_lib_def`, kill switch `TSZ_DISABLE_LIB_DEF_FREEZE=1`)
+    // — freezes it in the shared `DefinitionStore`. Lib interfaces the prime
+    // pass does not touch are materialized + frozen at first demand under the
+    // deterministic sequential checking order; per-file checkers afterwards
+    // consume the frozen bodies without republishing (different-body writes
+    // are dropped at the store).
     let has_js_input = program
         .files
         .iter()

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -365,15 +365,25 @@ pub struct DefinitionStore {
     /// matching tsc's collapse of the alias to the error type.
     depth_poisoned_defs: DefDashSet<DefId>,
 
-    /// Mutation-isolation campaign prototype: defs whose shared-store body is
-    /// **published once** — after the first body materialization, later
-    /// publications carrying a *different* body form are dropped instead of
-    /// overwriting (first-writer-wins instead of last-writer-wins). Used to
-    /// measure whether a def class can be pre-materialized and kept immutable
-    /// during per-file checking without diagnostic drift. Populated only when
-    /// the `TSZ_EXPERIMENT_LIB_DEF_PUBLISH_ONCE` experiment is enabled by the
-    /// driver; empty (and skipped via a cheap `is_empty` gate) otherwise.
+    /// Mutation-isolation campaign: defs whose shared-store body is
+    /// **frozen** — after the finalized body materialization
+    /// (heritage-merged + augmented lib interface form), later publications
+    /// carrying a *different* body form are dropped instead of overwriting
+    /// (the shared store stays immutable for the def; per-file checkers keep
+    /// using their own `TypeEnvironment` bodies). Populated by the checker's
+    /// finalized-lib-body registration; empty (and skipped via a cheap
+    /// `is_empty` gate) when freezing is disabled.
     publish_once_defs: DefDashSet<DefId>,
+
+    /// Mutation-isolation campaign experiment
+    /// (`TSZ_EXPERIMENT_LIB_DEF_DEFER_PUBLISH`): defs whose **pre-finalize**
+    /// different-body overwrites are deferred (dropped). The store keeps the
+    /// def's first published form until [`Self::set_body_finalized`]
+    /// overwrites it with the finalized form (which then freezes it via
+    /// `publish_once_defs`). Closes the intermediate-stage publication
+    /// residue (initial -> heritage-merged refinement writes) so the shared
+    /// store only ever observes `first form -> finalized form`.
+    deferred_publish_defs: DefDashSet<DefId>,
 
     /// Reverse index: `file_id` -> `Vec<DefId>` for per-file definition lookups.
     ///
@@ -635,6 +645,7 @@ impl DefinitionStore {
             directly_named_alias_bodies: DefDashSet::default(),
             depth_poisoned_defs: DefDashSet::default(),
             publish_once_defs: DefDashSet::default(),
+            deferred_publish_defs: DefDashSet::default(),
             shape_to_def: DefDashMap::default(),
             file_to_defs: DefDashMap::with_capacity_and_hasher(file_capacity, Default::default()),
             class_to_constructor: DefDashMap::with_capacity_and_hasher(
@@ -892,18 +903,48 @@ impl DefinitionStore {
         body: TypeId,
         params: Option<Vec<TypeParamInfo>>,
     ) {
-        // Mutation-isolation prototype: defs marked publish-once keep their
-        // first published body; a later attempt to overwrite it with a
-        // *different* body form is dropped (the shared store stays immutable
-        // for that def after first materialization). Identical republication
-        // is allowed through (it is a no-op write).
-        let suppressed = !self.publish_once_defs.is_empty()
-            && self.publish_once_defs.contains(&id)
-            && self
-                .definitions
-                .get(&id)
-                .and_then(|entry| entry.body)
-                .is_some_and(|prev| prev != body);
+        self.set_body_with_params_impl(id, body, params, false);
+    }
+
+    /// Publish a definition body through the **finalize entry point**.
+    ///
+    /// Identical to [`Self::set_body_with_params`] except that it bypasses
+    /// the deferred-publication drop (`deferred_publish_defs`): the finalized
+    /// lib-body form must overwrite whatever earlier form the store carries.
+    /// Frozen defs (`publish_once_defs`) still win — once a def's finalized
+    /// body is frozen, later checkers' re-finalizations (checker-relative
+    /// `TypeId`s for the byte-identical semantic form) are dropped.
+    #[track_caller]
+    pub fn set_body_finalized(&self, id: DefId, body: TypeId, params: Option<Vec<TypeParamInfo>>) {
+        self.set_body_with_params_impl(id, body, params, true);
+    }
+
+    #[track_caller]
+    fn set_body_with_params_impl(
+        &self,
+        id: DefId,
+        body: TypeId,
+        params: Option<Vec<TypeParamInfo>>,
+        finalize: bool,
+    ) {
+        // Mutation-isolation: defs frozen after their finalized
+        // materialization keep that body; a later attempt to overwrite it
+        // with a *different* body form is dropped (the shared store stays
+        // immutable for that def). Identical republication is allowed
+        // through (it is a no-op write).
+        let prev_body = self.definitions.get(&id).and_then(|entry| entry.body);
+        let is_different_overwrite = prev_body.is_some_and(|prev| prev != body);
+        let suppressed = is_different_overwrite
+            && !self.publish_once_defs.is_empty()
+            && self.publish_once_defs.contains(&id);
+        // Deferred-publication experiment: pre-finalize different-body
+        // overwrites of marked defs are dropped; only the finalize entry
+        // point may replace the first published form.
+        let deferred = !suppressed
+            && !finalize
+            && is_different_overwrite
+            && !self.deferred_publish_defs.is_empty()
+            && self.deferred_publish_defs.contains(&id);
         // Mutation-isolation campaign census (env-gated, see
         // `publication_census`): classify this publication against the
         // pre-write entry state with caller attribution.
@@ -917,6 +958,8 @@ impl DefinitionStore {
                     (
                         if suppressed {
                             publication_census::PublicationOutcome::SuppressedDifferentBody
+                        } else if deferred {
+                            publication_census::PublicationOutcome::DeferredDifferentBody
                         } else {
                             publication_census::classify(entry.body, body, params_changed, true)
                         },
@@ -934,7 +977,7 @@ impl DefinitionStore {
             };
             publication_census::record_publication(id, kind, name, file_id, body, outcome, caller);
         }
-        if suppressed {
+        if suppressed || deferred {
             return;
         }
         if let Some(mut entry) = self.definitions.get_mut(&id) {
@@ -988,17 +1031,19 @@ impl DefinitionStore {
         }
     }
 
-    /// Mutation-isolation campaign prototype: mark every **interface**
+    /// Mutation-isolation campaign experiment
+    /// (`TSZ_EXPERIMENT_LIB_DEF_DEFER_PUBLISH`): mark every **interface**
     /// definition that does not originate from a program source file (lib
     /// binder symbols carry the binder's "no declaration file" sentinel
-    /// index) as publish-once. After each such def's first body
-    /// materialization, later publications with a different body form are
-    /// dropped, keeping the shared store immutable for the class while
-    /// per-file checkers continue to use their own `TypeEnvironment` bodies.
+    /// index) as deferred-publication. Pre-finalize different-body
+    /// overwrites of such defs are dropped; only
+    /// [`Self::set_body_finalized`] replaces the first published form (and
+    /// the checker freezes the def right after). Per-file checkers continue
+    /// to use their own `TypeEnvironment` bodies for in-flight refinement.
     ///
-    /// Returns the number of definitions marked. Driver-invoked only when the
-    /// `TSZ_EXPERIMENT_LIB_DEF_PUBLISH_ONCE` experiment is enabled.
-    pub fn mark_non_program_interface_defs_publish_once(&self) -> usize {
+    /// Returns the number of definitions marked. Driver-invoked only when
+    /// the experiment is enabled.
+    pub fn mark_non_program_interface_defs_deferred(&self) -> usize {
         /// `tsz_binder` symbols without a program declaration file (every
         /// lib-binder symbol) carry `u32::MAX` as `decl_file_idx`.
         const NON_PROGRAM_FILE_SENTINEL: u32 = u32::MAX;
@@ -1006,17 +1051,17 @@ impl DefinitionStore {
         for entry in &self.definitions {
             let info = entry.value();
             if info.kind == DefKind::Interface && info.file_id == Some(NON_PROGRAM_FILE_SENTINEL) {
-                self.publish_once_defs.insert(*entry.key());
+                self.deferred_publish_defs.insert(*entry.key());
                 marked += 1;
             }
         }
         marked
     }
 
-    /// Mutation-isolation campaign prototype: mark a single def publish-once
-    /// **after** its current body, so the form just published becomes the
-    /// frozen one (used to freeze at the *finalized* lib-body publication
-    /// point rather than at the first partial materialization).
+    /// Mutation-isolation campaign: freeze a single def's shared-store body
+    /// **after** its current (finalized) publication, so the form just
+    /// published becomes the immutable one. Later different-body
+    /// publications are dropped.
     pub fn mark_publish_once(&self, id: DefId) {
         self.publish_once_defs.insert(id);
     }

--- a/crates/tsz-solver/src/def/publication_census.rs
+++ b/crates/tsz-solver/src/def/publication_census.rs
@@ -56,13 +56,17 @@ pub enum PublicationOutcome {
     /// Different body `TypeId` *and* a different type-parameter list.
     DifferentBodyParamsChanged,
     /// A different-body publication that was *dropped* because the def is
-    /// marked publish-once (mutation-isolation prototype): the store kept
-    /// the first materialized form.
+    /// frozen (publish-once after its finalized materialization): the store
+    /// kept the finalized form.
     SuppressedDifferentBody,
+    /// A pre-finalize different-body overwrite that was *deferred* (dropped)
+    /// because the def belongs to the deferred-publication class: the store
+    /// keeps the first form until the finalize entry point overwrites it.
+    DeferredDifferentBody,
 }
 
 impl PublicationOutcome {
-    const ALL: [Self; 7] = [
+    const ALL: [Self; 8] = [
         Self::First,
         Self::MintedMinimal,
         Self::SameBody,
@@ -70,6 +74,7 @@ impl PublicationOutcome {
         Self::DifferentBody,
         Self::DifferentBodyParamsChanged,
         Self::SuppressedDifferentBody,
+        Self::DeferredDifferentBody,
     ];
 
     const fn label(self) -> &'static str {
@@ -81,6 +86,7 @@ impl PublicationOutcome {
             Self::DifferentBody => "different-body",
             Self::DifferentBodyParamsChanged => "different-body+params-changed",
             Self::SuppressedDifferentBody => "suppressed-different-body",
+            Self::DeferredDifferentBody => "deferred-different-body",
         }
     }
 
@@ -108,8 +114,17 @@ const MAX_TRACKED_BODIES: usize = 16;
 struct CensusState {
     /// (caller file, caller line, outcome) -> count.
     by_site: FxHashMap<(&'static str, u32, PublicationOutcome), u64>,
+    /// Same key, restricted to **lib interface** defs (`DefKind::Interface`
+    /// with the non-program `u32::MAX` decl-file sentinel) — the def class
+    /// the mutation-isolation campaign freezes; this cross-tab attributes
+    /// the post-freeze residue to its write-through channels.
+    by_site_lib_interface: FxHashMap<(&'static str, u32, PublicationOutcome), u64>,
     by_def: FxHashMap<DefId, DefCensus>,
 }
+
+/// `tsz_binder` symbols without a program declaration file (every lib-binder
+/// symbol) carry `u32::MAX` as their declaration file index.
+const NON_PROGRAM_FILE_SENTINEL: u32 = u32::MAX;
 
 fn state() -> &'static Mutex<CensusState> {
     static STATE: OnceLock<Mutex<CensusState>> = OnceLock::new();
@@ -136,6 +151,12 @@ pub fn record_publication(
         .by_site
         .entry((caller.file(), caller.line(), outcome))
         .or_insert(0) += 1;
+    if kind == Some(DefKind::Interface) && file_id == Some(NON_PROGRAM_FILE_SENTINEL) {
+        *state
+            .by_site_lib_interface
+            .entry((caller.file(), caller.line(), outcome))
+            .or_insert(0) += 1;
+    }
     let entry = state.by_def.entry(def_id).or_insert_with(|| DefCensus {
         name,
         kind,
@@ -305,6 +326,23 @@ pub fn dump_to_string(
             "  {count:>8}  {:<32} {file}:{line}\n",
             outcome.label()
         ));
+    }
+
+    // ---- Lib-interface defs by call site x outcome ----
+    if !state.by_site_lib_interface.is_empty() {
+        out.push_str("\n--- lib-interface publications by call site ---\n");
+        let mut sites: Vec<_> = state
+            .by_site_lib_interface
+            .iter()
+            .map(|(&(file, line, outcome), &count)| (file, line, outcome, count))
+            .collect();
+        sites.sort_by(|a, b| b.3.cmp(&a.3).then(a.0.cmp(b.0)).then(a.1.cmp(&b.1)));
+        for (file, line, outcome, count) in sites {
+            out.push_str(&format!(
+                "  {count:>8}  {:<32} {file}:{line}\n",
+                outcome.label()
+            ));
+        }
     }
 
     // ---- By def kind x file ----

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -806,11 +806,13 @@ impl TypeEnvironment {
             self.def_type_params.insert(def_id.0, params.clone());
         }
         // Write through to shared store for cross-checker visibility.
+        // Body and params go through the atomic single-entry-guard path:
+        // publishing them in two separate writes lets a concurrent reader
+        // observe a generic alias whose body is visible but whose parameter
+        // list is still missing (see `set_body_with_params`).
         if let Some(ref store) = self.definition_store {
-            store.set_body(def_id, type_id);
-            if !params.is_empty() {
-                store.set_type_params(def_id, params);
-            }
+            let store_params = (!params.is_empty()).then_some(params);
+            store.set_body_with_params(def_id, type_id, store_params);
         }
         self.bump_generation();
     }


### PR DESCRIPTION
Goal: fast

## Summary

Steps 1–2 of the mutation-isolation campaign (the path to lifting the DOM-lib sequential checking gate), reshaped by gate evidence into a default-on correctness core plus opt-in experiments.

**Default-on — identity-collision audit (step 1):** the boxed-def collision family (#13215) extends further: `get_existing_def_id` derives its verification name via first-raw-id-owner `find_map` over lib binders, and `lookup_by_symbol(raw, u32::MAX)` degenerates for lib symbols, so wrong defs self-confirm. Fixed seven more collision-prone resolution paths with a shared name-verified + canonical-fallback helper (`lib_def_id_verified`): ThisType markers, early `Function` def registration, lib-scoped heritage targets, namespace-export symbols, the `register_lib_def_resolved` publication funnel (now name-verified with a name-guarded canonical mirror), `lib_def_id_from_node` type-param/no-name branches, and one provably-always-colliding type-param probe (removed). Also default-on: `TypeEnvironment::insert_def_with_params` now publishes body+params atomically (closing the #13205 bypass at solver resolver.rs:810), and the publication census gains a lib-interface call-site cross-tab.

**Opt-in (`TSZ_ENABLE_LIB_DEF_FREEZE`, `TSZ_ENABLE_LIB_DEF_DEFER_PUBLISH`):** the finalize+freeze pre-pass and deferred publication (lib-interface different-body publications 780→221; per-file republication eliminated) each independently regress the declare-global augmentation class — witness: importMeta.ts gains a deterministic spurious TS2345 even with a program-wide augmentation name-gate, because a def *related* to the augmented name is pinned through a channel the gate doesn't cover. Both are gated off with the witness documented in place; the campaign's next step is augmentation-aware invalidation (suspect channel: the `import.meta` meta-property type path). The original coupled kill-switches made the first bisect lie — they are now independent.

## Project Corpus Impact
- Row: foundation for the sequential-gate lift on DOM-lib rows (ts-toolbelt metric path); all rows verified byte-identical
- Bug family: DefId identity collisions in lib-def resolution (shared-store corruption)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: high

## Verification

- Full local conformance (after flipping the experiments to opt-in): 12583/12585 — zero new vs the accepted ledger; importMeta 3/3 (it regressed under default-on freeze/defer, caught by this gate, hence the split).
- ts-toolbelt 0.65–0.66s wall / 0.85–0.86s user (metric unregressed); ts-toolbelt/vite/next-app/zodmin byte-identical; 5× determinism loops byte-identical.
- `cargo nextest run -p tsz-solver`: failure set identical to main; checker `--lib` identical (stash A/B); cli identical (the TS7056 emit-lane interaction was found and gated during development).
- Conformance filters 100%: conditionalType 17/17, infer 87/87, mappedType 55/55, moduleResolution 111/111, libReference 4/4, jsx shard 65/65.
- clippy clean (the 2 release all-target errors are the documented pre-existing `force_enable_perf_counters_for_tests` cfg artifact, identical on main); arch guards pass.
