### PR TITLE
fix(emitter): drive ES5 async lexical-this capture from the IR fact, dedupe __awaiter wrapper emission

### DIFF
--- a/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/emit_declaration.rs
@@ -216,16 +216,7 @@ impl<'a> Printer<'a> {
                 };
                 self.sync_es5_class_emitter_state(&mut es5_emitter);
                 let mappings = es5_emitter.take_mappings();
-                if !mappings.is_empty() && self.writer.has_source_map() {
-                    self.writer.write("");
-                    let base_line = self.writer.current_line();
-                    let base_column = self.writer.current_column();
-                    self.writer
-                        .add_offset_mappings(base_line, base_column, &mappings);
-                    self.writer.write(&output);
-                } else {
-                    self.write(&output);
-                }
+                self.write_with_offset_mappings(&output, &mappings);
                 while self.comment_emit_idx < self.all_comments.len()
                     && self.all_comments[self.comment_emit_idx].pos < node.end
                 {
@@ -421,16 +412,7 @@ impl<'a> Printer<'a> {
             };
             self.sync_es5_class_emitter_state(&mut es5_emitter);
             let mappings = es5_emitter.take_mappings();
-            if !mappings.is_empty() && self.writer.has_source_map() {
-                self.writer.write("");
-                let base_line = self.writer.current_line();
-                let base_column = self.writer.current_column();
-                self.writer
-                    .add_offset_mappings(base_line, base_column, &mappings);
-                self.writer.write(&output);
-            } else {
-                self.write(&output);
-            }
+            self.write_with_offset_mappings(&output, &mappings);
             // Emit any trailing comment from the class's closing `}` line
             // (e.g., `class Foo { ... } // comment` → `}()); // comment`).
             // This must happen BEFORE `skip_comments_for_erased_node` consumes

--- a/crates/tsz-emitter/src/emitter/es5/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers.rs
@@ -976,15 +976,8 @@ impl<'a> Printer<'a> {
             self.write_helper("__awaiter");
             self.write("(");
             self.write(this_expr);
-            self.write(", void 0, ");
-            self.write_awaiter_promise_arg(&promise_ctor);
-            self.write(", function () {");
-            self.write_line();
-            self.increase_indent();
-            self.emit_async_arrow_hoisted_var_groups(
-                &hoisted_var_groups,
-                needs_lexical_this_capture,
-            );
+            self.open_awaiter_callback(&promise_ctor);
+            self.emit_async_hoisted_var_groups(&hoisted_var_groups, needs_lexical_this_capture);
             self.emit_param_binding_prologue(&param_transforms);
             self.write(&generator_body);
             self.decrease_indent();
@@ -1009,25 +1002,9 @@ impl<'a> Printer<'a> {
             self.write_helper("__awaiter");
             self.write("(");
             self.write(this_expr);
-            self.write(", void 0, ");
-            self.write_awaiter_promise_arg(&promise_ctor);
-            self.write(", function () {");
-            self.write_line();
-            self.increase_indent();
-            self.emit_async_arrow_hoisted_var_groups(
-                &hoisted_var_groups,
-                needs_lexical_this_capture,
-            );
-            if !generator_mappings.is_empty() && self.writer.has_source_map() {
-                self.writer.write("");
-                let base_line = self.writer.current_line();
-                let base_column = self.writer.current_column();
-                self.writer
-                    .add_offset_mappings(base_line, base_column, &generator_mappings);
-                self.writer.write(&generator_body);
-            } else {
-                self.write(&generator_body);
-            }
+            self.open_awaiter_callback(&promise_ctor);
+            self.emit_async_hoisted_var_groups(&hoisted_var_groups, needs_lexical_this_capture);
+            self.write_with_offset_mappings(&generator_body, &generator_mappings);
             self.decrease_indent();
             self.write_line();
             self.write("});");
@@ -1042,120 +1019,38 @@ impl<'a> Printer<'a> {
             self.write_helper("__awaiter");
             self.write("(");
             self.write(this_expr);
-            if hoisted_var_groups.is_empty() {
-                let can_inline_wrapper = func.equals_greater_than_token
-                    && body_is_single_line
-                    && !body_has_await
-                    && !needs_lexical_this_capture
-                    && generator_mappings.is_empty();
-                if can_inline_wrapper {
-                    self.write(", void 0, ");
-                    self.write_awaiter_promise_arg(&promise_ctor);
-                    self.write(", function () { ");
-                    self.write(&Self::inline_async_arrow_generator_body(&generator_body));
-                    self.write(" }); }");
-                    if synced_visual_indent {
-                        self.writer.set_indent_level(original_indent_level);
-                    }
-                    self.skip_comments_for_async_lowered_body(func.body);
-                    self.pop_temp_scope();
-                    return;
-                }
-                // Multi-line format (matches tsc): __generator on new line
+            let can_inline_wrapper = hoisted_var_groups.is_empty()
+                && func.equals_greater_than_token
+                && body_is_single_line
+                && !body_has_await
+                && !needs_lexical_this_capture
+                && generator_mappings.is_empty();
+            if can_inline_wrapper {
                 self.write(", void 0, ");
                 self.write_awaiter_promise_arg(&promise_ctor);
-                self.write(", function () {");
-                self.write_line();
-                self.increase_indent();
-                self.emit_async_arrow_hoisted_var_groups(
-                    &hoisted_var_groups,
-                    needs_lexical_this_capture,
-                );
-                if !generator_mappings.is_empty() && self.writer.has_source_map() {
-                    self.writer.write("");
-                    let base_line = self.writer.current_line();
-                    let base_column = self.writer.current_column();
-                    self.writer
-                        .add_offset_mappings(base_line, base_column, &generator_mappings);
-                    self.writer.write(&generator_body);
-                } else {
-                    self.write(&generator_body);
+                self.write(", function () { ");
+                self.write(&Self::inline_async_generator_body(&generator_body));
+                self.write(" }); }");
+                if synced_visual_indent {
+                    self.writer.set_indent_level(original_indent_level);
                 }
-                self.decrease_indent();
-                self.write_line();
-                self.write("}); }");
-            } else {
-                // Multi-line format with hoisted vars
-                self.write(", void 0, ");
-                self.write_awaiter_promise_arg(&promise_ctor);
-                self.write(", function () {");
-                self.write_line();
-                self.increase_indent();
-                self.emit_async_arrow_hoisted_var_groups(
-                    &hoisted_var_groups,
-                    needs_lexical_this_capture,
-                );
-                if !generator_mappings.is_empty() && self.writer.has_source_map() {
-                    self.writer.write("");
-                    let base_line = self.writer.current_line();
-                    let base_column = self.writer.current_column();
-                    self.writer
-                        .add_offset_mappings(base_line, base_column, &generator_mappings);
-                    self.writer.write(&generator_body);
-                } else {
-                    self.write(&generator_body);
-                }
-                self.decrease_indent();
-                self.write_line();
-                self.write("}); }");
+                self.skip_comments_for_async_lowered_body(func.body);
+                self.pop_temp_scope();
+                return;
             }
+            // Multi-line format (matches tsc): __generator on new line
+            self.open_awaiter_callback(&promise_ctor);
+            self.emit_async_hoisted_var_groups(&hoisted_var_groups, needs_lexical_this_capture);
+            self.write_with_offset_mappings(&generator_body, &generator_mappings);
+            self.decrease_indent();
+            self.write_line();
+            self.write("}); }");
         }
         if synced_visual_indent {
             self.writer.set_indent_level(original_indent_level);
         }
         self.skip_comments_for_async_lowered_body(func.body);
         self.pop_temp_scope();
-    }
-
-    fn inline_async_arrow_generator_body(generator_body: &str) -> String {
-        let mut lines = generator_body.lines();
-        let Some(first_line) = lines.next() else {
-            return String::new();
-        };
-
-        let following_strip = 4;
-        let mut output = String::from(first_line.trim_start());
-        for line in lines {
-            output.push('\n');
-            output.push_str(line.get(following_strip..).unwrap_or(line).trim_end());
-        }
-        output
-    }
-
-    fn emit_async_arrow_hoisted_var_groups(
-        &mut self,
-        hoisted_var_groups: &[Vec<String>],
-        needs_lexical_this_capture: bool,
-    ) {
-        for group in hoisted_var_groups {
-            if group.is_empty() {
-                continue;
-            }
-            self.write("var ");
-            for (i, var_name) in group.iter().enumerate() {
-                if i > 0 {
-                    self.write(", ");
-                }
-                self.write(var_name);
-            }
-            self.write(";");
-            self.write_line();
-        }
-
-        if needs_lexical_this_capture {
-            self.write("var _this = this;");
-            self.write_line();
-        }
     }
 
     fn emit_async_arrow_es5_await_param_recovery(

--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -254,11 +254,7 @@ impl<'a> Printer<'a> {
                 self.write_helper("__awaiter");
                 self.write("(");
                 self.write(this_expr);
-                self.write(", void 0, ");
-                self.write_awaiter_promise_arg(&promise_ctor);
-                self.write(", function () {");
-                self.write_line();
-                self.increase_indent();
+                self.open_awaiter_callback(&promise_ctor);
 
                 if let Some(body_node) = self.arena.get(body)
                     && let Some(block) = self.arena.get_block(body_node)
@@ -309,12 +305,16 @@ impl<'a> Printer<'a> {
                 }
             }
 
-            let (generator_body, hoisted_var_groups, directive_prologue, _) = async_emitter
-                .emit_generator_body_and_hoisted_vars_skipping(
-                    body,
-                    body_has_await,
-                    &hoisted_function_decls,
-                );
+            let (
+                generator_body,
+                hoisted_var_groups,
+                directive_prologue,
+                needs_lexical_this_capture,
+            ) = async_emitter.emit_generator_body_and_hoisted_vars_skipping(
+                body,
+                body_has_await,
+                &hoisted_function_decls,
+            );
             let generator_mappings = async_emitter.take_mappings();
             self.next_disposable_env_id = async_emitter.disposable_env_counter();
             self.next_dynamic_import_promise_id = async_emitter.dynamic_import_promise_counter();
@@ -328,109 +328,50 @@ impl<'a> Printer<'a> {
             self.write_helper("__awaiter");
             self.write("(");
             self.write(this_expr);
-            if hoisted_var_groups.is_empty() {
-                let can_inline_wrapper = body_is_single_line
-                    && hoisted_function_decls.is_empty()
-                    && directive_prologue.is_empty()
-                    && !(this_expr != "this" && generator_body.contains("return _this"))
-                    && generator_mappings.is_empty();
-                if can_inline_wrapper {
-                    self.write(", void 0, ");
-                    self.write_awaiter_promise_arg(&promise_ctor);
-                    self.write(", function () { ");
-                    self.write(&Self::inline_async_generator_body(&generator_body));
-                    self.write(" });");
-                    self.write_line();
-                    self.decrease_indent();
-                    self.write("}");
-                    self.skip_comments_for_async_lowered_body(body);
-                    // emit_function_parameters_es5() pushed a temp scope; the
-                    // other early-return paths in this function (and the
-                    // multi-line/normal exit below) all call pop_temp_scope.
-                    // Forgetting it here would leak temp-name state across
-                    // functions and corrupt subsequent emissions.
-                    self.pop_temp_scope();
-                    return;
-                }
-
-                // Multi-line format (matches tsc):
-                // return __awaiter(this, void 0, void 0, function () {
-                //     return __generator(this, function (_a) {
-                //         ...
-                //     });
-                // });
+            let can_inline_wrapper = hoisted_var_groups.is_empty()
+                && body_is_single_line
+                && hoisted_function_decls.is_empty()
+                && directive_prologue.is_empty()
+                && !needs_lexical_this_capture
+                && generator_mappings.is_empty();
+            if can_inline_wrapper {
                 self.write(", void 0, ");
                 self.write_awaiter_promise_arg(&promise_ctor);
-                self.write(", function () {");
+                self.write(", function () { ");
+                self.write(&Self::inline_async_generator_body(&generator_body));
+                self.write(" });");
                 self.write_line();
-                self.increase_indent();
-                for directive in &directive_prologue {
-                    self.write("\"");
-                    self.write(directive);
-                    self.write("\";");
-                    self.write_line();
-                }
-                self.emit_async_hoisted_function_declarations(&hoisted_function_decls);
-                if this_expr != "this" && generator_body.contains("return _this") {
-                    self.write("var _this = this;");
-                    self.write_line();
-                }
-                if !generator_mappings.is_empty() && self.writer.has_source_map() {
-                    self.writer.write("");
-                    let base_line = self.writer.current_line();
-                    let base_column = self.writer.current_column();
-                    self.writer
-                        .add_offset_mappings(base_line, base_column, &generator_mappings);
-                    self.writer.write(&generator_body);
-                } else {
-                    self.write(&generator_body);
-                }
                 self.decrease_indent();
-                self.write_line();
-                self.write("});");
-            } else {
-                // Multi-line format with hoisted vars
-                self.write(", void 0, ");
-                self.write_awaiter_promise_arg(&promise_ctor);
-                self.write(", function () {");
-                self.write_line();
-                self.increase_indent();
-                for directive in &directive_prologue {
-                    self.write("\"");
-                    self.write(directive);
-                    self.write("\";");
-                    self.write_line();
-                }
-                self.emit_async_hoisted_function_declarations(&hoisted_function_decls);
-                for group in &hoisted_var_groups {
-                    self.write("var ");
-                    for (i, var_name) in group.iter().enumerate() {
-                        if i > 0 {
-                            self.write(", ");
-                        }
-                        self.write(var_name);
-                    }
-                    self.write(";");
-                    self.write_line();
-                }
-                if this_expr != "this" && generator_body.contains("return _this") {
-                    self.write("var _this = this;");
-                    self.write_line();
-                }
-                if !generator_mappings.is_empty() && self.writer.has_source_map() {
-                    self.writer.write("");
-                    let base_line = self.writer.current_line();
-                    let base_column = self.writer.current_column();
-                    self.writer
-                        .add_offset_mappings(base_line, base_column, &generator_mappings);
-                    self.writer.write(&generator_body);
-                } else {
-                    self.write(&generator_body);
-                }
-                self.decrease_indent();
-                self.write_line();
-                self.write("});");
+                self.write("}");
+                self.skip_comments_for_async_lowered_body(body);
+                // emit_function_parameters_es5() pushed a temp scope; the
+                // other early-return paths in this function (and the
+                // multi-line/normal exit below) all call pop_temp_scope.
+                // Forgetting it here would leak temp-name state across
+                // functions and corrupt subsequent emissions.
+                self.pop_temp_scope();
+                return;
             }
+
+            // Multi-line format (matches tsc):
+            // return __awaiter(this, void 0, void 0, function () {
+            //     return __generator(this, function (_a) {
+            //         ...
+            //     });
+            // });
+            self.open_awaiter_callback(&promise_ctor);
+            for directive in &directive_prologue {
+                self.write("\"");
+                self.write(directive);
+                self.write("\";");
+                self.write_line();
+            }
+            self.emit_async_hoisted_function_declarations(&hoisted_function_decls);
+            self.emit_async_hoisted_var_groups(&hoisted_var_groups, needs_lexical_this_capture);
+            self.write_with_offset_mappings(&generator_body, &generator_mappings);
+            self.decrease_indent();
+            self.write_line();
+            self.write("});");
             self.write_line();
             self.decrease_indent();
             self.write("}");
@@ -789,7 +730,7 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn inline_async_generator_body(generator_body: &str) -> String {
+    pub(in crate::emitter) fn inline_async_generator_body(generator_body: &str) -> String {
         let mut lines = generator_body.lines();
         let Some(first_line) = lines.next() else {
             return String::new();
@@ -802,6 +743,46 @@ impl<'a> Printer<'a> {
             output.push_str(line.get(following_strip..).unwrap_or(line).trim_end());
         }
         output
+    }
+
+    /// Open the multi-line `__awaiter` callback: `, void 0, <promise>,
+    /// function () {` plus the newline/indent for the callback body.
+    pub(in crate::emitter) fn open_awaiter_callback(&mut self, promise_ctor: &Option<String>) {
+        self.write(", void 0, ");
+        self.write_awaiter_promise_arg(promise_ctor);
+        self.write(", function () {");
+        self.write_line();
+        self.increase_indent();
+    }
+
+    /// Emit the hoisted `var` groups for a lowered async body, followed by the
+    /// `var _this = this;` capture when the generator body references a
+    /// lexically captured `this` (an `IR`-level fact computed by the async
+    /// transformer, mirroring tsc's placement after the hoisted groups).
+    pub(in crate::emitter) fn emit_async_hoisted_var_groups(
+        &mut self,
+        hoisted_var_groups: &[Vec<String>],
+        needs_lexical_this_capture: bool,
+    ) {
+        for group in hoisted_var_groups {
+            if group.is_empty() {
+                continue;
+            }
+            self.write("var ");
+            for (i, var_name) in group.iter().enumerate() {
+                if i > 0 {
+                    self.write(", ");
+                }
+                self.write(var_name);
+            }
+            self.write(";");
+            self.write_line();
+        }
+
+        if needs_lexical_this_capture {
+            self.write("var _this = this;");
+            self.write_line();
+        }
     }
 
     pub(in crate::emitter) fn emit_function_parameter_names_only(&mut self, params: &[NodeIndex]) {

--- a/crates/tsz-emitter/src/emitter/mod.rs
+++ b/crates/tsz-emitter/src/emitter/mod.rs
@@ -49,6 +49,7 @@ mod literals;
 mod module_emission;
 mod module_wrapper;
 mod namespace_directives;
+mod offset_mapped_output;
 mod source_file;
 mod special_expressions;
 mod statement_erasure;

--- a/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
@@ -478,16 +478,7 @@ impl<'a> Printer<'a> {
         let es5_output = es5_emitter.emit_class_with_name(class_node, &temp_name);
         self.sync_es5_class_emitter_state(&mut es5_emitter);
         let mappings = es5_emitter.take_mappings();
-        if !mappings.is_empty() && self.writer.has_source_map() {
-            self.writer.write("");
-            let base_line = self.writer.current_line();
-            let base_column = self.writer.current_column();
-            self.writer
-                .add_offset_mappings(base_line, base_column, &mappings);
-            self.writer.write(&es5_output);
-        } else {
-            self.write(&es5_output);
-        }
+        self.write_with_offset_mappings(&es5_output, &mappings);
         self.write_line();
         self.write_export_binding_start("default");
         self.write(&temp_name);

--- a/crates/tsz-emitter/src/emitter/module_emission/exports.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/exports.rs
@@ -979,19 +979,7 @@ impl<'a> Printer<'a> {
                                 let output = es5_emitter.emit_class(export.export_clause);
                                 self.sync_es5_class_emitter_state(&mut es5_emitter);
                                 let mappings = es5_emitter.take_mappings();
-                                if !mappings.is_empty() && self.writer.has_source_map() {
-                                    self.writer.write("");
-                                    let base_line = self.writer.current_line();
-                                    let base_column = self.writer.current_column();
-                                    self.writer.add_offset_mappings(
-                                        base_line,
-                                        base_column,
-                                        &mappings,
-                                    );
-                                    self.writer.write(&output);
-                                } else {
-                                    self.write(&output);
-                                }
+                                self.write_with_offset_mappings(&output, &mappings);
                                 while self.comment_emit_idx < self.all_comments.len()
                                     && self.all_comments[self.comment_emit_idx].pos
                                         < clause_node.end

--- a/crates/tsz-emitter/src/emitter/offset_mapped_output.rs
+++ b/crates/tsz-emitter/src/emitter/offset_mapped_output.rs
@@ -1,0 +1,30 @@
+//! Writing pre-rendered output fragments into the active source map.
+//!
+//! Several lowering paths render a fragment with a nested emitter (ES5 class
+//! IIFEs, async `__generator` bodies) and splice the text into the outer
+//! writer. When a source map is active, the fragment's mappings must be
+//! re-anchored at the splice position; otherwise the text is written as-is.
+
+use super::Printer;
+use tsz_common::source_map::Mapping;
+
+impl Printer<'_> {
+    /// Write a pre-rendered fragment, re-anchoring its source mappings at the
+    /// current writer position when a source map is active.
+    pub(in crate::emitter) fn write_with_offset_mappings(
+        &mut self,
+        rendered: &str,
+        mappings: &[Mapping],
+    ) {
+        if !mappings.is_empty() && self.writer.has_source_map() {
+            self.writer.write("");
+            let base_line = self.writer.current_line();
+            let base_column = self.writer.current_column();
+            self.writer
+                .add_offset_mappings(base_line, base_column, mappings);
+            self.writer.write(rendered);
+        } else {
+            self.write(rendered);
+        }
+    }
+}

--- a/crates/tsz-emitter/src/emitter/source_file/es5_async_lexical_this_tests.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/es5_async_lexical_this_tests.rs
@@ -1,0 +1,93 @@
+//! ES5 async lowering: `var _this = this;` capture inside the `__awaiter`
+//! callback.
+//!
+//! When a closure nested in an async body references `this`, the lowered
+//! generator body renders that reference as `_this`, and tsc declares
+//! `var _this = this;` inside the `__awaiter` callback (after the hoisted
+//! `var` groups). The capture decision is an `IR`-level fact
+//! (`needs_lexical_this_capture`), never a scan of rendered output.
+
+use crate::context::emit::EmitContext;
+use crate::emitter::{Printer as EmitterPrinter, PrinterOptions};
+use crate::lowering::LoweringPass;
+use tsz_common::ScriptTarget;
+
+fn emit_es5(source: &str) -> String {
+    let mut parser = tsz_parser::ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let options = PrinterOptions {
+        target: ScriptTarget::ES5,
+        ..Default::default()
+    };
+    let ctx = EmitContext::with_options(options.clone());
+    let transforms = LoweringPass::new(&parser.arena, &ctx).run(root);
+    let mut printer =
+        EmitterPrinter::with_transforms_and_options(&parser.arena, transforms, options);
+    printer.set_source_text(source);
+    printer.emit(root);
+    printer.get_output().to_string()
+}
+
+#[test]
+fn async_function_declaration_nested_arrow_captures_this() {
+    let source = "async function f() {\n    await Promise.resolve();\n    const g = () => this;\n    g();\n}\n";
+    let output = emit_es5(source);
+
+    assert!(
+        output.contains("var _this = this;"),
+        "Nested arrow capturing `this` after an await must declare `var _this = this;` inside the __awaiter callback.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("var g;\n        var _this = this;"),
+        "The lexical-this capture belongs after the hoisted var groups (tsc placement).\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_function_expression_nested_arrow_captures_this() {
+    let source = "const make = () => {\n    return async function inner() {\n        await Promise.resolve();\n        const h = () => this;\n        return h();\n    };\n};\n";
+    let output = emit_es5(source);
+
+    assert!(
+        output.contains("var _this = this;"),
+        "Async function expressions get the same lexical-this capture as declarations.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_function_single_line_body_with_captured_this_is_not_inlined() {
+    let source = "async function f() { return () => this; }\n";
+    let output = emit_es5(source);
+
+    assert!(
+        output.contains("var _this = this;"),
+        "A single-line body whose nested arrow captures `this` still needs the capture, so the inline wrapper format is unavailable.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("return [2 /*return*/, function () { return _this; }];"),
+        "The nested arrow must reference the captured `_this`.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_function_top_level_this_does_not_capture() {
+    let source = "async function f() {\n    await Promise.resolve();\n    return this;\n}\n";
+    let output = emit_es5(source);
+
+    assert!(
+        !output.contains("var _this = this;"),
+        "`this` at the top level of the async body runs with the __awaiter thisArg; no capture is needed.\nOutput:\n{output}"
+    );
+}
+
+#[test]
+fn async_function_string_literal_mentioning_this_capture_does_not_capture() {
+    let source =
+        "async function f() {\n    await Promise.resolve();\n    return \"return _this\";\n}\n";
+    let output = emit_es5(source);
+
+    assert!(
+        !output.contains("var _this = this;"),
+        "A string literal spelling `return _this` must not trigger the capture; the decision is an `IR` fact, not an output scan.\nOutput:\n{output}"
+    );
+}

--- a/crates/tsz-emitter/src/emitter/source_file/mod.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/mod.rs
@@ -56,6 +56,8 @@ mod async_arrow_arguments_capture_tests;
 #[cfg(test)]
 mod empty_statement_comment_elision_tests;
 #[cfg(test)]
+mod es5_async_lexical_this_tests;
+#[cfg(test)]
 mod es5_emit_recovery_tail_tests;
 #[cfg(test)]
 mod es5_emit_tests;

--- a/crates/tsz-emitter/src/emitter/transform_dispatch.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch.rs
@@ -146,16 +146,7 @@ impl<'a> Printer<'a> {
                     es5_output.len()
                 );
                 let es5_mappings = es5_emitter.take_mappings();
-                if !es5_mappings.is_empty() && self.writer.has_source_map() {
-                    self.writer.write("");
-                    let base_line = self.writer.current_line();
-                    let base_column = self.writer.current_column();
-                    self.writer
-                        .add_offset_mappings(base_line, base_column, &es5_mappings);
-                    self.writer.write(&es5_output);
-                } else {
-                    self.write(&es5_output);
-                }
+                self.write_with_offset_mappings(&es5_output, &es5_mappings);
                 // Emit any trailing comment from the class's closing `}` line
                 // (e.g., `class Foo { ... } // comment` → `}()); // comment`).
                 // The ES5 class emitter (IR printer) already handles comments INSIDE the
@@ -1611,16 +1602,7 @@ impl<'a> Printer<'a> {
                 );
                 self.sync_es5_class_emitter_state(&mut es5_emitter);
                 let es5_mappings = es5_emitter.take_mappings();
-                if !es5_mappings.is_empty() && self.writer.has_source_map() {
-                    self.writer.write("");
-                    let base_line = self.writer.current_line();
-                    let base_column = self.writer.current_column();
-                    self.writer
-                        .add_offset_mappings(base_line, base_column, &es5_mappings);
-                    self.writer.write(&es5_output);
-                } else {
-                    self.write(&es5_output);
-                }
+                self.write_with_offset_mappings(&es5_output, &es5_mappings);
                 let class_close_pos = self.find_token_end_before_trivia(node.pos, node.end);
                 while self.comment_emit_idx < self.all_comments.len()
                     && self.all_comments[self.comment_emit_idx].pos < class_close_pos

--- a/crates/tsz-emitter/src/emitter/transform_dispatch_chain.rs
+++ b/crates/tsz-emitter/src/emitter/transform_dispatch_chain.rs
@@ -58,16 +58,7 @@ impl<'a> Printer<'a> {
                 );
                 self.sync_es5_class_emitter_state(&mut es5_emitter);
                 let es5_mappings = es5_emitter.take_mappings();
-                if !es5_mappings.is_empty() && self.writer.has_source_map() {
-                    self.writer.write("");
-                    let base_line = self.writer.current_line();
-                    let base_column = self.writer.current_column();
-                    self.writer
-                        .add_offset_mappings(base_line, base_column, &es5_mappings);
-                    self.writer.write(&es5_output);
-                } else {
-                    self.write(&es5_output);
-                }
+                self.write_with_offset_mappings(&es5_output, &es5_mappings);
                 let class_close_pos = self.find_token_end_before_trivia(node.pos, node.end);
                 while self.comment_emit_idx < self.all_comments.len()
                     && self.all_comments[self.comment_emit_idx].pos < class_close_pos


### PR DESCRIPTION
Goal: hold

Advances #9330 (one visible state-machine construction path for async/generator ES5 lowering). Claimed via RNG over the open non-WIP backlog (seed `384115635`, recorded on the issue).

## Problem

**Failure family:** ES5 async lowering, `__awaiter` callback prologue (lexical `this` capture).

**Structural rule:** When a closure nested in an async body references `this`, the lowered generator body renders that reference as `_this`, and tsc declares `var _this = this;` inside the `__awaiter` callback, after the hoisted `var` groups. tsz does this through the async transformer's IR fact `needs_lexical_this_capture` (`IRNode::contains_captured_this_reference`), owned by the emitter's ES5 async lowering — never by scanning rendered output.

Before this PR the async-**function** path decided the capture by sniffing the rendered generator body for the substring `"return _this"`, behind a `this_expr != "this"` guard that is dead (every caller passes `"this"`). So the capture was **never** emitted on that path, producing runtime-broken output (a reference to an undeclared `_this`):

```ts
async function f() {
    await Promise.resolve();
    const g = () => this;
    g();
}
```

tsz emitted `g = function () { return _this; };` with no `_this` declaration; tsc declares `var _this = this;` after `var g;`. The async-**arrow** path already consumed the IR fact — the two construction paths had drifted, which is exactly the bug class #9330 targets.

## Change

- Thread the transformer-returned `needs_lexical_this_capture` fact into `emit_async_function_es5_body` (it was computed and discarded); delete the three rendered-output sniffs. The fact also blocks the single-line inline wrapper when a capture is required, matching tsc.
- One shared construction path for statements and expressions: `open_awaiter_callback`, `emit_async_hoisted_var_groups` (hoisted groups + capture placement), and `inline_async_generator_body` are now single implementations shared by the async-function and async-arrow paths; the duplicated multi-line wrapper branches collapse into one.
- Generalize the source-map re-anchoring block into `Printer::write_with_offset_mappings` and convert the seven pre-existing verbatim copies (class declarations, module emission, transform dispatch). Output-surgery audit: 0 findings, empty allowlist.
- New regression shard `es5_async_lexical_this_tests.rs` (the suite file at the 2000-line cap was split rather than grown).

Net: −64 lines, 250 insertions / 314 deletions.

## Adjacent-case matrix (all byte-identical to tsc 6.0.3, `target=es5`)

| Case | Before | After |
|---|---|---|
| async function declaration, nested `this`-arrow after `await` | broken (`_this` undeclared) | matches tsc |
| async function expression returned from an arrow | broken (`_this` undeclared) | matches tsc |
| single-line body `async function f() { return () => this; }` | broken | matches tsc (capture blocks inline format) |
| top-level `this` in async body (no nested closure) | no capture | no capture (negative case) |
| string literal spelling `"return _this"` | no capture | no capture (decoy for the removed sniff) |
| class async method / object-literal async method | already fact-based | unchanged |
| async arrows (all forms) | already fact-based | unchanged |

Fallback: when the fact is false the emission is unchanged, including the inline single-line wrapper format.

## Why no semantic validation / output surgery

The capture decision moves from a scan of already-rendered JS to a planned IR fact computed during transformation; the emitter writes text only from planned facts. No checker/solver imports, no post-hoc patching of emitted output.

## Verification

- `scripts/emit/run.sh --js-only` filters, all 100%: `es5-asyncFunction` 46/46, `emitter.forAwait` 4/4 (the two acceptance commands from #9330), `asyncArrowFunction` 51/51, `asyncFunctionDeclaration` 63/63, `downlevelGenerator` 8/8, `asyncMethod` 5/5, `async` 299/299, `await` 207/207, `generator` 126/126, `sourceMap` 143/143, `class` 1480/1480, `module` 1742/1742, `export` 928/928, `namespace` 208/208.
- `cargo test -p tsz-emitter --lib`: 3710 passed; the 2 failures (`declaration_emitter::…::take_diagnostics_*_ts2883_*`) reproduce on the parent commit `057951f` and are unrelated pre-existing failures.
- 8 hand-written probe fixtures diffed byte-for-byte against tsc 6.0.3 output (matrix above).
- `cargo clippy -p tsz-emitter --lib` clean; `scripts/emit/audit-output-surgery.py` passes with 0 findings.

Follow-up noted on #9330: migrating this path to construct `IRNode::AwaiterCall` outright (the printer already owns that node's capture emission) would retire the remaining hand-written wrapper text; deferred to keep this change behavior-verifiable.

## Provenance
Machine: cloud
Assistant: claude-code
Model: undisclosed-by-harness
Effort: high

https://claude.ai/code/session_01QHKEMbB2cjxvZ5zzv46iz5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHKEMbB2cjxvZ5zzv46iz5)_