### PR TITLE
chore(arch): ratchet module-path solver computation imports (#8204)

### DIFF
--- a/scripts/arch/arch_guard.py
+++ b/scripts/arch/arch_guard.py
@@ -226,6 +226,19 @@ def main() -> int:
 
     for (
         name,
+        search_roots,
+        exclude_path_prefixes,
+        max_references,
+    ) in MODULE_PATH_SOLVER_COMPUTATION_IMPORT_COUNT_CHECKS:
+        hits = scan_module_path_solver_computation_import_count(
+            search_roots, exclude_path_prefixes, max_references
+        )
+        total_hits += len(hits)
+        if hits:
+            failures.append((name, hits))
+
+    for (
+        name,
         file_path,
         root_module_prefixes,
         max_reexports,

--- a/scripts/arch/arch_guard_config.py
+++ b/scripts/arch/arch_guard_config.py
@@ -141,6 +141,52 @@ ROOT_SOLVER_COMPUTATION_IMPORT_COUNT_CHECKS = [
     ),
 ]
 
+# Seal the module-path escape hatch around the #8204 tiered solver API: the
+# flat-root ratchet above pins re-exported symbol names, but the solver still
+# declares `pub mod operations`/`relations`/`evaluation`/..., so downstream
+# crates can reach computation internals by full module path
+# (`tsz_solver::operations::widening::widen_type`). This pins those references
+# in the emitter/LSP/CLI/wasm source trees at the current count; migrating a
+# site to a tiered facade or checker query-boundary helper should ratchet the
+# cap down in the same diff.
+#
+# Transitional exceptions pinned by the current cap (#8204 successor debt —
+# each file below still reaches computation modules by path and is the
+# migration backlog for sealing the tiered API):
+#   - crates/tsz-cli/src/bin/tsz.rs (relations::subtype thread-local reset)
+#   - crates/tsz-cli/src/driver/check_tests/check_tests_part2.rs
+#     (operations::property::PropertyAccessResult)
+#   - crates/tsz-emitter/src/declaration_emitter/core/emit_class_properties.rs
+#   - crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
+#   - crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+#   - crates/tsz-emitter/src/declaration_emitter/helpers/
+#     type_inference_return_normalization.rs
+#   - crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+#   - crates/tsz-emitter/src/declaration_emitter/helpers/
+#     variable_decl_type_helpers.rs
+#     (operations::widening / operations iterator helpers)
+#   - crates/tsz-emitter/src/lowering/helpers_private_fields.rs
+#     (operations::compound_assignment)
+#   - crates/tsz-lsp/src/code_actions/code_action_extract.rs
+#     (operations::compound_assignment)
+#   - crates/tsz-lsp/src/completions/mod.rs (objects apparent-member helpers)
+#
+# Each entry:
+#   (description, search_roots, exclude_path_prefixes, max_references).
+MODULE_PATH_SOLVER_COMPUTATION_IMPORT_COUNT_CHECKS = [
+    (
+        "Solver API boundary: module-path computation imports in emitter/LSP/CLI/wasm (#8204)",
+        [
+            ROOT / "crates" / "tsz-emitter" / "src",
+            ROOT / "crates" / "tsz-lsp" / "src",
+            ROOT / "crates" / "tsz-cli" / "src",
+            ROOT / "crates" / "tsz-wasm" / "src",
+        ],
+        (),
+        16,
+    ),
+]
+
 # Pin the producer-side compatibility surface that still re-exports solver
 # computation/construction APIs from the crate root. The zero wildcard guard
 # below prevents broad `pub use module::*` growth; this count makes explicit
@@ -249,7 +295,10 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         #
         # Ratcheted 3163→3155 after arch-smoke caught current-main slack in the
         # live direct-reference count.
-        3155,
+        #
+        # Ratcheted 3155→3040 after the #8204 module-path ratchet PR's
+        # arch-smoke run caught current-main slack in the live count.
+        3040,
     ),
 ]
 

--- a/scripts/arch/arch_guard_counts.py
+++ b/scripts/arch/arch_guard_counts.py
@@ -126,6 +126,23 @@ _ROOT_SOLVER_COMPUTATION_IMPORT_PATTERN = re.compile(
     + r")\b"
 )
 
+MODULE_PATH_SOLVER_COMPUTATION_MODULES = (
+    "contextual",
+    "evaluation",
+    "instantiation",
+    "intern",
+    "narrowing",
+    "objects",
+    "operations",
+    "relations",
+)
+
+_MODULE_PATH_SOLVER_COMPUTATION_IMPORT_PATTERN = re.compile(
+    r"\btsz_solver::(?:"
+    + "|".join(MODULE_PATH_SOLVER_COMPUTATION_MODULES)
+    + r")::"
+)
+
 _QUERY_BOUNDARY_COMMON_REFERENCE_PATTERN = re.compile(
     r"\b(?:crate::)?query_boundaries::common::"
 )
@@ -267,6 +284,67 @@ def scan_root_solver_computation_import_count(
         hits.append(
             f"total flat root solver computation API references outside "
             f"query boundaries: {len(matching_lines)} (cap {max_references}; "
+            f"bump cap intentionally, or route the new site through a named "
+            f"solver facade / checker query-boundary helper — #8204)"
+        )
+        return hits
+    return []
+
+
+def scan_module_path_solver_computation_import_count(
+    search_roots: list[pathlib.Path],
+    exclude_path_prefixes: tuple[str, ...],
+    max_references: int,
+) -> list[str]:
+    """Count module-path `tsz_solver::<computation module>::` references in
+    production code.
+
+    This seals the remaining #8204 escape hatch: the flat-root ratchet above
+    pins re-exported symbol names, but the solver still declares
+    `pub mod operations`/`relations`/`evaluation`/..., so downstream crates can
+    reach computation internals by full module path
+    (`tsz_solver::operations::widening::widen_type`). Existing references are
+    transitional compatibility debt; new sites should route through the tiered
+    solver facades or a checker query-boundary helper. Test files are
+    excluded, and `exclude_path_prefixes` marks approved boundary modules.
+    """
+    matching_lines: list[tuple[str, int]] = []
+    for base in search_roots:
+        if not base.exists():
+            continue
+        for path in base.rglob("*.rs"):
+            try:
+                rel_to_root = path.relative_to(ROOT).as_posix()
+            except ValueError:
+                rel_to_root = path.relative_to(base).as_posix()
+            parts = set(rel_to_root.split("/"))
+            if EXCLUDE_DIRS.intersection(parts):
+                continue
+            if "tests" in parts or "benches" in parts:
+                continue
+            if is_test_file(rel_to_root):
+                continue
+            if any(rel_to_root.startswith(prefix) for prefix in exclude_path_prefixes):
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for line_no, line in enumerate(text.splitlines(), start=1):
+                if line.lstrip().startswith("//"):
+                    continue
+                if _MODULE_PATH_SOLVER_COMPUTATION_IMPORT_PATTERN.search(line):
+                    matching_lines.append((rel_to_root, line_no))
+
+    matching_lines.sort()
+    if len(matching_lines) > max_references:
+        hits = [
+            f"module-path solver computation reference #{i + 1}: {rel}:{line_no}"
+            for i, (rel, line_no) in enumerate(matching_lines)
+        ]
+        hits.append(
+            f"total module-path solver computation references outside "
+            f"approved boundaries: {len(matching_lines)} (cap {max_references}; "
             f"bump cap intentionally, or route the new site through a named "
             f"solver facade / checker query-boundary helper — #8204)"
         )

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -977,6 +977,48 @@ FILE_LINE_LIMIT_CHECKS = [
         ROOT / "crates" / "tsz-emitter" / "src" / "transforms" / "module_commonjs.rs",
         2016,
     ),
+    # Current-main drift refresh (2026-06-12, #8204 ratchet PR): the
+    # unguarded-oversized-file smoke test found these five production files
+    # already past 2000 lines on main with no guard entry. Pinned at their
+    # live counts; ratchet down as submodules land (§19).
+    (
+        "Solver boundary: def/core.rs size ratchet",
+        ROOT / "crates" / "tsz-solver" / "src" / "def" / "core.rs",
+        2298,
+    ),
+    (
+        "Common boundary: perf_counters/runtime.rs size ratchet",
+        ROOT / "crates" / "tsz-common" / "src" / "perf_counters" / "runtime.rs",
+        2114,
+    ),
+    (
+        "Solver boundary: evaluate_rules/index_access.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-solver"
+        / "src"
+        / "evaluation"
+        / "evaluate_rules"
+        / "index_access.rs",
+        2056,
+    ),
+    (
+        "Solver boundary: subtype/rules/generics.rs size ratchet",
+        ROOT
+        / "crates"
+        / "tsz-solver"
+        / "src"
+        / "relations"
+        / "subtype"
+        / "rules"
+        / "generics.rs",
+        2017,
+    ),
+    (
+        "Solver boundary: intern/normalize.rs size ratchet",
+        ROOT / "crates" / "tsz-solver" / "src" / "intern" / "normalize.rs",
+        2010,
+    ),
 ]
 
 # Pin field counts on giant coordination structs so workstream-4 (Checker
@@ -1116,6 +1158,52 @@ ROOT_SOLVER_COMPUTATION_IMPORT_COUNT_CHECKS = [
         ],
         ("crates/tsz-checker/src/query_boundaries/",),
         0,
+    ),
+]
+
+# Seal the module-path escape hatch around the #8204 tiered solver API: the
+# flat-root ratchet above pins re-exported symbol names, but the solver still
+# declares `pub mod operations`/`relations`/`evaluation`/..., so downstream
+# crates can reach computation internals by full module path
+# (`tsz_solver::operations::widening::widen_type`). This pins those references
+# in the emitter/LSP/CLI/wasm source trees at the current count; migrating a
+# site to a tiered facade or checker query-boundary helper should ratchet the
+# cap down in the same diff.
+#
+# Transitional exceptions pinned by the current cap (#8204 successor debt —
+# each file below still reaches computation modules by path and is the
+# migration backlog for sealing the tiered API):
+#   - crates/tsz-cli/src/bin/tsz.rs (relations::subtype thread-local reset)
+#   - crates/tsz-cli/src/driver/check_tests/check_tests_part2.rs
+#     (operations::property::PropertyAccessResult)
+#   - crates/tsz-emitter/src/declaration_emitter/core/emit_class_properties.rs
+#   - crates/tsz-emitter/src/declaration_emitter/helpers/generic_call_literal.rs
+#   - crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+#   - crates/tsz-emitter/src/declaration_emitter/helpers/
+#     type_inference_return_normalization.rs
+#   - crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+#   - crates/tsz-emitter/src/declaration_emitter/helpers/
+#     variable_decl_type_helpers.rs
+#     (operations::widening / operations iterator helpers)
+#   - crates/tsz-emitter/src/lowering/helpers_private_fields.rs
+#     (operations::compound_assignment)
+#   - crates/tsz-lsp/src/code_actions/code_action_extract.rs
+#     (operations::compound_assignment)
+#   - crates/tsz-lsp/src/completions/mod.rs (objects apparent-member helpers)
+#
+# Each entry:
+#   (description, search_roots, exclude_path_prefixes, max_references).
+MODULE_PATH_SOLVER_COMPUTATION_IMPORT_COUNT_CHECKS = [
+    (
+        "Solver API boundary: module-path computation imports in emitter/LSP/CLI/wasm (#8204)",
+        [
+            ROOT / "crates" / "tsz-emitter" / "src",
+            ROOT / "crates" / "tsz-lsp" / "src",
+            ROOT / "crates" / "tsz-cli" / "src",
+            ROOT / "crates" / "tsz-wasm" / "src",
+        ],
+        (),
+        16,
     ),
 ]
 
@@ -1276,7 +1364,10 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         #
         # Ratcheted 3163→3155 after arch-smoke caught current-main slack in the
         # live direct-reference count.
-        3155,
+        #
+        # Ratcheted 3155→3040 after the #8204 module-path ratchet PR's
+        # arch-smoke run caught current-main slack in the live count.
+        3040,
     ),
 ]
 

--- a/scripts/arch/test_arch_guard_counts.py
+++ b/scripts/arch/test_arch_guard_counts.py
@@ -421,6 +421,113 @@ class ArchGuardRootSolverComputationImportCountTests(unittest.TestCase):
             )
 
 
+class ArchGuardModulePathSolverComputationImportCountTests(unittest.TestCase):
+    """Cover the #8204 ratchet for module-path solver computation imports."""
+
+    def setUp(self):
+        self.arch_guard = load_arch_guard_module()
+
+    def _make_tree(self, files: dict[str, str]):
+        tmp = tempfile.mkdtemp()
+        root = pathlib.Path(tmp)
+        for rel, content in files.items():
+            full = root / rel
+            full.parent.mkdir(parents=True, exist_ok=True)
+            full.write_text(content, encoding="utf-8")
+        return root
+
+    def test_flags_module_path_computation_references(self):
+        root = self._make_tree(
+            {
+                "crates/tsz-emitter/src/declaration.rs": (
+                    "let widened = tsz_solver::operations::widening::widen_type(interner, ty);\n"
+                    "use tsz_solver::objects::apparent_primitive_members;\n"
+                ),
+                "crates/tsz-cli/src/driver.rs": (
+                    "tsz_solver::relations::subtype::reset_subtype_thread_local_state();\n"
+                ),
+            }
+        )
+        hits = self.arch_guard.scan_module_path_solver_computation_import_count(
+            [root], (), 0
+        )
+        self.assertEqual(len(hits), 4, f"unexpected hits: {hits!r}")
+        self.assertIn("driver.rs:1", hits[0])
+        self.assertIn("declaration.rs:1", hits[1])
+        self.assertIn("declaration.rs:2", hits[2])
+        self.assertIn(
+            "total module-path solver computation references", hits[3]
+        )
+
+    def test_ignores_non_computation_modules_tests_and_comment_lines(self):
+        root = self._make_tree(
+            {
+                "crates/tsz-lsp/src/handles.rs": (
+                    "use tsz_solver::type_handles::TypeId;\n"
+                    "let q = tsz_solver::query::TypeQueries::new(db);\n"
+                ),
+                "crates/tsz-lsp/src/foo_tests.rs": (
+                    "let w = tsz_solver::operations::widening::widen_type(interner, ty);\n"
+                ),
+                "crates/tsz-emitter/tests/declaration.rs": (
+                    "use tsz_solver::operations::widening::widen_type;\n"
+                ),
+                "crates/tsz-cli/src/commented.rs": (
+                    "// let w = tsz_solver::operations::widening::widen_type(interner, ty);\n"
+                ),
+                "crates/tsz-checker/src/query_boundaries/common.rs": (
+                    "let w = tsz_solver::operations::widening::widen_type(interner, ty);\n"
+                ),
+            }
+        )
+        hits = self.arch_guard.scan_module_path_solver_computation_import_count(
+            [root], ("crates/tsz-checker/src/query_boundaries/",), 0
+        )
+        self.assertEqual(hits, [], f"unexpected hits: {hits!r}")
+
+    def test_passes_when_at_or_under_cap(self):
+        root = self._make_tree(
+            {
+                "crates/tsz-emitter/src/declaration.rs": (
+                    "let widened = tsz_solver::operations::widening::widen_type(interner, ty);\n"
+                ),
+                "crates/tsz-lsp/src/completions.rs": (
+                    "use tsz_solver::objects::apparent_primitive_members;\n"
+                ),
+            }
+        )
+        scan = self.arch_guard.scan_module_path_solver_computation_import_count
+        self.assertEqual(scan([root], (), 2), [])
+        self.assertEqual(scan([root], (), 3), [])
+
+    def test_check_is_registered(self):
+        names = [
+            entry[0]
+            for entry in self.arch_guard.MODULE_PATH_SOLVER_COMPUTATION_IMPORT_COUNT_CHECKS
+        ]
+        self.assertTrue(any("#8204" in name for name in names))
+
+    def test_real_count_passes_at_pinned_cap(self):
+        """The pinned cap must match the live count (no slack)."""
+        for entry in self.arch_guard.MODULE_PATH_SOLVER_COMPUTATION_IMPORT_COUNT_CHECKS:
+            name, search_roots, exclude_path_prefixes, max_references = entry
+            hits = self.arch_guard.scan_module_path_solver_computation_import_count(
+                search_roots, exclude_path_prefixes, max_references
+            )
+            self.assertEqual(
+                hits,
+                [],
+                f"{name}: cap is too tight — guard fires at the live count.",
+            )
+            self.assertNotEqual(
+                self.arch_guard.scan_module_path_solver_computation_import_count(
+                    search_roots, exclude_path_prefixes, max_references - 1
+                ),
+                [],
+                f"{name}: cap has slack and should be ratcheted to the live count.",
+            )
+
+
 class ArchGuardQueryBoundaryCommonReferenceTests(unittest.TestCase):
     """Cover the #8225 ratchet for broad query-boundary common callers."""
 


### PR DESCRIPTION
Goal: hold

Seals the remaining module-path escape hatch around the tiered solver API: adds an arch-guard ratchet pinning `tsz_solver::<computation module>::` references in emitter/LSP/CLI/wasm at the current count so new flat imports fail CI.

Structural rule: downstream crates consume solver semantics through the tiered `type_handles`/`query`/`computation`/`construction` facade; module-path imports of internal computation modules are frozen transitional debt, ratcheted to current count.

Closes #8204

Fresh measurement: 16 module-path references across 11 non-test files (matches the triage estimate). The transitional files are documented in the config comment next to the new check.

Notes / deviations found during implementation:
- The check-list constants in `scripts/arch/arch_guard_config.py` are not what `arch_guard.py` consumes at runtime — the live definitions come from `arch_guard_shared.py` (last wildcard import wins; `arch_guard_config.py` is only imported by `arch_guard_projects.py` for project-row constants). The new `MODULE_PATH_SOLVER_COMPUTATION_IMPORT_COUNT_CHECKS` is therefore added to both files, matching how the existing #8204 sibling checks are duplicated there.
- Two pre-existing arch-smoke failures exist on current main and would turn this arch-tool-only PR's `arch-tool-smoke` CI lane red, so they are refreshed in the same diff (precedented ratchet discipline): the #8225 common-quarantine cap is ratcheted 3155 -> 3040 to the live count, and five production files already past 2000 lines on main (`tsz-solver/src/def/core.rs`, `tsz-common/src/perf_counters/runtime.rs`, `tsz-solver/src/evaluation/evaluate_rules/index_access.rs`, `tsz-solver/src/relations/subtype/rules/generics.rs`, `tsz-solver/src/intern/normalize.rs`) get the `FILE_LINE_LIMIT_CHECKS` entries the smoke test prescribes, pinned at their live counts.

## Verification
- `python3 scripts/arch/arch_guard.py` — passes ("Architecture guardrails passed.")
- `python3 -m py_compile scripts/arch/*.py` — passes
- `python3 scripts/arch/test_arch_guard.py` — 236 tests, OK (this is the file CI's `arch-tool-smoke` job executes that aggregates `test_arch_guard_counts.py` via wildcard import; `test_arch_guard_counts.py` has no `__main__` block and is a no-op when run directly). On clean origin/main the same run is 231 tests with 2 failures — the drift refreshed above.
- All other `scripts/arch/test_*.py` files run individually exit 0, mirroring the `arch-tool-smoke` loop.

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
