### PR TITLE
perf(solver): pack interner predicate caches

### DIFF
--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -6,8 +6,8 @@
 use crate::caches::instantiation_cache::InstantiationCacheKey;
 use crate::caches::subtype_reduction_cache::SubtypeReductionKey;
 use crate::def::DefId;
-use crate::intern::TypeInterner;
 use crate::intern::type_factory::TypeFactory;
+use crate::intern::{PredicateCacheKind, TypeInterner};
 use crate::narrowing;
 use crate::objects::ObjectLiteralBuilder;
 use crate::objects::element_access::{ElementAccessEvaluator, ElementAccessResult};
@@ -622,114 +622,115 @@ pub trait TypeDatabase:
 
 impl TypePredicateCache for TypeInterner {
     fn contains_this_type_cached(&self, type_id: TypeId) -> Option<bool> {
-        self.contains_this_cache.get(&type_id).map(|v| *v)
+        self.predicate_cache_get(type_id, PredicateCacheKind::ContainsThis)
     }
 
     fn set_contains_this_type_cache(&self, type_id: TypeId, result: bool) {
-        self.contains_this_cache.insert(type_id, result);
+        self.predicate_cache_set(type_id, PredicateCacheKind::ContainsThis, result);
     }
 
     fn contains_infer_types_cached(&self, type_id: TypeId) -> Option<bool> {
-        self.contains_infer_cache.get(&type_id).map(|v| *v)
+        self.predicate_cache_get(type_id, PredicateCacheKind::ContainsInfer)
     }
 
     fn set_contains_infer_types_cache(&self, type_id: TypeId, result: bool) {
-        self.contains_infer_cache.insert(type_id, result);
+        self.predicate_cache_set(type_id, PredicateCacheKind::ContainsInfer, result);
     }
 
     fn contains_type_query_cached(&self, type_id: TypeId) -> Option<bool> {
-        self.contains_type_query_cache.get(&type_id).map(|v| *v)
+        self.predicate_cache_get(type_id, PredicateCacheKind::ContainsTypeQuery)
     }
 
     fn set_contains_type_query_cache(&self, type_id: TypeId, result: bool) {
-        self.contains_type_query_cache.insert(type_id, result);
+        self.predicate_cache_set(type_id, PredicateCacheKind::ContainsTypeQuery, result);
     }
 
     fn contains_type_params_cached(&self, type_id: TypeId) -> Option<bool> {
-        self.contains_type_params_cache.get(&type_id).map(|v| *v)
+        self.predicate_cache_get(type_id, PredicateCacheKind::ContainsTypeParams)
     }
 
     fn set_contains_type_params_cache(&self, type_id: TypeId, result: bool) {
-        self.contains_type_params_cache.insert(type_id, result);
+        self.predicate_cache_set(type_id, PredicateCacheKind::ContainsTypeParams, result);
     }
 
     fn contains_lazy_or_recursive_cached(&self, type_id: TypeId) -> Option<bool> {
-        self.contains_lazy_or_recursive_cache
-            .get(&type_id)
-            .map(|v| *v)
+        self.predicate_cache_get(type_id, PredicateCacheKind::ContainsLazyOrRecursive)
     }
 
     fn set_contains_lazy_or_recursive_cache(&self, type_id: TypeId, result: bool) {
-        self.contains_lazy_or_recursive_cache
-            .insert(type_id, result);
+        self.predicate_cache_set(type_id, PredicateCacheKind::ContainsLazyOrRecursive, result);
     }
 
     fn contains_unresolved_application_cached(&self, type_id: TypeId) -> Option<bool> {
-        self.contains_unresolved_application_cache
-            .get(&type_id)
-            .map(|v| *v)
+        self.predicate_cache_get(type_id, PredicateCacheKind::ContainsUnresolvedApplication)
     }
 
     fn set_contains_unresolved_application_cache(&self, type_id: TypeId, result: bool) {
-        self.contains_unresolved_application_cache
-            .insert(type_id, result);
+        self.predicate_cache_set(
+            type_id,
+            PredicateCacheKind::ContainsUnresolvedApplication,
+            result,
+        );
     }
 
     fn contains_resolver_dependent_cached(&self, type_id: TypeId) -> Option<bool> {
-        self.contains_resolver_dependent_cache
-            .get(&type_id)
-            .map(|v| *v)
+        self.predicate_cache_get(type_id, PredicateCacheKind::ContainsResolverDependent)
     }
 
     fn set_contains_resolver_dependent_cache(&self, type_id: TypeId, result: bool) {
-        self.contains_resolver_dependent_cache
-            .insert(type_id, result);
+        self.predicate_cache_set(
+            type_id,
+            PredicateCacheKind::ContainsResolverDependent,
+            result,
+        );
     }
 
     fn contains_conditional_cached(&self, type_id: TypeId) -> Option<bool> {
-        self.contains_conditional_cache.get(&type_id).map(|v| *v)
+        self.predicate_cache_get(type_id, PredicateCacheKind::ContainsConditional)
     }
 
     fn set_contains_conditional_cache(&self, type_id: TypeId, result: bool) {
-        self.contains_conditional_cache.insert(type_id, result);
+        self.predicate_cache_set(type_id, PredicateCacheKind::ContainsConditional, result);
     }
 
     fn contains_param_or_infer_root_cached(&self, type_id: TypeId) -> Option<bool> {
-        self.contains_param_or_infer_root_cache
-            .get(&type_id)
-            .map(|v| *v)
+        self.predicate_cache_get(type_id, PredicateCacheKind::ContainsParamOrInferRoot)
     }
 
     fn set_contains_param_or_infer_root_cache(&self, type_id: TypeId, result: bool) {
-        self.contains_param_or_infer_root_cache
-            .insert(type_id, result);
+        self.predicate_cache_set(
+            type_id,
+            PredicateCacheKind::ContainsParamOrInferRoot,
+            result,
+        );
     }
 
     fn contains_generic_params_root_cached(&self, type_id: TypeId) -> Option<bool> {
-        self.contains_generic_params_root_cache
-            .get(&type_id)
-            .map(|v| *v)
+        self.predicate_cache_get(type_id, PredicateCacheKind::ContainsGenericParamsRoot)
     }
 
     fn set_contains_generic_params_root_cache(&self, type_id: TypeId, result: bool) {
-        self.contains_generic_params_root_cache
-            .insert(type_id, result);
+        self.predicate_cache_set(
+            type_id,
+            PredicateCacheKind::ContainsGenericParamsRoot,
+            result,
+        );
     }
 
     fn eval_contains_infer_cached(&self, type_id: TypeId) -> Option<bool> {
-        self.eval_contains_infer_cache.get(&type_id).map(|v| *v)
+        self.predicate_cache_get(type_id, PredicateCacheKind::EvalContainsInfer)
     }
 
     fn set_eval_contains_infer_cache(&self, type_id: TypeId, result: bool) {
-        self.eval_contains_infer_cache.insert(type_id, result);
+        self.predicate_cache_set(type_id, PredicateCacheKind::EvalContainsInfer, result);
     }
 
     fn contains_file_relative_cached(&self, type_id: TypeId) -> Option<bool> {
-        self.contains_file_relative_cache.get(&type_id).map(|v| *v)
+        self.predicate_cache_get(type_id, PredicateCacheKind::ContainsFileRelative)
     }
 
     fn set_contains_file_relative_cache(&self, type_id: TypeId, result: bool) {
-        self.contains_file_relative_cache.insert(type_id, result);
+        self.predicate_cache_set(type_id, PredicateCacheKind::ContainsFileRelative, result);
     }
 }
 

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -4,7 +4,8 @@
 //! interned types: literals, unions, intersections, objects, functions, etc.
 
 use super::interner::{
-    CachedUnionMember, TYPE_LIST_INLINE, TypeInterner, TypeListBuffer, TypeShard,
+    CachedUnionMember, PredicateCacheEntry, TYPE_LIST_INLINE, TypeInterner, TypeListBuffer,
+    TypeShard,
 };
 use crate::def::DefId;
 use crate::types::{
@@ -1720,30 +1721,10 @@ impl TypeInterner {
         // --- Auxiliary caches ---
         size += self.identity_comparable_cache.len()
             * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
-        size += self.contains_this_cache.len()
-            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
-        size += self.contains_infer_cache.len()
-            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
-        size += self.contains_type_query_cache.len()
-            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
-        size += self.contains_type_params_cache.len()
-            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
-        size += self.contains_lazy_or_recursive_cache.len()
-            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
-        size += self.contains_unresolved_application_cache.len()
-            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
-        size += self.contains_resolver_dependent_cache.len()
-            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
-        size += self.contains_conditional_cache.len()
-            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
-        size += self.contains_param_or_infer_root_cache.len()
-            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
-        size += self.contains_generic_params_root_cache.len()
-            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
-        size += self.eval_contains_infer_cache.len()
-            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
-        size += self.contains_file_relative_cache.len()
-            * (DASHMAP_ENTRY_OVERHEAD + std::mem::size_of::<TypeId>() + 1);
+        size += self.predicate_cache.len()
+            * (DASHMAP_ENTRY_OVERHEAD
+                + std::mem::size_of::<TypeId>()
+                + std::mem::size_of::<PredicateCacheEntry>());
         size += self
             .union_normalize_cache
             .iter()

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -149,7 +149,7 @@ impl PredicateCacheEntry {
     }
 
     #[inline]
-    fn set(&mut self, kind: PredicateCacheKind, result: bool) {
+    const fn set(&mut self, kind: PredicateCacheKind, result: bool) {
         let bit = kind.bit();
         self.known |= bit;
         if result {

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -109,6 +109,62 @@ pub(crate) struct InternedTypeLimitContext {
     pub(crate) fallback_type: TypeId,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PredicateCacheKind {
+    ContainsThis = 0,
+    ContainsInfer = 1,
+    ContainsTypeQuery = 2,
+    ContainsTypeParams = 3,
+    ContainsLazyOrRecursive = 4,
+    ContainsUnresolvedApplication = 5,
+    ContainsResolverDependent = 6,
+    ContainsConditional = 7,
+    ContainsParamOrInferRoot = 8,
+    ContainsGenericParamsRoot = 9,
+    EvalContainsInfer = 10,
+    ContainsFileRelative = 11,
+}
+
+impl PredicateCacheKind {
+    const fn bit(self) -> u16 {
+        1u16 << (self as u8)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct PredicateCacheEntry {
+    known: u16,
+    truthy: u16,
+}
+
+impl PredicateCacheEntry {
+    #[inline]
+    const fn get(self, kind: PredicateCacheKind) -> Option<bool> {
+        let bit = kind.bit();
+        if self.known & bit == 0 {
+            None
+        } else {
+            Some(self.truthy & bit != 0)
+        }
+    }
+
+    #[inline]
+    fn set(&mut self, kind: PredicateCacheKind, result: bool) {
+        let bit = kind.bit();
+        self.known |= bit;
+        if result {
+            self.truthy |= bit;
+        } else {
+            self.truthy &= !bit;
+        }
+    }
+
+    #[inline]
+    const fn has(self, kind: PredicateCacheKind) -> bool {
+        self.known & kind.bit() != 0
+    }
+}
+
 /// Type interning table with lock-free concurrent access.
 ///
 /// Uses sharded `DashMap` structures for all internal storage, enabling
@@ -135,54 +191,14 @@ pub struct TypeInterner {
     pub(super) applications: ConcurrentValueInterner<TypeApplication>,
     /// Cache for `is_identity_comparable_type` checks (memoized O(1) lookup after first computation)
     pub(super) identity_comparable_cache: DashMap<TypeId, bool, FxBuildHasher>,
-    /// Cache for `contains_this_type` checks. Result is stable per TypeId
-    /// within a single interner, so memoizing project-wide eliminates the
-    /// repeated recursive walk that showed up at ~5% of total CPU on
-    /// multi-file workloads.
-    pub(crate) contains_this_cache: DashMap<TypeId, bool, FxBuildHasher>,
-    /// Cache for `contains_infer_types_db` checks. Evaluation/cache filtering
-    /// and conditional subtype paths ask this repeatedly for the same
-    /// conditional/application shapes.
-    pub(crate) contains_infer_cache: DashMap<TypeId, bool, FxBuildHasher>,
-    /// Cache for `contains_type_query_db` checks. Results are immutable per
-    /// `TypeId` and shared across evaluator instances.
-    pub(crate) contains_type_query_cache: DashMap<TypeId, bool, FxBuildHasher>,
-    /// Per-`TypeId` caches for deep `contains_*` content walks (immutable per
-    /// `TypeId`; O(1) on repeat shapes). `contains_resolver_dependent_cache`
-    /// backs `is_substitution_dependent_type`, the `closed_eval_cache` gate.
-    pub(crate) contains_type_params_cache: DashMap<TypeId, bool, FxBuildHasher>,
-    pub(crate) contains_lazy_or_recursive_cache: DashMap<TypeId, bool, FxBuildHasher>,
-    pub(crate) contains_unresolved_application_cache: DashMap<TypeId, bool, FxBuildHasher>,
-    pub(crate) contains_resolver_dependent_cache: DashMap<TypeId, bool, FxBuildHasher>,
-    /// Alias-opaque `contains Conditional` cache for the closed-eval gate.
-    /// The answer is immutable per `TypeId` and avoids repeated subtree walks
-    /// on dense recursive mapped/conditional/index-access expansions.
-    pub(crate) contains_conditional_cache: DashMap<TypeId, bool, FxBuildHasher>,
-    /// Per-`TypeId` cache for the narrow
-    /// `visitor_predicates::contains_type_parameters` walk
-    /// (`TypeParameter | Infer` predicate). Recursive conditional evaluation
-    /// and instantiation gates re-ask this for the same shared subtrees
-    /// constantly.
-    pub(crate) contains_param_or_infer_root_cache: DashMap<TypeId, bool, FxBuildHasher>,
-    /// Root-result cache for the depth-limited
-    /// `contains_generic_type_parameters_db` walk
-    /// (`TypeParameter | Infer | BoundParameter` predicate). Same purity
-    /// argument as `contains_param_or_infer_root_cache`; display-alias
-    /// bookkeeping re-asks this for the same application args after every
-    /// evaluation.
-    pub(crate) contains_generic_params_root_cache: DashMap<TypeId, bool, FxBuildHasher>,
-    /// Per-node cache for the evaluator's `type_contains_infer` walk.
-    /// That walk differs from `contains_infer_types_db` (it descends
-    /// `Application` bases and matches only structural `Infer` nodes), so it
-    /// gets its own slot. Entries are only written for fully-explored
-    /// (cycle-untainted) subtrees; the answer is immutable per `TypeId`.
-    pub(crate) eval_contains_infer_cache: DashMap<TypeId, bool, FxBuildHasher>,
-    /// Per-node cache for the `contains_file_relative_content_db` walk
-    /// (`UnresolvedTypeName | TypeQuery | UniqueSymbol | ModuleNamespace |
-    /// ThisType | Recursive` predicate). Gates which constraint-validation
-    /// proofs may be published to program-wide caches shared across file
-    /// checkers.
-    pub(crate) contains_file_relative_cache: DashMap<TypeId, bool, FxBuildHasher>,
+    /// Packed per-`TypeId` caches for immutable structural content predicates.
+    ///
+    /// Each bit records one predicate's known/truthy state. This preserves the
+    /// existing accessor surface while replacing the independent
+    /// `DashMap<TypeId, bool>` tables for content predicates with one shared
+    /// table. Predicate identity remains part of the key through the bit, so
+    /// distinct walks do not alias each other.
+    pub(crate) predicate_cache: DashMap<TypeId, PredicateCacheEntry, FxBuildHasher>,
     /// Result memo for `normalize_union`, keyed by the exact flattened
     /// pre-normalization member list. Normalization (semantic sort, dedup,
     /// absorption passes, subtype reduction) is deterministic in the input
@@ -363,25 +379,66 @@ impl TypeInterner {
     pub fn type_predicate_cache_statistics(&self) -> TypePredicateCacheStatistics {
         TypePredicateCacheStatistics {
             identity_comparable_cache_entries: self.identity_comparable_cache.len(),
-            contains_this_cache_entries: self.contains_this_cache.len(),
-            contains_infer_cache_entries: self.contains_infer_cache.len(),
-            contains_type_query_cache_entries: self.contains_type_query_cache.len(),
-            contains_type_params_cache_entries: self.contains_type_params_cache.len(),
-            contains_lazy_or_recursive_cache_entries: self.contains_lazy_or_recursive_cache.len(),
+            contains_this_cache_entries: self
+                .predicate_cache_entries_for(PredicateCacheKind::ContainsThis),
+            contains_infer_cache_entries: self
+                .predicate_cache_entries_for(PredicateCacheKind::ContainsInfer),
+            contains_type_query_cache_entries: self
+                .predicate_cache_entries_for(PredicateCacheKind::ContainsTypeQuery),
+            contains_type_params_cache_entries: self
+                .predicate_cache_entries_for(PredicateCacheKind::ContainsTypeParams),
+            contains_lazy_or_recursive_cache_entries: self
+                .predicate_cache_entries_for(PredicateCacheKind::ContainsLazyOrRecursive),
             contains_unresolved_application_cache_entries: self
-                .contains_unresolved_application_cache
-                .len(),
-            contains_resolver_dependent_cache_entries: self.contains_resolver_dependent_cache.len(),
-            contains_conditional_cache_entries: self.contains_conditional_cache.len(),
+                .predicate_cache_entries_for(PredicateCacheKind::ContainsUnresolvedApplication),
+            contains_resolver_dependent_cache_entries: self
+                .predicate_cache_entries_for(PredicateCacheKind::ContainsResolverDependent),
+            contains_conditional_cache_entries: self
+                .predicate_cache_entries_for(PredicateCacheKind::ContainsConditional),
             contains_param_or_infer_root_cache_entries: self
-                .contains_param_or_infer_root_cache
-                .len(),
+                .predicate_cache_entries_for(PredicateCacheKind::ContainsParamOrInferRoot),
             contains_generic_params_root_cache_entries: self
-                .contains_generic_params_root_cache
-                .len(),
-            eval_contains_infer_cache_entries: self.eval_contains_infer_cache.len(),
-            contains_file_relative_cache_entries: self.contains_file_relative_cache.len(),
+                .predicate_cache_entries_for(PredicateCacheKind::ContainsGenericParamsRoot),
+            eval_contains_infer_cache_entries: self
+                .predicate_cache_entries_for(PredicateCacheKind::EvalContainsInfer),
+            contains_file_relative_cache_entries: self
+                .predicate_cache_entries_for(PredicateCacheKind::ContainsFileRelative),
         }
+    }
+
+    #[inline]
+    pub(crate) fn predicate_cache_get(
+        &self,
+        type_id: TypeId,
+        kind: PredicateCacheKind,
+    ) -> Option<bool> {
+        self.predicate_cache
+            .get(&type_id)
+            .and_then(|entry| entry.get(kind))
+    }
+
+    #[inline]
+    pub(crate) fn predicate_cache_set(
+        &self,
+        type_id: TypeId,
+        kind: PredicateCacheKind,
+        result: bool,
+    ) {
+        match self.predicate_cache.entry(type_id) {
+            Entry::Occupied(mut entry) => entry.get_mut().set(kind, result),
+            Entry::Vacant(entry) => {
+                let mut value = PredicateCacheEntry::default();
+                value.set(kind, result);
+                entry.insert(value);
+            }
+        }
+    }
+
+    fn predicate_cache_entries_for(&self, kind: PredicateCacheKind) -> usize {
+        self.predicate_cache
+            .iter()
+            .filter(|entry| entry.value().has(kind))
+            .count()
     }
 
     /// Create a new type interner with pre-registered intrinsics.
@@ -406,18 +463,7 @@ impl TypeInterner {
             mapped_types: ConcurrentValueInterner::new(),
             applications: ConcurrentValueInterner::new(),
             identity_comparable_cache: DashMap::with_hasher(FxBuildHasher),
-            contains_this_cache: DashMap::with_hasher(FxBuildHasher),
-            contains_infer_cache: DashMap::with_hasher(FxBuildHasher),
-            contains_type_query_cache: DashMap::with_hasher(FxBuildHasher),
-            contains_type_params_cache: DashMap::with_hasher(FxBuildHasher),
-            contains_lazy_or_recursive_cache: DashMap::with_hasher(FxBuildHasher),
-            contains_unresolved_application_cache: DashMap::with_hasher(FxBuildHasher),
-            contains_resolver_dependent_cache: DashMap::with_hasher(FxBuildHasher),
-            contains_conditional_cache: DashMap::with_hasher(FxBuildHasher),
-            contains_param_or_infer_root_cache: DashMap::with_hasher(FxBuildHasher),
-            contains_generic_params_root_cache: DashMap::with_hasher(FxBuildHasher),
-            eval_contains_infer_cache: DashMap::with_hasher(FxBuildHasher),
-            contains_file_relative_cache: DashMap::with_hasher(FxBuildHasher),
+            predicate_cache: DashMap::with_hasher(FxBuildHasher),
             union_normalize_cache: DashMap::with_hasher(FxBuildHasher),
             array_base_type: AtomicU32::new(u32::MAX),
             array_display_base_type: AtomicU32::new(u32::MAX),

--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::caches::db::TypeDatabase;
+use crate::caches::db::{TypeDatabase, TypePredicateCache};
 
 #[test]
 fn interned_type_limit_fallback_poison_returns_error() {
@@ -67,11 +67,9 @@ fn estimated_size_accounts_for_retained_predicate_caches() {
     let interner = TypeInterner::new();
     let before = interner.estimated_size_bytes();
 
-    interner.contains_this_cache.insert(TypeId::NUMBER, true);
-    interner.contains_infer_cache.insert(TypeId::STRING, false);
-    interner
-        .contains_type_query_cache
-        .insert(TypeId::BOOLEAN, true);
+    interner.set_contains_this_type_cache(TypeId::NUMBER, true);
+    interner.set_contains_infer_types_cache(TypeId::STRING, false);
+    interner.set_contains_type_query_cache(TypeId::BOOLEAN, true);
 
     assert!(
         interner.estimated_size_bytes() > before,

--- a/crates/tsz-solver/src/intern/core/mod.rs
+++ b/crates/tsz-solver/src/intern/core/mod.rs
@@ -14,6 +14,4 @@ pub(crate) use interner::PROPERTY_MAP_THRESHOLD;
 pub use interner::SharedDefVariance;
 pub use interner::TypeInterner;
 pub use interner::clear_thread_local_cache;
-pub(crate) use interner::{
-    PredicateCacheEntry, PredicateCacheKind, TEMPLATE_LITERAL_EXPANSION_LIMIT, TypeListBuffer,
-};
+pub(crate) use interner::{PredicateCacheKind, TEMPLATE_LITERAL_EXPANSION_LIMIT, TypeListBuffer};

--- a/crates/tsz-solver/src/intern/core/mod.rs
+++ b/crates/tsz-solver/src/intern/core/mod.rs
@@ -14,4 +14,6 @@ pub(crate) use interner::PROPERTY_MAP_THRESHOLD;
 pub use interner::SharedDefVariance;
 pub use interner::TypeInterner;
 pub use interner::clear_thread_local_cache;
-pub(crate) use interner::{TEMPLATE_LITERAL_EXPANSION_LIMIT, TypeListBuffer};
+pub(crate) use interner::{
+    PredicateCacheEntry, PredicateCacheKind, TEMPLATE_LITERAL_EXPANSION_LIMIT, TypeListBuffer,
+};

--- a/crates/tsz-solver/src/intern/mod.rs
+++ b/crates/tsz-solver/src/intern/mod.rs
@@ -32,7 +32,7 @@ pub mod type_factory;
 pub use self::core::SharedDefVariance;
 pub use self::core::TypeInterner;
 pub use self::core::clear_thread_local_cache;
-pub(crate) use self::core::{TEMPLATE_LITERAL_EXPANSION_LIMIT, TypeListBuffer};
+pub(crate) use self::core::{PredicateCacheKind, TEMPLATE_LITERAL_EXPANSION_LIMIT, TypeListBuffer};
 pub(crate) use self::tuple_normalization::tuple_normalized;
 // Used by intern_tests.rs (included via #[path] below).
 #[cfg(test)]


### PR DESCRIPTION
Goal: fast

## Summary
- Replace the TypeInterner's independent immutable content-predicate boolean maps with one packed per-TypeId predicate bit table.
- Preserve the existing TypePredicateCache accessor API so callers keep the same per-predicate semantics and cache keys.
- Keep identity-comparability and evaluator-local caches separate; this PR only packs the interner-owned content predicate table.

## Structural Rule
When a predicate answer is an immutable function of a TypeId within one TypeInterner, the cache key is (TypeId, predicate-kind). The packed table stores predicate-kind as a bit in PredicateCacheEntry, preserving distinct answers while reducing repeated DashMap allocation/probe surfaces.

## Verification
- GitHub draft light CI passed at head `762bc7bc64e97719a0c0459ba3900c76fb9c94be`: lint, unit, unit-checker-integration, unit-cloudbuild, dist-binaries, cargo-deny, cargo-shear, project-row-drift, gate.
- Pre-commit formatting hook ran during commit.
- Not run locally: targeted solver tests or compiler checks, per current instruction to avoid local validation unless explicitly requested.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: gpt-5
Effort: medium

Refs #13098
Refs #13250
