### PR TITLE
refactor(core): unify strict-family expansion across option engines (#13062)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/check.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/check.rs
@@ -17,6 +17,7 @@ use tsz::lib_loader::LibFile;
 use tsz::parallel;
 use tsz::parser::ParserState;
 use tsz::parser::node::NodeArena;
+use tsz_cli::config::strict_family::{StrictFamilyOverrides, apply_strict_family};
 use tsz_cli::config::{
     checker_target_from_emitter, default_lib_name_for_target, resolve_default_lib_files_from_dir,
     resolve_lib_files_from_dir,
@@ -893,28 +894,16 @@ impl Server {
         let emitter_target = Self::parse_target(&options.target);
         let checker_target = checker_target_from_emitter(emitter_target);
 
-        // Note: We don't use CheckerOptions::default() as a base here.
-        // When strict is explicitly set (true or false), all strict-family flags
-        // that are not explicitly set should inherit from strict's value.
-        // This matches tsc behavior where @strict: false disables all strict checks.
-        // Only use defaults for flags that are truly not specified.
-
-        CheckerOptions {
-            strict: options.strict,
-            strict_null_checks: options.strict_null_checks.unwrap_or(options.strict),
-            strict_function_types: options.strict_function_types.unwrap_or(options.strict),
-            strict_bind_call_apply: options.strict_bind_call_apply.unwrap_or(options.strict),
-            strict_property_initialization: options
-                .strict_property_initialization
-                .unwrap_or(options.strict),
-            no_implicit_any: options.no_implicit_any.unwrap_or(options.strict),
-            no_implicit_this: options.no_implicit_this.unwrap_or(options.strict),
+        // Strict-family members are resolved by the shared `strict_family`
+        // table below (umbrella expansion first, then explicit member
+        // overrides — tsc 6.0 `getStrictOptionValue`, issue #3861 ordering).
+        // The placeholders contributed by `..CheckerOptions::default()` for
+        // those members are always overwritten because the server protocol's
+        // `strict` is non-optional.
+        let mut checker_options = CheckerOptions {
             no_implicit_returns: options.no_implicit_returns,
             exact_optional_property_types: options.exact_optional_property_types,
             no_unchecked_indexed_access: options.no_unchecked_indexed_access,
-            use_unknown_in_catch_variables: options
-                .use_unknown_in_catch_variables
-                .unwrap_or(options.strict),
             isolated_modules: options.isolated_modules,
             no_lib: options.no_lib,
             no_types_and_symbols: false,
@@ -936,7 +925,11 @@ impl Server {
             experimental_decorators: options.experimental_decorators,
             no_unused_locals: options.no_unused_locals,
             no_unused_parameters: options.no_unused_parameters,
-            always_strict: options.always_strict.unwrap_or(options.strict),
+            // tsc 6.0: alwaysStrict is no longer a strict-family member
+            // (utilities.ts computedOptions.alwaysStrict: "Previously a
+            // strict-mode flag, but no longer"); it resolves as
+            // `alwaysStrict !== false`, independent of `strict`.
+            always_strict: options.always_strict.unwrap_or(true),
             resolve_json_module: options.resolve_json_module,
             check_js: options.check_js,
             allow_js: options.allow_js,
@@ -978,11 +971,24 @@ impl Server {
             ignore_deprecations: false,
             allow_umd_global_access: options.allow_umd_global_access,
             preserve_const_enums: options.preserve_const_enums,
-            strict_builtin_iterator_return: options
-                .strict_builtin_iterator_return
-                .unwrap_or(options.strict),
             erasable_syntax_only: options.erasable_syntax_only,
             no_fallthrough_cases_in_switch: options.no_fallthrough_cases_in_switch,
-        }
+            ..CheckerOptions::default()
+        };
+        apply_strict_family(
+            &mut checker_options,
+            &StrictFamilyOverrides {
+                strict: Some(options.strict),
+                no_implicit_any: options.no_implicit_any,
+                no_implicit_this: options.no_implicit_this,
+                strict_null_checks: options.strict_null_checks,
+                strict_function_types: options.strict_function_types,
+                strict_bind_call_apply: options.strict_bind_call_apply,
+                strict_property_initialization: options.strict_property_initialization,
+                strict_builtin_iterator_return: options.strict_builtin_iterator_return,
+                use_unknown_in_catch_variables: options.use_unknown_in_catch_variables,
+            },
+        );
+        checker_options
     }
 }

--- a/crates/tsz-cli/src/driver/plan.rs
+++ b/crates/tsz-cli/src/driver/plan.rs
@@ -12,7 +12,7 @@ use crate::args::{CliArgs, Module, ModuleDetection, ModuleResolution, NewLine, T
 use crate::config::{
     CompilerOptions, ModuleResolutionKind, ResolvedCompilerOptions, TsConfig,
     checker_target_from_emitter, parse_tsconfig_with_diagnostics, resolve_default_lib_files,
-    resolve_lib_files,
+    resolve_lib_files, strict_family,
 };
 use tsz::checker::diagnostics::{Diagnostic, diagnostic_codes};
 use tsz_common::common::NewLineKind;
@@ -152,69 +152,43 @@ pub(super) fn apply_cli_overrides_with_config_options(
         // importHelpers means "import from tslib" — suppress inline helper emission
         options.printer.no_emit_helpers = true;
     }
-    if args.strict {
-        options.checker.strict = true;
-        // Expand --strict to individual flags (matching TypeScript behavior).
-        // NOTE: noImplicitReturns is NOT part of --strict in TypeScript.
-        options.checker.no_implicit_any = true;
-        options.checker.strict_null_checks = true;
-        options.checker.strict_function_types = true;
-        options.checker.strict_bind_call_apply = true;
-        options.checker.strict_property_initialization = true;
-        options.checker.no_implicit_this = true;
-        options.checker.use_unknown_in_catch_variables = true;
-        options.checker.strict_builtin_iterator_return = true;
-        options.checker.always_strict = true;
-        options.printer.always_strict = true;
+    // Strict-family expansion and explicit member overrides are owned by the
+    // shared `strict_family` table (tsc 6.0 `getStrictOptionValue`).
+    // NOTE: noImplicitReturns is NOT part of --strict in TypeScript.
+    // An explicit `--strict false` (forwarded by `preprocess_args` through
+    // the hidden side-channel) contracts a config `strict: true` plus its
+    // expansion to `false`; the explicit `Option<bool>` member overrides are
+    // applied after the umbrella inside the helper, so `--strict false
+    // --strictNullChecks=true` still keeps `strict_null_checks = true`
+    // (issue #3861). `alwaysStrict` is not a strict-family member in tsc 6.0
+    // (`alwaysStrict !== false`, independent of `strict`), so neither
+    // `--strict` nor `--strict false` touches it; only the explicit
+    // `--alwaysStrict` override below does.
+    let strict_umbrella = if args.strict {
+        Some(true)
     } else if args
         .explicitly_disabled_bool_flags
         .iter()
         .any(|name| name == "strict")
     {
-        // Mirror config loader's strict-disable expansion: explicit
-        // `--strict false` (forwarded by `preprocess_args` through the hidden
-        // side-channel) flips a config `strict: true` plus its expansion to
-        // `false`. Must run before the individual `Option<bool>` family
-        // overrides below so that `--strict false --strictNullChecks=true`
-        // still keeps `strict_null_checks = true` (issue #3861).
-        options.checker.strict = false;
-        options.checker.no_implicit_any = false;
-        // noImplicitReturns is NOT part of the strict family; do not reset it here.
-        options.checker.strict_null_checks = false;
-        options.checker.strict_function_types = false;
-        options.checker.strict_bind_call_apply = false;
-        options.checker.strict_property_initialization = false;
-        options.checker.no_implicit_this = false;
-        options.checker.use_unknown_in_catch_variables = false;
-        options.checker.strict_builtin_iterator_return = false;
-        options.checker.always_strict = false;
-        options.printer.always_strict = false;
-    }
-    // Individual strict flag overrides (must come after --strict expansion)
-    if let Some(val) = args.strict_null_checks {
-        options.checker.strict_null_checks = val;
-    }
-    if let Some(val) = args.strict_function_types {
-        options.checker.strict_function_types = val;
-    }
-    if let Some(val) = args.strict_property_initialization {
-        options.checker.strict_property_initialization = val;
-    }
-    if let Some(val) = args.strict_bind_call_apply {
-        options.checker.strict_bind_call_apply = val;
-    }
-    if let Some(val) = args.no_implicit_this {
-        options.checker.no_implicit_this = val;
-    }
-    if let Some(val) = args.no_implicit_any {
-        options.checker.no_implicit_any = val;
-    }
-    if let Some(val) = args.use_unknown_in_catch_variables {
-        options.checker.use_unknown_in_catch_variables = val;
-    }
-    if let Some(val) = args.strict_builtin_iterator_return {
-        options.checker.strict_builtin_iterator_return = val;
-    }
+        Some(false)
+    } else {
+        None
+    };
+    strict_family::apply_strict_family(
+        &mut options.checker,
+        &strict_family::StrictFamilyOverrides {
+            strict: strict_umbrella,
+            no_implicit_any: args.no_implicit_any,
+            no_implicit_this: args.no_implicit_this,
+            strict_null_checks: args.strict_null_checks,
+            strict_function_types: args.strict_function_types,
+            strict_bind_call_apply: args.strict_bind_call_apply,
+            strict_property_initialization: args.strict_property_initialization,
+            strict_builtin_iterator_return: args.strict_builtin_iterator_return,
+            use_unknown_in_catch_variables: args.use_unknown_in_catch_variables,
+        },
+    );
     if args.no_unchecked_indexed_access {
         options.checker.no_unchecked_indexed_access = true;
     }
@@ -532,10 +506,10 @@ fn apply_explicitly_disabled_bool_flags(options: &mut ResolvedCompilerOptions, a
     for name in &args.explicitly_disabled_bool_flags {
         if matches!(
             name.as_str(),
-            // `strict` is handled earlier (just after the `--strict` true
-            // expansion) so the strict-family `Option<bool>` overrides that
-            // run between can still win over the disable. See the
-            // `else if` branch on `args.strict` above.
+            // `strict` is handled earlier by the shared `strict_family`
+            // helper, which applies the explicit `Option<bool>` member
+            // overrides after the umbrella so they win over the disable
+            // (issue #3861). See `apply_strict_family` above.
             "strict"
                 // CLI-only display flag; no compiler option to toggle.
                 | "noErrorTruncation"

--- a/crates/tsz-cli/src/driver/tests.rs
+++ b/crates/tsz-cli/src/driver/tests.rs
@@ -500,6 +500,11 @@ fn test_cli_module_resolution_preserves_config_package_json_resolution_false() {
 /// `tsconfig.json`. `preprocess_args` forwards the explicit-false intent
 /// through the hidden `--__explicitly-disabled-bool-flag` side-channel; this
 /// test simulates the post-preprocess args directly. Issue #3861.
+///
+/// `alwaysStrict` must survive the contraction: tsc 6.0 removed it from the
+/// strict family (`utilities.ts` `computedOptions.alwaysStrict`: "Previously
+/// a strict-mode flag, but no longer"), so it resolves as
+/// `alwaysStrict !== false`, independent of `strict`.
 #[test]
 fn test_cli_strict_false_overrides_config_strict_true() {
     let args = CliArgs::try_parse_from(["tsz", "--__explicitly-disabled-bool-flag=strict"])
@@ -509,6 +514,7 @@ fn test_cli_strict_false_overrides_config_strict_true() {
     options.checker.no_implicit_any = true;
     options.checker.strict_null_checks = true;
     options.checker.always_strict = true;
+    options.printer.always_strict = true;
     let config_options = CompilerOptions {
         strict: Some(true),
         ..Default::default()
@@ -525,8 +531,58 @@ fn test_cli_strict_false_overrides_config_strict_true() {
         "--strict false must reset the strict-family expansion"
     );
     assert!(!options.checker.strict_null_checks);
-    assert!(!options.checker.always_strict);
+    assert!(
+        options.checker.always_strict,
+        "--strict false must not reset alwaysStrict (tsc 6.0: not a strict-family member)"
+    );
+    assert!(
+        options.printer.always_strict,
+        "--strict false must not reset the printer alwaysStrict either"
+    );
+}
+
+/// `--strict` on the command line must not clobber an explicit
+/// `alwaysStrict: false` from `tsconfig.json`: tsc 6.0 resolves
+/// `alwaysStrict` as `alwaysStrict !== false`, independent of `strict`.
+#[test]
+fn test_cli_strict_true_preserves_config_always_strict_false() {
+    let args = CliArgs::try_parse_from(["tsz", "--strict"]).expect("parse args");
+    let mut options = ResolvedCompilerOptions::default();
+    // Simulate a config with `alwaysStrict: false` already resolved.
+    options.checker.always_strict = false;
+    options.printer.always_strict = false;
+
+    super::apply_cli_overrides(&mut options, &args).expect("apply overrides");
+
+    assert!(options.checker.strict);
+    assert!(options.checker.no_implicit_any, "family expanded");
+    assert!(options.checker.strict_null_checks, "family expanded");
+    assert!(
+        !options.checker.always_strict,
+        "--strict must not force alwaysStrict over an explicit config false (tsc 6.0)"
+    );
     assert!(!options.printer.always_strict);
+}
+
+/// Issue #3861 ordering, inverse permutation: `--strict` plus an explicit
+/// `--strictFunctionTypes=false` keeps the member off while the rest of the
+/// family expands.
+#[test]
+fn test_cli_strict_true_with_explicit_member_false() {
+    let args = CliArgs::try_parse_from(["tsz", "--strict", "--strictFunctionTypes=false"])
+        .expect("parse args");
+    let mut options = ResolvedCompilerOptions::default();
+    options.checker.strict_function_types = true;
+
+    super::apply_cli_overrides(&mut options, &args).expect("apply overrides");
+
+    assert!(options.checker.strict);
+    assert!(
+        !options.checker.strict_function_types,
+        "explicit member must win over the --strict expansion (#3861)"
+    );
+    assert!(options.checker.strict_null_checks);
+    assert!(options.checker.no_implicit_any);
 }
 
 #[test]

--- a/crates/tsz-common/src/options/checker.rs
+++ b/crates/tsz-common/src/options/checker.rs
@@ -269,21 +269,24 @@ impl Default for CheckerOptions {
 
 impl CheckerOptions {
     /// Apply TypeScript's `--strict` defaults to individual strict flags.
-    /// In tsc, enabling `strict` turns on the strict family unless explicitly disabled.
-    /// We mirror that behavior by OR-ing the per-flag booleans with `strict`.
+    ///
+    /// In tsc, enabling `strict` turns on every strict-family member that is
+    /// not explicitly provided. This builder variant has no explicitly-set
+    /// mask, so it re-expands the umbrella over the whole family table;
+    /// callers that track which members the user provided must use
+    /// [`super::strict_family::apply_strict_family`] instead so explicit
+    /// members win over the umbrella.
+    ///
+    /// `alwaysStrict` is not touched: tsc 6.0 removed it from the strict
+    /// family (`TypeScript/src/compiler/utilities.ts`
+    /// `computedOptions.alwaysStrict`: "Previously a strict-mode flag, but
+    /// no longer"); it resolves as `alwaysStrict !== false`, independent of
+    /// `strict`. `exactOptionalPropertyTypes` and other options are likewise
+    /// not implied by `--strict`.
     #[must_use]
-    pub const fn apply_strict_defaults(mut self) -> Self {
+    pub fn apply_strict_defaults(mut self) -> Self {
         if self.strict {
-            self.no_implicit_any = true;
-            self.no_implicit_this = true;
-            self.strict_null_checks = true;
-            self.strict_function_types = true;
-            self.strict_bind_call_apply = true;
-            self.strict_property_initialization = true;
-            self.use_unknown_in_catch_variables = true;
-            self.always_strict = true;
-            self.strict_builtin_iterator_return = true;
-            // exactOptionalPropertyTypes and other opts are not implied by --strict
+            super::strict_family::expand_strict(&mut self, true);
         }
         self
     }

--- a/crates/tsz-common/src/options/mod.rs
+++ b/crates/tsz-common/src/options/mod.rs
@@ -1,1 +1,2 @@
 pub mod checker;
+pub mod strict_family;

--- a/crates/tsz-common/src/options/strict_family.rs
+++ b/crates/tsz-common/src/options/strict_family.rs
@@ -1,0 +1,284 @@
+//! Single owner of TypeScript's `--strict` umbrella expansion.
+//!
+//! TypeScript 6.0 defines the strict family via `StrictOptionName` and
+//! `getStrictOptionValue` (`TypeScript/src/compiler/utilities.ts`): a member
+//! that is not explicitly provided resolves to `strict !== false`; an
+//! explicitly provided member always wins over the umbrella value.
+//!
+//! `alwaysStrict` is intentionally NOT in this table. TypeScript 6.0 removed
+//! it from the strict family (`utilities.ts` `computedOptions.alwaysStrict`:
+//! "Previously a strict-mode flag, but no longer"); it resolves as
+//! `alwaysStrict !== false`, independent of `strict`. Each options surface
+//! owns its explicit `alwaysStrict` override separately.
+//!
+//! `noImplicitReturns` is likewise NOT part of the family in tsc.
+
+use super::checker::CheckerOptions;
+
+/// Explicitly provided strict-family values from one options surface
+/// (CLI args, tsconfig, WASM JSON, or the server protocol).
+///
+/// `None` means "not provided by the user": the member follows the `strict`
+/// umbrella when `strict` is provided, and otherwise keeps the value already
+/// present on the [`CheckerOptions`] being resolved.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StrictFamilyOverrides {
+    pub strict: Option<bool>,
+    pub no_implicit_any: Option<bool>,
+    pub no_implicit_this: Option<bool>,
+    pub strict_null_checks: Option<bool>,
+    pub strict_function_types: Option<bool>,
+    pub strict_bind_call_apply: Option<bool>,
+    pub strict_property_initialization: Option<bool>,
+    pub strict_builtin_iterator_return: Option<bool>,
+    pub use_unknown_in_catch_variables: Option<bool>,
+}
+
+/// One strict-family member: the tsc option name plus accessors for the
+/// per-surface explicit value and the resolved [`CheckerOptions`] slot.
+pub struct StrictFamilyMember {
+    /// tsc camelCase option name (one of tsc 6.0's `StrictOptionName`).
+    pub name: &'static str,
+    explicit: fn(&StrictFamilyOverrides) -> Option<bool>,
+    slot: fn(&mut CheckerOptions) -> &mut bool,
+}
+
+/// The strict family, one row per tsc 6.0 `StrictOptionName` member
+/// (`TypeScript/src/compiler/utilities.ts`).
+pub const STRICT_FAMILY: &[StrictFamilyMember] = &[
+    StrictFamilyMember {
+        name: "noImplicitAny",
+        explicit: |overrides| overrides.no_implicit_any,
+        slot: |options| &mut options.no_implicit_any,
+    },
+    StrictFamilyMember {
+        name: "noImplicitThis",
+        explicit: |overrides| overrides.no_implicit_this,
+        slot: |options| &mut options.no_implicit_this,
+    },
+    StrictFamilyMember {
+        name: "strictNullChecks",
+        explicit: |overrides| overrides.strict_null_checks,
+        slot: |options| &mut options.strict_null_checks,
+    },
+    StrictFamilyMember {
+        name: "strictFunctionTypes",
+        explicit: |overrides| overrides.strict_function_types,
+        slot: |options| &mut options.strict_function_types,
+    },
+    StrictFamilyMember {
+        name: "strictBindCallApply",
+        explicit: |overrides| overrides.strict_bind_call_apply,
+        slot: |options| &mut options.strict_bind_call_apply,
+    },
+    StrictFamilyMember {
+        name: "strictPropertyInitialization",
+        explicit: |overrides| overrides.strict_property_initialization,
+        slot: |options| &mut options.strict_property_initialization,
+    },
+    StrictFamilyMember {
+        name: "strictBuiltinIteratorReturn",
+        explicit: |overrides| overrides.strict_builtin_iterator_return,
+        slot: |options| &mut options.strict_builtin_iterator_return,
+    },
+    StrictFamilyMember {
+        name: "useUnknownInCatchVariables",
+        explicit: |overrides| overrides.use_unknown_in_catch_variables,
+        slot: |options| &mut options.use_unknown_in_catch_variables,
+    },
+];
+
+/// Apply tsc's strict-family resolution to `options`.
+///
+/// Mirrors tsc 6.0 `getStrictOptionValue`: when `strict` is provided, the
+/// umbrella value is expanded to every family member first, then explicitly
+/// provided members override it. This bakes in the issue #3861 ordering:
+/// `--strict false --strictNullChecks true` keeps `strictNullChecks` on.
+/// Members that are not provided and have no umbrella keep the values
+/// already present on `options`.
+pub fn apply_strict_family(options: &mut CheckerOptions, overrides: &StrictFamilyOverrides) {
+    if let Some(strict) = overrides.strict {
+        options.strict = strict;
+        for member in STRICT_FAMILY {
+            *(member.slot)(options) = strict;
+        }
+    }
+    for member in STRICT_FAMILY {
+        if let Some(value) = (member.explicit)(overrides) {
+            *(member.slot)(options) = value;
+        }
+    }
+}
+
+/// Expand only the `strict` umbrella across the family, with no explicit
+/// member overrides.
+///
+/// Used by re-application sites (e.g. `CheckerOptions::apply_strict_defaults`)
+/// that operate on an already-resolved `CheckerOptions` without an
+/// explicitly-set mask. Sites that know which members the user provided must
+/// use [`apply_strict_family`] so explicit members win over the umbrella.
+pub fn expand_strict(options: &mut CheckerOptions, strict: bool) {
+    apply_strict_family(
+        options,
+        &StrictFamilyOverrides {
+            strict: Some(strict),
+            ..Default::default()
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{STRICT_FAMILY, StrictFamilyOverrides, apply_strict_family, expand_strict};
+    use crate::options::checker::CheckerOptions;
+
+    /// Pin the table to tsc 6.0's `StrictOptionName` union
+    /// (`TypeScript/src/compiler/utilities.ts`). `alwaysStrict` must NOT be
+    /// present: tsc 6.0 removed it from the strict family.
+    #[test]
+    fn table_matches_tsc_6_0_strict_option_name() {
+        let names: Vec<&str> = STRICT_FAMILY.iter().map(|member| member.name).collect();
+        assert_eq!(
+            names,
+            [
+                "noImplicitAny",
+                "noImplicitThis",
+                "strictNullChecks",
+                "strictFunctionTypes",
+                "strictBindCallApply",
+                "strictPropertyInitialization",
+                "strictBuiltinIteratorReturn",
+                "useUnknownInCatchVariables",
+            ]
+        );
+        assert!(!names.contains(&"alwaysStrict"));
+        assert!(!names.contains(&"noImplicitReturns"));
+    }
+
+    /// Issue #3861 ordering: `strict: false` plus an explicit member keeps
+    /// the explicit member while contracting the rest of the family.
+    #[test]
+    fn strict_false_then_explicit_member_true_keeps_member() {
+        let mut options = CheckerOptions::default();
+        apply_strict_family(
+            &mut options,
+            &StrictFamilyOverrides {
+                strict: Some(false),
+                strict_null_checks: Some(true),
+                ..Default::default()
+            },
+        );
+
+        assert!(!options.strict);
+        assert!(options.strict_null_checks, "explicit member wins (#3861)");
+        assert!(!options.no_implicit_any);
+        assert!(!options.no_implicit_this);
+        assert!(!options.strict_function_types);
+        assert!(!options.strict_bind_call_apply);
+        assert!(!options.strict_property_initialization);
+        assert!(!options.strict_builtin_iterator_return);
+        assert!(!options.use_unknown_in_catch_variables);
+    }
+
+    /// Issue #3861 ordering, inverse permutation: `strict: true` plus an
+    /// explicit `false` member keeps the member off.
+    #[test]
+    fn strict_true_then_explicit_member_false_keeps_member_off() {
+        let mut options = CheckerOptions::default();
+        apply_strict_family(
+            &mut options,
+            &StrictFamilyOverrides {
+                strict: Some(true),
+                strict_function_types: Some(false),
+                ..Default::default()
+            },
+        );
+
+        assert!(options.strict);
+        assert!(
+            !options.strict_function_types,
+            "explicit member wins (#3861)"
+        );
+        assert!(options.strict_null_checks);
+        assert!(options.no_implicit_any);
+    }
+
+    /// With no `strict` umbrella, explicit members still apply and the rest
+    /// of the family keeps the existing values.
+    #[test]
+    fn no_umbrella_applies_only_explicit_members() {
+        let mut options = CheckerOptions {
+            strict_null_checks: false,
+            no_implicit_any: false,
+            ..CheckerOptions::default()
+        };
+        apply_strict_family(
+            &mut options,
+            &StrictFamilyOverrides {
+                strict_null_checks: Some(true),
+                ..Default::default()
+            },
+        );
+
+        assert!(options.strict, "untouched: umbrella not provided");
+        assert!(options.strict_null_checks, "explicit member applied");
+        assert!(!options.no_implicit_any, "non-provided member untouched");
+    }
+
+    /// Empty overrides are a no-op.
+    #[test]
+    fn empty_overrides_are_a_no_op() {
+        let mut options = CheckerOptions {
+            strict: false,
+            strict_null_checks: false,
+            ..CheckerOptions::default()
+        };
+        apply_strict_family(&mut options, &StrictFamilyOverrides::default());
+
+        assert!(!options.strict);
+        assert!(!options.strict_null_checks);
+        assert!(options.no_implicit_any);
+    }
+
+    /// tsc 6.0: `alwaysStrict` is not a strict-family member
+    /// (`computedOptions.alwaysStrict` resolves `alwaysStrict !== false`
+    /// independent of `strict`), so neither umbrella direction touches it.
+    #[test]
+    fn always_strict_is_independent_of_strict() {
+        let mut options = CheckerOptions {
+            always_strict: false,
+            ..CheckerOptions::default()
+        };
+        expand_strict(&mut options, true);
+        assert!(
+            !options.always_strict,
+            "strict: true must not force alwaysStrict (tsc 6.0)"
+        );
+
+        let mut options = CheckerOptions::default();
+        assert!(options.always_strict, "tsc 6.0 default: alwaysStrict on");
+        expand_strict(&mut options, false);
+        assert!(
+            options.always_strict,
+            "strict: false must not reset alwaysStrict (tsc 6.0)"
+        );
+    }
+
+    /// Non-family flags are never touched by the umbrella.
+    #[test]
+    fn expand_strict_false_leaves_non_family_flags() {
+        let mut options = CheckerOptions {
+            no_implicit_returns: true,
+            exact_optional_property_types: true,
+            no_unchecked_indexed_access: true,
+            ..CheckerOptions::default()
+        };
+        expand_strict(&mut options, false);
+
+        assert!(!options.strict);
+        assert!(!options.strict_null_checks);
+        assert!(options.no_implicit_returns);
+        assert!(options.exact_optional_property_types);
+        assert!(options.no_unchecked_indexed_access);
+    }
+}

--- a/crates/tsz-common/tests/checker_options_tests.rs
+++ b/crates/tsz-common/tests/checker_options_tests.rs
@@ -282,6 +282,7 @@ fn test_apply_strict_defaults_enables_all_strict_flags() {
         strict_function_types: false,
         strict_bind_call_apply: false,
         strict_property_initialization: false,
+        strict_builtin_iterator_return: false,
         use_unknown_in_catch_variables: false,
         always_strict: false,
         ..CheckerOptions::default()
@@ -289,15 +290,19 @@ fn test_apply_strict_defaults_enables_all_strict_flags() {
 
     let opts = opts.apply_strict_defaults();
 
-    // All should be re-enabled by strict
+    // All strict-family members should be re-enabled by strict
     assert!(opts.no_implicit_any);
     assert!(opts.no_implicit_this);
     assert!(opts.strict_null_checks);
     assert!(opts.strict_function_types);
     assert!(opts.strict_bind_call_apply);
     assert!(opts.strict_property_initialization);
+    assert!(opts.strict_builtin_iterator_return);
     assert!(opts.use_unknown_in_catch_variables);
-    assert!(opts.always_strict);
+    // tsc 6.0 removed alwaysStrict from the strict family
+    // (utilities.ts computedOptions.alwaysStrict: "Previously a strict-mode
+    // flag, but no longer"): `strict` must not force it back on.
+    assert!(!opts.always_strict);
 }
 
 #[test]

--- a/crates/tsz-core/src/api/wasm/compiler_options.rs
+++ b/crates/tsz-core/src/api/wasm/compiler_options.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use tsz_common::options::strict_family::{StrictFamilyOverrides, apply_strict_family};
 use wasm_bindgen::prelude::JsValue;
 
 /// Compiler options passed from JavaScript/WASM.
@@ -196,73 +197,35 @@ impl CompilerOptions {
             .unwrap_or(crate::common::ModuleKind::None)
     }
 
-    const fn apply_strict_option(
-        options: &mut crate::checker::context::CheckerOptions,
-        strict: bool,
-    ) {
-        options.strict = strict;
-        if strict {
-            options.no_implicit_any = true;
-            options.strict_null_checks = true;
-            options.strict_function_types = true;
-            options.strict_bind_call_apply = true;
-            options.strict_property_initialization = true;
-            options.no_implicit_this = true;
-            options.use_unknown_in_catch_variables = true;
-            options.always_strict = true;
-            options.strict_builtin_iterator_return = true;
-        } else {
-            options.no_implicit_any = false;
-            options.strict_null_checks = false;
-            options.strict_function_types = false;
-            options.strict_bind_call_apply = false;
-            options.strict_property_initialization = false;
-            options.no_implicit_this = false;
-            options.use_unknown_in_catch_variables = false;
-            options.strict_builtin_iterator_return = false;
-        }
-    }
-
     /// Convert to `CheckerOptions` for type checking.
     ///
-    /// Resolution starts from the shared `CheckerOptions::default()`,
-    /// applies the `strict` family implication (when `strict` is set), and
-    /// finally applies individual flag overrides. Options left `None` keep
-    /// the shared defaults.
+    /// Resolution starts from the shared `CheckerOptions::default()`, routes
+    /// the strict family through the shared `strict_family` table (umbrella
+    /// expansion first, then explicit member overrides — tsc 6.0
+    /// `getStrictOptionValue`, issue #3861 ordering), and finally applies the
+    /// non-family flag overrides. Options left `None` keep the shared
+    /// defaults.
     #[must_use]
     pub fn to_checker_options(&self) -> crate::checker::context::CheckerOptions {
         let mut options = crate::checker::context::CheckerOptions::default();
 
-        if let Some(strict) = self.strict {
-            Self::apply_strict_option(&mut options, strict);
-        }
+        apply_strict_family(
+            &mut options,
+            &StrictFamilyOverrides {
+                strict: self.strict,
+                no_implicit_any: self.no_implicit_any,
+                no_implicit_this: self.no_implicit_this,
+                strict_null_checks: self.strict_null_checks,
+                strict_function_types: self.strict_function_types,
+                strict_bind_call_apply: self.strict_bind_call_apply,
+                strict_property_initialization: self.strict_property_initialization,
+                strict_builtin_iterator_return: self.strict_builtin_iterator_return,
+                use_unknown_in_catch_variables: self.use_unknown_in_catch_variables,
+            },
+        );
 
-        if let Some(v) = self.no_implicit_any {
-            options.no_implicit_any = v;
-        }
         if let Some(v) = self.no_implicit_returns {
             options.no_implicit_returns = v;
-        }
-        if let Some(v) = self.strict_null_checks {
-            options.strict_null_checks = v;
-        }
-        if let Some(v) = self.strict_function_types {
-            options.strict_function_types = v;
-        }
-        if let Some(v) = self.strict_bind_call_apply {
-            options.strict_bind_call_apply = v;
-        }
-        if let Some(v) = self.strict_property_initialization {
-            options.strict_property_initialization = v;
-        }
-        if let Some(v) = self.no_implicit_this {
-            options.no_implicit_this = v;
-        }
-        if let Some(v) = self.use_unknown_in_catch_variables {
-            options.use_unknown_in_catch_variables = v;
-        }
-        if let Some(v) = self.strict_builtin_iterator_return {
-            options.strict_builtin_iterator_return = v;
         }
         if let Some(v) = self.no_unchecked_indexed_access {
             options.no_unchecked_indexed_access = v;
@@ -366,8 +329,23 @@ mod tests {
         assert!(!options.strict_builtin_iterator_return);
         assert!(
             options.always_strict,
-            "strict:false should not clobber the shared alwaysStrict default"
+            "strict:false should not clobber the shared alwaysStrict default \
+             (tsc 6.0: alwaysStrict is not a strict-family member)"
         );
+    }
+
+    /// Issue #3861 ordering through the WASM lane: an explicit member wins
+    /// over the `strict: false` umbrella contraction.
+    #[test]
+    fn to_checker_options_strict_false_with_explicit_member_true() {
+        let options = parse_compiler_options_json(r#"{"strict":false,"strictNullChecks":true}"#)
+            .unwrap()
+            .to_checker_options();
+
+        assert!(!options.strict);
+        assert!(options.strict_null_checks, "explicit member wins (#3861)");
+        assert!(!options.no_implicit_any);
+        assert!(!options.strict_function_types);
     }
 
     #[test]

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -434,6 +434,11 @@ pub struct CompilerOptions {
 // Re-export CheckerOptions from checker::context for unified API
 pub use crate::checker::context::CheckerOptions;
 
+// Re-export the shared strict-family expansion table so every option-merge
+// surface (CLI driver, tsconfig resolution, WASM, tsz-server) resolves the
+// `--strict` umbrella through the same owner.
+pub use tsz_common::options::strict_family;
+
 /// Check whether a JSON value represents a truthy compiler option.
 /// Returns true for `true` booleans, non-empty strings, and non-null values
 /// that aren't `false`. Returns false for `None`, `null`, and `false`.

--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use crate::checker::context::CheckerOptions;
 use crate::emitter::{ModuleKind, PrinterOptions, ScriptTarget};
+use tsz_common::options::strict_family::{StrictFamilyOverrides, apply_strict_family};
 
 use super::{
     CompilerOptions, build_path_mappings, checker_target_from_emitter,
@@ -643,29 +644,37 @@ pub fn resolve_compiler_options(
         resolved.incremental = incremental;
     }
 
-    if let Some(strict) = options.strict {
-        resolved.checker.strict = strict;
-        if strict {
-            resolved.checker.no_implicit_any = true;
-            resolved.checker.strict_null_checks = true;
-            resolved.checker.strict_function_types = true;
-            resolved.checker.strict_bind_call_apply = true;
-            resolved.checker.strict_property_initialization = true;
-            resolved.checker.no_implicit_this = true;
-            resolved.checker.use_unknown_in_catch_variables = true;
-            resolved.checker.always_strict = true;
-            resolved.checker.strict_builtin_iterator_return = true;
-            resolved.printer.always_strict = true;
-        } else {
-            resolved.checker.no_implicit_any = false;
-            resolved.checker.strict_null_checks = false;
-            resolved.checker.strict_function_types = false;
-            resolved.checker.strict_bind_call_apply = false;
-            resolved.checker.strict_property_initialization = false;
-            resolved.checker.no_implicit_this = false;
-            resolved.checker.use_unknown_in_catch_variables = false;
-            resolved.checker.strict_builtin_iterator_return = false;
-        }
+    // Strict-family expansion and explicit member overrides are owned by the
+    // shared `strict_family` table (tsc 6.0 `getStrictOptionValue`): the
+    // `strict` umbrella is expanded first, then explicitly provided members
+    // win (issue #3861 ordering). `alwaysStrict` is not a family member in
+    // tsc 6.0 (`alwaysStrict !== false`, independent of `strict`); only the
+    // explicit `alwaysStrict` override below touches it.
+    apply_strict_family(
+        &mut resolved.checker,
+        &StrictFamilyOverrides {
+            strict: options.strict,
+            no_implicit_any: options.no_implicit_any,
+            no_implicit_this: options.no_implicit_this,
+            strict_null_checks: options.strict_null_checks,
+            strict_function_types: options.strict_function_types,
+            strict_bind_call_apply: options.strict_bind_call_apply,
+            strict_property_initialization: options.strict_property_initialization,
+            strict_builtin_iterator_return: options.strict_builtin_iterator_return,
+            use_unknown_in_catch_variables: options.use_unknown_in_catch_variables,
+        },
+    );
+    if options.strict_builtin_iterator_return.is_none()
+        && options
+            .invalidated_options
+            .iter()
+            .any(|key| key == "strictBuiltinIteratorReturn")
+        && let Some(strict) = options.strict
+    {
+        // tsc reports TS5024 for an invalid explicitly-provided
+        // strictBuiltinIteratorReturn value, but the invalid sub-option does
+        // not block the strict umbrella from selecting the effective value.
+        resolved.checker.strict_builtin_iterator_return = strict;
     }
 
     if let Some(sound) = options.sound {
@@ -686,21 +695,10 @@ pub fn resolve_compiler_options(
     // effective default. CheckerOptions::default() already reflects this
     // (strict=true, all sub-flags=true). No override needed here.
 
-    // Individual strict-family options (override strict if set explicitly)
-    if let Some(v) = options.no_implicit_any {
-        resolved.checker.no_implicit_any = v;
-    }
+    // Non-strict-family individual options. The strict-family members are
+    // resolved by `apply_strict_family` above.
     if let Some(v) = options.no_implicit_returns {
         resolved.checker.no_implicit_returns = v;
-    }
-    if let Some(v) = options.strict_null_checks {
-        resolved.checker.strict_null_checks = v;
-    }
-    if let Some(v) = options.strict_function_types {
-        resolved.checker.strict_function_types = v;
-    }
-    if let Some(v) = options.strict_property_initialization {
-        resolved.checker.strict_property_initialization = v;
     }
     if let Some(v) = options.no_unchecked_indexed_access {
         resolved.checker.no_unchecked_indexed_access = v;
@@ -711,33 +709,11 @@ pub fn resolve_compiler_options(
     if let Some(v) = options.no_property_access_from_index_signature {
         resolved.checker.no_property_access_from_index_signature = v;
     }
-    if let Some(v) = options.no_implicit_this {
-        resolved.checker.no_implicit_this = v;
-    }
-    if let Some(v) = options.use_unknown_in_catch_variables {
-        resolved.checker.use_unknown_in_catch_variables = v;
-    }
-    if let Some(v) = options.strict_bind_call_apply {
-        resolved.checker.strict_bind_call_apply = v;
-    }
     if let Some(v) = options.no_implicit_override {
         resolved.checker.no_implicit_override = v;
     }
     if let Some(v) = options.no_unchecked_side_effect_imports {
         resolved.checker.no_unchecked_side_effect_imports = v;
-    }
-    if let Some(v) = options.strict_builtin_iterator_return {
-        resolved.checker.strict_builtin_iterator_return = v;
-    } else if options
-        .invalidated_options
-        .iter()
-        .any(|key| key == "strictBuiltinIteratorReturn")
-        && let Some(strict) = options.strict
-    {
-        // tsc reports TS5024 for an invalid explicitly-provided
-        // strictBuiltinIteratorReturn value, but the invalid sub-option does
-        // not block the strict umbrella from selecting the effective value.
-        resolved.checker.strict_builtin_iterator_return = strict;
     }
 
     if let Some(no_emit) = options.no_emit {

--- a/crates/tsz-core/src/config/tests/strict_lib_extends.rs
+++ b/crates/tsz-core/src/config/tests/strict_lib_extends.rs
@@ -506,6 +506,41 @@ fn test_individual_strict_option_overrides_default() {
     );
 }
 
+/// Issue #3861 ordering through the tsconfig lane: an explicit member wins
+/// over the `strict: false` umbrella contraction.
+#[test]
+fn test_strict_false_with_explicit_member_true_keeps_member() {
+    let json = r#"{"compilerOptions":{"strict":false,"strictNullChecks":true}}"#;
+    let config: TsConfig = serde_json::from_str(json).unwrap();
+    let resolved = resolve_compiler_options(config.compiler_options.as_ref()).unwrap();
+    assert!(!resolved.checker.strict);
+    assert!(
+        resolved.checker.strict_null_checks,
+        "explicit strictNullChecks: true must win over strict: false (#3861)"
+    );
+    assert!(
+        !resolved.checker.no_implicit_any,
+        "rest of the family still contracted by strict: false"
+    );
+    assert!(!resolved.checker.strict_function_types);
+}
+
+/// Issue #3861 ordering, inverse permutation: `strict: true` plus an explicit
+/// `false` member keeps the member off while the rest of the family expands.
+#[test]
+fn test_strict_true_with_explicit_member_false_keeps_member_off() {
+    let json = r#"{"compilerOptions":{"strict":true,"strictFunctionTypes":false}}"#;
+    let config: TsConfig = serde_json::from_str(json).unwrap();
+    let resolved = resolve_compiler_options(config.compiler_options.as_ref()).unwrap();
+    assert!(resolved.checker.strict);
+    assert!(
+        !resolved.checker.strict_function_types,
+        "explicit strictFunctionTypes: false must win over strict: true (#3861)"
+    );
+    assert!(resolved.checker.strict_null_checks);
+    assert!(resolved.checker.no_implicit_any);
+}
+
 #[test]
 fn test_ts5024_boolean_string_uses_always_strict_default() {
     // tsc still enforces strict-mode syntax here: the invalid string value is


### PR DESCRIPTION
Goal: hold

Extracts one table-driven strict-family expansion helper in tsz-core and routes the divergent option-merge sites (driver plan, resolved tsconfig options, WASM resolution, tsz_server checker options) through it. Sites whose current behavior matches tsc are byte-identical; proven parity divergences are fixed and individually documented with tsc references.

Structural rule: when `strict` is set, tsc derives each strict-family member unless individually specified, in one place; tsz derives them through the single tsz-core helper at every options surface.

The helper is `tsz_common::options::strict_family` (it must live beside `CheckerOptions` so the tsz-checker re-application site can share it), re-exported as `tsz::config::strict_family`. One row per tsc 6.0 `StrictOptionName` member; `apply_strict_family` expands the umbrella first, then applies explicit member overrides (issue #3861 ordering baked in).

## Divergence matrix (live main, post-#13332)

| Site | 8-member expand/contract | explicit-member ordering | `alwaysStrict` on `strict: true` | `alwaysStrict` on `strict: false` |
| --- | --- | --- | --- | --- |
| CLI `tsz-cli/src/driver/plan.rs` | both directions | after umbrella | forced `true` (parity bug) | reset `false` (parity bug) |
| tsconfig `tsz-core/src/config/resolved_options.rs` | both directions | after umbrella | set `true` (no-op: default already true, explicit override runs later) | untouched (correct) |
| WASM `tsz-core/src/api/wasm/compiler_options.rs` | both directions | after umbrella | set `true` (no-op) | untouched (correct) |
| tsz_server `tsz-cli/src/bin/tsz_server/check.rs` | `unwrap_or(strict)` (equivalent) | equivalent | `unwrap_or(strict)` = true (correct) | `unwrap_or(strict)` = false (parity bug) |
| re-application `CheckerOptions::apply_strict_defaults` (tsz-common) | true-direction only, no explicitly-set mask | n/a (lossy) | forced `true` (parity bug) | n/a |

The 8 family members (`noImplicitAny`, `noImplicitThis`, `strictNullChecks`, `strictFunctionTypes`, `strictBindCallApply`, `strictPropertyInitialization`, `strictBuiltinIteratorReturn`, `useUnknownInCatchVariables`) and the expand-then-override ordering were already identical at all sites, so routing them through the table is byte-identical. The tsconfig TS5024 `strictBuiltinIteratorReturn` invalidation quirk stays at its call site.

## Parity fixes (each pinned to tsc 6.0 source; submodule at v6.0.3)

Issue #13062 assumed plan.rs's `--strict false` reset of `always_strict` was correct and resolved_options/WASM were divergent. The pinned tsc 6.0 source shows the opposite: `alwaysStrict` was REMOVED from the strict family.

- `TypeScript/src/compiler/utilities.ts:9358` — `StrictOptionName` has 8 members; `alwaysStrict` is absent.
- `TypeScript/src/compiler/utilities.ts:9271` — `computedOptions.alwaysStrict`: "// Previously a strict-mode flag, but no longer" — `computeValue: alwaysStrict !== false`, `dependencies: []` (independent of `strict`).
- `TypeScript/src/compiler/commandLineParser.ts:1009` — `alwaysStrict` declares no `strictFlag: true`; `defaultValueDescription: true`.
- `TypeScript/src/compiler/program.ts:4532` — explicit `alwaysStrict: false` is deprecated but still honored.

Fixes (all toward the pinned behavior; the tsconfig lane — the one conformance exercises via `directives_to_tsconfig` — already had it right):
1. CLI plan.rs: `--strict`/`--strict false` no longer touch `checker.always_strict`/`printer.always_strict`; only the explicit `--alwaysStrict` override does. Fixes both `--strict false` wrongly dropping the `use strict` prologue and `--strict` wrongly clobbering a tsconfig `alwaysStrict: false`.
2. `CheckerOptions::apply_strict_defaults` (production: tsz-checker constructors/state) no longer forces `always_strict = true`, which previously re-clobbered an explicit `alwaysStrict: false` whenever `strict` was on.
3. tsz_server `build_checker_options`: `always_strict: options.always_strict.unwrap_or(true)` instead of `unwrap_or(options.strict)` (correct under both readings of the protocol's non-optional `strict`, since tsc 6.0 decouples them entirely).

Adjacent-case matrix in tests: umbrella true/false x explicit member true/false x member-unset, alwaysStrict decoupling in both umbrella directions, #3861 ordering permutations per lane (helper unit tests, CLI driver tests, tsconfig lane tests, WASM lane tests), non-family flags (`noImplicitReturns`, `exactOptionalPropertyTypes`) untouched by the umbrella.

Refs #13062 — PR 1; remaining: single raw `CompilerOptions` + explicitly-set-mask builder (issue steps 1-2), checker/printer fan-out table for non-strict options (`esModuleInterop` triple-mirror, `printer.strict_null_checks`, module inference; step 3), deleting `build_checker_options`/per-flag WASM mapping in favor of the shared resolve (step 4), threading an explicitly-set mask into the `apply_strict_defaults` re-application sites so the umbrella stops re-expanding over explicit member falses, and the server protocol's non-optional `strict` conflating unset with false.

## Verification
- `cargo nextest run -p tsz-core -E 'test(/option|strict|config/)'` — 312/312 pass
- `cargo nextest run -p tsz-cli -E 'test(/option|strict|plan/)'` — 97/98; the 1 failure (`driver_tests::compile_cross_module_nested_interface_method_allows_optional_argument_currently`) fails identically on unmodified origin/main (pre-existing)
- `cargo nextest run -p tsz-wasm` — 59/59 pass
- `cargo nextest run -p tsz-common` — 530/531; the 1 failure (`perf_counters::json_tests::wired_keys_match_snapshot_struct_fields`) fails identically on unmodified origin/main (pre-existing)
- `cargo clippy -p tsz-core -p tsz-cli -p tsz-wasm -- -D warnings` — clean (also `-p tsz-common`)
- `cargo check --workspace` — clean

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
