### PR TITLE
perf(common,core,cli): residency byte-gauge breakdown in the perf-counter snapshot (#13249 step 1)

### DIFF
--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -333,6 +333,31 @@ impl Symbol {
         }
     }
 
+    /// Estimate the heap bytes owned by this symbol beyond
+    /// `size_of::<Symbol>()` (name, declaration lists, member tables).
+    ///
+    /// Capacity-based estimate for residency accounting (#13249 step 1);
+    /// called only at perf-counter snapshot time, never on a hot path.
+    #[must_use]
+    pub fn estimated_heap_bytes(&self) -> usize {
+        let mut size = self.escaped_name.capacity();
+        size += self.declarations.capacity() * std::mem::size_of::<NodeIndex>();
+        size += self.stable_declarations.capacity() * std::mem::size_of::<StableLocation>();
+        if let Some(exports) = &self.exports {
+            size += std::mem::size_of::<SymbolTable>() + exports.estimated_size_bytes();
+        }
+        if let Some(members) = &self.members {
+            size += std::mem::size_of::<SymbolTable>() + members.estimated_size_bytes();
+        }
+        if let Some(module) = &self.import_module {
+            size += module.capacity();
+        }
+        if let Some(name) = &self.import_name {
+            size += name.capacity();
+        }
+        size
+    }
+
     /// Check if symbol has all specified flags.
     #[must_use]
     pub const fn has_flags(&self, flags: u32) -> bool {
@@ -552,6 +577,21 @@ impl SymbolTable {
     pub fn iter(&self) -> impl Iterator<Item = (&String, &SymbolId)> {
         self.symbols.iter()
     }
+
+    /// Estimate the heap bytes owned by this table (map buckets + name
+    /// strings). Capacity-based estimate for residency accounting (#13249
+    /// step 1); called only at perf-counter snapshot time.
+    #[must_use]
+    pub fn estimated_size_bytes(&self) -> usize {
+        // FxHashMap per-bucket overhead: hash + alignment padding.
+        const BUCKET_OVERHEAD: usize = 16;
+        let mut size = self.symbols.capacity()
+            * (BUCKET_OVERHEAD + std::mem::size_of::<String>() + std::mem::size_of::<SymbolId>());
+        for name in self.symbols.keys() {
+            size += name.capacity();
+        }
+        size
+    }
 }
 
 // =============================================================================
@@ -734,6 +774,28 @@ impl SymbolArena {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.symbols.is_empty()
+    }
+
+    /// Estimate the heap bytes owned by this arena: symbol slots, per-symbol
+    /// heap (names, declaration lists, member tables), and the name index.
+    ///
+    /// Capacity-based estimate for residency accounting (#13249 step 1);
+    /// walks every symbol, so call only at perf-counter snapshot time.
+    #[must_use]
+    pub fn estimated_size_bytes(&self) -> usize {
+        const BUCKET_OVERHEAD: usize = 16;
+        let mut size = self.symbols.capacity() * std::mem::size_of::<Symbol>();
+        for sym in self.symbols.iter() {
+            size += sym.estimated_heap_bytes();
+        }
+        size += self.name_index.capacity()
+            * (BUCKET_OVERHEAD
+                + std::mem::size_of::<String>()
+                + std::mem::size_of::<Vec<SymbolId>>());
+        for (name, ids) in self.name_index.iter() {
+            size += name.capacity() + ids.capacity() * std::mem::size_of::<SymbolId>();
+        }
+        size
     }
 
     /// Reserve additional capacity for the symbol arena and its name index.

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -312,6 +312,84 @@ pub struct TypeCache {
     pub namespace_module_names: FxHashMap<TypeId, String>,
 }
 
+impl TypeCache {
+    /// Estimate the resident heap bytes of this per-file cache snapshot.
+    ///
+    /// Entry-count-based estimate for residency accounting (#13249 step 1):
+    /// emit runs pin one `TypeCache` per file until emit completes, so the
+    /// CLI driver sums this across the retained map at perf-counter
+    /// snapshot time. Never called on a checking hot path.
+    #[must_use]
+    pub fn estimated_size_bytes(&self) -> usize {
+        // FxHashMap per-entry overhead: hash + bucket slot + padding.
+        const ENTRY_OVERHEAD: usize = 16;
+        let entry = |len: usize, key: usize, value: usize| len * (ENTRY_OVERHEAD + key + value);
+        let id = std::mem::size_of::<TypeId>();
+        let node = std::mem::size_of::<NodeIndex>();
+        let sym = std::mem::size_of::<SymbolId>();
+
+        let mut size = std::mem::size_of::<Self>();
+        size += entry(self.symbol_types.len(), sym, id);
+        size += entry(self.symbol_instance_types.len(), sym, id);
+        size += entry(self.node_types.len(), 4, id);
+        size += entry(
+            self.symbol_dependencies.len(),
+            sym,
+            std::mem::size_of::<FxHashSet<SymbolId>>(),
+        );
+        size += self
+            .symbol_dependencies
+            .values()
+            .map(|deps| deps.len() * (ENTRY_OVERHEAD + sym))
+            .sum::<usize>();
+        size += entry(self.def_to_symbol.len(), 8, sym);
+        size += entry(self.def_to_name.len(), 8, std::mem::size_of::<String>());
+        size += self
+            .def_to_name
+            .values()
+            .map(String::capacity)
+            .sum::<usize>();
+        size += entry(self.def_types.len(), 4, id);
+        size += entry(
+            self.def_type_params.len(),
+            4,
+            std::mem::size_of::<Vec<tsz_solver::TypeParamInfo>>(),
+        );
+        size += self
+            .def_type_params
+            .values()
+            .map(|params| params.capacity() * std::mem::size_of::<tsz_solver::TypeParamInfo>())
+            .sum::<usize>();
+        size += entry(self.boxed_types.len(), 8, id);
+        size += entry(
+            self.boxed_def_ids.len(),
+            8,
+            std::mem::size_of::<Vec<tsz_solver::DefId>>(),
+        );
+        size += entry(
+            self.well_known_symbol_names.len(),
+            std::mem::size_of::<String>(),
+            std::mem::size_of::<tsz_solver::SymbolRef>(),
+        );
+        size += entry(self.flow_analysis_cache.len(), 8 + sym + id, id);
+        size += entry(self.class_instance_type_to_decl.len(), id, node);
+        size += entry(self.class_instance_type_cache.len(), node, id);
+        size += entry(self.class_constructor_type_cache.len(), node, id);
+        size += entry(self.type_only_nodes.len(), node, 0);
+        size += entry(
+            self.namespace_module_names.len(),
+            id,
+            std::mem::size_of::<String>(),
+        );
+        size += self
+            .namespace_module_names
+            .values()
+            .map(String::capacity)
+            .sum::<usize>();
+        size
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct EnvEvalCacheEntry {
     pub(crate) result: TypeId,

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -1461,6 +1461,18 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
                 parallel_qc_stats.merge(&query_cache.statistics());
             }
         }
+        // Residency accounting (#13249 step 1): the shared cross-file query
+        // cache drops at the end of this branch, so record its resident size
+        // here while it is still alive. No-op unless TSZ_PERF_COUNTERS is
+        // set; the walk is O(1) (DashMap len() per map).
+        if tsz_common::perf_counters::enabled()
+            && let Some(shared) = shared_query_cache.as_ref()
+        {
+            tsz_common::perf_counters::record_shared_query_cache_residency(
+                shared.total_entries() as u64,
+                shared.estimated_size_bytes() as u64,
+            );
+        }
         // PERF: `DefinitionStore::statistics()` walks every entry (and
         // `estimated_size_bytes()` walks again) — only worth paying for
         // when --diagnostics or --extendedDiagnostics is requested.
@@ -1883,6 +1895,24 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
         } else {
             tracing::info!(target: "def_publication_census", "\n{report}");
         }
+    }
+
+    // Residency accounting (#13249 step 1): record the per-category byte
+    // breakdown into the process-wide perf-counter gauges before the driver
+    // writes the JSON snapshot. The merged program is at its final retained
+    // size here; the per-file `TypeCache` map (pinned for emit; empty under
+    // pure `--noEmit`) is fully populated. No-op (single branch) unless
+    // `TSZ_PERF_COUNTERS` is set.
+    if tsz_common::perf_counters::enabled() {
+        program.record_residency_breakdown();
+        let tc_out = type_cache_output
+            .lock()
+            .expect("type_cache_output mutex poisoned");
+        let type_cache_bytes: usize = tc_out.values().map(TypeCache::estimated_size_bytes).sum();
+        tsz_common::perf_counters::record_type_cache_residency(
+            tc_out.len() as u64,
+            type_cache_bytes as u64,
+        );
     }
 
     CollectDiagnosticsResult {

--- a/crates/tsz-common/src/perf_counters.rs
+++ b/crates/tsz-common/src/perf_counters.rs
@@ -20,9 +20,13 @@ include!("perf_counters/definitions.rs");
 include!("perf_counters/runtime.rs");
 include!("perf_counters/dump.rs");
 include!("perf_counters/snapshot.rs");
+include!("perf_counters/residency.rs");
 
 #[cfg(test)]
 include!("perf_counters/tests.rs");
 
 #[cfg(test)]
 include!("perf_counters/dump_tests.rs");
+
+#[cfg(test)]
+include!("perf_counters/residency_tests.rs");

--- a/crates/tsz-common/src/perf_counters/residency.rs
+++ b/crates/tsz-common/src/perf_counters/residency.rs
@@ -1,0 +1,234 @@
+// ─── residency breakdown (snapshot-time byte gauges) ─────────────────────
+//
+// Per-category resident-bytes accounting for issue #13249 step 1 ("account
+// first"). Unlike the event counters in `runtime.rs`, these are *gauges*:
+// each owning layer records its category once, at end of run, after the
+// structure has reached its final size:
+//
+// - `MergedProgram` (tsz-core) records ASTs/`NodeArena`s, per-file binder
+//   state, lib binders, program-wide symbol state, the `DefinitionStore`,
+//   the `TypeInterner` (including its per-`TypeId` predicate `DashMap`s),
+//   and the skeleton index.
+// - The CLI driver records the `SharedQueryCache` (before it drops at the
+//   end of the check phase) and the retained per-file `TypeCache` map.
+//
+// All values are *estimates* (capacity-based byte math, not allocator
+// truth), hence the `_bytes_est` suffixes. The walks that produce them are
+// gated on [`enabled_fast`] at every call site, so disabled runs pay one
+// branch and never touch these statics.
+
+/// Process-wide residency gauges. Written once per category at snapshot
+/// time; read by [`PerfCounters::snapshot`].
+pub struct ResidencyGauges {
+    /// True once any category has been recorded. Distinguishes "not
+    /// measured" (`residency: null` in the JSON) from "measured zero".
+    recorded_any: AtomicBool,
+    ast_unique_arena_count: AtomicU64,
+    ast_unique_arena_bytes_est: AtomicU64,
+    bound_file_count: AtomicU64,
+    bound_file_state_bytes_est: AtomicU64,
+    lib_binder_count: AtomicU64,
+    lib_binder_symbol_bytes_est: AtomicU64,
+    program_symbol_state_bytes_est: AtomicU64,
+    definition_store_bytes_est: AtomicU64,
+    type_interner_bytes_est: AtomicU64,
+    skeleton_index_bytes_est: AtomicU64,
+    pre_merge_bind_total_bytes_est: AtomicU64,
+    shared_query_cache_entries: AtomicU64,
+    shared_query_cache_bytes_est: AtomicU64,
+    type_cache_count: AtomicU64,
+    type_cache_bytes_est: AtomicU64,
+}
+
+static RESIDENCY_GAUGES: OnceLock<ResidencyGauges> = OnceLock::new();
+
+fn residency_gauges() -> &'static ResidencyGauges {
+    RESIDENCY_GAUGES.get_or_init(|| ResidencyGauges {
+        recorded_any: AtomicBool::new(false),
+        ast_unique_arena_count: AtomicU64::new(0),
+        ast_unique_arena_bytes_est: AtomicU64::new(0),
+        bound_file_count: AtomicU64::new(0),
+        bound_file_state_bytes_est: AtomicU64::new(0),
+        lib_binder_count: AtomicU64::new(0),
+        lib_binder_symbol_bytes_est: AtomicU64::new(0),
+        program_symbol_state_bytes_est: AtomicU64::new(0),
+        definition_store_bytes_est: AtomicU64::new(0),
+        type_interner_bytes_est: AtomicU64::new(0),
+        skeleton_index_bytes_est: AtomicU64::new(0),
+        pre_merge_bind_total_bytes_est: AtomicU64::new(0),
+        shared_query_cache_entries: AtomicU64::new(0),
+        shared_query_cache_bytes_est: AtomicU64::new(0),
+        type_cache_count: AtomicU64::new(0),
+        type_cache_bytes_est: AtomicU64::new(0),
+    })
+}
+
+/// Merged-program residency categories, recorded by
+/// `MergedProgram::record_residency_breakdown` in tsz-core once the program
+/// has been fully checked. Field semantics mirror [`ResidencySnapshot`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MergedProgramResidencyRecord {
+    pub ast_unique_arena_count: u64,
+    pub ast_unique_arena_bytes_est: u64,
+    pub bound_file_count: u64,
+    pub bound_file_state_bytes_est: u64,
+    pub lib_binder_count: u64,
+    pub lib_binder_symbol_bytes_est: u64,
+    pub program_symbol_state_bytes_est: u64,
+    pub definition_store_bytes_est: u64,
+    pub type_interner_bytes_est: u64,
+    pub skeleton_index_bytes_est: u64,
+    pub pre_merge_bind_total_bytes_est: u64,
+}
+
+/// Record the merged-program residency categories. Gated on
+/// [`enabled_fast`]; callers should also gate the (much more expensive)
+/// arena walk that computes the record on the same check.
+pub fn record_merged_program_residency(record: &MergedProgramResidencyRecord) {
+    if !enabled_fast() {
+        return;
+    }
+    let g = residency_gauges();
+    g.ast_unique_arena_count
+        .store(record.ast_unique_arena_count, Ordering::Relaxed);
+    g.ast_unique_arena_bytes_est
+        .store(record.ast_unique_arena_bytes_est, Ordering::Relaxed);
+    g.bound_file_count
+        .store(record.bound_file_count, Ordering::Relaxed);
+    g.bound_file_state_bytes_est
+        .store(record.bound_file_state_bytes_est, Ordering::Relaxed);
+    g.lib_binder_count
+        .store(record.lib_binder_count, Ordering::Relaxed);
+    g.lib_binder_symbol_bytes_est
+        .store(record.lib_binder_symbol_bytes_est, Ordering::Relaxed);
+    g.program_symbol_state_bytes_est
+        .store(record.program_symbol_state_bytes_est, Ordering::Relaxed);
+    g.definition_store_bytes_est
+        .store(record.definition_store_bytes_est, Ordering::Relaxed);
+    g.type_interner_bytes_est
+        .store(record.type_interner_bytes_est, Ordering::Relaxed);
+    g.skeleton_index_bytes_est
+        .store(record.skeleton_index_bytes_est, Ordering::Relaxed);
+    g.pre_merge_bind_total_bytes_est
+        .store(record.pre_merge_bind_total_bytes_est, Ordering::Relaxed);
+    g.recorded_any.store(true, Ordering::Relaxed);
+}
+
+/// Record the shared cross-file query cache's resident size. Called by the
+/// CLI driver at the end of the check phase, while the cache is still alive.
+pub fn record_shared_query_cache_residency(entries: u64, bytes_est: u64) {
+    if !enabled_fast() {
+        return;
+    }
+    let g = residency_gauges();
+    g.shared_query_cache_entries
+        .store(entries, Ordering::Relaxed);
+    g.shared_query_cache_bytes_est
+        .store(bytes_est, Ordering::Relaxed);
+    g.recorded_any.store(true, Ordering::Relaxed);
+}
+
+/// Record the retained per-file `TypeCache` map's resident size (emit runs
+/// pin one `TypeCache` per file until emit completes; pure `--noEmit` runs
+/// skip extraction and record zero here).
+pub fn record_type_cache_residency(count: u64, bytes_est: u64) {
+    if !enabled_fast() {
+        return;
+    }
+    let g = residency_gauges();
+    g.type_cache_count.store(count, Ordering::Relaxed);
+    g.type_cache_bytes_est.store(bytes_est, Ordering::Relaxed);
+    g.recorded_any.store(true, Ordering::Relaxed);
+}
+
+/// JSON view of the residency gauges. All `*_bytes_est` values are
+/// capacity-based estimates, not allocator ground truth; compare against
+/// `/usr/bin/time -l` max RSS for the unaccounted remainder.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct ResidencySnapshot {
+    /// Unique `NodeArena` allocations (user files + lib files, deduplicated
+    /// by pointer identity across all retaining maps).
+    pub ast_unique_arena_count: u64,
+    pub ast_unique_arena_bytes_est: u64,
+    /// `BoundFile` entries retained by `MergedProgram.files`.
+    pub bound_file_count: u64,
+    /// Per-file binder state (`node_symbols`, scopes, flow graph, …)
+    /// excluding the arenas counted above.
+    pub bound_file_state_bytes_est: u64,
+    /// Lib `BinderState`s retained for global type resolution.
+    pub lib_binder_count: u64,
+    /// Lib binder symbol-arena bytes (lib `NodeArena`s are deduplicated
+    /// into `ast_unique_arena_bytes_est`).
+    pub lib_binder_symbol_bytes_est: u64,
+    /// Program-wide symbol state: merged `SymbolArena`, globals/file-locals
+    /// tables, module exports, semantic defs, declaration-arena map
+    /// overhead.
+    pub program_symbol_state_bytes_est: u64,
+    /// Shared solver `DefinitionStore`.
+    pub definition_store_bytes_est: u64,
+    /// `TypeInterner` storage including its per-`TypeId` predicate
+    /// `DashMap` caches.
+    pub type_interner_bytes_est: u64,
+    /// Skeleton index (zero when not computed).
+    pub skeleton_index_bytes_est: u64,
+    /// Pre-merge `BindResult` footprint captured before the merge consumed
+    /// per-file data (informational; this memory is released after merge).
+    pub pre_merge_bind_total_bytes_est: u64,
+    /// `SharedQueryCache` entries across eval/subtype/assignability maps.
+    pub shared_query_cache_entries: u64,
+    pub shared_query_cache_bytes_est: u64,
+    /// Per-file `TypeCache` snapshots retained for emit.
+    pub type_cache_count: u64,
+    pub type_cache_bytes_est: u64,
+    /// Sum of every `*_bytes_est` category above except
+    /// `pre_merge_bind_total_bytes_est` (which is transient, not resident
+    /// at snapshot time).
+    pub tracked_total_bytes_est: u64,
+}
+
+/// Load the residency gauges into a snapshot. Returns `None` when no
+/// category has been recorded (counters disabled, or a driver that does
+/// not wire residency recording).
+pub(crate) fn snapshot_residency() -> Option<ResidencySnapshot> {
+    let g = RESIDENCY_GAUGES.get()?;
+    if !g.recorded_any.load(Ordering::Relaxed) {
+        return None;
+    }
+    let load = |a: &AtomicU64| a.load(Ordering::Relaxed);
+    let ast_unique_arena_bytes_est = load(&g.ast_unique_arena_bytes_est);
+    let bound_file_state_bytes_est = load(&g.bound_file_state_bytes_est);
+    let lib_binder_symbol_bytes_est = load(&g.lib_binder_symbol_bytes_est);
+    let program_symbol_state_bytes_est = load(&g.program_symbol_state_bytes_est);
+    let definition_store_bytes_est = load(&g.definition_store_bytes_est);
+    let type_interner_bytes_est = load(&g.type_interner_bytes_est);
+    let skeleton_index_bytes_est = load(&g.skeleton_index_bytes_est);
+    let shared_query_cache_bytes_est = load(&g.shared_query_cache_bytes_est);
+    let type_cache_bytes_est = load(&g.type_cache_bytes_est);
+    let tracked_total_bytes_est = ast_unique_arena_bytes_est
+        + bound_file_state_bytes_est
+        + lib_binder_symbol_bytes_est
+        + program_symbol_state_bytes_est
+        + definition_store_bytes_est
+        + type_interner_bytes_est
+        + skeleton_index_bytes_est
+        + shared_query_cache_bytes_est
+        + type_cache_bytes_est;
+    Some(ResidencySnapshot {
+        ast_unique_arena_count: load(&g.ast_unique_arena_count),
+        ast_unique_arena_bytes_est,
+        bound_file_count: load(&g.bound_file_count),
+        bound_file_state_bytes_est,
+        lib_binder_count: load(&g.lib_binder_count),
+        lib_binder_symbol_bytes_est,
+        program_symbol_state_bytes_est,
+        definition_store_bytes_est,
+        type_interner_bytes_est,
+        skeleton_index_bytes_est,
+        pre_merge_bind_total_bytes_est: load(&g.pre_merge_bind_total_bytes_est),
+        shared_query_cache_entries: load(&g.shared_query_cache_entries),
+        shared_query_cache_bytes_est,
+        type_cache_count: load(&g.type_cache_count),
+        type_cache_bytes_est,
+        tracked_total_bytes_est,
+    })
+}

--- a/crates/tsz-common/src/perf_counters/residency_tests.rs
+++ b/crates/tsz-common/src/perf_counters/residency_tests.rs
@@ -1,0 +1,91 @@
+mod residency_tests {
+    use super::*;
+
+    /// Recording all three residency categories (merged program, shared
+    /// query cache, type caches) with counters force-enabled must surface a
+    /// `Some(residency)` snapshot with the recorded values and a coherent
+    /// tracked total.
+    ///
+    /// Note: the gauges are process-wide and nextest runs each test in its
+    /// own process, so this test owns the gauge state for its lifetime.
+    #[test]
+    fn residency_record_propagates_into_snapshot() {
+        force_enable_perf_counters_for_tests();
+
+        record_merged_program_residency(&MergedProgramResidencyRecord {
+            ast_unique_arena_count: 12,
+            ast_unique_arena_bytes_est: 1_000,
+            bound_file_count: 3,
+            bound_file_state_bytes_est: 200,
+            lib_binder_count: 9,
+            lib_binder_symbol_bytes_est: 30,
+            program_symbol_state_bytes_est: 40,
+            definition_store_bytes_est: 50,
+            type_interner_bytes_est: 60,
+            skeleton_index_bytes_est: 7,
+            pre_merge_bind_total_bytes_est: 999,
+        });
+        record_shared_query_cache_residency(21, 80);
+        record_type_cache_residency(2, 90);
+
+        let snap = PerfCounters::snapshot();
+        let residency = snap.residency.expect("residency recorded => Some");
+        assert_eq!(residency.ast_unique_arena_count, 12);
+        assert_eq!(residency.ast_unique_arena_bytes_est, 1_000);
+        assert_eq!(residency.bound_file_count, 3);
+        assert_eq!(residency.bound_file_state_bytes_est, 200);
+        assert_eq!(residency.lib_binder_count, 9);
+        assert_eq!(residency.lib_binder_symbol_bytes_est, 30);
+        assert_eq!(residency.program_symbol_state_bytes_est, 40);
+        assert_eq!(residency.definition_store_bytes_est, 50);
+        assert_eq!(residency.type_interner_bytes_est, 60);
+        assert_eq!(residency.skeleton_index_bytes_est, 7);
+        assert_eq!(residency.pre_merge_bind_total_bytes_est, 999);
+        assert_eq!(residency.shared_query_cache_entries, 21);
+        assert_eq!(residency.shared_query_cache_bytes_est, 80);
+        assert_eq!(residency.type_cache_count, 2);
+        assert_eq!(residency.type_cache_bytes_est, 90);
+        // Total excludes the transient pre-merge bytes.
+        assert_eq!(
+            residency.tracked_total_bytes_est,
+            1_000 + 200 + 30 + 40 + 50 + 60 + 7 + 80 + 90
+        );
+
+        // JSON shape: residency must serialize as an object with the
+        // estimate-labeled field names the bench harness reads.
+        let json = serde_json::to_value(&snap).expect("serializes");
+        assert_eq!(json["residency"]["ast_unique_arena_bytes_est"], 1_000);
+        assert_eq!(json["residency"]["type_interner_bytes_est"], 60);
+        assert_eq!(json["residency"]["tracked_total_bytes_est"], 1_557);
+    }
+
+    /// Without any record call the snapshot must say "not measured"
+    /// (`residency: null`), not "measured zero". The recording helpers are
+    /// gated on `enabled_fast()`, which latches `false` in this process
+    /// because `TSZ_PERF_COUNTERS` is unset for unit tests, so the calls
+    /// below must leave the gauges unrecorded.
+    #[test]
+    fn residency_absent_when_disabled() {
+        // Deliberately do NOT force-enable counters here.
+        if enabled_fast() {
+            // Defensive: if the suite ever runs with TSZ_PERF_COUNTERS set,
+            // this test's premise does not hold; skip rather than mis-assert.
+            return;
+        }
+        record_shared_query_cache_residency(123, 456);
+        record_type_cache_residency(1, 2);
+        record_merged_program_residency(&MergedProgramResidencyRecord {
+            ast_unique_arena_count: 1,
+            ast_unique_arena_bytes_est: 1,
+            ..Default::default()
+        });
+
+        let snap = PerfCounters::snapshot();
+        assert!(
+            snap.residency.is_none(),
+            "disabled counters must not record residency"
+        );
+        let json = serde_json::to_value(&snap).expect("serializes");
+        assert!(json["residency"].is_null());
+    }
+}

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -1,6 +1,6 @@
 /// Stable schema version for `PerfCounterSnapshot`. Bump when the JSON
 /// shape changes in a way the bench harness must adapt to.
-pub const PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION: u32 = 7;
+pub const PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION: u32 = 8;
 
 /// Frozen value-object view of the counter state. Built by
 /// [`PerfCounters::snapshot`]; serializable to JSON via serde.
@@ -273,6 +273,12 @@ pub struct PerfCounterSnapshot {
     /// This bounded list is sorted by descending elapsed time. Alias names are
     /// labels for humans reading the report, not compiler-policy inputs.
     pub slow_type_alias_check_timings: Vec<SlowTypeAliasCheckTiming>,
+    /// Per-category resident-bytes breakdown (issue #13249 step 1).
+    ///
+    /// `None` ("not measured") when counters are disabled or no layer
+    /// recorded its category; `Some` with capacity-based byte estimates
+    /// otherwise. See [`ResidencySnapshot`] for category semantics.
+    pub residency: Option<ResidencySnapshot>,
 }
 
 /// Per-bucket "is this wired up to its producer?" flag. Lets the bench
@@ -785,6 +791,7 @@ impl PerfCounters {
             slow_check_file_timings: Self::snapshot_slow_check_file_timings(),
             slow_check_statement_timings: Self::snapshot_slow_check_statement_timings(),
             slow_type_alias_check_timings: Self::snapshot_slow_type_alias_check_timings(),
+            residency: snapshot_residency(),
         }
     }
 

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -2,10 +2,11 @@ mod json_tests {
     use super::*;
 
     #[test]
-    fn schema_version_is_seven() {
+    fn schema_version_is_eight() {
         // Bumping schema_version is a breaking change for the bench harness;
-        // make the intent explicit.
-        assert_eq!(PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION, 7);
+        // make the intent explicit. v8 added the `residency` breakdown
+        // (issue #13249 step 1).
+        assert_eq!(PERF_COUNTER_SNAPSHOT_SCHEMA_VERSION, 8);
     }
 
     #[test]
@@ -54,10 +55,11 @@ mod json_tests {
             "slow_check_file_timings",
             "slow_check_statement_timings",
             "slow_type_alias_check_timings",
+            "residency",
         ] {
             assert!(json.get(key).is_some(), "missing top-level key: {key}");
         }
-        assert_eq!(json["schema_version"], 7);
+        assert_eq!(json["schema_version"], 8);
     }
 
     #[test]

--- a/crates/tsz-core/src/parallel/residency.rs
+++ b/crates/tsz-core/src/parallel/residency.rs
@@ -60,14 +60,18 @@ pub struct MergedProgramResidencyStats {
 }
 
 impl MergedProgram {
-    /// Return residency-oriented counters for the current merged program.
-    #[must_use]
-    pub fn residency_stats(&self) -> MergedProgramResidencyStats {
+    /// Collect every unique `NodeArena` retained by the merged program,
+    /// deduplicated by pointer identity. `include_lib_binders` additionally
+    /// walks the lib `BinderState` arena maps (lib arenas are usually also
+    /// reachable through the merged `symbol_arenas`/`declaration_arenas`
+    /// maps, but the dedup makes the extra walk safe either way).
+    fn collect_unique_arenas(
+        &self,
+        include_lib_binders: bool,
+    ) -> rustc_hash::FxHashMap<usize, &Arc<tsz_parser::parser::NodeArena>> {
         use rustc_hash::FxHashMap;
         use tsz_parser::parser::NodeArena;
 
-        // Collect unique arenas by pointer identity, keeping a reference to
-        // each for size estimation.
         let mut unique_arena_map: FxHashMap<usize, &Arc<NodeArena>> = FxHashMap::default();
 
         for file in &self.files {
@@ -84,6 +88,31 @@ impl MergedProgram {
                 unique_arena_map.entry(ptr).or_insert(arena);
             }
         }
+        if include_lib_binders {
+            for binder in self.lib_binders.iter() {
+                for arena in binder.symbol_arenas.values() {
+                    let ptr = Arc::as_ptr(arena) as usize;
+                    unique_arena_map.entry(ptr).or_insert(arena);
+                }
+                for arenas in binder.declaration_arenas.values() {
+                    for arena in arenas {
+                        let ptr = Arc::as_ptr(arena) as usize;
+                        unique_arena_map.entry(ptr).or_insert(arena);
+                    }
+                }
+            }
+        }
+        unique_arena_map
+    }
+
+    /// Return residency-oriented counters for the current merged program.
+    #[must_use]
+    pub fn residency_stats(&self) -> MergedProgramResidencyStats {
+        // Collect unique arenas by pointer identity, keeping a reference to
+        // each for size estimation. Lib binder arenas are excluded here to
+        // keep `--diagnostics-json` numbers comparable with prior runs; the
+        // perf-counter breakdown includes them.
+        let unique_arena_map = self.collect_unique_arenas(false);
 
         let unique_arena_count = unique_arena_map.len();
         let unique_arena_estimated_bytes: usize = unique_arena_map
@@ -152,6 +181,119 @@ impl MergedProgram {
             dep_graph_cycle_count: dep_cycle_count,
             dep_graph_unresolved_count: dep_unresolved,
         }
+    }
+
+    /// Estimate the heap bytes of the program-wide symbol state retained by
+    /// the merge: the merged `SymbolArena`, global/file-local symbol tables,
+    /// module export tables, semantic-def entries, and the map overhead of
+    /// the declaration-arena lookup tables (the arenas themselves are
+    /// counted by the unique-arena walk).
+    fn program_symbol_state_bytes_est(&self) -> usize {
+        use std::mem::size_of;
+        const ENTRY_OVERHEAD: usize = 16;
+
+        let mut size = self.symbols.estimated_size_bytes();
+        size += self.globals.estimated_size_bytes();
+        size += self.lib_globals.estimated_size_bytes();
+        size += self
+            .file_locals
+            .iter()
+            .map(super::super::binder::SymbolTable::estimated_size_bytes)
+            .sum::<usize>();
+        for (name, table) in self.module_exports.iter() {
+            size += ENTRY_OVERHEAD + name.capacity() + table.estimated_size_bytes();
+        }
+        for entry in self.semantic_defs.values() {
+            size += ENTRY_OVERHEAD + size_of::<crate::binder::SemanticDefEntry>();
+            size += entry.name.capacity();
+            size += entry
+                .type_param_names
+                .iter()
+                .map(|n| size_of::<String>() + n.capacity())
+                .sum::<usize>();
+            size += entry
+                .enum_member_names
+                .iter()
+                .map(|n| size_of::<String>() + n.capacity())
+                .sum::<usize>();
+            size += entry
+                .extends_names
+                .iter()
+                .map(|n| size_of::<String>() + n.capacity())
+                .sum::<usize>();
+            size += entry
+                .implements_names
+                .iter()
+                .map(|n| size_of::<String>() + n.capacity())
+                .sum::<usize>();
+        }
+        // Program-wide arena lookup tables: count entry overhead only (the
+        // pointed-to arenas are owned by the unique-arena category).
+        size += self.symbol_arenas.len() * (ENTRY_OVERHEAD + size_of::<u32>() + size_of::<usize>());
+        size += self
+            .declaration_arenas
+            .values()
+            .map(|arenas| {
+                ENTRY_OVERHEAD + size_of::<(u32, u32)>() + arenas.len() * size_of::<usize>()
+            })
+            .sum::<usize>();
+        size += self
+            .sym_to_decl_indices
+            .values()
+            .map(|indices| ENTRY_OVERHEAD + size_of::<u32>() + indices.len() * size_of::<u32>())
+            .sum::<usize>();
+        size += self.cross_file_node_symbols.len()
+            * (ENTRY_OVERHEAD + size_of::<usize>() + size_of::<usize>());
+        size += self.alias_partners.len() * (ENTRY_OVERHEAD + 2 * size_of::<u32>());
+        size
+    }
+
+    /// Record the per-category residency breakdown into the process-wide
+    /// perf-counter gauges (issue #13249 step 1).
+    ///
+    /// Zero overhead when `TSZ_PERF_COUNTERS` is unset: the gate is checked
+    /// before any walk happens. When enabled, this walks every retained
+    /// arena, bound file, lib binder, and program-wide map exactly once —
+    /// intended to be called a single time at the end of a batch compile,
+    /// immediately before the CLI writes the perf-counter JSON snapshot.
+    pub fn record_residency_breakdown(&self) {
+        use tsz_common::perf_counters as pc;
+        if !pc::enabled() {
+            return;
+        }
+
+        let unique_arena_map = self.collect_unique_arenas(true);
+        let ast_unique_arena_bytes_est: usize = unique_arena_map
+            .values()
+            .map(|a| a.estimated_size_bytes())
+            .sum();
+
+        let bound_file_state_bytes_est: usize =
+            self.files.iter().map(|f| f.estimated_size_bytes()).sum();
+
+        let lib_binder_symbol_bytes_est: usize = self
+            .lib_binders
+            .iter()
+            .map(|binder| binder.symbols.estimated_size_bytes())
+            .sum();
+
+        pc::record_merged_program_residency(&pc::MergedProgramResidencyRecord {
+            ast_unique_arena_count: unique_arena_map.len() as u64,
+            ast_unique_arena_bytes_est: ast_unique_arena_bytes_est as u64,
+            bound_file_count: self.files.len() as u64,
+            bound_file_state_bytes_est: bound_file_state_bytes_est as u64,
+            lib_binder_count: self.lib_binders.len() as u64,
+            lib_binder_symbol_bytes_est: lib_binder_symbol_bytes_est as u64,
+            program_symbol_state_bytes_est: self.program_symbol_state_bytes_est() as u64,
+            definition_store_bytes_est: self.definition_store.estimated_size_bytes() as u64,
+            type_interner_bytes_est: self.type_interner.estimated_size_bytes() as u64,
+            skeleton_index_bytes_est: self
+                .skeleton_index
+                .as_ref()
+                .map_or(0, |idx| idx.estimated_size_bytes())
+                as u64,
+            pre_merge_bind_total_bytes_est: self.pre_merge_bind_total_bytes as u64,
+        });
     }
 }
 

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -149,6 +149,27 @@ impl SharedQueryCache {
     pub fn total_entries(&self) -> usize {
         self.eval_cache.len() + self.subtype_cache.len() + self.assignability_cache.len()
     }
+
+    /// Estimate the resident heap bytes of the shared cache maps.
+    ///
+    /// Entry-count-based estimate (`DashMap` does not expose bucket
+    /// capacity) for residency accounting (#13249 step 1); called once at
+    /// perf-counter snapshot time, never on a checking hot path.
+    #[must_use]
+    pub fn estimated_size_bytes(&self) -> usize {
+        // DashMap per-entry overhead: bucket slot + hash + shard padding.
+        const DASHMAP_ENTRY_OVERHEAD: usize = 64;
+        let mut size = std::mem::size_of::<Self>();
+        size += self.eval_cache.len()
+            * (DASHMAP_ENTRY_OVERHEAD
+                + std::mem::size_of::<EvaluationCacheKey>()
+                + std::mem::size_of::<TypeId>());
+        size += (self.subtype_cache.len() + self.assignability_cache.len())
+            * (DASHMAP_ENTRY_OVERHEAD
+                + std::mem::size_of::<RelationCacheKey>()
+                + std::mem::size_of::<bool>());
+        size
+    }
 }
 
 impl Default for SharedQueryCache {


### PR DESCRIPTION
Goal: fast

Step 1 of #13249 ("account first"): a per-category resident-bytes breakdown in the perf-counter JSON snapshot, so the eviction work in later steps targets measured categories instead of guesses.

## Structural rule
When `TSZ_PERF_COUNTERS` is set and the CLI writes `--perf-counters-json`, each owning layer records its retained-bytes category once at snapshot time into process-wide gauges (`residency` block, schema v8); when counters are off, every call site is a single branch and the JSON reports `residency: null` ("not measured", distinct from "measured zero").

Owner layers:
- tsz-common: gauge storage + `ResidencySnapshot` JSON (schema v7 -> v8).
- tsz-binder / tsz-checker / tsz-solver: capacity-based `estimated_size_bytes` helpers on `SymbolArena`/`SymbolTable`/`Symbol`, `TypeCache`, `SharedQueryCache` (snapshot-time only, never on a checking hot path).
- tsz-core: `MergedProgram::record_residency_breakdown` walks unique `NodeArena`s (pointer-deduplicated, lib binders included), bound-file state, lib binder symbol arenas, program-wide symbol state, `DefinitionStore`, `TypeInterner`, skeleton index.
- tsz-cli: records `SharedQueryCache` while still alive at end of the parallel check branch; merged-program categories + retained per-file `TypeCache` map at end of diagnostics collection.

## Measurements (this branch, release + perf-tools, m-series studio)
| category (bytes_est) | monorepo-002 (1k files) | monorepo-003 (5k files) | ts-toolbelt (242 files) |
|---|---|---|---|
| program_symbol_state | 129.9 MB | 788.0 MB | 66.7 MB |
| bound_file_state | 77.8 MB | 392.9 MB | 35.2 MB |
| definition_store | 43.0 MB | 216.5 MB | 20.2 MB |
| ast_unique_arenas | 35.7 MB (1081) | 150.5 MB (5170) | 34.3 MB (314) |
| type_interner | 6.2 MB | 29.9 MB | 7.6 MB |
| skeleton_index | 1.4 MB | 7.2 MB | 0.14 MB |
| shared_query_cache | 0.8 MB | 4.0 MB | 0.14 MB |
| lib_binder_symbols | 0.37 MB | 0.23 MB | 1.9 MB |
| type_cache (--noEmit) | 0 | 0 | 0 |
| **tracked total** | **295.1 MB** | **1589.2 MB** | **166.3 MB** |
| max RSS (`/usr/bin/time -l`) | 537.6 MB | 2794.8 MB | 459.7 MB |
| tracked / RSS | 55% | 57% | 36% |
| pre_merge_bind (transient, excluded from total) | 127.5 MB | 643.6 MB | 60.6 MB |

Findings for step 2 targeting:
- Program-wide merged symbol state is the dominant retained category at scale (~50% of tracked, ~155 KB/file at 5k), ahead of per-file binder state (~77 KB/file), `DefinitionStore` (~42 KB/file), and ASTs (~30 KB/file).
- The transient pre-merge `BindResult` footprint (644 MB at 5k, released after merge) plus allocator slack plausibly accounts for most of the tracked-vs-RSS gap on the monorepo shapes; ts-toolbelt's lower ratio (36%) matches its check-heavy profile where the peak occurs mid-check, outside these retained structures.
- Emit-mode adjacent case: a `--declaration` run records `type_cache_count=2, type_cache_bytes_est=344 KB` on a 2-file project; all `--noEmit` runs record zero, matching the #13047/#13249 TypeCache-pinning model.

## Performance
- Counters disabled: every new call site is one branch; 5k fixture wall 18.54s (off) vs 18.91s (on, includes all attribution-mode counter overhead), max RSS identical (2798.3 MB vs 2794.8 MB).
- All estimators are walk-once-at-snapshot; no per-check-path work added.

## Adjacent-case matrix
- counters off -> `residency: null`, `enabled: false` (verified end-to-end and by unit test `residency_absent_when_disabled`).
- counters on, --noEmit -> `type_cache_*` zero; emit run -> nonzero (verified both).
- multi-file (shared query cache present) -> `shared_query_cache_entries` nonzero; lib binders counted once via pointer dedup against `symbol_arenas`/`declaration_arenas` maps.
- `--diagnostics-json` residency stats unchanged (lib binder arenas still excluded there for comparability; the new walk dedups them separately).

## Verification
- `cargo nextest run -p tsz-common residency` (2 new tests pass: gauge propagation into snapshot; absent-when-disabled).
- `cargo clippy -p tsz-common -p tsz-binder -p tsz-checker -p tsz-solver -p tsz-core -p tsz-cli --features tsz-cli/perf-tools --all-targets` clean.
- Manual: `TSZ_PERF_COUNTERS=1 /usr/bin/time -l .target/release/tsz -p <fixture> --noEmit --perf-counters-json out.json` on monorepo-002/003 + ts-toolbelt (tables above).

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: max
