### PR TITLE
perf(checker): O(1) speculation snapshots and child-cache inheritance via CowCache Arc/COW (#13087, #13078)

### DIFF
--- a/crates/tsz-checker/src/context/aliases.rs
+++ b/crates/tsz-checker/src/context/aliases.rs
@@ -8,6 +8,15 @@ use rustc_hash::FxHashMap;
 use std::sync::Arc;
 
 use tsz_binder::{ModuleAugmentation, SymbolId, SymbolTable};
+use tsz_solver::TypeId;
+
+/// Flow-analysis result memo: `(FlowNodeId, SymbolId, InitialTypeId) ->
+/// NarrowedTypeId`.
+pub type FlowAnalysisCacheMap = FxHashMap<(tsz_binder::FlowNodeId, SymbolId, TypeId), TypeId>;
+
+/// Stable-flow confirmation memo: `(SymbolId, DeclaredTypeId)` to the last
+/// `FlowNodeId` where flow analysis confirmed no narrowing.
+pub type SymbolFlowConfirmedMap = FxHashMap<(SymbolId, TypeId), tsz_binder::FlowNodeId>;
 
 /// Represents a failed module resolution with specific error details.
 #[derive(Clone, Debug)]

--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -5,6 +5,88 @@ use tsz_binder::SymbolId;
 use tsz_solver::def::DefId;
 use tsz_solver::{TypeId, TypeParamInfo};
 
+/// O(1)-cloneable copy-on-write wrapper for checker cache collections.
+///
+/// Speculation snapshots (`CheckerContext::snapshot_full` /
+/// `snapshot_return_type`) and child-checker construction
+/// (`CheckerContext::with_parent_cache`) historically deep-cloned whole cache
+/// maps to get an isolated copy, paying O(cache-size) per snapshot/child even
+/// when nothing was subsequently mutated. `CowCache` makes the snapshot an
+/// `Arc` bump instead, following the `NodeArena`/`NodeTypeCache` idiom
+/// (PR #13033): `clone()` is O(1), and the first mutable access after a clone
+/// detaches the map via [`Arc::make_mut`], so the deep copy is paid at most
+/// once per diverging holder — and never for snapshots that are dropped or
+/// rolled back without intervening writes.
+///
+/// Isolation semantics are unchanged from a deep clone: every writer goes
+/// through `DerefMut` (`Arc::make_mut`), so mutations on one holder are never
+/// visible through another holder's `Arc`, regardless of write order.
+///
+/// Method-call reads (`get`, `contains_key`, `iter`, `len`, ...) auto-deref
+/// immutably and never copy; only `&mut self` collection methods (`insert`,
+/// `remove`, `retain`, `clear`, `extend`, `entry`) trigger the copy-on-write
+/// detach. Avoid calling mutating methods that are likely no-ops (e.g.
+/// `remove` of a probably-absent key) on a probably-shared holder.
+#[derive(Debug)]
+pub struct CowCache<T: Clone>(Arc<T>);
+
+impl<T: Clone> CowCache<T> {
+    #[inline]
+    pub fn new(value: T) -> Self {
+        Self(Arc::new(value))
+    }
+
+    /// Unwrap into the inner collection, cloning only when still shared.
+    #[inline]
+    pub fn into_inner(self) -> T {
+        Arc::try_unwrap(self.0).unwrap_or_else(|shared| (*shared).clone())
+    }
+
+    /// `true` when both wrappers share the same underlying allocation
+    /// (used by tests asserting snapshot/COW behavior).
+    #[inline]
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl<T: Clone> Clone for CowCache<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+
+    #[inline]
+    fn clone_from(&mut self, source: &Self) {
+        if !Arc::ptr_eq(&self.0, &source.0) {
+            self.0 = Arc::clone(&source.0);
+        }
+    }
+}
+
+impl<T: Clone + Default> Default for CowCache<T> {
+    #[inline]
+    fn default() -> Self {
+        Self(Arc::new(T::default()))
+    }
+}
+
+impl<T: Clone> std::ops::Deref for CowCache<T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T: Clone> std::ops::DerefMut for CowCache<T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        Arc::make_mut(&mut self.0)
+    }
+}
+
 /// File-local synthetic type-node surface caches.
 #[derive(Debug, Default)]
 pub struct TypeNodeSurfaceCaches {

--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -660,6 +660,73 @@ mod tests {
     use super::*;
 
     #[test]
+    fn cow_cache_clone_is_shared_until_first_write() {
+        let mut live: CowCache<FxHashMap<u32, u32>> = CowCache::default();
+        live.insert(1, 10);
+        let snapshot = live.clone();
+        assert!(live.ptr_eq(&snapshot));
+
+        // Reads through either holder never detach.
+        assert_eq!(live.get(&1), Some(&10));
+        assert_eq!(snapshot.get(&1), Some(&10));
+        assert!(live.ptr_eq(&snapshot));
+
+        // First write detaches the writer; the snapshot is isolated.
+        live.insert(2, 20);
+        assert!(!live.ptr_eq(&snapshot));
+        assert_eq!(live.get(&2), Some(&20));
+        assert_eq!(snapshot.get(&2), None);
+        assert_eq!(snapshot.get(&1), Some(&10));
+    }
+
+    #[test]
+    fn cow_cache_clone_from_restores_sharing_with_snapshot() {
+        let mut live: CowCache<FxHashMap<u32, u32>> = CowCache::default();
+        live.insert(1, 10);
+        let snapshot = live.clone();
+        live.insert(2, 20);
+
+        // Rollback: O(1) Arc swap back to the snapshot state.
+        live.clone_from(&snapshot);
+        assert!(live.ptr_eq(&snapshot));
+        assert_eq!(live.get(&2), None);
+        assert_eq!(live.get(&1), Some(&10));
+
+        // Rolling back twice is a no-op that keeps sharing.
+        live.clone_from(&snapshot);
+        assert!(live.ptr_eq(&snapshot));
+    }
+
+    #[test]
+    fn cow_cache_parent_writes_after_child_snapshot_stay_isolated() {
+        // `with_parent_cache` ordering: the child snapshots first, the parent
+        // keeps mutating afterwards. Parent writes must not leak into the
+        // child (and vice versa), exactly as with a deep clone.
+        let mut parent: CowCache<FxHashMap<u32, u32>> = CowCache::default();
+        parent.insert(1, 10);
+        let mut child = parent.clone();
+
+        parent.insert(2, 20);
+        assert_eq!(child.get(&2), None);
+
+        child.insert(3, 30);
+        assert_eq!(parent.get(&3), None);
+        assert_eq!(parent.get(&2), Some(&20));
+        assert_eq!(child.get(&1), Some(&10));
+    }
+
+    #[test]
+    fn cow_cache_into_inner_clones_only_when_shared() {
+        let mut live: CowCache<FxHashMap<u32, u32>> = CowCache::default();
+        live.insert(1, 10);
+        let snapshot = live.clone();
+        let inner = live.into_inner();
+        assert_eq!(inner.get(&1), Some(&10));
+        // The outstanding snapshot still sees its state.
+        assert_eq!(snapshot.get(&1), Some(&10));
+    }
+
+    #[test]
     fn node_type_cache_absent_remove_does_not_detach_shared_snapshot() {
         let mut parent = NodeTypeCache::new();
         parent.insert(1, TypeId::STRING);

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -69,13 +69,13 @@ impl<'a> CheckerContext<'a> {
             symbol_instance_types: crate::context::SymbolTypeCache::with_capacity(
                 symbol_cache_capacity,
             ),
-            enum_namespace_types: FxHashMap::default(),
+            enum_namespace_types: crate::context::CowCache::default(),
             var_decl_types: FxHashMap::default(),
             lib_type_resolution_cache: FxHashMap::default(),
             lib_delegation_cache: crate::context::CrossFileDelegationCache::default(),
-            namespace_member_resolution_cache: RefCell::new(FxHashMap::default()),
-            export_equals_named_cache: RefCell::new(FxHashMap::default()),
-            nested_namespace_candidates_cache: RefCell::new(FxHashMap::default()),
+            namespace_member_resolution_cache: RefCell::new(crate::context::CowCache::default()),
+            export_equals_named_cache: RefCell::new(crate::context::CowCache::default()),
+            nested_namespace_candidates_cache: RefCell::new(crate::context::CowCache::default()),
             symbol_name_candidates_cache: RefCell::new(FxHashMap::default()),
             jsdoc_global_typedef_lookup_cache: crate::context::JSDocGlobalTypedefLookupCache {
                 miss_cache: RefCell::new(FxHashSet::default()),
@@ -83,15 +83,15 @@ impl<'a> CheckerContext<'a> {
                 typedef_presence_by_file: Arc::new(dashmap::DashMap::new()),
             },
             nested_namespace_candidates_cache_complete: Cell::new(false),
-            lowering_entity_name_resolution_cache: RefCell::new(FxHashMap::default()),
+            lowering_entity_name_resolution_cache: RefCell::new(crate::context::CowCache::default()),
             namespace_exports_cache: RefCell::new(FxHashMap::default()),
             shared_lib_type_cache: None,
             shared_constraint_proofs: None,
             cross_file_type_params_cache: None,
             skip_lib_type_resolution: false,
-            lib_heritage_in_progress: FxHashSet::default(),
+            lib_heritage_in_progress: crate::context::CowCache::default(),
             node_types: crate::context::NodeTypeCache::with_capacity(arena.nodes.len()),
-            request_node_types: FxHashMap::default(),
+            request_node_types: crate::context::CowCache::default(),
             object_literal_tracking: crate::context::ObjectLiteralTracking::default(),
             request_cache_counters: crate::context::RequestCacheCounters::default(),
             type_environment: RefCell::new(TypeEnvironment::new()),
@@ -100,11 +100,10 @@ impl<'a> CheckerContext<'a> {
             mapped_eval_set: FxHashSet::default(),
             type_resolution_visiting: FxHashSet::default(),
             pruning_union_members: false,
-            jsdoc_typedef_resolving: RefCell::new(FxHashSet::default()),
-            jsdoc_generic_typedef_resolving: RefCell::new(FxHashMap::default()),
-            flow_analysis_cache: RefCell::new(FxHashMap::with_capacity_and_hasher(
-                128,
-                Default::default(),
+            jsdoc_typedef_resolving: RefCell::new(crate::context::CowCache::default()),
+            jsdoc_generic_typedef_resolving: RefCell::new(crate::context::CowCache::default()),
+            flow_analysis_cache: RefCell::new(crate::context::CowCache::new(
+                FxHashMap::with_capacity_and_hasher(128, Default::default()),
             )),
             flow_reference_keys: RefCell::new(FxHashMap::default()),
             narrowable_identifier_cache: RefCell::new(
@@ -118,19 +117,21 @@ impl<'a> CheckerContext<'a> {
             flow_results: RefCell::new(FxHashMap::with_capacity_and_hasher(64, Default::default())),
             flow_reference_match_cache: RefCell::new(FxHashMap::default()),
             symbol_flow_memo: crate::context::SymbolFlowMemoCaches::default(),
-            symbol_flow_confirmed: RefCell::new(FxHashMap::default()),
+            symbol_flow_confirmed: RefCell::new(crate::context::CowCache::default()),
             narrowing_cache: tsz_solver::narrowing::NarrowingCache::new(),
             call_type_predicates: crate::control_flow::CallPredicateMap::default(),
-            daa_error_nodes: FxHashSet::default(),
+            daa_error_nodes: crate::context::CowCache::default(),
             deferred_ts2454_errors: Vec::new(),
-            flow_narrowed_nodes: FxHashSet::with_capacity_and_hasher(256, Default::default()),
+            flow_narrowed_nodes: crate::context::CowCache::new(
+                FxHashSet::with_capacity_and_hasher(256, Default::default()),
+            ),
             refs_resolved: FxHashSet::default(),
             application_symbols_resolved: FxHashSet::default(),
             application_symbols_resolution_set: FxHashSet::default(),
             namespace_module_names: FxHashMap::default(),
             js_export_surface_cache: FxHashMap::default(),
             js_export_surface_resolution_set: FxHashSet::default(),
-            expando_property_resolution_set: FxHashSet::default(),
+            expando_property_resolution_set: crate::context::CowCache::default(),
             module_specifiers: Arc::new(FxHashMap::default()),
             module_path_specifiers: Arc::new(FxHashMap::default()),
             class_instance_type_to_decl: FxHashMap::default(),
@@ -170,9 +171,9 @@ impl<'a> CheckerContext<'a> {
             diagnostics: Vec::new(),
             diagnostics_discarded: false,
             diagnostic_indices: DiagnosticIndices::default(),
-            no_overload_call_nodes: FxHashSet::default(),
+            no_overload_call_nodes: crate::context::CowCache::default(),
             callback_return_type_errors: Vec::new(),
-            modules_with_ts2307_emitted: FxHashSet::default(),
+            modules_with_ts2307_emitted: crate::context::CowCache::default(),
             deferred_truthiness_diagnostics: Vec::new(),
             deferred_excess_property_implicit_any_diagnostics: Vec::new(),
             symbol_resolution_stack: Vec::new(),
@@ -189,14 +190,14 @@ impl<'a> CheckerContext<'a> {
             window_partial_ctor_types: FxHashMap::default(),
             jsdoc_enum_resolution_set: FxHashSet::default(),
             circular_class_symbols: FxHashSet::default(),
-            pending_implicit_any_vars: FxHashMap::default(),
+            pending_implicit_any_vars: crate::context::CowCache::default(),
             pending_circular_return_sites: PendingCircularReturnSites::default(),
             non_closure_circular_return_tracking_depth: 0,
-            reported_implicit_any_vars: FxHashMap::default(),
+            reported_implicit_any_vars: crate::context::CowCache::default(),
             inheritance_graph: tsz_solver::classes::inheritance::InheritanceGraph::new(),
             node_resolution_stack: Vec::new(),
-            implicit_any_checked_closures: FxHashSet::default(),
-            implicit_any_contextual_closures: FxHashSet::default(),
+            implicit_any_checked_closures: crate::context::CowCache::default(),
+            implicit_any_contextual_closures: crate::context::CowCache::default(),
             deferred_implicit_any_closures: Vec::new(),
             speculative_implicit_any_closures: Vec::new(),
             closures_with_contextual_this_type: FxHashSet::default(),
@@ -312,7 +313,7 @@ impl<'a> CheckerContext<'a> {
             had_outer_loop: false,
             suppress_definite_assignment_errors: false,
             js_body_uses_arguments: false,
-            emitted_ts2454_errors: FxHashSet::default(),
+            emitted_ts2454_errors: crate::context::CowCache::default(),
             emitted_ts2411_for_iface_prop: FxHashSet::default(),
             type_resolution_fuel: Cell::new(crate::state::MAX_TYPE_RESOLUTION_OPS),
             typeof_resolution_stack: RefCell::new(FxHashSet::default()),
@@ -483,7 +484,8 @@ impl<'a> CheckerContext<'a> {
         // node_types is per-arena (keyed by raw node index u32), so it must NOT
         // be carried across files — indices from file A collide with file B.
         // We keep the fresh per-arena allocation from base().
-        self.flow_analysis_cache = RefCell::new(cache.flow_analysis_cache);
+        self.flow_analysis_cache =
+            RefCell::new(crate::context::CowCache::new(cache.flow_analysis_cache));
         // Reset flow worklist/visited buffers since they had pre-allocated capacity
         // in base() but cache path historically used empty defaults.
         self.flow_worklist = RefCell::new(VecDeque::new());
@@ -657,42 +659,26 @@ impl<'a> CheckerContext<'a> {
         // child writes must be visible to the parent and to sibling children
         // within the same file-check session.
         ctx.lib_delegation_cache = parent.lib_delegation_cache.clone();
-        // Skip the deep `HashMap::clone` for caches that are empty on the
-        // parent: `ctx` was just constructed via `Self::base(...)` so its
-        // matching cache is already an empty HashMap, and cloning an empty
-        // parent into it would be wasted allocation. On the scale-cliff
-        // fixtures, `with_parent_cache` fires 6,735 times per run — even a
-        // single saved allocation per call is meaningful, and these four
-        // caches are typically empty at construction time for the
-        // `TypeEnvironmentCore` / `AliasResolution` /
-        // `DelegateCrossArenaSymbol` child checkers that dominate the call
-        // graph (see #5632's `by_reason` data on monorepo-006).
-        {
-            let parent_cache = parent.namespace_member_resolution_cache.borrow();
-            if !parent_cache.is_empty() {
-                *ctx.namespace_member_resolution_cache.borrow_mut() = parent_cache.clone();
-            }
-        }
-        {
-            let parent_cache = parent.export_equals_named_cache.borrow();
-            if !parent_cache.is_empty() {
-                *ctx.export_equals_named_cache.borrow_mut() = parent_cache.clone();
-            }
-        }
-        {
-            let parent_cache = parent.nested_namespace_candidates_cache.borrow();
-            if !parent_cache.is_empty() {
-                *ctx.nested_namespace_candidates_cache.borrow_mut() = parent_cache.clone();
-            }
-        }
+        // These per-checker caches are `CowCache`-backed: inheriting the
+        // parent's entries is an O(1) `Arc` bump, and the child copy-on-writes
+        // only if it actually mutates the inherited map. The historical
+        // per-child deep `HashMap::clone` here was O(children × cache-size) —
+        // `with_parent_cache` fires 6,735 times per run on the scale-cliff
+        // fixtures (issue #13087).
+        ctx.namespace_member_resolution_cache
+            .borrow_mut()
+            .clone_from(&parent.namespace_member_resolution_cache.borrow());
+        ctx.export_equals_named_cache
+            .borrow_mut()
+            .clone_from(&parent.export_equals_named_cache.borrow());
+        ctx.nested_namespace_candidates_cache
+            .borrow_mut()
+            .clone_from(&parent.nested_namespace_candidates_cache.borrow());
         ctx.nested_namespace_candidates_cache_complete =
             Cell::new(parent.nested_namespace_candidates_cache_complete.get());
-        {
-            let parent_cache = parent.lowering_entity_name_resolution_cache.borrow();
-            if !parent_cache.is_empty() {
-                *ctx.lowering_entity_name_resolution_cache.borrow_mut() = parent_cache.clone();
-            }
-        }
+        ctx.lowering_entity_name_resolution_cache
+            .borrow_mut()
+            .clone_from(&parent.lowering_entity_name_resolution_cache.borrow());
         ctx.jsdoc_global_typedef_lookup_cache
             .typedef_presence_by_file = Arc::clone(
             &parent
@@ -712,16 +698,12 @@ impl<'a> CheckerContext<'a> {
         // Cross-file JSDoc import/typedef resolution spawns nested CheckerStates;
         // if the active typedef set is reset at that boundary, cyclic CommonJS
         // JSDoc graphs can recurse until stack overflow.
-        {
-            let parent_typedefs = parent.jsdoc_typedef_resolving.borrow();
-            if !parent_typedefs.is_empty() {
-                ctx.jsdoc_typedef_resolving = RefCell::new(parent_typedefs.clone());
-            }
-            let parent_generic_typedefs = parent.jsdoc_generic_typedef_resolving.borrow();
-            if !parent_generic_typedefs.is_empty() {
-                ctx.jsdoc_generic_typedef_resolving = RefCell::new(parent_generic_typedefs.clone());
-            }
-        }
+        ctx.jsdoc_typedef_resolving
+            .borrow_mut()
+            .clone_from(&parent.jsdoc_typedef_resolving.borrow());
+        ctx.jsdoc_generic_typedef_resolving
+            .borrow_mut()
+            .clone_from(&parent.jsdoc_generic_typedef_resolving.borrow());
 
         // Propagate expando-property resolution state so child checkers do not
         // lose recursion protection while resolving CommonJS/JS property reads
@@ -735,12 +717,8 @@ impl<'a> CheckerContext<'a> {
         // cross-arena delegation (replaces thread-local guards).
         ctx.eval_session = Rc::clone(&parent.eval_session);
 
-        if !parent.implicit_any_checked_closures.is_empty() {
-            ctx.implicit_any_checked_closures = parent.implicit_any_checked_closures.clone();
-        }
-        if !parent.implicit_any_contextual_closures.is_empty() {
-            ctx.implicit_any_contextual_closures = parent.implicit_any_contextual_closures.clone();
-        }
+        ctx.implicit_any_checked_closures = parent.implicit_any_checked_closures.clone();
+        ctx.implicit_any_contextual_closures = parent.implicit_any_contextual_closures.clone();
 
         // Propagate depth from parent to prevent infinite recursion across arena boundaries.
         ctx.recursion_depth =

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -1557,7 +1557,7 @@ impl<'a> CheckerContext<'a> {
             // pure memo entries and are cheaply recomputed; real-symbol and
             // per-node keys are program-stable and kept.
             flow_analysis_cache: {
-                let mut cache = self.flow_analysis_cache.into_inner();
+                let mut cache = self.flow_analysis_cache.into_inner().into_inner();
                 cache.retain(|(_, symbol, _), _| {
                     crate::control_flow::is_session_stable_flow_cache_symbol(*symbol)
                 });

--- a/crates/tsz-checker/src/context/diagnostic_indices.rs
+++ b/crates/tsz-checker/src/context/diagnostic_indices.rs
@@ -6,7 +6,7 @@ use crate::diagnostics::{Diagnostic, diagnostic_codes};
 
 #[derive(Clone, Default)]
 pub(crate) struct DiagnosticIndices {
-    pub(crate) emitted: FxHashSet<(u32, u32)>,
+    pub(crate) emitted: super::CowCache<FxHashSet<(u32, u32)>>,
     ts2353_2561_positions: BTreeSet<u32>,
     ts2322_msg_spans: FxHashMap<u64, Vec<(u32, u32)>>,
 }

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -589,9 +589,7 @@ pub struct CheckerContext<'a> {
     /// Prevents re-traversing the flow graph for the same symbol/flow combination.
     /// Fixes performance regression on binaryArithmeticControlFlowGraphNotTooLarge.ts
     /// where each operand in a + b + c was triggering fresh graph traversals.
-    pub flow_analysis_cache: RefCell<
-        CowCache<FxHashMap<(tsz_binder::FlowNodeId, tsz_binder::SymbolId, TypeId), TypeId>>,
-    >,
+    pub flow_analysis_cache: RefCell<CowCache<FlowAnalysisCacheMap>>,
 
     /// Interner that gives property/element reference *paths* (`a.b`) a
     /// session-stable synthetic cache symbol, so `flow_analysis_cache` is shared
@@ -640,8 +638,7 @@ pub struct CheckerContext<'a> {
     /// is skipped entirely, returning the declared type directly.
     /// This eliminates O(N) flow cache misses for N sequential accesses to the same
     /// identifier (e.g., 34 references to `options` in sequential statements).
-    pub symbol_flow_confirmed:
-        RefCell<CowCache<FxHashMap<(SymbolId, TypeId), tsz_binder::FlowNodeId>>>,
+    pub symbol_flow_confirmed: RefCell<CowCache<SymbolFlowConfirmedMap>>,
 
     /// Instantiated type predicates from generic call resolutions.
     /// Keyed by call expression node index. Used by flow narrowing to get

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -11,8 +11,8 @@ mod cross_file_delegation_cache;
 mod cross_file_type_params_cache;
 pub use cache_statistics::CheckerContextCacheStatistics;
 pub use caches::{
-    AssignabilityEvalMemo, AssignabilityEvalStamp, NarrowableIdentifierCache, NodeTypeCache,
-    SharedConstraintProofCache, SymbolTypeCache, TypeNodeSurfaceCaches,
+    AssignabilityEvalMemo, AssignabilityEvalStamp, CowCache, NarrowableIdentifierCache,
+    NodeTypeCache, SharedConstraintProofCache, SymbolTypeCache, TypeNodeSurfaceCaches,
     TypeReferenceValidationCaches,
 };
 pub(crate) use compiler_options::is_declaration_file_name;
@@ -445,7 +445,7 @@ pub struct CheckerContext<'a> {
 
     /// Cached namespace object types for enums (for `typeof Enum` / `keyof typeof Enum`).
     /// Maps enum `SymbolId` → namespace object `TypeId` with member names as properties.
-    pub enum_namespace_types: FxHashMap<SymbolId, TypeId>,
+    pub enum_namespace_types: CowCache<FxHashMap<SymbolId, TypeId>>,
 
     /// Cached types for variable declarations (used for TS2403 checks).
     pub var_decl_types: FxHashMap<SymbolId, TypeId>,
@@ -461,17 +461,17 @@ pub struct CheckerContext<'a> {
     /// Keyed by (`namespace_name`, `member_name`) and stores both hits and misses.
     /// This avoids repeatedly rescanning all binders for hot qualified React lookups
     /// like `React.Component`, `React.ComponentClass`, `React.ReactNode`, etc.
-    pub namespace_member_resolution_cache: RefCell<NamespaceMemberResolutionCache>,
+    pub namespace_member_resolution_cache: RefCell<CowCache<NamespaceMemberResolutionCache>>,
 
     /// Per-checker cache for named exports resolved through `export=`.
     /// Misses are cached only for lookups that enter without alias-cycle state.
-    pub export_equals_named_cache: RefCell<ExportEqualsNamedCache>,
+    pub export_equals_named_cache: RefCell<CowCache<ExportEqualsNamedCache>>,
 
     /// Per-checker cache for nested namespace candidates found through namespace exports.
     /// Keyed by `namespace_name` and stores the candidate nested namespace symbols with
     /// their owning file index. This avoids rescanning every binder when resolving many
     /// different members from the same nested namespace.
-    pub nested_namespace_candidates_cache: RefCell<NestedNamespaceCandidatesCache>,
+    pub nested_namespace_candidates_cache: RefCell<CowCache<NestedNamespaceCandidatesCache>>,
 
     /// Per-checker cache for same-name symbol candidates across the current binder
     /// and all cross-file binders.
@@ -490,7 +490,7 @@ pub struct CheckerContext<'a> {
     /// Keyed by names like `React.ReactNode` / `JSX.Element` and stores both
     /// hits and misses to avoid repeatedly walking the same symbol graph during
     /// declaration-file interface/type lowering.
-    pub lowering_entity_name_resolution_cache: RefCell<FxHashMap<String, Option<DefId>>>,
+    pub lowering_entity_name_resolution_cache: RefCell<CowCache<FxHashMap<String, Option<DefId>>>>,
 
     /// Per-checker cache for cross-file namespace export resolution.
     /// Keyed by the requesting file and module specifier because relative
@@ -528,13 +528,13 @@ pub struct CheckerContext<'a> {
     /// Names currently being resolved in `merge_lib_interface_heritage`.
     /// Used to break cycles in the `resolve_lib_type_by_name` ↔ `merge_lib_interface_heritage`
     /// mutual recursion (e.g., Array extends ReadonlyArray which extends Iterable ...).
-    pub lib_heritage_in_progress: FxHashSet<String>,
+    pub lib_heritage_in_progress: CowCache<FxHashSet<String>>,
 
     /// Cached types for nodes (dense flat-vec, O(1) lookup by node index).
     pub node_types: NodeTypeCache,
 
     /// Request-aware cache for audited non-empty request paths only.
-    pub request_node_types: FxHashMap<(u32, RequestCacheKey), TypeId>,
+    pub request_node_types: CowCache<FxHashMap<(u32, RequestCacheKey), TypeId>>,
 
     /// Object-literal diagnostic recovery and active initializer state.
     pub object_literal_tracking: ObjectLiteralTracking,
@@ -573,7 +573,7 @@ pub struct CheckerContext<'a> {
     /// Recursion guard for `resolve_jsdoc_typedef_type`.
     /// Prevents infinite recursion when a JSDoc `@typedef` references itself
     /// (e.g., `@typedef {... | Json[]} Json`).
-    pub jsdoc_typedef_resolving: RefCell<rustc_hash::FxHashSet<String>>,
+    pub jsdoc_typedef_resolving: RefCell<CowCache<rustc_hash::FxHashSet<String>>>,
 
     /// Recursion guard for *generic* JSDoc `@typedef` resolution, mapping the
     /// typedef name currently being expanded to the `DefId` of its lazy alias.
@@ -582,15 +582,16 @@ pub struct CheckerContext<'a> {
     /// `Application(Lazy(DefId), args)` instead of eagerly re-expanding the body,
     /// which would otherwise recurse until the stack overflows. The solver then
     /// resolves the alias coinductively, keyed by `(DefId, type args)`.
-    pub jsdoc_generic_typedef_resolving: RefCell<rustc_hash::FxHashMap<String, DefId>>,
+    pub jsdoc_generic_typedef_resolving: RefCell<CowCache<rustc_hash::FxHashMap<String, DefId>>>,
 
     /// Cache for control flow analysis results.
     /// Key: (`FlowNodeId`, `SymbolId`, `InitialTypeId`) -> `NarrowedTypeId`
     /// Prevents re-traversing the flow graph for the same symbol/flow combination.
     /// Fixes performance regression on binaryArithmeticControlFlowGraphNotTooLarge.ts
     /// where each operand in a + b + c was triggering fresh graph traversals.
-    pub flow_analysis_cache:
-        RefCell<FxHashMap<(tsz_binder::FlowNodeId, tsz_binder::SymbolId, TypeId), TypeId>>,
+    pub flow_analysis_cache: RefCell<
+        CowCache<FxHashMap<(tsz_binder::FlowNodeId, tsz_binder::SymbolId, TypeId), TypeId>>,
+    >,
 
     /// Interner that gives property/element reference *paths* (`a.b`) a
     /// session-stable synthetic cache symbol, so `flow_analysis_cache` is shared
@@ -639,7 +640,8 @@ pub struct CheckerContext<'a> {
     /// is skipped entirely, returning the declared type directly.
     /// This eliminates O(N) flow cache misses for N sequential accesses to the same
     /// identifier (e.g., 34 references to `options` in sequential statements).
-    pub symbol_flow_confirmed: RefCell<FxHashMap<(SymbolId, TypeId), tsz_binder::FlowNodeId>>,
+    pub symbol_flow_confirmed:
+        RefCell<CowCache<FxHashMap<(SymbolId, TypeId), tsz_binder::FlowNodeId>>>,
 
     /// Instantiated type predicates from generic call resolutions.
     /// Keyed by call expression node index. Used by flow narrowing to get
@@ -650,7 +652,7 @@ pub struct CheckerContext<'a> {
     /// When TS2454 fires, `check_flow_usage` returns the declared type (un-narrowed).
     /// The second narrowing pass in `get_type_of_node` must NOT re-narrow these nodes,
     /// otherwise the declared type gets overridden with the narrowed type.
-    pub daa_error_nodes: FxHashSet<u32>,
+    pub daa_error_nodes: CowCache<FxHashSet<u32>>,
 
     /// Deferred TS2454 diagnostics that survive speculative rollback.
     /// `check_flow_usage` can run inside speculative call-checker contexts
@@ -662,7 +664,7 @@ pub struct CheckerContext<'a> {
     /// Nodes where `check_flow_usage` already applied flow narrowing.
     /// The second narrowing pass in `get_type_of_node` must skip these to avoid
     /// double-narrowing (e.g., `any` → `string` → `string & Object`).
-    pub flow_narrowed_nodes: FxHashSet<u32>,
+    pub flow_narrowed_nodes: CowCache<FxHashSet<u32>>,
 
     /// `TypeIds` whose lazy/type-query refs have been walked and resolved.
     /// This avoids repeated deep traversals in `ensure_refs_resolved`.
@@ -694,7 +696,7 @@ pub struct CheckerContext<'a> {
     /// Recursion guard for JS expando property reads.
     /// Prevents `NS.K = class { return new NS.K() }`-style self-reference loops
     /// from recursively re-evaluating the same expando property via the RHS.
-    pub expando_property_resolution_set: FxHashSet<String>,
+    pub expando_property_resolution_set: CowCache<FxHashSet<String>>,
 
     /// Maps `file_id` -> module specifier for import-qualified type display.
     /// When a type is defined in a module file, the formatter qualifies its name
@@ -895,14 +897,14 @@ pub struct CheckerContext<'a> {
     /// speculative context. Used so overload resolution can reject outer
     /// candidates whose callback bodies contain a failed nested overload even
     /// when the nested diagnostic is rolled back or suppressed for recovery.
-    pub no_overload_call_nodes: FxHashSet<u32>,
+    pub no_overload_call_nodes: CowCache<FxHashSet<u32>>,
     /// Callback return-type TS2322 diagnostics that were emitted during
     /// function body checking but may be pruned by arg collection filters.
     /// Stored separately so they can be restored after pruning and used to
     /// suppress the outer TS2345 argument mismatch.
     pub callback_return_type_errors: Vec<Diagnostic>,
     /// Set of modules that have already had TS2307 emitted (prevents duplicate emissions).
-    pub modules_with_ts2307_emitted: FxHashSet<String>,
+    pub modules_with_ts2307_emitted: CowCache<FxHashSet<String>>,
     /// Deferred truthiness diagnostics (TS2872/TS2873) that survive speculative
     /// rollbacks. These are purely syntactic facts emitted during binary
     /// expression evaluation but lost when call-resolution speculation rolls
@@ -963,7 +965,7 @@ pub struct CheckerContext<'a> {
     /// Deferred implicit-any candidates keyed by variable symbol.
     /// Bare implicit-any declarations stay capture-only, while evolving empty
     /// arrays also report on unsafe same-scope reads.
-    pub pending_implicit_any_vars: FxHashMap<SymbolId, PendingImplicitAnyVar>,
+    pub pending_implicit_any_vars: CowCache<FxHashMap<SymbolId, PendingImplicitAnyVar>>,
     /// Closure/function-expression sites whose return expressions read a variable
     /// symbol currently being resolved. Used to centralize TS7022/TS7023/TS7024
     /// emission and suppress downstream relation noise from the circularity.
@@ -974,7 +976,7 @@ pub struct CheckerContext<'a> {
     pub non_closure_circular_return_tracking_depth: usize,
     /// Variables that have already had TS7034 emitted, keyed by the deferred
     /// implicit-any classification that triggered it.
-    pub reported_implicit_any_vars: FxHashMap<SymbolId, PendingImplicitAnyKind>,
+    pub reported_implicit_any_vars: CowCache<FxHashMap<SymbolId, PendingImplicitAnyKind>>,
 
     /// Inheritance graph tracking class/interface relationships
     pub inheritance_graph: tsz_solver::classes::inheritance::InheritanceGraph,
@@ -988,11 +990,11 @@ pub struct CheckerContext<'a> {
     /// Prevents duplicate diagnostics when `get_type_of_function` is called multiple
     /// times for the same closure (e.g., once with contextual type during call
     /// resolution, then again without context during body checking).
-    pub implicit_any_checked_closures: FxHashSet<NodeIndex>,
+    pub implicit_any_checked_closures: CowCache<FxHashSet<NodeIndex>>,
     /// Closures that have already been checked with a real contextual parameter type.
     /// Preserve this across cache clears so later context-free rechecks do not
     /// emit false TS7006/TS7031 diagnostics.
-    pub implicit_any_contextual_closures: FxHashSet<NodeIndex>,
+    pub implicit_any_contextual_closures: CowCache<FxHashSet<NodeIndex>>,
     /// Closures that were processed during type env building without contextual types.
     /// These closures deferred TS7006 checking (because `is_checking_statements` was false).
     /// After `is_checking_statements` is set to true, these closures need a re-check
@@ -1566,7 +1568,7 @@ pub struct CheckerContext<'a> {
     /// Track which (node, symbol) pairs have already emitted TS2454 errors
     /// to avoid duplicate errors when the same usage is checked multiple times.
     /// Key: (`node_position`, `symbol_id`)
-    pub emitted_ts2454_errors: FxHashSet<(u32, SymbolId)>,
+    pub emitted_ts2454_errors: CowCache<FxHashSet<(u32, SymbolId)>>,
 
     /// Track which (`interface_type`, `property_name`, `is_number_index`) combinations
     /// have already emitted TS2411 errors for merged interface declarations.

--- a/crates/tsz-checker/src/context/speculation.rs
+++ b/crates/tsz-checker/src/context/speculation.rs
@@ -40,7 +40,9 @@ use tsz_solver::TypeId;
 
 use crate::diagnostics::Diagnostic;
 
-use super::{CheckerContext, PendingImplicitAnyKind, PendingImplicitAnyVar, RequestCacheKey};
+use super::{
+    CheckerContext, CowCache, PendingImplicitAnyKind, PendingImplicitAnyVar, RequestCacheKey,
+};
 
 // ---------------------------------------------------------------------------
 // Internal helpers (free functions to avoid borrow conflicts)
@@ -50,7 +52,7 @@ use super::{CheckerContext, PendingImplicitAnyKind, PendingImplicitAnyVar, Reque
 /// with code 2454. Without this cleanup, discarded TS2454 errors remain in
 /// the dedup set and prevent re-emission on subsequent passes.
 fn cleanup_ts2454_dedup(
-    emitted_ts2454_errors: &mut FxHashSet<(u32, SymbolId)>,
+    emitted_ts2454_errors: &mut CowCache<FxHashSet<(u32, SymbolId)>>,
     discarded: &[Diagnostic],
 ) {
     for diag in discarded {
@@ -95,11 +97,12 @@ fn is_always_emit_grammar_code(code: u32) -> bool {
 pub(crate) struct DiagnosticSnapshot {
     /// Length of `ctx.diagnostics` at snapshot time (truncation point).
     pub diagnostics_len: usize,
-    /// Clone of `ctx.diagnostic_indices.emitted` for dedup restoration.
-    pub emitted_diagnostics: FxHashSet<(u32, u32)>,
+    /// O(1) `CowCache` snapshot of `ctx.diagnostic_indices.emitted` for
+    /// dedup restoration.
+    pub emitted_diagnostics: CowCache<FxHashSet<(u32, u32)>>,
     /// Clone of nested no-overload call markers for recovery-aware overload
     /// candidate rejection.
-    pub no_overload_call_nodes: FxHashSet<u32>,
+    pub no_overload_call_nodes: CowCache<FxHashSet<u32>>,
     /// Length of `ctx.deferred_ts2454_errors` at snapshot time.
     pub deferred_ts2454_len: usize,
 }
@@ -110,12 +113,12 @@ pub(crate) struct DiagnosticSnapshot {
 /// inference) that mutate more than just the diagnostic vector.
 pub(crate) struct FullSnapshot {
     pub diag: DiagnosticSnapshot,
-    pub emitted_ts2454_errors: FxHashSet<(u32, SymbolId)>,
-    pub modules_with_ts2307_emitted: FxHashSet<String>,
-    pub pending_implicit_any_vars: FxHashMap<SymbolId, PendingImplicitAnyVar>,
-    pub reported_implicit_any_vars: FxHashMap<SymbolId, PendingImplicitAnyKind>,
-    pub implicit_any_checked_closures: FxHashSet<NodeIndex>,
-    pub request_node_types: FxHashMap<(u32, RequestCacheKey), TypeId>,
+    pub emitted_ts2454_errors: CowCache<FxHashSet<(u32, SymbolId)>>,
+    pub modules_with_ts2307_emitted: CowCache<FxHashSet<String>>,
+    pub pending_implicit_any_vars: CowCache<FxHashMap<SymbolId, PendingImplicitAnyVar>>,
+    pub reported_implicit_any_vars: CowCache<FxHashMap<SymbolId, PendingImplicitAnyKind>>,
+    pub implicit_any_checked_closures: CowCache<FxHashSet<NodeIndex>>,
+    pub request_node_types: CowCache<FxHashMap<(u32, RequestCacheKey), TypeId>>,
 }
 
 /// Cache snapshot for return-type inference, which also corrupts `node_types`,
@@ -126,24 +129,22 @@ pub(crate) struct FullSnapshot {
 pub(crate) struct CacheSnapshot {
     /// Clone of the flat `node_types` cache before speculation.
     pub node_types: super::NodeTypeCache,
-    /// Full request-aware cache snapshot. Speculation may overwrite existing
-    /// entries, so rollback must restore values, not just prune additions.
-    pub request_node_types: FxHashMap<(u32, RequestCacheKey), TypeId>,
-    /// Clone of the flow analysis cache.
-    pub flow_analysis_cache: rustc_hash::FxHashMap<(FlowNodeId, SymbolId, TypeId), TypeId>,
+    /// O(1) `CowCache` snapshot of the flow analysis cache.
+    pub flow_analysis_cache:
+        CowCache<rustc_hash::FxHashMap<(FlowNodeId, SymbolId, TypeId), TypeId>>,
     /// Clone of `flow_narrowed_nodes`: nodes `check_flow_usage` already
     /// narrowed, for which `get_type_of_node` skips its second narrowing
     /// pass. Markers minted during speculation describe node types and flow
     /// results this snapshot rolls back; leaving them behind suppresses
     /// re-narrowing against the restored caches and yields stale types.
-    pub flow_narrowed_nodes: FxHashSet<u32>,
+    pub flow_narrowed_nodes: CowCache<FxHashSet<u32>>,
     /// Clone of `daa_error_nodes`: nodes whose definite-assignment (TS2454)
     /// error suppresses flow narrowing. Restored together with the TS2454
     /// diagnostics and dedup state that produced the markers.
-    pub daa_error_nodes: FxHashSet<u32>,
+    pub daa_error_nodes: CowCache<FxHashSet<u32>>,
     /// Clone of the stable-flow confirmation cache. Confirmations recorded
     /// during a speculative pass describe rolled-back flow analysis results.
-    pub symbol_flow_confirmed: FxHashMap<(SymbolId, TypeId), FlowNodeId>,
+    pub symbol_flow_confirmed: CowCache<FxHashMap<(SymbolId, TypeId), FlowNodeId>>,
     /// Thread-local global resolution fuel counter at snapshot time. Speculative
     /// sites (return-type inference) shouldn't bill their work against the
     /// global budget when rolled back — the work will be redone non-
@@ -234,7 +235,6 @@ impl<'a> CheckerContext<'a> {
             full: self.snapshot_full(),
             cache: CacheSnapshot {
                 node_types: self.node_types.clone(),
-                request_node_types: self.request_node_types.clone(),
                 flow_analysis_cache: self.flow_analysis_cache.borrow().clone(),
                 flow_narrowed_nodes: self.flow_narrowed_nodes.clone(),
                 daa_error_nodes: self.daa_error_nodes.clone(),
@@ -328,13 +328,15 @@ impl<'a> CheckerContext<'a> {
         );
         self.rollback_full(&snap.full);
         self.node_types.clone_from(&snap.cache.node_types);
-        self.request_node_types
-            .clone_from(&snap.cache.request_node_types);
-        *self.flow_analysis_cache.borrow_mut() = snap.cache.flow_analysis_cache.clone();
+        self.flow_analysis_cache
+            .borrow_mut()
+            .clone_from(&snap.cache.flow_analysis_cache);
         self.flow_narrowed_nodes
             .clone_from(&snap.cache.flow_narrowed_nodes);
         self.daa_error_nodes.clone_from(&snap.cache.daa_error_nodes);
-        *self.symbol_flow_confirmed.borrow_mut() = snap.cache.symbol_flow_confirmed.clone();
+        self.symbol_flow_confirmed
+            .borrow_mut()
+            .clone_from(&snap.cache.symbol_flow_confirmed);
         crate::state_domain::type_environment::lazy::restore_global_resolution_fuel(
             snap.cache.global_resolution_fuel,
         );
@@ -490,14 +492,14 @@ impl<'a> CheckerContext<'a> {
 
     /// Restore TS2454 dedup state from a snapshot, allowing re-emission during
     /// a retry pass (e.g., after overload resolution failure).
-    pub(crate) fn restore_ts2454_state(&mut self, snap: &FxHashSet<(u32, SymbolId)>) {
+    pub(crate) fn restore_ts2454_state(&mut self, snap: &CowCache<FxHashSet<(u32, SymbolId)>>) {
         self.emitted_ts2454_errors.clone_from(snap);
     }
 }
 
 /// Snapshot of speculation-scoped implicit-any closure state.
 pub(crate) struct ImplicitAnyClosureSnapshot {
-    checked_closures: FxHashSet<NodeIndex>,
+    checked_closures: CowCache<FxHashSet<NodeIndex>>,
 }
 
 impl ImplicitAnyClosureSnapshot {

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -14,7 +14,7 @@ use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::{ParamInfo, TupleElement, TypeId, TypePredicate};
 
-type FlowCache = FxHashMap<(FlowNodeId, SymbolId, TypeId), TypeId>;
+type FlowCache = crate::context::CowCache<FxHashMap<(FlowNodeId, SymbolId, TypeId), TypeId>>;
 type ReferenceMatchCache = RefCell<FxHashMap<(u32, u32), bool>>;
 type ReferenceSymbolCache = RefCell<FxHashMap<u32, Option<SymbolId>>>;
 /// Session-scoped interner mapping a structural reference *path*
@@ -717,10 +717,7 @@ impl<'a> FlowAnalyzer<'a> {
     }
 
     /// Set the flow analysis cache to avoid redundant graph traversals.
-    pub const fn with_flow_cache(
-        mut self,
-        cache: &'a RefCell<FxHashMap<(FlowNodeId, SymbolId, TypeId), TypeId>>,
-    ) -> Self {
+    pub const fn with_flow_cache(mut self, cache: &'a RefCell<FlowCache>) -> Self {
         self.flow_cache = Some(cache);
         self
     }


### PR DESCRIPTION
Goal: fast

Implements #13087 and #13078 together (parent #13250, workstream D): checker speculation snapshots and child-checker cache inheritance become O(1) Arc bumps via a `CowCache<T>` copy-on-write wrapper (`crates/tsz-checker/src/context/caches.rs`), replacing unconditional deep map clones.

## Structural rule
A snapshot or child-checker cache copy must cost O(1) unless the holder actually diverges; the deep copy is paid at most once per diverging holder via `Arc::make_mut`, and isolation semantics are unchanged because every `&mut` access detaches. This is the same idiom that made `NodeArena` O(1)-cloneable in #13033 (Arc<Inner> + Deref/DerefMut(make_mut)), applied to the checker's cache maps.

Per-issue halves:
- **#13087 (speculation snapshots)**: `DiagnosticSnapshot`/`FullSnapshot`/`CacheSnapshot` fields are `CowCache`; snapshot = Arc bump; rollback (`clone_from`) is an O(1) Arc swap and re-shares. Also drops the duplicate `request_node_types` clone+restore per return-type speculation level (#13078's double-clone finding).
- **#13078 (`with_parent_cache`)**: ~10 inherited cache maps (symbol/enum-namespace/lowering/heritage/jsdoc-typedef/implicit-any/…) are Arc-shared into child checkers instead of deep-cloned per child.

## Performance (interleaved hyperfine A/B, 10 runs + 3 warmup, parent-commit binary vs branch binary)
| Fixture | parent | this PR | delta |
|---|---|---|---|
| speculation-heavy stress | 554.3 ± 18.5 ms | 498.2 ± 8.7 ms | **−10.1%** |
| zodmin | 992.2 ± 12.2 ms | 978.9 ± 7.7 ms | −1.3% (≈1.3σ) |
| ts-toolbelt (flat) | 551.5 ± 6.1 ms | 557.3 ± 8.2 ms | +1.1% (within noise) |

Peak footprint on the stress fixture 45.3 → 43.8 MB; max RSS 59.2 → 57.8 MB. The split is explained by counters: the stress fixture exercises the snapshot half (0 `with_parent_cache` calls); ts-toolbelt exercises the inheritance half (191 child checkers) where the inherited caches are small — wall-neutral there, honestly reported.

## Adjacent-case matrix
- `CowCache` share-until-write; `clone_from` rollback re-sharing; parent writes after a child snapshot stay isolated (both directions); `into_inner` — 4 unit tests.
- Known cost edge (documented on the type): `remove`/`entry` of an absent key on a shared holder deep-copies once per snapshot boundary — bounded, strictly cheaper than the old unconditional clones.
- `FlowAnalysisCacheMap`/`SymbolFlowConfirmedMap` aliases satisfy `clippy::type_complexity` without suppressions.

## Verification
- Full local conformance (release): 12583/12585, zero new vs accepted regressions (only the 2 accepted Mac-delta cases), re-run after rebase onto current main (post #13261/#13262).
- `cargo nextest run -p tsz-checker`: identical failure-name set vs parent commit at the teammate's base (diff empty; 7 ts2859 template-union timeouts and the rest reproduce on clean main); 4/4 new CowCache tests pass post-rebase.
- clippy --all-targets clean; arch_guard + checker_field_inventory pass.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: max
