### PR TITLE
perf(core): skip dropped lib prefix during densify (#13047)

### DIFF
--- a/crates/tsz-core/src/parallel/core.rs
+++ b/crates/tsz-core/src/parallel/core.rs
@@ -58,6 +58,7 @@ use tsz_common::interner::{AstAtom, Interner};
 use tsz_scanner::SyntaxKind;
 
 include!("core/parse_and_libs.rs");
+include!("core/premerged_lib_compaction.rs");
 include!("core/merge_support.rs");
 include!("core/bind_result_reducer.rs");
 include!("core/checking.rs");

--- a/crates/tsz-core/src/parallel/core/parse_and_libs.rs
+++ b/crates/tsz-core/src/parallel/core/parse_and_libs.rs
@@ -1842,22 +1842,26 @@ fn densify_bind_symbols(
     lib_symbol_ids: &FxHashSet<SymbolId>,
     retained_lib_symbols: &FxHashSet<SymbolId>,
 ) -> FxHashMap<SymbolId, SymbolId> {
-    let retained_count = binder
-        .symbols
-        .iter()
-        .filter(|sym| !lib_symbol_ids.contains(&sym.id) || retained_lib_symbols.contains(&sym.id))
-        .count();
+    let mut retained_count = 0;
+    for_each_densify_source_symbol(
+        &binder.symbols,
+        lib_symbol_ids,
+        retained_lib_symbols,
+        |_| retained_count += 1,
+    );
     let mut compacted_symbols = SymbolArena::with_capacity(retained_count);
     let mut id_remap = FxHashMap::with_capacity_and_hasher(retained_count, Default::default());
 
-    for sym in binder.symbols.iter() {
-        if lib_symbol_ids.contains(&sym.id) && !retained_lib_symbols.contains(&sym.id) {
-            continue;
-        }
-        let old_id = sym.id;
-        let new_id = compacted_symbols.alloc_from(sym);
-        id_remap.insert(old_id, new_id);
-    }
+    for_each_densify_source_symbol(
+        &binder.symbols,
+        lib_symbol_ids,
+        retained_lib_symbols,
+        |sym| {
+            let old_id = sym.id;
+            let new_id = compacted_symbols.alloc_from(sym);
+            id_remap.insert(old_id, new_id);
+        },
+    );
 
     for sym in compacted_symbols.iter_mut() {
         sym.parent = id_remap.get(&sym.parent).copied().unwrap_or(SymbolId::NONE);

--- a/crates/tsz-core/src/parallel/core/premerged_lib_compaction.rs
+++ b/crates/tsz-core/src/parallel/core/premerged_lib_compaction.rs
@@ -1,0 +1,81 @@
+fn for_each_densify_source_symbol(
+    symbols: &SymbolArena,
+    lib_symbol_ids: &FxHashSet<SymbolId>,
+    retained_lib_symbols: &FxHashSet<SymbolId>,
+    mut visit: impl FnMut(&crate::binder::Symbol),
+) {
+    if symbols.shared_prefix_len() == lib_symbol_ids.len() {
+        let mut retained_prefix_ids: Vec<_> = retained_lib_symbols.iter().copied().collect();
+        retained_prefix_ids.sort_unstable();
+        for sym_id in retained_prefix_ids {
+            if lib_symbol_ids.contains(&sym_id)
+                && let Some(sym) = symbols.get(sym_id)
+            {
+                visit(sym);
+            }
+        }
+        for sym in symbols.iter_private_symbols() {
+            visit(sym);
+        }
+        return;
+    }
+
+    for sym in symbols
+        .iter()
+        .filter(|sym| !lib_symbol_ids.contains(&sym.id) || retained_lib_symbols.contains(&sym.id))
+    {
+        visit(sym);
+    }
+}
+
+#[cfg(test)]
+mod premerged_lib_compaction_tests {
+    use super::*;
+
+    #[test]
+    fn densify_source_symbols_skip_unretained_shared_lib_prefix() {
+        let mut binder = BinderState::new();
+        let dropped_lib = binder.symbols.alloc(0, "Array".to_owned());
+        let retained_lib = binder.symbols.alloc(0, "Promise".to_owned());
+        binder.symbols.share_current_symbols_for_append();
+        let local = binder.symbols.alloc(0, "Local".to_owned());
+        binder.symbols.get_mut(local).expect("local symbol").parent = retained_lib;
+
+        let lib_symbol_ids = FxHashSet::from_iter([dropped_lib, retained_lib]);
+        let retained_lib_symbols = FxHashSet::from_iter([retained_lib]);
+
+        let mut source_ids = Vec::new();
+        for_each_densify_source_symbol(
+            &binder.symbols,
+            &lib_symbol_ids,
+            &retained_lib_symbols,
+            |sym| source_ids.push(sym.id),
+        );
+
+        assert_eq!(source_ids, vec![retained_lib, local]);
+        assert!(!source_ids.contains(&dropped_lib));
+    }
+
+    #[test]
+    fn densify_source_symbols_mixed_prefix_uses_full_filter_order() {
+        let mut binder = BinderState::new();
+        let shared_lib = binder.symbols.alloc(0, "Array".to_owned());
+        let shared_non_lib = binder.symbols.alloc(0, "SharedUser".to_owned());
+        binder.symbols.share_current_symbols_for_append();
+        let local = binder.symbols.alloc(0, "Local".to_owned());
+
+        let lib_symbol_ids = FxHashSet::from_iter([shared_lib]);
+        let retained_lib_symbols = FxHashSet::default();
+
+        let mut source_ids = Vec::new();
+        for_each_densify_source_symbol(
+            &binder.symbols,
+            &lib_symbol_ids,
+            &retained_lib_symbols,
+            |sym| source_ids.push(sym.id),
+        );
+
+        assert_eq!(source_ids, vec![shared_non_lib, local]);
+        assert!(!source_ids.contains(&shared_lib));
+    }
+}


### PR DESCRIPTION
Goal: fast

## Summary
- Add a focused premerged-lib compaction helper for the densify workset.
- In the pure shared-lib-prefix case, copy only retained lib symbols plus private appended user symbols instead of scanning every dropped lib-prefix symbol twice.
- Keep mixed-prefix arenas on the old full-filter path and split the helper/tests into a small owner file so parse_and_libs.rs stays below the 2000-line gate.

## Structural rule
When a cloned premerged-lib binder keeps the entire lib universe in SymbolArena shared prefix, per-file compaction only needs retained lib symbols plus private appended file symbols. tsz preserves binder/core semantics by using the optimized workset only when shared_prefix_len == lib_symbol_ids.len(); any mixed-prefix or unusual arena shape falls back to the previous full symbol filter.

## Verification
- Synced with current origin/main; latest pushed head preserves the same diff plus CI-refresh-only commits as needed for merge queue eligibility.
- scripts/safe-run.sh cargo nextest run -p tsz-core premerged_lib_compaction_tests (2/2 passed)
- python3 scripts/arch/arch_guard.py
- cargo fmt --check
- git diff --check origin/main..HEAD
- Line ceiling checked: parse_and_libs.rs 1994 lines, premerged_lib_compaction.rs 81 lines.
- Fresh ready-review CI is required before queueing.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: high