### PR TITLE
perf(core): expose retained residency pressure

### DIFF
--- a/crates/tsz-common/src/perf_counters/residency.rs
+++ b/crates/tsz-common/src/perf_counters/residency.rs
@@ -34,6 +34,8 @@ pub struct ResidencyGauges {
     type_interner_bytes_est: AtomicU64,
     skeleton_index_bytes_est: AtomicU64,
     pre_merge_bind_total_bytes_est: AtomicU64,
+    retained_file_state_bytes_est: AtomicU64,
+    retained_file_state_pressure: AtomicU64,
     shared_query_cache_entries: AtomicU64,
     shared_query_cache_bytes_est: AtomicU64,
     type_cache_count: AtomicU64,
@@ -56,6 +58,8 @@ fn residency_gauges() -> &'static ResidencyGauges {
         type_interner_bytes_est: AtomicU64::new(0),
         skeleton_index_bytes_est: AtomicU64::new(0),
         pre_merge_bind_total_bytes_est: AtomicU64::new(0),
+        retained_file_state_bytes_est: AtomicU64::new(0),
+        retained_file_state_pressure: AtomicU64::new(0),
         shared_query_cache_entries: AtomicU64::new(0),
         shared_query_cache_bytes_est: AtomicU64::new(0),
         type_cache_count: AtomicU64::new(0),
@@ -79,6 +83,39 @@ pub struct MergedProgramResidencyRecord {
     pub type_interner_bytes_est: u64,
     pub skeleton_index_bytes_est: u64,
     pub pre_merge_bind_total_bytes_est: u64,
+    pub retained_file_state_bytes_est: u64,
+    pub retained_file_state_pressure: ResidencyPressureLevel,
+}
+
+/// Default-budget retained-state pressure level for residency accounting.
+///
+/// This is an observation only. It lets perf-counter artifacts show what the
+/// batch/LSP residency decision would see without wiring eviction behavior.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResidencyPressureLevel {
+    #[default]
+    Low,
+    Medium,
+    High,
+}
+
+impl ResidencyPressureLevel {
+    const fn as_u64(self) -> u64 {
+        match self {
+            Self::Low => 0,
+            Self::Medium => 1,
+            Self::High => 2,
+        }
+    }
+
+    const fn from_u64(value: u64) -> Self {
+        match value {
+            1 => Self::Medium,
+            2 => Self::High,
+            _ => Self::Low,
+        }
+    }
 }
 
 /// Record the merged-program residency categories. Gated on
@@ -111,6 +148,12 @@ pub fn record_merged_program_residency(record: &MergedProgramResidencyRecord) {
         .store(record.skeleton_index_bytes_est, Ordering::Relaxed);
     g.pre_merge_bind_total_bytes_est
         .store(record.pre_merge_bind_total_bytes_est, Ordering::Relaxed);
+    g.retained_file_state_bytes_est
+        .store(record.retained_file_state_bytes_est, Ordering::Relaxed);
+    g.retained_file_state_pressure.store(
+        record.retained_file_state_pressure.as_u64(),
+        Ordering::Relaxed,
+    );
     g.recorded_any.store(true, Ordering::Relaxed);
 }
 
@@ -174,6 +217,13 @@ pub struct ResidencySnapshot {
     /// Pre-merge `BindResult` footprint captured before the merge consumed
     /// per-file data (informational; this memory is released after merge).
     pub pre_merge_bind_total_bytes_est: u64,
+    /// Retained state used by the default `ResidencyBudget` pressure
+    /// assessment: post-merge bound-file state plus unique user-file arenas.
+    /// This intentionally excludes `pre_merge_bind_total_bytes_est` because
+    /// that footprint is transient after owned merge paths complete.
+    pub retained_file_state_bytes_est: u64,
+    /// Default-budget pressure level for `retained_file_state_bytes_est`.
+    pub retained_file_state_pressure: ResidencyPressureLevel,
     /// `SharedQueryCache` entries across eval/subtype/assignability maps.
     pub shared_query_cache_entries: u64,
     pub shared_query_cache_bytes_est: u64,
@@ -225,6 +275,10 @@ pub(crate) fn snapshot_residency() -> Option<ResidencySnapshot> {
         type_interner_bytes_est,
         skeleton_index_bytes_est,
         pre_merge_bind_total_bytes_est: load(&g.pre_merge_bind_total_bytes_est),
+        retained_file_state_bytes_est: load(&g.retained_file_state_bytes_est),
+        retained_file_state_pressure: ResidencyPressureLevel::from_u64(
+            load(&g.retained_file_state_pressure),
+        ),
         shared_query_cache_entries: load(&g.shared_query_cache_entries),
         shared_query_cache_bytes_est,
         type_cache_count: load(&g.type_cache_count),

--- a/crates/tsz-common/src/perf_counters/residency_tests.rs
+++ b/crates/tsz-common/src/perf_counters/residency_tests.rs
@@ -24,6 +24,8 @@ mod residency_tests {
             type_interner_bytes_est: 60,
             skeleton_index_bytes_est: 7,
             pre_merge_bind_total_bytes_est: 999,
+            retained_file_state_bytes_est: 1_200,
+            retained_file_state_pressure: ResidencyPressureLevel::Medium,
         });
         record_shared_query_cache_residency(21, 80);
         record_type_cache_residency(2, 90);
@@ -41,6 +43,11 @@ mod residency_tests {
         assert_eq!(residency.type_interner_bytes_est, 60);
         assert_eq!(residency.skeleton_index_bytes_est, 7);
         assert_eq!(residency.pre_merge_bind_total_bytes_est, 999);
+        assert_eq!(residency.retained_file_state_bytes_est, 1_200);
+        assert_eq!(
+            residency.retained_file_state_pressure,
+            ResidencyPressureLevel::Medium
+        );
         assert_eq!(residency.shared_query_cache_entries, 21);
         assert_eq!(residency.shared_query_cache_bytes_est, 80);
         assert_eq!(residency.type_cache_count, 2);
@@ -56,6 +63,8 @@ mod residency_tests {
         let json = serde_json::to_value(&snap).expect("serializes");
         assert_eq!(json["residency"]["ast_unique_arena_bytes_est"], 1_000);
         assert_eq!(json["residency"]["type_interner_bytes_est"], 60);
+        assert_eq!(json["residency"]["retained_file_state_bytes_est"], 1_200);
+        assert_eq!(json["residency"]["retained_file_state_pressure"], "medium");
         assert_eq!(json["residency"]["tracked_total_bytes_est"], 1_557);
     }
 

--- a/crates/tsz-core/src/parallel/residency.rs
+++ b/crates/tsz-core/src/parallel/residency.rs
@@ -262,6 +262,17 @@ impl MergedProgram {
             return;
         }
 
+        let retained_stats = self.residency_stats();
+        let retained_file_state_bytes_est = retained_stats
+            .total_bound_file_bytes
+            .saturating_add(retained_stats.unique_arena_estimated_bytes);
+        let retained_file_state_pressure = match ResidencyBudget::default().assess(&retained_stats)
+        {
+            MemoryPressure::Low => pc::ResidencyPressureLevel::Low,
+            MemoryPressure::Medium => pc::ResidencyPressureLevel::Medium,
+            MemoryPressure::High => pc::ResidencyPressureLevel::High,
+        };
+
         let unique_arena_map = self.collect_unique_arenas(true);
         let ast_unique_arena_bytes_est: usize = unique_arena_map
             .values()
@@ -293,6 +304,8 @@ impl MergedProgram {
                 .map_or(0, |idx| idx.estimated_size_bytes())
                 as u64,
             pre_merge_bind_total_bytes_est: self.pre_merge_bind_total_bytes as u64,
+            retained_file_state_bytes_est: retained_file_state_bytes_est as u64,
+            retained_file_state_pressure,
         });
     }
 }


### PR DESCRIPTION
Goal: fast

## Summary
- Refs #13249 and #13250.
- Add `retained_file_state_bytes_est` to the residency perf-counter JSON as the exact byte total used by the retained-state pressure decision: post-merge bound-file state plus unique user-file arenas.
- Add `retained_file_state_pressure` (`low` / `medium` / `high`) so artifacts show what `ResidencyBudget::default()` would decide before any batch/LSP eviction behavior is wired.
- Keep `pre_merge_bind_total_bytes_est` informational only; it remains excluded from `tracked_total_bytes_est` and from retained pressure.

## Structural rule
When owned merge has consumed pre-merge `BindResult`s, residency pressure must be assessed from retained post-merge file state, not transient merge-time bytes. This PR preserves compile behavior and only records the default-budget pressure decision through `tsz_common::perf_counters`, so later #13249 eviction wiring can prove whether it would have triggered before changing batch semantics.

## Residency invariant
- Pressure input: `MergedProgramResidencyStats.total_bound_file_bytes + MergedProgramResidencyStats.unique_arena_estimated_bytes`.
- Pressure owner: `tsz-core::parallel::residency::ResidencyBudget`.
- Observation owner: `tsz_common::perf_counters` residency snapshot.
- Disabled behavior: unchanged; recording remains gated behind `TSZ_PERF_COUNTERS` / `enabled_fast()`.
- No eviction, cache clearing, scheduler change, diagnostic change, or wall-time speedup claim in this slice.

## Adjacent cases / fallback
- `pre_merge_bind_total_bytes_est` remains serialized for peak analysis but is not counted as retained state.
- `tracked_total_bytes_est` remains a resident-category sum and still excludes transient pre-merge bytes.
- Existing residency snapshots without recording remain `residency: null`.
- Default pressure serializes as `low` when callers use default/zero records.

## Verification
- Pre-commit formatting hook ran during `git commit`.
- Local tests/benchmarks not run per current instruction.
- Draft PR CI/light run 27414847870 passed at exact head `e5731a90b5cc93589a2eb38e7bad043e8f43d92d`.
- Ready-review CI is now expected to run the full PR-head gate before merge queue.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: medium
