### PR TITLE
refactor(checker): route basic diagnostic display roles (#13081)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/mod.rs
@@ -47,7 +47,7 @@ mod recursive_alias_display;
 mod render_failure;
 mod suggestions;
 mod ts2820_display;
-mod type_display_policy;
+pub(crate) mod type_display_policy;
 mod type_query_alias_display;
 mod type_value;
 

--- a/crates/tsz-checker/src/error_reporter/type_display_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/type_display_policy.rs
@@ -10,7 +10,7 @@ use tsz_solver::TypeId;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[allow(dead_code)]
-pub(in crate::error_reporter) enum DiagnosticTypeDisplayRole {
+pub(crate) enum DiagnosticTypeDisplayRole {
     DefaultDiagnostic,
     WidenedDiagnostic,
     FlattenedDiagnostic,
@@ -124,11 +124,14 @@ impl<'a> CheckerState<'a> {
         {
             return self.format_type_diagnostic(ty);
         }
+        if let Some(display) = self.format_type_for_basic_diagnostic_role(ty, role) {
+            return display;
+        }
         match role {
-            DiagnosticTypeDisplayRole::DefaultDiagnostic => self.format_type_diagnostic(ty),
-            DiagnosticTypeDisplayRole::WidenedDiagnostic => self.format_type_diagnostic_widened(ty),
-            DiagnosticTypeDisplayRole::FlattenedDiagnostic => {
-                self.format_type_diagnostic_flattened(ty)
+            DiagnosticTypeDisplayRole::DefaultDiagnostic
+            | DiagnosticTypeDisplayRole::WidenedDiagnostic
+            | DiagnosticTypeDisplayRole::FlattenedDiagnostic => {
+                unreachable!("basic diagnostic roles are handled by the checker formatting factory")
             }
             DiagnosticTypeDisplayRole::Assignability => {
                 self.format_type_for_assignability_message(ty)

--- a/crates/tsz-checker/src/state/type_environment/formatting.rs
+++ b/crates/tsz-checker/src/state/type_environment/formatting.rs
@@ -2,6 +2,7 @@
 //!
 //! Extracted from `core.rs` to keep module size manageable.
 
+use crate::error_reporter::type_display_policy::DiagnosticTypeDisplayRole;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
@@ -111,6 +112,14 @@ impl<'a> CheckerState<'a> {
     /// Enables display properties to preserve original literal types from the
     /// freshness model (e.g., `"frizzlebizzle"` not `string`) matching tsc.
     pub fn format_type_diagnostic(&self, type_id: TypeId) -> String {
+        self.format_type_for_basic_diagnostic_role(
+            type_id,
+            DiagnosticTypeDisplayRole::DefaultDiagnostic,
+        )
+        .expect("DefaultDiagnostic is a basic diagnostic display role")
+    }
+
+    fn format_type_diagnostic_impl(&self, type_id: TypeId) -> String {
         if let Some(sym_id) = self.ctx.resolve_type_to_symbol_id(type_id)
             && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
             && (symbol.flags & tsz_binder::symbol_flags::ENUM_MEMBER) != 0
@@ -562,6 +571,14 @@ impl<'a> CheckerState<'a> {
     /// tsc shows widened property types in assignability messages:
     /// `{ two: number }` not `{ two: 1 }`.
     pub fn format_type_diagnostic_widened(&self, type_id: TypeId) -> String {
+        self.format_type_for_basic_diagnostic_role(
+            type_id,
+            DiagnosticTypeDisplayRole::WidenedDiagnostic,
+        )
+        .expect("WidenedDiagnostic is a basic diagnostic display role")
+    }
+
+    fn format_type_diagnostic_widened_impl(&self, type_id: TypeId) -> String {
         let mut formatter = self
             .ctx
             .create_type_formatter()
@@ -573,6 +590,14 @@ impl<'a> CheckerState<'a> {
     /// Format a type for TS2741 messages, showing the merged object form
     /// instead of following `display_alias` to intersection types.
     pub fn format_type_diagnostic_flattened(&self, type_id: TypeId) -> String {
+        self.format_type_for_basic_diagnostic_role(
+            type_id,
+            DiagnosticTypeDisplayRole::FlattenedDiagnostic,
+        )
+        .expect("FlattenedDiagnostic is a basic diagnostic display role")
+    }
+
+    fn format_type_diagnostic_flattened_impl(&self, type_id: TypeId) -> String {
         let mut formatter = self
             .ctx
             .create_diagnostic_type_formatter()
@@ -652,6 +677,29 @@ impl<'a> CheckerState<'a> {
             .create_diagnostic_type_formatter()
             .with_display_properties();
         formatter.format(type_id).into_owned()
+    }
+
+    /// Format checker-owned diagnostic display roles that are pure formatter
+    /// policy selections. Context-sensitive roles still live in the
+    /// `error_reporter` dispatcher because they may evaluate the peer type or
+    /// inspect the diagnostic anchor before choosing the display surface.
+    pub(crate) fn format_type_for_basic_diagnostic_role(
+        &self,
+        type_id: TypeId,
+        role: DiagnosticTypeDisplayRole,
+    ) -> Option<String> {
+        match role {
+            DiagnosticTypeDisplayRole::DefaultDiagnostic => {
+                Some(self.format_type_diagnostic_impl(type_id))
+            }
+            DiagnosticTypeDisplayRole::WidenedDiagnostic => {
+                Some(self.format_type_diagnostic_widened_impl(type_id))
+            }
+            DiagnosticTypeDisplayRole::FlattenedDiagnostic => {
+                Some(self.format_type_diagnostic_flattened_impl(type_id))
+            }
+            _ => None,
+        }
     }
 
     /// Format a pair of types for diagnostics that display two types side by side.


### PR DESCRIPTION
Goal: hold

## Summary
- Refs #13081 and #13250.
- Makes `DiagnosticTypeDisplayRole` visible as the checker-wide diagnostic display policy enum instead of keeping it private to `error_reporter`.
- Routes the basic diagnostic roles (`DefaultDiagnostic`, `WidenedDiagnostic`, `FlattenedDiagnostic`) through a single checker formatting helper, while preserving the old public method names as compatibility wrappers.
- Leaves context-sensitive assignment/call/property roles in the existing mutable error-reporter dispatcher because those still need peer-type and anchor-aware display decisions.

## Structural rule
When a diagnostic only needs a pure display-policy choice, tsz should select that policy through the checker-owned `DiagnosticTypeDisplayRole` path. Context-sensitive diagnostics still go through the error-reporter dispatcher because they may evaluate the peer type or diagnostic anchor before selecting the final display surface.

## Adjacent cases / fallback
- Default diagnostic formatting keeps enum-member qualification and display properties.
- Widened diagnostics still omit display properties for assignability-style widened object displays.
- Flattened diagnostics still suppress intersection display aliases for TS2741-style messages.
- No user-chosen identifier, file name, source text, rendered type string, or fixture-specific condition drives the result.

## Verification
- Draft/light CI passed at exact head `2e5d32bd1dbafd9181c597122f12ff8b6bc9ba8b`: `CI Light Summary`, `unit-cloudbuild`, `unit-checker-integration`, `dist-binaries`, `unit`, `cargo-deny`, `project-row-drift`, `lint`, `cargo-shear`, and `gate`.
- Local tests not run per current instruction.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
