### PR TITLE
perf(cli): reuse source resolution misses

### DIFF
--- a/crates/tsz-cli/src/driver/check.rs
+++ b/crates/tsz-cli/src/driver/check.rs
@@ -485,7 +485,7 @@ pub(super) fn collect_diagnostics(
     cache: Option<&mut CompilationCache>,
     type_cache_output: &std::sync::Mutex<FxHashMap<PathBuf, TypeCache>>,
 ) -> CollectDiagnosticsResult {
-    collect_diagnostics_with_source_resolutions(input, cache, type_cache_output, None)
+    collect_diagnostics_with_source_resolutions(input, cache, type_cache_output, None, None)
 }
 
 pub(super) fn collect_diagnostics_with_source_resolutions(
@@ -495,6 +495,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
     source_module_resolutions: Option<
         &FxHashMap<SourceModuleResolutionKey, SourceModuleResolution>,
     >,
+    source_module_resolution_misses: Option<&FxHashSet<SourceModuleResolutionKey>>,
 ) -> CollectDiagnosticsResult {
     let &CollectDiagnosticsInput {
         program,
@@ -601,6 +602,7 @@ pub(super) fn collect_diagnostics_with_source_resolutions(
         options,
         base_dir,
         source_module_resolutions,
+        source_module_resolution_misses,
         program_file_index: &program_file_index,
         program_paths: &program_paths,
         package_redirects: &package_redirects,

--- a/crates/tsz-cli/src/driver/core_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/core_diagnostics.rs
@@ -541,6 +541,7 @@ pub(super) fn compile_inner(
         outfile_bundle_paths,
         outfile_bundle_dependencies,
         module_resolutions,
+        module_resolution_misses,
         type_reference_errors,
         resolution_mode_errors,
     } = {
@@ -964,6 +965,7 @@ pub(super) fn compile_inner(
         effective_cache,
         &parallel_type_caches,
         Some(&module_resolutions),
+        Some(&module_resolution_misses),
     );
     let mut diagnostics: Vec<Diagnostic> = collected.diagnostics;
     let check_duration = collect_diagnostics_start.elapsed();

--- a/crates/tsz-cli/src/driver/source_resolution_setup.rs
+++ b/crates/tsz-cli/src/driver/source_resolution_setup.rs
@@ -29,6 +29,7 @@ pub(super) struct SourceResolutionSetupInput<'a> {
     pub(super) base_dir: &'a Path,
     pub(super) source_module_resolutions:
         Option<&'a FxHashMap<SourceModuleResolutionKey, SourceModuleResolution>>,
+    pub(super) source_module_resolution_misses: Option<&'a FxHashSet<SourceModuleResolutionKey>>,
     pub(super) program_file_index: &'a ProgramFileIndex,
     pub(super) program_paths: &'a FxHashSet<PathBuf>,
     pub(super) package_redirects: &'a FxHashMap<PathBuf, PathBuf>,
@@ -43,6 +44,7 @@ pub(super) fn prepare_source_resolution_setup(
         options,
         base_dir,
         source_module_resolutions,
+        source_module_resolution_misses,
         program_file_index,
         program_paths,
         package_redirects,
@@ -165,14 +167,15 @@ pub(super) fn prepare_source_resolution_setup(
                     *resolution_mode_override,
                 );
                 let request_kind_key = checker_resolution_request_kind(*import_kind);
-                if let Some(discovered) = source_module_resolutions.and_then(|resolutions| {
-                    resolutions.get(&SourceModuleResolutionKey {
-                        containing_file: file_path.to_path_buf(),
-                        specifier: specifier.clone(),
-                        import_kind: *import_kind,
-                        resolution_mode_override: *resolution_mode_override,
-                    })
-                }) {
+                let source_resolution_key = SourceModuleResolutionKey {
+                    containing_file: file_path.to_path_buf(),
+                    specifier: specifier.clone(),
+                    import_kind: *import_kind,
+                    resolution_mode_override: *resolution_mode_override,
+                };
+                if let Some(discovered) = source_module_resolutions
+                    .and_then(|resolutions| resolutions.get(&source_resolution_key))
+                {
                     resolved_module_specifiers.insert((file_idx, specifier.clone()));
                     let canonical = if should_apply_duplicate_package_redirect(file_path) {
                         package_redirects
@@ -215,9 +218,14 @@ pub(super) fn prepare_source_resolution_setup(
                     continue;
                 }
 
+                let source_discovery_missed = source_module_resolution_misses
+                    .is_some_and(|misses| misses.contains(&source_resolution_key));
                 let result = module_resolver.lookup(
                     &request,
                     |spec, fp| {
+                        if source_discovery_missed && fp == file_path && spec == specifier {
+                            return None;
+                        }
                         resolve_module_specifier(
                             fp,
                             spec,

--- a/crates/tsz-cli/src/driver/sources.rs
+++ b/crates/tsz-cli/src/driver/sources.rs
@@ -267,6 +267,7 @@ pub(super) struct SourceReadResult {
     pub(super) outfile_bundle_paths: FxHashSet<PathBuf>,
     pub(super) outfile_bundle_dependencies: FxHashMap<PathBuf, FxHashSet<PathBuf>>,
     pub(super) module_resolutions: FxHashMap<SourceModuleResolutionKey, SourceModuleResolution>,
+    pub(super) module_resolution_misses: FxHashSet<SourceModuleResolutionKey>,
     /// Tuples of (`file_path`, `type_name`, `byte_offset_of_types_attr`, `span_length`).
     pub(super) type_reference_errors: Vec<(PathBuf, String, usize, usize)>,
     /// TS1453: Invalid `resolution-mode` values in `/// <reference types="..." />` directives.
@@ -647,6 +648,7 @@ pub(super) fn read_source_files(
         FxHashMap::default();
     let mut module_resolutions: FxHashMap<SourceModuleResolutionKey, SourceModuleResolution> =
         FxHashMap::default();
+    let mut module_resolution_misses: FxHashSet<SourceModuleResolutionKey> = FxHashSet::default();
     let mut seen = FxHashSet::default();
     let mut discovery_order: FxHashMap<PathBuf, usize> = FxHashMap::default();
     let mut next_discovery_order = 0usize;
@@ -900,6 +902,13 @@ pub(super) fn read_source_files(
                             next_discovery_order += 1;
                             pending.push_back(canonical);
                         }
+                    } else {
+                        module_resolution_misses.insert(SourceModuleResolutionKey {
+                            containing_file: path.clone(),
+                            specifier: specifier.clone(),
+                            import_kind,
+                            resolution_mode_override,
+                        });
                     }
                 }
             }
@@ -1099,6 +1108,7 @@ pub(super) fn read_source_files(
         outfile_bundle_paths,
         outfile_bundle_dependencies,
         module_resolutions,
+        module_resolution_misses,
         type_reference_errors,
         resolution_mode_errors,
     })
@@ -1387,6 +1397,23 @@ mod tests {
         assert!(
             result.module_resolutions.is_empty(),
             "failed resolution must fall back to diagnostic lookup"
+        );
+        let containing_file = result
+            .sources
+            .iter()
+            .find(|source| source.path.ends_with("main.ts"))
+            .expect("main.ts loaded")
+            .path
+            .clone();
+        assert!(
+            result
+                .module_resolution_misses
+                .contains(&SourceModuleResolutionKey {
+                    containing_file,
+                    specifier: "./missing".to_string(),
+                    import_kind: ImportKind::EsmImport,
+                    resolution_mode_override: None,
+                })
         );
     }
 


### PR DESCRIPTION
Goal: fast

## Summary
- Record exact source-discovery module-resolution misses next to the existing successful `source_module_resolutions` map.
- Thread those miss keys into the checker resolution setup pass.
- When the second pass asks for the same `(containing file, specifier, import kind, resolution mode)` miss, skip the repeated filesystem resolver callback while still letting `ModuleResolver` own diagnostics and ambient-module handling.

## Structural rule
When source discovery has already attempted an exact module lookup and found no source/declaration file, the later checker setup pass should reuse that negative fact for the same lookup key instead of repeating path resolution. tsz still routes the diagnostic decision through the CLI `ModuleResolver`; this PR only reduces duplicated filesystem probes for identical misses.

## Issue
Fixes #13111.
Refs #13250.

## Verification
- Commit hook formatting ran during `git commit`.
- CI Light Summary passed on head `88cc7fd94e4caa0e924b5452e68c69fd88a27800`.
- Full ready-review CI pending after marking ready.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium
