### PR TITLE
refactor(solver): centralize relation policy application (#13094)

### DIFF
--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -724,7 +724,7 @@ fn configure_compat_checker_policy_bits<R: TypeResolver>(
     apply_policy_bits_to_subtype_checker(&mut checker.subtype, policy);
 }
 
-fn configure_subtype_checker_policy<'a, R: TypeResolver>(
+const fn configure_subtype_checker_policy<'a, R: TypeResolver>(
     checker: SubtypeChecker<'a, R>,
     policy: RelationPolicy,
 ) -> SubtypeChecker<'a, R> {

--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -662,17 +662,8 @@ pub(crate) fn configured_compat_checker<'a, R: TypeResolver>(
     context: RelationContext<'a>,
 ) -> CompatChecker<'a, R> {
     let mut checker = CompatChecker::with_resolver(interner, resolver);
-    configure_compat_checker_policy_bits(&mut checker, policy);
+    configure_compat_checker_policy(&mut checker, policy);
     checker.set_inheritance_graph(context.inheritance_graph);
-    checker.set_strict_subtype_checking(policy.strict_subtype_checking);
-    checker.set_strict_any_propagation(policy.strict_any_propagation);
-    checker.set_any_source_not_related(matches!(
-        policy.any_propagation_mode,
-        AnyPropagationMode::AnySourceNotRelated
-    ));
-    checker.set_assume_related_on_cycle(policy.assume_related_on_cycle);
-    checker.set_skip_weak_type_checks(policy.skip_weak_type_checks);
-    checker.set_erase_generics(policy.erase_generics);
     if let Some(query_db) = context.query_db {
         checker.set_query_db(query_db);
     }
@@ -688,12 +679,8 @@ pub(crate) fn configured_subtype_checker<'a, R: TypeResolver>(
     policy: RelationPolicy,
     context: RelationContext<'a>,
 ) -> SubtypeChecker<'a, R> {
-    let mut checker = configure_subtype_checker_policy_bits(
-        SubtypeChecker::with_resolver(interner, resolver),
-        policy,
-    )
-    .with_any_propagation_mode(policy.any_propagation_mode)
-    .with_assume_related_on_cycle(policy.assume_related_on_cycle);
+    let mut checker =
+        configure_subtype_checker_policy(SubtypeChecker::with_resolver(interner, resolver), policy);
     if let Some(query_db) = context.query_db {
         checker = checker.with_query_db(query_db);
     }
@@ -704,6 +691,22 @@ pub(crate) fn configured_subtype_checker<'a, R: TypeResolver>(
         checker = checker.with_class_check(class_check);
     }
     checker
+}
+
+fn configure_compat_checker_policy<R: TypeResolver>(
+    checker: &mut CompatChecker<'_, R>,
+    policy: RelationPolicy,
+) {
+    configure_compat_checker_policy_bits(checker, policy);
+    checker.set_strict_subtype_checking(policy.strict_subtype_checking);
+    checker.set_strict_any_propagation(policy.strict_any_propagation);
+    checker.set_any_source_not_related(matches!(
+        policy.any_propagation_mode,
+        AnyPropagationMode::AnySourceNotRelated
+    ));
+    checker.set_assume_related_on_cycle(policy.assume_related_on_cycle);
+    checker.set_skip_weak_type_checks(policy.skip_weak_type_checks);
+    checker.set_erase_generics(policy.erase_generics);
 }
 
 fn configure_compat_checker_policy_bits<R: TypeResolver>(
@@ -719,6 +722,15 @@ fn configure_compat_checker_policy_bits<R: TypeResolver>(
     checker.set_disable_method_bivariance(policy.disable_method_bivariance());
 
     apply_policy_bits_to_subtype_checker(&mut checker.subtype, policy);
+}
+
+fn configure_subtype_checker_policy<'a, R: TypeResolver>(
+    checker: SubtypeChecker<'a, R>,
+    policy: RelationPolicy,
+) -> SubtypeChecker<'a, R> {
+    configure_subtype_checker_policy_bits(checker, policy)
+        .with_any_propagation_mode(policy.any_propagation_mode)
+        .with_assume_related_on_cycle(policy.assume_related_on_cycle)
 }
 
 const fn configure_subtype_checker_policy_bits<'a, R: TypeResolver>(


### PR DESCRIPTION
Goal: fast

## Summary
- Refs #13094 and #13250.
- Centralize full `RelationPolicy` application for compat checker construction behind one solver-owned helper.
- Centralize full `RelationPolicy` application for subtype checker construction behind one solver-owned helper.
- Keep the existing policy-bit helper as the shared core; no relation semantics, cache key, or diagnostic behavior is intentionally changed.

## Structural rule
When a relation query carries a typed `RelationPolicy`, tsz should apply that policy through solver-owned configuration helpers for the target relation engine. Call sites should not keep local tails of policy-owned fields that can drift when the policy grows.

## Owner layer
Solver owns relation policy interpretation and relation-engine configuration. Checker-facing callers continue to pass typed `RelationPolicy` values through query boundaries rather than configuring relation engine internals directly.

## Adjacent cases / fallback
- Compat checker construction still applies compat-layer setters plus the embedded subtype policy bits through one helper.
- Raw subtype checker construction still applies subtype policy bits, any-propagation mode, and cycle-assumption mode before optional shared context is attached.
- Existing top-level setter behavior and cache clearing behavior are preserved.
- No cache key, relation result, diagnostic rendering, or compatibility-mode behavior is intentionally changed.

## Verification
- Pre-commit formatting hook ran during `git commit`.
- Draft lint failure on the previous head was addressed by making the subtype policy helper `const fn`.
- Branch synced with `origin/main` after the lint fix; exact head `5c39ad6f917d35d6ef33d1a8095fbd4729db4bc0`.
- Local tests not run per current instruction.
- Draft/light CI passed on the exact head: `CI Light Summary`, `gate`.
- Ready-review CI is required before queueing.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
