### PR TITLE
perf(solver): cache narrow param-or-infer walks (#13049)

### DIFF
--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -133,16 +133,16 @@ pub trait TypePredicateCache {
     /// shared interner cache. Default impl is a no-op.
     fn set_contains_conditional_cache(&self, _type_id: TypeId, _result: bool) {}
 
-    /// Look up a cached root result for the depth-limited
-    /// `visitor_predicates::contains_type_parameters` walk. The walk always
-    /// starts from a fresh recursion guard, so the answer is a pure function
-    /// of the root `TypeId`. Default impl returns `None` (no caching).
+    /// Look up a cached result for the narrow
+    /// `visitor_predicates::contains_type_parameters` walk
+    /// (`TypeParameter | Infer`). The answer is a pure function of each
+    /// visited `TypeId`. Default impl returns `None` (no caching).
     fn contains_param_or_infer_root_cached(&self, _type_id: TypeId) -> Option<bool> {
         None
     }
 
-    /// Record a root result of the depth-limited
-    /// `visitor_predicates::contains_type_parameters` walk. Default no-op.
+    /// Record a narrow `visitor_predicates::contains_type_parameters` walk
+    /// result. Default no-op.
     fn set_contains_param_or_infer_root_cache(&self, _type_id: TypeId, _result: bool) {}
 
     /// Look up a cached root result for the depth-limited

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -166,12 +166,11 @@ pub struct TypeInterner {
     /// The answer is immutable per `TypeId` and avoids repeated subtree walks
     /// on dense recursive mapped/conditional/index-access expansions.
     pub(crate) contains_conditional_cache: DashMap<TypeId, bool, FxBuildHasher>,
-    /// Root-result cache for the depth-limited
+    /// Per-`TypeId` cache for the narrow
     /// `visitor_predicates::contains_type_parameters` walk
-    /// (`TypeParameter | Infer` predicate). The walk always starts from a
-    /// fresh guard, so the answer is a pure function of the root `TypeId`
-    /// and can be shared project-wide. Recursive conditional evaluation
-    /// re-asks this for the same check/extends roots constantly.
+    /// (`TypeParameter | Infer` predicate). Recursive conditional evaluation
+    /// and instantiation gates re-ask this for the same shared subtrees
+    /// constantly.
     pub(crate) contains_param_or_infer_root_cache: DashMap<TypeId, bool, FxBuildHasher>,
     /// Root-result cache for the depth-limited
     /// `contains_generic_type_parameters_db` walk
@@ -345,7 +344,7 @@ pub struct TypePredicateCacheStatistics {
     pub contains_resolver_dependent_cache_entries: usize,
     /// Number of memoized conditional-type containment predicate results.
     pub contains_conditional_cache_entries: usize,
-    /// Number of memoized depth-limited param-or-infer root walk results.
+    /// Number of memoized narrow param-or-infer containment results.
     pub contains_param_or_infer_root_cache_entries: usize,
     /// Number of memoized depth-limited generic-params root walk results.
     pub contains_generic_params_root_cache_entries: usize,

--- a/crates/tsz-solver/src/tests/visitor_tests.rs
+++ b/crates/tsz-solver/src/tests/visitor_tests.rs
@@ -372,6 +372,43 @@ fn test_contains_type_parameters() {
 }
 
 #[test]
+fn contains_type_parameters_uses_deep_cache_without_broadening_semantics() {
+    let interner = TypeInterner::new();
+
+    let this_type = interner.this_type();
+    let bound_param = interner.bound_parameter(0);
+    assert!(!contains_type_parameters(&interner, this_type));
+    assert!(!contains_type_parameters(&interner, bound_param));
+    assert!(crate::type_queries::contains_type_parameters_db(
+        &interner, this_type
+    ));
+    assert!(crate::type_queries::contains_type_parameters_db(
+        &interner,
+        bound_param
+    ));
+
+    let t_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: interner.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+    }));
+    let arr = interner.array(t_param);
+    let union = interner.union(vec![TypeId::STRING, arr]);
+    let idx = interner.index_access(union, TypeId::NUMBER);
+
+    assert!(contains_type_parameters(&interner, idx));
+    assert!(contains_type_parameters(&interner, idx));
+    let entries = interner
+        .type_predicate_cache_statistics()
+        .contains_param_or_infer_root_cache_entries;
+    assert!(
+        entries >= 3,
+        "expected param-or-infer cache to retain child entries, got {entries}"
+    );
+}
+
+#[test]
 fn test_contains_error_type() {
     let interner = TypeInterner::new();
 

--- a/crates/tsz-solver/src/type_queries/data/content_predicates.rs
+++ b/crates/tsz-solver/src/type_queries/data/content_predicates.rs
@@ -94,6 +94,50 @@ impl ContentPredicate for TypeParamPredicate {
     }
 }
 
+struct ParamOrInferPredicate;
+impl ContentPredicate for ParamOrInferPredicate {
+    fn matches_node(&self, _db: &dyn TypeDatabase, key: &TypeData) -> bool {
+        matches!(key, TypeData::TypeParameter(_) | TypeData::Infer(_))
+    }
+    fn cached(&self, db: &dyn TypeDatabase, type_id: TypeId) -> Option<bool> {
+        db.contains_param_or_infer_root_cached(type_id)
+    }
+    fn set_cache(&self, db: &dyn TypeDatabase, type_id: TypeId, result: bool) {
+        db.set_contains_param_or_infer_root_cache(type_id, result);
+    }
+}
+
+/// Check whether `type_id` contains the legacy solver-internal
+/// `TypeParameter | Infer` predicate.
+///
+/// This preserves `visitor_predicates::contains_type_parameters` semantics:
+/// `ThisType` and `BoundParameter` are not considered matches here. The answer
+/// is immutable per `TypeId`, so repeated instantiation/evaluation gates share
+/// the project-wide content-predicate cache instead of re-walking each subtree.
+pub fn contains_param_or_infer_db(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    if type_id.is_intrinsic() {
+        return false;
+    }
+    match db.lookup(type_id) {
+        Some(TypeData::TypeParameter(_) | TypeData::Infer(_)) => return true,
+        Some(
+            TypeData::Literal(_)
+            | TypeData::Intrinsic(_)
+            | TypeData::Error
+            | TypeData::ThisType
+            | TypeData::BoundParameter(_)
+            | TypeData::Lazy(_)
+            | TypeData::Recursive(_)
+            | TypeData::TypeQuery(_)
+            | TypeData::UniqueSymbol(_)
+            | TypeData::ModuleNamespace(_)
+            | TypeData::UnresolvedTypeName(_),
+        ) => return false,
+        _ => {}
+    }
+    contains_content_cached(db, type_id, &ParamOrInferPredicate)
+}
+
 struct InferPredicate;
 impl ContentPredicate for InferPredicate {
     fn matches_node(&self, db: &dyn TypeDatabase, key: &TypeData) -> bool {

--- a/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
@@ -10,22 +10,12 @@ use super::predicate_pool::with_predicate_buffers;
 
 /// Check if a type contains any type parameters.
 ///
-/// The depth-limited walk always starts from a fresh recursion guard, so the
-/// answer is a pure function of the root `TypeId`. Recursive conditional
-/// evaluation re-asks this for the same check/extends roots constantly, so the
-/// root result is memoized project-wide on the interner.
+/// This is the legacy narrow predicate: it matches `TypeParameter | Infer`,
+/// but not `ThisType` or `BoundParameter`. The deep walk is memoized per node
+/// in the project-wide param-or-infer cache so recursive instantiation and
+/// conditional evaluation do not re-walk shared subtrees.
 pub fn contains_type_parameters(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    if type_id.is_intrinsic() {
-        return false;
-    }
-    if let Some(cached) = types.contains_param_or_infer_root_cached(type_id) {
-        return cached;
-    }
-    let result = contains_type_matching(types, type_id, |key| {
-        matches!(key, TypeData::TypeParameter(_) | TypeData::Infer(_))
-    });
-    types.set_contains_param_or_infer_root_cache(type_id, result);
-    result
+    crate::type_queries::contains_param_or_infer_db(types, type_id)
 }
 
 /// Check if a type contains free type parameters, excluding those bound by


### PR DESCRIPTION
Goal: fast
AgentName: Codex
Track: solver predicate-cache tech debt

## Invariant
`visitor_predicates::contains_type_parameters` remains the narrow legacy predicate: it matches `TypeParameter | Infer` and continues to exclude `ThisType` and `BoundParameter`. Because interned `TypeId` data is immutable within one interner, the deep containment answer can be cached per visited `TypeId` and reused across instantiation/evaluation gates.

## Scope
- Add a solver-owned `contains_param_or_infer_db` content predicate backed by the existing param-or-infer cache slot.
- Route the legacy visitor helper through the cached query so hot `crate::visitor::contains_type_parameters` callers retain narrow semantics while avoiding repeated subtree walks.
- Update cache docs/stat comments and add a regression test proving both deep-cache retention and the narrow-vs-broad semantic split.

## Project Corpus Impact
No behavior change intended. This ratchets #13049 by turning repeated solver param-or-infer subtree walks into amortized cache hits on shared recursive mapped/conditional/index-access shapes.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(test_contains_type_parameters) or test(contains_type_parameters_uses_deep_cache_without_broadening_semantics) or test(contains_type_parameters_db_is_name_agnostic_and_cache_stable)'`
- `scripts/safe-run.sh cargo check -p tsz-solver`
- `cargo fmt --check`
- `git diff --check`

## Coordination Notes
Closes #13049.
Checked open PRs before publishing; the active solver PRs target alias/identity/member-lookup behavior and do not overlap the param-or-infer content-predicate cache path.

## Provenance
Machine: Mohsens-MacBook-Pro.local
Assistant: codex
Model: gpt-5
Effort: medium