### PR TITLE
perf(bench): count attribution sidecar coverage (#13247)

### DIFF
--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -974,6 +974,61 @@ withTempDir((dir) => {
 withTempDir((dir) => {
   const input = path.join(dir, "bench.json");
   const output = path.join(dir, "report.json");
+  const perfPath = path.join(dir, "bench.ts-essentials-project.perf.json");
+  writeJson(input, {
+    results: [
+      {
+        name: "ts-essentials-project",
+        winner: "tsgo",
+        factor: 1.2,
+        tsz_ms: 120,
+        tsgo_ms: 100,
+        compatibility: {
+          state: "green",
+          exit_class: "exit success",
+          phase: "check",
+          last_successful_phase: "check",
+          diagnostic_status: "none",
+          semantic_owner_family: "utility types plus recursive JSON shapes",
+        },
+      },
+    ],
+  });
+  writeJson(perfPath, {
+    schema_version: 9,
+    enabled: true,
+    mode: "attribution",
+    wired: {
+      delegate_cross_arena: true,
+      checker_construction: true,
+      interner_intern_calls: true,
+    },
+    delegate: { misses: 0 },
+    checker: { with_parent_cache_constructed: 0 },
+    interner: { intern_calls: 0 },
+  });
+
+  const result = spawnSync(process.execPath, [SCRIPT, input, output], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /2x target gaps with attribution: 1\/1/);
+
+  const report = JSON.parse(fs.readFileSync(output, "utf8"));
+  assert.equal(report.two_x_target.rows_below_target, 1);
+  assert.equal(report.two_x_target.rows_with_attribution, 1);
+  assert.deepEqual(report.two_x_target.missing_attribution_rows, []);
+  assert.deepEqual(report.two_x_target.missing_attribution_plan, []);
+  assert.equal(
+    report.target_gaps[0].attribution_status.warning,
+    "attribution dominant_subsystem missing",
+  );
+});
+
+withTempDir((dir) => {
+  const input = path.join(dir, "bench.json");
+  const output = path.join(dir, "report.json");
   const perfPath = path.join(dir, "bench.perf.json");
   writeJson(input, {
     results: [

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -515,7 +515,10 @@ function attributionStatusForRow(row, fallbackArtifact = null) {
 }
 
 function hasCompleteAttribution(status) {
-  return Boolean(status?.present && status?.dominant_subsystem && !status?.warning);
+  return Boolean(
+    status?.present &&
+      (status.mode === "attribution" || (status.dominant_subsystem && !status.warning)),
+  );
 }
 
 function missingAttributionPlanForRow(row) {


### PR DESCRIPTION
Goal: fast

This is a narrow #13247 / #13250 Fast-goal measurement-loop slice. It fixes the tsgo-winner report coverage predicate after Bench run 27441411589 produced attribution-mode perf sidecars but still reported `rows_with_attribution=0`.

Structural rule:
When a target-gap row has a discovered sidecar perf snapshot with `mode: "attribution"`, the report should count that row as having attribution artifact coverage. Dominant-subsystem inference is a separate quality signal and may still warn when the current counter snapshot is present but uninformative.

Owner layer:
The bench report generator owns attribution coverage accounting. This change stays in `scripts/bench/tsgo-winner-report.mjs` and its Node test; it does not change compiler behavior, benchmark timing mode, CI gate thresholds, or perf-counter collection.

Invariant:
Timing-mode sidecars still do not count as attribution coverage. Rows with attribution-mode sidecars remain visibly annotated with `attribution dominant_subsystem missing` when no subsystem can be inferred, so follow-up work can distinguish artifact presence from counter usefulness.

Adjacent matrix:
- Existing slow-timing attribution snapshots still count and keep dominant hotspot/subsystem details.
- Row-specific sidecars beside `bench-results.json` still resolve by row name.
- Timing-mode sidecars remain present-but-missing attribution evidence.
- Recomputing Bench run 27441411589 moves target-gap attribution coverage from 0/14 to 6/14 while preserving warnings on those six rows.

## Verification
- `node scripts/bench/test-tsgo-winner-report.mjs`
- `git diff --check`
- `wc -l scripts/bench/tsgo-winner-report.mjs scripts/bench/test-tsgo-winner-report.mjs`
- Recomputed downloaded Bench run 27441411589: `rows_with_attribution` changed from 0/14 to 6/14 with warnings preserved for attribution-mode sidecars lacking inferred dominant subsystem.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
