### PR TITLE
perf(solver): skip visited alias branch clones

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -1780,6 +1780,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     if let Some(alias) = self.interner().get_display_alias(source)
                         && alias != source
                     {
+                        if visited.contains(&(alias, expanded_pattern)) {
+                            return true;
+                        }
                         let mut alias_bindings = bindings.clone();
                         let mut alias_visited = visited.clone();
                         if self.match_infer_pattern(


### PR DESCRIPTION
Goal: fast

## Summary
- Refs #8356 and #13250.
- Avoid cloning `bindings` and the branch-local infer-pattern `visited` set when the display-alias fallback is about to re-enter a `(alias, expanded_pattern)` pair that the current infer-pattern walk has already visited.
- Preserve the existing branch-isolation behavior for non-visited alias fallback attempts: failed alias matching still uses cloned bindings and cloned visited state so it cannot poison the main fallback path.

## Structural rule
When infer-pattern matching falls back from an application pattern to a display-alias branch, a branch whose `(alias, expanded_pattern)` pair is already in the current visited set is semantically equivalent to calling `match_infer_pattern` and hitting its first-line cycle guard. tsz can return that guard result directly through the solver evaluator owner, avoiding a branch-local `FxHashMap`/`FxHashSet` clone on recursive alias re-entry without changing cache, fuel, or cycle behavior.

## Adjacent matrix
- Already-visited display-alias branch: returns `true` exactly as `match_infer_pattern` would before touching bindings.
- Fresh display-alias branch: unchanged; clones bindings and visited state before trying the branch.
- Failed fresh branch: unchanged; cloned state is discarded and the main source-vs-expanded-pattern fallback still runs.
- No display alias or unchanged expanded pattern: unchanged.

## Verification
- Commit hook formatting ran during `git commit`.
- Draft PR CI on exact head `fa75b666eacb24248a7f9b11b8250da355e51856`: `CI Light Summary` passed; `dist-binaries`, `lint`, `unit`, and `unit-checker-integration` passed; `project-compile-canary` skipped for draft/light scope.
- No local tests or benchmarks run per current instruction.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
