### PR TITLE
fix(solver): preserve string index property result shape (#13101)

### DIFF
--- a/crates/tsz-solver/src/operations/property_visitor.rs
+++ b/crates/tsz-solver/src/operations/property_visitor.rs
@@ -228,8 +228,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
             && let Some(ref idx) = shape.string_index
             && self.string_index_signature_accepts_property(idx, prop_atom)
         {
-            let bound = self.bind_object_receiver_this(obj_type, idx.value_type);
-            return Some(self.index_signature_result_with_nuia_write_type(bound));
+            return Some(self.index_signature_result_with_nuia_write_type(idx.value_type));
         }
 
         Some(PropertyAccessResult::PropertyNotFound {

--- a/crates/tsz-solver/src/operations/property_visitor.rs
+++ b/crates/tsz-solver/src/operations/property_visitor.rs
@@ -140,9 +140,7 @@ impl<'a> PropertyAccessEvaluator<'a> {
                 .is_none_or(|idx| self.string_index_signature_accepts_property(idx, prop_atom))
         {
             return Some(PropertyAccessResult::from_index(
-                self.add_undefined_if_unchecked(
-                    self.bind_object_receiver_this(obj_type, value_type),
-                ),
+                self.add_undefined_if_unchecked(value_type),
             ));
         }
 


### PR DESCRIPTION
Goal: hold

## Summary
- Refs #13101 and #13250.
- Follow-up to merged PR #13310 after current `main` CI exposed a new unlisted `temporal.ts` conformance aggregate regression.
- Restore the pre-Atom-refactor result shape for string-index property resolution on both plain object and object-with-index paths.
- Keep the Atom-threaded lookup path intact while avoiding new receiver-`this` substitution on string index signature values.

## Structural rule
When an object receiver resolves a property through a string index signature, the Atom-keyed property access refactor must preserve the previous solver result semantics. Property-name transport may become `Atom`-keyed, but string index signature values must not gain receiver-`this` binding as a side effect of the lookup refactor.

## Owner layer
Solver property access owns this behavior. The checker and conformance aggregate only observe the diagnostic outcome; they should not patch or allowlist the `temporal.ts` regression.

## Adjacent cases / fallback
- Explicit object properties still bind receiver `this` exactly as before.
- Numeric index signatures keep their existing receiver binding path.
- Plain object string index signatures and object-with-index string signatures both preserve the unbound value-result shape.
- String index signatures still respect `noUncheckedIndexedAccess` write/read behavior through `index_signature_result_with_nuia_write_type` or read-side undefined widening.
- The property-name key remains an interned `Atom`; no user identifier, fixture path, source text, or rendered diagnostic string drives the decision.

## Verification
- Remote evidence before this PR: current `main` run 27433203585 at `e86c754c7940b8d4a89703745a13297b4b39cf3a` failed `conformance-aggregate` with unlisted `TypeScript/tests/cases/compiler/temporal.ts`.
- Pre-commit formatting hook ran during commits.
- Prior local focused conformance reported by previous update: `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "temporal.ts" --verbose` (`1/1 passed`) at head `576ea04a792c661d446957acbe91579343f2f3c6`.
- Ready-review CI run 27435585677 failed conformance aggregate at head `576ea04a792c661d446957acbe91579343f2f3c6` with unlisted regression `temporal.ts`; shard failures also included accepted `deeplyNestedMappedTypes.ts`.
- Pushed plain-object string-index follow-up at head `eff4734acb5f9fbb6a2c7229478a8feb7c55f6ba`; CI is rerunning.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
