### PR TITLE
perf(core): assess residency pressure from retained state

### DIFF
--- a/crates/tsz-core/src/parallel/residency.rs
+++ b/crates/tsz-core/src/parallel/residency.rs
@@ -341,7 +341,14 @@ impl ResidencyBudget {
     /// Assess memory pressure from residency stats.
     #[must_use]
     pub const fn assess(&self, stats: &MergedProgramResidencyStats) -> MemoryPressure {
-        let total = stats.pre_merge_bind_total_bytes + stats.total_bound_file_bytes;
+        // `pre_merge_bind_total_bytes` is a transient merge-time footprint:
+        // owned merge paths release consumed `BindResult`s after their data has
+        // been copied into `MergedProgram`. Residency pressure must therefore
+        // use retained file state only; otherwise future eviction wiring would
+        // react to bytes that no longer exist after merge.
+        let total = stats
+            .total_bound_file_bytes
+            .saturating_add(stats.unique_arena_estimated_bytes);
         if total >= self.high_watermark_bytes {
             MemoryPressure::High
         } else if total >= self.low_watermark_bytes {


### PR DESCRIPTION
Goal: fast

## Summary
- Change residency pressure assessment to use retained file state instead of transient pre-merge bind-result bytes.
- Keep pre-merge bytes as reporting input only; they still describe merge-time peak pressure but should not trigger post-merge eviction decisions.
- This is a prerequisite for wiring ResidencyBudget safely into batch/LSP eviction without reacting to bytes already released by owned merge paths.

## Structural Rule
When owned merge consumes bind results, pre-merge BindResult state is transient and released after its data is copied into MergedProgram. ResidencyBudget should assess retained MergedProgram file state through BoundFile plus unique arena estimates; future eviction owners can still report pre-merge bytes separately for peak analysis.

## Verification
- Local targeted residency tests/compiler checks not run in this continuation.
- Pre-commit formatting hook ran during `git commit`.
- Draft/light PR CI at `ae8d8f3c90f9c10588d1b7d1918ae8f57a57e17f`: `CI Light Summary`, `lint`, `unit`, `unit-cloudbuild`, `unit-checker-integration`, `dist-binaries`, `project-row-drift`, `cargo-deny`, `cargo-shear`, and `gate` passed.
- Ready/full PR CI is expected to provide any additional path-filtered gate signal for the residency assessment change.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium

Refs #13249
Refs #13250
