### PR TITLE
perf(checker): skip disjoint flow assignment roots (#13393)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -1279,6 +1279,7 @@ impl<'a> FlowAnalyzer<'a> {
         let ant_flags = ant_flow.flags;
         let ant_is_targeting_assignment = (ant_flags & flow_flags::ASSIGNMENT) != 0
             && ant_flow.node.is_some()
+            && self.assignment_root_symbols_may_overlap(ant_flow.node, reference, symbol_id)
             && (symbol_id
                 .zip(self.reference_symbol(ant_flow.node))
                 .is_some_and(|(target, assignment)| target == assignment)

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -351,11 +351,15 @@ impl<'a> FlowAnalyzer<'a> {
                 // Switch clause - apply switch-specific narrowing
                 self.handle_switch_clause_iterative(reference, current_type, flow, results)
             } else if flow.has_any_flags(flow_flags::ASSIGNMENT) {
+                let assignment_roots_may_overlap =
+                    self.assignment_root_symbols_may_overlap(flow.node, reference, symbol_id);
                 // OPTIMIZATION: Quick symbol-based filtering before expensive AST comparison.
                 // If we have a resolved symbol and the assignment's target has a different symbol,
                 // we can skip this assignment entirely. This turns O(N²) into O(N) for cases like
                 // many independent variable assignments.
-                let targets_reference = if let Some(target_sym) = symbol_id {
+                let targets_reference = if !assignment_roots_may_overlap {
+                    false
+                } else if let Some(target_sym) = symbol_id {
                     // Get the assignment target's symbol (O(1) lookup)
                     let assignment_sym = self.reference_symbol(flow.node);
                     if assignment_sym.is_some() && assignment_sym != Some(target_sym) {
@@ -656,7 +660,9 @@ impl<'a> FlowAnalyzer<'a> {
                             }
                         }
                     }
-                } else if self.assignment_affects_reference_node(flow.node, reference) {
+                } else if assignment_roots_may_overlap
+                    && self.assignment_affects_reference_node(flow.node, reference)
+                {
                     // Two sub-cases of "affects reference":
                     // 1. Base reassignment (obj = ... affects obj.prop): clears narrowing
                     // 2. Property mutation (obj.prop.x = ... affects obj.prop): preserves narrowing

--- a/crates/tsz-checker/src/flow/control_flow/references.rs
+++ b/crates/tsz-checker/src/flow/control_flow/references.rs
@@ -844,6 +844,65 @@ impl<'a> FlowAnalyzer<'a> {
         None
     }
 
+    pub(crate) fn assignment_root_symbols_may_overlap(
+        &self,
+        assignment: NodeIndex,
+        reference: NodeIndex,
+        reference_symbol: Option<SymbolId>,
+    ) -> bool {
+        let Some(assignment_root) = self.reference_root_symbol(assignment) else {
+            return true;
+        };
+        let Some(reference_root) =
+            reference_symbol.or_else(|| self.reference_root_symbol(reference))
+        else {
+            return true;
+        };
+        assignment_root == reference_root
+    }
+
+    fn reference_root_symbol(&self, idx: NodeIndex) -> Option<SymbolId> {
+        let idx = self.skip_parenthesized(idx);
+        let node = self.arena.get(idx)?;
+
+        if node.kind == syntax_kind_ext::NON_NULL_EXPRESSION {
+            let unary = self.arena.get_unary_expr_ex(node)?;
+            return self.reference_root_symbol(unary.expression);
+        }
+
+        if node.kind == syntax_kind_ext::TYPE_ASSERTION
+            || node.kind == syntax_kind_ext::AS_EXPRESSION
+            || node.kind == syntax_kind_ext::SATISFIES_EXPRESSION
+        {
+            let assertion = self.arena.get_type_assertion(node)?;
+            return self.reference_root_symbol(assertion.expression);
+        }
+
+        if node.kind == syntax_kind_ext::BINARY_EXPRESSION {
+            let bin = self.arena.get_binary_expr(node)?;
+            if self.is_assignment_operator(bin.operator_token) {
+                return self.reference_root_symbol(bin.left);
+            }
+        }
+
+        if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            || node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        {
+            let access = self.arena.get_access_expr(node)?;
+            if access.question_dot_token {
+                return None;
+            }
+            return self.reference_root_symbol(access.expression);
+        }
+
+        if node.kind == syntax_kind_ext::QUALIFIED_NAME {
+            let qn = self.arena.get_qualified_name(node)?;
+            return self.reference_root_symbol(qn.left);
+        }
+
+        self.reference_symbol(idx)
+    }
+
     pub(crate) fn reference_symbol(&self, idx: NodeIndex) -> Option<SymbolId> {
         let idx = self.skip_parenthesized(idx);
         if let Some(&cached) = self.reference_symbol_cache.borrow().get(&idx.0) {

--- a/crates/tsz-checker/tests/flow_dp_memoization_tests.rs
+++ b/crates/tsz-checker/tests/flow_dp_memoization_tests.rs
@@ -39,6 +39,28 @@ fn diagnostics_within(source: &str, budget: Duration) -> Vec<(u32, String)> {
     diagnostics
 }
 
+#[test]
+fn assignment_flow_prefilters_disjoint_member_roots_before_ast_matching() {
+    let source = include_str!("../src/flow/control_flow/core/flow_traversal.rs");
+    assert!(
+        source.contains("assignment_root_symbols_may_overlap("),
+        "ASSIGNMENT flow should compare receiver-root symbols before full AST reference matching",
+    );
+    assert!(
+        source.contains("assignment_roots_may_overlap\n                    && self.assignment_affects_reference_node"),
+        "ASSIGNMENT flow should guard affects-reference AST matching with receiver-root overlap",
+    );
+}
+
+#[test]
+fn antecedent_defer_prefilters_disjoint_member_roots_before_ast_matching() {
+    let source = include_str!("../src/flow/control_flow/core.rs");
+    assert!(
+        source.contains("assignment_root_symbols_may_overlap(ant_flow.node, reference, symbol_id)"),
+        "antecedent defer checks should compare receiver-root symbols before full AST reference matching",
+    );
+}
+
 /// 32-level `instanceof` chain on a single `unknown`-typed binding. The
 /// pre-fix `O(2^N)` traversal explodes here (each new branch doubles the
 /// work); the memoized DP completes in milliseconds. The chain itself does
@@ -207,5 +229,33 @@ function probe(items: unknown[]) {
             .iter()
             .all(|(code, _)| *code != 2322 && *code != 2345),
         "loop back-edge should not cause spurious narrowing errors, got: {diagnostics:?}",
+    );
+}
+
+/// Member-like references should not re-scan every unrelated assignment on a
+/// different receiver root. The historical path compared each `other.value`
+/// assignment against every later `source.value` read through the full AST
+/// reference matcher, producing an O(N^2) flow walk.
+#[test]
+fn member_reference_skips_unrelated_assignment_roots() {
+    let mut source = String::from(
+        "type Box = { value: string | number };\n\
+         function probe(source: Box, other: Box, seed: number) {\n\
+             if (typeof source.value === \"string\") {\n",
+    );
+    for index in 0..450 {
+        source.push_str(&format!(
+            "        other.value = seed + {index};\n\
+             const narrowed{index}: string = source.value;\n"
+        ));
+    }
+    source.push_str("        return source.value;\n    }\n    return source.value;\n}\n");
+
+    let diagnostics = diagnostics_within(&source, Duration::from_secs(2));
+    assert!(
+        diagnostics
+            .iter()
+            .all(|(code, _)| *code != 2322 && *code != 2345),
+        "unrelated receiver assignments must not disturb member narrowing, got: {diagnostics:?}",
     );
 }


### PR DESCRIPTION
Goal: fast

## Summary
- Add a conservative receiver-root symbol prefilter for checker flow ASSIGNMENT nodes.
- Skip expensive assignment target/affects AST matching only when the assignment root and narrowed reference root are both known and different.
- Apply the same root-overlap guard to antecedent-defer checks so scheduling predicates do not reintroduce the same assignment-chain scan.

## Structural rule
When a flow assignment target has a known receiver root that differs from the member-like reference being narrowed, that assignment cannot target or affect the reference; tsz owns this as checker flow orchestration and falls back to existing AST matching whenever either root is unknown or the roots may overlap.

## Owner layer
Checker flow traversal only. No solver relation/evaluation behavior changes, no diagnostic policy changes, and no user/file-name/string predicates.

## Adjacent cases
- Disjoint member roots skip the full assignment/reference AST matcher.
- Same-root, unknown-root, destructuring, and complex assignment shapes conservatively keep the old matcher path.
- A generated member-reference chain preserves narrowing while bounding the unrelated-assignment walk.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test flow_dp_memoization_tests assignment_flow_prefilters_disjoint_member_roots_before_ast_matching member_reference_skips_unrelated_assignment_roots` (RED/GREEN focused cycle before rebase)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test flow_dp_memoization_tests antecedent_defer_prefilters_disjoint_member_roots_before_ast_matching` (RED for defer path)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test flow_dp_memoization_tests` (after rebase onto `origin/main` `0fd316947ef`)
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --test flow_dp_memoization_tests -- -D warnings`
- Draft `CI Light Summary` and `gate` passed on exact head `a51935de373e7dcf7d0ba9724ab8a736a53ce128`.
- Ready-review `CI Summary` pending after promotion.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high

Refs #13393.
