### PR TITLE
perf(checker): avoid memoizing exhausted display evals (#13040)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/display_budget.rs
+++ b/crates/tsz-checker/src/error_reporter/display_budget.rs
@@ -46,6 +46,7 @@ struct DisplayBudget {
     visits: u32,
     eval_fuel: u32,
     eval_memo: FxHashMap<TypeId, TypeId>,
+    exhausted: bool,
 }
 
 thread_local! {
@@ -77,6 +78,7 @@ impl DisplayBudgetScope {
                         visits: DISPLAY_VISIT_BUDGET,
                         eval_fuel: DISPLAY_EVAL_FUEL,
                         eval_memo: FxHashMap::default(),
+                        exhausted: false,
                     });
                 });
             }
@@ -93,7 +95,7 @@ impl Drop for DisplayBudgetScope {
             if depth.get() == 0 {
                 ACTIVE.with(|active| {
                     if let Some(budget) = active.borrow_mut().take()
-                        && (budget.visits == 0 || budget.eval_fuel == 0)
+                        && budget.exhausted
                     {
                         tracing::debug!(
                             visits_left = budget.visits,
@@ -115,6 +117,7 @@ fn try_consume(counter: fn(&mut DisplayBudget) -> &mut u32) -> bool {
         Some(budget) => {
             let counter = counter(budget);
             if *counter == 0 {
+                budget.exhausted = true;
                 false
             } else {
                 *counter -= 1;
@@ -165,6 +168,9 @@ pub(crate) fn record_eval(type_id: TypeId, result: TypeId) {
     }
     ACTIVE.with(|active| {
         if let Some(budget) = active.borrow_mut().as_mut() {
+            if budget.exhausted {
+                return;
+            }
             budget.eval_memo.insert(type_id, result);
         }
     });
@@ -236,6 +242,18 @@ mod tests {
             assert_eq!(cached_eval(TypeId::STRING), Some(TypeId::NUMBER));
         }
         let _scope = DisplayBudgetScope::enter();
+        assert_eq!(cached_eval(TypeId::STRING), None);
+    }
+
+    #[test]
+    fn exhausted_budget_does_not_record_eval_memo() {
+        let _scope = DisplayBudgetScope::enter();
+        for _ in 0..DISPLAY_EVAL_FUEL {
+            assert!(try_consume_eval_fuel());
+        }
+        assert!(!try_consume_eval_fuel());
+
+        record_eval(TypeId::STRING, TypeId::NUMBER);
         assert_eq!(cached_eval(TypeId::STRING), None);
     }
 }


### PR DESCRIPTION
Goal: fast

## Summary
- Tightens the #13040 diagnostic-display work budget so once a rendered-type budget is exhausted, the scope stops recording `evaluate_type_for_assignability` results into the per-rendered-type display memo.
- Keeps the existing display visit/eval fuel behavior and relation/semantic paths unchanged; helpers remain inert outside a display-budget scope.
- Targets the residual safety invariant after #13176/#13217: truncated display normalization must not replay a degraded evaluation as if it were complete later in the same rendered type.

## Structural rule / invariant
When diagnostic display exhausts its per-rendered-type work budget, tsz may truncate display normalization for that diagnostic, but it must not cache budget-degraded evaluation results as complete display facts. The owner remains `error_reporter::display_budget`; `evaluate_type_for_assignability` still owns semantic evaluation and only consults this scope-local budget on display paths.

## Cache / performance invariant
The display eval memo remains scoped to one rendered type and keyed by the local `TypeId`. This change adds an exhaustion bit to that same scope: after any visit/eval fuel overrun, `record_eval` becomes a no-op until the outer display scope drops. A fresh display scope starts with a clean budget and memo.

## Adjacent cases / fallback
- No active display scope: all budget helpers stay inert and no relation/semantic path behavior changes.
- Non-exhausted display scope: eval memo behavior is unchanged.
- Exhausted display scope: later display evaluation falls back to input/truncated types rather than replaying a partially computed memo result.
- No fixture names, rendered diagnostic strings, source text, or benchmark row names drive behavior.

## Verification
- Pre-commit formatting hook ran during `git commit`.
- Draft exact-head CI passed for `4dcd573d43babfdb8faf8f8024a8cfa423f92e20`: `CI Light Summary`, `unit-cloudbuild`, `lint`, `cargo-deny`, `unit`, `project-row-drift`, `cargo-shear`, `dist-binaries`, `unit-checker-integration`, and `gate`.
- No local benchmarks, conformance, emit, or fourslash runs per current repo instruction; ready PR CI will provide the full safety signal before queueing.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
