### PR TITLE
perf(solver): avoid cloning application args in inference probe (#8356)

### DIFF
--- a/crates/tsz-solver/src/inference/infer_matching.rs
+++ b/crates/tsz-solver/src/inference/infer_matching.rs
@@ -1637,12 +1637,12 @@ impl<'a> InferenceContext<'a> {
             TypeData::TypeParameter(ref info) => self.find_type_param(info.name).is_some(),
             TypeData::Application(app_id) => {
                 let app = self.interner.type_application(app_id);
-                let base = app.base;
-                let args = app.args.clone();
-                self.target_contains_inference_param_inner(base, visited)
-                    || args
+                self.target_contains_inference_param_inner(app.base, visited)
+                    || app
+                        .args
                         .iter()
-                        .any(|&arg| self.target_contains_inference_param_inner(arg, visited))
+                        .copied()
+                        .any(|arg| self.target_contains_inference_param_inner(arg, visited))
             }
             TypeData::Union(members) | TypeData::Intersection(members) => {
                 let list = self.interner.type_list(members);

--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -22,10 +22,11 @@ impl<'a> InferenceContext<'a> {
     fn discard_self_referential_candidates(
         &mut self,
         root: InferenceVar,
-        candidates: Vec<InferenceCandidate>,
+        candidates: &[InferenceCandidate],
     ) -> Vec<InferenceCandidate> {
         candidates
-            .into_iter()
+            .iter()
+            .copied()
             .filter(|candidate| !self.occurs_in(root, candidate.type_id))
             .collect()
     }
@@ -437,9 +438,9 @@ impl<'a> InferenceContext<'a> {
         let mut upper_bounds = Vec::new();
         let mut self_referential_bounds = Vec::new();
         let mut seen_upper_bounds = FxHashSet::default();
-        let mut candidates = self.discard_self_referential_candidates(root, info.candidates);
+        let mut candidates = self.discard_self_referential_candidates(root, &info.candidates);
         let contra_candidates =
-            self.discard_self_referential_candidates(root, info.contra_candidates);
+            self.discard_self_referential_candidates(root, &info.contra_candidates);
         for bound in info.upper_bounds {
             if self.occurs_in(root, bound) {
                 self_referential_bounds.push(bound);
@@ -1757,8 +1758,7 @@ impl<'a> InferenceContext<'a> {
             let dc = self.declared_constraints.get(&root).copied();
             let dc_preserves_literals =
                 self.literal_preserving_declared_constraints.contains(&root);
-            let mut candidates =
-                self.discard_self_referential_candidates(root, info.candidates.clone());
+            let mut candidates = self.discard_self_referential_candidates(root, &info.candidates);
             if !info.upper_bounds.is_empty() {
                 let has_informative_upper_bound = info
                     .upper_bounds
@@ -1774,7 +1774,7 @@ impl<'a> InferenceContext<'a> {
                 });
             }
             let mut concrete_contra_candidates: Vec<_> = self
-                .discard_self_referential_candidates(root, info.contra_candidates.clone())
+                .discard_self_referential_candidates(root, &info.contra_candidates)
                 .into_iter()
                 .filter(|c| self.is_concrete_contra_candidate(c.type_id))
                 .collect();
@@ -1903,9 +1903,9 @@ impl<'a> InferenceContext<'a> {
                     );
 
                     let candidates =
-                        self.discard_self_referential_candidates(root, info.candidates.clone());
-                    let contra_candidates = self
-                        .discard_self_referential_candidates(root, info.contra_candidates.clone());
+                        self.discard_self_referential_candidates(root, &info.candidates);
+                    let contra_candidates =
+                        self.discard_self_referential_candidates(root, &info.contra_candidates);
 
                     if !candidates.is_empty() {
                         let is_const = self.is_var_const(root);


### PR DESCRIPTION
Goal: fast

## Summary
- Remove the per-application argument vector clone from the inference-parameter containment walker.
- Borrow inference candidate slices when filtering self-referential candidates, avoiding candidate-vector clones in current-fix/current-substitution paths.
- Keep the same traversal, filter order, visited-set, and candidate priority semantics.

## Structural rule
When checking whether an inference target contains an inference parameter or filtering inference candidates that occur in their own target variable, `tsc`-parity behavior depends on traversing and filtering the existing type/candidate structure, not on owning cloned vectors. `tsz` should do that through solver inference traversal using borrowed application argument and candidate slices, falling back to the same collected filtered output where later resolution needs ownership.

## Owner layer
Solver inference traversal and inference resolution only; no checker, binder, emitter, or diagnostic policy change.

## Adjacent matrix
- Application base traversal remains before argument traversal.
- Application arguments still recurse through the same containment helper.
- Type parameter detection still flows through `find_type_param`.
- Union/intersection traversal and visited cycle handling are unchanged.
- Candidate filtering still preserves input order and drops only candidates where `occurs_in(root, candidate.type_id)` is true.
- Candidate priority, freshness, readonly, array-element, and source metadata are copied unchanged from the original `InferenceCandidate` records.
- No new cache key, invalidation path, or fixture-name fast path is introduced.

## Performance note
This removes repeated allocation/copy residue on recursive application-type probes and inference candidate filtering in the #8356 ts-toolbelt performance lane. It is intentionally allocation-residue cleanup, not a claimed benchmark lift until full ready-review CI or a targeted benchmark run proves it.

## Verification
- No local tests or benchmarks run per current instruction.
- Pre-commit formatting hook ran during commits.
- Draft CI at head `56f531269c337ef2c7bf99aaeb483ce56beb5ccc`: `CI Light Summary`, `lint`, `cargo-shear`, `cargo-deny`, `unit`, `unit-checker-integration`, `unit-cloudbuild`, `dist-binaries`, and `project-row-drift` passed.
- Full ready-review CI is expected to cover the complete PR-head gate set before queueing.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: high

Refs #8356.
Refs #13250.
