### PR TITLE
revert(checker,binder): restore conformance floor — revert #13083 (temporal) and #13299 (globalThis)

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -6,7 +6,6 @@
 use crate::state::FileFeatures;
 use crate::{ContainerKind, FlowNodeId, SymbolId, SymbolTable, symbol_flags};
 use std::sync::Arc;
-use tsz_common::interner::AstAtom;
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::node_flags;
 use tsz_parser::parser::syntax_kind_ext;
@@ -29,12 +28,6 @@ pub(crate) struct SemanticDefDetails {
 }
 
 impl BinderState {
-    fn identifier_atom(arena: &NodeArena, index: NodeIndex) -> Option<AstAtom> {
-        arena
-            .get_identifier_at(index)
-            .and_then(|ident| (ident.atom != AstAtom::NONE).then_some(ident.atom))
-    }
-
     /// Append a `(name, declaration)` entry to the `module_augmentations`
     /// table for the given target module specifier.
     pub(crate) fn record_module_augmentation_entry(
@@ -165,14 +158,7 @@ impl BinderState {
                         .push(crate::state::GlobalAugmentation::new(idx, flags));
                 }
 
-                let sym_id = self.declare_symbol_with_atom(
-                    arena,
-                    name,
-                    Self::identifier_atom(arena, decl.name),
-                    flags,
-                    idx,
-                    is_exported,
-                );
+                let sym_id = self.declare_symbol(arena, name, flags, idx, is_exported);
                 Arc::make_mut(&mut self.node_symbols).insert(decl.name.0, sym_id);
                 self.record_semantic_def(
                     sym_id,
@@ -263,14 +249,8 @@ impl BinderState {
                         .push(crate::state::ModuleAugmentation::new(name.to_string(), idx));
                 }
 
-                let sym_id = self.declare_symbol_with_atom(
-                    arena,
-                    name,
-                    Self::identifier_atom(arena, func.name),
-                    symbol_flags::FUNCTION,
-                    idx,
-                    is_exported,
-                );
+                let sym_id =
+                    self.declare_symbol(arena, name, symbol_flags::FUNCTION, idx, is_exported);
                 if self.in_global_augmentation {
                     self.record_global_value_augmentation(
                         name,
@@ -318,10 +298,9 @@ impl BinderState {
             self.bind_modifiers(arena, param.modifiers.as_ref());
             if let Some(name) = Self::get_identifier_name(arena, param.name) {
                 tracing::debug!(param_name = %name, param_name_idx = param.name.0, "Binding parameter");
-                let sym_id = self.declare_symbol_with_atom(
+                let sym_id = self.declare_symbol(
                     arena,
                     name,
-                    Self::identifier_atom(arena, param.name),
                     symbol_flags::FUNCTION_SCOPED_VARIABLE,
                     idx,
                     false,
@@ -394,14 +373,7 @@ impl BinderState {
             }
             // Use the parameter node as the declaration so the checker can
             // distinguish parameter-property PROPERTY symbols from regular ones.
-            self.declare_symbol_with_atom(
-                arena,
-                name,
-                Self::identifier_atom(arena, param.name),
-                flags,
-                param_idx,
-                false,
-            );
+            self.declare_symbol(arena, name, flags, param_idx, false);
         }
     }
 
@@ -452,10 +424,9 @@ impl BinderState {
                         type_param_name = %name,
                         "Binding type parameter"
                     );
-                    let sym_id = self.declare_symbol_with_atom(
+                    let sym_id = self.declare_symbol(
                         arena,
                         name,
-                        Self::identifier_atom(arena, type_param.name),
                         symbol_flags::TYPE_PARAMETER,
                         param_idx,
                         false,
@@ -1036,14 +1007,8 @@ impl BinderState {
                 return;
             }
 
-            let sym_id = self.declare_symbol_with_atom(
-                arena,
-                name,
-                Self::identifier_atom(arena, iface.name),
-                symbol_flags::INTERFACE,
-                idx,
-                is_exported,
-            );
+            let sym_id =
+                self.declare_symbol(arena, name, symbol_flags::INTERFACE, idx, is_exported);
             let tp_count = iface
                 .type_parameters
                 .as_ref()
@@ -1220,14 +1185,8 @@ impl BinderState {
                     },
                 );
             } else {
-                let sym_id = self.declare_symbol_with_atom(
-                    arena,
-                    name,
-                    Self::identifier_atom(arena, alias.name),
-                    symbol_flags::TYPE_ALIAS,
-                    idx,
-                    is_exported,
-                );
+                let sym_id =
+                    self.declare_symbol(arena, name, symbol_flags::TYPE_ALIAS, idx, is_exported);
                 let tp_count = alias
                     .type_parameters
                     .as_ref()
@@ -1280,14 +1239,7 @@ impl BinderState {
                 symbol_flags::REGULAR_ENUM
             };
 
-            let enum_sym_id = self.declare_symbol_with_atom(
-                arena,
-                name,
-                Self::identifier_atom(arena, enum_decl.name),
-                enum_flags,
-                idx,
-                is_exported,
-            );
+            let enum_sym_id = self.declare_symbol(arena, name, enum_flags, idx, is_exported);
 
             // Collect enum member names at bind time for stable identity.
             let enum_member_names: Vec<String> = enum_decl

--- a/crates/tsz-binder/src/modules/binding.rs
+++ b/crates/tsz-binder/src/modules/binding.rs
@@ -7,19 +7,12 @@ use crate::binding::SemanticDefDetails;
 use crate::state::BinderState;
 use crate::{ContainerKind, Symbol, SymbolId, SymbolTable, symbol_flags};
 use std::sync::Arc;
-use tsz_common::interner::AstAtom;
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::{NodeIndex, NodeList};
 use tsz_scanner::SyntaxKind;
 
 impl BinderState {
-    fn module_identifier_atom(arena: &NodeArena, index: NodeIndex) -> Option<AstAtom> {
-        arena
-            .get_identifier_at(index)
-            .and_then(|ident| (ident.atom != AstAtom::NONE).then_some(ident.atom))
-    }
-
     /// Check if `idx` is nested inside an ambient module (one with `declare` or
     /// a string-literal name). Walks up through `MODULE_BLOCK` / `MODULE_DECLARATION`
     /// ancestors until it finds one that is ambient or reaches the source file.
@@ -204,7 +197,6 @@ impl BinderState {
                 // (TS1437: "Namespace must be given a name"). Treat empty name as None
                 // so the anonymous module promotion logic kicks in.
                 .filter(|n| !n.is_empty());
-            let name_atom = Self::module_identifier_atom(arena, module.name);
             let mut prior_exports: Option<SymbolTable> = None;
             let mut module_symbol_id = SymbolId::NONE;
             if let Some(name) = name {
@@ -236,8 +228,7 @@ impl BinderState {
                 }
 
                 let flags = symbol_flags::VALUE_MODULE | symbol_flags::NAMESPACE_MODULE;
-                module_symbol_id =
-                    self.declare_symbol_with_atom(arena, &name, name_atom, flags, idx, is_exported);
+                module_symbol_id = self.declare_symbol(arena, &name, flags, idx, is_exported);
                 let is_declare = Self::has_declare_modifier(arena, module.modifiers.as_ref());
                 self.record_semantic_def_with_declare(
                     module_symbol_id,
@@ -259,8 +250,7 @@ impl BinderState {
                 // to cross-file resolution and the checker cannot resolve
                 // JSX.IntrinsicElements, causing false-positive TS7026 diagnostics.
                 if self.in_global_augmentation {
-                    self.file_locals
-                        .set_with_atom(name.clone(), name_atom, module_symbol_id);
+                    self.file_locals.set(name.clone(), module_symbol_id);
                 }
 
                 prior_exports = self
@@ -282,11 +272,7 @@ impl BinderState {
                         .get(child_id)
                         .is_some_and(|s| s.flags & symbol_flags::ENUM_MEMBER != 0);
                     if !is_enum_member {
-                        self.current_scope.set_with_atom(
-                            name.clone(),
-                            exports.atom_for_symbol(child_id),
-                            child_id,
-                        );
+                        self.current_scope.set(name.clone(), child_id);
                     }
                 }
             }
@@ -358,20 +344,14 @@ impl BinderState {
             // `namespace Outer { module { export function f() {} } }` makes `Outer.f`
             // visible.  Collect the exported symbols before exiting so we can promote
             // them to the parent scope afterwards.
-            let anon_promoted: Vec<(String, Option<AstAtom>, SymbolId)> =
+            let anon_promoted: Vec<(String, SymbolId)> =
                 if module_symbol_id.is_none() && module.body.is_some() {
                     // Promote ALL symbols — since the module has no name, there is
                     // nothing to export FROM. TSC treats the body as if it were
                     // written directly in the enclosing scope.
                     self.current_scope
                         .iter()
-                        .map(|(name, &sym_id)| {
-                            (
-                                name.clone(),
-                                self.current_scope.atom_for_symbol(sym_id),
-                                sym_id,
-                            )
-                        })
+                        .map(|(name, &sym_id)| (name.clone(), sym_id))
                         .collect()
                 } else {
                     Vec::new()
@@ -396,8 +376,8 @@ impl BinderState {
             // After exiting the anonymous module scope, promote exported symbols
             // into the parent (enclosing namespace) scope so they are accessible
             // as members of the parent namespace.
-            for (name, name_atom, sym_id) in anon_promoted {
-                self.current_scope.set_with_atom(name, name_atom, sym_id);
+            for (name, sym_id) in anon_promoted {
+                self.current_scope.set(name, sym_id);
                 // Mark as exported so the parent namespace's exit_scope includes
                 // them in its exports table (they're effectively declared inline
                 // in the parent scope).
@@ -875,15 +855,11 @@ impl BinderState {
 
                     // Now add them to exports
                     for (name, sym_id) in &exported_symbols {
-                        let name_atom = self
-                            .current_scope
-                            .atom_for_symbol(*sym_id)
-                            .or_else(|| self.file_locals.atom_for_symbol(*sym_id));
                         if let Some(module_sym) = self.symbols.get_mut(module_symbol_id) {
                             let exports = module_sym
                                 .exports
                                 .get_or_insert_with(|| Box::new(SymbolTable::new()));
-                            exports.set_with_atom(name.clone(), name_atom, *sym_id);
+                            exports.set(name.clone(), *sym_id);
                         }
                         if let Some(child_sym) = self.symbols.get_mut(*sym_id) {
                             child_sym.is_exported = true;
@@ -919,15 +895,11 @@ impl BinderState {
                             {
                                 sym_id = type_sym_id;
                             }
-                            let name_atom = self
-                                .current_scope
-                                .atom_for_symbol(sym_id)
-                                .or_else(|| self.file_locals.atom_for_symbol(sym_id));
                             if let Some(module_sym) = self.symbols.get_mut(module_symbol_id) {
                                 let exports = module_sym
                                     .exports
                                     .get_or_insert_with(|| Box::new(SymbolTable::new()));
-                                exports.set_with_atom(name.clone(), name_atom, sym_id);
+                                exports.set(name.clone(), sym_id);
                             }
                             // Mark the child symbol as exported
                             if let Some(child_sym) = self.symbols.get_mut(sym_id) {

--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -6,19 +6,12 @@
 use crate::state::BinderState;
 use crate::{ContainerKind, SymbolTable, symbol_flags};
 use std::sync::Arc;
-use tsz_common::interner::AstAtom;
 use tsz_parser::NodeIndex;
 use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 
 impl BinderState {
-    fn import_export_identifier_atom(arena: &NodeArena, index: NodeIndex) -> Option<AstAtom> {
-        arena
-            .get_identifier_at(index)
-            .and_then(|ident| (ident.atom != AstAtom::NONE).then_some(ident.atom))
-    }
-
     pub(crate) fn bind_import_declaration(
         &mut self,
         arena: &NodeArena,
@@ -56,10 +49,9 @@ impl BinderState {
             && let Some(name) = Self::get_identifier_name(arena, clause.name)
         {
             // Use import_clause node as the declaration node
-            let sym_id = self.declare_symbol_with_atom(
+            let sym_id = self.declare_symbol(
                 arena,
                 name,
-                Self::import_export_identifier_atom(arena, clause.name),
                 symbol_flags::ALIAS,
                 import.import_clause,
                 false,
@@ -83,10 +75,9 @@ impl BinderState {
         {
             if bindings_node.kind == SyntaxKind::Identifier as u16 {
                 if let Some(name) = Self::get_identifier_name(arena, clause.named_bindings) {
-                    let sym_id = self.declare_symbol_with_atom(
+                    let sym_id = self.declare_symbol(
                         arena,
                         name,
-                        Self::import_export_identifier_atom(arena, clause.named_bindings),
                         symbol_flags::ALIAS,
                         clause.named_bindings,
                         false,
@@ -106,10 +97,9 @@ impl BinderState {
                     && let Some(name) = Self::get_identifier_name(arena, named.name)
                 {
                     // Use named_bindings (NamespaceImport) as the declaration node
-                    let sym_id = self.declare_symbol_with_atom(
+                    let sym_id = self.declare_symbol(
                         arena,
                         name,
-                        Self::import_export_identifier_atom(arena, named.name),
                         symbol_flags::ALIAS,
                         clause.named_bindings,
                         false,
@@ -145,14 +135,8 @@ impl BinderState {
                         continue;
                     };
 
-                    let sym_id = self.declare_symbol_with_atom(
-                        arena,
-                        name,
-                        Self::import_export_identifier_atom(arena, local_ident),
-                        symbol_flags::ALIAS,
-                        spec_idx,
-                        false,
-                    );
+                    let sym_id =
+                        self.declare_symbol(arena, name, symbol_flags::ALIAS, spec_idx, false);
 
                     // Get property name before mutable borrow to avoid borrow checker error
                     let prop_name = if spec.name.is_some() && spec.property_name.is_some() {
@@ -217,15 +201,8 @@ impl BinderState {
                 }
 
                 // Create symbol with ALIAS flag
-                let name_atom = Self::import_export_identifier_atom(arena, import.import_clause);
-                let sym_id = self.declare_symbol_with_atom(
-                    arena,
-                    name,
-                    name_atom,
-                    symbol_flags::ALIAS,
-                    idx,
-                    is_exported,
-                );
+                let sym_id =
+                    self.declare_symbol(arena, name, symbol_flags::ALIAS, idx, is_exported);
 
                 if let Some(sym) = self.symbols.get_mut(sym_id) {
                     let span = arena.get(idx).map(|node| (node.pos, node.end));
@@ -256,8 +233,7 @@ impl BinderState {
                 // We still need to explicit export handling if declare_symbol didn't handle it fully?
                 // declare_symbol takes is_exported flag.
                 if self.in_global_augmentation {
-                    self.file_locals
-                        .set_with_atom(name.to_string(), name_atom, sym_id);
+                    self.file_locals.set(name.to_string(), sym_id);
                     Arc::make_mut(&mut self.global_augmentations)
                         .entry(name.to_string())
                         .or_default()
@@ -499,11 +475,6 @@ impl BinderState {
                                 } else {
                                     Self::get_identifier_or_string_literal_name(arena, spec.name)
                                 };
-                                let exported_atom = if spec.name.is_none() {
-                                    Self::import_export_identifier_atom(arena, spec.property_name)
-                                } else {
-                                    Self::import_export_identifier_atom(arena, spec.name)
-                                };
 
                                 if let (Some(orig), Some(exp)) = (original_name, exported_name) {
                                     // Resolve the original symbol in the current scope
@@ -576,11 +547,7 @@ impl BinderState {
                                                         ns_sym.exports.get_or_insert_with(|| {
                                                             Box::new(SymbolTable::new())
                                                         });
-                                                    exports.set_with_atom(
-                                                        exp.to_string(),
-                                                        exported_atom,
-                                                        sym_id,
-                                                    );
+                                                    exports.set(exp.to_string(), sym_id);
                                                 }
                                             } else if let Some(parent_id) = container_sym {
                                                 sym.parent = parent_id;
@@ -634,27 +601,11 @@ impl BinderState {
                                                 clone_sym.is_type_only = true;
                                                 clone_sym.is_exported = true;
                                             }
-                                            self.current_scope.set_with_atom(
-                                                exp.to_string(),
-                                                exported_atom,
-                                                clone_id,
-                                            );
-                                            self.file_locals.set_with_atom(
-                                                exp.to_string(),
-                                                exported_atom,
-                                                clone_id,
-                                            );
+                                            self.current_scope.set(exp.to_string(), clone_id);
+                                            self.file_locals.set(exp.to_string(), clone_id);
                                         } else if orig != exp {
-                                            self.current_scope.set_with_atom(
-                                                exp.to_string(),
-                                                exported_atom,
-                                                sym_id,
-                                            );
-                                            self.file_locals.set_with_atom(
-                                                exp.to_string(),
-                                                exported_atom,
-                                                sym_id,
-                                            );
+                                            self.current_scope.set(exp.to_string(), sym_id);
+                                            self.file_locals.set(exp.to_string(), sym_id);
                                         }
                                     }
                                 }
@@ -682,7 +633,6 @@ impl BinderState {
                             // and `Bar` value-bearing (matches tsc's TS1361/TS1362).
                             struct ReexportSpec {
                                 exported: String,
-                                exported_atom: Option<AstAtom>,
                                 original: Option<String>,
                                 spec_idx: NodeIndex,
                                 is_type_only: bool,
@@ -711,19 +661,10 @@ impl BinderState {
                                     } else {
                                         None
                                     };
-                                    let exported_atom = if spec.name.is_some() {
-                                        Self::import_export_identifier_atom(arena, spec.name)
-                                    } else {
-                                        Self::import_export_identifier_atom(
-                                            arena,
-                                            spec.property_name,
-                                        )
-                                    };
 
                                     if let Some(exported) = exported_name.or(original_name) {
                                         reexport_specs.push(ReexportSpec {
                                             exported: exported.to_string(),
-                                            exported_atom,
                                             original: original_name
                                                 .map(std::string::ToString::to_string),
                                             spec_idx,
@@ -753,10 +694,9 @@ impl BinderState {
                                         .insert(spec.spec_idx.0, existing_id);
                                     continue;
                                 }
-                                let sym_id = self.declare_symbol_with_atom(
+                                let sym_id = self.declare_symbol(
                                     arena,
                                     &spec.exported,
-                                    spec.exported_atom,
                                     symbol_flags::ALIAS | symbol_flags::EXPORT_VALUE,
                                     spec.spec_idx,
                                     true,
@@ -806,8 +746,6 @@ impl BinderState {
                 }
                 // Namespace export: export * as ns from 'mod'  OR  UMD: export as namespace Foo
                 else if let Some(name) = Self::get_identifier_name(arena, export.export_clause) {
-                    let name_atom =
-                        Self::import_export_identifier_atom(arena, export.export_clause);
                     let is_umd = export.module_specifier.is_none()
                         && node.kind == syntax_kind_ext::NAMESPACE_EXPORT_DECLARATION;
                     let container_sym = self
@@ -859,22 +797,18 @@ impl BinderState {
                     if let Some(type_alias_id) = existing_type_alias_id {
                         Arc::make_mut(&mut self.alias_partners).insert(type_alias_id, sym_id);
                     } else if is_umd {
-                        self.current_scope
-                            .set_with_atom(name.to_string(), name_atom, sym_id);
+                        self.current_scope.set(name.to_string(), sym_id);
                     }
                     Arc::make_mut(&mut self.node_symbols).insert(export.export_clause.0, sym_id);
 
                     if is_umd {
                         // UMD namespace exports register a global name.
                         // Add to file_locals + root scope so the name is visible cross-file.
-                        self.file_locals
-                            .set_with_atom(name.to_string(), name_atom, sym_id);
+                        self.file_locals.set(name.to_string(), sym_id);
                         if let Some(root_scope) = Arc::make_mut(&mut self.scopes).first_mut()
                             && !root_scope.table.has(name)
                         {
-                            root_scope
-                                .table
-                                .set_with_atom(name.to_string(), name_atom, sym_id);
+                            root_scope.table.set(name.to_string(), sym_id);
                         }
                     } else {
                         // Regular namespace re-export — add to module exports
@@ -882,7 +816,7 @@ impl BinderState {
                         Arc::make_mut(&mut self.module_exports)
                             .entry(current_file)
                             .or_default()
-                            .set_with_atom(name.to_string(), name_atom, sym_id);
+                            .set(name.to_string(), sym_id);
                     }
                 }
             }

--- a/crates/tsz-binder/src/nodes/binding.rs
+++ b/crates/tsz-binder/src/nodes/binding.rs
@@ -1319,21 +1319,6 @@ impl BinderState {
         declaration: NodeIndex,
         is_exported: bool,
     ) -> SymbolId {
-        let name_atom = arena.get_identifier_at(declaration).and_then(|ident| {
-            (ident.atom != tsz_common::interner::AstAtom::NONE).then_some(ident.atom)
-        });
-        self.declare_symbol_with_atom(arena, name, name_atom, flags, declaration, is_exported)
-    }
-
-    pub(crate) fn declare_symbol_with_atom(
-        &mut self,
-        arena: &NodeArena,
-        name: &str,
-        name_atom: Option<tsz_common::interner::AstAtom>,
-        flags: u32,
-        declaration: NodeIndex,
-        is_exported: bool,
-    ) -> SymbolId {
         if let Some(existing_id) = self.current_scope.get(name) {
             // Check if the existing symbol is in the local symbol table.
             // If not (e.g., it's from a lib binder), we should create a new local symbol
@@ -1359,14 +1344,12 @@ impl BinderState {
                     }
                 }
                 // Update current_scope to point to the local symbol (shadowing)
-                self.current_scope
-                    .set_with_atom(owned_name.clone(), name_atom, sym_id);
+                self.current_scope.set(owned_name.clone(), sym_id);
                 // CRITICAL: Also update file_locals to shadow lib symbol in file-level scope
                 // This ensures symbol resolution finds the local symbol instead of the lib one
-                self.file_locals
-                    .set_with_atom(owned_name.clone(), name_atom, sym_id);
+                self.file_locals.set(owned_name.clone(), sym_id);
                 Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-                self.declare_in_persistent_scope_with_atom(owned_name, name_atom, sym_id);
+                self.declare_in_persistent_scope(owned_name, sym_id);
                 return sym_id;
             }
 
@@ -1489,12 +1472,10 @@ impl BinderState {
                             .or_insert_with(|| lib_arenas.clone());
                     }
                 }
-                self.current_scope
-                    .set_with_atom(owned_name.clone(), name_atom, sym_id);
-                self.file_locals
-                    .set_with_atom(owned_name.clone(), name_atom, sym_id);
+                self.current_scope.set(owned_name.clone(), sym_id);
+                self.file_locals.set(owned_name.clone(), sym_id);
                 Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-                self.declare_in_persistent_scope_with_atom(owned_name, name_atom, sym_id);
+                self.declare_in_persistent_scope(owned_name, sym_id);
                 return sym_id;
             }
             // In merged namespace blocks, a non-exported variable must not merge with an
@@ -1530,10 +1511,9 @@ impl BinderState {
                         sym.parent = parent_id;
                     }
                 }
-                self.current_scope
-                    .set_with_atom(owned_name.clone(), name_atom, sym_id);
+                self.current_scope.set(owned_name.clone(), sym_id);
                 Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-                self.declare_in_persistent_scope_with_atom(owned_name, name_atom, sym_id);
+                self.declare_in_persistent_scope(owned_name, sym_id);
                 return sym_id;
             }
 
@@ -1567,10 +1547,9 @@ impl BinderState {
                         sym.parent = parent_id;
                     }
                 }
-                self.current_scope
-                    .set_with_atom(owned_name.clone(), name_atom, sym_id);
+                self.current_scope.set(owned_name.clone(), sym_id);
                 Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-                self.declare_in_persistent_scope_with_atom(owned_name, name_atom, sym_id);
+                self.declare_in_persistent_scope(owned_name, sym_id);
                 return sym_id;
             }
 
@@ -1631,7 +1610,7 @@ impl BinderState {
             }
 
             Arc::make_mut(&mut self.node_symbols).insert(declaration.0, existing_id);
-            self.declare_in_persistent_scope_with_atom(name.to_string(), name_atom, existing_id);
+            self.declare_in_persistent_scope(name.to_string(), existing_id);
             return existing_id;
         }
 
@@ -1661,7 +1640,7 @@ impl BinderState {
                     sym.is_exported = true;
                 }
             }
-            self.declare_in_persistent_scope_with_atom(name.to_string(), name_atom, existing_id);
+            self.declare_in_persistent_scope(name.to_string(), existing_id);
             return existing_id;
         }
 
@@ -1685,8 +1664,7 @@ impl BinderState {
                 sym.parent = parent_id;
             }
         }
-        self.current_scope
-            .set_with_atom(owned_name.clone(), name_atom, sym_id);
+        self.current_scope.set(owned_name.clone(), sym_id);
 
         // Keep source-file declarations visible through file_locals.
         // This is required for nested module scopes resolving references to
@@ -1704,12 +1682,11 @@ impl BinderState {
                 .get(self.current_scope_id.0 as usize)
                 .is_some_and(|scope| scope.kind == ContainerKind::SourceFile)
         {
-            self.file_locals
-                .set_with_atom(owned_name.clone(), name_atom, sym_id);
+            self.file_locals.set(owned_name.clone(), sym_id);
         }
 
         Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-        self.declare_in_persistent_scope_with_atom(owned_name, name_atom, sym_id);
+        self.declare_in_persistent_scope(owned_name, sym_id);
 
         // Record declaration event (new symbol)
         self.debugger

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -612,15 +612,6 @@ impl BinderState {
     /// Skipped during module augmentation to prevent augmented symbols from
     /// leaking into the augmenting file's scope (and subsequently into `file_locals/globals`).
     pub(crate) fn declare_in_persistent_scope(&mut self, name: String, sym_id: SymbolId) {
-        self.declare_in_persistent_scope_with_atom(name, None, sym_id);
-    }
-
-    pub(crate) fn declare_in_persistent_scope_with_atom(
-        &mut self,
-        name: String,
-        atom: Option<tsz_common::interner::AstAtom>,
-        sym_id: SymbolId,
-    ) {
         if self.in_module_augmentation {
             return;
         }
@@ -628,7 +619,7 @@ impl BinderState {
             && let Some(scope) =
                 Arc::make_mut(&mut self.scopes).get_mut(self.current_scope_id.0 as usize)
         {
-            scope.table.set_with_atom(name, atom, sym_id);
+            scope.table.set(name, sym_id);
         }
     }
 
@@ -1281,11 +1272,7 @@ impl BinderState {
                     if let Some(module_exports) = symbol.exports.as_ref() {
                         for (export_name, &export_sym_id) in module_exports.iter() {
                             if !file_exports.has(export_name) {
-                                file_exports.set_with_atom(
-                                    export_name.clone(),
-                                    module_exports.atom_for_symbol(export_sym_id),
-                                    export_sym_id,
-                                );
+                                file_exports.set(export_name.clone(), export_sym_id);
                             }
                         }
                     }
@@ -1310,11 +1297,7 @@ impl BinderState {
                     {
                         Arc::make_mut(&mut self.alias_partners).insert(sym_id, existing_id);
                     }
-                    file_exports.set_with_atom(
-                        name.clone(),
-                        self.file_locals.atom_for_symbol(sym_id),
-                        sym_id,
-                    );
+                    file_exports.set(name.clone(), sym_id);
                 }
             }
         }

--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -53,16 +53,15 @@ pub type FileReexportsMap = FxHashMap<String, FileReexports>;
 /// Maps `current_file` -> `Vec<(source_module, is_type_only)>`.
 /// The `is_type_only` flag is `true` for `export type * from "X"` chains.
 pub type WildcardReexportsMap = FxHashMap<String, Vec<(String, bool)>>;
-type ExportCache = FxHashMap<String, FxHashMap<String, Option<SymbolId>>>;
+type ExportCache = FxHashMap<(String, String), Option<SymbolId>>;
 /// Cache for the type-only re-export resolver. Mirrors [`ExportCache`] but also
 /// records whether the resolution path crossed an `export type * from ...`
-/// wildcard (the `bool` in the value). Keyed by `module_specifier` then
-/// `export_name`, so cache-hit lookup can borrow request strings without
-/// allocating an owned tuple. The result is a pure function of the request plus the
+/// wildcard (the `bool` in the value). Keyed by `(module_specifier,
+/// export_name)`. The result is a pure function of the request plus the
 /// binder's immutable re-export tables, so it is safe to memoize for the
 /// lifetime of the binder and is cleared alongside [`ExportCache`] whenever
 /// resolution caches are invalidated.
-type ExportTypeOnlyCache = FxHashMap<String, FxHashMap<String, Option<(SymbolId, bool)>>>;
+type ExportTypeOnlyCache = FxHashMap<(String, String), Option<(SymbolId, bool)>>;
 type IdentifierCache = FxHashMap<(usize, u32), Option<SymbolId>>;
 /// Cache for [`BinderState::find_enclosing_scope`], keyed by
 /// `(arena_pointer, node_index)` -> the resolved enclosing [`ScopeId`].
@@ -1110,16 +1109,12 @@ impl BinderState {
                 .resolved_export_cache
                 .read()
                 .expect("resolved_export_cache RwLock poisoned")
-                .values()
-                .map(FxHashMap::len)
-                .sum(),
+                .len(),
             export_type_only_cache_entries: self
                 .resolved_export_type_only_cache
                 .read()
                 .expect("resolved_export_type_only_cache RwLock poisoned")
-                .values()
-                .map(FxHashMap::len)
-                .sum(),
+                .len(),
             identifier_cache_entries: self
                 .resolved_identifier_cache
                 .read()

--- a/crates/tsz-binder/src/state/resolution.rs
+++ b/crates/tsz-binder/src/state/resolution.rs
@@ -100,8 +100,8 @@ impl BinderState {
 
         let result = 'resolve: {
             // Get the identifier text
-            let (name, name_atom) = if let Some(ident) = arena.get_identifier_at(node_idx) {
-                (&ident.escaped_text, ident.atom)
+            let name = if let Some(ident) = arena.get_identifier_at(node_idx) {
+                &ident.escaped_text
             } else {
                 break 'resolve None;
             };
@@ -113,7 +113,7 @@ impl BinderState {
                 let mut scope_depth = 0;
                 while scope_id.is_some() {
                     if let Some(scope) = self.scopes.get(scope_id.0 as usize) {
-                        if let Some(sym_id) = scope.table.get_by_atom_or_name(name_atom, name) {
+                        if let Some(sym_id) = scope.table.get(name) {
                             debug!(
                                 "[RESOLVE] '{}' FOUND in scope at depth {} (id={})",
                                 name, scope_depth, sym_id.0
@@ -146,7 +146,7 @@ impl BinderState {
             }
 
             // Finally check file locals / globals
-            if let Some(sym_id) = self.file_locals.get_by_atom_or_name(name_atom, name) {
+            if let Some(sym_id) = self.file_locals.get(name) {
                 debug!(
                     "[RESOLVE] '{}' FOUND in file_locals (id={})",
                     name, sym_id.0
@@ -169,7 +169,7 @@ impl BinderState {
             // Chained lookup: check lib binders for global symbols
             // This enables resolving console, Array, Object, etc. from lib.d.ts
             for (i, lib_binder) in self.lib_binders.iter().enumerate() {
-                if let Some(sym_id) = lib_binder.file_locals.get_by_atom_or_name(name_atom, name) {
+                if let Some(sym_id) = lib_binder.file_locals.get(name) {
                     debug!(
                         "[RESOLVE] '{}' FOUND in lib_binder[{}] (id={}) - LIB SYMBOL",
                         name, i, sym_id.0
@@ -280,9 +280,7 @@ impl BinderState {
         F: FnMut(SymbolId) -> bool,
     {
         let node = arena.get(node_idx)?;
-        let ident = arena.get_identifier(node)?;
-        let name = ident.escaped_text.as_str();
-        let name_atom = ident.atom;
+        let name = arena.get_identifier(node)?.escaped_text.as_str();
 
         let mut consider =
             |sym_id: SymbolId| -> Option<SymbolId> { accept(sym_id).then_some(sym_id) };
@@ -302,7 +300,7 @@ impl BinderState {
                     break;
                 };
 
-                if let Some(sym_id) = scope.table.get_by_atom_or_name(name_atom, name)
+                if let Some(sym_id) = scope.table.get(name)
                     && let Some(found) = consider(sym_id)
                 {
                     return Some(found);
@@ -323,7 +321,7 @@ impl BinderState {
             }
         }
 
-        if let Some(sym_id) = self.file_locals.get_by_atom_or_name(name_atom, name)
+        if let Some(sym_id) = self.file_locals.get(name)
             && let Some(found) = consider(sym_id)
         {
             return Some(found);
@@ -348,7 +346,7 @@ impl BinderState {
         // `resolve_identifier_symbol` and `resolve_type_symbol` fallbacks.
         if !self.lib_symbols_merged {
             for lib_binder in lib_binders {
-                if let Some(sym_id) = lib_binder.file_locals.get_by_atom_or_name(name_atom, name)
+                if let Some(sym_id) = lib_binder.file_locals.get(name)
                     && let Some(found) = consider(sym_id)
                 {
                     return Some(found);
@@ -634,12 +632,12 @@ impl BinderState {
         export_name: &str,
     ) -> Option<SymbolId> {
         // Check cache first for fast path
+        let cache_key = (module_specifier.to_string(), export_name.to_string());
         if let Some(&cached) = self
             .resolved_export_cache
             .read()
             .expect("RwLock not poisoned")
-            .get(module_specifier)
-            .and_then(|module_cache| module_cache.get(export_name))
+            .get(&cache_key)
         {
             return cached;
         }
@@ -658,9 +656,7 @@ impl BinderState {
         self.resolved_export_cache
             .write()
             .expect("resolved_export_cache RwLock poisoned")
-            .entry(module_specifier.to_string())
-            .or_default()
-            .insert(export_name.to_string(), result);
+            .insert(cache_key, result);
         result
     }
 
@@ -692,12 +688,12 @@ impl BinderState {
             );
         }
 
+        let cache_key = (module_specifier.to_string(), export_name.to_string());
         if let Some(&cached) = self
             .resolved_export_type_only_cache
             .read()
             .expect("resolved_export_type_only_cache RwLock poisoned")
-            .get(module_specifier)
-            .and_then(|module_cache| module_cache.get(export_name))
+            .get(&cache_key)
         {
             return cached;
         }
@@ -713,9 +709,7 @@ impl BinderState {
         self.resolved_export_type_only_cache
             .write()
             .expect("resolved_export_type_only_cache RwLock poisoned")
-            .entry(module_specifier.to_string())
-            .or_default()
-            .insert(export_name.to_string(), result);
+            .insert(cache_key, result);
         result
     }
 

--- a/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
+++ b/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
@@ -1305,8 +1305,7 @@ fn type_only_reexport_resolution_is_cached_and_stable() {
             .resolved_export_type_only_cache
             .read()
             .expect("cache lock")
-            .get("./entry")
-            .and_then(|module_cache| module_cache.get("Widget"))
+            .get(&("./entry".to_string(), "Widget".to_string()))
             .copied(),
         Some(Some((leaf_sym, false))),
         "type-only resolution should be memoized per (module, export)"
@@ -1349,8 +1348,7 @@ fn type_only_reexport_cache_missing_export_is_cached_as_none() {
             .resolved_export_type_only_cache
             .read()
             .expect("cache lock")
-            .get("./entry")
-            .and_then(|module_cache| module_cache.get("DoesNotExist"))
+            .get(&("./entry".to_string(), "DoesNotExist".to_string()))
             .copied(),
         Some(None),
         "negative type-only results must also be memoized"

--- a/crates/tsz-binder/src/state/tests/state_storage.rs
+++ b/crates/tsz-binder/src/state/tests/state_storage.rs
@@ -510,9 +510,7 @@ fn seed_resolution_caches(binder: &mut BinderState) {
         .resolved_export_cache
         .write()
         .expect("not poisoned")
-        .entry("stub.ts".to_string())
-        .or_default()
-        .insert("x".to_string(), Some(SymbolId(99)));
+        .insert(("stub.ts".to_string(), "x".to_string()), Some(SymbolId(99)));
     binder
         .resolved_identifier_cache
         .write()
@@ -522,9 +520,10 @@ fn seed_resolution_caches(binder: &mut BinderState) {
         .resolved_export_type_only_cache
         .write()
         .expect("not poisoned")
-        .entry("stub.ts".to_string())
-        .or_default()
-        .insert("T".to_string(), Some((SymbolId(88), true)));
+        .insert(
+            ("stub.ts".to_string(), "T".to_string()),
+            Some((SymbolId(88), true)),
+        );
     binder
         .find_enclosing_scope_cache
         .write()

--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -511,13 +511,6 @@ impl Symbol {
 pub struct SymbolTable {
     /// Symbols indexed by their escaped name (using `FxHashMap` for faster hashing)
     symbols: Arc<FxHashMap<String, SymbolId>>,
-    /// Symbols indexed by parsed identifier `AstAtom` when the binder had one.
-    ///
-    /// This is a migration index for #13073: string keys remain authoritative
-    /// for compatibility, while parsed identifiers can avoid hashing their
-    /// escaped text on hot resolution paths.
-    #[serde(skip)]
-    atom_symbols: Arc<FxHashMap<tsz_common::interner::AstAtom, SymbolId>>,
 }
 
 impl SymbolTable {
@@ -525,7 +518,6 @@ impl SymbolTable {
     pub fn new() -> Self {
         Self {
             symbols: Arc::new(FxHashMap::default()),
-            atom_symbols: Arc::new(FxHashMap::default()),
         }
     }
 
@@ -539,10 +531,6 @@ impl SymbolTable {
                 capacity,
                 Default::default(),
             )),
-            atom_symbols: Arc::new(FxHashMap::with_capacity_and_hasher(
-                capacity,
-                Default::default(),
-            )),
         }
     }
 
@@ -552,60 +540,14 @@ impl SymbolTable {
         self.symbols.get(name).copied()
     }
 
-    /// Get a symbol by parsed identifier atom.
-    #[must_use]
-    pub fn get_by_atom(&self, atom: tsz_common::interner::AstAtom) -> Option<SymbolId> {
-        if atom == tsz_common::interner::AstAtom::NONE {
-            return None;
-        }
-        self.atom_symbols.get(&atom).copied()
-    }
-
-    /// Get a symbol by atom when present, falling back to escaped text.
-    #[must_use]
-    pub fn get_by_atom_or_name(
-        &self,
-        atom: tsz_common::interner::AstAtom,
-        name: &str,
-    ) -> Option<SymbolId> {
-        self.get_by_atom(atom).or_else(|| self.get(name))
-    }
-
-    /// Find the parsed identifier atom that currently points at `symbol`.
-    #[must_use]
-    pub fn atom_for_symbol(&self, symbol: SymbolId) -> Option<tsz_common::interner::AstAtom> {
-        self.atom_symbols
-            .iter()
-            .find_map(|(&atom, &id)| (id == symbol).then_some(atom))
-    }
-
     /// Set a symbol by name.
     pub fn set(&mut self, name: String, symbol: SymbolId) {
         Arc::make_mut(&mut self.symbols).insert(name, symbol);
     }
 
-    /// Set a symbol by name and, when available, by parsed identifier atom.
-    pub fn set_with_atom(
-        &mut self,
-        name: String,
-        atom: Option<tsz_common::interner::AstAtom>,
-        symbol: SymbolId,
-    ) {
-        self.set(name, symbol);
-        if let Some(atom) = atom
-            && atom != tsz_common::interner::AstAtom::NONE
-        {
-            Arc::make_mut(&mut self.atom_symbols).insert(atom, symbol);
-        }
-    }
-
     /// Remove a symbol by name.
     pub fn remove(&mut self, name: &str) -> Option<SymbolId> {
-        let removed = Arc::make_mut(&mut self.symbols).remove(name);
-        if let Some(symbol) = removed {
-            Arc::make_mut(&mut self.atom_symbols).retain(|_, id| *id != symbol);
-        }
-        removed
+        Arc::make_mut(&mut self.symbols).remove(name)
     }
 
     /// Check if a name exists in the table.
@@ -629,7 +571,6 @@ impl SymbolTable {
     /// Clear all symbols while keeping the allocated capacity.
     pub fn clear(&mut self) {
         Arc::make_mut(&mut self.symbols).clear();
-        Arc::make_mut(&mut self.atom_symbols).clear();
     }
 
     /// Iterate over symbols.
@@ -646,10 +587,6 @@ impl SymbolTable {
         const BUCKET_OVERHEAD: usize = 16;
         let mut size = self.symbols.capacity()
             * (BUCKET_OVERHEAD + std::mem::size_of::<String>() + std::mem::size_of::<SymbolId>());
-        size += self.atom_symbols.capacity()
-            * (BUCKET_OVERHEAD
-                + std::mem::size_of::<tsz_common::interner::AstAtom>()
-                + std::mem::size_of::<SymbolId>());
         for name in self.symbols.keys() {
             size += name.capacity();
         }


### PR DESCRIPTION
Goal: hold

## Summary
Restores the exact conformance floor (12,585/12,585) by reverting the two commits that wedged the merge queue on 2026-06-12. They are **independent** regressions with different mechanisms; both reverts are needed for green main.

### 1. Revert 38221b12ed (#13083 / #13330) — deterministic `temporal.ts` regression
- The current `main` tip. `perf(checker): hoist switch-chain DP memo, finish null-exclusion threading`.
- Deterministically produces an extra `TS2552 Cannot find name 'DateTimeFormatPart'` in `lib.es2021.intl.d.ts` / `lib.esnext.intl.d.ts` while checking `compiler/temporal.ts`.
- `git bisect` over the 14-commit window `e86c754c79..38221b12ed` pins it exactly: `644732da3a` (one commit below tip) passes `temporal` 1/1; `38221b12ed` fails. A flow-DP memo cache-key defect surfaces as corrupted name resolution.
- NOTE: open PR #13347 claims to fix `temporal.ts` but its diff (string-index `this`-binding in `property_visitor.rs`) is unrelated to this `Cannot find name` failure, and `temporal.ts` still fails 4/4 at #13347's head. That PR does not address this regression.

### 2. Revert 2587314d39 (#13299) — probabilistic `globalThisAmbientModules.ts` regression
- `perf(binder): add atom-backed symbol table lookups`. Stores per-file `AstAtom`s in `SymbolTable.atom_symbols` and makes `get_by_atom_or_name` prefer the atom index over the authoritative string key.
- `state/resolution.rs` queries lib binders' `file_locals` with the *user file's* atom, and `state/core.rs` copies atoms across tables from foreign arenas — violating the documented `AstAtom` contract (`crates/tsz-common/src/interner/mod.rs`: cross-arena comparison "is a logic error").
- A numeric atom-id collision resolves an identifier to a foreign arena's symbol: `globalThis` → `captureEvents` (`lib.dom.d.ts`), yielding an extra `TS2339 Property 'valueModule' does not exist on type 'typeof captureEvents'`.
- Scheduling-dependent (~1 in 190 runner invocations locally; ~43% of CI conformance runs on 2026-06-12). This is the rotating flake that ejected every PR from the queue; #13299's own queue attempts were ejected 4× by it before a flaky-green attempt landed it (runs 27417480252, 27421120255, 27424726430, 27425842007).

## Structural rule
- (#13083) A flow control-flow DP memo must key on the full narrowing state it caches; a memo that returns stale/cross-keyed results corrupts downstream symbol resolution. Reverted to the green pre-memo path; re-land with a cache-key/invalidation invariant and a `temporal.ts` adjacent case.
- (#13299) When a symbol table can be queried from (or populated by) a file other than the one whose arena minted its atoms, identifier resolution must use the interned string key; per-file `AstAtom`s are only comparable within their owning arena. Re-land only with a per-arena provenance guarantee.

## Owner layer
Checker flow analysis (`crates/tsz-checker/src/flow/control_flow/*`) and binder symbol resolution (`crates/tsz-binder/src/{symbols.rs, state/*, modules/*}`). Pure reverts; no new logic.

## Adjacent cases
- `temporal.ts` 1/1 after revert; narrowing 29/29, switch 15/15, controlFlow 94/94, discriminant 9/9 — flow families unaffected (the revert restores the pre-#13083 green state).
- `globalThisAmbientModules` 1/1; `global*` family stress (25 tests) ×6 = 150/150; `infiniteConstraints` 1/1.
- Same-file lookups and cached/deserialized symbol tables (`atom_symbols` was `#[serde(skip)]`) were already on the string path — cache/order honesty restored for fresh tables.

## Verification
- `cargo nextest run -p tsz-binder`: 542/542.
- Narrow conformance (direct runner, corpus pinned `050880ce`): `temporal` 1/1 ×3; `global*` 25/25 ×6; narrowing/switch/controlFlow/discriminant 147/147.
- Bisect log: `git bisect start 38221b12ed e86c754c79; git bisect run ./bisect-temporal.sh` → `38221b12ed is the first bad commit`.
- Pre-revert evidence: temporal fails 3/3 at `38221b12ed`; globalThis flips merge_group-pass (run 27439623747) vs push-fail (27440526648) on identical sha `38ae9ca728`.

## Provenance
Machine: Mohsens-MacBook-Pro.local
Assistant: claude-code
Model: claude-fable-5
Effort: max