### PR TITLE
fix(solver): arrival-order-immune append protocol for slice/value interners (#13046)

### DIFF
--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -989,8 +989,8 @@ impl TypeInterner {
                     .write()
                     .expect("interner alloc_order lock poisoned")
             });
-            write_id_slot(&mut vec, local_index as usize, key, &TypeData::Error);
-            write_id_slot(&mut ord, local_index as usize, order, &u32::MAX);
+            write_id_slot(&mut vec, local_index as usize, key, || TypeData::Error);
+            write_id_slot(&mut ord, local_index as usize, order, || u32::MAX);
         }
 
         self.make_id(local_index, shard_idx as u32)
@@ -1067,8 +1067,8 @@ impl TypeInterner {
                                 .write()
                                 .expect("interner alloc_order lock poisoned")
                         });
-                    write_id_slot(&mut vec, local_index as usize, key, &TypeData::Error);
-                    write_id_slot(&mut ord, local_index as usize, order, &u32::MAX);
+                    write_id_slot(&mut vec, local_index as usize, key, || TypeData::Error);
+                    write_id_slot(&mut ord, local_index as usize, order, || u32::MAX);
                 }
                 // Publish the index only after its slot is readable so a
                 // concurrent `key_to_index` hit can never observe an

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -38,7 +38,7 @@ mod display;
 mod storage;
 
 pub(super) use storage::{CachedUnionMember, TypeShard};
-use storage::{ConcurrentSliceInterner, ConcurrentValueInterner};
+use storage::{ConcurrentSliceInterner, ConcurrentValueInterner, write_id_slot};
 
 /// Global counter for assigning unique `instance_id`s to `TypeInterner`
 /// instances. `0` is reserved as "empty/no-interner" so it will never match
@@ -989,13 +989,8 @@ impl TypeInterner {
                     .write()
                     .expect("interner alloc_order lock poisoned")
             });
-            let target_len = local_index as usize + 1;
-            if vec.len() < target_len {
-                vec.resize(target_len, TypeData::Error);
-                ord.resize(target_len, u32::MAX);
-            }
-            vec[local_index as usize] = key;
-            ord[local_index as usize] = order;
+            write_id_slot(&mut vec, local_index as usize, key, &TypeData::Error);
+            write_id_slot(&mut ord, local_index as usize, order, &u32::MAX);
         }
 
         self.make_id(local_index, shard_idx as u32)
@@ -1050,7 +1045,6 @@ impl TypeInterner {
         // Double-check: another thread might have inserted while we allocated
         match inner.key_to_index.entry(key) {
             Entry::Vacant(e) => {
-                e.insert(local_index);
                 // Record allocation order for deterministic union member sorting.
                 let order = self.alloc_counter.fetch_add(1, Ordering::Relaxed);
                 {
@@ -1073,14 +1067,13 @@ impl TypeInterner {
                                 .write()
                                 .expect("interner alloc_order lock poisoned")
                         });
-                    let target_len = local_index as usize + 1;
-                    if vec.len() < target_len {
-                        vec.resize(target_len, TypeData::Error);
-                        ord.resize(target_len, u32::MAX);
-                    }
-                    vec[local_index as usize] = key;
-                    ord[local_index as usize] = order;
+                    write_id_slot(&mut vec, local_index as usize, key, &TypeData::Error);
+                    write_id_slot(&mut ord, local_index as usize, order, &u32::MAX);
                 }
+                // Publish the index only after its slot is readable so a
+                // concurrent `key_to_index` hit can never observe an
+                // unwritten `index_to_key` slot via `lookup`.
+                e.insert(local_index);
                 if let Some(c) = pc {
                     c.interner_intern_misses
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/crates/tsz-solver/src/intern/core/interner/storage.rs
+++ b/crates/tsz-solver/src/intern/core/interner/storage.rs
@@ -104,16 +104,26 @@ impl TypeShard {
 /// holds the index from its own `fetch_add`) or belong to ids that lost an
 /// insertion race and are never published, so they are never observed as
 /// long as ids are published only after this write completes.
+///
+/// `placeholder` is invoked only when earlier ids have not written their
+/// slots yet, i.e. only on contended out-of-order arrivals; the common
+/// in-order append pays no placeholder cost.
+#[inline]
 pub(in crate::intern::core) fn write_id_slot<T: Clone>(
     vec: &mut Vec<T>,
     index: usize,
     value: T,
-    placeholder: &T,
+    placeholder: impl FnOnce() -> T,
 ) {
-    if vec.len() <= index {
-        vec.resize(index + 1, placeholder.clone());
+    if vec.len() < index {
+        let fill = placeholder();
+        vec.resize(index, fill);
     }
-    vec[index] = value;
+    if vec.len() == index {
+        vec.push(value);
+    } else {
+        vec[index] = value;
+    }
 }
 
 /// Inner data for `ConcurrentSliceInterner`, lazily initialized.
@@ -188,9 +198,8 @@ where
                     let mut vec = tsz_common::perf_counters::time_shard_write(0, || {
                         inner.items.write().expect("interner items lock poisoned")
                     });
-                    // Gap slots get the pre-seeded empty slice (id 0).
-                    let placeholder = Arc::clone(&vec[0]);
-                    write_id_slot(&mut vec, id as usize, temp_arc, &placeholder);
+                    // Gap slots get an empty slice.
+                    write_id_slot(&mut vec, id as usize, temp_arc, || Arc::from(Vec::new()));
                 }
                 // Publish the id only after its slot is readable so a
                 // concurrent map hit can never observe an unwritten slot.
@@ -284,11 +293,10 @@ where
                     let mut vec = tsz_common::perf_counters::time_shard_write(0, || {
                         inner.items.write().expect("interner items lock poisoned")
                     });
-                    // No cheap empty value exists for arbitrary `T`; gap
-                    // slots get clones of this value's `Arc` and rightful
-                    // owners overwrite their own index.
-                    let placeholder = Arc::clone(&value_arc);
-                    write_id_slot(&mut vec, id as usize, value_arc, &placeholder);
+                    // No empty value exists for arbitrary `T`; gap slots get
+                    // this value's `Arc` and rightful owners overwrite their
+                    // own index.
+                    write_id_slot(&mut vec, id as usize, Arc::clone(&value_arc), || value_arc);
                 }
                 // Publish the id only after its slot is readable so a
                 // concurrent map hit can never observe an unwritten slot.

--- a/crates/tsz-solver/src/intern/core/interner/storage.rs
+++ b/crates/tsz-solver/src/intern/core/interner/storage.rs
@@ -115,14 +115,13 @@ pub(in crate::intern::core) fn write_id_slot<T: Clone>(
     value: T,
     placeholder: impl FnOnce() -> T,
 ) {
-    if vec.len() < index {
-        let fill = placeholder();
-        vec.resize(index, fill);
-    }
-    if vec.len() == index {
-        vec.push(value);
-    } else {
-        vec[index] = value;
+    match vec.len().cmp(&index) {
+        std::cmp::Ordering::Less => {
+            vec.resize(index, placeholder());
+            vec.push(value);
+        }
+        std::cmp::Ordering::Equal => vec.push(value),
+        std::cmp::Ordering::Greater => vec[index] = value,
     }
 }
 

--- a/crates/tsz-solver/src/intern/core/interner/storage.rs
+++ b/crates/tsz-solver/src/intern/core/interner/storage.rs
@@ -91,6 +91,31 @@ impl TypeShard {
     }
 }
 
+/// Arrival-order-immune append protocol for id-indexed interner storage.
+///
+/// `index` is allocated by an atomic counter *before* the storage lock is
+/// taken, so writers may reach the lock out of id order. Growing the vec with
+/// `placeholder` clones and then writing at `index` keeps every id mapped to
+/// its own data regardless of arrival order. A while-`push` backfill loop is
+/// NOT safe here: an earlier-arriving higher id would fill a later-arriving
+/// lower id's slot with its own data, permanently misaligning ids and slots.
+///
+/// Placeholder slots are either overwritten by their rightful owner (which
+/// holds the index from its own `fetch_add`) or belong to ids that lost an
+/// insertion race and are never published, so they are never observed as
+/// long as ids are published only after this write completes.
+pub(in crate::intern::core) fn write_id_slot<T: Clone>(
+    vec: &mut Vec<T>,
+    index: usize,
+    value: T,
+    placeholder: &T,
+) {
+    if vec.len() <= index {
+        vec.resize(index + 1, placeholder.clone());
+    }
+    vec[index] = value;
+}
+
 /// Inner data for `ConcurrentSliceInterner`, lazily initialized.
 pub(in crate::intern::core) struct SliceInternerInner<T> {
     /// Flat array from ID to slice value. Sequential IDs make Vec optimal for reverse lookup.
@@ -154,7 +179,6 @@ where
         // Double-check: another thread might have inserted while we allocated
         match inner.map.entry(std::sync::Arc::clone(&temp_arc)) {
             Entry::Vacant(e) => {
-                e.insert(id);
                 {
                     // T2.4 instrumentation: wrap the write-lock acquisition
                     // so contention on the slice-interner's `items` vec lands
@@ -164,11 +188,13 @@ where
                     let mut vec = tsz_common::perf_counters::time_shard_write(0, || {
                         inner.items.write().expect("interner items lock poisoned")
                     });
-                    while vec.len() < id as usize {
-                        vec.push(Arc::clone(&temp_arc));
-                    }
-                    vec.push(temp_arc);
+                    // Gap slots get the pre-seeded empty slice (id 0).
+                    let placeholder = Arc::clone(&vec[0]);
+                    write_id_slot(&mut vec, id as usize, temp_arc, &placeholder);
                 }
+                // Publish the id only after its slot is readable so a
+                // concurrent map hit can never observe an unwritten slot.
+                e.insert(id);
                 id
             }
             Entry::Occupied(e) => *e.get(),
@@ -251,7 +277,6 @@ where
         // Double-check: another thread might have inserted while we allocated
         match inner.map.entry(std::sync::Arc::clone(&value_arc)) {
             Entry::Vacant(e) => {
-                e.insert(id);
                 {
                     // T2.4 instrumentation: see the matching wrapper in
                     // `ConcurrentSliceInterner::intern`. Same rationale,
@@ -259,11 +284,15 @@ where
                     let mut vec = tsz_common::perf_counters::time_shard_write(0, || {
                         inner.items.write().expect("interner items lock poisoned")
                     });
-                    while vec.len() < id as usize {
-                        vec.push(Arc::clone(&value_arc));
-                    }
-                    vec.push(value_arc);
+                    // No cheap empty value exists for arbitrary `T`; gap
+                    // slots get clones of this value's `Arc` and rightful
+                    // owners overwrite their own index.
+                    let placeholder = Arc::clone(&value_arc);
+                    write_id_slot(&mut vec, id as usize, value_arc, &placeholder);
                 }
+                // Publish the id only after its slot is readable so a
+                // concurrent map hit can never observe an unwritten slot.
+                e.insert(id);
                 id
             }
             Entry::Occupied(e) => *e.get(),

--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -151,3 +151,152 @@ fn same_name_type_parameter_replacement_dedups_non_adjacent_members() {
 
     assert_eq!(&*interner.type_list(list_id), &[constrained_t, u]);
 }
+
+/// Append-protocol regression tests for #13046: ids are allocated by
+/// `fetch_add` before the storage lock is taken, so writers can reach the
+/// lock out of id order. The old while-`push` backfill let an
+/// earlier-arriving higher id claim a later-arriving lower id's slot,
+/// silently corrupting `get(id)` for the rest of the session.
+mod append_protocol {
+    use super::storage::write_id_slot;
+    use super::*;
+    use std::sync::Barrier;
+    use std::thread;
+
+    const THREADS: usize = 8;
+    const PER_THREAD: u32 = 2_000;
+
+    #[test]
+    fn write_id_slot_round_trips_out_of_order_arrivals() {
+        let mut vec: Vec<u32> = Vec::new();
+        // A higher id reaches the lock first; lower ids arrive later and
+        // must still land in their own slots.
+        write_id_slot(&mut vec, 5, 50, &u32::MAX);
+        write_id_slot(&mut vec, 1, 10, &u32::MAX);
+        write_id_slot(&mut vec, 3, 30, &u32::MAX);
+        assert_eq!(vec.len(), 6);
+        assert_eq!((vec[1], vec[3], vec[5]), (10, 30, 50));
+        // Unwritten gaps hold the placeholder, never another id's data.
+        assert_eq!((vec[0], vec[2], vec[4]), (u32::MAX, u32::MAX, u32::MAX));
+    }
+
+    #[test]
+    fn slice_interner_ids_round_trip_under_concurrent_interning() {
+        let interner = ConcurrentSliceInterner::<u32>::new();
+        let barrier = Barrier::new(THREADS);
+        thread::scope(|s| {
+            let handles: Vec<_> = (0..THREADS as u32)
+                .map(|t| {
+                    let (interner, barrier) = (&interner, &barrier);
+                    s.spawn(move || {
+                        barrier.wait();
+                        (0..PER_THREAD)
+                            .map(|i| (interner.intern(&[t, i]), [t, i]))
+                            .collect::<Vec<_>>()
+                    })
+                })
+                .collect();
+            for handle in handles {
+                for (id, slice) in handle.join().expect("intern thread panicked") {
+                    let stored = interner.get(id).expect("interned id must resolve");
+                    assert_eq!(
+                        &*stored, &slice,
+                        "id {id} resolved to another writer's slice"
+                    );
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn value_interner_ids_round_trip_under_concurrent_interning() {
+        let interner = ConcurrentValueInterner::<u64>::new();
+        let barrier = Barrier::new(THREADS);
+        thread::scope(|s| {
+            let handles: Vec<_> = (0..THREADS as u64)
+                .map(|t| {
+                    let (interner, barrier) = (&interner, &barrier);
+                    s.spawn(move || {
+                        barrier.wait();
+                        (0..u64::from(PER_THREAD))
+                            .map(|i| {
+                                let value = (t << 32) | i;
+                                (interner.intern(value), value)
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                })
+                .collect();
+            for handle in handles {
+                for (id, value) in handle.join().expect("intern thread panicked") {
+                    assert_eq!(
+                        interner.get_copy(id),
+                        Some(value),
+                        "id {id} resolved to another writer's value"
+                    );
+                }
+            }
+        });
+    }
+
+    /// Threads race on the same value first (losers leak their allocated
+    /// ids), then intern unique values; leaked ids must not shift later
+    /// slots out of alignment.
+    #[test]
+    fn value_interner_duplicate_race_keeps_later_ids_aligned() {
+        let interner = ConcurrentValueInterner::<u64>::new();
+        let barrier = Barrier::new(THREADS);
+        thread::scope(|s| {
+            let handles: Vec<_> = (0..THREADS as u64)
+                .map(|t| {
+                    let (interner, barrier) = (&interner, &barrier);
+                    s.spawn(move || {
+                        barrier.wait();
+                        let shared = interner.intern(u64::MAX);
+                        let unique = (t + 1) * 10_000;
+                        (shared, interner.intern(unique), unique)
+                    })
+                })
+                .collect();
+            for handle in handles {
+                let (shared, unique_id, unique) = handle.join().expect("intern thread panicked");
+                assert_eq!(interner.get_copy(shared), Some(u64::MAX));
+                assert_eq!(interner.get_copy(unique_id), Some(unique));
+            }
+        });
+    }
+
+    #[test]
+    fn type_interner_lookup_round_trips_under_concurrent_interning() {
+        let interner = TypeInterner::new();
+        let barrier = Barrier::new(THREADS);
+        thread::scope(|s| {
+            let handles: Vec<_> = (0..THREADS as u32)
+                .map(|t| {
+                    let (interner, barrier) = (&interner, &barrier);
+                    s.spawn(move || {
+                        barrier.wait();
+                        (0..PER_THREAD)
+                            .map(|i| {
+                                let key = TypeData::Array(TypeId(
+                                    TypeId::FIRST_USER + t * PER_THREAD + i,
+                                ));
+                                (interner.intern(key), key)
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                })
+                .collect();
+            for handle in handles {
+                for (id, key) in handle.join().expect("intern thread panicked") {
+                    assert_eq!(
+                        interner.lookup(id),
+                        Some(key),
+                        "id {id:?} resolved to another writer's TypeData"
+                    );
+                    assert_eq!(interner.intern(key), id, "re-intern must be stable");
+                }
+            }
+        });
+    }
+}

--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -171,9 +171,9 @@ mod append_protocol {
         let mut vec: Vec<u32> = Vec::new();
         // A higher id reaches the lock first; lower ids arrive later and
         // must still land in their own slots.
-        write_id_slot(&mut vec, 5, 50, &u32::MAX);
-        write_id_slot(&mut vec, 1, 10, &u32::MAX);
-        write_id_slot(&mut vec, 3, 30, &u32::MAX);
+        write_id_slot(&mut vec, 5, 50, || u32::MAX);
+        write_id_slot(&mut vec, 1, 10, || u32::MAX);
+        write_id_slot(&mut vec, 3, 30, || u32::MAX);
         assert_eq!(vec.len(), 6);
         assert_eq!((vec[1], vec[3], vec[5]), (10, 30, 50));
         // Unwritten gaps hold the placeholder, never another id's data.


### PR DESCRIPTION
Goal: green

Fixes #13046.

## Summary

`ConcurrentSliceInterner::intern` and `ConcurrentValueInterner::intern` allocated an id with `next_id.fetch_add` *before* taking the `items` write lock, then appended with an arrival-order-dependent while-`push` backfill loop. When a thread holding a higher id reached the lock first, it backfilled the lower id's slot with its own data; the dedup map then permanently mapped the loser's value to an index holding someone else's data, and the misalignment offset every subsequent vacant insert. Silent type corruption (wrong type list, wrong object shape) under parallel checking — `check.rs` already documents "non-deterministic false positives from concurrent type interning" as a known flake family on the default `par_iter` project path.

## Structural rule

When an id is allocated by an atomic counter before the storage lock is taken, the slot write must be arrival-order-immune: grow with placeholders and write at the owned index (`tsc` has no analogue — this is an internal determinism/correctness invariant; the user-visible rule is that parallel and serial checking produce identical diagnostics). Owner: solver intern storage (`tsz_solver::intern::core::interner::storage`).

## What changed

- Extracted the already-safe `TypeShard` resize+indexed-write protocol into one shared `write_id_slot` helper (three-way `len` vs `index` match: gap-fill / push / overwrite) used by all four write sites: slice interner, value interner, `TypeShard::intern_slow`, `TypeShard::intern_fresh`. One protocol, no future re-divergence.
- Hardened publish ordering at all three dedup-map sites: the id is inserted into the map only *after* its slot is written, so a concurrent map hit can never observe an unwritten or placeholder slot. Lock order (map entry guard → items write lock) is unchanged and unidirectional; readers take only the items lock.
- Placeholder is `FnOnce`, evaluated only on contended out-of-order gaps; the common in-order append is a direct `push` with zero placeholder cost. Gap slots: empty slice for the slice interner, the writer's own `Arc` for the value interner, `TypeData::Error`/`u32::MAX` for the shard vecs — all either overwritten by their rightful owner or owned by never-published leaked ids.

## Adjacent-case matrix

- In-order arrival (single-threaded and uncontended): identical layout and ids to the old code (covered by the existing 272 intern unit tests).
- Out-of-order unique-key contention: slice, value, and `TypeData` shard paths each stress-tested (8 threads × 2000 unique keys behind a barrier) with full id→data round-trip verification.
- Duplicate-key race (`Entry::Occupied` leaked ids): later unique interns stay aligned.
- Negative control: the three new concurrent stress tests fail against the old while-push protocol (verified by temporarily restoring it: 3/5 tests fail with cross-thread data corruption) and pass with the fix.

## Cache/order honesty

Cache-enabled vs cache-disabled agreement is unaffected (no cache key changes); this removes a source of run-to-run diagnostic nondeterminism, moving parallel runs toward the serial baseline.

## Verification

- `cargo test -p tsz-solver --lib append_protocol` — 5/5 pass (new regression suite).
- `cargo test -p tsz-solver --lib intern::` — 272/272 pass.
- Negative verification: with the old backfill loops restored, `slice_interner_ids_round_trip_under_concurrent_interning`, `value_interner_ids_round_trip_under_concurrent_interning`, and `value_interner_duplicate_race_keeps_later_ids_aligned` all fail.
- `cargo clippy -p tsz-solver --lib --tests` clean.
- Pre-existing (also on base commit `ed1c5b0` before this change): `operations::tests::higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder` and `operations::tests::test_generic_call_widening_applies_when_constraint_satisfied` fail under plain `cargo test`; unrelated to this PR.
- Branch rebased onto `main` head `8a3b5db`; merges clean.

## Provenance

Machine: cloud
Assistant: claude-code
Model: undisclosed
Effort: high

https://claude.ai/code/session_01CHHnf2Gcup1gqonnrdG4ya

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHHnf2Gcup1gqonnrdG4ya)_