### PR TITLE
refactor(solver): delegate application variance to one fast path (#13051)

### DIFF
--- a/crates/tsz-solver/src/relations/relation_queries.rs
+++ b/crates/tsz-solver/src/relations/relation_queries.rs
@@ -844,32 +844,21 @@ pub fn check_application_variance<R: TypeResolver>(
         checker.set_query_db(qdb);
     }
 
-    let mut any_checked = false;
-    let mut all_ok = true;
-    for (i, variance) in variances.iter().enumerate() {
-        let s_arg = s_app.args[i];
-        let t_arg = t_app.args[i];
-
-        if variance.is_invariant() {
-            any_checked = true;
-            if !checker.is_assignable(s_arg, t_arg) || !checker.is_assignable(t_arg, s_arg) {
-                all_ok = false;
-                break;
-            }
-        } else if variance.is_covariant() {
-            any_checked = true;
-            if !checker.is_assignable(s_arg, t_arg) {
-                all_ok = false;
-                break;
-            }
-        } else if variance.is_contravariant() {
-            any_checked = true;
-            if !checker.is_assignable(t_arg, s_arg) {
-                all_ok = false;
-                break;
-            }
-        }
-    }
+    // Walk the per-argument variance positions through the single shared loop
+    // (`run_application_variance_arg_loop`) so this boundary entry and the
+    // engine fast path (`SubtypeChecker::try_variance_fast_path`) cannot drift
+    // on argument orientation. This boundary relates arguments through the
+    // lawyer (`CompatChecker::is_assignable`); the engine uses the raw judge.
+    let crate::relations::variance::VarianceArgLoopOutcome {
+        any_checked,
+        all_ok,
+        forward_rejected: _,
+    } = crate::relations::variance::run_application_variance_arg_loop(
+        &variances,
+        &s_app.args,
+        &t_app.args,
+        |s_arg, t_arg| checker.is_assignable(s_arg, t_arg),
+    );
 
     let source_args_contain_type_parameters = s_app
         .args

--- a/crates/tsz-solver/src/relations/subtype/rules/generics.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/generics.rs
@@ -774,40 +774,23 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
 
         let needs_structural_fallback = variances.iter().any(|v| v.needs_structural_fallback());
-        let mut all_ok = true;
-        let mut any_checked = false;
-        let mut forward_rejected = false;
 
-        for (i, variance) in variances.iter().enumerate() {
-            let s_arg = s_args[i];
-            let t_arg = t_args[i];
-
-            if variance.is_invariant() {
-                any_checked = true;
-                if !self.check_subtype(s_arg, t_arg).is_true() {
-                    forward_rejected = true;
-                    all_ok = false;
-                    break;
-                }
-                if !self.check_subtype(t_arg, s_arg).is_true() {
-                    all_ok = false;
-                    break;
-                }
-            } else if variance.is_covariant() {
-                any_checked = true;
-                if !self.check_subtype(s_arg, t_arg).is_true() {
-                    forward_rejected = true;
-                    all_ok = false;
-                    break;
-                }
-            } else if variance.is_contravariant() {
-                any_checked = true;
-                if !self.check_subtype(t_arg, s_arg).is_true() {
-                    all_ok = false;
-                    break;
-                }
-            }
-        }
+        // Walk the per-argument variance positions through the single shared
+        // loop (`run_application_variance_arg_loop`) so this engine fast path
+        // and the relation-query boundary
+        // (`relation_queries::check_application_variance`) cannot drift on
+        // argument orientation. The engine relates arguments through the raw
+        // judge (`check_subtype`); the boundary uses the lawyer.
+        let crate::relations::variance::VarianceArgLoopOutcome {
+            any_checked,
+            all_ok,
+            forward_rejected,
+        } = crate::relations::variance::run_application_variance_arg_loop(
+            &variances,
+            &s_args,
+            &t_args,
+            |s_arg, t_arg| self.check_subtype(s_arg, t_arg).is_true(),
+        );
 
         if any_checked && all_ok && !needs_structural_fallback {
             return Some(SubtypeResult::True);

--- a/crates/tsz-solver/src/relations/variance.rs
+++ b/crates/tsz-solver/src/relations/variance.rs
@@ -43,6 +43,95 @@ use rustc_hash::FxHashMap;
 use std::sync::Arc;
 use tsz_common::interner::Atom;
 
+/// Outcome of the shared per-argument Application-variance loop.
+///
+/// This is the single source of truth for how a same-base/same-arity
+/// `Application`-vs-`Application` pair is walked against its declared
+/// per-parameter [`Variance`]. Both Application-variance fast paths
+/// (`relation_queries::check_application_variance` at the relation-query
+/// boundary, and `SubtypeChecker::try_variance_fast_path` in the engine)
+/// run this exact loop so they cannot drift on which argument orientation a
+/// given variance position checks. Each caller still owns the *relation* used
+/// to relate two argument types (the boundary uses the lawyer
+/// `CompatChecker::is_assignable`; the engine uses the raw judge
+/// `check_subtype`) and the mapping from this outcome to its own
+/// accept/reject/fall-through verdict — only the variance walk itself is
+/// shared.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct VarianceArgLoopOutcome {
+    /// At least one argument was in a variance-relevant (non-independent)
+    /// position and was therefore relation-checked.
+    pub any_checked: bool,
+    /// Every relation check performed so far succeeded (no mismatch).
+    pub all_ok: bool,
+    /// A *forward* (source-relates-to-target) check failed. Set for covariant
+    /// and invariant positions; never set by the contravariant orientation
+    /// (which only performs a reverse check). Used by the engine's
+    /// recursive-mapped-alias rejection refinement.
+    pub forward_rejected: bool,
+}
+
+/// Walk an `Application`-vs-`Application` argument list against its declared
+/// per-parameter variances, relating argument types through the supplied
+/// `arg_related` relation, and report the [`VarianceArgLoopOutcome`].
+///
+/// `arg_related(a, b)` must answer "is `a` related to `b`" under the caller's
+/// chosen relation. The loop relates arguments per position:
+/// - invariant: `arg_related(s, t)` then `arg_related(t, s)` (forward first);
+/// - covariant: `arg_related(s, t)` (forward);
+/// - contravariant: `arg_related(t, s)` (reverse only);
+/// - independent: skipped.
+///
+/// The loop stops at the first mismatch, matching the historical
+/// short-circuit behavior of both fast paths.
+pub(crate) fn run_application_variance_arg_loop(
+    variances: &[Variance],
+    source_args: &[TypeId],
+    target_args: &[TypeId],
+    mut arg_related: impl FnMut(TypeId, TypeId) -> bool,
+) -> VarianceArgLoopOutcome {
+    let mut any_checked = false;
+    let mut all_ok = true;
+    let mut forward_rejected = false;
+
+    for (i, variance) in variances.iter().enumerate() {
+        let s_arg = source_args[i];
+        let t_arg = target_args[i];
+
+        if variance.is_invariant() {
+            any_checked = true;
+            if !arg_related(s_arg, t_arg) {
+                forward_rejected = true;
+                all_ok = false;
+                break;
+            }
+            if !arg_related(t_arg, s_arg) {
+                all_ok = false;
+                break;
+            }
+        } else if variance.is_covariant() {
+            any_checked = true;
+            if !arg_related(s_arg, t_arg) {
+                forward_rejected = true;
+                all_ok = false;
+                break;
+            }
+        } else if variance.is_contravariant() {
+            any_checked = true;
+            if !arg_related(t_arg, s_arg) {
+                all_ok = false;
+                break;
+            }
+        }
+    }
+
+    VarianceArgLoopOutcome {
+        any_checked,
+        all_ok,
+        forward_rejected,
+    }
+}
+
 /// Compute the variance of a type parameter within a type.
 ///
 /// This is the main entry point for variance calculation. It analyzes how


### PR DESCRIPTION
Goal: hold

Unifies the two drifted Application-variance fast paths by giving them a single solver-owned per-argument variance loop. Previously `relation_queries::check_application_variance` (the relation-query boundary) and `SubtypeChecker::try_variance_fast_path` (the engine) each carried their own near-identical per-arg loop that walked a same-base/same-arity `Application` pair against its declared per-parameter variances — the literal duplicated code the issue calls out, and the surface where they had drifted. Both now call the new `run_application_variance_arg_loop` in `relations::variance`, which owns the invariant/covariant/contravariant argument orientation in one place.

Behavior is preserved bit-for-bit. The boundary and the engine legitimately differ on two axes that are NOT the loop and are left untouched: (1) the argument *relation* — the boundary relates args through the lawyer `CompatChecker::is_assignable`, the engine through the raw judge `check_subtype` — passed in as a closure; (2) the accept/reject/fall-through *mapping* of the loop outcome, which each entry still owns (the boundary stays rejection-only with its method-bivariance/`has_direct_usage` guards; the engine keeps its `Some(True)` accept, concrete-arg rejection, and recursive-mapped-alias refinement, the last of which still consumes `forward_rejected`). Only the variance *walk* is shared, so no verdict changes — the merged #13303 had already tuned each entry's mapping, and this slice does not alter it.

Structural rule: when a same-base/same-arity `Application`/`Application` pair is checked against its declared per-parameter variances, both fast paths walk the per-argument orientation through one shared loop (`run_application_variance_arg_loop`); each entry only supplies its own argument relation and outcome mapping, so the orientation logic cannot drift again.

Note on scope: a blind "forward `try_variance_fast_path`'s `SubtypeResult` from the boundary" delegation is NOT behavior-preserving against current `origin/main` — the boundary never returns `Some(true)` and uses lawyer arg-relations with different rejection guards, so forwarding the engine result would change Hold-floor assignability diagnostics. This PR unifies the genuinely-shared logic (the loop) without collapsing the two distinct, intentionally-tuned outcome mappings.

Closes #13051

## Verification
- `cargo nextest run -p tsz-checker --test contravariant_app_constrained_type_param_target_tests` — 12/12 pass (full contravariant/covariant/invariant/conditional-alias/recursive/mapped/promise/WeakRef matrix)
- `cargo nextest run -p tsz-solver -E 'test(/variance|application|subtype/)'` — 1535/1535 pass
- `cargo nextest run -p tsz-core -E 'test(test_check_files_parallel_generic_indexed_access_variance_preserves_ts2322)'` — 1/1 (directly cross-checks `check_application_variance` output)
- conformance filters: `recursiveConditionalTypes` 2/2, `conditionalTypes` 5/5, `variance` 16/16 (incl. `varianceProblingAndZeroOrderIndexSignatureRelationsAlign`, `varianceCallbacksAndIndexedAccesses`), `promisesWithConstraints` 1/1
- `cargo clippy -p tsz-solver -- -D warnings` — clean
- `cargo check --workspace` — clean

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
