### PR TITLE
ci(health): main-red sentinel to detect and track a wedged merge queue

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -9,7 +9,9 @@ on:
 permissions:
   contents: read
   actions: read
-  issues: read
+  # main-red-sentinel files/updates/closes a single tracking issue when main's
+  # post-merge CI breaches the conformance/parity floor.
+  issues: write
   pull-requests: read
 
 env:
@@ -40,6 +42,26 @@ jobs:
         run: |
           set -euo pipefail
           node scripts/ci/check-stale-ci-runs.mjs --advisory --stale-minutes 45 --max-runs 100 \
+            | tee -a "${GITHUB_STEP_SUMMARY}"
+
+  main-red-sentinel:
+    name: main-red-sentinel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Detect and track red main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Advisory by design: a monitoring job must not fail the health
+          # workflow. --file-issue opens/updates/closes one deduplicated
+          # tracking issue keyed on a hidden marker in the issue body.
+          node scripts/ci/check-main-red.mjs --file-issue --max-runs 60 \
             | tee -a "${GITHUB_STEP_SUMMARY}"
 
   health:

--- a/scripts/ci/check-main-red.mjs
+++ b/scripts/ci/check-main-red.mjs
@@ -1,0 +1,367 @@
+#!/usr/bin/env node
+// Main-red sentinel: detect when the tip of `main` is failing CI (specifically
+// the conformance/parity gate) and surface it as a deduplicated tracking issue.
+//
+// Rationale: merges land on `main` every few minutes through the native merge
+// queue. A flaky-pass at merge_group time can land a real conformance
+// regression; once `main` is red, every subsequent merge_group run inherits the
+// red base and the queue ejects every PR. Nothing in CI watched `main`'s own
+// post-merge conclusion, so the wedge went unnoticed for hours. This sentinel
+// runs from `ci-health.yml` (every 15 min) and turns that silent wedge into an
+// alert that names the first red commit and the regressed tests.
+//
+// Pure functions (mainCiHealth/formatIssueBody/formatReport) are unit tested;
+// gh I/O lives in main() behind injectable fetchers.
+import fs from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const DEFAULT_MAX_RUNS = 60;
+const DEFAULT_GH_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
+const WORKFLOW_NAME = "CI";
+const MAIN_EVENTS = new Set(["push", "merge_group"]);
+// Conclusions that do not represent a real verdict on the merged tree.
+const INCONCLUSIVE = new Set(["skipped", "cancelled", "neutral", "stale", null, undefined, ""]);
+const ISSUE_MARKER = "<!-- main-red-sentinel -->";
+const ISSUE_TITLE = "🔴 main CI is red — conformance/parity floor breached";
+const REGRESSED_RE = /REGRESSED:\s*(\S+)/g;
+
+function usage() {
+  return [
+    "usage: check-main-red.mjs [--fixture path] [--repository owner/repo] [--now iso]",
+    "                         [--max-runs n] [--file-issue] [--enforce]",
+    "",
+    "Inspects the most recent conclusive CI run on `main` (push or merge_group).",
+    "When it failed, reports it and — with --file-issue — opens or updates a single",
+    "tracking issue; when `main` is green again, closes that issue.",
+  ].join("\n");
+}
+
+function parseArgs(argv) {
+  const options = {
+    fixture: null,
+    repository: process.env.REPOSITORY || process.env.GITHUB_REPOSITORY || null,
+    now: null,
+    maxRuns: DEFAULT_MAX_RUNS,
+    fileIssue: false,
+    enforce: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--fixture") {
+      options.fixture = argv[++i];
+      if (!options.fixture) throw new Error("--fixture requires a path");
+      continue;
+    }
+    if (arg === "--repository") {
+      options.repository = argv[++i];
+      if (!options.repository) throw new Error("--repository requires owner/repo");
+      continue;
+    }
+    if (arg === "--now") {
+      options.now = argv[++i];
+      if (!options.now || !Number.isFinite(Date.parse(options.now))) {
+        throw new Error("--now requires an ISO timestamp");
+      }
+      continue;
+    }
+    if (arg === "--max-runs") {
+      const value = Number.parseInt(argv[++i], 10);
+      if (!Number.isInteger(value) || value <= 0) {
+        throw new Error("--max-runs requires a positive integer");
+      }
+      options.maxRuns = value;
+      continue;
+    }
+    if (arg === "--file-issue") {
+      options.fileIssue = true;
+      continue;
+    }
+    if (arg === "--enforce") {
+      options.enforce = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function runGhJson(args) {
+  const result = spawnSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error([`gh ${args.join(" ")} failed`, result.stdout?.trim(), result.stderr?.trim()]
+      .filter(Boolean).join("\n"));
+  }
+  return JSON.parse(result.stdout);
+}
+
+function runGh(args) {
+  const result = spawnSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) return { status: 1, stdout: "", stderr: result.error.message };
+  return {
+    status: result.status ?? 1,
+    stdout: (result.stdout || "").trim(),
+    stderr: (result.stderr || "").trim(),
+  };
+}
+
+function normalizeRuns(payload) {
+  const runs = Array.isArray(payload) ? payload : payload?.workflow_runs;
+  if (!Array.isArray(runs)) {
+    throw new Error("fixture or API response must be an array or contain workflow_runs");
+  }
+  return runs;
+}
+
+function readFixture(path) {
+  return normalizeRuns(JSON.parse(fs.readFileSync(path, "utf8")));
+}
+
+export function readMainRuns(repository, maxRuns, fetchJson = runGhJson) {
+  if (!repository) throw new Error("REPOSITORY or GITHUB_REPOSITORY is required");
+  const payload = fetchJson([
+    "api",
+    "-H",
+    "Accept: application/vnd.github+json",
+    `repos/${repository}/actions/runs?branch=main&per_page=${Math.min(100, maxRuns)}`,
+  ]);
+  return normalizeRuns(payload).slice(0, maxRuns);
+}
+
+function runField(run, keys) {
+  for (const key of keys) {
+    if (run[key] !== undefined && run[key] !== null) return run[key];
+  }
+  return undefined;
+}
+
+function eventOf(run) {
+  return runField(run, ["event"]) || "";
+}
+
+function workflowOf(run) {
+  return runField(run, ["name", "workflow_name", "workflowName"]) || "";
+}
+
+function createdMs(run) {
+  const iso = runField(run, ["created_at", "createdAt", "run_started_at", "updated_at"]);
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+// Verdict on `main`'s tip: find the most recent *conclusive* CI run from a
+// push/merge_group event and report whether it failed.
+export function mainCiHealth(runs, options = {}) {
+  const workflow = options.workflow ?? WORKFLOW_NAME;
+  const candidates = runs
+    .filter((run) => (runField(run, ["status"]) || "completed") === "completed")
+    .filter((run) => workflowOf(run) === workflow)
+    .filter((run) => MAIN_EVENTS.has(eventOf(run)))
+    .filter((run) => !INCONCLUSIVE.has(runField(run, ["conclusion"])))
+    .sort((a, b) => createdMs(b) - createdMs(a));
+
+  if (candidates.length === 0) {
+    return { red: false, status: "unknown", run: null };
+  }
+
+  const newest = candidates[0];
+  const conclusion = runField(newest, ["conclusion"]);
+  const red = conclusion === "failure" || conclusion === "timed_out" || conclusion === "startup_failure";
+  return {
+    red,
+    status: red ? "red" : "green",
+    conclusion,
+    run: {
+      id: runField(newest, ["id", "databaseId"]),
+      sha: runField(newest, ["head_sha", "headSha"]) || "",
+      event: eventOf(newest),
+      title: runField(newest, ["display_title", "displayTitle"]) || workflowOf(newest),
+      url: runField(newest, ["html_url", "url"]) || "",
+      createdAt: runField(newest, ["created_at", "createdAt"]) || "",
+    },
+    // Most recent green run before the failure, if any — helps bound the
+    // suspect merge window.
+    lastGreen: (() => {
+      const g = candidates.find((run) => runField(run, ["conclusion"]) === "success");
+      if (!g) return null;
+      return {
+        sha: runField(g, ["head_sha", "headSha"]) || "",
+        url: runField(g, ["html_url", "url"]) || "",
+        createdAt: runField(g, ["created_at", "createdAt"]) || "",
+      };
+    })(),
+  };
+}
+
+export function extractRegressedTests(log) {
+  if (!log) return [];
+  const out = new Set();
+  let m;
+  while ((m = REGRESSED_RE.exec(log)) !== null) out.add(m[1]);
+  return [...out];
+}
+
+export function formatIssueBody(verdict, regressedTests, nowIso) {
+  const run = verdict.run || {};
+  const lines = [
+    ISSUE_MARKER,
+    "",
+    "`main` is failing its post-merge CI on the conformance/parity gate. While",
+    "this is red, every queued PR inherits the red base through the merge queue",
+    "and is ejected, so the queue is effectively wedged until a fix/revert lands.",
+    "",
+    "| Field | Value |",
+    "|-------|-------|",
+    `| First red run | [${run.id ?? "?"}](${run.url || ""}) (${run.event || "?"}) |`,
+    `| Head commit | \`${(run.sha || "").slice(0, 12)}\` |`,
+    `| Title | ${escapeInline(run.title || "")} |`,
+    `| Detected | ${nowIso} |`,
+  ];
+  if (verdict.lastGreen?.sha) {
+    lines.push(`| Last green | \`${verdict.lastGreen.sha.slice(0, 12)}\` ([run](${verdict.lastGreen.url})) |`);
+  }
+  lines.push("");
+  if (regressedTests.length > 0) {
+    lines.push("### Regressed tests");
+    lines.push("");
+    for (const t of regressedTests) lines.push(`- \`${t}\``);
+    lines.push("");
+  }
+  lines.push("### What to do");
+  lines.push("");
+  lines.push("1. Identify the offending merge in the window above (bisect the named test with a narrow `--filter`).");
+  lines.push("2. Land a `Goal: hold` fix or revert PR; its merge group (fix on top of red `main`) goes green and drains the queue.");
+  lines.push("3. This issue auto-closes once a conclusive `main` CI run is green again.");
+  lines.push("");
+  lines.push("_Filed automatically by `scripts/ci/check-main-red.mjs` (ci-health). Do not edit the marker line._");
+  return lines.join("\n");
+}
+
+function escapeInline(value) {
+  return String(value ?? "").replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+export function formatReport(verdict, regressedTests = []) {
+  const lines = ["## Main-Red Sentinel", ""];
+  if (verdict.status === "unknown") {
+    lines.push("No conclusive CI run found on `main` yet (push/merge_group). Nothing to report.");
+    return lines.join("\n");
+  }
+  if (!verdict.red) {
+    lines.push(`✅ \`main\` is green — latest conclusive CI run \`${(verdict.run.sha || "").slice(0, 12)}\` (${verdict.conclusion}).`);
+    return lines.join("\n");
+  }
+  lines.push(`🔴 \`main\` is RED — run [${verdict.run.id}](${verdict.run.url}) (${verdict.run.event}) concluded \`${verdict.conclusion}\` at \`${(verdict.run.sha || "").slice(0, 12)}\`.`);
+  if (regressedTests.length > 0) {
+    lines.push("");
+    lines.push("Regressed tests:");
+    for (const t of regressedTests) lines.push(`- \`${t}\``);
+  }
+  return lines.join("\n");
+}
+
+// --- issue lifecycle (gh I/O) ---
+
+function findSentinelIssue(repository, fetchJson) {
+  const issues = fetchJson([
+    "api",
+    "-H",
+    "Accept: application/vnd.github+json",
+    `repos/${repository}/issues?state=open&per_page=100`,
+  ]);
+  if (!Array.isArray(issues)) return null;
+  return issues.find((it) => typeof it.body === "string" && it.body.includes(ISSUE_MARKER)) || null;
+}
+
+export function reconcileIssue(verdict, regressedTests, nowIso, ctx) {
+  const { repository, fetchJson = runGhJson, runCommand = runGh } = ctx;
+  const existing = findSentinelIssue(repository, fetchJson);
+  const body = formatIssueBody(verdict, regressedTests, nowIso);
+
+  if (verdict.red) {
+    if (existing) {
+      // Refresh the body and add a heartbeat comment if the red head changed.
+      runCommand(["issue", "edit", String(existing.number), "--repo", repository, "--body", body]);
+      runCommand(["issue", "comment", String(existing.number), "--repo", repository,
+        "--body", `Still red as of ${nowIso}: \`${(verdict.run.sha || "").slice(0, 12)}\` ([run](${verdict.run.url})).`]);
+      return { action: "updated", number: existing.number };
+    }
+    const created = runCommand(["issue", "create", "--repo", repository,
+      "--title", ISSUE_TITLE, "--body", body, "--label", "tech-debt"]);
+    return { action: "created", detail: created.stdout || created.stderr };
+  }
+
+  // Green: close any open sentinel issue.
+  if (existing) {
+    runCommand(["issue", "comment", String(existing.number), "--repo", repository,
+      "--body", `✅ \`main\` is green again as of ${nowIso} (\`${(verdict.run.sha || "").slice(0, 12)}\`). Closing.`]);
+    runCommand(["issue", "close", String(existing.number), "--repo", repository,
+      "--reason", "completed"]);
+    return { action: "closed", number: existing.number };
+  }
+  return { action: "noop" };
+}
+
+function bestEffortRegressedTests(repository, verdict) {
+  if (!verdict.red || !verdict.run?.id) return [];
+  // Find the failing conformance-aggregate job and scrape REGRESSED lines.
+  try {
+    const jobs = runGhJson([
+      "api",
+      "-H",
+      "Accept: application/vnd.github+json",
+      `repos/${repository}/actions/runs/${verdict.run.id}/jobs?per_page=100`,
+    ]);
+    const list = Array.isArray(jobs?.jobs) ? jobs.jobs : [];
+    const agg = list.find((j) => /conformance-aggregate/i.test(j.name || "") && j.conclusion === "failure");
+    if (!agg) return [];
+    const log = runGh(["run", "view", "--repo", repository, "--job", String(agg.id), "--log"]);
+    if (log.status !== 0) return [];
+    return extractRegressedTests(log.stdout);
+  } catch {
+    return [];
+  }
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const nowIso = options.now || new Date().toISOString();
+  const runs = options.fixture
+    ? readFixture(options.fixture)
+    : readMainRuns(options.repository, options.maxRuns);
+  const verdict = mainCiHealth(runs);
+
+  const regressed = (!options.fixture && verdict.red && options.repository)
+    ? bestEffortRegressedTests(options.repository, verdict)
+    : [];
+
+  console.log(formatReport(verdict, regressed));
+
+  if (options.fileIssue && options.repository && !options.fixture) {
+    const result = reconcileIssue(verdict, regressed, nowIso, { repository: options.repository });
+    console.log(`sentinel issue: ${result.action}${result.number ? ` #${result.number}` : ""}`);
+  }
+
+  if (verdict.red && options.enforce) process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -421,6 +421,7 @@ run_lint() {
   node scripts/ci/test-pr-ready-state.mjs || return $?
   node scripts/ci/test-refresh-green-prs.mjs || return $?
   node scripts/ci/test-check-stale-ci-runs.mjs || return $?
+  node scripts/ci/test-check-main-red.mjs || return $?
   node scripts/ci/test-cloudbuild-config-paths.mjs || return $?
   node scripts/ci/test-wip-state-comments.mjs || return $?
   node scripts/ci/test-project-compatibility.mjs || return $?

--- a/scripts/ci/test-check-main-red.mjs
+++ b/scripts/ci/test-check-main-red.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import {
+  mainCiHealth,
+  extractRegressedTests,
+  formatIssueBody,
+  formatReport,
+  reconcileIssue,
+} from "./check-main-red.mjs";
+
+const NOW = "2026-06-13T00:00:00Z";
+
+function run(overrides = {}) {
+  return {
+    id: 100,
+    status: "completed",
+    name: "CI",
+    event: "push",
+    conclusion: "success",
+    head_sha: "aaaaaaaaaaaa1111",
+    display_title: "perf(checker): something",
+    html_url: "https://gh.example/runs/100",
+    created_at: "2026-06-12T20:00:00Z",
+    ...overrides,
+  };
+}
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log(`ok - ${name}`);
+}
+
+test("green when newest conclusive main run succeeded", () => {
+  const v = mainCiHealth([
+    run({ id: 1, conclusion: "success", created_at: "2026-06-12T21:00:00Z" }),
+    run({ id: 2, conclusion: "failure", created_at: "2026-06-12T19:00:00Z" }),
+  ]);
+  assert.equal(v.red, false);
+  assert.equal(v.status, "green");
+  assert.equal(v.run.id, 1);
+});
+
+test("red when newest conclusive main run failed", () => {
+  const v = mainCiHealth([
+    run({ id: 2, conclusion: "failure", created_at: "2026-06-12T21:00:00Z", head_sha: "deadbeefcafe0000" }),
+    run({ id: 1, conclusion: "success", created_at: "2026-06-12T19:00:00Z", head_sha: "feedface0001" }),
+  ]);
+  assert.equal(v.red, true);
+  assert.equal(v.run.id, 2);
+  assert.equal(v.lastGreen.sha, "feedface0001");
+});
+
+test("ignores skipped/cancelled push runs (gate-skip), uses merge_group verdict", () => {
+  const v = mainCiHealth([
+    run({ id: 3, event: "push", conclusion: "skipped", created_at: "2026-06-12T21:30:00Z" }),
+    run({ id: 2, event: "merge_group", conclusion: "success", created_at: "2026-06-12T21:00:00Z" }),
+  ]);
+  assert.equal(v.red, false);
+  assert.equal(v.run.id, 2);
+});
+
+test("ignores non-CI workflows and non-main events", () => {
+  const v = mainCiHealth([
+    run({ id: 9, name: "Deploy Website", conclusion: "failure", created_at: "2026-06-12T22:00:00Z" }),
+    run({ id: 8, name: "CI", event: "pull_request", conclusion: "failure", created_at: "2026-06-12T21:59:00Z" }),
+    run({ id: 7, name: "CI", event: "push", conclusion: "success", created_at: "2026-06-12T21:00:00Z" }),
+  ]);
+  assert.equal(v.red, false, "Deploy/PR failures must not mark main red");
+  assert.equal(v.run.id, 7);
+});
+
+test("unknown when no conclusive main run exists", () => {
+  const v = mainCiHealth([
+    run({ id: 1, status: "in_progress", conclusion: null }),
+    run({ id: 2, conclusion: "cancelled" }),
+  ]);
+  assert.equal(v.status, "unknown");
+  assert.equal(v.red, false);
+});
+
+test("timed_out and startup_failure count as red", () => {
+  for (const c of ["timed_out", "startup_failure"]) {
+    const v = mainCiHealth([run({ id: 1, conclusion: c, created_at: "2026-06-12T21:00:00Z" })]);
+    assert.equal(v.red, true, `${c} should be red`);
+  }
+});
+
+test("extractRegressedTests dedupes and parses aggregate log", () => {
+  const log = [
+    "error: unlisted conformance regressions:",
+    "  REGRESSED: TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts",
+    "  REGRESSED: TypeScript/tests/cases/compiler/temporal.ts",
+    "  REGRESSED: TypeScript/tests/cases/compiler/temporal.ts",
+  ].join("\n");
+  assert.deepEqual(extractRegressedTests(log), [
+    "TypeScript/tests/cases/conformance/es2019/globalThisAmbientModules.ts",
+    "TypeScript/tests/cases/compiler/temporal.ts",
+  ]);
+  assert.deepEqual(extractRegressedTests(""), []);
+});
+
+test("issue body embeds marker, window, and regressed tests", () => {
+  const v = mainCiHealth([
+    run({ id: 42, conclusion: "failure", head_sha: "deadbeefcafe9999", created_at: "2026-06-12T21:00:00Z" }),
+    run({ id: 41, conclusion: "success", head_sha: "00ddff112233", created_at: "2026-06-12T20:00:00Z" }),
+  ]);
+  const body = formatIssueBody(v, ["TypeScript/tests/cases/compiler/temporal.ts"], NOW);
+  assert.match(body, /<!-- main-red-sentinel -->/);
+  assert.match(body, /deadbeefcafe/);
+  assert.match(body, /00ddff112233/);
+  assert.match(body, /temporal\.ts/);
+});
+
+test("formatReport summarizes green/red/unknown", () => {
+  assert.match(formatReport(mainCiHealth([run({ conclusion: "success", created_at: "2026-06-12T21:00:00Z" })])), /green/);
+  assert.match(formatReport(mainCiHealth([run({ conclusion: "failure", created_at: "2026-06-12T21:00:00Z" })])), /RED/);
+  assert.match(formatReport(mainCiHealth([])), /No conclusive/);
+});
+
+test("reconcileIssue creates when red and no existing issue", () => {
+  const calls = [];
+  const v = mainCiHealth([run({ id: 5, conclusion: "failure", created_at: "2026-06-12T21:00:00Z" })]);
+  const result = reconcileIssue(v, [], NOW, {
+    repository: "o/r",
+    fetchJson: () => [],
+    runCommand: (args) => { calls.push(args); return { status: 0, stdout: "https://gh/issues/77", stderr: "" }; },
+  });
+  assert.equal(result.action, "created");
+  assert.ok(calls.some((a) => a[0] === "issue" && a[1] === "create"));
+});
+
+test("reconcileIssue updates existing open issue when still red", () => {
+  const calls = [];
+  const v = mainCiHealth([run({ id: 5, conclusion: "failure", created_at: "2026-06-12T21:00:00Z" })]);
+  const result = reconcileIssue(v, [], NOW, {
+    repository: "o/r",
+    fetchJson: () => [{ number: 77, body: "x <!-- main-red-sentinel --> y" }],
+    runCommand: (args) => { calls.push(args); return { status: 0, stdout: "", stderr: "" }; },
+  });
+  assert.equal(result.action, "updated");
+  assert.equal(result.number, 77);
+  assert.ok(calls.some((a) => a[0] === "issue" && a[1] === "edit"));
+});
+
+test("reconcileIssue closes existing issue when green", () => {
+  const calls = [];
+  const v = mainCiHealth([run({ id: 6, conclusion: "success", created_at: "2026-06-12T21:00:00Z" })]);
+  const result = reconcileIssue(v, [], NOW, {
+    repository: "o/r",
+    fetchJson: () => [{ number: 77, body: "<!-- main-red-sentinel -->" }],
+    runCommand: (args) => { calls.push(args); return { status: 0, stdout: "", stderr: "" }; },
+  });
+  assert.equal(result.action, "closed");
+  assert.ok(calls.some((a) => a[0] === "issue" && a[1] === "close"));
+});
+
+test("reconcileIssue noop when green and no issue", () => {
+  const v = mainCiHealth([run({ id: 6, conclusion: "success", created_at: "2026-06-12T21:00:00Z" })]);
+  const result = reconcileIssue(v, [], NOW, {
+    repository: "o/r",
+    fetchJson: () => [],
+    runCommand: () => { throw new Error("must not be called"); },
+  });
+  assert.equal(result.action, "noop");
+});
+
+console.log(`\n${passed} tests passed`);


### PR DESCRIPTION
Goal: hold

## Summary
Adds detection for the failure mode that wedged the merge queue on 2026-06-12 (and previously in #7626 / #12436): when `main`'s post-merge CI breaches the conformance/parity floor, every queued PR inherits the red base through the merge queue and is ejected, but **nothing watched `main`'s own conclusion** — so the wedge went unnoticed for ~2h while every PR burned a full suite.

- New `scripts/ci/check-main-red.mjs`, run from `ci-health.yml` every 15 min on free `ubuntu-latest`.
- Reads the newest **conclusive** CI run on `main` (push/merge_group; ignores gate-skipped and cancelled runs so the gate's intentional main-skip and queue-eviction churn don't produce false positives).
- On failure: opens or updates **one** deduplicated tracking issue (keyed on a hidden body marker) naming the first red run, the head commit, the suspect window (last green → first red), and the `REGRESSED` test list scraped best-effort from the failing `conformance-aggregate` job log.
- On green: auto-closes that issue.

## Structural rule
When `main`'s most recent conclusive CI run (push or merge_group) fails the conformance/parity gate, the queue is wedged until a fix/revert lands; surface it within one health cycle instead of waiting for a human to notice ejected PRs. Detection only — it does not revert, does not edit the accepted-regressions ledger, and does not alter any merge gate, so it cannot normalize red `main` or float the exact `12,585/12,585` floor (ROADMAP Hold).

## Owner layer
CI tooling (`scripts/ci/`, `.github/workflows/ci-health.yml`). No compiler/solver/emitter changes. Extends the existing advisory-probe pattern already in `ci-health.yml` (stale-runs, runner-pool) rather than introducing a new shape — deliberately avoids the historically reverted approaches (auto-revert, ledger-addition unwedge, retry-masking) flagged in the gate-history audit.

## Adjacent cases (unit-tested, 13 cases)
- Green when newest conclusive run succeeded; red when it failed.
- Gate-skipped/cancelled push runs ignored; merge_group success then used.
- Non-CI workflows (Deploy Website) and `pull_request` events never mark `main` red.
- `timed_out` / `startup_failure` count as red; `unknown` when no conclusive run exists.
- `REGRESSED` log scraping dedupes; issue lifecycle create/update/close/noop driven by injected fakes (no network in tests).

## Verification
- `node scripts/ci/test-check-main-red.mjs`: 13/13 passed.
- `node --check scripts/ci/check-main-red.mjs`; `python3 -c "yaml.safe_load(...)"` on `ci-health.yml` (jobs + `issues: write` confirmed).
- Fixture smoke: red verdict on a push-fail-after-merge_group-pass fixture prints the expected `🔴 main is RED` report.
- Registered in `scripts/ci/gcp-full-ci.sh` ci-scripts test list.

## Provenance
Machine: Mohsens-MacBook-Pro.local
Assistant: claude-code
Model: claude-fable-5
Effort: max