### PR TITLE
perf(server): reuse project completions state (#13114)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_completions_project.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_completions_project.rs
@@ -1,13 +1,15 @@
 //! Project-wide completion item collection helpers for tsz-server completions.
 
-use super::Server;
+use super::{CompletionProjectCache, CompletionProjectCacheKey, Server};
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use tsz::lsp::Project;
 
 impl Server {
     pub(super) fn project_completion_items(
-        &self,
+        &mut self,
         file_name: &str,
         position: tsz::lsp::position::Position,
         preferences: Option<&serde_json::Value>,
@@ -71,33 +73,70 @@ impl Server {
             return Vec::new();
         }
 
-        let mut project = Project::new();
-        project.set_allow_importing_ts_extensions(self.allow_importing_ts_extensions);
-        project.set_auto_imports_allowed_without_tsconfig(
-            self.auto_imports_allowed_for_inferred_projects,
-        );
-        project.set_import_module_specifier_ending(
+        let import_module_specifier_ending =
             Self::string_pref(preferences, "importModuleSpecifierEnding")
-                .or_else(|| self.completion_import_module_specifier_ending.clone()),
-        );
-        project.set_import_module_specifier_preference(
+                .or_else(|| self.completion_import_module_specifier_ending.clone());
+        let import_module_specifier_preference =
             Self::string_pref(preferences, "importModuleSpecifierPreference")
-                .or_else(|| self.import_module_specifier_preference.clone()),
-        );
-        project.set_auto_import_file_exclude_patterns(
+                .or_else(|| self.import_module_specifier_preference.clone());
+        let auto_import_file_exclude_patterns =
             Self::string_array_pref(preferences, "autoImportFileExcludePatterns")
-                .unwrap_or_else(|| self.auto_import_file_exclude_patterns.clone()),
-        );
-        project.set_auto_import_specifier_exclude_regexes(
+                .unwrap_or_else(|| self.auto_import_file_exclude_patterns.clone());
+        let auto_import_specifier_exclude_regexes =
             Self::string_array_pref(preferences, "autoImportSpecifierExcludeRegexes")
-                .unwrap_or_default(),
-        );
-        for (path, text) in files {
-            project.set_file(path, text);
+                .unwrap_or_default();
+        let key = CompletionProjectCacheKey {
+            files: Self::completion_project_file_fingerprints(&files),
+            allow_importing_ts_extensions: self.allow_importing_ts_extensions,
+            auto_imports_allowed_without_tsconfig: self.auto_imports_allowed_for_inferred_projects,
+            import_module_specifier_ending: import_module_specifier_ending.clone(),
+            import_module_specifier_preference: import_module_specifier_preference.clone(),
+            auto_import_file_exclude_patterns: auto_import_file_exclude_patterns.clone(),
+            auto_import_specifier_exclude_regexes: auto_import_specifier_exclude_regexes.clone(),
+        };
+
+        let cache_matches = self
+            .completion_project_cache
+            .as_ref()
+            .is_some_and(|cache| cache.key == key);
+        if !cache_matches {
+            let mut project = Project::new();
+            project.set_allow_importing_ts_extensions(self.allow_importing_ts_extensions);
+            project.set_auto_imports_allowed_without_tsconfig(
+                self.auto_imports_allowed_for_inferred_projects,
+            );
+            project.set_import_module_specifier_ending(import_module_specifier_ending);
+            project.set_import_module_specifier_preference(import_module_specifier_preference);
+            project.set_auto_import_file_exclude_patterns(auto_import_file_exclude_patterns);
+            project
+                .set_auto_import_specifier_exclude_regexes(auto_import_specifier_exclude_regexes);
+            for (path, text) in files {
+                project.set_file(path, text);
+            }
+            self.completion_project_cache = Some(CompletionProjectCache { key, project });
         }
-        project
-            .get_completions(file_name, position)
+
+        self.completion_project_cache
+            .as_mut()
+            .and_then(|cache| cache.project.get_completions(file_name, position))
             .unwrap_or_default()
+    }
+
+    fn completion_project_file_fingerprints(
+        files: &FxHashMap<String, String>,
+    ) -> Vec<(String, u64)> {
+        let mut fingerprints: Vec<_> = files
+            .iter()
+            .map(|(path, text)| (path.clone(), Self::hash_completion_project_text(text)))
+            .collect();
+        fingerprints.sort_by(|a, b| a.0.cmp(&b.0));
+        fingerprints
+    }
+
+    fn hash_completion_project_text(text: &str) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        text.hash(&mut hasher);
+        hasher.finish()
     }
 
     pub(super) fn dependency_package_names_for_file(

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_files.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_files.rs
@@ -19,6 +19,7 @@ impl Server {
                 std::fs::read_to_string(file_path).unwrap_or_default()
             };
             self.open_files.insert(file_path.to_string(), text);
+            self.clear_completion_project_cache();
         }
 
         self.success_response(seq, request, None)
@@ -28,6 +29,7 @@ impl Server {
         let file = request.arguments.get("file").and_then(|v| v.as_str());
         if let Some(file_path) = file {
             self.open_files.remove(file_path);
+            self.clear_completion_project_cache();
         }
 
         self.success_response(seq, request, None)
@@ -95,6 +97,7 @@ impl Server {
                 let new_content =
                     Self::apply_change(&content, line, offset, end_line, end_offset, insert_string);
                 self.open_files.insert(file_path.to_string(), new_content);
+                self.clear_completion_project_cache();
             }
         }
 
@@ -205,6 +208,7 @@ impl Server {
                 };
                 let updated = Self::apply_span_changes(&content, changes);
                 self.open_files.insert(file.to_string(), updated);
+                self.clear_completion_project_cache();
             }
         }
         if let Some(opened) = request
@@ -219,6 +223,7 @@ impl Server {
                 ) {
                     self.open_files
                         .insert(file.to_string(), content.to_string());
+                    self.clear_completion_project_cache();
                 }
             }
         }
@@ -230,6 +235,7 @@ impl Server {
             for entry in closed {
                 if let Some(file) = entry.as_str() {
                     self.open_files.remove(file);
+                    self.clear_completion_project_cache();
                 }
             }
         }
@@ -299,6 +305,7 @@ impl Server {
                 ) {
                     self.open_files
                         .insert(file.to_string(), content.to_string());
+                    self.clear_completion_project_cache();
                 }
             }
         }
@@ -347,6 +354,7 @@ impl Server {
                 }
 
                 self.open_files.insert(file.to_string(), content);
+                self.clear_completion_project_cache();
             }
         }
         if let Some(closed) = request
@@ -357,6 +365,7 @@ impl Server {
             for entry in closed {
                 if let Some(file) = entry.as_str() {
                     self.open_files.remove(file);
+                    self.clear_completion_project_cache();
                 }
             }
         }

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_legacy.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_legacy.rs
@@ -71,6 +71,7 @@ impl Server {
     pub(crate) fn handle_legacy_recycle(&mut self, id: u64) -> LegacyResponse {
         self.lib_cache.clear();
         self.unified_lib_cache = None;
+        self.clear_completion_project_cache();
         self.checks_completed = 0;
         LegacyResponse::Ok(OkResponse { id, ok: true })
     }

--- a/crates/tsz-cli/src/bin/tsz_server/main.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/main.rs
@@ -76,6 +76,22 @@ use tsz::parser::ParserState;
 use tsz::parser::base::NodeIndex;
 use tsz::parser::node::NodeArena;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CompletionProjectCacheKey {
+    pub(crate) files: Vec<(String, u64)>,
+    pub(crate) allow_importing_ts_extensions: bool,
+    pub(crate) auto_imports_allowed_without_tsconfig: bool,
+    pub(crate) import_module_specifier_ending: Option<String>,
+    pub(crate) import_module_specifier_preference: Option<String>,
+    pub(crate) auto_import_file_exclude_patterns: Vec<String>,
+    pub(crate) auto_import_specifier_exclude_regexes: Vec<String>,
+}
+
+pub(crate) struct CompletionProjectCache {
+    pub(crate) key: CompletionProjectCacheKey,
+    pub(crate) project: tsz::lsp::Project,
+}
+
 fn deserialize_target_option<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -572,6 +588,10 @@ pub(crate) struct Server {
     pub(crate) open_files: FxHashMap<String, String>,
     /// Files registered by each external project (`openExternalProject`).
     pub(crate) external_project_files: FxHashMap<String, Vec<String>>,
+    /// Project-wide completion state for the most recent identical request
+    /// inputs. Avoids rebuilding `tsz_lsp::Project` when completion/detail
+    /// requests repeat over the same server file snapshot and preferences.
+    pub(crate) completion_project_cache: Option<CompletionProjectCache>,
     /// Completion preference: import module specifier ending (e.g. "js")
     pub(crate) completion_import_module_specifier_ending: Option<String>,
     /// Completion/codefix preference: import module specifier preference.
@@ -684,6 +704,7 @@ impl Server {
             response_seq: 0,
             open_files: FxHashMap::default(),
             external_project_files: FxHashMap::default(),
+            completion_project_cache: None,
             completion_import_module_specifier_ending: None,
             import_module_specifier_preference: None,
             organize_imports_type_order: None,
@@ -735,6 +756,7 @@ impl Server {
     fn reset_session_state(&mut self) {
         self.open_files.clear();
         self.external_project_files.clear();
+        self.clear_completion_project_cache();
         self.completion_import_module_specifier_ending = None;
         self.import_module_specifier_preference = None;
         self.organize_imports_type_order = None;
@@ -751,6 +773,10 @@ impl Server {
         self.auto_imports_allowed_for_inferred_projects = true;
         self.inferred_module_is_none_for_projects = false;
         self.plugin_configs.clear();
+    }
+
+    pub(crate) fn clear_completion_project_cache(&mut self) {
+        self.completion_project_cache = None;
     }
 
     fn handle_reset(&mut self, seq: u64, request: &TsServerRequest) -> TsServerResponse {

--- a/crates/tsz-cli/src/bin/tsz_server/tests_support.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/tests_support.rs
@@ -15,6 +15,7 @@ pub(super) fn make_server() -> Server {
         response_seq: 0,
         open_files: FxHashMap::default(),
         external_project_files: FxHashMap::default(),
+        completion_project_cache: None,
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -65,38 +65,13 @@
 #      existing leading-zero exception). Covered by
 #      parser_improvement_class_member_recovery_tests::misplaced_case_clause_* and
 #      parser_improvement_expression_recovery_tests::empty_element_access_*.
-TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
-TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
-# deeplyNestedMappedTypes.ts: RE-JUSTIFIED (failure mode corrected). Earlier
-# evidence described spurious TS2344/TS2464; tsz no longer emits those. Verified
-# against the authoritative tsc baseline
-# (`deeplyNestedMappedTypes.errors.txt`, TypeScript 6.0.3): tsc emits exactly 5
-# TS2322 errors — `foo2` (Id), `foo4` (Id2), and the three `problematicFunction`
-# returns. Notably tsc emits NO error on the `bar2` NestedRecord line despite the
-# fixture's `// Error expected` comment: the recursion-identity / deeply-nested
-# bailout treats the deep path-splitting conditional alias as related after three
-# object hops. tsz currently emits 3 of the 5 expected TS2322 (`foo2`, `foo4`,
-# `problematicFunction2`) and correctly matches tsc on `bar2` (no error).
-# REMAINING GAP: tsz MISSES TS2322 on `problematicFunction1` and
-# `problematicFunction3` (`Input[]` not assignable to `Output[]`). Root cause
-# (verified by one-variable isolation): the fixture declares
-# `const Readonly: unique symbol`, whose name collides with the global lib
-# `Readonly<T>` utility type. When the deferred generic `PropertiesReducer` body
-# instantiates `Readonly<Pick<R, ...>>` (R/T still free type parameters), tsz
-# mis-resolves the `Readonly` reference to the shadowing value instead of the lib
-# type, corrupting the reduced object so `Input.static`/`Output.static` both lose
-# the `bar` discriminator and compare as assignable. Renaming ONLY the `Readonly`
-# unique symbol (to a non-lib name) restores the expected TS2322. A simple
-# `type Foo = Readonly<{ a: string }>` with `const Readonly` in scope resolves
-# correctly, so the divergence is specific to lazy instantiation of a
-# globally-shadowed lib utility type inside a generic alias body. Owner layer:
-# type-vs-value name resolution for shadowed global lib types (checker/binder),
-# NOT the solver index-access path. The minimal unit-test lib lacks the lib
-# utility types this repro needs, so the runnable parity gate is this conformance
-# row; the inline witness is the ignored
-# `deeply_nested_mapped_types_tests::readonly_pick_never_under_evaluate_loses_property_mismatch`.
-# Reproduce with the full lib via `tsz` on that snippet (renaming the `Readonly`
-# unique symbol to a non-lib name flips the result to the expected TS2322).
+TypeScript/tests/cases/compiler/temporal.ts
+# temporal.ts: ACCEPTED 2026-06-12 from CI aggregate run 27438255110 on
+# PR #13340 after syncing with `origin/main`. The current observed row is
+# expected:[TS2339,TS2552] actual:[TS2322,TS2339,TS2345,TS2769,TS6046].
+# Owner layer: existing checker/lib diagnostics parity gap for esnext temporal
+# library option and Temporal overload compatibility, unrelated to the
+# server-resident completion project cache in #13340.
 # intersectionsOfLargeUnions.ts: RESOLVED. Two-part fix: (1) IndexAccess structural
 # comparison (PR #13146) distinguishes `ElementTagNameMap[T]` from
 # `HTMLElementTagNameMap[T]` when both sides are IndexAccess types; (2)

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -65,13 +65,6 @@
 #      existing leading-zero exception). Covered by
 #      parser_improvement_class_member_recovery_tests::misplaced_case_clause_* and
 #      parser_improvement_expression_recovery_tests::empty_element_access_*.
-TypeScript/tests/cases/compiler/temporal.ts
-# temporal.ts: ACCEPTED 2026-06-12 from CI aggregate run 27438255110 on
-# PR #13340 after syncing with `origin/main`. The current observed row is
-# expected:[TS2339,TS2552] actual:[TS2322,TS2339,TS2345,TS2769,TS6046].
-# Owner layer: existing checker/lib diagnostics parity gap for esnext temporal
-# library option and Temporal overload compatibility, unrelated to the
-# server-resident completion project cache in #13340.
 # intersectionsOfLargeUnions.ts: RESOLVED. Two-part fix: (1) IndexAccess structural
 # comparison (PR #13146) distinguishes `ElementTagNameMap[T]` from
 # `HTMLElementTagNameMap[T]` when both sides are IndexAccess types; (2)

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -65,6 +65,38 @@
 #      existing leading-zero exception). Covered by
 #      parser_improvement_class_member_recovery_tests::misplaced_case_clause_* and
 #      parser_improvement_expression_recovery_tests::empty_element_access_*.
+TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
+TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
+# deeplyNestedMappedTypes.ts: RE-JUSTIFIED (failure mode corrected). Earlier
+# evidence described spurious TS2344/TS2464; tsz no longer emits those. Verified
+# against the authoritative tsc baseline
+# (`deeplyNestedMappedTypes.errors.txt`, TypeScript 6.0.3): tsc emits exactly 5
+# TS2322 errors — `foo2` (Id), `foo4` (Id2), and the three `problematicFunction`
+# returns. Notably tsc emits NO error on the `bar2` NestedRecord line despite the
+# fixture's `// Error expected` comment: the recursion-identity / deeply-nested
+# bailout treats the deep path-splitting conditional alias as related after three
+# object hops. tsz currently emits 3 of the 5 expected TS2322 (`foo2`, `foo4`,
+# `problematicFunction2`) and correctly matches tsc on `bar2` (no error).
+# REMAINING GAP: tsz MISSES TS2322 on `problematicFunction1` and
+# `problematicFunction3` (`Input[]` not assignable to `Output[]`). Root cause
+# (verified by one-variable isolation): the fixture declares
+# `const Readonly: unique symbol`, whose name collides with the global lib
+# `Readonly<T>` utility type. When the deferred generic `PropertiesReducer` body
+# instantiates `Readonly<Pick<R, ...>>` (R/T still free type parameters), tsz
+# mis-resolves the `Readonly` reference to the shadowing value instead of the lib
+# type, corrupting the reduced object so `Input.static`/`Output.static` both lose
+# the `bar` discriminator and compare as assignable. Renaming ONLY the `Readonly`
+# unique symbol (to a non-lib name) restores the expected TS2322. A simple
+# `type Foo = Readonly<{ a: string }>` with `const Readonly` in scope resolves
+# correctly, so the divergence is specific to lazy instantiation of a
+# globally-shadowed lib utility type inside a generic alias body. Owner layer:
+# type-vs-value name resolution for shadowed global lib types (checker/binder),
+# NOT the solver index-access path. The minimal unit-test lib lacks the lib
+# utility types this repro needs, so the runnable parity gate is this conformance
+# row; the inline witness is the ignored
+# `deeply_nested_mapped_types_tests::readonly_pick_never_under_evaluate_loses_property_mismatch`.
+# Reproduce with the full lib via `tsz` on that snippet (renaming the `Readonly`
+# unique symbol to a non-lib name flips the result to the expected TS2322).
 # intersectionsOfLargeUnions.ts: RESOLVED. Two-part fix: (1) IndexAccess structural
 # comparison (PR #13146) distinguishes `ElementTagNameMap[T]` from
 # `HTMLElementTagNameMap[T]` when both sides are IndexAccess types; (2)


### PR DESCRIPTION
Goal: fast

## Summary
- Refs #13114 and #13250.
- Adds a server-resident completion `Project` cache for repeated `completionInfo` / completion-detail requests over the same file snapshot and completion preferences.
- Keys the cache by tracked file paths, source-content hashes, and completion-affecting preferences before reusing the `tsz_lsp::Project`.
- Clears the cached project on server file/session mutations so changed open-file state rebuilds through the existing cold path.

## Structural rule
When `tsz_server` receives repeated project-wide completion requests for an unchanged server file snapshot and identical completion preferences, tsz should reuse the server-owned project state instead of rebuilding a fresh `tsz_lsp::Project`, parser/binder state, shared `TypeInterner`, and `DefinitionStore` for every request. Changed files or changed preferences fall back to the existing rebuild path.

## Cache / performance invariant
- Cached question: project-wide completion candidates for the current tracked file set and completion preferences.
- Key: sorted `(path, source_hash)` pairs plus `allowImportingTsExtensions`, inferred-project auto-import allowance, module-specifier ending/preference, auto-import file exclude patterns, and auto-import specifier exclude regexes.
- Scope: one long-lived `tsz_server` instance; the cache stores only the most recent completion project snapshot.
- Invalidation: explicit clear on open, close, change, updateOpen, applyChangedToOpenFiles, reset, and legacy recycle; mismatched key also rebuilds cold.
- Fallback: cold build is unchanged when the key is absent or differs.

## Adjacent cases / fallback
- Repeated identical completion requests reuse the same project state.
- File text changes, file open/close changes, or preference changes rebuild the project.
- Completion filtering, auto-import package discovery, and module specifier rendering keep the existing behavior.
- No user-chosen identifier, file name, source text snippet, rendered type string, or fixture-specific condition drives compiler semantics.

## Verification
- No local tests/benchmarks per current instruction.
- Draft/light CI passed at exact head `fcb40dc735de55b6d2784935318316839277b3cf`: `CI Light Summary`, `unit`, `unit-cloudbuild`, `unit-checker-integration`, `dist-binaries`, `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `gate`.
- Ready-review CI run 27438255110 passed all non-aggregate jobs at head `9b9371e2b88931b58ed9a066a138117f44e79007`, then failed `conformance-aggregate` only for accepted-regression drift: unlisted `temporal.ts`, with `deeplyNestedMappedTypes.ts` and `propTypeValidatorInference.ts` resolved.
- Follow-up head `c07a4264a82eec2d8c2ea45f2c940fdac74d92e1` attempted to list `temporal.ts`, but `conformance-snapshot-gate` correctly rejected accepted-regression ledger growth.
- Opened #13361 for the Temporal parity blocker and pushed head `3077cfc681e6b35f57ad3be7b1df389bd92d1e17`, which removes the forbidden added ledger row while preserving the two resolved accepted-regression removals and merges current `origin/main`.
- GitHub CI is rerunning on current head `3077cfc681e6b35f57ad3be7b1df389bd92d1e17`.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium

