### PR TITLE
perf(cli): lift wildcard barrel project fallback

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -334,11 +334,16 @@ fn parallel_file_session_reuse_requested() -> bool {
 /// Decide whether fresh per-file checkers run sequentially instead of on the
 /// rayon pool.
 ///
-/// Tiny batches stay sequential to avoid pool overhead. Large wildcard
-/// barrels (PR #5881) and DOM/webworker-lib projects (PR #7312) stay
+/// Tiny batches stay sequential to avoid pool overhead. DOM/webworker-lib
+/// projects (PR #7312) stay
 /// sequential because correctness and termination on type-heavy projects
 /// currently depend on checking files in deterministic order with a
 /// progressively warmed `SharedQueryCache`.
+///
+/// Large wildcard barrels are still detected and tested separately, but they
+/// no longer force the entire project onto one core: the mutation-isolation
+/// and cold-start cache work that landed before #13244 made the whole-project
+/// fallback too blunt for large-ts-repo-sized projects.
 ///
 /// Investigated 2026-06 while attempting to lift the DOM gate for the
 /// ts-toolbelt row: the blocker is not (only) racing shared state. Checking
@@ -381,11 +386,10 @@ fn parallel_file_session_reuse_requested() -> bool {
 /// mutation-isolation campaign makes shared def state schedule-independent.
 const fn should_use_sequential_fresh_checking(
     work_item_count: usize,
-    has_large_wildcard_barrel: bool,
+    _has_large_wildcard_barrel: bool,
     has_parallel_order_sensitive_global_lib: bool,
 ) -> bool {
     work_item_count <= FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES
-        || has_large_wildcard_barrel
         || has_parallel_order_sensitive_global_lib
 }
 

--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -340,6 +340,11 @@ fn parallel_file_session_reuse_requested() -> bool {
 /// currently depend on checking files in deterministic order with a
 /// progressively warmed `SharedQueryCache`.
 ///
+/// `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK` is a diagnosis-only escape hatch for
+/// the DOM/webworker gate-lift campaign: it bypasses only the order-sensitive
+/// global-lib gate so forced-parallel rows can be byte-compared against the
+/// sequential baseline without also changing tiny-batch policy.
+///
 /// Large wildcard barrels are still detected and tested separately, but they
 /// no longer force the entire project onto one core: the mutation-isolation
 /// and cold-start cache work that landed before #13244 made the whole-project
@@ -388,9 +393,10 @@ const fn should_use_sequential_fresh_checking(
     work_item_count: usize,
     _has_large_wildcard_barrel: bool,
     has_parallel_order_sensitive_global_lib: bool,
+    force_parallel_order_sensitive_global_lib: bool,
 ) -> bool {
     work_item_count <= FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES
-        || has_parallel_order_sensitive_global_lib
+        || (has_parallel_order_sensitive_global_lib && !force_parallel_order_sensitive_global_lib)
 }
 
 const fn needs_separate_boxed_prime_checker(
@@ -1289,21 +1295,18 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
                     work_items: &work_items,
                     large_export_threshold: LARGE_WILDCARD_BARREL_EXPORTS,
                 });
-            // Experiment escape hatch for the parallel fresh-checking gate
-            // lift campaign: force the rayon path regardless of the
-            // DOM-lib/barrel heuristics so livelock/determinism repros can be
-            // driven from the env without rebuilding.
-            let force_parallel_experiment =
+            // Experiment escape hatch for the DOM/webworker fresh-checking
+            // gate-lift campaign: force the rayon path past that one
+            // heuristic so livelock/determinism repros can be driven from the
+            // env without also bypassing tiny-batch policy.
+            let force_parallel_order_sensitive_global_lib =
                 std::env::var_os("TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK").is_some();
-            let use_sequential_checking = if force_parallel_experiment {
-                false
-            } else {
-                should_use_sequential_fresh_checking(
-                    work_items.len(),
-                    has_large_wildcard_barrel,
-                    has_parallel_order_sensitive_global_lib,
-                )
-            };
+            let use_sequential_checking = should_use_sequential_fresh_checking(
+                work_items.len(),
+                has_large_wildcard_barrel,
+                has_parallel_order_sensitive_global_lib,
+                force_parallel_order_sensitive_global_lib,
+            );
             // T2.1.B (`PERFORMANCE_PLAN.md` §6 PR table): the sequential
             // no-emit path *can* construct one `CheckerState` and re-target
             // it across files via `CheckerContext::switch_to_file` instead

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
@@ -697,20 +697,32 @@ fn large_reuse_off_batches_keep_fresh_parallel_eligible() {
     let large_project = FILE_SESSION_REUSE_SMALL_PROJECT_MAX_FILES + 1;
 
     assert!(
-        !should_use_sequential_fresh_checking(large_project, false, false),
+        !should_use_sequential_fresh_checking(large_project, false, false, false),
         "large fresh-checker batches should stay parallel-eligible even when session reuse is off"
     );
     assert!(
-        should_use_sequential_fresh_checking(10, false, false),
+        should_use_sequential_fresh_checking(10, false, false, false),
         "tiny batches stay sequential for deterministic cross-file behavior"
     );
     assert!(
-        !should_use_sequential_fresh_checking(large_project, true, false),
+        should_use_sequential_fresh_checking(10, false, true, true),
+        "the force-parallel experiment must not bypass tiny-batch policy"
+    );
+    assert!(
+        !should_use_sequential_fresh_checking(large_project, true, false, false),
         "large wildcard barrels stay parallel-eligible after the #13244 gate lift"
     );
     assert!(
-        should_use_sequential_fresh_checking(large_project, false, true),
+        !should_use_sequential_fresh_checking(large_project, true, true, true),
+        "large wildcard-barrel detection is not a scheduling veto, even in forced DOM probes"
+    );
+    assert!(
+        should_use_sequential_fresh_checking(large_project, false, true, false),
         "order-sensitive global libraries stay on the deterministic sequential fallback"
+    );
+    assert!(
+        !should_use_sequential_fresh_checking(large_project, false, true, true),
+        "the force-parallel experiment should bypass only the order-sensitive global-lib gate"
     );
 }
 

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part1.rs
@@ -705,8 +705,8 @@ fn large_reuse_off_batches_keep_fresh_parallel_eligible() {
         "tiny batches stay sequential for deterministic cross-file behavior"
     );
     assert!(
-        should_use_sequential_fresh_checking(large_project, true, false),
-        "large wildcard barrels stay on the deterministic sequential fallback"
+        !should_use_sequential_fresh_checking(large_project, true, false),
+        "large wildcard barrels stay parallel-eligible after the #13244 gate lift"
     );
     assert!(
         should_use_sequential_fresh_checking(large_project, false, true),

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part3.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part3.rs
@@ -1288,9 +1288,11 @@ interface Node {
         })
     }
 
-    /// Threshold boundary for the PR #5881 sequential fallback: 31 wildcard
-    /// re-exports stay parallel-eligible, 32 and far above (the 201-re-export
-    /// barrel shape from the large-ts-repo row) trip the gate.
+    /// Threshold boundary for wildcard-barrel detection: 31 wildcard
+    /// re-exports stay below the large-barrel threshold, 32 and far above (the
+    /// 201-re-export barrel shape from the large-ts-repo row) are reported as
+    /// large. The scheduling fallback was lifted in #13244; this still guards
+    /// the analysis input used by diagnostics and future targeted policies.
     #[test]
     fn wildcard_barrel_threshold_boundary_31_32_201() {
         assert!(
@@ -1303,11 +1305,11 @@ interface Node {
             program_has_large_wildcard_barrel(&program_with_wildcard_barrel(
                 LARGE_WILDCARD_BARREL_EXPORTS
             )),
-            "32 wildcard re-exports must trip the sequential fallback"
+            "32 wildcard re-exports must be reported as a large wildcard barrel"
         );
         assert!(
             program_has_large_wildcard_barrel(&program_with_wildcard_barrel(201)),
-            "201 wildcard re-exports (large-ts-repo heavy barrel) must trip the fallback"
+            "201 wildcard re-exports (large-ts-repo heavy barrel) must be reported as large"
         );
     }
 


### PR DESCRIPTION
Goal: fast
AgentName: Codex
Track: fast
Invariant: Fresh-check scheduling only serializes tiny batches and DOM/webworker global-lib batches; wildcard-barrel detection is no longer a whole-project one-core veto, and `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK` bypasses only the DOM/webworker gate.
Scope: CLI fresh-check scheduling policy plus focused scheduler tests.
Project Corpus Impact: Large wildcard-barrel rows such as large-ts-repo can use parallel fresh checking after the #13244 lift, while DOM/webworker rows keep their default sequential safeguard until #13245 is proven safe.

## Summary
- Lift the >=32 export-star wildcard-barrel whole-project sequential fallback from fresh checking.
- Keep wildcard-barrel detection and the 31/32/201 boundary matrix intact as analysis guardrails.
- Scope `TSZ_EXPERIMENT_FORCE_PARALLEL_CHECK` to the DOM/webworker gate so follow-up determinism harnesses do not also bypass tiny-batch policy.
- Leave the default DOM/webworker global-lib sequential fallback unchanged.

## Structural Rule
When a large project contains a wildcard barrel, tsz should not serialize the entire project unless the current wildcard-barrel shape is proven schedule-sensitive. The mutation-isolation and cold-start cache work landed before #13244, and #13256 already pinned the barrel threshold matrix; this PR stops treating `has_large_wildcard_barrel` as a whole-project one-core scheduling veto while preserving tiny-batch and DOM/webworker safeguards.

## Issue
Refs #13244.
Refs #13250.

## Coordination Notes
- Rebasing onto `origin/main` at `41b383c6a1` pulled in the queue that had advanced after the first push.
- #13256 established the wildcard-barrel boundary tests and noted synthetic monorepo-005 was 5/5 byte-stable forced-parallel after mutation-isolation merges.
- #13273 landed the #13255 schedule-sensitivity fix after that boundary-test PR.
- The root-cause fix also makes this compose with the #13245/#13293 DOM gate harness: the experiment flag now bypasses the DOM/webworker heuristic only.
- This PR does not lift #13245's default DOM/webworker gate.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-cli -E 'test(large_reuse_off_batches_keep_fresh_parallel_eligible) or test(wildcard_barrel_threshold_boundary_31_32_201) or test(detects_large_wildcard_barrel)'`
- `scripts/safe-run.sh cargo nextest run -p tsz-cli --test parallel_sequential_agreement_tests`
- `git diff --check`
- Pushed head: `2cebc06cb4971ad82362740a79c238677e50b177`.
- Ready-review CI should provide the broad conformance, emit, fourslash, and project-compile signal before queueing.

## Provenance
Machine: Mohsens-MacBook-Pro.local
Assistant: codex
Model: GPT-5
Effort: high