### PR TITLE
perf(emitter): share TypeCacheView via Arc across per-file emitters (#13103)

### DIFF
--- a/crates/tsz-cli/src/driver/emit.rs
+++ b/crates/tsz-cli/src/driver/emit.rs
@@ -166,32 +166,41 @@ pub(crate) fn emit_outputs(
     };
     let mut seen_duplicate_global_var_types: FxHashMap<String, String> = FxHashMap::default();
 
-    // Build mapping from arena address to file path for module resolution
-    let arena_to_path: rustc_hash::FxHashMap<usize, String> = context
-        .program
-        .files
-        .iter()
-        .map(|file| {
-            let arena_addr = std::sync::Arc::as_ptr(&file.arena) as usize;
-            (arena_addr, file.file_name.clone())
-        })
-        .collect();
+    // Build mapping from arena address to file path for module resolution.
+    // Built once per emit and shared by `Arc` with every per-file emitter;
+    // the map is read-only during emit.
+    let arena_to_path: std::sync::Arc<rustc_hash::FxHashMap<usize, String>> = std::sync::Arc::new(
+        context
+            .program
+            .files
+            .iter()
+            .map(|file| {
+                let arena_addr = std::sync::Arc::as_ptr(&file.arena) as usize;
+                (arena_addr, file.file_name.clone())
+            })
+            .collect(),
+    );
 
     // Build mapping from file index to file path for decl_file_idx-based
-    // symbol source resolution (fallback when symbol_arenas is incomplete)
-    let file_idx_to_path: rustc_hash::FxHashMap<u32, String> = context
-        .program
-        .files
-        .iter()
-        .enumerate()
-        .map(|(idx, file)| (idx as u32, file.file_name.clone()))
-        .collect();
-    let root_file_paths: FxHashSet<String> = context
-        .root_file_paths
-        .iter()
-        .map(|path| canonicalize_or_owned(path.as_path()))
-        .map(|path| path.to_string_lossy().replace('\\', "/"))
-        .collect();
+    // symbol source resolution (fallback when symbol_arenas is incomplete).
+    // Shared by `Arc` with every per-file emitter.
+    let file_idx_to_path: std::sync::Arc<rustc_hash::FxHashMap<u32, String>> = std::sync::Arc::new(
+        context
+            .program
+            .files
+            .iter()
+            .enumerate()
+            .map(|(idx, file)| (idx as u32, file.file_name.clone()))
+            .collect(),
+    );
+    let root_file_paths: std::sync::Arc<FxHashSet<String>> = std::sync::Arc::new(
+        context
+            .root_file_paths
+            .iter()
+            .map(|path| canonicalize_or_owned(path.as_path()))
+            .map(|path| path.to_string_lossy().replace('\\', "/"))
+            .collect(),
+    );
     let file_lookup = build_program_file_lookup(context.program);
 
     // Use the MergedProgram's global symbol-to-arena mapping.
@@ -203,14 +212,17 @@ pub(crate) fn emit_outputs(
     // Collect file paths that contain module augmentations.
     // The declaration emitter uses this to preserve side-effect imports for
     // files whose named bindings were all elided but whose augmentations must
-    // still take effect.
-    let files_with_augmentations: rustc_hash::FxHashSet<String> = context
-        .program
-        .files
-        .iter()
-        .filter(|file| !file.module_augmentations.is_empty())
-        .map(|file| file.file_name.clone())
-        .collect();
+    // still take effect. Shared by `Arc` with every per-file emitter.
+    let files_with_augmentations: std::sync::Arc<rustc_hash::FxHashSet<String>> =
+        std::sync::Arc::new(
+            context
+                .program
+                .files
+                .iter()
+                .filter(|file| !file.module_augmentations.is_empty())
+                .map(|file| file.file_name.clone())
+                .collect(),
+        );
     let declaration_const_enum_exports = build_declaration_const_enum_exports(context.program);
     let ambient_global_type_only_names = build_ambient_global_type_only_names(
         context.program,
@@ -579,9 +591,16 @@ pub(crate) fn emit_outputs(
             if let Some(dts_path) =
                 declaration_output_path(context.base_dir, context.root_dir, decl_base, &input_path)
             {
-                // Get type cache for this file if available
+                // Get type cache for this file if available. Build the
+                // emitter view once per file and share it by `Arc`: the
+                // per-file emitter, its scratch emitters, and the usage
+                // analyzer below all read the same immutable view, so no
+                // checker cache or view map is deep-cloned.
                 let file_path = PathBuf::from(&file.file_name);
-                let type_cache = context.type_caches.get(&file_path).cloned();
+                let cache_view = context
+                    .type_caches
+                    .get(&file_path)
+                    .map(|cache| std::sync::Arc::new(type_cache_view(cache)));
 
                 // Per-file BinderState (shared with the JS import-elision
                 // facts when both emits run) to enable usage analysis.
@@ -590,11 +609,10 @@ pub(crate) fn emit_outputs(
                 });
 
                 // Create emitter with type information and binder
-                let mut emitter = if let Some(ref cache) = type_cache {
-                    let cache_view = type_cache_view(cache);
-                    let mut emitter = DeclarationEmitter::with_type_info(
+                let mut emitter = if let Some(cache_view) = &cache_view {
+                    let mut emitter = DeclarationEmitter::with_shared_type_info(
                         &file.arena,
-                        cache_view,
+                        std::sync::Arc::clone(cache_view),
                         &context.program.type_interner,
                         binder,
                     );
@@ -604,9 +622,9 @@ pub(crate) fn emit_outputs(
                         file.file_name.clone(),
                     );
                     // Set arena to path mapping for module resolution
-                    emitter.set_arena_to_path(arena_to_path.clone());
-                    emitter.set_file_idx_to_path(file_idx_to_path.clone());
-                    emitter.set_root_file_paths(root_file_paths.clone());
+                    emitter.set_shared_arena_to_path(std::sync::Arc::clone(&arena_to_path));
+                    emitter.set_shared_file_idx_to_path(std::sync::Arc::clone(&file_idx_to_path));
+                    emitter.set_shared_root_file_paths(std::sync::Arc::clone(&root_file_paths));
                     emitter.set_shared_global_symbol_arenas(std::sync::Arc::clone(
                         &global_symbol_arenas,
                     ));
@@ -615,7 +633,9 @@ pub(crate) fn emit_outputs(
                     emitter.set_strict_null_checks(context.options.checker.strict_null_checks);
                     emitter
                         .set_isolated_declarations(context.options.checker.isolated_declarations);
-                    emitter.set_files_with_augmentations(files_with_augmentations.clone());
+                    emitter.set_shared_files_with_augmentations(std::sync::Arc::clone(
+                        &files_with_augmentations,
+                    ));
                     emitter
                 } else {
                     let mut emitter = DeclarationEmitter::new(&file.arena);
@@ -626,9 +646,9 @@ pub(crate) fn emit_outputs(
                         std::sync::Arc::clone(&file.arena),
                         file.file_name.clone(),
                     );
-                    emitter.set_arena_to_path(arena_to_path.clone());
-                    emitter.set_file_idx_to_path(file_idx_to_path.clone());
-                    emitter.set_root_file_paths(root_file_paths.clone());
+                    emitter.set_shared_arena_to_path(std::sync::Arc::clone(&arena_to_path));
+                    emitter.set_shared_file_idx_to_path(std::sync::Arc::clone(&file_idx_to_path));
+                    emitter.set_shared_root_file_paths(std::sync::Arc::clone(&root_file_paths));
                     emitter.set_shared_global_symbol_arenas(std::sync::Arc::clone(
                         &global_symbol_arenas,
                     ));
@@ -637,7 +657,9 @@ pub(crate) fn emit_outputs(
                     emitter.set_strict_null_checks(context.options.checker.strict_null_checks);
                     emitter
                         .set_isolated_declarations(context.options.checker.isolated_declarations);
-                    emitter.set_files_with_augmentations(files_with_augmentations.clone());
+                    emitter.set_shared_files_with_augmentations(std::sync::Arc::clone(
+                        &files_with_augmentations,
+                    ));
                     emitter
                 };
 
@@ -686,7 +708,7 @@ pub(crate) fn emit_outputs(
                 }
 
                 // Run usage analysis and calculate required imports if we have type cache
-                if let Some(ref cache) = type_cache {
+                if let Some(ref cache_view) = cache_view {
                     use rustc_hash::FxHashMap;
                     use tsz::declaration_emitter::usage_analyzer::{
                         UsageAnalyzer, UsageAnalyzerSourceFlags,
@@ -694,12 +716,11 @@ pub(crate) fn emit_outputs(
 
                     // Empty import_name_map for this usage (not needed for auto-import calculation)
                     let import_name_map = FxHashMap::default();
-                    let cache_view = type_cache_view(cache);
 
                     let mut analyzer = UsageAnalyzer::new(
                         &file.arena,
                         binder,
-                        &cache_view,
+                        cache_view,
                         &context.program.type_interner,
                         std::sync::Arc::clone(&file.arena),
                         Some(file.file_name.clone()),

--- a/crates/tsz-emitter/src/declaration_emitter/core/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/mod.rs
@@ -55,8 +55,12 @@ pub struct DeclarationEmitter<'a> {
     pub(super) public_api_scope_depth: u32,
     /// Raw source text for this source file, used for keyword fallback emission.
     pub(super) source_file_text: Option<Arc<str>>,
-    /// Type cache for looking up inferred types
-    pub(super) type_cache: Option<TypeCacheView>,
+    /// Type cache for looking up inferred types.
+    ///
+    /// Read-only after construction; shared by `Arc` so per-file and scratch
+    /// emitters reference one program-produced view instead of deep-cloning
+    /// every cache map.
+    pub(super) type_cache: Option<Arc<TypeCacheView>>,
     /// Root source-file node for the current emit pass.
     pub(super) current_source_file_idx: Option<NodeIndex>,
     /// Type interner for printing types
@@ -76,12 +80,16 @@ pub struct DeclarationEmitter<'a> {
     pub(super) current_file_path: Option<String>,
     /// Parsed JSON module values keyed by resolved source path.
     pub(super) json_module_value_cache: FxHashMap<PathBuf, Arc<serde_json::Value>>,
-    /// Map of arena address -> file path (for resolving foreign symbol locations)
-    pub(super) arena_to_path: FxHashMap<usize, String>,
-    /// Map of file index -> file path (fallback for resolving symbol source via `decl_file_idx`)
-    pub(super) file_idx_to_path: FxHashMap<u32, String>,
+    /// Map of arena address -> file path (for resolving foreign symbol locations).
+    /// Program-wide and read-only after construction; `Arc`-shared across
+    /// per-file and scratch emitters.
+    pub(super) arena_to_path: Arc<FxHashMap<usize, String>>,
+    /// Map of file index -> file path (fallback for resolving symbol source via `decl_file_idx`).
+    /// Program-wide and read-only after construction; `Arc`-shared.
+    pub(super) file_idx_to_path: Arc<FxHashMap<u32, String>>,
     /// Canonicalized root files from the original compilation request.
-    pub(super) root_file_paths: FxHashSet<String>,
+    /// Program-wide and read-only after construction; `Arc`-shared.
+    pub(super) root_file_paths: Arc<FxHashSet<String>>,
     /// Global symbol-to-arena mapping from all program files, enabling cross-file
     /// symbol source path resolution for TS2883 portability checks.
     pub(super) global_symbol_arenas: Arc<FxHashMap<SymbolId, Arc<NodeArena>>>,
@@ -156,7 +164,8 @@ pub struct DeclarationEmitter<'a> {
     /// When true, strip declarations annotated with `@internal` (--stripInternal)
     pub(super) strip_internal: bool,
     /// Set of absolute file paths whose source contains module augmentations.
-    pub(super) files_with_augmentations: FxHashSet<String>,
+    /// Program-wide and read-only after construction; `Arc`-shared.
+    pub(super) files_with_augmentations: Arc<FxHashSet<String>>,
     /// Tracks whether any non-exported declaration was actually emitted
     /// (used for deciding whether `export {};` scope fix marker is needed)
     pub(super) emitted_non_exported_declaration: bool,

--- a/crates/tsz-emitter/src/declaration_emitter/core/setup.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/core/setup.rs
@@ -36,9 +36,9 @@ impl<'a> DeclarationEmitter<'a> {
             current_arena: None,
             current_file_path: None,
             json_module_value_cache: FxHashMap::default(),
-            arena_to_path: FxHashMap::default(),
-            file_idx_to_path: FxHashMap::default(),
-            root_file_paths: FxHashSet::default(),
+            arena_to_path: Arc::new(FxHashMap::default()),
+            file_idx_to_path: Arc::new(FxHashMap::default()),
+            root_file_paths: Arc::new(FxHashSet::default()),
             global_symbol_arenas: Arc::new(FxHashMap::default()),
             bundled_duplicate_global_var_types: FxHashMap::default(),
             required_imports: FxHashMap::default(),
@@ -68,7 +68,7 @@ impl<'a> DeclarationEmitter<'a> {
             current_statement_jsdoc_chain: Vec::new(),
             remove_comments: false,
             strip_internal: false,
-            files_with_augmentations: FxHashSet::default(),
+            files_with_augmentations: Arc::new(FxHashSet::default()),
             emitted_non_exported_declaration: false,
             emitted_scope_marker: false,
             emitted_module_indicator: false,
@@ -128,9 +128,28 @@ impl<'a> DeclarationEmitter<'a> {
         }
     }
 
+    /// Construct an emitter from a caller-owned `TypeCacheView`.
+    ///
+    /// Compatibility wrapper over [`Self::with_shared_type_info`] for callers
+    /// (mostly tests) that build a one-off view; batch emit should construct
+    /// the view once and share it via `Arc`.
     pub fn with_type_info(
         arena: &'a NodeArena,
         type_cache: TypeCacheView,
+        type_interner: &'a TypeInterner,
+        binder: &'a BinderState,
+    ) -> Self {
+        Self::with_shared_type_info(arena, Arc::new(type_cache), type_interner, binder)
+    }
+
+    /// Construct an emitter that shares a program-produced `TypeCacheView`.
+    ///
+    /// The view is read-only after construction, so per-file emitters and the
+    /// scratch emitters they spawn reference one `Arc` instead of deep-cloning
+    /// every cache map per emitter.
+    pub fn with_shared_type_info(
+        arena: &'a NodeArena,
+        type_cache: Arc<TypeCacheView>,
         type_interner: &'a TypeInterner,
         binder: &'a BinderState,
     ) -> Self {
@@ -164,9 +183,9 @@ impl<'a> DeclarationEmitter<'a> {
             current_arena: None,
             current_file_path: None,
             json_module_value_cache: FxHashMap::default(),
-            arena_to_path: FxHashMap::default(),
-            file_idx_to_path: FxHashMap::default(),
-            root_file_paths: FxHashSet::default(),
+            arena_to_path: Arc::new(FxHashMap::default()),
+            file_idx_to_path: Arc::new(FxHashMap::default()),
+            root_file_paths: Arc::new(FxHashSet::default()),
             global_symbol_arenas: Arc::new(FxHashMap::default()),
             bundled_duplicate_global_var_types: FxHashMap::default(),
             required_imports: FxHashMap::default(),
@@ -196,7 +215,7 @@ impl<'a> DeclarationEmitter<'a> {
             current_statement_jsdoc_chain: Vec::new(),
             remove_comments: false,
             strip_internal: false,
-            files_with_augmentations: FxHashSet::default(),
+            files_with_augmentations: Arc::new(FxHashSet::default()),
             emitted_non_exported_declaration: false,
             emitted_scope_marker: false,
             emitted_module_indicator: false,
@@ -336,6 +355,12 @@ impl<'a> DeclarationEmitter<'a> {
     ///
     /// This enables resolving foreign symbols to their source files.
     pub fn set_arena_to_path(&mut self, arena_to_path: FxHashMap<usize, String>) {
+        self.arena_to_path = Arc::new(arena_to_path);
+    }
+
+    /// Share the program-wide arena-address-to-path mapping without cloning
+    /// it into each per-file emitter. The map is read-only during emit.
+    pub fn set_shared_arena_to_path(&mut self, arena_to_path: Arc<FxHashMap<usize, String>>) {
         self.arena_to_path = arena_to_path;
     }
 
@@ -345,10 +370,22 @@ impl<'a> DeclarationEmitter<'a> {
     /// the symbol is not in `symbol_arenas` (e.g., for cross-file interface
     /// references created during type checking).
     pub fn set_file_idx_to_path(&mut self, file_idx_to_path: FxHashMap<u32, String>) {
+        self.file_idx_to_path = Arc::new(file_idx_to_path);
+    }
+
+    /// Share the program-wide file-index-to-path mapping without cloning it
+    /// into each per-file emitter. The map is read-only during emit.
+    pub fn set_shared_file_idx_to_path(&mut self, file_idx_to_path: Arc<FxHashMap<u32, String>>) {
         self.file_idx_to_path = file_idx_to_path;
     }
 
     pub fn set_root_file_paths(&mut self, root_file_paths: FxHashSet<String>) {
+        self.root_file_paths = Arc::new(root_file_paths);
+    }
+
+    /// Share the canonicalized root-file set without cloning it into each
+    /// per-file emitter. The set is read-only during emit.
+    pub fn set_shared_root_file_paths(&mut self, root_file_paths: Arc<FxHashSet<String>>) {
         self.root_file_paths = root_file_paths;
     }
 
@@ -391,6 +428,12 @@ impl<'a> DeclarationEmitter<'a> {
 
     /// Set the collection of file paths that contain module augmentations.
     pub fn set_files_with_augmentations(&mut self, files: FxHashSet<String>) {
+        self.files_with_augmentations = Arc::new(files);
+    }
+
+    /// Share the program-wide augmentation-file set without cloning it into
+    /// each per-file emitter. The set is read-only during emit.
+    pub fn set_shared_files_with_augmentations(&mut self, files: Arc<FxHashSet<String>>) {
         self.files_with_augmentations = files;
     }
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
@@ -666,9 +666,9 @@ impl<'a> DeclarationEmitter<'a> {
         let mut scratch = if let (Some(type_cache), Some(type_interner), Some(binder)) =
             (&self.type_cache, self.type_interner, self.binder)
         {
-            DeclarationEmitter::with_type_info(
+            DeclarationEmitter::with_shared_type_info(
                 self.arena,
-                type_cache.clone(),
+                std::sync::Arc::clone(type_cache),
                 type_interner,
                 binder,
             )

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_expression_literals.rs
@@ -554,9 +554,9 @@ impl<'a> DeclarationEmitter<'a> {
         let mut scratch = if let (Some(type_cache), Some(type_interner), Some(binder)) =
             (&self.type_cache, self.type_interner, self.binder)
         {
-            DeclarationEmitter::with_type_info(
+            DeclarationEmitter::with_shared_type_info(
                 self.arena,
-                type_cache.clone(),
+                std::sync::Arc::clone(type_cache),
                 type_interner,
                 binder,
             )

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_callables.rs
@@ -763,9 +763,9 @@ impl<'a> DeclarationEmitter<'a> {
             && let (Some(type_cache), Some(type_interner), Some(binder)) =
                 (&self.type_cache, self.type_interner, self.binder)
         {
-            DeclarationEmitter::with_type_info(
+            DeclarationEmitter::with_shared_type_info(
                 source_arena,
-                type_cache.clone(),
+                std::sync::Arc::clone(type_cache),
                 type_interner,
                 binder,
             )

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_text.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_text.rs
@@ -653,9 +653,9 @@ impl<'a> DeclarationEmitter<'a> {
         let mut scratch = if let (Some(type_cache), Some(type_interner), Some(binder)) =
             (&self.type_cache, self.type_interner, self.binder)
         {
-            DeclarationEmitter::with_type_info(
+            DeclarationEmitter::with_shared_type_info(
                 self.arena,
-                type_cache.clone(),
+                std::sync::Arc::clone(type_cache),
                 type_interner,
                 binder,
             )

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_type_annotations.rs
@@ -347,9 +347,9 @@ impl<'a> DeclarationEmitter<'a> {
         let mut scratch = if let (Some(type_cache), Some(type_interner), Some(binder)) =
             (&self.type_cache, self.type_interner, self.binder)
         {
-            DeclarationEmitter::with_type_info(
+            DeclarationEmitter::with_shared_type_info(
                 source_arena,
-                type_cache.clone(),
+                std::sync::Arc::clone(type_cache),
                 type_interner,
                 binder,
             )

--- a/crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/enum_template_and_advanced.rs
@@ -1286,10 +1286,12 @@ fn check_symbol_portability_prefers_symlinked_nested_package_over_public_root_ex
     let nested_source = nested_source.to_string_lossy().into_owned();
     let top_level_source = top_level_source.to_string_lossy().into_owned();
     let current_path = current_path.to_string_lossy().into_owned();
-    emitter.arena_to_path.insert(
+    let mut arena_to_path = rustc_hash::FxHashMap::default();
+    arena_to_path.insert(
         std::sync::Arc::as_ptr(&source_arena) as usize,
         nested_source,
     );
+    emitter.set_arena_to_path(arena_to_path);
 
     let mut binder = tsz_binder::BinderState::new();
     let sym_id = binder.symbols.alloc(

--- a/crates/tsz-emitter/src/declaration_emitter/tests/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/mod.rs
@@ -318,6 +318,7 @@ mod misc_inference_features;
 mod probes_issues;
 mod probes_systematic;
 mod probes_tsc_comparison;
+mod shared_views;
 mod simple_declarations;
 mod type_formatting;
 mod type_info;

--- a/crates/tsz-emitter/src/declaration_emitter/tests/shared_views.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/tests/shared_views.rs
@@ -1,0 +1,100 @@
+// Evidence tests for #13103: per-file and scratch emitters share one
+// `Arc<TypeCacheView>` (and the program-wide path maps) instead of
+// deep-cloning the view per emitter.
+
+use super::*;
+use crate::type_cache_view::TypeCacheView;
+use rustc_hash::FxHashSet;
+
+#[test]
+fn scratch_emitter_shares_type_cache_view_arc() {
+    let mut parser = ParserState::new("test.ts".to_string(), "export const value = 1;".to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+
+    let interner = TypeInterner::new();
+    let shared_view = Arc::new(TypeCacheView::default());
+    let emitter = DeclarationEmitter::with_shared_type_info(
+        &parser.arena,
+        Arc::clone(&shared_view),
+        &interner,
+        &binder,
+    );
+
+    let scratch = emitter.scratch_declaration_emitter();
+    let parent_view = emitter
+        .type_cache
+        .as_ref()
+        .expect("parent emitter should hold a type cache view");
+    let scratch_view = scratch
+        .type_cache
+        .as_ref()
+        .expect("scratch emitter should hold a type cache view");
+
+    // One allocation serves the program view, the per-file emitter, and the
+    // scratch emitter: no deep clone of the cache maps.
+    assert!(Arc::ptr_eq(&shared_view, parent_view));
+    assert!(Arc::ptr_eq(parent_view, scratch_view));
+}
+
+#[test]
+fn owned_with_type_info_still_constructs_and_shares_with_scratch() {
+    let mut parser = ParserState::new("test.ts".to_string(), "export const value = 1;".to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+
+    let interner = TypeInterner::new();
+    // Compatibility path: caller-owned view is wrapped once, then shared.
+    let emitter = DeclarationEmitter::with_type_info(
+        &parser.arena,
+        TypeCacheView::default(),
+        &interner,
+        &binder,
+    );
+
+    let scratch = emitter.scratch_declaration_emitter();
+    assert!(Arc::ptr_eq(
+        emitter.type_cache.as_ref().expect("parent view"),
+        scratch.type_cache.as_ref().expect("scratch view"),
+    ));
+}
+
+#[test]
+fn scratch_emitter_shares_program_wide_path_maps() {
+    let mut parser = ParserState::new("test.ts".to_string(), "export const value = 1;".to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(&parser.arena, root);
+
+    let interner = TypeInterner::new();
+    let mut emitter = DeclarationEmitter::with_shared_type_info(
+        &parser.arena,
+        Arc::new(TypeCacheView::default()),
+        &interner,
+        &binder,
+    );
+
+    let arena_to_path: Arc<FxHashMap<usize, String>> = Arc::new(FxHashMap::default());
+    let file_idx_to_path: Arc<FxHashMap<u32, String>> = Arc::new(FxHashMap::default());
+    let root_file_paths: Arc<FxHashSet<String>> = Arc::new(FxHashSet::default());
+    let files_with_augmentations: Arc<FxHashSet<String>> = Arc::new(FxHashSet::default());
+    emitter.set_shared_arena_to_path(Arc::clone(&arena_to_path));
+    emitter.set_shared_file_idx_to_path(Arc::clone(&file_idx_to_path));
+    emitter.set_shared_root_file_paths(Arc::clone(&root_file_paths));
+    emitter.set_shared_files_with_augmentations(Arc::clone(&files_with_augmentations));
+
+    assert!(Arc::ptr_eq(&arena_to_path, &emitter.arena_to_path));
+    assert!(Arc::ptr_eq(&file_idx_to_path, &emitter.file_idx_to_path));
+    assert!(Arc::ptr_eq(&root_file_paths, &emitter.root_file_paths));
+    assert!(Arc::ptr_eq(
+        &files_with_augmentations,
+        &emitter.files_with_augmentations
+    ));
+
+    // Scratch emitters re-share the parent's `arena_to_path` instead of
+    // cloning the map contents.
+    let scratch = emitter.scratch_declaration_emitter();
+    assert!(Arc::ptr_eq(&arena_to_path, &scratch.arena_to_path));
+}


### PR DESCRIPTION
Goal: fast

Stops deep-cloning `TypeCacheView` (and the read-only program-wide maps) for every per-file and scratch `DeclarationEmitter`: the view is immutable after construction, so emitters now share one `Arc`. Mutated-per-file maps (if any) are left owned and documented.

Structural rule: read-only-after-construction emitter inputs are shared by reference across per-file/scratch emitters; per-file mutation stays per-file-owned. Output is byte-identical — emit tests and workspace check gate it.

Closes #13103

## Clone-site inventory

Arc-shared (read-only after construction):
- `crates/tsz-cli/src/driver/emit.rs` per-file loop: `context.type_caches.get(&file_path).cloned()` deep-cloned the whole checker `TypeCache` per file, then `type_cache_view()` materialized the emitter view **twice** per file (once for the emitter, once for the standalone `UsageAnalyzer`). Now: no checker-cache clone, one `Arc<TypeCacheView>` per file shared by emitter, scratch emitters, and analyzer.
- Scratch-emitter `TypeCacheView::clone()` (5 sites): `helpers/type_inference.rs`, `type_inference_expression_literals.rs`, `type_inference_source_callables.rs`, `type_inference_source_text.rs`, `type_inference_type_annotations.rs` — all now `Arc::clone` via new `DeclarationEmitter::with_shared_type_info`.
- Program-wide maps cloned per file in the driver loop, now `Arc`-shared via `set_shared_*` setters: `arena_to_path`, `file_idx_to_path`, `root_file_paths`, `files_with_augmentations`. (`global_symbol_arenas` was already shared by #13292.)

Left owned (documented why):
- `type_only_nodes` (driver JS-emit path): per-file set, mutated by `mark_ambient_global_type_only_export_specifiers` — must stay owned.
- `required_imports`, `bundled_duplicate_global_var_types`: per-file content, not program-wide.
- Owned setters (`set_arena_to_path`, `with_type_info`, ...) kept as source-compatible wrappers that wrap in `Arc` once; tests keep building one-off owned values.

Evidence of sharing: new `declaration_emitter/tests/shared_views.rs` asserts `Arc::ptr_eq` between the program view and the per-file/scratch emitters' views and between the shared program-wide maps.

## Verification
- `cargo nextest run -p tsz-emitter` — 4271/4274 passed; the 3 failures (`take_diagnostics_*_ts2883_*` x2, `fix_generic_rest_identity_preserves_parameters_tuple_labels`) reproduce identically on clean `origin/main` (verified via `git stash`), pre-existing.
- `cargo nextest run -p tsz-cli -E 'test(/emit/)'` — 205/210 passed; the same 5 failures fail identically on clean `origin/main`, pre-existing.
- `cargo nextest run -p tsz-emitter -E 'test(shared_views)'` — 3/3 new Arc-sharing assertions pass.
- `cargo clippy -p tsz-emitter -- -D warnings` (also `--all-targets`) — clean.
- `cargo check --workspace` — clean.

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
