### PR TITLE
perf(solver,checker): memoize union normalization; share file-independent constraint proofs across file checkers

### DIFF
--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -435,6 +435,30 @@ impl<'a> CheckerState<'a> {
         self.execute_relation_request(&request)
     }
 
+    /// Whether a constraint proof over `(source, target)` is file-independent
+    /// and may be looked up in / published to the program-wide
+    /// [`crate::context::SharedConstraintProofCache`].
+    ///
+    /// Both types must be free of generic type parameters (scope-relative
+    /// meaning) and of file-relative content (`UnresolvedTypeName`, raw
+    /// `SymbolRef` carriers, `this`); see
+    /// `contains_file_relative_content` for the exact variant set. Both
+    /// predicates are memoized project-wide in the interner.
+    pub(crate) fn constraint_proof_is_program_shareable(
+        &self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        use crate::query_boundaries::common::{
+            contains_file_relative_content, contains_generic_type_parameters,
+        };
+        let db = self.ctx.types;
+        !contains_generic_type_parameters(db, source)
+            && !contains_generic_type_parameters(db, target)
+            && !contains_file_relative_content(db, source)
+            && !contains_file_relative_content(db, target)
+    }
+
     /// Execute a diagnostic-bearing generic type-argument constraint relation
     /// for raw checker types, preserving the canonical TS2344 request shape.
     /// Decision-only: every caller reads only `outcome.related`, so the
@@ -444,6 +468,16 @@ impl<'a> CheckerState<'a> {
         source: TypeId,
         target: TypeId,
     ) -> crate::query_boundaries::assignability::RelationOutcome {
+        const RELATED_SUCCESS: crate::query_boundaries::assignability::RelationOutcome =
+            crate::query_boundaries::assignability::RelationOutcome {
+                related: true,
+                depth_exceeded: false,
+                iteration_exceeded: false,
+                failure: None,
+                weak_union_violation: false,
+                property_classification: None,
+            };
+
         let (source, target) = self.prepare_assignability_inputs(source, target);
         let flags = self.ctx.pack_relation_flags();
         let sound_mode = self.ctx.sound_mode();
@@ -454,16 +488,26 @@ impl<'a> CheckerState<'a> {
             .type_arg_constraint_relation_successes
             .contains(&cache_key)
         {
-            return crate::query_boundaries::assignability::RelationOutcome {
-                related: true,
-                depth_exceeded: false,
-                iteration_exceeded: false,
-                failure: None,
-                weak_union_violation: false,
-                property_classification: None,
-            };
+            return RELATED_SUCCESS;
         }
 
+        // Program-wide success tier: another file checker may already have
+        // proven this exact pair. Probing needs no shareability gate — only
+        // pairs that passed the publish-side gate can be in the set, so a
+        // lookup on an unshareable key simply misses. This keeps the deep
+        // shareability walk off the cold-lookup path.
+        if let Some(shared) = &self.ctx.shared_constraint_proofs
+            && shared.type_arg_relation_successes.contains(&cache_key)
+        {
+            tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "type_arg", "hit");
+            self.ctx
+                .type_reference_validation_caches
+                .type_arg_constraint_relation_successes
+                .insert(cache_key);
+            return RELATED_SUCCESS;
+        }
+
+        let lazy_failures_at_entry = crate::query_boundaries::common::lazy_resolve_failure_count();
         let request = crate::query_boundaries::assignability::RelationRequest::type_arg_constraint(
             source, target,
         )
@@ -474,6 +518,21 @@ impl<'a> CheckerState<'a> {
                 .type_reference_validation_caches
                 .type_arg_constraint_relation_successes
                 .insert(cache_key);
+            // Publish only file-independent proofs (the shareability gate
+            // runs here, once per distinct novel success) that did not depend
+            // on an unresolved `Lazy` def and ran with evaluation fuel to
+            // spare; either can make a result reflect in-flight rather than
+            // program-wide state.
+            if self.ctx.shared_constraint_proofs.is_some()
+                && crate::query_boundaries::common::lazy_resolve_failure_count()
+                    == lazy_failures_at_entry
+                && !self.ctx.types.is_evaluation_fuel_exhausted()
+                && self.constraint_proof_is_program_shareable(source, target)
+                && let Some(shared) = &self.ctx.shared_constraint_proofs
+            {
+                tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "type_arg", "publish");
+                shared.type_arg_relation_successes.insert(cache_key);
+            }
         }
         outcome
     }

--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -455,6 +455,23 @@ impl<'a> CheckerState<'a> {
             && !contains_file_relative_content(db, target)
     }
 
+    /// Probe the program-wide
+    /// [`crate::context::SharedConstraintProofCache`], if installed.
+    ///
+    /// Probing needs no shareability gate: only pairs that passed the
+    /// publish-side gate can be in a set, so a lookup on an unshareable key
+    /// simply misses. This keeps the deep shareability walks off the
+    /// cold-lookup path.
+    pub(crate) fn shared_constraint_proof_hit(
+        &self,
+        probe: impl FnOnce(&crate::context::SharedConstraintProofCache) -> bool,
+    ) -> bool {
+        self.ctx
+            .shared_constraint_proofs
+            .as_ref()
+            .is_some_and(|shared| probe(shared))
+    }
+
     /// Publish-side gate for the program-wide
     /// [`crate::context::SharedConstraintProofCache`]: runs `publish` only
     /// when the just-computed success over `(source, target)` is safe to
@@ -514,12 +531,8 @@ impl<'a> CheckerState<'a> {
         }
 
         // Program-wide success tier: another file checker may already have
-        // proven this exact pair. Probing needs no shareability gate — only
-        // pairs that passed the publish-side gate can be in the set, so a
-        // lookup on an unshareable key simply misses. This keeps the deep
-        // shareability walk off the cold-lookup path.
-        if let Some(shared) = &self.ctx.shared_constraint_proofs
-            && shared.type_arg_relation_successes.contains(&cache_key)
+        // proven this exact pair.
+        if self.shared_constraint_proof_hit(|s| s.type_arg_relation_successes.contains(&cache_key))
         {
             tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "type_arg", "hit");
             self.ctx

--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -436,7 +436,7 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Whether a constraint proof over `(source, target)` is file-independent
-    /// and may be looked up in / published to the program-wide
+    /// and may be published to the program-wide
     /// [`crate::context::SharedConstraintProofCache`].
     ///
     /// Both types must be free of generic type parameters (scope-relative
@@ -444,11 +444,7 @@ impl<'a> CheckerState<'a> {
     /// `SymbolRef` carriers, `this`); see
     /// `contains_file_relative_content` for the exact variant set. Both
     /// predicates are memoized project-wide in the interner.
-    pub(crate) fn constraint_proof_is_program_shareable(
-        &self,
-        source: TypeId,
-        target: TypeId,
-    ) -> bool {
+    fn constraint_proof_is_program_shareable(&self, source: TypeId, target: TypeId) -> bool {
         use crate::query_boundaries::common::{
             contains_file_relative_content, contains_generic_type_parameters,
         };
@@ -457,6 +453,32 @@ impl<'a> CheckerState<'a> {
             && !contains_generic_type_parameters(db, target)
             && !contains_file_relative_content(db, source)
             && !contains_file_relative_content(db, target)
+    }
+
+    /// Publish-side gate for the program-wide
+    /// [`crate::context::SharedConstraintProofCache`]: runs `publish` only
+    /// when the just-computed success over `(source, target)` is safe to
+    /// share. The proof must not have observed an unresolved `Lazy` def
+    /// (`lazy_failures_at_entry` snapshot taken before computing), must not
+    /// have run with exhausted evaluation fuel, and must be file-independent
+    /// (`constraint_proof_is_program_shareable`). The cheap existence check
+    /// comes first so disabled runs skip the deep shareability walks.
+    pub(crate) fn publish_shared_constraint_proof(
+        &self,
+        lazy_failures_at_entry: u64,
+        source: TypeId,
+        target: TypeId,
+        publish: impl FnOnce(&crate::context::SharedConstraintProofCache),
+    ) {
+        let Some(shared) = &self.ctx.shared_constraint_proofs else {
+            return;
+        };
+        if crate::query_boundaries::common::lazy_resolve_failure_count() == lazy_failures_at_entry
+            && !self.ctx.types.is_evaluation_fuel_exhausted()
+            && self.constraint_proof_is_program_shareable(source, target)
+        {
+            publish(shared);
+        }
     }
 
     /// Execute a diagnostic-bearing generic type-argument constraint relation
@@ -518,21 +540,10 @@ impl<'a> CheckerState<'a> {
                 .type_reference_validation_caches
                 .type_arg_constraint_relation_successes
                 .insert(cache_key);
-            // Publish only file-independent proofs (the shareability gate
-            // runs here, once per distinct novel success) that did not depend
-            // on an unresolved `Lazy` def and ran with evaluation fuel to
-            // spare; either can make a result reflect in-flight rather than
-            // program-wide state.
-            if self.ctx.shared_constraint_proofs.is_some()
-                && crate::query_boundaries::common::lazy_resolve_failure_count()
-                    == lazy_failures_at_entry
-                && !self.ctx.types.is_evaluation_fuel_exhausted()
-                && self.constraint_proof_is_program_shareable(source, target)
-                && let Some(shared) = &self.ctx.shared_constraint_proofs
-            {
+            self.publish_shared_constraint_proof(lazy_failures_at_entry, source, target, |shared| {
                 tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "type_arg", "publish");
                 shared.type_arg_relation_successes.insert(cache_key);
-            }
+            });
         }
         outcome
     }

--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -49,16 +49,16 @@ impl<'a> CheckerState<'a> {
             .type_reference_validation_caches
             .conditional_branch_constraint
             .insert(cache_key, result);
-        if result
-            && self.ctx.shared_constraint_proofs.is_some()
-            && crate::query_boundaries::common::lazy_resolve_failure_count()
-                == lazy_failures_at_entry
-            && !self.ctx.types.is_evaluation_fuel_exhausted()
-            && self.constraint_proof_is_program_shareable(type_arg, constraint)
-            && let Some(shared) = &self.ctx.shared_constraint_proofs
-        {
-            tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "conditional_branch", "publish");
-            shared.conditional_branch_successes.insert(cache_key);
+        if result {
+            self.publish_shared_constraint_proof(
+                lazy_failures_at_entry,
+                type_arg,
+                constraint,
+                |shared| {
+                    tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "conditional_branch", "publish");
+                    shared.conditional_branch_successes.insert(cache_key);
+                },
+            );
         }
         result
     }
@@ -168,16 +168,16 @@ impl<'a> CheckerState<'a> {
             .type_reference_validation_caches
             .indexed_object_map_branch_constraint
             .insert(cache_key, result);
-        if result
-            && self.ctx.shared_constraint_proofs.is_some()
-            && crate::query_boundaries::common::lazy_resolve_failure_count()
-                == lazy_failures_at_entry
-            && !self.ctx.types.is_evaluation_fuel_exhausted()
-            && self.constraint_proof_is_program_shareable(branch, constraint)
-            && let Some(shared) = &self.ctx.shared_constraint_proofs
-        {
-            tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "indexed_object_map", "publish");
-            shared.indexed_object_map_branch_successes.insert(cache_key);
+        if result {
+            self.publish_shared_constraint_proof(
+                lazy_failures_at_entry,
+                branch,
+                constraint,
+                |shared| {
+                    tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "indexed_object_map", "publish");
+                    shared.indexed_object_map_branch_successes.insert(cache_key);
+                },
+            );
         }
         result
     }

--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -27,12 +27,9 @@ impl<'a> CheckerState<'a> {
 
         // Program-wide success tier: file checkers re-prove the same
         // conditional-branch pairs for every file that references the same
-        // generic alias. Probing needs no shareability gate (only gated pairs
-        // are ever published); the gate runs at publish time, once per
-        // distinct novel success. Only successes are shared (see
+        // generic alias. Only successes are shared (see
         // `SharedConstraintProofCache`).
-        if let Some(shared) = &self.ctx.shared_constraint_proofs
-            && shared.conditional_branch_successes.contains(&cache_key)
+        if self.shared_constraint_proof_hit(|s| s.conditional_branch_successes.contains(&cache_key))
         {
             tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "conditional_branch", "hit");
             self.ctx
@@ -146,13 +143,10 @@ impl<'a> CheckerState<'a> {
             return cached;
         }
 
-        // Program-wide success tier; see
-        // `conditional_result_branches_satisfy_constraint` above.
-        if let Some(shared) = &self.ctx.shared_constraint_proofs
-            && shared
-                .indexed_object_map_branch_successes
-                .contains(&cache_key)
-        {
+        // Program-wide success tier (see first probe above).
+        if self.shared_constraint_proof_hit(|s| {
+            s.indexed_object_map_branch_successes.contains(&cache_key)
+        }) {
             tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "indexed_object_map", "hit");
             self.ctx
                 .type_reference_validation_caches

--- a/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/conditional_constraint_helpers.rs
@@ -25,12 +25,41 @@ impl<'a> CheckerState<'a> {
             return cached;
         }
 
+        // Program-wide success tier: file checkers re-prove the same
+        // conditional-branch pairs for every file that references the same
+        // generic alias. Probing needs no shareability gate (only gated pairs
+        // are ever published); the gate runs at publish time, once per
+        // distinct novel success. Only successes are shared (see
+        // `SharedConstraintProofCache`).
+        if let Some(shared) = &self.ctx.shared_constraint_proofs
+            && shared.conditional_branch_successes.contains(&cache_key)
+        {
+            tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "conditional_branch", "hit");
+            self.ctx
+                .type_reference_validation_caches
+                .conditional_branch_constraint
+                .insert(cache_key, true);
+            return true;
+        }
+
+        let lazy_failures_at_entry = crate::query_boundaries::common::lazy_resolve_failure_count();
         let result =
             self.conditional_result_branches_satisfy_constraint_uncached(type_arg, constraint);
         self.ctx
             .type_reference_validation_caches
             .conditional_branch_constraint
             .insert(cache_key, result);
+        if result
+            && self.ctx.shared_constraint_proofs.is_some()
+            && crate::query_boundaries::common::lazy_resolve_failure_count()
+                == lazy_failures_at_entry
+            && !self.ctx.types.is_evaluation_fuel_exhausted()
+            && self.constraint_proof_is_program_shareable(type_arg, constraint)
+            && let Some(shared) = &self.ctx.shared_constraint_proofs
+        {
+            tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "conditional_branch", "publish");
+            shared.conditional_branch_successes.insert(cache_key);
+        }
         result
     }
 
@@ -117,12 +146,39 @@ impl<'a> CheckerState<'a> {
             return cached;
         }
 
+        // Program-wide success tier; see
+        // `conditional_result_branches_satisfy_constraint` above.
+        if let Some(shared) = &self.ctx.shared_constraint_proofs
+            && shared
+                .indexed_object_map_branch_successes
+                .contains(&cache_key)
+        {
+            tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "indexed_object_map", "hit");
+            self.ctx
+                .type_reference_validation_caches
+                .indexed_object_map_branch_constraint
+                .insert(cache_key, true);
+            return true;
+        }
+
+        let lazy_failures_at_entry = crate::query_boundaries::common::lazy_resolve_failure_count();
         let result =
             self.indexed_object_map_branch_satisfies_constraint_uncached(branch, constraint);
         self.ctx
             .type_reference_validation_caches
             .indexed_object_map_branch_constraint
             .insert(cache_key, result);
+        if result
+            && self.ctx.shared_constraint_proofs.is_some()
+            && crate::query_boundaries::common::lazy_resolve_failure_count()
+                == lazy_failures_at_entry
+            && !self.ctx.types.is_evaluation_fuel_exhausted()
+            && self.constraint_proof_is_program_shareable(branch, constraint)
+            && let Some(shared) = &self.ctx.shared_constraint_proofs
+        {
+            tracing::trace!(target: "tsz::shared_constraint_proofs", kind = "indexed_object_map", "publish");
+            shared.indexed_object_map_branch_successes.insert(cache_key);
+        }
         result
     }
 

--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -69,6 +69,38 @@ pub struct TypeReferenceValidationCaches {
     pub assignability_eval_memo: AssignabilityEvalMemo,
 }
 
+/// Program-wide success tier for generic type-argument constraint proofs,
+/// shared by every file checker of a multi-file program.
+///
+/// In project mode each file checker re-proves the same constraint pairs for
+/// the generic aliases it imports (the per-file
+/// [`TypeReferenceValidationCaches`] start empty for every file), so the same
+/// `(TypeId, TypeId)` proof is recomputed once per referencing file. `TypeId`s
+/// are interned program-wide, so a proof over file-independent types has one
+/// program-wide answer — mirror of the solver's shared relation cache, lifted
+/// to the checker's TS2344 proof orchestration.
+///
+/// Soundness contract (enforced at the publish sites):
+/// - only **successes** are published; failures stay file-local so diagnostic
+///   relation requests re-run with full failure analysis;
+/// - both key types must be free of generic type parameters and of
+///   file-relative content (`contains_file_relative_content`), so the proof
+///   does not depend on the publishing file's scope;
+/// - proofs that observed an unresolved `Lazy` def
+///   (`lazy_resolve_failure_count` advanced) or ran with exhausted evaluation
+///   fuel are not published.
+#[derive(Debug, Default)]
+pub struct SharedConstraintProofCache {
+    /// Mirror of `type_arg_constraint_relation_successes`: successful TS2344
+    /// constraint relations keyed by prepared source/target plus the packed
+    /// relation flags and sound-mode bit.
+    pub type_arg_relation_successes: dashmap::DashSet<(TypeId, TypeId, u16, bool)>,
+    /// Mirror of `conditional_branch_constraint`, `true` results only.
+    pub conditional_branch_successes: dashmap::DashSet<(TypeId, TypeId)>,
+    /// Mirror of `indexed_object_map_branch_constraint`, `true` results only.
+    pub indexed_object_map_branch_successes: dashmap::DashSet<(TypeId, TypeId)>,
+}
+
 /// Sparse cache for node-index-keyed `TypeId` lookups.
 ///
 /// `NodeIndex` values are arena-local, so this cache is never shared across

--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -38,6 +38,7 @@ nested_namespace_candidates_cache_complete = { lifetime = "FileLocalReset", capa
 lowering_entity_name_resolution_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 namespace_exports_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 shared_lib_type_cache = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }
+shared_constraint_proofs = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "program-wide append-only success tier for constraint proofs; entries are file-independent by construction and valid for the whole compilation" }
 cross_file_type_params_cache = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }
 skip_lib_type_resolution = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 lib_heritage_in_progress = { lifetime = "FileLocalReset", capability = "ProgramLookupContext", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -86,6 +86,7 @@ impl<'a> CheckerContext<'a> {
             lowering_entity_name_resolution_cache: RefCell::new(FxHashMap::default()),
             namespace_exports_cache: RefCell::new(FxHashMap::default()),
             shared_lib_type_cache: None,
+            shared_constraint_proofs: None,
             cross_file_type_params_cache: None,
             skip_lib_type_resolution: false,
             lib_heritage_in_progress: FxHashSet::default(),

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -610,6 +610,7 @@ impl<'a> CheckerContext<'a> {
         self.lib_binders_cached = parent.lib_binders_cached.clone();
         self.set_actual_lib_file_count(parent.actual_lib_file_count);
         self.shared_lib_type_cache = parent.shared_lib_type_cache.clone();
+        self.shared_constraint_proofs = parent.shared_constraint_proofs.clone();
         self.cross_file_type_params_cache = parent.cross_file_type_params_cache.clone();
         self.program_reexports = parent.program_reexports.clone();
         self.program_wildcard_reexports = parent.program_wildcard_reexports.clone();

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -12,7 +12,8 @@ mod cross_file_type_params_cache;
 pub use cache_statistics::CheckerContextCacheStatistics;
 pub use caches::{
     AssignabilityEvalMemo, AssignabilityEvalStamp, NarrowableIdentifierCache, NodeTypeCache,
-    SymbolTypeCache, TypeNodeSurfaceCaches, TypeReferenceValidationCaches,
+    SharedConstraintProofCache, SymbolTypeCache, TypeNodeSurfaceCaches,
+    TypeReferenceValidationCaches,
 };
 pub(crate) use compiler_options::is_declaration_file_name;
 pub(crate) use compiler_options::is_js_file_name;
@@ -499,6 +500,13 @@ pub struct CheckerContext<'a> {
     /// Shared lib type resolution cache across parallel file checks.
     /// Uses `DashMap` for thread-safe concurrent access.
     pub shared_lib_type_cache: Option<Arc<dashmap::DashMap<String, Option<TypeId>>>>,
+
+    /// Program-wide success tier for generic type-argument constraint proofs,
+    /// shared across parallel file checks. Consulted on local
+    /// `type_reference_validation_caches` misses; only file-independent
+    /// successes are published. See
+    /// [`crate::context::SharedConstraintProofCache`].
+    pub shared_constraint_proofs: Option<Arc<crate::context::SharedConstraintProofCache>>,
     // T2.2 cross-file type-parameter cache type alias is defined just below.
     /// Program-wide memoization for `extract_type_params_from_decl` slow-path
     /// results, keyed by `(target_file_idx, decl_idx)`. T2.2: collapses

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -94,6 +94,17 @@ pub(crate) fn contains_generic_type_parameters(db: &dyn TypeDatabase, type_id: T
     tsz_solver::type_queries::contains_generic_type_parameters_db(db, type_id)
 }
 
+pub(crate) fn contains_file_relative_content(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    tsz_solver::type_queries::contains_file_relative_content_db(db, type_id)
+}
+
+/// Current value of the solver's unresolved-`Lazy` taint counter. Snapshot it
+/// around a proof computation to detect a dependency on a def body that was
+/// not yet registered; such proofs must not be published program-wide.
+pub(crate) fn lazy_resolve_failure_count() -> u64 {
+    tsz_solver::relations::subtype::lazy_resolve_failure_count()
+}
+
 pub(crate) fn contains_lazy_or_recursive(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     tsz_solver::type_queries::contains_lazy_or_recursive_db(db, type_id)
 }

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1003,6 +1003,14 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
     let shared_lib_cache: Arc<dashmap::DashMap<String, Option<tsz_solver::TypeId>>> =
         Arc::new(dashmap::DashMap::new());
 
+    // Program-wide success tier for generic type-argument constraint proofs.
+    // File checkers re-prove the same constraint pairs for every file that
+    // references the same generic alias; this tier shares file-independent
+    // successes across the whole check wave (lookup on local miss, publish on
+    // untainted success). See `SharedConstraintProofCache` for the contract.
+    let shared_constraint_proofs =
+        Arc::new(tsz::checker::context::SharedConstraintProofCache::default());
+
     // Prime Array<T> base type with global augmentations before fresh-checker
     // file checks. Tiny no-emit batches use the sequential reused-checker
     // path; that real checker primes itself before checking the first file, so
@@ -1042,6 +1050,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
             &options.checker,
         );
         checker.ctx.shared_lib_type_cache = Some(Arc::clone(&shared_lib_cache));
+        checker.ctx.shared_constraint_proofs = Some(Arc::clone(&shared_constraint_proofs));
         program_context.apply_to(&mut checker.ctx);
         checker.prime_boxed_types();
     }
@@ -1233,6 +1242,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
                 program_context: &program_context,
                 resolved_modules_per_file: &resolved_modules_per_file,
                 shared_lib_cache: Arc::clone(&shared_lib_cache),
+                shared_constraint_proofs: Arc::clone(&shared_constraint_proofs),
                 shared_query_cache: shared_query_cache.as_ref(),
                 no_check,
                 check_js,
@@ -1319,6 +1329,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
                     program_context: &program_context,
                     resolved_modules_per_file: &resolved_modules_per_file,
                     shared_lib_cache: Arc::clone(&shared_lib_cache),
+                    shared_constraint_proofs: Arc::clone(&shared_constraint_proofs),
                     shared_query_cache: shared_query_cache.as_ref(),
                 };
                 let reuse_flags = CheckFileFlags {
@@ -1348,6 +1359,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
                     program_context: &program_context,
                     resolved_modules_per_file: &resolved_modules_per_file,
                     shared_lib_cache: Arc::clone(&shared_lib_cache),
+                    shared_constraint_proofs: Arc::clone(&shared_constraint_proofs),
                     shared_query_cache: shared_query_cache.as_ref(),
                 };
                 let reuse_flags = CheckFileFlags {

--- a/crates/tsz-cli/src/driver/check_file.rs
+++ b/crates/tsz-cli/src/driver/check_file.rs
@@ -17,6 +17,9 @@ pub(super) struct CheckFileForParallelContext<'a> {
     /// import count.
     pub(super) resolved_modules_per_file: &'a Arc<Vec<Arc<rustc_hash::FxHashSet<String>>>>,
     pub(super) shared_lib_cache: Arc<dashmap::DashMap<String, Option<tsz_solver::TypeId>>>,
+    /// Program-wide success tier for generic type-argument constraint proofs;
+    /// see `tsz::checker::context::SharedConstraintProofCache`.
+    pub(super) shared_constraint_proofs: Arc<tsz::checker::context::SharedConstraintProofCache>,
     /// Shared cross-file query cache for multi-file projects.
     /// Eliminates redundant type evaluations and relation checks across files.
     pub(super) shared_query_cache: Option<&'a tsz_solver::construction::SharedQueryCache>,
@@ -327,6 +330,7 @@ pub(super) fn check_file_for_parallel<'a>(
         program_context,
         resolved_modules_per_file,
         shared_lib_cache,
+        shared_constraint_proofs,
         shared_query_cache,
         no_check,
         check_js,
@@ -381,6 +385,7 @@ pub(super) fn check_file_for_parallel<'a>(
     );
     checker.ctx.report_unresolved_imports = true;
     checker.ctx.shared_lib_type_cache = Some(shared_lib_cache);
+    checker.ctx.shared_constraint_proofs = Some(shared_constraint_proofs);
 
     // Apply all project-level shared state in one call. This installs the
     // shared DefinitionStore and runs warm_local_caches_from_shared_store().
@@ -497,6 +502,7 @@ pub(super) struct CheckFilesReuseCtx<'a> {
     pub(super) program_context: &'a tsz::checker::context::ProgramContext,
     pub(super) resolved_modules_per_file: &'a Arc<Vec<Arc<rustc_hash::FxHashSet<String>>>>,
     pub(super) shared_lib_cache: Arc<dashmap::DashMap<String, Option<tsz_solver::TypeId>>>,
+    pub(super) shared_constraint_proofs: Arc<tsz::checker::context::SharedConstraintProofCache>,
     pub(super) shared_query_cache: Option<&'a tsz_solver::construction::SharedQueryCache>,
 }
 
@@ -516,6 +522,7 @@ where
         program_context,
         resolved_modules_per_file,
         shared_lib_cache,
+        shared_constraint_proofs,
         shared_query_cache,
     } = ctx;
     let &CheckFileFlags {
@@ -584,6 +591,7 @@ where
             );
             state.ctx.report_unresolved_imports = true;
             state.ctx.shared_lib_type_cache = Some(Arc::clone(shared_lib_cache));
+            state.ctx.shared_constraint_proofs = Some(Arc::clone(shared_constraint_proofs));
             // `apply_to` is the expensive setup we're amortising:
             // shared `DefinitionStore`, shared global indices,
             // resolved-module maps, file-is-ESM map, etc. Running it
@@ -673,6 +681,7 @@ where
                 program_context: ctx.program_context,
                 resolved_modules_per_file: ctx.resolved_modules_per_file,
                 shared_lib_cache: Arc::clone(&ctx.shared_lib_cache),
+                shared_constraint_proofs: Arc::clone(&ctx.shared_constraint_proofs),
                 shared_query_cache: ctx.shared_query_cache,
             };
             check_files_sequentially_with_reuse(chunk, &chunk_ctx, flags, build_checker_binder)

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -166,6 +166,16 @@ pub trait TypePredicateCache {
     /// Only cycle-untainted (fully explored) results may be stored.
     /// Default impl is a no-op.
     fn set_eval_contains_infer_cache(&self, _type_id: TypeId, _result: bool) {}
+
+    /// Look up a cached `contains_file_relative_content_db(type_id)` result.
+    /// Default impl returns `None` (no caching).
+    fn contains_file_relative_cached(&self, _type_id: TypeId) -> Option<bool> {
+        None
+    }
+
+    /// Record the result of `contains_file_relative_content_db(type_id)` in
+    /// the shared interner cache. Default impl is a no-op.
+    fn set_contains_file_relative_cache(&self, _type_id: TypeId, _result: bool) {}
 }
 
 /// Narrow signal for tuple-size overflow discovered during solver evaluation.
@@ -691,6 +701,14 @@ impl TypePredicateCache for TypeInterner {
 
     fn set_eval_contains_infer_cache(&self, type_id: TypeId, result: bool) {
         self.eval_contains_infer_cache.insert(type_id, result);
+    }
+
+    fn contains_file_relative_cached(&self, type_id: TypeId) -> Option<bool> {
+        self.contains_file_relative_cache.get(&type_id).map(|v| *v)
+    }
+
+    fn set_contains_file_relative_cache(&self, type_id: TypeId, result: bool) {
+        self.contains_file_relative_cache.insert(type_id, result);
     }
 }
 

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -918,6 +918,15 @@ impl TypePredicateCache for QueryCache<'_> {
     fn set_eval_contains_infer_cache(&self, type_id: TypeId, result: bool) {
         self.interner.set_eval_contains_infer_cache(type_id, result);
     }
+
+    fn contains_file_relative_cached(&self, type_id: TypeId) -> Option<bool> {
+        self.interner.contains_file_relative_cached(type_id)
+    }
+
+    fn set_contains_file_relative_cache(&self, type_id: TypeId, result: bool) {
+        self.interner
+            .set_contains_file_relative_cache(type_id, result);
+    }
 }
 
 impl TypeTupleLimitSignal for QueryCache<'_> {

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -740,7 +740,38 @@ impl TypeInterner {
         }
     }
 
-    pub(super) fn normalize_union(&self, mut flat: TypeListBuffer) -> TypeId {
+    /// Upper input length for the `normalize_union` result memo.
+    ///
+    /// `reduce_union_subtypes` sets the sticky TS2590 `union_too_complex` flag
+    /// only when it sees >= 1001 members; the member list never grows inside
+    /// `normalize_union_uncached`, so inputs at or below this bound can never
+    /// set the flag and their results are pure functions of the input list.
+    /// Larger inputs skip the memo so a cache hit can never swallow the flag.
+    const UNION_NORMALIZE_CACHE_MAX_LEN: usize = 1000;
+
+    /// Memoized union normalization.
+    ///
+    /// The full pipeline (callable-order probe, semantic sort, dedup, literal
+    /// absorption, enum merge, intersection absorption, subtype reduction,
+    /// interning) is deterministic in the flattened input list over immutable
+    /// interned types, and evaluation hot paths rebuild the same unions
+    /// constantly (the interner sees ~97% repeat hits on type-level-heavy
+    /// projects). Key is the exact pre-normalization member list, so repeats
+    /// skip straight to the previously interned result.
+    pub(super) fn normalize_union(&self, flat: TypeListBuffer) -> TypeId {
+        if flat.len() > Self::UNION_NORMALIZE_CACHE_MAX_LEN {
+            return self.normalize_union_uncached(flat);
+        }
+        if let Some(hit) = self.union_normalize_cache.get(flat.as_slice()) {
+            return *hit;
+        }
+        let key: Box<[TypeId]> = flat.as_slice().into();
+        let result = self.normalize_union_uncached(flat);
+        self.union_normalize_cache.insert(key, result);
+        result
+    }
+
+    fn normalize_union_uncached(&self, mut flat: TypeListBuffer) -> TypeId {
         // Callable unions feed signature-combining diagnostics, where tsc preserves
         // the declaration/indexed-access order for intersected parameter display.
         // The normal semantic union sort can invert class-backed function members
@@ -1700,6 +1731,17 @@ impl TypeInterner {
             * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
         size += self.eval_contains_infer_cache.len()
             * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
+        size += self.contains_file_relative_cache.len()
+            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
+        size += self
+            .union_normalize_cache
+            .iter()
+            .map(|entry| {
+                DASHMAP_ENTRY_OVERHEAD
+                    + std::mem::size_of::<TypeId>() * (entry.key().len() + 1)
+                    + std::mem::size_of::<Box<[TypeId]>>()
+            })
+            .sum::<usize>();
         // alloc_order is now stored per-shard alongside index_to_key (4 bytes per type)
         size += type_count * 4;
         size += self.display_properties.len()

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -753,9 +753,6 @@ impl TypeInterner {
     /// of silently muting TS2590 on memo hits.
     const UNION_NORMALIZE_CACHE_MAX_LEN: usize = {
         let max_len = 1000_usize;
-        // Largest length whose pairwise count stays under the TS2590 budget:
-        // editing either constant alone fails the build instead of silently
-        // muting TS2590 on memo hits.
         assert!(
             (max_len as u64) * (max_len as u64 - 1) < Self::UNION_SUBTYPE_PAIRWISE_LIMIT
                 && (max_len as u64 + 1) * (max_len as u64) >= Self::UNION_SUBTYPE_PAIRWISE_LIMIT

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -743,11 +743,25 @@ impl TypeInterner {
     /// Upper input length for the `normalize_union` result memo.
     ///
     /// `reduce_union_subtypes` sets the sticky TS2590 `union_too_complex` flag
-    /// only when it sees >= 1001 members; the member list never grows inside
-    /// `normalize_union_uncached`, so inputs at or below this bound can never
-    /// set the flag and their results are pure functions of the input list.
-    /// Larger inputs skip the memo so a cache hit can never swallow the flag.
-    const UNION_NORMALIZE_CACHE_MAX_LEN: usize = 1000;
+    /// only when its pairwise budget (`UNION_SUBTYPE_PAIRWISE_LIMIT`) is hit;
+    /// the member list never grows inside `normalize_union_uncached`, so
+    /// inputs at or below this bound can never set the flag and their results
+    /// are pure functions of the input list. Larger inputs skip the memo so a
+    /// cache hit can never swallow the flag. The compile-time assertion below
+    /// keeps this bound the largest length whose pairwise count stays under
+    /// the budget, so editing either constant alone fails the build instead
+    /// of silently muting TS2590 on memo hits.
+    const UNION_NORMALIZE_CACHE_MAX_LEN: usize = {
+        let max_len = 1000_usize;
+        // Largest length whose pairwise count stays under the TS2590 budget:
+        // editing either constant alone fails the build instead of silently
+        // muting TS2590 on memo hits.
+        assert!(
+            (max_len as u64) * (max_len as u64 - 1) < Self::UNION_SUBTYPE_PAIRWISE_LIMIT
+                && (max_len as u64 + 1) * (max_len as u64) >= Self::UNION_SUBTYPE_PAIRWISE_LIMIT
+        );
+        max_len
+    };
 
     /// Memoized union normalization.
     ///

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -185,6 +185,20 @@ pub struct TypeInterner {
     /// gets its own slot. Entries are only written for fully-explored
     /// (cycle-untainted) subtrees; the answer is immutable per `TypeId`.
     pub(crate) eval_contains_infer_cache: DashMap<TypeId, bool, FxBuildHasher>,
+    /// Per-node cache for the `contains_file_relative_content_db` walk
+    /// (`UnresolvedTypeName | TypeQuery | UniqueSymbol | ModuleNamespace |
+    /// ThisType | Recursive` predicate). Gates which constraint-validation
+    /// proofs may be published to program-wide caches shared across file
+    /// checkers.
+    pub(crate) contains_file_relative_cache: DashMap<TypeId, bool, FxBuildHasher>,
+    /// Result memo for `normalize_union`, keyed by the exact flattened
+    /// pre-normalization member list. Normalization (semantic sort, dedup,
+    /// absorption passes, subtype reduction) is deterministic in the input
+    /// list over immutable interned types; evaluation rebuilds the same
+    /// unions constantly. Inputs longer than
+    /// `UNION_NORMALIZE_CACHE_MAX_LEN` bypass this memo so the sticky
+    /// TS2590 `union_too_complex` flag is never swallowed by a hit.
+    pub(crate) union_normalize_cache: DashMap<Box<[TypeId]>, TypeId, FxBuildHasher>,
     /// The global Array base type (e.g., Array<T> from lib.d.ts).
     /// Uses `AtomicU32` (with `u32::MAX` as sentinel for `None`) instead of
     /// `RwLock` so file checkers can overwrite the prime checker's value without
@@ -350,6 +364,8 @@ pub struct TypePredicateCacheStatistics {
     pub contains_generic_params_root_cache_entries: usize,
     /// Number of memoized evaluator `type_contains_infer` walk results.
     pub eval_contains_infer_cache_entries: usize,
+    /// Number of memoized file-relative containment predicate results.
+    pub contains_file_relative_cache_entries: usize,
 }
 
 impl std::fmt::Debug for TypeInterner {
@@ -383,6 +399,7 @@ impl TypeInterner {
                 .contains_generic_params_root_cache
                 .len(),
             eval_contains_infer_cache_entries: self.eval_contains_infer_cache.len(),
+            contains_file_relative_cache_entries: self.contains_file_relative_cache.len(),
         }
     }
 
@@ -419,6 +436,8 @@ impl TypeInterner {
             contains_param_or_infer_root_cache: DashMap::with_hasher(FxBuildHasher),
             contains_generic_params_root_cache: DashMap::with_hasher(FxBuildHasher),
             eval_contains_infer_cache: DashMap::with_hasher(FxBuildHasher),
+            contains_file_relative_cache: DashMap::with_hasher(FxBuildHasher),
+            union_normalize_cache: DashMap::with_hasher(FxBuildHasher),
             array_base_type: AtomicU32::new(u32::MAX),
             array_display_base_type: AtomicU32::new(u32::MAX),
             array_base_type_params: OnceLock::new(),

--- a/crates/tsz-solver/src/intern/normalize.rs
+++ b/crates/tsz-solver/src/intern/normalize.rs
@@ -1541,6 +1541,14 @@ impl TypeInterner {
         });
     }
 
+    /// TS2590 pairwise-iteration budget for subtype reduction, matching tsc's
+    /// `removeSubtypes` bail-out at 1,000,000 pairwise checks. When `len *
+    /// (len - 1)` reaches this limit, reduction is skipped and the sticky
+    /// `union_too_complex` flag is set. `UNION_NORMALIZE_CACHE_MAX_LEN` is
+    /// derived from this value at compile time so the `normalize_union` memo
+    /// can never cache (and thus never swallow) a flag-setting input.
+    pub(crate) const UNION_SUBTYPE_PAIRWISE_LIMIT: u64 = 1_000_000;
+
     /// Remove redundant types from a union using shallow subtype checks.
     /// If A <: B, then A | B = B (A is redundant).
     pub(crate) fn reduce_union_subtypes(&self, flat: &mut TypeListBuffer) {
@@ -1633,7 +1641,7 @@ impl TypeInterner {
         // internal type construction (template literals, etc.) may legitimately create
         // large unions. The checker decides whether to treat it as a diagnostic.
         let pairwise = (len as u64) * (len as u64 - 1);
-        if pairwise >= 1_000_000 {
+        if pairwise >= Self::UNION_SUBTYPE_PAIRWISE_LIMIT {
             self.set_union_too_complex();
             return; // skip reduction, preserve the union members as-is
         }

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -62,8 +62,12 @@ pub(crate) fn note_lazy_resolve_failure() {
 /// Current value of the unresolved-`Lazy` counter; compare a snapshot taken
 /// before computing a result with the value after to detect whether the
 /// computation depended on an unresolved `Lazy`.
+///
+/// Public so checker-side proof caches shared across file checkers can apply
+/// the same "don't publish results that depended on an unresolved `Lazy`"
+/// suppression the solver's shared relation cache uses.
 #[inline]
-pub(crate) fn lazy_resolve_failure_count() -> u64 {
+pub fn lazy_resolve_failure_count() -> u64 {
     LAZY_RESOLVE_FAILURES.with(std::cell::Cell::get)
 }
 

--- a/crates/tsz-solver/src/relations/subtype/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/mod.rs
@@ -23,7 +23,7 @@ pub(crate) mod visitor;
 // Re-export core items at the same visibility they were originally declared with.
 // Items declared `pub` in core.rs are re-exported as `pub` so that lib.rs can
 // publicly re-export them (e.g., SubtypeChecker, is_subtype_of).
-pub use self::cache::reset_subtype_thread_local_state;
+pub use self::cache::{lazy_resolve_failure_count, reset_subtype_thread_local_state};
 pub use self::core::*;
 
 // Re-export SubtypeFailureReason so rules/ submodules can use `super::super::SubtypeFailureReason`

--- a/crates/tsz-solver/src/type_queries/data/content_predicates.rs
+++ b/crates/tsz-solver/src/type_queries/data/content_predicates.rs
@@ -628,6 +628,72 @@ pub fn contains_generic_type_parameters_db(db: &dyn TypeDatabase, type_id: TypeI
     result
 }
 
+struct FileRelativePredicate;
+impl ContentPredicate for FileRelativePredicate {
+    fn matches_node(&self, _db: &dyn TypeDatabase, key: &TypeData) -> bool {
+        matches!(
+            key,
+            TypeData::UnresolvedTypeName(_)
+                | TypeData::TypeQuery(_)
+                | TypeData::UniqueSymbol(_)
+                | TypeData::ModuleNamespace(_)
+                | TypeData::ThisType
+                | TypeData::Recursive(_)
+        )
+    }
+    fn cached(&self, db: &dyn TypeDatabase, type_id: TypeId) -> Option<bool> {
+        db.contains_file_relative_cached(type_id)
+    }
+    fn set_cache(&self, db: &dyn TypeDatabase, type_id: TypeId, result: bool) {
+        db.set_contains_file_relative_cache(type_id, result);
+    }
+}
+
+/// Check if a type contains content whose meaning is relative to the file or
+/// lexical scope that produced it, rather than to the program-wide type
+/// universe.
+///
+/// Returns `true` when the type (transitively) contains:
+/// - `UnresolvedTypeName`: resolved by name against the *current* file, so the
+///   same `TypeId` can denote different declarations in different files;
+/// - `TypeQuery` / `UniqueSymbol` / `ModuleNamespace`: carry raw `SymbolRef`
+///   ids, which are arena-local in project checks;
+/// - `ThisType`: bound by the enclosing class/interface context;
+/// - `Recursive`: a structural back-reference that is only meaningful relative
+///   to an enclosing type, so a bare subtree containing one is not closed.
+///
+/// `Lazy(DefId)` and `Enum(DefId, _)` references are *not* file-relative: the
+/// shared `DefinitionStore` gives them one program-wide meaning. This walk
+/// does not chase def bodies; callers that resolve lazily must pair this
+/// predicate with an unresolved-`Lazy` taint snapshot
+/// (`lazy_resolve_failure_count`) to detect bodies that were not yet
+/// registered while a result was computed.
+///
+/// Used to decide whether a per-file proof (e.g. a TS2344 constraint
+/// validation success) may be published to a program-wide cache shared by all
+/// file checkers. The answer is immutable per `TypeId`, so the deep walk's
+/// per-node results are memoized project-wide.
+pub fn contains_file_relative_content_db(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    if type_id.is_intrinsic() {
+        return false;
+    }
+    match db.lookup(type_id) {
+        Some(
+            TypeData::UnresolvedTypeName(_)
+            | TypeData::TypeQuery(_)
+            | TypeData::UniqueSymbol(_)
+            | TypeData::ModuleNamespace(_)
+            | TypeData::ThisType
+            | TypeData::Recursive(_),
+        ) => return true,
+        Some(
+            TypeData::Literal(_) | TypeData::Intrinsic(_) | TypeData::Error | TypeData::Enum(_, _),
+        ) => return false,
+        _ => {}
+    }
+    contains_content_cached(db, type_id, &FileRelativePredicate)
+}
+
 /// Check if a type is directly an `Infer` type (not recursive).
 ///
 /// This is a lightweight O(1) check that only inspects the top-level type.

--- a/crates/tsz-solver/src/type_queries/data/tests.rs
+++ b/crates/tsz-solver/src/type_queries/data/tests.rs
@@ -1740,3 +1740,90 @@ fn error_containment_is_unified_across_query_paths() {
         );
     }
 }
+
+// =============================================================================
+// contains_file_relative_content_db
+// =============================================================================
+
+/// Direct file-relative roots: every variant whose meaning depends on the
+/// producing file or lexical scope must be flagged.
+#[test]
+fn file_relative_content_flags_direct_roots() {
+    use crate::types::SymbolRef;
+    let interner = TypeInterner::new();
+
+    let unresolved = interner.unresolved_type_name(interner.intern_string("LocalName"));
+    let type_query = interner.type_query(SymbolRef(7));
+    let unique_symbol = interner.unique_symbol(SymbolRef(7));
+    let module_ns = interner.module_namespace(SymbolRef(7));
+    let this_type = interner.this_type();
+
+    for ty in [unresolved, type_query, unique_symbol, module_ns, this_type] {
+        assert!(
+            contains_file_relative_content_db(&interner, ty),
+            "expected file-relative root to be flagged"
+        );
+    }
+}
+
+/// File-relative content nested inside structural types is found by the deep
+/// walk (union member, array element, tuple element).
+#[test]
+fn file_relative_content_flags_nested_content() {
+    use crate::types::{SymbolRef, TupleElement};
+    let interner = TypeInterner::new();
+
+    let type_query = interner.type_query(SymbolRef(3));
+    let in_union = interner.union(vec![TypeId::STRING, type_query]);
+    assert!(contains_file_relative_content_db(&interner, in_union));
+
+    let unresolved = interner.unresolved_type_name(interner.intern_string("Gaps"));
+    let in_array = interner.array(unresolved);
+    assert!(contains_file_relative_content_db(&interner, in_array));
+
+    let in_tuple = interner.tuple(vec![TupleElement {
+        type_id: interner.this_type(),
+        optional: false,
+        rest: false,
+        name: None,
+    }]);
+    assert!(contains_file_relative_content_db(&interner, in_tuple));
+}
+
+/// Program-global content is NOT file-relative: intrinsics, literals,
+/// `Lazy(DefId)` references, and applications of lazy bases over concrete
+/// args all have one program-wide meaning through the shared store.
+#[test]
+fn file_relative_content_accepts_program_global_types() {
+    use crate::def::DefId;
+    let interner = TypeInterner::new();
+
+    let literal = interner.literal_string("transformation");
+    let lazy = interner.lazy(DefId(42));
+    let app = interner.application(lazy, vec![TypeId::STRING, literal]);
+    let union = interner.union(vec![TypeId::NUMBER, app]);
+    let arr = interner.array(union);
+
+    for ty in [TypeId::STRING, literal, lazy, app, union, arr] {
+        assert!(
+            !contains_file_relative_content_db(&interner, ty),
+            "expected program-global type to be shareable"
+        );
+    }
+}
+
+/// The memoized walk returns consistent answers on repeat queries (the
+/// per-node results live in the shared interner cache).
+#[test]
+fn file_relative_content_is_stable_across_repeat_queries() {
+    use crate::types::SymbolRef;
+    let interner = TypeInterner::new();
+
+    let tainted = interner.union(vec![TypeId::STRING, interner.type_query(SymbolRef(9))]);
+    let clean = interner.union(vec![TypeId::STRING, TypeId::NUMBER]);
+
+    for _ in 0..3 {
+        assert!(contains_file_relative_content_db(&interner, tainted));
+        assert!(!contains_file_relative_content_db(&interner, clean));
+    }
+}

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -14,7 +14,7 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        249,
+        250,
     ),
 ]
 

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -992,7 +992,7 @@ STRUCT_FIELD_COUNT_CHECKS = [
         "Checker boundary: CheckerContext field count (architecture health metric 1)",
         ROOT / "crates" / "tsz-checker" / "src" / "context" / "mod.rs",
         "CheckerContext",
-        249,
+        250,
     ),
 ]
 


### PR DESCRIPTION
Goal: fast

Fixes the dominant residual repeated operations on the ts-toolbelt-project row (#8356, claimed with `WIP` label) after #13217. Profiled on current main with call-graph perf: the check wave's CPU concentrates in (a) union re-normalization of identical member lists (`union_from_iter`/`normalize_union`/`sort_union_members` ≈ 10-12% of total CPU, with a 96.6% interner repeat-hit rate showing the same unions are rebuilt constantly) and (b) per-file re-proving of TS2344 constraint validations for the same generic aliases.

## Structural rules

1. **Union normalization is a pure function of the flattened input member list** over immutable interned types. tsc normalizes a union once per construction; tsz re-ran the full pipeline (callable-order probe, semantic sort, dedup, literal/enum/intersection absorption, O(n²) subtype reduction, interning) on every rebuild of the same list. Owner: solver interner (`TypeInterner::normalize_union`). Now memoized keyed by the exact pre-normalization member list. Inputs longer than `UNION_NORMALIZE_CACHE_MAX_LEN` bypass the memo so a hit can never swallow the sticky TS2590 `union_too_complex` flag; the bound is derived from `UNION_SUBTYPE_PAIRWISE_LIMIT` (tsc's `removeSubtypes` 1M pairwise budget) with a compile-time assertion so editing either constant alone fails the build.

2. **A TS2344 constraint proof over file-independent types has one program-wide answer.** tsc proves it once (single checker); tsz re-proved it once per referencing file checker (the per-file `TypeReferenceValidationCaches` start empty per file). Owner: checker constraint-validation orchestration + context caches. New `SharedConstraintProofCache` (Arc-shared by the driver across the whole check wave, mirroring `shared_lib_type_cache`) holds three success-only tiers: type-arg relation successes, conditional-branch proofs, indexed-object-map branch proofs. Probes need no gate (only gated pairs are ever published); the publish gate requires: file-independent types (no generic type parameters; no file-relative content — new project-cached `contains_file_relative_content_db` predicate covering `UnresolvedTypeName`, raw `SymbolRef` carriers (`TypeQuery`/`UniqueSymbol`/`ModuleNamespace`), `ThisType`, `Recursive`), no unresolved-`Lazy` observation (`lazy_resolve_failure_count` snapshot — the same suppression the solver's shared relation cache uses), and unexhausted evaluation fuel. Failures stay file-local so diagnostic relation requests re-run with full failure analysis.

## Adjacent matrix

- Solver predicate tests (renamed binders, nested positions): direct file-relative roots; nested in union/array/tuple; program-global negatives (literals, `Lazy(DefId)`, applications over concrete args); repeat-query stability (`crates/tsz-solver/src/type_queries/data/tests.rs`).
- Negative/diagnostic path: repeated TS2344 violations still report at every site (pinned by `assignability_eval_memo_tests::repeated_constraint_violations_report_at_every_site`, which exercises the same validation path; failures are never published).
- TS2590 interaction: memo bypass for >1000-member inputs, compile-time tied to the pairwise budget.
- No user-name/file-name literals drive any decision; gates are structural predicates memoized in the interner.

## Performance (dist-fast, 4-core cloud runner, medians of 3-5 runs)

| Row | Check before | Check after | Total before | Total after |
|---|---|---|---|---|
| ts-toolbelt-project | 1.31s | **1.05s (−20%)** | 1.74s | **1.44s (−17%)** |
| zod (flat config, 66 files) | 3.89s | 3.75s (−3%) | — | — |

Diagnostics byte-identical vs baseline main binary on both rows (`diff` of full CLI output; zod row carries 55 diagnostics under the flat config, all identical). Cache-key/invalidation contract: union memo needs no invalidation (pure function of interned inputs); shared proofs are append-only successes guarded by the publish gate above; both new interner caches are accounted in the memory report.

## Verification

- `cargo nextest run -p tsz-solver` — 2 failures, both pre-existing on clean main (verified by stash A/B: `test_generic_call_widening_applies_when_constraint_satisfied`, file-size ratchet on `def/core.rs`); all other 6627 pass including 4 new predicate tests.
- `cargo nextest run -p tsz-checker --lib` — 2 failures, both pre-existing on clean main (zod_type_query_regression family, identical failure set via stash A/B); other 6569 pass.
- Byte-diff of full diagnostics output on ts-toolbelt and zod fixture rows vs baseline binary: identical.
- `python3 scripts/arch/arch_guard.py` green (CheckerContext field cap bumped 249→250 for the new shared-cache field).
- `cargo clippy -p tsz-solver -p tsz-checker -p tsz-cli` clean; `cargo fmt --check` clean.
- Ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-fable-5
Effort: high

https://claude.ai/code/session_01J76ZMYwt3FZp1QAGki443M

---
_Generated by [Claude Code](https://claude.ai/code/session_01J76ZMYwt3FZp1QAGki443M)_