### PR TITLE
perf(checker): truncate display normalization after eval fuel (#13040)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -707,6 +707,11 @@ impl<'a> CheckerState<'a> {
                         self.evaluate_type_for_assignability(ty)
                     };
 
+                if crate::error_reporter::display_budget::is_exhausted() {
+                    visiting.remove(&ty);
+                    return evaluated;
+                }
+
                 if self.should_truncate_assignability_display_type(evaluated, depth) {
                     visiting.remove(&ty);
                     return evaluated;
@@ -940,6 +945,11 @@ impl<'a> CheckerState<'a> {
                         self.evaluate_type_for_assignability(ty)
                     };
 
+                if crate::error_reporter::display_budget::is_exhausted() {
+                    visiting.remove(&ty);
+                    return evaluated;
+                }
+
                 if self.should_truncate_assignability_display_type(evaluated, depth) {
                     visiting.remove(&ty);
                     return evaluated;
@@ -969,6 +979,11 @@ impl<'a> CheckerState<'a> {
                 } else {
                     self.evaluate_type_for_assignability(ty)
                 };
+
+            if crate::error_reporter::display_budget::is_exhausted() {
+                visiting.remove(&ty);
+                return evaluated;
+            }
 
             if self.should_truncate_assignability_display_type(evaluated, depth) {
                 visiting.remove(&ty);

--- a/crates/tsz-checker/src/error_reporter/display_budget.rs
+++ b/crates/tsz-checker/src/error_reporter/display_budget.rs
@@ -158,6 +158,22 @@ pub(crate) fn cached_eval(type_id: TypeId) -> Option<TypeId> {
     })
 }
 
+/// Returns true after the active display scope has exhausted either budget.
+///
+/// Callers use this to truncate the current display-normalization frame after
+/// a fuel-limited evaluation returns its input type.
+pub(crate) fn is_exhausted() -> bool {
+    if !scope_is_active() {
+        return false;
+    }
+    ACTIVE.with(|active| {
+        active
+            .borrow()
+            .as_ref()
+            .is_some_and(|budget| budget.exhausted)
+    })
+}
+
 /// Record a fully computed evaluation result within the active scope.
 ///
 /// Only complete results may be recorded — cycle-truncated returns must not
@@ -252,8 +268,23 @@ mod tests {
             assert!(try_consume_eval_fuel());
         }
         assert!(!try_consume_eval_fuel());
+        assert!(is_exhausted());
 
         record_eval(TypeId::STRING, TypeId::NUMBER);
         assert_eq!(cached_eval(TypeId::STRING), None);
+    }
+
+    #[test]
+    fn exhaustion_state_resets_per_scope() {
+        {
+            let _scope = DisplayBudgetScope::enter();
+            for _ in 0..DISPLAY_EVAL_FUEL {
+                assert!(try_consume_eval_fuel());
+            }
+            assert!(!try_consume_eval_fuel());
+            assert!(is_exhausted());
+        }
+        let _scope = DisplayBudgetScope::enter();
+        assert!(!is_exhausted());
     }
 }


### PR DESCRIPTION
Goal: fast

## Summary
- Refs #13040 and #13250.
- Stops diagnostic display normalization at the current frame once the active display eval budget is exhausted.
- Adds an explicit `display_budget::is_exhausted()` query so normalization does not keep expanding a budget-degraded evaluation result.
- Keeps relation/semantic paths unchanged; the helper is inert outside a display-budget scope.

## Structural rule / invariant
When diagnostic display exhausts its per-rendered-type evaluation fuel, tsz may render a truncated type surface, but it must not continue recursively normalizing the fuel-degraded type as though evaluation completed. The owner remains `error_reporter::display_budget` plus diagnostic display normalization; `evaluate_type_for_assignability` still owns semantic evaluation and only consults display-budget fuel on display paths.

## Cache / performance invariant
The display budget remains scoped to one rendered type. The new exhaustion query reads the same scope-local `exhausted` bit set by visit/eval budget depletion and resets with the outer display scope. After an evaluation call observes exhausted display fuel, the current normalization frame returns the evaluated/input type immediately instead of walking application, function, object, union, or intersection children.

## Adjacent cases / fallback
- No active display scope: `is_exhausted()` is false and relation/semantic paths remain unchanged.
- Non-exhausted display scope: normalization behavior is unchanged.
- Eval-fuel-exhausted display scope: current frame truncates immediately after evaluation instead of continuing with a degraded type.
- Visit-budget-exhausted display scope: existing hard truncation remains unchanged.
- No fixture names, rendered diagnostic strings, source text, or benchmark row names drive behavior.

## Verification
- No local tests or benchmarks run per current instruction.
- Pre-commit formatting hook ran during commit.
- Draft CI passed for exact head `3f7c99ba56761e3882c3a0d82d3e13d8129fa210`: `CI Light Summary`, `gate`, `project-row-drift`, `lint`, `cargo-shear`, `cargo-deny`, `dist-binaries`, `unit-cloudbuild`, `unit-checker-integration`, and advisory `premerge-microbench`.
- Ready-review CI is required before merge queue.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
