### PR TITLE
refactor(binder): derive declaration spans on Symbol (PR 1, #13072)

### DIFF
--- a/crates/tsz-binder/src/nodes/binding.rs
+++ b/crates/tsz-binder/src/nodes/binding.rs
@@ -82,7 +82,7 @@ impl BinderState {
         let lib_sym = self.symbols.get(existing_id)?;
         let lib_flags = lib_sym.flags;
         let lib_value_decl = lib_sym.value_declaration;
-        let lib_value_span = lib_sym.value_declaration_span;
+        let lib_value_span = lib_sym.value_declaration_span();
         let lib_decls: Vec<PreservedDecl> = lib_sym
             .declarations
             .iter()

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -1771,22 +1771,16 @@ impl BinderState {
                         i += 1;
                     }
                 }
-                sym.first_declaration_span = sym
-                    .declarations
-                    .first()
-                    .and_then(|decl| arena.get(*decl).map(|n| (n.pos, n.end)));
                 if sym.value_declaration == node {
                     sym.value_declaration =
                         sym.declarations.first().copied().unwrap_or(NodeIndex::NONE);
-                    sym.value_declaration_span = if sym.value_declaration.is_some() {
+                    let value_span = if sym.value_declaration.is_some() {
                         arena.pos_end_at(sym.value_declaration)
                     } else {
                         None
                     };
-                    sym.stable_value_declaration = crate::symbols::StableLocation::from_span(
-                        self.file_idx,
-                        sym.value_declaration_span,
-                    );
+                    sym.stable_value_declaration =
+                        crate::symbols::StableLocation::from_span(self.file_idx, value_span);
                 }
             }
         }

--- a/crates/tsz-binder/src/state/lib_merge.rs
+++ b/crates/tsz-binder/src/state/lib_merge.rs
@@ -235,8 +235,10 @@ impl BinderState {
                                         if !aug_nodes.contains(&decl) {
                                             continue;
                                         }
-                                        existing_mut
-                                            .add_declaration(decl, lib_sym.first_declaration_span);
+                                        existing_mut.add_declaration(
+                                            decl,
+                                            lib_sym.first_declaration_span(),
+                                        );
                                         let arenas = Arc::make_mut(&mut self.declaration_arenas)
                                             .entry((existing_id, decl))
                                             .or_default();
@@ -259,8 +261,10 @@ impl BinderState {
                                 } else {
                                     existing_mut.flags |= lib_sym.flags;
                                     for &decl in &lib_sym.declarations {
-                                        existing_mut
-                                            .add_declaration(decl, lib_sym.first_declaration_span);
+                                        existing_mut.add_declaration(
+                                            decl,
+                                            lib_sym.first_declaration_span(),
+                                        );
                                         let arenas = Arc::make_mut(&mut self.declaration_arenas)
                                             .entry((existing_id, decl))
                                             .or_default();
@@ -286,7 +290,7 @@ impl BinderState {
                                                 {
                                                     existing_mut.set_value_declaration(
                                                         aug.node,
-                                                        lib_sym.first_declaration_span,
+                                                        lib_sym.first_declaration_span(),
                                                     );
                                                     break;
                                                 }
@@ -295,7 +299,7 @@ impl BinderState {
                                     } else if lib_sym.value_declaration.is_some() {
                                         existing_mut.set_value_declaration(
                                             lib_sym.value_declaration,
-                                            lib_sym.value_declaration_span,
+                                            lib_sym.value_declaration_span(),
                                         );
                                     }
                                 }

--- a/crates/tsz-binder/src/state/tests/semantic_defs_core.rs
+++ b/crates/tsz-binder/src/state/tests/semantic_defs_core.rs
@@ -159,8 +159,8 @@ const value = 1;
         .expect("expected symbol for Merged");
     let first_decl = merged.declarations[0];
     let expected_first_span = arena.get(first_decl).map(|node| (node.pos, node.end));
-    assert_eq!(merged.first_declaration_span, expected_first_span);
-    assert_eq!(merged.value_declaration_span, None);
+    assert_eq!(merged.first_declaration_span(), expected_first_span);
+    assert_eq!(merged.value_declaration_span(), None);
 
     let value_sym_id = binder.file_locals.get("value").expect("expected value");
     let value = binder
@@ -170,8 +170,8 @@ const value = 1;
     let expected_value_span = arena
         .get(value.value_declaration)
         .map(|node| (node.pos, node.end));
-    assert_eq!(value.first_declaration_span, expected_value_span);
-    assert_eq!(value.value_declaration_span, expected_value_span);
+    assert_eq!(value.first_declaration_span(), expected_value_span);
+    assert_eq!(value.value_declaration_span(), expected_value_span);
 }
 
 #[test]

--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -258,8 +258,6 @@ pub struct Symbol {
     ///
     /// [plan]: ../../../docs/plan/ROADMAP.md
     pub stable_declarations: Vec<StableLocation>,
-    /// Stable source span of the first declaration, if known.
-    pub first_declaration_span: Option<(u32, u32)>,
     /// First value declaration of the symbol
     pub value_declaration: NodeIndex,
     /// File-stable location parallel to [`Self::value_declaration`].
@@ -268,8 +266,6 @@ pub struct Symbol {
     /// `value_declaration` is set. Defaults to [`StableLocation::NONE`] when
     /// no value declaration has been recorded.
     pub stable_value_declaration: StableLocation,
-    /// Stable source span of the value declaration, if known.
-    pub value_declaration_span: Option<(u32, u32)>,
     /// Parent symbol (for nested symbols)
     pub parent: SymbolId,
     /// Unique ID for this symbol
@@ -315,10 +311,8 @@ impl Symbol {
             escaped_name: name,
             declarations: Vec::new(),
             stable_declarations: Vec::new(),
-            first_declaration_span: None,
             value_declaration: NodeIndex::NONE,
             stable_value_declaration: StableLocation::NONE,
-            value_declaration_span: None,
             parent: SymbolId::NONE,
             id,
             exports: None,
@@ -432,9 +426,6 @@ impl Symbol {
             self.stable_declarations
                 .push(StableLocation::from_span(u32::MAX, span));
         }
-        if self.first_declaration_span.is_none() {
-            self.first_declaration_span = span;
-        }
     }
 
     /// Record the symbol's value declaration and stable source span.
@@ -447,10 +438,43 @@ impl Symbol {
         span: Option<(u32, u32)>,
     ) {
         self.value_declaration = declaration;
-        self.value_declaration_span = span;
         self.stable_value_declaration = StableLocation::from_span(u32::MAX, span);
-        if self.first_declaration_span.is_none() {
-            self.first_declaration_span = span;
+    }
+
+    /// Stable source span `(pos, end)` of the first declaration, if known.
+    ///
+    /// Derived from the first [`StableLocation::is_known`] entry of
+    /// [`Self::stable_declarations`] (declarations are pushed in binding
+    /// order), falling back to [`Self::value_declaration_span`] for symbols
+    /// whose only recorded declaration is a value declaration. The
+    /// declaration lists are the single source of truth; no separate span
+    /// field is stored.
+    #[inline]
+    #[must_use]
+    pub fn first_declaration_span(&self) -> Option<(u32, u32)> {
+        self.stable_declarations
+            .iter()
+            .find(|loc| loc.is_known())
+            .map(|loc| (loc.pos, loc.end))
+            .or_else(|| self.value_declaration_span())
+    }
+
+    /// Stable source span `(pos, end)` of the value declaration, if known.
+    ///
+    /// Derived from [`Self::stable_value_declaration`], which
+    /// [`Self::set_value_declaration`] keeps in lockstep with
+    /// [`Self::value_declaration`]. A `(0, 0)` location is the documented
+    /// [`StableLocation`] "unknown" sentinel and yields `None`.
+    #[inline]
+    #[must_use]
+    pub const fn value_declaration_span(&self) -> Option<(u32, u32)> {
+        if self.stable_value_declaration.is_known() {
+            Some((
+                self.stable_value_declaration.pos,
+                self.stable_value_declaration.end,
+            ))
+        } else {
+            None
         }
     }
 
@@ -1104,6 +1128,92 @@ mod tests {
     fn primary_declaration_none_when_empty() {
         let s = sym();
         assert_eq!(s.primary_declaration(), None);
+    }
+
+    /// Pin the size of `Symbol` so accidental field growth is caught in
+    /// review. Dropping the redundant `first_declaration_span` /
+    /// `value_declaration_span` fields (#13072) brought this from 200 to
+    /// 176 bytes; every interned symbol pays this footprint.
+    #[test]
+    fn symbol_size_is_pinned() {
+        assert_eq!(std::mem::size_of::<Symbol>(), 176);
+    }
+
+    /// The derived span accessors must reproduce the semantics of the
+    /// removed stored fields: first non-`None` span across
+    /// `add_declaration`/`set_value_declaration` events, and the span
+    /// recorded by the last `set_value_declaration`.
+    #[test]
+    fn declaration_span_accessors_empty_symbol() {
+        let s = sym();
+        assert_eq!(s.first_declaration_span(), None);
+        assert_eq!(s.value_declaration_span(), None);
+    }
+
+    #[test]
+    fn declaration_span_accessors_add_then_set_same_span() {
+        // The dominant binder pattern: add_declaration followed by
+        // set_value_declaration with the same node and span.
+        let mut s = sym();
+        s.add_declaration(NodeIndex(1), Some((10, 20)));
+        s.set_value_declaration(NodeIndex(1), Some((10, 20)));
+        assert_eq!(s.first_declaration_span(), Some((10, 20)));
+        assert_eq!(s.value_declaration_span(), Some((10, 20)));
+    }
+
+    #[test]
+    fn declaration_span_accessors_first_span_sticks_across_merges() {
+        // Declaration merging: later declarations must not change the
+        // first-declaration span.
+        let mut s = sym();
+        s.add_declaration(NodeIndex(1), Some((10, 20)));
+        s.add_declaration(NodeIndex(2), Some((30, 40)));
+        s.set_value_declaration(NodeIndex(2), Some((30, 40)));
+        assert_eq!(s.first_declaration_span(), Some((10, 20)));
+        assert_eq!(s.value_declaration_span(), Some((30, 40)));
+    }
+
+    #[test]
+    fn declaration_span_accessors_set_before_add_enum_member_pattern() {
+        // Enum members call set_value_declaration before add_declaration
+        // with the same node and span (binding/declaration.rs).
+        let mut s = sym();
+        s.set_value_declaration(NodeIndex(7), Some((5, 9)));
+        s.add_declaration(NodeIndex(7), Some((5, 9)));
+        assert_eq!(s.first_declaration_span(), Some((5, 9)));
+        assert_eq!(s.value_declaration_span(), Some((5, 9)));
+    }
+
+    #[test]
+    fn declaration_span_accessors_value_only_symbol_falls_back() {
+        // A symbol whose only recorded declaration is a value declaration
+        // (no add_declaration) reports the value span as its first span,
+        // matching the old stored-field write in set_value_declaration.
+        let mut s = sym();
+        s.set_value_declaration(NodeIndex(3), Some((42, 50)));
+        assert_eq!(s.first_declaration_span(), Some((42, 50)));
+        assert_eq!(s.value_declaration_span(), Some((42, 50)));
+    }
+
+    #[test]
+    fn declaration_span_accessors_skip_unknown_entries() {
+        // A None-span declaration must not shadow a later known span,
+        // matching the old "first non-None event span" semantics.
+        let mut s = sym();
+        s.add_declaration(NodeIndex(1), None);
+        s.add_declaration(NodeIndex(2), Some((30, 40)));
+        assert_eq!(s.first_declaration_span(), Some((30, 40)));
+        assert_eq!(s.value_declaration_span(), None);
+    }
+
+    #[test]
+    fn declaration_span_accessors_resetting_value_declaration_clears_span() {
+        // The incremental prune path resets the value declaration through
+        // set_value_declaration with None; the derived span must follow.
+        let mut s = sym();
+        s.set_value_declaration(NodeIndex(3), Some((42, 50)));
+        s.set_value_declaration(NodeIndex::NONE, None);
+        assert_eq!(s.value_declaration_span(), None);
     }
 
     #[test]

--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -325,9 +325,9 @@ impl<'a> CheckerContext<'a> {
         // Prefer binder-owned stable declaration spans over raw NodeIndex-based
         // reconstruction so fallback identity does not treat syntax handles as
         // semantic coordinates.
-        let span = symbol.first_declaration_span.or_else(|| {
+        let span = symbol.first_declaration_span().or_else(|| {
             if symbol.value_declaration.is_some() {
-                symbol.value_declaration_span
+                symbol.value_declaration_span()
             } else {
                 None
             }
@@ -541,9 +541,9 @@ impl<'a> CheckerContext<'a> {
         } else {
             tsz_solver::def::DefKind::TypeAlias
         };
-        let span = symbol.first_declaration_span.or_else(|| {
+        let span = symbol.first_declaration_span().or_else(|| {
             if symbol.value_declaration.is_some() {
-                symbol.value_declaration_span
+                symbol.value_declaration_span()
             } else {
                 None
             }

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1688,20 +1688,11 @@ impl<'a> CheckerState<'a> {
                 let Some(decl_idx) = sym.primary_declaration() else {
                     continue;
                 };
-                let fallback_span = sym
-                    .first_declaration_span
-                    .or_else(|| {
-                        sym.stable_value_declaration.is_known().then_some((
-                            sym.stable_value_declaration.pos,
-                            sym.stable_value_declaration.end,
-                        ))
-                    })
-                    .or_else(|| {
-                        sym.stable_declarations
-                            .iter()
-                            .find(|stable| stable.is_known())
-                            .map(|stable| (stable.pos, stable.end))
-                    });
+                // `Symbol::first_declaration_span` already derives from the
+                // first known `stable_declarations` entry with a
+                // `stable_value_declaration` fallback, subsuming the previous
+                // hand-rolled chain over the same data.
+                let fallback_span = sym.first_declaration_span();
 
                 let mut error_node_idx = decl_idx;
 

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -63,8 +63,8 @@ impl<'a> CheckerState<'a> {
                     .or_else(|| self.get_cross_file_symbol(sym_id))
                     .and_then(|symbol| {
                         symbol
-                            .first_declaration_span
-                            .or(symbol.value_declaration_span)
+                            .first_declaration_span()
+                            .or_else(|| symbol.value_declaration_span())
                     });
                 (name.as_str(), sym_id, span)
             })

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
@@ -1539,8 +1539,8 @@ impl<'a> CheckerState<'a> {
                 return false;
             };
             candidate_symbol.escaped_name == symbol.escaped_name
-                && (candidate_symbol.value_declaration_span == symbol.value_declaration_span
-                    || candidate_symbol.first_declaration_span == symbol.first_declaration_span)
+                && (candidate_symbol.value_declaration_span() == symbol.value_declaration_span()
+                    || candidate_symbol.first_declaration_span() == symbol.first_declaration_span())
         };
 
         for candidate in owner_binder.symbols.iter() {

--- a/crates/tsz-checker/src/tests/architecture_contract_tests/part_00.rs
+++ b/crates/tsz-checker/src/tests/architecture_contract_tests/part_00.rs
@@ -165,7 +165,7 @@ fn def_id_fallback_prefers_symbol_stable_declaration_span() {
         .get(def_id)
         .expect("fallback should register DefinitionInfo");
 
-    assert_eq!(info.span, symbol.first_declaration_span);
+    assert_eq!(info.span, symbol.first_declaration_span());
     assert_eq!(ctx.def_fallback_count.get(), 1);
 }
 

--- a/crates/tsz-cli/tests/driver_tests_parts/part_01.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_01.rs
@@ -1709,8 +1709,8 @@ fn symbol_snapshot_by_id(binder: &BinderState, sym_id: SymbolId) -> Option<Symbo
         flags: sym.flags,
         declarations_len: sym.declarations.len(),
         value_declaration: sym.value_declaration.0,
-        value_declaration_span: sym.value_declaration_span,
-        first_declaration_span: sym.first_declaration_span,
+        value_declaration_span: sym.value_declaration_span(),
+        first_declaration_span: sym.first_declaration_span(),
         parent_name: (sym.parent.is_some()).then(|| {
             symbol_name_for_id(binder, sym.parent).unwrap_or_else(|| format!("#{}", sym.parent.0))
         }),


### PR DESCRIPTION
Goal: hold

PR 1 of 2 for #13072: removes the redundant `first_declaration_span`/`value_declaration_span` fields from `Symbol` (derived from declaration data via `#[inline]` accessors), shrinking every interned symbol by 24 bytes (200 -> 176) with zero behavior change. PR 2 will out-of-line the import-alias payload, finishing the issue.

Structural rule: `Symbol` stores only non-derivable identity data; declaration spans are computed at the accessor from the declarations list as the single source of truth.

Refs #13072 — PR 1 of 2.

## Verification
- `cargo nextest run -p tsz-binder`
- `cargo nextest run -p tsz-checker -E 'test(/symbol|declaration/)'`
- `cargo clippy -p tsz-binder -- -D warnings`
- `cargo check --workspace`

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
