### PR TITLE
perf(checker): checkpoint property access visited branches

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -11,6 +11,7 @@ use crate::state::CheckerState;
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_solver::TypeId;
 
+use super::property_access_visited::PropertyAccessVisited;
 use crate::query_boundaries::state::type_environment::for_each_direct_referenced_type;
 
 pub(crate) use super::lazy_fuel::{
@@ -935,15 +936,12 @@ impl<'a> CheckerState<'a> {
     /// the property-access path when the lazy single-member fast path missed
     /// (e.g. a heritage-inherited member) and the full structural shape is needed.
     pub(crate) fn resolve_type_for_property_access_force(&mut self, type_id: TypeId) -> TypeId {
-        use rustc_hash::FxHashSet;
         self.ensure_relation_input_ready(type_id);
-        let mut visited = FxHashSet::default();
+        let mut visited = PropertyAccessVisited::default();
         self.resolve_type_for_property_access_inner(type_id, &mut visited)
     }
 
     pub(crate) fn resolve_type_for_property_access(&mut self, type_id: TypeId) -> TypeId {
-        use rustc_hash::FxHashSet;
-
         // A union whose members are `Application(Lazy(DefId), …)` instantiations
         // of generic lib references (e.g. `Int32Array | Uint8Array`) keeps those
         // members opaque under the solver's environment-free evaluator, hiding
@@ -1003,7 +1001,7 @@ impl<'a> CheckerState<'a> {
 
         self.ensure_relation_input_ready(type_id);
 
-        let mut visited = FxHashSet::default();
+        let mut visited = PropertyAccessVisited::default();
         let result = self.resolve_type_for_property_access_inner(type_id, &mut visited);
         // Use entry().or_insert() to avoid overwriting a value that evaluate_application_type
         // may have stored in this cache during the inner call above. For homomorphic mapped
@@ -1030,7 +1028,7 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn resolve_type_for_property_access_inner(
         &mut self,
         type_id: TypeId,
-        visited: &mut rustc_hash::FxHashSet<TypeId>,
+        visited: &mut PropertyAccessVisited,
     ) -> TypeId {
         use tsz_binder::SymbolId;
         let factory = self.ctx.types.factory();
@@ -1233,8 +1231,10 @@ impl<'a> CheckerState<'a> {
                 let resolved_members: Vec<TypeId> = members
                     .iter()
                     .map(|&member| {
-                        let mut branch_visited = visited.clone();
-                        self.resolve_type_for_property_access_inner(member, &mut branch_visited)
+                        let checkpoint = visited.checkpoint();
+                        let resolved = self.resolve_type_for_property_access_inner(member, visited);
+                        visited.rollback_to(checkpoint);
+                        resolved
                     })
                     .collect();
                 factory.union_preserve_members(resolved_members)

--- a/crates/tsz-checker/src/state/type_environment/mod.rs
+++ b/crates/tsz-checker/src/state/type_environment/mod.rs
@@ -6,6 +6,7 @@ mod core;
 mod formatting;
 pub(crate) mod lazy;
 mod lazy_fuel;
+mod property_access_visited;
 mod source_location;
 mod type_node_resolution;
 mod type_params;

--- a/crates/tsz-checker/src/state/type_environment/property_access_visited.rs
+++ b/crates/tsz-checker/src/state/type_environment/property_access_visited.rs
@@ -1,0 +1,70 @@
+use rustc_hash::FxHashSet;
+use tsz_solver::TypeId;
+
+#[derive(Default)]
+pub(crate) struct PropertyAccessVisited {
+    seen: FxHashSet<TypeId>,
+    inserted: Vec<TypeId>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct PropertyAccessVisitedCheckpoint {
+    len: usize,
+}
+
+impl PropertyAccessVisited {
+    pub(crate) fn insert(&mut self, type_id: TypeId) -> bool {
+        if self.seen.insert(type_id) {
+            self.inserted.push(type_id);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) const fn checkpoint(&self) -> PropertyAccessVisitedCheckpoint {
+        PropertyAccessVisitedCheckpoint {
+            len: self.inserted.len(),
+        }
+    }
+
+    pub(crate) fn rollback_to(&mut self, checkpoint: PropertyAccessVisitedCheckpoint) {
+        while self.inserted.len() > checkpoint.len {
+            if let Some(type_id) = self.inserted.pop() {
+                self.seen.remove(&type_id);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PropertyAccessVisited;
+    use tsz_solver::TypeId;
+
+    #[test]
+    fn rollback_removes_branch_insertions() {
+        let mut visited = PropertyAccessVisited::default();
+        assert!(visited.insert(TypeId(1)));
+
+        let checkpoint = visited.checkpoint();
+        assert!(visited.insert(TypeId(2)));
+        assert!(!visited.insert(TypeId(2)));
+
+        visited.rollback_to(checkpoint);
+
+        assert!(visited.insert(TypeId(2)));
+    }
+
+    #[test]
+    fn rollback_preserves_ancestor_insertions() {
+        let mut visited = PropertyAccessVisited::default();
+        assert!(visited.insert(TypeId(1)));
+
+        let checkpoint = visited.checkpoint();
+        assert!(visited.insert(TypeId(2)));
+        visited.rollback_to(checkpoint);
+
+        assert!(!visited.insert(TypeId(1)));
+    }
+}

--- a/crates/tsz-checker/tests/stable_identity_helpers_tests.rs
+++ b/crates/tsz-checker/tests/stable_identity_helpers_tests.rs
@@ -243,6 +243,25 @@ const v: string = cfg.data.value;
     );
 }
 
+#[test]
+fn union_application_members_keep_branch_local_property_resolution() {
+    let source = r#"
+interface RenamedBox<T> {
+    value: T;
+}
+declare const item:
+    | (RenamedBox<number> & { left: string })
+    | (RenamedBox<number> & { right: boolean });
+const value: number = item.value;
+"#;
+    let diags = check_and_get_diagnostics(source);
+    let has_ts2339 = diags.iter().any(|(code, _)| *code == 2339);
+    assert!(
+        !has_ts2339,
+        "Expected no TS2339 for shared Application property across union arms, got: {diags:?}"
+    );
+}
+
 // =========================================================================
 // Mapped type template resolution
 // =========================================================================


### PR DESCRIPTION
Goal: fast

## Summary
- Replace per-union-arm cloning of the property-access visited set with checkpoint/rollback logging.
- Preserve branch-local cycle isolation for union receivers whose arms share the same generic Application base.
- Add a focused helper unit test and a checker regression for shared Application properties across union arms.

## Structural Rule
When a union receiver has branches that share an Application base, tsc resolves each union arm without letting one arm's cycle guard suppress expansion in another arm; tsz owns this in checker property-access receiver preparation through a checkpointed visited set.

## Owner Layer
Checker orchestration only. This changes receiver-preparation cycle tracking before existing solver property lookup; it does not add checker-local semantic shape matching or name/file heuristics.

## Adjacent Matrix
- Positive: `RenamedBox<number> & { left: string } | RenamedBox<number> & { right: boolean }` reads shared `value` without TS2339.
- Helper positive: rollback removes branch-local insertions.
- Helper fallback: rollback preserves ancestor insertions.

## Verification
- `cargo nextest run -p tsz-checker --lib property_access_visited`
- `cargo nextest run -p tsz-checker --test stable_identity_helpers_tests union_application_members_keep_branch_local_property_resolution`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `python3 scripts/perf/visited-clone-report.py --root crates/tsz-checker/src --json`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high