### PR TITLE
perf(cli): clear batch caches after residency probe (#13249)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -297,6 +297,12 @@ fn extract_batch_residency_budget_arg(
     (normalized, residency_budget)
 }
 
+fn clear_batch_iteration_state() {
+    tsz_solver::construction::clear_thread_local_cache();
+    tsz_solver::relations::subtype::reset_subtype_thread_local_state();
+    tsz::checker::clear_all_thread_local_state();
+}
+
 /// Batch compilation mode: read project directory paths from stdin (one per line),
 /// compile each with `--project <path> --noEmit --pretty false`, print diagnostics,
 /// then print a sentinel line so the caller can demarcate output boundaries.
@@ -334,9 +340,7 @@ fn run_batch_mode(residency_budget: bool) -> Result<()> {
         // same TypeId values would get stale TypeData from the old interner.
         // The checker thread-locals hold NodeIndex-keyed caches that similarly get
         // stale when a new AST arena reuses the same indices.
-        tsz_solver::construction::clear_thread_local_cache();
-        tsz_solver::relations::subtype::reset_subtype_thread_local_state();
-        tsz::checker::clear_all_thread_local_state();
+        clear_batch_iteration_state();
 
         let project_path = std::path::Path::new(project_dir);
 
@@ -365,7 +369,8 @@ fn run_batch_mode(residency_budget: bool) -> Result<()> {
                 project_path.display()
             )
         })?;
-        match driver::compile(&batch_args, project_path) {
+        let compile_result = driver::compile(&batch_args, project_path);
+        match compile_result {
             Ok(result) => {
                 if !result.diagnostics.is_empty() {
                     let mut reporter = Reporter::new(false);
@@ -375,10 +380,17 @@ fn run_batch_mode(residency_budget: bool) -> Result<()> {
                         write!(stdout, "{output}")?;
                     }
                 }
+                if residency_budget {
+                    drop(result);
+                    clear_batch_iteration_state();
+                }
             }
             Err(e) => {
                 // Print the error so the runner can see it, but don't exit
                 writeln!(stdout, "error: {e}")?;
+                if residency_budget {
+                    clear_batch_iteration_state();
+                }
             }
         }
         std::env::set_current_dir(previous_cwd).context("failed to restore batch cwd")?;


### PR DESCRIPTION
Goal: fast

## Summary
- Extract the batch worker thread-local cleanup into a shared helper.
- When the hidden batch residency-budget probe is enabled, clear solver/checker thread-local caches again after each finished batch project.
- Keep default batch behavior unchanged and avoid scheduler/checker/solver semantic changes.

## Structural rule
When a batch worker finishes a project under the residency-budget probe, any cleanup action must happen after diagnostics are rendered and must only clear finished-project thread-local caches. tsz owns that at the CLI batch boundary; live checker/type state remains untouched.

## Verification
- Not run locally per current instruction.
- Draft CI at exact head `2ff04f86453a2d6a9469208617bfce9d30bd99da`: `CI Light Summary` passed at 2026-06-13T06:22:02Z, with `unit`, `dist-binaries`, `lint`, `cargo-deny`, `cargo-shear`, `unit-cloudbuild`, `unit-checker-integration`, `project-row-drift`, and `premerge-microbench` passing.
- Ready-review CI pending after promotion.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: high

Refs #13249.
