### PR TITLE
perf(tools): show reset cache byte share (#13246)

### DIFF
--- a/scripts/perf/query-perf-counters.py
+++ b/scripts/perf/query-perf-counters.py
@@ -52,6 +52,12 @@ def fmt_int(n):
     return f"{n:,}"
 
 
+def fmt_pct(part: int, total: int) -> str:
+    if total <= 0:
+        return "0.0%"
+    return f"{100.0 * part / total:.1f}%"
+
+
 def by_reason_rows(snap, optional=False):
     # type: (dict, bool) -> list
     rows = snap.get("by_reason")
@@ -111,17 +117,21 @@ def print_reset_cache_high_water(checker: dict, indent: str = "  ") -> None:
         return
 
     rows_by_bytes = sorted(rows, key=lambda row: (-row["bytes"], row["name"]))
+    total_for_share = size if size is not None else sum(row["bytes"] for row in rows)
     dominant = rows_by_bytes[0]
     for row in rows_by_bytes:
         if row["entries"] == 0 and row["bytes"] == 0:
             continue
         print(
             f"{indent}  {row['name']:<22} "
-            f"entries={fmt_int(row['entries']):>8}  bytes={fmt_int(row['bytes']):>10}"
+            f"entries={fmt_int(row['entries']):>8}  "
+            f"bytes={fmt_int(row['bytes']):>10}  "
+            f"byte_share={fmt_pct(row['bytes'], total_for_share):>6}"
         )
     print(
         f"{indent}  dominant={dominant['name']} "
-        f"bytes={fmt_int(dominant['bytes'])}"
+        f"bytes={fmt_int(dominant['bytes'])} "
+        f"byte_share={fmt_pct(dominant['bytes'], total_for_share)}"
     )
 
 
@@ -367,6 +377,12 @@ def print_diff(post: dict, base: dict) -> None:
         post_by_name = {row["name"]: row for row in post_rows}
         base_by_name = {row["name"]: row for row in base_rows}
         print("  reset-cache high-water by family:")
+        post_total = post["checker"].get("file_session_reset_cache_bytes_max")
+        base_total = base["checker"].get("file_session_reset_cache_bytes_max")
+        if post_total is None:
+            post_total = sum(row["bytes"] for row in post_rows)
+        if base_total is None:
+            base_total = sum(row["bytes"] for row in base_rows)
         for name in sorted(set(post_by_name) | set(base_by_name)):
             post_row = post_by_name.get(name, {"entries": 0, "bytes": 0})
             base_row = base_by_name.get(name, {"entries": 0, "bytes": 0})
@@ -379,7 +395,9 @@ def print_diff(post: dict, base: dict) -> None:
                 f"entries {fmt_int(base_row['entries']):>8} → {fmt_int(post_row['entries']):>8} "
                 f"({entries_sign}{fmt_int(entries_delta)})  "
                 f"bytes {fmt_int(base_row['bytes']):>10} → {fmt_int(post_row['bytes']):>10} "
-                f"({bytes_sign}{fmt_int(bytes_delta)})"
+                f"({bytes_sign}{fmt_int(bytes_delta)})  "
+                f"share {fmt_pct(base_row['bytes'], base_total):>6} → "
+                f"{fmt_pct(post_row['bytes'], post_total):>6}"
             )
     post_slow = post.get("slow_check_file_timings") or []
     base_slow = base.get("slow_check_file_timings") or []

--- a/scripts/perf/test_query_perf_counters.py
+++ b/scripts/perf/test_query_perf_counters.py
@@ -127,6 +127,7 @@ class QueryPerfCountersTests(unittest.TestCase):
         self.assertIn("phase=body", result.stdout)
         self.assertIn("file-session reset cache high-water:", result.stdout)
         self.assertIn("dominant=env_eval", result.stdout)
+        self.assertIn("byte_share=40.6%", result.stdout)
         self.assertIn("Dominant: TypeEnvironmentCore = 7", result.stdout)
         self.assertIn("Top non-baseline T2.2 target: ImportType = 3", result.stdout)
 
@@ -164,6 +165,7 @@ class QueryPerfCountersTests(unittest.TestCase):
         self.assertIn("regressed", result.stdout)
         self.assertIn("reset-cache high-water by family:", result.stdout)
         self.assertIn("env_eval", result.stdout)
+        self.assertIn("share  40.6% →  40.6%", result.stdout)
 
     def test_by_reason_requires_by_reason_rows(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Goal: fast

## Summary
- Extend `scripts/perf/query-perf-counters.py` so file-session reset cache high-water rows include per-family byte share.
- Include the same byte-share comparison in baseline diffs, making #13246 accumulation runs easier to triage by dominant retained family.
- Keep this as tooling-only evidence work; no scheduler or checker semantics change.

## Structural rule
When session reuse retains cache state across file boundaries, the #13246 root-cause path needs field/family-level residency attribution before bounded checker partitions can be designed. tsz now reports each reset-cache family's share of retained high-water bytes through the perf-counter query tool.

## Verification
- Not run locally per instruction.
- Pre-commit formatting hook ran during commit.
- Exact-head draft CI passed on `f2ce0b564a8f2a3ee879cc7d24782a3ee0beedda`: `gate`, `perf-tool-smoke`, and `CI Light Summary`.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
