### PR TITLE
fix(checker): guard def param fallback by name

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -1339,8 +1339,13 @@ impl<'a> CheckerContext<'a> {
         // referenced from different checker contexts. Use the symbol_only_index
         // to find the canonical DefId and retrieve its type params.
         let sym_id = self.def_to_symbol.borrow().get(&def_id).copied()?;
+        let requesting_def_name = self.definition_store.get(def_id).map(|info| info.name)?;
         let canonical_def_id = self.definition_store.find_def_by_symbol(sym_id.0)?;
         if canonical_def_id != def_id
+            && self
+                .definition_store
+                .get(canonical_def_id)
+                .is_some_and(|info| info.name == requesting_def_name)
             && let Some(canonical_params) = self.definition_store.get_type_params(canonical_def_id)
             && !canonical_params.is_empty()
         {

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types_tests.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types_tests.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use tsz_binder::{BinderState, symbol_flags};
 use tsz_parser::parser::node::NodeArena;
 use tsz_parser::parser::{NodeIndex, ParserState};
+use tsz_solver::{TypeId, TypeParamInfo};
 
 fn parse_and_bind(file_name: &str, source: &str) -> (Arc<NodeArena>, Arc<BinderState>, NodeIndex) {
     let mut parser = ParserState::new(file_name.to_string(), source.to_string());
@@ -179,5 +180,71 @@ type Remote = number;
     assert!(
         params.is_empty(),
         "a same-name local SymbolId collision without a local def should not delegate to the remote generic alias"
+    );
+}
+
+#[test]
+fn def_type_params_fallback_rejects_different_name_symbol_collision() {
+    let (target_arena, target_binder, _) = parse_and_bind(
+        "target.ts",
+        r#"
+type Padding0 = unknown;
+export interface Other<T, U = string> { value: T; }
+"#,
+    );
+    let (entry_arena, entry_binder, _) = parse_and_bind(
+        "entry.ts",
+        r#"
+type Padding0 = number;
+interface Promise<T> { value: T; }
+"#,
+    );
+
+    let other_sym_id = target_binder
+        .file_locals
+        .get("Other")
+        .expect("target file should bind exported Other interface");
+    let promise_sym_id = entry_binder
+        .file_locals
+        .get("Promise")
+        .expect("entry file should bind local Promise interface");
+    assert_eq!(
+        other_sym_id.0, promise_sym_id.0,
+        "test setup needs a raw SymbolId collision"
+    );
+
+    let all_arenas = Arc::new(vec![target_arena, entry_arena]);
+    let all_binders = Arc::new(vec![target_binder, entry_binder]);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        all_arenas[1].as_ref(),
+        all_binders[1].as_ref(),
+        &types,
+        "entry.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
+    checker.ctx.set_all_binders(Arc::clone(&all_binders));
+    checker.ctx.set_current_file_idx(1);
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker.ctx.register_symbol_file_target(other_sym_id, 0);
+
+    let other_def = checker
+        .ctx
+        .get_or_create_def_id_for_symbol_name(other_sym_id, "Other");
+    let first = TypeParamInfo::simple(types.intern_string("T"));
+    let mut second = TypeParamInfo::simple(types.intern_string("U"));
+    second.default = Some(TypeId::STRING);
+    checker
+        .ctx
+        .insert_def_type_params(other_def, vec![first, second]);
+
+    let promise_def = checker
+        .ctx
+        .get_or_create_def_id_for_symbol_name(promise_sym_id, "Promise");
+
+    assert!(
+        checker.ctx.get_def_type_params(promise_def).is_none(),
+        "file-agnostic raw SymbolId fallback must not copy generic params/defaults from a differently named definition"
     );
 }


### PR DESCRIPTION
Goal: green

## Summary
- Guard CheckerContext::get_def_type_params so its file-agnostic raw SymbolId fallback only reuses params from a same-named definition.
- Add a regression for two definitions sharing the same raw SymbolId where the first has a second type parameter with a default and the second must not inherit it.
- Synced the branch with origin/main after the focused fix was committed.

## Structural rule
When two definitions share a raw SymbolId across different binder/file arenas, tsc keeps their generic parameter lists tied to the actual declaration identity. tsz should only use the DefinitionStore symbol-only fallback for same-declaration/same-name convergence; otherwise the checker must leave the requesting def's params absent instead of borrowing another generic's defaults.

## Issue
Fixes #13272.
Refs #13255.
Refs #13250.

## Adjacent matrix
- Different-name raw SymbolId collision: params/defaults are not copied.
- Same-name/lib-clone convergence path is preserved by allowing the fallback when stored definition names match.

## Verification
- Local tests not run in this continuation.
- Commit hook formatting ran during `git commit`.
- Branch synced with origin/main and pushed at `fbdbc8ed1966941da3e5a25f758c3c2867e9f09b`.
- Draft PR CI passed at exact head `fbdbc8ed1966941da3e5a25f758c3c2867e9f09b`: `CI Light Summary`, `lint`, `unit`, `unit-checker-integration`, `dist-binaries`, `cargo-shear`, `cargo-deny`, `project-row-drift`, `unit-cloudbuild`, and `gate`.
- Ready-review CI is expected to provide the full conformance/emit/project-row signal.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
