### PR TITLE
perf(solver): reuse concrete conditional branch evaluator (#8356)

### DIFF
--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -1413,22 +1413,26 @@ fn resolve_concrete_conditional_branch(
     db: &dyn TypeDatabase,
     cond: &crate::types::ConditionalType,
 ) -> Option<TypeId> {
-    resolve_concrete_conditional_result(db, cond, cond.check_type)
+    let mut evaluator = TypeEvaluator::new(db);
+    resolve_concrete_conditional_result(db, &mut evaluator, cond, cond.check_type)
 }
 
 fn resolve_concrete_conditional_result(
     db: &dyn TypeDatabase,
+    evaluator: &mut TypeEvaluator<'_>,
     cond: &crate::types::ConditionalType,
     check_input: TypeId,
 ) -> Option<TypeId> {
-    let check_type = crate::evaluation::evaluate::evaluate_type(db, check_input);
-    let extends_type = crate::evaluation::evaluate::evaluate_type(db, cond.extends_type);
+    let check_type = evaluator.evaluate(check_input);
+    let extends_type = evaluator.evaluate(cond.extends_type);
 
     if let Some(TypeData::Union(members)) = db.lookup(check_type) {
         let members = db.type_list(members);
         let mut results = Vec::new();
         for &member in members.iter() {
-            results.push(resolve_concrete_conditional_result(db, cond, member)?);
+            results.push(resolve_concrete_conditional_result(
+                db, evaluator, cond, member,
+            )?);
         }
         return Some(crate::utils::union_or_single(db, results));
     }
@@ -1443,8 +1447,7 @@ fn resolve_concrete_conditional_result(
     if let Some(TypeData::StringIntrinsic { kind, type_arg }) = db.lookup(extends_type)
         && type_arg == TypeId::STRING
     {
-        let transformed =
-            crate::evaluation::evaluate::evaluate_type(db, db.string_intrinsic(kind, check_type));
+        let transformed = evaluator.evaluate(db.string_intrinsic(kind, check_type));
         return Some(if transformed == check_type {
             cond.true_type
         } else {
@@ -1455,7 +1458,6 @@ fn resolve_concrete_conditional_result(
     if contains_type_parameters_db(db, extends_type)
         && !contains_type_parameters_db(db, cond.check_type)
     {
-        let evaluator = TypeEvaluator::new(db);
         if evaluator.type_contains_infer(cond.extends_type) {
             let mut bindings = rustc_hash::FxHashMap::default();
             let mut visited = FxHashSet::default();
@@ -1468,7 +1470,7 @@ fn resolve_concrete_conditional_result(
                 &mut checker,
             ) {
                 let substituted = evaluator.substitute_infer(cond.true_type, &bindings);
-                let evaluated = crate::evaluation::evaluate::evaluate_type(db, substituted);
+                let evaluated = evaluator.evaluate(substituted);
                 return Some(evaluated);
             }
             return Some(cond.false_type);


### PR DESCRIPTION
Goal: fast

## Summary
- Reuses one `TypeEvaluator` across `resolve_concrete_conditional_branch` and its recursive union-member branch resolution.
- Keeps concrete conditional branch evaluation within the existing solver/type-query owner layer instead of adding a new cache or checker shortcut.
- Targets #8356 / #13250 residual recursive conditional evaluation pressure after the larger evaluator-memo and alias-validation slices landed.

## Structural rule / invariant
When resolving a concrete conditional branch, each recursive branch asks the same semantic question under the same `TypeDatabase`, request options, and resolver mode. The evaluator's operation-local memo state is valid for the whole branch-resolution operation and should not be discarded between the check type, extends type, string-intrinsic transform, infer substitution, or union-member recursion.

## Cache / performance invariant
This does not add a new cache or widen residency. It only preserves the existing `TypeEvaluator` operation-local memo tables for the duration of one concrete conditional branch resolution. The cache key semantics remain the evaluator's existing `TypeId`/conditional-subtype/contains-infer state and are dropped when the branch resolution returns.

## Adjacent cases / fallback
- Non-concrete conditional branches still return `None` and fall back to existing structural/evaluation paths.
- Union check types reuse the same evaluator across member recursion but still resolve each member independently.
- Infer-pattern branches reuse the same evaluator for `contains infer`, substitution, and final evaluation.
- No fixture names, source text, rendered diagnostic strings, or benchmark row names drive compiler behavior.

## Verification
- Draft exact-head CI passed for `734c803db9c2b81d4c6335719ace318d245bb9e4`: `CI Light Summary`, `unit`, `unit-cloudbuild`, `unit-checker-integration`, `dist-binaries`, `lint`, `cargo-shear`, `cargo-deny`, `project-row-drift`, and `gate`.
- Ready-review full CI is the remaining verification path before merge queue.
- No local tests or benchmarks run per current repo instruction.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
