### PR TITLE
fix(checker,solver): sound type-arg display projection + same-base all-any-args assignability shortcut

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1004,6 +1004,9 @@ path = "tests/import_type_ambient_module_member_tests.rs"
 name = "json_namespace_import_tests"
 path = "tests/json_namespace_import_tests.rs"
 [[test]]
+name = "same_base_any_args_application_tests"
+path = "tests/same_base_any_args_application_tests.rs"
+[[test]]
 name = "self_namespace_import_alias_leak_tests"
 path = "tests/self_namespace_import_alias_leak_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -592,168 +592,76 @@ impl<'a> CheckerState<'a> {
                     }
                 }
 
-                // If display_alias didn't provide type args, try heuristic recovery.
+                // If display_alias didn't provide type args, recover the
+                // application's ACTUAL arguments from properties whose declared
+                // type is a bare type parameter (`value: T` → the instantiated
+                // property type IS the argument for `T`, at `T`'s declared
+                // index). Each recovered argument is placed at its parameter's
+                // index; the display is only rewritten when every parameter is
+                // recovered consistently. Harvesting other member types (the
+                // old name-sorted property-type zip) fabricated argument lists
+                // unrelated to the actual instantiation, so unrecoverable
+                // arguments are elided (bare name) instead.
                 if !formatted.contains('<') {
-                    let def_id = self.ctx.get_or_create_def_id(sym_id);
                     let type_param_names = self.symbol_type_param_names_for_display(symbol);
-                    let type_param_count = if !type_param_names.is_empty() {
-                        type_param_names.len()
-                    } else if let Some(type_params) = self.ctx.get_def_type_params(def_id) {
-                        type_params.len()
-                    } else {
-                        symbol
-                            .declarations
-                            .iter()
-                            .find_map(|decl| {
-                                let node = self.ctx.arena.get(*decl)?;
-                                let class = self.ctx.arena.get_class(node)?;
-                                Some(class.type_parameters.as_ref().map_or(0, |p| p.nodes.len()))
-                            })
-                            .unwrap_or(0)
-                    };
+                    let type_param_count = type_param_names.len();
                     if type_param_count > 0 {
-                        // Recover instantiation args from actual value-carrying members.
-                        // For methods, use return type (not the full function signature)
-                        // since method return types often directly reflect type params.
-                        // E.g. `compareTo(other: T): T` with T=number → return type is `number`.
-                        let resolve_candidate_type = |prop: &tsz_solver::PropertyInfo| -> TypeId {
-                            if prop.is_method {
-                                // For methods, extract a representative type instead of
-                                // the full function signature.
-                                // Strategy: prefer return type, but if it's trivial
-                                // (void/never/any/unknown/undefined), use the first
-                                // non-trivial parameter type. This handles both
-                                // `compareTo(other: T): T` → return type `number`, and
-                                // `foo(a: T): void` → param type `{ a: string }`.
-                                let extract_from_shape =
-                                    |params: &[tsz_solver::ParamInfo],
-                                     return_type: TypeId|
-                                     -> TypeId {
-                                        let is_trivial = matches!(
-                                            return_type,
-                                            TypeId::VOID
-                                                | TypeId::NEVER
-                                                | TypeId::ANY
-                                                | TypeId::UNKNOWN
-                                                | TypeId::UNDEFINED
-                                                | TypeId::NULL
-                                        );
-                                        if !is_trivial {
-                                            return return_type;
-                                        }
-                                        // Return type is trivial — use first substantive param
-                                        for param in params {
-                                            if !matches!(
-                                                param.type_id,
-                                                TypeId::VOID
-                                                    | TypeId::NEVER
-                                                    | TypeId::ANY
-                                                    | TypeId::UNKNOWN
-                                                    | TypeId::UNDEFINED
-                                                    | TypeId::NULL
-                                            ) {
-                                                return param.type_id;
-                                            }
-                                        }
-                                        return_type
-                                    };
-                                if let Some(fn_shape) =
-                                    crate::query_boundaries::common::function_shape_for_type(
-                                        self.ctx.types,
-                                        prop.type_id,
-                                    )
-                                {
-                                    return extract_from_shape(
-                                        &fn_shape.params,
-                                        fn_shape.return_type,
-                                    );
-                                }
-                                if let Some(callable) =
-                                    crate::query_boundaries::common::callable_shape_for_type(
-                                        self.ctx.types,
-                                        prop.type_id,
-                                    )
-                                    && callable.call_signatures.len() == 1
-                                {
-                                    let sig = &callable.call_signatures[0];
-                                    return extract_from_shape(&sig.params, sig.return_type);
-                                }
+                        // For methods, the declared-type matcher inspects the
+                        // declared RETURN annotation, so project the
+                        // instantiated return type as the candidate value.
+                        let candidate_value_type = |prop: &tsz_solver::PropertyInfo| -> TypeId {
+                            if !prop.is_method {
+                                return prop.type_id;
+                            }
+                            if let Some(fn_shape) =
+                                crate::query_boundaries::common::function_shape_for_type(
+                                    self.ctx.types,
+                                    prop.type_id,
+                                )
+                            {
+                                return fn_shape.return_type;
+                            }
+                            if let Some(callable) =
+                                crate::query_boundaries::common::callable_shape_for_type(
+                                    self.ctx.types,
+                                    prop.type_id,
+                                )
+                                && callable.call_signatures.len() == 1
+                            {
+                                return callable.call_signatures[0].return_type;
                             }
                             prop.type_id
                         };
-                        let build_candidates =
-                            |predicate: fn(&tsz_solver::PropertyInfo) -> bool,
-                             types: &dyn tsz_solver::construction::TypeDatabase| {
-                                let mut candidates: Vec<(String, TypeId)> = shape
-                                    .properties
-                                    .iter()
-                                    .filter(|prop| predicate(prop))
-                                    .filter_map(|prop| {
-                                        let name = types.resolve_atom_ref(prop.name).to_string();
-                                        if tsz_solver::utils::is_synthetic_private_brand_name(&name)
-                                        {
-                                            None
-                                        } else {
-                                            Some((name, resolve_candidate_type(prop)))
-                                        }
-                                    })
-                                    .collect();
-                                candidates.sort_by(|a, b| a.0.cmp(&b.0));
-                                candidates
+                        let mut slots: Vec<Option<TypeId>> = vec![None; type_param_count];
+                        let mut conflict = false;
+                        for prop in shape.properties.iter() {
+                            let Some((index, candidate)) = self
+                                .declared_property_type_arg_candidate_for_display(
+                                    symbol,
+                                    prop.name,
+                                    candidate_value_type(prop),
+                                    &type_param_names,
+                                )
+                            else {
+                                continue;
                             };
-                        let mut candidates: Vec<(String, TypeId)> = if type_param_names.is_empty() {
-                            Vec::new()
-                        } else {
-                            shape
-                                .properties
-                                .iter()
-                                .filter_map(|prop| {
-                                    let candidate = self
-                                        .declared_property_type_arg_candidate_for_display(
-                                            symbol,
-                                            prop.name,
-                                            resolve_candidate_type(prop),
-                                            &type_param_names,
-                                        )?;
-                                    let name =
-                                        self.ctx.types.resolve_atom_ref(prop.name).to_string();
-                                    Some((name, candidate))
-                                })
-                                .collect()
-                        };
-                        candidates.sort_by(|a, b| a.0.cmp(&b.0));
-                        if candidates.len() < type_param_count
-                            && shape.properties.len() >= type_param_count
-                        {
-                            candidates = build_candidates(
-                                |prop| !prop.is_method && !prop.is_class_prototype,
-                                self.ctx.types.as_type_database(),
-                            );
-                            if candidates.len() < type_param_count {
-                                candidates = build_candidates(
-                                    |prop| !prop.is_method,
-                                    self.ctx.types.as_type_database(),
-                                );
-                            }
-                            if candidates.len() < type_param_count {
-                                candidates = build_candidates(
-                                    |prop| !prop.is_class_prototype,
-                                    self.ctx.types.as_type_database(),
-                                );
-                            }
-                            if candidates.len() < type_param_count {
-                                candidates =
-                                    build_candidates(|_| true, self.ctx.types.as_type_database());
+                            match slots[index] {
+                                None => slots[index] = Some(candidate),
+                                Some(existing) if existing == candidate => {}
+                                Some(_) => {
+                                    conflict = true;
+                                    break;
+                                }
                             }
                         }
-                        let args: Vec<String> = candidates
-                            .iter()
-                            .take(type_param_count)
-                            .map(|(_, type_id)| {
-                                self.format_type_diagnostic_for_assignability_display(*type_id)
-                            })
-                            .collect();
-                        if args.len() == type_param_count {
+                        if !conflict && slots.iter().all(Option::is_some) {
+                            let args: Vec<String> = slots
+                                .iter()
+                                .flatten()
+                                .map(|type_id| {
+                                    self.format_type_diagnostic_for_assignability_display(*type_id)
+                                })
+                                .collect();
                             formatted = format!("{}<{}>", symbol_name, args.join(", "));
                         }
                     }
@@ -761,6 +669,10 @@ impl<'a> CheckerState<'a> {
             }
         }
 
+        // Callable-only shapes (call/construct-signature interfaces) carry no
+        // properties, so recover their actual arguments from declared
+        // signature annotations that are bare type parameters — again
+        // index-placed and all-or-elide, never positional harvesting.
         if !formatted.contains('<')
             && let Some(sym_id) =
                 crate::query_boundaries::common::type_shape_symbol(self.ctx.types, display_ty)
@@ -770,11 +682,19 @@ impl<'a> CheckerState<'a> {
             let type_param_names = self.symbol_type_param_names_for_display(symbol);
             let type_param_count = type_param_names.len();
             if type_param_count > 0 {
-                let candidates = self.signature_type_arg_display_candidates(display_ty);
-                if candidates.len() >= type_param_count {
-                    let args: Vec<String> = candidates
+                let mut slots: Vec<Option<TypeId>> = vec![None; type_param_count];
+                let mut conflict = false;
+                self.fill_signature_type_arg_slots_for_display(
+                    symbol,
+                    display_ty,
+                    &type_param_names,
+                    &mut slots,
+                    &mut conflict,
+                );
+                if !conflict && slots.iter().all(Option::is_some) {
+                    let args: Vec<String> = slots
                         .iter()
-                        .take(type_param_count)
+                        .flatten()
                         .map(|type_id| {
                             self.format_type_diagnostic_for_assignability_display(*type_id)
                         })

--- a/crates/tsz-checker/src/error_reporter/generic_display_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/generic_display_helpers.rs
@@ -39,13 +39,22 @@ impl<'a> CheckerState<'a> {
             .unwrap_or_default()
     }
 
+    /// Recover one actual type argument from a property whose declared type is
+    /// a bare type parameter (or an array/`Array<T>` wrapper around one).
+    ///
+    /// Returns the declared index of the matched type parameter together with
+    /// the instantiated type that occupies it: when `value: T` is declared and
+    /// the instance's `value` property has type `number`, the application's
+    /// actual argument for `T` IS `number`. This is a sound projection of the
+    /// actual arguments — unlike harvesting arbitrary member types, which
+    /// fabricates an argument list unrelated to the instantiation.
     pub(super) fn declared_property_type_arg_candidate_for_display(
         &self,
         symbol: &tsz_binder::Symbol,
         property_name: Atom,
         actual_type: TypeId,
         type_param_names: &[Atom],
-    ) -> Option<TypeId> {
+    ) -> Option<(usize, TypeId)> {
         let arena = self.symbol_declaration_arena(symbol);
         for decl in &symbol.declarations {
             let Some(node) = arena.get(*decl) else {
@@ -97,39 +106,122 @@ impl<'a> CheckerState<'a> {
         None
     }
 
-    pub(super) fn signature_type_arg_display_candidates(&self, ty: TypeId) -> Vec<TypeId> {
-        let is_substantive = |type_id: TypeId| {
-            !matches!(
-                type_id,
-                TypeId::VOID
-                    | TypeId::NEVER
-                    | TypeId::ANY
-                    | TypeId::UNKNOWN
-                    | TypeId::UNDEFINED
-                    | TypeId::NULL
-            )
-        };
-        let mut candidates = Vec::new();
-        if let Some(callable) =
+    /// Recover actual type arguments from declared call/construct signatures
+    /// whose parameter (or return) annotations are bare type parameters.
+    ///
+    /// Only fills slots when the declared signature count matches the shape's
+    /// instantiated signature count (so positions correspond); each candidate
+    /// is placed at the matched parameter's declared index. Like the property
+    /// pass, this is a sound projection of the actual arguments, never a
+    /// harvest of arbitrary signature types.
+    pub(super) fn fill_signature_type_arg_slots_for_display(
+        &self,
+        symbol: &tsz_binder::Symbol,
+        ty: TypeId,
+        type_param_names: &[Atom],
+        slots: &mut [Option<TypeId>],
+        conflict: &mut bool,
+    ) {
+        use tsz_parser::parser::syntax_kind_ext::{CALL_SIGNATURE, CONSTRUCT_SIGNATURE};
+
+        let Some(callable) =
             crate::query_boundaries::diagnostics::callable_shape_for_type(self.ctx.types, ty)
-        {
-            for sig in callable
-                .call_signatures
-                .iter()
-                .chain(callable.construct_signatures.iter())
-            {
-                candidates.extend(
-                    sig.params
-                        .iter()
-                        .map(|param| param.type_id)
-                        .filter(|type_id| is_substantive(*type_id)),
-                );
-                if is_substantive(sig.return_type) {
-                    candidates.push(sig.return_type);
+        else {
+            return;
+        };
+        let arena = self.symbol_declaration_arena(symbol);
+
+        let mut declared_calls: Vec<&tsz_parser::parser::node::SignatureData> = Vec::new();
+        let mut declared_constructs: Vec<&tsz_parser::parser::node::SignatureData> = Vec::new();
+        for decl in &symbol.declarations {
+            let Some(node) = arena.get(*decl) else {
+                continue;
+            };
+            let Some(members) = arena
+                .get_class(node)
+                .map(|class| &class.members)
+                .or_else(|| {
+                    arena
+                        .get_interface(node)
+                        .map(|interface| &interface.members)
+                })
+            else {
+                continue;
+            };
+            for member_idx in &members.nodes {
+                let Some(member_node) = arena.get(*member_idx) else {
+                    continue;
+                };
+                let Some(sig) = arena.get_signature(member_node) else {
+                    continue;
+                };
+                match member_node.kind {
+                    CALL_SIGNATURE => declared_calls.push(sig),
+                    CONSTRUCT_SIGNATURE => declared_constructs.push(sig),
+                    _ => {}
                 }
             }
         }
-        candidates
+
+        let mut record = |index: usize, candidate: TypeId, conflict: &mut bool| match slots[index] {
+            None => slots[index] = Some(candidate),
+            Some(existing) if existing == candidate => {}
+            Some(_) => *conflict = true,
+        };
+
+        let mut fill_from_pairs = |declared: &[&tsz_parser::parser::node::SignatureData],
+                                   instantiated: &[tsz_solver::CallSignature],
+                                   conflict: &mut bool| {
+            if declared.is_empty() || declared.len() != instantiated.len() {
+                return;
+            }
+            for (decl_sig, inst_sig) in declared.iter().zip(instantiated.iter()) {
+                // Signature-local type parameters shadow the owner's; skip
+                // generic signatures so a same-named inner parameter never
+                // masquerades as the owner's argument.
+                if decl_sig.type_parameters.is_some() {
+                    continue;
+                }
+                if let Some(params) = &decl_sig.parameters {
+                    for (param_pos, param_idx) in params.nodes.iter().enumerate() {
+                        let Some(param_node) = arena.get(*param_idx) else {
+                            continue;
+                        };
+                        let Some(param) = arena.get_parameter(param_node) else {
+                            continue;
+                        };
+                        let Some(inst_param) = inst_sig.params.get(param_pos) else {
+                            continue;
+                        };
+                        if let Some((index, candidate)) = self
+                            .declared_type_arg_candidate_for_display(
+                                arena,
+                                param.type_annotation,
+                                inst_param.type_id,
+                                type_param_names,
+                            )
+                        {
+                            record(index, candidate, conflict);
+                        }
+                    }
+                }
+                if let Some((index, candidate)) = self.declared_type_arg_candidate_for_display(
+                    arena,
+                    decl_sig.type_annotation,
+                    inst_sig.return_type,
+                    type_param_names,
+                ) {
+                    record(index, candidate, conflict);
+                }
+            }
+        };
+
+        fill_from_pairs(&declared_calls, &callable.call_signatures, conflict);
+        fill_from_pairs(
+            &declared_constructs,
+            &callable.construct_signatures,
+            conflict,
+        );
     }
 
     fn symbol_declaration_arena<'b>(&'b self, symbol: &tsz_binder::Symbol) -> &'b NodeArena {
@@ -140,18 +232,20 @@ impl<'a> CheckerState<'a> {
         }
     }
 
-    fn type_node_is_display_type_param(
+    /// When `type_node` is a bare reference to one of `type_param_names`,
+    /// return that parameter's declared index.
+    fn display_type_param_index(
         &self,
         arena: &NodeArena,
         type_node: tsz_parser::parser::NodeIndex,
         type_param_names: &[Atom],
-    ) -> bool {
-        arena
+    ) -> Option<usize> {
+        let name = arena
             .get_type_ref_at(type_node)
             .filter(|type_ref| type_ref.type_arguments.is_none())
             .and_then(|type_ref| arena.get_identifier_at(type_ref.type_name))
-            .map(|ident| self.ctx.types.intern_string(&ident.escaped_text))
-            .is_some_and(|name| type_param_names.contains(&name))
+            .map(|ident| self.ctx.types.intern_string(&ident.escaped_text))?;
+        type_param_names.iter().position(|param| *param == name)
     }
 
     fn declared_type_arg_candidate_for_display(
@@ -160,12 +254,12 @@ impl<'a> CheckerState<'a> {
         declared_type: tsz_parser::parser::NodeIndex,
         actual_type: TypeId,
         type_param_names: &[Atom],
-    ) -> Option<TypeId> {
+    ) -> Option<(usize, TypeId)> {
         if declared_type.is_none() {
             return None;
         }
-        if self.type_node_is_display_type_param(arena, declared_type, type_param_names) {
-            return Some(actual_type);
+        if let Some(index) = self.display_type_param_index(arena, declared_type, type_param_names) {
+            return Some((index, actual_type));
         }
 
         let node = arena.get(declared_type)?;

--- a/crates/tsz-checker/tests/generic_property_mismatch_display_tests.rs
+++ b/crates/tsz-checker/tests/generic_property_mismatch_display_tests.rs
@@ -486,3 +486,104 @@ function f2<T>(args: T) {
         "expected TS2348 to preserve the construct-only interface application, got: {messages:#?}",
     );
 }
+
+/// Type arguments in instance displays must be the application's ACTUAL
+/// arguments. When they cannot be recovered from declared annotations, the
+/// arguments are elided — never harvested from name-sorted member types
+/// (kysely witness: `SelectQueryBuilderImpl<DB, TB, O>` displayed as
+/// `SelectQueryBuilderImpl<SelectQueryBuilderProps, O | undefined, true>`).
+#[test]
+fn generic_instance_display_never_zips_member_types_into_type_args() {
+    let diagnostic = ts2322_diagnostic(
+        r#"
+type AnyColumn<DB, TB extends keyof DB> = {
+  [T in TB]: keyof DB[T]
+}[TB] &
+  string
+
+type RefExpr<DB, TB extends keyof DB> = AnyColumn<DB, TB> | ((db: DB) => TB)
+
+interface Maker<DB, TB extends keyof DB, O> {
+  get expressionType(): O | undefined
+  get isMaker(): true
+  refine<LRE extends RefExpr<DB, TB>>(lhs: LRE): Maker<DB, TB, O>
+}
+
+class MakerImpl<DB, TB extends keyof DB, O> implements Maker<DB, TB, O> {
+  get expressionType(): O | undefined {
+    return undefined
+  }
+  get isMaker(): true {
+    return true
+  }
+  refine(lhs: RefExpr<DB, TB>): Maker<DB, TB, O> {
+    return new MakerImpl()
+  }
+}
+
+function probe<DB, TB extends keyof DB, O>(): Maker<DB, TB, O> & { extra: 1 } {
+  return new MakerImpl()
+}
+"#,
+    );
+
+    assert!(
+        diagnostic.message_text.contains("Type 'MakerImpl"),
+        "expected the instance type in the message, got {diagnostic:#?}"
+    );
+    // Member types (getter/method types, name-sorted) must never be zipped
+    // into the displayed argument list.
+    for fabricated in [
+        "MakerImpl<true",
+        "MakerImpl<O | undefined",
+        "MakerImpl<Maker<",
+    ] {
+        assert!(
+            !diagnostic.message_text.contains(fabricated),
+            "member types were harvested into the type-argument display ({fabricated}): {diagnostic:#?}"
+        );
+    }
+}
+
+/// Same witness with renamed binders and reordered members: the zip defect
+/// sorted properties alphabetically, so the fabricated argument list rotated
+/// with member names. No member-name ordering may leak into the display.
+#[test]
+fn generic_instance_display_zip_guard_is_member_name_independent() {
+    let diagnostic = ts2322_diagnostic(
+        r#"
+interface Zed<Alpha, Beta extends keyof Alpha, Out> {
+  get zz(): Out | undefined
+  get aa(): true
+  pick<K extends keyof Alpha>(key: K): Zed<Alpha, Beta, Out>
+}
+
+class ZedImpl<Alpha, Beta extends keyof Alpha, Out> implements Zed<Alpha, Beta, Out> {
+  get zz(): Out | undefined {
+    return undefined
+  }
+  get aa(): true {
+    return true
+  }
+  pick(key: keyof Alpha): Zed<Alpha, Beta, Out> {
+    return new ZedImpl()
+  }
+}
+
+function probe<Alpha, Beta extends keyof Alpha, Out>(): Zed<Alpha, Beta, Out> & { more: 1 } {
+  return new ZedImpl()
+}
+"#,
+    );
+
+    assert!(
+        diagnostic.message_text.contains("Type 'ZedImpl"),
+        "expected the instance type in the message, got {diagnostic:#?}"
+    );
+    for fabricated in ["ZedImpl<true", "ZedImpl<Out | undefined", "ZedImpl<Zed<"] {
+        assert!(
+            !diagnostic.message_text.contains(fabricated),
+            "member types were harvested into the type-argument display ({fabricated}): {diagnostic:#?}"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/same_base_any_args_application_tests.rs
+++ b/crates/tsz-checker/tests/same_base_any_args_application_tests.rs
@@ -1,0 +1,223 @@
+//! Same-definition all-`any`-args application assignability.
+//!
+//! When a generic class/alias instantiation `X<DB, TB>` is passed where
+//! `X<any, any>` is expected, tsc relates them under assignability (any
+//! propagation + same-reference comparison) even when the structural member
+//! comparison would stumble on generic-method constraints. The witness family
+//! is kysely's `Kysely<DB>` -> `Kysely<any>` /
+//! `Readonly<FilterObject<DB, TB>>` -> `Readonly<FilterObject<any, any>>`
+//! call-argument sites.
+//!
+//! Structural rule: when source and target are applications of the SAME
+//! definition (or the source is that definition's own instance type) and
+//! every target argument is `any`, the pair is related under assignability;
+//! different-base targets and concrete-argument targets keep the structural
+//! path.
+
+use tsz_checker::diagnostics::Diagnostic;
+use tsz_checker::test_utils::check_source_diagnostics;
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|diagnostic: Diagnostic| diagnostic.code)
+        .collect()
+}
+
+#[test]
+fn same_class_instance_assignable_to_all_any_args_target() {
+    let diagnostics = codes(
+        r#"
+declare function consume(db: Repo<any>): void
+
+class Repo<DB> {
+  pickFrom<TB extends keyof DB & string>(from: TB): TB {
+    return undefined as any
+  }
+  detach(): Repo<DB> {
+    return this
+  }
+  go() {
+    consume(this.detach())
+  }
+}
+"#,
+    );
+    assert!(
+        !diagnostics.contains(&2345),
+        "Repo<DB> must be assignable to Repo<any> (same definition, all-any target args), got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn same_class_instance_assignable_to_all_any_args_target_renamed_binders() {
+    let diagnostics = codes(
+        r#"
+declare function sink(value: Holder<any>): void
+
+class Holder<Inner> {
+  grab<Key extends keyof Inner & string>(key: Key): Key {
+    return undefined as any
+  }
+  fresh(): Holder<Inner> {
+    return this
+  }
+  run() {
+    sink(this.fresh())
+  }
+}
+"#,
+    );
+    assert!(
+        !diagnostics.contains(&2345),
+        "renamed binders: Holder<Inner> must be assignable to Holder<any>, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn same_class_with_heritage_assignable_to_all_any_args_target() {
+    let diagnostics = codes(
+        r#"
+interface Introspector {
+  getTables(): string[]
+}
+
+interface Dialect {
+  createIntrospector(db: Repo<any>): Introspector
+}
+
+interface RepoProps {
+  readonly dialect: Dialect
+}
+
+type AnyColumn<DB, TB extends keyof DB> = {
+  [T in TB]: keyof DB[T] & string
+}[TB]
+
+class Creator<DB> {
+  pickFrom<TB extends keyof DB & string>(from: TB): AnyColumn<DB, TB> {
+    return undefined as any
+  }
+  withSchema(schema: string): Creator<DB> {
+    return this
+  }
+}
+
+class Repo<DB> extends Creator<DB> {
+  readonly #props: RepoProps
+
+  constructor(props: RepoProps) {
+    super()
+    this.#props = props
+  }
+
+  get introspection(): Introspector {
+    return this.#props.dialect.createIntrospector(this.detach())
+  }
+
+  detach(): Repo<DB> {
+    return new Repo(this.#props)
+  }
+}
+"#,
+    );
+    assert!(
+        !diagnostics.contains(&2345),
+        "heritage case: Repo<DB> must be assignable to Repo<any>, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn different_base_all_any_args_target_stays_structural() {
+    // tsc 5.9.3 rejects this: the all-`any` shortcut is same-reference only;
+    // a different base with an identical shape keeps the structural path.
+    let diagnostics = codes(
+        r#"
+declare function consume(db: Other<any>): void
+
+class Repo<DB> {
+  pickFrom<TB extends keyof DB & string>(from: TB): TB {
+    return undefined as any
+  }
+  detach(): Repo<DB> {
+    return this
+  }
+  go() {
+    consume(this.detach())
+  }
+}
+
+class Other<DB> {
+  pickFrom<TB extends keyof DB & string>(from: TB): TB {
+    return undefined as any
+  }
+  detach(): Other<DB> {
+    return this
+  }
+}
+"#,
+    );
+    assert!(
+        diagnostics.contains(&2345),
+        "different-base all-any target must stay structural (tsc errors here), got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn all_any_source_to_concrete_target_unchanged() {
+    // Reverse direction: `Repo<any>` -> `Repo<{ a: 1 }>` is accepted via any
+    // propagation on the SOURCE arguments (tsc-clean); the target shortcut
+    // must not disturb it.
+    let diagnostics = codes(
+        r#"
+class Repo<DB> {
+  pickFrom<TB extends keyof DB & string>(from: TB): TB {
+    return undefined as any
+  }
+  detach(): Repo<DB> {
+    return this
+  }
+}
+
+declare const anyRepo: Repo<any>
+const concrete: Repo<{ a: 1 }> = anyRepo
+"#,
+    );
+    assert!(
+        !diagnostics.contains(&2322),
+        "Repo<any> must remain assignable to Repo<{{ a: 1 }}>, got {diagnostics:?}"
+    );
+}
+
+#[test]
+fn union_alias_all_any_args_target_stays_clean() {
+    let diagnostics = codes(
+        r#"
+interface DynRef<R> {
+  readonly dynamicReference: R
+}
+
+type AnyColumn<DB, TB extends keyof DB> = {
+  [T in TB]: keyof DB[T] & string
+}[TB]
+
+type StringReference<DB, TB extends keyof DB> = AnyColumn<DB, TB> | DynRef<any>
+
+type ReferenceOrList<DB, TB extends keyof DB> =
+  | ReadonlyArray<StringReference<DB, TB>>
+  | StringReference<DB, TB>
+
+declare function parseReference(reference: ReferenceOrList<any, any>): void
+
+class Builder<DB, TB extends keyof DB> {
+  partitionBy(reference: ReferenceOrList<DB, TB>): void {
+    parseReference(reference)
+  }
+}
+"#,
+    );
+    assert!(
+        !diagnostics.contains(&2345),
+        "union alias instantiation must be assignable to its all-any instantiation, got {diagnostics:?}"
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -812,9 +812,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     .get_display_alias(source)
                     .and_then(|alias| application_id(self.interner, alias))
             });
+            // When the TARGET also lost its Application identity to evaluation
+            // (e.g. a parameter type like `Kysely<any>` already expanded to an
+            // Object), recover it via display provenance as well — but use it
+            // only for the same-base all-`any`-target-args lawyer shortcut.
+            // Full variance checking on a provenance-recovered target is not
+            // attempted: provenance is display-grade, so it is only trusted
+            // for the permissive `X<...> <: X<any, ..., any>` direction.
+            let t_app_id_for_any_shortcut = t_app_id.or_else(|| {
+                self.interner
+                    .get_display_alias(target)
+                    .and_then(|alias| application_id(self.interner, alias))
+            });
             let variance_result =
                 if let (Some(s_app_id), Some(t_app_id)) = (s_app_id_for_variance, t_app_id) {
                     self.try_variance_fast_path(s_app_id, t_app_id)
+                } else if let Some(t_app_id) = t_app_id_for_any_shortcut {
+                    self.try_same_base_all_any_target_args(source, s_app_id_for_variance, t_app_id)
                 } else if let Some(s_app_id) = s_app_id {
                     // Source is Application, target might be Union containing an Application.
                     // This handles optional properties where target is App<X> | undefined.

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -616,6 +616,68 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         result
     }
 
+    /// Same-base all-`any`-target-args lawyer shortcut.
+    ///
+    /// When source and target are applications of the SAME generic definition
+    /// and every target argument is `any` (e.g. `Kysely<DB>` passed where
+    /// `Kysely<any>` is expected), tsc relates them under assignability:
+    /// `any` type arguments silence per-argument and structural comparison
+    /// for a same-reference target (`AnyPropagationRules` family). This is
+    /// the argument-free subset of the `try_variance_fast_path` shortcut,
+    /// safe to apply even when the application identities were recovered
+    /// from display provenance (full variance on recovered applications is
+    /// not attempted — provenance is display-grade, conclusive only for the
+    /// permissive all-`any` direction, never for rejection).
+    ///
+    /// Gated on any-propagation being permissive on both sides at the
+    /// current depth, so strict subtype/identity relations and asymmetric
+    /// overload passes fall through unchanged.
+    pub(crate) fn try_same_base_all_any_target_args(
+        &mut self,
+        source: TypeId,
+        s_app_id: Option<TypeApplicationId>,
+        t_app_id: TypeApplicationId,
+    ) -> Option<SubtypeResult> {
+        let t_app = self.interner.type_application(t_app_id);
+        if t_app.args.is_empty() || !t_app.args.iter().all(|arg| arg.is_any()) {
+            return None;
+        }
+        let allow_any = self
+            .any_propagation
+            .allows_any_source_at_depth(self.guard.depth())
+            && self
+                .any_propagation
+                .allows_any_target_at_depth(self.guard.depth());
+        if !allow_any {
+            return None;
+        }
+        let same_definition = if let Some(s_app_id) = s_app_id {
+            let s_app = self.interner.type_application(s_app_id);
+            s_app.base == t_app.base
+                || matches!(
+                    (
+                        crate::visitor::lazy_def_id(self.interner, s_app.base),
+                        crate::visitor::lazy_def_id(self.interner, t_app.base),
+                    ),
+                    (Some(s_def), Some(t_def)) if self.resolver.defs_are_equivalent(s_def, t_def)
+                )
+        } else {
+            // The source lost its Application identity to evaluation (e.g. a
+            // class's self-instantiated instance type like `Kysely<DB>` inside
+            // its own body). Match the instance object's nominal symbol
+            // against the target base definition's symbol: an instance of the
+            // SAME definition is assignable to its own all-`any` instantiation.
+            let s_shape_id = object_shape_id(self.interner, source)
+                .or_else(|| object_with_index_shape_id(self.interner, source));
+            let s_symbol =
+                s_shape_id.and_then(|shape_id| self.interner.object_shape(shape_id).symbol);
+            let t_symbol = crate::visitor::lazy_def_id(self.interner, t_app.base)
+                .and_then(|t_def| self.resolver.def_to_symbol_id(t_def));
+            matches!((s_symbol, t_symbol), (Some(s_sym), Some(t_sym)) if s_sym == t_sym)
+        };
+        same_definition.then_some(SubtypeResult::True)
+    }
+
     /// Pre-evaluation variance fast path for Application types.
     ///
     /// When both source and target are Application types with the same base generic


### PR DESCRIPTION
Goal: green

Two small independent display-layer + lawyer-rule fixes (separate commits) on the kysely row.

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-fable-5
Effort: medium

## Item 1 — type-arg display zip (checker, commit 1)
Structural rule: when rendering a generic instance type in an assignability diagnostic, the displayed `Name<args>` must be the application's ACTUAL type arguments, recovered only from declared annotations that ARE a bare type parameter (a `value: T` property / `pick(x: T)` parameter / `(): T` return whose instantiated member type IS the argument for `T`, placed at `T`'s declared index). When not every parameter is recoverable, the argument list is elided (bare name). tsc prints the type reference's resolved `typeArguments`; tsz now projects them soundly through the display owner (`crates/tsz-checker/src/error_reporter/core_formatting.rs` + `generic_display_helpers.rs`).

Previously the display harvested name-sorted member types and zipped the first N into the argument list, fabricating arguments unrelated to the instantiation (kysely witness: `SelectQueryBuilderImpl<DB, TB, O>` shown as `SelectQueryBuilderImpl<SelectQueryBuilderProps, O | undefined, true>`). The positional signature-type harvest fallback is removed in favor of the same index-placed declared-annotation projection. Printer reads types only; no semantic path consumes this string.

Adjacent matrix: 0/1/many type params; renamed binders; reordered members (name-independence guard); recovery-failure case elides instead of fabricating.

## Item 2 — same-definition all-any-args relation (solver, commit 2)
Structural rule: `X<DB, TB>` passed where `X<any, any>` is expected is related under assignability (tsc any-propagation + same-reference variance shortcut). When both the argument and parameter types were already evaluated to objects, the pre-evaluation variance fast path saw no `Application`s and fell through to structural member comparison, which can fail on a generic method's constraint. The fix recovers the target application via display provenance (`crates/tsz-solver/src/relations/subtype/cache.rs`) and applies a narrow lawyer shortcut (`relations/subtype/rules/generics.rs::try_same_base_all_any_target_args`): same definition (application base `DefId`, or the evaluated instance object's nominal symbol == target base def symbol) + every target argument is `any` + any-propagation permissive on BOTH sides => related. Rejection is never derived from recovered provenance, and strict subtype/identity relations and asymmetric overload passes fall through unchanged (any-propagation gate). Does not touch the `no_erase`/`bivariant_callbacks` paths.

Negative controls (tsc 5.9.3 cross-checked): different-base same-shape stays structural (errors); `X<any>` source -> concrete target unchanged; non-any concrete mismatches still error.

## Project Corpus Impact
- Row: kysely-project
- Bug family: type-arg display zip + same-base any-args relation

Kysely guard (`tsconfig.tsz-guard-mssql.json`, dev-fast, 2x/side, base 8cf6b693e3): 134/134 -> 131/131, byte-stable per side. Removed `kysely.ts(163,51)`, `expression-builder.ts(1335,54)`, `(1347,54)` (the F4 same-base any-args sites); zero new sites; zip displays gone, otherwise site-identical. Residual `over-builder.ts(129,26)` `PartitionByExpressionOrList` is a different family (alias erased to a union; member-wise compare on a template-literal indexed-access constraint) — out of scope.

Other rows (A/B, dev-fast): comlink 3->3 byte-identical; ts-rest 31->31; msw 207->207; valibot 1882->1882 site-identical. zod 54->52 (`types.ts(1748)` TS2345 + `(2513)` TS2339 removed, both tsc-clean — verified tsc=0 on guard config). ofetch 46->45 (`fetch.ts(259)` TS2352 removed; tsc has 12 errors, none at that site).

## Verification
- Witnesses cleared (tsc 5.9.3 cross-checked): display `d3.ts`; F4 `f4d.ts`/`f4b.ts`/`f4c.ts`.
- Conformance filters (PASS): `genericCallWithObjectTypeArgs` 12/12, `mappedTypeRelationships` 1/1, `genericClassPropertyInheritanceSpecialization` 1/1, `classExtendsValidConstructorFunction` 1/1, `anyAssignability` 1/1.
- Direct test binaries (dev-fast; nextest orchestrator unavailable on this machine): `tsz-solver` lib 6607 passed / 2 pre-existing machine-delta failures (same names at base); new `same_base_any_args_application_tests` 6/6; `generic_property_mismatch_display_tests` zip-guard additions pass; display/relational/mapped/generic-call binaries show failure-name sets identical to base (all pre-existing machine-delta).
- `cargo clippy -p tsz-solver -p tsz-checker --all-targets`: clean.
- `scripts/arch/check-checker-boundaries.sh`: passed (printer reads types; no new checker->solver boundary violation); field-lifetime inventory 249 classified.

## Coordination Notes
- Base: origin/main 8cf6b693e3.
- Sibling agent ../tsz-f1b owns `no_erase`/`bivariant_callbacks` generic-signature relation paths; this PR does not touch them.

AgentName: M1FableArchitect
