### PR TITLE
perf(binder): skip shared lib prefix during compaction scan (#13047)

### DIFF
--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -870,6 +870,16 @@ impl SymbolArena {
         self.shared_prefix.is_empty() && self.symbols.is_empty()
     }
 
+    /// Iterate only symbols allocated after the shared-prefix split.
+    ///
+    /// User-file binders cloned from a premerged lib binder keep the lib
+    /// universe in `shared_prefix` and append file-local/user symbols into
+    /// `symbols`. Callers that only need to inspect user allocations can avoid
+    /// walking the immutable lib prefix.
+    pub fn iter_private_symbols(&self) -> impl Iterator<Item = &Symbol> {
+        self.symbols.iter()
+    }
+
     /// Estimate the heap bytes owned by this arena: symbol slots, per-symbol
     /// heap (names, declaration lists, member tables), and the name index.
     ///

--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -880,6 +880,12 @@ impl SymbolArena {
         self.symbols.iter()
     }
 
+    /// Number of symbols held in the shared prefix.
+    #[must_use]
+    pub fn shared_prefix_len(&self) -> usize {
+        self.shared_prefix.len()
+    }
+
     /// Estimate the heap bytes owned by this arena: symbol slots, per-symbol
     /// heap (names, declaration lists, member tables), and the name index.
     ///

--- a/crates/tsz-core/src/parallel/core/parse_and_libs.rs
+++ b/crates/tsz-core/src/parallel/core/parse_and_libs.rs
@@ -1784,10 +1784,7 @@ fn collect_retained_lib_symbol_refs(
         retain_if_lib(sym_id, lib_symbol_ids, retained);
     }
 
-    for sym in binder.symbols.iter() {
-        if lib_symbol_ids.contains(&sym.id) {
-            continue;
-        }
+    for sym in binder.symbols.iter_private_symbols() {
         retain_if_lib(sym.parent, lib_symbol_ids, retained);
         if let Some(exports) = sym.exports.as_ref() {
             collect_lib_ids_from_table(exports, lib_symbol_ids, retained);

--- a/crates/tsz-core/src/parallel/core/parse_and_libs.rs
+++ b/crates/tsz-core/src/parallel/core/parse_and_libs.rs
@@ -1784,13 +1784,29 @@ fn collect_retained_lib_symbol_refs(
         retain_if_lib(sym_id, lib_symbol_ids, retained);
     }
 
-    for sym in binder.symbols.iter_private_symbols() {
-        retain_if_lib(sym.parent, lib_symbol_ids, retained);
-        if let Some(exports) = sym.exports.as_ref() {
-            collect_lib_ids_from_table(exports, lib_symbol_ids, retained);
+    if binder.symbols.shared_prefix_len() == lib_symbol_ids.len() {
+        for sym in binder.symbols.iter_private_symbols() {
+            retain_if_lib(sym.parent, lib_symbol_ids, retained);
+            if let Some(exports) = sym.exports.as_ref() {
+                collect_lib_ids_from_table(exports, lib_symbol_ids, retained);
+            }
+            if let Some(members) = sym.members.as_ref() {
+                collect_lib_ids_from_table(members, lib_symbol_ids, retained);
+            }
         }
-        if let Some(members) = sym.members.as_ref() {
-            collect_lib_ids_from_table(members, lib_symbol_ids, retained);
+    } else {
+        for sym in binder
+            .symbols
+            .iter()
+            .filter(|sym| !lib_symbol_ids.contains(&sym.id))
+        {
+            retain_if_lib(sym.parent, lib_symbol_ids, retained);
+            if let Some(exports) = sym.exports.as_ref() {
+                collect_lib_ids_from_table(exports, lib_symbol_ids, retained);
+            }
+            if let Some(members) = sym.members.as_ref() {
+                collect_lib_ids_from_table(members, lib_symbol_ids, retained);
+            }
         }
     }
 


### PR DESCRIPTION
Goal: fast

## Summary
- Refs #13047 and #13250.
- Add `SymbolArena::iter_private_symbols()` for symbols allocated after a shared-prefix split and `SymbolArena::shared_prefix_len()` so compaction can distinguish pure vs mixed prefixes.
- Use the private-symbol fast path only when the shared prefix is pure lib symbols; otherwise fall back to the old filtered all-symbol walk so mixed shared-prefix symbols still contribute retained lib references.
- Sync the branch with `origin/main` after the follow-up fix.

## Structural rule / owner layer
When a user-file binder is cloned from a premerged lib binder, lib symbols usually live in the read-only `SymbolArena` shared prefix and user/file-local symbols append privately. Core compaction may skip the shared prefix only when that prefix is pure lib symbols; if the prefix is mixed, it must inspect non-lib symbols there because their parent/export/member tables can retain lib symbols needed for structural identity.

Owner layer: binder symbol arena plus core bind-result compaction. Type semantics, lib merge identity, global augmentation behavior, symbol IDs, densification, and remapping remain unchanged.

## Cache / performance invariant
- No new resident cache is added.
- Shared-prefix lookup and mutation fallback keep the existing `SymbolArena` semantics.
- Compaction still strips pure lib entries, retains referenced lib symbols, densifies symbols, and remaps bind state exactly as before.
- The fast path remains O(private appended symbols) for pure lib prefixes; mixed prefixes intentionally use the old filtered scan to preserve retained-reference correctness.

## Adjacent cases / fallback
- Binders without a shared prefix still expose all allocated symbols as private appended symbols.
- Pure shared-lib prefixes skip the immutable lib-prefix scan.
- Mixed shared prefixes fall back to scanning all non-lib symbols, preserving references from their exports, members, and parents.
- Shared-prefix lib symbol mutation still materializes the prefix through the existing `get_mut` path.
- Pure lib entries in `file_locals` and scopes are still stripped by the existing compaction path.

## Verification
- Pre-commit formatting hook ran during commits.
- Branch synced with `origin/main` at exact head `dd086e98b0bed21f0be3f95b06698276ad4b6869`.
- No local tests/benchmarks per current instruction; ready-review CI is rerunning and must pass full PR-head gates before merge queue.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
