### PR TITLE
perf(solver): reuse property instantiation slots

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate/display_properties.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/display_properties.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::types::{PropertyInfo, TypeId};
+use rustc_hash::FxHashMap;
 
 impl<'a> TypeInstantiator<'a> {
     /// Propagate display properties from intersection members to the result.
@@ -23,10 +24,15 @@ impl<'a> TypeInstantiator<'a> {
         &mut self,
         properties: &[PropertyInfo],
     ) -> Option<Vec<PropertyInfo>> {
+        let mut local_results = (properties.len() >= 8).then(FxHashMap::default);
         let mut instantiated: Option<Vec<PropertyInfo>> = None;
         for (index, property) in properties.iter().enumerate() {
-            let type_id = self.instantiate(property.type_id);
-            let write_type = self.instantiate(property.write_type);
+            let type_id = self.instantiate_property_slot(property.type_id, &mut local_results);
+            let write_type = if property.write_type == property.type_id {
+                type_id
+            } else {
+                self.instantiate_property_slot(property.write_type, &mut local_results)
+            };
             if let Some(instantiated) = &mut instantiated {
                 let mut property = property.clone();
                 property.type_id = type_id;
@@ -47,6 +53,23 @@ impl<'a> TypeInstantiator<'a> {
             instantiated.is_some(),
         );
         instantiated
+    }
+
+    fn instantiate_property_slot(
+        &mut self,
+        type_id: TypeId,
+        local_results: &mut Option<FxHashMap<TypeId, TypeId>>,
+    ) -> TypeId {
+        if let Some(local_results) = local_results {
+            if let Some(cached) = local_results.get(&type_id) {
+                return *cached;
+            }
+            let instantiated = self.instantiate(type_id);
+            local_results.insert(type_id, instantiated);
+            instantiated
+        } else {
+            self.instantiate(type_id)
+        }
     }
 
     pub(super) fn propagate_instantiated_display_properties(


### PR DESCRIPTION
Goal: fast

## Summary
- Refs #13242 and #13250.
- Reuse repeated property-slot instantiation results within one object/callable property-list walk.
- Avoid a second instantiation call when a property read type and write type are already the same `TypeId`.
- Keep the memo local to one `TypeInstantiator` property walk; no cross-file or cross-request cache widening.

## Structural rule
When a property list is instantiated under one substitution/options/`this` state, identical property-slot `TypeId`s ask the same solver instantiation question. `tsz-solver` can answer repeated slots from a walk-local memo while preserving existing instantiation cache scope, depth behavior, and fallback semantics.

## Adjacent matrix
- Same read/write slot: instantiate once and reuse the result for both slots.
- Repeated slot across properties in the same list: reuse the walk-local result.
- Small property lists: keep the existing allocation-free path and instantiate directly.
- Different slot `TypeId`s, different substitution requests, and different `this`/mode options: unchanged because the memo is walk-local to the configured `TypeInstantiator`.

## Verification
- Draft CI Light Summary passed at `ace7783b04c130b84c240dd9eb2aac3d4c95a9e5` on 2026-06-12.
- `git diff --check`
- Commit hook formatting during `git commit`
- No local tests or benchmarks run per current instruction; ready-review CI is the broad verification path.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
