### PR TITLE
refactor(solver): exhaustive-destructure shape Eq/Hash impls (#13099)

### DIFF
--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -298,3 +298,169 @@ mod append_protocol {
         });
     }
 }
+
+/// Interning-identity invariants for the hand-maintained shape `Eq`/`Hash`
+/// impls in `types/shape_identity.rs` (#13099). These pin which fields are
+/// identity-bearing: cosmetic fields must not split interned ids, while
+/// display-preserving fields (index-signature `param_name`, and
+/// `declaration_order` under `PRESERVE_DECLARATION_ORDER`) deliberately must.
+mod shape_identity {
+    use super::*;
+    use crate::types::IndexSignature;
+
+    fn named_prop(interner: &TypeInterner, name: &str) -> PropertyInfo {
+        PropertyInfo::new(interner.intern_string(name), TypeId::STRING)
+    }
+
+    fn string_index_sig(interner: &TypeInterner, param_name: Option<&str>) -> IndexSignature {
+        IndexSignature {
+            key_type: TypeId::STRING,
+            value_type: TypeId::NUMBER,
+            readonly: false,
+            param_name: param_name.map(|name| interner.intern_string(name)),
+        }
+    }
+
+    fn shape_with_string_index(interner: &TypeInterner, param_name: Option<&str>) -> ObjectShape {
+        ObjectShape {
+            flags: ObjectFlags::empty(),
+            properties: Vec::new(),
+            string_index: Some(string_index_sig(interner, param_name)),
+            number_index: None,
+            symbol: None,
+        }
+    }
+
+    #[test]
+    fn cosmetic_property_fields_do_not_split_interned_ids() {
+        let interner = TypeInterner::new();
+        let base = named_prop(&interner, "alpha");
+
+        let mut quoted = base.clone();
+        quoted.single_quoted_name = true;
+        let mut prototype = base.clone();
+        prototype.is_class_prototype = true;
+        let mut ordered = base.clone();
+        ordered.declaration_order = 42;
+
+        let base_id = interner.object(vec![base]);
+        assert_eq!(
+            interner.object(vec![quoted]),
+            base_id,
+            "single_quoted_name is cosmetic quote style and must not split interning"
+        );
+        assert_eq!(
+            interner.object(vec![prototype]),
+            base_id,
+            "is_class_prototype is declaration-site metadata and must not split interning"
+        );
+        assert_eq!(
+            interner.object(vec![ordered]),
+            base_id,
+            "declaration_order is display-only without PRESERVE_DECLARATION_ORDER"
+        );
+    }
+
+    #[test]
+    fn semantic_property_fields_split_interned_ids() {
+        let interner = TypeInterner::new();
+        let base = named_prop(&interner, "alpha");
+        let mut optional = base.clone();
+        optional.optional = true;
+        let mut string_named = base.clone();
+        string_named.is_string_named = true;
+
+        let base_id = interner.object(vec![base]);
+        assert_ne!(
+            interner.object(vec![optional]),
+            base_id,
+            "optional is structural and must split interning"
+        );
+        assert_ne!(
+            interner.object(vec![string_named]),
+            base_id,
+            "is_string_named distinguishes \"100\" from 100 keys and must split interning"
+        );
+    }
+
+    #[test]
+    fn object_index_signature_param_name_is_display_preserving() {
+        let interner = TypeInterner::new();
+
+        // `IndexSignature` itself treats param_name as cosmetic...
+        assert_eq!(
+            string_index_sig(&interner, Some("key")),
+            string_index_sig(&interner, Some("idx")),
+            "IndexSignature eq ignores param_name"
+        );
+
+        // ...but `ObjectShape` re-adds it via index_signature_display_eq so the
+        // printer can reproduce the source parameter name after interning.
+        let key_id = interner.object_with_index(shape_with_string_index(&interner, Some("key")));
+        let renamed_id =
+            interner.object_with_index(shape_with_string_index(&interner, Some("idx")));
+        let unnamed_id = interner.object_with_index(shape_with_string_index(&interner, None));
+        assert_ne!(
+            key_id, renamed_id,
+            "different index-signature param_name must intern to distinct object ids"
+        );
+        assert_ne!(key_id, unnamed_id);
+        assert_eq!(
+            interner.object_with_index(shape_with_string_index(&interner, Some("key"))),
+            key_id,
+            "same param_name must re-intern to the same id"
+        );
+    }
+
+    #[test]
+    fn callable_index_signature_param_name_is_display_preserving() {
+        let interner = TypeInterner::new();
+        let with_name = |param_name: Option<&str>| CallableShape {
+            string_index: Some(string_index_sig(&interner, param_name)),
+            ..CallableShape::default()
+        };
+
+        let key_id = interner.callable(with_name(Some("key")));
+        let renamed_id = interner.callable(with_name(Some("idx")));
+        assert_ne!(
+            key_id, renamed_id,
+            "different index-signature param_name must intern to distinct callable ids"
+        );
+        assert_eq!(
+            interner.callable(with_name(Some("key"))),
+            key_id,
+            "same param_name must re-intern to the same id"
+        );
+    }
+
+    #[test]
+    fn preserve_declaration_order_makes_property_order_identity_bearing() {
+        let interner = TypeInterner::new();
+        let alpha = named_prop(&interner, "alpha");
+        let beta = PropertyInfo::new(interner.intern_string("beta"), TypeId::NUMBER);
+
+        // Without the flag, source order is cosmetic: constructors backfill
+        // declaration_order from insertion order, but it stays identity-exempt.
+        let ab = interner.object(vec![alpha.clone(), beta.clone()]);
+        let ba = interner.object(vec![beta.clone(), alpha.clone()]);
+        assert_eq!(
+            ab, ba,
+            "without PRESERVE_DECLARATION_ORDER, declaration order must not split interning"
+        );
+
+        // With the flag, the same properties in a different source order stay
+        // distinct so diagnostics can print source/display order after widening.
+        let flag = ObjectFlags::PRESERVE_DECLARATION_ORDER;
+        let ab_ordered = interner.object_with_flags(vec![alpha.clone(), beta.clone()], flag);
+        let ba_ordered = interner.object_with_flags(vec![beta.clone(), alpha.clone()], flag);
+        assert_ne!(
+            ab_ordered, ba_ordered,
+            "PRESERVE_DECLARATION_ORDER makes declaration order identity-bearing"
+        );
+        assert_eq!(
+            interner.object_with_flags(vec![alpha, beta], flag),
+            ab_ordered,
+            "same declaration order must re-intern to the same id"
+        );
+    }
+}

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -8,6 +8,11 @@ use serde::Serialize;
 use tsz_binder::SymbolId;
 use tsz_common::interner::Atom;
 
+/// Hand-maintained `PartialEq`/`Eq`/`Hash` impls for the interned shape types
+/// (`PropertyInfo`, `IndexSignature`, `ObjectShape`, `CallableShape`), with
+/// per-field identity decisions made explicit via exhaustive destructuring.
+mod shape_identity;
+
 /// A lightweight handle to an interned type.
 /// Equality check is O(1) - just compare the u32 values.
 ///
@@ -1000,38 +1005,6 @@ pub struct PropertyInfo {
     pub single_quoted_name: bool,
 }
 
-impl PartialEq for PropertyInfo {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
-            && self.type_id == other.type_id
-            && self.write_type == other.write_type
-            && self.optional == other.optional
-            && self.readonly == other.readonly
-            && self.is_method == other.is_method
-            && self.visibility == other.visibility
-            && self.parent_id == other.parent_id
-            && self.is_string_named == other.is_string_named
-            && self.is_symbol_named == other.is_symbol_named
-    }
-}
-
-impl Eq for PropertyInfo {}
-
-impl std::hash::Hash for PropertyInfo {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.name.hash(state);
-        self.type_id.hash(state);
-        self.write_type.hash(state);
-        self.optional.hash(state);
-        self.readonly.hash(state);
-        self.is_method.hash(state);
-        self.visibility.hash(state);
-        self.parent_id.hash(state);
-        self.is_string_named.hash(state);
-        self.is_symbol_named.hash(state);
-    }
-}
-
 impl PropertyInfo {
     /// Create a property with default settings (non-optional, non-readonly, public).
     /// Sets `write_type` equal to `type_id`.
@@ -1172,45 +1145,6 @@ pub struct IndexSignature {
     pub param_name: Option<Atom>,
 }
 
-impl PartialEq for IndexSignature {
-    fn eq(&self, other: &Self) -> bool {
-        // param_name is cosmetic (for display only) and excluded from equality
-        self.key_type == other.key_type
-            && self.value_type == other.value_type
-            && self.readonly == other.readonly
-    }
-}
-
-impl Eq for IndexSignature {}
-
-impl std::hash::Hash for IndexSignature {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        // param_name is excluded from hash to match PartialEq
-        self.key_type.hash(state);
-        self.value_type.hash(state);
-        self.readonly.hash(state);
-    }
-}
-
-fn index_signature_display_eq(
-    left: &Option<IndexSignature>,
-    right: &Option<IndexSignature>,
-) -> bool {
-    match (left, right) {
-        (Some(left), Some(right)) => left == right && left.param_name == right.param_name,
-        (None, None) => true,
-        _ => false,
-    }
-}
-
-fn hash_index_signature_display<H: std::hash::Hasher>(
-    index: &Option<IndexSignature>,
-    state: &mut H,
-) {
-    std::hash::Hash::hash(index, state);
-    std::hash::Hash::hash(&index.as_ref().and_then(|idx| idx.param_name), state);
-}
-
 /// Combined index signature information for a type
 /// Provides convenient access to both string and number index signatures
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
@@ -1274,43 +1208,6 @@ pub struct ObjectShape {
     pub number_index: Option<IndexSignature>,
     /// Nominal identity for class instance types (prevents structural interning of distinct classes)
     pub symbol: Option<tsz_binder::SymbolId>,
-}
-
-impl PartialEq for ObjectShape {
-    fn eq(&self, other: &Self) -> bool {
-        // Include symbol in equality check to ensure different classes get different TypeIds
-        // The Solver does structural subtyping explicitly, not via PartialEq
-        self.flags == other.flags
-            && self.properties == other.properties
-            && (!self.flags.contains(ObjectFlags::PRESERVE_DECLARATION_ORDER)
-                || self
-                    .properties
-                    .iter()
-                    .zip(&other.properties)
-                    .all(|(left, right)| left.declaration_order == right.declaration_order))
-            && index_signature_display_eq(&self.string_index, &other.string_index)
-            && index_signature_display_eq(&self.number_index, &other.number_index)
-            && self.symbol == other.symbol
-    }
-}
-
-impl Eq for ObjectShape {}
-
-impl std::hash::Hash for ObjectShape {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        // Include the `symbol` field in hash for nominal interning
-        // This ensures different classes get different TypeIds
-        self.flags.hash(state);
-        self.properties.hash(state);
-        if self.flags.contains(ObjectFlags::PRESERVE_DECLARATION_ORDER) {
-            for prop in &self.properties {
-                prop.declaration_order.hash(state);
-            }
-        }
-        hash_index_signature_display(&self.string_index, state);
-        hash_index_signature_display(&self.number_index, state);
-        self.symbol.hash(state);
-    }
 }
 
 impl ObjectShape {
@@ -1532,36 +1429,6 @@ impl CallableShape {
         } else {
             self.call_signatures.last()
         }
-    }
-}
-
-impl PartialEq for CallableShape {
-    fn eq(&self, other: &Self) -> bool {
-        // Include symbol in equality check to ensure different classes get different TypeIds
-        // The Solver does structural subtyping explicitly, not via PartialEq
-        self.call_signatures == other.call_signatures
-            && self.construct_signatures == other.construct_signatures
-            && self.properties == other.properties
-            && index_signature_display_eq(&self.string_index, &other.string_index)
-            && index_signature_display_eq(&self.number_index, &other.number_index)
-            && self.symbol == other.symbol
-            && self.is_abstract == other.is_abstract
-    }
-}
-
-impl Eq for CallableShape {}
-
-impl std::hash::Hash for CallableShape {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        // Include the `symbol` field in hash for nominal interning
-        // This ensures different classes get different TypeIds
-        self.call_signatures.hash(state);
-        self.construct_signatures.hash(state);
-        self.properties.hash(state);
-        hash_index_signature_display(&self.string_index, state);
-        hash_index_signature_display(&self.number_index, state);
-        self.symbol.hash(state);
-        self.is_abstract.hash(state);
     }
 }
 

--- a/crates/tsz-solver/src/types/shape_identity.rs
+++ b/crates/tsz-solver/src/types/shape_identity.rs
@@ -1,0 +1,259 @@
+//! Interning identity (`PartialEq`/`Eq`/`Hash`) for the interned shape types
+//! whose field membership is decided by hand: `PropertyInfo`,
+//! `IndexSignature`, `ObjectShape`, and `CallableShape`.
+//!
+//! Every impl exhaustively destructures `Self`, binding identity-exempt
+//! (cosmetic/display-only) fields as `field: _` with the reason stated at the
+//! destructuring site. Adding a field to any of these structs is therefore a
+//! compile error here until the field gets an explicit identity decision
+//! (#13099). No `..` rest patterns are allowed in this module.
+//!
+//! Display-preserving exceptions live at the shape level: index-signature
+//! `param_name` and (under `ObjectFlags::PRESERVE_DECLARATION_ORDER`) property
+//! `declaration_order` are deliberately identity-bearing for `ObjectShape` /
+//! `CallableShape` so diagnostics keep printing source spellings.
+
+use super::{CallableShape, IndexSignature, ObjectFlags, ObjectShape, PropertyInfo};
+
+impl PartialEq for PropertyInfo {
+    fn eq(&self, other: &Self) -> bool {
+        // Exhaustive destructuring: adding a field to `PropertyInfo` fails to
+        // compile here until that field gets an explicit identity decision.
+        let Self {
+            name,
+            type_id,
+            write_type,
+            optional,
+            readonly,
+            is_method,
+            // Identity-exempt: declaration-site metadata (spread exclusion), not structural.
+            is_class_prototype: _,
+            visibility,
+            parent_id,
+            // Identity-exempt: display/emit source ordering; `ObjectShape` re-adds it
+            // under `PRESERVE_DECLARATION_ORDER`.
+            declaration_order: _,
+            is_string_named,
+            is_symbol_named,
+            // Identity-exempt: cosmetic quote style for `.d.ts` output.
+            single_quoted_name: _,
+        } = self;
+        *name == other.name
+            && *type_id == other.type_id
+            && *write_type == other.write_type
+            && *optional == other.optional
+            && *readonly == other.readonly
+            && *is_method == other.is_method
+            && *visibility == other.visibility
+            && *parent_id == other.parent_id
+            && *is_string_named == other.is_string_named
+            && *is_symbol_named == other.is_symbol_named
+    }
+}
+
+impl Eq for PropertyInfo {}
+
+impl std::hash::Hash for PropertyInfo {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Exhaustive destructuring: keep field membership in lockstep with
+        // `PartialEq` above; adding a field fails to compile here.
+        let Self {
+            name,
+            type_id,
+            write_type,
+            optional,
+            readonly,
+            is_method,
+            // Identity-exempt: declaration-site metadata (spread exclusion), not structural.
+            is_class_prototype: _,
+            visibility,
+            parent_id,
+            // Identity-exempt: display/emit source ordering; `ObjectShape` re-adds it
+            // under `PRESERVE_DECLARATION_ORDER`.
+            declaration_order: _,
+            is_string_named,
+            is_symbol_named,
+            // Identity-exempt: cosmetic quote style for `.d.ts` output.
+            single_quoted_name: _,
+        } = self;
+        name.hash(state);
+        type_id.hash(state);
+        write_type.hash(state);
+        optional.hash(state);
+        readonly.hash(state);
+        is_method.hash(state);
+        visibility.hash(state);
+        parent_id.hash(state);
+        is_string_named.hash(state);
+        is_symbol_named.hash(state);
+    }
+}
+
+impl PartialEq for IndexSignature {
+    fn eq(&self, other: &Self) -> bool {
+        // Exhaustive destructuring: adding a field to `IndexSignature` fails to
+        // compile here until that field gets an explicit identity decision.
+        let Self {
+            key_type,
+            value_type,
+            readonly,
+            // Identity-exempt here: cosmetic source parameter name. `ObjectShape` /
+            // `CallableShape` re-add it via `index_signature_display_eq`, so display
+            // identity is preserved at the shape level.
+            param_name: _,
+        } = self;
+        *key_type == other.key_type
+            && *value_type == other.value_type
+            && *readonly == other.readonly
+    }
+}
+
+impl Eq for IndexSignature {}
+
+impl std::hash::Hash for IndexSignature {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Exhaustive destructuring: keep field membership in lockstep with
+        // `PartialEq` above; adding a field fails to compile here.
+        let Self {
+            key_type,
+            value_type,
+            readonly,
+            // Identity-exempt here: cosmetic; re-added at the shape level by
+            // `hash_index_signature_display`.
+            param_name: _,
+        } = self;
+        key_type.hash(state);
+        value_type.hash(state);
+        readonly.hash(state);
+    }
+}
+
+/// Shape-level index-signature equality that re-adds the display `param_name`
+/// on top of `IndexSignature`'s cosmetic-exempt equality, so interned shapes
+/// keep the source parameter name for diagnostics.
+fn index_signature_display_eq(
+    left: &Option<IndexSignature>,
+    right: &Option<IndexSignature>,
+) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => left == right && left.param_name == right.param_name,
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+/// Hash counterpart of [`index_signature_display_eq`].
+fn hash_index_signature_display<H: std::hash::Hasher>(
+    index: &Option<IndexSignature>,
+    state: &mut H,
+) {
+    std::hash::Hash::hash(index, state);
+    std::hash::Hash::hash(&index.as_ref().and_then(|idx| idx.param_name), state);
+}
+
+impl PartialEq for ObjectShape {
+    fn eq(&self, other: &Self) -> bool {
+        // Exhaustive destructuring: adding a field to `ObjectShape` fails to
+        // compile here until that field gets an explicit identity decision.
+        // Every current field is identity-bearing: `symbol` for nominal
+        // discrimination (the Solver does structural subtyping explicitly, not
+        // via `PartialEq`), index signatures including their display
+        // `param_name`, and `declaration_order` under
+        // `PRESERVE_DECLARATION_ORDER`.
+        let Self {
+            flags,
+            properties,
+            string_index,
+            number_index,
+            symbol,
+        } = self;
+        *flags == other.flags
+            && *properties == other.properties
+            && (!flags.contains(ObjectFlags::PRESERVE_DECLARATION_ORDER)
+                || properties
+                    .iter()
+                    .zip(&other.properties)
+                    .all(|(left, right)| left.declaration_order == right.declaration_order))
+            && index_signature_display_eq(string_index, &other.string_index)
+            && index_signature_display_eq(number_index, &other.number_index)
+            && *symbol == other.symbol
+    }
+}
+
+impl Eq for ObjectShape {}
+
+impl std::hash::Hash for ObjectShape {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Exhaustive destructuring: keep field membership in lockstep with
+        // `PartialEq` above; adding a field fails to compile here.
+        let Self {
+            flags,
+            properties,
+            string_index,
+            number_index,
+            symbol,
+        } = self;
+        flags.hash(state);
+        properties.hash(state);
+        if flags.contains(ObjectFlags::PRESERVE_DECLARATION_ORDER) {
+            for prop in properties {
+                prop.declaration_order.hash(state);
+            }
+        }
+        hash_index_signature_display(string_index, state);
+        hash_index_signature_display(number_index, state);
+        symbol.hash(state);
+    }
+}
+
+impl PartialEq for CallableShape {
+    fn eq(&self, other: &Self) -> bool {
+        // Exhaustive destructuring: adding a field to `CallableShape` fails to
+        // compile here until that field gets an explicit identity decision.
+        // Every current field is identity-bearing: `symbol` for nominal
+        // discrimination (the Solver does structural subtyping explicitly, not
+        // via `PartialEq`) and index signatures including their display
+        // `param_name`.
+        let Self {
+            call_signatures,
+            construct_signatures,
+            properties,
+            string_index,
+            number_index,
+            symbol,
+            is_abstract,
+        } = self;
+        *call_signatures == other.call_signatures
+            && *construct_signatures == other.construct_signatures
+            && *properties == other.properties
+            && index_signature_display_eq(string_index, &other.string_index)
+            && index_signature_display_eq(number_index, &other.number_index)
+            && *symbol == other.symbol
+            && *is_abstract == other.is_abstract
+    }
+}
+
+impl Eq for CallableShape {}
+
+impl std::hash::Hash for CallableShape {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Exhaustive destructuring: keep field membership in lockstep with
+        // `PartialEq` above; adding a field fails to compile here.
+        let Self {
+            call_signatures,
+            construct_signatures,
+            properties,
+            string_index,
+            number_index,
+            symbol,
+            is_abstract,
+        } = self;
+        call_signatures.hash(state);
+        construct_signatures.hash(state);
+        properties.hash(state);
+        hash_index_signature_display(string_index, state);
+        hash_index_signature_display(number_index, state);
+        symbol.hash(state);
+        is_abstract.hash(state);
+    }
+}


### PR DESCRIPTION
Goal: hold

Removes the silent-drift hazard in the four hand-maintained shape `Eq`/`Hash` impls (`PropertyInfo`, `IndexSignature`, `ObjectShape`, `CallableShape`): each impl now exhaustively destructures `Self` with excluded fields bound as `field: _` and a stated reason, so adding a field is a compile error forcing an explicit identity decision. Zero field-membership changes — interning identity is bit-for-bit unchanged, pinned by new invariant tests. The rewritten impls (plus the `index_signature_display_eq`/`hash_index_signature_display` helpers they own) move from `types.rs` to a new `types/shape_identity.rs` submodule because the explicit destructuring pushed `types.rs` past the repo's 2000-line shard cap.

Structural rule: interned-shape identity decisions are explicit per field; cosmetic display fields are identity-exempt only with a documented reason at the destructuring site.

Note: the issue's proposed TypeShape/TypeProvenance side-table split is intentionally NOT done — `param_name`/`declaration_order` are deliberately identity-bearing for display preservation (`index_signature_display_eq`, `PRESERVE_DECLARATION_ORDER`); a side-table would change interning identity and diagnostic output.

Closes #13099

## Verification
- `cargo nextest run -p tsz-solver -E 'test(intern)'`
- `cargo nextest run -p tsz-solver -E 'test(types)'`
- `cargo clippy -p tsz-solver -- -D warnings`

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
