### PR TITLE
fix(checker): enforce relation-routing and common-export arch ratchets in CI (#8227)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1768,3 +1768,6 @@ path = "tests/overload_argument_flow_narrowing_visibility_tests.rs"
 [[test]]
 name = "imported_ctor_alias_predicate_narrowing_tests"
 path = "tests/imported_ctor_alias_predicate_narrowing_tests.rs"
+[[test]]
+name = "arch_source_scans"
+path = "tests/arch_source_scans.rs"

--- a/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
+++ b/crates/tsz-checker/src/assignability/relation_outcome_helpers.rs
@@ -626,6 +626,20 @@ impl<'a> CheckerState<'a> {
         self.execute_relation_request(&request)
     }
 
+    /// Execute the diagnostic-bearing non-keyof index-constraint probe used by
+    /// foreign-keyof `TS2536` detection (`constraint -> keyof B`).
+    /// Decision-only: the caller reads only `outcome.related`. This wraps the
+    /// legacy boolean relation decision directly (no input re-preparation) so
+    /// `TS2536` emission/suppression behavior is byte-for-byte preserved while
+    /// the probe stays grep-distinct as a named indexed-access outcome.
+    pub(crate) fn indexed_access_foreign_keyof_constraint_relation_outcome(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> crate::query_boundaries::assignability::RelationOutcome {
+        self.diagnostic_relation_outcome(source, target)
+    }
+
     /// Execute a diagnostic-bearing conditional constraint component relation
     /// for raw checker types, preserving the canonical conditional request
     /// shape.

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -160,9 +160,6 @@ mod class_property_typed_const_initializer_tests;
 #[path = "tests/comlink_row_regression_tests.rs"]
 mod comlink_row_regression_tests;
 #[cfg(test)]
-#[path = "tests/common_boundary_export_ratchets.rs"]
-mod common_boundary_export_ratchets;
-#[cfg(test)]
 #[path = "../tests/constructor_overload_excess_property_tests.rs"]
 mod constructor_overload_excess_property_tests;
 #[cfg(test)]
@@ -1188,9 +1185,6 @@ mod ref_type_params_cache_tests;
 #[cfg(test)]
 #[path = "tests/relation_flags_boundary_contract_tests.rs"]
 mod relation_flags_boundary_contract_tests;
-#[cfg(test)]
-#[path = "tests/relation_routing_residual_arch_tests.rs"]
-mod relation_routing_residual_arch_tests;
 #[cfg(test)]
 #[path = "tests/remapped_missing_property_relation_routing_arch_tests.rs"]
 mod remapped_missing_property_relation_routing_arch_tests;

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -1347,7 +1347,13 @@ impl<'a> CheckerState<'a> {
                     // large-union issue doesn't apply here since the constraint is not
                     // itself a computed keyof union.
                     let keyof_current = self.ctx.types.factory().keyof(current_object);
-                    if self.is_assignable_to(index_constraint, keyof_current) {
+                    if self
+                        .indexed_access_foreign_keyof_constraint_relation_outcome(
+                            index_constraint,
+                            keyof_current,
+                        )
+                        .related
+                    {
                         return false;
                     }
                 }

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -1,0 +1,24 @@
+//! Architecture source-scan ratchets, declared as an explicit `[[test]]`
+//! integration target so the checker-integration CI lane (which enumerates
+//! `cargo metadata` targets with `kind == "test"`) builds and runs them.
+//!
+//! These ratchets previously lived as `#[cfg(test)]` lib-test mounts in
+//! `src/lib.rs`, but CI never builds the checker lib-test binary (it exceeds
+//! what the `32 GiB` runners can link; see `run_checker_integration_tests`
+//! in `scripts/ci/gcp-full-ci.sh`), so the invariants were silently
+//! unenforced.
+//!
+//! Both scans are pure source-text checks over `$CARGO_MANIFEST_DIR/src` with
+//! no dependency on crate internals:
+//! - `relation_routing_residual_arch_tests`: diagnostic-bearing relation
+//!   probes in production checker code must route through named
+//!   `*_relation_outcome` helpers at the assignability boundary
+//!   (issues #8227 / #12949).
+//! - `common_boundary_export_ratchets`: the `query_boundaries/common.rs`
+//!   `pub(crate) fn` surface only changes with an explicit allowlist update
+//!   (issue #12948).
+
+#[path = "arch_source_scans/common_boundary_export_ratchets.rs"]
+mod common_boundary_export_ratchets;
+#[path = "arch_source_scans/relation_routing_residual_arch_tests.rs"]
+mod relation_routing_residual_arch_tests;

--- a/crates/tsz-checker/tests/arch_source_scans/common_boundary_export_ratchets.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/common_boundary_export_ratchets.rs
@@ -32,9 +32,16 @@
 
 use std::collections::BTreeSet;
 use std::fs;
+use std::path::PathBuf;
 
 const COMMON_PATH: &str = "src/query_boundaries/common.rs";
 const DIAGNOSTICS_PATH: &str = "src/query_boundaries/diagnostics.rs";
+
+/// Resolve a checker-crate-relative path against the manifest directory so
+/// the scan works regardless of the test runner's working directory.
+fn checker_path(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
 
 /// Snapshot of every `pub(crate) fn` defined in `common.rs`. Sorted and unique.
 /// Regenerate with the command documented in the module header.
@@ -57,6 +64,7 @@ const ALLOWED_COMMON_PUB_CRATE_FNS: &[&str] = &[
     "classify_for_predicate_signature",
     "classify_for_traversal",
     "classify_for_type_resolution",
+    "classify_identity_mapped",
     "classify_literal_type",
     "classify_namespace_member",
     "classify_promise_type",
@@ -73,9 +81,11 @@ const ALLOWED_COMMON_PUB_CRATE_FNS: &[&str] = &[
     "contains_conditional_type",
     "contains_error_type",
     "contains_error_type_in_args",
+    "contains_file_relative_content",
     "contains_free_type_parameters",
     "contains_generic_indexed_access_surface",
     "contains_generic_type_parameters",
+    "contains_index_access_type",
     "contains_infer_types",
     "contains_keyof_type",
     "contains_lazy_def_id",
@@ -96,6 +106,7 @@ const ALLOWED_COMMON_PUB_CRATE_FNS: &[&str] = &[
     "find_property_by_str",
     "find_property_in_object",
     "find_property_in_object_by_str",
+    "format_excess_property_name",
     "function_shape_for_type",
     "function_shape_id",
     "get_application_base",
@@ -113,7 +124,6 @@ const ALLOWED_COMMON_PUB_CRATE_FNS: &[&str] = &[
     "get_iterator_info",
     "get_merged_object_shape_for_type",
     "get_noinfer_inner",
-    "get_object_symbol",
     "get_private_brand_name",
     "get_private_field_name",
     "get_readonly_inner",
@@ -138,6 +148,7 @@ const ALLOWED_COMMON_PUB_CRATE_FNS: &[&str] = &[
     "intersect_constructor_returns",
     "intersection_list_id",
     "intersection_members",
+    "intersection_or_single",
     "is_array_or_tuple_type",
     "is_array_type",
     "is_bare_infer_placeholder",
@@ -146,6 +157,8 @@ const ALLOWED_COMMON_PUB_CRATE_FNS: &[&str] = &[
     "is_callable_type",
     "is_conditional_type",
     "is_constructor_like_type",
+    "is_definitely_nullish",
+    "is_distributive_conditional_with_deferred_check",
     "is_empty_object_type",
     "is_enum_type",
     "is_error_type",
@@ -202,10 +215,12 @@ const ALLOWED_COMMON_PUB_CRATE_FNS: &[&str] = &[
     "keyof_inner_type",
     "keyof_object_properties",
     "lazy_def_id",
+    "lazy_resolve_failure_count",
     "literal_value",
     "map_compound_members_if_changed",
     "mapped_type_id",
     "mapped_type_info",
+    "mapped_type_is_deferred_generic",
     "needs_evaluation_for_merge",
     "new_binary_op_evaluator",
     "no_infer_inner_type",
@@ -333,8 +348,8 @@ fn extract_pub_crate_fns(source: &str) -> BTreeSet<String> {
 
 #[test]
 fn common_pub_crate_fn_surface_matches_allowlist() {
-    let source =
-        fs::read_to_string(COMMON_PATH).expect("failed to read query_boundaries/common.rs");
+    let source = fs::read_to_string(checker_path(COMMON_PATH))
+        .expect("failed to read query_boundaries/common.rs");
     let actual = extract_pub_crate_fns(&source);
     let allowed: BTreeSet<String> = ALLOWED_COMMON_PUB_CRATE_FNS
         .iter()
@@ -350,20 +365,22 @@ fn common_pub_crate_fn_surface_matches_allowlist() {
          A domain-specific semantic policy helper belongs in its named domain boundary module \
          (diagnostics / type_predicates / key_constraints / assignability / ...), not common.rs. \
          If this is an intentional cross-domain primitive, add it to ALLOWED_COMMON_PUB_CRATE_FNS \
-         in src/tests/common_boundary_export_ratchets.rs (see the regeneration command in that file)."
+         in tests/arch_source_scans/common_boundary_export_ratchets.rs (see the regeneration \
+         command in that file)."
     );
     assert!(
         removed.is_empty(),
         "pub(crate) fn definitions were removed from query_boundaries/common.rs but the ratchet \
          allowlist still lists them: {removed:?}. Regenerate ALLOWED_COMMON_PUB_CRATE_FNS in \
-         src/tests/common_boundary_export_ratchets.rs so the quarantine snapshot stays accurate."
+         tests/arch_source_scans/common_boundary_export_ratchets.rs so the quarantine snapshot \
+         stays accurate."
     );
 }
 
 #[test]
 fn migrated_helpers_do_not_reappear_in_common() {
-    let source =
-        fs::read_to_string(COMMON_PATH).expect("failed to read query_boundaries/common.rs");
+    let source = fs::read_to_string(checker_path(COMMON_PATH))
+        .expect("failed to read query_boundaries/common.rs");
     let mut violations = Vec::new();
     for name in migrated_out_of_common() {
         if defines_fn(&source, name) {
@@ -380,9 +397,9 @@ fn migrated_helpers_do_not_reappear_in_common() {
 
 #[test]
 fn display_widening_cluster_is_owned_by_diagnostics() {
-    let common =
-        fs::read_to_string(COMMON_PATH).expect("failed to read query_boundaries/common.rs");
-    let diagnostics = fs::read_to_string(DIAGNOSTICS_PATH)
+    let common = fs::read_to_string(checker_path(COMMON_PATH))
+        .expect("failed to read query_boundaries/common.rs");
+    let diagnostics = fs::read_to_string(checker_path(DIAGNOSTICS_PATH))
         .expect("failed to read query_boundaries/diagnostics.rs");
     for name in DISPLAY_WIDENING_IN_DIAGNOSTICS {
         assert!(

--- a/crates/tsz-checker/tests/arch_source_scans/relation_routing_residual_arch_tests.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/relation_routing_residual_arch_tests.rs
@@ -1,6 +1,19 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+/// Root of the checker crate's production sources, anchored on the manifest
+/// directory so the scan works regardless of the test runner's working
+/// directory.
+fn checker_src_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+/// Read one checker source file by its `src/`-relative path.
+fn read_checker_source(relative: &str) -> String {
+    fs::read_to_string(checker_src_root().join(relative))
+        .unwrap_or_else(|err| panic!("failed to read src/{relative}: {err}"))
+}
+
 const RAW_RELATION_PATTERNS: &[&str] = &[
     ".is_assignable_to(",
     ".is_assignable_to_bivariant(",
@@ -86,8 +99,7 @@ fn function_body_between<'a>(source: &'a str, start_marker: &str, end_marker: &s
 
 #[test]
 fn assign_relation_outcome_fast_path_uses_named_diagnostic_guard() {
-    let source = fs::read_to_string("src/assignability/assignability_relation.rs")
-        .expect("failed to read assignability relation source");
+    let source = read_checker_source("assignability/assignability_relation.rs");
     let body = function_body_between(
         &source,
         "pub(crate) fn assign_relation_outcome(",
@@ -107,8 +119,7 @@ fn assign_relation_outcome_fast_path_uses_named_diagnostic_guard() {
 
 #[test]
 fn relation_outcome_with_env_fast_path_uses_named_diagnostic_guard() {
-    let source = fs::read_to_string("src/assignability/assignability_relation.rs")
-        .expect("failed to read assignability relation source");
+    let source = read_checker_source("assignability/assignability_relation.rs");
     let body = function_body_between(
         &source,
         "fn relation_outcome_with_env(",
@@ -128,8 +139,7 @@ fn relation_outcome_with_env_fast_path_uses_named_diagnostic_guard() {
 
 #[test]
 fn type_parameter_constraint_elaboration_uses_named_outcome_helper() {
-    let source = fs::read_to_string("src/error_reporter/assignability.rs")
-        .expect("failed to read error reporter assignability source");
+    let source = read_checker_source("error_reporter/assignability.rs");
     let body = function_body_between(
         &source,
         "fn unrelated_type_parameter_target_related_info(",
@@ -152,9 +162,16 @@ fn type_parameter_constraint_elaboration_uses_named_outcome_helper() {
 #[test]
 fn production_checker_relation_truth_uses_outcome_boundaries() {
     let mut violations = Vec::new();
+    let src_root = checker_src_root();
 
-    for path in rust_sources_under(Path::new("src")) {
-        let relative_path = path.to_string_lossy().replace('\\', "/");
+    for path in rust_sources_under(&src_root) {
+        let relative_path = format!(
+            "src/{}",
+            path.strip_prefix(&src_root)
+                .expect("scanned path is under the src root")
+                .to_string_lossy()
+                .replace('\\', "/")
+        );
         let source = fs::read_to_string(&path).expect("failed to read Rust source");
         for (line_index, line) in source.lines().enumerate() {
             for pattern in RAW_RELATION_PATTERNS {


### PR DESCRIPTION
Goal: hold

Repairs and enforces the checker architecture ratchets that CI never executed (lib-test mounts are excluded by the 32GiB linker rule, so two ratchets went silently red on main): routes the raw `is_assignable_to` TS2536 probe from #13152 through the named indexed-access relation-outcome boundary (behavior preserving), regenerates the `common.rs` pub(crate) export allowlist (PR #13043 drift + one stale entry), and moves both source-scan ratchet families into an explicit integration test target that the checker-integration CI lane enumerates and runs.

Structural rule: diagnostic-bearing relation probes in production checker code go through named outcome helpers at the assignability/query boundary; `query_boundaries/common.rs` exports change only with an allowlist update; both invariants are now CI-executed, with mutation-tested failure proof.

Closes #8227
Closes #12949
Closes #12948

## Verification
- `cargo nextest run -p tsz-checker --test arch_source_scans` (7/7 green; mutation-tested: re-introducing the raw `is_assignable_to` probe in `src/types/.../indexed_access_helpers.rs` fails the relation ratchet at the exact line, and dropping one allowlist entry fails the export ratchet — both reverted)
- `cargo nextest run -p tsz-checker --test <all 16 indexed_access integration targets>` — 146/146 pass (behavior preserved; explicit `--test` flags used instead of `-E 'test(/indexed_access/)'` so the run does not build the CI-excluded checker lib-test binary)
- `cargo nextest run -p tsz-checker --test ts2536_keyof_string_index_signature_tests --test deferred_keyof_index_access_assignability_tests --test mapped_keyof_index_access_tests --test keyof_operand_indexed_access_validation_tests --test template_literal_generic_call_indexed_keyof_constraint_tests` — 55/56; the single failure (`nested_keyof_indexed_constraint_three_levels`, a TS2536 FP) reproduces identically with pristine `origin/main` production sources (verified by restoring both touched files to `origin/main` and rebuilding), i.e. pre-existing on main and unchanged by this PR
- `cargo clippy -p tsz-checker -- -D warnings` and `cargo clippy -p tsz-checker --test arch_source_scans -- -D warnings`
- `python3 scripts/arch/arch_guard.py` (passes)
- `cargo metadata` target enumeration (the exact jq from `checker_integration_test_names` in `scripts/ci/gcp-full-ci.sh`) lists `arch_source_scans` among the 573 `kind == "test"` targets, so `run_checker_integration_tests` picks it up automatically

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
