### PR TITLE
fix(wasm): unify WASM compiler-options mapping with tsz-core resolution (#13117)

### DIFF
--- a/crates/tsz-core/src/api/wasm/compiler_options.rs
+++ b/crates/tsz-core/src/api/wasm/compiler_options.rs
@@ -3,68 +3,74 @@ use wasm_bindgen::prelude::JsValue;
 
 /// Compiler options passed from JavaScript/WASM.
 /// Maps to TypeScript compiler options.
+///
+/// This is the single owner of WASM option -> `CheckerOptions` resolution:
+/// every WASM program surface (the website `WasmProgram` here and the npm
+/// wrapper's `TsProgram` in `tsz-wasm`) derives `CheckerOptions` through
+/// [`CompilerOptions::to_checker_options`], so strict-family implication
+/// semantics cannot drift per surface (#13117).
 #[derive(Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct CompilerOptions {
+pub struct CompilerOptions {
     /// Enable all strict type checking options.
     #[serde(default, deserialize_with = "deserialize_bool_option")]
-    strict: Option<bool>,
+    pub strict: Option<bool>,
 
     /// Raise error on expressions and declarations with an implied 'any' type.
     #[serde(default, deserialize_with = "deserialize_bool_option")]
-    no_implicit_any: Option<bool>,
+    pub no_implicit_any: Option<bool>,
 
     /// Enable strict null checks.
     #[serde(default, deserialize_with = "deserialize_bool_option")]
-    strict_null_checks: Option<bool>,
+    pub strict_null_checks: Option<bool>,
 
     /// Enable strict checking of function types.
     #[serde(default, deserialize_with = "deserialize_bool_option")]
-    strict_function_types: Option<bool>,
+    pub strict_function_types: Option<bool>,
 
     /// Enable strict checking of `bind`, `call`, and `apply` methods.
     #[serde(default, deserialize_with = "deserialize_bool_option")]
-    strict_bind_call_apply: Option<bool>,
+    pub strict_bind_call_apply: Option<bool>,
 
     /// Enable strict property initialization checks in classes.
     #[serde(default, deserialize_with = "deserialize_bool_option")]
-    strict_property_initialization: Option<bool>,
+    pub strict_property_initialization: Option<bool>,
 
     /// Report error when not all code paths in function return a value.
     #[serde(default, deserialize_with = "deserialize_bool_option")]
-    no_implicit_returns: Option<bool>,
+    pub no_implicit_returns: Option<bool>,
 
     /// Raise error on 'this' expressions with an implied 'any' type.
     #[serde(default, deserialize_with = "deserialize_bool_option")]
-    no_implicit_this: Option<bool>,
+    pub no_implicit_this: Option<bool>,
 
     /// Default catch clause variables as `unknown` instead of `any`.
     #[serde(default, deserialize_with = "deserialize_bool_option")]
-    use_unknown_in_catch_variables: Option<bool>,
+    pub use_unknown_in_catch_variables: Option<bool>,
 
     /// Enable strict built-in iterator return types.
     #[serde(default, deserialize_with = "deserialize_bool_option")]
-    strict_builtin_iterator_return: Option<bool>,
+    pub strict_builtin_iterator_return: Option<bool>,
 
     /// Specify ECMAScript target version (accepts string like "ES5" or numeric).
     #[serde(default, deserialize_with = "deserialize_target")]
-    target: Option<u32>,
+    pub target: Option<u32>,
 
     /// Specify module code generation mode (accepts string like `ESNext` or numeric).
     #[serde(default, deserialize_with = "deserialize_module")]
-    module: Option<u32>,
+    pub module: Option<u32>,
 
     /// Enable full iterator support when targeting ES5/ES3.
     #[serde(default, deserialize_with = "deserialize_bool_option")]
-    downlevel_iteration: Option<bool>,
+    pub downlevel_iteration: Option<bool>,
 
     /// Interpret optional property types as written, rather than adding 'undefined'.
     #[serde(default, deserialize_with = "deserialize_bool_option")]
-    exact_optional_property_types: Option<bool>,
+    pub exact_optional_property_types: Option<bool>,
 
     /// When true, do not include any library files.
     #[serde(default, deserialize_with = "deserialize_bool_option")]
-    no_lib: Option<bool>,
+    pub no_lib: Option<bool>,
 
     /// Add 'undefined' to a type when accessed using an index.
     #[serde(
@@ -72,11 +78,11 @@ pub(crate) struct CompilerOptions {
         alias = "noUncheckedIndexedAccess",
         deserialize_with = "deserialize_bool_option"
     )]
-    no_unchecked_indexed_access: Option<bool>,
+    pub no_unchecked_indexed_access: Option<bool>,
 
     /// Enable Sound Mode for stricter type checking beyond TypeScript's defaults.
     #[serde(default, deserialize_with = "deserialize_bool_option")]
-    sound_mode: Option<bool>,
+    pub sound_mode: Option<bool>,
 }
 
 /// Deserialize an optional boolean option.
@@ -218,7 +224,13 @@ impl CompilerOptions {
     }
 
     /// Convert to `CheckerOptions` for type checking.
-    pub(crate) fn to_checker_options(&self) -> crate::checker::context::CheckerOptions {
+    ///
+    /// Resolution starts from the shared `CheckerOptions::default()`,
+    /// applies the `strict` family implication (when `strict` is set), and
+    /// finally applies individual flag overrides. Options left `None` keep
+    /// the shared defaults.
+    #[must_use]
+    pub fn to_checker_options(&self) -> crate::checker::context::CheckerOptions {
         let mut options = crate::checker::context::CheckerOptions::default();
 
         if let Some(strict) = self.strict {

--- a/crates/tsz-core/src/lib.rs
+++ b/crates/tsz-core/src/lib.rs
@@ -2,6 +2,13 @@ use wasm_bindgen::prelude::wasm_bindgen;
 
 mod api;
 
+/// Shared WASM compiler-options DTO and its option -> `CheckerOptions`
+/// resolution. Every WASM program surface (website `WasmProgram`, npm
+/// wrapper `TsProgram` in `tsz-wasm`) must derive `CheckerOptions` through
+/// this single owner so strict-family implication semantics cannot drift
+/// per surface (#13117).
+pub use api::wasm::compiler_options::CompilerOptions as WasmCompilerOptions;
+
 // Shared test fixtures for reduced allocation overhead
 #[cfg(test)]
 #[path = "../tests/test_fixtures.rs"]

--- a/crates/tsz-wasm/src/wasm_api/program.rs
+++ b/crates/tsz-wasm/src/wasm_api/program.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use wasm_bindgen::prelude::{JsValue, wasm_bindgen};
 
+use tsz::WasmCompilerOptions;
 use tsz::binder::BinderState;
 use tsz::checker::context::CheckerOptions;
 use tsz::lib_loader::LibFile;
@@ -34,11 +35,17 @@ pub struct TsCompilerOptions {
     #[serde(default)]
     pub strict_function_types: Option<bool>,
     #[serde(default)]
+    pub strict_bind_call_apply: Option<bool>,
+    #[serde(default)]
     pub strict_property_initialization: Option<bool>,
     #[serde(default)]
     pub no_implicit_returns: Option<bool>,
     #[serde(default)]
     pub no_implicit_this: Option<bool>,
+    #[serde(default)]
+    pub use_unknown_in_catch_variables: Option<bool>,
+    #[serde(default)]
+    pub strict_builtin_iterator_return: Option<bool>,
     #[serde(default)]
     pub target: Option<u8>,
     #[serde(default)]
@@ -75,72 +82,55 @@ impl TsCompilerOptions {
     }
 
     /// Convert to internal `CheckerOptions`
+    ///
+    /// Delegates option -> `CheckerOptions` resolution (including the
+    /// `strict` family implications) to the shared owner in tsz-core,
+    /// [`WasmCompilerOptions`], so this surface cannot drift from the other
+    /// WASM program API (#13117). This wrapper only contributes:
+    /// - its non-strict default: `strict` omitted means `strict: false`,
+    ///   matching `tsc` without a tsconfig;
+    /// - options the shared resolver does not model (`declaration`,
+    ///   `checkJs`, `allowJs`, `noResolve`);
+    /// - the numeric `u8` `target`/`module` DTO encoding shared with the
+    ///   emit path (issue #3489: the checker target must follow the
+    ///   JS-supplied numeric target, collapsed post-ES2020 exactly like the
+    ///   CLI's resolved options).
     pub fn to_checker_options(&self) -> CheckerOptions {
-        let strict = self.strict.unwrap_or(false);
-        CheckerOptions {
-            strict,
-            no_implicit_any: self.no_implicit_any.unwrap_or(strict),
-            no_implicit_returns: self.no_implicit_returns.unwrap_or(false),
-            strict_null_checks: self.strict_null_checks.unwrap_or(strict),
-            strict_function_types: self.strict_function_types.unwrap_or(strict),
-            strict_property_initialization: self.strict_property_initialization.unwrap_or(strict),
-            no_implicit_this: self.no_implicit_this.unwrap_or(strict),
-            use_unknown_in_catch_variables: self.strict_null_checks.unwrap_or(strict),
-            isolated_modules: false,
-            emit_declarations: self.declaration.unwrap_or(false),
-            no_unchecked_indexed_access: false,
-            no_unchecked_side_effect_imports: false,
-            strict_bind_call_apply: false,
-            exact_optional_property_types: false,
-            no_lib: self.no_lib.unwrap_or(false),
-            no_types_and_symbols: false,
-            types_explicitly_set: false,
-            // Issue #3489: route the JS-supplied numeric `target` through to
-            // the checker. The hardcoded default silently dropped target-aware
-            // semantic diagnostics like TS2737 (BigInt literals).
-            target: tsz::config::checker_target_from_emitter(target_kind_from_u8(self.target)),
-            module: self.resolve_module(),
-            es_module_interop: false,
-            allow_synthetic_default_imports: false,
-            allow_unreachable_code: None,
-            allow_unused_labels: None,
-            no_property_access_from_index_signature: false,
-            sound_mode: self.sound_mode.unwrap_or(false),
-            sound_check_declarations: false,
-            sound_report_only: false,
-            sound_pedantic: false,
-            experimental_decorators: false,
-            no_unused_locals: false,
-            no_unused_parameters: false,
-            always_strict: strict,
-            resolve_json_module: false,
-            check_js: self.check_js.unwrap_or(false),
-            allow_js: self.allow_js.unwrap_or(false),
-            no_resolve: self.no_resolve.unwrap_or(false),
-            isolated_declarations: false,
-            no_implicit_override: false,
-            jsx_mode: tsz_common::checker_options::JsxMode::None,
-            jsx_factory: "React.createElement".to_string(),
-            jsx_factory_from_config: false,
-            jsx_fragment_factory: "React.Fragment".to_string(),
-            jsx_fragment_factory_from_config: false,
-            jsx_import_source: String::new(),
-            module_explicitly_set: self.module.is_some(),
-            suppress_excess_property_errors: false,
-            suppress_implicit_any_index_errors: false,
-            no_implicit_use_strict: false,
-            allow_importing_ts_extensions: false,
-            rewrite_relative_import_extensions: false,
-            implied_classic_resolution: false,
-            downlevel_iteration: self.downlevel_iteration.unwrap_or(false),
-            verbatim_module_syntax: false,
-            ignore_deprecations: false,
-            allow_umd_global_access: false,
-            preserve_const_enums: false,
-            strict_builtin_iterator_return: strict,
-            erasable_syntax_only: false,
-            no_fallthrough_cases_in_switch: false,
-        }
+        let shared = WasmCompilerOptions {
+            strict: Some(self.strict.unwrap_or(false)),
+            no_implicit_any: self.no_implicit_any,
+            strict_null_checks: self.strict_null_checks,
+            strict_function_types: self.strict_function_types,
+            strict_bind_call_apply: self.strict_bind_call_apply,
+            strict_property_initialization: self.strict_property_initialization,
+            no_implicit_returns: self.no_implicit_returns,
+            no_implicit_this: self.no_implicit_this,
+            use_unknown_in_catch_variables: self.use_unknown_in_catch_variables,
+            strict_builtin_iterator_return: self.strict_builtin_iterator_return,
+            target: None,
+            module: None,
+            downlevel_iteration: self.downlevel_iteration,
+            exact_optional_property_types: None,
+            no_lib: self.no_lib,
+            no_unchecked_indexed_access: None,
+            sound_mode: self.sound_mode,
+        };
+        let mut options = shared.to_checker_options();
+
+        // Surface-specific options the shared resolver does not model.
+        options.emit_declarations = self.declaration.unwrap_or(false);
+        options.check_js = self.check_js.unwrap_or(false);
+        options.allow_js = self.allow_js.unwrap_or(false);
+        options.no_resolve = self.no_resolve.unwrap_or(false);
+
+        // `target`/`module` arrive as numeric `u8` DTO fields and resolve
+        // through the same converters as the emit path (`None` -> ES5 /
+        // ModuleKind::None, matching tsc's defaults).
+        options.target = tsz::config::checker_target_from_emitter(target_kind_from_u8(self.target));
+        options.module = self.resolve_module();
+        options.module_explicitly_set = self.module.is_some();
+
+        options
     }
 }
 

--- a/crates/tsz-wasm/src/wasm_tests.rs
+++ b/crates/tsz-wasm/src/wasm_tests.rs
@@ -816,6 +816,115 @@ fn test_ts_compiler_options_threads_allow_js_and_declaration() {
 }
 
 #[test]
+fn test_strict_true_implies_full_strict_family() {
+    // Issue #13117: the hand-built CheckerOptions literal hardcoded
+    // strict_bind_call_apply: false even under strict: true, diverging from
+    // tsc (strict implies strictBindCallApply) and from the shared tsz-core
+    // resolution. The mapping now delegates to that single owner.
+    let opts: TsCompilerOptions = serde_json::from_str(r#"{"strict":true}"#).unwrap();
+    let checker = opts.to_checker_options();
+
+    assert!(checker.strict);
+    assert!(checker.no_implicit_any, "strict must imply noImplicitAny");
+    assert!(
+        checker.strict_null_checks,
+        "strict must imply strictNullChecks"
+    );
+    assert!(
+        checker.strict_function_types,
+        "strict must imply strictFunctionTypes"
+    );
+    assert!(
+        checker.strict_bind_call_apply,
+        "strict must imply strictBindCallApply (tsc parity, issue #13117)"
+    );
+    assert!(
+        checker.strict_property_initialization,
+        "strict must imply strictPropertyInitialization"
+    );
+    assert!(checker.no_implicit_this, "strict must imply noImplicitThis");
+    assert!(
+        checker.use_unknown_in_catch_variables,
+        "strict must imply useUnknownInCatchVariables"
+    );
+    assert!(checker.always_strict, "strict must imply alwaysStrict");
+    assert!(
+        checker.strict_builtin_iterator_return,
+        "strict must imply strictBuiltinIteratorReturn"
+    );
+}
+
+#[test]
+fn test_strict_false_or_omitted_disables_strict_family() {
+    // `strict: false` and omitted strict behave identically on this surface
+    // (the npm wrapper keeps tsc's non-strict CLI default).
+    for json in [r#"{"strict":false}"#, "{}"] {
+        let opts: TsCompilerOptions = serde_json::from_str(json).unwrap();
+        let checker = opts.to_checker_options();
+
+        assert!(!checker.strict, "{json}");
+        assert!(!checker.no_implicit_any, "{json}");
+        assert!(!checker.strict_null_checks, "{json}");
+        assert!(!checker.strict_function_types, "{json}");
+        assert!(!checker.strict_bind_call_apply, "{json}");
+        assert!(!checker.strict_property_initialization, "{json}");
+        assert!(!checker.no_implicit_this, "{json}");
+        assert!(!checker.use_unknown_in_catch_variables, "{json}");
+        assert!(!checker.strict_builtin_iterator_return, "{json}");
+        // alwaysStrict keeps the shared TS6 default (true unless explicitly
+        // disabled); it is not forced to mirror `strict`.
+        assert!(checker.always_strict, "{json}");
+    }
+}
+
+#[test]
+fn test_individual_strict_flags_override_strict() {
+    let opts: TsCompilerOptions = serde_json::from_str(
+        r#"{
+            "strict": true,
+            "noImplicitAny": false,
+            "strictBindCallApply": false,
+            "useUnknownInCatchVariables": false,
+            "strictBuiltinIteratorReturn": false
+        }"#,
+    )
+    .unwrap();
+    let checker = opts.to_checker_options();
+
+    assert!(checker.strict);
+    assert!(!checker.no_implicit_any);
+    assert!(!checker.strict_bind_call_apply);
+    assert!(!checker.use_unknown_in_catch_variables);
+    assert!(!checker.strict_builtin_iterator_return);
+    assert!(
+        checker.strict_null_checks,
+        "unrelated family members keep the strict implication"
+    );
+
+    let opts_on: TsCompilerOptions =
+        serde_json::from_str(r#"{"strict":false,"strictBindCallApply":true}"#).unwrap();
+    assert!(
+        opts_on.to_checker_options().strict_bind_call_apply,
+        "individual strict-family flags must also enable under strict:false"
+    );
+}
+
+#[test]
+fn test_use_unknown_in_catch_variables_not_coupled_to_strict_null_checks() {
+    // The old hand-built mapping derived use_unknown_in_catch_variables from
+    // strictNullChecks; tsc keys its default off `strict` only.
+    let opts: TsCompilerOptions =
+        serde_json::from_str(r#"{"strict":true,"strictNullChecks":false}"#).unwrap();
+    let checker = opts.to_checker_options();
+
+    assert!(!checker.strict_null_checks);
+    assert!(
+        checker.use_unknown_in_catch_variables,
+        "useUnknownInCatchVariables must follow strict, not strictNullChecks"
+    );
+}
+
+#[test]
 fn test_ts_program_emit_json_threads_declaration_and_source_map_flags() {
     // Issue #4748 / #4738: emit_json hardcoded per-file metadata to
     // declaration:false / sourceMap:false; verify the configured values


### PR DESCRIPTION
Goal: hold

Unifies the two divergent WASM compiler-options mappings: `TsCompilerOptions` (tsz-wasm) now delegates to tsz-core's shared option resolution instead of a hand-built `CheckerOptions` literal, fixing `strict: true` not implying `strict_bind_call_apply: true` on the WASM path (tsc parity). The zero-consumer wasm.rs trio was already deleted in #13263.

Structural rule: one option-resolution owner — every program API (CLI, WASM, website) derives `CheckerOptions` through the same tsz-core mapping, so strict-family implication semantics cannot drift per surface.

Full strict-family divergence audit of the old hand-built mapping (all fixed by delegation, all covered by new tests):
- `strict: true` left `strict_bind_call_apply: false` (tsc: strict implies strictBindCallApply).
- `use_unknown_in_catch_variables` was coupled to `strictNullChecks` instead of `strict` (tsc keys the default off `strict` only).
- `always_strict` was forced to mirror `strict`; the shared resolver keeps the TS6 default (true unless explicitly disabled).
- `no_unchecked_side_effect_imports` was hardcoded `false`; the shared default is `true` (TS6).
- `TsCompilerOptions` gains `strictBindCallApply`, `useUnknownInCatchVariables`, and `strictBuiltinIteratorReturn` fields so individual overrides work like tsc.

Preserved surface semantics: the npm wrapper keeps its non-strict default (`strict` omitted means `strict: false`, matching `tsc` without a tsconfig), and the numeric `u8` `target`/`module` DTO resolution (ES5/None defaults, CLI-style post-ES2020 checker-target collapse) is unchanged. Surface-only options the shared resolver does not model (`declaration`, `allowJs`, `checkJs`, `noResolve`) are applied on top.

Closes #13117

## Verification
- `cargo nextest run -p tsz-wasm` — 59/59 pass (4 new strict-family tests)
- `cargo nextest run -p tsz-core -E 'test(/wasm|compiler_options/)'` — 46/46 pass
- `cargo clippy -p tsz-wasm -p tsz-core -- -D warnings` — clean
- `cargo check --workspace` — clean

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
