### PR TITLE
ci(conformance): pin weighted shard planning inputs (#13397)

### DIFF
--- a/scripts/ci/lib/gcp-full-ci-conformance.sh
+++ b/scripts/ci/lib/gcp-full-ci-conformance.sh
@@ -104,14 +104,8 @@ run_conformance() {
   if [[ "$shard_count" -gt 1 ]]; then
     if [[ "$CONFORMANCE_SHARD_STRATEGY" == "weighted" ]]; then
       shard_weights_file="$METRICS_DIR/conformance-shard-weights.json"
-      local bucket="${_TSZ_CI_CACHE_BUCKET:-${TSZ_CI_CACHE_BUCKET:-}}"
-      if [[ -n "$bucket" ]] && command -v gsutil >/dev/null 2>&1 && \
-          gsutil -q cp "${bucket%/}/metrics/latest/conformance-timings.json" "$shard_weights_file" 2>/dev/null; then
-        echo "Using latest conformance timing weights from cache."
-      else
-        cp scripts/conformance/conformance-shard-weights.json "$shard_weights_file"
-        echo "Using checked-in conformance shard weights."
-      fi
+      cp scripts/conformance/conformance-shard-weights.json "$shard_weights_file"
+      echo "Using checked-in conformance shard weights."
     fi
     read -r shard_expected_passed shard_expected_total shard_expected_weight < <(
       conformance_shard_plan "$shard_index" "$shard_count" "$CONFORMANCE_SHARD_STRATEGY" "$shard_weights_file"

--- a/scripts/ci/test_gcp_full_ci_conformance_artifacts.py
+++ b/scripts/ci/test_gcp_full_ci_conformance_artifacts.py
@@ -57,6 +57,15 @@ class ConformanceArtifactHandoffTests(unittest.TestCase):
         failure_write_block = body[failure_write:upload_block]
         self.assertIn("XFAIL", failure_write_block)
 
+    def test_weighted_shards_use_checked_in_weights_not_latest_gcs(self):
+        body = self.function_body("run_conformance", "\nrun_conformance_aggregate() {")
+        self.assertIn(
+            'cp scripts/conformance/conformance-shard-weights.json "$shard_weights_file"',
+            body,
+        )
+        self.assertIn("Using checked-in conformance shard weights.", body)
+        self.assertNotIn("metrics/latest/conformance-timings.json", body)
+
     def test_aggregate_prefers_artifact_failure_lists_before_gcs(self):
         aggregate = self.function_body(
             "run_conformance_aggregate",


### PR DESCRIPTION
Goal: hold

## Summary
Pins weighted conformance shard planning to the checked-in `scripts/conformance/conformance-shard-weights.json` file instead of copying the mutable `metrics/latest/conformance-timings.json` blob from GCS at shard runtime.

The aggregate job still publishes fresh timing metrics after a completed run, but those metrics are now reporting/output data only. They no longer change shard membership for a later run of the same checkout.

## Structural rule
When conformance shards are planned for a given checkout, shard membership must be a deterministic function of repo state and explicit CI inputs. Mutable cross-run timing artifacts may be produced after the run, but must not feed back into same-sha partition decisions.

## Owner layer
CI tooling only: `scripts/ci/lib/gcp-full-ci-conformance.sh` and its contract test. No compiler/checker/solver behavior changes.

## Adjacent cases
- Weighted shard mode uses the checked-in weights file.
- The previous `metrics/latest/conformance-timings.json` input is absent from the shard execution path.
- Timing shards are still aggregated and published by `run_conformance_aggregate` for future reporting.

## Verification
- No local tests run in this continuation; CI-script-only change with draft CI evidence.
- Remote draft CI/light on exact head `c01b6f749b94742b18eda3b11630ddbf7c739b64`: `CI Light Summary` SUCCESS at 2026-06-13T06:37:00Z.
- Remote draft CI on exact head `c01b6f749b94742b18eda3b11630ddbf7c739b64`: `lint`, `unit`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `unit-cloudbuild`, `unit-checker-integration`, `project-row-drift`, and `premerge-microbench` SUCCESS.
- Ready-review CI pending after promotion.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
