### PR TITLE
perf(solver): reuse cached eval for array property guard (#8356)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/rules/tuples.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/tuples.rs
@@ -778,14 +778,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     /// additional required properties (e.g., `TemplateStringsArray.raw`), the
     /// mere element-type compatibility is not sufficient for assignability.
     fn target_has_extra_required_properties(
-        &self,
+        &mut self,
         instantiated_array: TypeId,
         target: TypeId,
     ) -> bool {
         use crate::visitor::{object_shape_id, object_with_index_shape_id};
 
-        // Evaluate target to resolve Lazy(DefId) / Application types.
-        let target_eval = crate::evaluation::evaluate::evaluate_type(self.interner, target);
+        // Evaluate through the subtype checker so this fallback reuses the same
+        // resolver-aware, per-relation evaluation cache as the surrounding array
+        // interface check instead of spinning up a fresh `NoopResolver`
+        // evaluator for every required-property probe.
+        let target_eval = self.evaluate_type(target);
 
         // Get the target's object shape
         let target_shape_id = object_shape_id(self.interner, target_eval)
@@ -798,8 +801,7 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         let internal_iter = self.interner.intern_string("__@iterator");
 
         // Get the source array's object shape
-        let source_eval =
-            crate::evaluation::evaluate::evaluate_type(self.interner, instantiated_array);
+        let source_eval = self.evaluate_type(instantiated_array);
         let source_shape_id = object_shape_id(self.interner, source_eval)
             .or_else(|| object_with_index_shape_id(self.interner, source_eval));
         let source_shape = source_shape_id.map(|id| self.interner.object_shape(id));


### PR DESCRIPTION
Goal: fast

This is a narrow #8356 / #13250 Fast-goal slice for the remaining ts-toolbelt evaluation residue after the concrete conditional branch reuse and recursive alias clone-skip slices landed.

Structural rule:
When the array-interface subtype fallback checks whether the target has required properties missing from the instantiated `Array<T>` source, tsz should resolve the target/source shapes through the same resolver-aware subtype evaluator used by the surrounding relation. It should not spin up fresh uncached `NoopResolver` evaluators for the required-property probe.

Owner layer:
Solver relation logic owns this check. The change stays inside the existing subtype relation path and reuses `SubtypeChecker::evaluate_type`, including its per-relation cache and query-backed evaluator wiring, instead of adding any cross-file cache, source-text heuristic, or fixture-specific special case.

Invariant:
The semantic question and fallback behavior are unchanged: the guard still compares required target properties against the instantiated array source shape before allowing iterator fallback. Only the evaluation path changes from fresh global evaluation to the already-active subtype evaluator/cache.

Adjacent matrix:
- `Array<T>` structural fallback still fails when the target has extra required properties such as `TemplateStringsArray.raw`.
- Iterator fallback remains available when the target has no extra required properties.
- Resolver-backed application/lazy targets use the same evaluator context as the surrounding relation.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test conditional_extends_readonly_variance_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test array_subclass_inheritance_tests`
- Draft/light exact-head CI run 27449003986 on `e4a083209ab1cd7614293b2142c53ac3d562ff70`: passed (`CI Light Summary`, `unit`, `dist-binaries`, `unit-cloudbuild`, `unit-checker-integration`, `lint`, `premerge-microbench`, `cargo-deny`, `cargo-shear`, `project-row-drift`).

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium
