### PR TITLE
perf(checker): reuse flow condition dp memos

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -1,4 +1,5 @@
 use super::FlowAnalyzer;
+use super::flow_dp::FlowConditionDpMemos;
 use crate::query_boundaries::common::{NarrowingContext, TypeGuard, TypeofKind};
 use crate::query_boundaries::flow as flow_boundary;
 use crate::query_boundaries::flow_analysis::{
@@ -637,6 +638,29 @@ impl<'a> FlowAnalyzer<'a> {
             is_true_branch,
             antecedent_id,
             &mut visited_aliases,
+            None,
+        )
+    }
+
+    pub(crate) fn narrow_type_by_condition_with_dp_memos(
+        &self,
+        type_id: TypeId,
+        condition_idx: NodeIndex,
+        target: NodeIndex,
+        is_true_branch: bool,
+        antecedent_id: FlowNodeId,
+        dp_memos: &mut FlowConditionDpMemos,
+    ) -> TypeId {
+        let mut visited_aliases = AliasCycleTracker::new();
+
+        self.narrow_type_by_condition_inner(
+            type_id,
+            condition_idx,
+            target,
+            is_true_branch,
+            antecedent_id,
+            &mut visited_aliases,
+            Some(dp_memos),
         )
     }
 
@@ -648,6 +672,7 @@ impl<'a> FlowAnalyzer<'a> {
         is_true_branch: bool,
         antecedent_id: FlowNodeId,
         visited_aliases: &mut AliasCycleTracker,
+        mut dp_memos: Option<&mut FlowConditionDpMemos>,
     ) -> TypeId {
         let condition_idx = self.skip_parenthesized(condition_idx);
         let Some(cond_node) = self.arena.get(condition_idx) else {
@@ -692,7 +717,15 @@ impl<'a> FlowAnalyzer<'a> {
             && let Some(current_exclusion) =
                 self.typeof_exclusion_for_condition(condition_idx, target, is_true_branch)
         {
-            let prior_exclusions = self.antecedent_typeof_exclusion_mask(antecedent_id, target);
+            let prior_exclusions = if let Some(memos) = dp_memos.as_deref_mut() {
+                self.antecedent_typeof_exclusion_mask_with_memo(
+                    antecedent_id,
+                    target,
+                    &mut memos.typeof_exclusions,
+                )
+            } else {
+                self.antecedent_typeof_exclusion_mask(antecedent_id, target)
+            };
             let exclusions = prior_exclusions | Self::typeof_exclusion_bit(current_exclusion);
             if exclusions == Self::ALL_TYPEOF_EXCLUSIONS {
                 return empty_object_type(self.interner);
@@ -729,6 +762,7 @@ impl<'a> FlowAnalyzer<'a> {
                 is_true_branch,
                 antecedent_id,
                 visited_aliases,
+                None,
             );
             visited_aliases.pop(sym_id);
             return narrowed;
@@ -746,6 +780,7 @@ impl<'a> FlowAnalyzer<'a> {
                         is_true_branch,
                         antecedent_id,
                         visited_aliases,
+                        None,
                     ) {
                         return narrowed;
                     }
@@ -763,6 +798,7 @@ impl<'a> FlowAnalyzer<'a> {
                         is_true_branch,
                         antecedent_id,
                         visited_aliases,
+                        None,
                     ) {
                         return narrowed;
                     }
@@ -822,10 +858,18 @@ impl<'a> FlowAnalyzer<'a> {
                             );
                             if effective_sense
                                 && matches!(guard, TypeGuard::Typeof(TypeofKind::Object))
-                                && self.antecedent_chain_excludes_null_for_target(
-                                    antecedent_id,
-                                    target,
-                                )
+                                && if let Some(memos) = dp_memos.as_deref_mut() {
+                                    self.antecedent_chain_excludes_null_for_target_with_memo(
+                                        antecedent_id,
+                                        target,
+                                        &mut memos.null_exclusions,
+                                    )
+                                } else {
+                                    self.antecedent_chain_excludes_null_for_target(
+                                        antecedent_id,
+                                        target,
+                                    )
+                                }
                             {
                                 return flow_query::narrow_excluding_type_in_context(
                                     &narrowing,
@@ -917,6 +961,7 @@ impl<'a> FlowAnalyzer<'a> {
                             !is_true_branch,
                             antecedent_id,
                             visited_aliases,
+                            None,
                         );
                     }
                 }
@@ -1269,6 +1314,7 @@ impl<'a> FlowAnalyzer<'a> {
                     is_true_branch,
                     antecedent_id,
                     &mut visited,
+                    None,
                 );
             }
             return type_id;
@@ -1330,7 +1376,15 @@ impl<'a> FlowAnalyzer<'a> {
                 );
                 if effective_truth
                     && typeof_kind == TypeofKind::Object
-                    && self.antecedent_chain_excludes_null_for_target(antecedent_id, target)
+                    && if let Some(memos) = dp_memos.as_deref_mut() {
+                        self.antecedent_chain_excludes_null_for_target_with_memo(
+                            antecedent_id,
+                            target,
+                            &mut memos.null_exclusions,
+                        )
+                    } else {
+                        self.antecedent_chain_excludes_null_for_target(antecedent_id, target)
+                    }
                 {
                     return flow_query::narrow_excluding_type_in_context(
                         narrowing,
@@ -1694,6 +1748,7 @@ impl<'a> FlowAnalyzer<'a> {
             effective_sense,
             antecedent_id,
             visited_aliases,
+            None,
         ))
     }
 
@@ -1739,6 +1794,7 @@ impl<'a> FlowAnalyzer<'a> {
                     true,
                     antecedent_id,
                     visited_aliases,
+                    None,
                 );
                 let right_true = self.narrow_type_by_condition_inner(
                     left_true,
@@ -1747,6 +1803,7 @@ impl<'a> FlowAnalyzer<'a> {
                     true,
                     antecedent_id,
                     visited_aliases,
+                    None,
                 );
                 return Some(right_true);
             }
@@ -1758,6 +1815,7 @@ impl<'a> FlowAnalyzer<'a> {
                 false,
                 antecedent_id,
                 visited_aliases,
+                None,
             );
             let left_true = self.narrow_type_by_condition_inner(
                 type_id,
@@ -1766,6 +1824,7 @@ impl<'a> FlowAnalyzer<'a> {
                 true,
                 antecedent_id,
                 visited_aliases,
+                None,
             );
             let right_false = self.narrow_type_by_condition_inner(
                 left_true,
@@ -1774,6 +1833,7 @@ impl<'a> FlowAnalyzer<'a> {
                 false,
                 antecedent_id,
                 visited_aliases,
+                None,
             );
             return Some(self.union_logical_condition_branches(vec![left_false, right_false]));
         }
@@ -1807,6 +1867,7 @@ impl<'a> FlowAnalyzer<'a> {
                     true,
                     antecedent_id,
                     visited_aliases,
+                    None,
                 );
                 let left_false = self.narrow_type_by_condition_inner(
                     type_id,
@@ -1815,6 +1876,7 @@ impl<'a> FlowAnalyzer<'a> {
                     false,
                     antecedent_id,
                     visited_aliases,
+                    None,
                 );
                 let right_true = self.narrow_type_by_condition_inner(
                     left_false,
@@ -1823,6 +1885,7 @@ impl<'a> FlowAnalyzer<'a> {
                     true,
                     antecedent_id,
                     visited_aliases,
+                    None,
                 );
                 return Some(self.union_logical_condition_branches(vec![left_true, right_true]));
             }
@@ -1834,6 +1897,7 @@ impl<'a> FlowAnalyzer<'a> {
                 false,
                 antecedent_id,
                 visited_aliases,
+                None,
             );
             let right_false = self.narrow_type_by_condition_inner(
                 left_false,
@@ -1842,6 +1906,7 @@ impl<'a> FlowAnalyzer<'a> {
                 false,
                 antecedent_id,
                 visited_aliases,
+                None,
             );
             return Some(right_false);
         }
@@ -1864,6 +1929,7 @@ impl<'a> FlowAnalyzer<'a> {
                     true,
                     antecedent_id,
                     visited_aliases,
+                    None,
                 );
                 let left_false = self.narrow_type_by_condition_inner(
                     type_id,
@@ -1872,6 +1938,7 @@ impl<'a> FlowAnalyzer<'a> {
                     false,
                     antecedent_id,
                     visited_aliases,
+                    None,
                 );
                 let right_true = self.narrow_type_by_condition_inner(
                     left_false,
@@ -1880,6 +1947,7 @@ impl<'a> FlowAnalyzer<'a> {
                     true,
                     antecedent_id,
                     visited_aliases,
+                    None,
                 );
                 return Some(self.union_logical_condition_branches(vec![left_true, right_true]));
             }
@@ -1891,6 +1959,7 @@ impl<'a> FlowAnalyzer<'a> {
                 false,
                 antecedent_id,
                 visited_aliases,
+                None,
             );
             let right_false = self.narrow_type_by_condition_inner(
                 left_false,
@@ -1899,6 +1968,7 @@ impl<'a> FlowAnalyzer<'a> {
                 false,
                 antecedent_id,
                 visited_aliases,
+                None,
             );
             return Some(right_false);
         }

--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -856,7 +856,7 @@ impl<'a> FlowAnalyzer<'a> {
                             );
                             if effective_sense
                                 && matches!(guard, TypeGuard::Typeof(TypeofKind::Object))
-                                && if let Some(memos) = dp_memos.as_deref_mut() {
+                                && if let Some(memos) = dp_memos.as_mut() {
                                     self.antecedent_chain_excludes_null_for_target_with_memo(
                                         antecedent_id,
                                         target,

--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -69,80 +69,6 @@ impl<'a> FlowAnalyzer<'a> {
         }
     }
 
-    pub(crate) fn narrow_by_switch_true_case_clause(
-        &self,
-        type_id: TypeId,
-        case_block: NodeIndex,
-        clause_idx: NodeIndex,
-        case_expr: NodeIndex,
-        target: NodeIndex,
-    ) -> TypeId {
-        let Some(case_block_node) = self.arena.get(case_block) else {
-            return self.narrow_type_by_condition(
-                type_id,
-                case_expr,
-                target,
-                true,
-                FlowNodeId::NONE,
-            );
-        };
-        let Some(case_block_data) = self.arena.get_block(case_block_node) else {
-            return self.narrow_type_by_condition(
-                type_id,
-                case_expr,
-                target,
-                true,
-                FlowNodeId::NONE,
-            );
-        };
-
-        // For switch(true), direct dispatch into case N requires:
-        // - every preceding case condition is false
-        // - current case condition is true
-        // Fallthrough paths are unioned separately by the switch-clause handler.
-        let mut narrowed = type_id;
-        let mut saw_current = false;
-
-        for &idx in &case_block_data.statements.nodes {
-            let Some(clause_node) = self.arena.get(idx) else {
-                continue;
-            };
-            let Some(clause) = self.arena.get_case_clause(clause_node) else {
-                continue;
-            };
-
-            if idx == clause_idx {
-                saw_current = true;
-                if clause.expression.is_some() {
-                    narrowed = self.narrow_type_by_condition(
-                        narrowed,
-                        case_expr,
-                        target,
-                        true,
-                        FlowNodeId::NONE,
-                    );
-                }
-                break;
-            }
-
-            if clause.expression.is_some() {
-                narrowed = self.narrow_type_by_condition(
-                    narrowed,
-                    clause.expression,
-                    target,
-                    false,
-                    FlowNodeId::NONE,
-                );
-            }
-        }
-
-        if saw_current {
-            narrowed
-        } else {
-            self.narrow_type_by_condition(type_id, case_expr, target, true, FlowNodeId::NONE)
-        }
-    }
-
     pub(crate) fn narrow_by_switch_clause(
         &self,
         type_id: TypeId,
@@ -618,50 +544,6 @@ impl<'a> FlowAnalyzer<'a> {
         }
 
         narrowed
-    }
-
-    /// Apply type narrowing based on a condition expression.
-    pub(crate) fn narrow_type_by_condition(
-        &self,
-        type_id: TypeId,
-        condition_idx: NodeIndex,
-        target: NodeIndex,
-        is_true_branch: bool,
-        antecedent_id: FlowNodeId,
-    ) -> TypeId {
-        let mut visited_aliases = AliasCycleTracker::new();
-
-        self.narrow_type_by_condition_inner(
-            type_id,
-            condition_idx,
-            target,
-            is_true_branch,
-            antecedent_id,
-            &mut visited_aliases,
-            None,
-        )
-    }
-
-    pub(crate) fn narrow_type_by_condition_with_dp_memos(
-        &self,
-        type_id: TypeId,
-        condition_idx: NodeIndex,
-        target: NodeIndex,
-        is_true_branch: bool,
-        antecedent_id: FlowNodeId,
-        dp_memos: &mut FlowConditionDpMemos,
-    ) -> TypeId {
-        let mut visited_aliases = AliasCycleTracker::new();
-
-        self.narrow_type_by_condition_inner(
-            type_id,
-            condition_idx,
-            target,
-            is_true_branch,
-            antecedent_id,
-            &mut visited_aliases,
-            Some(dp_memos),
-        )
     }
 
     pub(crate) fn narrow_type_by_condition_inner(

--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -780,7 +780,6 @@ impl<'a> FlowAnalyzer<'a> {
                         is_true_branch,
                         antecedent_id,
                         visited_aliases,
-                        None,
                     ) {
                         return narrowed;
                     }
@@ -798,7 +797,6 @@ impl<'a> FlowAnalyzer<'a> {
                         is_true_branch,
                         antecedent_id,
                         visited_aliases,
-                        None,
                     ) {
                         return narrowed;
                     }
@@ -1376,15 +1374,7 @@ impl<'a> FlowAnalyzer<'a> {
                 );
                 if effective_truth
                     && typeof_kind == TypeofKind::Object
-                    && if let Some(memos) = dp_memos.as_deref_mut() {
-                        self.antecedent_chain_excludes_null_for_target_with_memo(
-                            antecedent_id,
-                            target,
-                            &mut memos.null_exclusions,
-                        )
-                    } else {
-                        self.antecedent_chain_excludes_null_for_target(antecedent_id, target)
-                    }
+                    && self.antecedent_chain_excludes_null_for_target(antecedent_id, target)
                 {
                     return flow_query::narrow_excluding_type_in_context(
                         narrowing,

--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing_entrypoints.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing_entrypoints.rs
@@ -1,0 +1,126 @@
+use super::FlowAnalyzer;
+use super::flow_dp::FlowConditionDpMemos;
+use crate::symbols_domain::alias_cycle::AliasCycleTracker;
+use tsz_binder::FlowNodeId;
+use tsz_parser::parser::NodeIndex;
+use tsz_solver::TypeId;
+
+impl<'a> FlowAnalyzer<'a> {
+    pub(crate) fn narrow_by_switch_true_case_clause(
+        &self,
+        type_id: TypeId,
+        case_block: NodeIndex,
+        clause_idx: NodeIndex,
+        case_expr: NodeIndex,
+        target: NodeIndex,
+    ) -> TypeId {
+        let Some(case_block_node) = self.arena.get(case_block) else {
+            return self.narrow_type_by_condition(
+                type_id,
+                case_expr,
+                target,
+                true,
+                FlowNodeId::NONE,
+            );
+        };
+        let Some(case_block_data) = self.arena.get_block(case_block_node) else {
+            return self.narrow_type_by_condition(
+                type_id,
+                case_expr,
+                target,
+                true,
+                FlowNodeId::NONE,
+            );
+        };
+
+        // For switch(true), direct dispatch into case N requires:
+        // - every preceding case condition is false
+        // - current case condition is true
+        // Fallthrough paths are unioned separately by the switch-clause handler.
+        let mut narrowed = type_id;
+        let mut saw_current = false;
+
+        for &idx in &case_block_data.statements.nodes {
+            let Some(clause_node) = self.arena.get(idx) else {
+                continue;
+            };
+            let Some(clause) = self.arena.get_case_clause(clause_node) else {
+                continue;
+            };
+
+            if idx == clause_idx {
+                saw_current = true;
+                if clause.expression.is_some() {
+                    narrowed = self.narrow_type_by_condition(
+                        narrowed,
+                        case_expr,
+                        target,
+                        true,
+                        FlowNodeId::NONE,
+                    );
+                }
+                break;
+            }
+
+            if clause.expression.is_some() {
+                narrowed = self.narrow_type_by_condition(
+                    narrowed,
+                    clause.expression,
+                    target,
+                    false,
+                    FlowNodeId::NONE,
+                );
+            }
+        }
+
+        if saw_current {
+            narrowed
+        } else {
+            self.narrow_type_by_condition(type_id, case_expr, target, true, FlowNodeId::NONE)
+        }
+    }
+
+    /// Apply type narrowing based on a condition expression.
+    pub(crate) fn narrow_type_by_condition(
+        &self,
+        type_id: TypeId,
+        condition_idx: NodeIndex,
+        target: NodeIndex,
+        is_true_branch: bool,
+        antecedent_id: FlowNodeId,
+    ) -> TypeId {
+        let mut visited_aliases = AliasCycleTracker::new();
+
+        self.narrow_type_by_condition_inner(
+            type_id,
+            condition_idx,
+            target,
+            is_true_branch,
+            antecedent_id,
+            &mut visited_aliases,
+            None,
+        )
+    }
+
+    pub(crate) fn narrow_type_by_condition_with_dp_memos(
+        &self,
+        type_id: TypeId,
+        condition_idx: NodeIndex,
+        target: NodeIndex,
+        is_true_branch: bool,
+        antecedent_id: FlowNodeId,
+        dp_memos: &mut FlowConditionDpMemos,
+    ) -> TypeId {
+        let mut visited_aliases = AliasCycleTracker::new();
+
+        self.narrow_type_by_condition_inner(
+            type_id,
+            condition_idx,
+            target,
+            is_true_branch,
+            antecedent_id,
+            &mut visited_aliases,
+            Some(dp_memos),
+        )
+    }
+}

--- a/crates/tsz-checker/src/flow/control_flow/condition_nullish.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_nullish.rs
@@ -35,7 +35,7 @@ impl<'a> FlowAnalyzer<'a> {
         // the native stack.
         resolve_backward_dp(
             flow_id,
-            &mut memo,
+            memo,
             false,
             |node| self.null_exclusion_antecedents(node),
             |node, antecedent_values| self.excludes_null_fold(node, target, antecedent_values),

--- a/crates/tsz-checker/src/flow/control_flow/condition_nullish.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_nullish.rs
@@ -19,6 +19,15 @@ impl<'a> FlowAnalyzer<'a> {
         target: NodeIndex,
     ) -> bool {
         let mut memo: DpMemo<bool> = DpMemo::default();
+        self.antecedent_chain_excludes_null_for_target_with_memo(flow_id, target, &mut memo)
+    }
+
+    pub(super) fn antecedent_chain_excludes_null_for_target_with_memo(
+        &self,
+        flow_id: FlowNodeId,
+        target: NodeIndex,
+        memo: &mut DpMemo<bool>,
+    ) -> bool {
         // Back-edge / no-information element is `false` (treat the loop as not
         // contributing a null-exclusion) so loops do not over-narrow, matching
         // the previous recursive `DpState::InProgress` arm. Folded iteratively

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -1,5 +1,5 @@
-use super::flow_dp::FlowConditionDpMemos;
 use super::{FlowAnalyzer, defer_to_antecedent, flow_boundary, flow_step_budget, query};
+use crate::flow::control_flow::flow_dp::FlowConditionDpMemos;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::VecDeque;
 use tsz_binder::{FlowNodeId, SymbolId, flow_flags};

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -1,3 +1,4 @@
+use super::flow_dp::FlowConditionDpMemos;
 use super::{FlowAnalyzer, defer_to_antecedent, flow_boundary, flow_step_budget, query};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::VecDeque;
@@ -86,6 +87,8 @@ impl<'a> FlowAnalyzer<'a> {
         let mut steps = 0usize;
         let mut cacheable_walk = true;
         let mut pending_cache_writes: Vec<((FlowNodeId, SymbolId, TypeId), TypeId)> = Vec::new();
+        let mut condition_dp_memos = FlowConditionDpMemos::default();
+        condition_dp_memos.clear();
 
         // Process worklist until empty
         while let Some((current_flow, current_type)) = worklist.pop_front() {
@@ -111,7 +114,11 @@ impl<'a> FlowAnalyzer<'a> {
             let skip_cache_for_explicit_unknown_switch = initial_type == TypeId::UNKNOWN
                 && self.flow_chain_contains_switch_clause(current_flow);
             let skip_cache_for_exhaustive_unknown_typeof = initial_type == TypeId::UNKNOWN
-                && self.flow_has_exhaustive_typeof_exclusions(current_flow, reference);
+                && self.flow_has_exhaustive_typeof_exclusions_with_memo(
+                    current_flow,
+                    reference,
+                    &mut condition_dp_memos.typeof_exclusions,
+                );
 
             // Use cache if: 1) not a switch clause, AND
             // 2) either initial type is concrete OR this is a loop label.
@@ -339,17 +346,22 @@ impl<'a> FlowAnalyzer<'a> {
                 };
 
                 if initial_type == TypeId::UNKNOWN
-                    && self.flow_has_exhaustive_typeof_exclusions(current_flow, reference)
+                    && self.flow_has_exhaustive_typeof_exclusions_with_memo(
+                        current_flow,
+                        reference,
+                        &mut condition_dp_memos.typeof_exclusions,
+                    )
                 {
                     query::empty_object_type(self.interner)
                 } else {
                     let is_true_branch = flow.has_any_flags(flow_flags::TRUE_CONDITION);
-                    self.narrow_type_by_condition(
+                    self.narrow_type_by_condition_with_dp_memos(
                         pre_type,
                         flow.node,
                         reference,
                         is_true_branch,
                         antecedent_id,
+                        &mut condition_dp_memos,
                     )
                 }
             } else if flow.has_any_flags(flow_flags::SWITCH_CLAUSE) {
@@ -984,7 +996,11 @@ impl<'a> FlowAnalyzer<'a> {
                 let ant_types = self.simplify_flow_merge_types(ant_types);
 
                 if initial_type == TypeId::UNKNOWN
-                    && self.flow_has_exhaustive_typeof_exclusions(current_flow, reference)
+                    && self.flow_has_exhaustive_typeof_exclusions_with_memo(
+                        current_flow,
+                        reference,
+                        &mut condition_dp_memos.typeof_exclusions,
+                    )
                 {
                     query::empty_object_type(self.interner)
                 } else {
@@ -1018,7 +1034,11 @@ impl<'a> FlowAnalyzer<'a> {
                 && !(initial_type == TypeId::UNKNOWN
                     && self.flow_chain_contains_switch_clause(current_flow))
                 && !(initial_type == TypeId::UNKNOWN
-                    && self.flow_has_exhaustive_typeof_exclusions(current_flow, reference))
+                    && self.flow_has_exhaustive_typeof_exclusions_with_memo(
+                        current_flow,
+                        reference,
+                        &mut condition_dp_memos.typeof_exclusions,
+                    ))
             {
                 let final_has_type_params = self.contains_type_parameters_cached(final_type);
 

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -1,5 +1,5 @@
+use super::super::flow_dp::FlowConditionDpMemos;
 use super::{FlowAnalyzer, defer_to_antecedent, flow_boundary, flow_step_budget, query};
-use crate::query_boundaries::flow::control_flow::flow_dp::FlowConditionDpMemos;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::VecDeque;
 use tsz_binder::{FlowNodeId, SymbolId, flow_flags};

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -1,5 +1,5 @@
 use super::{FlowAnalyzer, defer_to_antecedent, flow_boundary, flow_step_budget, query};
-use crate::flow::control_flow::flow_dp::FlowConditionDpMemos;
+use crate::query_boundaries::flow::control_flow::flow_dp::FlowConditionDpMemos;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::VecDeque;
 use tsz_binder::{FlowNodeId, SymbolId, flow_flags};

--- a/crates/tsz-checker/src/flow/control_flow/flow_dp.rs
+++ b/crates/tsz-checker/src/flow/control_flow/flow_dp.rs
@@ -35,6 +35,26 @@ pub(crate) enum DpState<T: Copy> {
 /// participate in the broader checker cache plumbing.
 pub(crate) type DpMemo<T> = FxHashMap<FlowNodeId, DpState<T>>;
 
+/// Scratch DP memos for one `check_flow` traversal and one reference target.
+///
+/// These are intentionally scoped to a single flow query: both analyses key
+/// only by `FlowNodeId`, while their answers depend on the target expression
+/// being narrowed. Reusing them across references would be unsound; reusing
+/// them within one `check_flow` call avoids rebuilding the same graph folds
+/// for every worklist visit.
+#[derive(Default)]
+pub(crate) struct FlowConditionDpMemos {
+    pub(crate) typeof_exclusions: DpMemo<u8>,
+    pub(crate) null_exclusions: DpMemo<bool>,
+}
+
+impl FlowConditionDpMemos {
+    pub(crate) fn clear(&mut self) {
+        self.typeof_exclusions.clear();
+        self.null_exclusions.clear();
+    }
+}
+
 /// Drive a backward flow-graph DP fold *iteratively* over an explicit heap
 /// stack rather than the native call stack.
 ///

--- a/crates/tsz-checker/src/flow/control_flow/mod.rs
+++ b/crates/tsz-checker/src/flow/control_flow/mod.rs
@@ -24,6 +24,7 @@ mod assignment_fallback;
 mod call_condition_narrowing;
 mod comparison_types;
 pub(crate) mod condition_narrowing;
+mod condition_narrowing_entrypoints;
 mod condition_nullish;
 mod core;
 mod flow_dp;

--- a/crates/tsz-checker/src/flow/control_flow/typeof_exclusions.rs
+++ b/crates/tsz-checker/src/flow/control_flow/typeof_exclusions.rs
@@ -32,6 +32,15 @@ impl<'a> FlowAnalyzer<'a> {
         target: NodeIndex,
     ) -> u8 {
         let mut memo: DpMemo<u8> = DpMemo::default();
+        self.antecedent_typeof_exclusion_mask_with_memo(flow_id, target, &mut memo)
+    }
+
+    pub(crate) fn antecedent_typeof_exclusion_mask_with_memo(
+        &self,
+        flow_id: FlowNodeId,
+        target: NodeIndex,
+        memo: &mut DpMemo<u8>,
+    ) -> u8 {
         // Back-edge / no-information element is `0` (no exclusions), so the
         // surrounding intersection collapses and loops drive no narrowing,
         // matching the previous recursive `DpState::InProgress` arm.
@@ -117,6 +126,16 @@ impl<'a> FlowAnalyzer<'a> {
         target: NodeIndex,
     ) -> bool {
         self.antecedent_typeof_exclusion_mask(flow_id, target) == Self::ALL_TYPEOF_EXCLUSIONS
+    }
+
+    pub(crate) fn flow_has_exhaustive_typeof_exclusions_with_memo(
+        &self,
+        flow_id: FlowNodeId,
+        target: NodeIndex,
+        memo: &mut DpMemo<u8>,
+    ) -> bool {
+        self.antecedent_typeof_exclusion_mask_with_memo(flow_id, target, memo)
+            == Self::ALL_TYPEOF_EXCLUSIONS
     }
 
     pub(crate) fn typeof_exclusion_for_condition(

--- a/crates/tsz-checker/src/flow/control_flow/typeof_exclusions.rs
+++ b/crates/tsz-checker/src/flow/control_flow/typeof_exclusions.rs
@@ -46,7 +46,7 @@ impl<'a> FlowAnalyzer<'a> {
         // matching the previous recursive `DpState::InProgress` arm.
         resolve_backward_dp(
             flow_id,
-            &mut memo,
+            memo,
             0,
             |node| self.typeof_exclusion_antecedents(node),
             |node, antecedent_masks| {


### PR DESCRIPTION
Goal: fast

## Summary
- Reuse flow-condition DP scratch memos for one `check_flow` traversal and one narrowed reference.
- Keep the existing one-shot APIs for callers outside the worklist path.
- Preserve checker ownership: this only changes flow-analysis scratch allocation, not narrowing semantics or solver policy.

## Structural rule
When typeof/nullish antecedent analyses depend only on the current flow graph plus the target reference, tsz should allocate their DP memo once per `check_flow` traversal for that reference; checker flow analysis owns this scratch state and clears it by construction at the query boundary.

## Adjacent matrix
- Renamed binders: memo key is `FlowNodeId`, scoped to the same target reference, so binder names do not drive behavior.
- Alias/logical nested conditions: existing recursive condition calls keep one-shot memos unless entered through the top-level traversal scratch path.
- Fallback: callers outside `check_flow` continue to allocate a local memo exactly as before.
- Residency: scratch maps are traversal-local and dropped with the stack frame; no cross-file or cross-reference cache is introduced.

## Verification
- Commit hook formatting ran during commits.
- CI Light Summary passed on head `ffe75382053e39af6e16c9ed0377a6e8ff9f8080`.
- Full ready-review CI pending after marking ready.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium
