### PR TITLE
fix(checker): unify flow-narrowing finalization; roll narrowing markers back with return-type speculation

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -791,6 +791,9 @@ path = "tests/js_export_surface_tests.rs"
 name = "js_grammar_span_tests"
 path = "tests/js_grammar_span_tests.rs"
 [[test]]
+name = "flow_narrowing_finalization_tests"
+path = "tests/flow_narrowing_finalization_tests.rs"
+[[test]]
 name = "speculation_rollback_tests"
 path = "tests/speculation_rollback_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -65,11 +65,11 @@ flow_switch_reference_cache = { lifetime = "FileLocalReset", capability = "FlowS
 flow_numeric_atom_cache = { lifetime = "FileLocalReset", capability = "FlowSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 flow_reference_match_cache = { lifetime = "FileLocalReset", capability = "FlowSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 symbol_flow_memo = { lifetime = "FileLocalReset", capability = "FlowSessionState", reason = "symbol-stable flow memo tables reused only within the active file session; reset at file-session boundary" }
-symbol_flow_confirmed = { lifetime = "FileLocalReset", capability = "FlowSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
+symbol_flow_confirmed = { lifetime = "SpeculationScoped", capability = "SpeculationState", reason = "snapshot/rollback-sensitive state mutated during speculative checking; also reset at file-session boundary" }
 call_type_predicates = { lifetime = "FileLocalReset", capability = "FlowSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
-daa_error_nodes = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
+daa_error_nodes = { lifetime = "SpeculationScoped", capability = "SpeculationState", reason = "snapshot/rollback-sensitive narrowing-suppression markers tied to emitted TS2454 diagnostics; also cleared at file-session boundary" }
 deferred_ts2454_errors = { lifetime = "DiagnosticsOnly", capability = "DiagnosticState", reason = "diagnostic emission, dedupe, or suppression state; clear at file-session boundary" }
-flow_narrowed_nodes = { lifetime = "FileLocalReset", capability = "FlowSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
+flow_narrowed_nodes = { lifetime = "SpeculationScoped", capability = "SpeculationState", reason = "snapshot/rollback-sensitive state mutated during speculative checking; also reset at file-session boundary" }
 refs_resolved = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 application_symbols_resolved = { lifetime = "FileLocalReset", capability = "RelationSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 application_symbols_resolution_set = { lifetime = "FileLocalReset", capability = "RelationSessionState", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }

--- a/crates/tsz-checker/src/context/speculation.rs
+++ b/crates/tsz-checker/src/context/speculation.rs
@@ -118,8 +118,11 @@ pub(crate) struct FullSnapshot {
     pub request_node_types: FxHashMap<(u32, RequestCacheKey), TypeId>,
 }
 
-/// Cache snapshot for return-type inference, which also corrupts `node_types`
-/// and `flow_analysis_cache`.
+/// Cache snapshot for return-type inference, which also corrupts `node_types`,
+/// `flow_analysis_cache`, and the narrowing marker caches
+/// (`flow_narrowed_nodes`, `daa_error_nodes`, `symbol_flow_confirmed`).
+/// The narrowing caches roll back as one unit: restoring a subset leaves
+/// markers that describe discarded flow results (issue #13079).
 pub(crate) struct CacheSnapshot {
     /// Clone of the flat `node_types` cache before speculation.
     pub node_types: super::NodeTypeCache,
@@ -128,6 +131,19 @@ pub(crate) struct CacheSnapshot {
     pub request_node_types: FxHashMap<(u32, RequestCacheKey), TypeId>,
     /// Clone of the flow analysis cache.
     pub flow_analysis_cache: rustc_hash::FxHashMap<(FlowNodeId, SymbolId, TypeId), TypeId>,
+    /// Clone of `flow_narrowed_nodes`: nodes `check_flow_usage` already
+    /// narrowed, for which `get_type_of_node` skips its second narrowing
+    /// pass. Markers minted during speculation describe node types and flow
+    /// results this snapshot rolls back; leaving them behind suppresses
+    /// re-narrowing against the restored caches and yields stale types.
+    pub flow_narrowed_nodes: FxHashSet<u32>,
+    /// Clone of `daa_error_nodes`: nodes whose definite-assignment (TS2454)
+    /// error suppresses flow narrowing. Restored together with the TS2454
+    /// diagnostics and dedup state that produced the markers.
+    pub daa_error_nodes: FxHashSet<u32>,
+    /// Clone of the stable-flow confirmation cache. Confirmations recorded
+    /// during a speculative pass describe rolled-back flow analysis results.
+    pub symbol_flow_confirmed: FxHashMap<(SymbolId, TypeId), FlowNodeId>,
     /// Thread-local global resolution fuel counter at snapshot time. Speculative
     /// sites (return-type inference) shouldn't bill their work against the
     /// global budget when rolled back — the work will be redone non-
@@ -220,6 +236,9 @@ impl<'a> CheckerContext<'a> {
                 node_types: self.node_types.clone(),
                 request_node_types: self.request_node_types.clone(),
                 flow_analysis_cache: self.flow_analysis_cache.borrow().clone(),
+                flow_narrowed_nodes: self.flow_narrowed_nodes.clone(),
+                daa_error_nodes: self.daa_error_nodes.clone(),
+                symbol_flow_confirmed: self.symbol_flow_confirmed.borrow().clone(),
                 global_resolution_fuel:
                     crate::state_domain::type_environment::lazy::global_resolution_fuel_value(),
             },
@@ -312,6 +331,10 @@ impl<'a> CheckerContext<'a> {
         self.request_node_types
             .clone_from(&snap.cache.request_node_types);
         *self.flow_analysis_cache.borrow_mut() = snap.cache.flow_analysis_cache.clone();
+        self.flow_narrowed_nodes
+            .clone_from(&snap.cache.flow_narrowed_nodes);
+        self.daa_error_nodes.clone_from(&snap.cache.daa_error_nodes);
+        *self.symbol_flow_confirmed.borrow_mut() = snap.cache.symbol_flow_confirmed.clone();
         crate::state_domain::type_environment::lazy::restore_global_resolution_fuel(
             snap.cache.global_resolution_fuel,
         );

--- a/crates/tsz-checker/src/state/state.rs
+++ b/crates/tsz-checker/src/state/state.rs
@@ -1316,18 +1316,10 @@ impl<'a> CheckerState<'a> {
                 let key = (flow_node, sym_id, cached);
                 let flow_cached = self.ctx.flow_analysis_cache.borrow().get(&key).copied();
                 if let Some(flow_cached) = flow_cached {
-                    // Apply the same widening check as the full path
-                    if flow_cached != cached && flow_cached != TypeId::ERROR {
-                        let evaluated_cached = self.evaluate_type_for_assignability(cached);
-                        let widened_cached = crate::query_boundaries::common::widen_type(
-                            self.ctx.types,
-                            evaluated_cached,
-                        );
-                        if widened_cached == flow_cached {
-                            return cached;
-                        }
-                    }
-                    return flow_cached;
+                    // The flow cache stores raw analysis results; apply the
+                    // same finalization as the full paths so a cache hit
+                    // cannot change the observed type.
+                    return self.finalize_flow_narrowed_type(idx, cached, flow_cached, false);
                 }
 
                 // PERF: Stable flow cache — skip flow analysis for repeated identifier
@@ -1387,35 +1379,7 @@ impl<'a> CheckerState<'a> {
                     return cached;
                 }
                 let narrowed = self.apply_flow_narrowing(idx, cached);
-                // FIX: If flow analysis returns a widened version of a literal cached type
-                // (e.g., cached="foo" but flow returns string), use the cached type.
-                // This prevents zombie freshness where flow analysis undoes literal preservation.
-                // IMPORTANT: Evaluate the cached type first to expand type aliases
-                // and lazy references, so widen_type can see the actual union members.
-                if narrowed != cached && narrowed != TypeId::ERROR {
-                    let evaluated_cached = self.evaluate_type_for_assignability(cached);
-                    let widened_cached = crate::query_boundaries::common::widen_type(
-                        self.ctx.types,
-                        evaluated_cached,
-                    );
-                    if widened_cached == narrowed {
-                        // Update stable flow cache: flow returned declared type
-                        if should_narrow && cached != TypeId::UNKNOWN {
-                            self.update_symbol_flow_confirmed(idx, cached, true);
-                        }
-                        return cached;
-                    }
-                    // Flow returned a narrowed type — invalidate stable cache
-                    if should_narrow {
-                        self.update_symbol_flow_confirmed(idx, cached, false);
-                    }
-                } else {
-                    // Flow returned declared type unchanged — update stable cache
-                    if should_narrow && cached != TypeId::UNKNOWN {
-                        self.update_symbol_flow_confirmed(idx, cached, true);
-                    }
-                }
-                return narrowed;
+                return self.finalize_flow_narrowed_type(idx, cached, narrowed, should_narrow);
             }
 
             // TS 5.1+ divergent accessor types: when in a write context
@@ -1572,39 +1536,8 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            let mut narrowed = self.apply_flow_narrowing(idx, result);
-            // FIX: Flow narrowing may return the original fresh type from the initializer
-            // expression, undoing the freshness stripping that get_type_of_identifier
-            // already performed. Re-apply freshness stripping to prevent "Zombie Freshness"
-            // where excess property checks fire on non-literal variable references.
-            if !self.ctx.compiler_options.sound_mode {
-                use crate::query_boundaries::common::{is_fresh_object_type, widen_freshness};
-                if is_fresh_object_type(self.ctx.types, narrowed) {
-                    narrowed = widen_freshness(self.ctx.types, narrowed);
-                }
-            }
-            // FIX: For mutable variables with non-widened literal declared types
-            // (e.g., `declare var a: "foo"; let b = a` → b has declared type "foo"),
-            // flow analysis may return the widened primitive (string) even though
-            // there's no actual narrowing. Detect this case: if widen(result) == narrowed,
-            // the flow is just widening our literal, not genuinely narrowing.
-            // IMPORTANT: Evaluate the result type first to expand type aliases
-            // and lazy references, so widen_type can see the actual union members.
-            if narrowed != result && narrowed != TypeId::ERROR {
-                let evaluated_result = self.evaluate_type_for_assignability(result);
-                let widened_result =
-                    crate::query_boundaries::common::widen_type(self.ctx.types, evaluated_result);
-                if widened_result == narrowed {
-                    // Flow just widened our literal type - use the original result
-                    narrowed = result;
-                }
-            }
-            // Update stable flow cache based on whether narrowing occurred
-            if narrowed == result && result != TypeId::UNKNOWN {
-                self.update_symbol_flow_confirmed(idx, result, true);
-            } else {
-                self.update_symbol_flow_confirmed(idx, result, false);
-            }
+            let narrowed = self.apply_flow_narrowing(idx, result);
+            let narrowed = self.finalize_flow_narrowed_type(idx, result, narrowed, true);
             tracing::trace!(
                 idx = idx.0,
                 type_id = result.0,
@@ -1774,6 +1707,57 @@ impl<'a> CheckerState<'a> {
         }
         // Can't determine the target — conservatively assume it targets our symbol
         true
+    }
+
+    /// Finalize a flow-narrowed type before it is returned from
+    /// `get_type_of_node_with_request`.
+    ///
+    /// Every flow-narrowed return path — the flow-cache fast path, the
+    /// cached-hit path, and the computed path — must agree on three rules;
+    /// keeping them here is what prevents per-path drift.
+    ///
+    /// 1. Freshness stripping: flow narrowing may return the original fresh
+    ///    object type from the initializer expression, undoing the freshness
+    ///    widening the declared type already received. Without re-stripping,
+    ///    excess-property checks fire on non-literal variable references
+    ///    ("zombie freshness").
+    /// 2. Literal-widening undo: for mutable variables with non-widened
+    ///    literal declared types (e.g. `declare var a: "foo"; let b = a`),
+    ///    flow analysis may return the widened primitive even though nothing
+    ///    narrowed. The declared type is evaluated first so aliases and lazy
+    ///    references expand; if widening it reproduces the flow result, the
+    ///    flow pass only widened the literal — keep the declared type.
+    /// 3. Stable-flow-cache update (when `update_stable_cache` is set):
+    ///    record a confirmed "no narrowing" observation only when flow
+    ///    analysis returned the declared type unchanged and the declared
+    ///    type is not `unknown`; any other result — including `error` —
+    ///    invalidates the confirmation.
+    fn finalize_flow_narrowed_type(
+        &mut self,
+        idx: NodeIndex,
+        declared: TypeId,
+        mut narrowed: TypeId,
+        update_stable_cache: bool,
+    ) -> TypeId {
+        if !self.ctx.compiler_options.sound_mode {
+            use crate::query_boundaries::common::{is_fresh_object_type, widen_freshness};
+            if is_fresh_object_type(self.ctx.types, narrowed) {
+                narrowed = widen_freshness(self.ctx.types, narrowed);
+            }
+        }
+        if narrowed != declared && narrowed != TypeId::ERROR {
+            let evaluated_declared = self.evaluate_type_for_assignability(declared);
+            let widened_declared =
+                crate::query_boundaries::common::widen_type(self.ctx.types, evaluated_declared);
+            if widened_declared == narrowed {
+                narrowed = declared;
+            }
+        }
+        if update_stable_cache {
+            let confirmed_stable = narrowed == declared && declared != TypeId::UNKNOWN;
+            self.update_symbol_flow_confirmed(idx, declared, confirmed_stable);
+        }
+        narrowed
     }
 
     /// Update the stable flow cache for a symbol after flow analysis.

--- a/crates/tsz-checker/tests/flow_narrowing_finalization_tests.rs
+++ b/crates/tsz-checker/tests/flow_narrowing_finalization_tests.rs
@@ -1,0 +1,237 @@
+//! Regression tests for the unified flow-narrowing finalization in
+//! `get_type_of_node_with_request` and for speculation rollback of the
+//! narrowing marker caches (issue #13079).
+//!
+//! The finalization rules (freshness stripping, literal-widening undo,
+//! stable-flow-cache update) previously existed as three drifting copies —
+//! one per return path (flow-cache fast path, cached-hit path, computed
+//! path) — and the return-type speculation rollback restored `node_types` /
+//! `flow_analysis_cache` without the narrowing markers
+//! (`flow_narrowed_nodes`, `daa_error_nodes`, `symbol_flow_confirmed`)
+//! written by the same pipeline. These tests pin the agreeing behavior
+//! across all paths, with positive and negative cases per family.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+
+fn check(source: &str) -> Vec<Diagnostic> {
+    tsz_checker::test_utils::check_source(source, "test.ts", CheckerOptions::default())
+}
+
+fn check_strict_null(source: &str) -> Vec<Diagnostic> {
+    tsz_checker::test_utils::check_source(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Freshness stripping must hold on every return path (zombie freshness).
+// ---------------------------------------------------------------------------
+
+/// Repeated reads of a variable bound to an object literal route through the
+/// computed path first, then the cached-hit and flow-cache fast paths. None
+/// of them may resurrect the initializer's fresh literal type — a fresh type
+/// would re-arm excess-property checking on a plain variable reference.
+#[test]
+fn repeated_variable_reads_do_not_resurrect_freshness() {
+    let diags = check(
+        r#"
+        declare function take(arg: { a: number }): void;
+        const source = { a: 1, extra: 2 };
+        source;
+        take(source);
+        take(source);
+    "#,
+    );
+    assert!(
+        diags.is_empty(),
+        "variable references must not carry freshness: {diags:?}"
+    );
+}
+
+/// Same shape with renamed binders and an interface annotation, read through
+/// an assignment-narrowed union. The narrowed type at the use site comes from
+/// the assignment's flow node; finalization must strip freshness there too.
+#[test]
+fn assignment_narrowed_reference_does_not_resurrect_freshness() {
+    let diags = check_strict_null(
+        r#"
+        interface Wide { width: number; height: number; }
+        let target: Wide | undefined;
+        target = { width: 10, height: 20 };
+        const slim: { width?: number } = target;
+        const slimAgain: { width?: number } = target;
+    "#,
+    );
+    assert!(
+        diags.is_empty(),
+        "assignment-narrowed references must not carry freshness: {diags:?}"
+    );
+}
+
+/// Negative control: excess-property checking must still fire on a direct
+/// object literal — freshness stripping applies to variable references, not
+/// to the literal itself.
+#[test]
+fn direct_object_literal_still_reports_excess_property() {
+    let diags = check(
+        r#"
+        const direct: { a: number } = { a: 1, extra: 2 };
+    "#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2353 || d.code == 2322),
+        "fresh object literals must keep excess-property errors: {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Literal-widening undo must hold on cached re-reads.
+// ---------------------------------------------------------------------------
+
+/// A mutable variable initialized from a declared literal-typed var widens to
+/// the primitive. Re-reads through the cached paths must agree with the first
+/// (computed) read instead of flip-flopping between literal and primitive.
+#[test]
+fn literal_widening_is_stable_across_repeated_reads() {
+    let diags = check(
+        r#"
+        declare var tag: "foo";
+        let copy = tag;
+        copy;
+        const first: string = copy;
+        const second: string = copy;
+    "#,
+    );
+    assert!(
+        diags.is_empty(),
+        "widened literal must stay assignable to its primitive on every read: {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Narrowing agreement across repeated reads in one branch.
+// ---------------------------------------------------------------------------
+
+/// Repeated uses of a narrowed identifier inside one guard exercise the
+/// computed path (first read), the cached-hit path, and the flow-cache fast
+/// path (later reads). All must return the narrowed type.
+#[test]
+fn repeated_reads_in_guard_agree_on_narrowed_type() {
+    let diags = check(
+        r#"
+        function pick(x: string | number) {
+            if (typeof x === "string") {
+                const a: string = x;
+                const b: string = x;
+                const c: string = x;
+                return a;
+            }
+            const d: number = x;
+            return "fallback";
+        }
+        const result: string = pick(1);
+    "#,
+    );
+    assert!(
+        diags.is_empty(),
+        "every read path must observe the same narrowed type: {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Return-type speculation must roll narrowing markers back with the caches.
+// ---------------------------------------------------------------------------
+
+/// Return-type inference evaluates the body speculatively without narrowing
+/// context, then rolls back and re-checks with proper context. Narrowing
+/// markers minted during speculation must not suppress the re-check's
+/// narrowing pass.
+#[test]
+fn inferred_return_type_keeps_guard_narrowing_after_rollback() {
+    let diags = check(
+        r#"
+        function coerce(u: unknown) {
+            if (typeof u === "string") {
+                return u;
+            }
+            return "fallback";
+        }
+        const s: string = coerce(1);
+    "#,
+    );
+    assert!(
+        diags.is_empty(),
+        "speculative body evaluation must not leak stale narrowing markers: {diags:?}"
+    );
+}
+
+/// Discriminated-union narrowing inside an inferred-return function: the
+/// speculative pass sees no narrowing context, so property accesses on the
+/// union would fail there; after rollback, the real pass must narrow cleanly.
+#[test]
+fn inferred_return_type_keeps_discriminant_narrowing_after_rollback() {
+    let diags = check(
+        r#"
+        type Shape =
+            | { kind: "circle"; radius: number }
+            | { kind: "square"; side: number };
+        function measure(s: Shape) {
+            if (s.kind === "circle") {
+                return s.radius;
+            }
+            return s.side;
+        }
+        const m: number = measure({ kind: "circle", radius: 1 });
+    "#,
+    );
+    assert!(
+        diags.is_empty(),
+        "discriminant narrowing must survive speculation rollback: {diags:?}"
+    );
+}
+
+/// TS2454 from a speculative body evaluation rolls back with its
+/// definite-assignment markers, then re-emits exactly once in the real pass.
+#[test]
+fn use_before_assignment_in_inferred_return_emits_single_ts2454() {
+    let diags = check_strict_null(
+        r#"
+        function f() {
+            let v: number;
+            return v;
+        }
+    "#,
+    );
+    let ts2454_count = tsz_checker::test_utils::diagnostic_count(&diags, 2454);
+    assert_eq!(
+        ts2454_count, 1,
+        "expected exactly one TS2454 after speculation rollback: {diags:?}"
+    );
+}
+
+/// Negative control: assigning before the read clears both the diagnostic and
+/// the markers; narrowing of the assigned value must flow into the inferred
+/// return type.
+#[test]
+fn assigned_before_read_has_no_ts2454_and_narrowed_return() {
+    let diags = check_strict_null(
+        r#"
+        function f() {
+            let v: number;
+            v = 42;
+            return v;
+        }
+        const n: number = f();
+    "#,
+    );
+    assert!(
+        diags.is_empty(),
+        "assignment before read must produce no diagnostics: {diags:?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Closes #13079 (claimed via RNG seed 1781175888 over the non-WIP bug-class pool).

## Problem

`get_type_of_node_with_request` finalized flow-narrowed types through three drifting inline copies — one per return path:

- **flow-cache fast path** (`state.rs` ~1316): literal-widening undo only; no freshness stripping.
- **cached-hit path** (~1381): literal-widening undo + stable-flow-cache update; no freshness stripping, and it recorded a `symbol_flow_confirmed` "no narrowing" confirmation even when narrowing returned the `error` type.
- **computed path** (~1575): the full version (freshness stripping + widening undo + stable-cache update).

Which rules applied to a node therefore depended on cache temperature, not semantics.

Separately, the return-type speculation snapshot (`CacheSnapshot` / `rollback_return_type`) restored `node_types`, `request_node_types`, and `flow_analysis_cache` but **not** the narrowing marker caches written by the same pipeline (`flow_narrowed_nodes`, `daa_error_nodes`, `symbol_flow_confirmed`). Markers minted during the speculative body evaluation survived rollback and described discarded flow results — suppressing the second narrowing pass against the restored caches (the call-checker retry sites already hand-flush exactly these markers per argument; the return-type speculation path omitted the equivalent flush).

## Structural rule

When `get_type_of_node` returns a flow-narrowed type, tsc applies one consistent finalization regardless of how the result was obtained; tsz does the same through a single `finalize_flow_narrowed_type` owner in the checker state layer (freshness stripping → literal-widening undo → stable-flow-cache update), and speculation rollback restores the narrowing marker caches atomically with the node/flow caches they annotate.

Owner layer: checker (`CheckerState` flow finalization; `CheckerContext` speculation snapshot). No solver changes; the helper consumes only sanctioned `query_boundaries::common` helpers (`is_fresh_object_type`, `widen_freshness`, `widen_type`).

## Changes

- `crates/tsz-checker/src/state/state.rs`: extract `finalize_flow_narrowed_type`; route all three return paths through it. Drift fixes: cached-hit and fast paths gain freshness stripping; an `error` narrowing result now invalidates (rather than confirms) the stable-flow cache entry.
- `crates/tsz-checker/src/context/speculation.rs`: `CacheSnapshot` now snapshots/restores `flow_narrowed_nodes`, `daa_error_nodes`, `symbol_flow_confirmed` as one unit with the existing caches.
- `crates/tsz-checker/src/context/checker_context_lifetimes.toml`: reclassify the three marker caches as `SpeculationScoped`/`SpeculationState` (still reset at file-session boundary).
- `crates/tsz-checker/tests/flow_narrowing_finalization_tests.rs` (new, registered in `Cargo.toml`): 9-case adjacent matrix.

## Adjacent matrix (new tests)

- freshness: repeated variable reads (computed → cached → fast path), assignment-narrowed union reference, renamed binders; negative: direct object literal keeps the excess-property error.
- literal-widening undo: repeated reads of a `let` widened from a declared literal var.
- narrowing agreement: repeated reads of a `typeof`-guarded identifier in one branch; negative branch typed as the complement.
- speculation rollback: `typeof` guard and discriminated-union narrowing inside inferred-return functions; TS2454 emitted exactly once after speculative body evaluation; negative: assignment-before-read stays clean.

The drift edges themselves (cache-order-dependent) are hardening; the matrix pins the agreeing behavior on every path so future drift fails loudly.

## Verification

- `cargo nextest run -p tsz-checker --test flow_narrowing_finalization_tests --test speculation_rollback_tests` — 49/49 pass.
- `cargo nextest run -p tsz-checker --lib` — failure set byte-identical to `main` base (60 pre-existing failures, zero new, zero resolved); 6488 passed.
- Adjacent integration suites (`control_flow_type_guard_tests`, `assignment_branch_merge_narrowing_tests`, `nested_discriminant_narrowing_tests`, `overload_argument_flow_narrowing_visibility_tests`, `flow_*_memoization/cache_tests`, excess-property/freshness suites) — 203/203 pass.
- `cargo clippy -p tsz-checker --lib --tests` clean; `cargo fmt --check` clean; `python3 scripts/arch/checker_field_inventory.py` passes (249 fields classified).
- Ready-review CI (conformance-aggregate, emit, fourslash) owns the broad suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01QqGQTZiSfgWTtoVjeqPqam)_