### PR TITLE
perf(binder): add atom-backed symbol table lookups

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -6,6 +6,7 @@
 use crate::state::FileFeatures;
 use crate::{ContainerKind, FlowNodeId, SymbolId, SymbolTable, symbol_flags};
 use std::sync::Arc;
+use tsz_common::interner::AstAtom;
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::node_flags;
 use tsz_parser::parser::syntax_kind_ext;
@@ -28,6 +29,12 @@ pub(crate) struct SemanticDefDetails {
 }
 
 impl BinderState {
+    fn identifier_atom(arena: &NodeArena, index: NodeIndex) -> Option<AstAtom> {
+        arena
+            .get_identifier_at(index)
+            .and_then(|ident| (ident.atom != AstAtom::NONE).then_some(ident.atom))
+    }
+
     /// Append a `(name, declaration)` entry to the `module_augmentations`
     /// table for the given target module specifier.
     pub(crate) fn record_module_augmentation_entry(
@@ -158,7 +165,14 @@ impl BinderState {
                         .push(crate::state::GlobalAugmentation::new(idx, flags));
                 }
 
-                let sym_id = self.declare_symbol(arena, name, flags, idx, is_exported);
+                let sym_id = self.declare_symbol_with_atom(
+                    arena,
+                    name,
+                    Self::identifier_atom(arena, decl.name),
+                    flags,
+                    idx,
+                    is_exported,
+                );
                 Arc::make_mut(&mut self.node_symbols).insert(decl.name.0, sym_id);
                 self.record_semantic_def(
                     sym_id,
@@ -249,8 +263,14 @@ impl BinderState {
                         .push(crate::state::ModuleAugmentation::new(name.to_string(), idx));
                 }
 
-                let sym_id =
-                    self.declare_symbol(arena, name, symbol_flags::FUNCTION, idx, is_exported);
+                let sym_id = self.declare_symbol_with_atom(
+                    arena,
+                    name,
+                    Self::identifier_atom(arena, func.name),
+                    symbol_flags::FUNCTION,
+                    idx,
+                    is_exported,
+                );
                 if self.in_global_augmentation {
                     self.record_global_value_augmentation(
                         name,
@@ -314,9 +334,10 @@ impl BinderState {
             self.bind_modifiers(arena, param.modifiers.as_ref());
             if let Some(name) = Self::get_identifier_name(arena, param.name) {
                 tracing::debug!(param_name = %name, param_name_idx = param.name.0, "Binding parameter");
-                let sym_id = self.declare_symbol(
+                let sym_id = self.declare_symbol_with_atom(
                     arena,
                     name,
+                    Self::identifier_atom(arena, param.name),
                     symbol_flags::FUNCTION_SCOPED_VARIABLE,
                     idx,
                     false,
@@ -389,7 +410,14 @@ impl BinderState {
             }
             // Use the parameter node as the declaration so the checker can
             // distinguish parameter-property PROPERTY symbols from regular ones.
-            self.declare_symbol(arena, name, flags, param_idx, false);
+            self.declare_symbol_with_atom(
+                arena,
+                name,
+                Self::identifier_atom(arena, param.name),
+                flags,
+                param_idx,
+                false,
+            );
         }
     }
 
@@ -440,9 +468,10 @@ impl BinderState {
                         type_param_name = %name,
                         "Binding type parameter"
                     );
-                    let sym_id = self.declare_symbol(
+                    let sym_id = self.declare_symbol_with_atom(
                         arena,
                         name,
+                        Self::identifier_atom(arena, type_param.name),
                         symbol_flags::TYPE_PARAMETER,
                         param_idx,
                         false,
@@ -1029,8 +1058,14 @@ impl BinderState {
                 return;
             }
 
-            let sym_id =
-                self.declare_symbol(arena, name, symbol_flags::INTERFACE, idx, is_exported);
+            let sym_id = self.declare_symbol_with_atom(
+                arena,
+                name,
+                Self::identifier_atom(arena, iface.name),
+                symbol_flags::INTERFACE,
+                idx,
+                is_exported,
+            );
             let tp_count = iface
                 .type_parameters
                 .as_ref()
@@ -1207,8 +1242,14 @@ impl BinderState {
                     },
                 );
             } else {
-                let sym_id =
-                    self.declare_symbol(arena, name, symbol_flags::TYPE_ALIAS, idx, is_exported);
+                let sym_id = self.declare_symbol_with_atom(
+                    arena,
+                    name,
+                    Self::identifier_atom(arena, alias.name),
+                    symbol_flags::TYPE_ALIAS,
+                    idx,
+                    is_exported,
+                );
                 let tp_count = alias
                     .type_parameters
                     .as_ref()
@@ -1261,7 +1302,14 @@ impl BinderState {
                 symbol_flags::REGULAR_ENUM
             };
 
-            let enum_sym_id = self.declare_symbol(arena, name, enum_flags, idx, is_exported);
+            let enum_sym_id = self.declare_symbol_with_atom(
+                arena,
+                name,
+                Self::identifier_atom(arena, enum_decl.name),
+                enum_flags,
+                idx,
+                is_exported,
+            );
 
             // Collect enum member names at bind time for stable identity.
             let enum_member_names: Vec<String> = enum_decl

--- a/crates/tsz-binder/src/modules/binding.rs
+++ b/crates/tsz-binder/src/modules/binding.rs
@@ -7,12 +7,19 @@ use crate::binding::SemanticDefDetails;
 use crate::state::BinderState;
 use crate::{ContainerKind, Symbol, SymbolId, SymbolTable, symbol_flags};
 use std::sync::Arc;
+use tsz_common::interner::AstAtom;
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
 
 impl BinderState {
+    fn module_identifier_atom(arena: &NodeArena, index: NodeIndex) -> Option<AstAtom> {
+        arena
+            .get_identifier_at(index)
+            .and_then(|ident| (ident.atom != AstAtom::NONE).then_some(ident.atom))
+    }
+
     /// Check if `idx` is nested inside an ambient module (one with `declare` or
     /// a string-literal name). Walks up through `MODULE_BLOCK` / `MODULE_DECLARATION`
     /// ancestors until it finds one that is ambient or reaches the source file.
@@ -197,6 +204,7 @@ impl BinderState {
                 // (TS1437: "Namespace must be given a name"). Treat empty name as None
                 // so the anonymous module promotion logic kicks in.
                 .filter(|n| !n.is_empty());
+            let name_atom = Self::module_identifier_atom(arena, module.name);
             let mut prior_exports: Option<SymbolTable> = None;
             let mut module_symbol_id = SymbolId::NONE;
             if let Some(name) = name {
@@ -228,7 +236,8 @@ impl BinderState {
                 }
 
                 let flags = symbol_flags::VALUE_MODULE | symbol_flags::NAMESPACE_MODULE;
-                module_symbol_id = self.declare_symbol(arena, &name, flags, idx, is_exported);
+                module_symbol_id =
+                    self.declare_symbol_with_atom(arena, &name, name_atom, flags, idx, is_exported);
                 let is_declare = Self::has_declare_modifier(arena, module.modifiers.as_ref());
                 self.record_semantic_def_with_declare(
                     module_symbol_id,
@@ -250,7 +259,8 @@ impl BinderState {
                 // to cross-file resolution and the checker cannot resolve
                 // JSX.IntrinsicElements, causing false-positive TS7026 diagnostics.
                 if self.in_global_augmentation {
-                    self.file_locals.set(name.clone(), module_symbol_id);
+                    self.file_locals
+                        .set_with_atom(name.clone(), name_atom, module_symbol_id);
                 }
 
                 prior_exports = self
@@ -272,7 +282,11 @@ impl BinderState {
                         .get(child_id)
                         .is_some_and(|s| s.flags & symbol_flags::ENUM_MEMBER != 0);
                     if !is_enum_member {
-                        self.current_scope.set(name.clone(), child_id);
+                        self.current_scope.set_with_atom(
+                            name.clone(),
+                            exports.atom_for_symbol(child_id),
+                            child_id,
+                        );
                     }
                 }
             }
@@ -344,14 +358,20 @@ impl BinderState {
             // `namespace Outer { module { export function f() {} } }` makes `Outer.f`
             // visible.  Collect the exported symbols before exiting so we can promote
             // them to the parent scope afterwards.
-            let anon_promoted: Vec<(String, SymbolId)> =
+            let anon_promoted: Vec<(String, Option<AstAtom>, SymbolId)> =
                 if module_symbol_id.is_none() && module.body.is_some() {
                     // Promote ALL symbols — since the module has no name, there is
                     // nothing to export FROM. TSC treats the body as if it were
                     // written directly in the enclosing scope.
                     self.current_scope
                         .iter()
-                        .map(|(name, &sym_id)| (name.clone(), sym_id))
+                        .map(|(name, &sym_id)| {
+                            (
+                                name.clone(),
+                                self.current_scope.atom_for_symbol(sym_id),
+                                sym_id,
+                            )
+                        })
                         .collect()
                 } else {
                     Vec::new()
@@ -376,8 +396,8 @@ impl BinderState {
             // After exiting the anonymous module scope, promote exported symbols
             // into the parent (enclosing namespace) scope so they are accessible
             // as members of the parent namespace.
-            for (name, sym_id) in anon_promoted {
-                self.current_scope.set(name, sym_id);
+            for (name, name_atom, sym_id) in anon_promoted {
+                self.current_scope.set_with_atom(name, name_atom, sym_id);
                 // Mark as exported so the parent namespace's exit_scope includes
                 // them in its exports table (they're effectively declared inline
                 // in the parent scope).
@@ -855,11 +875,15 @@ impl BinderState {
 
                     // Now add them to exports
                     for (name, sym_id) in &exported_symbols {
+                        let name_atom = self
+                            .current_scope
+                            .atom_for_symbol(*sym_id)
+                            .or_else(|| self.file_locals.atom_for_symbol(*sym_id));
                         if let Some(module_sym) = self.symbols.get_mut(module_symbol_id) {
                             let exports = module_sym
                                 .exports
                                 .get_or_insert_with(|| Box::new(SymbolTable::new()));
-                            exports.set(name.clone(), *sym_id);
+                            exports.set_with_atom(name.clone(), name_atom, *sym_id);
                         }
                         if let Some(child_sym) = self.symbols.get_mut(*sym_id) {
                             child_sym.is_exported = true;
@@ -895,11 +919,15 @@ impl BinderState {
                             {
                                 sym_id = type_sym_id;
                             }
+                            let name_atom = self
+                                .current_scope
+                                .atom_for_symbol(sym_id)
+                                .or_else(|| self.file_locals.atom_for_symbol(sym_id));
                             if let Some(module_sym) = self.symbols.get_mut(module_symbol_id) {
                                 let exports = module_sym
                                     .exports
                                     .get_or_insert_with(|| Box::new(SymbolTable::new()));
-                                exports.set(name.clone(), sym_id);
+                                exports.set_with_atom(name.clone(), name_atom, sym_id);
                             }
                             // Mark the child symbol as exported
                             if let Some(child_sym) = self.symbols.get_mut(sym_id) {

--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -6,12 +6,19 @@
 use crate::state::BinderState;
 use crate::{ContainerKind, SymbolTable, symbol_flags};
 use std::sync::Arc;
+use tsz_common::interner::AstAtom;
 use tsz_parser::NodeIndex;
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
 impl BinderState {
+    fn import_export_identifier_atom(arena: &NodeArena, index: NodeIndex) -> Option<AstAtom> {
+        arena
+            .get_identifier_at(index)
+            .and_then(|ident| (ident.atom != AstAtom::NONE).then_some(ident.atom))
+    }
+
     pub(crate) fn bind_import_declaration(
         &mut self,
         arena: &NodeArena,
@@ -49,9 +56,10 @@ impl BinderState {
             && let Some(name) = Self::get_identifier_name(arena, clause.name)
         {
             // Use import_clause node as the declaration node
-            let sym_id = self.declare_symbol(
+            let sym_id = self.declare_symbol_with_atom(
                 arena,
                 name,
+                Self::import_export_identifier_atom(arena, clause.name),
                 symbol_flags::ALIAS,
                 import.import_clause,
                 false,
@@ -75,9 +83,10 @@ impl BinderState {
         {
             if bindings_node.kind == SyntaxKind::Identifier as u16 {
                 if let Some(name) = Self::get_identifier_name(arena, clause.named_bindings) {
-                    let sym_id = self.declare_symbol(
+                    let sym_id = self.declare_symbol_with_atom(
                         arena,
                         name,
+                        Self::import_export_identifier_atom(arena, clause.named_bindings),
                         symbol_flags::ALIAS,
                         clause.named_bindings,
                         false,
@@ -97,9 +106,10 @@ impl BinderState {
                     && let Some(name) = Self::get_identifier_name(arena, named.name)
                 {
                     // Use named_bindings (NamespaceImport) as the declaration node
-                    let sym_id = self.declare_symbol(
+                    let sym_id = self.declare_symbol_with_atom(
                         arena,
                         name,
+                        Self::import_export_identifier_atom(arena, named.name),
                         symbol_flags::ALIAS,
                         clause.named_bindings,
                         false,
@@ -135,8 +145,14 @@ impl BinderState {
                         continue;
                     };
 
-                    let sym_id =
-                        self.declare_symbol(arena, name, symbol_flags::ALIAS, spec_idx, false);
+                    let sym_id = self.declare_symbol_with_atom(
+                        arena,
+                        name,
+                        Self::import_export_identifier_atom(arena, local_ident),
+                        symbol_flags::ALIAS,
+                        spec_idx,
+                        false,
+                    );
 
                     // Get property name before mutable borrow to avoid borrow checker error
                     let prop_name = if spec.name.is_some() && spec.property_name.is_some() {
@@ -201,8 +217,15 @@ impl BinderState {
                 }
 
                 // Create symbol with ALIAS flag
-                let sym_id =
-                    self.declare_symbol(arena, name, symbol_flags::ALIAS, idx, is_exported);
+                let name_atom = Self::import_export_identifier_atom(arena, import.import_clause);
+                let sym_id = self.declare_symbol_with_atom(
+                    arena,
+                    name,
+                    name_atom,
+                    symbol_flags::ALIAS,
+                    idx,
+                    is_exported,
+                );
 
                 if let Some(sym) = self.symbols.get_mut(sym_id) {
                     let span = arena.get(idx).map(|node| (node.pos, node.end));
@@ -233,7 +256,8 @@ impl BinderState {
                 // We still need to explicit export handling if declare_symbol didn't handle it fully?
                 // declare_symbol takes is_exported flag.
                 if self.in_global_augmentation {
-                    self.file_locals.set(name.to_string(), sym_id);
+                    self.file_locals
+                        .set_with_atom(name.to_string(), name_atom, sym_id);
                     Arc::make_mut(&mut self.global_augmentations)
                         .entry(name.to_string())
                         .or_default()
@@ -475,6 +499,11 @@ impl BinderState {
                                 } else {
                                     Self::get_identifier_or_string_literal_name(arena, spec.name)
                                 };
+                                let exported_atom = if spec.name.is_none() {
+                                    Self::import_export_identifier_atom(arena, spec.property_name)
+                                } else {
+                                    Self::import_export_identifier_atom(arena, spec.name)
+                                };
 
                                 if let (Some(orig), Some(exp)) = (original_name, exported_name) {
                                     // Resolve the original symbol in the current scope
@@ -547,7 +576,11 @@ impl BinderState {
                                                         ns_sym.exports.get_or_insert_with(|| {
                                                             Box::new(SymbolTable::new())
                                                         });
-                                                    exports.set(exp.to_string(), sym_id);
+                                                    exports.set_with_atom(
+                                                        exp.to_string(),
+                                                        exported_atom,
+                                                        sym_id,
+                                                    );
                                                 }
                                             } else if let Some(parent_id) = container_sym {
                                                 sym.parent = parent_id;
@@ -601,11 +634,27 @@ impl BinderState {
                                                 clone_sym.is_type_only = true;
                                                 clone_sym.is_exported = true;
                                             }
-                                            self.current_scope.set(exp.to_string(), clone_id);
-                                            self.file_locals.set(exp.to_string(), clone_id);
+                                            self.current_scope.set_with_atom(
+                                                exp.to_string(),
+                                                exported_atom,
+                                                clone_id,
+                                            );
+                                            self.file_locals.set_with_atom(
+                                                exp.to_string(),
+                                                exported_atom,
+                                                clone_id,
+                                            );
                                         } else if orig != exp {
-                                            self.current_scope.set(exp.to_string(), sym_id);
-                                            self.file_locals.set(exp.to_string(), sym_id);
+                                            self.current_scope.set_with_atom(
+                                                exp.to_string(),
+                                                exported_atom,
+                                                sym_id,
+                                            );
+                                            self.file_locals.set_with_atom(
+                                                exp.to_string(),
+                                                exported_atom,
+                                                sym_id,
+                                            );
                                         }
                                     }
                                 }
@@ -633,6 +682,7 @@ impl BinderState {
                             // and `Bar` value-bearing (matches tsc's TS1361/TS1362).
                             struct ReexportSpec {
                                 exported: String,
+                                exported_atom: Option<AstAtom>,
                                 original: Option<String>,
                                 spec_idx: NodeIndex,
                                 is_type_only: bool,
@@ -661,10 +711,19 @@ impl BinderState {
                                     } else {
                                         None
                                     };
+                                    let exported_atom = if spec.name.is_some() {
+                                        Self::import_export_identifier_atom(arena, spec.name)
+                                    } else {
+                                        Self::import_export_identifier_atom(
+                                            arena,
+                                            spec.property_name,
+                                        )
+                                    };
 
                                     if let Some(exported) = exported_name.or(original_name) {
                                         reexport_specs.push(ReexportSpec {
                                             exported: exported.to_string(),
+                                            exported_atom,
                                             original: original_name
                                                 .map(std::string::ToString::to_string),
                                             spec_idx,
@@ -694,9 +753,10 @@ impl BinderState {
                                         .insert(spec.spec_idx.0, existing_id);
                                     continue;
                                 }
-                                let sym_id = self.declare_symbol(
+                                let sym_id = self.declare_symbol_with_atom(
                                     arena,
                                     &spec.exported,
+                                    spec.exported_atom,
                                     symbol_flags::ALIAS | symbol_flags::EXPORT_VALUE,
                                     spec.spec_idx,
                                     true,
@@ -746,6 +806,8 @@ impl BinderState {
                 }
                 // Namespace export: export * as ns from 'mod'  OR  UMD: export as namespace Foo
                 else if let Some(name) = Self::get_identifier_name(arena, export.export_clause) {
+                    let name_atom =
+                        Self::import_export_identifier_atom(arena, export.export_clause);
                     let is_umd = export.module_specifier.is_none()
                         && node.kind == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION;
                     let container_sym = self
@@ -797,18 +859,22 @@ impl BinderState {
                     if let Some(type_alias_id) = existing_type_alias_id {
                         Arc::make_mut(&mut self.alias_partners).insert(type_alias_id, sym_id);
                     } else if is_umd {
-                        self.current_scope.set(name.to_string(), sym_id);
+                        self.current_scope
+                            .set_with_atom(name.to_string(), name_atom, sym_id);
                     }
                     Arc::make_mut(&mut self.node_symbols).insert(export.export_clause.0, sym_id);
 
                     if is_umd {
                         // UMD namespace exports register a global name.
                         // Add to file_locals + root scope so the name is visible cross-file.
-                        self.file_locals.set(name.to_string(), sym_id);
+                        self.file_locals
+                            .set_with_atom(name.to_string(), name_atom, sym_id);
                         if let Some(root_scope) = Arc::make_mut(&mut self.scopes).first_mut()
                             && !root_scope.table.has(name)
                         {
-                            root_scope.table.set(name.to_string(), sym_id);
+                            root_scope
+                                .table
+                                .set_with_atom(name.to_string(), name_atom, sym_id);
                         }
                     } else {
                         // Regular namespace re-export — add to module exports
@@ -816,7 +882,7 @@ impl BinderState {
                         Arc::make_mut(&mut self.module_exports)
                             .entry(current_file)
                             .or_default()
-                            .set(name.to_string(), sym_id);
+                            .set_with_atom(name.to_string(), name_atom, sym_id);
                     }
                 }
             }

--- a/crates/tsz-binder/src/nodes/binding.rs
+++ b/crates/tsz-binder/src/nodes/binding.rs
@@ -1322,6 +1322,18 @@ impl BinderState {
         let name_atom = arena.get_identifier_at(declaration).and_then(|ident| {
             (ident.atom != tsz_common::interner::AstAtom::NONE).then_some(ident.atom)
         });
+        self.declare_symbol_with_atom(arena, name, name_atom, flags, declaration, is_exported)
+    }
+
+    pub(crate) fn declare_symbol_with_atom(
+        &mut self,
+        arena: &NodeArena,
+        name: &str,
+        name_atom: Option<tsz_common::interner::AstAtom>,
+        flags: u32,
+        declaration: NodeIndex,
+        is_exported: bool,
+    ) -> SymbolId {
         if let Some(existing_id) = self.current_scope.get(name) {
             // Check if the existing symbol is in the local symbol table.
             // If not (e.g., it's from a lib binder), we should create a new local symbol

--- a/crates/tsz-binder/src/nodes/binding.rs
+++ b/crates/tsz-binder/src/nodes/binding.rs
@@ -1319,6 +1319,9 @@ impl BinderState {
         declaration: NodeIndex,
         is_exported: bool,
     ) -> SymbolId {
+        let name_atom = arena.get_identifier_at(declaration).and_then(|ident| {
+            (ident.atom != tsz_common::interner::AstAtom::NONE).then_some(ident.atom)
+        });
         if let Some(existing_id) = self.current_scope.get(name) {
             // Check if the existing symbol is in the local symbol table.
             // If not (e.g., it's from a lib binder), we should create a new local symbol
@@ -1344,12 +1347,14 @@ impl BinderState {
                     }
                 }
                 // Update current_scope to point to the local symbol (shadowing)
-                self.current_scope.set(owned_name.clone(), sym_id);
+                self.current_scope
+                    .set_with_atom(owned_name.clone(), name_atom, sym_id);
                 // CRITICAL: Also update file_locals to shadow lib symbol in file-level scope
                 // This ensures symbol resolution finds the local symbol instead of the lib one
-                self.file_locals.set(owned_name.clone(), sym_id);
+                self.file_locals
+                    .set_with_atom(owned_name.clone(), name_atom, sym_id);
                 Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-                self.declare_in_persistent_scope(owned_name, sym_id);
+                self.declare_in_persistent_scope_with_atom(owned_name, name_atom, sym_id);
                 return sym_id;
             }
 
@@ -1472,10 +1477,12 @@ impl BinderState {
                             .or_insert_with(|| lib_arenas.clone());
                     }
                 }
-                self.current_scope.set(owned_name.clone(), sym_id);
-                self.file_locals.set(owned_name.clone(), sym_id);
+                self.current_scope
+                    .set_with_atom(owned_name.clone(), name_atom, sym_id);
+                self.file_locals
+                    .set_with_atom(owned_name.clone(), name_atom, sym_id);
                 Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-                self.declare_in_persistent_scope(owned_name, sym_id);
+                self.declare_in_persistent_scope_with_atom(owned_name, name_atom, sym_id);
                 return sym_id;
             }
             // In merged namespace blocks, a non-exported variable must not merge with an
@@ -1511,9 +1518,10 @@ impl BinderState {
                         sym.parent = parent_id;
                     }
                 }
-                self.current_scope.set(owned_name.clone(), sym_id);
+                self.current_scope
+                    .set_with_atom(owned_name.clone(), name_atom, sym_id);
                 Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-                self.declare_in_persistent_scope(owned_name, sym_id);
+                self.declare_in_persistent_scope_with_atom(owned_name, name_atom, sym_id);
                 return sym_id;
             }
 
@@ -1547,9 +1555,10 @@ impl BinderState {
                         sym.parent = parent_id;
                     }
                 }
-                self.current_scope.set(owned_name.clone(), sym_id);
+                self.current_scope
+                    .set_with_atom(owned_name.clone(), name_atom, sym_id);
                 Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-                self.declare_in_persistent_scope(owned_name, sym_id);
+                self.declare_in_persistent_scope_with_atom(owned_name, name_atom, sym_id);
                 return sym_id;
             }
 
@@ -1610,7 +1619,7 @@ impl BinderState {
             }
 
             Arc::make_mut(&mut self.node_symbols).insert(declaration.0, existing_id);
-            self.declare_in_persistent_scope(name.to_string(), existing_id);
+            self.declare_in_persistent_scope_with_atom(name.to_string(), name_atom, existing_id);
             return existing_id;
         }
 
@@ -1640,7 +1649,7 @@ impl BinderState {
                     sym.is_exported = true;
                 }
             }
-            self.declare_in_persistent_scope(name.to_string(), existing_id);
+            self.declare_in_persistent_scope_with_atom(name.to_string(), name_atom, existing_id);
             return existing_id;
         }
 
@@ -1664,7 +1673,8 @@ impl BinderState {
                 sym.parent = parent_id;
             }
         }
-        self.current_scope.set(owned_name.clone(), sym_id);
+        self.current_scope
+            .set_with_atom(owned_name.clone(), name_atom, sym_id);
 
         // Keep source-file declarations visible through file_locals.
         // This is required for nested module scopes resolving references to
@@ -1682,11 +1692,12 @@ impl BinderState {
                 .get(self.current_scope_id.0 as usize)
                 .is_some_and(|scope| scope.kind == ContainerKind::SourceFile)
         {
-            self.file_locals.set(owned_name.clone(), sym_id);
+            self.file_locals
+                .set_with_atom(owned_name.clone(), name_atom, sym_id);
         }
 
         Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-        self.declare_in_persistent_scope(owned_name, sym_id);
+        self.declare_in_persistent_scope_with_atom(owned_name, name_atom, sym_id);
 
         // Record declaration event (new symbol)
         self.debugger

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -612,6 +612,15 @@ impl BinderState {
     /// Skipped during module augmentation to prevent augmented symbols from
     /// leaking into the augmenting file's scope (and subsequently into `file_locals/globals`).
     pub(crate) fn declare_in_persistent_scope(&mut self, name: String, sym_id: SymbolId) {
+        self.declare_in_persistent_scope_with_atom(name, None, sym_id);
+    }
+
+    pub(crate) fn declare_in_persistent_scope_with_atom(
+        &mut self,
+        name: String,
+        atom: Option<tsz_common::interner::AstAtom>,
+        sym_id: SymbolId,
+    ) {
         if self.in_module_augmentation {
             return;
         }
@@ -619,7 +628,7 @@ impl BinderState {
             && let Some(scope) =
                 Arc::make_mut(&mut self.scopes).get_mut(self.current_scope_id.0 as usize)
         {
-            scope.table.set(name, sym_id);
+            scope.table.set_with_atom(name, atom, sym_id);
         }
     }
 

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -1281,7 +1281,11 @@ impl BinderState {
                     if let Some(module_exports) = symbol.exports.as_ref() {
                         for (export_name, &export_sym_id) in module_exports.iter() {
                             if !file_exports.has(export_name) {
-                                file_exports.set(export_name.clone(), export_sym_id);
+                                file_exports.set_with_atom(
+                                    export_name.clone(),
+                                    module_exports.atom_for_symbol(export_sym_id),
+                                    export_sym_id,
+                                );
                             }
                         }
                     }
@@ -1306,7 +1310,11 @@ impl BinderState {
                     {
                         Arc::make_mut(&mut self.alias_partners).insert(sym_id, existing_id);
                     }
-                    file_exports.set(name.clone(), sym_id);
+                    file_exports.set_with_atom(
+                        name.clone(),
+                        self.file_locals.atom_for_symbol(sym_id),
+                        sym_id,
+                    );
                 }
             }
         }

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -53,15 +53,16 @@ pub type FileReexportsMap = FxHashMap<String, FileReexports>;
 /// Maps `current_file` -> `Vec<(source_module, is_type_only)>`.
 /// The `is_type_only` flag is `true` for `export type * from "X"` chains.
 pub type WildcardReexportsMap = FxHashMap<String, Vec<(String, bool)>>;
-type ExportCache = FxHashMap<(String, String), Option<SymbolId>>;
+type ExportCache = FxHashMap<String, FxHashMap<String, Option<SymbolId>>>;
 /// Cache for the type-only re-export resolver. Mirrors [`ExportCache`] but also
 /// records whether the resolution path crossed an `export type * from ...`
-/// wildcard (the `bool` in the value). Keyed by `(module_specifier,
-/// export_name)`. The result is a pure function of the request plus the
+/// wildcard (the `bool` in the value). Keyed by `module_specifier` then
+/// `export_name`, so cache-hit lookup can borrow request strings without
+/// allocating an owned tuple. The result is a pure function of the request plus the
 /// binder's immutable re-export tables, so it is safe to memoize for the
 /// lifetime of the binder and is cleared alongside [`ExportCache`] whenever
 /// resolution caches are invalidated.
-type ExportTypeOnlyCache = FxHashMap<(String, String), Option<(SymbolId, bool)>>;
+type ExportTypeOnlyCache = FxHashMap<String, FxHashMap<String, Option<(SymbolId, bool)>>>;
 type IdentifierCache = FxHashMap<(usize, u32), Option<SymbolId>>;
 /// Cache for [`BinderState::find_enclosing_scope`], keyed by
 /// `(arena_pointer, node_index)` -> the resolved enclosing [`ScopeId`].
@@ -1109,12 +1110,16 @@ impl BinderState {
                 .resolved_export_cache
                 .read()
                 .expect("resolved_export_cache RwLock poisoned")
-                .len(),
+                .values()
+                .map(FxHashMap::len)
+                .sum(),
             export_type_only_cache_entries: self
                 .resolved_export_type_only_cache
                 .read()
                 .expect("resolved_export_type_only_cache RwLock poisoned")
-                .len(),
+                .values()
+                .map(FxHashMap::len)
+                .sum(),
             identifier_cache_entries: self
                 .resolved_identifier_cache
                 .read()

--- a/crates/tsz-binder/src/state/resolution.rs
+++ b/crates/tsz-binder/src/state/resolution.rs
@@ -100,8 +100,8 @@ impl BinderState {
 
         let result = 'resolve: {
             // Get the identifier text
-            let name = if let Some(ident) = arena.get_identifier_at(node_idx) {
-                &ident.escaped_text
+            let (name, name_atom) = if let Some(ident) = arena.get_identifier_at(node_idx) {
+                (&ident.escaped_text, ident.atom)
             } else {
                 break 'resolve None;
             };
@@ -113,7 +113,7 @@ impl BinderState {
                 let mut scope_depth = 0;
                 while scope_id.is_some() {
                     if let Some(scope) = self.scopes.get(scope_id.0 as usize) {
-                        if let Some(sym_id) = scope.table.get(name) {
+                        if let Some(sym_id) = scope.table.get_by_atom_or_name(name_atom, name) {
                             debug!(
                                 "[RESOLVE] '{}' FOUND in scope at depth {} (id={})",
                                 name, scope_depth, sym_id.0
@@ -146,7 +146,7 @@ impl BinderState {
             }
 
             // Finally check file locals / globals
-            if let Some(sym_id) = self.file_locals.get(name) {
+            if let Some(sym_id) = self.file_locals.get_by_atom_or_name(name_atom, name) {
                 debug!(
                     "[RESOLVE] '{}' FOUND in file_locals (id={})",
                     name, sym_id.0
@@ -169,7 +169,7 @@ impl BinderState {
             // Chained lookup: check lib binders for global symbols
             // This enables resolving console, Array, Object, etc. from lib.d.ts
             for (i, lib_binder) in self.lib_binders.iter().enumerate() {
-                if let Some(sym_id) = lib_binder.file_locals.get(name) {
+                if let Some(sym_id) = lib_binder.file_locals.get_by_atom_or_name(name_atom, name) {
                     debug!(
                         "[RESOLVE] '{}' FOUND in lib_binder[{}] (id={}) - LIB SYMBOL",
                         name, i, sym_id.0
@@ -280,7 +280,9 @@ impl BinderState {
         F: FnMut(SymbolId) -> bool,
     {
         let node = arena.get(node_idx)?;
-        let name = arena.get_identifier(node)?.escaped_text.as_str();
+        let ident = arena.get_identifier(node)?;
+        let name = ident.escaped_text.as_str();
+        let name_atom = ident.atom;
 
         let mut consider =
             |sym_id: SymbolId| -> Option<SymbolId> { accept(sym_id).then_some(sym_id) };
@@ -300,7 +302,7 @@ impl BinderState {
                     break;
                 };
 
-                if let Some(sym_id) = scope.table.get(name)
+                if let Some(sym_id) = scope.table.get_by_atom_or_name(name_atom, name)
                     && let Some(found) = consider(sym_id)
                 {
                     return Some(found);
@@ -321,7 +323,7 @@ impl BinderState {
             }
         }
 
-        if let Some(sym_id) = self.file_locals.get(name)
+        if let Some(sym_id) = self.file_locals.get_by_atom_or_name(name_atom, name)
             && let Some(found) = consider(sym_id)
         {
             return Some(found);
@@ -346,7 +348,7 @@ impl BinderState {
         // `resolve_identifier_symbol` and `resolve_type_symbol` fallbacks.
         if !self.lib_symbols_merged {
             for lib_binder in lib_binders {
-                if let Some(sym_id) = lib_binder.file_locals.get(name)
+                if let Some(sym_id) = lib_binder.file_locals.get_by_atom_or_name(name_atom, name)
                     && let Some(found) = consider(sym_id)
                 {
                     return Some(found);

--- a/crates/tsz-binder/src/state/resolution.rs
+++ b/crates/tsz-binder/src/state/resolution.rs
@@ -634,12 +634,12 @@ impl BinderState {
         export_name: &str,
     ) -> Option<SymbolId> {
         // Check cache first for fast path
-        let cache_key = (module_specifier.to_string(), export_name.to_string());
         if let Some(&cached) = self
             .resolved_export_cache
             .read()
             .expect("RwLock not poisoned")
-            .get(&cache_key)
+            .get(module_specifier)
+            .and_then(|module_cache| module_cache.get(export_name))
         {
             return cached;
         }
@@ -658,7 +658,9 @@ impl BinderState {
         self.resolved_export_cache
             .write()
             .expect("resolved_export_cache RwLock poisoned")
-            .insert(cache_key, result);
+            .entry(module_specifier.to_string())
+            .or_default()
+            .insert(export_name.to_string(), result);
         result
     }
 
@@ -690,12 +692,12 @@ impl BinderState {
             );
         }
 
-        let cache_key = (module_specifier.to_string(), export_name.to_string());
         if let Some(&cached) = self
             .resolved_export_type_only_cache
             .read()
             .expect("resolved_export_type_only_cache RwLock poisoned")
-            .get(&cache_key)
+            .get(module_specifier)
+            .and_then(|module_cache| module_cache.get(export_name))
         {
             return cached;
         }
@@ -711,7 +713,9 @@ impl BinderState {
         self.resolved_export_type_only_cache
             .write()
             .expect("resolved_export_type_only_cache RwLock poisoned")
-            .insert(cache_key, result);
+            .entry(module_specifier.to_string())
+            .or_default()
+            .insert(export_name.to_string(), result);
         result
     }
 

--- a/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
+++ b/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
@@ -1305,7 +1305,8 @@ fn type_only_reexport_resolution_is_cached_and_stable() {
             .resolved_export_type_only_cache
             .read()
             .expect("cache lock")
-            .get(&("./entry".to_string(), "Widget".to_string()))
+            .get("./entry")
+            .and_then(|module_cache| module_cache.get("Widget"))
             .copied(),
         Some(Some((leaf_sym, false))),
         "type-only resolution should be memoized per (module, export)"
@@ -1348,7 +1349,8 @@ fn type_only_reexport_cache_missing_export_is_cached_as_none() {
             .resolved_export_type_only_cache
             .read()
             .expect("cache lock")
-            .get(&("./entry".to_string(), "DoesNotExist".to_string()))
+            .get("./entry")
+            .and_then(|module_cache| module_cache.get("DoesNotExist"))
             .copied(),
         Some(None),
         "negative type-only results must also be memoized"

--- a/crates/tsz-binder/src/state/tests/state_storage.rs
+++ b/crates/tsz-binder/src/state/tests/state_storage.rs
@@ -510,7 +510,9 @@ fn seed_resolution_caches(binder: &mut BinderState) {
         .resolved_export_cache
         .write()
         .expect("not poisoned")
-        .insert(("stub.ts".to_string(), "x".to_string()), Some(SymbolId(99)));
+        .entry("stub.ts".to_string())
+        .or_default()
+        .insert("x".to_string(), Some(SymbolId(99)));
     binder
         .resolved_identifier_cache
         .write()
@@ -520,10 +522,9 @@ fn seed_resolution_caches(binder: &mut BinderState) {
         .resolved_export_type_only_cache
         .write()
         .expect("not poisoned")
-        .insert(
-            ("stub.ts".to_string(), "T".to_string()),
-            Some((SymbolId(88), true)),
-        );
+        .entry("stub.ts".to_string())
+        .or_default()
+        .insert("T".to_string(), Some((SymbolId(88), true)));
     binder
         .find_enclosing_scope_cache
         .write()

--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -571,6 +571,14 @@ impl SymbolTable {
         self.get_by_atom(atom).or_else(|| self.get(name))
     }
 
+    /// Find the parsed identifier atom that currently points at `symbol`.
+    #[must_use]
+    pub fn atom_for_symbol(&self, symbol: SymbolId) -> Option<tsz_common::interner::AstAtom> {
+        self.atom_symbols
+            .iter()
+            .find_map(|(&atom, &id)| (id == symbol).then_some(atom))
+    }
+
     /// Set a symbol by name.
     pub fn set(&mut self, name: String, symbol: SymbolId) {
         Arc::make_mut(&mut self.symbols).insert(name, symbol);

--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -511,6 +511,13 @@ impl Symbol {
 pub struct SymbolTable {
     /// Symbols indexed by their escaped name (using `FxHashMap` for faster hashing)
     symbols: Arc<FxHashMap<String, SymbolId>>,
+    /// Symbols indexed by parsed identifier `AstAtom` when the binder had one.
+    ///
+    /// This is a migration index for #13073: string keys remain authoritative
+    /// for compatibility, while parsed identifiers can avoid hashing their
+    /// escaped text on hot resolution paths.
+    #[serde(skip)]
+    atom_symbols: Arc<FxHashMap<tsz_common::interner::AstAtom, SymbolId>>,
 }
 
 impl SymbolTable {
@@ -518,6 +525,7 @@ impl SymbolTable {
     pub fn new() -> Self {
         Self {
             symbols: Arc::new(FxHashMap::default()),
+            atom_symbols: Arc::new(FxHashMap::default()),
         }
     }
 
@@ -531,6 +539,10 @@ impl SymbolTable {
                 capacity,
                 Default::default(),
             )),
+            atom_symbols: Arc::new(FxHashMap::with_capacity_and_hasher(
+                capacity,
+                Default::default(),
+            )),
         }
     }
 
@@ -540,14 +552,52 @@ impl SymbolTable {
         self.symbols.get(name).copied()
     }
 
+    /// Get a symbol by parsed identifier atom.
+    #[must_use]
+    pub fn get_by_atom(&self, atom: tsz_common::interner::AstAtom) -> Option<SymbolId> {
+        if atom == tsz_common::interner::AstAtom::NONE {
+            return None;
+        }
+        self.atom_symbols.get(&atom).copied()
+    }
+
+    /// Get a symbol by atom when present, falling back to escaped text.
+    #[must_use]
+    pub fn get_by_atom_or_name(
+        &self,
+        atom: tsz_common::interner::AstAtom,
+        name: &str,
+    ) -> Option<SymbolId> {
+        self.get_by_atom(atom).or_else(|| self.get(name))
+    }
+
     /// Set a symbol by name.
     pub fn set(&mut self, name: String, symbol: SymbolId) {
         Arc::make_mut(&mut self.symbols).insert(name, symbol);
     }
 
+    /// Set a symbol by name and, when available, by parsed identifier atom.
+    pub fn set_with_atom(
+        &mut self,
+        name: String,
+        atom: Option<tsz_common::interner::AstAtom>,
+        symbol: SymbolId,
+    ) {
+        self.set(name, symbol);
+        if let Some(atom) = atom
+            && atom != tsz_common::interner::AstAtom::NONE
+        {
+            Arc::make_mut(&mut self.atom_symbols).insert(atom, symbol);
+        }
+    }
+
     /// Remove a symbol by name.
     pub fn remove(&mut self, name: &str) -> Option<SymbolId> {
-        Arc::make_mut(&mut self.symbols).remove(name)
+        let removed = Arc::make_mut(&mut self.symbols).remove(name);
+        if let Some(symbol) = removed {
+            Arc::make_mut(&mut self.atom_symbols).retain(|_, id| *id != symbol);
+        }
+        removed
     }
 
     /// Check if a name exists in the table.
@@ -571,6 +621,7 @@ impl SymbolTable {
     /// Clear all symbols while keeping the allocated capacity.
     pub fn clear(&mut self) {
         Arc::make_mut(&mut self.symbols).clear();
+        Arc::make_mut(&mut self.atom_symbols).clear();
     }
 
     /// Iterate over symbols.
@@ -587,6 +638,10 @@ impl SymbolTable {
         const BUCKET_OVERHEAD: usize = 16;
         let mut size = self.symbols.capacity()
             * (BUCKET_OVERHEAD + std::mem::size_of::<String>() + std::mem::size_of::<SymbolId>());
+        size += self.atom_symbols.capacity()
+            * (BUCKET_OVERHEAD
+                + std::mem::size_of::<tsz_common::interner::AstAtom>()
+                + std::mem::size_of::<SymbolId>());
         for name in self.symbols.keys() {
             size += name.capacity();
         }


### PR DESCRIPTION
Goal: fast

## Summary
- Add a runtime-only `AstAtom` side index to binder `SymbolTable` while keeping escaped-name string keys authoritative.
- Populate the side index from `declare_symbol` when the declaration node itself is an identifier, and from `declare_symbol_with_atom` when binders already know the declaration-name node.
- Thread parsed identifier atoms through common declaration binding paths: variables, functions, parameters, type parameters, interfaces, type aliases, and enums.
- Thread parsed identifier atoms through import/export binder paths: default imports, namespace imports, named imports, import-equals aliases, local export aliases, re-export aliases, namespace re-exports, and UMD namespace exports.
- Preserve atom side keys across module/namespace declaration binding, reopened namespace export seeding, anonymous module promotion, module export table population, and final file-level export population.
- Change re-export resolution caches from tuple-string keys to nested maps so cache hits borrow `module_specifier` and `export_name` instead of allocating owned key strings.
- Route binder identifier resolution through `get_by_atom_or_name`, preserving string fallback for synthetic names, serialized binders, and call sites that are not migrated yet.

## Structural rule
When binder scope lookup or export-cache lookup has stable parsed/request identity, `tsc` uses stable name identity for symbol lookup; tsz now lets the binder owner use atom side keys for `SymbolTable` lookup and borrowed request strings for export-cache hits, falling back to escaped-name strings when no atom-backed entry exists.

## Owner layer
Binder owns scope tables, symbol tables, export-resolution caches, and name lookup. Display and downstream checker/LSP paths still resolve text at their existing edges.

## Cache / performance invariant
The re-export cache question remains `(module_specifier, export_name) -> resolved SymbolId` and `(module_specifier, export_name) -> (resolved SymbolId, crossed_type_only_wildcard)`. This slice changes only the storage shape to `module_specifier -> export_name -> result`, so cache hits borrow both request strings and misses allocate only when inserting. Cache clearing and statistics still count per-export entries.

## Adjacent matrix
- Parsed identifier declarations with atoms: Atom side index populated for current scope, file locals, namespace export tables, module export tables, root scope entries, and persistent scope entries created through `declare_symbol` / `declare_symbol_with_atom`.
- Declaration nodes whose names live on child identifier nodes: binder call sites pass the child name atom explicitly where already available.
- Import/export aliases: local binding names keep their parsed atom side key; string-literal export names remain string-only fallback entries.
- Reopened namespaces and copied exports: `SymbolTable` copies preserve the existing atom side key for the copied `SymbolId` when one exists.
- File-level module export population: exports copied from module/file-local tables keep their existing atom side key.
- Re-export cache hits: repeated lookups avoid allocating `(String, String)` keys.
- Synthetic/string-only names: existing string-keyed `set`/`get` behavior remains unchanged.
- Serialized/reloaded symbol tables: Atom index is runtime-only and may be empty; lookup falls back to escaped-name strings.

## Verification
- Draft CI/light passed on `7292bfd50e31912a15587fdd0544911a4a15dee9`: `CI Light Summary`, `lint`, `dist-binaries`, `unit`, `unit-cloudbuild`, `unit-checker-integration`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `gate` passed.
- Synced with `origin/main` after #13296/#13297 landed; merge commit `9dd367c62f9414e786acde3dd8742bed5cb281ea` includes current `origin/main` plus the binder atom slice.
- Fresh draft CI/light run 27414966971 passed at exact head `9dd367c62f9414e786acde3dd8742bed5cb281ea`.
- Local tests not run per instruction.
- Ready-review CI is now expected to run the full PR-head gate before merge queue.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: medium
