### PR TITLE
refactor(conformance): plan shards in Rust

### DIFF
--- a/crates/conformance/src/cli.rs
+++ b/crates/conformance/src/cli.rs
@@ -44,6 +44,10 @@ pub struct Args {
     #[arg(long)]
     pub shard: Option<String>,
 
+    /// Emit a JSON plan for N conformance shards, then exit.
+    #[arg(long, value_name = "N")]
+    pub plan: Option<usize>,
+
     /// Shard assignment strategy.
     #[arg(long, default_value = "hash", value_enum)]
     pub shard_strategy: ShardStrategy,
@@ -159,6 +163,14 @@ impl Args {
             // --all flag just means use a very high max
             // No additional validation needed
         }
+        if let Some(count) = self.plan {
+            if count == 0 {
+                anyhow::bail!("--plan count must be greater than zero");
+            }
+            if self.shard.is_some() {
+                anyhow::bail!("--plan cannot be combined with --shard");
+            }
+        }
         Ok(())
     }
 
@@ -220,5 +232,24 @@ mod tests {
         let args = parse_args(&["tsz-conformance", "--all"]);
         assert!(args.validate().is_ok());
         assert!(args.is_verbose() == (args.verbose || args.print_test_files));
+    }
+
+    #[test]
+    fn validate_accepts_positive_plan_count() {
+        let args = parse_args(&["tsz-conformance", "--plan", "4"]);
+        assert_eq!(args.plan, Some(4));
+        assert!(args.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_zero_plan_count() {
+        let args = parse_args(&["tsz-conformance", "--plan", "0"]);
+        assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_plan_with_selected_shard() {
+        let args = parse_args(&["tsz-conformance", "--plan", "4", "--shard", "0/4"]);
+        assert!(args.validate().is_err());
     }
 }

--- a/crates/conformance/src/main.rs
+++ b/crates/conformance/src/main.rs
@@ -44,6 +44,12 @@ async fn main() -> anyhow::Result<()> {
         return handle_cache_clear(&args.cache_file);
     }
 
+    if let Some(shard_count) = args.plan {
+        let plan = runner::plan::build_shard_plan(&args, shard_count)?;
+        println!("{}", serde_json::to_string(&plan)?);
+        return Ok(());
+    }
+
     // Run tests
     let runner = Runner::new(args.clone())?;
     let stats = runner.run().await?;

--- a/crates/conformance/src/runner.rs
+++ b/crates/conformance/src/runner.rs
@@ -4,9 +4,8 @@
 
 use crate::batch_pool::{BatchOutcome, ProcessPool};
 use crate::cache::{self, load_cache};
-use crate::cli::{Args, RunMode, ShardStrategy};
+use crate::cli::{Args, RunMode};
 use crate::server_pool::{ServerOutcome, ServerPool};
-use crate::test_filter::{is_conformance_source_file, matches_path_filter};
 use crate::test_parser::{
     expand_option_variants, filter_incompatible_module_resolution_variants, parse_test_file,
     should_skip_test,
@@ -29,6 +28,8 @@ use tracing::{debug, info, warn};
 #[path = "runner/helpers.rs"]
 mod runner_helpers;
 use runner_helpers::*;
+#[path = "runner/plan.rs"]
+pub mod plan;
 
 /// Collects paths of crashed, timed-out, and fingerprint-only-mismatch tests for the final summary.
 #[derive(Default)]
@@ -49,28 +50,6 @@ pub struct Runner {
 }
 
 impl Runner {
-    fn parse_shard_spec(&self) -> anyhow::Result<Option<(usize, usize)>> {
-        let Some(spec) = self.args.shard.as_deref() else {
-            return Ok(None);
-        };
-        let Some((index, count)) = spec.split_once('/') else {
-            anyhow::bail!("--shard must be formatted as index/count, got {spec:?}");
-        };
-        let index = index
-            .parse::<usize>()
-            .with_context(|| format!("invalid --shard index in {spec:?}"))?;
-        let count = count
-            .parse::<usize>()
-            .with_context(|| format!("invalid --shard count in {spec:?}"))?;
-        if count == 0 {
-            anyhow::bail!("--shard count must be greater than zero");
-        }
-        if index >= count {
-            anyhow::bail!("--shard index {index} must be less than count {count}");
-        }
-        Ok(Some((index, count)))
-    }
-
     fn absolutize_binary_path(path: &Path) -> String {
         let absolute = if path.is_absolute() {
             path.to_path_buf()
@@ -129,7 +108,7 @@ impl Runner {
 
     /// Run all tests
     pub async fn run(&self) -> anyhow::Result<TestStats> {
-        let test_files = self.discover_tests()?;
+        let test_files = plan::discover_tests(&self.args)?;
 
         if test_files.is_empty() {
             warn!("No test files found!");
@@ -586,91 +565,6 @@ impl Runner {
             known_failures: AtomicUsize::new(stats.known_failures.load(Ordering::SeqCst)),
             fingerprint_only: AtomicUsize::new(stats.fingerprint_only.load(Ordering::SeqCst)),
         })
-    }
-
-    /// Discover all test files recursively using walkdir
-    fn discover_tests(&self) -> anyhow::Result<Vec<PathBuf>> {
-        use walkdir::WalkDir;
-
-        let test_dir = &self.args.test_dir;
-        let mut files = Vec::new();
-
-        // Walk directory tree recursively
-        for entry in WalkDir::new(test_dir)
-            .follow_links(true)
-            .into_iter()
-            .filter_map(std::result::Result::ok)
-        {
-            let path = entry.path();
-
-            // Skip directories
-            if path.is_dir() {
-                continue;
-            }
-
-            if is_appledouble_file(path) {
-                continue;
-            }
-
-            if !is_conformance_source_file(path) {
-                continue;
-            }
-
-            if !matches_path_filter(path, self.args.filter.as_deref()) {
-                continue;
-            }
-
-            files.push(path.to_path_buf());
-        }
-
-        // Sort for deterministic order
-        files.sort();
-
-        if let Some((shard_index, shard_count)) = self.parse_shard_spec()? {
-            let test_dir_path = std::path::Path::new(test_dir);
-            files = match self.args.shard_strategy {
-                ShardStrategy::Hash => files
-                    .into_iter()
-                    .filter_map(|path| {
-                        if stable_shard_for_path(&path, test_dir_path, shard_count) == shard_index {
-                            Some(path)
-                        } else {
-                            None
-                        }
-                    })
-                    .collect(),
-                ShardStrategy::Weighted => {
-                    let weights = self
-                        .args
-                        .shard_weights
-                        .as_deref()
-                        .and_then(|path| load_json_weights(Path::new(path)));
-                    weighted_shard_files(
-                        files,
-                        test_dir_path,
-                        shard_index,
-                        shard_count,
-                        weights.as_ref(),
-                    )
-                }
-            };
-        }
-
-        // Apply offset (skip first N tests)
-        if self.args.offset > 0 {
-            if self.args.offset >= files.len() {
-                files.clear();
-            } else {
-                files = files.split_off(self.args.offset);
-            }
-        }
-
-        // Apply max limit
-        if files.len() > self.args.max {
-            files.truncate(self.args.max);
-        }
-
-        Ok(files)
     }
 
     /// Run a single test.

--- a/crates/conformance/src/runner/helpers.rs
+++ b/crates/conformance/src/runner/helpers.rs
@@ -466,6 +466,22 @@ pub(super) fn weighted_shard_files(
     shard_count: usize,
     weights: Option<&ShardWeights>,
 ) -> Vec<PathBuf> {
+    weighted_shards(files, test_dir, shard_count, weights)
+        .into_iter()
+        .nth(shard_index)
+        // Keep the weighted assignment order. The runner feeds this list into a
+        // bounded concurrent stream, so starting heavier tests first avoids
+        // leaving a slow test to extend the tail after lighter work has drained.
+        .map(|(_, selected)| selected)
+        .unwrap_or_default()
+}
+
+pub(super) fn weighted_shards(
+    files: Vec<PathBuf>,
+    test_dir: &Path,
+    shard_count: usize,
+    weights: Option<&ShardWeights>,
+) -> Vec<(f64, Vec<PathBuf>)> {
     let mut weighted: Vec<(PathBuf, String, f64)> = files
         .into_iter()
         .map(|path| {
@@ -485,6 +501,10 @@ pub(super) fn weighted_shard_files(
 
     let mut shards: Vec<(f64, Vec<PathBuf>)> =
         (0..shard_count).map(|_| (0.0, Vec::new())).collect();
+    if shards.is_empty() {
+        return shards;
+    }
+
     for (path, _key, weight) in weighted {
         let mut best = 0;
         for idx in 1..shards.len() {
@@ -499,11 +519,4 @@ pub(super) fn weighted_shard_files(
     }
 
     shards
-        .into_iter()
-        .nth(shard_index)
-        // Keep the weighted assignment order. The runner feeds this list into a
-        // bounded concurrent stream, so starting heavier tests first avoids
-        // leaving a slow test to extend the tail after lighter work has drained.
-        .map(|(_, selected)| selected)
-        .unwrap_or_default()
 }

--- a/crates/conformance/src/runner/plan.rs
+++ b/crates/conformance/src/runner/plan.rs
@@ -1,0 +1,405 @@
+use crate::cli::{Args, ShardStrategy};
+use crate::test_filter::{is_conformance_source_file, matches_path_filter};
+use crate::test_parser::{parse_test_file, should_skip_test};
+use crate::text_decode::{decode_source_text, DecodedSourceText};
+use anyhow::Context;
+use serde::Serialize;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+use super::runner_helpers::{
+    estimated_test_weight, is_appledouble_file, load_json_weights, normalized_path,
+    stable_shard_for_path, weighted_shard_files, weighted_shards,
+};
+
+const DEFAULT_BASELINE_PATH: &str = "scripts/conformance/conformance-baseline.txt";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ConformanceShardPlan {
+    pub strategy: String,
+    pub shard_count: usize,
+    pub total: usize,
+    pub passed: usize,
+    pub weight: usize,
+    pub shards: Vec<ConformanceShardPlanEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ConformanceShardPlanEntry {
+    pub index: usize,
+    pub total: usize,
+    pub passed: usize,
+    pub weight: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SkipPolicy {
+    IncludeSkipped,
+    ExcludeSkipped,
+}
+
+#[derive(Debug, Default)]
+struct ShardAccumulator {
+    total: usize,
+    passed: usize,
+    weight: f64,
+}
+
+impl ShardAccumulator {
+    fn add(&mut self, passed: bool, weight: f64) {
+        self.total += 1;
+        self.passed += usize::from(passed);
+        self.weight += weight;
+    }
+
+    fn entry(&self, index: usize) -> ConformanceShardPlanEntry {
+        ConformanceShardPlanEntry {
+            index,
+            total: self.total,
+            passed: self.passed,
+            weight: integer_weight(self.weight),
+        }
+    }
+}
+
+pub fn build_shard_plan(args: &Args, shard_count: usize) -> anyhow::Result<ConformanceShardPlan> {
+    build_shard_plan_with_baseline(args, shard_count, Path::new(DEFAULT_BASELINE_PATH))
+}
+
+fn build_shard_plan_with_baseline(
+    args: &Args,
+    shard_count: usize,
+    baseline_path: &Path,
+) -> anyhow::Result<ConformanceShardPlan> {
+    if shard_count == 0 {
+        anyhow::bail!("--plan count must be greater than zero");
+    }
+
+    let files = discover_candidate_tests(args, SkipPolicy::ExcludeSkipped)?;
+    let test_dir = Path::new(&args.test_dir);
+    let baseline_passes = load_baseline_passes(baseline_path)?;
+    let weights = args
+        .shard_weights
+        .as_deref()
+        .and_then(|path| load_json_weights(Path::new(path)));
+    let mut shards: Vec<ShardAccumulator> = (0..shard_count)
+        .map(|_| ShardAccumulator::default())
+        .collect();
+
+    match args.shard_strategy {
+        ShardStrategy::Hash => {
+            for path in files {
+                let index = stable_shard_for_path(&path, test_dir, shard_count);
+                let weight = estimated_test_weight(weights.as_ref(), &path, test_dir);
+                let passed = is_baseline_pass(&baseline_passes, &path, test_dir);
+                shards[index].add(passed, weight);
+            }
+        }
+        ShardStrategy::Weighted => {
+            for (index, (_weight, paths)) in
+                weighted_shards(files, test_dir, shard_count, weights.as_ref())
+                    .into_iter()
+                    .enumerate()
+            {
+                for path in paths {
+                    let weight = estimated_test_weight(weights.as_ref(), &path, test_dir);
+                    let passed = is_baseline_pass(&baseline_passes, &path, test_dir);
+                    shards[index].add(passed, weight);
+                }
+            }
+        }
+    }
+
+    let total = shards.iter().map(|shard| shard.total).sum();
+    let passed = shards.iter().map(|shard| shard.passed).sum();
+    let weight = integer_weight(shards.iter().map(|shard| shard.weight).sum());
+    let shards = shards
+        .iter()
+        .enumerate()
+        .map(|(index, shard)| shard.entry(index))
+        .collect();
+
+    Ok(ConformanceShardPlan {
+        strategy: shard_strategy_name(&args.shard_strategy).to_string(),
+        shard_count,
+        total,
+        passed,
+        weight,
+        shards,
+    })
+}
+
+pub(crate) fn discover_tests(args: &Args) -> anyhow::Result<Vec<PathBuf>> {
+    let mut files = discover_candidate_tests(args, SkipPolicy::IncludeSkipped)?;
+
+    if let Some((shard_index, shard_count)) = parse_shard_spec(args.shard.as_deref())? {
+        let test_dir_path = Path::new(&args.test_dir);
+        files = match args.shard_strategy {
+            ShardStrategy::Hash => files
+                .into_iter()
+                .filter(|path| {
+                    stable_shard_for_path(path, test_dir_path, shard_count) == shard_index
+                })
+                .collect(),
+            ShardStrategy::Weighted => {
+                let weights = args
+                    .shard_weights
+                    .as_deref()
+                    .and_then(|path| load_json_weights(Path::new(path)));
+                weighted_shard_files(
+                    files,
+                    test_dir_path,
+                    shard_index,
+                    shard_count,
+                    weights.as_ref(),
+                )
+            }
+        };
+    }
+
+    if args.offset > 0 {
+        if args.offset >= files.len() {
+            files.clear();
+        } else {
+            files = files.split_off(args.offset);
+        }
+    }
+
+    if files.len() > args.max {
+        files.truncate(args.max);
+    }
+
+    Ok(files)
+}
+
+pub(crate) fn parse_shard_spec(spec: Option<&str>) -> anyhow::Result<Option<(usize, usize)>> {
+    let Some(spec) = spec else {
+        return Ok(None);
+    };
+    let Some((index, count)) = spec.split_once('/') else {
+        anyhow::bail!("--shard must be formatted as index/count, got {spec:?}");
+    };
+    let index = index
+        .parse::<usize>()
+        .with_context(|| format!("invalid --shard index in {spec:?}"))?;
+    let count = count
+        .parse::<usize>()
+        .with_context(|| format!("invalid --shard count in {spec:?}"))?;
+    if count == 0 {
+        anyhow::bail!("--shard count must be greater than zero");
+    }
+    if index >= count {
+        anyhow::bail!("--shard index {index} must be less than count {count}");
+    }
+    Ok(Some((index, count)))
+}
+
+fn discover_candidate_tests(args: &Args, skip_policy: SkipPolicy) -> anyhow::Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for entry in WalkDir::new(&args.test_dir)
+        .follow_links(true)
+        .into_iter()
+        .filter_map(std::result::Result::ok)
+    {
+        let path = entry.path();
+        if path.is_dir() || is_appledouble_file(path) {
+            continue;
+        }
+        if !is_conformance_source_file(path) {
+            continue;
+        }
+        if !matches_path_filter(path, args.filter.as_deref()) {
+            continue;
+        }
+        if skip_policy == SkipPolicy::ExcludeSkipped && has_skip_directive(path)? {
+            continue;
+        }
+        files.push(path.to_path_buf());
+    }
+
+    files.sort();
+    Ok(files)
+}
+
+fn has_skip_directive(path: &Path) -> anyhow::Result<bool> {
+    let Ok(bytes) = std::fs::read(path) else {
+        return Ok(false);
+    };
+    let content = match decode_source_text(&bytes) {
+        DecodedSourceText::Text(content) | DecodedSourceText::TextWithOriginalBytes(content, _) => {
+            content
+        }
+        DecodedSourceText::Binary(_) => return Ok(false),
+    };
+    let parsed = parse_test_file(&content)
+        .with_context(|| format!("failed to parse test directives in {}", path.display()))?;
+    Ok(should_skip_test(&parsed.directives).is_some())
+}
+
+fn load_baseline_passes(path: &Path) -> anyhow::Result<HashSet<String>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read conformance baseline {}", path.display()))?;
+    let mut passes = HashSet::new();
+    for line in content.lines() {
+        let Some((status, rest)) = line.split_once(' ') else {
+            continue;
+        };
+        if status != "PASS" {
+            continue;
+        }
+        let path = rest.split(" | ").next().unwrap_or(rest).replace('\\', "/");
+        passes.insert(path);
+    }
+    Ok(passes)
+}
+
+fn is_baseline_pass(baseline_passes: &HashSet<String>, path: &Path, test_dir: &Path) -> bool {
+    baseline_keys(path, test_dir)
+        .into_iter()
+        .any(|key| baseline_passes.contains(&key))
+}
+
+fn baseline_keys(path: &Path, test_dir: &Path) -> Vec<String> {
+    let full = normalized_path(path);
+    let rel = path
+        .strip_prefix(test_dir)
+        .map(normalized_path)
+        .unwrap_or_else(|_| full.clone());
+    vec![full, rel.clone(), format!("TypeScript/tests/cases/{rel}")]
+}
+
+fn integer_weight(weight: f64) -> usize {
+    if weight.is_finite() && weight > 0.0 {
+        weight as usize
+    } else {
+        0
+    }
+}
+
+fn shard_strategy_name(strategy: &ShardStrategy) -> &'static str {
+    match strategy {
+        ShardStrategy::Hash => "hash",
+        ShardStrategy::Weighted => "weighted",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn parse_args(input: &[&str]) -> Args {
+        Args::try_parse_from(input).expect("argument parsing should succeed in test")
+    }
+
+    fn write(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("parent directory should be created");
+        }
+        std::fs::write(path, content).expect("test file should be written");
+    }
+
+    #[test]
+    fn plan_excludes_skipped_tests_and_counts_baseline_passes() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cases = temp.path().join("TypeScript/tests/cases");
+        write(&cases.join("compiler/pass.ts"), "let pass = 1;\n");
+        write(&cases.join("compiler/fail.js"), "let fail = 1;\n");
+        write(
+            &cases.join("compiler/skipped.ts"),
+            "// @skip: tracked upstream\n",
+        );
+        write(
+            &cases.join("compiler/lib.d.ts"),
+            "declare const ignored: string;\n",
+        );
+        write(&cases.join("fourslash/quickInfo.ts"), "ignored\n");
+        let baseline = temp.path().join("baseline.txt");
+        write(
+            &baseline,
+            "PASS TypeScript/tests/cases/compiler/pass.ts\n\
+             FAIL TypeScript/tests/cases/compiler/fail.js\n\
+             PASS TypeScript/tests/cases/compiler/skipped.ts\n",
+        );
+
+        let args = parse_args(&[
+            "tsz-conformance",
+            "--plan",
+            "2",
+            "--test-dir",
+            cases.to_str().unwrap(),
+        ]);
+        let plan = build_shard_plan_with_baseline(&args, 2, &baseline).unwrap();
+
+        assert_eq!(plan.shard_count, 2);
+        assert_eq!(plan.total, 2);
+        assert_eq!(plan.passed, 1);
+        assert_eq!(
+            plan.shards.iter().map(|shard| shard.total).sum::<usize>(),
+            2
+        );
+        assert_eq!(
+            plan.shards.iter().map(|shard| shard.passed).sum::<usize>(),
+            1
+        );
+    }
+
+    #[test]
+    fn weighted_plan_uses_historical_weights_for_all_shards() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let cases = temp.path().join("TypeScript/tests/cases");
+        write(&cases.join("compiler/a.ts"), "let a = 1;\n");
+        write(&cases.join("compiler/b.ts"), "let b = 1;\n");
+        write(&cases.join("compiler/c.ts"), "let c = 1;\n");
+        let baseline = temp.path().join("baseline.txt");
+        write(
+            &baseline,
+            "PASS TypeScript/tests/cases/compiler/a.ts\n\
+             PASS TypeScript/tests/cases/compiler/b.ts\n\
+             PASS TypeScript/tests/cases/compiler/c.ts\n",
+        );
+        let weights = temp.path().join("weights.json");
+        write(
+            &weights,
+            &serde_json::json!({
+                "path_weights": {
+                    "TypeScript/tests/cases/compiler/a.ts": 8.0,
+                    "TypeScript/tests/cases/compiler/b.ts": 5.0,
+                    "TypeScript/tests/cases/compiler/c.ts": 3.0
+                }
+            })
+            .to_string(),
+        );
+
+        let args = parse_args(&[
+            "tsz-conformance",
+            "--plan",
+            "2",
+            "--test-dir",
+            cases.to_str().unwrap(),
+            "--shard-strategy",
+            "weighted",
+            "--shard-weights",
+            weights.to_str().unwrap(),
+        ]);
+        let plan = build_shard_plan_with_baseline(&args, 2, &baseline).unwrap();
+
+        assert_eq!(plan.strategy, "weighted");
+        assert_eq!(plan.total, 3);
+        assert_eq!(plan.passed, 3);
+        assert_eq!(
+            plan.shards
+                .iter()
+                .map(|shard| shard.weight)
+                .collect::<Vec<_>>(),
+            vec![8, 8]
+        );
+    }
+
+    #[test]
+    fn parse_shard_spec_rejects_out_of_range_index() {
+        let err = parse_shard_spec(Some("2/2")).unwrap_err().to_string();
+        assert!(err.contains("must be less than count"));
+    }
+}

--- a/scripts/ci/lib/gcp-full-ci-conformance.sh
+++ b/scripts/ci/lib/gcp-full-ci-conformance.sh
@@ -67,151 +67,20 @@ run_with_heartbeat() {
 
 conformance_shard_plan() {
   local shard_index="$1" shard_count="$2" strategy="${3:-hash}" weights_file="${4:-}"
-  python3 - "$shard_index" "$shard_count" "$strategy" "$weights_file" <<'PY'
-import json
-import sys
-from pathlib import Path
+  local root="${ROOT_DIR:-$(pwd)}"
+  local runner_bin="$root/.target/dist-fast/tsz-conformance"
+  local plan_args=(--plan "$shard_count" --test-dir "$root/TypeScript/tests/cases" --shard-strategy "$strategy")
+  if [[ -n "$weights_file" ]]; then
+    plan_args+=(--shard-weights "$weights_file")
+  fi
+  if [[ ! -x "$runner_bin" ]]; then
+    echo "error: missing conformance runner for shard planning: $runner_bin" >&2
+    return 1
+  fi
 
-index = int(sys.argv[1])
-count = int(sys.argv[2])
-strategy = sys.argv[3]
-weights_file = Path(sys.argv[4]) if sys.argv[4] else None
-baseline = Path("scripts/conformance/conformance-baseline.txt")
-if count < 1:
-    count = 1
-if index < 0 or index >= count:
-    raise SystemExit(f"invalid conformance shard {index}/{count}")
-
-baseline_status = {}
-for line in baseline.read_text(encoding="utf-8", errors="replace").splitlines():
-    status, _, rest = line.partition(" ")
-    if status not in {"PASS", "FAIL", "XFAIL", "CRASH", "TIMEOUT"} or not rest:
-        continue
-    path = rest.split(" | ", 1)[0]
-    baseline_status[path] = status
-
-test_dir = Path("TypeScript/tests/cases")
-files = []
-source_suffixes = {".ts", ".tsx", ".js", ".jsx", ".mts", ".cts"}
-declaration_suffixes = (".d.ts", ".d.mts", ".d.cts")
-
-def has_skip_directive(path):
-    # Keep shard-plan totals aligned with the Rust runner, which discovers the
-    # file but excludes it from result totals when `@skip` is present.
-    try:
-        text = path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return False
-    for line in text.splitlines():
-        stripped = line.lstrip()
-        if not stripped.startswith("//"):
-            continue
-        directive = stripped[2:].lstrip().lower()
-        if directive.startswith("@skip") and (
-            len(directive) == len("@skip")
-            or not (
-                directive[len("@skip")].isalnum()
-                or directive[len("@skip")] == "_"
-            )
-        ):
-            return True
-    return False
-
-for path in test_dir.rglob("*"):
-    if not path.is_file():
-        continue
-    path_str = path.as_posix()
-    if path.name.startswith("._"):
-        continue
-    if path.suffix not in source_suffixes:
-        continue
-    if path_str.endswith(declaration_suffixes):
-        continue
-    if "/fourslash/" in path_str:
-        continue
-    if "APISample" in path_str or "APILibCheck" in path_str:
-        continue
-    if has_skip_directive(path):
-        continue
-    files.append(path)
-
-files.sort()
-
-def stable_shard(path):
-    rel = path.relative_to(test_dir).as_posix()
-    h = 1469598103934665603
-    for byte in rel.encode("utf-8"):
-        h ^= byte
-        h = (h * 1099511628211) & 0xffffffffffffffff
-    return h % count
-
-def stable_shard_count(path, bucket_count):
-    rel = path.relative_to(test_dir).as_posix()
-    h = 1469598103934665603
-    for byte in rel.encode("utf-8"):
-        h ^= byte
-        h = (h * 1099511628211) & 0xffffffffffffffff
-    return h % bucket_count
-
-weights = {}
-default_weight = 1.0
-hash_bucket = None
-if weights_file and weights_file.is_file():
-    try:
-        data = json.loads(weights_file.read_text(encoding="utf-8"))
-        default_weight = float(data.get("default_weight", default_weight) or default_weight)
-        weights.update({
-            str(key).replace("\\", "/"): float(value)
-            for key, value in (data.get("path_weights") or {}).items()
-            if float(value) > 0
-        })
-        for result in data.get("results") or []:
-            file = str(result.get("file") or "").replace("\\", "/")
-            value = result.get("elapsed_ms", result.get("elapsed"))
-            if file and value is not None and float(value) > 0:
-                weights[file] = float(value)
-        hb = data.get("hash_bucket_weights") or {}
-        hb_count = int(hb.get("shard_count") or 0)
-        hb_weights = [float(value) for value in hb.get("weights") or []]
-        if hb_count > 0 and len(hb_weights) >= hb_count:
-            hash_bucket = (hb_count, hb_weights)
-    except Exception as exc:
-        print(f"warning: failed to read conformance shard weights {weights_file}: {exc}", file=sys.stderr)
-
-def path_keys(path):
-    rel = path.relative_to(test_dir).as_posix()
-    return [rel, f"TypeScript/tests/cases/{rel}", path.as_posix()]
-
-def weight_for(path):
-    for key in path_keys(path):
-        if key in weights:
-            return weights[key]
-    if hash_bucket:
-        hb_count, hb_weights = hash_bucket
-        return hb_weights[stable_shard_count(path, hb_count)]
-    try:
-        return min(max(path.stat().st_size / 4096.0, 1.0), 100.0)
-    except OSError:
-        return default_weight
-
-if strategy == "weighted":
-    shards = [{"weight": 0.0, "tests": []} for _ in range(count)]
-    weighted = [(weight_for(path), path.relative_to(test_dir).as_posix(), path) for path in files]
-    weighted.sort(key=lambda item: (-item[0], item[1]))
-    for weight, _rel, path in weighted:
-        best = min(range(count), key=lambda shard: (shards[shard]["weight"], len(shards[shard]["tests"]), shard))
-        shards[best]["weight"] += weight
-        shards[best]["tests"].append(path)
-    selected_paths = sorted(shards[index]["tests"])
-    selected_weight = shards[index]["weight"]
-else:
-    selected_paths = [path for path in files if stable_shard(path) == index]
-    selected_weight = sum(weight_for(path) for path in selected_paths)
-
-selected = [path.as_posix() for path in selected_paths]
-passed = sum(1 for path in selected if baseline_status.get(path) == "PASS")
-print(passed, len(selected), int(selected_weight))
-PY
+  "$runner_bin" "${plan_args[@]}" \
+    | jq -r --argjson index "$shard_index" \
+        '.shards[$index] // error("missing conformance shard plan entry") | "\(.passed) \(.total) \(.weight)"'
 }
 
 run_conformance() {

--- a/scripts/conformance/conformance.sh
+++ b/scripts/conformance/conformance.sh
@@ -63,6 +63,7 @@ Run options:
   --max N           Maximum number of tests to run (default: all)
   --offset N        Skip first N tests (default: 0)
   --shard I/N       Run one round-robin shard after sorting and filtering
+  --plan N          Emit JSON shard plan for N shards and exit
   --workers N       Number of parallel workers (default: 16)
   --profile NAME    Cargo build profile (default: dist-fast)
   --test-dir PATH   Override TypeScript test corpus path


### PR DESCRIPTION
Goal: hold

AgentName: Codex
Track: Hold / conformance CI shard planning
Invariant: Conformance shard expected totals and weights are planned by the Rust conformance runner using the same discovery filters, skip directives, stable hash, and weighted assignment helpers that select runtime shards; CI does not carry a second embedded Python shard planner.
Scope: Add `tsz-conformance --plan <N>` JSON output, move shared shard discovery/planning into `runner::plan`, expose all weighted shard assignments for planning, and have `scripts/ci/lib/gcp-full-ci-conformance.sh` parse the Rust plan with `jq`.
Project Corpus Impact: None. This is CI planning infrastructure only; no conformance execution, diagnostic parity, emit, or project-row behavior changes are intended.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-conformance -E 'test(plan) or test(shard) or test(validate_accepts_positive_plan_count) or test(validate_rejects_zero_plan_count) or test(validate_rejects_plan_with_selected_shard) or test(result_timings_override_stale_path_weights)'`
- `cargo fmt --check`
- `git diff --check`
- `bash -n scripts/ci/lib/gcp-full-ci-conformance.sh scripts/conformance/conformance.sh`
- `scripts/safe-run.sh bash -lc 'cargo run -q -p tsz-conformance --bin tsz-conformance -- --plan 2 --test-dir crates/conformance/src | jq -r "[.shard_count, (.shards | length), .total] | @tsv"'`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium

Coordination Notes: Closes #13123. Checked current open PRs before starting; no active conformance shard-planning PR was open. The local worktree does not have the TypeScript test corpus linked, so broad conformance was intentionally left to CI.