### PR TITLE
fix(scanner): exact ES ID_Start/ID_Continue identifier classification (#13069)

### DIFF
--- a/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_regex.rs
@@ -384,17 +384,10 @@ impl ParserState {
             }
 
             fn is_identifier_part_for_regex_flags(ch: char) -> bool {
-                if ch.is_ascii() {
-                    matches!(
-                        ch,
-                        '_' | '$' | 'a'..='z' | 'A'..='Z' | '0'..='9'
-                    )
-                } else {
-                    ch.is_alphabetic()
-                        || ch.is_ascii_digit()
-                        || ch == '\u{200c}'
-                        || ch == '\u{200d}'
-                }
+                // tsc terminates regex-flag scanning with `isIdentifierPart`
+                // (`scanner.ts`); route through the scanner predicate so flag
+                // termination matches identifier scanning exactly.
+                tsz_scanner::is_ecmascript_identifier_part(ch)
             }
 
             const fn is_regex_flag(ch: char) -> bool {

--- a/crates/tsz-parser/tests/parser_improvement_regex_recovery_tests.rs
+++ b/crates/tsz-parser/tests/parser_improvement_regex_recovery_tests.rs
@@ -541,3 +541,49 @@ fn test_regex_hex_escape_keeps_real_hex_digit_validation() {
         "regex `\\u\\i...` must still emit TS1125 for non-hex non-separator chars, got {diagnostics:?}"
     );
 }
+
+#[test]
+fn test_regex_trailing_flag_scan_uses_es_identifier_part() {
+    // tsc terminates regex-flag scanning with `isIdentifierPart`
+    // (`scanner.ts`), so any ES `ID_Continue` code point after the flags is
+    // consumed and reported as TS1499. U+00B7 (Other_ID_Continue) and U+309B
+    // (Other_ID_Start, NFKC-unstable so absent from XID tables) are both
+    // identifier parts; `char::is_alphabetic` rejected both.
+    for (source, label) in [
+        ("let r = /foo/g\u{00B7};\n", "U+00B7 MIDDLE DOT"),
+        (
+            "let r = /foo/\u{309B};\n",
+            "U+309B KATAKANA-HIRAGANA VOICED SOUND MARK",
+        ),
+    ] {
+        let (parser, _root) = parse_source(source);
+
+        let diagnostics = parser.get_diagnostics();
+        let ts1499_count = diagnostics
+            .iter()
+            .filter(|d| d.code == diagnostic_codes::UNKNOWN_REGULAR_EXPRESSION_FLAG)
+            .count();
+
+        assert_eq!(
+            ts1499_count, 1,
+            "{label} after regex flags must emit exactly one TS1499, got {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn test_regex_trailing_non_identifier_codepoint_ends_flag_scan() {
+    // Negative guard: U+2117 SOUND RECORDING COPYRIGHT is not in ES
+    // `ID_Continue`, so tsc ends the flag scan before it and never reports
+    // TS1499 for it.
+    let source = "let r = /foo/g\u{2117};\n";
+    let (parser, _root) = parse_source(source);
+
+    let diagnostics = parser.get_diagnostics();
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.code == diagnostic_codes::UNKNOWN_REGULAR_EXPRESSION_FLAG),
+        "non-ID_Continue code point after flags must not emit TS1499, got {diagnostics:?}"
+    );
+}

--- a/crates/tsz-scanner/src/scanner_impl.rs
+++ b/crates/tsz-scanner/src/scanner_impl.rs
@@ -1323,7 +1323,7 @@ pub(crate) fn is_identifier_start(ch: u32) -> bool {
     }
 
     if let Some(c) = char::from_u32(ch) {
-        return unicode_ident::is_xid_start(c);
+        return unicode_ident::is_xid_start(c) || is_es_id_start_not_xid_start(ch);
     }
 
     false
@@ -1335,38 +1335,64 @@ pub(crate) fn is_identifier_part(ch: u32) -> bool {
         return is_identifier_start(ch) || is_digit(ch);
     }
 
-    // Unicode path: ECMAScript ID_Continue includes ID_Start plus marks,
-    // decimal digits, connector punctuation, ZWNJ, and ZWJ. The unicode-ident
-    // table keeps astral-plane identifier characters valid without admitting
-    // `No` digits such as subscript/superscript numerals.
+    // Unicode path: ECMAScript `IdentifierPartChar` is `ID_Continue` plus
+    // ZWNJ/ZWJ. The unicode-ident crate implements `XID_Continue`; every
+    // `ID_Continue` code point that `XID_Continue` excludes is also in
+    // `ID_Start - XID_Start`, so the same patch set restores exact
+    // `ID_Continue` membership (verified by exhaustive sweep against tsc's
+    // `unicodeESNextIdentifierPart` table).
     if let Some(c) = char::from_u32(ch)
-        && unicode_ident::is_xid_continue(c)
+        && (unicode_ident::is_xid_continue(c) || is_es_id_start_not_xid_start(ch))
     {
         return true;
     }
 
-    // ZWNJ and ZWJ
+    // ZWNJ and ZWJ join controls (ES2024 12.7 IdentifierPartChar).
     if ch == 0x200C || ch == 0x200D {
         return true;
     }
 
-    if is_unicode_other_id_continue(ch) {
-        return true;
-    }
-
-    // Unicode combining marks (Mn, Mc categories) - needed for scripts like Devanagari, Arabic, etc.
-    // This covers the most common combining mark ranges used in identifiers:
-    // - Combining Diacritical Marks (U+0300-U+036F)
-    // - Devanagari combining marks (U+0900-U+097F range includes vowel signs and virama)
-    // - Arabic combining marks (U+064B-U+0652)
-    // - Hebrew combining marks (U+0591-U+05C7)
-    // - And other Indic scripts
-    is_unicode_combining_mark(ch)
+    is_unicode_other_id_continue(ch)
 }
 
-/// Unicode `Other_ID_Continue` code points that ECMAScript admits as
-/// identifier continuation characters even though they are not alphabetic,
-/// decimal digits, join controls, or combining marks.
+/// ECMAScript `ID_Start` code points that Unicode `XID_Start` excludes.
+///
+/// ES2024 12.7 defines `UnicodeIDStart` with the Unicode `ID_Start`
+/// property, while the unicode-ident crate implements UAX #31 `XID_Start`,
+/// which removes `ID_Start` code points whose NFKC normalization is not
+/// identifier-shaped (UAX #31 5.1). This is the complete difference set,
+/// verified by an exhaustive code-point sweep against tsc's
+/// `unicodeESNextIdentifierStart` table (`TypeScript/src/compiler/scanner.ts`,
+/// generated from Unicode 15.1 `ID_Start`/`Other_ID_Start`).
+///
+/// Note: U+2118 SCRIPT CAPITAL P and U+212E ESTIMATED SYMBOL are also in
+/// `Other_ID_Start` (UCD `PropList.txt`) but are NFKC-stable, so `XID_Start`
+/// already contains them and they need no patch here.
+const fn is_es_id_start_not_xid_start(ch: u32) -> bool {
+    matches!(
+        ch,
+        0x037A // GREEK YPOGEGRAMMENI (Lm); NFKC: space + U+0345
+            | 0x0E33 // THAI CHARACTER SARA AM (Lo); NFKC: U+0E4D U+0E32
+            | 0x0EB3 // LAO VOWEL SIGN AM (Lo); NFKC: U+0ECD U+0EB2
+            | 0x309B // KATAKANA-HIRAGANA VOICED SOUND MARK (Sk, Other_ID_Start)
+            | 0x309C // KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK (Sk, Other_ID_Start)
+            | 0xFC5E..=0xFC63 // ARABIC LIGATURE ... ISOLATED FORM (Lo); NFKC: space + marks
+            | 0xFDFA..=0xFDFB // ARABIC LIGATURE SALLALLAHOU/JALLAJALALOUHOU (Lo)
+            | 0xFE70 // ARABIC FATHATAN ISOLATED FORM (Lo); NFKC: space + mark
+            | 0xFE72 // ARABIC DAMMATAN ISOLATED FORM (Lo)
+            | 0xFE74 // ARABIC KASRATAN ISOLATED FORM (Lo)
+            | 0xFE76 // ARABIC FATHA ISOLATED FORM (Lo)
+            | 0xFE78 // ARABIC DAMMA ISOLATED FORM (Lo)
+            | 0xFE7A // ARABIC KASRA ISOLATED FORM (Lo)
+            | 0xFE7C // ARABIC SHADDA ISOLATED FORM (Lo)
+            | 0xFE7E // ARABIC SUKUN ISOLATED FORM (Lo)
+            | 0xFF9E..=0xFF9F // HALFWIDTH KATAKANA (SEMI-)VOICED SOUND MARK (Lm); NFKC: U+3099/U+309A
+    )
+}
+
+/// Unicode `Other_ID_Continue` code points (UCD `PropList.txt`) that
+/// ECMAScript admits as identifier continuation characters even though they
+/// are not alphabetic, decimal digits, join controls, or combining marks.
 const fn is_unicode_other_id_continue(ch: u32) -> bool {
     matches!(
         ch,
@@ -1376,61 +1402,6 @@ const fn is_unicode_other_id_continue(ch: u32) -> bool {
             ..=0x1371 // ETHIOPIC DIGIT ONE..THREE
             | 0x19DA // NEW TAI LUE THAM DIGIT ONE
     )
-}
-
-/// Check if a character is a Unicode combining mark (Mn or Mc category).
-/// These are characters that modify the preceding base character.
-fn is_unicode_combining_mark(ch: u32) -> bool {
-    // Combining Diacritical Marks
-    if (0x0300..=0x036F).contains(&ch) {
-        return true;
-    }
-    // Devanagari vowel signs, virama, etc. (U+0900-U+0903, U+093A-U+094F, U+0951-U+0957, U+0962-U+0963)
-    if (0x0900..=0x0903).contains(&ch)
-        || (0x093A..=0x094F).contains(&ch)
-        || (0x0951..=0x0957).contains(&ch)
-        || (0x0962..=0x0963).contains(&ch)
-    {
-        return true;
-    }
-    // Bengali combining marks
-    if (0x0981..=0x0983).contains(&ch) || (0x09BC..=0x09CD).contains(&ch) {
-        return true;
-    }
-    // Arabic combining marks (tashkil/harakat)
-    if (0x064B..=0x0652).contains(&ch) || (0x0670..=0x0670).contains(&ch) {
-        return true;
-    }
-    // Hebrew combining marks
-    if (0x0591..=0x05C7).contains(&ch) {
-        return true;
-    }
-    // Other Indic scripts - Tamil, Telugu, Kannada, Malayalam, etc.
-    if (0x0B01..=0x0B03).contains(&ch)  // Oriya
-        || (0x0B3C..=0x0B4D).contains(&ch)
-        || (0x0B82..=0x0B83).contains(&ch)  // Tamil
-        || (0x0BBE..=0x0BCD).contains(&ch)
-        || (0x0C00..=0x0C04).contains(&ch)  // Telugu
-        || (0x0C3E..=0x0C4D).contains(&ch)
-        || (0x0C81..=0x0C83).contains(&ch)  // Kannada
-        || (0x0CBC..=0x0CCD).contains(&ch)
-        || (0x0D00..=0x0D03).contains(&ch)  // Malayalam
-        || (0x0D3B..=0x0D4D).contains(&ch)
-    {
-        return true;
-    }
-    // Thai and other Southeast Asian
-    if (0x0E31..=0x0E3A).contains(&ch) || (0x0E47..=0x0E4E).contains(&ch) {
-        return true;
-    }
-    // Combining Diacritical Marks Extended, Supplement, for Symbols
-    if (0x1AB0..=0x1AFF).contains(&ch)
-        || (0x1DC0..=0x1DFF).contains(&ch)
-        || (0x20D0..=0x20FF).contains(&ch)
-    {
-        return true;
-    }
-    false
 }
 
 const fn is_line_break(ch: u32) -> bool {

--- a/crates/tsz-scanner/src/scanner_impl/tests.rs
+++ b/crates/tsz-scanner/src/scanner_impl/tests.rs
@@ -55,6 +55,150 @@ fn scan_identifier_with_other_id_continue_middle_dot() {
     assert_eq!(tokens[0], (SyntaxKind::Identifier, "a·b".to_string()));
 }
 
+// ── ECMAScript ID_Start/ID_Continue parity ────────────────────────
+
+/// ES2024 12.7 `UnicodeIDStart` is the Unicode `ID_Start` property, which
+/// includes the `Other_ID_Start` code points (UCD `PropList.txt`). tsc
+/// accepts all of them as identifier starts (`unicodeESNextIdentifierStart`).
+#[test]
+fn scan_other_id_start_codepoints_as_identifier_start() {
+    for source in ["\u{2118}", "\u{212E}", "\u{309B}", "\u{309C}"] {
+        let tokens = scan_all(source);
+        assert_eq!(
+            tokens,
+            vec![(SyntaxKind::Identifier, source.to_string())],
+            "U+{:04X} must scan as an identifier start",
+            source.chars().next().unwrap() as u32
+        );
+    }
+}
+
+#[test]
+fn scan_var_statement_with_script_capital_p_identifier() {
+    let tokens = scan_all("var ℘ = 1");
+    assert_eq!(tokens.len(), 4);
+    assert_eq!(tokens[0].0, SyntaxKind::VarKeyword);
+    assert_eq!(tokens[1], (SyntaxKind::Identifier, "℘".to_string()));
+    assert_eq!(tokens[2].0, SyntaxKind::EqualsToken);
+    assert_eq!(tokens[3].0, SyntaxKind::NumericLiteral);
+}
+
+/// Complete `ID_Start - XID_Start` difference set (Unicode 15.1), verified
+/// by an exhaustive code-point sweep against tsc's
+/// `unicodeESNextIdentifierStart`/`unicodeESNextIdentifierPart` tables.
+/// `ID_Continue` contains `ID_Start`, so each must also be a valid part.
+#[test]
+fn es_id_start_includes_nfkc_unstable_id_start_codepoints() {
+    for ch in [
+        0x037A, // GREEK YPOGEGRAMMENI
+        0x0E33, // THAI CHARACTER SARA AM
+        0x0EB3, // LAO VOWEL SIGN AM
+        0x309B, 0x309C, // KATAKANA-HIRAGANA (SEMI-)VOICED SOUND MARK
+        0xFC5E, 0xFC63, // ARABIC LIGATURE ... ISOLATED FORM (range ends)
+        0xFDFA, 0xFDFB, // ARABIC LIGATURE SALLALLAHOU/JALLAJALALOUHOU
+        0xFE70, 0xFE72, 0xFE74, 0xFE76, 0xFE78, 0xFE7A, 0xFE7C,
+        0xFE7E, // ARABIC ... ISOLATED FORM
+        0xFF9E, 0xFF9F, // HALFWIDTH KATAKANA (SEMI-)VOICED SOUND MARK
+    ] {
+        assert!(is_identifier_start(ch), "U+{ch:04X} is ES ID_Start");
+        assert!(is_identifier_part(ch), "U+{ch:04X} is ES ID_Continue");
+    }
+}
+
+/// U+2118 and U+212E are `Other_ID_Start` but NFKC-stable, so `XID_Start`
+/// already contains them; they need no patch entry, only this guard.
+#[test]
+fn nfkc_stable_other_id_start_codepoints_accepted() {
+    for ch in [0x2118, 0x212E] {
+        assert!(is_identifier_start(ch), "U+{ch:04X} is ES ID_Start");
+        assert!(is_identifier_part(ch), "U+{ch:04X} is ES ID_Continue");
+    }
+}
+
+/// `Other_ID_Continue` code points and ZWNJ/ZWJ join controls continue an
+/// identifier (ES2024 12.7 `IdentifierPartChar`), as do `Other_ID_Start`
+/// code points in continuation position.
+#[test]
+fn scan_other_id_continue_and_join_controls_as_identifier_part() {
+    for (source, label) in [
+        ("a\u{00B7}b", "U+00B7 MIDDLE DOT (Other_ID_Continue)"),
+        (
+            "a\u{19DA}b",
+            "U+19DA NEW TAI LUE THAM DIGIT ONE (Other_ID_Continue)",
+        ),
+        ("a\u{200C}b", "U+200C ZWNJ"),
+        ("a\u{200D}b", "U+200D ZWJ"),
+        ("a\u{309B}b", "U+309B as identifier continuation"),
+    ] {
+        let tokens = scan_all(source);
+        assert_eq!(
+            tokens.len(),
+            1,
+            "{label} must continue the identifier: {tokens:?}"
+        );
+        assert_eq!(tokens[0].0, SyntaxKind::Identifier, "{label}");
+    }
+}
+
+/// Representatives from every range of the deleted hand-maintained
+/// combining-mark list: each assigned Mn/Mc member is already covered by
+/// `XID_Continue`, so deleting the list keeps them accepted.
+#[test]
+fn combining_marks_accepted_via_xid_continue_after_list_deletion() {
+    for ch in [
+        0x0300, 0x036F, // Combining Diacritical Marks
+        0x0591, 0x05C7, // Hebrew points
+        0x064B, 0x0652, 0x0670, // Arabic harakat, superscript alef
+        0x0900, 0x0903, 0x093A, 0x094D, 0x0951, 0x0962, // Devanagari
+        0x0981, 0x09BC, 0x09CD, // Bengali
+        0x0B01, 0x0B3C, 0x0BBE, 0x0BCD, // Oriya, Tamil
+        0x0C00, 0x0C3E, 0x0C81, 0x0CBC, // Telugu, Kannada
+        0x0D00, 0x0D3B, 0x0D4D, // Malayalam
+        0x0E31, 0x0E3A, 0x0E47, 0x0E4E, // Thai
+        0x1AB0, 0x1DC0, 0x1DFF, // Combining Diacritical Marks Extended/Supplement
+        0x20D0, 0x20E1, 0x20F0, // Combining Diacritical Marks for Symbols (Mn)
+    ] {
+        assert!(
+            is_identifier_part(ch),
+            "U+{ch:04X} must stay accepted via XID_Continue after list deletion"
+        );
+    }
+}
+
+/// The deleted list was not a pure no-op: it also admitted code points that
+/// are NOT in ES `ID_Continue` — Me (enclosing) marks, Hebrew punctuation,
+/// and unassigned holes inside the listed blocks. tsc rejects all of these
+/// (absent from `unicodeESNextIdentifierPart`); they must stay rejected.
+#[test]
+fn non_id_continue_codepoints_from_deleted_list_rejected() {
+    for ch in [
+        0x05BE, // HEBREW PUNCTUATION MAQAF (Pd)
+        0x05C0, // HEBREW PUNCTUATION PASEQ (Po)
+        0x1ABE, // COMBINING PARENTHESES OVERLAY (Me)
+        0x20DD, // COMBINING ENCLOSING CIRCLE (Me)
+        0x20E0, // COMBINING ENCLOSING CIRCLE BACKSLASH (Me)
+        0x09C5, // unassigned hole in the Bengali block
+        0x20F1, // unassigned hole after COMBINING ASTERISK ABOVE
+    ] {
+        assert!(
+            !is_identifier_part(ch),
+            "U+{ch:04X} is not ES ID_Continue; tsc rejects it"
+        );
+    }
+}
+
+/// Adjacent negative cases: rejected by both `XID_Start` and ES `ID_Start`.
+#[test]
+fn non_id_start_codepoints_rejected() {
+    for ch in [
+        0x00D7, // MULTIPLICATION SIGN (Sm)
+        0x2117, // SOUND RECORDING COPYRIGHT (So), neighbor of U+2118
+    ] {
+        assert!(!is_identifier_start(ch), "U+{ch:04X} is not ES ID_Start");
+        assert!(!is_identifier_part(ch), "U+{ch:04X} is not ES ID_Continue");
+    }
+}
+
 #[test]
 fn scan_es2015_braced_astral_escape_as_identifier_start() {
     let mut scanner = ScannerState::new(r"\u{102A7}tail".to_string(), true);


### PR DESCRIPTION
Goal: hold

Makes the scanner's identifier classification exactly ECMAScript ID_Start/ID_Continue. An exhaustive code-point sweep against tsc's `unicodeESNextIdentifierStart`/`unicodeESNextIdentifierPart` tables (Unicode 15.1) verified the full delta: the `unicode_ident` XID tables exclude 23 NFKC-unstable ES ID_Start code points that tsc accepts (U+037A, U+0E33, U+0EB3, U+309B..U+309C, U+FC5E..U+FC63, U+FDFA..U+FDFB, U+FE70/72/74/76/78/7A/7C/7E, U+FF9E..U+FF9F); all are now patched with UCD citations. U+2118 and U+212E from the issue write-up are NFKC-stable `Other_ID_Start` members that `XID_Start` already contains, so they need tests only, no patch. The hand-maintained combining-mark range list is deleted: every assigned Mn/Mc member is already covered by `XID_Continue`, and its remaining members (Me enclosing marks such as U+20DD, Hebrew punctuation such as U+05BE, and unassigned block holes) are rejected by tsc, so the deletion is itself a parity fix, not just cleanup. The parser's regex-flag identifier-part predicate now routes through the scanner predicate instead of `char::is_alphabetic`, matching tsc's `isIdentifierPart` flag termination.

Structural rule: when a code point is in ES ID_Start/ID_Continue, tsc scans it as an identifier; tsz does the same through `tsz_scanner::is_ecmascript_identifier_{start,part}` as the single owner — downstream copies were already retired (#13135/#13148/#13167/#13208).

After this change the sweep reports zero code points that tsc accepts and tsz rejects, for both start and continue positions. Remaining known divergence (reported, not patched): `unicode-ident` 1.0.24 ships Unicode 16.0 tables while tsc's tables were generated from Unicode 15.1, so code points newly assigned in Unicode 16 (new scripts plus CJK extensions) are accepted by tsz and rejected by tsc.

Closes #13069

## Verification
- `cargo nextest run -p tsz-scanner` (409 passed; includes 8 new ID_Start/ID_Continue parity tests)
- `cargo nextest run -p tsz-parser -E 'test(/regex|identifier/)'` (94 passed; includes 2 new regex-flag routing tests)
- `cargo clippy -p tsz-scanner -p tsz-parser -- -D warnings` (clean)
- `./scripts/conformance/conformance.sh run --filter unicode` (72/72), `--filter regularExpression` (7/7), `--filter identifier` (3/3)

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
