### PR TITLE
fix(cli): carry forward latestChangedDtsFile on no-emit incremental saves (#13007)

### DIFF
--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -473,12 +473,18 @@ impl CompilationCache {
     }
 }
 
-/// Convert `CompilationCache` to `BuildInfo` for persistence
+/// Convert `CompilationCache` to `BuildInfo` for persistence.
+///
+/// `latest_changed_dts_file` is the most recently changed declaration output
+/// for this build, carried forward from the previously loaded `BuildInfo`
+/// when the build wrote no declaration file (tsc preserves
+/// `latestChangedDtsFile` across no-emit incremental saves).
 fn compilation_cache_to_build_info(
     cache: &CompilationCache,
     root_files: &[PathBuf],
     base_dir: &Path,
     options: &ResolvedCompilerOptions,
+    latest_changed_dts_file: Option<String>,
 ) -> BuildInfo {
     use crate::incremental::{
         BuildInfoOptions, CachedDiagnostic, CachedRelatedInformation, EmitSignature,
@@ -616,7 +622,7 @@ fn compilation_cache_to_build_info(
         dependencies,
         semantic_diagnostics_per_file,
         emit_signatures,
-        latest_changed_dts_file: None, // TODO: Track most recently changed .d.ts file
+        latest_changed_dts_file,
         options: build_options,
         build_time: std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/crates/tsz-cli/src/driver/core_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/core_diagnostics.rs
@@ -418,6 +418,13 @@ pub(super) fn compile_inner(
     // Only create when loading from BuildInfo (not when a cache is provided)
     let mut local_cache: Option<CompilationCache> = None;
 
+    // `latestChangedDtsFile` from the previously saved BuildInfo. tsc seeds
+    // its builder state with the old program's value and only reassigns it
+    // when a declaration file is actually written, so an incremental save
+    // that emits no declaration output must preserve the prior value rather
+    // than clear it.
+    let mut prior_latest_changed_dts_file: Option<String> = None;
+
     // Load BuildInfo only when incremental compilation is enabled and no cache was provided.
     // A standalone `tsBuildInfoFile` path does not activate build info reads/writes.
     if cache.is_none() && resolved.incremental {
@@ -429,6 +436,7 @@ pub(super) fn compile_inner(
                     Ok(Some(build_info)) => {
                         // Create a local cache from BuildInfo
                         local_cache = Some(build_info_to_compilation_cache(&build_info, &base_dir));
+                        prior_latest_changed_dts_file = build_info.latest_changed_dts_file;
                         tracing::info!("Loaded BuildInfo from: {}", build_info_path.display());
                     }
                     Ok(None) => {
@@ -1157,12 +1165,14 @@ pub(super) fn compile_inner(
         .iter()
         .any(|diag| diag.category == DiagnosticCategory::Error);
 
-    // Find the most recent .d.ts file for BuildInfo tracking
-    let latest_changed_dts_file = if !emitted_files.is_empty() {
-        find_latest_dts_file(&emitted_files, &base_dir)
-    } else {
-        None
-    };
+    // Most recent declaration output for BuildInfo tracking. When this build
+    // wrote no declaration file, carry the previously saved value forward:
+    // tsc preserves `latestChangedDtsFile` across no-emit incremental saves
+    // (`createBuilderProgramState` seeds it from the old program state and
+    // the write-file callback only reassigns it when a declaration file is
+    // written).
+    let latest_changed_dts_file =
+        find_latest_dts_file(&emitted_files, &base_dir).or(prior_latest_changed_dts_file);
 
     // Save BuildInfo if incremental compilation is enabled
     if should_save_build_info && !has_error {
@@ -1171,8 +1181,16 @@ pub(super) fn compile_inner(
         {
             // Build BuildInfo from the cache (which has been updated by collect_diagnostics)
             // If local_cache exists (from BuildInfo), use it; otherwise create minimal info
-            let mut build_info = if let Some(ref lc) = local_cache {
-                compilation_cache_to_build_info(lc, &file_paths, &base_dir, &resolved)
+            // The most recent declaration output (used for cross-project
+            // invalidation) is assigned at construction time in both branches.
+            let build_info = if let Some(ref lc) = local_cache {
+                compilation_cache_to_build_info(
+                    lc,
+                    &file_paths,
+                    &base_dir,
+                    &resolved,
+                    latest_changed_dts_file,
+                )
             } else {
                 // No cache available - create minimal BuildInfo with just file info
                 BuildInfo {
@@ -1187,12 +1205,10 @@ pub(super) fn compile_inner(
                                 .replace('\\', "/")
                         })
                         .collect(),
+                    latest_changed_dts_file,
                     ..Default::default()
                 }
             };
-
-            // Set the most recent .d.ts file for cross-project invalidation
-            build_info.latest_changed_dts_file = latest_changed_dts_file;
 
             if let Err(e) = build_info.save(&build_info_path) {
                 let build_info_path_text = build_info_path.display().to_string();

--- a/crates/tsz-cli/src/driver/plan.rs
+++ b/crates/tsz-cli/src/driver/plan.rs
@@ -1045,13 +1045,16 @@ const fn cli_module_resolution_value(module_resolution: ModuleResolution) -> &'s
     }
 }
 
-/// Selects the most recently modified `.d.ts` file among `emitted_files` and
-/// returns its path relative to `base_dir`, using forward slashes. Returns
-/// `None` if no `.d.ts` files exist or none have readable metadata.
+/// Selects the most recently modified declaration file among `emitted_files`
+/// and returns its path relative to `base_dir`, using forward slashes.
+/// Declaration outputs are matched with the same rule as tsc's
+/// `isDeclarationFileName` (`.d.ts`, `.d.mts`, `.d.cts`, `.d.<ext>.ts`).
+/// Returns `None` if no declaration files exist or none have readable
+/// metadata.
 pub(super) fn find_latest_dts_file(emitted_files: &[PathBuf], base_dir: &Path) -> Option<String> {
     let latest = emitted_files
         .iter()
-        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("d.ts"))
+        .filter(|p| tsz_common::file_extensions::is_ts_declaration_file(p))
         .filter_map(|p| std::fs::metadata(p).ok()?.modified().ok().map(|t| (t, p)))
         .max_by_key(|(t, _)| *t)
         .map(|(_, p)| p)?;

--- a/crates/tsz-cli/src/driver/tests.rs
+++ b/crates/tsz-cli/src/driver/tests.rs
@@ -100,6 +100,7 @@ fn compilation_cache_build_info_uses_source_hash_for_file_version() {
         std::slice::from_ref(&source_path),
         dir.path(),
         &ResolvedCompilerOptions::default(),
+        None,
     );
     let file_info = build_info
         .get_file_info("src/index.ts")
@@ -144,6 +145,7 @@ fn build_info_round_trip_preserves_dependency_order() {
         std::slice::from_ref(&main),
         base,
         &ResolvedCompilerOptions::default(),
+        None,
     );
     let restored = build_info_to_compilation_cache(&build_info, base);
     let restored_deps = restored

--- a/crates/tsz-cli/src/driver/tests_tail.rs
+++ b/crates/tsz-cli/src/driver/tests_tail.rs
@@ -166,6 +166,189 @@ fn test_ts5107_module_resolution_node10_has_migration_url() {
     );
 }
 
+/// `find_latest_dts_file` must select the newest declaration output by
+/// mtime and ignore non-declaration outputs entirely, even when those are
+/// newer. Declaration matching follows tsc's `isDeclarationFileName`
+/// (`.d.ts`/`.d.mts`/`.d.cts`), not `Path::extension()` — the final-dot
+/// extension of `a.d.ts` is just `ts`, which previously made this function
+/// return `None` for every emitted file.
+#[test]
+fn find_latest_dts_file_picks_newest_declaration_and_ignores_non_dts() {
+    use std::time::{Duration, SystemTime};
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let base = dir.path();
+    fs::create_dir_all(base.join("dist/nested")).expect("create dist dirs");
+
+    let old_dts = base.join("dist/alpha.d.ts");
+    let new_dts = base.join("dist/nested/beta.d.ts");
+    let newer_js = base.join("dist/alpha.js");
+    let newer_map = base.join("dist/alpha.d.ts.map");
+    for (path, contents) in [
+        (&old_dts, "export declare const a: number;\n"),
+        (&new_dts, "export declare const b: number;\n"),
+        (&newer_js, "var a = 1;\n"),
+        (&newer_map, "{}\n"),
+    ] {
+        fs::write(path, contents).expect("write output");
+    }
+
+    let now = SystemTime::now();
+    let set_mtime = |path: &Path, age_secs: u64| {
+        fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .expect("open output")
+            .set_modified(now - Duration::from_secs(age_secs))
+            .expect("set mtime");
+    };
+    set_mtime(&old_dts, 300);
+    set_mtime(&new_dts, 200);
+    // Non-declaration outputs are newest overall and must still lose.
+    set_mtime(&newer_js, 0);
+    set_mtime(&newer_map, 0);
+
+    let emitted = vec![newer_js, old_dts, newer_map, new_dts];
+    assert_eq!(
+        super::super::find_latest_dts_file(&emitted, base).as_deref(),
+        Some("dist/nested/beta.d.ts"),
+        "newest .d.ts must win; .js and .d.ts.map outputs must be ignored"
+    );
+}
+
+/// Declaration matching must cover the full tsc `isDeclarationFileName`
+/// family, not just `.d.ts`: `.d.mts` and `.d.cts` outputs participate too.
+#[test]
+fn find_latest_dts_file_matches_dmts_and_dcts_like_tsc() {
+    use std::time::{Duration, SystemTime};
+
+    let dir = tempfile::tempdir().expect("temp dir");
+    let base = dir.path();
+    let old_dts = base.join("old.d.ts");
+    let mid_dcts = base.join("mid.d.cts");
+    let new_dmts = base.join("new.d.mts");
+    for path in [&old_dts, &mid_dcts, &new_dmts] {
+        fs::write(path, "export {};\n").expect("write output");
+    }
+
+    let now = SystemTime::now();
+    for (path, age_secs) in [(&old_dts, 300u64), (&mid_dcts, 200), (&new_dmts, 100)] {
+        fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .expect("open output")
+            .set_modified(now - Duration::from_secs(age_secs))
+            .expect("set mtime");
+    }
+
+    let emitted = vec![old_dts, mid_dcts, new_dmts];
+    assert_eq!(
+        super::super::find_latest_dts_file(&emitted, base).as_deref(),
+        Some("new.d.mts"),
+        "newest declaration output must win across .d.ts/.d.cts/.d.mts"
+    );
+}
+
+/// No declaration outputs (or no outputs at all) yields `None`; the caller's
+/// carry-forward then preserves the previously saved value.
+#[test]
+fn find_latest_dts_file_returns_none_without_declaration_outputs() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let base = dir.path();
+    let js = base.join("dist/only.js");
+    fs::create_dir_all(js.parent().expect("parent")).expect("create dist");
+    fs::write(&js, "var x = 1;\n").expect("write js");
+
+    assert_eq!(super::super::find_latest_dts_file(&[js], base), None);
+    assert_eq!(super::super::find_latest_dts_file(&[], base), None);
+}
+
+/// Regression: an incremental save that emits no declaration output must
+/// preserve the previously recorded `latestChangedDtsFile` instead of
+/// clearing it. tsc seeds builder state from the old program
+/// (`createBuilderProgramState` in src/compiler/builder.ts) and only
+/// reassigns the field when a declaration file is written, so a `--noEmit`
+/// incremental re-save keeps the prior value.
+#[test]
+fn test_incremental_no_emit_save_carries_forward_latest_changed_dts_file() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    fs::write(
+        dir.path().join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "incremental": true,
+    "declaration": true,
+    "outDir": "dist",
+    "tsBuildInfoFile": "cache.tsbuildinfo"
+  },
+  "files": ["a.ts"]
+}"#,
+    )
+    .expect("write tsconfig");
+    fs::write(dir.path().join("a.ts"), "export const x: number = 1;\n").expect("write source");
+
+    let args = CliArgs::try_parse_from(["tsz", "-p", "tsconfig.json", "--pretty", "false"])
+        .expect("parse args");
+    let result = compile(&args, dir.path()).expect("first compile");
+    assert!(
+        result.diagnostics.is_empty(),
+        "expected clean first build, got: {:?}",
+        result.diagnostics
+    );
+
+    let build_info_path = dir.path().join("cache.tsbuildinfo");
+    let first = crate::incremental::BuildInfo::load(&build_info_path)
+        .expect("load first build info")
+        .expect("first build info is compatible");
+    assert_eq!(
+        first.latest_changed_dts_file.as_deref(),
+        Some("dist/a.d.ts"),
+        "declaration emit must record the latest changed .d.ts output"
+    );
+    let first_version = first
+        .get_file_info("a.ts")
+        .expect("a.ts recorded in first build info")
+        .version
+        .clone();
+
+    // Change the source so the second run actually recompiles and re-saves
+    // BuildInfo, then run with --noEmit so no declaration output is written.
+    fs::write(dir.path().join("a.ts"), "export const x: number = 2;\n").expect("rewrite source");
+    let no_emit_args = CliArgs::try_parse_from([
+        "tsz",
+        "-p",
+        "tsconfig.json",
+        "--noEmit",
+        "--pretty",
+        "false",
+    ])
+    .expect("parse args");
+    let second_result = compile(&no_emit_args, dir.path()).expect("second compile");
+    assert!(
+        second_result.diagnostics.is_empty(),
+        "expected clean no-emit build, got: {:?}",
+        second_result.diagnostics
+    );
+
+    let second = crate::incremental::BuildInfo::load(&build_info_path)
+        .expect("load second build info")
+        .expect("second build info is compatible");
+    assert_ne!(
+        second
+            .get_file_info("a.ts")
+            .expect("a.ts recorded in second build info")
+            .version,
+        first_version,
+        "second compile must have re-saved BuildInfo \
+         (guards against a stale file masking the carry-forward)"
+    );
+    assert_eq!(
+        second.latest_changed_dts_file.as_deref(),
+        Some("dist/a.d.ts"),
+        "no-emit incremental save must preserve the prior latestChangedDtsFile (tsc parity)"
+    );
+}
+
 #[test]
 fn test_compile_sound_report_only_collects_diagnostics_from_sound_mode() {
     let dir = tempfile::tempdir().expect("temp dir");


### PR DESCRIPTION
Goal: hold

Finishes latest-changed-.d.ts tracking in the driver: threads the computed value through `compilation_cache_to_build_info` (deleting the stale TODO), carries forward the prior BuildInfo value on no-emit incremental saves to match tsc's `latestChangedDtsFile` retention, and adds direct unit tests for `find_latest_dts_file`.

While wiring this, the compute path turned out to be dead code on main: `find_latest_dts_file` filtered on `Path::extension() == Some("d.ts")`, but `extension()` only returns the final-dot segment (`"ts"` for `a.d.ts`), so the function returned `None` for every emitted file and the driver never populated `latest_changed_dts_file`. The filter now uses `tsz_common::file_extensions::is_ts_declaration_file`, which mirrors tsc's `isDeclarationFileName` (`.d.ts`/`.d.mts`/`.d.cts`/`.d.<ext>.ts`).

Structural rule: when an incremental save emits no .d.ts, tsc preserves the prior `latestChangedDtsFile`; tsz does the same through the buildinfo save path in driver core. (tsc reference: `createBuilderProgramState` in `src/compiler/builder.ts` seeds builder state from the old program and the write-file callback only reassigns the field when a declaration file is written.) Before this change tsz cleared the field on every no-emit incremental save — and, due to the dead filter, never set it at all — so both halves are parity fixes.

Assignment point: the post-hoc overwrite in `core_diagnostics.rs` was removed in favor of construction-time assignment — the field is set exactly once per save, in whichever `BuildInfo` construction branch runs (the new `compilation_cache_to_build_info` parameter, or the minimal-BuildInfo literal). Removing the mutation window is what kept the TODO from recurring.

Adjacent cases covered by tests: newest-by-mtime selection across multiple `.d.ts` outputs; non-declaration outputs (`.js`, `.d.ts.map`) ignored even when newer; `.d.mts`/`.d.cts` family; `None` fallback with no declaration outputs; end-to-end `--noEmit` incremental re-save regression test (mutation-checked: deleting the carry-forward makes it fail with `None != Some("dist/a.d.ts")`).

Closes #13007

## Verification
- `cargo nextest run -p tsz-cli -E 'test(/find_latest_dts|latest_changed_dts|incremental/)'` — 23 passed (4 new)
- `cargo nextest run -p tsz-cli -E 'test(/build/)'` — 69 passed
- `cargo clippy -p tsz-cli -- -D warnings` — clean

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
