### PR TITLE
fix(checker): accept generic indexed option shapes (#13361)

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -349,17 +349,18 @@ impl CheckerState<'_> {
         &mut self,
         type_id: TypeId,
     ) -> Option<std::sync::Arc<tsz_solver::ObjectShape>> {
-        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, type_id).or_else(
-            || {
-                let evaluated = self.evaluate_type_for_assignability(type_id);
-                (evaluated != type_id).then(|| {
-                    crate::query_boundaries::common::object_shape_for_type(
-                        self.ctx.types,
-                        evaluated,
-                    )
-                })?
-            },
-        )
+        if let Some(shape) =
+            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, type_id)
+        {
+            return Some(shape);
+        }
+
+        let evaluated = self.evaluate_type_for_assignability(type_id);
+        if evaluated == type_id {
+            return None;
+        }
+
+        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, evaluated)
     }
 
     fn type_has_named_property_for_call_compat(&mut self, type_id: TypeId, name: &str) -> bool {

--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -321,7 +321,7 @@ impl CheckerState<'_> {
         source: TypeId,
         target: TypeId,
     ) -> bool {
-        if !crate::query_boundaries::common::contains_generic_indexed_access_surface(
+        if !crate::query_boundaries::checkers::call::contains_generic_indexed_access_surface_for_call(
             self.ctx.types,
             target,
         ) {
@@ -350,7 +350,7 @@ impl CheckerState<'_> {
         type_id: TypeId,
     ) -> Option<std::sync::Arc<tsz_solver::ObjectShape>> {
         if let Some(shape) =
-            crate::query_boundaries::common::object_shape_for_type(self.ctx.types, type_id)
+            crate::query_boundaries::checkers::call::object_shape_for_call(self.ctx.types, type_id)
         {
             return Some(shape);
         }
@@ -360,7 +360,7 @@ impl CheckerState<'_> {
             return None;
         }
 
-        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, evaluated)
+        crate::query_boundaries::checkers::call::object_shape_for_call(self.ctx.types, evaluated)
     }
 
     fn type_has_named_property_for_call_compat(&mut self, type_id: TypeId, name: &str) -> bool {
@@ -376,12 +376,12 @@ impl CheckerState<'_> {
         type_id: TypeId,
         name: &str,
     ) -> bool {
-        use crate::query_boundaries::common::PropertyAccessResult;
-
-        matches!(
-            self.resolve_property_access_with_env(type_id, name),
-            PropertyAccessResult::Success { .. }
-                | PropertyAccessResult::PossiblyNullOrUndefined { .. }
-        ) || crate::query_boundaries::common::has_property_by_str(self.ctx.types, type_id, name)
+        let access = self.resolve_property_access_with_env(type_id, name);
+        crate::query_boundaries::checkers::call::property_access_is_present_for_call(&access)
+            || crate::query_boundaries::checkers::call::has_property_by_str_for_call(
+                self.ctx.types,
+                type_id,
+                name,
+            )
     }
 }

--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -91,7 +91,7 @@ impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
         }
         if self
             .state
-            .temporal_rounding_options_shape_compatibility(source, target)
+            .generic_indexed_options_shape_compatibility(source, target)
         {
             return true;
         }
@@ -316,18 +316,50 @@ impl CheckerCallAssignabilityAdapter<'_, '_> {
 }
 
 impl CheckerState<'_> {
-    fn temporal_rounding_options_shape_compatibility(
+    fn generic_indexed_options_shape_compatibility(
         &mut self,
         source: TypeId,
         target: TypeId,
     ) -> bool {
-        crate::query_boundaries::common::contains_generic_indexed_access_surface(
+        if !crate::query_boundaries::common::contains_generic_indexed_access_surface(
             self.ctx.types,
             target,
-        ) && self.type_has_named_property_for_call_compat(target, "largestUnit")
-            && self.type_has_named_property_for_call_compat(target, "smallestUnit")
-            && self.type_has_named_property_for_call_compat(source, "largestUnit")
-            && self.type_has_named_property_for_call_compat(source, "smallestUnit")
+        ) {
+            return false;
+        }
+
+        let Some(source_shape) = self.object_shape_for_call_compat(source) else {
+            return false;
+        };
+        if source_shape.properties.is_empty() {
+            return false;
+        }
+
+        let source_names: Vec<_> = source_shape
+            .properties
+            .iter()
+            .map(|prop| self.ctx.types.resolve_atom(prop.name))
+            .collect();
+        source_names
+            .iter()
+            .all(|name| self.type_has_named_property_for_call_compat(target, name.as_ref()))
+    }
+
+    fn object_shape_for_call_compat(
+        &mut self,
+        type_id: TypeId,
+    ) -> Option<std::sync::Arc<tsz_solver::ObjectShape>> {
+        crate::query_boundaries::common::object_shape_for_type(self.ctx.types, type_id).or_else(
+            || {
+                let evaluated = self.evaluate_type_for_assignability(type_id);
+                (evaluated != type_id).then(|| {
+                    crate::query_boundaries::common::object_shape_for_type(
+                        self.ctx.types,
+                        evaluated,
+                    )
+                })?
+            },
+        )
     }
 
     fn type_has_named_property_for_call_compat(&mut self, type_id: TypeId, name: &str) -> bool {

--- a/crates/tsz-checker/src/query_boundaries/checkers/call.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/call.rs
@@ -1,8 +1,10 @@
+use std::sync::Arc;
+
 use tsz_solver::computation::{ContextualTypeContext, TypeSubstitution};
 use tsz_solver::construction::{QueryDatabase, TypeDatabase};
 use tsz_solver::operations::{AssignabilityChecker, CallResult};
 use tsz_solver::relations::subtype::{TypeEnvironment, TypeResolver};
-use tsz_solver::{FunctionShape, TupleElement, TypeId};
+use tsz_solver::{FunctionShape, ObjectShape, TupleElement, TypeId};
 
 pub(crate) use super::super::common::array_element_type as array_element_type_for_type;
 pub(crate) use super::super::common::is_type_parameter_like as is_type_parameter_type;
@@ -130,6 +132,38 @@ pub(crate) fn contains_index_access_with_variadic_tuple_object(
     type_id: TypeId,
 ) -> bool {
     tsz_solver::type_queries::contains_index_access_with_variadic_tuple_object(db, type_id)
+}
+
+pub(crate) fn contains_generic_indexed_access_surface_for_call(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> bool {
+    super::super::common::contains_generic_indexed_access_surface(db, type_id)
+}
+
+pub(crate) fn object_shape_for_call(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<Arc<ObjectShape>> {
+    super::super::common::object_shape_for_type(db, type_id)
+}
+
+pub(crate) fn property_access_is_present_for_call(
+    result: &super::super::common::PropertyAccessResult,
+) -> bool {
+    matches!(
+        result,
+        super::super::common::PropertyAccessResult::Success { .. }
+            | super::super::common::PropertyAccessResult::PossiblyNullOrUndefined { .. }
+    )
+}
+
+pub(crate) fn has_property_by_str_for_call(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    name: &str,
+) -> bool {
+    super::super::common::has_property_by_str(db, type_id, name)
 }
 
 pub(crate) fn stable_call_recovery_return_type(

--- a/crates/tsz-checker/src/query_boundaries/checkers/call.rs
+++ b/crates/tsz-checker/src/query_boundaries/checkers/call.rs
@@ -148,7 +148,7 @@ pub(crate) fn object_shape_for_call(
     super::super::common::object_shape_for_type(db, type_id)
 }
 
-pub(crate) fn property_access_is_present_for_call(
+pub(crate) const fn property_access_is_present_for_call(
     result: &super::super::common::PropertyAccessResult,
 ) -> bool {
     matches!(


### PR DESCRIPTION
Goal: hold

## Summary
- Refs #13361 and unblocks the #13250 performance PR stack that was red on `temporal.ts` aggregate drift.
- Generalize call-compatibility fallback for generic indexed-access option surfaces from a two-property Temporal rounding special case into a structural object-shape subset check.
- Preserve the existing relation path first; the fallback only applies when the target contains generic indexed-access machinery and every explicit source object property resolves on the target through the checker property boundary.

## Structural Rule
When a call argument is an object options bag whose explicit properties are a subset of a target option type built from generic indexed-access helpers, `tsc` accepts the object even if the target surface is represented through aliases such as `Pick`, `Exclude`, or indexed access. tsz now preserves that behavior in checker call compatibility by asking the existing property resolver whether each explicit source property exists on the target surface, without fixture-name checks or Temporal-specific property names.

Owner layer: checker call compatibility using query-boundary property resolution. Relation, inference, lib binding, and diagnostic rendering remain unchanged.

## Adjacent Cases / Fallback
- Single-property options such as `{ largestUnit: ... }` or `{ smallestUnit: ... }` can be accepted when the target exposes that property structurally.
- Multi-property options still require every explicit source property to exist on the target.
- Non-object sources, empty object shapes, and targets without generic indexed-access surfaces fall back to the existing relation result.
- Existing TS2339 checks for genuinely missing Temporal properties remain owned by property access.

## Verification
- Pre-commit formatting hook ran during `git commit`.
- Local tests/conformance not run per current instruction.
- Ready-review CI should cover `TypeScript/tests/cases/compiler/temporal.ts` in conformance aggregate.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
