### PR TITLE
perf(core,binder): share the bound lib binder read-only — per-run binder deep-clone eliminated

### DIFF
--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -1056,6 +1056,28 @@ impl BinderState {
     /// Clear resolution caches that were populated during binding.
     /// Called after cloning a binder for the checker, which needs a clean
     /// cache state for its own symbol resolution.
+    /// `&self` variant of [`Self::clear_resolution_caches`] for shared
+    /// (refcount > 1) lib binders: the caches are `RwLock`-interior, so a
+    /// shared instance can be reset without cloning the binder.
+    pub fn clear_resolution_caches_shared(&self) {
+        self.resolved_export_cache
+            .write()
+            .expect("not poisoned")
+            .clear();
+        self.resolved_export_type_only_cache
+            .write()
+            .expect("not poisoned")
+            .clear();
+        self.resolved_identifier_cache
+            .write()
+            .expect("not poisoned")
+            .clear();
+        self.find_enclosing_scope_cache
+            .write()
+            .expect("not poisoned")
+            .clear();
+    }
+
     pub fn clear_resolution_caches(&mut self) {
         self.resolved_export_cache
             .write()

--- a/crates/tsz-core/src/parallel/core/parse_and_libs.rs
+++ b/crates/tsz-core/src/parallel/core/parse_and_libs.rs
@@ -1241,12 +1241,19 @@ pub fn clone_lib_files_for_checker(
     should_clone_libs_in_parallel: bool,
 ) -> Vec<Arc<lib_loader::LibFile>> {
     let clone_lib_file = |lib: &Arc<lib_loader::LibFile>| {
-        let mut binder = (*lib.binder).clone();
-        binder.clear_resolution_caches();
+        // Share the bound lib BINDER read-only: merge_lib_contexts_into_binder
+        // is proven to read lib binders immutably (pinned by the tsz-binder
+        // refcount>1 immutability test), and its resolution caches are
+        // RwLock-interior — clear them once on the shared instance instead of
+        // deep-cloning the whole binder per run. The ARENA keeps its cheap
+        // clone (distinct outer Arc identity): arena-pointer-identity
+        // discriminators across the checker must keep behaving exactly as
+        // with the prior deep clone (the recursiveComplicatedClasses class).
+        lib.binder.clear_resolution_caches_shared();
         Arc::new(lib_loader::LibFile::new(
             lib.file_name.clone(),
             Arc::new((*lib.arena).clone()),
-            Arc::new(binder),
+            Arc::clone(&lib.binder),
             lib.root_index,
         ))
     };


### PR DESCRIPTION
Goal: fast

## Summary

The shared-lib-universe payoff, landed on its proven foundation: `clone_lib_files_for_checker` now **shares the bound lib binder read-only** (`Arc::clone`) instead of deep-cloning the whole `BinderState` per run. Justified by the chain this campaign built: the six-field binder immutability pin (#13209) proves `merge_lib_contexts_into_binder` reads lib binders immutably at refcount > 1, and the binder's resolution caches are `RwLock`-interior — cleared in place via a new `clear_resolution_caches_shared(&self)`.

The ARENA deliberately keeps its identity-preserving cheap clone (#13033's O(1) `Arc<NodeArenaInner>` bump): sharing the arena is the **falsified** path — arena-pointer-identity discriminators across the checker flip and silently drop diagnostics (the `recursiveComplicatedClasses` TS2345 witness, reproduced and documented earlier in this campaign) — so its distinct per-file outer `Arc` is retained by design.

## Structural rule

A bound lib binder is immutable during program binding and checking (test-pinned), so per-run isolation requires only resetting its interior resolution caches, not copying it. Arena identity remains per-clone because identity is semantically load-bearing for lib-origin/current-file discrimination.

## Measured

- `checker_lib_clone_elapsed_ms_total` (vite): 0.51ms → **0.356ms** — the binder deep-clone eliminated; the residual is the deliberate arena identity-bump floor (47 Arc-bumps + `LibFile` construction). Campaign total on this counter: 5.04ms → 0.356ms (−93%).
- vite 0 diagnostics; vite + nextjs **5× byte-identical** (the goal's determinism guardrail).

## Project Corpus Impact
- Row: DOM-lib rows (vite/nextjs verified; per-run fixed cost)
- Bug family: n/a (behavior-preserving; the falsified arena-share is explicitly NOT taken)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: medium

## Verification

- Full local conformance: 12583/12585 — zero new vs the accepted ledger.
- `recursiveComplicatedClasses` keeps TS2345 (1/1) — the arena-share falsification witness stays green.
- Recursive-lib Promise/PromiseLike parity gate: 2/2.
- vite/nextjs 5× byte-identical; clippy/arch guards clean.
