### PR TITLE
bench(corpus): register ts-pattern as a grow canary row

### DIFF
--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -88,6 +88,7 @@ EFFECT_DIR="$EXTERNAL_BENCH_DIR/effect"
 DRIZZLE_ORM_DIR="$EXTERNAL_BENCH_DIR/drizzle-orm"
 TS_REST_DIR="$EXTERNAL_BENCH_DIR/ts-rest"
 OFETCH_DIR="$EXTERNAL_BENCH_DIR/ofetch"
+TS_PATTERN_DIR="$EXTERNAL_BENCH_DIR/ts-pattern"
 LARGE_TS_LOCAL_DIR="${HOME}/code/large-ts-repo"
 # The local fallback was previously implicit, which silently contaminated
 # PR-quality numbers on any developer machine that happened to have a
@@ -400,6 +401,11 @@ ensure_ts_rest_fixture() {
 ensure_ofetch_fixture() {
     mkdir -p "$EXTERNAL_BENCH_DIR"
     tsz_ensure_git_fixture "ofetch" "$OFETCH_REPO" "$OFETCH_REF" "$OFETCH_DIR" 1
+}
+
+ensure_ts_pattern_fixture() {
+    mkdir -p "$EXTERNAL_BENCH_DIR"
+    tsz_ensure_git_fixture "ts-pattern" "$TS_PATTERN_REPO" "$TS_PATTERN_REF" "$TS_PATTERN_DIR" 1
 }
 
 run_utility_types_benchmarks() {
@@ -820,6 +826,21 @@ run_ofetch_project_benchmarks() {
     echo
 }
 
+run_ts_pattern_project_benchmarks() {
+    should_run_compile_canary_project || return 0
+    if ! is_benchmark_selected "ts-pattern-project"; then
+        return
+    fi
+
+    print_header "Real-world External Project - ts-pattern"
+    ensure_ts_pattern_fixture
+    local tsconfig="$TS_PATTERN_DIR/tsconfig.tsz-bench.json"
+    local src_dir="$TS_PATTERN_DIR/src"
+    tsz_write_ts_pattern_config "$tsconfig"
+    run_project_benchmark "ts-pattern-project" "$tsconfig" "$src_dir"
+    echo
+}
+
 run_nextjs_benchmarks() {
     if [ "$NEXTJS_BENCHMARK_ENABLED" != "1" ]; then
         return
@@ -1124,6 +1145,7 @@ main() {
     run_isolated "drizzle-orm-project"    run_drizzle_orm_project_benchmarks
     run_isolated "ts-rest-project"        run_ts_rest_project_benchmarks
     run_isolated "ofetch-project"         run_ofetch_project_benchmarks
+    run_isolated "ts-pattern-project"     run_ts_pattern_project_benchmarks
     run_isolated "vite-vanilla-ts-app"    run_vite_app_project_benchmarks
     run_isolated "nextjs-fresh-app"       run_next_app_project_benchmarks
     run_isolated "nextjs"                 run_nextjs_benchmarks

--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -40,6 +40,7 @@ TSZ_COMPILE_GUARD_CANARY_ROWS=(
   "drizzle-orm-project"
   "ts-rest-project"
   "ofetch-project"
+  "ts-pattern-project"
 )
 
 # Row metadata pre-loaded by tsz_load_fixture_pins_from_rows (pipe-delimited).
@@ -282,6 +283,9 @@ tsz_project_fixture_sources() {
       ;;
     ofetch-project)
       printf 'ofetch|%s|%s\n' "$OFETCH_REPO" "$OFETCH_REF"
+      ;;
+    ts-pattern-project)
+      printf 'ts-pattern|%s|%s\n' "$TS_PATTERN_REPO" "$TS_PATTERN_REF"
       ;;
     vite-vanilla-ts-app)
       local fixture_dir="${VITE_APP_BENCH_DIR:-}"
@@ -618,6 +622,10 @@ tsz_write_ts_rest_config() {
 }
 
 tsz_write_ofetch_config() {
+  tsz_write_basic_external_project_config "$1" "src"
+}
+
+tsz_write_ts_pattern_config() {
   tsz_write_basic_external_project_config "$1" "src"
 }
 

--- a/scripts/bench/project-rows.mjs
+++ b/scripts/bench/project-rows.mjs
@@ -299,6 +299,22 @@ export const PROJECT_ROW_DEFINITIONS = [
     benchmark_set: "canary",
     category: "external",
   },
+  {
+    name: "ts-pattern-project",
+    label: "ts-pattern",
+    readme_candidates: ["README.md"],
+    owner: "Tracks 1, 2",
+    family: "exhaustive pattern-matching union distribution/negation; canary for symbol-keyed computed-property members from a value/type name-merge",
+    fixture_dir: "ts-pattern",
+    source_dir: "src",
+    repo_env: "TS_PATTERN_REPO",
+    ref_env: "TS_PATTERN_REF",
+    repo: "https://github.com/gvergnaud/ts-pattern.git",
+    ref: "c92ca435c7e1827e0fd55c539080ef1bfd6fe3f0",
+    guard_set: "canary",
+    benchmark_set: "canary",
+    category: "external",
+  },
 ];
 
 export const REQUIRED_PROJECT_ROWS = PROJECT_ROW_DEFINITIONS

--- a/scripts/ci/project-compile-guard.sh
+++ b/scripts/ci/project-compile-guard.sh
@@ -738,6 +738,11 @@ run_project_row() {
       tsz_write_ofetch_config "$FIXTURE_ROOT/ofetch/tsconfig.tsz-guard.json"
       check_project "$name" "$FIXTURE_ROOT/ofetch/tsconfig.tsz-guard.json" "$FIXTURE_ROOT/ofetch/src"
       ;;
+    ts-pattern-project)
+      ensure_git_fixture "ts-pattern" "$TS_PATTERN_REPO" "$TS_PATTERN_REF" "$FIXTURE_ROOT/ts-pattern"
+      tsz_write_ts_pattern_config "$FIXTURE_ROOT/ts-pattern/tsconfig.tsz-guard.json"
+      check_project "$name" "$FIXTURE_ROOT/ts-pattern/tsconfig.tsz-guard.json" "$FIXTURE_ROOT/ts-pattern/src"
+      ;;
     vite-vanilla-ts-app)
       if [[ "$INCLUDE_GENERATED_APPS" != "1" ]]; then
         return 0


### PR DESCRIPTION
Registers **ts-pattern** as a new project-corpus **canary** row (Goal: grow). It adds
exhaustive pattern-matching surface that no existing row covers and pins a single,
cleanly attributable false positive as a tracked sentinel.

## Goal
Goal: grow

- Row: `ts-pattern-project` — gvergnaud/ts-pattern @`c92ca435` (MIT, 18 files / 4021 LOC), canary guard + canary benchmark.
- Bug family: false-positive — symbol-keyed computed-property member from a value/type name-merge (#13402).

## Why this row (novel surface)
ts-pattern's core is set-subtraction exhaustiveness (`DistributeUnions`, `DeepExclude`,
`ExtractPreciseValue`, `InvertPattern`) over discriminated unions — negation/exhaustiveness
machinery distinct from every current row (utility/mapped libs, schema builders, observable
generics, ORMs). Discovered and vetted via a discover→probe→rank scout over candidate OSS TS
projects; runners-up were `true-myth` and `neverthrow` (the latter duplicates ofetch's
TS5107 config-canary surface, so it was rejected).

## Structural rule (the canary's blocker)
> When an interface/object type declares a member via a computed property name `[X]`, where
> `X` is a `symbol`-typed `const` (from `Symbol.for(...)`) that is **name-merged** with a type
> alias `type X = typeof X`, `tsc` keys the member by the symbol value; tsz instead resolves
> `[X]` through the type alias, mis-models it as a phantom named property (`__unique_NNNNN`) /
> numeric index signature, and reports TS2536/TS2345/TS2741/TS2322/TS2464.

ts-pattern triggers this via `const matcher = Symbol.for('@ts-pattern/matcher')` +
`type matcher = typeof matcher` (`src/internals/symbols.ts`) used as `[matcher](): MatcherProtocol<…>`
in `src/types/Pattern.ts:60`. Owner layer: binder symbol-meaning selection feeding solver
member/type construction (the printer's `__unique_NNNNN` is the symptom, not the defect).
Controls confirm it is **not** general `unique symbol` handling: genuine `Symbol()` unique
symbols and the same `Symbol.for` const *without* the type alias both pass. Full minimal,
name-varied repro and controls in #13402.

## Parity evidence (worktree dist-fast binary, shared guard config)
- `tsc` 5.9.2 `-p tsconfig.tsz-guard.json`: **exit 0, 0 errors** (clean oracle).
- tsz `-p tsconfig.tsz-guard.json`: **exit 2, 32 errors** in 0.36s, all one root cause.
  Histogram: 9×TS2345, 8×TS2339, 7×TS2322, 3×TS7006, 2×TS2722, 1×TS2741, 1×TS2536, 1×TS2344.
  Clearest line: `src/patterns.ts(104,16): error TS2536: Type 'typeof matcher' cannot be used to index type 'CustomP<…>'`.

Verdict: **yellow** (both exit normally, no crash/hang/OOM). A single fix to symbol-keyed
computed-property-member construction should retire the whole multiset and move the row toward Green.

## Wiring
Synchronized across the four corpus files so the drift tests stay green:
`project-rows.mjs` (metadata source of truth), `project-fixtures.sh`
(canary array + fixture-source case + `tsz_write_ts_pattern_config`),
`bench-vs-tsgo.sh` (dir + `ensure_*_fixture` + `run_*_project_benchmarks` + isolation),
`project-compile-guard.sh` (guard case). No compiler behavior changes.

## Verification
- `node scripts/bench/validate-project-metadata.mjs` — pass
- `node scripts/bench/test-project-rows.mjs` — pass (drift assertions across all four files)
- `node scripts/bench/test-fixture-provenance.mjs`, `test-project-row-summary.mjs`, `test-validate-project-metadata.mjs` — pass
- `python3 scripts/arch/test_arch_guard_project.py` — 63 passed
- `bash -n` on all three modified shell scripts — clean
- Reproduced `tsc` 0 / tsz 32 against ts-pattern @`c92ca435` with the worktree `dist-fast` binary under the guard config.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-fable-5
Effort: high
