### PR TITLE
fix(checker): reject foreign-arena lib-decl fallback pairs poisoning shared defs under parallel checking (#13255)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,6 +1469,7 @@ version = "0.1.23"
 dependencies = [
  "indexmap",
  "rustc-hash",
+ "tracing",
  "tsz-binder",
  "tsz-common",
  "tsz-parser",

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -322,7 +322,13 @@ impl<'a> CheckerState<'a> {
     /// This is the primary entry point for type checking after parsing and binding.
     /// It traverses the entire AST and performs all type checking operations.
     pub fn check_source_file(&mut self, root_idx: NodeIndex) {
-        let _span = span!(Level::INFO, "check_source_file", idx = ?root_idx).entered();
+        let _span = span!(
+            Level::INFO,
+            "check_source_file",
+            idx = ?root_idx,
+            file = %self.ctx.file_name
+        )
+        .entered();
         // Open a deterministic, per-file naming scope for inference placeholders
         // so any `__infer_*` witness that surfaces in a diagnostic is stable
         // across runs and across parallel file checks.

--- a/crates/tsz-checker/src/types/queries/lib_decls.rs
+++ b/crates/tsz-checker/src/types/queries/lib_decls.rs
@@ -1,6 +1,7 @@
 //! Declaration-arena helpers for lib symbols and global augmentations.
 
 use std::sync::Arc;
+use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::{NodeArena, NodeIndex};
 
 /// Resolve fallback arena for a lib symbol from merged binders/lib contexts.
@@ -76,7 +77,22 @@ pub(crate) fn collect_lib_decls_with_arenas_in_contexts<'a>(
                 let lib_decl_arenas =
                     collect_decl_arenas_from_lib_contexts(binder, sym_id, decl_idx, lib_contexts);
                 if lib_decl_arenas.is_empty() {
-                    vec![(decl_idx, fallback_arena)]
+                    // Blind fallback: `decl_idx` was never proven to belong to
+                    // `fallback_arena`. `NodeIndex`es are arena-local, so for a
+                    // cross-file program symbol the same index addresses an
+                    // unrelated node in this arena; lowering that node
+                    // manufactures a wrong type (empty interface bodies,
+                    // mis-typed members) that then leaks into the shared
+                    // `DefinitionStore` and poisons sibling checkers under
+                    // parallel fresh checking (issue #13255). Keep the pair
+                    // only when the node is a named declaration that actually
+                    // declares this symbol's name.
+                    if fallback_arena_node_declares_symbol(binder, sym_id, decl_idx, fallback_arena)
+                    {
+                        vec![(decl_idx, fallback_arena)]
+                    } else {
+                        Vec::new()
+                    }
                 } else {
                     lib_decl_arenas
                         .into_iter()
@@ -86,6 +102,48 @@ pub(crate) fn collect_lib_decls_with_arenas_in_contexts<'a>(
             }
         })
         .collect()
+}
+
+/// Whether the node at `decl_idx` in `arena` is a named declaration whose
+/// declared name equals the symbol's escaped name.
+///
+/// Used to validate the blind arena fallback in
+/// [`collect_lib_decls_with_arenas_in_contexts`]: a pair is only usable for
+/// name-driven lib lowering when the node provably declares the looked-up
+/// name. Unrecognized node kinds and name mismatches are rejected — they are
+/// foreign-arena index collisions, not declarations of this symbol.
+fn fallback_arena_node_declares_symbol(
+    binder: &tsz_binder::BinderState,
+    sym_id: tsz_binder::SymbolId,
+    decl_idx: NodeIndex,
+    arena: &NodeArena,
+) -> bool {
+    let Some(symbol) = binder.get_symbol(sym_id) else {
+        return false;
+    };
+    let Some(node) = arena.get(decl_idx) else {
+        return false;
+    };
+    let name_idx = if let Some(interface) = arena.get_interface(node) {
+        interface.name
+    } else if let Some(alias) = arena.get_type_alias(node) {
+        alias.name
+    } else if let Some(class) = arena.get_class(node) {
+        class.name
+    } else if let Some(function) = arena.get_function(node) {
+        function.name
+    } else if let Some(enum_decl) = arena.get_enum(node) {
+        enum_decl.name
+    } else if let Some(module) = arena.get_module(node) {
+        module.name
+    } else if let Some(variable) = arena.get_variable_declaration(node) {
+        variable.name
+    } else {
+        return false;
+    };
+    arena
+        .get_identifier_text(name_idx)
+        .is_some_and(|name| name == symbol.escaped_name)
 }
 
 fn collect_decl_arenas_from_lib_contexts<'a>(

--- a/crates/tsz-checker/src/types/queries/lib_decls.rs
+++ b/crates/tsz-checker/src/types/queries/lib_decls.rs
@@ -253,3 +253,147 @@ pub(crate) fn dedup_decl_arenas<'a>(
     }
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsz_binder::BinderState;
+    use tsz_parser::parser::ParserState;
+
+    fn parse_and_bind(file_name: &str, source: &str) -> (Arc<NodeArena>, BinderState) {
+        let mut parser = ParserState::new(file_name.to_string(), source.to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(parser.get_arena(), root);
+        (Arc::new(parser.get_arena().clone()), binder)
+    }
+
+    fn interface_decl(
+        binder: &BinderState,
+        name: &str,
+    ) -> (tsz_binder::SymbolId, NodeIndex, usize) {
+        let sym_id = binder
+            .file_locals
+            .get(name)
+            .unwrap_or_else(|| panic!("binder should expose {name}"));
+        let symbol = binder.get_symbol(sym_id).expect("symbol should resolve");
+        let decl_idx = *symbol
+            .declarations
+            .first()
+            .expect("symbol should have a declaration");
+        (sym_id, decl_idx, symbol.declarations.len())
+    }
+
+    /// A `(decl_idx, fallback_arena)` pair where the index addresses an
+    /// unrelated node in a foreign arena must be dropped, not lowered.
+    /// This was the issue #13255 poison: cross-file program symbols fell
+    /// back to an arena that never declared them, and the colliding node
+    /// produced a wrong type in the shared definition store.
+    #[test]
+    fn foreign_arena_collision_pair_is_rejected() {
+        let (_, owner_binder) = parse_and_bind(
+            "telemetry.ts",
+            "export interface TelemetryFrame { gimbalAxis: string; }\n",
+        );
+        let (sym_id, decl_idx, decl_count) = interface_decl(&owner_binder, "TelemetryFrame");
+        assert_eq!(decl_count, 1);
+
+        // A foreign arena large enough that `decl_idx` addresses *some*
+        // node — just never a declaration of `TelemetryFrame`.
+        let (foreign_arena, _) = parse_and_bind(
+            "unrelated.ts",
+            "const pad0 = 0;\nconst pad1 = 1;\nconst pad2 = 2;\nconst pad3 = 3;\n\
+             const pad4 = 4;\nconst pad5 = 5;\nconst pad6 = 6;\nconst pad7 = 7;\n",
+        );
+        assert!(
+            foreign_arena.get(decl_idx).is_some(),
+            "collision setup requires the index to resolve in the foreign arena"
+        );
+
+        let pairs = collect_lib_decls_with_arenas(
+            &owner_binder,
+            sym_id,
+            &[decl_idx],
+            foreign_arena.as_ref(),
+            None,
+        );
+        assert!(
+            pairs.is_empty(),
+            "foreign-arena collision pair must be rejected, got {} pair(s)",
+            pairs.len()
+        );
+    }
+
+    /// The fallback stays usable when the arena really declares the symbol:
+    /// the node at `decl_idx` is a named declaration with the symbol's name.
+    #[test]
+    fn owning_arena_fallback_pair_is_kept() {
+        let (owner_arena, owner_binder) = parse_and_bind(
+            "telemetry.ts",
+            "export interface ApogeeWindow { ascentRate: number; }\n",
+        );
+        let (sym_id, decl_idx, _) = interface_decl(&owner_binder, "ApogeeWindow");
+
+        let pairs = collect_lib_decls_with_arenas(
+            &owner_binder,
+            sym_id,
+            &[decl_idx],
+            owner_arena.as_ref(),
+            None,
+        );
+        assert_eq!(
+            pairs.len(),
+            1,
+            "fallback pair in the declaring arena must be kept"
+        );
+        assert_eq!(pairs[0].0, decl_idx);
+        assert!(std::ptr::eq(pairs[0].1, owner_arena.as_ref()));
+    }
+
+    /// Declarations without a plain identifier name (destructuring binding
+    /// patterns here) cannot pass the name check, but the binder-registered
+    /// home arena proves ownership, so the pair must survive.
+    #[test]
+    fn registered_home_arena_pair_is_trusted_without_name_match() {
+        let (owner_arena, mut owner_binder) = parse_and_bind(
+            "boom.ts",
+            "export const { boomArmSpan } = { boomArmSpan: 4 };\n",
+        );
+        let sym_id = owner_binder
+            .file_locals
+            .get("boomArmSpan")
+            .expect("binder should expose boomArmSpan");
+        let symbol = owner_binder
+            .get_symbol(sym_id)
+            .expect("symbol should resolve");
+        let decl_idx = *symbol
+            .declarations
+            .first()
+            .expect("symbol should have a declaration");
+        assert!(
+            !fallback_arena_node_declares_symbol(
+                &owner_binder,
+                sym_id,
+                decl_idx,
+                owner_arena.as_ref()
+            ),
+            "test setup requires a declaration the name check cannot prove"
+        );
+
+        let symbol_arenas = Arc::make_mut(&mut owner_binder.symbol_arenas);
+        symbol_arenas.insert(sym_id, Arc::clone(&owner_arena));
+
+        let pairs = collect_lib_decls_with_arenas(
+            &owner_binder,
+            sym_id,
+            &[decl_idx],
+            owner_arena.as_ref(),
+            None,
+        );
+        assert_eq!(
+            pairs.len(),
+            1,
+            "registered home-arena pair must be trusted even without a provable name"
+        );
+    }
+}

--- a/crates/tsz-checker/src/types/queries/lib_decls.rs
+++ b/crates/tsz-checker/src/types/queries/lib_decls.rs
@@ -85,12 +85,22 @@ pub(crate) fn collect_lib_decls_with_arenas_in_contexts<'a>(
                     // mis-typed members) that then leaks into the shared
                     // `DefinitionStore` and poisons sibling checkers under
                     // parallel fresh checking (issue #13255). Keep the pair
-                    // only when the node is a named declaration that actually
-                    // declares this symbol's name.
-                    if fallback_arena_node_declares_symbol(binder, sym_id, decl_idx, fallback_arena)
-                    {
+                    // only when ownership is provable: either the binder
+                    // registered `fallback_arena` as this symbol's home arena,
+                    // or the node is a named declaration that declares this
+                    // symbol's name.
+                    if fallback_arena_pair_is_trusted(binder, sym_id, decl_idx, fallback_arena) {
                         vec![(decl_idx, fallback_arena)]
                     } else {
+                        tracing::debug!(
+                            sym_id = ?sym_id,
+                            symbol = %binder
+                                .get_symbol(sym_id)
+                                .map(|s| s.escaped_name.as_str())
+                                .unwrap_or("<unknown>"),
+                            decl_idx = ?decl_idx,
+                            "rejecting foreign-arena lib-decl fallback pair"
+                        );
                         Vec::new()
                     }
                 } else {
@@ -102,6 +112,39 @@ pub(crate) fn collect_lib_decls_with_arenas_in_contexts<'a>(
             }
         })
         .collect()
+}
+
+/// Whether a `(decl_idx, fallback_arena)` pair produced by the last-resort
+/// fallback in [`collect_lib_decls_with_arenas_in_contexts`] provably belongs
+/// together.
+///
+/// Two independent proofs are accepted:
+/// - the binder registered `fallback_arena` as the symbol's home arena in
+///   `symbol_arenas` (covers declarations without a plain identifier name:
+///   binding patterns, default exports, `export =`); or
+/// - the node at `decl_idx` is a named declaration whose declared name equals
+///   the symbol's escaped name.
+///
+/// Pairs that satisfy neither are foreign-arena `NodeIndex` collisions, not
+/// declarations of this symbol, and lowering them manufactures wrong types
+/// (issue #13255).
+fn fallback_arena_pair_is_trusted(
+    binder: &tsz_binder::BinderState,
+    sym_id: tsz_binder::SymbolId,
+    decl_idx: NodeIndex,
+    arena: &NodeArena,
+) -> bool {
+    if arena.get(decl_idx).is_none() {
+        return false;
+    }
+    if binder
+        .symbol_arenas
+        .get(&sym_id)
+        .is_some_and(|home| std::ptr::eq(home.as_ref(), arena))
+    {
+        return true;
+    }
+    fallback_arena_node_declares_symbol(binder, sym_id, decl_idx, arena)
 }
 
 /// Whether the node at `decl_idx` in `arena` is a named declaration whose
@@ -141,8 +184,11 @@ fn fallback_arena_node_declares_symbol(
     } else {
         return false;
     };
+    // Plain identifier names first; string-literal names (e.g. ambient
+    // `declare module "name"`) resolve through literal text.
     arena
         .get_identifier_text(name_idx)
+        .or_else(|| arena.get_literal_text(name_idx))
         .is_some_and(|name| name == symbol.escaped_name)
 }
 

--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -88,6 +88,10 @@ name = "recursive_conditional_infer_termination_tests"
 path = "tests/recursive_conditional_infer_termination_tests.rs"
 
 [[test]]
+name = "parallel_sequential_agreement_tests"
+path = "tests/parallel_sequential_agreement_tests.rs"
+
+[[test]]
 name = "recursive_const_arrow_dts_emit_tests"
 path = "tests/recursive_const_arrow_dts_emit_tests.rs"
 

--- a/crates/tsz-cli/src/reporting/tracing_config.rs
+++ b/crates/tsz-cli/src/reporting/tracing_config.rs
@@ -104,7 +104,12 @@ pub fn init_tracing() {
             Registry::default().with(filter).with(tree_layer).init();
         }
         LogFormat::Json => {
-            let json_layer = fmt::layer().json().with_writer(std::io::stderr);
+            // Thread ids let parallel-check traces attribute events to the
+            // worker that produced them (schedule-sensitivity debugging).
+            let json_layer = fmt::layer()
+                .json()
+                .with_thread_ids(true)
+                .with_writer(std::io::stderr);
 
             Registry::default().with(filter).with(json_layer).init();
         }

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement/bridge.ts
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement/bridge.ts
@@ -1,0 +1,48 @@
+import { Sigil } from './primitives.js';
+import type { CustodyBatch } from './custody';
+import type { StewardContext, LedgerEnvelope, StewardMatrix } from './shapes';
+
+export interface StewardStore {
+  saveEnvelope(ctx: StewardContext, envelope: LedgerEnvelope): Promise<void>;
+  loadEnvelope(ctx: StewardContext, envelopeId: Sigil<string, 'LedgerEnvelopeId'>): Promise<LedgerEnvelope | null>;
+  loadMatrix(ctx: StewardContext): Promise<StewardMatrix | null>;
+  saveCustody(ctx: StewardContext, batch: CustodyBatch): Promise<void>;
+}
+
+export interface StewardMemoryState {
+  envelopes: Map<string, LedgerEnvelope>;
+  matrices: Map<string, StewardMatrix>;
+  custody: Map<string, CustodyBatch[]>;
+}
+
+export class InMemoryStewardStore implements StewardStore {
+  private readonly state: StewardMemoryState;
+
+  constructor() {
+    this.state = {
+      envelopes: new Map(),
+      matrices: new Map(),
+      custody: new Map(),
+    };
+  }
+
+  async saveEnvelope(ctx: StewardContext, envelope: LedgerEnvelope): Promise<void> {
+    this.state.envelopes.set(`${ctx.regionId}:${envelope.id}`, envelope);
+  }
+
+  async loadEnvelope(ctx: StewardContext, envelopeId: Sigil<string, 'LedgerEnvelopeId'>): Promise<LedgerEnvelope | null> {
+    return this.state.envelopes.get(`${ctx.regionId}:${envelopeId}`) ?? null;
+  }
+
+  async loadMatrix(ctx: StewardContext): Promise<StewardMatrix | null> {
+    return this.state.matrices.get(ctx.regionId) ?? null;
+  }
+
+  async saveCustody(ctx: StewardContext, batch: CustodyBatch): Promise<void> {
+    const key = `${ctx.regionId}:${ctx.domain}`;
+    const existing = this.state.custody.get(key) ?? [];
+    this.state.custody.set(key, [batch, ...existing]);
+  }
+}
+
+export const storeKey = (ctx: StewardContext): string => `${ctx.regionId}:${ctx.domain}:${ctx.region}`;

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement/cadence.ts
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement/cadence.ts
@@ -1,0 +1,125 @@
+import { Sigil, normalizeLimit } from './primitives.js';
+import type { LedgerProfile, LedgerWindow, SeverityBand } from './shapes';
+
+export interface CadenceBucket {
+  readonly band: SeverityBand;
+  readonly totalWindows: number;
+  readonly activeWindows: number;
+  readonly utilization: number;
+}
+
+export interface WindowRequest {
+  readonly profile: LedgerProfile;
+  readonly band: SeverityBand;
+  readonly requested: number;
+  readonly preferredStart: string;
+  readonly preferredEnd: string;
+}
+
+export interface WindowAllocation {
+  readonly windowId: LedgerWindow['id'];
+  readonly profileId: LedgerProfile['ledgerId'];
+  readonly band: SeverityBand;
+  readonly startAt: string;
+  readonly endAt: string;
+  readonly score: number;
+}
+
+const toNumber = (value: string): number => {
+  const parsed = Number.parseInt(value.replace(/[^0-9]/g, ''), 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export const estimateWindowUtilization = (window: LedgerWindow, request: WindowRequest): number => {
+  const start = toNumber(window.startsAt);
+  const end = toNumber(window.endsAt);
+  const prefStart = toNumber(request.preferredStart);
+  const prefEnd = toNumber(request.preferredEnd);
+  const span = Math.max(1, end - start);
+  const overlapStart = Math.max(start, prefStart);
+  const overlapEnd = Math.min(end, prefEnd);
+  const overlap = Math.max(0, overlapEnd - overlapStart);
+  const ratio = overlap / span;
+  const bandMultiplier = request.band === 'critical' ? 1.2 : request.band === 'high' ? 1 : 0.8;
+  return normalizeLimit(Math.round(ratio * 100 * bandMultiplier));
+};
+
+export const allocateWindow = (request: WindowRequest): WindowAllocation | null => {
+  const candidates = request.profile.windowsByBand[request.band] ?? [];
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const requestedWindows = candidates.slice(0, Math.max(1, Math.min(request.requested, candidates.length)));
+  const chosen = requestedWindows[0];
+  const window: LedgerWindow = {
+    id: String(chosen) as LedgerWindow['id'],
+    regionId: request.profile.regionId,
+    startsAt: request.preferredStart,
+    endsAt: request.preferredEnd,
+    openForAllBands: false,
+    allowedBands: ['low', 'medium', 'high', 'critical'],
+  };
+
+  const score = estimateWindowUtilization(window, request);
+  return {
+    windowId: window.id,
+    profileId: request.profile.ledgerId,
+    band: request.band,
+    startAt: window.startsAt,
+    endAt: window.endsAt,
+    score,
+  };
+};
+
+export const bucketByBand = (profiles: readonly LedgerProfile[], bands: readonly SeverityBand[]): CadenceBucket[] => {
+  const map: Record<SeverityBand, LedgerProfile[]> = {
+    low: [],
+    medium: [],
+    high: [],
+    critical: [],
+  };
+
+  for (const profile of profiles) {
+    for (const band of bands) {
+      const windows = profile.windowsByBand[band] ?? [];
+      map[band] = map[band].concat(Array(windows.length).fill(profile));
+    }
+  }
+
+  return Object.entries(map).map(([band, profileList]) => {
+    const total = profileList.length;
+    const activeWindows = profileList.filter((profile) => profile.state === 'active').length;
+    const utilization = total > 0 ? normalizeLimit((activeWindows / total) * 100) : 0;
+    return {
+      band: band as SeverityBand,
+      totalWindows: total,
+      activeWindows,
+      utilization,
+    };
+  });
+};
+
+export const buildCadence = (profiles: readonly LedgerProfile[]): readonly WindowAllocation[] => {
+  const bands: SeverityBand[] = ['low', 'medium', 'high', 'critical'];
+  const allocations: WindowAllocation[] = [];
+
+  for (const profile of profiles) {
+    for (const band of bands) {
+      const ids = profile.windowsByBand[band];
+      const request: WindowRequest = {
+        profile,
+        band,
+        requested: Math.max(1, Math.min(3, ids.length)),
+        preferredStart: new Date().toISOString(),
+        preferredEnd: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      };
+      const allocation = allocateWindow(request);
+      if (allocation) {
+        allocations.push(allocation);
+      }
+    }
+  }
+
+  return allocations;
+};

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement/custody.ts
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement/custody.ts
@@ -1,0 +1,116 @@
+import { Sigil, normalizeLimit, withSigil } from './primitives.js';
+import { CustodyClause, StewardRegionId, LedgerProfile, SeverityBand } from './shapes';
+
+export interface CustodyCheck {
+  readonly regionId: StewardRegionId;
+  readonly ledgerId: Sigil<string, 'LedgerId'>;
+  readonly clauseId: CustodyClause['id'];
+  readonly severity: SeverityBand;
+  readonly satisfied: boolean;
+  readonly score: number;
+  readonly findings: readonly string[];
+}
+
+export interface CustodyBatch {
+  readonly regionId: StewardRegionId;
+  readonly profile: LedgerProfile;
+  readonly checks: readonly CustodyCheck[];
+  readonly passed: number;
+  readonly failed: number;
+  readonly averageScore: number;
+}
+
+const computeScore = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  if (value < 0) {
+    return 0;
+  }
+  return Math.min(100, value);
+};
+
+const custodyClauseSatisfied = (clause: CustodyClause, signals: readonly number[]): boolean => {
+  const hasCriticalSignal = signals.some((value) => value > clause.maxRtoMinutes);
+  const hasAuditRisk = signals.some((value) => value > clause.maxRpoMinutes);
+  return !hasCriticalSignal && !hasAuditRisk;
+};
+
+export const evaluateCustody = (
+  regionId: StewardRegionId,
+  profile: LedgerProfile,
+  clauses: readonly CustodyClause[],
+  signalsByName: Record<string, readonly number[]>,
+): CustodyBatch => {
+  const checks: CustodyCheck[] = [];
+
+  for (const clause of clauses) {
+    const observed = signalsByName[clause.title] ?? [];
+    const satisfied = custodyClauseSatisfied(clause, observed);
+    const severityPenalty = clause.requiresEncryption ? 0 : 5;
+    const score = satisfied
+      ? 100 - severityPenalty
+      : computeScore(100 - normalizeLimit(observed.length) * 0.5 - severityPenalty);
+    const findings = clause.requiresEncryption
+      ? observed.length > 0
+        ? ['encryption requirement active']
+        : []
+      : ['rto/rpo tracked'];
+
+    checks.push({
+      regionId,
+      ledgerId: profile.ledgerId,
+      clauseId: clause.id,
+      severity: profile.maxCriticality <= 3 ? 'low' : profile.maxCriticality <= 4 ? 'medium' : 'critical',
+      satisfied,
+      score,
+      findings,
+    });
+  }
+
+  const passed = checks.filter((check) => check.satisfied).length;
+  const failed = checks.length - passed;
+  const total = checks.reduce((sum, check) => sum + check.score, 0);
+  const averageScore = checks.length > 0 ? computeScore(total / checks.length) : 0;
+
+  return {
+    regionId,
+    profile,
+    checks,
+    passed,
+    failed,
+    averageScore,
+  };
+};
+
+export const createCustodyEnvelope = (regionId: StewardRegionId): CustodyClause => ({
+  id: withSigil(`${regionId}:default-custody`, 'CustodyId'),
+  regionId,
+  region: 'global',
+  title: 'DR posture and audit baseline',
+  description: 'Recovery lab operations should maintain minimal restoration and recovery guarantees',
+  requiresEncryption: true,
+  maxRtoMinutes: 30,
+  maxRpoMinutes: 60,
+  lastAuditAt: new Date().toISOString(),
+});
+
+export const custodyTrend = (history: readonly CustodyBatch[]): readonly { readonly at: string; readonly score: number }[] => {
+  return history
+    .slice()
+    .sort((left, right) => left.regionId.localeCompare(right.regionId))
+    .map((entry, index) => ({
+      at: String(index),
+      score: entry.averageScore,
+    }));
+};
+
+export const custodyHealth = (batch: CustodyBatch): 'pass' | 'warn' | 'fail' => {
+  if (batch.averageScore >= 90 && batch.failed === 0) {
+    return 'pass';
+  }
+  if (batch.averageScore >= 70 && batch.failed < batch.checks.length / 2) {
+    return 'warn';
+  }
+  return 'fail';
+};

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement/edicts.ts
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement/edicts.ts
@@ -1,0 +1,122 @@
+import { clampLedgerRatio, LedgerEdict, LedgerProfile, SeverityBand } from './shapes';
+
+export type LedgerScope = LedgerEdict['scope'];
+
+export interface EdictContext {
+  readonly band: SeverityBand;
+  readonly activeSignals: number;
+  readonly criticalSignals: number;
+  readonly coverage: number;
+}
+
+export interface EdictEvaluation {
+  readonly edict: LedgerEdict;
+  readonly passed: boolean;
+  readonly score: number;
+  readonly reason: string;
+}
+
+export interface ProfileCoverage {
+  readonly ledgerId: LedgerProfile['ledgerId'];
+  readonly totalEdicts: number;
+  readonly passingEdicts: number;
+  readonly score: number;
+}
+
+const normalizePenalty = (penalty: number): number => {
+  if (!Number.isFinite(penalty)) {
+    return 1;
+  }
+  return Math.max(0, Math.min(5, penalty));
+};
+
+const evaluateCondition = (edict: LedgerEdict, context: EdictContext): boolean => {
+  if (!edict.enabled) {
+    return true;
+  }
+  if (edict.condition.includes('critical_signal')) {
+    return context.criticalSignals <= 1;
+  }
+  if (edict.condition.includes('coverage_gap')) {
+    return context.coverage >= 0.5;
+  }
+  if (edict.condition.includes('band=')) {
+    const target = edict.condition.split('band=')[1] as SeverityBand;
+    return target === context.band;
+  }
+  if (edict.condition.includes('signal>=')) {
+    const limit = Number(edict.condition.split('>=')[1]);
+    return context.activeSignals >= (Number.isFinite(limit) ? limit : 0);
+  }
+  return true;
+};
+
+export const evaluateLedgerEdict = (edict: LedgerEdict, context: EdictContext): EdictEvaluation => {
+  const passed = evaluateCondition(edict, context);
+  const weight = clampLedgerRatio(100 - normalizePenalty(edict.penaltyPoints));
+  const score = passed ? weight : -weight;
+  const reason = passed ? 'Edict satisfied' : `Edict violated: ${edict.condition}`;
+  return { edict, passed, score, reason };
+};
+
+export const evaluateLedgerProfile = (profile: LedgerProfile, context: EdictContext): ProfileCoverage => {
+  const evaluations = profile.edicts.map((edict) => evaluateLedgerEdict(edict, context));
+  const passingEdicts = evaluations.filter((entry) => entry.passed).length;
+  const maxScore = profile.edicts.length * 5;
+  const rawScore = evaluations.reduce((sum, entry) => sum + entry.score, 0);
+  const score = maxScore > 0 ? clampLedgerRatio((rawScore + maxScore) / 2) / 20 : 0;
+  return {
+    ledgerId: profile.ledgerId,
+    totalEdicts: profile.edicts.length,
+    passingEdicts,
+    score,
+  };
+};
+
+export const rankProfiles = (profiles: readonly LedgerProfile[], context: EdictContext): readonly { readonly ledgerId: LedgerProfile['ledgerId']; readonly score: number }[] => {
+  return profiles
+    .map((profile) => {
+      const evaluation = evaluateLedgerProfile(profile, context);
+      return {
+        ledgerId: profile.ledgerId,
+        score: evaluation.score,
+      };
+    })
+    .sort((left, right) => right.score - left.score);
+};
+
+export const summarizeEdicts = (edicts: readonly EdictEvaluation[]) => {
+  const passed = edicts.filter((entry) => entry.passed);
+  return {
+    total: edicts.length,
+    passed: passed.length,
+    failed: edicts.length - passed.length,
+    score: edicts.reduce((sum, entry) => sum + entry.score, 0),
+  };
+};
+
+export const findBlockingEdicts = (edicts: readonly EdictEvaluation[]) => {
+  return edicts
+    .filter((entry) => !entry.passed)
+    .map((entry) => ({
+      edictId: entry.edict.id,
+      reason: entry.reason,
+      penalty: entry.score,
+    }));
+};
+
+export const mergeEdictSummaries = (left: readonly EdictEvaluation[], right: readonly EdictEvaluation[]) => {
+  const byId = new Map<string, EdictEvaluation>();
+  for (const entry of [...left, ...right]) {
+    byId.set(entry.edict.id, entry);
+  }
+  return [...byId.values()];
+};
+
+export const buildEdictIndex = (edicts: readonly LedgerEdict[]): Readonly<Record<string, LedgerEdict>> => {
+  const map: Record<string, LedgerEdict> = {};
+  for (const edict of edicts) {
+    map[edict.id] = edict;
+  }
+  return map;
+};

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement/index.ts
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement/index.ts
@@ -1,0 +1,7 @@
+export * from './shapes';
+export * from './edicts';
+export * from './limits';
+export * from './custody';
+export * from './cadence';
+export * from './bridge';
+export * from './pipeline';

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement/limits.ts
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement/limits.ts
@@ -1,0 +1,96 @@
+import { Sigil, normalizeLimit } from './primitives.js';
+import type { StewardContext, StewardSignal, SeverityBand, ConstraintEnvelope } from './shapes';
+
+export type ConstraintState = 'met' | 'partial' | 'breached';
+
+export interface ConstraintDefinition {
+  readonly id: Sigil<string, 'ConstraintDefinitionId'>;
+  readonly scope: string;
+  readonly severity: SeverityBand;
+  readonly maxLatencyMs: number;
+  readonly maxCostBps: number;
+  readonly requiresWindow: boolean;
+}
+
+export interface ConstraintExecution {
+  readonly envelope: ConstraintEnvelope;
+  readonly state: ConstraintState;
+  readonly coverage: number;
+  readonly reasons: readonly string[];
+}
+
+const clamp = (value: number): number => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(100, value));
+};
+
+export const buildConstraint = (ctx: StewardContext, definition: ConstraintDefinition): ConstraintEnvelope => {
+  const resource = `region/${ctx.regionId}` as Sigil<string, 'ResourceId'>;
+  return {
+    id: `${ctx.regionId}:${definition.id}` as ConstraintEnvelope['id'],
+    regionId: ctx.regionId,
+    title: `Constraint for ${definition.scope}`,
+    required: [resource],
+    forbidden: [
+      ...(definition.requiresWindow ? ([`window:${ctx.timestamp}` as Sigil<string, 'ResourceId'>] as Sigil<string, 'ResourceId'>[]) : []),
+    ],
+    rationale: `${ctx.domain} controls for ${definition.scope}`,
+  };
+};
+
+export const evaluateConstraintEnvelope = (envelope: ConstraintEnvelope, signals: readonly StewardSignal[]): ConstraintExecution => {
+  const reasons: string[] = [];
+  const covered = envelope.required.filter((resource) => resource.length > 0).length;
+  const totalSignals = normalizeLimit(signals.length);
+  const coverage = totalSignals > 0 ? clamp((covered / Math.max(1, totalSignals)) * 100) : 0;
+
+  for (const signal of signals) {
+    if (signal.value > 95 && envelope.forbidden.includes(`region:${signal.metric}` as Sigil<string, 'ResourceId'>)) {
+      reasons.push(`forbidden metric observed ${signal.metric}`);
+    }
+    if (signal.tags.includes('regulatory-risk')) {
+      reasons.push(`risk tag flagged on ${signal.metric}`);
+    }
+  }
+
+  if (coverage < 20) {
+    reasons.push('low signal coverage against constraint envelope');
+  }
+
+  let state: ConstraintState = 'met';
+  if (reasons.length > 0) {
+    state = coverage < 60 ? 'breached' : 'partial';
+  }
+
+  return {
+    envelope,
+    state,
+    coverage,
+    reasons,
+  };
+};
+
+export const summarizeConstraintState = (executions: readonly ConstraintExecution[]) => {
+  const met = executions.filter((entry) => entry.state === 'met').length;
+  const partial = executions.filter((entry) => entry.state === 'partial').length;
+  const breached = executions.filter((entry) => entry.state === 'breached').length;
+
+  return {
+    total: executions.length,
+    met,
+    partial,
+    breached,
+    health: met === executions.length ? 'green' : breached > 0 ? 'red' : 'yellow',
+  };
+};
+
+export const normalizeConstraint = (signalCount: number, maxBreach: number): number => {
+  const safeSignal = normalizeLimit(signalCount);
+  const safeBreach = normalizeLimit(maxBreach);
+  if (safeBreach === 0) {
+    return 0;
+  }
+  return clamp(100 - (safeSignal / safeBreach) * 100);
+};

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement/pipeline.ts
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement/pipeline.ts
@@ -1,0 +1,225 @@
+import { Sigil, withSigil } from './primitives.js';
+import { evaluateCustody, createCustodyEnvelope } from './custody';
+import {
+  ConstraintEnvelope,
+  StewardContext,
+  StewardEvaluation,
+  StewardMatrix,
+  StewardSignal,
+  LedgerEnvelope,
+  LedgerProfile,
+  LedgerEdict,
+  LedgerWindow,
+  createStewardRunId,
+  SeverityBand,
+} from './shapes';
+import { evaluateConstraintEnvelope, summarizeConstraintState } from './limits';
+import { evaluateLedgerProfile, evaluateLedgerEdict, findBlockingEdicts, rankProfiles } from './edicts';
+import { InMemoryStewardStore, type StewardStore } from './bridge';
+
+export interface StewardEngineInput {
+  readonly context: StewardContext;
+  readonly profile: LedgerProfile;
+  readonly signals: readonly StewardSignal[];
+  readonly profileList: readonly LedgerProfile[];
+  readonly windows: readonly LedgerWindow[];
+  readonly edicts: readonly LedgerEdict[];
+}
+
+export type ReadinessSnapshot = {
+  readonly regionId: StewardContext['regionId'];
+  readonly readiness: number;
+  readonly ledgerCoverage: number;
+  readonly warning: string[];
+};
+
+type RankedLedger = {
+  readonly ledgerId: LedgerProfile['ledgerId'];
+  readonly score: number;
+};
+
+const computeReadiness = (coverage: number, warningCount: number): number => {
+  const base = Math.max(0, Math.min(100, coverage * 100));
+  return Math.max(0, base - warningCount * 5);
+};
+
+export const buildConstraintEnvelope = (ctx: StewardContext, profile: LedgerProfile, index: number): ConstraintEnvelope => {
+  return {
+    id: `${ctx.regionId}:constraint-${index}` as Sigil<string, 'ConstraintEnvelopeId'>,
+    regionId: ctx.regionId,
+    title: `Constraint for ${profile.name}`,
+    required: [String(profile.regionId) as Sigil<string, 'ResourceId'>],
+    forbidden: [],
+    rationale: `${ctx.domain} controls for ${profile.domain}`,
+  };
+};
+
+export const buildEnvelope = (ctx: StewardContext, profiles: readonly LedgerProfile[]): LedgerEnvelope => {
+  const activeProfiles = profiles.filter((profile) => profile.state === 'active');
+
+  return {
+    id: `${ctx.regionId}:envelope` as LedgerEnvelope['id'],
+    regionId: ctx.regionId,
+    title: `Ledger envelope for ${ctx.domain}`,
+    policies: [...activeProfiles],
+    windows: [...(ctx.state === 'active' ? [] : [])],
+    edicts: activeProfiles.flatMap((profile) => profile.edicts),
+    constraints: activeProfiles.map((profile, index) => buildConstraintEnvelope(ctx, profile, index)),
+    custodyClauses: activeProfiles.map((profile, index) =>
+      ({
+        ...createCustodyEnvelope(ctx.regionId),
+        title: `Clause for ${profile.name} #${index}`,
+        description: `${profile.name} custody tracking`,
+      }),
+    ),
+    createdAt: new Date().toISOString(),
+  };
+};
+
+export const evaluateStewardMatrix = (ctx: StewardContext, profiles: readonly LedgerProfile[]): StewardMatrix => {
+  const activeProfiles = profiles.filter((profile) => profile.state === 'active');
+  const envelope = buildEnvelope(ctx, profiles);
+
+  return {
+    regionId: ctx.regionId,
+    asOf: new Date().toISOString(),
+    profileCount: activeProfiles.length,
+    activeProfiles,
+    envelopes: [envelope],
+    custodyScore: activeProfiles.length === 0 ? 0 : Math.min(100, activeProfiles.length * 20),
+  };
+};
+
+export const evaluateSteward = (
+  input: StewardEngineInput,
+  store: StewardStore = new InMemoryStewardStore(),
+): ReadinessSnapshot => {
+  const matrix = evaluateStewardMatrix(input.context, input.profileList);
+  void store.loadMatrix(input.context);
+
+  const contextSignalsByMetric: Record<string, readonly number[]> = {};
+  for (const signal of input.signals) {
+    contextSignalsByMetric[signal.metric] = [
+      ...(contextSignalsByMetric[signal.metric] ?? []),
+      signal.value,
+    ];
+  }
+
+  const constraintStats = summarizeConstraintState(
+    matrix.envelopes.flatMap((envelope) =>
+      envelope.constraints.map((constraint) => evaluateConstraintEnvelope(constraint, input.signals)),
+    ),
+  );
+
+  const profileContext = {
+    band: 'critical' as SeverityBand,
+    activeSignals: input.signals.length,
+    criticalSignals: input.signals.filter((signal) => signal.severity === 'critical').length,
+    coverage: input.signals.length > 0 ? Math.min(1, input.signals.length / 10) : 0,
+  };
+
+  const rankedProfiles = rankProfiles(input.profileList, profileContext);
+  const ledgerCoverage = rankedProfiles.length > 0 ? rankedProfiles[0]?.score ?? 0 : 0;
+
+  const profileViolations = input.profileList.flatMap((profile) => {
+    const summary = evaluateLedgerProfile(profile, profileContext);
+    if (summary.passingEdicts === summary.totalEdicts) {
+      return [];
+    }
+
+    return profile.edicts.map((edict) => evaluateLedgerEdict(edict, profileContext));
+  });
+
+  const blockingEdicts = findBlockingEdicts(profileViolations);
+  const custody = evaluateCustody(
+    input.context.regionId,
+    input.profile,
+    matrix.envelopes.flatMap((envelope) => envelope.custodyClauses),
+    contextSignalsByMetric,
+  );
+
+  const readiness = computeReadiness(ledgerCoverage, blockingEdicts.length + constraintStats.breached);
+
+  const evaluation: StewardEvaluation = {
+    regionId: input.context.regionId,
+    runId: createStewardRunId(`${input.context.regionId}:run`),
+    ledgerCoverage,
+    warningCount: blockingEdicts.length,
+    criticalCount: constraintStats.breached,
+    readinessScore: readiness,
+    ledgerSignals: profileViolations.map((entry) => ({
+      edictId: entry.edict.id,
+      fired: !entry.passed,
+      weight: Math.abs(entry.score),
+    })),
+    windowCustody: false,
+  };
+
+  void store.saveCustody(input.context, custody);
+  void store.saveEnvelope(input.context, matrix.envelopes[0]);
+
+  const warnings = [
+    `custody:${custodyHealth(custody)}`,
+    `matrices:${matrix.envelopes.length}`,
+    `signals:${input.signals.length}`,
+    `edicts:${profileViolations.length}`,
+    `blocking-edicts:${blockingEdicts.length}`,
+  ];
+
+  return {
+    regionId: input.context.regionId,
+    readiness,
+    ledgerCoverage,
+    warning: [...warnings, ...evaluation.ledgerSignals.map((signal) => `${String(signal.edictId)}:${signal.fired ? 'blocked' : 'ok'}`)],
+  };
+};
+
+export const buildReadinessEnvelope = (ctx: StewardContext): LedgerEnvelope => {
+  const profile: LedgerProfile = {
+    ledgerId: withSigil(`${ctx.regionId}-base`, 'LedgerId'),
+    regionId: ctx.regionId,
+    name: 'Base ledger profile',
+    domain: ctx.domain,
+    state: ctx.state,
+    maxConcurrent: 3,
+    maxCriticality: 4,
+    windowsByBand: {
+      low: [],
+      medium: [],
+      high: [],
+      critical: [],
+    },
+    edicts: [],
+  };
+
+  return {
+    id: `${ctx.regionId}:readiness` as LedgerEnvelope['id'],
+    regionId: ctx.regionId,
+    title: 'readiness envelope',
+    policies: [profile],
+    windows: [],
+    edicts: [],
+    constraints: [],
+    custodyClauses: [],
+    createdAt: new Date().toISOString(),
+  };
+};
+
+export const topRankedPolicies = (profiles: readonly LedgerProfile[]): RankedLedger[] => {
+  return profiles
+    .map((profile, index) => ({
+      ledgerId: profile.ledgerId,
+      score: 100 - index,
+    }))
+    .sort((left, right) => right.score - left.score);
+};
+
+const custodyHealth = (batch: ReturnType<typeof evaluateCustody>): 'pass' | 'warn' | 'fail' => {
+  if (batch.averageScore >= 80) {
+    return 'pass';
+  }
+  if (batch.averageScore >= 50 && batch.failed < batch.checks.length / 2) {
+    return 'warn';
+  }
+  return 'fail';
+};

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement/primitives.ts
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement/primitives.ts
@@ -1,0 +1,134 @@
+export type Sigil<T, B extends string> = T & { readonly __sigil: B };
+
+const limitBounds = {
+  fallback: 50,
+  min: 1,
+  max: 5000,
+} as const satisfies Record<'fallback' | 'min' | 'max', number>;
+
+export type ReadonlyDeep<T> =
+  T extends (...args: any[]) => any ? T :
+  T extends Array<infer U> ? ReadonlyArray<ReadonlyDeep<U>> :
+  T extends object ? { readonly [K in keyof T]: ReadonlyDeep<T[K]> } :
+  T;
+
+export type OptionalKeys<T> = {
+  [K in keyof T]-?: undefined extends T[K] ? K : never
+}[keyof T];
+
+export type RequiredKeys<T> = Exclude<keyof T, OptionalKeys<T>>;
+
+export type DeepPartial<T> = T extends Function
+  ? T
+  : T extends Array<infer U>
+    ? Array<DeepPartial<U>>
+    : T extends object
+      ? { [K in keyof T]?: DeepPartial<T[K]> }
+      : T;
+
+export type Replace<T, K extends keyof T, V> = Omit<T, K> & { [P in K]: V };
+
+export type Expand<T> = T extends infer O ? { [K in keyof O]: O[K] } : never;
+
+export interface WithId {
+  id: Sigil<string, "EntityId">;
+}
+
+export interface WithTrace {
+  traceId: Sigil<string, "TraceId">;
+  spanId: Sigil<string, "SpanId">;
+  requestId: Sigil<string, "RequestId">;
+}
+
+export type NodeId = Sigil<string, "NodeId">;
+export type EdgeId = Sigil<string, "EdgeId">;
+
+export interface Edge<T extends NodeId = NodeId, W = unknown> {
+  from: T;
+  to: T;
+  weight: number;
+  payload?: W;
+}
+
+export interface Graph<N extends NodeId = NodeId, E = unknown> {
+  nodes: readonly N[];
+  edges: readonly Edge<N, E>[];
+}
+
+export type MaybePromise<T> = T | Promise<T>;
+
+export type ResultState<T, E> = { ok: true; value: T } | { ok: false; error: E };
+
+export type TupleOf<T, N extends number, A extends T[] = []> =
+  A['length'] extends N ? A : TupleOf<T, N, [...A, T]>;
+
+export type NonEmpty<T extends readonly unknown[]> = T extends [infer H, ...infer R] ? [H, ...R] : never;
+
+export type Merge<A, B> = Omit<A, keyof B> & B;
+
+export type Flatten<T> = T extends readonly [infer A, ...infer R]
+  ? A | Flatten<R>
+  : never;
+
+export type RecursivePath<T> =
+  T extends object
+    ? {
+        [K in keyof T]: K extends string
+          ? T[K] extends object
+            ? K | `${K}.${RecursivePath<T[K]>}`
+            : K
+          : never
+      }[keyof T]
+    : never;
+
+export interface PageArgs {
+  limit: number;
+  cursor?: string;
+}
+
+export interface PageResult<T> {
+  items: T[];
+  nextCursor?: string;
+  hasMore: boolean;
+}
+
+export type CursorPage<T> = {
+  items: T[];
+  cursor: string;
+  total: number;
+};
+
+export function withSigil<T extends string, B extends string>(value: T, _sigil: B): Sigil<T, B> {
+  return value as Sigil<T, B>;
+}
+
+export function asReadonly<T>(value: T): ReadonlyDeep<T> {
+  return value as ReadonlyDeep<T>;
+}
+
+export type EnsureArray<T> = T extends readonly any[] ? T : T[];
+
+export function normalizeLimit(limit?: number): number {
+  if (typeof limit !== 'number' || !Number.isFinite(limit)) return limitBounds.fallback;
+  if (limit <= 0) return limitBounds.min;
+  if (limit > limitBounds.max) return limitBounds.max;
+  return Math.floor(limit);
+}
+
+export function isNil(value: unknown): value is null | undefined {
+  return value === null || value === undefined;
+}
+
+export type PromiseResult<T> = Promise<ResultState<T, Error>>;
+
+export function tuple<const T extends readonly unknown[]>(...values: T): T {
+  return values;
+}
+
+export async function toResult<T>(work: () => Promise<T>): Promise<ResultState<T, Error>> {
+  try {
+    return { ok: true, value: await work() };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
+  }
+}

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement/shapes.ts
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement/shapes.ts
@@ -1,0 +1,158 @@
+import { Sigil, normalizeLimit, withSigil } from './primitives.js';
+
+export type StewardRegionId = Sigil<string, 'StewardRegionId'>;
+export type StewardRunId = Sigil<string, 'StewardRunId'>;
+export type LedgerId = Sigil<string, 'LedgerId'>;
+export type EdictId = Sigil<string, 'EdictId'>;
+export type CustodyId = Sigil<string, 'CustodyId'>;
+
+export const severityBands = ['low', 'medium', 'high', 'critical'] as const;
+export type SeverityBand = (typeof severityBands)[number];
+
+export const domainStates = ['inactive', 'draft', 'active', 'paused', 'retired'] as const;
+export type StewardDomainState = (typeof domainStates)[number];
+
+export interface StewardContext {
+  readonly regionId: StewardRegionId;
+  readonly timestamp: string;
+  readonly domain: string;
+  readonly region: string;
+  readonly state: StewardDomainState;
+}
+
+export interface StewardSignal {
+  readonly id: Sigil<string, 'StewardSignalId'>;
+  readonly metric: string;
+  readonly severity: SeverityBand;
+  readonly value: number;
+  readonly tags: readonly string[];
+  readonly observedAt: string;
+}
+
+export interface LedgerWindow {
+  readonly id: Sigil<string, 'LedgerWindowId'>;
+  readonly regionId: StewardRegionId;
+  readonly startsAt: string;
+  readonly endsAt: string;
+  readonly openForAllBands: boolean;
+  readonly allowedBands: readonly SeverityBand[];
+}
+
+export interface LedgerEdict<TScope extends string = 'global'> {
+  readonly id: EdictId;
+  readonly regionId: StewardRegionId;
+  readonly ledgerId: LedgerId;
+  readonly scope: TScope;
+  readonly code: string;
+  readonly condition: string;
+  readonly penaltyPoints: number;
+  readonly enabled: boolean;
+  readonly createdAt: string;
+}
+
+export interface CustodyClause {
+  readonly id: CustodyId;
+  readonly regionId: StewardRegionId;
+  readonly region: string;
+  readonly title: string;
+  readonly description: string;
+  readonly requiresEncryption: boolean;
+  readonly maxRtoMinutes: number;
+  readonly maxRpoMinutes: number;
+  readonly lastAuditAt: string;
+}
+
+export interface ConstraintEnvelope {
+  readonly id: Sigil<string, 'ConstraintEnvelopeId'>;
+  readonly regionId: StewardRegionId;
+  readonly title: string;
+  readonly required: readonly Sigil<string, 'ResourceId'>[];
+  readonly forbidden: readonly Sigil<string, 'ResourceId'>[];
+  readonly rationale: string;
+}
+
+export interface StewardEvaluation {
+  readonly regionId: StewardRegionId;
+  readonly runId: StewardRunId;
+  readonly ledgerCoverage: number;
+  readonly warningCount: number;
+  readonly criticalCount: number;
+  readonly readinessScore: number;
+  readonly ledgerSignals: readonly { readonly edictId: EdictId; readonly fired: boolean; readonly weight: number }[];
+  readonly windowCustody: boolean;
+}
+
+export interface LedgerEnvelope {
+  readonly id: Sigil<string, 'LedgerEnvelopeId'>;
+  readonly regionId: StewardRegionId;
+  readonly title: string;
+  readonly policies: readonly LedgerProfile[];
+  readonly windows: readonly LedgerWindow[];
+  readonly edicts: readonly LedgerEdict[];
+  readonly constraints: readonly ConstraintEnvelope[];
+  readonly custodyClauses: readonly CustodyClause[];
+  readonly createdAt: string;
+}
+
+export interface LedgerProfile {
+  readonly ledgerId: LedgerId;
+  readonly regionId: StewardRegionId;
+  readonly name: string;
+  readonly domain: string;
+  readonly state: StewardDomainState;
+  readonly maxConcurrent: number;
+  readonly maxCriticality: number;
+  readonly windowsByBand: Record<SeverityBand, readonly LedgerWindow['id'][]>;
+  readonly edicts: readonly LedgerEdict[];
+}
+
+export interface RankedLedger {
+  readonly ledgerId: LedgerId;
+  readonly score: number;
+  readonly band: SeverityBand;
+}
+
+export interface StewardMatrix {
+  readonly regionId: StewardRegionId;
+  readonly asOf: string;
+  readonly profileCount: number;
+  readonly activeProfiles: readonly LedgerProfile[];
+  readonly envelopes: readonly LedgerEnvelope[];
+  readonly custodyScore: number;
+}
+
+export const createStewardRegionId = (value: string): StewardRegionId => withSigil(String(value).trim(), 'StewardRegionId');
+export const createLedgerId = (value: string): LedgerId => withSigil(String(value).trim(), 'LedgerId');
+export const createEdictId = (value: string): EdictId => withSigil(String(value).trim(), 'EdictId');
+export const createStewardRunId = (value: string): StewardRunId => withSigil(String(value).trim(), 'StewardRunId');
+export const clampLedgerRatio = (value: number): number => normalizeLimit(value);
+export const buildLedgerMap = <T extends { readonly id: string }>(values: readonly T[]): Record<string, T> => {
+  const map: Record<string, T> = {};
+  for (const value of values) {
+    map[value.id] = value;
+  }
+  return map;
+};
+
+export type OptionalBandRecord<T> = Partial<Record<SeverityBand, T>>;
+export type BandBuckets<T> = {
+  readonly low: readonly T[];
+  readonly medium: readonly T[];
+  readonly high: readonly T[];
+  readonly critical: readonly T[];
+};
+
+export const normalizeSeverityBands = (bands: readonly SeverityBand[]): readonly SeverityBand[] => {
+  const normalized = new Set<SeverityBand>();
+  for (const band of bands) {
+    normalized.add(band);
+  }
+  return Array.from(normalized);
+};
+
+export const pickTopSignals = (signals: readonly StewardSignal[], limit: number): readonly StewardSignal[] => {
+  const target = normalizeLimit(limit);
+  return [...signals]
+    .sort((left, right) => right.value - left.value)
+    .slice(0, target);
+};

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement/tsconfig.json
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/crates/tsz-cli/tests/parallel_sequential_agreement_tests.rs
+++ b/crates/tsz-cli/tests/parallel_sequential_agreement_tests.rs
@@ -10,7 +10,7 @@
 //! schedule-dependent, so the same project produced different diagnostics
 //! run to run (false TS2339/TS2344 storms).
 //!
-//! This test drives the real binary over a 9-file NodeNext project distilled
+//! This test drives the real binary over a 9-file `NodeNext` project distilled
 //! from the issue witness (binders renamed) and asserts forced-parallel runs
 //! are byte-identical to the sequential run. Before the lib-decl fallback
 //! validation this failed deterministically: the parallel output disagreed

--- a/crates/tsz-cli/tests/parallel_sequential_agreement_tests.rs
+++ b/crates/tsz-cli/tests/parallel_sequential_agreement_tests.rs
@@ -1,0 +1,142 @@
+//! Parallel-vs-sequential diagnostic agreement (issue #13255).
+//!
+//! Fresh per-file checkers share one `DefinitionStore`. A cross-file program
+//! symbol whose declaration could not be attributed to an arena used to fall
+//! back to an arbitrary arena (`lib_decls.rs`); the arena-local `NodeIndex`
+//! then addressed an unrelated node there, and lowering that foreign node
+//! published a wrong def body (empty interface shapes, mis-typed members)
+//! that poisoned sibling checkers. Under the default sequential path the
+//! poison was deterministic; under parallel fresh checking it was
+//! schedule-dependent, so the same project produced different diagnostics
+//! run to run (false TS2339/TS2344 storms).
+//!
+//! This test drives the real binary over a 9-file NodeNext project distilled
+//! from the issue witness (binders renamed) and asserts forced-parallel runs
+//! are byte-identical to the sequential run. Before the lib-decl fallback
+//! validation this failed deterministically: the parallel output disagreed
+//! with the sequential output on elaboration identity and carried extra
+//! false diagnostics.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(name: &str) -> std::io::Result<Self> {
+        let mut path = std::env::temp_dir();
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        path.push(format!("tsz_parallel_agreement_{name}_{nanos}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+const FIXTURE_FILES: &[(&str, &str)] = &[
+    (
+        "src/bridge.ts",
+        include_str!("fixtures/parallel_agreement/bridge.ts"),
+    ),
+    (
+        "src/cadence.ts",
+        include_str!("fixtures/parallel_agreement/cadence.ts"),
+    ),
+    (
+        "src/custody.ts",
+        include_str!("fixtures/parallel_agreement/custody.ts"),
+    ),
+    (
+        "src/edicts.ts",
+        include_str!("fixtures/parallel_agreement/edicts.ts"),
+    ),
+    (
+        "src/index.ts",
+        include_str!("fixtures/parallel_agreement/index.ts"),
+    ),
+    (
+        "src/limits.ts",
+        include_str!("fixtures/parallel_agreement/limits.ts"),
+    ),
+    (
+        "src/pipeline.ts",
+        include_str!("fixtures/parallel_agreement/pipeline.ts"),
+    ),
+    (
+        "src/primitives.ts",
+        include_str!("fixtures/parallel_agreement/primitives.ts"),
+    ),
+    (
+        "src/shapes.ts",
+        include_str!("fixtures/parallel_agreement/shapes.ts"),
+    ),
+];
+
+const FIXTURE_TSCONFIG: &str = include_str!("fixtures/parallel_agreement/tsconfig.json");
+
+fn run_project(tsz_bin: &Path, project_dir: &Path, force_parallel: bool) -> String {
+    let mut cmd = Command::new(tsz_bin);
+    cmd.args(["-p", "tsconfig.json", "--pretty", "false"])
+        .current_dir(project_dir);
+    if force_parallel {
+        cmd.env("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK", "1");
+    } else {
+        cmd.env_remove("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK");
+    }
+    let output = cmd.output().expect("run tsz on agreement fixture");
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// Forced-parallel fresh checking must produce byte-identical diagnostics to
+/// the default sequential path on a generic-heavy multi-file project.
+#[test]
+fn forced_parallel_diagnostics_match_sequential() {
+    let Some(tsz_bin) = find_tsz_binary() else {
+        println!("skipping parallel agreement test: tsz binary not found");
+        return;
+    };
+    let temp = TempDir::new("witness").expect("temp dir");
+    std::fs::create_dir_all(temp.path.join("src")).expect("src dir");
+    for (rel, contents) in FIXTURE_FILES {
+        std::fs::write(temp.path.join(rel), contents).expect("write fixture file");
+    }
+    std::fs::write(temp.path.join("tsconfig.json"), FIXTURE_TSCONFIG).expect("write tsconfig");
+
+    let sequential = run_project(&tsz_bin, &temp.path, false);
+    assert!(
+        !sequential.is_empty() || run_project(&tsz_bin, &temp.path, false) == sequential,
+        "sequential run should be reproducible"
+    );
+
+    for attempt in 0..3 {
+        let parallel = run_project(&tsz_bin, &temp.path, true);
+        assert_eq!(
+            parallel, sequential,
+            "forced-parallel diagnostics diverged from sequential on attempt {attempt}"
+        );
+    }
+}

--- a/crates/tsz-lowering/Cargo.toml
+++ b/crates/tsz-lowering/Cargo.toml
@@ -12,6 +12,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+tracing = { workspace = true }
 tsz-common = { workspace = true }
 tsz-scanner = { workspace = true }
 tsz-parser = { workspace = true }

--- a/crates/tsz-lowering/src/lower/core.rs
+++ b/crates/tsz-lowering/src/lower/core.rs
@@ -585,6 +585,7 @@ impl<'a> TypeLowering<'a> {
         let mut parts = ObjectTypeParts::new();
         let mut type_params_collected = false;
         let mut collected_params = Vec::new();
+        let mut lowered_interface_decls = 0usize;
 
         let is_lib_decl = |arena: &NodeArena, idx: NodeIndex| {
             let mut current = idx;
@@ -636,6 +637,7 @@ impl<'a> TypeLowering<'a> {
             let Some(interface) = decl_arena.get_interface(node) else {
                 continue;
             };
+            lowered_interface_decls += 1;
 
             // Collect or merge type parameters from this declaration
             if let Some(params) = &interface.type_parameters
@@ -659,6 +661,21 @@ impl<'a> TypeLowering<'a> {
 
             // Collect members using the arena-specific lowerer
             lowerer.collect_object_type_members(&interface.members, &mut parts);
+        }
+
+        // No declaration actually lowered as an interface: every pair either
+        // pointed at a missing node or at a non-interface node (foreign-arena
+        // `NodeIndex` collisions). Synthesizing an empty object here would
+        // manufacture a memberless body for a real interface — that body then
+        // leaks into shared definition state and produces false "property
+        // does not exist" diagnostics (issue #13255). A genuinely empty
+        // `interface Empty {}` still lowers normally: its declaration parses
+        // as an interface and increments the counter.
+        if lowered_interface_decls == 0 {
+            if type_params_collected {
+                self.pop_type_param_scope();
+            }
+            return (TypeId::ERROR, collected_params);
         }
 
         // Assign declaration_order in FORWARD declaration order for diagnostics.

--- a/crates/tsz-lowering/src/lower/core.rs
+++ b/crates/tsz-lowering/src/lower/core.rs
@@ -672,6 +672,11 @@ impl<'a> TypeLowering<'a> {
         // `interface Empty {}` still lowers normally: its declaration parses
         // as an interface and increments the counter.
         if lowered_interface_decls == 0 {
+            tracing::debug!(
+                num_declarations,
+                symbol_id = ?symbol_id,
+                "no merged interface declaration lowered; returning error type"
+            );
             if type_params_collected {
                 self.pop_type_param_scope();
             }

--- a/crates/tsz-solver/src/def/publication_census.rs
+++ b/crates/tsz-solver/src/def/publication_census.rs
@@ -102,8 +102,9 @@ struct DefCensus {
     file_id: Option<u32>,
     publications: u64,
     different_body: u64,
-    /// Distinct body `TypeId`s observed (deduped, capped).
-    bodies: Vec<TypeId>,
+    /// Distinct body `TypeId`s observed (deduped, capped), each with the
+    /// call site that first published that form.
+    bodies: Vec<(TypeId, &'static str, u32)>,
     /// True once the distinct-body list overflowed [`MAX_TRACKED_BODIES`].
     bodies_overflowed: bool,
 }
@@ -181,9 +182,9 @@ pub fn record_publication(
     if outcome.is_different_body() {
         entry.different_body += 1;
     }
-    if !entry.bodies.contains(&new_body) {
+    if !entry.bodies.iter().any(|(body, _, _)| *body == new_body) {
         if entry.bodies.len() < MAX_TRACKED_BODIES {
-            entry.bodies.push(new_body);
+            entry.bodies.push((new_body, caller.file(), caller.line()));
         } else {
             entry.bodies_overflowed = true;
         }
@@ -404,10 +405,13 @@ pub fn dump_to_string(
             census.bodies.len(),
             if census.bodies_overflowed { "+" } else { "" },
         ));
-        for body in &census.bodies {
+        for (body, caller_file, caller_line) in &census.bodies {
             let desc = describe_type(*body);
             let desc: String = desc.chars().take(400).collect();
-            body_details.push_str(&format!("    {} = {desc}\n", body.0));
+            body_details.push_str(&format!(
+                "    {} = {desc}\n        first published by {caller_file}:{caller_line}\n",
+                body.0
+            ));
         }
     }
     for (def_id, census) in defs.into_iter().take(60) {


### PR DESCRIPTION
Goal: green

Fixes the deterministic half of #13255 (parallel-vs-sequential check nondeterminism): foreign-arena `NodeIndex` collisions poisoning the shared definition state.

## Structural rule
When a symbol's declaration cannot be attributed to an owning arena, tsc cannot misattribute it — its declarations are node pointers that know their source file; tsz must not guess. The last-resort `(decl_idx, fallback_arena)` pair in `collect_lib_decls_with_arenas_in_contexts` (`crates/tsz-checker/src/types/queries/lib_decls.rs`) is now kept only when ownership is provable: the binder registered the arena as the symbol's home in `symbol_arenas`, or the node is a named declaration (identifier or string-literal name) of the symbol's name. `NodeIndex` is arena-local — an unproven pair addresses an unrelated node in a foreign arena, and lowering it manufactures a wrong type (empty interface bodies) that leaks into the shared `DefinitionStore` and produces false TS2339 in sibling checkers.

Second half, in lowering (`crates/tsz-lowering/src/lower/core.rs`): when zero pairs actually lower as interface declarations, return `TypeId::ERROR` instead of synthesizing a memberless body — tsc's analogue of failed declaration resolution is errorType, never a fabricated empty shape. A genuine `interface Empty {}` still lowers normally.

## Witness evidence
- 9-file #13255 witness: pre-fix sequential had 6 false positives (tsc reports 0) and forced-parallel gave 4 distinct outputs in 5 runs incl. false `TS2339 'policyId' does not exist on 'PolicyProfile'`; post-fix **11/11 runs byte-identical** (1 sequential + 10 forced-parallel) and sequential false positives drop 6 → 2 (the remaining 2 are a separate generic-instantiation family, now schedule-stable).
- In-repo flapping variant (recovery-lab-governance, large-ts-repo): 6/6 byte-identical.
- monorepo-005 (5,202-file scale-cliff barrel fixture): 4/4 byte-identical forced-parallel vs sequential, matching the documented baseline.
- Fallback archaeology: the blind fallback dates to `a7ba0892d1` / extracted by #2717; it was always blind, and all six call sites tolerate an empty pair list (fall through to correct cross-arena resolution) — validate-don't-remove is the right shape.

## Adjacent-case matrix
- Foreign-arena collision pair rejected; declaring-arena fallback kept; binder-registered home-arena pair trusted without a provable name (covers destructuring/default-export/`export =` names) — 3 unit tests, rejection test fails by construction pre-fix.
- String-literal declaration names (`declare module "name"`) accepted.
- Declaration-merging adjacents byte-identical before/after: interface+namespace, class+interface, function+namespace, enum+namespace.
- e2e subprocess test `parallel_sequential_agreement_tests` with systematically RENAMED binders: forced-parallel must byte-match sequential; validated to diverge deterministically on the pre-fix baseline binary.

## Remaining scope (NOT this PR)
The default-path flap on workspace-dep-heavy slices (witness 3 of #13255) is a different residual family (shared-`DefinitionStore` DefId identity races, `driver/check.rs:356-381`); the parallelism gates (#13244/#13245) stay down until that lands. This PR removes one proven poison channel and meets the issue's witness-4 exit criterion.

## Verification
- Full local conformance: 12583/12585, zero new vs accepted regressions (2 pre-existing Mac-delta cases reproduce on clean main).
- importMeta.ts 3/3; zodmin/vite/next byte-identical before/after.
- `cargo nextest -p tsz-checker` 14227/14234 (7 ts2859 timeouts pre-existing on clean main, same profile); tsz-cli/tsz-lowering failures all reproduce on clean main.
- New tests: 50/50 (lib-decl matrix scope) + 1/1 e2e agreement; arch_guard + checker_field_inventory + clippy --all-targets clean.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: max
