### PR TITLE
perf(checker): memo condition antecedent deferral checks (#13311)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -89,6 +89,7 @@ impl<'a> FlowAnalyzer<'a> {
         let mut pending_cache_writes: Vec<((FlowNodeId, SymbolId, TypeId), TypeId)> = Vec::new();
         let mut condition_dp_memos = FlowConditionDpMemos::default();
         let mut antecedent_defer_memo: FxHashMap<FlowNodeId, bool> = FxHashMap::default();
+        let mut condition_antecedent_defer_memo: FxHashMap<FlowNodeId, bool> = FxHashMap::default();
         condition_dp_memos.clear();
 
         // Process worklist until empty
@@ -289,47 +290,11 @@ impl<'a> FlowAnalyzer<'a> {
                         //     narrow the type (e.g. `s = new Set<number>();
                         //     if (s instanceof Set)` — without deferring, we'd narrow
                         //     the declared type instead of the assignment-narrowed type)
-                        let ant_flow = self.binder.flow_nodes.get(ant);
-                        let ant_flags = ant_flow.map(|f| f.flags).unwrap_or(0);
-                        // Check if the antecedent ASSIGNMENT targets our reference.
-                        let ant_is_targeting_assignment = (ant_flags & flow_flags::ASSIGNMENT) != 0
-                            && ant_flow.is_some_and(|f| {
-                                // Quick symbol check: does this assignment target our ref?
-                                let assignment_sym = self.reference_symbol(f.node);
-                                assignment_sym.is_some()
-                                    && symbol_id.is_some()
-                                    && assignment_sym == symbol_id
-                            });
-                        // Also defer to non-targeting ASSIGNMENT antecedents when
-                        // their own antecedent chain contains a deferrable node.
-                        // This covers the pattern: `x = 10; var b = x; typeof x`
-                        // where the non-targeting ASSIGNMENT (var b = x) passes
-                        // through to the targeting ASSIGNMENT (x = 10). Without
-                        // deferring, the CONDITION uses the stale initial_type.
-                        let ant_is_passthrough_assignment = !ant_is_targeting_assignment
-                            && (ant_flags & flow_flags::ASSIGNMENT) != 0
-                            && ant_flow.is_some_and(|f| {
-                                f.antecedent.first().is_some_and(|&grandparent| {
-                                    self.binder.flow_nodes.get(grandparent).is_some_and(|gp| {
-                                        gp.has_any_flags(
-                                            flow_flags::CONDITION
-                                                | flow_flags::CALL
-                                                | flow_flags::ASSIGNMENT
-                                                | flow_flags::LOOP_LABEL,
-                                        )
-                                    })
-                                })
-                            });
-                        let ant_needs_defer = (ant_flags & flow_flags::CONDITION) != 0
-                            // Closure START nodes may carry the enclosing flow
-                            // that preserves narrowing for effectively-const captures.
-                            || (ant_flags & flow_flags::START) != 0
-                            || (ant_flags & flow_flags::CALL) != 0
-                            || (ant_flags & flow_flags::LOOP_LABEL) != 0
-                            || (ant_flags & flow_flags::BRANCH_LABEL) != 0
-                            || (ant_flags & flow_flags::SWITCH_CLAUSE) != 0
-                            || ant_is_targeting_assignment
-                            || ant_is_passthrough_assignment;
+                        let ant_needs_defer = self.condition_antecedent_requires_defer_cached(
+                            ant,
+                            symbol_id,
+                            &mut condition_antecedent_defer_memo,
+                        );
                         if ant_needs_defer {
                             defer_to_antecedent(
                                 worklist,
@@ -1106,5 +1071,65 @@ impl<'a> FlowAnalyzer<'a> {
         let result = self.antecedent_requires_defer(antecedent, reference, symbol_id);
         memo.insert(antecedent, result);
         result
+    }
+
+    fn condition_antecedent_requires_defer_cached(
+        &self,
+        antecedent: FlowNodeId,
+        symbol_id: Option<SymbolId>,
+        memo: &mut FxHashMap<FlowNodeId, bool>,
+    ) -> bool {
+        if let Some(&cached) = memo.get(&antecedent) {
+            return cached;
+        }
+        let result = self.condition_antecedent_requires_defer(antecedent, symbol_id);
+        memo.insert(antecedent, result);
+        result
+    }
+
+    fn condition_antecedent_requires_defer(
+        &self,
+        antecedent: FlowNodeId,
+        symbol_id: Option<SymbolId>,
+    ) -> bool {
+        let Some(ant_flow) = self.binder.flow_nodes.get(antecedent) else {
+            return false;
+        };
+        let ant_flags = ant_flow.flags;
+        let ant_is_assignment = (ant_flags & flow_flags::ASSIGNMENT) != 0;
+        // Check if the antecedent ASSIGNMENT targets our reference.
+        let ant_is_targeting_assignment = ant_is_assignment && {
+            // Quick symbol check: does this assignment target our ref?
+            let assignment_sym = self.reference_symbol(ant_flow.node);
+            assignment_sym.is_some() && symbol_id.is_some() && assignment_sym == symbol_id
+        };
+        // Also defer to non-targeting ASSIGNMENT antecedents when
+        // their own antecedent chain contains a deferrable node.
+        // This covers the pattern: `x = 10; var b = x; typeof x`
+        // where the non-targeting ASSIGNMENT (var b = x) passes
+        // through to the targeting ASSIGNMENT (x = 10). Without
+        // deferring, the CONDITION uses the stale initial_type.
+        let ant_is_passthrough_assignment = !ant_is_targeting_assignment
+            && ant_is_assignment
+            && ant_flow.antecedent.first().is_some_and(|&grandparent| {
+                self.binder.flow_nodes.get(grandparent).is_some_and(|gp| {
+                    gp.has_any_flags(
+                        flow_flags::CONDITION
+                            | flow_flags::CALL
+                            | flow_flags::ASSIGNMENT
+                            | flow_flags::LOOP_LABEL,
+                    )
+                })
+            });
+        (ant_flags & flow_flags::CONDITION) != 0
+            // Closure START nodes may carry the enclosing flow
+            // that preserves narrowing for effectively-const captures.
+            || (ant_flags & flow_flags::START) != 0
+            || (ant_flags & flow_flags::CALL) != 0
+            || (ant_flags & flow_flags::LOOP_LABEL) != 0
+            || (ant_flags & flow_flags::BRANCH_LABEL) != 0
+            || (ant_flags & flow_flags::SWITCH_CLAUSE) != 0
+            || ant_is_targeting_assignment
+            || ant_is_passthrough_assignment
     }
 }


### PR DESCRIPTION
Goal: fast

## Summary
- Refs #13311 and #13250.
- Memoize the CONDITION-branch antecedent deferral predicate within one `check_flow` traversal.
- Avoid recalculating repeated antecedent flag, assignment-symbol, and passthrough-assignment checks for the same flow node in large single-function control-flow graphs.
- Keep the memo local to the traversal; no new resident checker cache is added.

## Structural rule
When a CONDITION flow node needs to know whether an unprocessed antecedent can carry narrowing into the condition, tsz asks a checker-owned control-flow scheduling question based on the antecedent flags, assignment target symbol, and the antecedent's immediate predecessor. For one `check_flow(reference, initial_type, flow_id, symbol_id)` request, `reference` and `symbol_id` are fixed and the flow graph is immutable, so repeated questions for the same antecedent can reuse the boolean result.

Owner layer: checker `FlowAnalyzer` traversal scheduling. Narrowing semantics, assignment targeting, relation/evaluation behavior, and solver-owned type operations are unchanged.

## Cache invariant
- Cache question: for one CONDITION antecedent in one `check_flow` request, whether that antecedent should be deferred before condition narrowing.
- Key: `FlowNodeId`; `reference` is not needed because the preserved predicate only used the fixed `symbol_id` quick check.
- Scope: local stack memo for a single flow walk; dropped after `check_flow` returns.
- Invalidation/reset: automatic at function return; no file/session residency.
- Fallback: cache miss runs the same predicate previously inlined in the CONDITION branch.

## Adjacent cases / fallback
- CONDITION, START, CALL, LOOP_LABEL, BRANCH_LABEL, and SWITCH_CLAUSE antecedents still defer exactly as before.
- Targeting ASSIGNMENT antecedents still defer exactly as before via the same symbol equality check.
- Non-targeting passthrough ASSIGNMENT antecedents still defer when their immediate predecessor can carry condition/call/assignment/loop narrowing.
- Other assignment/default/CALL/ARRAY_MUTATION traversal paths keep their existing deferral helpers unchanged.
- No user-chosen identifier, property name, file name, rendered type string, or fixture-specific condition drives the result.

## Verification
- No local tests or benchmarks run per current instruction.
- Pre-commit formatting hook ran during commit.
- Draft CI passed for exact head `1dbe456154f4200f9fafeaee52387564eed5f503`: `CI Light Summary`, `gate`, `project-row-drift`, `lint`, `cargo-shear`, `cargo-deny`, `dist-binaries`, `unit`, `unit-checker-integration`, `unit-cloudbuild`, and advisory `premerge-microbench`.
- Ready-review CI is required before merge queue.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
