### PR TITLE
refactor(binder): dedupe IIFE finalization and flow helper templates (#13074)

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -283,23 +283,7 @@ impl BinderState {
             self.bind_type_parameters(arena, func.type_parameters.as_ref());
 
             self.with_fresh_flow(|binder| {
-                // Bind parameters
-                for &param_idx in &func.parameters.nodes {
-                    binder.bind_parameter(arena, param_idx);
-                }
-
-                // Hoisting: Collect var and function declarations from the function body
-                // This ensures declarations are accessible throughout the function scope
-                // before their actual declaration point (JavaScript hoisting behavior)
-                //
-                // Note: Function declarations in blocks are block-scoped in strict mode
-                // and external modules. In non-strict scripts, they hoist (Annex B).
-                binder.collect_hoisted_from_node(arena, func.body);
-                binder.process_hoisted_functions(arena);
-                binder.process_hoisted_vars(arena);
-
-                // Bind body
-                binder.bind_node(arena, func.body);
+                binder.bind_function_body_parts(arena, &func.parameters, func.body);
             });
 
             self.exit_scope(arena);
@@ -453,6 +437,69 @@ impl BinderState {
         }
     }
 
+    /// Bind the shared function-body template: parameters, hoisted
+    /// declarations, then the body itself.
+    ///
+    /// Hoisting collects `var` and function declarations from the function
+    /// body before binding it, so declarations are accessible throughout the
+    /// function scope before their actual declaration point (JavaScript
+    /// hoisting behavior). Function declarations in blocks are block-scoped
+    /// in strict mode and external modules; in non-strict scripts they hoist
+    /// (Annex B).
+    ///
+    /// Statement order is load-bearing for flow-graph construction; every
+    /// call site previously inlined this exact sequence.
+    fn bind_function_body_parts(
+        &mut self,
+        arena: &NodeArena,
+        parameters: &NodeList,
+        body: NodeIndex,
+    ) {
+        for &param_idx in &parameters.nodes {
+            self.bind_parameter(arena, param_idx);
+        }
+        self.collect_hoisted_from_node(arena, body);
+        self.process_hoisted_functions(arena);
+        self.process_hoisted_vars(arena);
+        self.bind_node(arena, body);
+    }
+
+    /// Bind an IIFE body inline in the outer flow context (no `FlowStart`
+    /// node). This preserves narrowing from the outer scope and propagates
+    /// assignments inside the IIFE to the outer scope's control flow.
+    ///
+    /// Return statements are redirected to a fresh branch label; after the
+    /// body is bound, the fall-through flow merges into that label and the
+    /// label is finalized the way tsc's `finishFlowLabel` does.
+    ///
+    /// Ordering invariant: the fall-through antecedent is added before the
+    /// return label is popped from `return_targets`.
+    fn bind_iife_body(&mut self, arena: &NodeArena, parameters: &NodeList, body: NodeIndex) {
+        let return_label = self.create_branch_label();
+        self.return_targets.push(return_label);
+
+        self.bind_function_body_parts(arena, parameters, body);
+
+        // Merge the fall-through flow with the return label
+        self.add_antecedent(return_label, self.current_flow);
+        let return_label = self
+            .return_targets
+            .pop()
+            .expect("return_targets pushed before function body binding");
+
+        // Finalize: if the return label has antecedents, use it as current flow.
+        // This mirrors tsc's finishFlowLabel behavior.
+        if let Some(label_node) = self.flow_nodes.get(return_label) {
+            match label_node.antecedent.len() {
+                0 => self.current_flow = self.unreachable_flow,
+                1 => self.current_flow = label_node.antecedent[0],
+                _ => self.current_flow = return_label,
+            }
+        } else {
+            self.current_flow = self.unreachable_flow;
+        }
+    }
+
     /// Bind an arrow function expression - creates a scope and binds the body.
     #[tracing::instrument(level = "debug", skip(self, arena, node), fields(arrow_fn_idx = idx.0))]
     pub(crate) fn bind_arrow_function(&mut self, arena: &NodeArena, node: &Node, idx: NodeIndex) {
@@ -474,38 +521,11 @@ impl BinderState {
             self.bind_type_parameters(arena, func.type_parameters.as_ref());
 
             if is_iife {
-                // IIFE: bind body inline in the outer flow context (no FlowStart node).
-                let return_label = self.create_branch_label();
-                self.return_targets.push(return_label);
-
                 tracing::debug!(
                     param_count = func.parameters.nodes.len(),
                     "Binding arrow IIFE parameters"
                 );
-                for &param_idx in &func.parameters.nodes {
-                    self.bind_parameter(arena, param_idx);
-                }
-                self.collect_hoisted_from_node(arena, func.body);
-                self.process_hoisted_functions(arena);
-                self.process_hoisted_vars(arena);
-                self.bind_node(arena, func.body);
-
-                // Merge fall-through with return flows
-                self.add_antecedent(return_label, self.current_flow);
-                let return_label = self
-                    .return_targets
-                    .pop()
-                    .expect("return_targets pushed before function body binding");
-
-                if let Some(label_node) = self.flow_nodes.get(return_label) {
-                    match label_node.antecedent.len() {
-                        0 => self.current_flow = self.unreachable_flow,
-                        1 => self.current_flow = label_node.antecedent[0],
-                        _ => self.current_flow = return_label,
-                    }
-                } else {
-                    self.current_flow = self.unreachable_flow;
-                }
+                self.bind_iife_body(arena, &func.parameters, func.body);
             } else {
                 // Non-IIFE: isolated flow scope
                 self.with_fresh_flow_inner(
@@ -514,13 +534,7 @@ impl BinderState {
                             param_count = func.parameters.nodes.len(),
                             "Binding arrow function parameters"
                         );
-                        for &param_idx in &func.parameters.nodes {
-                            binder.bind_parameter(arena, param_idx);
-                        }
-                        binder.collect_hoisted_from_node(arena, func.body);
-                        binder.process_hoisted_functions(arena);
-                        binder.process_hoisted_vars(arena);
-                        binder.bind_node(arena, func.body);
+                        binder.bind_function_body_parts(arena, &func.parameters, func.body);
                     },
                     true,
                 );
@@ -567,48 +581,12 @@ impl BinderState {
             self.bind_type_parameters(arena, func.type_parameters.as_ref());
 
             if is_iife {
-                // IIFE: bind body inline in the outer flow context (no FlowStart node).
-                // This preserves narrowing and propagates assignments to the outer scope.
-                let return_label = self.create_branch_label();
-                self.return_targets.push(return_label);
-
-                for &param_idx in &func.parameters.nodes {
-                    self.bind_parameter(arena, param_idx);
-                }
-                self.collect_hoisted_from_node(arena, func.body);
-                self.process_hoisted_functions(arena);
-                self.process_hoisted_vars(arena);
-                self.bind_node(arena, func.body);
-
-                // Merge the fall-through flow with the return label
-                self.add_antecedent(return_label, self.current_flow);
-                let return_label = self
-                    .return_targets
-                    .pop()
-                    .expect("return_targets pushed before function body binding");
-
-                // Finalize: if the return label has antecedents, use it as current flow.
-                // This mirrors tsc's finishFlowLabel behavior.
-                if let Some(label_node) = self.flow_nodes.get(return_label) {
-                    match label_node.antecedent.len() {
-                        0 => self.current_flow = self.unreachable_flow,
-                        1 => self.current_flow = label_node.antecedent[0],
-                        _ => self.current_flow = return_label,
-                    }
-                } else {
-                    self.current_flow = self.unreachable_flow;
-                }
+                self.bind_iife_body(arena, &func.parameters, func.body);
             } else {
                 // Non-IIFE: isolated flow scope with captured enclosing flow
                 self.with_fresh_flow_inner(
                     |binder| {
-                        for &param_idx in &func.parameters.nodes {
-                            binder.bind_parameter(arena, param_idx);
-                        }
-                        binder.collect_hoisted_from_node(arena, func.body);
-                        binder.process_hoisted_functions(arena);
-                        binder.process_hoisted_vars(arena);
-                        binder.bind_node(arena, func.body);
+                        binder.bind_function_body_parts(arena, &func.parameters, func.body);
                     },
                     true,
                 );

--- a/crates/tsz-binder/src/state/flow_helpers.rs
+++ b/crates/tsz-binder/src/state/flow_helpers.rs
@@ -59,74 +59,45 @@ impl BinderState {
         id
     }
 
-    /// Create a flow node for an assignment.
-    pub(crate) fn create_flow_assignment(&mut self, assignment: NodeIndex) -> FlowNodeId {
+    /// Shared template for flow nodes that record an AST node and chain the
+    /// current flow as their antecedent. The five `create_flow_*` wrappers
+    /// below differ only in the `flow_flags` constant they pass here.
+    fn create_flow_node_with_node(&mut self, flags: u32, node_idx: NodeIndex) -> FlowNodeId {
         let current_flow = self.current_flow;
         let flow_nodes = Arc::make_mut(&mut self.flow_nodes);
-        let id = flow_nodes.alloc(flow_flags::ASSIGNMENT);
+        let id = flow_nodes.alloc(flags);
         if let Some(node) = flow_nodes.get_mut(id) {
-            node.node = assignment;
+            node.node = node_idx;
             if current_flow.is_some() {
                 node.antecedent.push(current_flow);
             }
         }
         id
+    }
+
+    /// Create a flow node for an assignment.
+    pub(crate) fn create_flow_assignment(&mut self, assignment: NodeIndex) -> FlowNodeId {
+        self.create_flow_node_with_node(flow_flags::ASSIGNMENT, assignment)
     }
 
     /// Create a flow node for a call expression.
     pub(crate) fn create_flow_call(&mut self, call: NodeIndex) -> FlowNodeId {
-        let current_flow = self.current_flow;
-        let flow_nodes = Arc::make_mut(&mut self.flow_nodes);
-        let id = flow_nodes.alloc(flow_flags::CALL);
-        if let Some(node) = flow_nodes.get_mut(id) {
-            node.node = call;
-            if current_flow.is_some() {
-                node.antecedent.push(current_flow);
-            }
-        }
-        id
+        self.create_flow_node_with_node(flow_flags::CALL, call)
     }
 
     /// Create a flow node for array mutation (e.g. push/splice).
     pub(crate) fn create_flow_array_mutation(&mut self, call: NodeIndex) -> FlowNodeId {
-        let current_flow = self.current_flow;
-        let flow_nodes = Arc::make_mut(&mut self.flow_nodes);
-        let id = flow_nodes.alloc(flow_flags::ARRAY_MUTATION);
-        if let Some(node) = flow_nodes.get_mut(id) {
-            node.node = call;
-            if current_flow.is_some() {
-                node.antecedent.push(current_flow);
-            }
-        }
-        id
+        self.create_flow_node_with_node(flow_flags::ARRAY_MUTATION, call)
     }
 
     /// Create a flow node for await expression (async suspension point).
     pub(crate) fn create_flow_await_point(&mut self, await_expr: NodeIndex) -> FlowNodeId {
-        let current_flow = self.current_flow;
-        let flow_nodes = Arc::make_mut(&mut self.flow_nodes);
-        let id = flow_nodes.alloc(flow_flags::AWAIT_POINT);
-        if let Some(node) = flow_nodes.get_mut(id) {
-            node.node = await_expr;
-            if current_flow.is_some() {
-                node.antecedent.push(current_flow);
-            }
-        }
-        id
+        self.create_flow_node_with_node(flow_flags::AWAIT_POINT, await_expr)
     }
 
     /// Create a flow node for yield expression (generator suspension point).
     pub(crate) fn create_flow_yield_point(&mut self, yield_expr: NodeIndex) -> FlowNodeId {
-        let current_flow = self.current_flow;
-        let flow_nodes = Arc::make_mut(&mut self.flow_nodes);
-        let id = flow_nodes.alloc(flow_flags::YIELD_POINT);
-        if let Some(node) = flow_nodes.get_mut(id) {
-            node.node = yield_expr;
-            if current_flow.is_some() {
-                node.antecedent.push(current_flow);
-            }
-        }
-        id
+        self.create_flow_node_with_node(flow_flags::YIELD_POINT, yield_expr)
     }
 
     /// Add an antecedent to a flow node (for merging branches).


### PR DESCRIPTION
Goal: hold

Deduplicates three copy-paste families in the binder with zero behavior change: the verbatim IIFE flow-finalization blocks in `bind_arrow_function`/`bind_function_expression`, the six-site params/hoist/bind function-body template, and the five `create_flow_*` helpers that differ only in their flow-flags constant.

Structural rule: behavior unchanged — flow graph construction order is preserved statement-for-statement; this enables future binder flow work to edit one template instead of six copies.

Closes #13074

## Verification
- `cargo nextest run -p tsz-binder`
- `cargo nextest run -p tsz-checker -E 'test(/iife|narrow|flow/)'`
- `cargo clippy -p tsz-binder -- -D warnings`

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
