### PR TITLE
test(solver): add RelationPolicy cache-key tripwire (#8207)

### DIFF
--- a/crates/tsz-solver/tests/relation_cache_config_tests.rs
+++ b/crates/tsz-solver/tests/relation_cache_config_tests.rs
@@ -47,7 +47,11 @@ mod cache_agreement;
 /// assignability cache keys for the same `(STRING, NUMBER)` pair. Centralises
 /// the build-two-keys / `assert_ne!` shape used by the per-flag partition
 /// regression tests below.
-fn assert_assignability_partitions(name: &str, on: RelationPolicy, off: RelationPolicy) {
+///
+/// `pub(crate)`: also reused by the exhaustive-destructuring tripwire in
+/// `relations::relation_queries::tests`, which must live next to
+/// `RelationPolicy` to see its private `flags` field.
+pub(crate) fn assert_assignability_partitions(name: &str, on: RelationPolicy, off: RelationPolicy) {
     let key_on =
         RelationCacheKey::for_assignability(TypeId::STRING, TypeId::NUMBER, on.cache_config());
     let key_off =
@@ -56,7 +60,7 @@ fn assert_assignability_partitions(name: &str, on: RelationPolicy, off: Relation
 }
 
 /// Subtype-cache counterpart of [`assert_assignability_partitions`].
-fn assert_subtype_partitions(name: &str, on: RelationPolicy, off: RelationPolicy) {
+pub(crate) fn assert_subtype_partitions(name: &str, on: RelationPolicy, off: RelationPolicy) {
     let key_on = RelationCacheKey::for_subtype(TypeId::STRING, TypeId::NUMBER, on.cache_config());
     let key_off = RelationCacheKey::for_subtype(TypeId::STRING, TypeId::NUMBER, off.cache_config());
     assert_ne!(key_on, key_off, "{name} must partition the cache");

--- a/crates/tsz-solver/tests/relation_queries_tests.rs
+++ b/crates/tsz-solver/tests/relation_queries_tests.rs
@@ -473,3 +473,90 @@ fn redeclaration_identity_same_union_is_identical() {
         "C | D should be identical to C | D for redeclaration"
     );
 }
+
+/// Compile-time tripwire for the relation cache-key contract (#8207).
+///
+/// `RelationPolicy` is the single canonical cache-key input for relation
+/// queries: every behavior-affecting field must be projected into
+/// `RelationCacheConfig` by `RelationPolicy::cache_config`.
+///
+/// The destructuring below is intentionally exhaustive (no `..` rest
+/// pattern), so adding a field to `RelationPolicy` fails compilation here.
+/// When that happens, the new field must:
+///
+/// (a) be mapped into `RelationCacheConfig` / the relation cache key, or be
+///     explicitly documented as cache-neutral (diagnostic-only) on the
+///     struct doc comment; and
+/// (b) get a cache-partition test (see `relation_cache_config_tests` and the
+///     per-field assertions below) before this pattern is extended with the
+///     new field.
+///
+/// This test lives next to `RelationPolicy` (instead of in
+/// `relation_cache_config_tests`) because the exhaustive pattern needs
+/// visibility of the private `flags` field.
+#[test]
+fn relation_policy_fields_are_exhaustively_partitioned_in_cache_keys() {
+    use crate::relation_cache_config_tests::{
+        assert_assignability_partitions, assert_subtype_partitions,
+    };
+
+    let policy = RelationPolicy::default();
+    let RelationPolicy {
+        flags,
+        strict_subtype_checking,
+        strict_any_propagation,
+        any_propagation_mode,
+        assume_related_on_cycle,
+        skip_weak_type_checks,
+        erase_generics,
+    } = policy;
+
+    // `flags`: toggle a representative typed bit relative to the current
+    // default; the full per-bit matrix lives in
+    // `relation_cache_config_tests::each_relation_flag_bit_produces_a_distinct_key`.
+    assert_subtype_partitions(
+        "flags",
+        RelationPolicy::from_relation_flags(flags),
+        RelationPolicy::from_relation_flags(
+            flags.symmetric_difference(RelationFlags::STRICT_NULL_CHECKS),
+        ),
+    );
+    assert_assignability_partitions(
+        "strict_subtype_checking",
+        policy.with_strict_subtype_checking(!strict_subtype_checking),
+        policy,
+    );
+    assert_assignability_partitions(
+        "strict_any_propagation",
+        policy.with_strict_any_propagation(!strict_any_propagation),
+        policy,
+    );
+    // Exhaustive over `AnyPropagationMode` as well: a new variant must pick a
+    // distinct `CachedAnyMode` projection in `RelationPolicy::cache_config`.
+    let other_any_mode = match any_propagation_mode {
+        AnyPropagationMode::All => AnyPropagationMode::TopLevelOnly,
+        AnyPropagationMode::TopLevelOnly | AnyPropagationMode::AnySourceNotRelated => {
+            AnyPropagationMode::All
+        }
+    };
+    assert_subtype_partitions(
+        "any_propagation_mode",
+        policy.with_any_propagation_mode(other_any_mode),
+        policy,
+    );
+    assert_subtype_partitions(
+        "assume_related_on_cycle",
+        policy.with_assume_related_on_cycle(!assume_related_on_cycle),
+        policy,
+    );
+    assert_assignability_partitions(
+        "skip_weak_type_checks",
+        policy.with_skip_weak_type_checks(!skip_weak_type_checks),
+        policy,
+    );
+    assert_subtype_partitions(
+        "erase_generics",
+        policy.with_erase_generics(!erase_generics),
+        policy,
+    );
+}


### PR DESCRIPTION
Goal: hold

Adds the last acceptance criterion of #8207: an exhaustive-destructuring tripwire so any new `RelationPolicy` field fails compilation until it is mapped into the relation cache key (or documented cache-neutral) with a partition test. All legacy flag protocols were already retired by the merged PR chain (#9268, #11920, #11922, #12009, #12056, #12060, #12068, #12924).

Structural rule: RelationPolicy is the single canonical cache-key input for relation queries; every behavior-affecting policy field must partition the relation caches.

Closes #8207

## Verification
- `cargo nextest run -p tsz-solver relation_queries`
- `cargo nextest run -p tsz-solver relation_cache_config`
- `cargo clippy -p tsz-solver --tests`

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
