### PR TITLE
perf(solver): alpha-cache generic instantiations (#13394)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -135,6 +135,9 @@ path = "tests/array_element_naked_inference_tests.rs"
 name = "recursive_array_utility_inference_tests"
 path = "tests/recursive_array_utility_inference_tests.rs"
 [[test]]
+name = "recursive_tuple_mapped_index_tests"
+path = "tests/recursive_tuple_mapped_index_tests.rs"
+[[test]]
 name = "homomorphic_mapped_keyof_modifier_tests"
 path = "tests/homomorphic_mapped_keyof_modifier_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/call_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/mod.rs
@@ -144,7 +144,7 @@ impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
     }
 
     fn expand_type_alias_application(&mut self, type_id: TypeId) -> Option<TypeId> {
-        use crate::query_boundaries::common::{TypeSubstitution, instantiate_type};
+        use crate::query_boundaries::common::{TypeSubstitution, instantiate_type_preserving_meta};
         use crate::query_boundaries::state::type_environment::application_info;
 
         let (base, args) = application_info(self.state.ctx.types, type_id)?;
@@ -178,7 +178,7 @@ impl AssignabilityChecker for CheckerCallAssignabilityAdapter<'_, '_> {
             return None;
         }
         let subst = TypeSubstitution::from_args(self.state.ctx.types, &type_params, &args);
-        let instantiated = instantiate_type(self.state.ctx.types, body, &subst);
+        let instantiated = instantiate_type_preserving_meta(self.state.ctx.types, body, &subst);
         if instantiated == type_id {
             None
         } else {

--- a/crates/tsz-checker/src/tests/dispatch_tests/part_01.rs
+++ b/crates/tsz-checker/src/tests/dispatch_tests/part_01.rs
@@ -590,6 +590,28 @@ const result: [string, number] = extractPrimitives({ primitive: "" }, { primitiv
 }
 
 #[test]
+fn reverse_mapped_variadic_tuple_tail_preserves_rest_positions() {
+    let diags = check_source_diagnostics(
+        r#"
+type Arrayify<T> = { [P in keyof T]: T[P][] };
+declare function inferTail<Tail extends unknown[]>(value: Arrayify<[string, number, ...Tail]>): Tail;
+const tail: [boolean, string] = inferTail([["abc"], [42], [true], ["def"]]);
+
+type Items<Row> = { [Slot in keyof Row]: Row[Slot][] };
+declare function inferMiddle<Rest extends unknown[]>(value: Items<[string, ...Rest, number]>): Rest;
+const middle: [boolean, string] = inferMiddle([["head"], [true], ["mid"], [99]]);
+"#,
+    );
+    let ts2322 = diagnostics_with_code(&diags, 2322);
+    assert_eq!(
+        ts2322.len(),
+        0,
+        "Expected reverse-mapped variadic tuple tail to infer [boolean, string], got: {:?}",
+        diagnostic_messages(&ts2322)
+    );
+}
+
+#[test]
 fn generic_tuple_rest_argument_infers_union_from_all_rest_elements() {
     let diags = check_source_diagnostics(
         r#"

--- a/crates/tsz-checker/src/tests/noUIA_any_index_emits_ts2322_tests.rs
+++ b/crates/tsz-checker/src/tests/noUIA_any_index_emits_ts2322_tests.rs
@@ -252,3 +252,46 @@ const e: boolean = strMap[0 as 0 | 1];
         "A string index signature accepts numeric keys, so numeric-literal unions must not emit TS7053. Got: {codes:?}",
     );
 }
+
+/// Tuple literal indices under NUIA are guaranteed only while they address the
+/// fixed prefix before the first rest. With a fixed suffix after a variable rest,
+/// tsc widens the first literal position after the minimum suffix offset.
+#[test]
+fn nuia_tuple_rest_region_literal_index_adds_undefined() {
+    let source = r#"
+declare const leadingRest: [...number[], number];
+const okLeadingBoundary: number = leadingRest[0];
+const badLeadingSuffixOffset: number = leadingRest[1];
+
+declare const prefixedRest: [number, ...number[], number];
+const okPrefix: number = prefixedRest[0];
+const okRestBoundary: number = prefixedRest[1];
+const badRestSuffixOffset: number = prefixedRest[2];
+
+declare const noSuffix: [boolean, ...boolean[]];
+const okNoSuffixPrefix: boolean = noSuffix[0];
+const badNoSuffixRest: boolean = noSuffix[1];
+"#;
+    let diags = diags_for_strict_nuia(source);
+    let ts2322_count = diags.iter().filter(|d| d.code == 2322).count();
+    assert_eq!(
+        ts2322_count,
+        3,
+        "NUIA should reject suffix-offset literal indices and keep fixed prefix/rest-boundary positions exact. Got: {:?}",
+        diagnostic_codes(&diags)
+    );
+}
+
+#[test]
+fn nuia_tuple_rest_region_literal_index_renamed_value_type() {
+    let source = r#"
+declare const values: [...string[], string];
+const first: string = values[1];
+"#;
+    let diags = diags_for_strict_nuia(source);
+    let codes = diagnostic_codes(&diags);
+    assert!(
+        codes.contains(&2322),
+        "Renamed leading-rest tuple should read string|undefined at the suffix-offset index. Got: {codes:?}",
+    );
+}

--- a/crates/tsz-checker/tests/recursive_tuple_mapped_index_tests.rs
+++ b/crates/tsz-checker/tests/recursive_tuple_mapped_index_tests.rs
@@ -1,0 +1,125 @@
+//! Regression tests for recursive conditional tuple reconstruction followed by
+//! homomorphic mapped-type indexing.
+//!
+//! Structural rule: when a recursive conditional reconstructs a finite
+//! variadic tuple and a homomorphic mapped type later indexes a fixed numeric
+//! slot, `tsc` preserves that slot's concrete element type. tsz owns this in
+//! solver tuple/mapped evaluation; the checker should not report a missing
+//! property from a union of the wrong tuple slots.
+
+use tsz_checker::test_utils::check_source_code_messages;
+
+#[test]
+fn recursive_tuple_then_homomorphic_map_preserves_fixed_slot() {
+    let source = r#"
+interface Leaf {
+    id: string;
+    flags: { labels: readonly ["fast", "safe"] };
+}
+type NormalizeBox<Input> =
+    Input extends object ? { [Field in keyof Input]: NormalizeBox<Input[Field]> } : Input;
+type DeepTuple<Subject> =
+    Subject extends readonly [infer First, ...infer Rest]
+        ? readonly [DeepTuple<First>, ...DeepTuple<Rest>]
+        : Subject;
+type Source = { readonly value: Leaf; readonly next: { readonly value: Leaf } };
+type Tuple = NormalizeBox<DeepTuple<readonly [Source, Leaf, { wrapped: Source }]>>;
+declare const tuple: Tuple;
+const value: string = tuple[2].wrapped.next.value.flags.labels[0];
+"#;
+
+    let diagnostics = check_source_code_messages(source);
+    assert!(
+        !diagnostics.iter().any(|(code, _)| *code == 2339),
+        "recursive tuple mapped access must keep slot 2 as the object with `wrapped`. Got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn recursive_tuple_then_homomorphic_map_preserves_fixed_slot_renamed() {
+    let source = r#"
+interface Node {
+    name: string;
+    meta: { tags: readonly ["hot", "path"] };
+}
+type WalkBox<Item> =
+    Item extends object ? { [Part in keyof Item]: WalkBox<Item[Part]> } : Item;
+type RebuildList<Entry> =
+    Entry extends readonly [infer Head, ...infer Tail]
+        ? readonly [RebuildList<Head>, ...RebuildList<Tail>]
+        : Entry;
+type Branch = { readonly node: Node; readonly child: { readonly node: Node } };
+type Result = WalkBox<RebuildList<readonly [Branch, Node, { focus: Branch }]>>;
+declare const result: Result;
+const tag: string = result[2].focus.child.node.meta.tags[1];
+"#;
+
+    let diagnostics = check_source_code_messages(source);
+    assert!(
+        !diagnostics.iter().any(|(code, _)| *code == 2339),
+        "renamed recursive tuple mapped access must keep slot 2 as the object with `focus`. Got: {diagnostics:#?}"
+    );
+}
+
+#[test]
+fn recursive_alias_pipeline_preserves_mapped_tuple_fixed_slot() {
+    let source = r#"
+type AliasCompute<Value> = Value extends (...args: infer Params) => infer Result
+    ? (...args: Params) => Result
+    : Value extends readonly [infer Head, ...infer Tail]
+        ? readonly [AliasCompute<Head>, ...AliasCompute<Tail>]
+        : Value extends object
+            ? { [Key in keyof Value]: AliasCompute<Value[Key]> }
+            : Value;
+
+type NormalizeBox<Input> = Input extends object
+    ? { [Field in keyof Input]: NormalizeBox<Input[Field]> }
+    : Input;
+
+type DeepReadonlyVariant<Subject> = Subject extends (...args: any[]) => any
+    ? Subject
+    : Subject extends readonly [infer First, ...infer Rest]
+        ? readonly [DeepReadonlyVariant<First>, ...DeepReadonlyVariant<Rest>]
+        : Subject extends object
+            ? { readonly [Name in keyof Subject]: DeepReadonlyVariant<Subject[Name]> }
+            : Subject;
+
+type PickStringKeys<RecordLike> = {
+    [Member in keyof RecordLike as Member extends string ? Member : never]: RecordLike[Member]
+};
+
+type UtilityPipeline<Seed> = AliasCompute<
+    NormalizeBox<
+        DeepReadonlyVariant<
+            PickStringKeys<Seed>
+        >
+    >
+>;
+
+interface LeafPayload {
+    flags: { labels: readonly ["fast", "safe"] };
+}
+
+type Variant<Source> = UtilityPipeline<{
+    readonly item: Source;
+    readonly nested: {
+        readonly tuple: readonly [Source, LeafPayload, { wrapped: Source }];
+    };
+}>;
+
+type Materialized = Variant<{
+    readonly next: {
+        readonly value: LeafPayload;
+    };
+}>;
+
+declare const materialized: Materialized;
+const value: string = materialized.nested.tuple[2].wrapped.next.value.flags.labels[0];
+"#;
+
+    let diagnostics = check_source_code_messages(source);
+    assert!(
+        !diagnostics.iter().any(|(code, _)| *code == 2339),
+        "recursive alias pipeline must keep slot 2 as the object with `wrapped`. Got: {diagnostics:#?}"
+    );
+}

--- a/crates/tsz-solver/src/caches/instantiation_cache_test.rs
+++ b/crates/tsz-solver/src/caches/instantiation_cache_test.rs
@@ -751,6 +751,138 @@ fn instantiate_generic_cached_is_invariant_to_type_param_renaming() {
 }
 
 #[test]
+fn instantiate_generic_cached_reuses_alpha_equivalent_independent_args() {
+    // Issue #13394: utility pipelines often instantiate the same alias body
+    // with structurally identical object arguments whose leaf type parameters
+    // only differ by local binder name. When the instantiated result erases
+    // those binders (here, `keyof T`), the cache should reuse the first walk.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let (t_atom, t_id) = type_param(&interner, "T");
+    let body = interner.keyof(t_id);
+    let param = param_info(t_atom);
+
+    let (_, source_a) = type_param(&interner, "SourceA");
+    let (_, source_b) = type_param(&interner, "SourceB");
+    let arg_a = object_with(&interner, source_a);
+    let arg_b = object_with(&interner, source_b);
+
+    let stats0 = db.statistics();
+    let r_a = instantiate_generic_cached(&interner, Some(&db), body, &[param], &[arg_a]);
+    let stats1 = db.statistics();
+    let r_b = instantiate_generic_cached(&interner, Some(&db), body, &[param], &[arg_b]);
+    let stats2 = db.statistics();
+
+    let expected_b = instantiate_generic_cached(&interner, None, body, &[param], &[arg_b]);
+    assert_ne!(
+        r_a, expected_b,
+        "the witness should require restoring the current binder, not returning the first result"
+    );
+    assert_eq!(
+        r_b, expected_b,
+        "alpha-equivalent cache hits must restore the current binder identity"
+    );
+    assert!(
+        stats1.instantiation_cache_misses > stats0.instantiation_cache_misses,
+        "first alpha-equivalent request must still miss and populate"
+    );
+    assert!(
+        stats2.instantiation_cache_hits > stats1.instantiation_cache_hits,
+        "second alpha-equivalent request should hit instead of re-walking"
+    );
+}
+
+#[test]
+fn instantiate_type_cached_does_not_alpha_reuse_independent_args() {
+    // Request scope matters: the alpha-equivalent cache is only for generic
+    // alias/application instantiation. Ordinary instantiate_type_cached calls
+    // keep exact substitution keys so broad substitution walks cannot perturb
+    // diagnostic shape on already-wrong programs.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let (t_atom, t_id) = type_param(&interner, "T");
+    let body = interner.keyof(t_id);
+
+    let (_, source_a) = type_param(&interner, "SourceA");
+    let (_, source_b) = type_param(&interner, "SourceB");
+    let arg_a = object_with(&interner, source_a);
+    let arg_b = object_with(&interner, source_b);
+
+    let mut subst_a = TypeSubstitution::new();
+    subst_a.insert(t_atom, arg_a);
+    let mut subst_b = TypeSubstitution::new();
+    subst_b.insert(t_atom, arg_b);
+
+    let stats0 = db.statistics();
+    let _ = instantiate_type_cached(&interner, Some(&db), body, &subst_a);
+    let stats1 = db.statistics();
+    let cached_b = instantiate_type_cached(&interner, Some(&db), body, &subst_b);
+    let stats2 = db.statistics();
+    let expected_b = instantiate_type_cached(&interner, None, body, &subst_b);
+
+    assert_eq!(
+        cached_b, expected_b,
+        "exact-key instantiate_type_cached should still compute the current result"
+    );
+    assert!(
+        stats1.instantiation_cache_misses > stats0.instantiation_cache_misses,
+        "first request should miss"
+    );
+    assert_eq!(
+        stats2.instantiation_cache_hits, stats1.instantiation_cache_hits,
+        "instantiate_type_cached must not use alpha-equivalent cache slots"
+    );
+}
+
+#[test]
+fn instantiate_generic_cached_keeps_constrained_type_param_args_distinct() {
+    // Alpha-cache reuse is only sound for simple local binders. Constrained
+    // type parameters carry semantic information and must keep their ordinary
+    // exact cache keys.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let (t_atom, t_id) = type_param(&interner, "T");
+    let body = interner.keyof(t_id);
+    let param = param_info(t_atom);
+
+    let source_a_atom = interner.intern_string("SourceA");
+    let source_b_atom = interner.intern_string("SourceB");
+    let source_a = interner.type_param(TypeParamInfo {
+        constraint: Some(TypeId::STRING),
+        ..param_info(source_a_atom)
+    });
+    let source_b = interner.type_param(TypeParamInfo {
+        constraint: Some(TypeId::NUMBER),
+        ..param_info(source_b_atom)
+    });
+    let arg_a = object_with(&interner, source_a);
+    let arg_b = object_with(&interner, source_b);
+
+    let stats0 = db.statistics();
+    let _ = instantiate_generic_cached(&interner, Some(&db), body, &[param], &[arg_a]);
+    let stats1 = db.statistics();
+    let cached_b = instantiate_generic_cached(&interner, Some(&db), body, &[param], &[arg_b]);
+    let stats2 = db.statistics();
+    let expected_b = instantiate_generic_cached(&interner, None, body, &[param], &[arg_b]);
+
+    assert_eq!(
+        cached_b, expected_b,
+        "constrained arg instantiation must still compute the current result"
+    );
+    assert!(
+        stats1.instantiation_cache_misses > stats0.instantiation_cache_misses,
+        "first constrained request should miss"
+    );
+    assert_eq!(
+        stats2.instantiation_cache_hits, stats1.instantiation_cache_hits,
+        "constrained type parameters must not use the simple alpha cache"
+    );
+}
+
+#[test]
 fn evaluator_recursive_utility_application_populates_cache() {
     // End-to-end wiring evidence for issue #10851: route an alias body that
     // contains the type parameter twice through the actual `TypeEvaluator`

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -1628,13 +1628,20 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 let elements = self.interner().tuple_list(tuple_id);
                 if let Some(result) =
                     super::index_access_tuple_literal::evaluate_tuple_literal_index(
-                        self,
-                        &elements,
-                        index_type,
-                        self.no_unchecked_indexed_access(),
+                        self, &elements, index_type,
                     )
                     && result != TypeId::UNDEFINED
                 {
+                    let result = if self.no_unchecked_indexed_access()
+                        && super::index_access_tuple_literal::literal_index_needs_unchecked_undefined(
+                            &elements,
+                            index_type,
+                            self.interner(),
+                        ) {
+                        self.add_undefined_if_unchecked(result)
+                    } else {
+                        result
+                    };
                     return self.evaluate_index_access_result(result);
                 }
             }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -10,9 +10,9 @@ use crate::instantiation::instantiate::{
 use crate::objects::PropertyCollectionResult;
 use crate::relations::subtype::TypeResolver;
 use crate::types::{
-    CallableShape, CallableShapeId, IntrinsicKind, LiteralValue, MappedModifier, MappedType,
-    MappedTypeId, ObjectShape, ObjectShapeId, PropertyInfo, SymbolRef, TupleElement, TupleListId,
-    TypeData, TypeId, TypeListId, TypeParamInfo,
+    CallableShapeId, IntrinsicKind, LiteralValue, MappedModifier, MappedType, MappedTypeId,
+    ObjectShape, ObjectShapeId, PropertyInfo, SymbolRef, TupleElement, TupleListId, TypeData,
+    TypeId, TypeListId, TypeParamInfo,
 };
 use crate::utils;
 use crate::visitor::{
@@ -1028,6 +1028,12 @@ impl<'a, 'b, R: TypeResolver> TypeVisitor for IndexAccessVisitor<'a, 'b, R> {
             }
             return None;
         }
+        if self
+            .evaluator
+            .mapped_tuple_literal_index_should_materialize(&mapped, self.index_type)
+        {
+            return None;
+        }
 
         // Name-match TypeParams so expanded `Record<K, V>` constraints still
         // substitute for the caller's distinct-but-same-name `K`.
@@ -1320,6 +1326,23 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         (self.evaluate(self.interner().keyof(source)) == mapped.constraint).then_some(source)
     }
 
+    fn mapped_tuple_literal_index_should_materialize(
+        &mut self,
+        mapped: &MappedType,
+        index_type: TypeId,
+    ) -> bool {
+        if mapped.name_type.is_some() || literal_number(self.interner(), index_type).is_none() {
+            return false;
+        }
+
+        let Some(source) = keyof_inner_type(self.interner(), mapped.constraint) else {
+            return false;
+        };
+        let source = self.evaluate(source);
+        let source = crate::type_queries::data::unwrap_readonly(self.interner(), source);
+        matches!(self.interner().lookup(source), Some(TypeData::Tuple(_)))
+    }
+
     fn constrained_index_type(&mut self, index_type: TypeId) -> Option<TypeId> {
         if index_type.is_intrinsic() {
             return None;
@@ -1396,6 +1419,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
         // Skip if there's a name remapping (as clause)
         if mapped.name_type.is_some() {
+            return None;
+        }
+        if self.mapped_tuple_literal_index_should_materialize(&mapped, index_type) {
             return None;
         }
 
@@ -1595,6 +1621,22 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     ///
     /// This resolves property access on object types.
     pub fn evaluate_index_access(&mut self, object_type: TypeId, index_type: TypeId) -> TypeId {
+        if literal_number(self.interner(), index_type).is_some() {
+            let tuple_object =
+                crate::type_queries::data::unwrap_readonly(self.interner(), object_type);
+            if let Some(TypeData::Tuple(tuple_id)) = self.interner().lookup(tuple_object) {
+                let elements = self.interner().tuple_list(tuple_id);
+                if let Some(result) =
+                    super::index_access_tuple_literal::evaluate_tuple_literal_index(
+                        self, &elements, index_type,
+                    )
+                    && result != TypeId::UNDEFINED
+                {
+                    return self.evaluate_index_access_result(result);
+                }
+            }
+        }
+
         // Pre-evaluation check: if the object is a mapped type and the index is a type
         // parameter whose constraint matches the mapped constraint, substitute K into
         // the mapped template directly. This MUST happen before evaluate(object_type)
@@ -1885,128 +1927,6 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // are all subtypes of string. When the object has a string index signature,
         // these index types should resolve to the string index signature's value type,
         // just like TypeId::STRING does.
-        if let Some(string_index) = string_index
-            && string_index_signature_applies(self, string_index, index_type)
-        {
-            return self.add_undefined_if_unchecked(string_index.value_type);
-        }
-
-        TypeId::UNDEFINED
-    }
-
-    /// Evaluate index access on a callable type (class constructor / `typeof ClassName`).
-    ///
-    /// Callable types have static properties and index signatures, analogous to
-    /// `ObjectWithIndex`. This resolves type-level indexed access like
-    /// `(typeof B)["foo"]` or `(typeof B)[number]`.
-    pub(crate) fn evaluate_callable_index(
-        &self,
-        shape: &CallableShape,
-        index_type: TypeId,
-    ) -> TypeId {
-        let string_index = shape
-            .string_index
-            .as_ref()
-            .filter(|idx| idx.key_type != TypeId::SYMBOL);
-        let symbol_index = shape
-            .string_index
-            .as_ref()
-            .filter(|idx| idx.key_type == TypeId::SYMBOL);
-
-        // If index is a union, evaluate each member
-        if let Some(members) = union_list_id(self.interner(), index_type) {
-            let members = self.interner().type_list(members);
-            let mut results = Vec::new();
-            for &member in members.iter() {
-                let result = self.evaluate_callable_index(shape, member);
-                if result != TypeId::UNDEFINED || self.no_unchecked_indexed_access() {
-                    results.push(result);
-                }
-            }
-            if results.is_empty() {
-                return TypeId::UNDEFINED;
-            }
-            return self.interner().union(results);
-        }
-
-        // If index is a literal string or unique symbol, look up properties first,
-        // then fallback to index sigs.
-        if let Some(name) =
-            crate::type_queries::get_literal_property_name(self.interner(), index_type)
-        {
-            let is_symbol_key = matches!(
-                self.interner().lookup(index_type),
-                Some(TypeData::UniqueSymbol(_))
-            );
-            for prop in &shape.properties {
-                if prop.name == name {
-                    return self.optional_property_type(prop);
-                }
-            }
-            if utils::is_numeric_property_name(self.interner(), name)
-                && let Some(number_index) = shape.number_index.as_ref()
-            {
-                return self.add_undefined_if_unchecked(number_index.value_type);
-            }
-            if is_symbol_key && let Some(symbol_index) = symbol_index {
-                return self.add_undefined_if_unchecked(symbol_index.value_type);
-            }
-            // Symbol-keyed properties must NOT fall through to string index signatures
-            if !is_symbol_key
-                && let Some(string_index) = string_index
-                && string_index_signature_applies(self, string_index, index_type)
-            {
-                return self.add_undefined_if_unchecked(string_index.value_type);
-            }
-            return TypeId::UNDEFINED;
-        }
-
-        // If index is a literal number, prefer number index, then string index.
-        if literal_number(self.interner(), index_type).is_some() {
-            if let Some(number_index) = shape.number_index.as_ref() {
-                return self.add_undefined_if_unchecked(number_index.value_type);
-            }
-            if let Some(string_index) = string_index
-                && string_index_signature_applies(self, string_index, index_type)
-            {
-                return self.add_undefined_if_unchecked(string_index.value_type);
-            }
-            return TypeId::UNDEFINED;
-        }
-
-        // Bare `string`/`number`/`symbol` indices that match no applicable index
-        // signature are a TS2536/TS2537 failure: tsc resolves the access to the error
-        // type rather than the union of all member value types, so downstream checks
-        // are suppressed. A numeric index still falls back to a string index signature
-        // (numeric keys are string keys).
-        if index_type == TypeId::STRING {
-            if let Some(string_index) = string_index
-                && string_index_signature_applies(self, string_index, index_type)
-            {
-                return self.add_undefined_if_unchecked(string_index.value_type);
-            }
-            return TypeId::ERROR;
-        }
-
-        if index_type == TypeId::NUMBER {
-            if let Some(number_index) = shape.number_index.as_ref() {
-                return self.add_undefined_if_unchecked(number_index.value_type);
-            }
-            if let Some(string_index) = string_index {
-                return self.add_undefined_if_unchecked(string_index.value_type);
-            }
-            return TypeId::ERROR;
-        }
-
-        if index_type == TypeId::SYMBOL {
-            if let Some(symbol_index) = symbol_index {
-                return self.add_undefined_if_unchecked(symbol_index.value_type);
-            }
-            return TypeId::ERROR;
-        }
-
-        // String-like index types (template literals, string intrinsics, branded strings)
-        // should use the string index signature when available.
         if let Some(string_index) = string_index
             && string_index_signature_applies(self, string_index, index_type)
         {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -1628,7 +1628,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 let elements = self.interner().tuple_list(tuple_id);
                 if let Some(result) =
                     super::index_access_tuple_literal::evaluate_tuple_literal_index(
-                        self, &elements, index_type,
+                        self,
+                        &elements,
+                        index_type,
+                        self.no_unchecked_indexed_access(),
                     )
                     && result != TypeId::UNDEFINED
                 {

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_callable.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_callable.rs
@@ -1,0 +1,133 @@
+//! Callable-shape index access evaluation.
+
+use crate::relations::subtype::TypeResolver;
+use crate::types::{CallableShape, TypeData, TypeId};
+use crate::utils;
+use crate::visitor::{literal_number, union_list_id};
+
+use super::super::evaluate::TypeEvaluator;
+use super::string_index_helpers::string_index_signature_applies;
+
+impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+    /// Evaluate index access on a callable type (class constructor / `typeof ClassName`).
+    ///
+    /// Callable types have static properties and index signatures, analogous to
+    /// `ObjectWithIndex`. This resolves type-level indexed access like
+    /// `(typeof B)["foo"]` or `(typeof B)[number]`.
+    pub(crate) fn evaluate_callable_index(
+        &self,
+        shape: &CallableShape,
+        index_type: TypeId,
+    ) -> TypeId {
+        let string_index = shape
+            .string_index
+            .as_ref()
+            .filter(|idx| idx.key_type != TypeId::SYMBOL);
+        let symbol_index = shape
+            .string_index
+            .as_ref()
+            .filter(|idx| idx.key_type == TypeId::SYMBOL);
+
+        // If index is a union, evaluate each member.
+        if let Some(members) = union_list_id(self.interner(), index_type) {
+            let members = self.interner().type_list(members);
+            let mut results = Vec::new();
+            for &member in members.iter() {
+                let result = self.evaluate_callable_index(shape, member);
+                if result != TypeId::UNDEFINED || self.no_unchecked_indexed_access() {
+                    results.push(result);
+                }
+            }
+            if results.is_empty() {
+                return TypeId::UNDEFINED;
+            }
+            return self.interner().union(results);
+        }
+
+        // If index is a literal string or unique symbol, look up properties first,
+        // then fallback to index sigs.
+        if let Some(name) =
+            crate::type_queries::get_literal_property_name(self.interner(), index_type)
+        {
+            let is_symbol_key = matches!(
+                self.interner().lookup(index_type),
+                Some(TypeData::UniqueSymbol(_))
+            );
+            for prop in &shape.properties {
+                if prop.name == name {
+                    return self.optional_property_type(prop);
+                }
+            }
+            if utils::is_numeric_property_name(self.interner(), name)
+                && let Some(number_index) = shape.number_index.as_ref()
+            {
+                return self.add_undefined_if_unchecked(number_index.value_type);
+            }
+            if is_symbol_key && let Some(symbol_index) = symbol_index {
+                return self.add_undefined_if_unchecked(symbol_index.value_type);
+            }
+            // Symbol-keyed properties must NOT fall through to string index signatures.
+            if !is_symbol_key
+                && let Some(string_index) = string_index
+                && string_index_signature_applies(self, string_index, index_type)
+            {
+                return self.add_undefined_if_unchecked(string_index.value_type);
+            }
+            return TypeId::UNDEFINED;
+        }
+
+        // If index is a literal number, prefer number index, then string index.
+        if literal_number(self.interner(), index_type).is_some() {
+            if let Some(number_index) = shape.number_index.as_ref() {
+                return self.add_undefined_if_unchecked(number_index.value_type);
+            }
+            if let Some(string_index) = string_index
+                && string_index_signature_applies(self, string_index, index_type)
+            {
+                return self.add_undefined_if_unchecked(string_index.value_type);
+            }
+            return TypeId::UNDEFINED;
+        }
+
+        // Bare `string`/`number`/`symbol` indices that match no applicable index
+        // signature are a TS2536/TS2537 failure: tsc resolves the access to the error
+        // type rather than the union of all member value types, so downstream checks
+        // are suppressed. A numeric index still falls back to a string index signature
+        // (numeric keys are string keys).
+        if index_type == TypeId::STRING {
+            if let Some(string_index) = string_index
+                && string_index_signature_applies(self, string_index, index_type)
+            {
+                return self.add_undefined_if_unchecked(string_index.value_type);
+            }
+            return TypeId::ERROR;
+        }
+
+        if index_type == TypeId::NUMBER {
+            if let Some(number_index) = shape.number_index.as_ref() {
+                return self.add_undefined_if_unchecked(number_index.value_type);
+            }
+            if let Some(string_index) = string_index {
+                return self.add_undefined_if_unchecked(string_index.value_type);
+            }
+            return TypeId::ERROR;
+        }
+
+        if index_type == TypeId::SYMBOL {
+            if let Some(symbol_index) = symbol_index {
+                return self.add_undefined_if_unchecked(symbol_index.value_type);
+            }
+            return TypeId::ERROR;
+        }
+
+        // String-like index types (template literals, string intrinsics, branded strings)
+        // should use the string index signature when available.
+        if let Some(string_index) = string_index
+            && string_index_signature_applies(self, string_index, index_type)
+        {
+            return self.add_undefined_if_unchecked(string_index.value_type);
+        }
+
+        TypeId::UNDEFINED
+    }
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs
@@ -3,7 +3,7 @@
 use crate::construction::TypeDatabase;
 use crate::objects::ApparentMemberKind;
 use crate::objects::apparent::is_member;
-use crate::types::{IntrinsicKind, LiteralValue, TupleElement, TypeId, TypeListId};
+use crate::types::{IntrinsicKind, LiteralValue, TupleElement, TypeData, TypeId, TypeListId};
 use crate::utils;
 use crate::visitor::{TypeVisitor, array_element_type, literal_number, tuple_list_id};
 
@@ -226,6 +226,27 @@ impl<'a> TupleKeyVisitor<'a> {
                     // Recursively search in rest elements.
                     let inner_visitor = TupleKeyVisitor::new(self.db, &rest_elements);
                     return inner_visitor.tuple_index_literal(inner_idx);
+                }
+                if let Some(TypeData::Union(list_id)) = self.db.lookup(element.type_id) {
+                    let inner_idx = idx.saturating_sub(logical_idx);
+                    let mut results = Vec::new();
+                    for &member in self.db.type_list(list_id).iter() {
+                        let member = crate::type_queries::data::unwrap_readonly(self.db, member);
+                        if let Some(member_elements_id) = tuple_list_id(self.db, member) {
+                            let member_elements = self.db.tuple_list(member_elements_id);
+                            let inner_visitor = TupleKeyVisitor::new(self.db, &member_elements);
+                            if let Some(result) = inner_visitor.tuple_index_literal(inner_idx)
+                                && result != TypeId::UNDEFINED
+                            {
+                                results.push(result);
+                            }
+                        }
+                    }
+                    return match results.as_slice() {
+                        [] => Some(TypeId::UNDEFINED),
+                        [only] => Some(*only),
+                        _ => Some(self.db.union(results)),
+                    };
                 }
                 return Some(self.tuple_element_type(element));
             }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs
@@ -235,7 +235,9 @@ impl<'a> TupleKeyVisitor<'a> {
                         if let Some(member_elements_id) = tuple_list_id(self.db, member) {
                             let member_elements = self.db.tuple_list(member_elements_id);
                             let inner_visitor = TupleKeyVisitor::new(self.db, &member_elements);
-                            if let Some(result) = inner_visitor.tuple_index_literal(inner_idx) {
+                            if let Some(result) = inner_visitor.tuple_index_literal(inner_idx)
+                                && result != TypeId::UNDEFINED
+                            {
                                 results.push(result);
                             }
                         }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs
@@ -235,9 +235,7 @@ impl<'a> TupleKeyVisitor<'a> {
                         if let Some(member_elements_id) = tuple_list_id(self.db, member) {
                             let member_elements = self.db.tuple_list(member_elements_id);
                             let inner_visitor = TupleKeyVisitor::new(self.db, &member_elements);
-                            if let Some(result) = inner_visitor.tuple_index_literal(inner_idx)
-                                && result != TypeId::UNDEFINED
-                            {
+                            if let Some(result) = inner_visitor.tuple_index_literal(inner_idx) {
                                 results.push(result);
                             }
                         }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_tuple_literal.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_tuple_literal.rs
@@ -10,26 +10,53 @@ pub(super) fn evaluate_tuple_literal_index<R: TypeResolver>(
     evaluator: &mut TypeEvaluator<'_, R>,
     elements: &[TupleElement],
     index_type: TypeId,
-    no_unchecked_indexed_access: bool,
 ) -> Option<TypeId> {
     let value = literal_number(evaluator.interner(), index_type)?;
     if !value.0.is_finite() || value.0.fract() != 0.0 || value.0 < 0.0 {
         return Some(TypeId::UNDEFINED);
     }
-    evaluate_tuple_literal_index_inner(
-        evaluator,
-        elements,
-        value.0 as usize,
-        no_unchecked_indexed_access,
-        0,
-    )
+    evaluate_tuple_literal_index_inner(evaluator, elements, value.0 as usize, 0)
+}
+
+pub(super) fn literal_index_needs_unchecked_undefined(
+    elements: &[TupleElement],
+    index_type: TypeId,
+    interner: &dyn crate::construction::TypeDatabase,
+) -> bool {
+    let Some(value) = literal_number(interner, index_type) else {
+        return false;
+    };
+    if !value.0.is_finite() || value.0.fract() != 0.0 || value.0 < 0.0 {
+        return false;
+    }
+
+    let fixed_prefix_len = elements
+        .iter()
+        .take_while(|element| !element.rest && element.is_required())
+        .count();
+    let index = value.0 as usize;
+    if index < fixed_prefix_len {
+        return false;
+    }
+
+    let Some(rest_position) = elements.iter().position(|element| element.rest) else {
+        return false;
+    };
+    let fixed_suffix_len = elements[rest_position + 1..]
+        .iter()
+        .filter(|element| !element.rest && element.is_required())
+        .count();
+    if fixed_suffix_len > 0 {
+        index == fixed_prefix_len.saturating_add(fixed_suffix_len)
+    } else {
+        true
+    }
 }
 
 fn evaluate_tuple_literal_index_inner<R: TypeResolver>(
     evaluator: &mut TypeEvaluator<'_, R>,
     elements: &[TupleElement],
     index: usize,
-    no_unchecked_indexed_access: bool,
     depth: usize,
 ) -> Option<TypeId> {
     const MAX_TUPLE_SPREAD_DEPTH: usize = 64;
@@ -45,7 +72,6 @@ fn evaluate_tuple_literal_index_inner<R: TypeResolver>(
                 evaluator,
                 element.type_id,
                 rest_index,
-                no_unchecked_indexed_access,
                 depth,
             );
         }
@@ -67,7 +93,6 @@ fn evaluate_rest_tuple_literal_index<R: TypeResolver>(
     evaluator: &mut TypeEvaluator<'_, R>,
     rest_type: TypeId,
     index: usize,
-    no_unchecked_indexed_access: bool,
     depth: usize,
 ) -> Option<TypeId> {
     if rest_type.is_intrinsic() {
@@ -79,21 +104,9 @@ fn evaluate_rest_tuple_literal_index<R: TypeResolver>(
     match evaluator.interner().lookup(evaluated) {
         Some(TypeData::Tuple(tuple_id)) => {
             let elements = evaluator.interner().tuple_list(tuple_id);
-            evaluate_tuple_literal_index_inner(
-                evaluator,
-                &elements,
-                index,
-                no_unchecked_indexed_access,
-                depth + 1,
-            )
+            evaluate_tuple_literal_index_inner(evaluator, &elements, index, depth + 1)
         }
-        Some(TypeData::Array(element_type)) => {
-            if no_unchecked_indexed_access {
-                Some(evaluator.interner().union2(element_type, TypeId::UNDEFINED))
-            } else {
-                Some(element_type)
-            }
-        }
+        Some(TypeData::Array(element_type)) => Some(element_type),
         Some(TypeData::Union(list_id)) => {
             let members: Vec<_> = evaluator
                 .interner()
@@ -103,13 +116,10 @@ fn evaluate_rest_tuple_literal_index<R: TypeResolver>(
                 .collect();
             let mut results = Vec::new();
             for member in members {
-                if let Some(result) = evaluate_rest_tuple_literal_index(
-                    evaluator,
-                    member,
-                    index,
-                    no_unchecked_indexed_access,
-                    depth + 1,
-                ) {
+                if let Some(result) =
+                    evaluate_rest_tuple_literal_index(evaluator, member, index, depth + 1)
+                    && result != TypeId::UNDEFINED
+                {
                     results.push(result);
                 }
             }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_tuple_literal.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_tuple_literal.rs
@@ -1,0 +1,99 @@
+//! Literal numeric indexing through tuple rest elements.
+
+use crate::relations::subtype::TypeResolver;
+use crate::types::{TupleElement, TypeData, TypeId};
+use crate::visitor::literal_number;
+
+use super::super::evaluate::TypeEvaluator;
+
+pub(super) fn evaluate_tuple_literal_index<R: TypeResolver>(
+    evaluator: &mut TypeEvaluator<'_, R>,
+    elements: &[TupleElement],
+    index_type: TypeId,
+) -> Option<TypeId> {
+    let value = literal_number(evaluator.interner(), index_type)?;
+    if !value.0.is_finite() || value.0.fract() != 0.0 || value.0 < 0.0 {
+        return Some(TypeId::UNDEFINED);
+    }
+    evaluate_tuple_literal_index_inner(evaluator, elements, value.0 as usize, 0)
+}
+
+fn evaluate_tuple_literal_index_inner<R: TypeResolver>(
+    evaluator: &mut TypeEvaluator<'_, R>,
+    elements: &[TupleElement],
+    index: usize,
+    depth: usize,
+) -> Option<TypeId> {
+    const MAX_TUPLE_SPREAD_DEPTH: usize = 64;
+    if depth > MAX_TUPLE_SPREAD_DEPTH {
+        return None;
+    }
+
+    let mut position = 0usize;
+    for element in elements {
+        if element.rest {
+            let rest_index = index.checked_sub(position)?;
+            return evaluate_rest_tuple_literal_index(
+                evaluator,
+                element.type_id,
+                rest_index,
+                depth,
+            );
+        }
+
+        if position == index {
+            let mut type_id = element.type_id;
+            if element.optional {
+                type_id = evaluator.interner().union2(type_id, TypeId::UNDEFINED);
+            }
+            return Some(type_id);
+        }
+        position = position.checked_add(1)?;
+    }
+
+    Some(TypeId::UNDEFINED)
+}
+
+fn evaluate_rest_tuple_literal_index<R: TypeResolver>(
+    evaluator: &mut TypeEvaluator<'_, R>,
+    rest_type: TypeId,
+    index: usize,
+    depth: usize,
+) -> Option<TypeId> {
+    if rest_type.is_intrinsic() {
+        return None;
+    }
+
+    let evaluated = evaluator.evaluate(rest_type);
+    let evaluated = crate::type_queries::data::unwrap_readonly(evaluator.interner(), evaluated);
+    match evaluator.interner().lookup(evaluated) {
+        Some(TypeData::Tuple(tuple_id)) => {
+            let elements = evaluator.interner().tuple_list(tuple_id);
+            evaluate_tuple_literal_index_inner(evaluator, &elements, index, depth + 1)
+        }
+        Some(TypeData::Array(element_type)) => Some(element_type),
+        Some(TypeData::Union(list_id)) => {
+            let members: Vec<_> = evaluator
+                .interner()
+                .type_list(list_id)
+                .iter()
+                .copied()
+                .collect();
+            let mut results = Vec::new();
+            for member in members {
+                if let Some(result) =
+                    evaluate_rest_tuple_literal_index(evaluator, member, index, depth + 1)
+                    && result != TypeId::UNDEFINED
+                {
+                    results.push(result);
+                }
+            }
+            match results.as_slice() {
+                [] => Some(TypeId::UNDEFINED),
+                [only] => Some(*only),
+                _ => Some(evaluator.interner().union(results)),
+            }
+        }
+        _ => None,
+    }
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_tuple_literal.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_tuple_literal.rs
@@ -10,18 +10,26 @@ pub(super) fn evaluate_tuple_literal_index<R: TypeResolver>(
     evaluator: &mut TypeEvaluator<'_, R>,
     elements: &[TupleElement],
     index_type: TypeId,
+    no_unchecked_indexed_access: bool,
 ) -> Option<TypeId> {
     let value = literal_number(evaluator.interner(), index_type)?;
     if !value.0.is_finite() || value.0.fract() != 0.0 || value.0 < 0.0 {
         return Some(TypeId::UNDEFINED);
     }
-    evaluate_tuple_literal_index_inner(evaluator, elements, value.0 as usize, 0)
+    evaluate_tuple_literal_index_inner(
+        evaluator,
+        elements,
+        value.0 as usize,
+        no_unchecked_indexed_access,
+        0,
+    )
 }
 
 fn evaluate_tuple_literal_index_inner<R: TypeResolver>(
     evaluator: &mut TypeEvaluator<'_, R>,
     elements: &[TupleElement],
     index: usize,
+    no_unchecked_indexed_access: bool,
     depth: usize,
 ) -> Option<TypeId> {
     const MAX_TUPLE_SPREAD_DEPTH: usize = 64;
@@ -37,6 +45,7 @@ fn evaluate_tuple_literal_index_inner<R: TypeResolver>(
                 evaluator,
                 element.type_id,
                 rest_index,
+                no_unchecked_indexed_access,
                 depth,
             );
         }
@@ -58,6 +67,7 @@ fn evaluate_rest_tuple_literal_index<R: TypeResolver>(
     evaluator: &mut TypeEvaluator<'_, R>,
     rest_type: TypeId,
     index: usize,
+    no_unchecked_indexed_access: bool,
     depth: usize,
 ) -> Option<TypeId> {
     if rest_type.is_intrinsic() {
@@ -69,9 +79,21 @@ fn evaluate_rest_tuple_literal_index<R: TypeResolver>(
     match evaluator.interner().lookup(evaluated) {
         Some(TypeData::Tuple(tuple_id)) => {
             let elements = evaluator.interner().tuple_list(tuple_id);
-            evaluate_tuple_literal_index_inner(evaluator, &elements, index, depth + 1)
+            evaluate_tuple_literal_index_inner(
+                evaluator,
+                &elements,
+                index,
+                no_unchecked_indexed_access,
+                depth + 1,
+            )
         }
-        Some(TypeData::Array(element_type)) => Some(element_type),
+        Some(TypeData::Array(element_type)) => {
+            if no_unchecked_indexed_access {
+                Some(evaluator.interner().union2(element_type, TypeId::UNDEFINED))
+            } else {
+                Some(element_type)
+            }
+        }
         Some(TypeData::Union(list_id)) => {
             let members: Vec<_> = evaluator
                 .interner()
@@ -81,10 +103,13 @@ fn evaluate_rest_tuple_literal_index<R: TypeResolver>(
                 .collect();
             let mut results = Vec::new();
             for member in members {
-                if let Some(result) =
-                    evaluate_rest_tuple_literal_index(evaluator, member, index, depth + 1)
-                    && result != TypeId::UNDEFINED
-                {
+                if let Some(result) = evaluate_rest_tuple_literal_index(
+                    evaluator,
+                    member,
+                    index,
+                    no_unchecked_indexed_access,
+                    depth + 1,
+                ) {
                     results.push(result);
                 }
             }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern.rs
@@ -1060,7 +1060,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // the canonical form tsc would produce, so identity probes such as
         // `Equal<RestOf<...>, T[]>` resolve to `true`.
         let residual_type = if residual.len() == 1 && residual[0].rest && !residual[0].optional {
-            residual[0].type_id
+            self.reify_application_over_tuple_index_residual(residual[0].type_id)
+                .unwrap_or(residual[0].type_id)
         } else {
             self.interner().tuple(residual.to_vec())
         };

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_tuple_residual.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_tuple_residual.rs
@@ -1,0 +1,96 @@
+//! Tuple-rest residual helpers for conditional `infer` pattern matching.
+
+use crate::relations::subtype::TypeResolver;
+use crate::types::{TupleElement, TypeData, TypeId};
+
+use super::super::evaluate::TypeEvaluator;
+
+impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+    pub(super) fn reify_application_over_tuple_index_residual(
+        &self,
+        type_id: TypeId,
+    ) -> Option<TypeId> {
+        let Some(TypeData::Application(app_id)) = self.interner().lookup(type_id) else {
+            return None;
+        };
+        let app = self.interner().type_application(app_id);
+        if app.args.len() != 1 {
+            return None;
+        }
+
+        let Some(TypeData::IndexAccess(object, index)) = self.interner().lookup(app.args[0]) else {
+            return None;
+        };
+        if index != TypeId::NUMBER {
+            return None;
+        }
+
+        let object = crate::type_queries::data::unwrap_readonly(self.interner(), object);
+        let Some(TypeData::Tuple(list_id)) = self.interner().lookup(object) else {
+            return None;
+        };
+
+        // Rest inference lost slot correlation when mapped recursion collapsed to
+        // `F<Tuple[number]>`; reify it as `[F<T0>, ...F<Rest>]` for this tuple.
+        let elements = self.interner().tuple_list(list_id);
+        let mut fixed_prefix_len = 0usize;
+        let reified = elements
+            .iter()
+            .map(|element| {
+                let type_id = self.interner().application(
+                    app.base,
+                    vec![self.evaluated_tuple_rest_argument(*element, fixed_prefix_len)],
+                );
+                if !element.rest {
+                    fixed_prefix_len = fixed_prefix_len.saturating_add(1);
+                }
+                TupleElement {
+                    type_id,
+                    name: element.name,
+                    optional: element.optional,
+                    rest: element.rest,
+                }
+            })
+            .collect();
+        Some(self.interner().tuple(reified))
+    }
+
+    fn evaluated_tuple_rest_argument(
+        &self,
+        element: TupleElement,
+        fixed_prefix_len: usize,
+    ) -> TypeId {
+        if !element.rest {
+            return element.type_id;
+        }
+
+        let evaluated = self.evaluate_for_infer_match(element.type_id);
+        if evaluated == element.type_id {
+            return element.type_id;
+        }
+        let tuple_like = crate::type_queries::data::unwrap_readonly(self.interner(), evaluated);
+        if matches!(self.interner().lookup(tuple_like), Some(TypeData::Tuple(_))) {
+            // The evaluated rest application may include fixed slots already
+            // emitted by the outer tuple reconstruction.
+            self.drop_reified_rest_prefix(evaluated, fixed_prefix_len)
+                .unwrap_or(evaluated)
+        } else {
+            element.type_id
+        }
+    }
+
+    fn drop_reified_rest_prefix(&self, type_id: TypeId, fixed_prefix_len: usize) -> Option<TypeId> {
+        if fixed_prefix_len == 0 {
+            return None;
+        }
+        let tuple_like = crate::type_queries::data::unwrap_readonly(self.interner(), type_id);
+        let Some(TypeData::Tuple(list_id)) = self.interner().lookup(tuple_like) else {
+            return None;
+        };
+        let elements = self.interner().tuple_list(list_id);
+        if elements.len() <= fixed_prefix_len {
+            return None;
+        }
+        Some(self.interner().tuple(elements[fixed_prefix_len..].to_vec()))
+    }
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -503,8 +503,9 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // Tuple type: map each element. Source is mutable, so the
                 // result is readonly only if the modifier adds `+readonly`.
                 Some(TypeData::Tuple(tuple_id)) => {
-                    return self
-                        .evaluate_mapped_tuple_with_readonly(mapped, tuple_id, source, false);
+                    return self.evaluate_mapped_tuple_with_readonly_source(
+                        mapped, tuple_id, source, resolved, false,
+                    );
                 }
 
                 // `readonly` tuple/array source, delegated (`None` => object path).

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped_array.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped_array.rs
@@ -146,7 +146,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     ) -> Option<TypeId> {
         match self.interner().lookup(inner) {
             Some(TypeData::Tuple(tuple_id)) => {
-                Some(self.evaluate_mapped_tuple_with_readonly(mapped, tuple_id, source, true))
+                let resolved_source = self.interner().readonly_type(inner);
+                Some(self.evaluate_mapped_tuple_with_readonly_source(
+                    mapped,
+                    tuple_id,
+                    source,
+                    resolved_source,
+                    true,
+                ))
             }
             Some(TypeData::Array(element_type)) => {
                 if mapped.name_type.is_some()
@@ -185,7 +192,31 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         source: TypeId,
         source_readonly: bool,
     ) -> TypeId {
-        let mapped_tuple = self.evaluate_mapped_tuple(mapped, tuple_id, source);
+        self.evaluate_mapped_tuple_with_readonly_source(
+            mapped,
+            tuple_id,
+            source,
+            source,
+            source_readonly,
+        )
+    }
+
+    pub(crate) fn evaluate_mapped_tuple_with_readonly_source(
+        &mut self,
+        mapped: &MappedType,
+        tuple_id: TupleListId,
+        original_source: TypeId,
+        mapped_source: TypeId,
+        source_readonly: bool,
+    ) -> TypeId {
+        let rebound_mapped;
+        let mapped = if original_source == mapped_source {
+            mapped
+        } else {
+            rebound_mapped = self.rebind_mapped_source(mapped, original_source, mapped_source);
+            &rebound_mapped
+        };
+        let mapped_tuple = self.evaluate_mapped_tuple(mapped, tuple_id, mapped_source);
         if mapped.resolve_readonly(source_readonly) {
             self.interner().readonly_type(mapped_tuple)
         } else {
@@ -217,6 +248,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         tuple_id: TupleListId,
         source: TypeId,
     ) -> TypeId {
+        use tsz_common::limits::MAX_REPRESENTABLE_TUPLE_LENGTH;
+
         let tuple_elements = self.interner().tuple_list(tuple_id);
         let mut mapped_elements = Vec::with_capacity(tuple_elements.len());
         let mut seen_rest = false;
@@ -230,8 +263,26 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             if elem.rest {
                 seen_rest = true;
             }
-            mapped_elements
-                .push(self.evaluate_mapped_tuple_element(mapped, source, index, elem, is_suffix));
+            let mapped_element =
+                self.evaluate_mapped_tuple_element(mapped, source, index, elem, is_suffix);
+            if mapped_element.rest {
+                let mapped_rest = crate::type_queries::data::unwrap_readonly(
+                    self.interner(),
+                    mapped_element.type_id,
+                );
+                if let Some(TypeData::Tuple(inner_tuple_id)) = self.interner().lookup(mapped_rest) {
+                    let inner_elements = self.interner().tuple_list(inner_tuple_id);
+                    if mapped_elements.len().saturating_add(inner_elements.len())
+                        > MAX_REPRESENTABLE_TUPLE_LENGTH
+                    {
+                        self.interner().mark_tuple_too_large();
+                        return TypeId::ERROR;
+                    }
+                    mapped_elements.extend(inner_elements.iter().copied());
+                    continue;
+                }
+            }
+            mapped_elements.push(mapped_element);
         }
 
         self.interner().tuple(mapped_elements)
@@ -257,17 +308,24 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         elem: TupleElement,
         is_suffix: bool,
     ) -> TupleElement {
-        let rest_inner_kind = elem.rest.then(|| self.interner().lookup(elem.type_id));
-
+        let evaluated_rest_type =
+            if elem.rest && self.mapped_tuple_rest_needs_evaluation(elem.type_id) {
+                self.evaluate(elem.type_id)
+            } else {
+                elem.type_id
+            };
+        let rest_inner =
+            crate::type_queries::data::unwrap_readonly(self.interner(), evaluated_rest_type);
+        let rest_inner_kind = elem.rest.then(|| self.interner().lookup(rest_inner));
         // Variadic spread of a tuple: rebind T -> the inner tuple across
         // template/constraint/name_type and recurse so the inner tuple's
         // elements are mapped position-by-position. The result is a tuple
         // in the rest's `type_id`; `expand_tuple_rest` flattens it
         // downstream.
         if let Some(Some(TypeData::Tuple(inner_tuple_id))) = rest_inner_kind {
-            let inner_mapped = self.rebind_mapped_source(mapped, source, elem.type_id);
+            let inner_mapped = self.rebind_mapped_source(mapped, source, evaluated_rest_type);
             let inner_result =
-                self.evaluate_mapped_tuple(&inner_mapped, inner_tuple_id, elem.type_id);
+                self.evaluate_mapped_tuple(&inner_mapped, inner_tuple_id, evaluated_rest_type);
             return TupleElement {
                 type_id: inner_result,
                 name: elem.name,
@@ -384,6 +442,27 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let instantiated =
             instantiate_type_cached(self.interner(), self.query_db(), rewritten, &subst);
         self.evaluate(instantiated)
+    }
+
+    fn mapped_tuple_rest_needs_evaluation(&self, type_id: TypeId) -> bool {
+        if type_id.is_intrinsic() {
+            return false;
+        }
+        matches!(
+            self.interner().lookup(type_id),
+            Some(
+                TypeData::Application(_)
+                    | TypeData::Conditional(_)
+                    | TypeData::IndexAccess(_, _)
+                    | TypeData::KeyOf(_)
+                    | TypeData::Lazy(_)
+                    | TypeData::Mapped(_)
+                    | TypeData::ReadonlyType(_)
+                    | TypeData::StringIntrinsic { .. }
+                    | TypeData::TemplateLiteral(_)
+                    | TypeData::TypeQuery(_)
+            )
+        )
     }
 
     /// Build a new `MappedType` with `old_source` replaced by `new_source`

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mod.rs
@@ -16,11 +16,14 @@
 pub mod apparent;
 pub mod conditional;
 pub mod index_access;
+mod index_access_callable;
 mod index_access_keys;
+mod index_access_tuple_literal;
 pub mod infer_pattern;
 mod infer_pattern_helpers;
 mod infer_pattern_object_match;
 mod infer_pattern_template_match;
+mod infer_pattern_tuple_residual;
 pub mod infer_substitutor;
 pub mod keyof;
 pub mod mapped;

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -1,9 +1,11 @@
 use super::*;
 use crate::caches::db::QueryDatabase;
+use crate::caches::instantiation_cache::{CanonicalSubst, InstantiationCacheKey};
 use crate::instantiation::request::{InstantiationOptions, InstantiationRequest};
 use crate::instantiation::result::InstantiationResult;
-use crate::types::FunctionShape;
-use rustc_hash::FxHashSet;
+use crate::types::{ConditionalType, FunctionShape, PropertyInfo};
+use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
 use std::cell::RefCell;
 
 thread_local! {
@@ -192,9 +194,538 @@ fn instantiate_with_options_cached(
     instantiate_with_request_cached(
         interner,
         query_db,
+        false,
         InstantiationRequest::new(type_id, substitution).with_options(options),
     )
     .into_type_id()
+}
+
+struct AlphaInstantiationCacheKey {
+    key: InstantiationCacheKey,
+    bindings: SmallVec<[TypeId; 4]>,
+}
+
+fn alpha_instantiation_cache_key(
+    interner: &dyn TypeDatabase,
+    request: InstantiationRequest<'_>,
+) -> Option<AlphaInstantiationCacheKey> {
+    if request.options().mode_bits() != 0 || request.this_type().is_some() {
+        return None;
+    }
+
+    let mut binders = FxHashMap::default();
+    let mut bindings = SmallVec::<[TypeId; 4]>::new();
+    let mut changed = false;
+    let mut alpha_pairs = SmallVec::<[(Atom, TypeId); 4]>::new();
+
+    for (name, type_id) in request.substitution().canonical_pairs() {
+        let mut visited = FxHashSet::default();
+        let alpha_type = alpha_canonicalize_type(
+            interner,
+            type_id,
+            &mut binders,
+            &mut bindings,
+            &mut changed,
+            &mut visited,
+        )?;
+        alpha_pairs.push((name, alpha_type));
+    }
+
+    changed.then(|| AlphaInstantiationCacheKey {
+        key: InstantiationCacheKey::new(
+            request.type_id(),
+            CanonicalSubst::from_pairs(alpha_pairs),
+            request.options().mode_bits(),
+            request.this_type(),
+        ),
+        bindings,
+    })
+}
+
+fn alpha_canonicalize_type(
+    interner: &dyn TypeDatabase,
+    type_id: TypeId,
+    binders: &mut FxHashMap<Atom, u32>,
+    bindings: &mut SmallVec<[TypeId; 4]>,
+    changed: &mut bool,
+    visited: &mut FxHashSet<TypeId>,
+) -> Option<TypeId> {
+    if type_id.is_intrinsic() {
+        return Some(type_id);
+    }
+
+    let key = interner.lookup(type_id)?;
+    match key {
+        TypeData::TypeParameter(info)
+            if info.constraint.is_none() && info.default.is_none() && !info.is_const =>
+        {
+            let index = if let Some(index) = binders.get(&info.name).copied() {
+                index
+            } else {
+                let index = bindings.len() as u32;
+                binders.insert(info.name, index);
+                bindings.push(type_id);
+                index
+            };
+            *changed = true;
+            Some(interner.bound_parameter(index))
+        }
+        TypeData::TypeParameter(_) => Some(type_id),
+        TypeData::BoundParameter(_) => None,
+        _ if !visited.insert(type_id) => Some(type_id),
+        TypeData::Array(element) => {
+            let next =
+                alpha_canonicalize_type(interner, element, binders, bindings, changed, visited)?;
+            Some(if next == element {
+                type_id
+            } else {
+                interner.array(next)
+            })
+        }
+        TypeData::ReadonlyType(inner) => {
+            let next =
+                alpha_canonicalize_type(interner, inner, binders, bindings, changed, visited)?;
+            Some(if next == inner {
+                type_id
+            } else {
+                interner.readonly_type(next)
+            })
+        }
+        TypeData::NoInfer(inner) => {
+            let next =
+                alpha_canonicalize_type(interner, inner, binders, bindings, changed, visited)?;
+            Some(if next == inner {
+                type_id
+            } else {
+                interner.no_infer(next)
+            })
+        }
+        TypeData::Tuple(tuple_id) => {
+            let elements = interner.tuple_list(tuple_id);
+            let mut local_changed = false;
+            let mut next = Vec::with_capacity(elements.len());
+            for element in elements.iter() {
+                let type_id = alpha_canonicalize_type(
+                    interner,
+                    element.type_id,
+                    binders,
+                    bindings,
+                    changed,
+                    visited,
+                )?;
+                local_changed |= type_id != element.type_id;
+                next.push(TupleElement {
+                    type_id,
+                    ..*element
+                });
+            }
+            Some(if local_changed {
+                interner.tuple(next)
+            } else {
+                type_id
+            })
+        }
+        TypeData::Union(list_id) | TypeData::Intersection(list_id) => {
+            let members = interner.type_list(list_id);
+            let mut local_changed = false;
+            let mut next = Vec::with_capacity(members.len());
+            for &member in members.iter() {
+                let alpha =
+                    alpha_canonicalize_type(interner, member, binders, bindings, changed, visited)?;
+                local_changed |= alpha != member;
+                next.push(alpha);
+            }
+            Some(if !local_changed {
+                type_id
+            } else if matches!(key, TypeData::Union(_)) {
+                interner.union(next)
+            } else {
+                interner.intersection(next)
+            })
+        }
+        TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
+            let shape = interner.object_shape(shape_id);
+            let mut local_changed = false;
+            let mut properties = Vec::with_capacity(shape.properties.len());
+            for prop in &shape.properties {
+                let read = alpha_canonicalize_type(
+                    interner,
+                    prop.type_id,
+                    binders,
+                    bindings,
+                    changed,
+                    visited,
+                )?;
+                let write = alpha_canonicalize_type(
+                    interner,
+                    prop.write_type,
+                    binders,
+                    bindings,
+                    changed,
+                    visited,
+                )?;
+                local_changed |= read != prop.type_id || write != prop.write_type;
+                properties.push(PropertyInfo {
+                    type_id: read,
+                    write_type: write,
+                    ..prop.clone()
+                });
+            }
+
+            let string_index = alpha_canonicalize_index_signature(
+                interner,
+                shape.string_index,
+                binders,
+                bindings,
+                changed,
+                visited,
+                &mut local_changed,
+            )?;
+            let number_index = alpha_canonicalize_index_signature(
+                interner,
+                shape.number_index,
+                binders,
+                bindings,
+                changed,
+                visited,
+                &mut local_changed,
+            )?;
+
+            if !local_changed {
+                return Some(type_id);
+            }
+
+            let shape = ObjectShape {
+                flags: shape.flags,
+                properties,
+                string_index,
+                number_index,
+                symbol: shape.symbol,
+            };
+            Some(if matches!(key, TypeData::ObjectWithIndex(_)) {
+                interner.object_with_index(shape)
+            } else {
+                interner.object_with_flags_and_symbol(shape.properties, shape.flags, shape.symbol)
+            })
+        }
+        TypeData::IndexAccess(object, index) => {
+            let object_next =
+                alpha_canonicalize_type(interner, object, binders, bindings, changed, visited)?;
+            let index_next =
+                alpha_canonicalize_type(interner, index, binders, bindings, changed, visited)?;
+            Some(if object_next == object && index_next == index {
+                type_id
+            } else {
+                interner.index_access(object_next, index_next)
+            })
+        }
+        TypeData::KeyOf(operand) => {
+            let next =
+                alpha_canonicalize_type(interner, operand, binders, bindings, changed, visited)?;
+            Some(if next == operand {
+                type_id
+            } else {
+                interner.keyof(next)
+            })
+        }
+        TypeData::Conditional(cond_id) => {
+            let cond = interner.get_conditional(cond_id);
+            let check_type = alpha_canonicalize_type(
+                interner,
+                cond.check_type,
+                binders,
+                bindings,
+                changed,
+                visited,
+            )?;
+            let extends_type = alpha_canonicalize_type(
+                interner,
+                cond.extends_type,
+                binders,
+                bindings,
+                changed,
+                visited,
+            )?;
+            let true_type = alpha_canonicalize_type(
+                interner,
+                cond.true_type,
+                binders,
+                bindings,
+                changed,
+                visited,
+            )?;
+            let false_type = alpha_canonicalize_type(
+                interner,
+                cond.false_type,
+                binders,
+                bindings,
+                changed,
+                visited,
+            )?;
+            Some(
+                if check_type == cond.check_type
+                    && extends_type == cond.extends_type
+                    && true_type == cond.true_type
+                    && false_type == cond.false_type
+                {
+                    type_id
+                } else {
+                    interner.conditional(ConditionalType {
+                        check_type,
+                        extends_type,
+                        true_type,
+                        false_type,
+                        is_distributive: cond.is_distributive,
+                    })
+                },
+            )
+        }
+        TypeData::Intrinsic(_)
+        | TypeData::Literal(_)
+        | TypeData::UnresolvedTypeName(_)
+        | TypeData::Error
+        | TypeData::Lazy(_)
+        | TypeData::Recursive(_)
+        | TypeData::TypeQuery(_)
+        | TypeData::UniqueSymbol(_)
+        | TypeData::ThisType
+        | TypeData::ModuleNamespace(_) => Some(type_id),
+        TypeData::Infer(_)
+        | TypeData::Enum(_, _)
+        | TypeData::Function(_)
+        | TypeData::Callable(_)
+        | TypeData::Mapped(_)
+        | TypeData::TemplateLiteral(_)
+        | TypeData::StringIntrinsic { .. }
+        | TypeData::Application(_) => None,
+    }
+}
+
+fn alpha_canonicalize_index_signature(
+    interner: &dyn TypeDatabase,
+    signature: Option<IndexSignature>,
+    binders: &mut FxHashMap<Atom, u32>,
+    bindings: &mut SmallVec<[TypeId; 4]>,
+    changed: &mut bool,
+    visited: &mut FxHashSet<TypeId>,
+    local_changed: &mut bool,
+) -> Option<Option<IndexSignature>> {
+    let Some(signature) = signature else {
+        return Some(None);
+    };
+    let key_type = alpha_canonicalize_type(
+        interner,
+        signature.key_type,
+        binders,
+        bindings,
+        changed,
+        visited,
+    )?;
+    let value_type = alpha_canonicalize_type(
+        interner,
+        signature.value_type,
+        binders,
+        bindings,
+        changed,
+        visited,
+    )?;
+    *local_changed |= key_type != signature.key_type || value_type != signature.value_type;
+    Some(Some(IndexSignature {
+        key_type,
+        value_type,
+        ..signature
+    }))
+}
+
+fn restore_alpha_result(
+    interner: &dyn TypeDatabase,
+    type_id: TypeId,
+    bindings: &[TypeId],
+) -> Option<TypeId> {
+    let mut visited = FxHashSet::default();
+    restore_alpha_type(interner, type_id, bindings, &mut visited)
+}
+
+fn restore_alpha_type(
+    interner: &dyn TypeDatabase,
+    type_id: TypeId,
+    bindings: &[TypeId],
+    visited: &mut FxHashSet<TypeId>,
+) -> Option<TypeId> {
+    if type_id.is_intrinsic() {
+        return Some(type_id);
+    }
+    let key = interner.lookup(type_id)?;
+    match key {
+        TypeData::BoundParameter(index) => bindings.get(index as usize).copied(),
+        _ if !visited.insert(type_id) => Some(type_id),
+        TypeData::Array(element) => {
+            let next = restore_alpha_type(interner, element, bindings, visited)?;
+            Some(if next == element {
+                type_id
+            } else {
+                interner.array(next)
+            })
+        }
+        TypeData::ReadonlyType(inner) => {
+            let next = restore_alpha_type(interner, inner, bindings, visited)?;
+            Some(if next == inner {
+                type_id
+            } else {
+                interner.readonly_type(next)
+            })
+        }
+        TypeData::NoInfer(inner) => {
+            let next = restore_alpha_type(interner, inner, bindings, visited)?;
+            Some(if next == inner {
+                type_id
+            } else {
+                interner.no_infer(next)
+            })
+        }
+        TypeData::Tuple(tuple_id) => {
+            let elements = interner.tuple_list(tuple_id);
+            let mut changed = false;
+            let mut next = Vec::with_capacity(elements.len());
+            for element in elements.iter() {
+                let restored = restore_alpha_type(interner, element.type_id, bindings, visited)?;
+                changed |= restored != element.type_id;
+                next.push(TupleElement {
+                    type_id: restored,
+                    ..*element
+                });
+            }
+            Some(if changed {
+                interner.tuple(next)
+            } else {
+                type_id
+            })
+        }
+        TypeData::Union(list_id) | TypeData::Intersection(list_id) => {
+            let members = interner.type_list(list_id);
+            let mut changed = false;
+            let mut next = Vec::with_capacity(members.len());
+            for &member in members.iter() {
+                let restored = restore_alpha_type(interner, member, bindings, visited)?;
+                changed |= restored != member;
+                next.push(restored);
+            }
+            Some(if !changed {
+                type_id
+            } else if matches!(key, TypeData::Union(_)) {
+                interner.union(next)
+            } else {
+                interner.intersection(next)
+            })
+        }
+        TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id) => {
+            let shape = interner.object_shape(shape_id);
+            let mut changed = false;
+            let mut properties = Vec::with_capacity(shape.properties.len());
+            for prop in &shape.properties {
+                let read = restore_alpha_type(interner, prop.type_id, bindings, visited)?;
+                let write = restore_alpha_type(interner, prop.write_type, bindings, visited)?;
+                changed |= read != prop.type_id || write != prop.write_type;
+                properties.push(PropertyInfo {
+                    type_id: read,
+                    write_type: write,
+                    ..prop.clone()
+                });
+            }
+            let string_index = restore_alpha_index_signature(
+                interner,
+                shape.string_index,
+                bindings,
+                visited,
+                &mut changed,
+            )?;
+            let number_index = restore_alpha_index_signature(
+                interner,
+                shape.number_index,
+                bindings,
+                visited,
+                &mut changed,
+            )?;
+            if !changed {
+                return Some(type_id);
+            }
+            let shape = ObjectShape {
+                flags: shape.flags,
+                properties,
+                string_index,
+                number_index,
+                symbol: shape.symbol,
+            };
+            Some(if matches!(key, TypeData::ObjectWithIndex(_)) {
+                interner.object_with_index(shape)
+            } else {
+                interner.object_with_flags_and_symbol(shape.properties, shape.flags, shape.symbol)
+            })
+        }
+        TypeData::IndexAccess(object, index) => {
+            let object_next = restore_alpha_type(interner, object, bindings, visited)?;
+            let index_next = restore_alpha_type(interner, index, bindings, visited)?;
+            Some(if object_next == object && index_next == index {
+                type_id
+            } else {
+                interner.index_access(object_next, index_next)
+            })
+        }
+        TypeData::KeyOf(operand) => {
+            let next = restore_alpha_type(interner, operand, bindings, visited)?;
+            Some(if next == operand {
+                type_id
+            } else {
+                interner.keyof(next)
+            })
+        }
+        TypeData::Conditional(cond_id) => {
+            let cond = interner.get_conditional(cond_id);
+            let check_type = restore_alpha_type(interner, cond.check_type, bindings, visited)?;
+            let extends_type = restore_alpha_type(interner, cond.extends_type, bindings, visited)?;
+            let true_type = restore_alpha_type(interner, cond.true_type, bindings, visited)?;
+            let false_type = restore_alpha_type(interner, cond.false_type, bindings, visited)?;
+            Some(
+                if check_type == cond.check_type
+                    && extends_type == cond.extends_type
+                    && true_type == cond.true_type
+                    && false_type == cond.false_type
+                {
+                    type_id
+                } else {
+                    interner.conditional(ConditionalType {
+                        check_type,
+                        extends_type,
+                        true_type,
+                        false_type,
+                        is_distributive: cond.is_distributive,
+                    })
+                },
+            )
+        }
+        TypeData::Application(_) => None,
+        _ => Some(type_id),
+    }
+}
+
+fn restore_alpha_index_signature(
+    interner: &dyn TypeDatabase,
+    signature: Option<IndexSignature>,
+    bindings: &[TypeId],
+    visited: &mut FxHashSet<TypeId>,
+    changed: &mut bool,
+) -> Option<Option<IndexSignature>> {
+    let Some(signature) = signature else {
+        return Some(None);
+    };
+    let key_type = restore_alpha_type(interner, signature.key_type, bindings, visited)?;
+    let value_type = restore_alpha_type(interner, signature.value_type, bindings, visited)?;
+    *changed |= key_type != signature.key_type || value_type != signature.value_type;
+    Some(Some(IndexSignature {
+        key_type,
+        value_type,
+        ..signature
+    }))
 }
 
 /// Apply the instantiator walk that `request` describes, with optional
@@ -214,6 +745,7 @@ fn instantiate_with_options_cached(
 pub(crate) fn instantiate_with_request_cached(
     interner: &dyn TypeDatabase,
     query_db: Option<&dyn QueryDatabase>,
+    allow_alpha_cache: bool,
     request: InstantiationRequest<'_>,
 ) -> InstantiationResult {
     if let Some(db) = query_db {
@@ -221,13 +753,61 @@ pub(crate) fn instantiate_with_request_cached(
         if let Some(cached) = db.lookup_instantiation_cache(&key) {
             return InstantiationResult::ok(cached);
         }
+        let alpha_key = if allow_alpha_cache {
+            alpha_instantiation_cache_key(interner, request)
+        } else {
+            None
+        };
+        if let Some(alpha_key) = &alpha_key
+            && alpha_key.key != key
+            && let Some(cached) = db.lookup_instantiation_cache(&alpha_key.key)
+            && let Some(restored) = restore_alpha_result(interner, cached, &alpha_key.bindings)
+        {
+            db.insert_instantiation_cache(key, restored);
+            return InstantiationResult::ok(restored);
+        }
         let result = run_instantiator(interner, request);
         if !result.depth_exceeded() {
             db.insert_instantiation_cache(key, result.type_id());
+            if let Some(alpha_key) = alpha_key
+                && let Some(alpha_result) = alpha_canonicalize_cached_result(
+                    interner,
+                    result.type_id(),
+                    &alpha_key.bindings,
+                )
+            {
+                db.insert_instantiation_cache(alpha_key.key, alpha_result);
+            }
         }
         return result;
     }
     run_instantiator(interner, request)
+}
+
+fn alpha_canonicalize_cached_result(
+    interner: &dyn TypeDatabase,
+    type_id: TypeId,
+    bindings: &[TypeId],
+) -> Option<TypeId> {
+    let mut binders = FxHashMap::default();
+    let mut alpha_bindings = SmallVec::<[TypeId; 4]>::new();
+    for (index, binding) in bindings.iter().copied().enumerate() {
+        let TypeData::TypeParameter(info) = interner.lookup(binding)? else {
+            return None;
+        };
+        binders.insert(info.name, index as u32);
+        alpha_bindings.push(binding);
+    }
+    let mut changed = false;
+    let mut visited = FxHashSet::default();
+    alpha_canonicalize_type(
+        interner,
+        type_id,
+        &mut binders,
+        &mut alpha_bindings,
+        &mut changed,
+        &mut visited,
+    )
 }
 
 /// Drive a single `TypeInstantiator` configured from `request`, without
@@ -278,7 +858,7 @@ pub fn instantiate_type_with_request(
     interner: &dyn TypeDatabase,
     request: InstantiationRequest<'_>,
 ) -> InstantiationResult {
-    instantiate_with_request_cached(interner, None, request)
+    instantiate_with_request_cached(interner, None, false, request)
 }
 
 /// Like [`instantiate_type`], but treats `shadowed_params` as locally bound.
@@ -392,6 +972,7 @@ pub fn instantiate_type_cached(
     instantiate_with_request_cached(
         interner,
         query_db,
+        false,
         InstantiationRequest::new(type_id, substitution),
     )
     .into_type_id()
@@ -655,6 +1236,7 @@ pub fn instantiate_generic_cached(
     instantiate_with_request_cached(
         interner,
         query_db,
+        true,
         InstantiationRequest::new(type_id, &substitution),
     )
     .into_type_id()
@@ -701,6 +1283,7 @@ pub fn substitute_this_type_cached(
     instantiate_with_request_cached(
         interner,
         query_db,
+        false,
         InstantiationRequest::new(type_id, &empty_subst)
             .with_options(InstantiationOptions::new().with_preserve_unsubstituted_type_params(true))
             .with_this_type(this_type),
@@ -741,6 +1324,7 @@ pub fn substitute_this_type_at_return_position(
     instantiate_with_request_cached(
         interner,
         query_db,
+        false,
         InstantiationRequest::new(type_id, &empty_subst)
             .with_options(
                 InstantiationOptions::new()

--- a/crates/tsz-solver/src/instantiation/instantiate/mapped.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/mapped.rs
@@ -40,7 +40,8 @@ impl<'a> TypeInstantiator<'a> {
 
         // HOMOMORPHIC UNION DISTRIBUTION (tsc: instantiateMappedType → mapTypeWithAlias)
         // Excluded: array/tuple-like unions are handled by the blocks below.
-        if let Some(TypeData::KeyOf(keyof_source)) = self.interner.lookup(mapped.constraint)
+        if !self.preserve_meta_types
+            && let Some(TypeData::KeyOf(keyof_source)) = self.interner.lookup(mapped.constraint)
             && let Some(TypeData::TypeParameter(tp_info)) = self.interner.lookup(keyof_source)
             && !self.is_shadowed(tp_info.name)
             && let Some(substituted) = self.substitution.get(tp_info.name)
@@ -103,7 +104,8 @@ impl<'a> TypeInstantiator<'a> {
         // template references T[K]. Templates that DO reference T[K]
         // are still handled by the main array-preservation block below
         // (which mirrors tsc's full instantiateMappedArrayType path).
-        if crate::type_queries::mapped::is_identity_name_mapping(self.interner, &mapped)
+        if !self.preserve_meta_types
+            && crate::type_queries::mapped::is_identity_name_mapping(self.interner, &mapped)
             && let Some(TypeData::KeyOf(keyof_source)) = self.interner.lookup(mapped.constraint)
             && let Some(TypeData::TypeParameter(tp_info)) = self.interner.lookup(keyof_source)
             && !self.is_shadowed(tp_info.name)
@@ -151,7 +153,8 @@ impl<'a> TypeInstantiator<'a> {
             };
         }
 
-        if crate::type_queries::mapped::is_identity_name_mapping(self.interner, &mapped)
+        if !self.preserve_meta_types
+            && crate::type_queries::mapped::is_identity_name_mapping(self.interner, &mapped)
             && let Some(TypeData::KeyOf(keyof_source)) = self.interner.lookup(mapped.constraint)
             && let Some(TypeData::TypeParameter(tp_info)) = self.interner.lookup(keyof_source)
             && !self.is_shadowed(tp_info.name)

--- a/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
+++ b/crates/tsz-solver/src/operations/constraints/reverse_mapped.rs
@@ -686,6 +686,32 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
             }
         }
 
+        // Case 1b: template is an array/readonly wrapper around the indexed
+        // access (e.g. `T[K][]`). Peel matching source wrappers and continue
+        // reversing through the element/template inner types.
+        if let Some(TypeData::Array(template_elem)) = self.interner.lookup(template) {
+            let source_inner =
+                crate::type_queries::data::unwrap_readonly(self.interner, source_value);
+            if let Some(TypeData::Array(source_elem)) = self.interner.lookup(source_inner) {
+                return self.reverse_infer_through_template(
+                    source_elem,
+                    template_elem,
+                    target_placeholder,
+                );
+            }
+            return None;
+        }
+
+        if let Some(TypeData::ReadonlyType(template_inner)) = self.interner.lookup(template) {
+            let source_inner =
+                crate::type_queries::data::unwrap_readonly(self.interner, source_value);
+            return self.reverse_infer_through_template(
+                source_inner,
+                template_inner,
+                target_placeholder,
+            );
+        }
+
         // Case 2: template is Application(F, args) and source is Application(F, args')
         // with same base → recurse into matching args to find the T[K] position
         if let Some(TypeData::Application(template_app_id)) = self.interner.lookup(template) {


### PR DESCRIPTION
Goal: fast

## Summary
- Add an opt-in alpha-equivalent instantiation cache layer for `instantiate_generic_cached` so generic alias/application requests can reuse walks when substitutions differ only by simple local type-parameter binder names, then restore cached alpha results to the current binder identities before filling the exact cache slot.
- Preserve recursive mapped tuple slot correlation through homomorphic tuple/rest evaluation, literal numeric tuple indexing, conditional-infer rest residual reification, and reverse-mapped variadic tuple inference through array-wrapped element templates.
- Split callable index access, tuple-literal index access, and tuple-residual infer helpers into focused solver shards so touched files stay below the 2000-line cap.

## Structural Rule
When a generic instantiation request differs only by simple locally-bound type-parameter leaves in its substitution argument, `tsc` treats the alias body structurally; TSZ may cache the solver walk through `instantiate_generic_cached` using canonical `BoundParameter(index)` placeholders, then restore those placeholders to the current binders before returning. Constrained/free/unsupported shapes fall back to exact instantiation cache keys.

When recursive conditional and homomorphic mapped utilities reconstruct a tuple with fixed slots plus a variadic rest, `tsc` preserves correlation between numeric tuple positions and mapped element templates. TSZ now keeps that correlation in solver tuple/mapped evaluation and solver infer-pattern residual reification instead of widening through `Tuple[number]`.

When a homomorphic mapped alias such as `{ [K in keyof T]: T[K][] }` is used as a generic call parameter over a tuple with a variadic rest, `tsc` reverse-infers each source tuple element through the mapped template before inferring the rest slice. TSZ now preserves the mapped alias during call-inference expansion and peels array/readonly wrappers in solver reverse-mapped inference, so `Tail` is inferred as `[boolean, string]` rather than `boolean[] | string[]`.

Owner layer: solver instantiation/cache boundary, solver tuple/mapped/infer evaluation, and checker call-inference expansion boundary.

Adjacent matrix:
- renamed simple binders: alpha-share and restore current binder identity
- constrained/default/const binders: kept distinct, no alpha hit
- exact `instantiate_type_cached`: no alpha reuse, exact-key behavior retained
- mode/`this_type` requests and unsupported composite result shapes: no alpha key/result fill
- recursive tuple pipelines: concrete and renamed binder cases preserve fixed slot 2
- reverse-mapped tuple tails: prefix-only and fixed-suffix variadic rests preserve element positions through renamed mapped keys
- tuple/index fallbacks: optional, out-of-range, readonly wrapper, union variant, and mapped-key cases remain covered by focused tests

## Status
Ready for review. The target synthetic hotspot is no longer correctness-red and has zero green tsgo winners for the filtered smoke. It is still below the 2x fast target (`1.68x`), so follow-up fast work remains.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib reverse_mapped_variadic_tuple_tail_preserves_rest_positions` (1 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib reverse_mapped_tuple_inference_through_conditional_template reverse_mapped_variadic_tuple_tail_preserves_rest_positions` (2 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib reverse_mapped` (35 passed)
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter 'conformance/types/tuple/variadicTuples1.ts' --verbose` (1/1 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib nuia_tuple_rest_region_literal_index` (2 passed)
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter indexedAccessWithVariableElement --verbose` (1/1 passed)
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter 'conformance/pedantic/noUncheckedIndexedAccess.ts' --verbose` (1/1 passed; TypeScript submodule clean warned but run completed)
- after merging `origin/main` (`4f6cd9de4b`): `cargo fmt --check`, `git diff --check`, `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib reverse_mapped_variadic_tuple_tail_preserves_rest_positions` (1 passed), `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib nuia_tuple_rest_region_literal_index` (2 passed), `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter 'conformance/types/tuple/variadicTuples1.ts' --verbose` (1/1 passed)
- debug/instrumentation scan: `rg "println!|eprintln!|dbg!|tuple_tail_debug|literal tuple rest direct index|residual spread app payload|infer tuple source|literal numeric index entry|literal tuple fast path|tuple residual spread infer expansion|mapped_tuple_rest_needs_expansion_for_literal|evaluate_for_infer_match\\(rest_type\\)" crates/tsz-solver/src/evaluation/evaluate_rules crates/tsz-checker/tests/recursive_tuple_mapped_index_tests.rs` (no matches)
- `scripts/safe-run.sh cargo nextest run -p tsz-solver -E 'test(instantiate_generic_cached_reuses_alpha_equivalent_independent_args) or test(instantiate_generic_cached_keeps_constrained_type_param_args_distinct) or test(instantiate_type_cached_does_not_alpha_reuse_independent_args)'` (3 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-solver instantiation_cache_wiring_tests` (25 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test recursive_tuple_mapped_index_tests --test tuple_index_access_tests --test tuple_infer_mapped_recursive_tests --test recursive_array_utility_inference_tests --test inline_mapped_array_return_tests --test homomorphic_indexed_access_tests --test mapped_keyof_index_access_tests` (76 passed)
- `scripts/safe-run.sh cargo nextest run -p tsz-solver --test conditional_infer_tuple_numeric_key_tests` (6 passed)
- `python3 scripts/arch/arch_guard.py`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh ./scripts/bench/perf-hotspots.sh --quick --filter '^Recursive utility aliases N=30$' --json-file /tmp/tsz-alpha-subst-13394-rebased-tail-fix-hotspots.json` (`tsz` 90.09 ms, `tsgo` 151.67 ms, `tsz` 1.68x faster; green tsgo winners: 0; 2x target gaps: 1/1)

- after merging current `origin/main` and remote #13394 follow-up fixes (`8c870d0eda2c09bba64ee3229ae90f502711eff2`): no local tests run in this continuation; PR-head CI is rerunning.
- after merging current `origin/main` (`48d5f0ae59`, includes `ca5c183af37`): `cargo fmt --check`, `git diff --check`, `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib reverse_mapped_variadic_tuple_tail_preserves_rest_positions` (1 passed), `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib nuia_tuple_rest_region_literal_index` (2 passed), `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter 'conformance/types/tuple/variadicTuples1.ts' --verbose` (1/1 passed)
- merge-only head `7032a3b4f4` after integrating remote PR-branch updates is tree-identical to verified `48d5f0ae59` (`git diff --stat 48d5f0ae5945d70496f38eed1feff0339586892e..HEAD` and `git diff --name-status 48d5f0ae5945d70496f38eed1feff0339586892e..HEAD` produced no output).

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high