### PR TITLE
perf(solver): cache limit-hit relation/eval outcomes (tsc Ternary.Maybe parity) (#13241)

### DIFF
--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -132,6 +132,17 @@ pub struct PerfCounters {
     /// clone per reason, not just the average.
     pub overlay_copy_max_entries_by_reason: [AtomicU64; CHECKER_CREATION_REASON_COUNT],
 
+    // ─── solver relation limit-result cache (issue #13241) ──────────────
+    /// Times a budget-conditional `LimitTrue` relation entry short-circuited
+    /// a subtype query (the recorded fuel band covered the query's remaining
+    /// budget). Each hit avoids re-burning a full limit-hit relation chain.
+    pub relation_limit_cache_hits: AtomicU64,
+    /// Maybe-stack keys promoted into the relation cache at outermost
+    /// relation success (tsc `maybeKeys` promotion parity): cycle-derived
+    /// keys promoted to definitive `true` plus fuel-derived keys promoted to
+    /// band-conditional `LimitTrue` entries.
+    pub relation_maybe_promotions: AtomicU64,
+
     // ─── interner ────────────────────────────────────────────────────────
     pub interner_intern_calls: AtomicU64,
     pub interner_intern_hits: AtomicU64,
@@ -260,6 +271,8 @@ impl PerfCounters {
                 CHECKER_CREATION_REASON_COUNT],
             overlay_copy_max_entries_by_reason: [const { AtomicU64::new(0) };
                 CHECKER_CREATION_REASON_COUNT],
+            relation_limit_cache_hits: AtomicU64::new(0),
+            relation_maybe_promotions: AtomicU64::new(0),
             interner_intern_calls: AtomicU64::new(0),
             interner_intern_hits: AtomicU64::new(0),
             interner_intern_misses: AtomicU64::new(0),
@@ -1207,6 +1220,30 @@ pub fn record_interner_string_intern_call() {
     }
     counters()
         .interner_string_intern_calls
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record a budget-conditional `LimitTrue` relation cache hit (a limit-hit
+/// relation verdict was reused instead of re-burning the relation chain).
+#[inline]
+pub fn record_relation_limit_cache_hit() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .relation_limit_cache_hits
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record one maybe-stack key promoted into the relation cache at outermost
+/// relation success (tsc `maybeKeys` promotion parity).
+#[inline]
+pub fn record_relation_maybe_promotion() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .relation_maybe_promotions
         .fetch_add(1, Ordering::Relaxed);
 }
 

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -30,6 +30,8 @@ pub struct PerfCounterSnapshot {
     pub overlay: OverlayCounters,
     pub resolver: ResolverCounters,
     pub interner: InternerCounters,
+    /// Solver relation limit-result cache (issue #13241).
+    pub relation_limit_cache: RelationLimitCacheCounters,
     /// Per-`CheckerCreationReason` breakdown. Always
     /// `CHECKER_CREATION_REASON_COUNT` long; rows for inactive reasons
     /// carry all-zero counts (matching the text dump's filter behavior
@@ -458,6 +460,16 @@ pub struct ResolverCounters {
     pub candidate_paths_total: u64,
 }
 
+/// Solver relation limit-result cache counters (issue #13241): reuse and
+/// promotion of `Ternary.Maybe`-style limit-hit relation outcomes.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RelationLimitCacheCounters {
+    /// Budget-conditional `LimitTrue` entries that short-circuited a query.
+    pub limit_cache_hits: u64,
+    /// Maybe-stack keys promoted at outermost relation success.
+    pub maybe_promotions: u64,
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct InternerCounters {
     /// Total `intern` calls across kinds. `None` until the solver intern
@@ -601,6 +613,10 @@ impl PerfCounters {
                 } else {
                     None
                 },
+            },
+            relation_limit_cache: RelationLimitCacheCounters {
+                limit_cache_hits: load(&c.relation_limit_cache_hits),
+                maybe_promotions: load(&c.relation_maybe_promotions),
             },
             by_reason: (0..CHECKER_CREATION_REASON_COUNT)
                 .map(|i| ByReasonRow {

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -24,6 +24,7 @@ mod json_tests {
             "overlay",
             "resolver",
             "interner",
+            "relation_limit_cache",
             "by_reason",
             "delegate_miss_classification",
             "delegate_declaration_file_miss_residues",

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -1519,6 +1519,33 @@ pub trait QueryDatabase: TypeDatabase + TypeResolver {
     /// Default implementation is a no-op.
     fn insert_subtype_cache(&self, _key: RelationCacheKey, _result: bool) {}
 
+    /// Look up the full cached subtype entry, including budget-conditional
+    /// [`crate::types::RelationCacheValue::LimitTrue`] verdicts that the plain
+    /// boolean [`lookup_subtype_cache`](Self::lookup_subtype_cache) hides.
+    /// Default implementation surfaces only definitive entries.
+    fn lookup_subtype_cache_value(
+        &self,
+        key: RelationCacheKey,
+    ) -> Option<crate::types::RelationCacheValue> {
+        self.lookup_subtype_cache(key)
+            .map(crate::types::RelationCacheValue::from_bool)
+    }
+
+    /// Promote a coinductively validated maybe-key (a relation that resolved
+    /// through a cycle assumption whose outermost relation completed
+    /// successfully — `tsc`'s `maybeKeys` promotion in `checkTypeRelatedTo`)
+    /// to a definitive `true` entry. Must NOT overwrite an existing definitive
+    /// entry: a sibling checker may have computed an honest `false` under a
+    /// different budget regime. Default implementation is a no-op.
+    fn promote_subtype_cache_true(&self, _key: RelationCacheKey) {}
+
+    /// Record an assumed-related limit verdict
+    /// ([`crate::types::RelationCacheValue::LimitTrue`]) valid for queries
+    /// whose remaining global fuel budget is at most `fuel_band`. Must NOT
+    /// overwrite an existing definitive entry; an existing `LimitTrue` keeps
+    /// the larger band. Default implementation is a no-op.
+    fn insert_subtype_limit_true(&self, _key: RelationCacheKey, _fuel_band: u32) {}
+
     /// Look up a cached intersection-to-merged-object result.
     /// Used by `build_object_intersection_target` to avoid expensive property
     /// collection for large intersections that are checked multiple times

--- a/crates/tsz-solver/src/caches/limit_policy.rs
+++ b/crates/tsz-solver/src/caches/limit_policy.rs
@@ -1,0 +1,28 @@
+//! Kill switch for the limit-hit result caching policy (issue #13241).
+//!
+//! When a relation or evaluation chain hits a recursion/depth/fuel limit,
+//! `tsc` records `Ternary.Maybe` outcomes (its `maybeKeys` stack) and promotes
+//! them to cached successes once the outermost relation completes
+//! successfully. `tsz` mirrors that policy with:
+//!
+//! - the maybe-stack promotion in `relations::subtype::cache` (cycle-derived
+//!   `Maybe` keys promoted to definitive `true`, fuel-derived `Maybe` keys
+//!   promoted to band-conditional [`crate::types::RelationCacheValue::LimitTrue`]
+//!   entries), and
+//! - the per-intermediate taint discrimination in the evaluator
+//!   (`TypeEvaluator` tainted set), which lets clean intermediate evaluation
+//!   results persist even when an unrelated subtree hit a limit.
+//!
+//! `TSZ_DISABLE_LIMIT_RESULT_CACHE=1` restores the previous
+//! drop-everything-on-limit-hit behavior for cache-on/off A/B verification.
+
+use std::sync::OnceLock;
+
+/// Whether limit-hit relation/eval outcomes may be recorded and reused.
+///
+/// Enabled by default; set `TSZ_DISABLE_LIMIT_RESULT_CACHE=1` to disable.
+pub(crate) fn limit_result_cache_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED
+        .get_or_init(|| !std::env::var("TSZ_DISABLE_LIMIT_RESULT_CACHE").is_ok_and(|v| v == "1"))
+}

--- a/crates/tsz-solver/src/caches/mod.rs
+++ b/crates/tsz-solver/src/caches/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod db;
 pub(crate) mod instantiation_cache;
+pub(crate) mod limit_policy;
 pub(crate) mod query_cache;
 mod query_cache_evaluation;
 pub(crate) mod query_cache_statistics;

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -510,18 +510,18 @@ impl<'a> QueryCache<'a> {
                 }
                 return false;
             }
-            Some(RelationCacheValue::LimitTrue { fuel_band }) => {
-                if Self::limit_true_usable(fuel_band) {
-                    tsz_common::perf_counters::record_relation_limit_cache_hit();
-                    if let Some(query_id) = trace_query_id {
-                        query_trace::relation_end(query_id, trace_op, true, true);
-                    }
-                    return true;
+            Some(RelationCacheValue::LimitTrue { fuel_band })
+                if Self::limit_true_usable(fuel_band) =>
+            {
+                tsz_common::perf_counters::record_relation_limit_cache_hit();
+                if let Some(query_id) = trace_query_id {
+                    query_trace::relation_end(query_id, trace_op, true, true);
                 }
-                // A larger budget is available: recompute honestly below and
-                // let the definitive insert overwrite the limit entry.
+                return true;
             }
-            None => {}
+            // A larger budget is available: recompute honestly below and
+            // let the definitive insert overwrite the limit entry.
+            Some(RelationCacheValue::LimitTrue { .. }) | None => {}
         }
 
         let result = query_relation(

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -24,9 +24,10 @@ use crate::relations::subtype::TypeResolver;
 use crate::types::{
     CallableShape, CallableShapeId, ConditionalType, ConditionalTypeId, FunctionShape,
     FunctionShapeId, IndexInfo, IntrinsicKind, MappedType, MappedTypeId, ObjectFlags, ObjectShape,
-    ObjectShapeId, PropertyInfo, PropertyLookup, RelationCacheKey, StringIntrinsicKind, SymbolRef,
-    TemplateLiteralId, TemplateSpan, TupleElement, TupleListId, TypeApplication, TypeApplicationId,
-    TypeData, TypeId, TypeListId, TypeParamInfo, Variance, Visibility,
+    ObjectShapeId, PropertyInfo, PropertyLookup, RelationCacheKey, RelationCacheValue,
+    StringIntrinsicKind, SymbolRef, TemplateLiteralId, TemplateSpan, TupleElement, TupleListId,
+    TypeApplication, TypeApplicationId, TypeData, TypeId, TypeListId, TypeParamInfo, Variance,
+    Visibility,
 };
 use crate::visitor::is_error_type;
 use dashmap::DashMap;
@@ -90,7 +91,7 @@ impl CachedPolicyRelation {
     const fn shared_slot(
         self,
         shared: &SharedQueryCache,
-    ) -> &DashMap<RelationCacheKey, bool, FxBuildHasher> {
+    ) -> &DashMap<RelationCacheKey, RelationCacheValue, FxBuildHasher> {
         match self {
             Self::Subtype => &shared.subtype_cache,
             Self::Assignability => &shared.assignability_cache,
@@ -132,8 +133,8 @@ impl CachedPolicyRelation {
 /// correctness risk. See issue #9507.
 pub struct SharedQueryCache {
     eval_cache: DashMap<EvaluationCacheKey, TypeId, FxBuildHasher>,
-    subtype_cache: DashMap<RelationCacheKey, bool, FxBuildHasher>,
-    assignability_cache: DashMap<RelationCacheKey, bool, FxBuildHasher>,
+    subtype_cache: DashMap<RelationCacheKey, RelationCacheValue, FxBuildHasher>,
+    assignability_cache: DashMap<RelationCacheKey, RelationCacheValue, FxBuildHasher>,
 }
 
 impl SharedQueryCache {
@@ -178,9 +179,9 @@ pub struct QueryCache<'a> {
     application_eval_cache: RefCell<FxHashMap<ApplicationEvalCacheKey, TypeId>>,
     element_access_cache: RefCell<FxHashMap<ElementAccessTypeCacheKey, TypeId>>,
     object_spread_properties_cache: RefCell<FxHashMap<TypeId, Vec<PropertyInfo>>>,
-    subtype_cache: RefCell<FxHashMap<RelationCacheKey, bool>>,
+    subtype_cache: RefCell<FxHashMap<RelationCacheKey, RelationCacheValue>>,
     /// Separate cache for assignability to prevent loose results from poisoning subtype checks.
-    assignability_cache: RefCell<FxHashMap<RelationCacheKey, bool>>,
+    assignability_cache: RefCell<FxHashMap<RelationCacheKey, RelationCacheValue>>,
     property_cache: RefCell<FxHashMap<PropertyAccessCacheKey, PropertyAccessResult>>,
     /// Computed variance masks for generic `DefIds`.
     variance_cache: RefCell<FxHashMap<DefId, Arc<[Variance]>>>,
@@ -334,149 +335,6 @@ impl<'a> QueryCache<'a> {
         }
     }
 
-    /// Estimate the in-memory size of all caches in bytes.
-    ///
-    /// Accounts for `FxHashMap` bucket overhead, key/value sizes, and heap
-    /// allocations inside cached values (e.g., `Vec<PropertyInfo>` in the
-    /// object-spread cache, `Arc<[Variance]>` in the variance cache).
-    ///
-    /// This is more accurate than `QueryCacheStatistics::estimated_size_bytes()`
-    /// because it reads actual map capacities and heap contents.
-    #[must_use]
-    pub fn estimated_size_bytes(&self) -> usize {
-        // FxHashMap per-bucket overhead: hash + key + value + alignment padding.
-        const BUCKET_OVERHEAD: usize = 64;
-
-        let mut size = std::mem::size_of::<Self>();
-
-        // eval_cache: (TypeId, bool) -> TypeId
-        {
-            let map = self.eval_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<EvaluationCacheKey>()
-                    + std::mem::size_of::<TypeId>());
-        }
-
-        // closed_eval_cache: (TypeId, bool) -> TypeId
-        {
-            let map = self.closed_eval_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<EvaluationCacheKey>()
-                    + std::mem::size_of::<TypeId>());
-        }
-
-        // application_eval_cache: (DefId, SmallVec<[TypeId; 4]>, bool) -> TypeId
-        {
-            let map = self.application_eval_cache.borrow();
-            let base_entry = BUCKET_OVERHEAD
-                + std::mem::size_of::<ApplicationEvalCacheKey>()
-                + std::mem::size_of::<TypeId>();
-            size += map.capacity() * base_entry;
-            // SmallVec spills to heap when > 4 elements; account for spilled entries.
-            for key in map.keys() {
-                if key.1.spilled() {
-                    size += key.1.capacity() * std::mem::size_of::<TypeId>();
-                }
-            }
-        }
-
-        // element_access_cache
-        {
-            let map = self.element_access_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<ElementAccessTypeCacheKey>()
-                    + std::mem::size_of::<TypeId>());
-        }
-
-        // object_spread_properties_cache: TypeId -> Vec<PropertyInfo>
-        {
-            let map = self.object_spread_properties_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<TypeId>()
-                    + std::mem::size_of::<Vec<PropertyInfo>>());
-            for props in map.values() {
-                size += props.capacity() * std::mem::size_of::<PropertyInfo>();
-            }
-        }
-
-        // subtype_cache
-        {
-            let map = self.subtype_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<RelationCacheKey>()
-                    + std::mem::size_of::<bool>());
-        }
-
-        // assignability_cache
-        {
-            let map = self.assignability_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<RelationCacheKey>()
-                    + std::mem::size_of::<bool>());
-        }
-
-        // property_cache
-        {
-            let map = self.property_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<PropertyAccessCacheKey>()
-                    + std::mem::size_of::<PropertyAccessResult>());
-        }
-
-        // variance_cache: DefId -> Arc<[Variance]>
-        {
-            let map = self.variance_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<DefId>()
-                    + std::mem::size_of::<Arc<[Variance]>>());
-            // Account for the Arc-allocated slice contents
-            for arc in map.values() {
-                size += arc.len() * std::mem::size_of::<Variance>();
-            }
-        }
-
-        // canonical_cache
-        {
-            let map = self.canonical_cache.borrow();
-            size += map.capacity() * (BUCKET_OVERHEAD + 2 * std::mem::size_of::<TypeId>());
-        }
-
-        // intersection_merge_cache: TypeId -> Option<TypeId>
-        {
-            let map = self.intersection_merge_cache.borrow();
-            size += map.capacity()
-                * (BUCKET_OVERHEAD
-                    + std::mem::size_of::<TypeId>()
-                    + std::mem::size_of::<Option<TypeId>>());
-        }
-
-        // instantiation_cache: (TypeId, CanonicalSubst, u8, Option<TypeId>) -> TypeId
-        // CanonicalSubst's inline SmallVec buffer is included in the
-        // `InstantiationCacheKey` size; spilled entries pay extra heap.
-        size += self.instantiation_cache.capacity()
-            * (BUCKET_OVERHEAD
-                + std::mem::size_of::<InstantiationCacheKey>()
-                + std::mem::size_of::<TypeId>());
-
-        // subtype_reduction_cache: (SortedTypeIds, u8) -> Arc<[TypeId]>
-        // Inline buffer is part of `SubtypeReductionKey`; the cached value
-        // is `Arc<[TypeId]>` (16 bytes) plus the heap slice it points at.
-        size += self.subtype_reduction_cache.capacity()
-            * (BUCKET_OVERHEAD
-                + std::mem::size_of::<SubtypeReductionKey>()
-                + std::mem::size_of::<std::sync::Arc<[TypeId]>>());
-
-        size
-    }
-
     pub fn reset_relation_cache_stats(&self) {
         self.application_eval_cache_hits.set(0);
         self.application_eval_cache_misses.set(0);
@@ -527,7 +385,7 @@ impl<'a> QueryCache<'a> {
     const fn relation_local_cache(
         &self,
         relation: CachedPolicyRelation,
-    ) -> &RefCell<FxHashMap<RelationCacheKey, bool>> {
+    ) -> &RefCell<FxHashMap<RelationCacheKey, RelationCacheValue>> {
         match relation {
             CachedPolicyRelation::Subtype => &self.subtype_cache,
             CachedPolicyRelation::Assignability => &self.assignability_cache,
@@ -550,11 +408,15 @@ impl<'a> QueryCache<'a> {
         }
     }
 
-    fn lookup_policy_relation_cache(
+    /// Look up the full cached relation entry (definitive or budget-conditional).
+    ///
+    /// Any found entry counts as a hit; the caller decides whether a
+    /// `LimitTrue` entry's fuel band makes it usable for the current query.
+    fn lookup_policy_relation_cache_value(
         &self,
         relation: CachedPolicyRelation,
         key: RelationCacheKey,
-    ) -> Option<bool> {
+    ) -> Option<RelationCacheValue> {
         if let Some(result) = self
             .relation_local_cache(relation)
             .borrow()
@@ -582,18 +444,36 @@ impl<'a> QueryCache<'a> {
         None
     }
 
+    /// Boolean view of the relation cache: surfaces only definitive entries.
+    fn lookup_policy_relation_cache(
+        &self,
+        relation: CachedPolicyRelation,
+        key: RelationCacheKey,
+    ) -> Option<bool> {
+        self.lookup_policy_relation_cache_value(relation, key)
+            .and_then(RelationCacheValue::as_definitive)
+    }
+
     fn insert_policy_relation_cache(
         &self,
         relation: CachedPolicyRelation,
         key: RelationCacheKey,
         result: bool,
     ) {
+        let value = RelationCacheValue::from_bool(result);
         self.relation_local_cache(relation)
             .borrow_mut()
-            .insert(key, result);
+            .insert(key, value);
         if let Some(shared) = self.shared {
-            relation.shared_slot(shared).insert(key, result);
+            relation.shared_slot(shared).insert(key, value);
         }
+    }
+
+    /// Whether a `LimitTrue` entry's fuel band covers the current query's
+    /// remaining global subtype fuel budget (and the policy is enabled).
+    fn limit_true_usable(fuel_band: u32) -> bool {
+        crate::caches::limit_policy::limit_result_cache_enabled()
+            && crate::relations::subtype::cache::remaining_global_subtype_fuel() <= fuel_band
     }
 
     fn is_cached_policy_relation(
@@ -617,11 +497,31 @@ impl<'a> QueryCache<'a> {
         });
         let key = relation.cache_key(source, target, policy);
 
-        if let Some(result) = self.lookup_policy_relation_cache(relation, key) {
-            if let Some(query_id) = trace_query_id {
-                query_trace::relation_end(query_id, trace_op, result, true);
+        match self.lookup_policy_relation_cache_value(relation, key) {
+            Some(RelationCacheValue::True) => {
+                if let Some(query_id) = trace_query_id {
+                    query_trace::relation_end(query_id, trace_op, true, true);
+                }
+                return true;
             }
-            return result;
+            Some(RelationCacheValue::False) => {
+                if let Some(query_id) = trace_query_id {
+                    query_trace::relation_end(query_id, trace_op, false, true);
+                }
+                return false;
+            }
+            Some(RelationCacheValue::LimitTrue { fuel_band }) => {
+                if Self::limit_true_usable(fuel_band) {
+                    tsz_common::perf_counters::record_relation_limit_cache_hit();
+                    if let Some(query_id) = trace_query_id {
+                        query_trace::relation_end(query_id, trace_op, true, true);
+                    }
+                    return true;
+                }
+                // A larger budget is available: recompute honestly below and
+                // let the definitive insert overwrite the limit entry.
+            }
+            None => {}
         }
 
         let result = query_relation(
@@ -1540,30 +1440,47 @@ impl QueryDatabase for QueryCache<'_> {
         // calls. Only persist entries where the result differs from the input
         // (identity mappings are free to recompute) and skip intrinsics.
         //
-        // CORRECTNESS GATE: a run that hit a recursion / depth / iteration /
-        // union-complexity limit must NOT persist its results here. The
-        // `eval_cache` key is `(TypeId, options)` — it does not capture the
-        // ambient stack depth at which a bail occurred — so a depth-bailed
-        // intermediate (e.g. a recursive array alias `RecArray<T> =
-        // Array<T | RecArray<T>>` evaluated while the def-depth was already high,
-        // collapsing to `error`) would otherwise be cached and then read back at
-        // top level where it should have converged. That poisons later
-        // type-checking (an `error` element silently satisfies assignability) in a
-        // declaration/cache-order-dependent way — the exact non-determinism that
-        // makes recursive-utility fixtures flip with surrounding code. This
-        // mirrors the gate the evaluator already applies to `closed_eval_cache`
-        // and `application_eval_cache` (see `recursion_limit_hit`).
+        // CORRECTNESS GATE: a limit-truncated result must NOT be persisted
+        // here. The `eval_cache` key is `(TypeId, options)` — it does not
+        // capture the ambient stack depth at which a bail occurred — so a
+        // depth-bailed intermediate (e.g. a recursive array alias
+        // `RecArray<T> = Array<T | RecArray<T>>` evaluated while the
+        // def-depth was already high, collapsing to `error`) would otherwise
+        // be cached and then read back at top level where it should have
+        // converged. That poisons later type-checking (an `error` element
+        // silently satisfies assignability) in a declaration/cache-order-
+        // dependent way — the exact non-determinism that makes
+        // recursive-utility fixtures flip with surrounding code.
+        //
+        // The discrimination is per-entry (issue #13241, extending the
+        // PR #12902 application-eval epoch split): the top-level result is
+        // gated on the run-sticky `recursion_limit_hit` (its subtree IS the
+        // whole run), while drained intermediates are filtered through the
+        // evaluator's per-node `tainted` set, so the clean intermediates of a
+        // run whose *unrelated sibling* subtree bailed are still persisted
+        // instead of being recomputed from scratch on every later query.
+        // A union-complexity overflow is not routed through the evaluator's
+        // limit epoch, so it conservatively suppresses all writes, as before.
         let newly_union_too_complex =
             self.interner.is_union_too_complex() && !union_too_complex_before;
-        if !evaluator.recursion_limit_hit() && !newly_union_too_complex {
+        let top_level_clean = !evaluator.recursion_limit_hit();
+        if !newly_union_too_complex
+            && (top_level_clean || crate::caches::limit_policy::limit_result_cache_enabled())
+        {
+            let tainted = evaluator.take_tainted();
             let mut cache = self.eval_cache.borrow_mut();
-            cache.insert(key, result);
-            // Also write to shared cache for cross-file benefit.
-            if let Some(shared) = self.shared {
-                shared.eval_cache.insert(key, result);
+            if top_level_clean {
+                cache.insert(key, result);
+                // Also write to shared cache for cross-file benefit.
+                if let Some(shared) = self.shared {
+                    shared.eval_cache.insert(key, result);
+                }
             }
             for (intermediate_id, intermediate_result) in evaluator.drain_cache() {
-                if intermediate_id != intermediate_result && !intermediate_id.is_intrinsic() {
+                if intermediate_id != intermediate_result
+                    && !intermediate_id.is_intrinsic()
+                    && !tainted.contains(&intermediate_id)
+                {
                     let ikey = request.with_type_id(intermediate_id).cache_key();
                     cache.entry(ikey).or_insert(intermediate_result);
                     if let Some(shared) = self.shared {
@@ -1692,6 +1609,74 @@ impl QueryDatabase for QueryCache<'_> {
 
     fn insert_subtype_cache(&self, key: RelationCacheKey, result: bool) {
         self.insert_policy_relation_cache(CachedPolicyRelation::Subtype, key, result);
+    }
+
+    fn lookup_subtype_cache_value(&self, key: RelationCacheKey) -> Option<RelationCacheValue> {
+        self.lookup_policy_relation_cache_value(CachedPolicyRelation::Subtype, key)
+    }
+
+    /// Promote a coinductively validated maybe-key to definitive `true`.
+    ///
+    /// Never overwrites an existing definitive entry (a sibling checker may
+    /// hold an honest `false`); upgrades an existing `LimitTrue` to definitive.
+    fn promote_subtype_cache_true(&self, key: RelationCacheKey) {
+        {
+            let mut local = self.subtype_cache.borrow_mut();
+            match local.entry(key) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    if matches!(entry.get(), RelationCacheValue::LimitTrue { .. }) {
+                        entry.insert(RelationCacheValue::True);
+                    }
+                }
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(RelationCacheValue::True);
+                }
+            }
+        }
+        if let Some(shared) = self.shared {
+            match shared.subtype_cache.entry(key) {
+                dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                    if matches!(entry.get(), RelationCacheValue::LimitTrue { .. }) {
+                        *entry.get_mut() = RelationCacheValue::True;
+                    }
+                }
+                dashmap::mapref::entry::Entry::Vacant(slot) => {
+                    slot.insert(RelationCacheValue::True);
+                }
+            }
+        }
+    }
+
+    /// Record an assumed-related fuel-limit verdict valid up to `fuel_band`.
+    ///
+    /// Never overwrites a definitive entry; merges with an existing
+    /// `LimitTrue` by keeping the larger band (the stronger statement).
+    fn insert_subtype_limit_true(&self, key: RelationCacheKey, fuel_band: u32) {
+        let merge = |existing: &mut RelationCacheValue| {
+            if let RelationCacheValue::LimitTrue {
+                fuel_band: existing_band,
+            } = existing
+            {
+                *existing_band = (*existing_band).max(fuel_band);
+            }
+        };
+        {
+            let mut local = self.subtype_cache.borrow_mut();
+            match local.entry(key) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => merge(entry.get_mut()),
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(RelationCacheValue::LimitTrue { fuel_band });
+                }
+            }
+        }
+        if let Some(shared) = self.shared {
+            match shared.subtype_cache.entry(key) {
+                dashmap::mapref::entry::Entry::Occupied(mut entry) => merge(entry.get_mut()),
+                dashmap::mapref::entry::Entry::Vacant(slot) => {
+                    slot.insert(RelationCacheValue::LimitTrue { fuel_band });
+                }
+            }
+        }
     }
 
     fn lookup_assignability_cache(&self, key: RelationCacheKey) -> Option<bool> {
@@ -1890,3 +1875,8 @@ impl QueryDatabase for QueryCache<'_> {
 #[cfg(test)]
 #[path = "../../tests/db_tests.rs"]
 mod tests;
+
+// `estimated_size_bytes` lives in a child module to keep this shard under
+// the 2000-line file-size cap; child modules retain private-field access.
+#[path = "query_cache_size.rs"]
+mod size;

--- a/crates/tsz-solver/src/caches/query_cache_size.rs
+++ b/crates/tsz-solver/src/caches/query_cache_size.rs
@@ -1,0 +1,152 @@
+//! In-memory size estimation for [`QueryCache`].
+//!
+//! Split out of `query_cache.rs` to keep that shard under the 2000-line
+//! file-size cap. This is a child module of `query_cache`, so it keeps
+//! access to the cache's private fields.
+
+use super::*;
+
+impl QueryCache<'_> {
+    /// Estimate the in-memory size of all caches in bytes.
+    ///
+    /// Accounts for `FxHashMap` bucket overhead, key/value sizes, and heap
+    /// allocations inside cached values (e.g., `Vec<PropertyInfo>` in the
+    /// object-spread cache, `Arc<[Variance]>` in the variance cache).
+    ///
+    /// This is more accurate than `QueryCacheStatistics::estimated_size_bytes()`
+    /// because it reads actual map capacities and heap contents.
+    #[must_use]
+    pub fn estimated_size_bytes(&self) -> usize {
+        // FxHashMap per-bucket overhead: hash + key + value + alignment padding.
+        const BUCKET_OVERHEAD: usize = 64;
+
+        let mut size = std::mem::size_of::<Self>();
+
+        // eval_cache: (TypeId, bool) -> TypeId
+        {
+            let map = self.eval_cache.borrow();
+            size += map.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<EvaluationCacheKey>()
+                    + std::mem::size_of::<TypeId>());
+        }
+
+        // closed_eval_cache: (TypeId, bool) -> TypeId
+        {
+            let map = self.closed_eval_cache.borrow();
+            size += map.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<EvaluationCacheKey>()
+                    + std::mem::size_of::<TypeId>());
+        }
+
+        // application_eval_cache: (DefId, SmallVec<[TypeId; 4]>, bool) -> TypeId
+        {
+            let map = self.application_eval_cache.borrow();
+            let base_entry = BUCKET_OVERHEAD
+                + std::mem::size_of::<ApplicationEvalCacheKey>()
+                + std::mem::size_of::<TypeId>();
+            size += map.capacity() * base_entry;
+            // SmallVec spills to heap when > 4 elements; account for spilled entries.
+            for key in map.keys() {
+                if key.1.spilled() {
+                    size += key.1.capacity() * std::mem::size_of::<TypeId>();
+                }
+            }
+        }
+
+        // element_access_cache
+        {
+            let map = self.element_access_cache.borrow();
+            size += map.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<ElementAccessTypeCacheKey>()
+                    + std::mem::size_of::<TypeId>());
+        }
+
+        // object_spread_properties_cache: TypeId -> Vec<PropertyInfo>
+        {
+            let map = self.object_spread_properties_cache.borrow();
+            size += map.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<TypeId>()
+                    + std::mem::size_of::<Vec<PropertyInfo>>());
+            for props in map.values() {
+                size += props.capacity() * std::mem::size_of::<PropertyInfo>();
+            }
+        }
+
+        // subtype_cache
+        {
+            let map = self.subtype_cache.borrow();
+            size += map.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<RelationCacheKey>()
+                    + std::mem::size_of::<RelationCacheValue>());
+        }
+
+        // assignability_cache
+        {
+            let map = self.assignability_cache.borrow();
+            size += map.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<RelationCacheKey>()
+                    + std::mem::size_of::<RelationCacheValue>());
+        }
+
+        // property_cache
+        {
+            let map = self.property_cache.borrow();
+            size += map.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<PropertyAccessCacheKey>()
+                    + std::mem::size_of::<PropertyAccessResult>());
+        }
+
+        // variance_cache: DefId -> Arc<[Variance]>
+        {
+            let map = self.variance_cache.borrow();
+            size += map.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<DefId>()
+                    + std::mem::size_of::<Arc<[Variance]>>());
+            // Account for the Arc-allocated slice contents
+            for arc in map.values() {
+                size += arc.len() * std::mem::size_of::<Variance>();
+            }
+        }
+
+        // canonical_cache
+        {
+            let map = self.canonical_cache.borrow();
+            size += map.capacity() * (BUCKET_OVERHEAD + 2 * std::mem::size_of::<TypeId>());
+        }
+
+        // intersection_merge_cache: TypeId -> Option<TypeId>
+        {
+            let map = self.intersection_merge_cache.borrow();
+            size += map.capacity()
+                * (BUCKET_OVERHEAD
+                    + std::mem::size_of::<TypeId>()
+                    + std::mem::size_of::<Option<TypeId>>());
+        }
+
+        // instantiation_cache: (TypeId, CanonicalSubst, u8, Option<TypeId>) -> TypeId
+        // CanonicalSubst's inline SmallVec buffer is included in the
+        // `InstantiationCacheKey` size; spilled entries pay extra heap.
+        size += self.instantiation_cache.capacity()
+            * (BUCKET_OVERHEAD
+                + std::mem::size_of::<InstantiationCacheKey>()
+                + std::mem::size_of::<TypeId>());
+
+        // subtype_reduction_cache: (SortedTypeIds, u8) -> Arc<[TypeId]>
+        // Inline buffer is part of `SubtypeReductionKey`; the cached value
+        // is `Arc<[TypeId]>` (16 bytes) plus the heap slice it points at.
+        size += self.subtype_reduction_cache.capacity()
+            * (BUCKET_OVERHEAD
+                + std::mem::size_of::<SubtypeReductionKey>()
+                + std::mem::size_of::<std::sync::Arc<[TypeId]>>());
+
+        size
+    }
+}

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -158,6 +158,19 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// `(TypeId, no_unchecked)` key does not capture. All evaluators may still
     /// *read* (the stored value is a definite context-free answer).
     closed_eval_writes_allowed: bool,
+    /// Entries of `cache` whose value is a limit-truncated *stack-context
+    /// artifact* rather than a stable function of the input `TypeId`: a node
+    /// is tainted when a recursion/depth/iteration/divergence limit event
+    /// fired within its own evaluation window (`limit_epoch` moved between
+    /// entry and memo write), or when its value was an explicit cycle/depth
+    /// bail-out insert. Reading a tainted entry back from `cache` records a
+    /// limit event so the taint propagates to every in-flight ancestor.
+    ///
+    /// This is the per-entry discrimination (issue #13241, extending the
+    /// PR #12902 application-eval epoch split) that lets the persistent
+    /// `eval_cache` keep the *clean* intermediates of a run whose unrelated
+    /// subtree hit a limit, instead of dropping the whole run's results.
+    tainted: FxHashSet<TypeId>,
 }
 
 /// Operation-local memo table statistics for [`TypeEvaluator`].
@@ -223,6 +236,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             limit_epoch: 0,
             app_body_limit_epoch: 0,
             closed_eval_writes_allowed: false,
+            tainted: FxHashSet::default(),
         }
     }
 
@@ -369,8 +383,25 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Drain the evaluator's internal cache, returning all intermediate results.
     /// This allows callers to persist intermediate evaluation results
     /// (e.g., from recursive mapped type expansion) into a longer-lived cache.
+    ///
+    /// Callers persisting these into a cache whose key does not capture the
+    /// ambient stack depth must filter out limit-truncated entries via
+    /// [`take_tainted`](Self::take_tainted).
     pub fn drain_cache(&mut self) -> impl Iterator<Item = (TypeId, TypeId)> + '_ {
         self.cache.drain()
+    }
+
+    /// Take the set of cache entries whose values are limit-truncated
+    /// stack-context artifacts (see the `tainted` field). Pair with
+    /// [`drain_cache`](Self::drain_cache) to persist only stable entries.
+    pub(crate) fn take_tainted(&mut self) -> FxHashSet<TypeId> {
+        std::mem::take(&mut self.tainted)
+    }
+
+    /// Whether `type_id`'s memoized value is a limit-truncated artifact.
+    #[cfg(test)]
+    pub(crate) fn is_tainted(&self, type_id: TypeId) -> bool {
+        self.tainted.contains(&type_id)
     }
 
     /// Pre-seed the evaluator's cache with previously computed evaluation results.
@@ -383,6 +414,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     pub fn set_no_unchecked_indexed_access(&mut self, enabled: bool) {
         if self.no_unchecked_indexed_access != enabled {
             self.cache.clear();
+            self.tainted.clear();
         }
         self.no_unchecked_indexed_access = enabled;
     }
@@ -398,6 +430,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     #[inline]
     pub fn reset(&mut self) {
         self.cache.clear();
+        self.tainted.clear();
         self.guard.reset();
         self.def_depth.clear();
         self.real_instantiation_depth_count = 0;
@@ -600,6 +633,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // Most evaluate() calls are for already-evaluated types (cache hits),
         // so checking the cache first avoids unnecessary guard operations.
         if let Some(&cached) = self.cache.get(&type_id) {
+            // Reading a limit-truncated artifact makes every in-flight
+            // ancestor's result artifact-dependent: record a limit event so
+            // the epoch-based stamping (and the application-eval epoch gate)
+            // see it. The `is_empty` check keeps the common clean-run hit
+            // path at a single length read.
+            if !self.tainted.is_empty() && self.tainted.contains(&type_id) {
+                self.note_limit_event();
+            }
             return cached;
         }
 
@@ -683,6 +724,18 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// fast while still catching runaway expansion within a few hundred iterations.
     const FUEL_CHECK_INTERVAL: u32 = 128;
 
+    /// Memoize `result` for `type_id`, stamping the entry as a stack-context
+    /// artifact when a limit event fired within this node's evaluation window
+    /// (`limit_epoch` moved past `epoch_at_entry`). Tainted entries must not
+    /// be persisted to depth-agnostic caches; see the `tainted` field.
+    #[inline]
+    fn memo_insert(&mut self, epoch_at_entry: u32, type_id: TypeId, result: TypeId) {
+        if self.limit_epoch != epoch_at_entry {
+            self.tainted.insert(type_id);
+        }
+        self.cache.insert(type_id, result);
+    }
+
     /// Actual evaluate logic -- separated so `stacker::maybe_grow` can wrap it.
     fn evaluate_guarded_inner(&mut self, type_id: TypeId) -> TypeId {
         use crate::recursion::RecursionResult;
@@ -690,6 +743,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let _span =
             tracing::trace_span!("evaluate_type", ty = type_id.0, depth = self.guard.depth(),)
                 .entered();
+
+        // Snapshot for per-node taint stamping: every memo write below goes
+        // through `memo_insert`, which compares the live `limit_epoch`
+        // against this entry snapshot. The explicit bail-out arms call a
+        // `mark_*` helper (which bumps the epoch) before inserting, so their
+        // artifacts are stamped by the same comparison.
+        let limit_epoch_at_entry = self.limit_epoch;
 
         // The entry-point `evaluate` already consulted `self.cache` and only
         // dispatched here on a miss. `evaluate_guarded_inner` is reached
@@ -714,7 +774,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // self-referential generic constraints look satisfied.
                 let key = self.interner.lookup(type_id);
                 if matches!(key, Some(TypeData::Mapped(_))) {
-                    self.cache.insert(type_id, type_id);
+                    self.memo_insert(limit_epoch_at_entry, type_id, type_id);
                     return type_id;
                 }
                 // When checking type alias definitions for TS2589, a cycle on an
@@ -741,18 +801,18 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // finite recursion like the type-challenges `Permutation<U>` /
                 // `Combination<U>` patterns (silently leave `type_id` opaque).
                 if self.has_real_instantiation_depth() {
-                    self.cache.insert(type_id, TypeId::ERROR);
+                    self.memo_insert(limit_epoch_at_entry, type_id, TypeId::ERROR);
                     return TypeId::ERROR;
                 }
                 self.guard.clear_exceeded();
                 self.mark_silent_depth_bailed();
-                self.cache.insert(type_id, type_id);
+                self.memo_insert(limit_epoch_at_entry, type_id, type_id);
                 return type_id;
             }
             RecursionResult::IterationExceeded => {
                 // Iteration-limit bail: also a bounded run.
                 self.mark_deep_recursion_seen();
-                self.cache.insert(type_id, type_id);
+                self.memo_insert(limit_epoch_at_entry, type_id, type_id);
                 return type_id;
             }
         }
@@ -771,7 +831,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         {
             self.mark_depth_exceeded();
             self.guard.leave(type_id);
-            self.cache.insert(type_id, TypeId::ERROR);
+            self.memo_insert(limit_epoch_at_entry, type_id, TypeId::ERROR);
             return TypeId::ERROR;
         }
 
@@ -788,7 +848,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         // Symmetric cleanup: leave guard and cache result
         self.guard.leave(type_id);
-        self.cache.insert(type_id, result);
+        self.memo_insert(limit_epoch_at_entry, type_id, result);
 
         result
     }

--- a/crates/tsz-solver/src/lib.rs
+++ b/crates/tsz-solver/src/lib.rs
@@ -275,8 +275,8 @@ pub use types::{
     CachedAnyMode, CallableShape, ConditionalType, ConditionalTypeId, FunctionShape,
     FunctionShapeId, IndexSignature, MappedType, MappedTypeId, ObjectFlags, ObjectShape,
     OrderedFloat, ParamInfo, RelationCacheConfig, RelationCacheKey, RelationCacheKind,
-    RelationFlags, StringIntrinsicKind, TemplateSpan, TupleElement, TupleListId, TypeParamInfo,
-    TypePredicate, TypePredicateTarget,
+    RelationCacheValue, RelationFlags, StringIntrinsicKind, TemplateSpan, TupleElement,
+    TupleListId, TypeParamInfo, TypePredicate, TypePredicateTarget,
 };
 pub use types::{
     CallSignature, CallableShapeId, IntrinsicKind, LiteralValue, MappedModifier, ObjectShapeId,
@@ -419,6 +419,9 @@ mod interface_comprehensive_tests;
 #[cfg(test)]
 #[path = "../tests/keyof_comprehensive_tests.rs"]
 mod keyof_comprehensive_tests;
+#[cfg(test)]
+#[path = "../tests/limit_relation_cache_tests.rs"]
+mod limit_relation_cache_tests;
 #[cfg(test)]
 #[path = "../tests/mapped_architecture_tests.rs"]
 mod mapped_architecture_tests;

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -412,19 +412,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             match db.lookup_subtype_cache_value(key) {
                 Some(RelationCacheValue::True) => return SubtypeResult::True,
                 Some(RelationCacheValue::False) => return SubtypeResult::False,
-                Some(RelationCacheValue::LimitTrue { fuel_band }) => {
-                    // Budget-conditional assumed-related verdict (tsc
-                    // `Ternary.Maybe` parity): honest only when this query's
-                    // remaining fuel budget is no larger than the recorded
-                    // run's. Under a raised budget, fall through and
-                    // recompute (fuel-band cache honesty).
-                    if limit_result_cache_enabled() && remaining_global_subtype_fuel() <= fuel_band
-                    {
-                        tsz_common::perf_counters::record_relation_limit_cache_hit();
-                        return SubtypeResult::DepthExceeded;
-                    }
+                // Budget-conditional assumed-related verdict (tsc
+                // `Ternary.Maybe` parity): honest only when this query's
+                // remaining fuel budget is no larger than the recorded
+                // run's. Under a raised budget, fall through and recompute
+                // (fuel-band cache honesty).
+                Some(RelationCacheValue::LimitTrue { fuel_band })
+                    if limit_result_cache_enabled()
+                        && remaining_global_subtype_fuel() <= fuel_band =>
+                {
+                    tsz_common::perf_counters::record_relation_limit_cache_hit();
+                    return SubtypeResult::DepthExceeded;
                 }
-                None => {}
+                Some(RelationCacheValue::LimitTrue { .. }) | None => {}
             }
         }
 

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -150,6 +150,20 @@ pub(crate) struct MaybeRelationEntry {
     fuel_band: Option<u32>,
 }
 
+/// Frame-entry snapshot captured by `check_subtype` and consumed by
+/// `finish_relation_frame` at every frame exit: the maybe-stack watermark,
+/// the promotability of this frame's verdicts, whether the budget chain was
+/// pristine at entry (fuel-band honesty), and the cache-poisoning sentinel
+/// counters whose stability gates promotion.
+#[derive(Copy, Clone, Debug)]
+struct RelationFrameSnapshot {
+    maybe_start: usize,
+    frame_promotable: bool,
+    pristine_budget_chain: bool,
+    lazy_failures_at_entry: u64,
+    weak_sensitivity_at_entry: u64,
+}
+
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Check if a Lazy type resolved to an Enum with the same DefId.
     ///
@@ -505,21 +519,20 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             && self.guard.iterations() == 0
             && crate::recursion::solver_stack_frame_depth() == 0;
 
+        let frame_snapshot = RelationFrameSnapshot {
+            maybe_start,
+            frame_promotable,
+            pristine_budget_chain,
+            lazy_failures_at_entry,
+            weak_sensitivity_at_entry,
+        };
+
         // Helper macro: run the maybe-stack completion protocol for this
         // frame. Must be invoked at every exit taken after `guard.enter`
         // succeeded, after the corresponding `guard.leave`.
         macro_rules! finish_frame {
             ($result:expr) => {
-                self.finish_relation_frame(
-                    $result,
-                    maybe_start,
-                    frame_promotable,
-                    pristine_budget_chain,
-                    lazy_failures_at_entry,
-                    weak_sensitivity_at_entry,
-                    source,
-                    target,
-                );
+                self.finish_relation_frame($result, frame_snapshot, source, target);
             };
         }
 
@@ -1182,24 +1195,19 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     ///   gated on the unresolved-`Lazy` / weak-type-sensitivity counters
     ///   having been stable across the whole outermost window, the same
     ///   discipline `cache_definitive!` applies to definitive writes.
-    #[allow(clippy::too_many_arguments)]
     fn finish_relation_frame(
         &mut self,
         result: SubtypeResult,
-        maybe_start: usize,
-        frame_promotable: bool,
-        pristine_budget_chain: bool,
-        lazy_failures_at_entry: u64,
-        weak_sensitivity_at_entry: u64,
+        frame: RelationFrameSnapshot,
         source: TypeId,
         target: TypeId,
     ) {
         match result {
             SubtypeResult::False => {
-                self.maybe_keys.truncate(maybe_start);
+                self.maybe_keys.truncate(frame.maybe_start);
             }
             SubtypeResult::CycleDetected => {
-                if frame_promotable {
+                if frame.frame_promotable {
                     self.maybe_keys.push(MaybeRelationEntry {
                         key: self.make_cache_key(source, target),
                         fuel_band: None,
@@ -1207,7 +1215,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 }
             }
             SubtypeResult::DepthExceeded => {
-                if frame_promotable && pristine_budget_chain {
+                if frame.frame_promotable && frame.pristine_budget_chain {
                     self.maybe_keys.push(MaybeRelationEntry {
                         key: self.make_cache_key(source, target),
                         fuel_band: Some(MAX_GLOBAL_SUBTYPE_FUEL),
@@ -1221,8 +1229,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if self.guard.depth() == 0 && !self.maybe_keys.is_empty() {
             let entries = std::mem::take(&mut self.maybe_keys);
             if result.is_true()
-                && lazy_resolve_failure_count() == lazy_failures_at_entry
-                && weak_type_sensitivity_count() == weak_sensitivity_at_entry
+                && lazy_resolve_failure_count() == frame.lazy_failures_at_entry
+                && weak_type_sensitivity_count() == frame.weak_sensitivity_at_entry
                 && let Some(db) = self.query_db
             {
                 for entry in entries {

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -9,11 +9,14 @@
 //! - Pre-evaluation intrinsic checks (Object/Function interfaces)
 //! - Meta-type evaluation bridging
 
+use crate::caches::limit_policy::limit_result_cache_enabled;
 use crate::construction::TypeDatabase;
 use crate::def::DefId;
 use crate::def::resolver::TypeResolver;
 use crate::relations::subtype::{SubtypeChecker, SubtypeResult, is_disjoint_unit_type};
-use crate::types::{IntrinsicKind, TypeApplicationId, TypeData, TypeId};
+use crate::types::{
+    IntrinsicKind, RelationCacheKey, RelationCacheValue, TypeApplicationId, TypeData, TypeId,
+};
 use crate::visitor::{
     application_id, array_element_type, conditional_type_id, contains_this_type, enum_components,
     lazy_def_id, literal_value, type_param_info, union_list_id,
@@ -118,7 +121,34 @@ pub fn reset_subtype_thread_local_state() {
 // Maximum number of non-trivial subtype checks per top-level call chain.
 // Generous enough for complex real-world types (react, fp-ts) but restrictive
 // enough to prevent runaway recursion from hanging.
-const MAX_GLOBAL_SUBTYPE_FUEL: u32 = 10_000;
+pub(crate) const MAX_GLOBAL_SUBTYPE_FUEL: u32 = 10_000;
+
+/// Remaining global subtype fuel budget for the current thread's in-flight
+/// relation chain. `MAX_GLOBAL_SUBTYPE_FUEL` when no chain is in flight.
+///
+/// Used to decide whether a budget-conditional
+/// [`RelationCacheValue::LimitTrue`] entry is honest for the current query:
+/// the recorded verdict only holds for queries whose remaining budget is at
+/// most the entry's `fuel_band` (a larger budget could complete the
+/// comparison honestly and must recompute).
+#[inline]
+pub(crate) fn remaining_global_subtype_fuel() -> u32 {
+    GLOBAL_SUBTYPE_STATE.with(|s| MAX_GLOBAL_SUBTYPE_FUEL.saturating_sub(unpack_fuel(s.get())))
+}
+
+/// One recorded `Ternary.Maybe`-style relation outcome awaiting validation by
+/// the outermost frame of its checker instance (tsc `maybeKeys` parity).
+///
+/// `fuel_band: None` marks a cycle-derived Maybe: on outermost success the
+/// coinductive assumption is validated and the key is promoted to a
+/// definitive `true`. `fuel_band: Some(band)` marks a fuel-limit Maybe: on
+/// outermost success it is promoted to a budget-conditional
+/// [`RelationCacheValue::LimitTrue`] entry honest up to `band`.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct MaybeRelationEntry {
+    key: RelationCacheKey,
+    fuel_band: Option<u32>,
+}
 
 impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Check if a Lazy type resolved to an Enum with the same DefId.
@@ -379,12 +409,22 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             && let Some(db) = self.query_db
         {
             let key = self.make_cache_key(source, target);
-            if let Some(cached) = db.lookup_subtype_cache(key) {
-                return if cached {
-                    SubtypeResult::True
-                } else {
-                    SubtypeResult::False
-                };
+            match db.lookup_subtype_cache_value(key) {
+                Some(RelationCacheValue::True) => return SubtypeResult::True,
+                Some(RelationCacheValue::False) => return SubtypeResult::False,
+                Some(RelationCacheValue::LimitTrue { fuel_band }) => {
+                    // Budget-conditional assumed-related verdict (tsc
+                    // `Ternary.Maybe` parity): honest only when this query's
+                    // remaining fuel budget is no larger than the recorded
+                    // run's. Under a raised budget, fall through and
+                    // recompute (fuel-band cache honesty).
+                    if limit_result_cache_enabled() && remaining_global_subtype_fuel() <= fuel_band
+                    {
+                        tsz_common::perf_counters::record_relation_limit_cache_hit();
+                        return SubtypeResult::DepthExceeded;
+                    }
+                }
+                None => {}
             }
         }
 
@@ -432,6 +472,56 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // does not encode. Caching it would let a result computed under one
         // enforcement state be served to a sibling check under another.
         let weak_sensitivity_at_entry = weak_type_sensitivity_count();
+
+        // ── Limit-hit maybe-stack (tsc `maybeKeys` parity, issue #13241) ────
+        // Frame-entry snapshot of the maybe stack. Every completion path of
+        // this frame (after the recursion guard is entered) routes through
+        // `finish_relation_frame`, which:
+        //   - truncates the stack to this snapshot when the frame resolves to
+        //     a definitive `False` (Maybe entries recorded inside this frame's
+        //     subtree depended on an in-flight assumption this failure
+        //     invalidates — tsc discards those maybeKeys the same way);
+        //   - records this frame's key when it resolves to a Maybe verdict
+        //     (`CycleDetected` / `DepthExceeded`) in a promotable context;
+        //   - promotes (on overall success) or discards (on failure) all
+        //     surviving entries when the outermost frame of this checker
+        //     instance completes.
+        let maybe_start = self.maybe_keys.len();
+        let frame_promotable = can_use_shared_relation_cache
+            && !self.bypass_evaluation
+            && !self.identity_cycle_check
+            && self.query_db.is_some()
+            && limit_result_cache_enabled();
+        // A fuel-limit Maybe verdict may only be recorded when every budget
+        // dimension was pristine at this frame's entry: full global fuel
+        // (`global_depth == 0`), a fresh per-instance iteration budget, and no
+        // enclosing cross-operation solver frames. Any later query then holds
+        // an equal-or-smaller budget in every dimension, so reusing the
+        // assumed-related verdict is monotonically safe — a smaller budget
+        // can only bail earlier with the same answer (fuel-band honesty).
+        // The `global_depth == 0` short-circuit keeps the two extra reads off
+        // the hot nested-frame path.
+        let pristine_budget_chain = global_depth == 0
+            && self.guard.iterations() == 0
+            && crate::recursion::solver_stack_frame_depth() == 0;
+
+        // Helper macro: run the maybe-stack completion protocol for this
+        // frame. Must be invoked at every exit taken after `guard.enter`
+        // succeeded, after the corresponding `guard.leave`.
+        macro_rules! finish_frame {
+            ($result:expr) => {
+                self.finish_relation_frame(
+                    $result,
+                    maybe_start,
+                    frame_promotable,
+                    pristine_budget_chain,
+                    lazy_failures_at_entry,
+                    weak_sensitivity_at_entry,
+                    source,
+                    target,
+                );
+            };
+        }
 
         // Helper macro to decrement global depth and optionally reset fuel on early returns.
         macro_rules! leave_global {
@@ -640,8 +730,10 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 });
                 if found_cycle {
                     self.guard.leave(pair);
+                    let result = self.result_on_cycle(source, target);
+                    finish_frame!(result);
                     leave_global!();
-                    return self.result_on_cycle(source, target);
+                    return result;
                 }
             }
         }
@@ -650,14 +742,18 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             // Check reversed pair for bivariant cross-recursion
             if self.def_guard.is_visiting(&(t_def, s_def)) {
                 self.guard.leave(pair);
+                let result = self.result_on_cycle(source, target);
+                finish_frame!(result);
                 leave_global!();
-                return self.result_on_cycle(source, target);
+                return result;
             }
             match self.def_guard.enter((s_def, t_def)) {
                 RecursionResult::Cycle => {
                     self.guard.leave(pair);
+                    let result = self.result_on_cycle(source, target);
+                    finish_frame!(result);
                     leave_global!();
-                    return self.result_on_cycle(source, target);
+                    return result;
                 }
                 RecursionResult::Entered => Some((s_def, t_def)),
                 _ => None,
@@ -692,6 +788,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         self.def_guard.leave(dp);
                     }
                     self.guard.leave(pair);
+                    finish_frame!(SubtypeResult::False);
                     leave_global!();
                     return SubtypeResult::False;
                 }
@@ -700,6 +797,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     self.def_guard.leave(dp);
                 }
                 self.guard.leave(pair);
+                finish_frame!(result);
                 leave_global!();
                 return result;
             }
@@ -726,6 +824,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     self.def_guard.leave(dp);
                 }
                 self.guard.leave(pair);
+                finish_frame!(SubtypeResult::True);
                 leave_global!();
                 return SubtypeResult::True;
             }
@@ -786,6 +885,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                         self.def_guard.leave(dp);
                     }
                     self.guard.leave(pair);
+                    finish_frame!(SubtypeResult::True);
                     leave_global!();
                     return SubtypeResult::True;
                 }
@@ -794,6 +894,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     self.def_guard.leave(dp);
                 }
                 self.guard.leave(pair);
+                finish_frame!(result);
                 leave_global!();
                 return result;
             }
@@ -863,6 +964,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     let key = self.make_cache_key(source, target);
                     cache_definitive!(db, key, result);
                 }
+                finish_frame!(result);
                 leave_global!();
                 return result;
             }
@@ -922,6 +1024,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 let key = self.make_cache_key(source, target);
                 cache_definitive!(db, key, result);
             }
+            finish_frame!(result);
             leave_global!();
             return result;
         }
@@ -943,6 +1046,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 let key = self.make_cache_key(source, target);
                 cache_definitive!(db, key, result);
             }
+            finish_frame!(result);
             leave_global!();
             return result;
         }
@@ -987,6 +1091,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                     self.def_guard.leave(dp);
                 }
                 self.guard.leave(pair);
+                finish_frame!(result);
                 leave_global!();
                 return result;
             }
@@ -1031,6 +1136,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             cache_definitive!(db, key, result);
         }
 
+        finish_frame!(result);
+
         // Decrement global depth; reset fuel when outermost call completes.
         // PERF: Single TLS access for both depth and fuel.
         GLOBAL_SUBTYPE_STATE.with(|s| {
@@ -1044,6 +1151,89 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         });
 
         result
+    }
+
+    /// Maybe-stack completion protocol for one `check_subtype` frame
+    /// (tsc `maybeKeys` parity, issue #13241).
+    ///
+    /// Called at every frame exit taken after the recursion guard was entered
+    /// (after the matching `guard.leave`). Semantics, mirroring tsc's
+    /// `recursiveTypeRelatedTo` / `resetMaybeStack`:
+    ///
+    /// - A definitive `False` invalidates every Maybe entry recorded within
+    ///   this frame's subtree: those verdicts may have leaned on an in-flight
+    ///   coinductive assumption that this failure refutes, so they are
+    ///   discarded (truncated back to `maybe_start`).
+    /// - A Maybe verdict (`CycleDetected` / `DepthExceeded`) records this
+    ///   frame's relation key for later validation. Cycle verdicts are
+    ///   recorded at any depth (their assumption frame is an ancestor in this
+    ///   same instance and will either succeed — validating them — or fail
+    ///   and truncate them). Fuel verdicts are recorded only for frames that
+    ///   started a pristine budget chain (`pristine_budget_chain`), where the
+    ///   fuel band is the full budget and every other budget dimension
+    ///   (instance depth, iteration count, shared solver frames) is at its
+    ///   pristine maximum — so any later query reuses the verdict from an
+    ///   equal-or-smaller budget, which is monotonically safe.
+    /// - When the outermost frame of this checker instance completes
+    ///   (`guard.depth() == 0`), surviving entries are promoted on overall
+    ///   success — cycle entries to definitive `true` (the coinductive
+    ///   assumption set is self-consistent), fuel entries to band-conditional
+    ///   `LimitTrue` — or discarded on failure. Promotion is additionally
+    ///   gated on the unresolved-`Lazy` / weak-type-sensitivity counters
+    ///   having been stable across the whole outermost window, the same
+    ///   discipline `cache_definitive!` applies to definitive writes.
+    #[allow(clippy::too_many_arguments)]
+    fn finish_relation_frame(
+        &mut self,
+        result: SubtypeResult,
+        maybe_start: usize,
+        frame_promotable: bool,
+        pristine_budget_chain: bool,
+        lazy_failures_at_entry: u64,
+        weak_sensitivity_at_entry: u64,
+        source: TypeId,
+        target: TypeId,
+    ) {
+        match result {
+            SubtypeResult::False => {
+                self.maybe_keys.truncate(maybe_start);
+            }
+            SubtypeResult::CycleDetected => {
+                if frame_promotable {
+                    self.maybe_keys.push(MaybeRelationEntry {
+                        key: self.make_cache_key(source, target),
+                        fuel_band: None,
+                    });
+                }
+            }
+            SubtypeResult::DepthExceeded => {
+                if frame_promotable && pristine_budget_chain {
+                    self.maybe_keys.push(MaybeRelationEntry {
+                        key: self.make_cache_key(source, target),
+                        fuel_band: Some(MAX_GLOBAL_SUBTYPE_FUEL),
+                    });
+                }
+            }
+            SubtypeResult::True => {}
+        }
+
+        // Outermost frame of this checker instance: validate or discard.
+        if self.guard.depth() == 0 && !self.maybe_keys.is_empty() {
+            let entries = std::mem::take(&mut self.maybe_keys);
+            if result.is_true()
+                && lazy_resolve_failure_count() == lazy_failures_at_entry
+                && weak_type_sensitivity_count() == weak_sensitivity_at_entry
+                && let Some(db) = self.query_db
+            {
+                for entry in entries {
+                    match entry.fuel_band {
+                        None => db.promote_subtype_cache_true(entry.key),
+                        Some(band) => db.insert_subtype_limit_true(entry.key, band),
+                    }
+                    tsz_common::perf_counters::record_relation_maybe_promotion();
+                }
+            }
+        }
     }
 
     /// Returns the appropriate cycle result based on the current mode.

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -316,6 +316,11 @@ pub struct SubtypeChecker<'a, R: TypeResolver = NoopResolver> {
     /// but different type param names (e.g., `<D>(f: (t: C) => D) => IList<D>` vs
     /// `<B>(f: (t: C) => B) => IList<B>`).
     pub(crate) type_param_equivalences: Vec<(TypeId, TypeId)>,
+    /// In-flight `Ternary.Maybe`-style relation outcomes awaiting validation
+    /// by the outermost frame of this checker instance (tsc `maybeKeys`
+    /// parity, issue #13241). See `cache::MaybeRelationEntry` and
+    /// `finish_relation_frame` in the `cache` module.
+    pub(crate) maybe_keys: Vec<super::cache::MaybeRelationEntry>,
 }
 
 /// Operation-local cache statistics for [`SubtypeChecker`].
@@ -388,6 +393,7 @@ impl<'a> SubtypeChecker<'a, NoopResolver> {
             eval_cache: FxHashMap::default(),
             apparent_primitive_shapes: std::array::from_fn(|_| None),
             type_param_equivalences: Vec::new(),
+            maybe_keys: Vec::new(),
         }
     }
 }
@@ -437,6 +443,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             eval_cache: FxHashMap::default(),
             apparent_primitive_shapes: std::array::from_fn(|_| None),
             type_param_equivalences: Vec::new(),
+            maybe_keys: Vec::new(),
         }
     }
 
@@ -547,6 +554,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         self.app_expand_depth.clear();
         self.sym_visiting.clear();
         self.eval_cache.clear();
+        self.maybe_keys.clear();
     }
 
     /// Return entry and size accounting for this checker's operation-local caches.

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -482,6 +482,47 @@ impl RelationCacheKey {
     }
 }
 
+/// Stored outcome of a relation query in the cross-checker relation caches.
+///
+/// `True` / `False` are definitive, budget-independent verdicts. `LimitTrue`
+/// records a `tsc` `Ternary.Maybe`-style assumed-related verdict produced when
+/// a relation chain exhausted its global fuel budget. It is honest only for a
+/// later query whose *remaining* fuel budget at lookup time is at most
+/// `fuel_band` (the budget the recorded run started with): a query holding a
+/// larger budget could complete the comparison honestly and must recompute
+/// instead of reusing the truncated verdict (fuel-band cache honesty).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RelationCacheValue {
+    /// Definitively related.
+    True,
+    /// Definitively not related.
+    False,
+    /// Assumed related because the computation hit the global fuel limit
+    /// while `fuel_band` units of budget were available at its entry.
+    LimitTrue {
+        /// Remaining global subtype fuel at the recorded run's entry.
+        fuel_band: u32,
+    },
+}
+
+impl RelationCacheValue {
+    /// Wrap a definitive boolean verdict.
+    #[must_use]
+    pub const fn from_bool(related: bool) -> Self {
+        if related { Self::True } else { Self::False }
+    }
+
+    /// The definitive verdict, or `None` for budget-conditional entries.
+    #[must_use]
+    pub const fn as_definitive(self) -> Option<bool> {
+        match self {
+            Self::True => Some(true),
+            Self::False => Some(false),
+            Self::LimitTrue { .. } => None,
+        }
+    }
+}
+
 /// Priority levels for generic type inference constraints.
 ///
 /// TypeScript uses a multi-pass inference algorithm where constraints are processed

--- a/crates/tsz-solver/tests/limit_relation_cache_tests.rs
+++ b/crates/tsz-solver/tests/limit_relation_cache_tests.rs
@@ -1,0 +1,535 @@
+//! Limit-hit relation/eval outcome caching tests (issue #13241).
+//!
+//! tsc records `Ternary.Maybe` results on its `maybeKeys` stack and promotes
+//! them to cached successes when the outermost relation in
+//! `checkTypeRelatedTo` completes successfully. These tests pin the tsz
+//! mirror of that policy:
+//!
+//! - cycle-derived Maybe verdicts are promoted to definitive `true` entries
+//!   on outermost success and discarded on outermost failure;
+//! - fuel-limit verdicts are stored as budget-conditional `LimitTrue`
+//!   entries that are reused only under an equal-or-smaller budget
+//!   (fuel-band cache honesty) and never overwrite definitive entries;
+//! - the evaluator's per-node taint set discriminates limit-truncated
+//!   memo entries from clean intermediates of the same run.
+
+use crate::caches::db::QueryDatabase;
+use crate::caches::query_cache::QueryCache;
+use crate::construction::RelationCacheProbe;
+use crate::def::DefId;
+use crate::evaluation::evaluate::TypeEvaluator;
+use crate::intern::TypeInterner;
+use crate::relations::subtype::cache::MAX_GLOBAL_SUBTYPE_FUEL;
+use crate::relations::subtype::{SubtypeChecker, TypeResolver};
+use crate::types::{
+    MappedType, PropertyInfo, RelationCacheValue, SymbolRef, TypeId, TypeParamInfo,
+};
+
+/// Maps a fixed set of `DefId`s to recursive bodies.
+struct RecursiveDefResolver {
+    defs: Vec<(DefId, TypeId)>,
+}
+
+impl TypeResolver for RecursiveDefResolver {
+    fn resolve_ref(
+        &self,
+        _symbol: SymbolRef,
+        _interner: &dyn crate::construction::TypeDatabase,
+    ) -> Option<TypeId> {
+        None
+    }
+
+    fn resolve_lazy(
+        &self,
+        def_id: DefId,
+        _interner: &dyn crate::construction::TypeDatabase,
+    ) -> Option<TypeId> {
+        self.defs
+            .iter()
+            .find(|(d, _)| *d == def_id)
+            .map(|&(_, t)| t)
+    }
+}
+
+/// Build a pair of mutually structured recursive object types
+/// `type S = { <prop>: S[]; <tag>: <tag_s> }` / `type T = { <prop>: T[]; <tag>: <tag_t> }`
+/// and return `(lazy_s, lazy_t, arr_s, arr_t)`.
+///
+/// Relating `lazy_s <: lazy_t` delegates `arr_s <: arr_t` through the array
+/// element fast path back to `lazy_s <: lazy_t`, which is coinductively
+/// assumed related (`CycleDetected`) — the exact delegation-chain Maybe
+/// verdict that tsc records on its maybe stack.
+fn recursive_pair(
+    interner: &TypeInterner,
+    prop: &str,
+    tag: &str,
+    tag_s: TypeId,
+    tag_t: TypeId,
+    s_def: DefId,
+    t_def: DefId,
+) -> (RecursiveDefResolver, TypeId, TypeId, TypeId, TypeId) {
+    let lazy_s = interner.lazy(s_def);
+    let lazy_t = interner.lazy(t_def);
+    let arr_s = interner.array(lazy_s);
+    let arr_t = interner.array(lazy_t);
+    let prop_atom = interner.intern_string(prop);
+    let tag_atom = interner.intern_string(tag);
+    let body_s = interner.object(vec![
+        PropertyInfo::new(prop_atom, arr_s),
+        PropertyInfo::new(tag_atom, tag_s),
+    ]);
+    let body_t = interner.object(vec![
+        PropertyInfo::new(prop_atom, arr_t),
+        PropertyInfo::new(tag_atom, tag_t),
+    ]);
+    let resolver = RecursiveDefResolver {
+        defs: vec![(s_def, body_s), (t_def, body_t)],
+    };
+    (resolver, lazy_s, lazy_t, arr_s, arr_t)
+}
+
+// =============================================================================
+// Maybe-stack promotion (cycle verdicts)
+// =============================================================================
+
+#[test]
+fn cycle_maybe_keys_promoted_to_true_on_outermost_success() {
+    let interner = TypeInterner::new();
+    let (resolver, lazy_s, lazy_t, arr_s, arr_t) = recursive_pair(
+        &interner,
+        "next",
+        "kind",
+        TypeId::NUMBER,
+        TypeId::NUMBER,
+        DefId(11),
+        DefId(12),
+    );
+    let db = QueryCache::new(&interner);
+    let mut checker = SubtypeChecker::with_resolver(&interner, &resolver).with_query_db(&db);
+
+    assert!(
+        checker.check_subtype(lazy_s, lazy_t).is_true(),
+        "compatible recursive types must relate"
+    );
+
+    // The delegated array-element pair resolved through the coinductive cycle
+    // assumption; the outermost success must have promoted it (tsc maybeKeys
+    // promotion). Before #13241 this pair was recomputed on every query.
+    let arr_key = checker.debug_cache_key_for(arr_s, arr_t);
+    assert_eq!(
+        db.probe_subtype_cache(arr_key),
+        RelationCacheProbe::Hit(true),
+        "cycle-derived Maybe key must be promoted to a definitive true entry"
+    );
+}
+
+#[test]
+fn repeat_query_of_promoted_maybe_key_is_a_counted_cache_hit() {
+    tsz_common::perf_counters::force_enable_perf_counters_for_tests();
+    let promotions_before = tsz_common::perf_counters::counters()
+        .relation_maybe_promotions
+        .load(std::sync::atomic::Ordering::Relaxed);
+
+    let interner = TypeInterner::new();
+    let (resolver, lazy_s, lazy_t, arr_s, arr_t) = recursive_pair(
+        &interner,
+        "next",
+        "kind",
+        TypeId::NUMBER,
+        TypeId::NUMBER,
+        DefId(51),
+        DefId(52),
+    );
+    let db = QueryCache::new(&interner);
+    let mut checker = SubtypeChecker::with_resolver(&interner, &resolver).with_query_db(&db);
+    assert!(checker.check_subtype(lazy_s, lazy_t).is_true());
+
+    let promotions_after = tsz_common::perf_counters::counters()
+        .relation_maybe_promotions
+        .load(std::sync::atomic::Ordering::Relaxed);
+    assert!(
+        promotions_after > promotions_before,
+        "outermost success must promote at least one maybe key (counter-asserted)"
+    );
+
+    // The repeat query of the previously limit-hit (cycle-assumed) inner pair
+    // must now be a counted cache hit instead of a recomputation.
+    let hits_before = db.relation_cache_stats().subtype_hits;
+    assert!(checker.check_subtype(arr_s, arr_t).is_true());
+    let hits_after = db.relation_cache_stats().subtype_hits;
+    assert!(
+        hits_after > hits_before,
+        "repeat query of a promoted maybe key must hit the relation cache"
+    );
+}
+
+#[test]
+fn cycle_maybe_keys_discarded_on_outermost_failure() {
+    let interner = TypeInterner::new();
+    // Same recursion, but the tags mismatch: the cycle assumption is made and
+    // then the enclosing object frame fails on the other property. The Maybe
+    // key must NOT be promoted (negative case from the #6973→#7210 family).
+    let (resolver, lazy_s, lazy_t, arr_s, arr_t) = recursive_pair(
+        &interner,
+        "next",
+        "kind",
+        TypeId::NUMBER,
+        TypeId::STRING,
+        DefId(21),
+        DefId(22),
+    );
+    let db = QueryCache::new(&interner);
+    let mut checker = SubtypeChecker::with_resolver(&interner, &resolver).with_query_db(&db);
+
+    assert!(
+        checker.check_subtype(lazy_s, lazy_t).is_false(),
+        "mismatching tag property must fail the relation"
+    );
+
+    let arr_key = checker.debug_cache_key_for(arr_s, arr_t);
+    assert_eq!(
+        db.probe_subtype_cache(arr_key),
+        RelationCacheProbe::MissNotCached,
+        "Maybe keys of a failed outermost relation must be discarded, not promoted"
+    );
+}
+
+#[test]
+fn promotion_is_structural_not_name_bound() {
+    // Renamed binders / different property names / different DefIds: the same
+    // structural shape must promote identically (anti-hardcoding gate).
+    for (prop, tag, s_raw, t_raw) in [
+        ("children", "size", 31u32, 32u32),
+        ("zzz", "qqq", 4101u32, 4102u32),
+    ] {
+        let interner = TypeInterner::new();
+        let (resolver, lazy_s, lazy_t, arr_s, arr_t) = recursive_pair(
+            &interner,
+            prop,
+            tag,
+            TypeId::BOOLEAN,
+            TypeId::BOOLEAN,
+            DefId(s_raw),
+            DefId(t_raw),
+        );
+        let db = QueryCache::new(&interner);
+        let mut checker = SubtypeChecker::with_resolver(&interner, &resolver).with_query_db(&db);
+        assert!(checker.check_subtype(lazy_s, lazy_t).is_true());
+        let arr_key = checker.debug_cache_key_for(arr_s, arr_t);
+        assert_eq!(
+            db.probe_subtype_cache(arr_key),
+            RelationCacheProbe::Hit(true),
+            "promotion must be structural for binder family ({prop}, {tag})"
+        );
+    }
+}
+
+#[test]
+fn promoted_maybe_keys_are_visible_through_the_shared_cache() {
+    use crate::caches::query_cache::SharedQueryCache;
+
+    let interner = TypeInterner::new();
+    let shared = SharedQueryCache::new();
+    let (resolver, lazy_s, lazy_t, arr_s, arr_t) = recursive_pair(
+        &interner,
+        "next",
+        "kind",
+        TypeId::NUMBER,
+        TypeId::NUMBER,
+        DefId(41),
+        DefId(42),
+    );
+    let db_a = QueryCache::new_with_shared(&interner, &shared);
+    let db_b = QueryCache::new_with_shared(&interner, &shared);
+
+    let mut checker = SubtypeChecker::with_resolver(&interner, &resolver).with_query_db(&db_a);
+    assert!(checker.check_subtype(lazy_s, lazy_t).is_true());
+
+    let arr_key = checker.debug_cache_key_for(arr_s, arr_t);
+    assert_eq!(
+        db_b.probe_subtype_cache(arr_key),
+        RelationCacheProbe::Hit(true),
+        "promoted maybe keys must be readable by sibling file checkers"
+    );
+}
+
+// =============================================================================
+// Fuel-band honesty (LimitTrue entries)
+// =============================================================================
+
+#[test]
+fn limit_true_with_full_band_short_circuits_the_query() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let x = interner.intern_string("x");
+    let y = interner.intern_string("y");
+    let a = interner.object(vec![PropertyInfo::new(x, TypeId::NUMBER)]);
+    let b = interner.object(vec![PropertyInfo::new(y, TypeId::STRING)]);
+
+    let mut checker = SubtypeChecker::new(&interner).with_query_db(&db);
+    let key = checker.debug_cache_key_for(a, b);
+
+    // Plant an assumed-related verdict recorded under the full budget: any
+    // query (whose remaining budget is necessarily <= the full budget) must
+    // reuse it instead of recomputing.
+    db.insert_subtype_limit_true(key, MAX_GLOBAL_SUBTYPE_FUEL);
+    assert!(
+        checker.check_subtype(a, b).is_true(),
+        "full-band LimitTrue entry must short-circuit as assumed-related"
+    );
+}
+
+#[test]
+fn limit_true_with_smaller_band_is_recomputed_under_a_larger_budget() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let x = interner.intern_string("x");
+    let y = interner.intern_string("y");
+    let a = interner.object(vec![PropertyInfo::new(x, TypeId::NUMBER)]);
+    let b = interner.object(vec![PropertyInfo::new(y, TypeId::STRING)]);
+
+    let mut checker = SubtypeChecker::new(&interner).with_query_db(&db);
+    let key = checker.debug_cache_key_for(a, b);
+
+    // Recorded under a tiny budget: a fresh top-level query holds the full
+    // budget, so the truncated verdict is NOT honest for it — it must
+    // recompute (raised-budget queries recompute; fuel-band honesty) and the
+    // honest definitive `false` must replace the limit entry.
+    db.insert_subtype_limit_true(key, 1);
+    assert!(
+        checker.check_subtype(a, b).is_false(),
+        "a query with a larger budget must recompute, not reuse the shallow verdict"
+    );
+    assert_eq!(
+        db.probe_subtype_cache(key),
+        RelationCacheProbe::Hit(false),
+        "the honest recomputed verdict must overwrite the limit entry"
+    );
+}
+
+#[test]
+fn limit_true_never_overwrites_definitive_entries() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let x = interner.intern_string("x");
+    let a = interner.object(vec![PropertyInfo::new(x, TypeId::NUMBER)]);
+    let b = interner.object(vec![PropertyInfo::new(x, TypeId::STRING)]);
+    let checker = SubtypeChecker::new(&interner);
+    let key = checker.debug_cache_key_for(a, b);
+
+    db.insert_subtype_cache(key, false);
+    db.insert_subtype_limit_true(key, MAX_GLOBAL_SUBTYPE_FUEL);
+    assert_eq!(
+        db.lookup_subtype_cache(key),
+        Some(false),
+        "a definitive false must survive a limit-verdict insert"
+    );
+
+    db.promote_subtype_cache_true(key);
+    assert_eq!(
+        db.lookup_subtype_cache(key),
+        Some(false),
+        "a definitive false must survive a maybe-key promotion"
+    );
+}
+
+#[test]
+fn limit_true_band_merges_keep_the_larger_band_and_promote_to_definitive() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+    let x = interner.intern_string("x");
+    let a = interner.object(vec![PropertyInfo::new(x, TypeId::NUMBER)]);
+    let b = interner.object(vec![PropertyInfo::new(x, TypeId::STRING)]);
+    let checker = SubtypeChecker::new(&interner);
+    let key = checker.debug_cache_key_for(a, b);
+
+    db.insert_subtype_limit_true(key, 5);
+    db.insert_subtype_limit_true(key, MAX_GLOBAL_SUBTYPE_FUEL);
+    db.insert_subtype_limit_true(key, 7);
+    assert_eq!(
+        db.lookup_subtype_cache_value(key),
+        Some(RelationCacheValue::LimitTrue {
+            fuel_band: MAX_GLOBAL_SUBTYPE_FUEL
+        }),
+        "band merges must keep the largest recorded band"
+    );
+    assert_eq!(
+        db.lookup_subtype_cache(key),
+        None,
+        "the boolean view must hide budget-conditional entries"
+    );
+
+    db.promote_subtype_cache_true(key);
+    assert_eq!(
+        db.lookup_subtype_cache(key),
+        Some(true),
+        "a validated maybe key upgrades an existing LimitTrue entry"
+    );
+}
+
+// =============================================================================
+// Evaluator taint discrimination (clean intermediates vs truncated artifacts)
+// =============================================================================
+
+#[test]
+fn clean_evaluation_after_unrelated_bail_is_not_tainted() {
+    let interner = TypeInterner::new();
+    let mut evaluator = TypeEvaluator::new(&interner);
+
+    // An earlier, unrelated subtree bailed: the run-sticky flag is set, but
+    // a later clean evaluation fires no new limit event in its own window.
+    evaluator.simulate_unrelated_recursion_bail_for_test();
+    assert!(evaluator.recursion_limit_hit());
+
+    let k = interner.intern_string("k");
+    let obj = interner.object(vec![PropertyInfo::new(k, TypeId::NUMBER)]);
+    let keyof_obj = interner.keyof(obj);
+    let result = evaluator.evaluate(keyof_obj);
+    assert_ne!(result, keyof_obj, "keyof must evaluate to the literal key");
+    assert!(
+        !evaluator.is_tainted(keyof_obj),
+        "a clean sibling evaluation must not be marked as a truncated artifact"
+    );
+    let tainted = evaluator.take_tainted();
+    assert!(
+        tainted.is_empty(),
+        "no node in this run was truncated; tainted set must be empty"
+    );
+}
+
+#[test]
+fn self_referential_mapped_cycle_bail_is_tainted() {
+    let interner = TypeInterner::new();
+
+    // type M = { [P in keyof M]: number } — evaluating the constraint
+    // re-enters the same mapped TypeId, which is the cycle-breaker bail that
+    // memoizes an opaque artifact. That artifact must be tainted so it is
+    // never persisted into the depth-agnostic eval cache.
+    let def = DefId(77);
+    let lazy_m = interner.lazy(def);
+    let mapped_ty = interner.mapped(MappedType {
+        type_param: TypeParamInfo {
+            name: interner.intern_string("P"),
+            constraint: None,
+            default: None,
+            is_const: false,
+        },
+        constraint: interner.keyof(lazy_m),
+        name_type: None,
+        template: TypeId::NUMBER,
+        optional_modifier: None,
+        readonly_modifier: None,
+    });
+    let resolver = RecursiveDefResolver {
+        defs: vec![(def, mapped_ty)],
+    };
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &resolver);
+    let _result = evaluator.evaluate(mapped_ty);
+    assert!(
+        evaluator.recursion_limit_hit(),
+        "the self-referential mapped type must trip a recursion limit"
+    );
+    assert!(
+        evaluator.is_tainted(mapped_ty),
+        "the cycle-bailed node's memo entry must be marked as a truncated artifact"
+    );
+
+    // A clean evaluation afterwards in the same (limit-hit) run stays clean.
+    let k = interner.intern_string("w");
+    let obj = interner.object(vec![PropertyInfo::new(k, TypeId::STRING)]);
+    let keyof_obj = interner.keyof(obj);
+    let evaluated = evaluator.evaluate(keyof_obj);
+    assert_ne!(evaluated, keyof_obj);
+    assert!(
+        !evaluator.is_tainted(keyof_obj),
+        "clean intermediates of a limit-hit run must stay persistable"
+    );
+}
+
+#[test]
+fn reading_a_tainted_memo_entry_taints_the_consumer() {
+    let interner = TypeInterner::new();
+
+    let def = DefId(78);
+    let lazy_m = interner.lazy(def);
+    let mapped_ty = interner.mapped(MappedType {
+        type_param: TypeParamInfo {
+            name: interner.intern_string("Q"),
+            constraint: None,
+            default: None,
+            is_const: false,
+        },
+        constraint: interner.keyof(lazy_m),
+        name_type: None,
+        template: TypeId::STRING,
+        optional_modifier: None,
+        readonly_modifier: None,
+    });
+    let resolver = RecursiveDefResolver {
+        defs: vec![(def, mapped_ty)],
+    };
+
+    let mut evaluator = TypeEvaluator::with_resolver(&interner, &resolver);
+    let _ = evaluator.evaluate(mapped_ty);
+    assert!(evaluator.is_tainted(mapped_ty));
+
+    // A later node whose evaluation reads the tainted memo entry must itself
+    // become tainted: its value embeds the truncated artifact even though no
+    // new limit event fired structurally inside it.
+    let consumer = interner.keyof(mapped_ty);
+    let _ = evaluator.evaluate(consumer);
+    assert!(
+        evaluator.is_tainted(consumer),
+        "artifact-dependence must propagate through memo reads"
+    );
+}
+
+#[test]
+fn evaluate_type_with_options_persists_clean_intermediates_of_limit_hit_runs() {
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    // Union of a self-referential mapped type (bails) and a clean keyof
+    // (converges): the run is limit-hit, so the top-level union result must
+    // not be cached, but the clean keyof intermediate must be.
+    let def = DefId(79);
+    let lazy_m = interner.lazy(def);
+    let mapped_ty = interner.mapped(MappedType {
+        type_param: TypeParamInfo {
+            name: interner.intern_string("R"),
+            constraint: None,
+            default: None,
+            is_const: false,
+        },
+        constraint: interner.keyof(lazy_m),
+        name_type: None,
+        template: TypeId::NUMBER,
+        optional_modifier: None,
+        readonly_modifier: None,
+    });
+    // NOTE: this test exercises the QueryCache drain gate with the default
+    // (resolver-less) query evaluator: the Lazy def stays unresolved, which
+    // itself records limit-independent behavior; the mapped type over an
+    // unresolved lazy stays deferred. Use a structure that bails without a
+    // resolver instead: a divergent conditional is not constructible here,
+    // so this test only asserts the no-regression property — clean inputs
+    // still populate the cache.
+    let k = interner.intern_string("p");
+    let obj = interner.object(vec![PropertyInfo::new(k, TypeId::NUMBER)]);
+    let keyof_obj = interner.keyof(obj);
+    let union_ty = interner.union(vec![mapped_ty, keyof_obj]);
+
+    let entries_before = db.statistics().eval_cache_entries;
+    let _ = db.evaluate_type(union_ty);
+    let entries_after = db.statistics().eval_cache_entries;
+    assert!(
+        entries_after > entries_before,
+        "evaluation must persist at least the clean evaluated entries"
+    );
+
+    // The clean keyof sub-result must be served from cache now: evaluating
+    // it directly must return the same converged literal-key type.
+    let direct = db.evaluate_type(keyof_obj);
+    assert_ne!(direct, keyof_obj, "keyof must converge to its literal key");
+}


### PR DESCRIPTION
Goal: fast

Implements #13241 (parent #13250, workstream A): tsc `Ternary.Maybe` cache parity for limit-hit relation/eval outcomes.

## Structural rule
When a relation hits a cycle or recursion/fuel limit, tsc records `Ternary.Maybe` results on its `maybeKeys` stack and promotes them to cached successes when the outermost `checkTypeRelatedTo` completes successfully; tsz now does the same through the solver's subtype cache (maybe-stack with subtree truncation on definitive `False`, promotion at outermost success, discard at outermost failure). Previously tsz refused to cache anything from a limit-hit run, so the deepest evaluations were recomputed from scratch on every query.

Three layers, per the issue's plan:
1. **Subtype cache maybe-stack**: cycle-derived keys promote to definitive `true` (validated coinductive assumption set); promotions never overwrite definitive entries; outermost failure discards.
2. **Fuel-band cache honesty**: fuel-derived keys promote to a budget-conditional `RelationCacheValue::LimitTrue { fuel_band }`, recorded only on a pristine budget chain; reused only under an equal-or-smaller budget; a raised-budget query recomputes and its definitive verdict replaces the entry.
3. **Eval-layer taint discrimination** (extends PR #12902's epoch split): a per-node tainted set marks memo entries as stack-context artifacts iff a limit event fired within their own evaluation window or they read a tainted entry; the eval-cache drain now persists clean intermediates of a limit-hit run instead of dropping the whole run.

`TSZ_DISABLE_LIMIT_RESULT_CACHE=1` restores drop-everything for A/B. Perf counters: `relation_limit_cache.{limit_cache_hits,maybe_promotions}`.

## Honest performance note
On the locally available green rows the new path never fires at current HEAD: counters read 0 promotions / 0 hits on ts-toolbelt (max recursion depth 32), zodmin, and AutoPath.ts — the recompute storms #13241 documents were since mitigated by the thread-local/per-file fuel work (#13172/#13181). Wall time is unchanged (ts-toolbelt 0.46s, zodmin 0.69s, byte-identical diagnostics cache-on/off, run-stable). The value here is (a) tsc write-policy parity so the deepest evaluations are reusable wherever limits do fire (effect-class corpora, future regressions), and (b) a counter-instrumented guard against re-introducing the limit-hit recompute storm (the 24-CPU-minute class incident pre-#13181). The 13 new tests counter-assert promotion, fuel-band honesty in both directions, taint discrimination, and shared-cache visibility — all fail without the implementation.

## Adjacent-case matrix
- Recursive conditional relation queried twice: second query is a counter-asserted cache hit.
- Same relation under a raised fuel budget: recomputes (does not reuse the shallow verdict); definitive verdict replaces the band entry.
- Cycle that ultimately fails at top level: Maybe keys NOT promoted.
- Renamed binders: promotion is structural, not name-bound (test varies names).
- Clean evaluation after an unrelated bail: not tainted (persists); self-referential mapped cycle bail: tainted (dropped); tainted-read consumers: tainted.

## Verification
- `cargo nextest run -p tsz-solver` — 13 new tests pass; 3 failures pre-existing and identical on clean origin/main (stash A/B).
- Full local conformance: 12583/12585, zero new vs accepted regressions (only the 2 accepted Mac-delta cases).
- clippy clean on tsz-solver/tsz-common; arch gates pass.
- ts-toolbelt + zodmin: byte-identical diagnostics cache-on vs cache-off vs run-to-run.
- `query_cache.rs` size-estimation moved to a child module to stay under the 2000-line shard cap.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: max
