### PR TITLE
perf(bench): report project-weighted target metric

### DIFF
--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -218,6 +218,15 @@ withTempDir((dir) => {
     rows_meeting_target: 1,
     rows_below_target: 3,
     project_rows_below_target: 2,
+    project_rows_aggregate: {
+      eligible_green_rows: 2,
+      measured_rows: 2,
+      tsz_ms_total: 873.92 + 165.15,
+      tsgo_ms_total: 106.15 + 54.51,
+      tsz_speedup_vs_tsgo: (106.15 + 54.51) / (873.92 + 165.15),
+      target_speedup: 2,
+      target_met: false,
+    },
     rows_with_attribution: 1,
     missing_attribution_rows: ["single-file-loss", "vite-vanilla-ts-app"],
     rows_with_attribution_command: 2,
@@ -804,6 +813,8 @@ withTempDir((dir) => {
       ["target-short", 15 / 10],
     ],
   );
+  assert.equal(report.target_gaps.find((row) => row.name === "target-short").startup_floor_win, true);
+  assert.equal(report.target_gaps.find((row) => row.name === "tsgo-win").startup_floor_win, false);
 });
 
 withTempDir((dir) => {

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -7,6 +7,7 @@ import { PROJECT_ROWS_BY_NAME } from "./project-rows.mjs";
 import { isGreen, isIncompleteCompat } from "./row-utils.mjs";
 
 const TARGET_TSZ_SPEEDUP = 2;
+const TSGO_STARTUP_FLOOR_MS = 500;
 
 function readJson(file) {
   return JSON.parse(fs.readFileSync(file, "utf8"));
@@ -19,6 +20,41 @@ function toPortablePath(file) {
 function asNumber(value) {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function isProjectRowName(name) {
+  return typeof name === "string" && Object.hasOwn(PROJECT_ROWS_BY_NAME, name);
+}
+
+function startupFloorWin(row, tsgoMs) {
+  return row?.winner === "tsz" && tsgoMs != null && tsgoMs > 0 && tsgoMs <= TSGO_STARTUP_FLOOR_MS;
+}
+
+function projectRowsAggregate(rows) {
+  const projectRows = rows.filter((row) => row.is_project_row);
+  let measuredRows = 0;
+  let tszTotal = 0;
+  let tsgoTotal = 0;
+
+  for (const row of projectRows) {
+    if (row.tsz_ms == null || row.tsz_ms <= 0 || row.tsgo_ms == null || row.tsgo_ms <= 0) {
+      continue;
+    }
+    measuredRows += 1;
+    tszTotal += row.tsz_ms;
+    tsgoTotal += row.tsgo_ms;
+  }
+
+  const speedup = measuredRows > 0 && tszTotal > 0 ? tsgoTotal / tszTotal : null;
+  return {
+    eligible_green_rows: projectRows.length,
+    measured_rows: measuredRows,
+    tsz_ms_total: tszTotal,
+    tsgo_ms_total: tsgoTotal,
+    tsz_speedup_vs_tsgo: speedup,
+    target_speedup: TARGET_TSZ_SPEEDUP,
+    target_met: speedup != null ? speedup >= TARGET_TSZ_SPEEDUP : false,
+  };
 }
 
 const LOSS_CLOSURE_BY_ROW = new Map([
@@ -604,7 +640,7 @@ function duplicateProjectRows(rows) {
   const counts = new Map();
   for (const row of rows) {
     const name = typeof row?.name === "string" ? row.name : null;
-    if (!name || !Object.hasOwn(PROJECT_ROWS_BY_NAME, name)) continue;
+    if (!isProjectRowName(name)) continue;
     counts.set(name, (counts.get(name) ?? 0) + 1);
   }
 
@@ -629,14 +665,18 @@ export function createTsgoWinnerReport(input, inputPath) {
     .map((row) => {
       const speedup = tszSpeedupVsTsgo(row);
       const gapFactor = speedup == null ? null : targetGapFactor(speedup);
+      const tszMs = asNumber(row.tsz_ms);
+      const tsgoMs = asNumber(row.tsgo_ms);
       return {
         name: row.name,
         winner: row.winner ?? null,
         factor: asNumber(row.factor),
         tsz_speedup_vs_tsgo: speedup,
         target_gap_factor: gapFactor,
-        tsz_ms: asNumber(row.tsz_ms),
-        tsgo_ms: asNumber(row.tsgo_ms),
+        tsz_ms: tszMs,
+        tsgo_ms: tsgoMs,
+        is_project_row: isProjectRowName(row.name),
+        startup_floor_win: startupFloorWin(row, tsgoMs),
         lines: asNumber(row.lines),
         kb: asNumber(row.kb),
         project_files: asNumber(row.project_files),
@@ -668,6 +708,8 @@ export function createTsgoWinnerReport(input, inputPath) {
       factor: asNumber(row.factor),
       tsz_ms: asNumber(row.tsz_ms),
       tsgo_ms: asNumber(row.tsgo_ms),
+      is_project_row: isProjectRowName(row.name),
+      startup_floor_win: startupFloorWin(row, asNumber(row.tsgo_ms)),
       lines: asNumber(row.lines),
       kb: asNumber(row.kb),
       project_files: asNumber(row.project_files),
@@ -726,10 +768,11 @@ export function createTsgoWinnerReport(input, inputPath) {
     two_x_target: {
       tsz_speedup_target: TARGET_TSZ_SPEEDUP,
       eligible_green_rows: eligibleRows.length,
-      project_eligible_green_rows: eligibleRows.filter((row) => row.semantic_owner_family).length,
+      project_eligible_green_rows: eligibleRows.filter((row) => row.is_project_row).length,
       rows_meeting_target: eligibleRows.length - targetGapRows.length,
       rows_below_target: targetGapRows.length,
-      project_rows_below_target: targetGapRows.filter((row) => row.semantic_owner_family).length,
+      project_rows_below_target: targetGapRows.filter((row) => row.is_project_row).length,
+      project_rows_aggregate: projectRowsAggregate(eligibleRows),
       rows_with_attribution: targetGapRows.length - missingTargetGapAttributionRows.length,
       missing_attribution_rows: missingTargetGapAttributionRows,
       rows_with_attribution_command: targetGapRowsWithAttributionCommand,


### PR DESCRIPTION
Goal: fast

## Summary
- Add a project-weighted 2x target aggregate to the tsgo winner report by summing canonical project-row tsz/tsgo wall time.
- Add per-row startup-floor win reporting so tiny tsz wins near the tsgo startup floor can be separated from substantive project wins.
- Keep this PR limited to reporting shape; no compiler behavior, benchmark runner, or attribution workflow changes.

## Structural Rule
When a green benchmark result is one of the canonical project rows, project-weighted reporting should compare total tsgo wall time against total tsz wall time across those project rows. The report generator owns this metric; micro/single-file rows still contribute to row-level target gaps but not the project aggregate.

## Verification
- Local targeted node tests/benchmark commands not run in this continuation.
- Pre-commit formatting hook ran during `git commit`.
- Draft/light PR CI at `21ca1e0e318fa74bfe3c7ebeab42eb0597c9b1a5`: `CI Light Summary`, `lint`, `project-row-drift`, `cargo-deny`, `cargo-shear`, and `gate` passed.
- Ready/full PR CI is expected to provide any additional path-filtered gate signal for the report-shape change.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium

Refs #13247
Refs #13250
