### PR TITLE
fix(bench/ci): cap shard Cloud Build submissions and fail fast on quota-starved CreateBuild (#13306)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1029,6 +1029,13 @@ jobs:
     timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
+      # Cap concurrent Cloud Build submissions: 8 simultaneous CreateBuild
+      # calls exceed the project's concurrent-build headroom when PR CI is
+      # busy, and gcloud retries the throttled call silently until the job
+      # timeout (#13306: three shards sat 120 minutes with the tarball
+      # uploaded and no build ever created). Four at a time keeps every
+      # submit under quota; queued shards start with a fresh per-job timeout.
+      max-parallel: 4
       matrix:
         include:
           - label: compiler-files
@@ -1084,7 +1091,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          submit_output="$(gcloud builds submit \
+          # Even with --async, a quota-throttled CreateBuild is retried by
+          # gcloud silently (#13306: tarball uploaded, no build created, two
+          # hours of silence until the job timeout). Bound the submit so a
+          # starved shard fails fast with an attributable message instead of
+          # burning the whole job budget.
+          submit_rc=0
+          submit_output="$(timeout 600 gcloud builds submit \
             --async \
             --project=tsz-ci \
             --region=us-central1 \
@@ -1092,7 +1105,15 @@ jobs:
             --gcs-source-staging-dir=gs://tsz-ci_cloudbuild/cb-source-staging \
             --substitutions=_BENCH_TARGET_SHA="${BENCH_TARGET_SHA}",_BENCH_SHARD_LABEL="${{ matrix.label }}",_BENCH_SHARD_FILTER="${{ matrix.filter }}" \
             --format='value(id)' \
-            .)"
+            .)" || submit_rc=$?
+          if [[ "$submit_rc" -eq 124 ]]; then
+            echo "::error::Cloud Build submit for ${{ matrix.label }} produced no build within 10 minutes — concurrent-build quota starvation (#13306), not a benchmark result. Re-run when the pool drains." >&2
+            exit 1
+          elif [[ "$submit_rc" -ne 0 ]]; then
+            printf '%s\n' "$submit_output"
+            echo "Cloud Build shard submit failed with exit ${submit_rc}." >&2
+            exit "$submit_rc"
+          fi
           build_id="$(grep -Eo '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' <<<"$submit_output" | tail -n 1 || true)"
           if [[ -z "$build_id" ]]; then
             printf '%s\n' "$submit_output"

--- a/scripts/bench/lib/measure-protocol.sh
+++ b/scripts/bench/lib/measure-protocol.sh
@@ -170,11 +170,18 @@ tsz_process_tree_cpu_seconds() {
 # ordering: a dead process tree has no CPU time left to read.
 tsz_start_timeout_watchdog() {
   local timeout_secs="$1" pid="$2" cpu_file="$3"
+  # The caller captures this function with command substitution, and a
+  # backgrounded job inherits the substitution's stdout pipe. Without the
+  # explicit redirect, $() blocks until the watchdog's sleep finishes, so
+  # EVERY wrapped run pays the full deadline as idle wall time (#13306: this
+  # broke every benchmark row at 15s/iteration and cascaded into the Cloud
+  # Build pool congestion). Detach stdout so the substitution returns as soon
+  # as the pid is echoed.
   (
     sleep "$timeout_secs"
     tsz_process_tree_cpu_seconds "$pid" > "$cpu_file" 2>/dev/null || true
     kill -KILL "$pid" 2>/dev/null || true
-  ) &
+  ) >/dev/null 2>&1 &
   echo $!
 }
 


### PR DESCRIPTION
Goal: fast

Three fixes from the #13306 benchmark-delivery-outage diagnosis (no data published for ~30h; full evidence chain on the issue).

## Structural rules
1. **A wrapped benchmark run must cost the child's wall time, not the watchdog's deadline.** #13206's `tsz_start_timeout_watchdog` is captured via command substitution, and the backgrounded watchdog subshell inherited the substitution's stdout pipe — so `$()` blocked until the watchdog's `sleep` finished. EVERY hyperfine iteration of EVERY row paid the full `run_timeout=15` as idle wall (witness: `run-with-timeout.sh 15 -- echo hello` = 15.044s before, 0.023s after; live bench rows read 15.03s ± 0.01 with 0.046s user CPU for both compilers). This silently corrupted all measured numbers since 06-11 08:04Z AND inflated shard runtimes ~6.5min/row, which is what congested the Cloud Build pool. Fix: detach the watchdog's stdout. Timeout path verified intact (kills at deadline, exit 124, CPU-evidence note).
2. **A shard's job budget must be spent measuring, not silently waiting on a throttled CreateBuild**: `max-parallel: 4` on the shard matrix caps concurrent submissions (witness: 3 of 8 shards uploaded their tarball then sat silent 120 minutes with no `Created` line; the 5 that got slots created builds in ~1s).
3. **A starved submit must fail attributably, fast**: the shard submit is bounded by `timeout 600` and classifies exit 124 as "quota starvation (#13306), not a benchmark result" — the #13206 evidence discipline applied to the submission path itself.

## Remaining #13306 items (not this PR)
Partial-publish semantics (`Expected 8 benchmark shard JSON files, found 5.` hard-fail discards completed shards — confirmed on run 27408899478), catch-up dispatch rate-limiting, pool/quota sizing.

## Verification
- `run-with-timeout.sh 15 -- echo hello`: 15.044s → 0.023s; `run-with-timeout.sh 2 -- sleep 30`: kills at 2.08s, exit 124, contention note printed.
- `node scripts/bench/test-measure-protocol.mjs`, `test-measure-tsz.mjs`, `test-timeout-runner.mjs`: all pass.
- `test-bench-workflow-cloudbuild-prep.mjs`, `test-tsgo-winner-report.mjs`, `test-benchmark-artifact-selection.mjs`, `test-gh-pages-benchmark-artifact-gate.mjs`, `test-ci-health-benchmark-readiness.mjs`: all pass; YAML parse check clean.
- No Rust code touched. Live verification: the first post-merge Bench run must show row times back at ms-scale, all 8 shards `Created`, and bench-publish reaching 8/8 JSONs.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-fable-5[1m]
Effort: max