### PR TITLE
perf(solver): add opt-in shared instantiation cache witness

### DIFF
--- a/crates/tsz-solver/src/caches/mod.rs
+++ b/crates/tsz-solver/src/caches/mod.rs
@@ -4,4 +4,5 @@ pub(crate) mod query_cache;
 mod query_cache_evaluation;
 pub(crate) mod query_cache_statistics;
 pub(crate) mod query_trace;
+mod shared_instantiation;
 pub(crate) mod subtype_reduction_cache;

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -130,11 +130,16 @@ impl CachedPolicyRelation {
 /// state during the first evaluation of a generic type alias (e.g. `Promise<T>`,
 /// `Awaited<T>`), producing a stale result that is then returned to sibling
 /// files. Keeping those caches per-file eliminates the ordering-sensitive
-/// correctness risk. See issue #9507.
+/// correctness risk. See issue #9507. `TSZ_SHARE_INSTANTIATION_CACHES=1`
+/// enables an experimental witness path for issue #13240; it is deliberately
+/// opt-in until the ordering/staleness matrix proves it safe.
 pub struct SharedQueryCache {
     eval_cache: DashMap<EvaluationCacheKey, TypeId, FxBuildHasher>,
     subtype_cache: DashMap<RelationCacheKey, RelationCacheValue, FxBuildHasher>,
     assignability_cache: DashMap<RelationCacheKey, RelationCacheValue, FxBuildHasher>,
+    application_eval_cache: DashMap<ApplicationEvalCacheKey, TypeId, FxBuildHasher>,
+    instantiation_cache: DashMap<InstantiationCacheKey, TypeId, FxBuildHasher>,
+    share_instantiation_family: bool,
 }
 
 impl SharedQueryCache {
@@ -143,12 +148,24 @@ impl SharedQueryCache {
             eval_cache: DashMap::with_hasher(FxBuildHasher),
             subtype_cache: DashMap::with_hasher(FxBuildHasher),
             assignability_cache: DashMap::with_hasher(FxBuildHasher),
+            application_eval_cache: DashMap::with_hasher(FxBuildHasher),
+            instantiation_cache: DashMap::with_hasher(FxBuildHasher),
+            share_instantiation_family: shared_instantiation_family_requested(),
         }
     }
 
     /// Number of entries across all shared caches.
     pub fn total_entries(&self) -> usize {
-        self.eval_cache.len() + self.subtype_cache.len() + self.assignability_cache.len()
+        self.eval_cache.len()
+            + self.subtype_cache.len()
+            + self.assignability_cache.len()
+            + self.application_eval_cache.len()
+            + self.instantiation_cache.len()
+    }
+
+    #[inline]
+    fn shares_instantiation_family(&self) -> bool {
+        self.share_instantiation_family
     }
 
     /// Estimate the resident heap bytes of the shared cache maps.
@@ -169,6 +186,14 @@ impl SharedQueryCache {
             * (DASHMAP_ENTRY_OVERHEAD
                 + std::mem::size_of::<RelationCacheKey>()
                 + std::mem::size_of::<bool>());
+        size += self.application_eval_cache.len()
+            * (DASHMAP_ENTRY_OVERHEAD
+                + std::mem::size_of::<ApplicationEvalCacheKey>()
+                + std::mem::size_of::<TypeId>());
+        size += self.instantiation_cache.len()
+            * (DASHMAP_ENTRY_OVERHEAD
+                + std::mem::size_of::<InstantiationCacheKey>()
+                + std::mem::size_of::<TypeId>());
         size
     }
 }
@@ -177,6 +202,10 @@ impl Default for SharedQueryCache {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn shared_instantiation_family_requested() -> bool {
+    std::env::var_os("TSZ_SHARE_INSTANTIATION_CACHES").is_some_and(|value| value != "0")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -584,12 +613,26 @@ impl<'a> QueryCache<'a> {
                 .set(self.application_eval_cache_hits.get() + 1);
             return Some(result);
         }
+        if let Some(shared) = self.shared
+            && shared.shares_instantiation_family()
+            && let Some(result) = shared.application_eval_cache.get(&key).map(|entry| *entry)
+        {
+            self.application_eval_cache.borrow_mut().insert(key, result);
+            self.application_eval_cache_hits
+                .set(self.application_eval_cache_hits.get() + 1);
+            return Some(result);
+        }
         self.application_eval_cache_misses
             .set(self.application_eval_cache_misses.get() + 1);
         None
     }
 
     fn insert_application_eval_cache(&self, key: ApplicationEvalCacheKey, result: TypeId) {
+        if let Some(shared) = self.shared
+            && shared.shares_instantiation_family()
+        {
+            shared.application_eval_cache.insert(key.clone(), result);
+        }
         self.application_eval_cache.borrow_mut().insert(key, result);
     }
 
@@ -972,16 +1015,41 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
 
     fn invalidate_application_eval_cache_for_def(&self, def_id: DefId) {
         let mut cache = self.application_eval_cache.borrow_mut();
-        if cache.is_empty() {
-            return;
+        if !cache.is_empty() {
+            cache.retain(|(key_def, key_args, _, _), &mut result| {
+                *key_def != def_id
+                    && !key_args.iter().any(|&arg| {
+                        crate::visitors::visitor::contains_lazy_def_id(self.interner, arg, def_id)
+                    })
+                    && !crate::visitors::visitor::contains_lazy_def_id(
+                        self.interner,
+                        result,
+                        def_id,
+                    )
+            });
         }
-        cache.retain(|(key_def, key_args, _, _), &mut result| {
-            *key_def != def_id
-                && !key_args.iter().any(|&arg| {
-                    crate::visitors::visitor::contains_lazy_def_id(self.interner, arg, def_id)
-                })
-                && !crate::visitors::visitor::contains_lazy_def_id(self.interner, result, def_id)
-        });
+        if let Some(shared) = self.shared
+            && shared.shares_instantiation_family()
+            && !shared.application_eval_cache.is_empty()
+        {
+            shared
+                .application_eval_cache
+                .retain(|(key_def, key_args, _, _), result| {
+                    *key_def != def_id
+                        && !key_args.iter().any(|&arg| {
+                            crate::visitors::visitor::contains_lazy_def_id(
+                                self.interner,
+                                arg,
+                                def_id,
+                            )
+                        })
+                        && !crate::visitors::visitor::contains_lazy_def_id(
+                            self.interner,
+                            *result,
+                            def_id,
+                        )
+                });
+        }
     }
 
     fn lookup_closed_eval_cache(
@@ -1577,6 +1645,15 @@ impl QueryDatabase for QueryCache<'_> {
                 Some(result)
             }
             None => {
+                if let Some(shared) = self.shared
+                    && shared.shares_instantiation_family()
+                    && let Some(result) = shared.instantiation_cache.get(key).map(|entry| *entry)
+                {
+                    self.instantiation_cache.insert(key.clone(), result);
+                    self.instantiation_cache_hits
+                        .set(self.instantiation_cache_hits.get() + 1);
+                    return Some(result);
+                }
                 self.instantiation_cache_misses
                     .set(self.instantiation_cache_misses.get() + 1);
                 None
@@ -1586,6 +1663,11 @@ impl QueryDatabase for QueryCache<'_> {
 
     /// Store an `instantiate_type` result in the cross-call cache.
     fn insert_instantiation_cache(&self, key: InstantiationCacheKey, result: TypeId) {
+        if let Some(shared) = self.shared
+            && shared.shares_instantiation_family()
+        {
+            shared.instantiation_cache.insert(key.clone(), result);
+        }
         self.instantiation_cache.insert(key, result);
     }
 

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -164,7 +164,7 @@ impl SharedQueryCache {
     }
 
     #[inline]
-    fn shares_instantiation_family(&self) -> bool {
+    const fn shares_instantiation_family(&self) -> bool {
         self.share_instantiation_family
     }
 

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -11,6 +11,9 @@ use crate::caches::db::{
 use crate::caches::instantiation_cache::{InstantiationCache, InstantiationCacheKey};
 use crate::caches::query_cache_statistics::{QueryCacheStatistics, RelationCacheStats};
 use crate::caches::query_trace;
+use crate::caches::shared_instantiation::{
+    application_eval_entry_references_def, shared_instantiation_family_requested,
+};
 use crate::caches::subtype_reduction_cache::{SubtypeReductionCache, SubtypeReductionKey};
 use crate::def::DefId;
 use crate::evaluation::request::{EvaluationCacheKey, EvaluationRequest};
@@ -42,7 +45,7 @@ use tsz_common::interner::Atom;
 // homomorphic mapped type whose optional-modifier stripping depends on
 // `exactOptionalPropertyTypes`, so both options are part of the cache identity
 // (issue #10970).
-type ApplicationEvalCacheKey = (DefId, smallvec::SmallVec<[TypeId; 4]>, bool, bool);
+pub(super) type ApplicationEvalCacheKey = (DefId, smallvec::SmallVec<[TypeId; 4]>, bool, bool);
 // Element access (indexed access) of an optional property includes `undefined`
 // under both `exactOptionalPropertyTypes` settings (matching tsc), so the result
 // does not depend on that option and it is intentionally not part of this key.
@@ -201,24 +204,6 @@ impl Default for SharedQueryCache {
     fn default() -> Self {
         Self::new()
     }
-}
-
-fn shared_instantiation_family_requested() -> bool {
-    std::env::var_os("TSZ_SHARE_INSTANTIATION_CACHES").is_some_and(|value| value != "0")
-}
-
-fn application_eval_entry_references_def(
-    interner: &dyn crate::construction::TypeDatabase,
-    key: &ApplicationEvalCacheKey,
-    result: TypeId,
-    def_id: DefId,
-) -> bool {
-    let (key_def, key_args, _, _) = key;
-    *key_def == def_id
-        || key_args
-            .iter()
-            .any(|&arg| crate::visitors::visitor::contains_lazy_def_id(interner, arg, def_id))
-        || crate::visitors::visitor::contains_lazy_def_id(interner, result, def_id)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -131,8 +131,7 @@ impl CachedPolicyRelation {
 /// `Awaited<T>`), producing a stale result that is then returned to sibling
 /// files. Keeping those caches per-file eliminates the ordering-sensitive
 /// correctness risk. See issue #9507. `TSZ_SHARE_INSTANTIATION_CACHES=1`
-/// enables an experimental witness path for issue #13240; it is deliberately
-/// opt-in until the ordering/staleness matrix proves it safe.
+/// enables the experimental #13240 witness path.
 pub struct SharedQueryCache {
     eval_cache: DashMap<EvaluationCacheKey, TypeId, FxBuildHasher>,
     subtype_cache: DashMap<RelationCacheKey, RelationCacheValue, FxBuildHasher>,
@@ -206,6 +205,20 @@ impl Default for SharedQueryCache {
 
 fn shared_instantiation_family_requested() -> bool {
     std::env::var_os("TSZ_SHARE_INSTANTIATION_CACHES").is_some_and(|value| value != "0")
+}
+
+fn application_eval_entry_references_def(
+    interner: &dyn crate::construction::TypeDatabase,
+    key: &ApplicationEvalCacheKey,
+    result: TypeId,
+    def_id: DefId,
+) -> bool {
+    let (key_def, key_args, _, _) = key;
+    *key_def == def_id
+        || key_args
+            .iter()
+            .any(|&arg| crate::visitors::visitor::contains_lazy_def_id(interner, arg, def_id))
+        || crate::visitors::visitor::contains_lazy_def_id(interner, result, def_id)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1015,40 +1028,16 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
 
     fn invalidate_application_eval_cache_for_def(&self, def_id: DefId) {
         let mut cache = self.application_eval_cache.borrow_mut();
-        if !cache.is_empty() {
-            cache.retain(|(key_def, key_args, _, _), &mut result| {
-                *key_def != def_id
-                    && !key_args.iter().any(|&arg| {
-                        crate::visitors::visitor::contains_lazy_def_id(self.interner, arg, def_id)
-                    })
-                    && !crate::visitors::visitor::contains_lazy_def_id(
-                        self.interner,
-                        result,
-                        def_id,
-                    )
-            });
-        }
+        cache.retain(|key, &mut result| {
+            !application_eval_entry_references_def(self.interner, key, result, def_id)
+        });
         if let Some(shared) = self.shared
             && shared.shares_instantiation_family()
             && !shared.application_eval_cache.is_empty()
         {
-            shared
-                .application_eval_cache
-                .retain(|(key_def, key_args, _, _), result| {
-                    *key_def != def_id
-                        && !key_args.iter().any(|&arg| {
-                            crate::visitors::visitor::contains_lazy_def_id(
-                                self.interner,
-                                arg,
-                                def_id,
-                            )
-                        })
-                        && !crate::visitors::visitor::contains_lazy_def_id(
-                            self.interner,
-                            *result,
-                            def_id,
-                        )
-                });
+            shared.application_eval_cache.retain(|key, result| {
+                !application_eval_entry_references_def(self.interner, key, *result, def_id)
+            });
         }
     }
 

--- a/crates/tsz-solver/src/caches/shared_instantiation.rs
+++ b/crates/tsz-solver/src/caches/shared_instantiation.rs
@@ -1,0 +1,21 @@
+use crate::caches::query_cache::ApplicationEvalCacheKey;
+use crate::def::DefId;
+use crate::types::TypeId;
+
+pub(super) fn shared_instantiation_family_requested() -> bool {
+    std::env::var_os("TSZ_SHARE_INSTANTIATION_CACHES").is_some_and(|value| value != "0")
+}
+
+pub(super) fn application_eval_entry_references_def(
+    interner: &dyn crate::construction::TypeDatabase,
+    key: &ApplicationEvalCacheKey,
+    result: TypeId,
+    def_id: DefId,
+) -> bool {
+    let (key_def, key_args, _, _) = key;
+    *key_def == def_id
+        || key_args
+            .iter()
+            .any(|&arg| crate::visitors::visitor::contains_lazy_def_id(interner, arg, def_id))
+        || crate::visitors::visitor::contains_lazy_def_id(interner, result, def_id)
+}


### PR DESCRIPTION
Goal: fast

## Summary
- Adds an opt-in `TSZ_SHARE_INSTANTIATION_CACHES=1` witness path for #13240.
- Extends `SharedQueryCache` with shared application-eval and instantiation maps while leaving default behavior unchanged.
- Warms each file-local cache from the shared map on opt-in hits, writes opt-in inserts to both local and shared maps, and invalidates opt-in shared application-eval entries for affected defs.

## Structural rule
When multiple file checkers ask the same generic application or instantiation question, cross-file reuse is only sound when the shared entry was produced under a compatible lib/def publication state. tsz keeps this owned by the solver cache boundary: defaults remain per-file, and this PR exposes an opt-in witness path so #13240 can measure reuse and staleness before any default flip.

## Owner layer
Solver cache plumbing in `tsz-solver`; core/CLI continue to pass the existing project shared query cache and do not own semantic cache policy.

## Adjacent matrix
- Default env: application-eval and instantiation caches remain per-file.
- `TSZ_SHARE_INSTANTIATION_CACHES=1`: local misses can hit shared application-eval/instantiation maps and warm the local cache.
- Def invalidation: local and opt-in shared application-eval entries for the affected def are removed together.
- Remaining before default flip: run #9507/#13240 order-stability witnesses before enabling shared instantiation caches by default.

## Verification
- Commit hook formatting ran during commits.
- CI Light Summary passed on head `fcbe4394770e04546b5bed14441f8c16f94530d3`.
- Full ready-review CI pending after marking ready.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium
