### PR TITLE
fix(solver): exclude unresolved-name applications from evaluator union simplification (kysely F1(b))

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -696,6 +696,9 @@ mod cross_file_type_param_decl_identity_tests;
 #[path = "../tests/cross_file_type_params_cache_tests.rs"]
 mod cross_file_type_params_cache_tests;
 #[cfg(test)]
+#[path = "tests/cross_file_unresolved_alias_union_simplification_tests.rs"]
+mod cross_file_unresolved_alias_union_simplification_tests;
+#[cfg(test)]
 #[path = "tests/cross_module_generic_interface_heritage_tests.rs"]
 mod cross_module_generic_interface_heritage_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/cross_file_unresolved_alias_union_simplification_tests.rs
+++ b/crates/tsz-checker/src/tests/cross_file_unresolved_alias_union_simplification_tests.rs
@@ -1,0 +1,267 @@
+//! Cross-file alias unions whose members are applications of
+//! display-preserving `UnresolvedTypeName` bases must keep ALL members.
+//!
+//! When a file checker lowers an imported alias body (e.g. Kysely's
+//! `OperandExpression<V> = Expression<V> | SelectQueryBuilderExpression<...>`),
+//! the inner names are interned as `Application(UnresolvedTypeName(..), args)`
+//! and resolved on demand later. The relation layer treats unresolved names as
+//! error types that relate to everything, so the evaluator's subtype-based
+//! union simplification (`remove_redundant_members`) must not consult it for
+//! such members: doing so removed the supertype arm (`Expression<any>`),
+//! collapsed the union, and produced false `TS2416` on every method of an
+//! implementing class (Kysely `SelectQueryBuilderImpl` family,
+//! #10663 / F1(b) no-erase generic-signature relation).
+//!
+//! tsc never subtype-reduces annotation unions (`UnionReduction.Literal`) and
+//! never treats a resolvable name as `error`. Cases vary binder names, cover
+//! method and arrow-property members, keep a smaller-union control, and include
+//! genuine-mismatch negative controls so the rule follows the type shape rather
+//! than identifier names.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::{Diagnostic, diagnostic_codes};
+use crate::test_utils::{check_multi_file_with_libs, load_lib_files};
+use tsz_common::common::ModuleKind;
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    check_multi_file_with_libs(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &load_lib_files(&["es5.d.ts"]),
+    )
+}
+
+fn implements_member_errors(diagnostics: &[Diagnostic]) -> Vec<(u32, String)> {
+    diagnostics
+        .iter()
+        .filter(|d| {
+            d.code
+                == diagnostic_codes::PROPERTY_IN_TYPE_IS_NOT_ASSIGNABLE_TO_THE_SAME_PROPERTY_IN_BASE_TYPE
+        })
+        .map(|d| (d.code, d.message_text.to_string()))
+        .collect()
+}
+
+/// The kysely-min3 witness shape: two subtype-related object arms
+/// (`Expression<any>` is a structural supertype of
+/// `SelectQueryBuilderExpression<Record<string, any>>`) plus a factory
+/// function arm, reached through two alias layers across a module boundary.
+const REFS_SRC: &str = r#"
+export interface Expression<T> {
+    readonly expressionType?: T | undefined;
+}
+
+export interface SelectQueryBuilderExpression<O> {
+    readonly isSelectQueryBuilder: true;
+    readonly expressionType?: O | undefined;
+}
+
+export type OperandExpression<V> =
+    | Expression<V>
+    | SelectQueryBuilderExpression<Record<string, V>>;
+
+export interface ExpressionBuilder<DB, TB extends keyof DB> {
+    ref(reference: TB & string): unknown;
+}
+
+type OperandExpressionFactory<DB, TB extends keyof DB, V> = (
+    eb: ExpressionBuilder<DB, TB>,
+) => OperandExpression<V>;
+
+export type ExpressionOrFactory<DB, TB extends keyof DB, V> =
+    | OperandExpression<V>
+    | OperandExpressionFactory<DB, TB, V>;
+
+export type AnyColumn<DB, TB extends keyof DB> = keyof DB[TB] & string;
+
+export type ReferenceExpression<DB, TB extends keyof DB> =
+    | AnyColumn<DB, TB>
+    | ExpressionOrFactory<DB, TB, any>;
+"#;
+
+const BUILDER_SRC: &str = r#"
+import { type ReferenceExpression } from "./refs";
+
+export interface SelectQueryBuilder<DB, TB extends keyof DB, O> {
+    whereRef<LRE extends ReferenceExpression<DB, TB>, RRE extends ReferenceExpression<DB, TB>>(
+        lhs: LRE,
+        op: string,
+        rhs: RRE,
+    ): SelectQueryBuilder<DB, TB, O>;
+}
+
+class SelectQueryBuilderImpl<DB, TB extends keyof DB, O>
+    implements SelectQueryBuilder<DB, TB, O>
+{
+    whereRef(
+        lhs: ReferenceExpression<DB, TB>,
+        op: string,
+        rhs: ReferenceExpression<DB, TB>,
+    ): SelectQueryBuilder<DB, TB, O> {
+        return this;
+    }
+}
+"#;
+
+#[test]
+fn subtype_related_union_arms_survive_cross_file_implements() {
+    let diags = check(
+        &[("./refs.ts", REFS_SRC), ("./builder.ts", BUILDER_SRC)],
+        "./builder.ts",
+    );
+    let errors = implements_member_errors(&diags);
+    assert!(
+        errors.is_empty(),
+        "expected the non-generic override of the generic interface method to be accepted, got: {errors:?}",
+    );
+}
+
+#[test]
+fn renamed_binders_and_generic_impl_control_stay_clean() {
+    let refs = r#"
+export interface Wrapped<T> {
+    readonly wrappedKind?: T | undefined;
+}
+
+export interface Tagged<O> {
+    readonly isTagged: true;
+    readonly wrappedKind?: O | undefined;
+}
+
+export type Operand<V> = Wrapped<V> | Tagged<Record<string, V>>;
+
+export interface Builder<Schema, Table extends keyof Schema> {
+    pick(reference: Table & string): unknown;
+}
+
+type OperandFactory<Schema, Table extends keyof Schema, V> = (
+    b: Builder<Schema, Table>,
+) => Operand<V>;
+
+export type OperandOrFactory<Schema, Table extends keyof Schema, V> =
+    | Operand<V>
+    | OperandFactory<Schema, Table, V>;
+
+export type RefLike<Schema, Table extends keyof Schema> =
+    | (keyof Schema[Table] & string)
+    | OperandOrFactory<Schema, Table, any>;
+"#;
+    let main = r#"
+import { type RefLike } from "./refs";
+
+export interface QB<D, T extends keyof D, R> {
+    cmp<L extends RefLike<D, T>, Rr extends RefLike<D, T>>(l: L, op: string, r: Rr): QB<D, T, R>;
+}
+
+class QBImpl<D, T extends keyof D, R> implements QB<D, T, R> {
+    cmp(l: RefLike<D, T>, op: string, r: RefLike<D, T>): QB<D, T, R> {
+        return this;
+    }
+}
+
+// NOTE: the arrow-PROPERTY form of this override (`cmp: <L extends ...>(l: L) => ...`
+// implemented by a non-generic arrow property) is a separate pre-existing
+// defect in the strict-function-types property lane: it fails on origin/main
+// before and after this fix, and is order-sensitive (passes when a method-form
+// check of the same union precedes it in CLI runs). It is intentionally not
+// pinned here.
+
+class QBGenericImpl<D, T extends keyof D, R> implements QB<D, T, R> {
+    cmp<L extends RefLike<D, T>, Rr extends RefLike<D, T>>(l: L, op: string, r: Rr): QB<D, T, R> {
+        return this;
+    }
+}
+"#;
+    let diags = check(&[("./refs.ts", refs), ("./main.ts", main)], "./main.ts");
+    let errors = implements_member_errors(&diags);
+    assert!(
+        errors.is_empty(),
+        "expected renamed-binder and generic-impl variants to stay clean, got: {errors:?}",
+    );
+}
+
+#[test]
+fn genuinely_incompatible_override_still_reports_ts2416() {
+    // Negative control: with the unresolved-name members excluded from union
+    // simplification, a genuine member mismatch (wrong return type) must keep
+    // being reported.
+    //
+    // NOTE on scope: in this harness's lowering conditions the relation layer
+    // still treats the not-yet-resolved constraint arms as error-related, so on
+    // origin/main both before and after this fix only the return-type mismatch
+    // (QBNeg2Impl) is reported here while the parameter-narrower mismatch
+    // (QBNegImpl, reported by the CLI pipeline) is under-reported. That
+    // pre-existing relation-layer gap is tracked with the F1(b) family; this
+    // test asserts the surviving genuine report so a future relation fix can
+    // tighten it to both.
+    let main = r#"
+import { type ReferenceExpression } from "./refs";
+
+export interface QBNeg<D, T extends keyof D, R> {
+    cmp<L extends ReferenceExpression<D, T>>(l: L, op: string): QBNeg<D, T, R>;
+}
+
+class QBNegImpl<D, T extends keyof D, R> implements QBNeg<D, T, R> {
+    cmp(l: number, op: string): QBNeg<D, T, R> {
+        return this;
+    }
+}
+
+export interface QBNeg2<D, T extends keyof D, R> {
+    cmp<L extends ReferenceExpression<D, T>>(l: L): QBNeg2<D, T, R>;
+}
+
+class QBNeg2Impl<D, T extends keyof D, R> implements QBNeg2<D, T, R> {
+    cmp(l: ReferenceExpression<D, T>): string {
+        return "";
+    }
+}
+"#;
+    let diags = check(&[("./refs.ts", REFS_SRC), ("./main.ts", main)], "./main.ts");
+    let errors = implements_member_errors(&diags);
+    assert!(
+        !errors.is_empty(),
+        "expected the genuine return-type member mismatch to keep being reported, got none",
+    );
+    assert!(
+        errors.iter().any(|(_, msg)| msg.contains("QBNeg2Impl")),
+        "expected the QBNeg2Impl return-type mismatch among the reports, got: {errors:?}",
+    );
+}
+
+#[test]
+fn smaller_union_without_factory_arm_stays_clean() {
+    // Smaller-union control: two arms, no function arm — passed before the fix
+    // and must keep passing.
+    let refs = r#"
+export interface Wrapped<T> {
+    readonly wrappedKind?: T | undefined;
+}
+
+export type RefSmall<DB, TB extends keyof DB> = (keyof DB[TB] & string) | Wrapped<any>;
+"#;
+    let main = r#"
+import { type RefSmall } from "./refs";
+
+export interface QBS<D, T extends keyof D, R> {
+    cmp<L extends RefSmall<D, T>>(l: L): QBS<D, T, R>;
+}
+
+class QBSImpl<D, T extends keyof D, R> implements QBS<D, T, R> {
+    cmp(l: RefSmall<D, T>): QBS<D, T, R> {
+        return this;
+    }
+}
+"#;
+    let diags = check(&[("./refs.ts", refs), ("./main.ts", main)], "./main.ts");
+    let errors = implements_member_errors(&diags);
+    assert!(
+        errors.is_empty(),
+        "expected the smaller-union control to stay clean, got: {errors:?}",
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -18,6 +18,7 @@ type MemberModifierMap = Option<FxHashMap<u32, (bool, bool)>>;
 
 /// Controls which subtype direction makes a member redundant when simplifying
 /// a union or intersection.
+#[derive(Debug)]
 enum SubtypeDirection {
     /// member[i] <: member[j] -> member[i] is redundant (union semantics).
     SourceSubsumedByOther,
@@ -368,6 +369,16 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         };
 
         match key {
+            // `UnresolvedTypeName` is a display-preserving unresolved type
+            // name (cross-file alias bodies lowered before the referenced
+            // declaration's name is resolvable in this checker) and is just
+            // as inherently deferred as the other variants in this arm: the
+            // relation layer treats it as an error type that is related to
+            // EVERYTHING, so any subtype-based simplification over it would
+            // collapse distinct union members (e.g. `Expression<any> |
+            // SelectQueryBuilderExpression<...>` losing its supertype arm).
+            // The evaluator resolves these on demand later, so keep them out
+            // of simplification entirely.
             TypeData::TypeParameter(_)
             | TypeData::Infer(_)
             | TypeData::Conditional(_)
@@ -378,7 +389,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             | TypeData::TemplateLiteral(_)
             | TypeData::ReadonlyType(_)
             | TypeData::StringIntrinsic { .. }
-            | TypeData::ThisType => true,
+            | TypeData::ThisType
+            | TypeData::UnresolvedTypeName(_) => true,
             // Intersection/union types containing complex members are also complex.
             // Without this, the evaluator's subtype-based simplification can incorrectly
             // collapse union members like `(T&U&1) | (T&U&2) | (T&U&3)` to just `T&U&2`
@@ -395,9 +407,15 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // not subtype-reduce union members that depend on unresolved type
             // parameters, so keep them. Fully-concrete applications stay
             // simplifiable via the canonicalizer.
+            // An application whose BASE is an unresolved type name is just as
+            // deferred as the bare name: `is_error_type` follows application
+            // bases, so the bypass-evaluation subtype checker would judge the
+            // whole application universally related and let simplification drop
+            // a sibling member. Check the base alongside the arguments.
             TypeData::Application(app_id) => {
                 let app = self.interner.type_application(app_id);
-                app.args.iter().any(|&arg| self.is_complex_type(arg))
+                self.is_complex_type(app.base)
+                    || app.args.iter().any(|&arg| self.is_complex_type(arg))
             }
             TypeData::Array(_) | TypeData::Tuple(_) => self.has_nested_complex_marker(type_id),
             // Function types with Application/Lazy return *or parameter* types are
@@ -874,6 +892,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     }
                 };
                 if is_subtype {
+                    tracing::trace!(
+                        removed = ?members[i],
+                        subsumed_by = ?members[j],
+                        ?direction,
+                        "remove_redundant_members: removing member"
+                    );
                     keep &= !(1u32 << i);
                     break;
                 }


### PR DESCRIPTION
Goal: green

## Provenance
Machine: m1
Assistant: claude-code
Model: claude-fable-5
Effort: high

Track: kysely-project row / F1(b) no-erase generic-signature relation family (#10663, gate chain #13044)
Invariant: the evaluator's subtype-based union/intersection simplification never consults a relation over members the relation layer cannot judge (unresolved-name applications are deferred, like generic-dependent applications); tsc parity for non-generic overrides of generic interface methods across files.
Scope: solver only — `crates/tsz-solver/src/evaluation/evaluate/support.rs` (`is_complex_type` + a trace event in `remove_redundant_members`); new checker regression test file + its `lib.rs` registration. No checker gate, relation rule, or emitter changes.

## Summary
F1(b) family (kysely row #10663, gate chain from #13044): TS2416 `Property 'whereRef' in type 'SelectQueryBuilderImpl<DB, TB, O>' is not assignable...` on non-generic impl methods overriding generic interface methods, cross-file.

Traced divergence: the relation gates were innocent — the DERIVED-side param union was silently missing its `Expression<any>` arm. When a file checker lowers an imported alias body, inner cross-file names are interned as `Application(UnresolvedTypeName(..), args)` (resolved on demand later). `check_subtype` has an `is_error_type` early return that follows application bases into `UnresolvedTypeName` and treats such types as related to everything. The evaluator's subtype-based union simplification (`remove_redundant_members`, union direction, `bypass_evaluation=true`) therefore judged `Expression<any> <: SelectQueryBuilderExpression<Record<string, any>>` true and deleted the supertype arm, permanently collapsing `OperandExpression<any>` in that checker universe. Every downstream type (factory return, `ReferenceExpression<DB, TB>`, impl method params) inherited the collapsed union; the no-erase/bivariant override relation then failed because the interface-side constraint union kept the arm the impl side lost.

Structural rule: when a union member is (or applies) a display-preserving unresolved type name, tsc performs no subtype-based member elimination (tsc only reduces unions structurally after full resolution, and never treats a resolvable name as error-compatible); tsz marks such members as complex/deferred in `is_complex_type` so `remove_redundant_members` skips the whole simplification — same treatment as the existing generic-dependent-application guard documented in the same match.

Owner layer: solver (`crates/tsz-solver/src/evaluation/evaluate/support.rs`). The checker gates (`should_report_own_member_type_mismatch` -> `no_erase_generics_relation_outcome` -> `nongeneric_input_only_generic_override_is_valid`) consume relation outcomes and are unchanged.

## Adjacent-case matrix
- kysely-min3 2-file witness (subtype-related object arms + factory arm through 2 alias layers): false TS2416 -> clean (tsc 5.9.3 clean).
- Renamed binders (Wrapped/Tagged/RefLike/QB/cmp): clean.
- Generic impl method overriding generic interface method (control): clean before and after.
- Smaller union without function arm (control): clean before and after.
- Single-file form (control): clean before and after.
- Negative controls (param narrower than constraint; wrong return type): still report TS2416 via CLI (1x TS2322 + 2x TS2416, exactly tsc's codes).
- Pinned in `crates/tsz-checker/src/tests/cross_file_unresolved_alias_union_simplification_tests.rs` (4 tests).

Documented non-regressions discovered while building the matrix (pre-existing on origin/main, fail identically before/after):
- arrow-PROPERTY override form of the same shape fails when checked alone and passes when a method-form check of the same union precedes it (order-sensitive, strict-function-types lane);
- the multi-file test harness under-reports the param-narrower negative (relation layer treats still-unresolved constraint arms as error-related).

## Project Corpus Impact
- Row: kysely-project
- Bug family: F1(b) no-erase generic-signature relation (#13044/#10663)

Kysely row A/B (both sides built at base 8cf6b693e3, i.e. before #13191/#13218 merged — CI validates the merge result at the current head; 2 runs/side, deterministic): 151 -> 145 errors, ZERO new error sites; 6 sites removed (3x TS2769 introspectors/migrator overloads, 2x TS2345 dynamic-reference-builder/over-builder, 1 more). The 6 TS2416 sites in `select-query-builder.ts` REMAIN: their derived-param display now shows the full uncollapsed union, and the residual divergence is a leaked mapped binder (`keyof DB[T]` with free `T` from kysely's mapped-indexed `AnyColumn`/`AnyColumnWithTable`) that only reproduces at row scale (isolated witnesses with the mapped-indexed arm, `DynamicReferenceBuilder` arm, heritage hop, and op-union all pass) — next sub-defect for the family, evidence preserved in the PR discussion.

## Verification
- Witness `/tmp/kysely-min3` (rp.ts/sqb.ts): tsz clean, tsc 5.9.3 clean.
- New tests: `cargo build --tests -p tsz-checker` + direct binary `cross_file_unresolved_alias_union_simplification` -> 4/4 pass.
- Full tsz-checker suite (worktree env): 6242 pass / 275 fail vs baseline 6238 pass / 275 fail -> delta is exactly the 4 new tests; the 275 are pre-existing environment failures in this sister worktree (missing scripts/node_modules lib roots), identical at baseline.
- tsz-solver suite: 6607 pass / 2 fail; both failures (`higher_order_generic_pipe_regeneralizes...`, `test_generic_call_widening...`) fail identically at baseline in this environment (thread-count-sensitive) -> not regressions.
- Kysely guard A/B: 151 -> 145, zero new sites (2 runs/side, identical; measured at base 8cf6b693e3, predates #13191/#13218).
- comlink guard: 1 -> 1 site-identical. zod guard: 3 -> 3 site-identical.
- Conformance narrow filters at merged head + fix: typeGuard 86/86, keyof 14/14, interface 116/116, override 33/33 (all 100%).
- clippy (CI crate set, ci-lint profile, -D warnings) + arch guard (`scripts/arch/check-checker-boundaries.sh`): pass.
- Re-measured at merged head (includes #13191/#13218/#13163): kysely 145 errors, TS2416 still 6 — #13163's mapped-binder substitution does not move the remaining family sites.

## Coordination Notes
Builds on the type-param identity campaign (#13165/#13170). Remaining 6 TS2416 row sites are the mapped-binder-leak sub-defect; findings checkpointed for the next F1(b) slice. No other agent's open PR touches `evaluation/evaluate/support.rs` simplification.

AgentName: M1FableArchitect
