### PR TITLE
refactor(solver): canonical identity-first global Object/Function interface query, retiring 12 diverged sniff sites (#13090)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/diagnostics.rs
+++ b/crates/tsz-checker/src/query_boundaries/diagnostics.rs
@@ -240,14 +240,11 @@ pub(crate) fn is_global_object_interface_for_diagnostic(
     db: &dyn tsz_solver::construction::TypeDatabase,
     type_id: TypeId,
 ) -> bool {
-    if db
-        .get_boxed_type(tsz_solver::IntrinsicKind::Object)
-        .is_some_and(|object_type| object_type == type_id)
-    {
-        return true;
-    }
-    lazy_def_id(db, type_id)
-        .is_some_and(|def_id| db.is_boxed_def_id(def_id, tsz_solver::IntrinsicKind::Object))
+    tsz_solver::type_queries::is_global_interface_by_identity(
+        db,
+        type_id,
+        tsz_solver::IntrinsicKind::Object,
+    )
 }
 
 pub(crate) fn simple_intersection_head_for_this_assignment_display(

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -1552,28 +1552,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         {
             return true;
         }
-        // Check if the evaluated target is structurally the Function interface
-        // (has apply, call, bind properties) — this catches cases where the
+        // Canonical query (issue #13090): boxed-registry identity first, then
+        // the shared structural fallback — this catches cases where the
         // Function type was resolved from a Lazy(DefId) to its ObjectShape form.
-        if let Some(
-            crate::types::TypeData::Object(shape_id)
-            | crate::types::TypeData::ObjectWithIndex(shape_id),
-        ) = interner.lookup(extends_type)
-        {
-            let shape = interner.object_shape(shape_id);
-            if shape.properties.len() <= 20 {
-                let apply = interner.intern_string("apply");
-                let call = interner.intern_string("call");
-                let bind = interner.intern_string("bind");
-                let has_apply = shape.properties.iter().any(|p| p.name == apply);
-                let has_call = shape.properties.iter().any(|p| p.name == call);
-                let has_bind = shape.properties.iter().any(|p| p.name == bind);
-                if has_apply && has_call && has_bind {
-                    return true;
-                }
-            }
-        }
-        false
+        crate::type_queries::is_global_function_interface(interner, extends_type)
     }
 
     fn function_intrinsic_extends_callable_target(

--- a/crates/tsz-solver/src/narrowing/core/helpers.rs
+++ b/crates/tsz-solver/src/narrowing/core/helpers.rs
@@ -373,20 +373,15 @@ impl<'a> NarrowingContext<'a> {
         if type_id == TypeId::OBJECT {
             return true;
         }
-        // Check the query database directly for boxed Object interface.
-        // Boxed types are registered on the interner during lib.d.ts processing,
-        // bypassing TypeResolver (which may be a different instance).
-        // Use as_type_database() to disambiguate from TypeResolver's get_boxed_type.
-        let db = self.db.as_type_database();
-        if db.get_boxed_type(crate::types::IntrinsicKind::Object) == Some(type_id) {
-            return true;
-        }
-        if let Some(def_id) = lazy_def_id(self.db, type_id)
-            && db.is_boxed_def_id(def_id, crate::types::IntrinsicKind::Object)
-        {
-            return true;
-        }
-        false
+        // Canonical identity query (issue #13090). Boxed types are registered
+        // on the interner during lib.d.ts processing, bypassing TypeResolver
+        // (which may be a different instance), so the interner-backed registry
+        // via as_type_database() is the authority here.
+        crate::type_queries::is_global_interface_by_identity(
+            self.db.as_type_database(),
+            type_id,
+            crate::types::IntrinsicKind::Object,
+        )
     }
 
     pub(in crate::narrowing) fn narrow_type_param(

--- a/crates/tsz-solver/src/operations/core/call_evaluator.rs
+++ b/crates/tsz-solver/src/operations/core/call_evaluator.rs
@@ -914,13 +914,12 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
         match self.interner.lookup(member) {
             Some(TypeData::Intrinsic(IntrinsicKind::Function))
             | Some(TypeData::Function(_) | TypeData::Callable(_)) => true,
-            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
-                let shape = self.interner.object_shape(shape_id);
-                let apply = self.interner.intern_string("apply");
-                let call = self.interner.intern_string("call");
-                let has_apply = shape.properties.iter().any(|prop| prop.name == apply);
-                let has_call = shape.properties.iter().any(|prop| prop.name == call);
-                has_apply && has_call
+            Some(TypeData::Object(_) | TypeData::ObjectWithIndex(_)) => {
+                // Canonical query (issue #13090). The historical inline sniff
+                // here only probed `apply` + `call` with no property-count cap;
+                // the canonical structural fallback also requires `bind` and
+                // caps the property count, and identity is consulted first.
+                crate::type_queries::is_global_function_interface(self.interner, member)
             }
             Some(TypeData::Union(members_id)) => self
                 .interner

--- a/crates/tsz-solver/src/relations/compat.rs
+++ b/crates/tsz-solver/src/relations/compat.rs
@@ -13,8 +13,8 @@ use crate::types::{
 };
 use crate::visitor::{
     TypeVisitor, application_id, array_element_type, index_access_parts, intrinsic_kind,
-    is_empty_object_type_through_type_constraints, is_error_type, keyof_inner_type, lazy_def_id,
-    mapped_type_id, tuple_list_id, type_param_info, union_list_id,
+    is_empty_object_type_through_type_constraints, is_error_type, keyof_inner_type, mapped_type_id,
+    tuple_list_id, type_param_info, union_list_id,
 };
 use rustc_hash::FxHashMap;
 use tsz_common::interner::Atom;
@@ -505,55 +505,15 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
 
     /// Detect whether a type is the global `Object` interface from lib.d.ts.
     ///
-    /// Checks via resolver boxed type lookup, Lazy DefId matching, and structural
-    /// detection (an `ObjectShape` with `constructor`, `toString`, `valueOf`,
-    /// `hasOwnProperty`, and `isPrototypeOf` properties).
+    /// Delegates to the canonical query in `type_queries::global_interfaces`
+    /// (issue #13090): boxed-registry identity first, then the shared
+    /// structural fallback for pre-evaluated `ObjectShape` forms.
     pub(crate) fn is_global_object_interface_target(&self, target: TypeId) -> bool {
-        if self
-            .subtype
-            .resolver
-            .is_boxed_type_id(target, IntrinsicKind::Object)
-            || self
-                .subtype
-                .resolver
-                .get_boxed_type(IntrinsicKind::Object)
-                .is_some_and(|boxed| boxed == target)
-        {
-            return true;
-        }
-        if lazy_def_id(self.interner, target).is_some_and(|def_id| {
-            self.subtype
-                .resolver
-                .is_boxed_def_id(def_id, IntrinsicKind::Object)
-        }) {
-            return true;
-        }
-        // Intrinsic OBJECT was already caught by the boxed-type checks above;
-        // other intrinsics never resolve to Object/ObjectWithIndex shapes.
-        if target.is_intrinsic() {
-            return false;
-        }
-        match self.interner.lookup(target) {
-            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
-                let shape = self.interner.object_shape(shape_id);
-                // Object interface has exactly 7 properties (constructor, toString,
-                // toLocaleString, valueOf, hasOwnProperty, isPrototypeOf,
-                // propertyIsEnumerable). Use tight cap to avoid matching derived
-                // types like Boolean (8 props) or Number (~10 props).
-                if shape.properties.len() > 7 {
-                    return false;
-                }
-                let constructor = self.interner.intern_string("constructor");
-                let has_own = self.interner.intern_string("hasOwnProperty");
-                let is_proto = self.interner.intern_string("isPrototypeOf");
-                let prop_is_enum = self.interner.intern_string("propertyIsEnumerable");
-                shape.properties.iter().any(|p| p.name == constructor)
-                    && shape.properties.iter().any(|p| p.name == has_own)
-                    && shape.properties.iter().any(|p| p.name == is_proto)
-                    && shape.properties.iter().any(|p| p.name == prop_is_enum)
-            }
-            _ => false,
-        }
+        crate::type_queries::is_global_object_interface_with_resolver(
+            self.interner,
+            self.subtype.resolver,
+            target,
+        )
     }
 
     /// Check if a source type is a type parameter (possibly wrapped in unions/intersections).
@@ -630,44 +590,12 @@ impl<'a, R: TypeResolver> CompatChecker<'a, R> {
     }
 
     fn is_function_target_member(&self, member: TypeId) -> bool {
-        let is_function_object_shape = if member.is_intrinsic() {
-            false
-        } else {
-            self.is_function_object_shape_member(member)
-        };
         intrinsic_kind(self.interner, member) == Some(IntrinsicKind::Function)
-            || is_function_object_shape
-            || self
-                .subtype
-                .resolver
-                .get_boxed_type(IntrinsicKind::Function)
-                .is_some_and(|boxed| boxed == member)
-            || lazy_def_id(self.interner, member).is_some_and(|def_id| {
-                self.subtype
-                    .resolver
-                    .is_boxed_def_id(def_id, IntrinsicKind::Function)
-            })
-    }
-
-    fn is_function_object_shape_member(&self, member: TypeId) -> bool {
-        match self.interner.lookup(member) {
-            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
-                let shape = self.interner.object_shape(shape_id);
-                // Function interface has ~15 properties (own + inherited Object).
-                // Cap at 20 to avoid false positives on large interfaces.
-                if shape.properties.len() > 20 {
-                    false
-                } else {
-                    let apply = self.interner.intern_string("apply");
-                    let call = self.interner.intern_string("call");
-                    let bind = self.interner.intern_string("bind");
-                    shape.properties.iter().any(|prop| prop.name == apply)
-                        && shape.properties.iter().any(|prop| prop.name == call)
-                        && shape.properties.iter().any(|prop| prop.name == bind)
-                }
-            }
-            _ => false,
-        }
+            || crate::type_queries::is_global_function_interface_with_resolver(
+                self.interner,
+                self.subtype.resolver,
+                member,
+            )
     }
 
     /// Create a new compatibility checker with a resolver.

--- a/crates/tsz-solver/src/relations/subtype/cache.rs
+++ b/crates/tsz-solver/src/relations/subtype/cache.rs
@@ -669,16 +669,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // assignable to it. We must check BEFORE evaluate_type() because
         // evaluation may change the target TypeId, losing the boxed identity.
         {
-            let is_object_interface_target = self
-                .resolver
-                .is_boxed_type_id(target, IntrinsicKind::Object)
-                || self
-                    .resolver
-                    .get_boxed_type(IntrinsicKind::Object)
-                    .is_some_and(|boxed| boxed == target)
-                || lazy_def_id(self.interner, target).is_some_and(|def_id| {
-                    self.resolver.is_boxed_def_id(def_id, IntrinsicKind::Object)
-                });
+            let is_object_interface_target =
+                crate::type_queries::is_global_interface_by_identity_with_resolver(
+                    self.interner,
+                    self.resolver,
+                    target,
+                    IntrinsicKind::Object,
+                );
             if is_object_interface_target {
                 // is_nullable() short-circuits before the interner lookup for common null/undefined/void cases.
                 if source.is_nullable() || !self.is_global_object_interface_type(source) {
@@ -706,12 +703,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // Lazy(DefId) → ObjectShape, losing the DefId identity needed to
         // recognize the type as an intrinsic interface.
         if !self.bypass_evaluation
-            && (lazy_def_id(self.interner, target).is_some_and(|t_def| {
-                self.resolver
-                    .is_boxed_def_id(t_def, IntrinsicKind::Function)
-            }) || self
-                .resolver
-                .is_boxed_type_id(target, IntrinsicKind::Function))
+            && crate::type_queries::is_global_interface_by_identity_with_resolver(
+                self.interner,
+                self.resolver,
+                target,
+                IntrinsicKind::Function,
+            )
         {
             let source_eval = self.evaluate_type(source);
             if self.is_callable_type(source_eval) {

--- a/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
+++ b/crates/tsz-solver/src/relations/subtype/core_dispatch.rs
@@ -803,17 +803,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let is_function_structural = self.is_function_interface_structural(target);
         let is_function_target = intrinsic_kind(self.interner, target)
             == Some(IntrinsicKind::Function)
-            || self
-                .resolver
-                .is_boxed_type_id(target, IntrinsicKind::Function)
-            || self
-                .resolver
-                .get_boxed_type(IntrinsicKind::Function)
-                .is_some_and(|boxed| boxed == target)
-            || lazy_def_id(self.interner, target).is_some_and(|def_id| {
-                self.resolver
-                    .is_boxed_def_id(def_id, IntrinsicKind::Function)
-            })
+            || crate::type_queries::is_global_interface_by_identity_with_resolver(
+                self.interner,
+                self.resolver,
+                target,
+                IntrinsicKind::Function,
+            )
             || is_function_structural;
         if is_function_target {
             if self.is_callable_type(source) {
@@ -839,15 +834,13 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         // - `object` (lowercase) includes callable values.
         // - `Object` (capitalized interface) should follow TS structural rules and
         //   exclude bare callable types from primitive-style object assignability.
-        let is_global_object_target = self
-            .resolver
-            .is_boxed_type_id(target, IntrinsicKind::Object)
-            || self
-                .resolver
-                .get_boxed_type(IntrinsicKind::Object)
-                .is_some_and(|boxed| boxed == target)
-            || lazy_def_id(self.interner, target)
-                .is_some_and(|t_def| self.resolver.is_boxed_def_id(t_def, IntrinsicKind::Object));
+        let is_global_object_target =
+            crate::type_queries::is_global_interface_by_identity_with_resolver(
+                self.interner,
+                self.resolver,
+                target,
+                IntrinsicKind::Object,
+            );
         if is_global_object_target {
             let source_eval = self.evaluate_type(source);
             if self.is_global_object_interface_type(source_eval) {

--- a/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/intrinsics.rs
@@ -331,27 +331,12 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// Structurally detect whether a type is the global `Function` interface.
     ///
     /// After pre-evaluation, `Function` from lib.d.ts becomes an `ObjectShape` and
-    /// loses its identity. This detects it by checking for the characteristic
-    /// properties: `apply`, `call`, and `bind`, with a property count cap to
-    /// avoid false matches on unrelated interfaces.
+    /// loses its identity. Delegates to the canonical shared structural fallback
+    /// in `type_queries::global_interfaces` (issue #13090). Deliberately
+    /// structural-only: callers like `core_dispatch` treat structural matches
+    /// differently from boxed-registry identity matches.
     pub(crate) fn is_function_interface_structural(&self, target: TypeId) -> bool {
-        let shape_id = object_shape_id(self.interner, target)
-            .or_else(|| object_with_index_shape_id(self.interner, target));
-        let Some(shape_id) = shape_id else {
-            return false;
-        };
-        let shape = self.interner.object_shape(shape_id);
-        // Function interface has ~8 own properties + ~7 inherited Object properties = ~15.
-        // Cap at 20 to avoid false positives on large interfaces.
-        if shape.properties.len() > 20 {
-            return false;
-        }
-        let apply = self.interner.intern_string("apply");
-        let call = self.interner.intern_string("call");
-        let bind = self.interner.intern_string("bind");
-        shape.properties.iter().any(|p| p.name == apply)
-            && shape.properties.iter().any(|p| p.name == call)
-            && shape.properties.iter().any(|p| p.name == bind)
+        crate::type_queries::matches_global_function_interface_shape(self.interner, target)
     }
 
     /// Get the apparent primitive shape for a type.

--- a/crates/tsz-solver/src/relations/subtype/rules/objects.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/objects.rs
@@ -1758,19 +1758,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// properties. Our shapes don't include inherited members, so we exempt
     /// `Object` explicitly to match tsc behavior (see TypeScript PR #16047).
     fn is_global_object_shape(&self, shape: &ObjectShape) -> bool {
-        // Object interface has exactly 7 properties: constructor, toString,
-        // toLocaleString, valueOf, hasOwnProperty, isPrototypeOf,
-        // propertyIsEnumerable. Use a tight cap to avoid matching derived
-        // types like Boolean (8+ props) or Number (~10 props).
-        if shape.properties.len() > 7 {
-            return false;
-        }
-        let constructor = self.interner.intern_string("constructor");
-        let has_own = self.interner.intern_string("hasOwnProperty");
-        let is_proto = self.interner.intern_string("isPrototypeOf");
-        shape.properties.iter().any(|p| p.name == constructor)
-            && shape.properties.iter().any(|p| p.name == has_own)
-            && shape.properties.iter().any(|p| p.name == is_proto)
+        // Delegates to the canonical shared structural matcher in
+        // `type_queries::global_interfaces` (issue #13090). Identity cannot be
+        // consulted here: only the bare `ObjectShape` is available, not the
+        // source `TypeId`.
+        crate::type_queries::object_shape_matches_global_object_interface(self.interner, shape)
     }
 
     /// `ObjectWithIndex` source vs `Tuple` target.

--- a/crates/tsz-solver/src/type_queries/core.rs
+++ b/crates/tsz-solver/src/type_queries/core.rs
@@ -228,32 +228,14 @@ pub fn has_call_signatures(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     }
 }
 
-/// Check if a type is structurally the Function interface from lib.d.ts.
+/// Check if a type is the Function interface from lib.d.ts.
 ///
-/// The Function interface may be lowered as an `Object` (without call signatures)
-/// due to cross-arena declaration splitting. This detects it by checking for the
-/// characteristic properties: `apply`, `call`, and `bind`.
+/// Delegates to the canonical query in [`super::global_interfaces`]:
+/// boxed-registry identity first, then the shared structural fallback
+/// (the Function interface may be lowered as an `Object` without call
+/// signatures due to cross-arena declaration splitting).
 pub fn is_function_interface_structural(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    if type_id.is_intrinsic() {
-        return false;
-    }
-    use crate::visitor::{object_shape_id, object_with_index_shape_id};
-    let shape_id = object_shape_id(db, type_id).or_else(|| object_with_index_shape_id(db, type_id));
-    let Some(shape_id) = shape_id else {
-        return false;
-    };
-    let shape = db.object_shape(shape_id);
-    // Function interface has ~8 own properties + ~7 inherited Object properties = ~15.
-    // Cap at 20 to avoid false positives on large interfaces.
-    if shape.properties.len() > 20 {
-        return false;
-    }
-    let apply = db.intern_string("apply");
-    let call = db.intern_string("call");
-    let bind = db.intern_string("bind");
-    shape.properties.iter().any(|p| p.name == apply)
-        && shape.properties.iter().any(|p| p.name == call)
-        && shape.properties.iter().any(|p| p.name == bind)
+    super::global_interfaces::is_global_function_interface(db, type_id)
 }
 
 pub fn type_may_display_iterator_protocol(db: &dyn TypeDatabase, type_id: TypeId) -> bool {

--- a/crates/tsz-solver/src/type_queries/global_interfaces/mod.rs
+++ b/crates/tsz-solver/src/type_queries/global_interfaces/mod.rs
@@ -187,3 +187,217 @@ pub fn is_global_function_interface_with_resolver<R: TypeResolver + ?Sized>(
     is_global_interface_by_identity_with_resolver(db, resolver, type_id, IntrinsicKind::Function)
         || matches_global_function_interface_shape(db, type_id)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::caches::db::QueryDatabase;
+    use crate::construction::TypeInterner;
+    use crate::def::DefId;
+    use crate::def::resolver::TypeEnvironment;
+    use crate::types::PropertyInfo;
+
+    /// Intern an object type whose property list matches the global `Object`
+    /// interface from lib.es5.d.ts (7 members), under arbitrary value types.
+    fn object_like_shape(interner: &TypeInterner) -> TypeId {
+        interner.object(
+            [
+                "constructor",
+                "toString",
+                "toLocaleString",
+                "valueOf",
+                "hasOwnProperty",
+                "isPrototypeOf",
+                "propertyIsEnumerable",
+            ]
+            .iter()
+            .map(|name| PropertyInfo::new(interner.intern_string(name), TypeId::ANY))
+            .collect(),
+        )
+    }
+
+    fn function_like_shape(interner: &TypeInterner, with_bind: bool) -> TypeId {
+        let mut names = vec!["apply", "call", "length", "arguments", "caller", "name"];
+        if with_bind {
+            names.push("bind");
+        }
+        interner.object(
+            names
+                .iter()
+                .map(|name| PropertyInfo::new(interner.intern_string(name), TypeId::ANY))
+                .collect(),
+        )
+    }
+
+    /// Lib-not-loaded ordering / `noLib`: with empty boxed registries the
+    /// identity tier must answer `false` for everything, including types that
+    /// are structurally indistinguishable from the lib interface.
+    #[test]
+    fn identity_is_false_when_lib_not_loaded() {
+        let interner = TypeInterner::new();
+        let object_like = object_like_shape(&interner);
+        let lazy = interner.lazy(DefId(7));
+        for candidate in [object_like, lazy, TypeId::OBJECT, TypeId::FUNCTION] {
+            assert!(!is_global_interface_by_identity(
+                &interner,
+                candidate,
+                IntrinsicKind::Object
+            ));
+            assert!(!is_global_interface_by_identity(
+                &interner,
+                candidate,
+                IntrinsicKind::Function
+            ));
+        }
+        let env = TypeEnvironment::new();
+        assert!(!is_global_interface_by_identity_with_resolver(
+            &interner,
+            &env,
+            object_like,
+            IntrinsicKind::Object
+        ));
+    }
+
+    /// A user interface that is structurally identical to `Object` (renamed,
+    /// e.g. `interface MyObjectLike { constructor: ...; hasOwnProperty: ...;
+    /// ... }`) must NOT match the identity tier; only the registered boxed
+    /// type does. The structural fallback intentionally still matches it —
+    /// that is the documented compatibility hazard the identity tier exists
+    /// to replace.
+    #[test]
+    fn renamed_object_shaped_interface_is_not_identity_matched() {
+        let interner = TypeInterner::new();
+        let user_iface = object_like_shape(&interner);
+        // Register a DIFFERENT type as the real boxed Object.
+        let real_object = interner.object(vec![PropertyInfo::new(
+            interner.intern_string("toString"),
+            TypeId::ANY,
+        )]);
+        interner.register_boxed_type(IntrinsicKind::Object, real_object);
+
+        assert!(!is_global_interface_by_identity(
+            &interner,
+            user_iface,
+            IntrinsicKind::Object
+        ));
+        assert!(is_global_interface_by_identity(
+            &interner,
+            real_object,
+            IntrinsicKind::Object
+        ));
+        // Documented fallback hazard: the shared structural matcher still
+        // accepts the impostor shape.
+        assert!(matches_global_object_interface_shape(&interner, user_iface));
+        assert!(is_global_object_interface(&interner, user_iface));
+    }
+
+    /// `Lazy(DefId)` forms registered as boxed def ids match the identity
+    /// tier through both the interner and a resolver registry.
+    #[test]
+    fn lazy_def_id_identity_matches_after_registration() {
+        let interner = TypeInterner::new();
+        let def_id = DefId(42);
+        let lazy = interner.lazy(def_id);
+        let other_lazy = interner.lazy(DefId(43));
+
+        let mut env = TypeEnvironment::new();
+        env.register_boxed_def_id(IntrinsicKind::Function, def_id);
+        assert!(is_global_interface_by_identity_with_resolver(
+            &interner,
+            &env,
+            lazy,
+            IntrinsicKind::Function
+        ));
+        assert!(!is_global_interface_by_identity_with_resolver(
+            &interner,
+            &env,
+            other_lazy,
+            IntrinsicKind::Function
+        ));
+        // Interner-registry tier (resolver may be a different instance).
+        interner.register_boxed_def_id(IntrinsicKind::Object, def_id);
+        assert!(is_global_interface_by_identity(
+            &interner,
+            lazy,
+            IntrinsicKind::Object
+        ));
+        assert!(!is_global_interface_by_identity(
+            &interner,
+            other_lazy,
+            IntrinsicKind::Object
+        ));
+    }
+
+    /// Structural Function fallback: requires all of `apply`/`call`/`bind`
+    /// and rejects shapes above the property-count cap.
+    #[test]
+    fn function_structural_fallback_requires_apply_call_bind_and_cap() {
+        let interner = TypeInterner::new();
+        let with_bind = function_like_shape(&interner, true);
+        let without_bind = function_like_shape(&interner, false);
+        assert!(matches_global_function_interface_shape(
+            &interner, with_bind
+        ));
+        assert!(!matches_global_function_interface_shape(
+            &interner,
+            without_bind
+        ));
+
+        // 21 properties incl. apply/call/bind: over the cap, must not match.
+        let mut props: Vec<PropertyInfo> = (0..18)
+            .map(|i| PropertyInfo::new(interner.intern_string(&format!("p{i}")), TypeId::ANY))
+            .collect();
+        for name in ["apply", "call", "bind"] {
+            props.push(PropertyInfo::new(interner.intern_string(name), TypeId::ANY));
+        }
+        let oversized = interner.object(props);
+        assert!(!matches_global_function_interface_shape(
+            &interner, oversized
+        ));
+        // Intrinsics never match the structural tier.
+        assert!(!matches_global_function_interface_shape(
+            &interner,
+            TypeId::FUNCTION
+        ));
+    }
+
+    /// Structural Object fallback requires `propertyIsEnumerable` (the
+    /// unified, strictest historical probe) and respects the 7-property cap.
+    #[test]
+    fn object_structural_fallback_requires_all_probe_members() {
+        let interner = TypeInterner::new();
+        let full = object_like_shape(&interner);
+        assert!(matches_global_object_interface_shape(&interner, full));
+
+        let missing_enumerable = interner.object(
+            ["constructor", "toString", "hasOwnProperty", "isPrototypeOf"]
+                .iter()
+                .map(|name| PropertyInfo::new(interner.intern_string(name), TypeId::ANY))
+                .collect(),
+        );
+        assert!(!matches_global_object_interface_shape(
+            &interner,
+            missing_enumerable
+        ));
+
+        // 8 properties: over the cap (derived interfaces like Boolean).
+        let mut props: Vec<PropertyInfo> = [
+            "constructor",
+            "toString",
+            "toLocaleString",
+            "valueOf",
+            "hasOwnProperty",
+            "isPrototypeOf",
+            "propertyIsEnumerable",
+        ]
+        .iter()
+        .map(|name| PropertyInfo::new(interner.intern_string(name), TypeId::ANY))
+        .collect();
+        props.push(PropertyInfo::new(
+            interner.intern_string("extra"),
+            TypeId::ANY,
+        ));
+        let oversized = interner.object(props);
+        assert!(!matches_global_object_interface_shape(&interner, oversized));
+    }
+}

--- a/crates/tsz-solver/src/type_queries/global_interfaces/mod.rs
+++ b/crates/tsz-solver/src/type_queries/global_interfaces/mod.rs
@@ -1,0 +1,189 @@
+//! Canonical queries for "is this type the global `Object`/`Function` interface".
+//!
+//! Before this module existed, seven hand-rolled structural sniffs across the
+//! solver (relations, evaluation, narrowing, operations) each re-derived the
+//! answer from member-name probes ("has `toString` and `hasOwnProperty`", "has
+//! `apply`/`call`/`bind`") with diverging property lists and count caps. Those
+//! copies were load-order sensitive (they pass differently before vs after lib
+//! materialization) and drifted semantically. See issue #13090.
+//!
+//! # Tiers
+//!
+//! 1. **Identity** ([`is_global_interface_by_identity`],
+//!    [`is_global_interface_by_identity_with_resolver`]): compares against the
+//!    boxed-type registry populated by the checker from binder/global builtin
+//!    ids when lib is loaded (`register_boxed_types`). This tier is exact:
+//!    a user interface that merely *looks like* `Object` never matches.
+//!    **When lib is not loaded (`noLib`, or before lib materialization) the
+//!    registry is empty and this tier returns `false`.**
+//! 2. **Structural shape fallback** ([`matches_global_object_interface_shape`],
+//!    [`matches_global_function_interface_shape`]): a single shared copy of
+//!    the historical member-name probe. It exists because pre-evaluation can
+//!    lower the lib interface to an `ObjectShape` whose `TypeId` differs from
+//!    every registered boxed id (cross-arena declaration splitting,
+//!    `get_type_of_symbol` vs `resolve_lib_type_by_name` producing distinct
+//!    `TypeId`s). Callers should prefer the combined queries below, which try
+//!    identity first; the structural tier is a documented compatibility
+//!    fallback, not a precise identity test.
+//!
+//! The combined queries ([`is_global_object_interface`],
+//! [`is_global_function_interface`] and their `_with_resolver` variants) are
+//! the intended entry points: identity first, then the shared structural
+//! fallback.
+
+use crate::TypeId;
+use crate::construction::TypeDatabase;
+use crate::def::resolver::TypeResolver;
+use crate::types::{IntrinsicKind, ObjectShape, ObjectShapeId};
+use crate::visitor::{lazy_def_id, object_shape_id, object_with_index_shape_id};
+
+/// The global `Object` interface declares exactly 7 properties
+/// (`constructor`, `toString`, `toLocaleString`, `valueOf`, `hasOwnProperty`,
+/// `isPrototypeOf`, `propertyIsEnumerable`). A tight cap avoids matching
+/// derived lib interfaces like `Boolean` (8 props) or `Number` (~10 props).
+const GLOBAL_OBJECT_INTERFACE_MAX_PROPERTIES: usize = 7;
+
+/// The global `Function` interface has ~8 own properties plus ~7 inherited
+/// `Object` properties (~15 when flattened). Cap at 20 to avoid false
+/// positives on large unrelated interfaces.
+const GLOBAL_FUNCTION_INTERFACE_MAX_PROPERTIES: usize = 20;
+
+/// Identity tier: is `type_id` a registered form of the global interface for
+/// `kind` (e.g. `IntrinsicKind::Object` / `IntrinsicKind::Function`)?
+///
+/// Checks the interner-backed boxed-type registry: the registered boxed
+/// `TypeId` and `Lazy(DefId)` forms whose `DefId` is registered as boxed.
+///
+/// Returns `false` when lib is not loaded (the registry is empty), including
+/// `noLib` compilations and any query issued before lib materialization. This
+/// is intentional: identity for a lib global is undefined until the lib
+/// declarations exist.
+pub fn is_global_interface_by_identity(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    kind: IntrinsicKind,
+) -> bool {
+    if db.get_boxed_type(kind) == Some(type_id) {
+        return true;
+    }
+    lazy_def_id(db, type_id).is_some_and(|def_id| db.is_boxed_def_id(def_id, kind))
+}
+
+/// Identity tier that also consults a [`TypeResolver`]'s boxed registry.
+///
+/// The resolver (`TypeEnvironment`) and the interner can hold independently
+/// populated boxed registries (boxed types are registered on the interner
+/// during lib processing, while a resolver instance may be created later or
+/// be a different instance). Checking both keeps the answer stable across
+/// call sites that historically consulted only one of the two.
+pub fn is_global_interface_by_identity_with_resolver<R: TypeResolver + ?Sized>(
+    db: &dyn TypeDatabase,
+    resolver: &R,
+    type_id: TypeId,
+    kind: IntrinsicKind,
+) -> bool {
+    if resolver.is_boxed_type_id(type_id, kind) || resolver.get_boxed_type(kind) == Some(type_id) {
+        return true;
+    }
+    if lazy_def_id(db, type_id).is_some_and(|def_id| resolver.is_boxed_def_id(def_id, kind)) {
+        return true;
+    }
+    is_global_interface_by_identity(db, type_id, kind)
+}
+
+/// Shape-level structural fallback for the global `Object` interface.
+///
+/// `true` when the shape has at most
+/// [`GLOBAL_OBJECT_INTERFACE_MAX_PROPERTIES`] properties and declares
+/// `constructor`, `hasOwnProperty`, `isPrototypeOf`, and
+/// `propertyIsEnumerable`. This is the single shared copy of the historical
+/// sniff; prefer [`is_global_object_interface`] which tries identity first.
+pub fn object_shape_matches_global_object_interface(
+    db: &dyn TypeDatabase,
+    shape: &ObjectShape,
+) -> bool {
+    if shape.properties.len() > GLOBAL_OBJECT_INTERFACE_MAX_PROPERTIES {
+        return false;
+    }
+    let constructor = db.intern_string("constructor");
+    let has_own = db.intern_string("hasOwnProperty");
+    let is_proto = db.intern_string("isPrototypeOf");
+    let prop_is_enum = db.intern_string("propertyIsEnumerable");
+    shape.properties.iter().any(|p| p.name == constructor)
+        && shape.properties.iter().any(|p| p.name == has_own)
+        && shape.properties.iter().any(|p| p.name == is_proto)
+        && shape.properties.iter().any(|p| p.name == prop_is_enum)
+}
+
+fn object_like_shape_id(db: &dyn TypeDatabase, type_id: TypeId) -> Option<ObjectShapeId> {
+    if type_id.is_intrinsic() {
+        return None;
+    }
+    object_shape_id(db, type_id).or_else(|| object_with_index_shape_id(db, type_id))
+}
+
+/// Structural fallback for the global `Object` interface on a `TypeId`.
+///
+/// See [`object_shape_matches_global_object_interface`]. Returns `false` for
+/// intrinsics and non-object types.
+pub fn matches_global_object_interface_shape(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    object_like_shape_id(db, type_id).is_some_and(|shape_id| {
+        let shape = db.object_shape(shape_id);
+        object_shape_matches_global_object_interface(db, &shape)
+    })
+}
+
+/// Structural fallback for the global `Function` interface on a `TypeId`.
+///
+/// `true` when the type is an object shape with at most
+/// [`GLOBAL_FUNCTION_INTERFACE_MAX_PROPERTIES`] properties declaring `apply`,
+/// `call`, and `bind`. This is the single shared copy of the historical
+/// sniff; prefer [`is_global_function_interface`] which tries identity first.
+pub fn matches_global_function_interface_shape(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    object_like_shape_id(db, type_id).is_some_and(|shape_id| {
+        let shape = db.object_shape(shape_id);
+        if shape.properties.len() > GLOBAL_FUNCTION_INTERFACE_MAX_PROPERTIES {
+            return false;
+        }
+        let apply = db.intern_string("apply");
+        let call = db.intern_string("call");
+        let bind = db.intern_string("bind");
+        shape.properties.iter().any(|p| p.name == apply)
+            && shape.properties.iter().any(|p| p.name == call)
+            && shape.properties.iter().any(|p| p.name == bind)
+    })
+}
+
+/// Is `type_id` the global `Object` interface? Identity first, then the
+/// shared structural fallback.
+pub fn is_global_object_interface(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    is_global_interface_by_identity(db, type_id, IntrinsicKind::Object)
+        || matches_global_object_interface_shape(db, type_id)
+}
+
+/// Is `type_id` the global `Function` interface? Identity first, then the
+/// shared structural fallback.
+pub fn is_global_function_interface(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    is_global_interface_by_identity(db, type_id, IntrinsicKind::Function)
+        || matches_global_function_interface_shape(db, type_id)
+}
+
+/// Resolver-aware variant of [`is_global_object_interface`].
+pub fn is_global_object_interface_with_resolver<R: TypeResolver + ?Sized>(
+    db: &dyn TypeDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> bool {
+    is_global_interface_by_identity_with_resolver(db, resolver, type_id, IntrinsicKind::Object)
+        || matches_global_object_interface_shape(db, type_id)
+}
+
+/// Resolver-aware variant of [`is_global_function_interface`].
+pub fn is_global_function_interface_with_resolver<R: TypeResolver + ?Sized>(
+    db: &dyn TypeDatabase,
+    resolver: &R,
+    type_id: TypeId,
+) -> bool {
+    is_global_interface_by_identity_with_resolver(db, resolver, type_id, IntrinsicKind::Function)
+        || matches_global_function_interface_shape(db, type_id)
+}

--- a/crates/tsz-solver/src/type_queries/mod.rs
+++ b/crates/tsz-solver/src/type_queries/mod.rs
@@ -34,6 +34,7 @@ pub mod data;
 pub mod extended;
 pub mod extended_constructors;
 pub mod flow;
+pub mod global_interfaces;
 pub mod iterable;
 pub mod mapped;
 pub mod mapped_declaration_surface;
@@ -93,6 +94,7 @@ pub use extended_constructors::{
 
 pub use data::*;
 pub use flow::*;
+pub use global_interfaces::*;
 pub use iterable::*;
 pub use mapped::*;
 pub use mapped_declaration_surface::*;


### PR DESCRIPTION
Goal: fast

Implements #13090 (perf/stability techdebt in the #13250 orbit): the solver's hand-rolled "is this the global `Object`/`Function` interface" structural sniffs are unified behind one canonical, identity-first query.

## Structural rule
A "global Object/Function interface" decision must be an identity comparison against the binder/global builtin registration (CLAUDE.md: use binder/global builtin ids for true built-ins), with at most ONE shared structural fallback for the pre-materialization window — never N diverged member-probe copies. Inventory at HEAD found 12 sites: 7 semantic sniffs (with real divergences: one missing `propertyIsEnumerable`, one missing `bind` AND the property-count cap), 4 copy-pasted boxed-identity blocks, and 1 checker-side copy.

## What changed
- New directory module `crates/tsz-solver/src/type_queries/global_interfaces/`: identity tier (boxed-registry comparison across both resolver and interner registries; documented `false` when lib isn't loaded — noLib/pre-materialization ordering), plus the single shared structural fallback carrying the strictest historical probe.
- All 12 sites route through it; the two diverged sniffs are unified (objects.rs gains `propertyIsEnumerable`; call_evaluator gains `bind` + the 20-prop cap + an identity tier). Net −150 lines in callers.
- Load-bearing fallback kept with witness evidence: the identity-only experiment broke 3 pinned behaviors (pre-evaluation genuinely loses lib identity across arenas), so the fallback stays — as one documented copy. Display-layer probes and Object.prototype-membership modeling are deliberately out of scope (printer/apparent-type concerns, not identity).

## Adjacent-case matrix (anti-hardcoding gate)
5 new unit tests pin: lib-not-loaded gate returns false; a renamed Object-shaped user impostor is rejected by the identity tier (and its fallback match is documented as the pre-existing hazard); Lazy-DefId registration via both registries; probe-member/cap requirements for both interfaces.

## Verification
- Full local conformance (release): 12583/12585, zero new vs accepted regressions (only the 2 accepted Mac-delta cases) — re-verified on this head over current main.
- nextest A/B vs clean main: solver and checker failure sets identical to main's (3 solver; 6 checker FAILs + 7 ts2859 timeouts + 2 source-grep tests — all pre-existing upstream).
- Byte-identical diagnostics branch-vs-main on zodmin (2 configs) and ts-toolbelt (2 configs).
- clippy --all-targets clean; no new `#[allow]`; new module is a directory module (403 lines).

## Risks
Identity is slightly broader (added interner-registry tiers) and structure stricter at the two diverged sites; suites and fixtures show no observable change — rare lib-augmentation setups are the residual surface. Fully retiring the structural fallback needs the lib-heritage campaign (#12299 context).

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: max
