### PR TITLE
fix(ci): let metadata light checks defer to active suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
       perf_tool_only: ${{ steps.gate.outputs.perf_tool_only }}
       arch_tool_only: ${{ steps.gate.outputs.arch_tool_only }}
       metadata_only_skip: ${{ steps.gate.outputs.metadata_only_skip }}
+      metadata_active_suite_found: ${{ steps.gate.outputs.metadata_active_suite_found }}
       compiler_checks_required: ${{ steps.gate.outputs.compiler_checks_required }}
       unit_packages: ${{ steps.gate.outputs.unit_packages }}
     steps:
@@ -424,6 +425,7 @@ jobs:
           echo "perf_tool_only=${perf_tool_only}" >> "$GITHUB_OUTPUT"
           echo "arch_tool_only=${arch_tool_only}" >> "$GITHUB_OUTPUT"
           echo "metadata_only_skip=${metadata_only_skip}" >> "$GITHUB_OUTPUT"
+          echo "metadata_active_suite_found=${METADATA_ACTIVE_SUITE_FOUND:-false}" >> "$GITHUB_OUTPUT"
           echo "compiler_checks_required=${compiler_checks_required}" >> "$GITHUB_OUTPUT"
           echo "unit_packages=${unit_packages}" >> "$GITHUB_OUTPUT"
 
@@ -1322,6 +1324,7 @@ jobs:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           CI_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          CI_METADATA_ACTIVE_SUITE_FOUND: ${{ needs.gate.outputs.metadata_active_suite_found }}
           NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
           python3 - <<'PY'
@@ -1339,6 +1342,7 @@ jobs:
           perf_tool_only = gate.get("outputs", {}).get("perf_tool_only") == "true"
           arch_tool_only = gate.get("outputs", {}).get("arch_tool_only") == "true"
           metadata_only_skip = gate.get("outputs", {}).get("metadata_only_skip") == "true"
+          metadata_active_suite_found = os.environ.get("CI_METADATA_ACTIVE_SUITE_FOUND") == "true"
           compiler_checks_required = gate.get("outputs", {}).get("compiler_checks_required") != "false"
           required_summary = gate.get("outputs", {}).get("required_summary") == "true"
 
@@ -1417,6 +1421,12 @@ jobs:
                       return
                   print(f"Previous {summary_name} for this head was {conclusion or 'missing'} in run {run['id']} with suite failures {suite_failures}: {url}")
                   sys.exit(1)
+              if not required_summary and metadata_active_suite_found:
+                  print(
+                      "Metadata-only CI found an active exact-head CI suite but no completed prior summary yet; "
+                      "CI Light Summary passes and the real suite remains authoritative."
+                  )
+                  return
               print(f"Metadata-only CI could not find a previous {accepted_summary_label} for head {head_sha}.")
               sys.exit(1)
 

--- a/.github/workflows/refresh-green-prs.yml
+++ b/.github/workflows/refresh-green-prs.yml
@@ -1,6 +1,11 @@
 name: Refresh Green PRs
 
 on:
+  push:
+    branches: [main]
+  schedule:
+    # Drain at most one stale green PR per run, away from the top of the hour.
+    - cron: '7,27,47 * * * *'
   workflow_dispatch:
     inputs:
       dry_run:

--- a/scripts/ci/test-pr-ready-state.mjs
+++ b/scripts/ci/test-pr-ready-state.mjs
@@ -156,6 +156,11 @@ assert.match(
 );
 assert.match(
   ciWorkflow,
+  /metadata_active_suite_found: \$\{\{ steps\.gate\.outputs\.metadata_active_suite_found \}\}[\s\S]+?echo "metadata_active_suite_found=\$\{METADATA_ACTIVE_SUITE_FOUND:-false\}" >> "\$GITHUB_OUTPUT"[\s\S]+?CI_METADATA_ACTIVE_SUITE_FOUND: \$\{\{ needs\.gate\.outputs\.metadata_active_suite_found \}\}[\s\S]+?metadata_active_suite_found = os\.environ\.get\("CI_METADATA_ACTIVE_SUITE_FOUND"\) == "true"[\s\S]+?if not required_summary and metadata_active_suite_found:[\s\S]+?active exact-head CI suite[\s\S]+?return/,
+  "metadata-only edited runs should pass CI Light Summary when an active exact-head suite has not published its summary yet",
+);
+assert.match(
+  ciWorkflow,
   /accepted_summary_label = "CI Summary" if required_summary else "CI Summary or CI Light Summary"[\s\S]+?previous \{accepted_summary_label\}/,
   "metadata-only edited runs should report the accepted prior summary class when no mirror exists",
 );

--- a/scripts/ci/test-refresh-green-prs.mjs
+++ b/scripts/ci/test-refresh-green-prs.mjs
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   autoMergeInFlightReason,
   candidateFromCompare,
@@ -11,6 +14,13 @@ import {
   parseArgs,
   selectSortedPullRequests,
 } from "./refresh-green-prs.mjs";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
+const REFRESH_WORKFLOW = fs.readFileSync(
+  path.join(ROOT, ".github", "workflows", "refresh-green-prs.yml"),
+  "utf8",
+);
 
 function check(overrides = {}) {
   return {
@@ -45,6 +55,12 @@ assert.deepEqual(parseArgs(["--no-default-required-check"]).requiredChecks, []);
 assert.deepEqual(
   parseArgs(["--no-default-required-check", "--required-check", "queue-ci"]).requiredChecks,
   ["queue-ci"],
+);
+
+assert.match(
+  REFRESH_WORKFLOW,
+  /on:\s*\n\s+push:\s*\n\s+branches: \[main\]\s*\n\s+schedule:\s*\n\s+# Drain at most one stale green PR per run, away from the top of the hour\.\s*\n\s+- cron: '7,27,47 \* \* \* \*'/,
+  "refresh-green-prs should run automatically on main pushes and a staggered schedule",
 );
 
 assert.equal(checkRollupState([check()]).kind, "passed");


### PR DESCRIPTION
Goal: hold

## Summary
- Fixes the metadata-only `CI Light Summary` path for edited PRs when an exact-head full CI suite is still running.
- Restores automatic `Refresh Green PRs` invocation on `main` pushes and the staggered schedule that drains stale green PRs one at a time.
- Keeps the existing PAT/dry-run safety: apply-mode refresh still requires `TSZ_PR_AUTOMATION_TOKEN`; otherwise the workflow reports dry-run only.

## Root Cause
1. PR body/title edits run a metadata-only CI lane. The lane already detects active exact-head full CI and renames its final job to `CI Light Summary`, but the summary job still tried to mirror a completed previous `CI Summary` immediately. On PR #13364, run 27446179861 started at 2026-06-12T22:15Z while full run 27446103678 was still running; the light summary failed at 22:16Z, then the real full `CI Summary` passed at 22:43Z. The stale failed light check kept the PR status rollup red and blocked queue/auto-merge despite the green protected summary.
2. The stale-green refresh workflow only had `workflow_dispatch` after #10018 removed its `push` and `schedule` triggers. Its latest automatic runs were from 2026-05-24, so green PRs whose base moved stayed `BLOCKED` until someone manually intervened.

## Structural Rule
When an edited-PR metadata-only run sees an active exact-head full CI suite, and no completed prior summary exists yet, the non-required `CI Light Summary` should pass and defer the authoritative verdict to the active full suite. If a previous completed suite summary exists with suite-job failures, the metadata lane still mirrors that failure.

When main advances, the stale-green refresher should run automatically and refresh at most one eligible green ready PR per invocation, using the existing one-by-one guard and PAT/dry-run safety.

## Verification
- `node scripts/ci/test-pr-ready-state.mjs`
- `node scripts/ci/test-refresh-green-prs.mjs`
- `git diff --check`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
