### PR TITLE
perf(binder): key atom lookups by arena provenance (#13389)

### DIFF
--- a/crates/tsz-binder/src/nodes/binding.rs
+++ b/crates/tsz-binder/src/nodes/binding.rs
@@ -1319,6 +1319,10 @@ impl BinderState {
         declaration: NodeIndex,
         is_exported: bool,
     ) -> SymbolId {
+        let name_atom_key = arena.get_identifier_at(declaration).and_then(|ident| {
+            (ident.atom != tsz_common::interner::AstAtom::NONE)
+                .then_some((arena.atom_owner_key(), ident.atom))
+        });
         if let Some(existing_id) = self.current_scope.get(name) {
             // Check if the existing symbol is in the local symbol table.
             // If not (e.g., it's from a lib binder), we should create a new local symbol
@@ -1341,12 +1345,14 @@ impl BinderState {
                     }
                 }
                 // Update current_scope to point to the local symbol (shadowing)
-                self.current_scope.set(owned_name.clone(), sym_id);
+                self.current_scope
+                    .set_with_atom(owned_name.clone(), name_atom_key, sym_id);
                 // CRITICAL: Also update file_locals to shadow lib symbol in file-level scope
                 // This ensures symbol resolution finds the local symbol instead of the lib one
-                self.file_locals.set(owned_name.clone(), sym_id);
+                self.file_locals
+                    .set_with_atom(owned_name.clone(), name_atom_key, sym_id);
                 Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-                self.declare_in_persistent_scope(owned_name, sym_id);
+                self.declare_in_persistent_scope_with_atom(owned_name, name_atom_key, sym_id);
                 return sym_id;
             }
 
@@ -1466,10 +1472,12 @@ impl BinderState {
                             .or_insert_with(|| lib_arenas.clone());
                     }
                 }
-                self.current_scope.set(owned_name.clone(), sym_id);
-                self.file_locals.set(owned_name.clone(), sym_id);
+                self.current_scope
+                    .set_with_atom(owned_name.clone(), name_atom_key, sym_id);
+                self.file_locals
+                    .set_with_atom(owned_name.clone(), name_atom_key, sym_id);
                 Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-                self.declare_in_persistent_scope(owned_name, sym_id);
+                self.declare_in_persistent_scope_with_atom(owned_name, name_atom_key, sym_id);
                 return sym_id;
             }
             // In merged namespace blocks, a non-exported variable must not merge with an
@@ -1501,9 +1509,10 @@ impl BinderState {
                         sym.parent = parent_id;
                     }
                 }
-                self.current_scope.set(owned_name.clone(), sym_id);
+                self.current_scope
+                    .set_with_atom(owned_name.clone(), name_atom_key, sym_id);
                 Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-                self.declare_in_persistent_scope(owned_name, sym_id);
+                self.declare_in_persistent_scope_with_atom(owned_name, name_atom_key, sym_id);
                 return sym_id;
             }
 
@@ -1534,9 +1543,10 @@ impl BinderState {
                         sym.parent = parent_id;
                     }
                 }
-                self.current_scope.set(owned_name.clone(), sym_id);
+                self.current_scope
+                    .set_with_atom(owned_name.clone(), name_atom_key, sym_id);
                 Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-                self.declare_in_persistent_scope(owned_name, sym_id);
+                self.declare_in_persistent_scope_with_atom(owned_name, name_atom_key, sym_id);
                 return sym_id;
             }
 
@@ -1597,7 +1607,11 @@ impl BinderState {
             }
 
             Arc::make_mut(&mut self.node_symbols).insert(declaration.0, existing_id);
-            self.declare_in_persistent_scope(name.to_string(), existing_id);
+            self.declare_in_persistent_scope_with_atom(
+                name.to_string(),
+                name_atom_key,
+                existing_id,
+            );
             return existing_id;
         }
 
@@ -1627,7 +1641,11 @@ impl BinderState {
                     sym.is_exported = true;
                 }
             }
-            self.declare_in_persistent_scope(name.to_string(), existing_id);
+            self.declare_in_persistent_scope_with_atom(
+                name.to_string(),
+                name_atom_key,
+                existing_id,
+            );
             return existing_id;
         }
 
@@ -1648,7 +1666,8 @@ impl BinderState {
                 sym.parent = parent_id;
             }
         }
-        self.current_scope.set(owned_name.clone(), sym_id);
+        self.current_scope
+            .set_with_atom(owned_name.clone(), name_atom_key, sym_id);
 
         // Keep source-file declarations visible through file_locals.
         // This is required for nested module scopes resolving references to
@@ -1666,11 +1685,12 @@ impl BinderState {
                 .get(self.current_scope_id.0 as usize)
                 .is_some_and(|scope| scope.kind == ContainerKind::SourceFile)
         {
-            self.file_locals.set(owned_name.clone(), sym_id);
+            self.file_locals
+                .set_with_atom(owned_name.clone(), name_atom_key, sym_id);
         }
 
         Arc::make_mut(&mut self.node_symbols).insert(declaration.0, sym_id);
-        self.declare_in_persistent_scope(owned_name, sym_id);
+        self.declare_in_persistent_scope_with_atom(owned_name, name_atom_key, sym_id);
 
         // Record declaration event (new symbol)
         self.debugger

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -609,6 +609,15 @@ impl BinderState {
     /// Skipped during module augmentation to prevent augmented symbols from
     /// leaking into the augmenting file's scope (and subsequently into `file_locals/globals`).
     pub(crate) fn declare_in_persistent_scope(&mut self, name: String, sym_id: SymbolId) {
+        self.declare_in_persistent_scope_with_atom(name, None, sym_id);
+    }
+
+    pub(crate) fn declare_in_persistent_scope_with_atom(
+        &mut self,
+        name: String,
+        atom_key: Option<(usize, tsz_common::interner::AstAtom)>,
+        sym_id: SymbolId,
+    ) {
         if self.in_module_augmentation {
             return;
         }
@@ -616,7 +625,7 @@ impl BinderState {
             && let Some(scope) =
                 Arc::make_mut(&mut self.scopes).get_mut(self.current_scope_id.0 as usize)
         {
-            scope.table.set(name, sym_id);
+            scope.table.set_with_atom(name, atom_key, sym_id);
         }
     }
 

--- a/crates/tsz-binder/src/state/resolution.rs
+++ b/crates/tsz-binder/src/state/resolution.rs
@@ -100,8 +100,11 @@ impl BinderState {
 
         let result = 'resolve: {
             // Get the identifier text
-            let name = if let Some(ident) = arena.get_identifier_at(node_idx) {
-                &ident.escaped_text
+            let (name, name_atom_key) = if let Some(ident) = arena.get_identifier_at(node_idx) {
+                (
+                    ident.escaped_text.as_str(),
+                    Some((arena.atom_owner_key(), ident.atom)),
+                )
             } else {
                 break 'resolve None;
             };
@@ -113,7 +116,7 @@ impl BinderState {
                 let mut scope_depth = 0;
                 while scope_id.is_some() {
                     if let Some(scope) = self.scopes.get(scope_id.0 as usize) {
-                        if let Some(sym_id) = scope.table.get(name) {
+                        if let Some(sym_id) = scope.table.get_by_atom_or_name(name_atom_key, name) {
                             debug!(
                                 "[RESOLVE] '{}' FOUND in scope at depth {} (id={})",
                                 name, scope_depth, sym_id.0
@@ -146,7 +149,7 @@ impl BinderState {
             }
 
             // Finally check file locals / globals
-            if let Some(sym_id) = self.file_locals.get(name) {
+            if let Some(sym_id) = self.file_locals.get_by_atom_or_name(name_atom_key, name) {
                 debug!(
                     "[RESOLVE] '{}' FOUND in file_locals (id={})",
                     name, sym_id.0
@@ -169,7 +172,10 @@ impl BinderState {
             // Chained lookup: check lib binders for global symbols
             // This enables resolving console, Array, Object, etc. from lib.d.ts
             for (i, lib_binder) in self.lib_binders.iter().enumerate() {
-                if let Some(sym_id) = lib_binder.file_locals.get(name) {
+                if let Some(sym_id) = lib_binder
+                    .file_locals
+                    .get_by_atom_or_name(name_atom_key, name)
+                {
                     debug!(
                         "[RESOLVE] '{}' FOUND in lib_binder[{}] (id={}) - LIB SYMBOL",
                         name, i, sym_id.0
@@ -280,7 +286,9 @@ impl BinderState {
         F: FnMut(SymbolId) -> bool,
     {
         let node = arena.get(node_idx)?;
-        let name = arena.get_identifier(node)?.escaped_text.as_str();
+        let ident = arena.get_identifier(node)?;
+        let name = ident.escaped_text.as_str();
+        let name_atom_key = Some((arena.atom_owner_key(), ident.atom));
 
         let mut consider =
             |sym_id: SymbolId| -> Option<SymbolId> { accept(sym_id).then_some(sym_id) };
@@ -300,7 +308,7 @@ impl BinderState {
                     break;
                 };
 
-                if let Some(sym_id) = scope.table.get(name)
+                if let Some(sym_id) = scope.table.get_by_atom_or_name(name_atom_key, name)
                     && let Some(found) = consider(sym_id)
                 {
                     return Some(found);
@@ -321,7 +329,7 @@ impl BinderState {
             }
         }
 
-        if let Some(sym_id) = self.file_locals.get(name)
+        if let Some(sym_id) = self.file_locals.get_by_atom_or_name(name_atom_key, name)
             && let Some(found) = consider(sym_id)
         {
             return Some(found);
@@ -346,7 +354,9 @@ impl BinderState {
         // `resolve_identifier_symbol` and `resolve_type_symbol` fallbacks.
         if !self.lib_symbols_merged {
             for lib_binder in lib_binders {
-                if let Some(sym_id) = lib_binder.file_locals.get(name)
+                if let Some(sym_id) = lib_binder
+                    .file_locals
+                    .get_by_atom_or_name(name_atom_key, name)
                     && let Some(found) = consider(sym_id)
                 {
                     return Some(found);

--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -511,6 +511,15 @@ impl Symbol {
 pub struct SymbolTable {
     /// Symbols indexed by their escaped name (using `FxHashMap` for faster hashing)
     symbols: Arc<FxHashMap<String, SymbolId>>,
+    /// Symbols indexed by `(NodeArena identity, parsed identifier AstAtom)`.
+    ///
+    /// `AstAtom` values are per-arena. The arena key is part of the side-index
+    /// key so tables shared across files can never resolve a same-number atom
+    /// from another arena. String keys remain authoritative and are used as the
+    /// fallback for cross-arena lookups, synthetic names, and deserialized
+    /// tables with an empty runtime-only atom index.
+    #[serde(skip)]
+    atom_symbols: Arc<FxHashMap<(usize, tsz_common::interner::AstAtom), SymbolId>>,
 }
 
 impl SymbolTable {
@@ -518,6 +527,7 @@ impl SymbolTable {
     pub fn new() -> Self {
         Self {
             symbols: Arc::new(FxHashMap::default()),
+            atom_symbols: Arc::new(FxHashMap::default()),
         }
     }
 
@@ -531,6 +541,10 @@ impl SymbolTable {
                 capacity,
                 Default::default(),
             )),
+            atom_symbols: Arc::new(FxHashMap::with_capacity_and_hasher(
+                capacity,
+                Default::default(),
+            )),
         }
     }
 
@@ -540,14 +554,57 @@ impl SymbolTable {
         self.symbols.get(name).copied()
     }
 
+    /// Get a symbol by parsed identifier atom when the atom owner matches.
+    #[must_use]
+    pub fn get_by_atom(
+        &self,
+        atom_key: Option<(usize, tsz_common::interner::AstAtom)>,
+    ) -> Option<SymbolId> {
+        let (owner_key, atom) = atom_key?;
+        if owner_key == 0 || atom == tsz_common::interner::AstAtom::NONE {
+            return None;
+        }
+        self.atom_symbols.get(&(owner_key, atom)).copied()
+    }
+
+    /// Get a symbol by same-arena atom when present, falling back to escaped text.
+    #[must_use]
+    pub fn get_by_atom_or_name(
+        &self,
+        atom_key: Option<(usize, tsz_common::interner::AstAtom)>,
+        name: &str,
+    ) -> Option<SymbolId> {
+        self.get_by_atom(atom_key).or_else(|| self.get(name))
+    }
+
     /// Set a symbol by name.
     pub fn set(&mut self, name: String, symbol: SymbolId) {
         Arc::make_mut(&mut self.symbols).insert(name, symbol);
     }
 
+    /// Set a symbol by name and by same-arena parsed identifier atom.
+    pub fn set_with_atom(
+        &mut self,
+        name: String,
+        atom_key: Option<(usize, tsz_common::interner::AstAtom)>,
+        symbol: SymbolId,
+    ) {
+        self.set(name, symbol);
+        if let Some((owner_key, atom)) = atom_key
+            && owner_key != 0
+            && atom != tsz_common::interner::AstAtom::NONE
+        {
+            Arc::make_mut(&mut self.atom_symbols).insert((owner_key, atom), symbol);
+        }
+    }
+
     /// Remove a symbol by name.
     pub fn remove(&mut self, name: &str) -> Option<SymbolId> {
-        Arc::make_mut(&mut self.symbols).remove(name)
+        let removed = Arc::make_mut(&mut self.symbols).remove(name);
+        if let Some(symbol) = removed {
+            Arc::make_mut(&mut self.atom_symbols).retain(|_, id| *id != symbol);
+        }
+        removed
     }
 
     /// Check if a name exists in the table.
@@ -571,6 +628,7 @@ impl SymbolTable {
     /// Clear all symbols while keeping the allocated capacity.
     pub fn clear(&mut self) {
         Arc::make_mut(&mut self.symbols).clear();
+        Arc::make_mut(&mut self.atom_symbols).clear();
     }
 
     /// Iterate over symbols.
@@ -587,6 +645,10 @@ impl SymbolTable {
         const BUCKET_OVERHEAD: usize = 16;
         let mut size = self.symbols.capacity()
             * (BUCKET_OVERHEAD + std::mem::size_of::<String>() + std::mem::size_of::<SymbolId>());
+        size += self.atom_symbols.capacity()
+            * (BUCKET_OVERHEAD
+                + std::mem::size_of::<(usize, tsz_common::interner::AstAtom)>()
+                + std::mem::size_of::<SymbolId>());
         for name in self.symbols.keys() {
             size += name.capacity();
         }

--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -1098,6 +1098,7 @@ impl SymbolArena {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tsz_common::interner::AstAtom;
 
     fn sym() -> Symbol {
         Symbol::new(SymbolId(0), 0, String::new())
@@ -1166,6 +1167,31 @@ mod tests {
     fn primary_declaration_none_when_empty() {
         let s = sym();
         assert_eq!(s.primary_declaration(), None);
+    }
+
+    #[test]
+    fn symbol_table_atom_lookup_ignores_foreign_arena_atoms() {
+        let lib_owner = 11;
+        let user_owner = 22;
+        let mut table = SymbolTable::new();
+
+        table.set_with_atom(
+            "captureEvents".to_string(),
+            Some((lib_owner, AstAtom(7))),
+            SymbolId(1),
+        );
+        table.set("globalThis".to_string(), SymbolId(2));
+
+        assert_eq!(
+            table.get_by_atom_or_name(Some((lib_owner, AstAtom(7))), "missing"),
+            Some(SymbolId(1)),
+            "same-arena atom lookups may use the side index"
+        );
+        assert_eq!(
+            table.get_by_atom_or_name(Some((user_owner, AstAtom(7))), "globalThis"),
+            Some(SymbolId(2)),
+            "foreign atoms must not hit the same raw atom id in this table"
+        );
     }
 
     #[test]

--- a/crates/tsz-parser/src/parser/node.rs
+++ b/crates/tsz-parser/src/parser/node.rs
@@ -1130,6 +1130,17 @@ impl NodeArena {
         }
     }
 
+    /// Stable identity key for `AstAtom`s minted by this arena's interner.
+    ///
+    /// `AstAtom` raw values are only meaningful within one `NodeArena`.
+    /// Callers that build atom-keyed side indexes must include this owner key
+    /// with the atom so a same-number atom from another file cannot collide.
+    #[inline]
+    #[must_use]
+    pub fn atom_owner_key(&self) -> usize {
+        Arc::as_ptr(&self.inner) as usize
+    }
+
     /// Construct an arena with pool capacity pre-reserved for `capacity` nodes.
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {


### PR DESCRIPTION
Goal: fast

## Summary
- Reintroduce a runtime-only atom side index for binder `SymbolTable`, keyed by `(NodeArena identity, AstAtom)` instead of raw `AstAtom`.
- Route binder identifier resolution through same-arena atom lookup with escaped-name fallback.
- Populate atom side entries from `declare_symbol` when the declaration node is itself an identifier.
- Add a focused unit test proving a foreign same-number atom falls back to the escaped-name table.

## Structural rule
When an identifier lookup crosses arena ownership, tsz must not use a per-arena `AstAtom` as a semantic key. Binder owns this provenance boundary: same-arena atom probes may hit the side index, while cross-file/lib/synthetic/deserialized lookups fall back to escaped-name strings.

## Scope notes
- This is a guarded foundation slice for re-landing #13299 after #13389.
- It does not re-thread every import/export declaration atom from the reverted PR yet.
- It avoids checker/solver semantic changes and does not use user/file-name strings as compiler policy.

## Verification
- `cargo nextest run -p tsz-binder --lib symbol_table_atom_lookup_ignores_foreign_arena_atoms`
- `cargo nextest run -p tsz-binder --lib symbol_table`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`
- `cargo clippy --profile ci-lint -p tsz-binder --lib -- -D warnings`
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "globalThisAmbientModules" --verbose`
- Remote draft CI/light on exact head `28760815b1d9238e636fe39bc061517ec819a9dc`: `CI Light Summary` SUCCESS at 2026-06-13T06:29:37Z.
- Remote ready-review CI is running on exact head `28760815b1d9238e636fe39bc061517ec819a9dc` after promotion.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high

Refs #13389.
