### PR TITLE
refactor(common): dedupe sharded interner insert tail (#13433)

### DIFF
--- a/crates/tsz-common/src/interner/mod.rs
+++ b/crates/tsz-common/src/interner/mod.rs
@@ -399,6 +399,23 @@ impl ShardedInterner {
         Self { shards }
     }
 
+    #[inline]
+    fn insert_into_shard(state: &mut ShardState, shard_idx: usize, owned: Arc<str>) -> Atom {
+        let Ok(local_index) = u32::try_from(state.strings.len()) else {
+            return Atom::NONE;
+        };
+        if local_index > (u32::MAX >> SHARD_BITS) {
+            // Return empty atom on overflow instead of panicking
+            return Atom::NONE;
+        }
+
+        let shard_idx_u32 = u32::try_from(shard_idx).unwrap_or(Atom::NONE.0);
+        let atom = Self::make_atom(local_index, shard_idx_u32);
+        state.strings.push(Arc::clone(&owned));
+        state.map.insert(owned, atom);
+        atom
+    }
+
     /// Intern a string, returning its Atom handle.
     /// If the string was already interned, returns the existing Atom.
     #[must_use]
@@ -428,20 +445,7 @@ impl ShardedInterner {
             return atom;
         }
 
-        let Ok(local_index) = u32::try_from(state.strings.len()) else {
-            return Atom::NONE;
-        };
-        if local_index > (u32::MAX >> SHARD_BITS) {
-            // Return empty atom on overflow instead of panicking
-            return Atom::NONE;
-        }
-
-        let shard_idx_u32 = u32::try_from(shard_idx).unwrap_or(Atom::NONE.0);
-        let atom = Self::make_atom(local_index, shard_idx_u32);
-        let owned: Arc<str> = Arc::from(s);
-        state.strings.push(Arc::clone(&owned));
-        state.map.insert(owned, atom);
-        atom
+        Self::insert_into_shard(&mut state, shard_idx, Arc::from(s))
     }
 
     /// Intern an owned String, avoiding allocation if possible.
@@ -463,20 +467,7 @@ impl ShardedInterner {
             return atom;
         }
 
-        let Ok(local_index) = u32::try_from(state.strings.len()) else {
-            return Atom::NONE;
-        };
-        if local_index > (u32::MAX >> SHARD_BITS) {
-            // Return empty atom on overflow instead of panicking
-            return Atom::NONE;
-        }
-
-        let shard_idx_u32 = u32::try_from(shard_idx).unwrap_or(Atom::NONE.0);
-        let atom = Self::make_atom(local_index, shard_idx_u32);
-        let owned: Arc<str> = Arc::from(s);
-        state.strings.push(Arc::clone(&owned));
-        state.map.insert(owned, atom);
-        atom
+        Self::insert_into_shard(&mut state, shard_idx, Arc::from(s))
     }
 
     /// Resolve an Atom back to its string value.


### PR DESCRIPTION
Goal: fast

## Summary
- Factor the duplicated `ShardedInterner::intern` / `intern_owned` atom-mint tail into one private `insert_into_shard` helper.
- Preserve each caller's existing empty-string check, lock-acquisition path, read-lock fast path, and write-lock double-check.
- Keep overflow fallback, atom layout, `strings.push`, and `map.insert` behavior unchanged.

## Structural rule
When a sharded interner write path has already selected a shard, acquired its write lock, and confirmed the string is absent, tsz should mint and insert the new `Atom` through one shared tail. `intern` and `intern_owned` differ only in how they reach that point and how they produce the owned `Arc<str>`; both now use the same helper for the shared insertion invariant.

## Owner layer
`tsz-common` interner implementation only. No checker, solver, binder, emitter, diagnostic, or semantic policy change.

## Adjacent matrix
- `intern` keeps the read-lock fast path before taking the write lock.
- `intern` keeps the write-lock double-check before insertion.
- `intern_owned` keeps direct write-lock behavior and lookup by `s.as_str()`.
- Empty strings still return `Atom::NONE` before shard lookup.
- Local-index overflow still returns `Atom::NONE`.
- Atom layout still flows through `make_atom(local_index, shard_idx_u32)`.
- The helper inserts the same owned `Arc<str>` into both `strings` and `map`.

## Verification
- No local tests run per current instruction.
- Pre-commit formatting hook ran during commit.
- Draft CI Light Summary passed for head `478fdd66798199c92c7a36b98a6b920dce176827`.
- Ready-review CI is expected to provide full `CI Summary` before merge queue.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium

Refs #13433.
Refs #13250.
