### PR TITLE
perf(solver): persist clean evaluator memos via per-file write-through with nested reads (#13097)

### DIFF
--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -143,6 +143,31 @@ pub struct PerfCounters {
     /// band-conditional `LimitTrue` entries.
     pub relation_maybe_promotions: AtomicU64,
 
+    // ─── solver evaluator memo lifecycle (issue #13097) ──────────────────
+    /// `TypeEvaluator` constructions (each is a fresh per-run memo set).
+    pub eval_evaluator_constructions: AtomicU64,
+    /// Hits on an evaluator's own per-run `TypeId -> TypeId` memo.
+    pub eval_local_memo_hits: AtomicU64,
+    /// Nodes actually computed (`evaluate_guarded_inner` entries past every
+    /// memo/cache layer).
+    pub eval_compute_nodes: AtomicU64,
+    /// Clean (untainted) computes whose `(TypeId, options)` key was already
+    /// computed clean — with the same result — by an *earlier* evaluator in
+    /// the same file scope. Each one is work a per-file shared memo would
+    /// have skipped; the fresh-evaluator pattern discarded it instead.
+    pub eval_lost_memo_recomputes: AtomicU64,
+    /// Same-key clean computes whose result *differed* from the earlier
+    /// evaluator's. Evidence that naive within-file result sharing across
+    /// evaluator contexts would change behavior (resolver/registration
+    /// dependence); these must stay per-run.
+    pub eval_lost_memo_mismatches: AtomicU64,
+    /// Per-run memo entries still resident when an evaluator was dropped
+    /// (i.e. not drained into a longer-lived cache).
+    pub eval_dropped_memo_entries: AtomicU64,
+    /// Auxiliary memo entries (conditional-subtype + contains-infer) dropped
+    /// with their evaluator; these tables are never drained anywhere.
+    pub eval_dropped_aux_entries: AtomicU64,
+
     // ─── interner ────────────────────────────────────────────────────────
     pub interner_intern_calls: AtomicU64,
     pub interner_intern_hits: AtomicU64,
@@ -273,6 +298,13 @@ impl PerfCounters {
                 CHECKER_CREATION_REASON_COUNT],
             relation_limit_cache_hits: AtomicU64::new(0),
             relation_maybe_promotions: AtomicU64::new(0),
+            eval_evaluator_constructions: AtomicU64::new(0),
+            eval_local_memo_hits: AtomicU64::new(0),
+            eval_compute_nodes: AtomicU64::new(0),
+            eval_lost_memo_recomputes: AtomicU64::new(0),
+            eval_lost_memo_mismatches: AtomicU64::new(0),
+            eval_dropped_memo_entries: AtomicU64::new(0),
+            eval_dropped_aux_entries: AtomicU64::new(0),
             interner_intern_calls: AtomicU64::new(0),
             interner_intern_hits: AtomicU64::new(0),
             interner_intern_misses: AtomicU64::new(0),
@@ -1245,6 +1277,85 @@ pub fn record_relation_maybe_promotion() {
     counters()
         .relation_maybe_promotions
         .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record a `TypeEvaluator` construction (issue #13097 memo-lifecycle audit).
+#[inline]
+pub fn record_eval_evaluator_construction() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .eval_evaluator_constructions
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record a hit on an evaluator's own per-run memo.
+#[inline]
+pub fn record_eval_local_memo_hit() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .eval_local_memo_hits
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record a node compute that passed every memo/cache layer.
+#[inline]
+pub fn record_eval_compute_node() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .eval_compute_nodes
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record a clean compute that an earlier same-file evaluator already
+/// produced (same key, same result) but discarded with its memo.
+#[inline]
+pub fn record_eval_lost_memo_recompute() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .eval_lost_memo_recomputes
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record a same-key clean compute whose result differed across evaluators.
+#[inline]
+pub fn record_eval_lost_memo_mismatch() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .eval_lost_memo_mismatches
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record memo entries discarded (not drained) when an evaluator dropped.
+#[inline]
+pub fn record_eval_dropped_memo_entries(count: u64) {
+    if count == 0 || !enabled_fast() {
+        return;
+    }
+    counters()
+        .eval_dropped_memo_entries
+        .fetch_add(count, Ordering::Relaxed);
+}
+
+/// Record auxiliary memo entries (conditional-subtype / contains-infer)
+/// discarded when an evaluator dropped.
+#[inline]
+pub fn record_eval_dropped_aux_entries(count: u64) {
+    if count == 0 || !enabled_fast() {
+        return;
+    }
+    counters()
+        .eval_dropped_aux_entries
+        .fetch_add(count, Ordering::Relaxed);
 }
 
 /// Record a `TypeInterner::intern_type_list` call (covers both the

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -161,6 +161,20 @@ pub struct PerfCounters {
     /// evaluator contexts would change behavior (resolver/registration
     /// dependence); these must stay per-run.
     pub eval_lost_memo_mismatches: AtomicU64,
+    /// `lookup_eval_memo` hits served at nested evaluate nodes.
+    pub eval_memo_nested_hits: AtomicU64,
+    /// Lost recomputes performed by a plain memo-reading evaluator.
+    pub eval_lost_memo_recomputes_plain: AtomicU64,
+    /// Lost recomputes performed by the checker's authoritative
+    /// (closed-eval-writing, resolver-backed) evaluator.
+    pub eval_lost_memo_recomputes_authoritative: AtomicU64,
+    /// Lost recomputes performed by other contexts (resolver-backed
+    /// non-authoritative, or mode-flagged plain evaluators).
+    pub eval_lost_memo_recomputes_other: AtomicU64,
+    /// Subset of `eval_lost_memo_recomputes` whose result equals its input
+    /// (`eval(T) == T`): identity walks the per-file drain deliberately
+    /// skips, so they are re-walked by every evaluator that meets them.
+    pub eval_lost_memo_recomputes_identity: AtomicU64,
     /// Per-run memo entries still resident when an evaluator was dropped
     /// (i.e. not drained into a longer-lived cache).
     pub eval_dropped_memo_entries: AtomicU64,
@@ -303,6 +317,11 @@ impl PerfCounters {
             eval_compute_nodes: AtomicU64::new(0),
             eval_lost_memo_recomputes: AtomicU64::new(0),
             eval_lost_memo_mismatches: AtomicU64::new(0),
+            eval_lost_memo_recomputes_identity: AtomicU64::new(0),
+            eval_memo_nested_hits: AtomicU64::new(0),
+            eval_lost_memo_recomputes_plain: AtomicU64::new(0),
+            eval_lost_memo_recomputes_authoritative: AtomicU64::new(0),
+            eval_lost_memo_recomputes_other: AtomicU64::new(0),
             eval_dropped_memo_entries: AtomicU64::new(0),
             eval_dropped_aux_entries: AtomicU64::new(0),
             interner_intern_calls: AtomicU64::new(0),
@@ -1321,6 +1340,44 @@ pub fn record_eval_lost_memo_recompute() {
     }
     counters()
         .eval_lost_memo_recomputes
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record a nested `lookup_eval_memo` hit inside an evaluator.
+#[inline]
+pub fn record_eval_memo_nested_hit() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .eval_memo_nested_hits
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record a lost-memo recompute attributed to an evaluator context class:
+/// 0 = plain memo-reading, 1 = authoritative checker pass, 2 = other.
+#[inline]
+pub fn record_eval_lost_memo_recompute_ctx(ctx: u8) {
+    if !enabled_fast() {
+        return;
+    }
+    let c = counters();
+    let field = match ctx {
+        0 => &c.eval_lost_memo_recomputes_plain,
+        1 => &c.eval_lost_memo_recomputes_authoritative,
+        _ => &c.eval_lost_memo_recomputes_other,
+    };
+    field.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Record a lost-memo recompute whose result was the input itself.
+#[inline]
+pub fn record_eval_lost_memo_recompute_identity() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .eval_lost_memo_recomputes_identity
         .fetch_add(1, Ordering::Relaxed);
 }
 

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -495,6 +495,16 @@ pub struct EvaluatorMemoCounters {
     pub lost_memo_recomputes: u64,
     /// Same-key clean computes whose result differed across evaluators.
     pub lost_memo_mismatches: u64,
+    /// Subset of `lost_memo_recomputes` with identity results.
+    pub lost_memo_recomputes_identity: u64,
+    /// Nested `lookup_eval_memo` hits inside evaluators.
+    pub memo_nested_hits: u64,
+    /// Lost recomputes by plain memo-reading evaluators.
+    pub lost_memo_recomputes_plain: u64,
+    /// Lost recomputes by the authoritative checker evaluator.
+    pub lost_memo_recomputes_authoritative: u64,
+    /// Lost recomputes by other evaluator contexts.
+    pub lost_memo_recomputes_other: u64,
     /// Memo entries discarded undrained at evaluator drop.
     pub dropped_memo_entries: u64,
     /// Auxiliary memo entries (conditional-subtype / contains-infer)
@@ -656,6 +666,11 @@ impl PerfCounters {
                 compute_nodes: load(&c.eval_compute_nodes),
                 lost_memo_recomputes: load(&c.eval_lost_memo_recomputes),
                 lost_memo_mismatches: load(&c.eval_lost_memo_mismatches),
+                lost_memo_recomputes_identity: load(&c.eval_lost_memo_recomputes_identity),
+                memo_nested_hits: load(&c.eval_memo_nested_hits),
+                lost_memo_recomputes_plain: load(&c.eval_lost_memo_recomputes_plain),
+                lost_memo_recomputes_authoritative: load(&c.eval_lost_memo_recomputes_authoritative),
+                lost_memo_recomputes_other: load(&c.eval_lost_memo_recomputes_other),
                 dropped_memo_entries: load(&c.eval_dropped_memo_entries),
                 dropped_aux_entries: load(&c.eval_dropped_aux_entries),
             },

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -32,6 +32,9 @@ pub struct PerfCounterSnapshot {
     pub interner: InternerCounters,
     /// Solver relation limit-result cache (issue #13241).
     pub relation_limit_cache: RelationLimitCacheCounters,
+    /// Solver evaluator memo lifecycle (issue #13097): what the per-run
+    /// fresh-evaluator pattern recomputes and discards.
+    pub evaluator_memo: EvaluatorMemoCounters,
     /// Per-`CheckerCreationReason` breakdown. Always
     /// `CHECKER_CREATION_REASON_COUNT` long; rows for inactive reasons
     /// carry all-zero counts (matching the text dump's filter behavior
@@ -476,6 +479,29 @@ pub struct RelationLimitCacheCounters {
     pub maybe_promotions: u64,
 }
 
+/// Solver evaluator memo-lifecycle counters (issue #13097): how much work
+/// the per-call fresh-`TypeEvaluator` pattern repeats or discards within a
+/// single file scope.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct EvaluatorMemoCounters {
+    /// `TypeEvaluator` constructions.
+    pub constructions: u64,
+    /// Hits on an evaluator's own per-run memo.
+    pub local_memo_hits: u64,
+    /// Nodes computed past every memo/cache layer.
+    pub compute_nodes: u64,
+    /// Clean computes an earlier same-file evaluator already produced
+    /// (same key and result) but discarded.
+    pub lost_memo_recomputes: u64,
+    /// Same-key clean computes whose result differed across evaluators.
+    pub lost_memo_mismatches: u64,
+    /// Memo entries discarded undrained at evaluator drop.
+    pub dropped_memo_entries: u64,
+    /// Auxiliary memo entries (conditional-subtype / contains-infer)
+    /// discarded at evaluator drop; never drained anywhere.
+    pub dropped_aux_entries: u64,
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct InternerCounters {
     /// Total `intern` calls across kinds. `None` until the solver intern
@@ -623,6 +649,15 @@ impl PerfCounters {
             relation_limit_cache: RelationLimitCacheCounters {
                 limit_cache_hits: load(&c.relation_limit_cache_hits),
                 maybe_promotions: load(&c.relation_maybe_promotions),
+            },
+            evaluator_memo: EvaluatorMemoCounters {
+                constructions: load(&c.eval_evaluator_constructions),
+                local_memo_hits: load(&c.eval_local_memo_hits),
+                compute_nodes: load(&c.eval_compute_nodes),
+                lost_memo_recomputes: load(&c.eval_lost_memo_recomputes),
+                lost_memo_mismatches: load(&c.eval_lost_memo_mismatches),
+                dropped_memo_entries: load(&c.eval_dropped_memo_entries),
+                dropped_aux_entries: load(&c.eval_dropped_aux_entries),
             },
             by_reason: (0..CHECKER_CREATION_REASON_COUNT)
                 .map(|i| ByReasonRow {

--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -359,6 +359,43 @@ pub trait TypeApplicationEvalCache {
     /// default is a no-op so raw `TypeInterner` backends and tests opt out.
     fn invalidate_application_eval_cache_for_def(&self, _def_id: DefId) {}
 
+    /// Look up a persisted evaluation memo entry for `type_id`.
+    ///
+    /// Backed by the same per-file (plus shared cross-file) eval cache that
+    /// `evaluate_type_with_options` consults at its top-level boundary; this
+    /// hook lets a *plain* evaluator (`NoopResolver`, default mode flags)
+    /// read those entries at nested nodes too, instead of re-walking
+    /// subtrees an earlier evaluator in the same file scope already
+    /// evaluated (issue #13097). Every stored entry is a clean
+    /// (limit-untainted) result keyed by
+    /// `(TypeId, no_unchecked_indexed_access, exact_optional_property_types)`
+    /// and written only from plain evaluators, so serving it at a nested
+    /// node is the same semantic operation the top-level boundary already
+    /// performs. Default returns `None` so raw `TypeInterner` backends and
+    /// tests opt out.
+    fn lookup_eval_memo(
+        &self,
+        _type_id: TypeId,
+        _no_unchecked_indexed_access: bool,
+    ) -> Option<TypeId> {
+        None
+    }
+
+    /// Store a clean evaluation result in the persistent eval memo.
+    ///
+    /// Write-through counterpart of [`Self::lookup_eval_memo`], called from
+    /// a plain evaluator's memo insert when the entry's evaluation window
+    /// saw no limit event (the per-entry taint discrimination of issue
+    /// #13241) and no union-complexity overflow. First write wins, matching
+    /// the boundary drain's `or_insert`. Default is a no-op.
+    fn insert_eval_memo(
+        &self,
+        _type_id: TypeId,
+        _no_unchecked_indexed_access: bool,
+        _result: TypeId,
+    ) {
+    }
+
     /// Look up a cached evaluation result for a *closed* type (one with no free
     /// type parameters, `this`, `infer`, or type-query operands).
     ///

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -265,6 +265,10 @@ impl<'a> QueryCache<'a> {
         interner: &'a TypeInterner,
         shared: Option<&'a SharedQueryCache>,
     ) -> Self {
+        // Measurement-only (issue #13097): a fresh `QueryCache` marks a new
+        // file scope for the cross-evaluator memo-loss audit, mirroring the
+        // per-file lifetime of the caches whose loss it measures.
+        crate::evaluation::memo_audit::begin_file_scope();
         QueryCache {
             interner,
             eval_cache: RefCell::new(FxHashMap::default()),

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -582,6 +582,23 @@ impl<'a> QueryCache<'a> {
         self.element_access_cache.borrow_mut().insert(key, result);
     }
 
+    /// Layered eval-memo lookup: local per-file cache first, then the shared
+    /// cross-file cache (promoting shared hits into the local map). Single
+    /// source of truth for both the top-level `evaluate_type_with_options`
+    /// boundary and nested `lookup_eval_memo` reads (issue #13097).
+    fn lookup_eval_cache_layers(&self, key: EvaluationCacheKey) -> Option<TypeId> {
+        if let Some(result) = self.eval_cache.borrow().get(&key).copied() {
+            return Some(result);
+        }
+        if let Some(shared) = self.shared
+            && let Some(result) = shared.eval_cache.get(&key).map(|r| *r)
+        {
+            self.eval_cache.borrow_mut().insert(key, result);
+            return Some(result);
+        }
+        None
+    }
+
     fn check_application_eval_cache(&self, key: ApplicationEvalCacheKey) -> Option<TypeId> {
         if let Some(result) = self.application_eval_cache.borrow().get(&key).copied() {
             self.application_eval_cache_hits
@@ -986,6 +1003,34 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
                 })
                 && !crate::visitors::visitor::contains_lazy_def_id(self.interner, result, def_id)
         });
+    }
+
+    /// Nested eval-memo read for plain evaluators (issue #13097).
+    /// Same layered lookup the top-level boundary uses.
+    fn lookup_eval_memo(
+        &self,
+        type_id: TypeId,
+        no_unchecked_indexed_access: bool,
+    ) -> Option<TypeId> {
+        self.lookup_eval_cache_layers(EvaluationCacheKey::new(
+            type_id,
+            no_unchecked_indexed_access,
+            self.exact_optional_property_types(),
+        ))
+    }
+
+    /// Write-through eval-memo store for plain evaluators (issue #13097).
+    /// First write wins, matching the top-level boundary drain.
+    fn insert_eval_memo(&self, type_id: TypeId, no_unchecked_indexed_access: bool, result: TypeId) {
+        let key = EvaluationCacheKey::new(
+            type_id,
+            no_unchecked_indexed_access,
+            self.exact_optional_property_types(),
+        );
+        self.eval_cache.borrow_mut().entry(key).or_insert(result);
+        if let Some(shared) = self.shared {
+            shared.eval_cache.entry(key).or_insert(result);
+        }
     }
 
     fn lookup_closed_eval_cache(
@@ -1425,17 +1470,7 @@ impl QueryDatabase for QueryCache<'_> {
             .with_no_unchecked_indexed_access(no_unchecked_indexed_access)
             .with_exact_optional_property_types(self.exact_optional_property_types());
         let key = request.cache_key();
-        let cached = self.eval_cache.borrow().get(&key).copied();
-
-        if let Some(result) = cached {
-            return result;
-        }
-
-        // L2: Check shared cross-file cache before doing expensive evaluation.
-        if let Some(shared) = self.shared
-            && let Some(result) = shared.eval_cache.get(&key).map(|r| *r)
-        {
-            self.eval_cache.borrow_mut().insert(key, result);
+        if let Some(result) = self.lookup_eval_cache_layers(key) {
             return result;
         }
 

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -837,10 +837,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // with this evaluator. Gates mirror the boundary drain: the
             // `TS2590` union-complexity snapshot, and the limit-result-cache
             // kill switch for entries computed after a limit event this run.
+            // The last clause skips the write only when the `TS2590` flag is
+            // newly set relative to the construction snapshot.
             if self.persistent_memo_reads
                 && !type_id.is_intrinsic()
                 && (self.limit_epoch == 0 || crate::limits::limit_result_cache_enabled())
-                && !(self.interner.is_union_too_complex() && !self.union_complex_at_construction)
+                && (self.union_complex_at_construction || !self.interner.is_union_too_complex())
             {
                 self.interner
                     .insert_eval_memo(type_id, self.no_unchecked_indexed_access, result);

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -192,7 +192,8 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// gate (a cached read must not swallow the diagnostic re-derivation).
     union_complex_at_construction: bool,
     /// When true, nested `evaluate` nodes consult the persistent eval memo
-    /// (`QueryDatabase::lookup_eval_memo`) after a local-cache miss, so this
+    /// (`TypeApplicationEvalCache::lookup_eval_memo`) after a local-cache
+    /// miss, so this
     /// evaluator reuses subtrees an earlier evaluator in the same file scope
     /// already evaluated instead of re-walking them (issue #13097).
     ///
@@ -386,8 +387,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     }
 
     /// Opt this evaluator in to reading the persistent eval memo at nested
-    /// nodes (see `persistent_memo_reads`). Only the plain query-backed
-    /// construction (`QueryCache::query_backed_evaluator`) should call this.
+    /// nodes (see `persistent_memo_reads`). Set by the plain `new`
+    /// constructor and revoked by the mode builders; resolver-backed
+    /// constructions never opt in.
     pub(crate) const fn with_persistent_eval_memo_reads(mut self) -> Self {
         self.persistent_memo_reads = true;
         self

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -186,6 +186,23 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// (issue #13097; see `evaluation::memo_audit`). 0 when perf counters
     /// are disabled.
     audit_evaluator_id: u64,
+    /// `is_union_too_complex` snapshot taken at construction. A memo
+    /// write-through is suppressed while the flag is newly set relative to
+    /// this snapshot, mirroring the top-level boundary drain's `TS2590`
+    /// gate (a cached read must not swallow the diagnostic re-derivation).
+    union_complex_at_construction: bool,
+    /// When true, nested `evaluate` nodes consult the persistent eval memo
+    /// (`QueryDatabase::lookup_eval_memo`) after a local-cache miss, so this
+    /// evaluator reuses subtrees an earlier evaluator in the same file scope
+    /// already evaluated instead of re-walking them (issue #13097).
+    ///
+    /// Only the plain query-backed (`NoopResolver`, no display/`this`/TS2589
+    /// mode flags) evaluator construction opts in — the same context that
+    /// produces every entry in that memo — so a hit is exactly the result
+    /// this evaluator would have computed. Resolver-backed or mode-flagged
+    /// evaluators must NOT opt in: their results can differ from the stored
+    /// plain-context entries.
+    persistent_memo_reads: bool,
 }
 
 /// Operation-local memo table statistics for [`TypeEvaluator`].
@@ -216,9 +233,14 @@ const DEFAULT_MAX_MAPPED_KEYS: usize = 500;
 
 impl<'a> TypeEvaluator<'a, NoopResolver> {
     /// Create a new evaluator without a resolver.
+    ///
+    /// Plain (`NoopResolver`, default mode flags) evaluators read the
+    /// persistent eval memo at nested nodes (issue #13097); the mode
+    /// builders below revoke that opt-in because their results are not the
+    /// plain-context function of `(TypeId, options)` the memo stores.
     pub fn new(interner: &'a dyn TypeDatabase) -> Self {
         static NOOP: NoopResolver = NoopResolver;
-        Self::with_resolver_and_defaults(interner, &NOOP)
+        Self::with_resolver_and_defaults(interner, &NOOP).with_persistent_eval_memo_reads()
     }
 }
 
@@ -255,6 +277,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             closed_eval_writes_allowed: false,
             tainted: FxHashSet::default(),
             audit_evaluator_id: crate::evaluation::memo_audit::next_evaluator_id(),
+            union_complex_at_construction: interner.is_union_too_complex(),
+            persistent_memo_reads: false,
         }
     }
 
@@ -361,6 +385,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         self
     }
 
+    /// Opt this evaluator in to reading the persistent eval memo at nested
+    /// nodes (see `persistent_memo_reads`). Only the plain query-backed
+    /// construction (`QueryCache::query_backed_evaluator`) should call this.
+    pub(crate) const fn with_persistent_eval_memo_reads(mut self) -> Self {
+        self.persistent_memo_reads = true;
+        self
+    }
+
     /// Suppress `this` type substitution during Lazy type evaluation.
     /// When set, `ThisType` references inside resolved Lazy types are preserved
     /// rather than being bound to the Lazy type's own identity. This is used
@@ -368,6 +400,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// bound to the final derived interface type.
     pub const fn with_suppress_this_binding(mut self) -> Self {
         self.suppress_this_binding = true;
+        self.persistent_memo_reads = false;
         self
     }
 
@@ -378,6 +411,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// preventing the normal per-DefId depth counter from triggering.
     pub const fn with_flag_depth_on_app_cycle(mut self) -> Self {
         self.flag_depth_on_app_cycle = true;
+        // TS2589 detection must re-walk the expansion; a memo hit would
+        // short-circuit the depth it is trying to observe.
+        self.persistent_memo_reads = false;
         self
     }
 
@@ -394,6 +430,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// chains in complex conditional cases.
     pub const fn with_expanded_application_display_alias_args(mut self) -> Self {
         self.expand_application_display_alias_args = true;
+        // Declaration-emit display aliasing is a side effect of the walk;
+        // a memo hit would skip recording it.
+        self.persistent_memo_reads = false;
         self
     }
 
@@ -438,6 +477,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
     pub const fn set_max_mapped_keys(&mut self, max_mapped_keys: usize) {
         self.max_mapped_keys = max_mapped_keys;
+        // A non-default expansion cap changes where evaluation bails; memo
+        // entries computed under the default cap must not be served here.
+        self.persistent_memo_reads = false;
     }
 
     /// Reset per-evaluation state so this evaluator can be reused.
@@ -692,6 +734,24 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return cached;
         }
 
+        // Persistent eval memo (issue #13097): reuse clean results an earlier
+        // plain query-backed evaluator in this file scope already computed,
+        // instead of re-walking the subtree. Opt-in is restricted to the same
+        // plain context that wrote every stored entry (see
+        // `persistent_memo_reads`), and stored entries are taint-filtered at
+        // the write boundary, so a hit is exactly what this evaluator would
+        // recompute. Mirrors the local-cache hit above: no guard, budget, or
+        // epoch interaction.
+        if self.persistent_memo_reads
+            && let Some(cached) = self
+                .interner
+                .lookup_eval_memo(type_id, self.no_unchecked_indexed_access)
+        {
+            tsz_common::perf_counters::record_eval_memo_nested_hit();
+            self.cache.insert(type_id, cached);
+            return cached;
+        }
+
         // Check if depth was already exceeded in a previous call
         if self.guard.is_exceeded() {
             return TypeId::ERROR;
@@ -770,6 +830,21 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         if self.limit_epoch != epoch_at_entry {
             self.tainted.insert(type_id);
         } else {
+            // Persistent write-through (issue #13097): a clean-window entry is
+            // a stable function of `(TypeId, options)` (the same per-entry
+            // taint discrimination the boundary drain uses, issue #13241), so
+            // plain evaluators publish it immediately instead of dropping it
+            // with this evaluator. Gates mirror the boundary drain: the
+            // `TS2590` union-complexity snapshot, and the limit-result-cache
+            // kill switch for entries computed after a limit event this run.
+            if self.persistent_memo_reads
+                && !type_id.is_intrinsic()
+                && (self.limit_epoch == 0 || crate::limits::limit_result_cache_enabled())
+                && !(self.interner.is_union_too_complex() && !self.union_complex_at_construction)
+            {
+                self.interner
+                    .insert_eval_memo(type_id, self.no_unchecked_indexed_access, result);
+            }
             // Measurement-only (issue #13097): record clean computes so the
             // memo audit can count cross-evaluator recomputation.
             crate::evaluation::memo_audit::record_clean_compute(
@@ -777,6 +852,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 self.no_unchecked_indexed_access,
                 result,
                 self.audit_evaluator_id,
+                if self.persistent_memo_reads {
+                    0
+                } else if self.closed_eval_writes_allowed {
+                    1
+                } else {
+                    2
+                },
             );
         }
         self.cache.insert(type_id, result);

--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -182,6 +182,10 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// `eval_cache` keep the *clean* intermediates of a run whose unrelated
     /// subtree hit a limit, instead of dropping the whole run's results.
     tainted: FxHashSet<TypeId>,
+    /// Measurement-only id for the cross-evaluator memo-loss audit
+    /// (issue #13097; see `evaluation::memo_audit`). 0 when perf counters
+    /// are disabled.
+    audit_evaluator_id: u64,
 }
 
 /// Operation-local memo table statistics for [`TypeEvaluator`].
@@ -220,6 +224,7 @@ impl<'a> TypeEvaluator<'a, NoopResolver> {
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     fn with_resolver_and_defaults(interner: &'a dyn TypeDatabase, resolver: &'a R) -> Self {
+        tsz_common::perf_counters::record_eval_evaluator_construction();
         TypeEvaluator {
             interner,
             query_db: None,
@@ -249,6 +254,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             unresolved_def_seen: false,
             closed_eval_writes_allowed: false,
             tainted: FxHashSet::default(),
+            audit_evaluator_id: crate::evaluation::memo_audit::next_evaluator_id(),
         }
     }
 
@@ -668,6 +674,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // Most evaluate() calls are for already-evaluated types (cache hits),
         // so checking the cache first avoids unnecessary guard operations.
         if let Some(&cached) = self.cache.get(&type_id) {
+            tsz_common::perf_counters::record_eval_local_memo_hit();
             // Reading a limit-truncated artifact makes every in-flight
             // ancestor's result artifact-dependent: record a limit event so
             // the epoch-based stamping (and the application-eval epoch gate)
@@ -762,6 +769,15 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     fn memo_insert(&mut self, epoch_at_entry: u32, type_id: TypeId, result: TypeId) {
         if self.limit_epoch != epoch_at_entry {
             self.tainted.insert(type_id);
+        } else {
+            // Measurement-only (issue #13097): record clean computes so the
+            // memo audit can count cross-evaluator recomputation.
+            crate::evaluation::memo_audit::record_clean_compute(
+                type_id,
+                self.no_unchecked_indexed_access,
+                result,
+                self.audit_evaluator_id,
+            );
         }
         self.cache.insert(type_id, result);
     }
@@ -769,6 +785,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Actual evaluate logic -- separated so `stacker::maybe_grow` can wrap it.
     fn evaluate_guarded_inner(&mut self, type_id: TypeId) -> TypeId {
         use crate::recursion::RecursionResult;
+
+        tsz_common::perf_counters::record_eval_compute_node();
 
         let _span =
             tracing::trace_span!("evaluate_type", ty = type_id.0, depth = self.guard.depth(),)
@@ -884,6 +902,22 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     }
 
     // Additional evaluator support methods live in the nested support module.
+}
+
+impl<R: TypeResolver> Drop for TypeEvaluator<'_, R> {
+    fn drop(&mut self) {
+        // Measurement-only (issue #13097): account for memo entries this
+        // evaluator computed but discarded. Entries persisted through
+        // `drain_cache` were removed before drop and are not counted.
+        // Single branch when `TSZ_PERF_COUNTERS` is unset.
+        if !tsz_common::perf_counters::enabled_fast() {
+            return;
+        }
+        tsz_common::perf_counters::record_eval_dropped_memo_entries(self.cache.len() as u64);
+        tsz_common::perf_counters::record_eval_dropped_aux_entries(
+            (self.conditional_subtype_cache.len() + self.contains_infer_cache.len()) as u64,
+        );
+    }
 }
 
 // Re-enabled evaluate tests - verifying API compatibility

--- a/crates/tsz-solver/src/evaluation/memo_audit.rs
+++ b/crates/tsz-solver/src/evaluation/memo_audit.rs
@@ -1,0 +1,96 @@
+//! Measurement-only audit of cross-evaluator memo loss (issue #13097).
+//!
+//! Each `TypeEvaluator` owns a per-run `TypeId -> TypeId` memo that is
+//! dropped with the evaluator. This module maintains a thread-local shadow
+//! record of every *clean* (untainted) compute in the current file scope so
+//! we can count how often a fresh evaluator recomputes a key an earlier
+//! evaluator in the same file already computed — and whether the result
+//! matched (a true memo loss) or differed (evidence the result is
+//! context-dependent and must stay per-run).
+//!
+//! Everything here is gated on `TSZ_PERF_COUNTERS` via
+//! [`tsz_common::perf_counters::enabled_fast`]; in normal runs the hooks are
+//! a single branch and the shadow map is never touched. The audit never
+//! feeds back into evaluation — it only increments perf counters.
+
+use crate::types::TypeId;
+use rustc_hash::FxHashMap;
+use std::cell::RefCell;
+use tsz_common::perf_counters;
+
+/// Shadow record key: `(root TypeId, no_unchecked_indexed_access)`.
+/// `exact_optional_property_types` is constant within one file scope, so it
+/// is not part of the key.
+type AuditKey = (TypeId, bool);
+
+struct AuditState {
+    /// Clean computes seen this file scope: key -> (result, evaluator id).
+    entries: FxHashMap<AuditKey, (TypeId, u64)>,
+    /// Monotonic evaluator id source for this thread.
+    next_evaluator_id: u64,
+}
+
+thread_local! {
+    static AUDIT: RefCell<AuditState> = RefCell::new(AuditState {
+        entries: FxHashMap::default(),
+        next_evaluator_id: 1,
+    });
+}
+
+/// Begin a new file scope: forget all shadow entries. Called when a fresh
+/// per-file `QueryCache` is constructed, mirroring the per-file lifetime of
+/// the caches whose loss we are measuring. No-op unless counters are on.
+pub(crate) fn begin_file_scope() {
+    if !perf_counters::enabled_fast() {
+        return;
+    }
+    AUDIT.with(|audit| audit.borrow_mut().entries.clear());
+}
+
+/// Allocate an id for a newly constructed evaluator. Returns 0 (unused)
+/// when counters are off.
+pub(crate) fn next_evaluator_id() -> u64 {
+    if !perf_counters::enabled_fast() {
+        return 0;
+    }
+    AUDIT.with(|audit| {
+        let mut audit = audit.borrow_mut();
+        let id = audit.next_evaluator_id;
+        audit.next_evaluator_id += 1;
+        id
+    })
+}
+
+/// Record a clean (untainted) compute of `type_id -> result` by evaluator
+/// `evaluator_id`. Counts a lost-memo recompute when a *different* evaluator
+/// in the same file scope already computed the same key with the same
+/// result, and a mismatch when the results differ.
+pub(crate) fn record_clean_compute(
+    type_id: TypeId,
+    no_unchecked_indexed_access: bool,
+    result: TypeId,
+    evaluator_id: u64,
+) {
+    if !perf_counters::enabled_fast() {
+        return;
+    }
+    AUDIT.with(|audit| {
+        let mut audit = audit.borrow_mut();
+        match audit.entries.entry((type_id, no_unchecked_indexed_access)) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let (prev_result, prev_evaluator) = *entry.get();
+                if prev_evaluator != evaluator_id {
+                    if prev_result == result {
+                        perf_counters::record_eval_lost_memo_recompute();
+                    } else {
+                        perf_counters::record_eval_lost_memo_mismatch();
+                    }
+                }
+                entry.insert((result, evaluator_id));
+            }
+            std::collections::hash_map::Entry::Vacant(slot) => {
+                slot.insert((result, evaluator_id));
+            }
+        }
+    });
+}

--- a/crates/tsz-solver/src/evaluation/memo_audit.rs
+++ b/crates/tsz-solver/src/evaluation/memo_audit.rs
@@ -70,6 +70,7 @@ pub(crate) fn record_clean_compute(
     no_unchecked_indexed_access: bool,
     result: TypeId,
     evaluator_id: u64,
+    context_tag: u8,
 ) {
     if !perf_counters::enabled_fast() {
         return;
@@ -82,6 +83,10 @@ pub(crate) fn record_clean_compute(
                 if prev_evaluator != evaluator_id {
                     if prev_result == result {
                         perf_counters::record_eval_lost_memo_recompute();
+                        perf_counters::record_eval_lost_memo_recompute_ctx(context_tag);
+                        if result == type_id {
+                            perf_counters::record_eval_lost_memo_recompute_identity();
+                        }
                     } else {
                         perf_counters::record_eval_lost_memo_mismatch();
                     }

--- a/crates/tsz-solver/src/evaluation/mod.rs
+++ b/crates/tsz-solver/src/evaluation/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod cross_eval_guard;
 pub(crate) mod evaluate;
 pub(crate) mod evaluate_rules;
+pub(crate) mod memo_audit;
 pub(crate) mod recursive_growth;
 pub mod request;
 pub mod result;


### PR DESCRIPTION
Goal: fast

Implements #13097 (parent #13250, workstream A): persist clean evaluator memo entries across the ~342 fresh-`TypeEvaluator` construction sites, measurement-first.

## Measurement findings (corrections to the issue text)
Audit counters (`evaluator_memo` group, TSZ_PERF_COUNTERS) + a thread-local shadow audit established what the fresh-evaluator pattern actually loses at HEAD:
1. The eval-result drain into the per-file + shared QueryCache existed already — but only at the top-level `evaluate_type_with_options` boundary; nested `evaluate()` nodes never read it.
2. The dominant loss is **identity results** (`eval(T)==T`, 88-97% of lost recomputes) which the drain deliberately skipped as "free to recompute" — false: deriving identity costs the full subtree walk. ts-toolbelt baseline: 99,528 evaluator constructions, 241,626 compute nodes, 225,810 (93%) same-key-same-result recomputes.
3. 71% of recomputation comes from raw `TypeEvaluator::new` plain evaluators (`query_db = None`) with no persist path at all.
4. The issue's "persistent DashMap on TypeInterner" proposal is unsound, with counter proof: 181/915 same-key DIFFERENT-result entries across evaluator contexts (ts-toolbelt/zodmin) — unconditional sharing is a correctness bug. Cross-file sharing remains #13240's epoch-keyed scope.

## Structural rule
Within one file scope, a clean (limit-untainted) `(TypeId, options) → TypeId` evaluation result computed by one evaluator must be visible to subsequent same-context evaluators — through the per-file eval cache (whose lifetime IS the file scope), not a new ownership layer. Mode-flagged contexts opt out: `persistent_memo_reads` is set only by the plain `NoopResolver` constructor and revoked by every mode builder (suppress-this-binding, flag-depth-on-app-cycle for TS2589 re-walks, display-alias expansion, non-default mapped-keys caps); resolver-backed constructions never opt in. Writes go through the established gates: per-entry limit-epoch taint (#13241), TS2590 union-complexity snapshot, `TSZ_DISABLE_LIMIT_RESULT_CACHE` kill switch, and #13268's registration-window epoch protection. No evaluator-local in-progress state crosses evaluators — only finalized clean entries.

## Performance (honest)
| Metric | ts-toolbelt | zodmin |
|---|---|---|
| compute nodes | 241,626 → 76,508 (−68%) | 56,986 → 27,515 (−52%) |
| plain-context lost recomputes | 159,935 → 364 | 27,602 → 296 |
| nested memo hits | 0 → 85,223 | 0 → 14,009 |
| wall (hyperfine, warm) | 475.0±13.5 → 479.9±16.0 ms (noise) | 3.107±0.232 → 3.002±0.123 s (within σ) |

Wall-neutral on these rows: the eliminated nodes are cheap walks; ts-toolbelt's wall lives in relation/constraint work (workstream A's other half). The structural elimination is the foundation that makes evaluation cost proportional to distinct types rather than call sites, and the audit counters make any future regression attributable.

## Verification
- Full local conformance (release): 12583/12585, zero new vs accepted regressions (only the 2 accepted Mac-delta cases), re-verified on this exact head over current main.
- `cargo nextest run -p tsz-solver`: 6649 passed; only the 3 known pre-existing failures (A/B-identical on clean main). 13/13 limit_relation_cache_tests green.
- Byte-identical diagnostics on ts-toolbelt, zodmin, and a generated 300-root recursive fixture vs baseline binary.
- clippy --all-targets clean; no new `#[allow]`; shards under cap; new module inside `evaluation/` (crate-root policy).

## Risks
- Per-file eval cache now holds identity entries → bounded residency growth (16B-class entries, distinct TypeIds per file); watch via #13249's residency counters.
- Memo hits skip walk side effects (display-alias provenance) — same class as existing top-level hits; no drift observed across conformance + byte-compares.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: max
