### PR TITLE
fix(bench): publish complete shard artifacts after failures

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1313,7 +1313,7 @@ jobs:
   publish:
     name: bench-publish
     needs: bench
-    if: always() && needs.bench.result == 'success'
+    if: always() && (needs.bench.result == 'success' || needs.bench.result == 'failure')
     runs-on: [self-hosted, tsz-cloud-run]
     timeout-minutes: 30
     steps:

--- a/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
@@ -64,6 +64,12 @@ assert.match(
   "bench shard waits should allow a nonzero shard status when the runner produced a complete benchmark artifact",
 );
 
+assert.match(
+  workflow,
+  /publish:[\s\S]+needs: bench[\s\S]+if: always\(\) && \(needs\.bench\.result == 'success' \|\| needs\.bench\.result == 'failure'\)[\s\S]+Merge benchmark results/,
+  "bench publish should run after failed shard jobs so uploaded complete shard artifacts can still be merged instead of pinning the website to stale data",
+);
+
 assert.doesNotMatch(
   workflow,
   /source "bench-status-\$\{\{ matrix\.label \}\}\.env"/,


### PR DESCRIPTION
Goal: fast

## Summary
- Let `bench-publish` run after failed benchmark shard matrix jobs, so uploaded complete shard artifacts can still be merged and published.
- Lock the recovery behavior in `test-bench-workflow-cloudbuild-shards.mjs`.

## Root Cause
A Bench run can produce complete per-shard artifacts while one shard job is still marked failed. The workflow previously gated `bench-publish` on `needs.bench.result == success`, so those artifacts were never merged or uploaded as `bench-results-merged`. The website then stayed pinned to the last fully successful artifact even though newer benchmark runs had usable data.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- CI: `pr-body-gate` and bench workflow path validation

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
