### PR TITLE
perf(solver): reuse mapped distribution substitutions

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -1250,6 +1250,13 @@ impl<'a> TypeInstantiator<'a> {
                         // constraint and produces `<member>[keyof <member>]`
                         // where the source said `<member>[K]`.
                         let iter_var_shadow = [mapped.type_param.name];
+                        // Reuse one substitution map across distributed
+                        // members. The only per-member semantic change is the
+                        // homomorphic source parameter (`tp_info.name`), so a
+                        // single mutable map preserves the same bindings as
+                        // clone+insert while avoiding O(members * subst_len)
+                        // entry copies for large union sources.
+                        let mut member_subst = self.substitution.clone();
                         for &member in &members {
                             if crate::visitors::visitor_predicates::is_primitive_type(
                                 self.interner,
@@ -1258,7 +1265,6 @@ impl<'a> TypeInstantiator<'a> {
                                 results.push(member);
                                 continue;
                             }
-                            let mut member_subst = self.substitution.clone();
                             member_subst.insert(tp_info.name, member);
                             let inst = |t| {
                                 instantiate_type_with_shadowed(


### PR DESCRIPTION
Goal: fast

## Summary
- Reuse the homomorphic mapped-type distribution substitution map across union members instead of cloning the whole map for each member.
- Keep the per-member semantic change scoped to the source type parameter binding that distribution overwrites.
- Preserve the existing primitive-member fallback and mapped-type reconstruction behavior.

## Structural rule
When a homomorphic mapped type distributes over a union source, each branch must instantiate the same mapped body with only the homomorphic source parameter changed to the current union member. tsz does this in the solver instantiation layer by reusing one branch-local `TypeSubstitution` and overwriting that single binding per member, preserving the clone+insert semantics while reducing entry copies from O(members * substitution entries) to O(substitution entries + members).

## Issue
Fixes #13102.
Refs #13250.

## Verification
- Local tests/benchmarks not run in this continuation.
- Commit hook formatting ran during `git commit`.
- Draft PR CI passed at `6f19a5c4a701fcdbaf8136ee539cc448bdd737bb`: `CI Light Summary`, `lint`, `unit`, `unit-checker-integration`, `dist-binaries`, `cargo-shear`, `cargo-deny`, `project-row-drift`, `unit-cloudbuild`, and `gate`.
- Ready-review CI is expected to provide the full parity and project-row signal.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
