### PR TITLE
perf(emitter): share global symbol arenas

### DIFF
--- a/crates/tsz-cli/src/driver/emit.rs
+++ b/crates/tsz-cli/src/driver/emit.rs
@@ -198,7 +198,7 @@ pub(crate) fn emit_outputs(
     // This enables the declaration emitter's portability check to resolve
     // cross-file symbols (e.g., imported types from node_modules) to their
     // source file paths, which is required for TS2883 diagnostics.
-    let global_symbol_arenas = (*context.program.symbol_arenas).clone();
+    let global_symbol_arenas = std::sync::Arc::clone(&context.program.symbol_arenas);
 
     // Collect file paths that contain module augmentations.
     // The declaration emitter uses this to preserve side-effect imports for
@@ -607,7 +607,9 @@ pub(crate) fn emit_outputs(
                     emitter.set_arena_to_path(arena_to_path.clone());
                     emitter.set_file_idx_to_path(file_idx_to_path.clone());
                     emitter.set_root_file_paths(root_file_paths.clone());
-                    emitter.set_global_symbol_arenas(global_symbol_arenas.clone());
+                    emitter.set_shared_global_symbol_arenas(std::sync::Arc::clone(
+                        &global_symbol_arenas,
+                    ));
                     emitter.set_remove_comments(context.options.printer.remove_comments);
                     emitter.set_strip_internal(context.options.strip_internal);
                     emitter.set_strict_null_checks(context.options.checker.strict_null_checks);
@@ -627,7 +629,9 @@ pub(crate) fn emit_outputs(
                     emitter.set_arena_to_path(arena_to_path.clone());
                     emitter.set_file_idx_to_path(file_idx_to_path.clone());
                     emitter.set_root_file_paths(root_file_paths.clone());
-                    emitter.set_global_symbol_arenas(global_symbol_arenas.clone());
+                    emitter.set_shared_global_symbol_arenas(std::sync::Arc::clone(
+                        &global_symbol_arenas,
+                    ));
                     emitter.set_remove_comments(context.options.printer.remove_comments);
                     emitter.set_strip_internal(context.options.strip_internal);
                     emitter.set_strict_null_checks(context.options.checker.strict_null_checks);

--- a/crates/tsz-emitter/src/declaration_emitter/core/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/mod.rs
@@ -84,7 +84,7 @@ pub struct DeclarationEmitter<'a> {
     pub(super) root_file_paths: FxHashSet<String>,
     /// Global symbol-to-arena mapping from all program files, enabling cross-file
     /// symbol source path resolution for TS2883 portability checks.
-    pub(super) global_symbol_arenas: FxHashMap<SymbolId, Arc<NodeArena>>,
+    pub(super) global_symbol_arenas: Arc<FxHashMap<SymbolId, Arc<NodeArena>>>,
     /// In declaration bundles, duplicate global `var` declarations share the
     /// first emitted type instead of each file independently narrowing its own
     /// initializer.

--- a/crates/tsz-emitter/src/declaration_emitter/core/setup.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/setup.rs
@@ -39,7 +39,7 @@ impl<'a> DeclarationEmitter<'a> {
             arena_to_path: FxHashMap::default(),
             file_idx_to_path: FxHashMap::default(),
             root_file_paths: FxHashSet::default(),
-            global_symbol_arenas: FxHashMap::default(),
+            global_symbol_arenas: Arc::new(FxHashMap::default()),
             bundled_duplicate_global_var_types: FxHashMap::default(),
             required_imports: FxHashMap::default(),
             reserved_names: FxHashSet::default(),
@@ -167,7 +167,7 @@ impl<'a> DeclarationEmitter<'a> {
             arena_to_path: FxHashMap::default(),
             file_idx_to_path: FxHashMap::default(),
             root_file_paths: FxHashSet::default(),
-            global_symbol_arenas: FxHashMap::default(),
+            global_symbol_arenas: Arc::new(FxHashMap::default()),
             bundled_duplicate_global_var_types: FxHashMap::default(),
             required_imports: FxHashMap::default(),
             reserved_names: FxHashSet::default(),
@@ -360,6 +360,19 @@ impl<'a> DeclarationEmitter<'a> {
     pub fn set_global_symbol_arenas(
         &mut self,
         global_symbol_arenas: FxHashMap<SymbolId, Arc<NodeArena>>,
+    ) {
+        self.global_symbol_arenas = Arc::new(global_symbol_arenas);
+    }
+
+    /// Share the global symbol-to-arena mapping from all program files.
+    ///
+    /// Batch declaration emit creates one scratch emitter per file. Passing the
+    /// program-owned map by `Arc` avoids cloning the full symbol universe into
+    /// every scratch emitter while preserving the same read-only lookup
+    /// behavior.
+    pub fn set_shared_global_symbol_arenas(
+        &mut self,
+        global_symbol_arenas: Arc<FxHashMap<SymbolId, Arc<NodeArena>>>,
     ) {
         self.global_symbol_arenas = global_symbol_arenas;
     }


### PR DESCRIPTION
Goal: fast

## Summary
- Keep the program-wide symbol-to-arena map shared with declaration emitters through an `Arc`.
- Add `set_shared_global_symbol_arenas` for batch DTS emit so each per-file scratch emitter avoids cloning the full map.
- Preserve `set_global_symbol_arenas` for tests and existing direct callers by wrapping caller-owned maps in an `Arc`.

## Issue
- Works toward #13103.

## Structural rule
When batch declaration emit creates one scratch emitter per file, tsz should share read-only program-wide symbol source maps through the emitter setup boundary; tsz now does this through `DeclarationEmitter::set_shared_global_symbol_arenas` instead of deep-cloning `MergedProgram::symbol_arenas` per file.

## Owner layer
Emitter/CLI setup only. This does not add semantic validation or output surgery; it changes the residency/clone ownership of read-only DTS support maps.

## Adjacent matrix
- Type-info DTS emit: shares the program symbol arena map.
- No-type-cache DTS emit: shares the same program symbol arena map.
- Existing unit-style emitter tests: can still pass owned `FxHashMap` values through `set_global_symbol_arenas`.

## Verification
- Commit hook formatting ran during commit.
- CI Light Summary passed on head `a0c5ad4041a2d93a7c2806041938c618cc4fdbdc`.
- Full ready-review CI pending after marking ready.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium
