### PR TITLE
perf(checker): memo alias path assignment scans (#13311)

### DIFF
--- a/crates/tsz-checker/src/context/cache_statistics.rs
+++ b/crates/tsz-checker/src/context/cache_statistics.rs
@@ -52,6 +52,8 @@ pub struct CheckerContextCacheStatistics {
     pub flow_reference_match_cache_estimated_size_bytes: usize,
     pub flow_alias_base_assignment_cache_entries: usize,
     pub flow_alias_base_assignment_cache_estimated_size_bytes: usize,
+    pub flow_alias_path_assignment_cache_entries: usize,
+    pub flow_alias_path_assignment_cache_estimated_size_bytes: usize,
     pub js_export_surface_cache_entries: usize,
     pub js_export_surface_cache_estimated_size_bytes: usize,
     pub class_instance_type_cache_entries: usize,
@@ -92,6 +94,7 @@ impl CheckerContextCacheStatistics {
             + self.flow_numeric_atom_cache_estimated_size_bytes
             + self.flow_reference_match_cache_estimated_size_bytes
             + self.flow_alias_base_assignment_cache_estimated_size_bytes
+            + self.flow_alias_path_assignment_cache_estimated_size_bytes
             + self.js_export_surface_cache_estimated_size_bytes
             + self.class_instance_type_cache_estimated_size_bytes
             + self.class_constructor_type_cache_estimated_size_bytes
@@ -121,6 +124,7 @@ impl CheckerContextCacheStatistics {
             + self.flow_numeric_atom_cache_entries
             + self.flow_reference_match_cache_entries
             + self.flow_alias_base_assignment_cache_entries
+            + self.flow_alias_path_assignment_cache_entries
             + self.js_export_surface_cache_entries
             + self.class_instance_type_cache_entries
             + self.class_constructor_type_cache_entries
@@ -158,6 +162,7 @@ impl<'a> CheckerContext<'a> {
         let flow_numeric_atom_cache = self.flow_numeric_atom_cache.borrow();
         let flow_reference_match_cache = self.flow_reference_match_cache.borrow();
         let flow_alias_base_assignment_cache = self.symbol_flow_memo.alias_base_assignment.borrow();
+        let flow_alias_path_assignment_cache = self.symbol_flow_memo.alias_path_assignment.borrow();
         let class_chain_summary_cache = self.class_chain_summary_cache.borrow();
         let env_eval_cache = self.env_eval_cache.borrow();
         let class_symbol_to_decl_cache = self.class_symbol_to_decl_cache.borrow();
@@ -245,6 +250,10 @@ impl<'a> CheckerContext<'a> {
             flow_alias_base_assignment_cache_entries: flow_alias_base_assignment_cache.len(),
             flow_alias_base_assignment_cache_estimated_size_bytes: fx_hash_map_estimated_size_bytes(
                 &flow_alias_base_assignment_cache,
+            ),
+            flow_alias_path_assignment_cache_entries: flow_alias_path_assignment_cache.len(),
+            flow_alias_path_assignment_cache_estimated_size_bytes: fx_hash_map_estimated_size_bytes(
+                &flow_alias_path_assignment_cache,
             ),
             js_export_surface_cache_entries: self.js_export_surface_cache.len(),
             js_export_surface_cache_estimated_size_bytes: fx_hash_map_estimated_size_bytes(

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -441,6 +441,7 @@ pub struct SymbolFlowMemoCaches {
     pub has_non_initializer_assignment: RefCell<FxHashMap<SymbolId, bool>>,
     pub first_identifier_ref: RefCell<FxHashMap<SymbolId, Option<NodeIndex>>>,
     pub alias_base_assignment: RefCell<FxHashMap<(u32, u32), bool>>,
+    pub alias_path_assignment: RefCell<FxHashMap<(u32, u32, u32), bool>>,
 }
 
 impl SymbolFlowMemoCaches {
@@ -450,6 +451,7 @@ impl SymbolFlowMemoCaches {
         self.has_non_initializer_assignment.borrow_mut().clear();
         self.first_identifier_ref.borrow_mut().clear();
         self.alias_base_assignment.borrow_mut().clear();
+        self.alias_path_assignment.borrow_mut().clear();
     }
 }
 

--- a/crates/tsz-checker/src/flow/control_flow/alias_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/alias_narrowing.rs
@@ -35,40 +35,9 @@ impl<'a> FlowAnalyzer<'a> {
             _ => return false,
         };
 
-        // Walk the flow graph backward from the condition's antecedent.
-        // Check if any ASSIGNMENT node on the current path targets the reference
-        // (or its base). Stop when we reach nodes at or before the alias position.
-        let mut visited = rustc_hash::FxHashSet::default();
-        let mut stack = vec![antecedent_id];
-
-        while let Some(flow_id) = stack.pop() {
-            if flow_id.is_none() || !visited.insert(flow_id) {
-                continue;
-            }
-
-            let Some(flow) = self.binder.flow_nodes.get(flow_id) else {
-                continue;
-            };
-
-            // Stop walking if this flow node is at or before the alias declaration
-            if let Some(node) = self.arena.get(flow.node)
-                && node.pos <= alias_pos
-            {
-                continue;
-            }
-
-            // Check if this is an assignment targeting our reference or its base
-            if flow.has_any_flags(flow_flags::ASSIGNMENT)
-                && (self.assignment_targets_reference_node(flow.node, target)
-                    || self.assignment_targets_base_of_reference(flow.node, target))
-            {
-                return true;
-            }
-
-            // Continue to antecedents
-            for &ant in &flow.antecedent {
-                stack.push(ant);
-            }
+        if self.alias_path_has_assignment_after_pos(alias_sym_id, target, antecedent_id, alias_pos)
+        {
+            return true;
         }
 
         // Mirrors tsc's `isConstantReference` (checker.ts ~28978):
@@ -90,6 +59,67 @@ impl<'a> FlowAnalyzer<'a> {
         }
 
         false
+    }
+
+    fn alias_path_has_assignment_after_pos(
+        &self,
+        alias_sym_id: SymbolId,
+        target: NodeIndex,
+        antecedent_id: FlowNodeId,
+        alias_pos: u32,
+    ) -> bool {
+        use tsz_binder::flow_flags;
+
+        let cache_key = (alias_sym_id.0, target.0, antecedent_id.0);
+        if let Some(cache) = self.shared_alias_path_assignment_cache {
+            let cached = cache.borrow().get(&cache_key).copied();
+            if let Some(result) = cached {
+                return result;
+            }
+        }
+
+        // Walk the flow graph backward from the condition's antecedent.
+        // Check if any ASSIGNMENT node on the current path targets the
+        // reference (or its base). Stop when we reach nodes at or before the
+        // alias position.
+        let mut visited = rustc_hash::FxHashSet::default();
+        let mut stack = vec![antecedent_id];
+
+        let mut result = false;
+        while let Some(flow_id) = stack.pop() {
+            if flow_id.is_none() || !visited.insert(flow_id) {
+                continue;
+            }
+
+            let Some(flow) = self.binder.flow_nodes.get(flow_id) else {
+                continue;
+            };
+
+            // Stop walking if this flow node is at or before the alias declaration
+            if let Some(node) = self.arena.get(flow.node)
+                && node.pos <= alias_pos
+            {
+                continue;
+            }
+
+            // Check if this is an assignment targeting our reference or its base
+            if flow.has_any_flags(flow_flags::ASSIGNMENT)
+                && (self.assignment_targets_reference_node(flow.node, target)
+                    || self.assignment_targets_base_of_reference(flow.node, target))
+            {
+                result = true;
+                break;
+            }
+
+            // Continue to antecedents
+            for &ant in &flow.antecedent {
+                stack.push(ant);
+            }
+        }
+        if let Some(cache) = self.shared_alias_path_assignment_cache {
+            cache.borrow_mut().insert(cache_key, result);
+        }
+        result
     }
 
     /// Determine whether `target` is a constant reference for the purposes of

--- a/crates/tsz-checker/src/flow/control_flow/alias_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/alias_narrowing.rs
@@ -23,8 +23,6 @@ impl<'a> FlowAnalyzer<'a> {
         target: NodeIndex,
         antecedent_id: FlowNodeId,
     ) -> bool {
-        use tsz_binder::flow_flags;
-
         // Get the alias declaration position
         let alias_pos = match self.binder.get_symbol(alias_sym_id) {
             Some(sym) if sym.value_declaration.is_some() => self

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -371,6 +371,8 @@ impl<'a> FlowGraph<'a> {
 
 type AliasBaseAssignmentKey = (u32, u32);
 type AliasBaseAssignmentCache = RefCell<FxHashMap<AliasBaseAssignmentKey, bool>>;
+type AliasPathAssignmentKey = (u32, u32, u32);
+type AliasPathAssignmentCache = RefCell<FxHashMap<AliasPathAssignmentKey, bool>>;
 
 /// Flow analyzer for control flow-based type narrowing.
 ///
@@ -410,6 +412,11 @@ pub struct FlowAnalyzer<'a> {
     /// containing-function assignment after the alias declaration targets the
     /// reference or its base.
     pub(crate) shared_alias_base_assignment_cache: Option<&'a AliasBaseAssignmentCache>,
+    /// Optional shared alias path-assignment cache.
+    /// Key: (`alias_symbol`, `target_reference_node`, `antecedent_flow`) ->
+    /// whether the backward path from the antecedent to the alias declaration
+    /// contains an assignment to the target reference or its base.
+    pub(crate) shared_alias_path_assignment_cache: Option<&'a AliasPathAssignmentCache>,
     /// Cache numeric atom conversions during a single flow walk.
     /// Key: normalized f64 bits (with +0 normalized separately from -0).
     pub(crate) numeric_atom_cache: RefCell<FxHashMap<u64, Atom>>,
@@ -654,6 +661,7 @@ impl<'a> FlowAnalyzer<'a> {
             reference_symbol_cache: RefCell::new(FxHashMap::default()),
             shared_reference_match_cache: None,
             shared_alias_base_assignment_cache: None,
+            shared_alias_path_assignment_cache: None,
             numeric_atom_cache: RefCell::new(FxHashMap::default()),
             shared_numeric_atom_cache: None,
             narrowing_cache: None,
@@ -694,6 +702,7 @@ impl<'a> FlowAnalyzer<'a> {
             reference_symbol_cache: RefCell::new(FxHashMap::default()),
             shared_reference_match_cache: None,
             shared_alias_base_assignment_cache: None,
+            shared_alias_path_assignment_cache: None,
             numeric_atom_cache: RefCell::new(FxHashMap::default()),
             shared_numeric_atom_cache: None,
             narrowing_cache: None,
@@ -744,6 +753,15 @@ impl<'a> FlowAnalyzer<'a> {
         cache: &'a RefCell<FxHashMap<(u32, u32), bool>>,
     ) -> Self {
         self.shared_alias_base_assignment_cache = Some(cache);
+        self
+    }
+
+    /// Set a shared alias path-assignment cache.
+    pub const fn with_alias_path_assignment_cache(
+        mut self,
+        cache: &'a RefCell<FxHashMap<(u32, u32, u32), bool>>,
+    ) -> Self {
+        self.shared_alias_path_assignment_cache = Some(cache);
         self
     }
 

--- a/crates/tsz-checker/src/flow/flow_analysis/definite.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/definite.rs
@@ -230,6 +230,7 @@ impl<'a> CheckerState<'a> {
         .with_numeric_atom_cache(&self.ctx.flow_numeric_atom_cache)
         .with_reference_match_cache(&self.ctx.flow_reference_match_cache)
         .with_alias_base_assignment_cache(&self.ctx.symbol_flow_memo.alias_base_assignment)
+        .with_alias_path_assignment_cache(&self.ctx.symbol_flow_memo.alias_path_assignment)
         .with_type_environment(&self.ctx.type_environment)
         .with_checker_context(&self.ctx)
         .with_narrowing_cache(&self.ctx.narrowing_cache)

--- a/crates/tsz-checker/src/flow/flow_analysis/usage.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/usage.rs
@@ -1383,6 +1383,7 @@ impl<'a> CheckerState<'a> {
         .with_flow_reference_keys(&self.ctx.flow_reference_keys)
         .with_reference_match_cache(&self.ctx.flow_reference_match_cache)
         .with_alias_base_assignment_cache(&self.ctx.symbol_flow_memo.alias_base_assignment)
+        .with_alias_path_assignment_cache(&self.ctx.symbol_flow_memo.alias_path_assignment)
         .with_type_environment(&self.ctx.type_environment)
         .with_checker_context(&self.ctx)
         .with_destructured_bindings(&self.ctx.destructured_bindings);

--- a/crates/tsz-checker/src/types/computation/identifier_flow.rs
+++ b/crates/tsz-checker/src/types/computation/identifier_flow.rs
@@ -604,6 +604,7 @@ impl<'a> CheckerState<'a> {
         .with_numeric_atom_cache(&self.ctx.flow_numeric_atom_cache)
         .with_reference_match_cache(&self.ctx.flow_reference_match_cache)
         .with_alias_base_assignment_cache(&self.ctx.symbol_flow_memo.alias_base_assignment)
+        .with_alias_path_assignment_cache(&self.ctx.symbol_flow_memo.alias_path_assignment)
         .with_type_environment(&self.ctx.type_environment)
         .with_checker_context(&self.ctx)
         .with_narrowing_cache(&self.ctx.narrowing_cache)

--- a/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/access_semantics.rs
@@ -214,6 +214,7 @@ impl<'a> CheckerState<'a> {
         .with_numeric_atom_cache(&self.ctx.flow_numeric_atom_cache)
         .with_reference_match_cache(&self.ctx.flow_reference_match_cache)
         .with_alias_base_assignment_cache(&self.ctx.symbol_flow_memo.alias_base_assignment)
+        .with_alias_path_assignment_cache(&self.ctx.symbol_flow_memo.alias_path_assignment)
         .with_type_environment(&self.ctx.type_environment)
         .with_checker_context(&self.ctx)
         .with_narrowing_cache(&self.ctx.narrowing_cache)

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -623,6 +623,9 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     .with_alias_base_assignment_cache(
                         &self.ctx.symbol_flow_memo.alias_base_assignment,
                     )
+                    .with_alias_path_assignment_cache(
+                        &self.ctx.symbol_flow_memo.alias_path_assignment,
+                    )
                     .with_type_environment(&self.ctx.type_environment)
                     .with_checker_context(self.ctx)
                     .with_narrowing_cache(&self.ctx.narrowing_cache)


### PR DESCRIPTION
Goal: fast

## Summary
- Refs #13311 and #13250.
- Memoize the alias path-assignment scan keyed by `(alias_symbol, target_reference_node, antecedent_flow)`.
- Reuse the memo across `FlowAnalyzer` instances within one file check, reset it with the existing symbol flow memo tables, and expose it through checker cache statistics.

## Structural rule
When alias-based narrowing asks whether the current flow path assigned to the target reference or its base after the alias declaration, `tsc` treats such an assignment as invalidating the alias projection. tsz continues to answer that checker control-flow question through `FlowAnalyzer`; this PR memoizes repeated identical path scans instead of re-walking the same antecedent graph for each alias condition.

## Cache invariant
- Semantic question: for one file-local alias symbol, target reference node, and antecedent flow node, whether the backward path to the alias declaration contains an assignment to the reference or its base.
- Key: `(alias_symbol, target_reference_node, antecedent_flow)`; all three identities are file-local and cleared at file-session reset.
- Scope: one checker context / file check, shared by all `FlowAnalyzer` instances for that file.
- Fallback: absent cache preserves the existing full backward path walk.
- Residency: entries are counted in checker cache statistics and cleared with other symbol-flow memos.

## Adjacent cases / fallback
- Assignment hits still return `true` and invalidate alias narrowing.
- Negative path scans are cached too, avoiding repeated full-chain walks in large single-function bodies.
- The constant-reference / readonly-property decision remains uncached because it can depend on node-type availability; only the pure CFG path scan is memoized.
- No user-chosen identifier, property name, file name, rendered type string, or fixture-specific condition drives the result.

## Verification
- Draft exact-head CI passed for `3531714bdeb8c82043e7496c9f25505010f32b44`: `CI Light Summary`, `lint`, `unit`, `unit-cloudbuild`, `unit-checker-integration`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `gate`.
- Local tests/benchmarks not run per current instruction; ready PR CI will provide the full conformance/project/fourslash signal before queueing.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
