### PR TITLE
perf(checker): stop display object normalization after budget exhaustion (#13040)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -822,6 +822,10 @@ impl<'a> CheckerState<'a> {
                             visiting,
                             depth + 1,
                         );
+                        if crate::error_reporter::display_budget::is_exhausted() {
+                            visiting.remove(&ty);
+                            return evaluated;
+                        }
                         changed |=
                             normalized_read != prop.type_id || normalized_write != prop.write_type;
                         prop.type_id = normalized_read;
@@ -833,6 +837,10 @@ impl<'a> CheckerState<'a> {
                             visiting,
                             depth + 1,
                         );
+                        if crate::error_reporter::display_budget::is_exhausted() {
+                            visiting.remove(&ty);
+                            return evaluated;
+                        }
                         changed |= normalized != index.value_type;
                         index.value_type = normalized;
                     }
@@ -842,6 +850,10 @@ impl<'a> CheckerState<'a> {
                             visiting,
                             depth + 1,
                         );
+                        if crate::error_reporter::display_budget::is_exhausted() {
+                            visiting.remove(&ty);
+                            return evaluated;
+                        }
                         changed |= normalized != index.value_type;
                         index.value_type = normalized;
                     }
@@ -1078,6 +1090,10 @@ impl<'a> CheckerState<'a> {
                         visiting,
                         depth + 1,
                     );
+                    if crate::error_reporter::display_budget::is_exhausted() {
+                        visiting.remove(&ty);
+                        return evaluated;
+                    }
                     changed |=
                         normalized_read != prop.type_id || normalized_write != prop.write_type;
                     prop.type_id = normalized_read;
@@ -1089,6 +1105,10 @@ impl<'a> CheckerState<'a> {
                         visiting,
                         depth + 1,
                     );
+                    if crate::error_reporter::display_budget::is_exhausted() {
+                        visiting.remove(&ty);
+                        return evaluated;
+                    }
                     changed |= normalized != index.value_type;
                     index.value_type = normalized;
                 }
@@ -1098,6 +1118,10 @@ impl<'a> CheckerState<'a> {
                         visiting,
                         depth + 1,
                     );
+                    if crate::error_reporter::display_budget::is_exhausted() {
+                        visiting.remove(&ty);
+                        return evaluated;
+                    }
                     changed |= normalized != index.value_type;
                     index.value_type = normalized;
                 }


### PR DESCRIPTION
Goal: fast

## Summary
- Stop object/member display normalization immediately once the per-rendered-type display budget is exhausted.
- Preserve the already-computed evaluated display type instead of walking the remaining object/index members after truncation has been requested.
- Keep relation and semantic evaluation unchanged; this is only inside diagnostic display normalization.

## Structural rule
When diagnostic display exhausts its shared per-rendered-type budget, `tsc` truncates display work rather than continuing to expand every remaining member of the current container. tsz owns this as checker diagnostic-display orchestration: after the display budget is exhausted, object/member normalization should return the current evaluated display frame and stop recursing.

## Verification
- No local tests or benchmarks run in this continuation per current instruction.
- Pre-commit formatting hook ran during commit.
- Exact-head draft CI/light passed at `27584b2677365d71d7dfc1f8e89a776f0fea49b1`: `CI Light Summary`, `lint`, `unit`, `unit-cloudbuild`, `unit-checker-integration`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `premerge-microbench`, and `gate` passed.
- Ready-review CI is now expected to run full PR-head gates before merge queue.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
