### PR TITLE
perf(tools): surface session reset cache high-water (#13246)

### DIFF
--- a/scripts/perf/query-perf-counters.py
+++ b/scripts/perf/query-perf-counters.py
@@ -68,6 +68,63 @@ def by_reason_rows(snap, optional=False):
     return rows
 
 
+RESET_CACHE_FIELDS = (
+    ("namespace_member", "namespace_member_entries", "namespace_member_bytes"),
+    ("export_equals", "export_equals_entries", "export_equals_bytes"),
+    ("nested_namespace", "nested_namespace_entries", "nested_namespace_bytes"),
+    ("lowering_entity_name", "lowering_entity_name_entries", "lowering_entity_name_bytes"),
+    ("env_eval", "env_eval_entries", "env_eval_bytes"),
+)
+
+
+def reset_cache_value(checker: dict, suffix: str) -> Optional[int]:
+    return checker.get(f"file_session_reset_{suffix}_max")
+
+
+def reset_cache_rows(checker: dict) -> list:
+    rows = []
+    for name, entries_suffix, bytes_suffix in RESET_CACHE_FIELDS:
+        entries = reset_cache_value(checker, entries_suffix)
+        size = reset_cache_value(checker, bytes_suffix)
+        if entries is None and size is None:
+            continue
+        rows.append(
+            {
+                "name": name,
+                "entries": entries or 0,
+                "bytes": size or 0,
+            }
+        )
+    return rows
+
+
+def print_reset_cache_high_water(checker: dict, indent: str = "  ") -> None:
+    entries = checker.get("file_session_reset_cache_entries_max")
+    size = checker.get("file_session_reset_cache_bytes_max")
+    rows = reset_cache_rows(checker)
+    if entries is None and size is None and not rows:
+        return
+
+    print(f"{indent}file-session reset cache high-water:")
+    print(f"{indent}  total_entries={fmt_int(entries)}  total_bytes={fmt_int(size)}")
+    if not rows:
+        return
+
+    rows_by_bytes = sorted(rows, key=lambda row: (-row["bytes"], row["name"]))
+    dominant = rows_by_bytes[0]
+    for row in rows_by_bytes:
+        if row["entries"] == 0 and row["bytes"] == 0:
+            continue
+        print(
+            f"{indent}  {row['name']:<22} "
+            f"entries={fmt_int(row['entries']):>8}  bytes={fmt_int(row['bytes']):>10}"
+        )
+    print(
+        f"{indent}  dominant={dominant['name']} "
+        f"bytes={fmt_int(dominant['bytes'])}"
+    )
+
+
 def print_summary(snap: dict) -> None:
     delegate = snap["delegate"]
     checker = snap["checker"]
@@ -130,6 +187,7 @@ def print_summary(snap: dict) -> None:
         f"  state_constructed={fmt_int(sc)}  with_parent_cache={fmt_int(wpc)}  "
         f"file_session_resets={fmt_int(fsr)}"
     )
+    print_reset_cache_high_water(checker)
     print(
         f"  compute_type_of_symbol  calls={fmt_int(cot_calls)}  "
         f"hits={fmt_int(cot_hits)}  hit%={cot_hit_pct:.2f}"
@@ -287,10 +345,42 @@ def print_diff(post: dict, base: dict) -> None:
         "state_constructed",
         "with_parent_cache_constructed",
         "file_session_resets",
+        "file_session_reset_cache_entries_max",
+        "file_session_reset_cache_bytes_max",
+        "file_session_reset_namespace_member_entries_max",
+        "file_session_reset_namespace_member_bytes_max",
+        "file_session_reset_export_equals_entries_max",
+        "file_session_reset_export_equals_bytes_max",
+        "file_session_reset_nested_namespace_entries_max",
+        "file_session_reset_nested_namespace_bytes_max",
+        "file_session_reset_lowering_entity_name_entries_max",
+        "file_session_reset_lowering_entity_name_bytes_max",
+        "file_session_reset_env_eval_entries_max",
+        "file_session_reset_env_eval_bytes_max",
         "compute_type_of_symbol_calls",
         "compute_type_of_symbol_cache_hits",
     ):
         print(f"  {delta(post['checker'], base['checker'], k)}")
+    post_rows = reset_cache_rows(post["checker"])
+    base_rows = reset_cache_rows(base["checker"])
+    if post_rows or base_rows:
+        post_by_name = {row["name"]: row for row in post_rows}
+        base_by_name = {row["name"]: row for row in base_rows}
+        print("  reset-cache high-water by family:")
+        for name in sorted(set(post_by_name) | set(base_by_name)):
+            post_row = post_by_name.get(name, {"entries": 0, "bytes": 0})
+            base_row = base_by_name.get(name, {"entries": 0, "bytes": 0})
+            entries_delta = post_row["entries"] - base_row["entries"]
+            bytes_delta = post_row["bytes"] - base_row["bytes"]
+            entries_sign = "+" if entries_delta > 0 else ""
+            bytes_sign = "+" if bytes_delta > 0 else ""
+            print(
+                f"    {name:<22} "
+                f"entries {fmt_int(base_row['entries']):>8} → {fmt_int(post_row['entries']):>8} "
+                f"({entries_sign}{fmt_int(entries_delta)})  "
+                f"bytes {fmt_int(base_row['bytes']):>10} → {fmt_int(post_row['bytes']):>10} "
+                f"({bytes_sign}{fmt_int(bytes_delta)})"
+            )
     post_slow = post.get("slow_check_file_timings") or []
     base_slow = base.get("slow_check_file_timings") or []
     if post_slow or base_slow:

--- a/scripts/perf/test_query_perf_counters.py
+++ b/scripts/perf/test_query_perf_counters.py
@@ -27,6 +27,18 @@ def sample_snapshot(*, type_environment_core: int = 7, import_type: int = 3):
             "state_constructed": 20,
             "with_parent_cache_constructed": type_environment_core + import_type,
             "file_session_resets": 2,
+            "file_session_reset_cache_entries_max": 52,
+            "file_session_reset_cache_bytes_max": 4096,
+            "file_session_reset_namespace_member_entries_max": 4,
+            "file_session_reset_namespace_member_bytes_max": 512,
+            "file_session_reset_export_equals_entries_max": 7,
+            "file_session_reset_export_equals_bytes_max": 1536,
+            "file_session_reset_nested_namespace_entries_max": 3,
+            "file_session_reset_nested_namespace_bytes_max": 256,
+            "file_session_reset_lowering_entity_name_entries_max": 2,
+            "file_session_reset_lowering_entity_name_bytes_max": 128,
+            "file_session_reset_env_eval_entries_max": 36,
+            "file_session_reset_env_eval_bytes_max": 1664,
             "compute_type_of_symbol_calls": 30,
             "compute_type_of_symbol_cache_hits": 10,
         },
@@ -113,6 +125,8 @@ class QueryPerfCountersTests(unittest.TestCase):
         self.assertIn("kind= 244", result.stdout)
         self.assertIn("slowest type alias check phases:", result.stdout)
         self.assertIn("phase=body", result.stdout)
+        self.assertIn("file-session reset cache high-water:", result.stdout)
+        self.assertIn("dominant=env_eval", result.stdout)
         self.assertIn("Dominant: TypeEnvironmentCore = 7", result.stdout)
         self.assertIn("Top non-baseline T2.2 target: ImportType = 3", result.stdout)
 
@@ -148,6 +162,8 @@ class QueryPerfCountersTests(unittest.TestCase):
         self.assertIn("improved", result.stdout)
         self.assertIn("ImportType", result.stdout)
         self.assertIn("regressed", result.stdout)
+        self.assertIn("reset-cache high-water by family:", result.stdout)
+        self.assertIn("env_eval", result.stdout)
 
     def test_by_reason_requires_by_reason_rows(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Goal: fast

## Summary
- Refs #13246 and #13250.
- Surface file-session reset cache high-water totals in `scripts/perf/query-perf-counters.py`.
- Break the reset high-water down by cache family: namespace members, export equals, nested namespaces, lowering entity names, and env eval.
- Add diff output so before/after artifacts can identify which retained reset-boundary cache family grew or shrank.
- Update the perf-counter script tests with representative reset-cache counters.

## Structural rule
When the checker records file-session reset cache high-water counters, the perf-counter query tool should report both total retained entries/bytes and the dominant cache family so #13246 session-reuse accumulation work can attribute residency before changing scheduler or checker partition semantics.

Owner layer: performance tooling and counter reporting only. Checker cache semantics, invalidation, reset behavior, and compiler diagnostics are unchanged.

## Cache / residency invariant
- No compiler cache key, reset policy, or relation/evaluation behavior changes.
- The script reads existing counter names emitted by checker statistics.
- Missing counters remain accepted for older artifacts; rows are omitted when no reset-cache counters are present.
- Diff mode reports per-family entry/byte deltas without changing artifact schema.

## Adjacent cases / fallback
- Snapshots without file-session reset cache counters still print the existing summary only.
- Partial snapshots with some per-family counters still print available rows and default missing family values to zero in diff mode.
- Dominant cache family is selected by bytes, then name for deterministic output.

## Verification
- Pre-commit formatting hook ran during the existing commit.
- Local tests not run per current instruction.
- Draft CI passed on exact head `07ded9e29262b82bd9243687806e66a60c7b27f6`: `perf-tool-smoke`, `gate`, `CI Light Summary`.
- Ready-review CI is required before queueing.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
