### PR TITLE
perf(bench): collect target gap attribution artifacts

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1381,6 +1381,19 @@ jobs:
             "$GITHUB_WORKSPACE/bench-results-tsgo-winners.json" \
             "$GITHUB_WORKSPACE/bench-results-missing-attribution.md"
 
+      - name: Collect target-gap attribution artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/bench/run-attribution-plan.mjs \
+            "$GITHUB_WORKSPACE/bench-results-tsgo-winners.json" \
+            "$GITHUB_WORKSPACE/bench-results" \
+            "$GITHUB_WORKSPACE/bench-results-attribution-manifest.json"
+          node scripts/bench/tsgo-winner-report.mjs \
+            "$GITHUB_WORKSPACE/bench-results.json" \
+            "$GITHUB_WORKSPACE/bench-results-tsgo-winners.json" \
+            "$GITHUB_WORKSPACE/bench-results-missing-attribution.md"
+
       - name: Compare project winner regressions
         continue-on-error: true
         shell: bash
@@ -1427,6 +1440,8 @@ jobs:
             bench-results.json
             bench-results-tsgo-winners.json
             bench-results-missing-attribution.md
+            bench-results-attribution-manifest.json
+            bench-results*.perf.json
             bench-results-project-winner-regressions.json
             bench-results-project-winner-regressions.md
             bench-results-readiness.json

--- a/scripts/bench/run-attribution-plan.mjs
+++ b/scripts/bench/run-attribution-plan.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+function usage() {
+  console.error(
+    "usage: run-attribution-plan.mjs <tsgo-winners.json> <artifact-prefix> <manifest.json>",
+  );
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function toPortablePath(file) {
+  return file.split(path.sep).join("/");
+}
+
+function unresolvedPlaceholder(command) {
+  const placeholders = [...String(command).matchAll(/<([^>]+)>/g)].map((match) => match[1]);
+  return placeholders.find((name) => name !== "artifact") ?? null;
+}
+
+function expectedPerfPath(command) {
+  const match = String(command).match(/--perf-counters-json\s+("[^"]+"|'[^']+'|\S+)/);
+  if (!match) return null;
+  return match[1].replace(/^["']|["']$/g, "");
+}
+
+function main() {
+  const [reportPath, artifactPrefix, manifestPath] = process.argv.slice(2);
+  if (!reportPath || !artifactPrefix || !manifestPath) {
+    usage();
+    process.exit(2);
+  }
+
+  const report = readJson(reportPath);
+  const rows = Array.isArray(report?.two_x_target?.missing_attribution_plan)
+    ? report.two_x_target.missing_attribution_plan
+    : [];
+  const manifest = {
+    schema_version: 1,
+    generated_at: new Date().toISOString(),
+    source_report: toPortablePath(reportPath),
+    artifact_prefix: artifactPrefix,
+    rows: [],
+  };
+
+  for (const row of rows) {
+    const commandTemplate = row?.attribution_command;
+    if (typeof commandTemplate !== "string" || commandTemplate.trim() === "") {
+      manifest.rows.push({
+        name: row?.name ?? null,
+        status: "skipped",
+        reason: "missing attribution_command",
+      });
+      continue;
+    }
+
+    const unresolved = unresolvedPlaceholder(commandTemplate);
+    if (unresolved) {
+      manifest.rows.push({
+        name: row?.name ?? null,
+        status: "skipped",
+        reason: `unresolved placeholder <${unresolved}>`,
+        command_template: commandTemplate,
+      });
+      continue;
+    }
+
+    const command = commandTemplate.replaceAll("<artifact>", artifactPrefix);
+    const perfPath = expectedPerfPath(command);
+    const result = spawnSync(command, {
+      shell: true,
+      stdio: "inherit",
+      env: { ...process.env, TSZ_PERF_COUNTERS: process.env.TSZ_PERF_COUNTERS ?? "1" },
+    });
+    const status = result.status === 0 && perfPath && fs.existsSync(perfPath)
+      ? "success"
+      : "failed";
+    manifest.rows.push({
+      name: row?.name ?? null,
+      status,
+      exit_code: result.status,
+      signal: result.signal,
+      perf_path: perfPath ? toPortablePath(perfPath) : null,
+      command,
+    });
+  }
+
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+  const counts = manifest.rows.reduce((acc, row) => {
+    acc[row.status] = (acc[row.status] ?? 0) + 1;
+    return acc;
+  }, {});
+  console.log(
+    `attribution plan: success=${counts.success ?? 0} failed=${counts.failed ?? 0} skipped=${counts.skipped ?? 0}`,
+  );
+}
+
+main();

--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -1032,8 +1032,18 @@ assert.match(
 );
 assert.match(
   benchWorkflow,
-  /bench-results\.json\s*\n\s+bench-results-tsgo-winners\.json\s*\n\s+bench-results-missing-attribution\.md/,
-  "merged benchmark artifact should upload the green tsgo winner report and attribution plan",
+  /node scripts\/bench\/run-attribution-plan\.mjs\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results-tsgo-winners\.json"\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results"\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results-attribution-manifest\.json"/,
+  "bench workflow should collect attribution artifacts from the generated missing-attribution plan",
+);
+assert.match(
+  benchWorkflow,
+  /run-attribution-plan\.mjs[\s\S]+node scripts\/bench\/tsgo-winner-report\.mjs\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results\.json"\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results-tsgo-winners\.json"\s+\\\s*\n\s+"\$GITHUB_WORKSPACE\/bench-results-missing-attribution\.md"/,
+  "bench workflow should refresh the winner report after attribution sidecars are collected",
+);
+assert.match(
+  benchWorkflow,
+  /bench-results\.json\s*\n\s+bench-results-tsgo-winners\.json\s*\n\s+bench-results-missing-attribution\.md\s*\n\s+bench-results-attribution-manifest\.json\s*\n\s+bench-results\*\.perf\.json/,
+  "merged benchmark artifact should upload the green tsgo winner report, attribution plan, manifest, and perf sidecars",
 );
 assert.match(
   benchWorkflow,


### PR DESCRIPTION
Goal: fast

## Summary
- Refs #13247 and #13250.
- Add `scripts/bench/run-attribution-plan.mjs` to execute concrete missing-attribution commands from the generated `tsgo-winner-report` plan.
- Wire `bench.yml` to collect attribution sidecars after timing-mode merge, then regenerate the winner report so `rows_with_attribution` reflects completed sidecars.
- Upload the attribution manifest and `bench-results*.perf.json` sidecars with `bench-results-merged`.

## Structural rule
When a benchmark run has timing-mode target gaps, attribution-mode counter collection is a separate pass over the report's own `missing_attribution_plan`; it must not feed back into timing measurements. The bench workflow owns this process boundary, producing sidecar perf-counter artifacts and a manifest while keeping timing JSON unchanged.

## Scope boundary
- Advisory artifact collection only; no pre-merge blocking gate in this slice.
- Commands with unresolved generated-fixture placeholders are skipped and recorded in the manifest.
- Attribution command failures are recorded per row; the publish path can still upload partial attribution evidence.
- No compiler behavior changes.

## Verification
- Draft CI Light Summary passed at `fe77c06bac77cf73b817347d1962339c02f3d32e` on 2026-06-12.
- `git diff --check`
- Commit hook formatting during `git commit`
- No local benchmark or test runs per current instruction; ready-review CI is the broad verification path.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
