### PR TITLE
refactor(common): share package exports reverse matching

### DIFF
--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
@@ -8,6 +8,7 @@ use crate::symbols_domain::alias_cycle::AliasCycleTracker;
 use rustc_hash::FxHashSet;
 use tsz_binder::SymbolId;
 use tsz_common::comments::is_jsdoc_comment;
+use tsz_common::module_resolution::package_exports::reverse_export_specifier_for_runtime_path as reverse_package_export_specifier_for_runtime_path;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
@@ -1721,114 +1722,6 @@ impl<'a> CheckerState<'a> {
         package_root: &std::path::Path,
         runtime_relative_path: &str,
     ) -> Option<String> {
-        let package_json_path = package_root.join("package.json");
-        let package_json = std::fs::read_to_string(package_json_path).ok()?;
-        let package_json: serde_json::Value = serde_json::from_str(&package_json).ok()?;
-        let exports = package_json.get("exports")?;
-        let runtime_relative_path = format!("./{}", runtime_relative_path.trim_start_matches("./"));
-        self.reverse_match_exports_subpath(exports, &runtime_relative_path)
-    }
-
-    fn reverse_match_exports_subpath(
-        &self,
-        exports: &serde_json::Value,
-        runtime_path: &str,
-    ) -> Option<String> {
-        match exports {
-            serde_json::Value::String(target) => {
-                self.match_export_target(".", target, runtime_path)
-            }
-            serde_json::Value::Array(entries) => entries
-                .iter()
-                .find_map(|entry| self.reverse_match_exports_subpath(entry, runtime_path)),
-            serde_json::Value::Object(map) => {
-                for (key, value) in map {
-                    if key == "." || key.starts_with("./") {
-                        if let Some(specifier) =
-                            self.reverse_match_export_entry(key, value, runtime_path)
-                        {
-                            return Some(specifier);
-                        }
-                        continue;
-                    }
-
-                    if let Some(specifier) = self.reverse_match_exports_subpath(value, runtime_path)
-                    {
-                        return Some(specifier);
-                    }
-                }
-                None
-            }
-            _ => None,
-        }
-    }
-
-    fn reverse_match_export_entry(
-        &self,
-        subpath_key: &str,
-        value: &serde_json::Value,
-        runtime_path: &str,
-    ) -> Option<String> {
-        match value {
-            serde_json::Value::String(target) => {
-                self.match_export_target(subpath_key, target, runtime_path)
-            }
-            serde_json::Value::Array(entries) => entries.iter().find_map(|entry| {
-                self.reverse_match_export_entry(subpath_key, entry, runtime_path)
-            }),
-            serde_json::Value::Object(map) => map.values().find_map(|entry| {
-                self.reverse_match_export_entry(subpath_key, entry, runtime_path)
-            }),
-            _ => None,
-        }
-    }
-
-    fn match_export_target(
-        &self,
-        subpath_key: &str,
-        target: &str,
-        runtime_path: &str,
-    ) -> Option<String> {
-        let target = target.trim();
-        let runtime_path = runtime_path.trim();
-
-        if target.contains('*') {
-            let wildcard = self.match_export_wildcard(target, runtime_path)?;
-            return Some(self.apply_export_wildcard(subpath_key, &wildcard));
-        }
-
-        if target.ends_with('/') && subpath_key.ends_with('/') {
-            let remainder = runtime_path.strip_prefix(target)?;
-            return Some(format!(
-                "{}{}",
-                subpath_key.trim_start_matches("./"),
-                remainder
-            ));
-        }
-
-        if target != runtime_path {
-            return None;
-        }
-
-        if subpath_key == "." {
-            return Some(String::new());
-        }
-
-        Some(subpath_key.trim_start_matches("./").to_string())
-    }
-
-    fn match_export_wildcard(&self, pattern: &str, value: &str) -> Option<String> {
-        let star_idx = pattern.find('*')?;
-        let prefix = &pattern[..star_idx];
-        let suffix = &pattern[star_idx + 1..];
-        let middle = value.strip_prefix(prefix)?.strip_suffix(suffix)?;
-        Some(middle.to_string())
-    }
-
-    fn apply_export_wildcard(&self, pattern: &str, wildcard: &str) -> String {
-        pattern
-            .replace('*', wildcard)
-            .trim_start_matches("./")
-            .to_string()
+        reverse_package_export_specifier_for_runtime_path(package_root, runtime_relative_path)
     }
 }

--- a/crates/tsz-common/src/module_resolution/mod.rs
+++ b/crates/tsz-common/src/module_resolution/mod.rs
@@ -4,5 +4,6 @@
 //! both the CLI driver resolver and the checker's resolution boundary can
 //! share one implementation instead of maintaining divergent copies.
 
+pub mod package_exports;
 pub mod path_identity;
 pub mod types_versions;

--- a/crates/tsz-common/src/module_resolution/package_exports.rs
+++ b/crates/tsz-common/src/module_resolution/package_exports.rs
@@ -1,0 +1,173 @@
+//! Shared reverse lookup helpers for `package.json#exports`.
+//!
+//! Declaration emit and checker nameability both need to answer the same
+//! question: given a package-local runtime target such as `./dist/index.js`,
+//! which public export specifier, if any, exposes it? Keeping this logic here
+//! prevents checker diagnostics and DTS output from drifting on condition,
+//! wildcard, array, and folder-entry handling.
+
+use serde_json::Value;
+use std::path::Path;
+
+/// Read `package.json` under `package_root` and reverse-match its `exports`
+/// map for `runtime_relative_path`.
+///
+/// The returned string omits the leading package name and leading `./`.
+/// The package root export (`"."`) is returned as an empty string so callers
+/// can append it directly to the package name.
+pub fn reverse_export_specifier_for_runtime_path(
+    package_root: &Path,
+    runtime_relative_path: &str,
+) -> Option<String> {
+    let package_json_path = package_root.join("package.json");
+    let package_json = std::fs::read_to_string(package_json_path).ok()?;
+    let package_json: Value = serde_json::from_str(&package_json).ok()?;
+    let exports = package_json.get("exports")?;
+    let runtime_relative_path = format!("./{}", runtime_relative_path.trim_start_matches("./"));
+    reverse_match_exports_subpath(exports, &runtime_relative_path)
+}
+
+/// Reverse-match a package `exports` value for a package-local runtime target.
+pub fn reverse_match_exports_subpath(exports: &Value, runtime_path: &str) -> Option<String> {
+    match exports {
+        Value::String(target) => match_export_target(".", target, runtime_path),
+        Value::Array(entries) => entries
+            .iter()
+            .find_map(|entry| reverse_match_exports_subpath(entry, runtime_path)),
+        Value::Object(map) => {
+            for (key, value) in map {
+                if key == "." || key.starts_with("./") {
+                    if let Some(specifier) = reverse_match_export_entry(key, value, runtime_path) {
+                        return Some(specifier);
+                    }
+                    continue;
+                }
+
+                if let Some(specifier) = reverse_match_exports_subpath(value, runtime_path) {
+                    return Some(specifier);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Reverse-match one export-map entry for a package-local runtime target.
+pub fn reverse_match_export_entry(
+    subpath_key: &str,
+    value: &Value,
+    runtime_path: &str,
+) -> Option<String> {
+    match value {
+        Value::String(target) => match_export_target(subpath_key, target, runtime_path),
+        Value::Array(entries) => entries
+            .iter()
+            .find_map(|entry| reverse_match_export_entry(subpath_key, entry, runtime_path)),
+        Value::Object(map) => map
+            .values()
+            .find_map(|entry| reverse_match_export_entry(subpath_key, entry, runtime_path)),
+        _ => None,
+    }
+}
+
+/// Match an `exports` target string and synthesize the public subpath.
+pub fn match_export_target(subpath_key: &str, target: &str, runtime_path: &str) -> Option<String> {
+    let target = target.trim();
+    let runtime_path = runtime_path.trim();
+
+    if target.contains('*') {
+        let wildcard = match_exports_wildcard(target, runtime_path)?;
+        return Some(apply_exports_wildcard(subpath_key, &wildcard));
+    }
+
+    if target.ends_with('/') && subpath_key.ends_with('/') {
+        let remainder = runtime_path.strip_prefix(target)?;
+        return Some(format!(
+            "{}{}",
+            subpath_key.trim_start_matches("./"),
+            remainder
+        ));
+    }
+
+    if target != runtime_path {
+        return None;
+    }
+
+    if subpath_key == "." {
+        return Some(String::new());
+    }
+
+    Some(subpath_key.trim_start_matches("./").to_string())
+}
+
+/// Return the wildcard substring captured by a single-star export pattern.
+pub fn match_exports_wildcard(pattern: &str, value: &str) -> Option<String> {
+    let star_idx = pattern.find('*')?;
+    let prefix = &pattern[..star_idx];
+    let suffix = &pattern[star_idx + 1..];
+    let middle = value.strip_prefix(prefix)?.strip_suffix(suffix)?;
+    Some(middle.to_string())
+}
+
+/// Apply a captured wildcard to a public export pattern.
+pub fn apply_exports_wildcard(pattern: &str, wildcard: &str) -> String {
+    pattern
+        .replace('*', wildcard)
+        .trim_start_matches("./")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn reverse_match_root_export_returns_empty_subpath() {
+        let exports = json!("./dist/index.js");
+        assert_eq!(
+            reverse_match_exports_subpath(&exports, "./dist/index.js"),
+            Some(String::new())
+        );
+    }
+
+    #[test]
+    fn reverse_match_subpath_wildcard_applies_captured_middle() {
+        let exports = json!({
+            "./feature/*": "./dist/feature/*.js"
+        });
+
+        assert_eq!(
+            reverse_match_exports_subpath(&exports, "./dist/feature/a/b.js"),
+            Some("feature/a/b".to_string())
+        );
+    }
+
+    #[test]
+    fn reverse_match_preserves_condition_order() {
+        let exports = json!({
+            ".": {
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            }
+        });
+
+        assert_eq!(
+            reverse_match_exports_subpath(&exports, "./dist/index.d.ts"),
+            Some(String::new())
+        );
+        assert_eq!(
+            reverse_match_exports_subpath(&exports, "./dist/index.js"),
+            Some(String::new())
+        );
+    }
+
+    #[test]
+    fn match_export_target_supports_folder_entries() {
+        assert_eq!(
+            match_export_target("./feature/", "./dist/feature/", "./dist/feature/a.js"),
+            Some("feature/a.js".to_string())
+        );
+    }
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
@@ -17,6 +17,8 @@ use tsz_binder::{BinderState, SymbolId, symbol_flags};
 #[allow(unused_imports)]
 use tsz_common::comments::{get_jsdoc_content, is_jsdoc_comment};
 #[allow(unused_imports)]
+use tsz_common::module_resolution::package_exports::{match_export_target, match_exports_wildcard};
+#[allow(unused_imports)]
 use tsz_parser::parser::ParserState;
 #[allow(unused_imports)]
 use tsz_parser::parser::node::{Node, NodeAccess, NodeArena};
@@ -1600,7 +1602,7 @@ impl<'a> DeclarationEmitter<'a> {
     ) -> bool {
         match exports {
             serde_json::Value::String(target) => {
-                subpath == "." || self.match_export_target(".", target, subpath).is_some()
+                subpath == "." || match_export_target(".", target, subpath).is_some()
             }
             serde_json::Value::Array(entries) => entries
                 .iter()
@@ -1630,7 +1632,7 @@ impl<'a> DeclarationEmitter<'a> {
         if key == subpath {
             return true;
         }
-        if key.contains('*') && self.match_exports_wildcard(key, subpath).is_some() {
+        if key.contains('*') && match_exports_wildcard(key, subpath).is_some() {
             return true;
         }
         if key.ends_with('/') && subpath.starts_with(key) {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing_paths.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing_paths.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use tracing::debug;
 use tsz_binder::{BinderState, SymbolId, symbol_flags};
 use tsz_common::file_extensions::strip_known_extension;
+use tsz_common::module_resolution::package_exports::reverse_export_specifier_for_runtime_path as reverse_package_export_specifier_for_runtime_path;
 use tsz_parser::parser::node::NodeArena;
 
 impl<'a> DeclarationEmitter<'a> {
@@ -1197,123 +1198,7 @@ impl<'a> DeclarationEmitter<'a> {
         package_root: &std::path::Path,
         runtime_relative_path: &str,
     ) -> Option<String> {
-        let package_json_path = package_root.join("package.json");
-        let package_json = std::fs::read_to_string(package_json_path).ok()?;
-        let package_json: serde_json::Value = serde_json::from_str(&package_json).ok()?;
-        let exports = package_json.get("exports")?;
-        let runtime_relative_path = format!("./{}", runtime_relative_path.trim_start_matches("./"));
-        self.reverse_match_exports_subpath(exports, &runtime_relative_path)
-    }
-
-    pub(in crate::declaration_emitter) fn reverse_match_exports_subpath(
-        &self,
-        exports: &serde_json::Value,
-        runtime_path: &str,
-    ) -> Option<String> {
-        match exports {
-            serde_json::Value::String(target) => {
-                self.match_export_target(".", target, runtime_path)
-            }
-            serde_json::Value::Array(entries) => entries
-                .iter()
-                .find_map(|entry| self.reverse_match_exports_subpath(entry, runtime_path)),
-            serde_json::Value::Object(map) => {
-                for (key, value) in map {
-                    if key == "." || key.starts_with("./") {
-                        if let Some(specifier) =
-                            self.reverse_match_export_entry(key, value, runtime_path)
-                        {
-                            return Some(specifier);
-                        }
-                        continue;
-                    }
-
-                    if let Some(specifier) = self.reverse_match_exports_subpath(value, runtime_path)
-                    {
-                        return Some(specifier);
-                    }
-                }
-                None
-            }
-            _ => None,
-        }
-    }
-
-    pub(in crate::declaration_emitter) fn reverse_match_export_entry(
-        &self,
-        subpath_key: &str,
-        value: &serde_json::Value,
-        runtime_path: &str,
-    ) -> Option<String> {
-        match value {
-            serde_json::Value::String(target) => {
-                self.match_export_target(subpath_key, target, runtime_path)
-            }
-            serde_json::Value::Array(entries) => entries.iter().find_map(|entry| {
-                self.reverse_match_export_entry(subpath_key, entry, runtime_path)
-            }),
-            serde_json::Value::Object(map) => map.values().find_map(|entry| {
-                self.reverse_match_export_entry(subpath_key, entry, runtime_path)
-            }),
-            _ => None,
-        }
-    }
-
-    pub(in crate::declaration_emitter) fn match_export_target(
-        &self,
-        subpath_key: &str,
-        target: &str,
-        runtime_path: &str,
-    ) -> Option<String> {
-        let target = target.trim();
-        let runtime_path = runtime_path.trim();
-
-        if target.contains('*') {
-            let wildcard = self.match_exports_wildcard(target, runtime_path)?;
-            return Some(self.apply_exports_wildcard(subpath_key, &wildcard));
-        }
-
-        if target.ends_with('/') && subpath_key.ends_with('/') {
-            let remainder = runtime_path.strip_prefix(target)?;
-            return Some(format!(
-                "{}{}",
-                subpath_key.trim_start_matches("./"),
-                remainder
-            ));
-        }
-
-        if target != runtime_path {
-            return None;
-        }
-
-        if subpath_key == "." {
-            return Some(String::new());
-        }
-
-        Some(subpath_key.trim_start_matches("./").to_string())
-    }
-
-    pub(in crate::declaration_emitter) fn match_exports_wildcard(
-        &self,
-        pattern: &str,
-        value: &str,
-    ) -> Option<String> {
-        let star_idx = pattern.find('*')?;
-        let prefix = &pattern[..star_idx];
-        let suffix = &pattern[star_idx + 1..];
-        let middle = value.strip_prefix(prefix)?.strip_suffix(suffix)?;
-        Some(middle.to_string())
-    }
-
-    pub(in crate::declaration_emitter) fn apply_exports_wildcard(
-        &self,
-        pattern: &str,
-        wildcard: &str,
-    ) -> String {
-        pattern
-            .replace('*', wildcard)
-            .trim_start_matches("./")
-            .to_string()
+        reverse_package_export_specifier_for_runtime_path(package_root, runtime_relative_path)
     }
 
     /// Strip an import-path extension using the shared TS/JS rules.


### PR DESCRIPTION
Goal: hold

AgentName: Codex
Track: Hold / DTS nameability and declaration emit path portability
Invariant: When checker declaration-nameability diagnostics and DTS emit need the public package subpath for the same package-local runtime target, tsz reverse-matches `package.json` `exports` through one shared `tsz-common::module_resolution::package_exports` helper. Checker no longer owns a local copy, and emitter no longer owns a second reverse matcher.
Scope: Add the shared package-exports reverse matcher to `tsz-common`, route checker declaration-emit nameability and emitter type-printing paths through it, and reuse the shared target/wildcard helpers in emitter portability checks.
Project Corpus Impact: None expected. This is a shared-helper refactor for existing package-exports path selection; no semantic validation or output surgery is added.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-common package_exports`
- `scripts/safe-run.sh cargo check -p tsz-common -p tsz-checker -p tsz-emitter`
- `scripts/safe-run.sh cargo nextest run -p tsz-emitter type_formatting`
- `cargo fmt --check && git diff --check`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium

Coordination Notes: Closes #13131. Checked current open PRs before starting; no active checker/emitter reverse package-exports helper PR was open. #13228 is a separate conformance CI planner PR and does not touch these paths.