### PR TITLE
perf(cli): report retained residency bytes (#13249)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz/diagnostics_report.rs
+++ b/crates/tsz-cli/src/bin/tsz/diagnostics_report.rs
@@ -110,6 +110,7 @@ struct DiagnosticsReport {
     residency_arena_kb: f64,
     residency_file_count: usize,
     residency_bound_kb: f64,
+    residency_retained_kb: f64,
     residency_pressure: &'static str,
     residency_has_pre_merge: bool,
     residency_pre_merge_kb: f64,
@@ -209,6 +210,7 @@ fn build_diagnostics_report(
         report.residency_arena_kb = rs.unique_arena_estimated_bytes as f64 / 1024.0;
         report.residency_file_count = rs.file_count;
         report.residency_bound_kb = rs.total_bound_file_bytes as f64 / 1024.0;
+        report.residency_retained_kb = rs.retained_file_state_bytes_est() as f64 / 1024.0;
         report.residency_pressure = residency_pressure_label(ResidencyBudget::default().assess(rs));
         report.residency_has_pre_merge = rs.pre_merge_bind_total_bytes > 0;
         report.residency_pre_merge_kb = rs.pre_merge_bind_total_bytes as f64 / 1024.0;
@@ -447,6 +449,11 @@ fn render_diagnostics_report(report: &DiagnosticsReport, extended: bool) -> Stri
             out,
             "Bound files:                   {} ({:.1}K)",
             report.residency_file_count, report.residency_bound_kb,
+        );
+        let _ = writeln!(
+            out,
+            "Retained file state:           {:.1}K",
+            report.residency_retained_kb
         );
         let _ = writeln!(
             out,

--- a/crates/tsz-core/src/parallel/residency.rs
+++ b/crates/tsz-core/src/parallel/residency.rs
@@ -59,6 +59,20 @@ pub struct MergedProgramResidencyStats {
     pub dep_graph_unresolved_count: usize,
 }
 
+impl MergedProgramResidencyStats {
+    /// Estimated retained per-file state considered by `ResidencyBudget`.
+    ///
+    /// `pre_merge_bind_total_bytes` is intentionally excluded because owned
+    /// merge paths release consumed `BindResult`s after moving their live data
+    /// into `MergedProgram`. Batch residency decisions must react to bytes that
+    /// remain after merge, not the transient merge-time double-residency window.
+    #[must_use]
+    pub const fn retained_file_state_bytes_est(&self) -> usize {
+        self.total_bound_file_bytes
+            .saturating_add(self.unique_arena_estimated_bytes)
+    }
+}
+
 impl MergedProgram {
     /// Collect every unique `NodeArena` retained by the merged program,
     /// deduplicated by pointer identity. `include_lib_binders` additionally
@@ -263,9 +277,7 @@ impl MergedProgram {
         }
 
         let retained_stats = self.residency_stats();
-        let retained_file_state_bytes_est = retained_stats
-            .total_bound_file_bytes
-            .saturating_add(retained_stats.unique_arena_estimated_bytes);
+        let retained_file_state_bytes_est = retained_stats.retained_file_state_bytes_est();
         let retained_file_state_pressure = match ResidencyBudget::default().assess(&retained_stats)
         {
             MemoryPressure::Low => pc::ResidencyPressureLevel::Low,
@@ -359,9 +371,7 @@ impl ResidencyBudget {
         // been copied into `MergedProgram`. Residency pressure must therefore
         // use retained file state only; otherwise future eviction wiring would
         // react to bytes that no longer exist after merge.
-        let total = stats
-            .total_bound_file_bytes
-            .saturating_add(stats.unique_arena_estimated_bytes);
+        let total = stats.retained_file_state_bytes_est();
         if total >= self.high_watermark_bytes {
             MemoryPressure::High
         } else if total >= self.low_watermark_bytes {


### PR DESCRIPTION
Goal: fast

## Summary
- centralize the retained file-state byte estimate on `MergedProgramResidencyStats`
- reuse that owner method in `ResidencyBudget::assess` and perf-counter residency recording
- print the retained file-state byte estimate in `--extendedDiagnostics` next to the retained residency pressure label

## Residency Invariant
Retained residency pressure is computed from post-merge file state only: `BoundFile` state plus retained unique AST arenas. Transient pre-merge `BindResult` bytes remain excluded so future batch eviction decisions do not react to data already released by owned merge paths.

## Verification
- Draft `CI Light Summary` passed for head `2b0c68c613e692647a7f36069381fb06bc340fe6`.
- No local tests or benchmarks run per standing instruction; ready-review CI owns broad verification.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
