### PR TITLE
perf(ci): add advisory premerge microbench (#13247)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,7 +800,7 @@ jobs:
   premerge-microbench:
     name: premerge-microbench
     needs: [gate, dist-binaries]
-    if: needs.gate.outputs.full_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true'
+    if: needs.gate.outputs.should_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true'
     runs-on: [self-hosted, tsz-cloud-run]
     timeout-minutes: 10
     continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -797,6 +797,74 @@ jobs:
           SUMMARY_JSONL_PATH: .target/project-compile-guard/project-compatibility.jsonl
         run: node scripts/ci/project-compatibility.mjs format-step-summary >> "${GITHUB_STEP_SUMMARY}"
 
+  premerge-microbench:
+    name: premerge-microbench
+    needs: [gate, dist-binaries]
+    if: needs.gate.outputs.full_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true'
+    runs-on: [self-hosted, tsz-cloud-run]
+    timeout-minutes: 10
+    continue-on-error: true
+    env:
+      TSZ_BENCH_PROFILE: dist-fast
+      TSZ_BENCH_TARGET_DIR: ${{ github.workspace }}/.target
+      TSZ_BENCH_RUNS: "2"
+      TSZ_BENCH_WARMUP: "1"
+      # Advisory-only while #13247 gathers per-run noise bands. The JSON
+      # artifact is the signal; blocking thresholds come after calibration.
+      TSZ_BENCH_THRESHOLD_PCT: "999999"
+      TSZ_BENCH_BASELINE_FILE: ${{ github.workspace }}/.target/premerge-microbench-baseline.json
+      TSZ_BENCH_OUTPUT_JSON: ${{ github.workspace }}/premerge-microbench.json
+      TSZ_BENCH_CASE_FILTER: deeppartial_optional_chain_15,union_members_100,mapped_type_keys_150
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Download dist-fast binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-fast-binaries
+          path: .
+      - name: Unpack dist-fast binaries
+        run: mkdir -p .target/dist-fast && tar -C .target/dist-fast -xf dist-fast-binaries.tar
+      - name: Run advisory pre-merge microbenchmarks
+        run: scripts/bench/precommit-microbench.sh --no-build
+      - name: Summarize advisory microbenchmarks
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -f premerge-microbench.json ]]; then
+            echo "No premerge-microbench.json was produced." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          node <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+          const fs = require("node:fs");
+          const report = JSON.parse(fs.readFileSync("premerge-microbench.json", "utf8"));
+          console.log("## Advisory pre-merge microbenchmarks");
+          console.log("");
+          console.log(`Status: ${report.status}`);
+          console.log(`Runs: ${report.runs}, warmup: ${report.warmup}`);
+          console.log("");
+          console.log("| Case | Median | Mean |");
+          console.log("| --- | ---: | ---: |");
+          for (const [name, data] of Object.entries(report.cases || {})) {
+            console.log(`| \`${name}\` | ${data.median_ms.toFixed(2)}ms | ${data.mean_ms.toFixed(2)}ms |`);
+          }
+          if ((report.regressions || []).length > 0) {
+            console.log("");
+            console.log(`Regressions detected: ${report.regressions.length}`);
+          }
+          NODE
+      - name: Upload advisory microbenchmark report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: premerge-microbench
+          path: premerge-microbench.json
+          retention-days: 14
+          if-no-files-found: warn
+          compression-level: 1
+
   wasm:
     name: wasm
     needs: gate

--- a/scripts/bench/precommit-microbench.mjs
+++ b/scripts/bench/precommit-microbench.mjs
@@ -18,6 +18,7 @@ function parseArgs(argv) {
     warmup: 1,
     updateBaseline: false,
     profile: "dev",
+    outputJson: "",
     cases: [],
   };
 
@@ -44,6 +45,9 @@ function parseArgs(argv) {
         break;
       case "--profile":
         out.profile = argv[++i] ?? "dev";
+        break;
+      case "--output-json":
+        out.outputJson = argv[++i] ?? "";
         break;
       case "--case": {
         const raw = argv[++i] ?? "";
@@ -121,6 +125,13 @@ function writeBaseline(filePath, baseline) {
   fs.writeFileSync(filePath, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
 }
 
+function writeReport(filePath, report) {
+  if (!filePath) return;
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+}
+
 function formatMs(value) {
   return `${value.toFixed(2)}ms`;
 }
@@ -173,14 +184,27 @@ function main() {
       ])
     ),
   };
+  let reportStatus = "passed";
+  let regressions = [];
 
   if (!baseline || baseline.schema_version !== 2 || baseline.profile !== opts.profile) {
     writeBaseline(opts.baseline, nextBaseline);
+    writeReport(opts.outputJson, {
+      schema_version: 1,
+      status: "baseline_initialized",
+      profile: opts.profile,
+      threshold_pct: opts.thresholdPct,
+      runs: opts.runs,
+      warmup: opts.warmup,
+      baseline_file: opts.baseline,
+      generated_at: nextBaseline.updated_at,
+      cases: measurements,
+      regressions: [],
+    });
     console.log(`   Baseline initialized at ${opts.baseline}`);
     return;
   }
 
-  const regressions = [];
   for (const [name, current] of Object.entries(measurements)) {
     const previous = baseline.cases?.[name];
     if (
@@ -214,6 +238,24 @@ function main() {
       });
     }
   }
+
+  if (regressions.length > 0) {
+    reportStatus = "regression";
+  }
+
+  writeReport(opts.outputJson, {
+    schema_version: 1,
+    status: reportStatus,
+    profile: opts.profile,
+    threshold_pct: opts.thresholdPct,
+    runs: opts.runs,
+    warmup: opts.warmup,
+    baseline_file: opts.baseline,
+    baseline_updated_at: baseline.updated_at,
+    generated_at: nextBaseline.updated_at,
+    cases: measurements,
+    regressions,
+  });
 
   if (regressions.length > 0) {
     console.error("");

--- a/scripts/bench/precommit-microbench.sh
+++ b/scripts/bench/precommit-microbench.sh
@@ -15,6 +15,8 @@
 #   TSZ_BENCH_WARMUP=1              Warmup runs per case.
 #   TSZ_BENCH_THRESHOLD_PCT=12      Allowed regression per case (%).
 #   TSZ_BENCH_BASELINE_FILE=...     Baseline JSON path.
+#   TSZ_BENCH_OUTPUT_JSON=...       Optional measurement report path.
+#   TSZ_BENCH_CASE_FILTER=a,b,c     Optional comma-separated case allowlist.
 #
 # Flags:
 #   --update-baseline               Replace baseline with current measurements.
@@ -49,6 +51,8 @@ Environment:
   TSZ_BENCH_WARMUP=1
   TSZ_BENCH_THRESHOLD_PCT=12
   TSZ_BENCH_BASELINE_FILE=.git/tsz-microbench-baseline.json
+  TSZ_BENCH_OUTPUT_JSON=
+  TSZ_BENCH_CASE_FILTER=
 EOF
 }
 
@@ -90,6 +94,8 @@ RUNS="${TSZ_BENCH_RUNS:-4}"
 WARMUP="${TSZ_BENCH_WARMUP:-1}"
 THRESHOLD_PCT="${TSZ_BENCH_THRESHOLD_PCT:-12}"
 BASELINE_FILE="${TSZ_BENCH_BASELINE_FILE:-$ROOT_DIR/.git/tsz-microbench-baseline.json}"
+OUTPUT_JSON="${TSZ_BENCH_OUTPUT_JSON:-}"
+CASE_FILTER="${TSZ_BENCH_CASE_FILTER:-}"
 
 profile_dir="$PROFILE"
 if [[ "$PROFILE" == "dev" ]]; then
@@ -175,6 +181,44 @@ register_generated "keyof_chain_20"                generate_keyof_chain_file    
 register_generated "overload_resolution_25"        generate_overload_resolution_file          25
 register_generated "object_literal_assign_20"      generate_object_literal_assign_file        20
 
+if [[ -n "$CASE_FILTER" ]]; then
+    requested_case_names=()
+    IFS=',' read -r -a requested_case_names <<< "$CASE_FILTER"
+    normalized_case_names=()
+    for raw_case_name in "${requested_case_names[@]}"; do
+        case_name="${raw_case_name#"${raw_case_name%%[![:space:]]*}"}"
+        case_name="${case_name%"${case_name##*[![:space:]]}"}"
+        [[ -n "$case_name" ]] || continue
+        normalized_case_names+=("$case_name")
+    done
+
+    filtered_names=()
+    filtered_files=()
+    missing_cases=()
+    for requested_case_name in "${normalized_case_names[@]}"; do
+        found_case=false
+        for idx in "${!MICROBENCH_CASE_NAMES[@]}"; do
+            case_name="${MICROBENCH_CASE_NAMES[$idx]}"
+            if [[ "$case_name" == "$requested_case_name" ]]; then
+                filtered_names+=("$case_name")
+                filtered_files+=("${MICROBENCH_CASE_FILES[$idx]}")
+                found_case=true
+                break
+            fi
+        done
+        if [[ "$found_case" != "true" ]]; then
+            missing_cases+=("$requested_case_name")
+        fi
+    done
+    if [[ "${#missing_cases[@]}" -gt 0 ]]; then
+        echo "Unknown TSZ_BENCH_CASE_FILTER case(s): ${missing_cases[*]}" >&2
+        exit 2
+    fi
+
+    MICROBENCH_CASE_NAMES=("${filtered_names[@]}")
+    MICROBENCH_CASE_FILES=("${filtered_files[@]}")
+fi
+
 if [[ "$NO_BUILD" != true ]]; then
     echo "   Building benchmark binary (profile=$PROFILE)..."
     CARGO_TARGET_DIR="$TARGET_DIR" cargo build --quiet --profile "$PROFILE" -p tsz-cli --bin tsz
@@ -194,6 +238,10 @@ case_args=()
 for idx in "${!MICROBENCH_CASE_NAMES[@]}"; do
     case_args+=(--case "${MICROBENCH_CASE_NAMES[$idx]}=${MICROBENCH_CASE_FILES[$idx]}")
 done
+output_args=()
+if [[ -n "$OUTPUT_JSON" ]]; then
+    output_args=(--output-json "$OUTPUT_JSON")
+fi
 
 node "$SCRIPT_DIR/precommit-microbench.mjs" \
     --bin "$TSZ_BIN" \
@@ -203,4 +251,5 @@ node "$SCRIPT_DIR/precommit-microbench.mjs" \
     --warmup "$WARMUP" \
     --update-baseline "$update_flag" \
     --profile "$PROFILE" \
+    "${output_args[@]}" \
     "${case_args[@]}"


### PR DESCRIPTION
Goal: fast

## Summary
- Adds a small advisory `premerge-microbench` CI job that reuses the dist-fast artifact instead of rebuilding `tsz`.
- Extends `precommit-microbench` with a case allowlist so CI can run a focused Fast-goal slice instead of the whole local pre-commit matrix.
- Writes a JSON microbenchmark report and uploads it as a PR artifact for #13247 noise-band calibration.

## Structural rule / invariant
This does not change compiler behavior. The measurement invariant is that pre-merge microbench evidence is advisory and artifact-backed until #13247 records a stable same-run/noise baseline; it must not block PRs or be mixed with public timing-mode benchmark publication.

## Verification
- No local validation run per repo instruction.
- Draft PR CI run 27429061117 passed at `b2a907107c627cd56bdd4c7eca9a0c7d96ed49de`.
- `premerge-microbench` passed and uploaded the `premerge-microbench` artifact (`premerge-microbench.json`) for #13247 calibration.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
