### PR TITLE
perf(checker): hoist switch-chain DP memo, finish null-exclusion threading (#13083)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -13,6 +13,12 @@ use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
+pub(crate) struct BinaryFlowNarrowingContext<'m> {
+    antecedent_id: FlowNodeId,
+    allow_untyped_comparison_fallback: bool,
+    dp_memos: Option<&'m mut FlowConditionDpMemos>,
+}
+
 impl<'a> FlowAnalyzer<'a> {
     fn narrow_to_falsy_via_flow_boundary(&self, type_id: TypeId) -> TypeId {
         let env_borrow = self.type_environment.as_ref().map(|env| env.borrow());
@@ -100,9 +106,11 @@ impl<'a> FlowAnalyzer<'a> {
             target,
             true,
             narrowing,
-            FlowNodeId::NONE,
-            true,
-            None,
+            BinaryFlowNarrowingContext {
+                antecedent_id: FlowNodeId::NONE,
+                allow_untyped_comparison_fallback: true,
+                dp_memos: None,
+            },
         )
     }
 
@@ -340,9 +348,11 @@ impl<'a> FlowAnalyzer<'a> {
                 target,
                 false,
                 narrowing,
-                FlowNodeId::NONE,
-                true,
-                None,
+                BinaryFlowNarrowingContext {
+                    antecedent_id: FlowNodeId::NONE,
+                    allow_untyped_comparison_fallback: true,
+                    dp_memos: None,
+                },
             );
         }
 
@@ -540,9 +550,11 @@ impl<'a> FlowAnalyzer<'a> {
                 target,
                 false,
                 narrowing,
-                FlowNodeId::NONE,
-                true,
-                None,
+                BinaryFlowNarrowingContext {
+                    antecedent_id: FlowNodeId::NONE,
+                    allow_untyped_comparison_fallback: true,
+                    dp_memos: None,
+                },
             );
         }
 
@@ -795,9 +807,11 @@ impl<'a> FlowAnalyzer<'a> {
                                     target,
                                     is_true_branch,
                                     &narrowing,
-                                    antecedent_id,
-                                    false,
-                                    dp_memos.as_deref_mut(),
+                                    BinaryFlowNarrowingContext {
+                                        antecedent_id,
+                                        allow_untyped_comparison_fallback: false,
+                                        dp_memos: dp_memos.as_deref_mut(),
+                                    },
                                 );
                             }
                         }
@@ -812,9 +826,11 @@ impl<'a> FlowAnalyzer<'a> {
                         target,
                         is_true_branch,
                         &narrowing,
-                        antecedent_id,
-                        false,
-                        dp_memos,
+                        BinaryFlowNarrowingContext {
+                            antecedent_id,
+                            allow_untyped_comparison_fallback: false,
+                            dp_memos,
+                        },
                     );
                     return narrowed;
                 }
@@ -1180,7 +1196,6 @@ impl<'a> FlowAnalyzer<'a> {
     /// outside that path pass `None` and the null-exclusion check below falls
     /// back to a one-shot memo, exactly like the threaded sites in
     /// `narrow_type_by_condition_inner`.
-    #[allow(clippy::too_many_arguments)]
     pub(crate) fn narrow_by_binary_expr(
         &self,
         type_id: TypeId,
@@ -1188,9 +1203,7 @@ impl<'a> FlowAnalyzer<'a> {
         target: NodeIndex,
         is_true_branch: bool,
         narrowing: &NarrowingContext,
-        antecedent_id: FlowNodeId,
-        allow_untyped_comparison_fallback: bool,
-        mut dp_memos: Option<&mut FlowConditionDpMemos>,
+        mut flow_context: BinaryFlowNarrowingContext<'_>,
     ) -> TypeId {
         let operator = bin.operator_token;
 
@@ -1205,9 +1218,9 @@ impl<'a> FlowAnalyzer<'a> {
                     bin.right,
                     target,
                     is_true_branch,
-                    antecedent_id,
+                    flow_context.antecedent_id,
                     &mut visited,
-                    dp_memos,
+                    flow_context.dp_memos,
                 );
             }
             return type_id;
@@ -1269,14 +1282,17 @@ impl<'a> FlowAnalyzer<'a> {
                 );
                 if effective_truth
                     && typeof_kind == TypeofKind::Object
-                    && if let Some(memos) = dp_memos.as_mut() {
+                    && if let Some(memos) = flow_context.dp_memos.as_deref_mut() {
                         self.antecedent_chain_excludes_null_for_target_with_memo(
-                            antecedent_id,
+                            flow_context.antecedent_id,
                             target,
                             &mut memos.null_exclusions,
                         )
                     } else {
-                        self.antecedent_chain_excludes_null_for_target(antecedent_id, target)
+                        self.antecedent_chain_excludes_null_for_target(
+                            flow_context.antecedent_id,
+                            target,
+                        )
                     }
                 {
                     return flow_query::narrow_excluding_type_in_context(
@@ -1494,11 +1510,11 @@ impl<'a> FlowAnalyzer<'a> {
                 // We need the type of the RIGHT side (y)
                 if let Some(right_type) = self.flow_comparison_type(
                     bin.right,
-                    antecedent_id,
-                    allow_untyped_comparison_fallback,
+                    flow_context.antecedent_id,
+                    flow_context.allow_untyped_comparison_fallback,
                 ) {
                     if effective_truth {
-                        if allow_untyped_comparison_fallback
+                        if flow_context.allow_untyped_comparison_fallback
                             && matches!(type_id, TypeId::UNKNOWN | TypeId::ANY)
                         {
                             return right_type;
@@ -1525,11 +1541,11 @@ impl<'a> FlowAnalyzer<'a> {
                 // We need the type of the LEFT side (y)
                 if let Some(left_type) = self.flow_comparison_type(
                     bin.left,
-                    antecedent_id,
-                    allow_untyped_comparison_fallback,
+                    flow_context.antecedent_id,
+                    flow_context.allow_untyped_comparison_fallback,
                 ) {
                     if effective_truth {
-                        if allow_untyped_comparison_fallback
+                        if flow_context.allow_untyped_comparison_fallback
                             && matches!(type_id, TypeId::UNKNOWN | TypeId::ANY)
                         {
                             return left_type;

--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -102,6 +102,7 @@ impl<'a> FlowAnalyzer<'a> {
             narrowing,
             FlowNodeId::NONE,
             true,
+            None,
         )
     }
 
@@ -341,6 +342,7 @@ impl<'a> FlowAnalyzer<'a> {
                 narrowing,
                 FlowNodeId::NONE,
                 true,
+                None,
             );
         }
 
@@ -540,6 +542,7 @@ impl<'a> FlowAnalyzer<'a> {
                 narrowing,
                 FlowNodeId::NONE,
                 true,
+                None,
             );
         }
 
@@ -794,6 +797,7 @@ impl<'a> FlowAnalyzer<'a> {
                                     &narrowing,
                                     antecedent_id,
                                     false,
+                                    dp_memos.as_deref_mut(),
                                 );
                             }
                         }
@@ -810,6 +814,7 @@ impl<'a> FlowAnalyzer<'a> {
                         &narrowing,
                         antecedent_id,
                         false,
+                        dp_memos,
                     );
                     return narrowed;
                 }
@@ -1169,6 +1174,13 @@ impl<'a> FlowAnalyzer<'a> {
     }
 
     /// Narrow type based on a binary expression (===, !==, typeof checks, etc.)
+    ///
+    /// `dp_memos` carries the per-`check_flow` flow-condition DP scratch when
+    /// this call is reachable from the top-level traversal worklist; callers
+    /// outside that path pass `None` and the null-exclusion check below falls
+    /// back to a one-shot memo, exactly like the threaded sites in
+    /// `narrow_type_by_condition_inner`.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn narrow_by_binary_expr(
         &self,
         type_id: TypeId,
@@ -1178,6 +1190,7 @@ impl<'a> FlowAnalyzer<'a> {
         narrowing: &NarrowingContext,
         antecedent_id: FlowNodeId,
         allow_untyped_comparison_fallback: bool,
+        mut dp_memos: Option<&mut FlowConditionDpMemos>,
     ) -> TypeId {
         let operator = bin.operator_token;
 
@@ -1194,7 +1207,7 @@ impl<'a> FlowAnalyzer<'a> {
                     is_true_branch,
                     antecedent_id,
                     &mut visited,
-                    None,
+                    dp_memos,
                 );
             }
             return type_id;
@@ -1256,7 +1269,15 @@ impl<'a> FlowAnalyzer<'a> {
                 );
                 if effective_truth
                     && typeof_kind == TypeofKind::Object
-                    && self.antecedent_chain_excludes_null_for_target(antecedent_id, target)
+                    && if let Some(memos) = dp_memos.as_mut() {
+                        self.antecedent_chain_excludes_null_for_target_with_memo(
+                            antecedent_id,
+                            target,
+                            &mut memos.null_exclusions,
+                        )
+                    } else {
+                        self.antecedent_chain_excludes_null_for_target(antecedent_id, target)
+                    }
                 {
                     return flow_query::narrow_excluding_type_in_context(
                         narrowing,

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -1,3 +1,4 @@
+use super::flow_dp::{ChainReachabilityMemo, resolve_chain_reachability};
 use crate::query_boundaries::common::QueryDatabase;
 use crate::query_boundaries::common::{NarrowingCache, NarrowingContext, TypeEnvironment};
 use crate::query_boundaries::flow as flow_boundary;
@@ -880,31 +881,44 @@ impl<'a> FlowAnalyzer<'a> {
             .is_some_and(|node| node.kind == SyntaxKind::TrueKeyword as u16)
     }
 
-    fn flow_chain_contains_switch_clause(&self, flow_id: FlowNodeId) -> bool {
-        let mut worklist = VecDeque::from([flow_id]);
-        let mut visited = FxHashSet::default();
-        let mut steps = 0usize;
-
-        while let Some(current) = worklist.pop_front() {
-            if current.is_none() || !visited.insert(current) {
-                continue;
-            }
-            steps += 1;
-            if steps > 32 {
-                return false;
-            }
-            let Some(flow) = self.binder.flow_nodes.get(current) else {
-                continue;
-            };
-            if flow.has_any_flags(flow_flags::SWITCH_CLAUSE) {
-                return true;
-            }
-            for &ant in &flow.antecedent {
-                worklist.push_back(ant);
-            }
-        }
-
-        false
+    /// Returns `true` when `flow_id`'s antecedent chain (including itself)
+    /// contains a `SWITCH_CLAUSE` flow node.
+    ///
+    /// Used by the `check_flow` worklist to skip flow-cache reads/writes for
+    /// `unknown`-typed references whose chain passes through switch clauses.
+    /// Memoized in the per-`check_flow` [`ChainReachabilityMemo`] scratch so
+    /// the worklist no longer allocates a fresh `VecDeque` + `FxHashSet` per
+    /// iteration (#13083). The verdict is a pure property of the flow graph,
+    /// which is immutable for the duration of one `check_flow` traversal, so
+    /// memoized answers stay valid for the scratch lifetime. The previous
+    /// one-shot BFS gave up after 32 nodes and reported `false`; the memoized
+    /// form is exact, so very deep switch chains now conservatively skip the
+    /// flow cache (recompute) instead of consulting it.
+    fn flow_chain_contains_switch_clause_with_memo(
+        &self,
+        flow_id: FlowNodeId,
+        memo: &mut ChainReachabilityMemo,
+    ) -> bool {
+        resolve_chain_reachability(
+            flow_id,
+            memo,
+            |node| {
+                let Some(flow) = self.binder.flow_nodes.get(node) else {
+                    return smallvec::SmallVec::new();
+                };
+                flow.antecedent
+                    .iter()
+                    .copied()
+                    .filter(|antecedent| !antecedent.is_none())
+                    .collect()
+            },
+            |node| {
+                self.binder
+                    .flow_nodes
+                    .get(node)
+                    .is_some_and(|flow| flow.has_any_flags(flow_flags::SWITCH_CLAUSE))
+            },
+        )
     }
 
     #[inline]

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -112,7 +112,10 @@ impl<'a> FlowAnalyzer<'a> {
                     (false, false)
                 };
             let skip_cache_for_explicit_unknown_switch = initial_type == TypeId::UNKNOWN
-                && self.flow_chain_contains_switch_clause(current_flow);
+                && self.flow_chain_contains_switch_clause_with_memo(
+                    current_flow,
+                    &mut condition_dp_memos.switch_chains,
+                );
             let skip_cache_for_exhaustive_unknown_typeof = initial_type == TypeId::UNKNOWN
                 && self.flow_has_exhaustive_typeof_exclusions_with_memo(
                     current_flow,
@@ -1032,7 +1035,10 @@ impl<'a> FlowAnalyzer<'a> {
                 && (!skip_cache_for_control_flow_typed_any
                     || flow.has_any_flags(flow_flags::LOOP_LABEL))
                 && !(initial_type == TypeId::UNKNOWN
-                    && self.flow_chain_contains_switch_clause(current_flow))
+                    && self.flow_chain_contains_switch_clause_with_memo(
+                        current_flow,
+                        &mut condition_dp_memos.switch_chains,
+                    ))
                 && !(initial_type == TypeId::UNKNOWN
                     && self.flow_has_exhaustive_typeof_exclusions_with_memo(
                         current_flow,

--- a/crates/tsz-checker/src/flow/control_flow/flow_dp.rs
+++ b/crates/tsz-checker/src/flow/control_flow/flow_dp.rs
@@ -19,8 +19,9 @@
 //!   tsz's previous, fail-safe (no-narrow-on-loop) behavior while collapsing
 //!   the asymptotic cost from exponential to linear.
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
+use std::collections::VecDeque;
 use tsz_binder::FlowNodeId;
 
 #[derive(Clone, Copy)]
@@ -37,22 +38,153 @@ pub(crate) type DpMemo<T> = FxHashMap<FlowNodeId, DpState<T>>;
 
 /// Scratch DP memos for one `check_flow` traversal and one reference target.
 ///
-/// These are intentionally scoped to a single flow query: both analyses key
-/// only by `FlowNodeId`, while their answers depend on the target expression
-/// being narrowed. Reusing them across references would be unsound; reusing
-/// them within one `check_flow` call avoids rebuilding the same graph folds
-/// for every worklist visit.
+/// These are intentionally scoped to a single flow query: all analyses key
+/// only by `FlowNodeId`, while the typeof/null answers also depend on the
+/// target expression being narrowed. Reusing those across references would be
+/// unsound; reusing them within one `check_flow` call avoids rebuilding the
+/// same graph folds for every worklist visit. The switch-chain memo is a pure
+/// property of the flow graph (target-independent) but shares the per-call
+/// lifetime for simplicity — the flow graph is immutable for the duration of
+/// one `check_flow` traversal, so its verdicts stay valid for the whole call.
 #[derive(Default)]
 pub(crate) struct FlowConditionDpMemos {
     pub(crate) typeof_exclusions: DpMemo<u8>,
     pub(crate) null_exclusions: DpMemo<bool>,
+    pub(crate) switch_chains: ChainReachabilityMemo,
 }
 
 impl FlowConditionDpMemos {
     pub(crate) fn clear(&mut self) {
         self.typeof_exclusions.clear();
         self.null_exclusions.clear();
+        self.switch_chains.clear();
     }
+}
+
+/// Memo plus reusable scratch buffers for exact "does any antecedent path
+/// from this node contain a flagged node" reachability queries (currently:
+/// `SWITCH_CLAUSE` containment).
+///
+/// Unlike the fold-based DP below, flag reachability through CFG back-edges
+/// has no no-information identity element: resolving an in-progress loop
+/// header as "no flag" memoizes a wrong `false` for loop-body nodes whose
+/// only route to the flagged node runs through that header (a `switch`
+/// statement feeding a `while` loop is enough to hit this shape). The BFS in
+/// [`resolve_chain_reachability`] therefore memoizes only proven verdicts:
+///
+/// - when a query exhausts its frontier without a hit, every node it visited
+///   had its entire reachable set explored (within `visited` plus
+///   already-proven-`false` nodes), so all of them are `false`;
+/// - when a query reaches a flagged (or already-proven-`true`) node, every
+///   node on the discovery path back to the query root reaches it, so the
+///   whole path is `true`.
+///
+/// Both common cases collapse to an O(1) verdict lookup on later queries of
+/// the same `check_flow` worklist, and the scratch buffers are reused across
+/// queries so no per-worklist-iteration allocation remains (issue #13083).
+#[derive(Default)]
+pub(crate) struct ChainReachabilityMemo {
+    verdicts: FxHashMap<FlowNodeId, bool>,
+    queue: VecDeque<FlowNodeId>,
+    visited: FxHashSet<FlowNodeId>,
+    /// Maps each newly discovered node to the (downstream) node whose
+    /// antecedent list it was discovered through.
+    discovered_from: FxHashMap<FlowNodeId, FlowNodeId>,
+}
+
+impl ChainReachabilityMemo {
+    pub(crate) fn clear(&mut self) {
+        self.verdicts.clear();
+        self.queue.clear();
+        self.visited.clear();
+        self.discovered_from.clear();
+    }
+}
+
+/// Exact memoized backward reachability of a flagged flow node.
+///
+/// Returns `true` when `root` is flagged or any node in its transitive
+/// antecedent chain is. Verdicts are memoized per node in `memo` and are pure
+/// properties of the (immutable-during-traversal) flow graph, so they are
+/// independent of query order — including for nodes on CFG cycles, where the
+/// fold-based [`resolve_backward_dp`] would memoize an order-dependent
+/// under-approximation.
+///
+/// `antecedents_of` must return the non-`none` antecedents of a node (nodes
+/// without a flow entry return no antecedents); `is_flagged` reports whether
+/// the node itself carries the searched flag.
+pub(crate) fn resolve_chain_reachability<FAnts, FFlag>(
+    root: FlowNodeId,
+    memo: &mut ChainReachabilityMemo,
+    antecedents_of: FAnts,
+    is_flagged: FFlag,
+) -> bool
+where
+    FAnts: Fn(FlowNodeId) -> SmallVec<[FlowNodeId; 2]>,
+    FFlag: Fn(FlowNodeId) -> bool,
+{
+    if root.is_none() {
+        return false;
+    }
+    if let Some(&verdict) = memo.verdicts.get(&root) {
+        return verdict;
+    }
+
+    memo.queue.clear();
+    memo.visited.clear();
+    memo.discovered_from.clear();
+    memo.queue.push_back(root);
+    memo.visited.insert(root);
+
+    let mut found: Option<FlowNodeId> = None;
+    while let Some(current) = memo.queue.pop_front() {
+        match memo.verdicts.get(&current) {
+            Some(true) => {
+                found = Some(current);
+                break;
+            }
+            // Proven flag-free by an earlier query: its entire reachable set
+            // was already explored, so do not re-expand it.
+            Some(false) => continue,
+            None => {}
+        }
+        if is_flagged(current) {
+            memo.verdicts.insert(current, true);
+            found = Some(current);
+            break;
+        }
+        for antecedent in antecedents_of(current) {
+            if antecedent.is_none() || !memo.visited.insert(antecedent) {
+                continue;
+            }
+            memo.discovered_from.insert(antecedent, current);
+            memo.queue.push_back(antecedent);
+        }
+    }
+
+    if let Some(found) = found {
+        // Every node on the discovery path `root -> .. -> found` has `found`
+        // in its antecedent chain, so the whole path shares the verdict. The
+        // worklist queries successive upstream nodes, which lie on this path,
+        // so marking it keeps repeated queries O(1).
+        let mut node = found;
+        loop {
+            memo.verdicts.insert(node, true);
+            match memo.discovered_from.get(&node) {
+                Some(&downstream) => node = downstream,
+                None => break,
+            }
+        }
+        return true;
+    }
+
+    // Exhausted without a hit: every visited node's reachable set lies within
+    // `visited` plus already-proven-`false` nodes, none of which are flagged,
+    // so all visited nodes are proven `false`.
+    for &node in &memo.visited {
+        memo.verdicts.insert(node, false);
+    }
+    false
 }
 
 /// Drive a backward flow-graph DP fold *iteratively* over an explicit heap
@@ -136,5 +268,183 @@ where
     match memo.get(&root) {
         Some(DpState::Done(v)) => *v,
         _ => in_progress_value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    /// Build closures over a synthetic antecedent graph. `flagged` marks the
+    /// nodes carrying the searched flag; `expansions` counts how many nodes a
+    /// query actually expanded, to prove memo hits across queries.
+    fn graph_closures<'a>(
+        edges: &'a [(u32, &'a [u32])],
+        flagged: &'a [u32],
+        expansions: &'a Cell<usize>,
+    ) -> (
+        impl Fn(FlowNodeId) -> SmallVec<[FlowNodeId; 2]> + 'a,
+        impl Fn(FlowNodeId) -> bool + 'a,
+    ) {
+        let antecedents_of = move |node: FlowNodeId| -> SmallVec<[FlowNodeId; 2]> {
+            expansions.set(expansions.get() + 1);
+            edges
+                .iter()
+                .find(|(id, _)| *id == node.0)
+                .map(|(_, ants)| ants.iter().map(|&a| FlowNodeId(a)).collect())
+                .unwrap_or_default()
+        };
+        let is_flagged = move |node: FlowNodeId| flagged.contains(&node.0);
+        (antecedents_of, is_flagged)
+    }
+
+    #[test]
+    fn chain_reachability_none_root_is_false() {
+        let expansions = Cell::new(0);
+        let (ants, flag) = graph_closures(&[], &[], &expansions);
+        let mut memo = ChainReachabilityMemo::default();
+        assert!(!resolve_chain_reachability(
+            FlowNodeId::NONE,
+            &mut memo,
+            ants,
+            flag
+        ));
+        assert_eq!(expansions.get(), 0);
+    }
+
+    #[test]
+    fn chain_reachability_finds_flag_through_linear_chain() {
+        // 1(flagged) <- 2 <- 3
+        let edges: &[(u32, &[u32])] = &[(3, &[2]), (2, &[1]), (1, &[])];
+        let expansions = Cell::new(0);
+        let (ants, flag) = graph_closures(edges, &[1], &expansions);
+        let mut memo = ChainReachabilityMemo::default();
+        assert!(resolve_chain_reachability(
+            FlowNodeId(3),
+            &mut memo,
+            &ants,
+            &flag
+        ));
+        // The discovery path 3 -> 2 -> 1 is marked, so upstream worklist
+        // queries are memo hits with no further graph expansion.
+        let after_first = expansions.get();
+        assert!(resolve_chain_reachability(
+            FlowNodeId(2),
+            &mut memo,
+            &ants,
+            &flag
+        ));
+        assert!(resolve_chain_reachability(
+            FlowNodeId(1),
+            &mut memo,
+            &ants,
+            &flag
+        ));
+        assert_eq!(expansions.get(), after_first);
+    }
+
+    #[test]
+    fn chain_reachability_exact_on_loop_back_edge() {
+        // The shape that breaks a fold-based OR DP: a switch upstream of a
+        // loop. Loop header 2 has antecedents [3 (back-edge), 1 (entry)],
+        // loop-body node 3 has antecedent [2], node 1 is flagged, and the
+        // reference node 4 hangs off the header. A fold DP querying from 4
+        // resolves 3 while 2 is still in progress and memoizes a wrong
+        // `false` for 3; exact reachability must say `true` for every node.
+        let edges: &[(u32, &[u32])] = &[(4, &[2]), (2, &[3, 1]), (3, &[2]), (1, &[])];
+        let expansions = Cell::new(0);
+        let (ants, flag) = graph_closures(edges, &[1], &expansions);
+        let mut memo = ChainReachabilityMemo::default();
+        // Downstream-most node first, mirroring `check_flow` worklist order.
+        assert!(resolve_chain_reachability(
+            FlowNodeId(4),
+            &mut memo,
+            &ants,
+            &flag
+        ));
+        assert!(resolve_chain_reachability(
+            FlowNodeId(2),
+            &mut memo,
+            &ants,
+            &flag
+        ));
+        assert!(resolve_chain_reachability(
+            FlowNodeId(3),
+            &mut memo,
+            &ants,
+            &flag
+        ));
+        assert!(resolve_chain_reachability(
+            FlowNodeId(1),
+            &mut memo,
+            &ants,
+            &flag
+        ));
+    }
+
+    #[test]
+    fn chain_reachability_negative_chain_is_memoized() {
+        // Diamond with a cycle and no flag anywhere:
+        // 4 <- {2, 3}; 2 <- 1; 3 <- 1; 1 <- 4 (back-edge).
+        let edges: &[(u32, &[u32])] = &[(4, &[2, 3]), (2, &[1]), (3, &[1]), (1, &[4])];
+        let expansions = Cell::new(0);
+        let (ants, flag) = graph_closures(edges, &[], &expansions);
+        let mut memo = ChainReachabilityMemo::default();
+        assert!(!resolve_chain_reachability(
+            FlowNodeId(4),
+            &mut memo,
+            &ants,
+            &flag
+        ));
+        let after_first = expansions.get();
+        // Every node the first query visited is proven `false`; repeated
+        // worklist queries are pure memo hits.
+        for id in [4, 3, 2, 1] {
+            assert!(!resolve_chain_reachability(
+                FlowNodeId(id),
+                &mut memo,
+                &ants,
+                &flag
+            ));
+        }
+        assert_eq!(expansions.get(), after_first);
+    }
+
+    #[test]
+    fn chain_reachability_flag_on_root_node() {
+        let edges: &[(u32, &[u32])] = &[(1, &[])];
+        let expansions = Cell::new(0);
+        let (ants, flag) = graph_closures(edges, &[1], &expansions);
+        let mut memo = ChainReachabilityMemo::default();
+        assert!(resolve_chain_reachability(
+            FlowNodeId(1),
+            &mut memo,
+            &ants,
+            &flag
+        ));
+    }
+
+    #[test]
+    fn chain_reachability_clear_resets_verdicts() {
+        let edges: &[(u32, &[u32])] = &[(2, &[1]), (1, &[])];
+        let expansions = Cell::new(0);
+        let (ants, flag) = graph_closures(edges, &[1], &expansions);
+        let mut memo = ChainReachabilityMemo::default();
+        assert!(resolve_chain_reachability(
+            FlowNodeId(2),
+            &mut memo,
+            &ants,
+            &flag
+        ));
+        memo.clear();
+        let before = expansions.get();
+        assert!(resolve_chain_reachability(
+            FlowNodeId(2),
+            &mut memo,
+            &ants,
+            &flag
+        ));
+        assert!(expansions.get() > before);
     }
 }


### PR DESCRIPTION
Goal: fast

Finishes #13083 after #13285: hoists the switch-chain containment check into the per-check_flow `FlowConditionDpMemos` scratch (was a fresh VecDeque + FxHashSet per worklist iteration at two call sites), and threads the scratch into `narrow_by_binary_expr` so the last worklist-reachable null-exclusion call stops allocating a one-shot memo per call.

Structural rule: flow-graph DP facts are invariant within one `check_flow` traversal (the graph is immutable during traversal), so all three DP families (typeof, null-exclusion, switch-chain) share the single hoisted scratch with one-shot fallback off the traversal path.

Closes #13083

## Notes
- The switch-chain memo is **not** the prescribed `resolve_backward_dp` OR-fold: flag reachability through CFG back-edges has no no-information identity element, so the fold memoizes an order-dependent `false` for loop-body nodes whose only route to the switch clause runs through an in-progress loop header (a `switch` feeding a `while` loop is enough to hit it) — that would let the flow cache be read/written where main skips it. The new `resolve_chain_reachability` BFS memoizes only proven verdicts (exhausted frontier => all visited nodes `false`; discovery path to a hit => whole path `true`), so per-node answers are pure properties of the immutable flow graph and order-invariant; both common cases collapse to O(1) verdict lookups, scratch buffers are reused, and zero per-iteration allocations remain. A unit test pins the loop back-edge shape.
- The old one-shot BFS gave up after 32 nodes and reported `false`; the memoized form is exact, so very deep switch chains now conservatively skip the flow cache (recompute) instead of consulting it. Cache-skip is the parity-safe direction.
- Adjacent matrix: memo keys are `FlowNodeId` (binder names cannot drive behavior); switch-chain verdicts are target-independent, typeof/null memos stay scoped to one reference per #13285; callers off the traversal path (`narrow_by_switch_clause`/`narrow_by_switch_case_clause`/`narrow_by_default_switch_clause`, alias recursion) pass `None` and keep the one-shot fallback; the assignment-RHS recursion inside `narrow_by_binary_expr` now forwards the scratch instead of dropping it.
- No flow-DP perf counters exist in `tsz_common::perf_counters`; memo hits are instead proven by closure call-counting in the new unit tests (`chain_reachability_negative_chain_is_memoized`, `chain_reachability_finds_flag_through_linear_chain`).

## Verification
- `cargo nextest run -p tsz-checker --lib -E 'test(/chain_reachability/)'` — 6/6 passed (loop back-edge exactness, negative-chain memoization, clear/reset)
- `cargo nextest run -p tsz-checker --test control_flow_type_guard_tests --test enum_equality_narrowing_tests --test equality_narrow_unknown_to_const_intrinsic_tests --test nested_discriminant_narrowing_tests --test unique_symbol_discriminant_narrowing_tests --test flow_narrowing_finalization_tests --test assignment_branch_merge_narrowing_tests --test typeof_function_like_flow_tests --test discriminant_literal_reference_narrowing_tests --test const_alias_discriminant_narrowing_tests --test closure_boundary_property_narrowing_tests --test ts2871_always_nullish_tests --test optional_chain_literal_nullish_ts2339_tests` — 185/185 passed
- `cargo nextest run -p tsz-binder` — 542/542 passed
- `cargo clippy -p tsz-checker --lib --tests -- -D warnings` — clean

## Provenance
Machine: Mohsens-MacBook-Pro.local
Assistant: claude-code
Model: claude-fable-5
Effort: max
