### PR TITLE
refactor(solver): reuse application ids on hot paths

### DIFF
--- a/crates/tsz-solver/src/objects/index_signatures.rs
+++ b/crates/tsz-solver/src/objects/index_signatures.rs
@@ -31,8 +31,7 @@ use crate::TypeId;
 use crate::construction::TypeDatabase;
 use crate::relations::subtype::{NoopResolver, TypeResolver};
 use crate::types::{
-    CallableShapeId, IndexInfo, IndexSignature, MappedTypeId, ObjectShapeId, TypeApplicationId,
-    TypeData,
+    CallableShapeId, IndexInfo, IndexSignature, MappedTypeId, ObjectShapeId, TypeData,
 };
 use crate::utils;
 use crate::visitor::TypeVisitor;
@@ -110,9 +109,7 @@ impl<R: TypeResolver> TypeVisitor for StringIndexResolver<'_, R> {
         self.visit_type(self.db, inner_type)
     }
 
-    fn visit_application(&mut self, app_id: u32) -> Self::Output {
-        let app = self.db.type_application(TypeApplicationId(app_id));
-        let type_id = self.db.application(app.base, app.args.clone());
+    fn visit_application_type(&mut self, type_id: TypeId, _app_id: u32) -> Self::Output {
         let evaluated = crate::evaluation::evaluate::evaluate_type_with_resolver(
             self.db,
             self.resolver,
@@ -121,6 +118,14 @@ impl<R: TypeResolver> TypeVisitor for StringIndexResolver<'_, R> {
         (evaluated != type_id)
             .then(|| self.visit_type(self.db, evaluated))
             .flatten()
+    }
+
+    fn visit_type(&mut self, types: &dyn TypeDatabase, type_id: TypeId) -> Self::Output {
+        match types.lookup(type_id) {
+            Some(TypeData::Application(app_id)) => self.visit_application_type(type_id, app_id.0),
+            Some(ref type_key) => self.visit_type_key(types, type_key),
+            None => Self::default_output(),
+        }
     }
 
     fn visit_mapped(&mut self, mapped_id: u32) -> Self::Output {
@@ -185,9 +190,7 @@ impl<R: TypeResolver> TypeVisitor for NumberIndexResolver<'_, R> {
         self.visit_type(self.db, inner_type)
     }
 
-    fn visit_application(&mut self, app_id: u32) -> Self::Output {
-        let app = self.db.type_application(TypeApplicationId(app_id));
-        let type_id = self.db.application(app.base, app.args.clone());
+    fn visit_application_type(&mut self, type_id: TypeId, _app_id: u32) -> Self::Output {
         let evaluated = crate::evaluation::evaluate::evaluate_type_with_resolver(
             self.db,
             self.resolver,
@@ -196,6 +199,14 @@ impl<R: TypeResolver> TypeVisitor for NumberIndexResolver<'_, R> {
         (evaluated != type_id)
             .then(|| self.visit_type(self.db, evaluated))
             .flatten()
+    }
+
+    fn visit_type(&mut self, types: &dyn TypeDatabase, type_id: TypeId) -> Self::Output {
+        match types.lookup(type_id) {
+            Some(TypeData::Application(app_id)) => self.visit_application_type(type_id, app_id.0),
+            Some(ref type_key) => self.visit_type_key(types, type_key),
+            None => Self::default_output(),
+        }
     }
 
     fn visit_mapped(&mut self, mapped_id: u32) -> Self::Output {

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -882,7 +882,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
                 // Use nominal resolution for Application types
                 // This preserves class/interface identity instead of structurally expanding
-                self.resolve_application_property(app_id, prop_name, prop_atom)
+                self.resolve_application_property(obj_type, app_id, prop_name, prop_atom)
             }
 
             // Mapped: try lazy property resolution first to avoid OOM on large mapped types

--- a/crates/tsz-solver/src/operations/property_helpers.rs
+++ b/crates/tsz-solver/src/operations/property_helpers.rs
@@ -712,20 +712,20 @@ impl<'a> PropertyAccessEvaluator<'a> {
     /// 5. Return instantiated property type (NOT the full structurally expanded type)
     pub(super) fn resolve_application_property(
         &self,
+        app_type: TypeId,
         app_id: TypeApplicationId,
         prop_name: &str,
         prop_atom: Option<Atom>,
     ) -> PropertyAccessResult {
         let app = self.interner().type_application(app_id);
         let prop_atom = prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
-        let app_type = self.interner().application(app.base, app.args.clone());
 
         // Get the base type (should be a Ref to class/interface/alias)
         let base_key = match self.interner().lookup(app.base) {
             Some(k) => k,
             None => {
                 return PropertyAccessResult::PropertyNotFound {
-                    type_id: self.interner().application(app.base, app.args.clone()),
+                    type_id: app_type,
                     property_name: prop_atom,
                 };
             }
@@ -751,7 +751,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
             }
 
             return PropertyAccessResult::PropertyNotFound {
-                type_id: self.interner().application(app.base, app.args.clone()),
+                type_id: app_type,
                 property_name: prop_atom,
             };
         }
@@ -783,7 +783,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
             }
 
             return PropertyAccessResult::PropertyNotFound {
-                type_id: self.interner().application(app.base, app.args.clone()),
+                type_id: app_type,
                 property_name: prop_atom,
             };
         }
@@ -808,7 +808,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
             }
 
             return PropertyAccessResult::PropertyNotFound {
-                type_id: self.interner().application(app.base, app.args.clone()),
+                type_id: app_type,
                 property_name: prop_atom,
             };
         }
@@ -844,10 +844,9 @@ impl<'a> PropertyAccessEvaluator<'a> {
         // We only handle Lazy types (def_id references)
         let TypeData::Lazy(def_id) = base_key else {
             // For non-Lazy bases (e.g., TypeParameter), fall back to structural evaluation
-            let evaluated = self.db.evaluate_type_with_options(
-                self.interner().application(app.base, app.args.clone()),
-                self.no_unchecked_indexed_access,
-            );
+            let evaluated = self
+                .db
+                .evaluate_type_with_options(app_type, self.no_unchecked_indexed_access);
             return self.resolve_property_access_inner(evaluated, prop_name, Some(prop_atom));
         };
 
@@ -893,10 +892,9 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
         let Some(body_type) = body_type else {
             // Resolution failed - fall back to structural evaluation
-            let evaluated = self.db.evaluate_type_with_options(
-                self.interner().application(app.base, app.args.clone()),
-                self.no_unchecked_indexed_access,
-            );
+            let evaluated = self
+                .db
+                .evaluate_type_with_options(app_type, self.no_unchecked_indexed_access);
             return self.resolve_property_access_inner(evaluated, prop_name, Some(prop_atom));
         };
 
@@ -938,7 +936,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
             Some(k) => k,
             None => {
                 return PropertyAccessResult::PropertyNotFound {
-                    type_id: self.interner().application(app.base, app.args.clone()),
+                    type_id: app_type,
                     property_name: prop_atom,
                 };
             }
@@ -1029,7 +1027,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
                 // Property not found
                 PropertyAccessResult::PropertyNotFound {
-                    type_id: self.interner().application(app.base, app.args.clone()),
+                    type_id: app_type,
                     property_name: prop_atom,
                 }
             }
@@ -1080,7 +1078,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     Some(TypeData::Mapped(mid)) => mid,
                     _ => {
                         return PropertyAccessResult::PropertyNotFound {
-                            type_id: self.interner().application(app.base, app.args.clone()),
+                            type_id: app_type,
                             property_name: prop_atom,
                         };
                     }
@@ -1101,7 +1099,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                         self.resolve_property_access_inner(evaluated, prop_name, Some(prop_atom))
                     } else {
                         PropertyAccessResult::PropertyNotFound {
-                            type_id: self.interner().application(app.base, app.args.clone()),
+                            type_id: app_type,
                             property_name: prop_atom,
                         }
                     }
@@ -1109,10 +1107,9 @@ impl<'a> PropertyAccessEvaluator<'a> {
             }
             // For non-Object body types (e.g., type aliases to unions), fall back to evaluation
             _ => {
-                let evaluated = self.db.evaluate_type_with_options(
-                    self.interner().application(app.base, app.args.clone()),
-                    self.no_unchecked_indexed_access,
-                );
+                let evaluated = self
+                    .db
+                    .evaluate_type_with_options(app_type, self.no_unchecked_indexed_access);
                 self.resolve_property_access_inner(evaluated, prop_name, Some(prop_atom))
             }
         }

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -1223,7 +1223,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             return true;
         }
         if let Some(app_id) = application_id(self.interner, target)
-            && let Some(expanded) = self.subtype.try_expand_application(app_id)
+            && let Some(expanded) = self.subtype.try_expand_application_type(target, app_id)
             && let Some(t_mapped_id) = mapped_type_id(self.interner, expanded)
             && self.is_source_assignable_to_homomorphic_mapped_target(source, t_mapped_id)
         {

--- a/crates/tsz-solver/src/relations/compat_mapped.rs
+++ b/crates/tsz-solver/src/relations/compat_mapped.rs
@@ -91,7 +91,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
             return Some(mapped_id);
         }
         let app_id = application_id(self.interner, type_id)?;
-        let expanded = self.subtype.try_expand_application(app_id)?;
+        let expanded = self.subtype.try_expand_application_type(type_id, app_id)?;
         mapped_type_id(self.interner, expanded)
     }
 
@@ -150,7 +150,7 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
         }
 
         if let Some(app_id) = application_id(self.interner, source)
-            && let Some(expanded) = self.subtype.try_expand_application(app_id)
+            && let Some(expanded) = self.subtype.try_expand_application_type(source, app_id)
             && self.mapped_template_structurally_assignable(expanded, target)
         {
             return true;

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -903,7 +903,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 } else if let Some(s_app_id) = s_app_id {
                     // Source is Application, target might be Union containing an Application.
                     // This handles optional properties where target is App<X> | undefined.
-                    self.try_variance_against_union_target(s_app_id, target)
+                    self.try_variance_against_union_target(source, s_app_id, target)
                 } else {
                     None
                 };

--- a/crates/tsz-solver/src/relations/subtype/core.rs
+++ b/crates/tsz-solver/src/relations/subtype/core.rs
@@ -849,7 +849,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
         // Try application that resolves to a mapped type (e.g., Readonly<T>, Partial<T>)
         if let Some(app_id) = application_id(self.interner, source)
-            && let Some(expanded) = self.try_expand_application(app_id)
+            && let Some(expanded) = self.try_expand_application_type(source, app_id)
             && let Some(mapped_id) = mapped_type_id(self.interner, expanded)
         {
             return self.check_homomorphic_mapped_to_target(mapped_id, target);

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -1168,7 +1168,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             application_id(self.interner, source),
             application_id(self.interner, target),
         ) {
-            return self.check_application_to_application_subtype(s_app_id, t_app_id);
+            return self
+                .check_application_to_application_subtype(source, target, s_app_id, t_app_id);
         }
 
         // When both source and target are applications, try mapped-to-mapped
@@ -1208,7 +1209,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // default type parameters for a precise comparison.
                 let t_type_id = self.interner.application(s_app.base, vec![]);
                 if let Some(t_app_id) = application_id(self.interner, t_type_id) {
-                    let result = self.check_application_to_application_subtype(s_app_id, t_app_id);
+                    let result = self.check_application_to_application_subtype(
+                        source, t_type_id, s_app_id, t_app_id,
+                    );
                     if result.is_true() {
                         return result;
                     }

--- a/crates/tsz-solver/src/relations/subtype/explain.rs
+++ b/crates/tsz-solver/src/relations/subtype/explain.rs
@@ -124,7 +124,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     fn apparent_type_for_keys(&mut self, type_id: TypeId) -> TypeId {
         let mut resolved = self.resolve_lazy_type(type_id);
         if let Some(app_id) = application_id(self.interner, resolved)
-            && let Some(expanded) = self.try_expand_application(app_id)
+            && let Some(expanded) = self.try_expand_application_type(resolved, app_id)
         {
             resolved = self.resolve_lazy_type(expanded);
         }
@@ -332,12 +332,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
         // Expand applications (like Array<number>, MyGeneric<string>) to structural forms
         if let Some(app_id) = crate::visitor::application_id(self.interner, resolved_source)
-            && let Some(expanded) = self.try_expand_application(app_id)
+            && let Some(expanded) = self.try_expand_application_type(resolved_source, app_id)
         {
             resolved_source = self.resolve_lazy_type(expanded);
         }
         if let Some(app_id) = crate::visitor::application_id(self.interner, resolved_target)
-            && let Some(expanded) = self.try_expand_application(app_id)
+            && let Some(expanded) = self.try_expand_application_type(resolved_target, app_id)
         {
             resolved_target = self.resolve_lazy_type(expanded);
         }

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -280,6 +280,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// If variance is unavailable or bases differ, fall back to structural expansion.
     pub(crate) fn check_application_to_application_subtype(
         &mut self,
+        source_type: TypeId,
+        target_type: TypeId,
         s_app_id: TypeApplicationId,
         t_app_id: TypeApplicationId,
     ) -> SubtypeResult {
@@ -322,12 +324,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 let s_new = if s_new_args.len() != s_app.args.len() {
                     self.interner.application(s_app.base, s_new_args.clone())
                 } else {
-                    self.interner.application(s_app.base, s_app.args.clone())
+                    source_type
                 };
                 let t_new = if t_new_args.len() != t_app.args.len() {
                     self.interner.application(t_app.base, t_new_args.clone())
                 } else {
-                    self.interner.application(t_app.base, t_app.args.clone())
+                    target_type
                 };
                 return self.check_subtype(s_new, t_new);
             }
@@ -371,8 +373,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         };
         let same_application_family =
             (same_arity && s_app.base == t_app.base) || variance_def_id.is_some();
-        let source_type = self.interner.application(s_app.base, s_app.args.clone());
-        let target_type = self.interner.application(t_app.base, t_app.args.clone());
 
         if !same_application_family
             && s_app.args.len() == 1
@@ -609,8 +609,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // - Generic types without variance annotations
         // - Type aliases with complex transformations
         // =======================================================================
-        let s_expanded = self.try_expand_application(s_app_id);
-        let t_expanded = self.try_expand_application(t_app_id);
+        let s_expanded = self.try_expand_application_type(source_type, s_app_id);
+        let t_expanded = self.try_expand_application_type(target_type, t_app_id);
         let result = match (s_expanded, t_expanded) {
             (Some(s_struct), Some(t_struct)) => self.check_subtype(s_struct, t_struct),
             (Some(s_struct), None) => self.check_subtype(s_struct, target_type),
@@ -921,6 +921,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Returns `Some(result)` if variance gives a conclusive answer, `None` otherwise.
     pub(crate) fn try_variance_against_union_target(
         &mut self,
+        source_type: TypeId,
         s_app_id: TypeApplicationId,
         target: TypeId,
     ) -> Option<SubtypeResult> {
@@ -955,8 +956,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
                 // Variance rejected the Application member. Check if the source
                 // is a subtype of any non-Application member (e.g., undefined).
                 // For a non-nullable Application type, this is typically false.
-                let s_app = self.interner.type_application(s_app_id);
-                let source_type = self.interner.application(s_app.base, s_app.args.clone());
                 for &non_app in &non_app_members {
                     if self.check_subtype(source_type, non_app).is_true() {
                         return Some(SubtypeResult::True);
@@ -981,8 +980,8 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         t_app_id: TypeApplicationId,
     ) -> SubtypeResult {
         // Try to resolve both applications to see if they are mapped types
-        let s_resolved = self.try_resolve_application_body(s_app_id);
-        let t_resolved = self.try_resolve_application_body(t_app_id);
+        let s_resolved = self.try_resolve_application_body(source, s_app_id);
+        let t_resolved = self.try_resolve_application_body(target, t_app_id);
 
         // If both resolve to mapped types, try direct mapped-to-mapped comparison
         if let (Some(s_body), Some(t_body)) = (s_resolved, t_resolved)
@@ -1000,7 +999,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Try to resolve the body of a type application (instantiated with its args),
     /// without requiring concrete expansion. This resolves the base type alias/interface
     /// body and instantiates it with the provided type arguments.
-    fn try_resolve_application_body(&mut self, app_id: TypeApplicationId) -> Option<TypeId> {
+    fn try_resolve_application_body(
+        &mut self,
+        app_type: TypeId,
+        app_id: TypeApplicationId,
+    ) -> Option<TypeId> {
         use crate::instantiation::instantiate::TypeSubstitution;
 
         let app = self.interner.type_application(app_id);
@@ -1046,7 +1049,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
 
         let substitution = TypeSubstitution::from_args(self.interner, &type_params, &app.args);
-        let app_type = self.interner.application(app.base, app.args.clone());
         let mut instantiated = crate::instantiation::instantiate::instantiate_type_cached(
             self.interner,
             self.query_db,
@@ -1090,7 +1092,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return self.depth_result();
         }
 
-        let result = match self.try_expand_application(app_id) {
+        let result = match self.try_expand_application_type(source, app_id) {
             Some(expanded) => self.check_subtype(expanded, target),
             None => {
                 let s_eval = self.evaluate_type(source);
@@ -1169,7 +1171,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
             return self.depth_result();
         }
 
-        let result = match self.try_expand_application(app_id) {
+        let result = match self.try_expand_application_type(target, app_id) {
             Some(expanded) => {
                 let expanded_result = self.check_subtype(source, expanded);
                 if expanded_result.is_true() {
@@ -1845,10 +1847,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         None
     }
 
-    /// Try to expand an Application type to its structural form.
-    /// Returns None if the application cannot be expanded (missing type params or body).
-    ///
-    pub(crate) fn try_expand_application(&mut self, app_id: TypeApplicationId) -> Option<TypeId> {
+    /// Try to expand an Application while preserving the caller's known
+    /// interned `TypeId` for the application itself.
+    pub(crate) fn try_expand_application_type(
+        &mut self,
+        app_type: TypeId,
+        app_id: TypeApplicationId,
+    ) -> Option<TypeId> {
         use crate::instantiation::instantiate::TypeSubstitution;
 
         let app = self.interner.type_application(app_id);
@@ -1935,7 +1940,6 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
         // Create substitution and instantiate
         let substitution = TypeSubstitution::from_args(self.interner, &type_params, &app.args);
-        let app_type = self.interner.application(app.base, app.args.clone());
 
         let mut instantiated = crate::instantiation::instantiate::instantiate_type_cached(
             self.interner,

--- a/crates/tsz-solver/src/relations/subtype/rules/unions.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/unions.rs
@@ -91,7 +91,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // e.g., MyMap<U> where type MyMap<T> = { [P in keyof T]: T[keyof T] }
         // The Application expands to a Mapped type which we can then check.
         if let Some(app_id) = application_id(self.interner, target)
-            && let Some(expanded) = self.try_expand_application(app_id)
+            && let Some(expanded) = self.try_expand_application_type(target, app_id)
             && let Some(mapped_id) = mapped_type_id(self.interner, expanded)
             && self.is_assignable_to_homomorphic_mapped(s_info.name, s_info.constraint, mapped_id)
         {

--- a/crates/tsz-solver/src/visitors/visitor.rs
+++ b/crates/tsz-solver/src/visitors/visitor.rs
@@ -162,6 +162,12 @@ pub trait TypeVisitor: Sized {
         Self::default_output()
     }
 
+    /// Visit a generic type application while preserving the already-interned
+    /// `TypeId` that carried the application.
+    fn visit_application_type(&mut self, _type_id: TypeId, app_id: u32) -> Self::Output {
+        self.visit_application(app_id)
+    }
+
     /// Visit a conditional type T extends U ? X : Y.
     fn visit_conditional(&mut self, _cond_id: u32) -> Self::Output {
         Self::default_output()

--- a/crates/tsz-solver/tests/generics_rules_tests.rs
+++ b/crates/tsz-solver/tests/generics_rules_tests.rs
@@ -146,7 +146,7 @@ fn test_try_expand_application_instantiates_type_params() {
     let app_id = application_id(&interner, app_type).expect("expected app id");
 
     let expanded = checker
-        .try_expand_application(app_id)
+        .try_expand_application_type(app_type, app_id)
         .expect("expected expanded application");
 
     let Some(TypeData::Object(shape_id)) = interner.lookup(expanded) else {
@@ -172,7 +172,11 @@ fn test_try_expand_application_non_ref_base_returns_none() {
     let app_type = interner.application(base, vec![TypeId::STRING]);
     let app_id = application_id(&interner, app_type).expect("expected app id");
 
-    assert!(checker.try_expand_application(app_id).is_none());
+    assert!(
+        checker
+            .try_expand_application_type(app_type, app_id)
+            .is_none()
+    );
 }
 
 #[test]
@@ -197,7 +201,11 @@ fn test_try_expand_application_self_reference_returns_none() {
     );
 
     let mut checker = SubtypeChecker::with_resolver(&interner, &env);
-    assert!(checker.try_expand_application(app_id).is_none());
+    assert!(
+        checker
+            .try_expand_application_type(app_type, app_id)
+            .is_none()
+    );
 }
 
 #[test]
@@ -362,7 +370,7 @@ fn test_non_interface_invariant_application_structural_fallback_accepts_equivale
     // since T is unused in the body. Structural comparison correctly returns True.
     assert!(
         checker
-            .check_application_to_application_subtype(source_app, target_app)
+            .check_application_to_application_subtype(source, target, source_app, target_app)
             .is_true()
     );
 }
@@ -460,7 +468,7 @@ fn test_type_alias_with_failed_variance_check_rejects_same_application_family() 
     // used as the object of an indexed-access T[K] here), we trust the structural result.
     assert!(
         checker
-            .check_application_to_application_subtype(source_app, target_app)
+            .check_application_to_application_subtype(source, target, source_app, target_app)
             .is_true()
     );
 }
@@ -568,7 +576,7 @@ fn test_indexed_access_object_variance_rejects_concrete_unrelated_args() {
     let mut checker = SubtypeChecker::with_resolver(&interner, &resolver);
     assert!(
         checker
-            .check_application_to_application_subtype(source_app, target_app)
+            .check_application_to_application_subtype(source, target, source_app, target_app)
             .is_false(),
         "T<A> must not be assignable to T<B> when A and B are unrelated"
     );
@@ -605,7 +613,7 @@ fn test_indexed_access_object_variance_rejects_concrete_unrelated_args_renamed_p
     let mut checker = SubtypeChecker::with_resolver(&interner, &resolver);
     assert!(
         checker
-            .check_application_to_application_subtype(source_app, target_app)
+            .check_application_to_application_subtype(source, target, source_app, target_app)
             .is_false(),
         "rejection must not depend on type parameter name"
     );
@@ -653,7 +661,8 @@ fn test_indexed_access_object_variance_with_type_param_args_falls_through() {
     };
     let mut checker = SubtypeChecker::with_resolver(&interner, &resolver);
     // Must not panic; result depends on structural expansion for type-param args
-    let _ = checker.check_application_to_application_subtype(source_app, target_app);
+    let _ =
+        checker.check_application_to_application_subtype(source, target, source_app, target_app);
 }
 
 #[test]
@@ -723,7 +732,12 @@ fn test_mapped_generic_parameter_with_indexed_access_is_covariant() {
     assert!(variance.needs_structural_fallback());
     assert!(
         checker
-            .check_application_to_application_subtype(source_app, target_app)
+            .check_application_to_application_subtype(
+                mapped_source,
+                mapped_target,
+                source_app,
+                target_app,
+            )
             .is_true()
     );
 }


### PR DESCRIPTION
Goal: fast

## AgentName
Codex

## Track
fast

## Invariant
When solver property, index-signature, and relation code already holds the `TypeId` for an `Application`, tsz preserves that application identity and reads base/args from the stored `TypeApplication`. It only interns a fresh `Application` when arity/default normalization creates a genuinely new argument list.

## Scope
- `crates/tsz-solver`: application property access, index-signature lookup, app-vs-app subtype relation, and direct relation tests.

## Project Corpus Impact
- Row: n/a
- Bug family: hot-path generic property access / app-vs-app relation allocation debt
- Evidence: closes #13100; targeted solver property, index-signature, and application relation filters pass.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-solver generics_rules_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver property_access`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver index_signature`
- `scripts/safe-run.sh cargo clippy -p tsz-solver --lib --tests`
- `python3 scripts/arch/arch_guard.py`
- `cargo fmt --check`
- `git diff --check`
- `scripts/check-crate-root-files.sh`
- Baseline note: `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib mapped_enum_discriminant_application_exposes_member_property` fails identically on clean `origin/main`.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high

## Coordination Notes
- Closes #13100.
- Open PR #13268 also edits `crates/tsz-solver/src/relations/subtype/rules/generics.rs`; this PR is limited to preserving already-held application `TypeId`s in property/index/relation hot paths. Rebase if #13268 lands first.
