### PR TITLE
fix(bench): publish after cancelled shard matrix runs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1313,7 +1313,7 @@ jobs:
   publish:
     name: bench-publish
     needs: bench
-    if: always() && (needs.bench.result == 'success' || needs.bench.result == 'failure')
+    if: always() && (needs.bench.result == 'success' || needs.bench.result == 'failure' || needs.bench.result == 'cancelled')
     runs-on: [self-hosted, tsz-cloud-run]
     timeout-minutes: 30
     steps:

--- a/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-shards.mjs
@@ -66,8 +66,8 @@ assert.match(
 
 assert.match(
   workflow,
-  /publish:[\s\S]+needs: bench[\s\S]+if: always\(\) && \(needs\.bench\.result == 'success' \|\| needs\.bench\.result == 'failure'\)[\s\S]+Merge benchmark results/,
-  "bench publish should run after failed shard jobs so uploaded complete shard artifacts can still be merged instead of pinning the website to stale data",
+  /publish:[\s\S]+needs: bench[\s\S]+if: always\(\) && \(needs\.bench\.result == 'success' \|\| needs\.bench\.result == 'failure' \|\| needs\.bench\.result == 'cancelled'\)[\s\S]+Merge benchmark results/,
+  "bench publish should run after failed or timed-out/cancelled shard jobs so uploaded complete shard artifacts can still be merged instead of pinning the website to stale data",
 );
 
 assert.doesNotMatch(


### PR DESCRIPTION
Goal: fast

## Summary
- Let `bench-publish` run when the benchmark shard matrix result is `cancelled`, which is what GitHub reports after long shard timeout cancellation.
- Update the workflow assertion so timeout/cancelled shard runs keep merging any uploaded complete shard artifacts instead of leaving the website pinned to stale data.

## Root Cause
The previous fix covered shard matrix `failure`, but the observed recovery run ended with `needs.bench.result == cancelled` after the remaining long shard jobs hit their timeout. Because `bench-publish` still skipped in that state, no `bench-results-merged` artifact was produced and the website stayed on the June 11 artifact.

## Verification
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `git diff --check`

## Provenance
Machine: Mohsens-MacBook-Pro.local
Assistant: codex
Model: GPT-5
Effort: high
