### PR TITLE
refactor(emitter): async ES5 lowering through IR printer (#9330)

### DIFF
--- a/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
+++ b/crates/tsz-emitter/src/emitter/es5/helpers_async.rs
@@ -247,6 +247,50 @@ impl<'a> Printer<'a> {
             let body_has_await = async_emitter.body_contains_await(body);
             let body_is_single_line = self.arena.get(body).is_some_and(|n| self.is_single_line(n));
             let hoisted_function_decls = self.async_body_function_declarations(body);
+
+            // Single construction path: when the body hoists no function
+            // declarations, the whole `__awaiter(...)` wrapper (inline or
+            // multi-line callback, directives, hoisted `var` groups, lexical
+            // `this` capture, generator state naming) is built as
+            // `IRNode::AwaiterCall` + `IRNode::GeneratorBody` and printed by
+            // the IR printer. Hoisted function declarations stay on the
+            // hand-written path below because they are emitted through the
+            // Printer's AST emitter, which consumes the file-level comment
+            // stream and contributes source-map mappings — neither of which
+            // has a channel through the IR printer.
+            if hoisted_function_decls.is_empty() {
+                // The awaiter call starts at the current statement indent
+                // (unlike the bare generator body, which nests one level
+                // deeper inside the hand-written callback).
+                async_emitter.set_indent_level(self.writer.indent_level());
+                async_emitter.set_helper_import_aliases(self.helper_import_aliases.clone());
+                // tsc keeps the multi-line callback format whenever the
+                // source body spans multiple lines, even if nothing is
+                // hoisted; the IR printer owns the remaining multi-line
+                // triggers (hoists, directives, lexical-this capture).
+                let rendered = async_emitter.emit_awaiter_call(
+                    body,
+                    body_has_await,
+                    this_expr,
+                    promise_ctor,
+                    !body_is_single_line,
+                );
+                self.next_disposable_env_id = async_emitter.disposable_env_counter();
+                self.next_dynamic_import_promise_id =
+                    async_emitter.dynamic_import_promise_counter();
+                self.next_catch_binding_ordinals = async_emitter.take_catch_binding_ordinals();
+                for generated_name in async_emitter.take_generated_disposable_env_names() {
+                    self.generated_temp_names.insert(generated_name);
+                }
+                self.write(&rendered);
+                self.write_line();
+                self.decrease_indent();
+                self.write("}");
+                self.pop_temp_scope();
+                self.skip_comments_for_async_lowered_body(body);
+                return;
+            }
+
             let hoist_function_decls_only =
                 !body_has_await && self.block_has_only_function_decls(body);
             if hoist_function_decls_only {
@@ -323,35 +367,15 @@ impl<'a> Printer<'a> {
                 self.generated_temp_names.insert(generated_name);
             }
 
-            // Write with surrounding __awaiter wrapper
+            // Write with surrounding __awaiter wrapper. The inline
+            // single-line wrapper format never applies here: this path only
+            // handles bodies with hoisted function declarations, which force
+            // the multi-line callback (function-decl-free bodies are printed
+            // from `IRNode::AwaiterCall` above).
             self.write("return ");
             self.write_helper("__awaiter");
             self.write("(");
             self.write(this_expr);
-            let can_inline_wrapper = hoisted_var_groups.is_empty()
-                && body_is_single_line
-                && hoisted_function_decls.is_empty()
-                && directive_prologue.is_empty()
-                && !needs_lexical_this_capture
-                && generator_mappings.is_empty();
-            if can_inline_wrapper {
-                self.write(", void 0, ");
-                self.write_awaiter_promise_arg(&promise_ctor);
-                self.write(", function () { ");
-                self.write(&Self::inline_async_generator_body(&generator_body));
-                self.write(" });");
-                self.write_line();
-                self.decrease_indent();
-                self.write("}");
-                self.skip_comments_for_async_lowered_body(body);
-                // emit_function_parameters_es5() pushed a temp scope; the
-                // other early-return paths in this function (and the
-                // multi-line/normal exit below) all call pop_temp_scope.
-                // Forgetting it here would leak temp-name state across
-                // functions and corrupt subsequent emissions.
-                self.pop_temp_scope();
-                return;
-            }
 
             // Multi-line format (matches tsc):
             // return __awaiter(this, void 0, void 0, function () {

--- a/crates/tsz-emitter/src/transforms/async_es5.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5.rs
@@ -98,6 +98,8 @@ pub struct AsyncES5Emitter<'a> {
     /// When true, prefix runtime helper calls with `tslib_1.` (for CJS importHelpers).
     tslib_prefix: bool,
     tslib_import_binding: String,
+    /// Per-file helper import renames (e.g. `__awaiter` -> `__awaiter_1`).
+    helper_import_aliases: rustc_hash::FxHashMap<String, String>,
     system_import_meta: bool,
     generator_this_arg: String,
 }
@@ -116,6 +118,7 @@ impl<'a> AsyncES5Emitter<'a> {
             outer_reserved_for_generator_state: Vec::new(),
             tslib_prefix: false,
             tslib_import_binding: "tslib_1".to_string(),
+            helper_import_aliases: rustc_hash::FxHashMap::default(),
             system_import_meta: false,
             generator_this_arg: "this".to_string(),
         }
@@ -131,6 +134,11 @@ impl<'a> AsyncES5Emitter<'a> {
 
     pub fn set_tslib_import_binding(&mut self, binding: String) {
         self.tslib_import_binding = binding;
+    }
+
+    /// Set per-file helper import renames (e.g. `__awaiter` -> `__awaiter_1`).
+    pub fn set_helper_import_aliases(&mut self, aliases: rustc_hash::FxHashMap<String, String>) {
+        self.helper_import_aliases = aliases;
     }
 
     pub const fn set_system_import_meta(&mut self, enabled: bool) {
@@ -356,6 +364,57 @@ impl<'a> AsyncES5Emitter<'a> {
             directives,
             needs_lexical_this_capture,
         )
+    }
+
+    /// Build the full `__awaiter` wrapper for an async function body as
+    /// `IRNode::AwaiterCall` (with its nested `IRNode::GeneratorBody`) and
+    /// print it through [`IRPrinter`], which owns the wrapper text: inline vs
+    /// multi-line callback format, directive prologues, hoisted `var` groups,
+    /// the `var _this = this;` lexical capture, and generator state naming.
+    ///
+    /// `force_multiline` mirrors tsc's rule that a multi-line source body
+    /// keeps the multi-line callback format even when nothing is hoisted.
+    pub fn emit_awaiter_call(
+        &mut self,
+        body_idx: NodeIndex,
+        has_await: bool,
+        this_expr: &str,
+        promise_constructor: Option<String>,
+        force_multiline: bool,
+    ) -> String {
+        let mut generator_body =
+            self.transformer
+                .transform_generator_body_skipping(body_idx, has_await, &[]);
+        let directives = Self::extract_and_remove_directive_prologue(&mut generator_body);
+        let hoisted_var_groups = self
+            .transformer
+            .extract_hoisted_var_groups(&mut generator_body);
+        let needs_lexical_this_capture = generator_body.contains_captured_this_reference();
+        let awaiter_call = IRNode::AwaiterCall {
+            this_arg: Box::new(IRNode::Raw(this_expr.to_string().into())),
+            generator_body: Box::new(generator_body),
+            needs_lexical_this_capture,
+            hoisted_var_groups,
+            promise_constructor,
+            multiline_callback: force_multiline,
+            directives,
+        };
+
+        let mut printer = IRPrinter::with_arena(self.arena);
+        if let Some(text) = self.source_text {
+            printer.set_source_text(text);
+        }
+        printer.set_indent_level(self.indent_level);
+        printer.set_tslib_prefix(self.tslib_prefix);
+        printer.set_tslib_import_binding(self.tslib_import_binding.clone());
+        printer.set_helper_import_aliases(self.helper_import_aliases.clone());
+        printer.set_system_import_meta(self.system_import_meta);
+        printer.set_generator_this_arg(self.generator_this_arg.clone());
+        printer.set_outer_reserved_for_generator_state(
+            self.outer_reserved_for_generator_state.clone(),
+        );
+        printer.emit(&awaiter_call);
+        printer.take_output()
     }
 
     fn extract_and_remove_directive_prologue(generator_body: &mut IRNode) -> Vec<String> {

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -81,6 +81,9 @@ pub struct IRPrinter<'a> {
     /// CommonJS `tslib` binding used to prefix runtime helper calls for importHelpers.
     tslib_prefix: bool,
     tslib_import_binding: String,
+    /// Per-file helper import renames (e.g. `__awaiter` -> `__awaiter_1`)
+    /// applied when ESM importHelpers renamed a helper at the import site.
+    helper_import_aliases: rustc_hash::FxHashMap<String, String>,
     commonjs_import_substitutions: rustc_hash::FxHashMap<String, String>,
     system_import_meta: bool,
     pub(crate) base_printer_options: Option<PrinterOptions>,
@@ -262,6 +265,7 @@ impl<'a> IRPrinter<'a> {
             remove_comments: false,
             tslib_prefix: false,
             tslib_import_binding: "tslib_1".to_string(),
+            helper_import_aliases: rustc_hash::FxHashMap::default(),
             commonjs_import_substitutions: rustc_hash::FxHashMap::default(),
             system_import_meta: false,
             base_printer_options: None,
@@ -295,6 +299,7 @@ impl<'a> IRPrinter<'a> {
             remove_comments: false,
             tslib_prefix: false,
             tslib_import_binding: "tslib_1".to_string(),
+            helper_import_aliases: rustc_hash::FxHashMap::default(),
             commonjs_import_substitutions: rustc_hash::FxHashMap::default(),
             system_import_meta: false,
             base_printer_options: None,
@@ -328,6 +333,7 @@ impl<'a> IRPrinter<'a> {
             remove_comments: false,
             tslib_prefix: false,
             tslib_import_binding: "tslib_1".to_string(),
+            helper_import_aliases: rustc_hash::FxHashMap::default(),
             commonjs_import_substitutions: rustc_hash::FxHashMap::default(),
             system_import_meta: false,
             base_printer_options: None,
@@ -371,6 +377,12 @@ impl<'a> IRPrinter<'a> {
 
     pub fn set_tslib_import_binding(&mut self, binding: String) {
         self.tslib_import_binding = binding;
+    }
+
+    /// Set per-file helper import renames (e.g. `__awaiter` -> `__awaiter_1`)
+    /// so helper references printed from IR match the import-site aliases.
+    pub fn set_helper_import_aliases(&mut self, aliases: rustc_hash::FxHashMap<String, String>) {
+        self.helper_import_aliases = aliases;
     }
 
     pub fn set_commonjs_import_substitutions(
@@ -444,11 +456,20 @@ impl<'a> IRPrinter<'a> {
         printer
     }
 
-    /// Write a runtime helper name, prefixing with `tslib_1.` when `tslib_prefix` is active.
+    /// Write a runtime helper name, prefixing with `tslib_1.` when `tslib_prefix` is
+    /// active, or substituting the import-site alias (e.g. `__awaiter_1`) when ESM
+    /// importHelpers renamed the helper. Mirrors `Printer::write_helper`.
     fn write_helper(&mut self, name: &str) {
         if self.tslib_prefix {
             self.output.push_str(&self.tslib_import_binding);
             self.output.push('.');
+            self.output.push_str(name);
+            return;
+        }
+        if let Some(alias) = self.helper_import_aliases.get(name) {
+            let alias_owned = alias.clone();
+            self.output.push_str(&alias_owned);
+            return;
         }
         self.output.push_str(name);
     }

--- a/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer_class_emit.rs
@@ -452,7 +452,9 @@ impl<'a> IRPrinter<'a> {
             );
             Self::generator_state_name_for_hoisted(&combined)
         };
-        self.write("return __awaiter(");
+        self.write("return ");
+        self.write_helper("__awaiter");
+        self.write("(");
         self.emit_node(this_arg);
         if let Some(ctor) = promise_constructor {
             self.write(", void 0, ");


### PR DESCRIPTION
Goal: hold

Migrates the remaining hand-written async ES5 body-lowering branches onto the existing IR printer (IRNode::AwaiterCall + GeneratorBody), so async/generator lowering has one structured owner. Output is byte-identical across the async emit fixture battery; families that could not be expressed byte-exactly in the IR remain hand-written with named blockers.

Structural rule: JS emit for async downleveling flows through the IR printer as the single construction path; no semantic decisions added to emit.

Refs #9330 — continues the migration (#13234 landed the shared wrapper construction; this PR retires the hand-written wrapper for function-decl-free bodies). Remaining: bodies hoisting function declarations and the `es5_await_param_recovery` case — both emit AST through the Printer inside the `__awaiter` callback, consuming the file-level comment stream (`emit_comments_before_pos`/`comment_emit_idx`) and contributing source-map mappings, neither of which has a channel through the IR printer — plus the async-arrow wrapper path in `es5/helpers.rs`.

## What changed

- `emit_async_function_es5_body` (ES5 target, function-decl-free bodies — the dominant path): builds `IRNode::AwaiterCall` + `IRNode::GeneratorBody` via the new `AsyncES5Emitter::emit_awaiter_call` and prints through the existing `IRPrinter::emit_awaiter_call_node`, which owns inline vs multi-line callback format, directive prologues, hoisted `var` groups, `var _this = this;` capture placement, and generator state naming. The hand-written inline-wrapper branch is deleted (it is unreachable on the remaining hoisted-decl path).
- `emit_awaiter_call_node` now writes `__awaiter` through `write_helper` instead of raw text, and `IRPrinter::write_helper` gained import-alias substitution mirroring `Printer::write_helper`, so `tslib_1.__awaiter` (importHelpers + CJS) and `__awaiter_1`-style ESM aliases survive the migration. No-op for existing `AwaiterCall` users without tslib prefix/aliases.
- The dropped `generator_mappings.is_empty()` inline condition was vacuous: `IRPrinter` produces no mappings, so `AsyncES5Emitter::take_mappings` is always empty on this path (the `Vec<Mapping>` field is never written; candidate for follow-up removal together with the arrow path).

Adjacent-case matrix (all byte-identical to baselines): inline single-line body, multi-line body, hoisted var groups, lexical-this capture (`var g; var _this = this;` ordering), directive prologue (`"use strict"` inside the callback), custom promise constructor third arg, importHelpers/tslib prefix, object-literal async methods and private class method defs (same entry point), negative cases on the kept hand-written paths (hoisted function decls, await-in-default-param recovery).

## Verification
- `scripts/safe-run.sh scripts/emit/run.sh --filter=<F> --js-only`, all 100%: `es5-asyncFunction` 46/46 and `emitter.forAwait` 4/4 (the #9330 acceptance commands), `async` 299/299, `await` 207/207, `importHelpers` 99/99, `asyncMethod` 5/5, `downlevelGenerator` 8/8, `sourceMap` 143/143, `class` 1480/1480, `objectLiteral` 162/162, `namespace` 208/208, `generator` 126/126
- `cargo nextest run -p tsz-emitter`: 4271 passed; the 3 failures (`declaration_emitter::…take_diagnostics_*_ts2883_*`, `fix_generic_rest_identity_preserves_parameters_tuple_labels`) reproduce on clean origin/main (verified via stash) — pre-existing, unrelated
- `cargo clippy -p tsz-emitter -- -D warnings` clean
- `scripts/emit/audit-output-surgery.py`: 0 findings, empty allowlist

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
