### PR TITLE
perf(solver): cache union string sort text (#13242)

### DIFF
--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -549,7 +549,7 @@ impl TypeInterner {
                     let b_short = str_b.len() <= 2;
                     match (a_short, b_short) {
                         (true, true) => {
-                            let cmp = str_a.cmp(&str_b);
+                            let cmp = str_a.cmp(str_b);
                             if cmp != Ordering::Equal {
                                 return cmp;
                             }

--- a/crates/tsz-solver/src/intern/core/constructors.rs
+++ b/crates/tsz-solver/src/intern/core/constructors.rs
@@ -450,6 +450,7 @@ impl TypeInterner {
                 obj_symbol: None,
                 obj_anon_shape: None,
                 callable_symbol: None,
+                string_literal_text: None,
                 alloc_order: None,
             };
         }
@@ -460,9 +461,13 @@ impl TypeInterner {
         let mut obj_symbol = None;
         let mut obj_anon_shape = None;
         let mut callable_symbol = None;
+        let mut string_literal_text = None;
 
         if let Some(ref d) = data {
             match d {
+                TypeData::Literal(LiteralValue::String(atom)) => {
+                    string_literal_text = Some(self.string_interner.resolve(*atom));
+                }
                 TypeData::Object(s) | TypeData::ObjectWithIndex(s) => {
                     let shape = self.object_shape(*s);
                     if let Some(sym) = shape.symbol {
@@ -488,6 +493,7 @@ impl TypeInterner {
             obj_symbol,
             obj_anon_shape,
             callable_symbol,
+            string_literal_text,
             alloc_order,
         }
     }
@@ -528,11 +534,17 @@ impl TypeInterner {
         if let (Some(data_a), Some(data_b)) = (&a.data, &b.data) {
             match (data_a, data_b) {
                 (
-                    TypeData::Literal(LiteralValue::String(sa)),
-                    TypeData::Literal(LiteralValue::String(sb)),
+                    TypeData::Literal(LiteralValue::String(_)),
+                    TypeData::Literal(LiteralValue::String(_)),
                 ) => {
-                    let str_a = self.string_interner.resolve(*sa);
-                    let str_b = self.string_interner.resolve(*sb);
+                    let str_a = a
+                        .string_literal_text
+                        .as_deref()
+                        .expect("string literal union member must cache resolved text");
+                    let str_b = b
+                        .string_literal_text
+                        .as_deref()
+                        .expect("string literal union member must cache resolved text");
                     let a_short = str_a.len() <= 2;
                     let b_short = str_b.len() <= 2;
                     match (a_short, b_short) {

--- a/crates/tsz-solver/src/intern/core/interner/storage.rs
+++ b/crates/tsz-solver/src/intern/core/interner/storage.rs
@@ -36,6 +36,8 @@ pub(in crate::intern::core) struct CachedUnionMember {
     pub(in crate::intern::core) obj_anon_shape: Option<u32>,
     /// For Callable: the symbol's raw u32 (if the shape has a symbol)
     pub(in crate::intern::core) callable_symbol: Option<u32>,
+    /// For string literals: resolved text used by union-member ordering.
+    pub(in crate::intern::core) string_literal_text: Option<Arc<str>>,
     /// Monotonic allocation counter for source-order sorting
     pub(in crate::intern::core) alloc_order: Option<u32>,
 }


### PR DESCRIPTION
Goal: fast

## Summary
- Cache resolved string-literal text in `CachedUnionMember` during union-member sort preparation.
- Reuse that cached text in the string-literal comparator instead of resolving atoms from the string interner on every comparison.
- Preserve the existing canonical union ordering rules: short string literals still sort lexically before falling back to allocation order.

## Structural rule
When concrete union members are sorted for canonical interning, ordering must remain a pure function of member structure and stable identities, but comparison should not repeatedly resolve string atoms inside the sort comparator. Solver interner owns the canonical union order; this PR only moves string text resolution from O(comparisons) to O(string-literal members).

## Verification
- No local tests run per current instruction.
- Draft/light CI passed at exact head `f0f70f7e385008d7d780030c5b969f5d13e73bf1` after rerunning an infra-only `cargo-shear` registry transfer failure.
- Ready-review CI is the next gate before queueing.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
