### PR TITLE
fix(checker): resolve package namespace validators in mapped filters

### DIFF
--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -1336,6 +1336,34 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                         .members
                         .as_ref()
                         .and_then(|members| members.get(segment))
+                })
+                .or_else(|| {
+                    if symbol.import_name.as_deref() != Some("*") {
+                        return None;
+                    }
+                    let module = symbol.import_module.as_deref()?;
+                    let source_file_idx = self
+                        .resolve_symbol_file_index_stable(current_sym)
+                        .or_else(|| {
+                            (symbol.decl_file_idx != u32::MAX)
+                                .then_some(symbol.decl_file_idx as usize)
+                        })
+                        .unwrap_or(self.current_file_idx);
+                    let target_idx =
+                        self.resolve_import_target_from_file(source_file_idx, module)?;
+                    let target_binder = self.get_binder_for_file(target_idx)?;
+                    let target_arena = self.get_arena_for_file(target_idx as u32);
+                    let file_name = target_arena
+                        .source_files
+                        .first()
+                        .map(|source_file| source_file.file_name.as_str());
+                    file_name
+                        .and_then(|file_name| {
+                            target_binder.resolve_import_with_reexports(file_name, segment)
+                        })
+                        .or_else(|| target_binder.resolve_import_with_reexports(module, segment))
+                        .or_else(|| target_binder.file_locals.get(segment))
+                        .inspect(|sym_id| self.register_symbol_file_target(*sym_id, target_idx))
                 })?;
         }
 

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -266,9 +266,17 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                         return None;
                     }
                     let module = symbol.import_module.as_deref()?;
+                    let source_file_idx = self
+                        .ctx
+                        .resolve_symbol_file_index(current_sym)
+                        .or_else(|| {
+                            (symbol.decl_file_idx != u32::MAX)
+                                .then_some(symbol.decl_file_idx as usize)
+                        })
+                        .unwrap_or(self.ctx.current_file_idx);
                     let target_idx = self
                         .ctx
-                        .resolve_import_target_from_file(self.ctx.current_file_idx, module)?;
+                        .resolve_import_target_from_file(source_file_idx, module)?;
                     let target_binder = self.ctx.get_binder_for_file(target_idx)?;
                     let target_arena = self.ctx.get_arena_for_file(target_idx as u32);
                     let file_name = target_arena
@@ -278,6 +286,8 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     file_name
                         .and_then(|fn_| target_binder.resolve_import_with_reexports(fn_, segment))
                         .or_else(|| target_binder.resolve_import_with_reexports(module, segment))
+                        .or_else(|| target_binder.file_locals.get(segment))
+                        .inspect(|sym_id| self.ctx.register_symbol_file_target(*sym_id, target_idx))
                 })?;
         }
 

--- a/crates/tsz-cli/tests/driver_tests_parts/part_04.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_04.rs
@@ -705,6 +705,59 @@ fn compile_resolves_node_modules_types() {
 }
 
 #[test]
+fn compile_filters_keys_through_namespace_imported_package_interface() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "strict": true,
+            "module": "commonjs",
+            "target": "es2017",
+            "moduleResolution": "node",
+            "ignoreDeprecations": "6.0",
+            "skipLibCheck": true
+          },
+          "files": ["src/index.ts"]
+        }"#,
+    );
+    write_file(
+        &base.join("src/index.ts"),
+        r#"import * as L from "lib";
+
+type Conc = {
+  array: L.Validator<string[]>;
+  bool: L.Validator<number>;
+};
+type RK<W> = { [K in keyof W]-?: W[K] extends L.Validator<any> ? K : never }[keyof W];
+type R = RK<Conc>;
+type KeepsArray = "array" extends R ? "Y" : "N";
+
+const result: "Y" = null as any as KeepsArray;
+"#,
+    );
+    write_file(
+        &base.join("node_modules/lib/index.d.ts"),
+        r#"export interface Validator<T> {
+  (props: object): null;
+  tag?: T;
+}
+"#,
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "Expected no diagnostics, got: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn compile_resolves_tsconfig_types_includes_selected_packages() {
     let temp = TempDir::new().expect("temp dir");
     let base = &temp.path;
@@ -1841,4 +1894,3 @@ fn compile_resolves_node_modules_types_versions_empty_env_uses_tsconfig() {
     }));
     assert!(!base.join("dist/src/index.js").is_file());
 }
-

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -1201,6 +1201,12 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 let r = self.resolver().resolve_lazy(def_id, self.interner())?;
                 (Some(def_id), r, false)
             }
+            TypeData::UnresolvedTypeName(atom) => {
+                let name = self.interner().resolve_atom(atom);
+                let def_id = self.resolver().resolve_unresolved_type_name(&name)?;
+                let r = self.resolver().resolve_lazy(def_id, self.interner())?;
+                (Some(def_id), r, false)
+            }
             TypeData::TypeQuery(sym_ref) => {
                 let def_id_opt = self.resolver().symbol_to_def_id(sym_ref);
                 let r = self

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -38,7 +38,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let evaluated_check = self.evaluate(cond.check_type);
         let mut check_type = self.normalize_conditional_object_operand(evaluated_check);
         let evaluated_extends = self.evaluate(cond.extends_type);
-        let extends_type = self.normalize_conditional_object_operand(evaluated_extends);
+        let mut extends_type = self.normalize_conditional_object_operand(evaluated_extends);
         if matches!(
             self.interner().lookup(check_type),
             Some(TypeData::Application(_))
@@ -46,6 +46,17 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             self.try_expand_application_for_conditional_check(check_type)
         {
             check_type = expanded_check;
+        }
+        if !crate::visitors::visitor_predicates::contains_infer_types(
+            self.interner(),
+            cond.extends_type,
+        ) && matches!(
+            self.interner().lookup(extends_type),
+            Some(TypeData::Application(_))
+        ) && let Some(expanded_extends) =
+            self.try_expand_application_for_conditional_check(extends_type)
+        {
+            extends_type = expanded_extends;
         }
 
         // When check_type is an unresolvable Application (e.g., Promise<string>


### PR DESCRIPTION
Goal: hold

When a package namespace import (`import * as L from "pkg"`) is used inside a mapped-key filter and the filtered value type references an interface exported from the package declaration file, tsc keeps the package member's generic identity across the namespace boundary. tsz now mirrors that by resolving namespace members from the owning import file, registering the target declaration-file symbol, and allowing conditional extends operands without real `infer` nodes to expand resolvable application targets through the solver.

This fixes the first #12951 layer where `L.Validator<any>` in `{ [K in keyof W]: W[K] extends L.Validator<any> ? K : never }[keyof W]` stayed as an unresolved application for bare `node_modules` package imports and collapsed the kept-key union to `never`.

Structural rule:
When a non-type-only conditional extends target is an application whose base is a namespace-imported package member, and the target contains no `infer` binder, tsc relates against the resolved instantiated package member. tsz now resolves that member through the checker namespace-member boundary and expands it in the solver conditional operand path.

Adjacent matrix:
- package namespace import from `node_modules/lib/index.d.ts` plus filtered mapped key keeps `"array"`
- existing relative namespace/named import #12951 checker cases remain green
- conditional targets with real `infer` binders keep the existing raw pattern path

Residual:
The full accepted conformance case `propTypeValidatorInference.ts` still has a second layer: stored-array generic-call inference for `PropTypes.shape(...)` displays/relates a bare `Requireable` before `oneOfType`. This PR does not remove that accepted-regression ledger entry or claim to close #12951.

## Verification
- `./scripts/safe-run.sh cargo nextest run -p tsz-cli --lib compile_filters_keys_through_namespace_imported_package_interface`
- `./scripts/safe-run.sh cargo nextest run -p tsz-checker --test cross_file_generic_interface_mapped_filter_tests`
- `./scripts/arch/check-checker-boundaries.sh`
- `cargo fmt --check && git diff --check`

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
