### PR TITLE
perf(solver): preserve property access atoms

### DIFF
--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -1898,7 +1898,7 @@ impl QueryDatabase for QueryCache<'_> {
         let mut evaluator = crate::operations::property::PropertyAccessEvaluator::new(self);
         evaluator.set_no_unchecked_indexed_access(no_unchecked_indexed_access);
         evaluator.set_exact_optional_property_types(exact_optional_property_types);
-        let result = evaluator.resolve_property_access(object_type, prop_name);
+        let result = evaluator.resolve_property_access_with_atom(object_type, prop_name, prop_atom);
         self.insert_property_cache(key, result);
         result
     }

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -466,12 +466,11 @@ impl<'a> PropertyAccessEvaluator<'a> {
         // Set context for visitor methods
         let prop_atom = prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
         *self.current_prop_atom.borrow_mut() = Some(prop_atom);
-        let prop_atom = Some(prop_atom);
 
         // Single-lookup dispatch: resolve property access based on type data.
         // All type variants are handled in one match to avoid redundant interner lookups.
         let Some(key) = self.interner().lookup(obj_type) else {
-            let prop_atom = prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+            let prop_atom = prop_atom;
             return PropertyAccessResult::PropertyNotFound {
                 type_id: obj_type,
                 property_name: prop_atom,
@@ -502,8 +501,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 .unwrap_or_else(|| PropertyAccessResult::simple(TypeId::ANY)),
 
             TypeData::Intrinsic(kind) => {
-                let prop_atom =
-                    prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                let prop_atom = prop_atom;
                 match kind {
                     IntrinsicKind::Any => PropertyAccessResult::simple(TypeId::ANY),
                     IntrinsicKind::Unknown => PropertyAccessResult::IsUnknown,
@@ -551,15 +549,13 @@ impl<'a> PropertyAccessEvaluator<'a> {
             }
 
             TypeData::Function(_) => {
-                let prop_atom =
-                    prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                let prop_atom = prop_atom;
                 self.resolve_function_property(obj_type, prop_name, prop_atom)
             }
 
             TypeData::Callable(shape_id) => {
                 let shape = self.interner().callable_shape(shape_id);
-                let prop_atom =
-                    prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                let prop_atom = prop_atom;
                 for prop in &shape.properties {
                     if prop.name == prop_atom {
                         let read_type = self
@@ -597,8 +593,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
             TypeData::Intersection(members) => {
                 let members = self.interner().type_list(members);
-                let prop_atom =
-                    prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                let prop_atom = prop_atom;
                 let mut results = Vec::with_capacity(members.len());
                 let mut write_results = Vec::with_capacity(members.len());
                 let mut any_from_index = false;
@@ -810,8 +805,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
             }
 
             TypeData::TypeParameter(info) | TypeData::Infer(info) => {
-                let prop_atom =
-                    prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                let prop_atom = prop_atom;
                 if let Some(constraint) = info.constraint {
                     // Skip `this` binding when resolving through a type parameter's
                     // constraint. The checker substitutes `this` with the actual
@@ -863,8 +857,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
             // TS apparent members: literals inherit primitive wrapper methods.
             TypeData::Literal(ref literal) => {
-                let prop_atom =
-                    prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                let prop_atom = prop_atom;
                 match literal {
                     LiteralValue::String(_) => self.resolve_string_property(prop_name, prop_atom),
                     LiteralValue::Number(_) => self.resolve_number_property(prop_name, prop_atom),
@@ -874,8 +867,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
             }
 
             TypeData::TemplateLiteral(_) => {
-                let prop_atom =
-                    prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                let prop_atom = prop_atom;
                 self.resolve_string_property(prop_name, prop_atom)
             }
 
@@ -884,8 +876,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 let _guard = match self.enter_property_access_guard(obj_type) {
                     Some(guard) => guard,
                     None => {
-                        let prop_atom =
-                            prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                        let prop_atom = prop_atom;
                         return self
                             .resolve_object_member_or_not_found(obj_type, prop_name, prop_atom);
                     }
@@ -898,8 +889,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
             // Mapped: try lazy property resolution first to avoid OOM on large mapped types
             TypeData::Mapped(mapped_id) => {
-                let prop_atom =
-                    prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                let prop_atom = prop_atom;
 
                 // Try lazy resolution first - only computes the requested property
                 if let Some(result) =
@@ -946,8 +936,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     self.resolve_property_access_inner(evaluated, prop_name, prop_atom)
                 } else {
                     // Evaluation didn't change the type - try apparent members
-                    let prop_atom =
-                        prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                    let prop_atom = prop_atom;
                     if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {
                         result
                     } else {
@@ -963,8 +952,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 let _guard = match self.enter_property_access_guard(obj_type) {
                     Some(guard) => guard,
                     None => {
-                        let prop_atom =
-                            prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                        let prop_atom = prop_atom;
                         return self
                             .resolve_object_member_or_not_found(obj_type, prop_name, prop_atom);
                     }
@@ -978,8 +966,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     self.resolve_property_access_inner(evaluated, prop_name, prop_atom)
                 } else {
                     // Evaluation didn't change the type - try apparent members
-                    let prop_atom =
-                        prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                    let prop_atom = prop_atom;
                     if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {
                         result
                     } else {
@@ -997,8 +984,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 let _guard = match self.enter_property_access_guard(obj_type) {
                     Some(guard) => guard,
                     None => {
-                        let prop_atom =
-                            prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                        let prop_atom = prop_atom;
                         return self
                             .resolve_object_member_or_not_found(obj_type, prop_name, prop_atom);
                     }
@@ -1039,8 +1025,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                         }
                     }
 
-                    let prop_atom =
-                        prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                    let prop_atom = prop_atom;
                     if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {
                         result
                     } else {
@@ -1058,8 +1043,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 if evaluated != obj_type {
                     self.resolve_property_access_inner(evaluated, prop_name, prop_atom)
                 } else {
-                    let prop_atom =
-                        prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                    let prop_atom = prop_atom;
                     // KeyOf typically returns string/number/symbol, try string member access
                     self.resolve_string_property(prop_name, prop_atom)
                 }
@@ -1068,8 +1052,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
             // ThisType: represents 'this' type in a class/interface context
             // Should be resolved to the actual class type by the checker
             TypeData::ThisType => {
-                let prop_atom =
-                    prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                let prop_atom = prop_atom;
                 if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {
                     return result;
                 }
@@ -1085,8 +1068,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 let _guard = match self.enter_property_access_guard(obj_type) {
                     Some(guard) => guard,
                     None => {
-                        let prop_atom =
-                            prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                        let prop_atom = prop_atom;
                         return self
                             .resolve_object_member_or_not_found(obj_type, prop_name, prop_atom);
                     }
@@ -1107,8 +1089,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     self.resolve_property_access_inner(resolved, prop_name, prop_atom)
                 } else {
                     // Can't resolve lazy type - try apparent members
-                    let prop_atom =
-                        prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                    let prop_atom = prop_atom;
                     if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {
                         result
                     } else {
@@ -1127,15 +1108,13 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
             // StringIntrinsic (Uppercase<T>, Lowercase<T>, etc.) — resolve as string
             TypeData::StringIntrinsic { .. } => {
-                let prop_atom =
-                    prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                let prop_atom = prop_atom;
                 self.resolve_string_property(prop_name, prop_atom)
             }
 
             _ => {
                 // Unknown type key - try apparent members before giving up
-                let prop_atom =
-                    prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+                let prop_atom = prop_atom;
                 if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {
                     return result;
                 }

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -485,11 +485,11 @@ impl<'a> PropertyAccessEvaluator<'a> {
             }
 
             TypeData::Object(shape_id) => self
-                .visit_object_impl(shape_id.0, prop_name, prop_atom)
+                .visit_object_impl(shape_id.0, prop_name, Some(prop_atom))
                 .unwrap_or_else(|| PropertyAccessResult::simple(TypeId::ANY)),
 
             TypeData::ObjectWithIndex(shape_id) => self
-                .visit_object_with_index_impl(shape_id.0, prop_name, prop_atom)
+                .visit_object_with_index_impl(shape_id.0, prop_name, Some(prop_atom))
                 .unwrap_or_else(|| PropertyAccessResult::simple(TypeId::ANY)),
 
             TypeData::Array(_) | TypeData::Tuple(_) => self
@@ -797,11 +797,11 @@ impl<'a> PropertyAccessEvaluator<'a> {
             // inner types it must resolve against ReadonlyArray<T> so that mutating
             // methods (push, pop, splice, etc.) are absent — matching tsc behaviour.
             TypeData::NoInfer(inner) => {
-                self.resolve_property_access_inner(inner, prop_name, prop_atom)
+                self.resolve_property_access_inner(inner, prop_name, Some(prop_atom))
             }
 
             TypeData::ReadonlyType(inner) => {
-                self.resolve_readonly_type_property(obj_type, inner, prop_name, prop_atom)
+                self.resolve_readonly_type_property(obj_type, inner, prop_name, Some(prop_atom))
             }
 
             TypeData::TypeParameter(info) | TypeData::Infer(info) => {
@@ -884,7 +884,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
                 // Use nominal resolution for Application types
                 // This preserves class/interface identity instead of structurally expanding
-                self.resolve_application_property(obj_type, app_id, prop_name, prop_atom)
+                self.resolve_application_property(obj_type, app_id, prop_name, Some(prop_atom))
             }
 
             // Mapped: try lazy property resolution first to avoid OOM on large mapped types
@@ -933,7 +933,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     .evaluate_type_with_options(obj_type, self.no_unchecked_indexed_access);
                 if evaluated != obj_type {
                     // Successfully evaluated - resolve property on the concrete type
-                    self.resolve_property_access_inner(evaluated, prop_name, prop_atom)
+                    self.resolve_property_access_inner(evaluated, prop_name, Some(prop_atom))
                 } else {
                     // Evaluation didn't change the type - try apparent members
                     let prop_atom = prop_atom;
@@ -963,7 +963,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     .evaluate_type_with_options(obj_type, self.no_unchecked_indexed_access);
                 if evaluated != obj_type {
                     // Successfully evaluated - resolve property on the concrete type
-                    self.resolve_property_access_inner(evaluated, prop_name, prop_atom)
+                    self.resolve_property_access_inner(evaluated, prop_name, Some(prop_atom))
                 } else {
                     // Evaluation didn't change the type - try apparent members
                     let prop_atom = prop_atom;
@@ -994,7 +994,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     .db
                     .evaluate_type_with_options(obj_type, self.no_unchecked_indexed_access);
                 if evaluated != obj_type {
-                    self.resolve_property_access_inner(evaluated, prop_name, prop_atom)
+                    self.resolve_property_access_inner(evaluated, prop_name, Some(prop_atom))
                 } else {
                     // Evaluation didn't change the type (still deferred).
                     // Try resolving the base constraint of the indexed access:
@@ -1020,7 +1020,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                             return self.resolve_property_access_inner(
                                 base_constraint,
                                 prop_name,
-                                prop_atom,
+                                Some(prop_atom),
                             );
                         }
                     }
@@ -1041,7 +1041,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     .db
                     .evaluate_type_with_options(obj_type, self.no_unchecked_indexed_access);
                 if evaluated != obj_type {
-                    self.resolve_property_access_inner(evaluated, prop_name, prop_atom)
+                    self.resolve_property_access_inner(evaluated, prop_name, Some(prop_atom))
                 } else {
                     let prop_atom = prop_atom;
                     // KeyOf typically returns string/number/symbol, try string member access
@@ -1086,7 +1086,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                         resolved
                     };
                     // Successfully resolved - resolve property on the concrete type
-                    self.resolve_property_access_inner(resolved, prop_name, prop_atom)
+                    self.resolve_property_access_inner(resolved, prop_name, Some(prop_atom))
                 } else {
                     // Can't resolve lazy type - try apparent members
                     let prop_atom = prop_atom;
@@ -1103,7 +1103,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
             // Enum values inherit methods from their structural member type
             // (number for numeric enums, string for string enums)
             TypeData::Enum(_def_id, member_type) => {
-                self.resolve_property_access_inner(member_type, prop_name, prop_atom)
+                self.resolve_property_access_inner(member_type, prop_name, Some(prop_atom))
             }
 
             // StringIntrinsic (Uppercase<T>, Lowercase<T>, etc.) — resolve as string

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -493,11 +493,11 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 .unwrap_or_else(|| PropertyAccessResult::simple(TypeId::ANY)),
 
             TypeData::Array(_) | TypeData::Tuple(_) => self
-                .visit_array_impl(obj_type, prop_name, prop_atom)
+                .visit_array_impl(obj_type, prop_name, Some(prop_atom))
                 .unwrap_or_else(|| PropertyAccessResult::simple(TypeId::ANY)),
 
             TypeData::Union(list_id) => self
-                .visit_union_impl(list_id.0, prop_name, prop_atom)
+                .visit_union_impl(list_id.0, prop_name, Some(prop_atom))
                 .unwrap_or_else(|| PropertyAccessResult::simple(TypeId::ANY)),
 
             TypeData::Intrinsic(kind) => {

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -268,6 +268,11 @@ impl<'a> PropertyAccessEvaluator<'a> {
         self.db.as_type_database()
     }
 
+    pub(crate) fn current_property_context(&self) -> Option<(std::sync::Arc<str>, Atom)> {
+        let atom = (*self.current_prop_atom.borrow())?;
+        Some((self.interner().resolve_atom_ref(atom), atom))
+    }
+
     fn resolver(&self) -> &dyn TypeResolver {
         self.resolver.unwrap_or_else(|| self.db.as_type_resolver())
     }

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -470,7 +470,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
         // Single-lookup dispatch: resolve property access based on type data.
         // All type variants are handled in one match to avoid redundant interner lookups.
         let Some(key) = self.interner().lookup(obj_type) else {
-            let prop_atom = prop_atom;
             return PropertyAccessResult::PropertyNotFound {
                 type_id: obj_type,
                 property_name: prop_atom,
@@ -501,7 +500,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 .unwrap_or_else(|| PropertyAccessResult::simple(TypeId::ANY)),
 
             TypeData::Intrinsic(kind) => {
-                let prop_atom = prop_atom;
                 match kind {
                     IntrinsicKind::Any => PropertyAccessResult::simple(TypeId::ANY),
                     IntrinsicKind::Unknown => PropertyAccessResult::IsUnknown,
@@ -548,14 +546,10 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 }
             }
 
-            TypeData::Function(_) => {
-                let prop_atom = prop_atom;
-                self.resolve_function_property(obj_type, prop_name, prop_atom)
-            }
+            TypeData::Function(_) => self.resolve_function_property(obj_type, prop_name, prop_atom),
 
             TypeData::Callable(shape_id) => {
                 let shape = self.interner().callable_shape(shape_id);
-                let prop_atom = prop_atom;
                 for prop in &shape.properties {
                     if prop.name == prop_atom {
                         let read_type = self
@@ -593,7 +587,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
             TypeData::Intersection(members) => {
                 let members = self.interner().type_list(members);
-                let prop_atom = prop_atom;
                 let mut results = Vec::with_capacity(members.len());
                 let mut write_results = Vec::with_capacity(members.len());
                 let mut any_from_index = false;
@@ -805,7 +798,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
             }
 
             TypeData::TypeParameter(info) | TypeData::Infer(info) => {
-                let prop_atom = prop_atom;
                 if let Some(constraint) = info.constraint {
                     // Skip `this` binding when resolving through a type parameter's
                     // constraint. The checker substitutes `this` with the actual
@@ -856,27 +848,20 @@ impl<'a> PropertyAccessEvaluator<'a> {
             }
 
             // TS apparent members: literals inherit primitive wrapper methods.
-            TypeData::Literal(ref literal) => {
-                let prop_atom = prop_atom;
-                match literal {
-                    LiteralValue::String(_) => self.resolve_string_property(prop_name, prop_atom),
-                    LiteralValue::Number(_) => self.resolve_number_property(prop_name, prop_atom),
-                    LiteralValue::Boolean(_) => self.resolve_boolean_property(prop_name, prop_atom),
-                    LiteralValue::BigInt(_) => self.resolve_bigint_property(prop_name, prop_atom),
-                }
-            }
+            TypeData::Literal(ref literal) => match literal {
+                LiteralValue::String(_) => self.resolve_string_property(prop_name, prop_atom),
+                LiteralValue::Number(_) => self.resolve_number_property(prop_name, prop_atom),
+                LiteralValue::Boolean(_) => self.resolve_boolean_property(prop_name, prop_atom),
+                LiteralValue::BigInt(_) => self.resolve_bigint_property(prop_name, prop_atom),
+            },
 
-            TypeData::TemplateLiteral(_) => {
-                let prop_atom = prop_atom;
-                self.resolve_string_property(prop_name, prop_atom)
-            }
+            TypeData::TemplateLiteral(_) => self.resolve_string_property(prop_name, prop_atom),
 
             // Application: handle nominally (preserve class/interface identity)
             TypeData::Application(app_id) => {
                 let _guard = match self.enter_property_access_guard(obj_type) {
                     Some(guard) => guard,
                     None => {
-                        let prop_atom = prop_atom;
                         return self
                             .resolve_object_member_or_not_found(obj_type, prop_name, prop_atom);
                     }
@@ -889,8 +874,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
 
             // Mapped: try lazy property resolution first to avoid OOM on large mapped types
             TypeData::Mapped(mapped_id) => {
-                let prop_atom = prop_atom;
-
                 // Try lazy resolution first - only computes the requested property
                 if let Some(result) =
                     self.resolve_mapped_property_lazy(mapped_id, prop_name, prop_atom)
@@ -936,7 +919,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     self.resolve_property_access_inner(evaluated, prop_name, Some(prop_atom))
                 } else {
                     // Evaluation didn't change the type - try apparent members
-                    let prop_atom = prop_atom;
                     if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {
                         result
                     } else {
@@ -952,7 +934,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 let _guard = match self.enter_property_access_guard(obj_type) {
                     Some(guard) => guard,
                     None => {
-                        let prop_atom = prop_atom;
                         return self
                             .resolve_object_member_or_not_found(obj_type, prop_name, prop_atom);
                     }
@@ -966,7 +947,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     self.resolve_property_access_inner(evaluated, prop_name, Some(prop_atom))
                 } else {
                     // Evaluation didn't change the type - try apparent members
-                    let prop_atom = prop_atom;
                     if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {
                         result
                     } else {
@@ -984,7 +964,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 let _guard = match self.enter_property_access_guard(obj_type) {
                     Some(guard) => guard,
                     None => {
-                        let prop_atom = prop_atom;
                         return self
                             .resolve_object_member_or_not_found(obj_type, prop_name, prop_atom);
                     }
@@ -1024,8 +1003,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
                             );
                         }
                     }
-
-                    let prop_atom = prop_atom;
                     if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {
                         result
                     } else {
@@ -1043,7 +1020,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 if evaluated != obj_type {
                     self.resolve_property_access_inner(evaluated, prop_name, Some(prop_atom))
                 } else {
-                    let prop_atom = prop_atom;
                     // KeyOf typically returns string/number/symbol, try string member access
                     self.resolve_string_property(prop_name, prop_atom)
                 }
@@ -1052,7 +1028,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
             // ThisType: represents 'this' type in a class/interface context
             // Should be resolved to the actual class type by the checker
             TypeData::ThisType => {
-                let prop_atom = prop_atom;
                 if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {
                     return result;
                 }
@@ -1068,7 +1043,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 let _guard = match self.enter_property_access_guard(obj_type) {
                     Some(guard) => guard,
                     None => {
-                        let prop_atom = prop_atom;
                         return self
                             .resolve_object_member_or_not_found(obj_type, prop_name, prop_atom);
                     }
@@ -1089,7 +1063,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
                     self.resolve_property_access_inner(resolved, prop_name, Some(prop_atom))
                 } else {
                     // Can't resolve lazy type - try apparent members
-                    let prop_atom = prop_atom;
                     if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {
                         result
                     } else {
@@ -1107,14 +1080,10 @@ impl<'a> PropertyAccessEvaluator<'a> {
             }
 
             // StringIntrinsic (Uppercase<T>, Lowercase<T>, etc.) — resolve as string
-            TypeData::StringIntrinsic { .. } => {
-                let prop_atom = prop_atom;
-                self.resolve_string_property(prop_name, prop_atom)
-            }
+            TypeData::StringIntrinsic { .. } => self.resolve_string_property(prop_name, prop_atom),
 
             _ => {
                 // Unknown type key - try apparent members before giving up
-                let prop_atom = prop_atom;
                 if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {
                     return result;
                 }

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -855,7 +855,9 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 LiteralValue::BigInt(_) => self.resolve_bigint_property(prop_name, prop_atom),
             },
 
-            TypeData::TemplateLiteral(_) => self.resolve_string_property(prop_name, prop_atom),
+            TypeData::TemplateLiteral(_) | TypeData::StringIntrinsic { .. } => {
+                self.resolve_string_property(prop_name, prop_atom)
+            }
 
             // Application: handle nominally (preserve class/interface identity)
             TypeData::Application(app_id) => {
@@ -1080,8 +1082,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
             }
 
             // StringIntrinsic (Uppercase<T>, Lowercase<T>, etc.) — resolve as string
-            TypeData::StringIntrinsic { .. } => self.resolve_string_property(prop_name, prop_atom),
-
             _ => {
                 // Unknown type key - try apparent members before giving up
                 if let Some(result) = self.resolve_object_member(prop_name, prop_atom) {

--- a/crates/tsz-solver/src/operations/property.rs
+++ b/crates/tsz-solver/src/operations/property.rs
@@ -188,9 +188,9 @@ pub struct PropertyAccessEvaluator<'a> {
     pub(crate) exact_optional_property_types: bool,
     /// Unified recursion guard for cycle detection and depth limiting.
     pub(crate) guard: RefCell<crate::recursion::RecursionGuard<TypeId>>,
-    // Context for visitor pattern (set during property access resolution)
-    // We store both the str (for immediate use) and Atom (for interned comparisons)
-    pub(crate) current_prop_name: RefCell<Option<String>>,
+    // Context for visitor pattern (set during property access resolution).
+    // Keep the interned property identity in the recursive hot path; string-only
+    // leaf helpers receive `prop_name` directly from the current stack frame.
     pub(crate) current_prop_atom: RefCell<Option<Atom>>,
     /// When true, `bind_object_receiver_this` is a no-op. Set when resolving
     /// properties through a type parameter's constraint so that `this` is
@@ -223,7 +223,6 @@ impl<'a> PropertyAccessEvaluator<'a> {
             guard: RefCell::new(crate::recursion::RecursionGuard::with_profile(
                 crate::recursion::RecursionProfile::PropertyAccess,
             )),
-            current_prop_name: RefCell::new(None),
             current_prop_atom: RefCell::new(None),
             skip_this_binding: Cell::new(false),
             allow_private_identifier_properties: Cell::new(false),
@@ -363,7 +362,22 @@ impl<'a> PropertyAccessEvaluator<'a> {
         obj_type: TypeId,
         prop_name: &str,
     ) -> PropertyAccessResult {
-        let result = self.resolve_property_access_inner(obj_type, prop_name, None);
+        let prop_atom = self.interner().intern_string(prop_name);
+        self.resolve_property_access_with_atom(obj_type, prop_name, prop_atom)
+    }
+
+    /// Resolve property access when the caller already has the interned property name.
+    ///
+    /// This is the hot query-cache path: the cache key is keyed by `Atom`, so
+    /// preserve that identity through evaluator recursion and avoid rebuilding
+    /// a side-channel `String` for visitor context.
+    pub(crate) fn resolve_property_access_with_atom(
+        &self,
+        obj_type: TypeId,
+        prop_name: &str,
+        prop_atom: Atom,
+    ) -> PropertyAccessResult {
+        let result = self.resolve_property_access_inner(obj_type, prop_name, Some(prop_atom));
 
         // For deferred conditionals: when the inner resolver returned ANY (the deferred
         // fallback), check the apparent type — union of branches — to detect genuine
@@ -402,9 +416,8 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 // of branches) to check whether the property genuinely exists.
                 // union2 normalises any|T→any and never|T→T.
                 let apparent = self.interner().union2(cond.true_type, cond.false_type);
-                match self.resolve_property_access_inner(apparent, prop_name, None) {
+                match self.resolve_property_access_inner(apparent, prop_name, Some(prop_atom)) {
                     PropertyAccessResult::PropertyNotFound { .. } => {
-                        let prop_atom = self.interner().intern_string(prop_name);
                         return PropertyAccessResult::PropertyNotFound {
                             type_id: obj_type,
                             property_name: prop_atom,
@@ -446,16 +459,9 @@ impl<'a> PropertyAccessEvaluator<'a> {
     ) -> PropertyAccessResult {
         // Milestone 2: Visitor Bridge Pattern
         // Set context for visitor methods
-        {
-            let mut current_name = self.current_prop_name.borrow_mut();
-            if let Some(name) = current_name.as_mut() {
-                name.clear();
-                name.push_str(prop_name);
-            } else {
-                *current_name = Some(prop_name.to_owned());
-            }
-        }
-        *self.current_prop_atom.borrow_mut() = prop_atom;
+        let prop_atom = prop_atom.unwrap_or_else(|| self.interner().intern_string(prop_name));
+        *self.current_prop_atom.borrow_mut() = Some(prop_atom);
+        let prop_atom = Some(prop_atom);
 
         // Single-lookup dispatch: resolve property access based on type data.
         // All type variants are handled in one match to avoid redundant interner lookups.

--- a/crates/tsz-solver/src/operations/property_visitor.rs
+++ b/crates/tsz-solver/src/operations/property_visitor.rs
@@ -34,12 +34,7 @@ impl<'a> TypeVisitor for &PropertyAccessEvaluator<'a> {
             IntrinsicKind::Void => {
                 // In tsc, accessing a property on `void` produces TS2339
                 // ("Property 'X' does not exist on type 'void'"), NOT TS2532.
-                let prop_atom = self.current_prop_atom.borrow();
-                let atom = prop_atom.unwrap_or_else(|| {
-                    let prop_name = self.current_prop_name.borrow();
-                    self.interner()
-                        .intern_string(prop_name.as_deref().unwrap_or(""))
-                });
+                let (_, atom) = self.current_property_context()?;
                 Some(PropertyAccessResult::PropertyNotFound {
                     type_id: TypeId::VOID,
                     property_name: atom,
@@ -58,48 +53,26 @@ impl<'a> TypeVisitor for &PropertyAccessEvaluator<'a> {
             }
             // Handle primitive intrinsic types by delegating to their boxed interfaces
             IntrinsicKind::String => {
-                let prop_name = self.current_prop_name.borrow();
-                let prop_atom = self.current_prop_atom.borrow();
-                match (prop_name.as_deref(), prop_atom.as_ref()) {
-                    (Some(name), Some(&atom)) => Some(self.resolve_string_property(name, atom)),
-                    _ => None,
-                }
+                let (prop_name, prop_atom) = self.current_property_context()?;
+                Some(self.resolve_string_property(prop_name.as_ref(), prop_atom))
             }
             IntrinsicKind::Number => {
-                let prop_name = self.current_prop_name.borrow();
-                let prop_atom = self.current_prop_atom.borrow();
-                match (prop_name.as_deref(), prop_atom.as_ref()) {
-                    (Some(name), Some(&atom)) => Some(self.resolve_number_property(name, atom)),
-                    _ => None,
-                }
+                let (prop_name, prop_atom) = self.current_property_context()?;
+                Some(self.resolve_number_property(prop_name.as_ref(), prop_atom))
             }
             IntrinsicKind::Boolean => {
-                let prop_name = self.current_prop_name.borrow();
-                let prop_atom = self.current_prop_atom.borrow();
-                match (prop_name.as_deref(), prop_atom.as_ref()) {
-                    (Some(name), Some(&atom)) => Some(self.resolve_boolean_property(name, atom)),
-                    _ => None,
-                }
+                let (prop_name, prop_atom) = self.current_property_context()?;
+                Some(self.resolve_boolean_property(prop_name.as_ref(), prop_atom))
             }
             IntrinsicKind::Bigint => {
-                let prop_name = self.current_prop_name.borrow();
-                let prop_atom = self.current_prop_atom.borrow();
-                match (prop_name.as_deref(), prop_atom.as_ref()) {
-                    (Some(name), Some(&atom)) => Some(self.resolve_bigint_property(name, atom)),
-                    _ => None,
-                }
+                let (prop_name, prop_atom) = self.current_property_context()?;
+                Some(self.resolve_bigint_property(prop_name.as_ref(), prop_atom))
             }
             // Symbol intrinsic is handled separately (has special properties)
             IntrinsicKind::Symbol => {
                 // Get the property name from context
-                let prop_name = self.current_prop_name.borrow();
-                let prop_atom = self.current_prop_atom.borrow();
-                match (prop_name.as_deref(), prop_atom.as_ref()) {
-                    (Some(name), Some(&atom)) => {
-                        Some(self.resolve_symbol_primitive_property(name, atom))
-                    }
-                    _ => None,
-                }
+                let (prop_name, prop_atom) = self.current_property_context()?;
+                Some(self.resolve_symbol_primitive_property(prop_name.as_ref(), prop_atom))
             }
             // Other intrinsics (Object, etc.) fall back to None
             _ => None,
@@ -109,14 +82,8 @@ impl<'a> TypeVisitor for &PropertyAccessEvaluator<'a> {
     fn visit_literal(&mut self, value: &LiteralValue) -> Self::Output {
         use crate::types::LiteralValue;
 
-        let prop_name = self.current_prop_name.borrow();
-        let prop_atom_opt = self.current_prop_atom.borrow();
-
-        let prop_name = prop_name.as_deref()?;
-        let prop_atom = match prop_atom_opt.as_ref() {
-            Some(&atom) => atom,
-            None => self.interner().intern_string(prop_name),
-        };
+        let (prop_name, prop_atom) = self.current_property_context()?;
+        let prop_name = prop_name.as_ref();
 
         // Handle primitive literals by delegating to their boxed interface types
         match value {
@@ -130,14 +97,8 @@ impl<'a> TypeVisitor for &PropertyAccessEvaluator<'a> {
     fn visit_object(&mut self, shape_id: u32) -> Self::Output {
         use crate::objects::index_signatures::{IndexKind, IndexSignatureResolver};
 
-        let prop_name = self.current_prop_name.borrow();
-        let prop_atom_opt = self.current_prop_atom.borrow();
-
-        let prop_name = prop_name.as_deref()?;
-        let prop_atom = match prop_atom_opt.as_ref() {
-            Some(&atom) => atom,
-            None => self.interner().intern_string(prop_name),
-        };
+        let (prop_name, prop_atom) = self.current_property_context()?;
+        let prop_name = prop_name.as_ref();
 
         let shape = self.interner().object_shape(ObjectShapeId(shape_id));
         // PERF: Reuse existing interned type for this shape instead of cloning
@@ -211,14 +172,8 @@ impl<'a> TypeVisitor for &PropertyAccessEvaluator<'a> {
     fn visit_object_with_index(&mut self, shape_id: u32) -> Self::Output {
         use crate::objects::index_signatures::IndexSignatureResolver;
 
-        let prop_name = self.current_prop_name.borrow();
-        let prop_atom_opt = self.current_prop_atom.borrow();
-
-        let prop_name = prop_name.as_deref()?;
-        let prop_atom = match prop_atom_opt.as_ref() {
-            Some(&atom) => atom,
-            None => self.interner().intern_string(prop_name),
-        };
+        let (prop_name, prop_atom) = self.current_property_context()?;
+        let prop_name = prop_name.as_ref();
 
         let shape = self.interner().object_shape(ObjectShapeId(shape_id));
         let obj_type = self
@@ -286,14 +241,8 @@ impl<'a> TypeVisitor for &PropertyAccessEvaluator<'a> {
     }
 
     fn visit_array(&mut self, element_type: TypeId) -> Self::Output {
-        let prop_name = self.current_prop_name.borrow();
-        let prop_atom_opt = self.current_prop_atom.borrow();
-
-        let prop_name = prop_name.as_deref()?;
-        let prop_atom = match prop_atom_opt.as_ref() {
-            Some(&atom) => atom,
-            None => self.interner().intern_string(prop_name),
-        };
+        let (prop_name, prop_atom) = self.current_property_context()?;
+        let prop_name = prop_name.as_ref();
 
         // Reconstruct obj_type for resolve_array_property
         let obj_type = self.interner().array(element_type);
@@ -301,14 +250,8 @@ impl<'a> TypeVisitor for &PropertyAccessEvaluator<'a> {
     }
 
     fn visit_tuple(&mut self, list_id: u32) -> Self::Output {
-        let prop_name = self.current_prop_name.borrow();
-        let prop_atom_opt = self.current_prop_atom.borrow();
-
-        let prop_name = prop_name.as_deref()?;
-        let prop_atom = match prop_atom_opt.as_ref() {
-            Some(&atom) => atom,
-            None => self.interner().intern_string(prop_name),
-        };
+        let (prop_name, prop_atom) = self.current_property_context()?;
+        let prop_name = prop_name.as_ref();
 
         // Reconstruct obj_type for resolve_array_property
         let obj_type = self
@@ -320,14 +263,8 @@ impl<'a> TypeVisitor for &PropertyAccessEvaluator<'a> {
     fn visit_template_literal(&mut self, _template_id: u32) -> Self::Output {
         // Template literals are string-like for property access
         // They support the same properties as the String interface
-        let prop_name = self.current_prop_name.borrow();
-        let prop_atom_opt = self.current_prop_atom.borrow();
-
-        let prop_name = prop_name.as_deref()?;
-        let prop_atom = match prop_atom_opt.as_ref() {
-            Some(&atom) => atom,
-            None => self.interner().intern_string(prop_name),
-        };
+        let (prop_name, prop_atom) = self.current_property_context()?;
+        let prop_name = prop_name.as_ref();
 
         Some(self.resolve_string_property(prop_name, prop_atom))
     }
@@ -339,25 +276,16 @@ impl<'a> TypeVisitor for &PropertyAccessEvaluator<'a> {
     ) -> Self::Output {
         // String intrinsics (Uppercase<T>, Lowercase<T>, Capitalize<T>, etc.)
         // are string-like for property access
-        let prop_name = self.current_prop_name.borrow();
-        let prop_atom_opt = self.current_prop_atom.borrow();
-
-        let prop_name = prop_name.as_deref()?;
-        let prop_atom = match prop_atom_opt.as_ref() {
-            Some(&atom) => atom,
-            None => self.interner().intern_string(prop_name),
-        };
+        let (prop_name, prop_atom) = self.current_property_context()?;
+        let prop_name = prop_name.as_ref();
 
         Some(self.resolve_string_property(prop_name, prop_atom))
     }
 
     fn visit_union(&mut self, list_id: u32) -> Self::Output {
-        let prop_name = self.current_prop_name.borrow();
-        let prop_atom_opt = self.current_prop_atom.borrow();
+        let (prop_name, prop_atom) = self.current_property_context()?;
 
-        let prop_name = prop_name.as_deref()?;
-
-        self.visit_union_impl(list_id, prop_name, prop_atom_opt.as_ref().copied())
+        self.visit_union_impl(list_id, prop_name.as_ref(), Some(prop_atom))
     }
 
     fn default_output() -> Self::Output {


### PR DESCRIPTION
Goal: fast

## Summary
- Preserve the property-name `Atom` that callers already intern for solver property access.
- Remove the recursive evaluator's `String` side-channel for current property context.
- Route `QueryCache` misses through an Atom-aware evaluator entry point so the cache key's interned name is reused instead of rediscovered.
- Update the legacy `property_visitor` bridge to derive text from the current `Atom` only at string-only helper leaves.
- Fix the Clippy `unnecessary_literal_unwrap` failure by keeping `prop_atom` as a concrete `Atom` after the optional caller input is normalized.
- Fix draft `dist-binaries` compile failures by wrapping normalized recursive `Atom` values back into `Some(prop_atom)` for APIs that still accept optional atoms.
- Fix draft `lint` redundant-local failures after normalization by removing stale `let prop_atom = prop_atom;` shadow scaffolding.
- Fix draft `lint` duplicate-match-arm failure by merging identical string-property primitive arms.

## Structural rule / owner layer
When a property lookup name is already interned as an `Atom`, tsz should keep that stable identity through solver property-access recursion and resolve text only at string-only leaf helpers. The owner is the solver property-access/query-cache boundary; checker behavior and diagnostics are unchanged.

## Cache / performance invariant
The cached semantic question remains `(object_type, property_atom, no_unchecked_indexed_access, exact_optional_property_types) -> PropertyAccessResult`. This slice does not widen residency or share results across sessions; it removes per-miss string side-channel churn and duplicate atom lookup on the `QueryCache` miss path while keeping `&str` leaf APIs as the fallback boundary.

## Adjacent cases / fallback
- Existing `&str` APIs remain in place for checker and non-cache callers.
- Helper paths that need text resolve it from `Atom` at the visitor/string-only leaf boundary.
- Recursive calls keep passing the concrete `prop_atom` through object, union, mapped, application, primitive, readonly, and lazy fallback paths after the initial `Option<Atom>` input is normalized.

## Verification
- Draft `dist-binaries` failed at `4263a5a0e91dcd7a0af56bb92c9352fe6420f17d` with stale `current_prop_name` references in `property_visitor.rs`; fixed in `882318ad5c`.
- Draft `lint` failed at `882318ad5c` with `clippy::unnecessary_literal_unwrap` in `property.rs`; fixed in `88946d6334d47aff306577846b8ad93873556884`.
- Draft `dist-binaries` failed at `88946d6334d47aff306577846b8ad93873556884` with `E0308` optional-atom call mismatches in `property.rs`; fixed in `5f602b2313fa444f772fa633495a8bdb2c3e328c`.
- Draft `dist-binaries` failed at `5f602b2313fa444f772fa633495a8bdb2c3e328c` with remaining `E0308` optional-atom visitor calls for arrays and unions in `property.rs`; fixed in `77c2caae9fbfab129551c7648b2086274a88c0f9`.
- Draft `lint` failed at `77c2caae9fbfab129551c7648b2086274a88c0f9` with `clippy::redundant_locals` for normalized `prop_atom` shadow scaffolding in `property.rs`; fixed in `e1f0a483393d096fcc4d86738a1c43f0ff057fd8`.
- Draft `lint` failed at `e1f0a483393d096fcc4d86738a1c43f0ff057fd8` with `clippy::match_same_arms` for identical primitive string-property arms in `property.rs`; fixed in `5ce296e69bb753f596a6658ca80b1ab2c843a0c2`.
- Branch sync: `git fetch origin main && git merge --no-edit origin/main` reported `Already up to date` after `e1f0a483393d096fcc4d86738a1c43f0ff057fd8`.
- Draft CI/light run 27415180815 passed at exact head `5ce296e69bb753f596a6658ca80b1ab2c843a0c2`.
- Local tests not run per instruction.
- Ready-review CI is now expected to run the full PR-head gate before merge queue.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: medium
