### PR TITLE
refactor(checker): construction-side query-boundary helpers (#13022)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1771,3 +1771,6 @@ path = "tests/imported_ctor_alias_predicate_narrowing_tests.rs"
 [[test]]
 name = "arch_source_scans"
 path = "tests/arch_source_scans.rs"
+[[test]]
+name = "construct_signature_boundary_matrix_tests"
+path = "tests/construct_signature_boundary_matrix_tests.rs"

--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -350,106 +350,60 @@ impl<'a> CheckerState<'a> {
         &mut self,
         shape: &tsz_solver::FunctionShape,
     ) -> Option<tsz_solver::FunctionShape> {
+        use crate::query_boundaries::construct_signatures::{
+            FunctionShapeTypeSlot, map_function_shape_types,
+        };
+
         let own_tp_names: Vec<_> = shape.type_params.iter().map(|tp| tp.name).collect();
 
-        let mut changed = false;
-        let params = shape
-            .params
-            .iter()
-            .map(|param| {
-                let skip = !own_tp_names.is_empty()
-                    && own_tp_names.iter().any(|&name| {
-                        crate::query_boundaries::common::contains_type_parameter_named(
-                            self.ctx.types,
-                            param.type_id,
-                            name,
-                        )
-                    });
-                let evaluated = if skip {
-                    param.type_id
-                } else {
-                    self.normalize_nested_type_for_assignability(param.type_id)
-                };
-                if evaluated != param.type_id {
-                    changed = true;
-                }
-                tsz_solver::ParamInfo {
-                    name: param.name,
-                    type_id: evaluated,
-                    optional: param.optional,
-                    rest: param.rest,
-                }
-            })
-            .collect();
-        let this_type = shape.this_type.map(|this_type| {
-            let evaluated = self.normalize_nested_type_for_assignability(this_type);
-            if evaluated != this_type {
-                changed = true;
-            }
-            evaluated
-        });
-        let return_type = {
-            let skip_for_type_params = !own_tp_names.is_empty()
+        map_function_shape_types(shape, |slot, type_id| {
+            // Component types that mention the shape's own type parameters
+            // must stay as declared so inference can still bind them; type
+            // queries and conditionals in return position are deferred forms
+            // whose normalization is owned elsewhere.
+            let references_own_tp = !own_tp_names.is_empty()
                 && own_tp_names.iter().any(|&name| {
                     crate::query_boundaries::common::contains_type_parameter_named(
                         self.ctx.types,
-                        shape.return_type,
+                        type_id,
                         name,
                     )
                 });
-            let skip_for_type_query = crate::query_boundaries::common::is_type_query_type(
-                self.ctx.types,
-                shape.return_type,
-            );
-            let skip_for_conditional = crate::query_boundaries::common::is_conditional_type(
-                self.ctx.types,
-                shape.return_type,
-            );
-            let skip = skip_for_type_params || skip_for_type_query || skip_for_conditional;
-            let evaluated = if skip {
-                shape.return_type
-            } else {
-                self.normalize_nested_type_for_assignability(shape.return_type)
-            };
-            if evaluated != shape.return_type {
-                changed = true;
-            }
-            evaluated
-        };
-        let type_predicate = shape.type_predicate.as_ref().map(|predicate| {
-            let type_id = predicate.type_id.map(|type_id| {
-                let evaluated = self.normalize_nested_type_for_assignability(type_id);
-                if evaluated != type_id {
-                    changed = true;
+            let skip = match slot {
+                FunctionShapeTypeSlot::Param => references_own_tp,
+                FunctionShapeTypeSlot::Return => {
+                    references_own_tp
+                        || crate::query_boundaries::common::is_type_query_type(
+                            self.ctx.types,
+                            type_id,
+                        )
+                        || crate::query_boundaries::common::is_conditional_type(
+                            self.ctx.types,
+                            type_id,
+                        )
                 }
-                evaluated
-            });
-            tsz_solver::TypePredicate {
-                asserts: predicate.asserts,
-                target: predicate.target,
-                type_id,
-                parameter_index: predicate.parameter_index,
+                FunctionShapeTypeSlot::This | FunctionShapeTypeSlot::PredicateTarget => false,
+            };
+            if skip {
+                type_id
+            } else {
+                self.normalize_nested_type_for_assignability(type_id)
             }
-        });
-
-        changed.then_some(tsz_solver::FunctionShape {
-            type_params: shape.type_params.clone(),
-            params,
-            this_type,
-            return_type,
-            type_predicate,
-            is_constructor: shape.is_constructor,
-            is_method: shape.is_method,
         })
     }
 
     fn normalize_callable_type_for_assignability(&mut self, type_id: TypeId) -> TypeId {
+        use crate::query_boundaries::construct_signatures::{
+            call_signature_from_function_shape, callable_with_signatures_replaced,
+            function_shape_from_call_signature, function_type_from_shape,
+        };
+
         if let Some(shape) =
             crate::query_boundaries::common::function_shape_for_type(self.ctx.types, type_id)
         {
             let result = self
                 .normalize_function_shape_for_assignability(&shape)
-                .map(|shape| self.ctx.types.factory().function(shape))
+                .map(|shape| function_type_from_shape(self.ctx.types, shape))
                 .unwrap_or(type_id);
             return result;
         }
@@ -457,82 +411,37 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::common::callable_shape_for_type(self.ctx.types, type_id)
         {
             let mut changed = false;
-            let call_signatures: Vec<_> = shape
-                .call_signatures
-                .iter()
-                .map(|sig| {
-                    let normalized = self.normalize_function_shape_for_assignability(
-                        &tsz_solver::FunctionShape {
-                            type_params: sig.type_params.clone(),
-                            params: sig.params.clone(),
-                            this_type: sig.this_type,
-                            return_type: sig.return_type,
-                            type_predicate: sig.type_predicate,
-                            is_constructor: false,
-                            is_method: false,
-                        },
+            let mut normalize_signature =
+                |checker: &mut Self, sig: &tsz_solver::CallSignature, is_constructor: bool| {
+                    let normalized = checker.normalize_function_shape_for_assignability(
+                        &function_shape_from_call_signature(sig, is_constructor),
                     );
                     if normalized.is_some() {
                         changed = true;
                     }
                     normalized.map_or_else(
                         || sig.clone(),
-                        |shape| tsz_solver::CallSignature {
-                            type_params: shape.type_params,
-                            params: shape.params,
-                            this_type: shape.this_type,
-                            return_type: shape.return_type,
-                            type_predicate: shape.type_predicate,
-                            is_method: sig.is_method,
-                        },
+                        |shape| call_signature_from_function_shape(shape, sig.is_method),
                     )
-                })
+                };
+            let call_signatures: Vec<_> = shape
+                .call_signatures
+                .iter()
+                .map(|sig| normalize_signature(self, sig, false))
                 .collect();
             let construct_signatures: Vec<_> = shape
                 .construct_signatures
                 .iter()
-                .map(|sig| {
-                    let normalized = self.normalize_function_shape_for_assignability(
-                        &tsz_solver::FunctionShape {
-                            type_params: sig.type_params.clone(),
-                            params: sig.params.clone(),
-                            this_type: sig.this_type,
-                            return_type: sig.return_type,
-                            type_predicate: sig.type_predicate,
-                            is_constructor: true,
-                            is_method: false,
-                        },
-                    );
-                    if normalized.is_some() {
-                        changed = true;
-                    }
-                    normalized.map_or_else(
-                        || sig.clone(),
-                        |shape| tsz_solver::CallSignature {
-                            type_params: shape.type_params,
-                            params: shape.params,
-                            this_type: shape.this_type,
-                            return_type: shape.return_type,
-                            type_predicate: shape.type_predicate,
-                            is_method: sig.is_method,
-                        },
-                    )
-                })
+                .map(|sig| normalize_signature(self, sig, true))
                 .collect();
 
             if changed {
-                self.ctx
-                    .types
-                    .factory()
-                    .callable(tsz_solver::CallableShape {
-                        call_signatures,
-                        construct_signatures,
-                        properties: shape.properties.clone(),
-                        string_index: shape.string_index,
-                        number_index: shape.number_index,
-                        symbol: shape.symbol,
-                        is_abstract: shape.is_abstract,
-                    })
+                callable_with_signatures_replaced(
+                    self.ctx.types,
+                    &shape,
+                    call_signatures,
+                    construct_signatures,
+                )
             } else {
                 type_id
             }

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -292,13 +292,10 @@ impl<'a> CheckerState<'a> {
                                 sig.is_method = false;
                             }
                             let combined =
-                                self.ctx
-                                    .types
-                                    .factory()
-                                    .callable(tsz_solver::CallableShape {
-                                        call_signatures: sigs,
-                                        ..tsz_solver::CallableShape::default()
-                                    });
+                                crate::query_boundaries::construct_signatures::call_only_callable_type(
+                                    self.ctx.types,
+                                    sigs,
+                                );
                             existing.type_id = combined;
                             existing.write_type = combined;
                             existing.is_method = false;

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -1,5 +1,24 @@
+//! Signature-construction query boundary (issue #13022).
+//!
+//! Owns both directions of the checker's signature-shape traffic with the
+//! solver:
+//!
+//! - reading construct signatures off arbitrary types
+//!   ([`construct_signatures_for_type`]), and
+//! - constructing signature-bearing solver types (functions and callables)
+//!   from checker-assembled [`CallSignature`] data.
+//!
+//! Production checker modules must route function/callable interning and
+//! `CallSignature` <-> `FunctionShape` conversion through these helpers
+//! instead of hand-building `FunctionShape`/`CallableShape` literals at call
+//! sites. The shape structs stay importable as read-only data (see the SAFE
+//! import list in `architecture_contract_tests`); what is quarantined here is
+//! shape *construction* and interning. `checkers/signature_builder.rs` remains
+//! the one checker module that assembles `CallSignature` data from AST
+//! signatures.
+
 use tsz_solver::construction::TypeDatabase;
-use tsz_solver::{CallSignature, TypeId};
+use tsz_solver::{CallSignature, CallableShape, FunctionShape, ParamInfo, TypeId, TypePredicate};
 
 pub(crate) fn construct_signatures_for_type(
     db: &dyn TypeDatabase,
@@ -24,4 +43,188 @@ pub(crate) fn construct_signatures_for_type(
 
 pub(crate) fn has_construct_overloads(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     construct_signatures_for_type(db, type_id).is_some_and(|sigs| sigs.len() > 1)
+}
+
+/// View one call/construct signature as a standalone, non-method
+/// `FunctionShape`.
+///
+/// Signature-level method-ness stays on the `CallSignature` (callers that
+/// round-trip restore it via [`call_signature_from_function_shape`]); the
+/// produced shape is always `is_method: false`, matching every checker site
+/// that previously expanded a signature inline.
+pub(crate) fn function_shape_from_call_signature(
+    sig: &CallSignature,
+    is_constructor: bool,
+) -> FunctionShape {
+    FunctionShape {
+        type_params: sig.type_params.clone(),
+        params: sig.params.clone(),
+        this_type: sig.this_type,
+        return_type: sig.return_type,
+        type_predicate: sig.type_predicate,
+        is_constructor,
+        is_method: false,
+    }
+}
+
+/// Collapse a `FunctionShape` back into a `CallSignature`.
+///
+/// Constructor-ness is positional in a `CallableShape` (which signature list
+/// the result joins), so `shape.is_constructor` is dropped. `is_method` is
+/// explicit because round-tripping callers restore the original signature's
+/// flag rather than the shape's.
+pub(crate) fn call_signature_from_function_shape(
+    shape: FunctionShape,
+    is_method: bool,
+) -> CallSignature {
+    CallSignature {
+        type_params: shape.type_params,
+        params: shape.params,
+        this_type: shape.this_type,
+        return_type: shape.return_type,
+        type_predicate: shape.type_predicate,
+        is_method,
+    }
+}
+
+/// Intern a function type from an explicit, helper-built shape.
+pub(crate) fn function_type_from_shape(db: &dyn TypeDatabase, shape: FunctionShape) -> TypeId {
+    db.function(shape)
+}
+
+/// Intern the standalone function type for one signature (a constructor
+/// function when `is_constructor` is set).
+pub(crate) fn function_type_from_call_signature(
+    db: &dyn TypeDatabase,
+    sig: &CallSignature,
+    is_constructor: bool,
+) -> TypeId {
+    db.function(function_shape_from_call_signature(sig, is_constructor))
+}
+
+/// Intern a bare callable carrying only call signatures.
+pub(crate) fn call_only_callable_type(
+    db: &dyn TypeDatabase,
+    call_signatures: Vec<CallSignature>,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures,
+        ..CallableShape::default()
+    })
+}
+
+/// Intern a bare callable carrying only construct signatures.
+pub(crate) fn construct_only_callable_type(
+    db: &dyn TypeDatabase,
+    construct_signatures: Vec<CallSignature>,
+) -> TypeId {
+    db.callable(CallableShape {
+        construct_signatures,
+        ..CallableShape::default()
+    })
+}
+
+/// Re-intern `base` with the given signature lists, preserving properties,
+/// index signatures, nominal `symbol`, and abstractness.
+pub(crate) fn callable_with_signatures_replaced(
+    db: &dyn TypeDatabase,
+    base: &CallableShape,
+    call_signatures: Vec<CallSignature>,
+    construct_signatures: Vec<CallSignature>,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures,
+        construct_signatures,
+        properties: base.properties.clone(),
+        string_index: base.string_index,
+        number_index: base.number_index,
+        symbol: base.symbol,
+        is_abstract: base.is_abstract,
+    })
+}
+
+/// Re-intern `base` with instantiated signature lists for type-argument
+/// application.
+///
+/// Properties and index signatures carry over; the nominal `symbol` and
+/// `is_abstract` markers are detached because the instantiation result is a
+/// structural callable, not the original class-constructor identity.
+pub(crate) fn instantiated_callable_from_base(
+    db: &dyn TypeDatabase,
+    base: &CallableShape,
+    call_signatures: Vec<CallSignature>,
+    construct_signatures: Vec<CallSignature>,
+) -> TypeId {
+    db.callable(CallableShape {
+        call_signatures,
+        construct_signatures,
+        properties: base.properties.clone(),
+        string_index: base.string_index,
+        number_index: base.number_index,
+        symbol: None,
+        is_abstract: false,
+    })
+}
+
+/// The component-type slots of a `FunctionShape`, used by
+/// [`map_function_shape_types`] callers to apply per-slot policy.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FunctionShapeTypeSlot {
+    /// A parameter's declared type.
+    Param,
+    /// The `this` parameter type.
+    This,
+    /// The return type.
+    Return,
+    /// The asserted type of a type predicate (`x is T`).
+    PredicateTarget,
+}
+
+/// Rebuild `shape` with every component type passed through `map_type`,
+/// preserving all non-type metadata (names, optionality, rest/method/
+/// constructor flags, type parameters, predicate target).
+///
+/// Returns `None` when no component type changed, so callers can keep the
+/// original interned `TypeId` for the unchanged case.
+pub(crate) fn map_function_shape_types(
+    shape: &FunctionShape,
+    mut map_type: impl FnMut(FunctionShapeTypeSlot, TypeId) -> TypeId,
+) -> Option<FunctionShape> {
+    let mut changed = false;
+    let mut visit = |slot: FunctionShapeTypeSlot, type_id: TypeId| {
+        let mapped = map_type(slot, type_id);
+        if mapped != type_id {
+            changed = true;
+        }
+        mapped
+    };
+
+    let params: Vec<ParamInfo> = shape
+        .params
+        .iter()
+        .map(|param| ParamInfo {
+            type_id: visit(FunctionShapeTypeSlot::Param, param.type_id),
+            ..*param
+        })
+        .collect();
+    let this_type = shape
+        .this_type
+        .map(|this_type| visit(FunctionShapeTypeSlot::This, this_type));
+    let return_type = visit(FunctionShapeTypeSlot::Return, shape.return_type);
+    let type_predicate = shape.type_predicate.map(|predicate| TypePredicate {
+        type_id: predicate
+            .type_id
+            .map(|type_id| visit(FunctionShapeTypeSlot::PredicateTarget, type_id)),
+        ..predicate
+    });
+
+    changed.then_some(FunctionShape {
+        type_params: shape.type_params.clone(),
+        params,
+        this_type,
+        return_type,
+        type_predicate,
+        is_constructor: shape.is_constructor,
+        is_method: shape.is_method,
+    })
 }

--- a/crates/tsz-checker/src/query_boundaries/type_construction.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_construction.rs
@@ -8,7 +8,25 @@
 use tsz_solver::construction::TypeDatabase;
 #[cfg(test)]
 pub(crate) use tsz_solver::construction::TypeInterner;
-use tsz_solver::{StringIntrinsicKind, TypeId};
+use tsz_solver::{IndexSignature, ObjectShape, StringIntrinsicKind, TypeId};
+
+/// Intern an object type carrying only a string index signature
+/// (`{ [key: string]: V }`).
+pub(crate) fn object_with_string_index_value(
+    db: &dyn TypeDatabase,
+    value_type: TypeId,
+    readonly: bool,
+) -> TypeId {
+    db.object_with_index(ObjectShape {
+        string_index: Some(IndexSignature {
+            key_type: TypeId::STRING,
+            value_type,
+            readonly,
+            param_name: None,
+        }),
+        ..ObjectShape::default()
+    })
+}
 
 /// Create a string intrinsic type from a validated lib intrinsic name.
 pub(crate) fn string_intrinsic_by_name(

--- a/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
@@ -11,11 +11,14 @@ use crate::query_boundaries::assignability::{
     erase_function_type_params_to_any, get_function_return_type, replace_function_return_type,
     rewrite_function_error_slots_to_any, strip_function_type_predicate,
 };
+use crate::query_boundaries::construct_signatures::{
+    construct_only_callable_type, function_type_from_call_signature,
+};
 use crate::state::CheckerState;
 use tsz_binder::SymbolId;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
-use tsz_solver::{CallableShape, FunctionShape, TypeId};
+use tsz_solver::TypeId;
 
 impl<'a> CheckerState<'a> {
     fn required_parameter_count_for_overload_compatibility(
@@ -235,15 +238,7 @@ impl<'a> CheckerState<'a> {
                 param.optional = jsdoc_optional;
             }
 
-            let overload_type = self.ctx.types.factory().callable(CallableShape {
-                call_signatures: Vec::new(),
-                construct_signatures: vec![signature],
-                properties: Vec::new(),
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            });
+            let overload_type = construct_only_callable_type(self.ctx.types, vec![signature]);
 
             let (error_pos, error_len) = self
                 .jsdoc_overload_tag_span(&comment, &sf.text)
@@ -288,15 +283,11 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        Some(self.ctx.types.factory().function(FunctionShape {
-            type_params: sig.type_params,
-            params: sig.params,
-            this_type: sig.this_type,
-            return_type: sig.return_type,
-            type_predicate: sig.type_predicate,
-            is_constructor: true,
-            is_method: false,
-        }))
+        Some(function_type_from_call_signature(
+            self.ctx.types,
+            &sig,
+            /* is_constructor */ true,
+        ))
     }
 
     /// Lower a type node with type parameter bindings.

--- a/crates/tsz-checker/src/state/type_resolution/constructors.rs
+++ b/crates/tsz-checker/src/state/type_resolution/constructors.rs
@@ -94,7 +94,10 @@ impl<'a> CheckerState<'a> {
         missing_type_args_become_any: bool,
         strip_on_non_generic_mismatch: bool,
     ) -> TypeId {
-        use tsz_solver::CallableShape;
+        use crate::query_boundaries::construct_signatures::{
+            call_signature_from_function_shape, construct_only_callable_type,
+            instantiated_callable_from_base,
+        };
 
         if type_args.is_empty() && !missing_type_args_become_any {
             return ctor_type;
@@ -129,14 +132,10 @@ impl<'a> CheckerState<'a> {
             crate::query_boundaries::common::function_shape_for_type(self.ctx.types, ctor_type)
             && function_shape.is_constructor
         {
-            let sig = tsz_solver::CallSignature {
-                type_params: function_shape.type_params.clone(),
-                params: function_shape.params.clone(),
-                this_type: function_shape.this_type,
-                return_type: function_shape.return_type,
-                type_predicate: function_shape.type_predicate,
-                is_method: function_shape.is_method,
-            };
+            let sig = call_signature_from_function_shape(
+                function_shape.as_ref().clone(),
+                function_shape.is_method,
+            );
             if sig.type_params.is_empty() {
                 return ctor_type;
             }
@@ -170,16 +169,7 @@ impl<'a> CheckerState<'a> {
                 args.truncate(sig.type_params.len());
             }
             let instantiated_construct = self.instantiate_signature(&sig, &args);
-            let new_shape = CallableShape {
-                call_signatures: vec![],
-                construct_signatures: vec![instantiated_construct],
-                properties: vec![],
-                string_index: None,
-                number_index: None,
-                symbol: None,
-                is_abstract: false,
-            };
-            return self.ctx.types.factory().callable(new_shape);
+            return construct_only_callable_type(self.ctx.types, vec![instantiated_construct]);
         }
 
         let Some(shape) = query::callable_shape_for_type(self.ctx.types, ctor_type) else {
@@ -215,17 +205,13 @@ impl<'a> CheckerState<'a> {
                     .iter()
                     .all(|sig| sig.type_params.is_empty())
             {
-                let empty_shape = CallableShape {
-                    call_signatures: shape.call_signatures.clone(),
-                    construct_signatures: vec![],
-                    properties: shape.properties.clone(),
-                    string_index: shape.string_index,
-                    number_index: shape.number_index,
-                    symbol: None,
-                    is_abstract: false,
-                };
-                let factory = self.ctx.types.factory();
-                return factory.callable(empty_shape);
+                let call_signatures = shape.call_signatures.clone();
+                return instantiated_callable_from_base(
+                    self.ctx.types,
+                    &shape,
+                    call_signatures,
+                    vec![],
+                );
             }
             return ctor_type;
         }
@@ -273,17 +259,13 @@ impl<'a> CheckerState<'a> {
             })
             .collect();
 
-        let new_shape = CallableShape {
-            call_signatures: shape.call_signatures.clone(),
-            construct_signatures: instantiated_constructs,
-            properties: shape.properties.clone(),
-            string_index: shape.string_index,
-            number_index: shape.number_index,
-            symbol: None,
-            is_abstract: false,
-        };
-        let factory = self.ctx.types.factory();
-        factory.callable(new_shape)
+        let call_signatures = shape.call_signatures.clone();
+        instantiated_callable_from_base(
+            self.ctx.types,
+            &shape,
+            call_signatures,
+            instantiated_constructs,
+        )
     }
 
     pub(crate) fn apply_instantiation_expression_type_arguments(
@@ -1155,18 +1137,11 @@ impl<'a> CheckerState<'a> {
     }
 
     fn implicit_any_index_base_instance_type(&self) -> TypeId {
-        self.ctx
-            .types
-            .factory()
-            .object_with_index(tsz_solver::ObjectShape {
-                string_index: Some(tsz_solver::IndexSignature {
-                    key_type: TypeId::STRING,
-                    value_type: TypeId::ANY,
-                    readonly: false,
-                    param_name: None,
-                }),
-                ..tsz_solver::ObjectShape::default()
-            })
+        crate::query_boundaries::type_construction::object_with_string_index_value(
+            self.ctx.types,
+            TypeId::ANY,
+            false,
+        )
     }
 
     /// Sanitize and cache a base-instance result. Drops `Some(ERROR)` to

--- a/crates/tsz-checker/src/state/type_resolution/constructors/callable_type_arguments.rs
+++ b/crates/tsz-checker/src/state/type_resolution/constructors/callable_type_arguments.rs
@@ -1,9 +1,12 @@
 use crate::query_boundaries::common::{self as common_query, TypeSubstitution};
+use crate::query_boundaries::construct_signatures::{
+    call_only_callable_type, call_signature_from_function_shape, instantiated_callable_from_base,
+};
 use crate::query_boundaries::state::type_resolution as query;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeList;
 use tsz_solver::def::DefKind;
-use tsz_solver::{CallSignature, CallableShape, TypeId};
+use tsz_solver::{CallSignature, TypeId};
 
 impl<'a> CheckerState<'a> {
     /// Apply explicit type arguments to a callable type for function calls.
@@ -104,16 +107,12 @@ impl<'a> CheckerState<'a> {
                 self.evaluate_substituted_signatures(&mut instantiated_calls);
                 self.evaluate_substituted_signatures(&mut instantiated_constructs);
 
-                let new_shape = CallableShape {
-                    call_signatures: instantiated_calls,
-                    construct_signatures: instantiated_constructs,
-                    properties: shape.properties.clone(),
-                    string_index: shape.string_index,
-                    number_index: shape.number_index,
-                    symbol: None,
-                    is_abstract: false,
-                };
-                factory.callable(new_shape)
+                instantiated_callable_from_base(
+                    self.ctx.types,
+                    &shape,
+                    instantiated_calls,
+                    instantiated_constructs,
+                )
             }
             query::SignatureTypeKind::Function(shape_id) => {
                 let shape = self.ctx.types.function_shape(shape_id);
@@ -121,13 +120,13 @@ impl<'a> CheckerState<'a> {
                     return callee_type;
                 }
 
-                let sig = tsz_solver::CallSignature {
-                    type_params: shape.type_params.clone(),
-                    params: shape.params.clone(),
-                    this_type: None,
-                    return_type: shape.return_type,
-                    type_predicate: shape.type_predicate,
-                    is_method: shape.is_method,
+                let sig = {
+                    let mut sig =
+                        call_signature_from_function_shape(shape.as_ref().clone(), shape.is_method);
+                    // This path deliberately drops the `this` parameter: an
+                    // instantiation expression yields a bare call signature.
+                    sig.this_type = None;
+                    sig
                 };
                 let instantiated_call = if type_args.len() < shape.type_params.len() {
                     if self.all_remaining_defaults_resolved(&sig, &type_args) {
@@ -165,16 +164,7 @@ impl<'a> CheckerState<'a> {
                 // See `evaluate_substituted_signatures` for why.
                 self.evaluate_substituted_signatures(&mut instantiated_calls);
 
-                let new_shape = CallableShape {
-                    call_signatures: instantiated_calls,
-                    construct_signatures: vec![],
-                    properties: vec![],
-                    string_index: None,
-                    number_index: None,
-                    symbol: None,
-                    is_abstract: false,
-                };
-                factory.callable(new_shape)
+                call_only_callable_type(self.ctx.types, instantiated_calls)
             }
             _ => callee_type,
         }

--- a/crates/tsz-checker/tests/arch_source_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans.rs
@@ -8,7 +8,7 @@
 //! in `scripts/ci/gcp-full-ci.sh`), so the invariants were silently
 //! unenforced.
 //!
-//! Both scans are pure source-text checks over `$CARGO_MANIFEST_DIR/src` with
+//! All scans are pure source-text checks over `$CARGO_MANIFEST_DIR/src` with
 //! no dependency on crate internals:
 //! - `relation_routing_residual_arch_tests`: diagnostic-bearing relation
 //!   probes in production checker code must route through named
@@ -17,8 +17,14 @@
 //! - `common_boundary_export_ratchets`: the `query_boundaries/common.rs`
 //!   `pub(crate) fn` surface only changes with an explicit allowlist update
 //!   (issue #12948).
+//! - `construction_boundary_signature_scans`: the issue #13022 module set
+//!   constructs signature-bearing solver types only through
+//!   `query_boundaries::construct_signatures`, never via inline shape
+//!   literals or direct interning calls.
 
 #[path = "arch_source_scans/common_boundary_export_ratchets.rs"]
 mod common_boundary_export_ratchets;
+#[path = "arch_source_scans/construction_boundary_signature_scans.rs"]
+mod construction_boundary_signature_scans;
 #[path = "arch_source_scans/relation_routing_residual_arch_tests.rs"]
 mod relation_routing_residual_arch_tests;

--- a/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
+++ b/crates/tsz-checker/tests/arch_source_scans/construction_boundary_signature_scans.rs
@@ -1,0 +1,168 @@
+//! Construction-side signature boundary scans (issue #13022).
+//!
+//! The modules listed in issue #13022 used to hand-build
+//! `FunctionShape`/`CallableShape` literals and intern them inline via
+//! `factory().function(..)` / `factory().callable(..)`. That construction
+//! traffic now flows through `query_boundaries::construct_signatures` (and
+//! `query_boundaries::type_construction` for the index-signature object
+//! fallback). These scans pin the converted modules clean so the quarantine
+//! does not refill during parity fixes.
+//!
+//! `checkers/signature_builder.rs` stays the one checker module allowed to
+//! assemble `CallSignature` *data* from AST signatures (the shape structs are
+//! SAFE read-only data per the `architecture_contract_tests` import policy);
+//! what is forbidden here is shape-literal construction of interned type
+//! shapes and direct interning calls.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The issue #13022 module set, including the split-off submodules of
+/// `state/type_resolution/constructors.rs` that belong to the same logical
+/// module.
+const SIGNATURE_CONSTRUCTION_CLEAN_MODULES: &[&str] = &[
+    "src/assignability/assignability_checker.rs",
+    "src/checkers/signature_builder.rs",
+    "src/classes/class_implements_checker/core.rs",
+    "src/context/cross_file_query.rs",
+    "src/state/state_checking_members/overload_compatibility.rs",
+    "src/state/type_resolution/constructors.rs",
+    "src/state/type_resolution/constructors/callable_type_arguments.rs",
+    "src/state/type_resolution/constructors/heritage_call_returns.rs",
+];
+
+/// The designated checker-side `CallSignature` data assembler.
+const SIGNATURE_DATA_BUILDER: &str = "src/checkers/signature_builder.rs";
+
+fn checker_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn scan_for_patterns(relative: &str, patterns: &[&str], violations: &mut Vec<String>) {
+    let source = fs::read_to_string(checker_path(relative))
+        .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") {
+            continue;
+        }
+        // A `Shape {` token in return-type position (`fn f(..) -> Shape {`)
+        // is a function header, not a shape-literal construction.
+        if trimmed.contains("->") {
+            continue;
+        }
+        for pattern in patterns {
+            if line.contains(pattern) {
+                violations.push(format!(
+                    "{relative}:{} contains `{pattern}`",
+                    line_index + 1
+                ));
+            }
+        }
+    }
+}
+
+/// The issue #13022 modules must not intern signature-bearing (or
+/// index-signature object) types directly; construction goes through
+/// `query_boundaries::construct_signatures` / `type_construction`.
+#[test]
+fn issue_13022_modules_do_not_intern_signature_types_directly() {
+    const INTERNING_PATTERNS: &[&str] = &[".function(", ".callable(", ".object_with_index("];
+
+    let mut violations = Vec::new();
+    for module in SIGNATURE_CONSTRUCTION_CLEAN_MODULES {
+        scan_for_patterns(module, INTERNING_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "issue #13022 modules must intern function/callable types through \
+         query_boundaries::construct_signatures, not direct factory/db calls:\n{}",
+        violations.join("\n")
+    );
+}
+
+/// The issue #13022 modules must not rebuild interned type shapes as literals;
+/// the conversion/rebuild helpers in `query_boundaries::construct_signatures`
+/// own the field-by-field shape traffic.
+#[test]
+fn issue_13022_modules_do_not_build_type_shape_literals() {
+    const SHAPE_LITERAL_PATTERNS: &[&str] = &[
+        "CallableShape {",
+        "CallableShape::default()",
+        "FunctionShape {",
+        "ObjectShape {",
+        "IndexSignature {",
+    ];
+
+    let mut violations = Vec::new();
+    for module in SIGNATURE_CONSTRUCTION_CLEAN_MODULES {
+        scan_for_patterns(module, SHAPE_LITERAL_PATTERNS, &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "issue #13022 modules must not hand-build interned type shape literals; \
+         use query_boundaries::construct_signatures helpers:\n{}",
+        violations.join("\n")
+    );
+}
+
+/// `CallSignature` literals are signature *data* assembly and belong to the
+/// designated builder module (`checkers/signature_builder.rs`) or the
+/// boundary itself; the other issue #13022 modules round-trip through
+/// `function_shape_from_call_signature` / `call_signature_from_function_shape`.
+#[test]
+fn call_signature_literals_stay_in_signature_builder() {
+    let mut violations = Vec::new();
+    for module in SIGNATURE_CONSTRUCTION_CLEAN_MODULES {
+        if *module == SIGNATURE_DATA_BUILDER {
+            continue;
+        }
+        scan_for_patterns(module, &["CallSignature {"], &mut violations);
+    }
+    assert!(
+        violations.is_empty(),
+        "CallSignature literal assembly outside the designated builder module; \
+         use the query_boundaries::construct_signatures conversion helpers:\n{}",
+        violations.join("\n")
+    );
+}
+
+/// The boundary helpers this campaign introduced must keep their definitions
+/// in `query_boundaries/construct_signatures.rs` (not drift back into
+/// `common.rs` or call sites).
+#[test]
+fn construct_signatures_boundary_owns_construction_helpers() {
+    let source = fs::read_to_string(checker_path("src/query_boundaries/construct_signatures.rs"))
+        .expect("failed to read query_boundaries/construct_signatures.rs");
+    for helper in [
+        "function_shape_from_call_signature",
+        "call_signature_from_function_shape",
+        "function_type_from_shape",
+        "function_type_from_call_signature",
+        "call_only_callable_type",
+        "construct_only_callable_type",
+        "callable_with_signatures_replaced",
+        "instantiated_callable_from_base",
+        "map_function_shape_types",
+    ] {
+        assert!(
+            source.contains(&format!("fn {helper}(")),
+            "query_boundaries::construct_signatures must own the `{helper}` helper"
+        );
+    }
+
+    let common = fs::read_to_string(checker_path("src/query_boundaries/common.rs"))
+        .expect("failed to read query_boundaries/common.rs");
+    for helper in [
+        "call_only_callable_type",
+        "construct_only_callable_type",
+        "callable_with_signatures_replaced",
+        "instantiated_callable_from_base",
+        "map_function_shape_types",
+    ] {
+        assert!(
+            !common.contains(&format!("fn {helper}(")),
+            "construction helper `{helper}` must not migrate into common.rs"
+        );
+    }
+}

--- a/crates/tsz-checker/tests/construct_signature_boundary_matrix_tests.rs
+++ b/crates/tsz-checker/tests/construct_signature_boundary_matrix_tests.rs
@@ -1,0 +1,210 @@
+//! Regression matrices for the construction-side signature boundary
+//! (issue #13022).
+//!
+//! The converted pathways construct signature-bearing types through
+//! `query_boundaries::construct_signatures`; these matrices pin the observable
+//! behavior of each converted construction site:
+//!
+//! - overload compatibility (TS2394) for function and constructor overloads
+//!   (`overload_compatibility.rs`: constructor function + constructor-only
+//!   callable construction);
+//! - type-argument application to constructor/callable types
+//!   (`type_resolution/constructors.rs` + `callable_type_arguments.rs`:
+//!   instantiated callable rebuilds, TS2345/TS2322 downstream);
+//! - class-implements overload-set combination
+//!   (`class_implements_checker/core.rs`: call-only callable, TS2416).
+//!
+//! Binder names are varied across cases per the anti-hardcoding gate.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+fn codes(source: &str) -> Vec<u32> {
+    let mut codes: Vec<u32> = check_source(source, "case.ts", CheckerOptions::default())
+        .into_iter()
+        .map(|d| d.code)
+        .collect();
+    codes.sort_unstable();
+    codes
+}
+
+// ── Overloaded call matrix (TS2394 pathway) ─────────────────────────────────
+
+#[test]
+fn function_overload_set_compatible_with_widened_implementation() {
+    let source = r#"
+function renderUnit(value: string): string;
+function renderUnit(value: number): number;
+function renderUnit(value: string | number): string | number {
+    return value;
+}
+"#;
+    let diags = codes(source);
+    assert!(
+        !diags.contains(&2394),
+        "compatible overload set must not report TS2394, got: {diags:?}"
+    );
+}
+
+#[test]
+fn function_overload_set_incompatible_implementation_reports_ts2394() {
+    let source = r#"
+function parseChunk(raw: string): string;
+function parseChunk(raw: number): number {
+    return raw;
+}
+"#;
+    let diags = codes(source);
+    assert!(
+        diags.contains(&2394),
+        "implementation incompatible with its overload must report TS2394, got: {diags:?}"
+    );
+}
+
+#[test]
+fn constructor_overload_set_compatible_with_widened_implementation() {
+    let source = r#"
+class Envelope {
+    constructor(seed: string);
+    constructor(seed: number);
+    constructor(seed: string | number) {}
+}
+"#;
+    let diags = codes(source);
+    assert!(
+        !diags.contains(&2394),
+        "compatible constructor overloads must not report TS2394, got: {diags:?}"
+    );
+}
+
+#[test]
+fn constructor_overload_set_incompatible_implementation_reports_ts2394() {
+    let source = r#"
+class Ledger {
+    constructor(entry: string);
+    constructor(entry: number) {}
+}
+"#;
+    let diags = codes(source);
+    assert!(
+        diags.contains(&2394),
+        "constructor implementation incompatible with its overload must report TS2394, got: {diags:?}"
+    );
+}
+
+// ── Class/assignability matrix (constructor instantiation + implements) ────
+
+#[test]
+fn generic_base_class_type_argument_application_accepts_matching_super_arg() {
+    let source = r#"
+class Carton<T> {
+    payload: T;
+    constructor(payload: T) {
+        this.payload = payload;
+    }
+}
+class LabelCarton extends Carton<string> {
+    constructor() {
+        super("label");
+    }
+}
+"#;
+    let diags = codes(source);
+    assert!(
+        !diags.contains(&2345),
+        "matching super argument against instantiated base constructor must not report TS2345, got: {diags:?}"
+    );
+}
+
+#[test]
+fn generic_base_class_type_argument_application_rejects_mismatched_super_arg() {
+    let source = r#"
+class Basket<T> {
+    payload: T;
+    constructor(payload: T) {
+        this.payload = payload;
+    }
+}
+class CountBasket extends Basket<string> {
+    constructor() {
+        super(41);
+    }
+}
+"#;
+    let diags = codes(source);
+    assert!(
+        diags.contains(&2345),
+        "mismatched super argument against instantiated base constructor must report TS2345, got: {diags:?}"
+    );
+}
+
+#[test]
+fn instantiation_expression_call_signature_application_matrix() {
+    // Positive: instantiated alias keeps the substituted signature.
+    let ok = r#"
+function lift<T>(value: T): T {
+    return value;
+}
+const liftNum = lift<number>;
+const widened: number = liftNum(7);
+"#;
+    let ok_diags = codes(ok);
+    assert!(
+        !ok_diags.contains(&2322),
+        "instantiation expression with matching use must not report TS2322, got: {ok_diags:?}"
+    );
+
+    // Negative: the substituted return type must flow to assignments.
+    let bad = r#"
+function box<T>(value: T): T {
+    return value;
+}
+const boxNum = box<number>;
+const label: string = boxNum(7);
+"#;
+    let bad_diags = codes(bad);
+    assert!(
+        bad_diags.contains(&2322),
+        "instantiation expression result misused must report TS2322, got: {bad_diags:?}"
+    );
+}
+
+#[test]
+fn implements_overloaded_interface_method_matrix() {
+    // Positive: implementation handles the full overload set.
+    let ok = r#"
+interface Codec {
+    convert(input: string): number;
+    convert(input: number): string;
+}
+class WideCodec implements Codec {
+    convert(input: string | number): any {
+        return input;
+    }
+}
+"#;
+    let ok_diags = codes(ok);
+    assert!(
+        !ok_diags.contains(&2416),
+        "implementation covering the full overload set must not report TS2416, got: {ok_diags:?}"
+    );
+
+    // Negative: implementation covering only one overload fails the combined
+    // overload-set check.
+    let bad = r#"
+interface Mapper {
+    remap(input: string): number;
+    remap(input: number): string;
+}
+class NarrowMapper implements Mapper {
+    remap(input: string): number {
+        return 0;
+    }
+}
+"#;
+    let bad_diags = codes(bad);
+    assert!(
+        bad_diags.contains(&2416),
+        "implementation covering one overload of the set must report TS2416, got: {bad_diags:?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Adds construction-side helpers to the checker query boundary and converts the inline solver-type construction call sites to consume them; direct interning/raw-shape construction leaves the checker's non-boundary code, with new CI-enforced `arch_source_scans` ratchets pinning the converted module set clean in the same change.

Structural rule: the checker constructs solver types only through query-boundary helpers; construction identity is unchanged (same TypeIds — every helper delegates to the same `TypeDatabase` interning calls the inline `factory()` paths used), pinned by existing suites, the new regression matrices, and the arch ratchets.

Closes #13022 — all three acceptance criteria are met: (1) raw-shape construction/interning is removed from every listed module (`overload_compatibility`, `assignability_checker`, `type_resolution/constructors` + its `callable_type_arguments` split-off, `class_implements_checker/core`; `signature_builder` and `cross_file_query` were already interning-free, and `signature_builder` remains the designated `CallSignature` *data* assembler per the SAFE-import policy), (2) assignability/overload/constructor behavior is unchanged, (3) an overloaded-call matrix and a class/assignability matrix were added on the existing `check_source` harness.

New boundary surface (domain module `query_boundaries/construct_signatures.rs`, not `common.rs`, so the `ALLOWED_COMMON_PUB_CRATE_FNS` ratchet is untouched): `function_shape_from_call_signature`, `call_signature_from_function_shape`, `function_type_from_shape`, `function_type_from_call_signature`, `call_only_callable_type`, `construct_only_callable_type`, `callable_with_signatures_replaced`, `instantiated_callable_from_base`, `map_function_shape_types`; plus `type_construction::object_with_string_index_value` for the implicit-any index fallback object.

## Verification
- `cargo nextest run -p tsz-checker --test arch_source_scans` (11 passed; 4 new scans pin the #13022 module set: no `.function(`/`.callable(`/`.object_with_index(` interning, no shape literals, `CallSignature` literals only in the designated builder, helper ownership stays in `construct_signatures.rs`)
- `cargo nextest run -p tsz-checker --test construct_signature_boundary_matrix_tests` (8 passed: TS2394 overload matrix incl. constructor overloads, TS2345 generic-base super-arg matrix, TS2322 instantiation-expression matrix, TS2416 implements-overload-set matrix; positive and negative cases, varied binder names)
- `cargo nextest run -p tsz-checker --test overload_modifier_tests --test abstract_method_overload_ts2416_tests --test class_implements_overloaded_method_ts2416_tests --test class_expression_heritage_ts2416_tests --test cross_file_lib_generic_heritage_tests` (80 passed)
- `cargo nextest run -p tsz-checker --test distributive_callable_branch_tests --test intersection_signatures --test new_generic_construct_signature_type_arg_display_tests --test index_signature_argument_assignability_tests` (31 passed)
- `cargo clippy -p tsz-checker -- -D warnings`
- `cargo check --workspace`

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
