### PR TITLE
refactor(solver): share relation policy bit application

### DIFF
--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -727,7 +727,7 @@ fn configure_subtype_checker_policy_bits<'a, R: TypeResolver>(
     checker
 }
 
-fn apply_policy_bits_to_subtype_checker<R: TypeResolver>(
+const fn apply_policy_bits_to_subtype_checker<R: TypeResolver>(
     checker: &mut SubtypeChecker<'_, R>,
     policy: RelationPolicy,
 ) {

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -718,7 +718,7 @@ fn configure_compat_checker_policy_bits<R: TypeResolver>(
     apply_policy_bits_to_subtype_checker(&mut checker.subtype, policy);
 }
 
-fn configure_subtype_checker_policy_bits<'a, R: TypeResolver>(
+const fn configure_subtype_checker_policy_bits<'a, R: TypeResolver>(
     mut checker: SubtypeChecker<'a, R>,
     policy: RelationPolicy,
 ) -> SubtypeChecker<'a, R> {

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -713,25 +713,24 @@ fn configure_compat_checker_policy_bits<R: TypeResolver>(
     checker.set_no_unchecked_indexed_access(policy.no_unchecked_indexed_access());
     checker.set_allow_bivariant_rest(policy.allow_bivariant_rest());
 
-    checker.subtype.strict_null_checks = policy.strict_null_checks();
-    checker.subtype.strict_function_types = policy.strict_function_types();
-    checker.subtype.exact_optional_property_types = policy.exact_optional_property_types();
-    checker.subtype.no_unchecked_indexed_access = policy.no_unchecked_indexed_access();
     checker.set_disable_method_bivariance(policy.disable_method_bivariance());
-    checker.subtype.disable_method_bivariance = policy.disable_method_bivariance();
-    checker.subtype.allow_void_return = policy.allow_void_return();
-    checker.subtype.allow_bivariant_rest = policy.allow_bivariant_rest();
-    checker.subtype.allow_bivariant_param_count = policy.allow_bivariant_param_count();
-    checker.subtype.allow_erased_generic_signature_retry =
-        policy.allow_erased_generic_signature_retry();
-    checker.subtype.in_callback_param_check = policy.in_callback_param_check();
-    checker.subtype.strict_readonly_identity = policy.strict_readonly_identity();
+
+    apply_policy_bits_to_subtype_checker(&mut checker.subtype, policy);
 }
 
-const fn configure_subtype_checker_policy_bits<'a, R: TypeResolver>(
+fn configure_subtype_checker_policy_bits<'a, R: TypeResolver>(
     mut checker: SubtypeChecker<'a, R>,
     policy: RelationPolicy,
 ) -> SubtypeChecker<'a, R> {
+    apply_policy_bits_to_subtype_checker(&mut checker, policy);
+    checker.erase_generics = policy.erase_generics;
+    checker
+}
+
+fn apply_policy_bits_to_subtype_checker<R: TypeResolver>(
+    checker: &mut SubtypeChecker<'_, R>,
+    policy: RelationPolicy,
+) {
     checker.strict_null_checks = policy.strict_null_checks();
     checker.strict_function_types = policy.strict_function_types();
     checker.exact_optional_property_types = policy.exact_optional_property_types();
@@ -741,10 +740,8 @@ const fn configure_subtype_checker_policy_bits<'a, R: TypeResolver>(
     checker.allow_bivariant_rest = policy.allow_bivariant_rest();
     checker.allow_bivariant_param_count = policy.allow_bivariant_param_count();
     checker.strict_readonly_identity = policy.strict_readonly_identity();
-    checker.erase_generics = policy.erase_generics;
     checker.allow_erased_generic_signature_retry = policy.allow_erased_generic_signature_retry();
     checker.in_callback_param_check = policy.in_callback_param_check();
-    checker
 }
 
 /// Variance-aware Application-to-Application assignability check.


### PR DESCRIPTION
Goal: fast

## Summary
- Refs #13094 and #13250.
- Collapse the duplicated `RelationPolicy` -> `SubtypeChecker` policy-bit assignment into one solver-owned helper.
- Keep the `CompatChecker` top-level setters intact, then configure its embedded `SubtypeChecker` through the same helper used by raw subtype queries.
- Preserve the existing subtype-only `erase_generics` assignment where the raw subtype checker was already setting it.

## Structural rule
When a relation query is configured by a typed `RelationPolicy`, tsz should apply the policy bits to `SubtypeChecker` through one solver-owned path. This avoids drift between assignability/compatibility entry points and raw subtype entry points while preserving the current relation semantics.

## Owner layer
Solver owns relation policy interpretation and relation-engine configuration. Checker-facing callers continue to pass typed `RelationPolicy` values through query boundaries rather than configuring relation engine internals directly.

## Adjacent cases / fallback
- Assignability and bivariant-callback paths still configure `CompatChecker` top-level options through existing setters.
- The embedded `CompatChecker::subtype` policy bits now share the same assignment helper as raw subtype/overlap paths.
- Raw subtype paths still apply subtype-only `erase_generics` exactly where they did before this slice.
- No cache key, relation result, diagnostic rendering, or compatibility-mode behavior is intentionally changed.

## Verification
- Pre-commit formatting hook ran during `git commit`.
- Local tests not run per current instruction.
- Draft PR CI Light Summary passed at exact head `c749517ec6c075fb46194e70738ef9d29400ee00` on run 27418165109.
- Ready-review CI is expected to run full PR-head gates before merge queue.

## Provenance
Machine: m4
Assistant: codex
Model: GPT-5
Effort: medium
