### PR TITLE
perf(solver): expose union normalize cache entries

### DIFF
--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -339,6 +339,8 @@ pub struct TypeInterner {
 pub struct TypePredicateCacheStatistics {
     /// Number of memoized identity-comparability predicate results.
     pub identity_comparable_cache_entries: usize,
+    /// Number of memoized union-normalization results.
+    pub union_normalize_cache_entries: usize,
     /// Number of memoized `ThisType` containment predicate results.
     pub contains_this_cache_entries: usize,
     /// Number of memoized `infer` containment predicate results.
@@ -379,6 +381,7 @@ impl TypeInterner {
     pub fn type_predicate_cache_statistics(&self) -> TypePredicateCacheStatistics {
         TypePredicateCacheStatistics {
             identity_comparable_cache_entries: self.identity_comparable_cache.len(),
+            union_normalize_cache_entries: self.union_normalize_cache.len(),
             contains_this_cache_entries: self
                 .predicate_cache_entries_for(PredicateCacheKind::ContainsThis),
             contains_infer_cache_entries: self

--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -78,6 +78,19 @@ fn estimated_size_accounts_for_retained_predicate_caches() {
 }
 
 #[test]
+fn type_predicate_cache_statistics_reports_union_normalize_entries() {
+    let interner = TypeInterner::new();
+    let _ = TypeDatabase::union2(&interner, TypeId::STRING, TypeId::NUMBER);
+
+    let stats = interner.type_predicate_cache_statistics();
+
+    assert!(
+        stats.union_normalize_cache_entries > 0,
+        "union normalization memo entries must be visible to cache residency reports"
+    );
+}
+
+#[test]
 fn boxed_def_id_registration_is_idempotent() {
     let interner = TypeInterner::new();
     let def_id = DefId(7);


### PR DESCRIPTION
Goal: fast

## Summary
- Add `union_normalize_cache_entries` to the existing `TypePredicateCacheStatistics` snapshot.
- Make the retained `TypeInterner::union_normalize_cache` visible to cache residency/visibility reports without changing cache keys, invalidation, fuel, or normalization behavior.
- Add a focused solver unit test proving union normalization memo entries are reported.

## Structural Rule
When a retained TypeInterner cache participates in Fast-goal residency/perf attribution, tsz should expose an entry-count signal through an existing observability surface. This PR reports the existing union-normalization memo size; it does not change type semantics.

## Owner Layer
Solver observability only. The owning cache remains `TypeInterner`; normalization logic and cache residency are unchanged.

## Adjacent Matrix
- Positive: a normalized `string | number` union creates a visible `union_normalize_cache_entries` count.
- Report coverage: `union_normalize_cache` changes from `size_signal=false` to `size_signal=true` in `cache-visibility-report.py`.
- Fallback/remaining debt: unrelated solver review surfaces remain `AnnotationWidenState.cache` and `FileRelativePredicate.memo`.

## Verification
- `cargo nextest run -p tsz-solver --lib type_predicate_cache_statistics_reports_union_normalize_entries`
- `python3 scripts/perf/cache-visibility-report.py --root crates/tsz-solver/src --json`
- `python3 scripts/perf/cache-visibility-report.py --json`
- `python3 scripts/perf/test_cache_visibility_report.py`
- `cargo fmt --check`
- `git diff --check`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high