### PR TITLE
refactor(core): table-drive non-strict option fan-out (#13062)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/check.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/check.rs
@@ -17,6 +17,7 @@ use tsz::lib_loader::LibFile;
 use tsz::parallel;
 use tsz::parser::ParserState;
 use tsz::parser::node::NodeArena;
+use tsz_cli::config::checker_fanout::apply_checker_fanout;
 use tsz_cli::config::strict_family::{StrictFamilyOverrides, apply_strict_family};
 use tsz_cli::config::{
     checker_target_from_emitter, default_lib_name_for_target, resolve_default_lib_files_from_dir,
@@ -911,9 +912,14 @@ impl Server {
             target: checker_target,
             module: Self::parse_module(&options.module),
             es_module_interop: options.es_module_interop,
+            // Raw value only: the `esModuleInterop -> allowSyntheticDefaultImports`
+            // implication is owned by the shared `apply_checker_fanout` table
+            // (called below) so the server lane derives it identically to the
+            // CLI/tsconfig lanes. An explicit value is re-applied after the
+            // table so it still wins over the implication.
             allow_synthetic_default_imports: options
                 .allow_synthetic_default_imports
-                .unwrap_or(options.es_module_interop),
+                .unwrap_or(false),
             allow_unreachable_code: options.allow_unreachable_code,
             allow_unused_labels: options.allow_unused_labels,
             no_property_access_from_index_signature: options
@@ -989,6 +995,18 @@ impl Server {
                 use_unknown_in_catch_variables: options.use_unknown_in_catch_variables,
             },
         );
+        // Fan out the checker-semantic non-strict-family implications
+        // (`verbatimModuleSyntax -> isolatedModules`,
+        // `esModuleInterop -> allowSyntheticDefaultImports`) through the shared
+        // table so the printer-less server lane derives them identically to the
+        // CLI/tsconfig lanes.
+        apply_checker_fanout(&mut checker_options);
+        // Re-apply an explicit `allowSyntheticDefaultImports` so it still wins
+        // over the `esModuleInterop -> allowSyntheticDefaultImports` implication
+        // (tsc resolves an explicitly provided value before any derivation).
+        if let Some(allow_synthetic_default_imports) = options.allow_synthetic_default_imports {
+            checker_options.allow_synthetic_default_imports = allow_synthetic_default_imports;
+        }
         checker_options
     }
 }

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_implement_interface_tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_implement_interface_tests.rs
@@ -18,6 +18,7 @@ fn make_server() -> Server {
         response_seq: 0,
         open_files: FxHashMap::default(),
         external_project_files: FxHashMap::default(),
+        completion_project_cache: None,
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_nested_pkg_tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_nested_pkg_tests.rs
@@ -31,6 +31,7 @@ fn make_server() -> Server {
         response_seq: 0,
         open_files: FxHashMap::default(),
         external_project_files: FxHashMap::default(),
+        completion_project_cache: None,
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests.rs
@@ -21,6 +21,7 @@ fn make_server() -> Server {
         response_seq: 0,
         open_files: FxHashMap::default(),
         external_project_files: FxHashMap::default(),
+        completion_project_cache: None,
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests_part2.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests_part2.rs
@@ -22,6 +22,7 @@ fn make_server() -> Server {
         response_seq: 0,
         open_files: FxHashMap::default(),
         external_project_files: FxHashMap::default(),
+        completion_project_cache: None,
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,

--- a/crates/tsz-cli/src/driver/plan.rs
+++ b/crates/tsz-cli/src/driver/plan.rs
@@ -112,11 +112,9 @@ pub(super) fn apply_cli_overrides_with_config_options(
         options.type_roots = Some(type_roots.clone());
     }
     if args.composite {
+        // `composite -> declaration + incremental` is owned by the shared
+        // `apply_non_strict_fanout` table below; record only the raw value.
         options.composite = true;
-        // composite implies declaration and incremental
-        options.emit_declarations = true;
-        options.checker.emit_declarations = true;
-        options.incremental = true;
     }
     if args.declaration {
         options.emit_declarations = true;
@@ -147,10 +145,9 @@ pub(super) fn apply_cli_overrides_with_config_options(
         options.incremental = true;
     }
     if args.import_helpers {
+        // `importHelpers -> printer.import_helpers + no_emit_helpers` is owned
+        // by the shared `apply_non_strict_fanout` table below.
         options.import_helpers = true;
-        options.printer.import_helpers = true;
-        // importHelpers means "import from tslib" — suppress inline helper emission
-        options.printer.no_emit_helpers = true;
     }
     // Strict-family expansion and explicit member overrides are owned by the
     // shared `strict_family` table (tsc 6.0 `getStrictOptionValue`).
@@ -284,9 +281,8 @@ pub(super) fn apply_cli_overrides_with_config_options(
         options.es_module_interop = true;
         options.checker.es_module_interop = true;
         options.printer.es_module_interop = true;
-        // esModuleInterop implies allowSyntheticDefaultImports
-        options.allow_synthetic_default_imports = true;
-        options.checker.allow_synthetic_default_imports = true;
+        // `esModuleInterop -> allowSyntheticDefaultImports` is owned by the
+        // shared `apply_non_strict_fanout` table below.
     }
     if let Some(allow_synthetic_default_imports) = args.allow_synthetic_default_imports {
         options.allow_synthetic_default_imports = allow_synthetic_default_imports;
@@ -401,21 +397,13 @@ pub(super) fn apply_cli_overrides_with_config_options(
     if args.preserve_const_enums {
         options.printer.preserve_const_enums = true;
     }
-    // isolatedModules implies preserveConstEnums: const enums cannot be
-    // inlined across file boundaries, so they must be emitted as regular enums.
-    // Also disables const enum value inlining at usage sites.
+    // `isolatedModules`/`verbatimModuleSyntax -> preserveConstEnums` (and
+    // `verbatimModuleSyntax -> isolatedModules`) are owned by the shared
+    // `apply_non_strict_fanout` table below; record only the raw source flags.
     if args.isolated_modules {
-        options.printer.preserve_const_enums = true;
-        options.printer.no_const_enum_inlining = true;
         options.checker.isolated_modules = true;
     }
-    // verbatimModuleSyntax implies preserveConstEnums (tsc 5.0+): import/export
-    // syntax is preserved verbatim, so const enums must be emitted as regular
-    // enums rather than erased+inlined.
     if args.verbatim_module_syntax {
-        options.printer.preserve_const_enums = true;
-        options.printer.no_const_enum_inlining = true;
-        options.printer.verbatim_module_syntax = true;
         options.checker.verbatim_module_syntax = true;
     }
     if let Some(jsx) = args.jsx {
@@ -482,6 +470,22 @@ pub(super) fn apply_cli_overrides_with_config_options(
     }
     if args.suppress_implicit_any_index_errors {
         options.checker.suppress_implicit_any_index_errors = true;
+    }
+
+    // Fan out the non-strict-family implications (composite -> declaration +
+    // incremental, isolatedModules/verbatimModuleSyntax -> preserveConstEnums,
+    // importHelpers -> no_emit_helpers, esModuleInterop ->
+    // allowSyntheticDefaultImports) through the shared table, so the CLI and
+    // tsconfig engines derive them identically. Runs before the explicit
+    // `--flag false` disable pass (which resets the source flags and their
+    // derived emit fields for the CLI-only `--flag false` side-channel).
+    crate::config::apply_non_strict_fanout(options);
+    // Re-apply an explicit `--allowSyntheticDefaultImports` so it still wins
+    // over the `esModuleInterop -> allowSyntheticDefaultImports` implication
+    // (tsc resolves an explicitly provided value before any default).
+    if let Some(allow_synthetic_default_imports) = args.allow_synthetic_default_imports {
+        options.allow_synthetic_default_imports = allow_synthetic_default_imports;
+        options.checker.allow_synthetic_default_imports = allow_synthetic_default_imports;
     }
 
     apply_explicitly_disabled_bool_flags(options, args);

--- a/crates/tsz-common/src/options/checker_fanout.rs
+++ b/crates/tsz-common/src/options/checker_fanout.rs
@@ -1,0 +1,83 @@
+//! Checker-only slice of TypeScript's non-strict-family option fan-out.
+//!
+//! `tsz_core::config::option_fanout` owns the full non-strict fan-out, but it
+//! operates on `ResolvedCompilerOptions` (which embeds the emit-only
+//! `PrinterOptions`) and therefore lives in `tsz-core`. The two derivations
+//! that are purely checker-semantic — `verbatimModuleSyntax -> isolatedModules`
+//! and `esModuleInterop -> allowSyntheticDefaultImports` — also have to fire on
+//! the bare [`CheckerOptions`] that the WASM and `tsz_server` lanes build
+//! (no printer, no emit). This module is their single owner so those lanes
+//! stop hand-rolling the implication.
+//!
+//! `tsz_core::config::option_fanout` delegates the checker half of its work
+//! here, so the CLI, tsconfig, and server lanes all derive these two members
+//! from exactly one place.
+//!
+//! Each rule is pinned to its tsc 6.0.3 `computedOptions` entry
+//! (`TypeScript/src/compiler/utilities.ts`).
+
+use super::checker::CheckerOptions;
+
+/// Apply the checker-semantic non-strict-family implications to `options`.
+///
+/// Idempotent: every rule is a monotonic set toward `true`, mirroring tsc's
+/// `computedOptions` (`value || derivedFrom`).
+pub const fn apply_checker_fanout(options: &mut CheckerOptions) {
+    // `verbatimModuleSyntax` implies `isolatedModules`
+    // (tsc `computedOptions.isolatedModules`:
+    // `isolatedModules || verbatimModuleSyntax`).
+    if options.verbatim_module_syntax {
+        options.isolated_modules = true;
+    }
+    // `esModuleInterop` implies `allowSyntheticDefaultImports` (tsz's
+    // historical coupling; tsc <= 5.x derived `allowSyntheticDefaultImports`
+    // from `esModuleInterop || module === system || moduleResolution ===
+    // bundler`). tsc 6.0.3 decoupled them
+    // (`computedOptions.allowSyntheticDefaultImports` is `dependencies: []`,
+    // defaulting to `true`); flipping tsz's default is a checker-semantic
+    // behavior change tracked separately, so this preserves current behavior.
+    if options.es_module_interop {
+        options.allow_synthetic_default_imports = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CheckerOptions, apply_checker_fanout};
+
+    #[test]
+    fn verbatim_module_syntax_implies_isolated_modules() {
+        let mut options = CheckerOptions {
+            verbatim_module_syntax: true,
+            isolated_modules: false,
+            ..Default::default()
+        };
+        apply_checker_fanout(&mut options);
+        assert!(options.isolated_modules);
+    }
+
+    #[test]
+    fn es_module_interop_implies_synthetic_default_imports() {
+        let mut options = CheckerOptions {
+            es_module_interop: true,
+            allow_synthetic_default_imports: false,
+            ..Default::default()
+        };
+        apply_checker_fanout(&mut options);
+        assert!(options.allow_synthetic_default_imports);
+    }
+
+    #[test]
+    fn no_implication_when_sources_unset() {
+        let mut options = CheckerOptions {
+            verbatim_module_syntax: false,
+            es_module_interop: false,
+            isolated_modules: false,
+            allow_synthetic_default_imports: false,
+            ..Default::default()
+        };
+        apply_checker_fanout(&mut options);
+        assert!(!options.isolated_modules);
+        assert!(!options.allow_synthetic_default_imports);
+    }
+}

--- a/crates/tsz-common/src/options/mod.rs
+++ b/crates/tsz-common/src/options/mod.rs
@@ -1,2 +1,3 @@
 pub mod checker;
+pub mod checker_fanout;
 pub mod strict_family;

--- a/crates/tsz-core/src/api/wasm/compiler_options.rs
+++ b/crates/tsz-core/src/api/wasm/compiler_options.rs
@@ -250,6 +250,16 @@ impl CompilerOptions {
             options.downlevel_iteration = v;
         }
 
+        // Route the checker-semantic non-strict-family implications
+        // (`verbatimModuleSyntax -> isolatedModules`,
+        // `esModuleInterop -> allowSyntheticDefaultImports`) through the shared
+        // table so this lane never re-derives them by hand. The WASM
+        // `CompilerOptions` surface does not yet expose those source flags, so
+        // this is currently a no-op, but it keeps the single-owner contract
+        // intact for when they are added (idempotent monotonic set toward
+        // `true`, matching tsc's `computedOptions`).
+        tsz_common::options::checker_fanout::apply_checker_fanout(&mut options);
+
         options
     }
 }

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -29,9 +29,11 @@ pub use lib_resolution::{
     resolve_lib_files_from_embedded, resolve_lib_files_with_options,
     resolve_lib_files_with_options_transitive,
 };
+mod option_fanout;
 mod parse;
 mod resolved_options;
 
+pub use option_fanout::apply_non_strict_fanout;
 pub use parse::{ParsedTsConfig, parse_tsconfig, parse_tsconfig_with_diagnostics};
 pub use resolved_options::{
     JsxEmit, ModuleResolutionKind, PathMapping, ResolvedCompilerOptions,
@@ -438,6 +440,12 @@ pub use crate::checker::context::CheckerOptions;
 // surface (CLI driver, tsconfig resolution, WASM, tsz-server) resolves the
 // `--strict` umbrella through the same owner.
 pub use tsz_common::options::strict_family;
+
+// Re-export the shared checker-only non-strict fan-out so the printer-less
+// surfaces (WASM, tsz-server) derive `verbatimModuleSyntax -> isolatedModules`
+// and `esModuleInterop -> allowSyntheticDefaultImports` from the same owner as
+// the emit-capable CLI/tsconfig lanes (which go through `apply_non_strict_fanout`).
+pub use tsz_common::options::checker_fanout;
 
 /// Check whether a JSON value represents a truthy compiler option.
 /// Returns true for `true` booleans, non-empty strings, and non-null values

--- a/crates/tsz-core/src/config/option_fanout.rs
+++ b/crates/tsz-core/src/config/option_fanout.rs
@@ -1,0 +1,268 @@
+//! Single owner of TypeScript's non-strict-family compiler-option fan-out.
+//!
+//! tsc keeps every implied option in one `computedOptions` table
+//! (`TypeScript/src/compiler/utilities.ts`): an option whose value is not
+//! provided is derived from other already-resolved options. tsz previously
+//! re-encoded the same implications field-by-field in the CLI driver
+//! (`driver/plan.rs`) and the tsconfig resolver (`resolved_options.rs`),
+//! which silently drifted (the tsconfig lane never mirrored the
+//! `isolatedModules`/`verbatimModuleSyntax` const-enum implication to the
+//! printer, so tsconfig-driven emit erased const enums that the CLI lane
+//! preserved).
+//!
+//! This module is the single declarative home for those derivations. Both
+//! emit-capable engines call [`apply_non_strict_fanout`] on a
+//! [`ResolvedCompilerOptions`] (which embeds both `checker` and `printer`)
+//! after the per-flag overrides have been applied, so the implications can
+//! never diverge per surface again.
+//!
+//! The strict-family umbrella is owned separately by
+//! `tsz_common::options::strict_family`; this module covers everything else.
+//!
+//! Each implication is pinned to its tsc 6.0.3 `computedOptions` entry. The
+//! WASM/server lanes build a bare `CheckerOptions` with no printer and no
+//! emit, so they cannot consume the printer-aware [`apply_non_strict_fanout`]
+//! directly; instead they call the checker-only slice
+//! [`tsz_common::options::checker_fanout::apply_checker_fanout`] (which this
+//! table also delegates to). That keeps the two purely checker-semantic
+//! derivations (`verbatimModuleSyntax -> isolatedModules`,
+//! `esModuleInterop -> allowSyntheticDefaultImports`) under one owner across
+//! every engine.
+
+use super::ResolvedCompilerOptions;
+
+/// Apply tsc's non-strict-family option implications to `resolved`.
+///
+/// Must run after the raw per-option overrides (so the source flags hold
+/// their resolved values) and after [`strict_family`](super::strict_family)
+/// (the strict umbrella is independent of these implications). Idempotent:
+/// every rule is a monotonic `||`-style set toward `true`, matching tsc's
+/// `computedOptions` (`value || derivedFrom`), so a second call is a no-op.
+pub const fn apply_non_strict_fanout(resolved: &mut ResolvedCompilerOptions) {
+    // Checker-semantic implications (`verbatimModuleSyntax -> isolatedModules`,
+    // `esModuleInterop -> allowSyntheticDefaultImports`) are owned by the
+    // shared `tsz_common` helper so the WASM/server lanes share them. It must
+    // run first so the printer-mirroring below sees the derived
+    // `isolated_modules` value.
+    tsz_common::options::checker_fanout::apply_checker_fanout(&mut resolved.checker);
+    apply_composite_implications(resolved);
+    apply_isolated_modules_const_enum(resolved);
+    apply_import_helpers(resolved);
+    apply_es_module_interop_synthetic_defaults(resolved);
+}
+
+/// `composite` implies `declaration` and `incremental`.
+///
+/// tsc 6.0.3 `computedOptions.declaration`
+/// (`utilities.ts`: `declaration || composite`) and
+/// `computedOptions.incremental` (`incremental || composite`).
+const fn apply_composite_implications(resolved: &mut ResolvedCompilerOptions) {
+    if resolved.composite {
+        resolved.emit_declarations = true;
+        resolved.checker.emit_declarations = true;
+        resolved.incremental = true;
+    }
+}
+
+/// `isolatedModules || verbatimModuleSyntax` implies `preserveConstEnums`
+/// (so const enums are emitted as real enums rather than erased + inlined),
+/// and `verbatimModuleSyntax` additionally implies `isolatedModules`.
+///
+/// tsc 6.0.3 `computedOptions.isolatedModules`
+/// (`utilities.ts`: `isolatedModules || verbatimModuleSyntax`) and
+/// `computedOptions.preserveConstEnums`
+/// (`preserveConstEnums || isolatedModules(computed)`), i.e.
+/// `shouldPreserveConstEnums` =
+/// `preserveConstEnums || isolatedModules || verbatimModuleSyntax`.
+///
+/// `no_const_enum_inlining` is the tsz-internal printer companion of
+/// `preserve_const_enums` (it disables inlining at const-enum usage sites);
+/// it tracks the same condition.
+///
+/// Parity note: before this table the tsconfig resolver set only
+/// `checker.isolated_modules`/`checker.verbatim_module_syntax` and never
+/// mirrored the const-enum implication to the printer, so a `tsconfig.json`
+/// with `isolatedModules: true` erased const enums that the CLI lane (and
+/// tsc) preserved. Routing both engines through this rule fixes that
+/// tsconfig-only emit divergence toward tsc.
+const fn apply_isolated_modules_const_enum(resolved: &mut ResolvedCompilerOptions) {
+    let verbatim = resolved.checker.verbatim_module_syntax;
+    // `verbatimModuleSyntax -> isolatedModules` is the checker-semantic half,
+    // owned by the shared `apply_checker_fanout` helper so the WASM/server
+    // lanes derive it identically; here it has already run via
+    // `apply_non_strict_fanout` before this printer-mirroring step.
+    if verbatim {
+        resolved.printer.verbatim_module_syntax = true;
+    }
+    if resolved.checker.isolated_modules || verbatim {
+        resolved.printer.preserve_const_enums = true;
+        resolved.printer.no_const_enum_inlining = true;
+    }
+}
+
+/// `importHelpers` suppresses inline helper emission (helpers are imported
+/// from `tslib` instead).
+///
+/// tsc emits `import ... from "tslib"` and stops inlining the `__` helpers
+/// when `importHelpers` is set (`transformers/utilities.ts` emit-helper
+/// scheduling). `no_emit_helpers` is the tsz printer flag that gates inline
+/// helper text; `import_helpers` is mirrored to the printer so the emitter
+/// knows to route through `tslib`.
+const fn apply_import_helpers(resolved: &mut ResolvedCompilerOptions) {
+    if resolved.import_helpers {
+        resolved.printer.import_helpers = true;
+        resolved.printer.no_emit_helpers = true;
+    }
+}
+
+/// `esModuleInterop` implies `allowSyntheticDefaultImports`.
+///
+/// This is tsz's historical coupling (tsc <= 5.x derived
+/// `allowSyntheticDefaultImports` from `esModuleInterop || module === system
+/// || moduleResolution === bundler`). tsc 6.0.3 decoupled them:
+/// `computedOptions.allowSyntheticDefaultImports` is now `dependencies: []`
+/// and resolves to `allowSyntheticDefaultImports !== undefined ? value :
+/// true` (`utilities.ts:9126`), independent of `esModuleInterop`. Flipping
+/// tsz to the unconditional `true` default is a checker-semantic behavior
+/// change (it gates TS1192/TS1259/TS2497 default-import diagnostics), so it
+/// is tracked separately and NOT made here; this rule preserves tsz's
+/// current behavior byte-for-byte while still owning it in one place. The
+/// `esModuleInterop` default-to-`true` and the `module === system` /
+/// `moduleResolution === bundler` fallbacks stay at the engine call sites
+/// because they depend on TS5024 invalidation / module-resolution state that
+/// is engine-local.
+const fn apply_es_module_interop_synthetic_defaults(resolved: &mut ResolvedCompilerOptions) {
+    // `checker.allow_synthetic_default_imports` is set by the shared
+    // `apply_checker_fanout` helper above; mirror the derived value to the
+    // top-level `ResolvedCompilerOptions` field consumed by the resolver/CLI.
+    if resolved.es_module_interop {
+        resolved.allow_synthetic_default_imports = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ResolvedCompilerOptions, apply_non_strict_fanout};
+
+    #[test]
+    fn composite_implies_declaration_and_incremental() {
+        let mut resolved = ResolvedCompilerOptions {
+            composite: true,
+            ..Default::default()
+        };
+        apply_non_strict_fanout(&mut resolved);
+
+        assert!(resolved.emit_declarations);
+        assert!(resolved.checker.emit_declarations);
+        assert!(resolved.incremental);
+    }
+
+    #[test]
+    fn isolated_modules_preserves_const_enums_on_printer() {
+        let mut resolved = ResolvedCompilerOptions::default();
+        resolved.checker.isolated_modules = true;
+        apply_non_strict_fanout(&mut resolved);
+
+        assert!(
+            resolved.printer.preserve_const_enums,
+            "isolatedModules must preserve const enums in emit (tsc \
+             shouldPreserveConstEnums)"
+        );
+        assert!(resolved.printer.no_const_enum_inlining);
+    }
+
+    #[test]
+    fn verbatim_module_syntax_implies_isolated_modules_and_const_enums() {
+        let mut resolved = ResolvedCompilerOptions::default();
+        resolved.checker.verbatim_module_syntax = true;
+        apply_non_strict_fanout(&mut resolved);
+
+        assert!(
+            resolved.checker.isolated_modules,
+            "verbatimModuleSyntax implies isolatedModules (tsc computedOptions)"
+        );
+        assert!(resolved.printer.verbatim_module_syntax);
+        assert!(resolved.printer.preserve_const_enums);
+        assert!(resolved.printer.no_const_enum_inlining);
+    }
+
+    #[test]
+    fn no_const_enum_implication_when_neither_set() {
+        let mut resolved = ResolvedCompilerOptions::default();
+        apply_non_strict_fanout(&mut resolved);
+
+        assert!(!resolved.printer.preserve_const_enums);
+        assert!(!resolved.printer.no_const_enum_inlining);
+        assert!(!resolved.checker.isolated_modules);
+    }
+
+    #[test]
+    fn import_helpers_suppresses_inline_helpers() {
+        let mut resolved = ResolvedCompilerOptions {
+            import_helpers: true,
+            ..Default::default()
+        };
+        apply_non_strict_fanout(&mut resolved);
+
+        assert!(resolved.printer.import_helpers);
+        assert!(resolved.printer.no_emit_helpers);
+    }
+
+    #[test]
+    fn es_module_interop_implies_synthetic_default_imports() {
+        // Both engines (CLI/tsconfig) populate the top-level and the
+        // `checker` copies of `esModuleInterop` together, so mirror that here:
+        // the checker-semantic half of the implication is owned by
+        // `apply_checker_fanout` (driven by `checker.es_module_interop`) and
+        // the top-level mirror by `apply_es_module_interop_synthetic_defaults`.
+        let mut resolved = ResolvedCompilerOptions {
+            es_module_interop: true,
+            ..Default::default()
+        };
+        resolved.checker.es_module_interop = true;
+        apply_non_strict_fanout(&mut resolved);
+
+        assert!(resolved.allow_synthetic_default_imports);
+        assert!(resolved.checker.allow_synthetic_default_imports);
+    }
+
+    #[test]
+    fn no_implications_fire_for_default_options() {
+        let mut resolved = ResolvedCompilerOptions::default();
+        apply_non_strict_fanout(&mut resolved);
+
+        assert!(!resolved.emit_declarations);
+        assert!(!resolved.incremental);
+        assert!(!resolved.allow_synthetic_default_imports);
+        assert!(!resolved.printer.no_emit_helpers);
+    }
+
+    #[test]
+    fn idempotent_second_call_is_a_no_op() {
+        let mut resolved = ResolvedCompilerOptions {
+            composite: true,
+            import_helpers: true,
+            es_module_interop: true,
+            ..Default::default()
+        };
+        resolved.checker.verbatim_module_syntax = true;
+        apply_non_strict_fanout(&mut resolved);
+        let once = resolved.clone();
+        apply_non_strict_fanout(&mut resolved);
+
+        assert_eq!(once.emit_declarations, resolved.emit_declarations);
+        assert_eq!(once.incremental, resolved.incremental);
+        assert_eq!(
+            once.checker.isolated_modules,
+            resolved.checker.isolated_modules
+        );
+        assert_eq!(
+            once.printer.preserve_const_enums,
+            resolved.printer.preserve_const_enums
+        );
+        assert_eq!(
+            once.allow_synthetic_default_imports,
+            resolved.allow_synthetic_default_imports
+        );
+    }
+}

--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -581,15 +581,12 @@ pub fn resolve_compiler_options(
         resolved.declaration_dir = Some(PathBuf::from(declaration_dir));
     }
 
-    // composite implies declaration and incremental (matching tsc behavior)
+    // composite implies declaration and incremental. The implication itself is
+    // owned by the shared `apply_non_strict_fanout` table (tsc 6.0.3
+    // `computedOptions.declaration`/`incremental`); here we only record the
+    // raw `composite` value so the table can fan it out below.
     if let Some(composite) = options.composite {
         resolved.composite = composite;
-        if composite {
-            // composite: true implies declaration: true and incremental: true
-            resolved.emit_declarations = true;
-            resolved.checker.emit_declarations = true;
-            resolved.incremental = true;
-        }
     }
 
     if let Some(declaration) = options.declaration {
@@ -616,10 +613,9 @@ pub fn resolve_compiler_options(
     if let Some(no_emit_helpers) = options.no_emit_helpers {
         resolved.printer.no_emit_helpers = no_emit_helpers;
     }
-    if options.import_helpers == Some(true) {
-        // importHelpers means "import from tslib" - suppress inline helper emission.
-        resolved.printer.no_emit_helpers = true;
-    }
+    // `importHelpers` suppressing inline helper emission is owned by the shared
+    // `apply_non_strict_fanout` table; `resolved.import_helpers` is recorded
+    // above so the table can fan it out below.
 
     if let Some(downlevel_iteration) = options.downlevel_iteration {
         resolved.printer.downlevel_iteration = downlevel_iteration;
@@ -741,10 +737,11 @@ pub fn resolve_compiler_options(
         resolved.checker.isolated_modules = isolated_modules;
     }
 
-    // verbatimModuleSyntax implies isolatedModules in tsc — const enums get
-    // runtime bindings and are subject to TDZ checks.
+    // Record the raw `verbatimModuleSyntax` value; the
+    // `verbatimModuleSyntax -> isolatedModules` implication and the const-enum
+    // printer mirroring are owned by the shared `apply_non_strict_fanout`
+    // table (tsc 6.0.3 `computedOptions.isolatedModules`/`preserveConstEnums`).
     if options.verbatim_module_syntax == Some(true) {
-        resolved.checker.isolated_modules = true;
         resolved.checker.verbatim_module_syntax = true;
     }
 
@@ -804,17 +801,16 @@ pub fn resolve_compiler_options(
         .invalidated_options
         .iter()
         .any(|k| k == "esModuleInterop");
+    // The `esModuleInterop -> allowSyntheticDefaultImports` implication is owned
+    // by the shared `apply_non_strict_fanout` table below; this block only
+    // resolves the `esModuleInterop` value/default (engine-local because it
+    // depends on TS5024 invalidation state).
     if let Some(es_module_interop) = options.es_module_interop
         && !esmodule_invalidated
     {
         resolved.es_module_interop = es_module_interop;
         resolved.checker.es_module_interop = es_module_interop;
         resolved.printer.es_module_interop = es_module_interop;
-        // esModuleInterop implies allowSyntheticDefaultImports
-        if es_module_interop {
-            resolved.allow_synthetic_default_imports = true;
-            resolved.checker.allow_synthetic_default_imports = true;
-        }
     } else if !esmodule_invalidated {
         // tsc 6.0 defaults esModuleInterop to true when not explicitly set.
         // But do NOT apply the default when TS5024 fired for this option —
@@ -823,9 +819,15 @@ pub fn resolve_compiler_options(
         resolved.es_module_interop = true;
         resolved.checker.es_module_interop = true;
         resolved.printer.es_module_interop = true;
-        resolved.allow_synthetic_default_imports = true;
-        resolved.checker.allow_synthetic_default_imports = true;
     }
+
+    // Fan out the non-strict-family implications (composite -> declaration +
+    // incremental, isolatedModules/verbatimModuleSyntax -> preserveConstEnums,
+    // importHelpers -> no_emit_helpers, esModuleInterop ->
+    // allowSyntheticDefaultImports) through the shared table. Runs before the
+    // explicit `allowSyntheticDefaultImports` override below so an explicit
+    // value still wins over the `esModuleInterop` implication.
+    super::apply_non_strict_fanout(&mut resolved);
 
     if let Some(allow_synthetic_default_imports) = options.allow_synthetic_default_imports {
         resolved.allow_synthetic_default_imports = allow_synthetic_default_imports;


### PR DESCRIPTION
Goal: hold

Finishes #13062: routes the remaining hand-mirrored non-strict option derivations (esModuleInterop fan-out, printer option mirroring, verbatim/isolated module flags) through new declarative fan-out tables (`tsz_common::options::checker_fanout`, `tsz_core::config::option_fanout`), so none of the three merge engines (driver, tsconfig resolution, WASM/checker) hand-rolls option derivation anymore. Builds on PR 1's `strict_family` (#13366). Proven parity divergences are fixed and documented with tsc references; matching behavior is byte-identical.

Structural rule: every compiler-option derivation — strict-family and non-strict — lives in one declarative table consumed by all engines; no engine re-derives options by hand.

Non-strict derivation matrix (each pinned to tsc 6.0.3 `computedOptions`, `TypeScript/src/compiler/utilities.ts`):

| derivation | rule | tsc ref | owner |
| --- | --- | --- | --- |
| `composite -> declaration` | `declaration \|\| composite` | `computedOptions.declaration` | `option_fanout::apply_composite_implications` |
| `composite -> incremental` | `incremental \|\| composite` | `computedOptions.incremental` | `option_fanout::apply_composite_implications` |
| `verbatimModuleSyntax -> isolatedModules` | `isolatedModules \|\| verbatimModuleSyntax` | `computedOptions.isolatedModules` | `checker_fanout::apply_checker_fanout` |
| `isolatedModules\|verbatimModuleSyntax -> preserveConstEnums` | `preserveConstEnums \|\| isolatedModules(computed)` | `computedOptions.preserveConstEnums` | `option_fanout::apply_isolated_modules_const_enum` |
| `importHelpers -> no_emit_helpers` | suppress inline helpers, import from tslib | emit-helper scheduling | `option_fanout::apply_import_helpers` |
| `esModuleInterop -> allowSyntheticDefaultImports` | tsz historical coupling (preserved byte-identically; tsc 6.0.3 decoupled to `dependencies: []` default `true`, tracked separately) | `computedOptions.allowSyntheticDefaultImports` | `checker_fanout` + `option_fanout` |

The two purely checker-semantic derivations (`verbatimModuleSyntax -> isolatedModules`, `esModuleInterop -> allowSyntheticDefaultImports`) live in the `tsz_common` checker slice so the printer-less WASM and `tsz_server` lanes share the same owner; the full table delegates to it. The CLI driver and tsconfig resolver call the full `apply_non_strict_fanout`; the `tsz_server` `build_checker_options` and WASM `to_checker_options` call `apply_checker_fanout`.

Closes #13062

## Verification
- `cargo nextest run -p tsz-core -E 'test(/option|config|strict/)'` — 320 passed (the `module` filter additionally surfaces 3 pre-existing ES5 async-lowering source-map panics in `async_es5_ir_control.rs`, unrelated to this change and present on `main` without it)
- `cargo nextest run -p tsz-common -E 'test(checker_fanout)'` — 3 passed; `cargo nextest run -p tsz-core -E 'test(option_fanout)'` — 8 passed
- `cargo nextest run -p tsz-cli -E 'test(/option|plan|driver/)'` — 977 passed; the 9 remaining `driver_tests` failures are pre-existing on `main` (verified by reverting this PR's fan-out edits and re-running: identical 9 failures), so this change is parity-neutral for them
- `cargo nextest run -p tsz-wasm` — 59 passed
- `cargo clippy -p tsz-common -p tsz-core -p tsz-cli -p tsz-wasm -- -D warnings` — clean
- `cargo check --workspace` — clean

Incidental: adds the missing `completion_project_cache` field (from #13340) to four `tsz_server` code-fixes test fixtures so the `tsz-cli` test binary compiles; without it the binary fails to build on current `main`.

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max
