### PR TITLE
fix(common): surface scalar perf counters in text dump

### DIFF
--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -122,6 +122,8 @@ impl PerfCounters {
             snap.resolver.candidate_paths_total,
             snap.identity.type_environment_raw_symbol_lazy_fallbacks,
         ) + &Self::dump_compute_type_of_symbol_outcomes()
+            + &Self::dump_relation_limit_cache(&snap)
+            + &Self::dump_evaluator_memo(&snap)
             + &Self::dump_compute_type_of_symbol_interface_simple_object_non_primitive_annotation_residues(
                 &snap.compute_type_of_symbol_interface_simple_object_non_primitive_annotation_residues,
             )
@@ -799,6 +801,65 @@ impl PerfCounters {
             ));
         }
         out
+    }
+
+    fn dump_relation_limit_cache(snap: &PerfCounterSnapshot) -> String {
+        let counters = &snap.relation_limit_cache;
+        if counters.limit_cache_hits == 0 && counters.maybe_promotions == 0 {
+            return String::new();
+        }
+        format!(
+            "\nRelation limit-result cache:\n  \
+             limit cache hits          {:>12}\n  \
+             maybe promotions          {:>12}\n",
+            counters.limit_cache_hits, counters.maybe_promotions,
+        )
+    }
+
+    fn dump_evaluator_memo(snap: &PerfCounterSnapshot) -> String {
+        let counters = &snap.evaluator_memo;
+        if counters.constructions == 0
+            && counters.local_memo_hits == 0
+            && counters.compute_nodes == 0
+            && counters.lost_memo_recomputes == 0
+            && counters.lost_memo_mismatches == 0
+            && counters.lost_memo_recomputes_identity == 0
+            && counters.memo_nested_hits == 0
+            && counters.lost_memo_recomputes_plain == 0
+            && counters.lost_memo_recomputes_authoritative == 0
+            && counters.lost_memo_recomputes_other == 0
+            && counters.dropped_memo_entries == 0
+            && counters.dropped_aux_entries == 0
+        {
+            return String::new();
+        }
+        format!(
+            "\nEvaluator memo lifecycle:\n  \
+             constructions             {:>12}\n  \
+             local memo hits           {:>12}\n  \
+             compute nodes             {:>12}\n  \
+             lost recomputes           {:>12}\n  \
+             lost mismatches           {:>12}\n  \
+             identity recomputes       {:>12}\n  \
+             nested memo hits          {:>12}\n  \
+             plain recomputes          {:>12}\n  \
+             authoritative recomputes  {:>12}\n  \
+             other recomputes          {:>12}\n  \
+             dropped memo entries      {:>12}\n  \
+             dropped aux entries       {:>12}\n",
+            counters.constructions,
+            counters.local_memo_hits,
+            counters.compute_nodes,
+            counters.lost_memo_recomputes,
+            counters.lost_memo_mismatches,
+            counters.lost_memo_recomputes_identity,
+            counters.memo_nested_hits,
+            counters.lost_memo_recomputes_plain,
+            counters.lost_memo_recomputes_authoritative,
+            counters.lost_memo_recomputes_other,
+            counters.dropped_memo_entries,
+            counters.dropped_aux_entries,
+        )
     }
 
     fn dump_slow_check_timings(snap: &PerfCounterSnapshot) -> String {

--- a/crates/tsz-common/src/perf_counters/dump_tests.rs
+++ b/crates/tsz-common/src/perf_counters/dump_tests.rs
@@ -111,4 +111,63 @@ mod dump_tests {
             );
         }
     }
+
+    #[test]
+    fn dump_string_surfaces_scalar_snapshot_counter_sections() {
+        // Keep scalar snapshot sections from repeating the original #13130
+        // drift pattern: a counter can be wired into storage and JSON while
+        // remaining invisible to humans reading the text dump.
+        force_enable_perf_counters_for_tests();
+
+        let c = counters();
+        c.relation_limit_cache_hits
+            .fetch_add(17, Ordering::Relaxed);
+        c.relation_maybe_promotions
+            .fetch_add(19, Ordering::Relaxed);
+        c.eval_evaluator_constructions
+            .fetch_add(23, Ordering::Relaxed);
+        c.eval_local_memo_hits.fetch_add(29, Ordering::Relaxed);
+        c.eval_compute_nodes.fetch_add(31, Ordering::Relaxed);
+        c.eval_lost_memo_recomputes
+            .fetch_add(37, Ordering::Relaxed);
+        c.eval_lost_memo_mismatches
+            .fetch_add(41, Ordering::Relaxed);
+        c.eval_lost_memo_recomputes_identity
+            .fetch_add(43, Ordering::Relaxed);
+        c.eval_memo_nested_hits.fetch_add(47, Ordering::Relaxed);
+        c.eval_lost_memo_recomputes_plain
+            .fetch_add(53, Ordering::Relaxed);
+        c.eval_lost_memo_recomputes_authoritative
+            .fetch_add(59, Ordering::Relaxed);
+        c.eval_lost_memo_recomputes_other
+            .fetch_add(61, Ordering::Relaxed);
+        c.eval_dropped_memo_entries
+            .fetch_add(67, Ordering::Relaxed);
+        c.eval_dropped_aux_entries.fetch_add(71, Ordering::Relaxed);
+
+        let dump = PerfCounters::dump_string();
+        for needle in [
+            "Relation limit-result cache",
+            "limit cache hits",
+            "maybe promotions",
+            "Evaluator memo lifecycle",
+            "constructions",
+            "local memo hits",
+            "compute nodes",
+            "lost recomputes",
+            "lost mismatches",
+            "identity recomputes",
+            "nested memo hits",
+            "plain recomputes",
+            "authoritative recomputes",
+            "other recomputes",
+            "dropped memo entries",
+            "dropped aux entries",
+        ] {
+            assert!(
+                dump.contains(needle),
+                "perf counter text dump omitted scalar counter `{needle}`:\n{dump}"
+            );
+        }
+    }
 }

--- a/crates/tsz-common/src/perf_counters/tests.rs
+++ b/crates/tsz-common/src/perf_counters/tests.rs
@@ -26,6 +26,7 @@ mod json_tests {
             "resolver",
             "interner",
             "relation_limit_cache",
+            "evaluator_memo",
             "by_reason",
             "delegate_miss_classification",
             "delegate_declaration_file_miss_residues",


### PR DESCRIPTION
Goal: fast

## Summary
- Surface relation-limit-cache counters in the human TSZ_PERF_COUNTERS text dump.
- Surface evaluator memo lifecycle counters in the human TSZ_PERF_COUNTERS text dump.
- Lock text-dump coverage for these scalar snapshot sections and add evaluator_memo to the top-level JSON key lock.
- Sync with current `origin/main`, preserving main's `solver_materialization` snapshot key alongside this PR's `evaluator_memo` key.

## Invariant
When a perf counter is wired into storage and the JSON snapshot, the human text dump must either surface it or intentionally mark it unwired. This PR fixes two scalar snapshot sections that were present in JSON but invisible in dump_string, continuing the #13259 enum-family registry ratchet for #13130 without changing producer behavior or the snapshot schema.

## Issue
Refs #13130.
Refs #13250.

## Scope
- Text formatting only for existing scalar counters.
- Test locks only; no new producer sites, no counter semantics change, no schema version bump.

## Verification
- Commit hook formatting ran during `git commit` and the merge commit.
- CI Light Summary passed on head `888151e7002d814312aab55ed57be6a98345e35a`.
- Full ready-review CI pending after marking ready.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium
