### PR TITLE
perf(checker): memo flow antecedent deferral checks (#13311)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -88,6 +88,7 @@ impl<'a> FlowAnalyzer<'a> {
         let mut cacheable_walk = true;
         let mut pending_cache_writes: Vec<((FlowNodeId, SymbolId, TypeId), TypeId)> = Vec::new();
         let mut condition_dp_memos = FlowConditionDpMemos::default();
+        let mut antecedent_defer_memo: FxHashMap<FlowNodeId, bool> = FxHashMap::default();
         condition_dp_memos.clear();
 
         // Process worklist until empty
@@ -843,8 +844,12 @@ impl<'a> FlowAnalyzer<'a> {
                 } else if affects_ref {
                     current_type
                 } else if let Some(&ant) = flow.antecedent.first() {
-                    if self.antecedent_requires_defer(ant, reference, symbol_id)
-                        && !visited.contains(&ant)
+                    if self.antecedent_requires_defer_cached(
+                        ant,
+                        reference,
+                        symbol_id,
+                        &mut antecedent_defer_memo,
+                    ) && !visited.contains(&ant)
                         && !results.contains_key(&ant)
                     {
                         defer_to_antecedent(worklist, in_worklist, ant, current_flow, current_type);
@@ -860,7 +865,12 @@ impl<'a> FlowAnalyzer<'a> {
                 }
             } else if flow.has_any_flags(flow_flags::CALL) {
                 if let Some(&ant) = flow.antecedent.first()
-                    && self.antecedent_requires_defer(ant, reference, symbol_id)
+                    && self.antecedent_requires_defer_cached(
+                        ant,
+                        reference,
+                        symbol_id,
+                        &mut antecedent_defer_memo,
+                    )
                     && !visited.contains(&ant)
                     && !results.contains_key(&ant)
                 {
@@ -922,7 +932,12 @@ impl<'a> FlowAnalyzer<'a> {
             } else {
                 // Default: continue to antecedent
                 if let Some(&ant) = flow.antecedent.first() {
-                    if self.antecedent_requires_defer(ant, reference, symbol_id) {
+                    if self.antecedent_requires_defer_cached(
+                        ant,
+                        reference,
+                        symbol_id,
+                        &mut antecedent_defer_memo,
+                    ) {
                         self.get_flow_type(reference, current_type, ant)
                     } else {
                         if !in_worklist.contains(&ant) && !visited.contains(&ant) {
@@ -1076,5 +1091,20 @@ impl<'a> FlowAnalyzer<'a> {
         } else {
             result
         }
+    }
+
+    fn antecedent_requires_defer_cached(
+        &self,
+        antecedent: FlowNodeId,
+        reference: NodeIndex,
+        symbol_id: Option<SymbolId>,
+        memo: &mut FxHashMap<FlowNodeId, bool>,
+    ) -> bool {
+        if let Some(&cached) = memo.get(&antecedent) {
+            return cached;
+        }
+        let result = self.antecedent_requires_defer(antecedent, reference, symbol_id);
+        memo.insert(antecedent, result);
+        result
     }
 }


### PR DESCRIPTION
Goal: fast

## Summary
- Refs #13311 and #13250.
- Memoize `antecedent_requires_defer` decisions within one `check_flow` traversal.
- Avoid recalculating the same antecedent deferral predicate from ARRAY_MUTATION, CALL, and default antecedent paths in large single-function flow graphs.
- Keep the memo local to the traversal; no new resident checker cache is added.

## Structural rule
When flow traversal asks whether an antecedent must be processed before the current node, tsz answers the same checker-owned control-flow question from antecedent flags, assignment targeting, the fixed reference, and the fixed optional symbol for the current `check_flow` request. Within one `check_flow` walk those inputs do not change, so repeated requests for the same antecedent can reuse the boolean result instead of recalculating reference-symbol and assignment-target checks.

Owner layer: checker `FlowAnalyzer` traversal scheduling. Narrowing semantics, assignment targeting, and relation/evaluation behavior are unchanged.

## Cache invariant
- Cache question: for one `check_flow(reference, initial_type, flow_id, symbol_id)` request, whether `antecedent` requires deferral.
- Key: `FlowNodeId`; `reference` and `symbol_id` are fixed by the surrounding traversal.
- Scope: local stack memo for a single flow walk; dropped after `check_flow` returns.
- Invalidation/reset: automatic at function return; no file/session residency.
- Fallback: cache miss calls the existing `antecedent_requires_defer` helper unchanged.

## Adjacent cases / fallback
- Targeting assignments still defer exactly when the existing helper says they do.
- Conditions, calls, loop labels, and branch labels still defer exactly as before.
- Non-deferrable antecedents still proceed through the existing worklist path.
- No user-chosen identifier, property name, file name, rendered type string, or fixture-specific condition drives the result.

## Verification
- No local tests or benchmarks run per current instruction.
- Pre-commit formatting hook ran during commit.
- Draft/light CI passed at exact head `60bdee29f16315ceaeccf2cfad5829871a46a714`: `CI Light Summary`, `gate`, `project-row-drift`, `lint`, `cargo-shear`, `cargo-deny`, `dist-binaries`, `unit`, `unit-checker-integration`, `unit-cloudbuild`, `premerge-microbench`.
- Ready-review CI is expected to cover conformance, emit, fourslash, LSP, and project compile gates after marking ready.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
