### PR TITLE
perf(solver): delay instantiation member list allocation (#13242)

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -352,6 +352,24 @@ impl<'a> TypeInstantiator<'a> {
         instantiated
     }
 
+    /// Instantiate a list of type IDs, allocating a replacement list only
+    /// after the first member changes.
+    fn instantiate_type_list_if_changed(&mut self, members: &[TypeId]) -> Option<Vec<TypeId>> {
+        let mut instantiated: Option<Vec<TypeId>> = None;
+        for (index, &member) in members.iter().enumerate() {
+            let inst = self.instantiate(member);
+            if let Some(instantiated) = &mut instantiated {
+                instantiated.push(inst);
+            } else if inst != member {
+                let mut changed = Vec::with_capacity(members.len());
+                changed.extend_from_slice(&members[..index]);
+                changed.push(inst);
+                instantiated = Some(changed);
+            }
+        }
+        instantiated
+    }
+
     /// Enter a shadowing scope for type parameters.
     ///
     /// Returns `(saved_shadowed_len, saved_visiting)` for restoring via
@@ -613,18 +631,7 @@ impl<'a> TypeInstantiator<'a> {
                 let members = origin_members
                     .as_deref()
                     .map_or(canonical_members.as_ref(), Vec::as_slice);
-                let mut changed = false;
-                let instantiated: Vec<TypeId> = members
-                    .iter()
-                    .map(|&m| {
-                        let inst = self.instantiate(m);
-                        if inst != m {
-                            changed = true;
-                        }
-                        inst
-                    })
-                    .collect();
-                if changed {
+                if let Some(instantiated) = self.instantiate_type_list_if_changed(members) {
                     let result = self.interner.union(instantiated.clone());
                     self.interner.store_union_origin(result, instantiated);
                     result
@@ -636,18 +643,8 @@ impl<'a> TypeInstantiator<'a> {
             // Intersection: instantiate all members, skip re-intern if nothing changed
             TypeData::Intersection(members) => {
                 let members = self.interner.type_list(*members);
-                let mut changed = false;
-                let instantiated: Vec<TypeId> = members
-                    .iter()
-                    .map(|&m| {
-                        let inst = self.instantiate(m);
-                        if inst != m {
-                            changed = true;
-                        }
-                        inst
-                    })
-                    .collect();
-                if changed {
+                if let Some(instantiated) = self.instantiate_type_list_if_changed(members.as_ref())
+                {
                     let result = self.interner.intersection(instantiated);
                     // Propagate display properties from original members to the result.
                     self.propagate_display_properties_for_intersection(members.as_ref(), result);

--- a/crates/tsz-solver/tests/instantiate_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/instantiate_tests_parts/part_00.rs
@@ -119,6 +119,42 @@ fn test_instantiate_union() {
 }
 
 #[test]
+fn test_instantiate_type_list_if_changed_allocates_on_first_change() {
+    let interner = TypeInterner::new();
+    let t_name = interner.intern_string("T");
+    let u_name = interner.intern_string("U");
+    let type_param_t = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: t_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+    }));
+    let type_param_u = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: u_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+    }));
+
+    let mut subst = TypeSubstitution::new();
+    subst.insert(u_name, TypeId::STRING);
+    let mut instantiator = TypeInstantiator::new(&interner, &subst);
+
+    let changed = instantiator
+        .instantiate_type_list_if_changed(&[TypeId::NUMBER, type_param_t, type_param_u])
+        .expect("last member should instantiate");
+    assert_eq!(changed, vec![TypeId::NUMBER, type_param_t, TypeId::STRING]);
+
+    let mut noop_instantiator = TypeInstantiator::new(&interner, &subst);
+    assert!(
+        noop_instantiator
+            .instantiate_type_list_if_changed(&[TypeId::NUMBER, type_param_t])
+            .is_none(),
+        "unchanged member lists should not allocate a replacement Vec"
+    );
+}
+
+#[test]
 fn test_instantiate_union_preserves_display_origin() {
     let interner = TypeInterner::new();
     let t_name = interner.intern_string("T");


### PR DESCRIPTION
Goal: fast

This is a narrow #13242 Fast-goal slice after the merged property-slot and union-sort slices. It targets concrete-materialization allocation inside solver type instantiation without changing lazy materialization policy.

Structural rule:
When a union or intersection instantiation walk substitutes type parameters but no member has changed yet, tsz should keep using the original member slice and allocate a replacement `Vec<TypeId>` only after the first changed member. Unchanged walks still return the original type, and changed walks preserve the unchanged prefix plus the instantiated suffix.

Owner layer:
Solver instantiation owns this member-list traversal. The change stays in `TypeInstantiator`; it does not add checker-local semantic logic, cross-file cache sharing, fixture-name shortcuts, rendered-type predicates, or broad #12142-style deferral.

Invariant:
The semantic result is unchanged. Union instantiation still uses the display-origin member list when present and records the instantiated origin on the rebuilt union. Intersection instantiation still rebuilds only when a member changes and still propagates display properties from the original members.

Adjacent matrix:
- Late-changing union/intersection member lists allocate on first change and preserve unchanged prefixes.
- Fully unchanged member lists return `None` from the helper, so callers preserve the original type.
- Existing union display-origin instantiation coverage still passes.
- Existing mapped, readonly mapped, generic instantiation, tuple-spread, and instantiation-cache tests still pass under the focused `instantiate` filter.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib test_instantiate_type_list_if_changed_allocates_on_first_change`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --lib instantiate`
- `cargo fmt --all -- --check`
- `git diff --check origin/main..HEAD`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium