### PR TITLE
perf(scanner): intern plain string literal slices

### DIFF
--- a/crates/tsz-scanner/src/scanner_impl/jsx.rs
+++ b/crates/tsz-scanner/src/scanner_impl/jsx.rs
@@ -262,20 +262,19 @@ impl ScannerState {
     /// Scan a JSX string literal (used for attribute values).
     /// Unlike regular strings, JSX strings don't support escape sequences.
     fn scan_jsx_string_literal(&mut self, quote: u32) {
+        self.token_atom = AstAtom::NONE;
+        self.token_value.clear();
         self.pos += 1; // Skip opening quote
-        let mut result = String::new();
+        let content_start = self.pos;
 
         while self.pos < self.end {
             let ch = self.char_code_unchecked(self.pos);
             if ch == quote {
+                let text = &self.source[content_start..self.pos];
+                self.token_atom = self.interner.intern(text);
                 self.pos += 1; // Closing quote
-                self.token_value = result;
                 self.token = SyntaxKind::StringLiteral;
                 return;
-            }
-            // JSX strings don't process escape sequences - they're literal
-            if let Some(c) = char::from_u32(ch) {
-                result.push(c);
             }
             // Advance by the character's UTF-8 byte length so multi-byte chars
             // are not re-decoded from a continuation-byte offset.
@@ -284,7 +283,7 @@ impl ScannerState {
 
         // Unterminated string
         self.token_flags |= TokenFlags::Unterminated as u32;
-        self.token_value = result;
+        self.token_value = self.source[content_start..self.pos].to_string();
         self.token = SyntaxKind::StringLiteral;
     }
 

--- a/crates/tsz-scanner/src/scanner_impl/strings.rs
+++ b/crates/tsz-scanner/src/scanner_impl/strings.rs
@@ -4,7 +4,28 @@ impl ScannerState {
     /// Scan a string literal.
     pub(crate) fn scan_string(&mut self, quote: u32) {
         self.pos += 1; // Skip opening quote
-        let mut result = String::new();
+        let content_start = self.pos;
+
+        while self.pos < self.end {
+            let ch = self.char_code_unchecked(self.pos);
+            if ch == quote {
+                let text = &self.source[content_start..self.pos];
+                self.token_atom = self.interner.intern(text);
+                self.pos += 1; // Closing quote
+                self.token_value.clear();
+                self.token = SyntaxKind::StringLiteral;
+                return;
+            }
+            if ch == CharacterCodes::BACKSLASH
+                || ch == CharacterCodes::LINE_FEED
+                || ch == CharacterCodes::CARRIAGE_RETURN
+            {
+                break;
+            }
+            self.pos += self.char_len_at(self.pos);
+        }
+
+        let mut result = self.source[content_start..self.pos].to_string();
 
         while self.pos < self.end {
             let ch = self.char_code_unchecked(self.pos);

--- a/crates/tsz-scanner/src/scanner_impl/tests.rs
+++ b/crates/tsz-scanner/src/scanner_impl/tests.rs
@@ -210,6 +210,26 @@ fn scan_no_substitution_template() {
     assert_eq!(tokens[0].1, "hello world");
 }
 
+// ── String literals ───────────────────────────────────────────────
+
+#[test]
+fn scan_plain_string_literal_uses_interned_source_slice() {
+    let mut scanner = ScannerState::new(r#""pkg/path""#.to_string(), true);
+    assert_eq!(scanner.scan(), SyntaxKind::StringLiteral);
+    assert_eq!(scanner.get_token_value_ref(), "pkg/path");
+    assert_eq!(scanner.token_value, "");
+    assert_ne!(scanner.token_atom, AstAtom::NONE);
+}
+
+#[test]
+fn scan_escaped_string_literal_keeps_cooked_value_path() {
+    let mut scanner = ScannerState::new(r#""a\nb""#.to_string(), true);
+    assert_eq!(scanner.scan(), SyntaxKind::StringLiteral);
+    assert_eq!(scanner.get_token_value_ref(), "a\nb");
+    assert_eq!(scanner.token_value, "a\nb");
+    assert_eq!(scanner.token_atom, AstAtom::NONE);
+}
+
 // ── JSX attribute string literals ─────────────────────────────────
 
 /// Regression for #3977: `scan_jsx_string_literal` advanced by one byte
@@ -237,6 +257,18 @@ fn scan_jsx_attribute_value_preserves_non_ascii() {
     let mut s = ScannerState::new("'héllo 中 😀'".to_string(), true);
     assert_eq!(s.scan_jsx_attribute_value(), SyntaxKind::StringLiteral);
     assert_eq!(s.get_token_value(), "héllo 中 😀");
+}
+
+#[test]
+fn scan_jsx_attribute_string_literal_uses_interned_source_slice() {
+    let mut scanner = ScannerState::new("\"plain attr\"".to_string(), true);
+    assert_eq!(
+        scanner.scan_jsx_attribute_value(),
+        SyntaxKind::StringLiteral
+    );
+    assert_eq!(scanner.get_token_value_ref(), "plain attr");
+    assert_eq!(scanner.token_value, "");
+    assert_ne!(scanner.token_atom, AstAtom::NONE);
 }
 
 // ── Punctuation ───────────────────────────────────────────────────


### PR DESCRIPTION
Goal: fast

AgentName: Codex
Track: Fast / scanner allocation pressure
Invariant: Closed string and JSX attribute literals whose raw content is already the cooked value store that content through the scanner interner and leave `token_value` empty; literals that hit an escape, line terminator, or EOF still use the existing cooked/recovery `String` path.
Scope: Add a no-escape scan path for regular string literals, route JSX attribute string literals through the same interned-slice token-value surface, and cover plain, escaped, JSX, and non-ASCII cases in scanner tests.
Project Corpus Impact: None expected. This changes scanner storage for value-equivalent literals only; token kind, token span, diagnostics, and cooked value remain unchanged. No benchmark timing claim is made in this PR.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-scanner -E 'test(scan_plain_string_literal_uses_interned_source_slice) or test(scan_escaped_string_literal_keeps_cooked_value_path) or test(scan_jsx_attribute_string_literal_uses_interned_source_slice) or test(scan_jsx_attribute_value_preserves_non_ascii)'`
- `scripts/safe-run.sh cargo check -p tsz-scanner`
- `cargo fmt --check`
- `git diff --check`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium

Coordination Notes: Closes #13068. Checked current open PRs before starting; active Codex PRs #13228 and #13229 touch conformance planning and checker/emitter package exports, so this scanner-only allocation change has no path overlap.