### PR TITLE
perf(solver): log infer-pattern visited branches (#8356)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -24,6 +24,7 @@ use tracing::trace;
 use tsz_common::interner::Atom;
 
 use super::super::evaluate::TypeEvaluator;
+use super::infer_pattern::InferPatternVisited;
 use crate::type_queries::get_application_base;
 use phases::TailCallStep;
 
@@ -198,7 +199,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // PERF: Pre-allocate bindings and visited sets outside the tail-recursion
         // loop so their capacity is preserved across iterations.
         let mut loop_bindings: FxHashMap<Atom, TypeId> = FxHashMap::default();
-        let mut loop_visited: FxHashSet<(TypeId, TypeId)> = FxHashSet::default();
+        let mut loop_visited = InferPatternVisited::default();
         let mut tail_application_branch: Option<TypeId> = None;
         // Cycle detection for the tail-recursion loop.
         // Tracks (check_type, extends_type) pairs seen during tail calls.
@@ -278,7 +279,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // e.g., `any extends infer U ? U : never` → union(any, never) → any
                 if extends_has_infer {
                     let mut bindings = FxHashMap::default();
-                    let mut visited = FxHashSet::default();
+                    let mut visited = InferPatternVisited::default();
                     let mut checker = self.conditional_subtype_checker();
                     checker.allow_bivariant_rest = true;
                     self.match_infer_pattern(
@@ -533,7 +534,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     let mut checker = self.conditional_subtype_checker();
                     checker.allow_bivariant_rest = true;
                     let mut bindings = FxHashMap::default();
-                    let mut visited = FxHashSet::default();
+                    let mut visited = InferPatternVisited::default();
                     if self.match_infer_pattern(
                         constraint,
                         extends_type,
@@ -864,7 +865,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     {
                         checked_concrete_constraint = true;
                         let mut bindings2 = FxHashMap::default();
-                        let mut visited2 = FxHashSet::default();
+                        let mut visited2 = InferPatternVisited::default();
                         let mut checker2 = self.conditional_subtype_checker();
                         checker2.allow_bivariant_rest = true;
                         if self.match_infer_pattern(
@@ -1765,7 +1766,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let mut checker = self.conditional_subtype_checker();
         checker.allow_bivariant_rest = true;
         let mut bindings = FxHashMap::default();
-        let mut visited = FxHashSet::default();
+        let mut visited = InferPatternVisited::default();
         let matched = self.match_infer_pattern(
             check_type,
             cond.extends_type,
@@ -1803,7 +1804,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 let mut checker = self.conditional_subtype_checker();
                 checker.allow_bivariant_rest = true;
                 let mut bindings = FxHashMap::default();
-                let mut visited = FxHashSet::default();
+                let mut visited = InferPatternVisited::default();
                 let matched = self.match_infer_pattern(
                     reduced,
                     cond.extends_type,
@@ -1824,7 +1825,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             let mut checker = self.conditional_subtype_checker();
             checker.allow_bivariant_rest = true;
             let mut bindings = FxHashMap::default();
-            let mut visited = FxHashSet::default();
+            let mut visited = InferPatternVisited::default();
             let matched = self.match_infer_pattern(
                 alias,
                 cond.extends_type,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/application_reduction.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/application_reduction.rs
@@ -1,7 +1,8 @@
 use super::super::super::evaluate::TypeEvaluator;
+use crate::evaluation::evaluate_rules::infer_pattern::InferPatternVisited;
 use crate::relations::subtype::TypeResolver;
 use crate::types::{TypeData, TypeId};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     /// Cheap pre-check before `reduce_alias_body_to_application_form`: only
@@ -55,7 +56,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                     let mut checker = self.conditional_subtype_checker();
                     checker.allow_bivariant_rest = true;
                     let mut bindings = FxHashMap::default();
-                    let mut visited = FxHashSet::default();
+                    let mut visited = InferPatternVisited::default();
                     if !self.match_infer_pattern(
                         check_eval,
                         cond_extends,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -71,6 +71,55 @@ struct InferContainsWalk {
     tainted: bool,
 }
 
+/// Logged visited set for one infer-pattern match operation.
+///
+/// The match algorithm needs branch-local rollback for speculative alias
+/// recovery, but cloning the full visited set on every branch is a hot-path
+/// multiplier for recursive conditional utilities. Logging only successful
+/// inserts lets a branch checkpoint and roll back the entries it added while
+/// preserving the parent walk's cycle guard.
+#[derive(Default)]
+pub(crate) struct InferPatternVisited {
+    entries: FxHashSet<(TypeId, TypeId)>,
+    insert_log: Vec<(TypeId, TypeId)>,
+}
+
+impl InferPatternVisited {
+    #[inline]
+    fn insert(&mut self, pair: (TypeId, TypeId)) -> bool {
+        if self.entries.insert(pair) {
+            self.insert_log.push(pair);
+            true
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    fn contains(&self, pair: &(TypeId, TypeId)) -> bool {
+        self.entries.contains(pair)
+    }
+
+    #[inline]
+    fn checkpoint(&self) -> usize {
+        self.insert_log.len()
+    }
+
+    fn rollback_to(&mut self, checkpoint: usize) {
+        while self.insert_log.len() > checkpoint {
+            if let Some(pair) = self.insert_log.pop() {
+                self.entries.remove(&pair);
+            }
+        }
+    }
+
+    #[inline]
+    pub(crate) fn clear(&mut self) {
+        self.entries.clear();
+        self.insert_log.clear();
+    }
+}
+
 /// RAII guard for [`INFER_MATCH_EXPANSION_DEPTH`].
 ///
 /// `enter` returns `None` when the budget is exhausted (the caller must then
@@ -924,7 +973,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         &self,
         pairs: &[(TypeId, TypeId)],
         bindings: &mut FxHashMap<Atom, TypeId>,
-        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> bool {
         self.match_co_located_with_merge(
@@ -940,7 +989,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         &self,
         pairs: &[(TypeId, TypeId)],
         bindings: &mut FxHashMap<Atom, TypeId>,
-        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
         merge_kind: CoLocatedMerge,
     ) -> bool {
@@ -991,7 +1040,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         residual: &[TupleElement],
         pattern_rest_type: TypeId,
         bindings: &mut FxHashMap<Atom, TypeId>,
-        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> bool {
         if let Some(array_elem_type) = self.unwrap_array_element_for_residual(pattern_rest_type) {
@@ -1047,7 +1096,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         residual: &[TupleElement],
         target_elem: TypeId,
         bindings: &mut FxHashMap<Atom, TypeId>,
-        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> bool {
         for source_elem in residual {
@@ -1167,7 +1216,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         source_elems: &[TupleElement],
         pattern_elems: &[TupleElement],
         bindings: &mut FxHashMap<Atom, TypeId>,
-        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> bool {
         let source_len = source_elems.len();
@@ -1309,7 +1358,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         source_params: &[ParamInfo],
         pattern_params: &[ParamInfo],
         bindings: &mut FxHashMap<Atom, TypeId>,
-        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> bool {
         if source_params.len() != pattern_params.len() {
@@ -1432,7 +1481,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         source: &TypeApplication,
         pattern: &TypeApplication,
         bindings: &mut FxHashMap<Atom, TypeId>,
-        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> Option<bool> {
         if source.args.len() != pattern.args.len() {
@@ -1509,7 +1558,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         members: &[TypeId],
         pattern: TypeId,
         bindings: &mut FxHashMap<Atom, TypeId>,
-        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> bool {
         let base = bindings.clone();
@@ -1555,7 +1604,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         source: TypeId,
         pattern: TypeId,
         bindings: &mut FxHashMap<Atom, TypeId>,
-        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> bool {
         if !visited.insert((source, pattern)) {
@@ -1784,17 +1833,19 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             return true;
                         }
                         let mut alias_bindings = bindings.clone();
-                        let mut alias_visited = visited.clone();
+                        let alias_checkpoint = visited.checkpoint();
                         if self.match_infer_pattern(
                             alias,
                             expanded_pattern,
                             &mut alias_bindings,
-                            &mut alias_visited,
+                            visited,
                             checker,
                         ) {
+                            visited.rollback_to(alias_checkpoint);
                             *bindings = alias_bindings;
                             return true;
                         }
+                        visited.rollback_to(alias_checkpoint);
                     }
                     return self.match_infer_pattern(
                         source,
@@ -1846,7 +1897,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 }) {
                     for &member in members.iter() {
                         let mut local_bindings = bindings.clone();
-                        let mut local_visited = FxHashSet::default();
+                        let mut local_visited = InferPatternVisited::default();
                         if self.match_infer_pattern(
                             source,
                             member,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -101,7 +101,7 @@ impl InferPatternVisited {
     }
 
     #[inline]
-    fn checkpoint(&self) -> usize {
+    const fn checkpoint(&self) -> usize {
         self.insert_log.len()
     }
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_helpers.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_helpers.rs
@@ -18,10 +18,11 @@ use crate::types::{
     TupleElement, TypeData, TypeId, TypeParamInfo,
 };
 use crate::visitor::array_element_type;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use tsz_common::interner::Atom;
 
 use super::super::evaluate::TypeEvaluator;
+use super::infer_pattern::InferPatternVisited;
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     pub(crate) fn implicit_sequence_property_type(
@@ -142,7 +143,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 .collect();
             self.interner().tuple(tuple_elems)
         };
-        let mut local_visited = FxHashSet::default();
+        let mut local_visited = InferPatternVisited::default();
         self.match_infer_pattern(
             source_tuple_or_array,
             infer_ty,
@@ -193,7 +194,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // slots to `unknown`. Match the overlapping prefix, default the rest.
         let matched_count = source_params.len().min(fixed_param_count);
 
-        let mut local_visited = FxHashSet::default();
+        let mut local_visited = InferPatternVisited::default();
         // Function/callable parameters are contravariant: co-located same-name
         // infer slots intersect their candidates instead of failing the
         // second match through `bind_infer`'s mutual subtype check. Route
@@ -278,7 +279,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         pattern_fn_id: FunctionShapeId,
         pattern: TypeId,
         bindings: &mut FxHashMap<Atom, TypeId>,
-        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> bool {
         let pattern_fn = self.interner().function_shape(pattern_fn_id);
@@ -950,7 +951,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 let tuple_ty = self.interner().tuple(tuple_elems);
 
                 // Match the tuple against the infer type
-                let mut local_visited = FxHashSet::default();
+                let mut local_visited = InferPatternVisited::default();
                 self.match_infer_pattern(tuple_ty, infer_ty, bindings, &mut local_visited, checker)
             };
 
@@ -1021,7 +1022,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // General case: match parameters individually
         let mut match_construct_params =
             |source_params: &[ParamInfo], bindings: &mut FxHashMap<Atom, TypeId>| -> bool {
-                let mut local_visited = FxHashSet::default();
+                let mut local_visited = InferPatternVisited::default();
                 self.match_signature_params(
                     source_params,
                     &pattern_fn.params,
@@ -1096,7 +1097,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         pattern_shape_id: CallableShapeId,
         pattern: TypeId,
         bindings: &mut FxHashMap<Atom, TypeId>,
-        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> bool {
         let pattern_shape = self.interner().callable_shape(pattern_shape_id);

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_object_match.rs
@@ -6,10 +6,11 @@ use crate::types::{
     TypeListId, TypeParamInfo,
 };
 use crate::utils;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use tsz_common::interner::Atom;
 
 use super::super::evaluate::TypeEvaluator;
+use super::infer_pattern::InferPatternVisited;
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     pub(crate) fn match_infer_callable_pattern_properties(
@@ -44,7 +45,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             };
 
             if self.type_contains_infer(pattern_prop.type_id) {
-                let mut visited = FxHashSet::default();
+                let mut visited = InferPatternVisited::default();
                 if !self.match_infer_pattern(
                     source_prop.type_id,
                     pattern_prop.type_id,
@@ -93,7 +94,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         pattern_props: &[PropertyInfo],
         pattern: TypeId,
         bindings: &mut FxHashMap<Atom, TypeId>,
-        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> bool {
         let contravariant_infers = self.collect_contravariant_infer_names(pattern);
@@ -148,7 +149,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         pattern_shape_id: ObjectShapeId,
         pattern: TypeId,
         bindings: &mut FxHashMap<Atom, TypeId>,
-        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> bool {
         match self.interner().lookup(source) {
@@ -416,7 +417,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         pattern_shape_id: ObjectShapeId,
         pattern: TypeId,
         bindings: &mut FxHashMap<Atom, TypeId>,
-        visited: &mut FxHashSet<(TypeId, TypeId)>,
+        visited: &mut InferPatternVisited,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> bool {
         let pattern_shape = self.interner().object_shape(pattern_shape_id);

--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -9,6 +9,7 @@ use super::content_predicates::{
 };
 use crate::construction::TypeDatabase;
 use crate::evaluation::evaluate::TypeEvaluator;
+use crate::evaluation::evaluate_rules::infer_pattern::InferPatternVisited;
 use crate::relations::subtype::SubtypeChecker;
 use crate::types::{IntrinsicKind, LiteralValue, TypeData, TypeId};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1460,7 +1461,7 @@ fn resolve_concrete_conditional_result(
     {
         if evaluator.type_contains_infer(cond.extends_type) {
             let mut bindings = rustc_hash::FxHashMap::default();
-            let mut visited = FxHashSet::default();
+            let mut visited = InferPatternVisited::default();
             let mut checker = SubtypeChecker::new(db);
             if evaluator.match_infer_pattern(
                 check_type,

--- a/scripts/perf/test_visited_clone_report.py
+++ b/scripts/perf/test_visited_clone_report.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 
 SCRIPT = Path(__file__).with_name("visited-clone-report.py")
+ROOT = SCRIPT.parents[2]
 
 
 def load_module():
@@ -83,6 +84,18 @@ class VisitedCloneReportTests(unittest.TestCase):
         self.assertEqual(payload["summary"]["schema_version"], 1)
         self.assertEqual(payload["summary"]["total"], 1)
         self.assertEqual(payload["hits"][0]["name"], "visited_modules")
+
+    def test_solver_infer_pattern_avoids_branch_local_visited_clone(self):
+        candidates = self.module.scan(
+            [ROOT / "crates/tsz-solver/src/evaluation/evaluate_rules"]
+        )
+
+        infer_pattern_hits = [
+            candidate
+            for candidate in candidates
+            if candidate.path.endswith("infer_pattern.rs")
+        ]
+        self.assertEqual(infer_pattern_hits, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Goal: fast

This is a narrow #8356 / #13250 Fast-goal slice after the queued resolver-aware array guard slice. It targets the remaining solver infer-pattern branch-local traversal clone reported by `scripts/perf/visited-clone-report.py`.

Structural rule:
When recursive conditional/infer matching speculatively tries a display-alias recovery branch, tsz should preserve branch isolation through solver-owned operation-local state. It should not clone the entire infer-pattern visited set for every speculative alias branch.

Owner layer:
Solver infer-pattern matching owns this traversal state. The change stays inside solver evaluation helpers and callers that already invoke `match_infer_pattern`; it does not add checker-local semantic logic, cross-file cache sharing, fixture-name shortcuts, or rendered-type predicates.

Invariant:
The semantic match result is unchanged. The visited set still detects `(source, pattern)` cycles, and speculative alias recovery still rolls back its branch-local visited inserts before returning to the parent path. The implementation changes the storage strategy from full-set clone to checkpointed insert logging.

Adjacent matrix:
- Variadic tuple infer residuals still bind and simplify the same tuple/array forms.
- Conditional infer over unresolved application/type-parameter patterns still defers rather than collapsing.
- Numeric-key tuple infer still preserves positive, negative, readonly, rest-spread, and distributive cases.
- The solver visited-clone report now has zero hits under `crates/tsz-solver/src`.

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `python3 scripts/perf/test_visited_clone_report.py`
- `python3 scripts/perf/visited-clone-report.py --root crates/tsz-solver/src --json`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib infer_pattern_variadic_residual_tests`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test conditional_deferred_return_tests --test conditional_infer_tuple_numeric_key_tests`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
