### PR TITLE
perf(solver): use query-backed inference shape probes (#8356)

### DIFF
--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -1481,8 +1481,7 @@ impl<'a> InferenceContext<'a> {
             let app_id = match self.interner.lookup(type_id) {
                 Some(TypeData::Application(app_id)) => Some(app_id),
                 _ => {
-                    let evaluated =
-                        crate::evaluation::evaluate::evaluate_type(self.interner, type_id);
+                    let evaluated = self.evaluate_type_for_inference_probe(type_id);
                     if evaluated == type_id {
                         None
                     } else {
@@ -1554,7 +1553,7 @@ impl<'a> InferenceContext<'a> {
         }
         let mut key = self.interner.lookup(type_id)?;
         if matches!(key, TypeData::Application(_) | TypeData::Lazy(_)) {
-            let evaluated = crate::evaluation::evaluate::evaluate_type(self.interner, type_id);
+            let evaluated = self.evaluate_type_for_inference_probe(type_id);
             if evaluated != type_id {
                 key = self.interner.lookup(evaluated)?;
             }
@@ -1587,8 +1586,15 @@ impl<'a> InferenceContext<'a> {
         if self.object_type_has_own_then_property(type_id) {
             return true;
         }
-        let evaluated = crate::evaluation::evaluate::evaluate_type(self.interner, type_id);
+        let evaluated = self.evaluate_type_for_inference_probe(type_id);
         evaluated != type_id && self.object_type_has_own_then_property(evaluated)
+    }
+
+    fn evaluate_type_for_inference_probe(&self, type_id: TypeId) -> TypeId {
+        if let Some(query_db) = self.query_db {
+            return query_db.evaluate_type(type_id);
+        }
+        crate::evaluation::evaluate::evaluate_type(self.interner, type_id)
     }
 
     fn object_type_has_own_then_property(&self, type_id: TypeId) -> bool {


### PR DESCRIPTION
Goal: fast

## Summary
- Route inference-time alias/application outer-shape probes through the existing query-backed evaluation path when an `InferenceContext` has a `QueryDatabase`.
- Keep the fallback behavior unchanged for raw interner/test contexts that do not carry query caches.
- Avoid new caches, fixture-name predicates, or checker-local semantic logic.

## Structural rule
When inference compares union arms whose outer shape may be hidden behind an alias/application, `tsc` treats the evaluated structural shape as the inference routing signal; tsz owns that probe in the solver `InferenceContext`. Query-backed inference should use the same query-aware evaluator/cache boundary as other solver evaluation entrypoints, while non-query contexts keep the existing fresh-evaluator fallback.

## Verification
- `python3 scripts/perf/visited-clone-report.py --root crates/tsz-solver/src --json` confirmed the previous #13373 visited-clone residue was clean before this slice.
- Branch synced with current `origin/main` after #13377/#13382 merged; no post-sync local tests or benchmarks run in this continuation.
- Exact-head draft `CI Light Summary` passed on `0f2794ee4eebbd558f2a068b843469758de15326`; full ready-review CI is the current gate.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
