### PR TITLE
chore(skills): add rust-hygiene-audit skill + audit workflow

### DIFF
--- a/.agents/skills/rust-hygiene-audit/SKILL.md
+++ b/.agents/skills/rust-hygiene-audit/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: rust-hygiene-audit
+description: Run a deep DRY + code-hygiene audit of the Rust workspace and turn the findings into verified, deduplicated, hierarchical GitHub tech-debt issues. Use this whenever the user asks to find duplication, code smells, derive/boilerplate bloat, oversized files, or "tech debt"; to tighten the Clippy/lint posture; to mass-file or triage hygiene issues; or to assign Priority/Effort issue Fields across the backlog. Reach for it even when the user only says "clean up the codebase", "find DRY violations", "what should we refactor", or "make issues for the cruft" — it is the right tool for evidence-backed, non-spammy hygiene issue creation.
+---
+
+# Rust Hygiene Audit
+
+Turn a fuzzy "clean up the codebase" request into a set of **evidence-backed,
+deduplicated, parent/child GitHub issues** — without flooding the tracker with
+smells. The guiding principle: every issue must cite real `file:line` evidence
+that survived an adversarial check, and must not duplicate an open issue.
+
+This skill is for hygiene/DRY/lint work, **not** behavior changes. It produces
+issues and field assignments; it does not edit compiler logic. Keep parity work
+(`tsc` matching) in the owner skills.
+
+## The four phases
+
+Run them in order. Phases 1–2 are analysis; 3–4 are writes — confirm scope with
+the user before mass-creating issues unless they already said "create them".
+
+### 1. Measure the Clippy posture (prevention evidence)
+
+The cheapest lever against *future* debt is a tighter lint floor, so quantify
+what the current floor lets through before proposing changes.
+
+```bash
+python3 .agents/skills/rust-hygiene-audit/scripts/measure_clippy.py --worktree . --out /tmp/hygiene
+```
+
+This runs `cargo clippy --workspace --lib -- -W clippy::pedantic -W clippy::nursery`
+(no files touched), aggregates warnings per lint, and prints a **promote vs
+defer** triage. Read `references/lint-triage.md` for the rationale behind which
+lints are worth promoting in a compiler (numeric casts and `must_use`/doc
+pedantry are mostly intentional; idiom/ownership lints are high-signal). The
+count and triage become the body of the clippy-posture epic.
+
+Disk note: a cold workspace clippy build needs ~8–12GB. If low, reclaim merged
+worktree caches first (see `tsz-disk-cache-hygiene`).
+
+### 2. Fan out the audit (find + verify)
+
+Drive the bundled workflow, which fans out per-crate DRY auditors and
+cross-cutting concern auditors, dedups against open issues, then
+**adversarially verifies every candidate against the real source** before
+authoring full issue bodies:
+
+```
+Workflow({ scriptPath: "scripts/agents/hygiene-audit-workflow.mjs" })
+```
+
+Before launching, snapshot the open issues the auditors dedup against:
+
+```bash
+gh issue list -R <owner>/<repo> --state open --limit 300 --json number,title,labels > /tmp/hygiene/open-issues.json
+```
+
+The workflow returns `{ epics, children, dropped, stats }`. `children` carry
+verified evidence and full `body_md`. `dropped` records findings that
+overlapped an existing issue — surface these so the user sees the dedup worked.
+Tune the auditor list (crates + concerns) in the workflow's `CRATES`/`CONCERNS`
+arrays for the target repo. The verify stage defaults to **reject** on weak
+evidence — that is the anti-spam gate; do not weaken it.
+
+### 3. Create the issue hierarchy
+
+Author epic `body_md` (summarize the theme + bake in the measured clippy data
+for the lint epic), then create epics and children with native sub-issue links:
+
+```bash
+python3 .agents/skills/rust-hygiene-audit/scripts/create_issues.py \
+  --repo <owner>/<repo> --specs /tmp/hygiene/result.json --apply
+```
+
+Match the repo's existing issue conventions. For tsz that is the
+`techdebt(scope):` title + the template in `references/issue-template.md`
+(`## Summary` with a structural rule → `## Evidence` → `## Why it matters` →
+`## Proposed fix` (sized S/M/L) → `## Risks / coordination`). The script writes
+a `## Child issue map` into each epic as a durable fallback even when native
+linking succeeds.
+
+### 4. Assign Priority / Effort Fields
+
+```bash
+python3 .agents/skills/rust-hygiene-audit/scripts/assign_fields.py \
+  --repo <owner>/<repo> --specs /tmp/hygiene/result.json --apply
+```
+
+Discovers the repo's `Priority`/`Effort` single-select issue Fields by name,
+then assigns by rule. Default priority ranking is **correctness > speed >
+tech-debt** (map to High/Medium/Low; reserve Urgent for `urgent`/`panic`
+labels). Effort comes from the audit `size` (S/M/L → Low/Medium/High) and
+epic-scale → the top level. See `references/github-fields-api.md` for the API
+gotchas — they are easy to get wrong:
+
+- Sub-issues: `gh api -X POST .../issues/<parent>/sub_issues -F sub_issue_id=<db_id>`
+  — `-F` (integer) not `-f` (string); the id is the issue **database id**, not
+  its number.
+- `setIssueFieldValue` works with `repo` scope, but `createIssueField` /
+  `updateIssueField` (changing a field's options) need **`admin:org`**. If you
+  must add an option and lack the scope, ask the user to add it in the UI or
+  fall back to the existing options.
+
+## What good output looks like
+
+- Issues cite ≥2 real sites for any DRY claim and name the **structural rule**.
+- Duplication that already drifted into a parity bug is flagged as such — that
+  is the highest-value finding, not a cosmetic one.
+- Nothing duplicates an open issue (the `dropped` list proves the check ran).
+- A small number of strong epics, each with actionable PR-sized children.
+
+## What to avoid
+
+- Smell-only issues with no `file:line` evidence.
+- Mass-creating before the user has agreed to issue creation.
+- Architecture-boundary refactors that overlap an active campaign — check open
+  issues first and let the auditors dedup.
+- Fixture-name / rendered-output string checks in any proposed fix (repo
+  anti-hardcoding gate).

--- a/.agents/skills/rust-hygiene-audit/references/github-fields-api.md
+++ b/.agents/skills/rust-hygiene-audit/references/github-fields-api.md
@@ -1,0 +1,56 @@
+# GitHub sub-issues + native Issue Fields API
+
+The non-obvious bits that cost time the first time. Driven via `gh api`.
+
+## Sub-issues (parent/child hierarchy)
+
+```bash
+# child_db_id is the issue DATABASE id, not its number:
+child_db_id=$(gh api repos/OWNER/REPO/issues/<child_number> -q .id)
+gh api -X POST repos/OWNER/REPO/issues/<parent_number>/sub_issues -F sub_issue_id=$child_db_id
+```
+
+- Use **`-F`** (typed integer). `-f` sends a *string* and the call 422s / fails
+  silently — this is the #1 gotcha.
+- `sub_issue_id` is the database id from `.id`, **not** the issue number.
+- Always write a `## Child issue map` into the parent body too, as a durable
+  fallback that survives even if a native link fails.
+
+## Native Issue Fields (GraphQL, preview)
+
+Read existing fields — `issueFields` is a **union**, query with `... on`:
+
+```graphql
+{ repository(owner:"O",name:"R"){ issueFields(first:30){ nodes{
+    __typename ... on IssueFieldSingleSelect { id name options{ id name } } } } } }
+```
+
+Set values (one mutation can set several fields — pass a list):
+
+```graphql
+mutation { setIssueFieldValue(input:{
+  issueId:"<issue node id>",
+  issueFields:[
+    {fieldId:"<Priority field id>", singleSelectOptionId:"<option id>"},
+    {fieldId:"<Effort field id>",   singleSelectOptionId:"<option id>"}
+  ]}){ issue{ number } } }
+```
+
+- `issueId` is the GraphQL **node id** (`gh issue list --json id`), not number.
+- `setIssueFieldValue` works with **`repo`** scope.
+- `createIssueField` / `updateIssueField` (creating a field, adding/renaming
+  options) require **`admin:org`**. A default `repo`+`read:org` token cannot add
+  a 4th option to an existing field. If you need to and lack the scope: ask the
+  user to add the option in the issue-fields UI, or `gh auth refresh -s
+  admin:org`, or fall back to the options that already exist.
+- `IssueFieldSingleSelectOptionInput.priority` is `Int!` (required) even though
+  introspection reports it nullable — pass an explicit ordering int.
+- Read back values via `issueFieldValues` → `... on IssueFieldSingleSelectValue
+  { field{ ... on IssueFieldSingleSelect{ name } } name }`.
+
+## Priority/Effort conventions used by this skill
+
+- Priority ranking **correctness > speed > tech-debt** → High / Medium / Low,
+  with Urgent reserved for `urgent`/`panic` labels.
+- Effort from audit size: S→low, M→mid, L→high, epic-scale→top option.
+- Both axes are independent: a tech-debt epic is `Priority=Low, Effort=High`.

--- a/.agents/skills/rust-hygiene-audit/references/issue-template.md
+++ b/.agents/skills/rust-hygiene-audit/references/issue-template.md
@@ -1,0 +1,68 @@
+# Tech-debt issue body template
+
+Match the repo's existing `techdebt(scope):` issues. The workflow authors
+children in this shape; epics summarize the theme and link children.
+
+## Title
+
+`techdebt(<crate-or-repo>): <imperative summary>` — e.g.
+`techdebt(solver): split over-cap god-files def/core.rs along concern axes`.
+
+## Child body
+
+```markdown
+## Summary
+<one paragraph + the structural rule:
+"When <structural condition>, idiomatic Rust does X; tsz does Y at <owner>.">
+
+## Evidence
+- `path/to/file.rs:LINE` — short quote of the duplicated/bloated code
+- `path/to/other.rs:LINE` — the second site (DRY claims need >=2)
+
+## Why it matters
+<concrete maintenance/correctness/perf cost; cite counts; name any parity bug
+the duplication has already produced — that is the highest-value evidence>
+
+## Proposed fix
+<concrete idiomatic Rust: declarative macro / derive_more / newtype / module
+split / lint promotion. Sized S / M / L; if L, sketch the multi-PR sequence.
+Keep files under the repo line cap.>
+
+## Risks / coordination
+<behavior-preservation argument, ordering subtleties, overlap with other open
+issues or active campaigns, and the exact verification commands / CI gates>
+```
+
+## Epic body
+
+```markdown
+## Summary
+<the theme + the structural rule it enforces across the codebase>
+
+## Measured evidence (this audit)
+<hard numbers: clippy warning counts + triage for the lint epic; derive-site
+counts; over-cap file table; etc.>
+
+## Why it matters
+<the compounding cost of leaving the whole family unaddressed>
+
+## Proposed approach
+<staged plan; one invariant per child PR>
+
+## Risks / coordination
+<cross-epic ordering, scope boundaries vs active campaigns>
+
+## Child issue map
+<appended automatically by create_issues.py>
+```
+
+## Senior framing that makes issues land
+
+- Lead with the **structural rule**, not the symptom. "The reported repro is one
+  witness, not the scope."
+- For derive bloat, name the idiomatic Rust fix precisely: a declarative
+  `define_id!` macro for repeated `u32` newtypes, `derive_more` for
+  `From`/`Deref`/`Display`, `#[derive(Default)]` for derivable manual impls.
+- Flag duplication that already drifted into divergent behavior as a **parity
+  bug inside the dedup**, and propose fixing it as a separate reviewed commit on
+  top of the mechanical consolidation.

--- a/.agents/skills/rust-hygiene-audit/references/lint-triage.md
+++ b/.agents/skills/rust-hygiene-audit/references/lint-triage.md
@@ -1,0 +1,53 @@
+# Clippy lint triage for a compiler codebase
+
+`measure_clippy.py` runs `pedantic`+`nursery` and buckets the results. This is
+the reasoning behind the default buckets — re-judge per repo, but the
+compiler-specific calls below hold up well.
+
+## Why promote these (signal > churn)
+
+These catch real maintenance and (occasionally) correctness debt with low
+false-positive rates:
+
+- **Idiom / readability**: `manual_let_else`, `explicit_iter_loop`,
+  `single_match_else`, `unnested_or_patterns`, `needless_continue`,
+  `redundant_closure_for_method_calls`, `map_unwrap_or`. Each makes control flow
+  read the way the compiler team already prefers.
+- **Ownership / perf**: `needless_pass_by_ref_mut` (over-broad `&mut` hides
+  aliasing intent), `needless_pass_by_value`, `implicit_clone`,
+  `assigning_clones`, `format_push_string`. These shrink accidental copies.
+- **Dead / over-broad surface**: `redundant_pub_crate`, `unused_self`. Both
+  narrow API surface, which compounds with dead-code paydown.
+- **Complexity / design**: `too_many_lines` (function-scoped; backs a file-size
+  campaign), `struct_excessive_bools` (usually wants an enum/bitflags),
+  `branches_sharing_code`, `useless_let_if_seq`, `default_trait_access`,
+  `elidable_lifetime_names`, `wildcard_imports`.
+- **Latent correctness**: `case_sensitive_file_extension_comparisons` — in a
+  TypeScript/JS toolchain, `.ts`/`.TS`/`.d.ts` case handling can be a real bug,
+  not style. Always read these hits.
+
+## Why defer/allow these (mostly intentional in a compiler)
+
+- **Numeric casts**: `cast_possible_truncation`, `cast_lossless`,
+  `cast_precision_loss`, `cast_sign_loss`. A compiler with `u32` id-newtypes and
+  arena indices casts deliberately and constantly; promoting these is pure
+  churn. Allow with a one-line rationale.
+- **API ergonomics pedantry**: `must_use_candidate`, `return_self_not_must_use`.
+  High volume, low value unless the crate is a public library.
+- **Doc pedantry**: `missing_panics_doc`, `missing_errors_doc`,
+  `too_long_first_doc_paragraph`. Worth it only for published API crates.
+- **Style coin-flips**: `items_after_statements`, `if_not_else`,
+  `option_if_let_else` (the last is often *less* readable than the `if let`).
+
+## Rollout shape
+
+Promote one family per PR, allow-list first:
+
+1. Land the allow-list (`allow` the defer set with rationale) so the floor can
+   rise without a wall of warnings.
+2. Raise the floor: `pedantic = { level = "warn", priority = -1 }`, then
+   `nursery = "warn"`; fix or allow the residual per crate.
+3. Add `unwrap_used`/`expect_used` at `warn` for non-test code if the repo
+   already has an `allow-unwrap-in-tests = false` posture.
+4. Re-measure after the derive/file-split campaigns — they erase thousands of
+   `redundant_pub_crate`/`too_many_lines` hits, so promote those last.

--- a/.agents/skills/rust-hygiene-audit/scripts/assign_fields.py
+++ b/.agents/skills/rust-hygiene-audit/scripts/assign_fields.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Assign Priority and Effort native issue Fields across all open issues.
+
+Discovers the repo's single-select issue Fields named Priority and Effort by
+name (so it is not hardcoded to one repo's field ids), then assigns:
+
+  Priority  — correctness > speed > tech-debt, by label:
+              urgent/panic -> Urgent; correctness labels -> High;
+              performance/bench -> Medium; everything else -> Low.
+  Effort    — from the audit `size` for issues we created (S/M/L), else a
+              label/title heuristic. Mapped onto whatever Effort options exist
+              (top option for epic-scale, descending for L/M/S).
+
+setIssueFieldValue works with `repo` scope. Changing field *options* needs
+admin:org — this script only sets values, never edits field definitions.
+
+Usage:
+  assign_fields.py --repo owner/name [--specs result.json] [--apply]
+"""
+import argparse, json, subprocess, sys, time
+from collections import Counter
+
+CORRECTNESS = {"bug","false-positive","false-negative","conformance","class-inheritance","type-inference",
+ "narrowing","overload-resolution","strict-mode","generic-inference","contextual-typing","recursive-types",
+ "conditional-types","variadic-tuples","index-signatures","module-resolution","diagnostic-chain","error-position",
+ "fingerprint-only","type-display","type-challenges","parity(solver)","declaration-emit","emit","emitter",
+ "diagnostics","diagnostic","jsdoc"}
+SPEED = {"performance","bench"}
+VHIGH_CUES = ("pay down","strip the","strip tsz","god-facade","unify the three","three parallel",
+ "three hand-rolled","three independent","campaign","boundary debt","master plan","family map")
+HIGH_CUES = ("unify","collapse","consolidate","retire","migrate","re-land","replace the","god-files",
+ "megafunction","table-drive","centralize")
+LOW_CUES = ("remove ","drop ","delete ","dedupe the","trim","fixture-scoped","hack","typo","rename")
+
+def gh(args, retries=4):
+    last = ""
+    for i in range(retries):
+        r = subprocess.run(["gh"] + args, capture_output=True, text=True, timeout=90)
+        if r.returncode == 0 and '"errors"' not in r.stdout:
+            return r.stdout, True
+        last = r.stdout or r.stderr
+        time.sleep(2 * (i + 1))
+    return last, False
+
+def discover_fields(repo):
+    owner, name = repo.split("/")
+    q = ('{ repository(owner:"%s",name:"%s"){ issueFields(first:30){ nodes{ '
+         '__typename ... on IssueFieldSingleSelect { id name options{ id name } } } } } }' % (owner, name))
+    out, ok = gh(["api", "graphql", "-f", f"query={q}"])
+    if not ok:
+        sys.exit("could not read issueFields (needs the issue-fields preview)")
+    fields = {}
+    for n in json.loads(out)["data"]["repository"]["issueFields"]["nodes"]:
+        if n.get("__typename") == "IssueFieldSingleSelect":
+            fields[n["name"]] = {"id": n["id"], "options": {o["name"]: o["id"] for o in n["options"]}}
+    return fields
+
+def priority(labels):
+    L = set(labels)
+    if "urgent" in L or "panic" in L: return "Urgent"
+    if L & CORRECTNESS: return "High"
+    if L & SPEED: return "Medium"
+    return "Low"
+
+def effort_rank(num, labels, title, epic_nums, size_by_title):
+    L, t = set(labels), title.lower()
+    if num in epic_nums: return 4
+    if title in size_by_title: return {"S": 1, "M": 2, "L": 3}[size_by_title[title]]
+    if "Project Direction" in L or any(c in t for c in VHIGH_CUES): return 4
+    if any(c in t for c in LOW_CUES) or "fingerprint-only" in L: return 1
+    if any(c in t for c in HIGH_CUES) or "performance" in L: return 3
+    return 2
+
+def effort_option(rank, opts):
+    """Map rank 1..4 onto the available Effort options (ordered by name heuristic)."""
+    order = ["Very High", "High", "Medium", "Low"]  # preferred 4-level naming
+    present = [o for o in order if o in opts]
+    if not present:                       # unknown naming: use options as-is
+        present = list(opts.keys())
+    # rank 4=top .. 1=bottom; clamp to available
+    idx_from_top = max(0, len(present) - rank)
+    return present[min(idx_from_top, len(present) - 1)]
+
+def set_fields(repo, node_id, field_pairs):
+    inner = ",".join(f'{{fieldId:"{fid}", singleSelectOptionId:"{oid}"}}' for fid, oid in field_pairs)
+    q = f'mutation {{ setIssueFieldValue(input:{{issueId:"{node_id}", issueFields:[{inner}]}}){{ issue{{number}} }} }}'
+    return gh(["api", "graphql", "-f", f"query={q}"])
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", required=True)
+    ap.add_argument("--specs", help="result.json to read created sizes/epics from")
+    ap.add_argument("--apply", action="store_true")
+    a = ap.parse_args()
+    dry = not a.apply
+
+    fields = discover_fields(a.repo)
+    pri = fields.get("Priority"); eff = fields.get("Effort")
+    if not pri:
+        sys.exit("no 'Priority' single-select field found")
+    print(f"Priority options: {list(pri['options'])}")
+    if eff: print(f"Effort options:   {list(eff['options'])}")
+
+    epic_nums, size_by_title = set(), {}
+    if a.specs:
+        d = json.load(open(a.specs))
+        size_by_title = {c["title"]: c.get("size", "M") for c in d.get("children", [])}
+        # epics are matched after creation by title; if numbers unknown, title cue handles it
+
+    out, _ = gh(["issue", "list", "-R", a.repo, "--state", "open", "--limit", "300",
+                 "--json", "id,number,title,labels"])
+    issues = json.loads(out)
+    pc, ec, ok, fail = Counter(), Counter(), 0, 0
+    for it in issues:
+        labels = [l["name"] for l in it["labels"]]
+        p = priority(labels)
+        rank = effort_rank(it["number"], labels, it["title"], epic_nums, size_by_title)
+        e_name = effort_option(rank, eff["options"]) if eff else None
+        pc[p] += 1; ec[e_name] += 1
+        if dry:
+            continue
+        pairs = [(pri["id"], pri["options"][p])]
+        if eff and e_name in eff["options"]:
+            pairs.append((eff["id"], eff["options"][e_name]))
+        _, good = set_fields(a.repo, it["id"], pairs)
+        ok += good; fail += (not good)
+    print(f"Priority dist: {dict(pc)}")
+    print(f"Effort dist:   {dict(ec)}")
+    if not dry:
+        print(f"set ok={ok} fail={fail}")
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/rust-hygiene-audit/scripts/create_issues.py
+++ b/.agents/skills/rust-hygiene-audit/scripts/create_issues.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Create a hierarchy of GitHub issues from an audit spec, with native sub-issues.
+
+Reads a specs JSON of the shape produced by hygiene-audit-workflow.mjs:
+  { "epics":    [ { "key","title", "body_md"? } ],
+    "children": [ { "epic_key","title","labels"[],"size","body_md" } ] }
+
+Creates each epic, then each child, links children as native GitHub sub-issues,
+and appends a "## Child issue map" to every epic as a durable fallback.
+
+Dry-run by default; pass --apply to write. Idempotent-ish: re-linking an
+existing sub-issue is harmless.
+
+Usage:
+  create_issues.py --repo owner/name --specs result.json [--apply]
+                   [--epic-labels tech-debt,Project Direction] [--footer FILE]
+"""
+import argparse, json, subprocess, sys, time
+
+def gh(args, body=None, retries=4):
+    last = ""
+    for i in range(retries):
+        try:
+            r = subprocess.run(["gh"] + args, input=body, capture_output=True, text=True, timeout=90)
+            if r.returncode == 0:
+                return r.stdout.strip(), True
+            last = (r.stderr or r.stdout).strip()
+            if "already exists" in last.lower():
+                return last, True
+        except subprocess.TimeoutExpired:
+            last = "timeout"
+        time.sleep(3 * (i + 1))
+    print(f"  gh failed: {' '.join(args)} :: {last[:160]}", file=sys.stderr)
+    return last, False
+
+def valid_labels(repo):
+    out, ok = gh(["label", "list", "-R", repo, "--limit", "200", "--json", "name", "-q", ".[].name"])
+    return set(out.splitlines()) if ok else set()
+
+def create_issue(repo, title, body, labels, valid, dry):
+    labels = [l for l in labels if l in valid]
+    if dry:
+        print(f"[dry] create {title[:70]!r} labels={labels}")
+        return {"number": 0, "id": 0}
+    args = ["issue", "create", "-R", repo, "-t", title, "-F", "-"]
+    for l in labels:
+        args += ["-l", l]
+    url, ok = gh(args, body=body)
+    if not ok:
+        return None
+    num = int(url.rstrip("/").split("/")[-1])
+    dbid, _ = gh(["api", f"repos/{repo}/issues/{num}", "-q", ".id"])
+    print(f"  created #{num} {title[:60]}")
+    return {"number": num, "id": int(dbid)}
+
+def link_sub_issue(repo, parent_num, child_id, dry):
+    if dry:
+        return True
+    _, ok = gh(["api", "-X", "POST", f"repos/{repo}/issues/{parent_num}/sub_issues",
+                "-F", f"sub_issue_id={child_id}"], retries=3)  # -F integer, db id
+    return ok
+
+def epic_fallback_body(epic, kids):
+    return (f"## Summary\n\nTracking epic: {epic['title']}\n\n"
+            f"Child issues carry the verified evidence and proposed fixes.")
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", required=True)
+    ap.add_argument("--specs", required=True)
+    ap.add_argument("--apply", action="store_true")
+    ap.add_argument("--epic-labels", default="tech-debt,Project Direction")
+    ap.add_argument("--footer", help="path to a markdown footer appended to every issue body")
+    a = ap.parse_args()
+    dry = not a.apply
+    data = json.load(open(a.specs))
+    valid = valid_labels(a.repo) if a.apply else set(["tech-debt", "Project Direction"])
+    footer = ("\n\n" + open(a.footer).read()) if a.footer else ""
+    epic_labels = [x for x in a.epic_labels.split(",") if x]
+
+    epic_rec, child_by_epic = {}, {e["key"]: [] for e in data["epics"]}
+    print("=== EPICS ===")
+    for e in data["epics"]:
+        kids = [c for c in data["children"] if c["epic_key"] == e["key"]]
+        body = (e.get("body_md") or epic_fallback_body(e, kids)) + footer
+        rec = create_issue(a.repo, e["title"], body, epic_labels, valid, dry)
+        epic_rec[e["key"]] = rec
+
+    print("\n=== CHILDREN ===")
+    for c in data["children"]:
+        rec = create_issue(a.repo, c["title"], (c["body_md"] + footer),
+                           c.get("labels", ["tech-debt"]), valid, dry)
+        if not rec:
+            continue
+        rec.update(title=c["title"], size=c.get("size", "?"))
+        rec["linked"] = link_sub_issue(a.repo, epic_rec[c["epic_key"]]["number"], rec["id"], dry)
+        child_by_epic[c["epic_key"]].append(rec)
+
+    print("\n=== CHILD MAPS ===")
+    for e in data["epics"]:
+        kids = child_by_epic[e["key"]]
+        lines = ["\n\n## Child issue map\n"] + [
+            f"- [ ] {('#'+str(k['number'])) if not dry else '#?'} ({k.get('size','?')}) {k['title']}"
+            + ("" if k.get("linked") else " *(see map)*") for k in kids]
+        if dry:
+            print(f"[dry] epic {e['key']}: {len(kids)} children")
+            continue
+        cur, _ = gh(["issue", "view", str(epic_rec[e["key"]]["number"]), "-R", a.repo, "--json", "body", "-q", ".body"])
+        gh(["issue", "edit", str(epic_rec[e["key"]]["number"]), "-R", a.repo, "-F", "-"], body=cur + "\n".join(lines))
+        print(f"  updated epic #{epic_rec[e['key']]['number']} ({len(kids)} children)")
+
+    print("\n=== TREE ===")
+    for e in data["epics"]:
+        er = epic_rec[e["key"]]
+        print(f"EPIC #{er['number']} {e['title']}")
+        for k in child_by_epic[e["key"]]:
+            print(f"   #{k['number']} ({k.get('size','?')}) {'sub' if k.get('linked') else 'map'} {k['title'][:60]}")
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/rust-hygiene-audit/scripts/measure_clippy.py
+++ b/.agents/skills/rust-hygiene-audit/scripts/measure_clippy.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Measure clippy pedantic+nursery warnings and triage them.
+
+Runs `cargo clippy --workspace --lib -- -W clippy::pedantic -W clippy::nursery`
+without modifying any files, aggregates warnings per lint, and prints a
+promote-vs-defer triage. Writes <out>/clippy.json (raw), <out>/clippy-triage.md.
+
+Usage:
+  measure_clippy.py --worktree . --out /tmp/hygiene [--no-build]
+"""
+import argparse, json, os, subprocess, sys, collections
+
+# Senior triage for a *compiler* codebase. These are defaults, not gospel —
+# re-judge per repo. The reasoning lives in references/lint-triage.md.
+PROMOTE = {  # high signal-to-churn: idiom, ownership, dead surface, complexity
+ "manual_let_else","explicit_iter_loop","redundant_closure_for_method_calls","implicit_clone",
+ "map_unwrap_or","single_match_else","unnested_or_patterns","needless_pass_by_ref_mut",
+ "needless_pass_by_value","default_trait_access","assigning_clones","branches_sharing_code",
+ "useless_let_if_seq","needless_continue","elidable_lifetime_names","unused_self",
+ "wildcard_imports","struct_excessive_bools","format_push_string","redundant_pub_crate",
+ "case_sensitive_file_extension_comparisons","too_many_lines"}
+DEFER = {  # mostly intentional in a compiler (numeric casts, must_use, doc pedantry)
+ "cast_possible_truncation","cast_lossless","cast_precision_loss","cast_sign_loss",
+ "must_use_candidate","return_self_not_must_use","missing_panics_doc","missing_errors_doc",
+ "too_long_first_doc_paragraph","items_after_statements","if_not_else","option_if_let_else"}
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--worktree", default=".")
+    ap.add_argument("--out", default="/tmp/hygiene")
+    ap.add_argument("--no-build", action="store_true", help="skip clippy, only re-triage an existing clippy.json")
+    a = ap.parse_args()
+    os.makedirs(a.out, exist_ok=True)
+    raw = os.path.join(a.out, "clippy.json")
+
+    if not a.no_build:
+        print("Running clippy (pedantic+nursery, libs only)...", file=sys.stderr)
+        cmd = ["cargo", "clippy", "--workspace", "--lib", "--message-format=json",
+               "--", "-W", "clippy::pedantic", "-W", "clippy::nursery"]
+        with open(raw, "w") as f:
+            subprocess.run(cmd, cwd=a.worktree, stdout=f, stderr=subprocess.DEVNULL)
+
+    counts = collections.Counter()
+    with open(raw) as f:
+        for line in f:
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                m = json.loads(line)
+            except Exception:
+                continue
+            if m.get("reason") != "compiler-message":
+                continue
+            msg = m.get("message", {})
+            code = (msg.get("code") or {}).get("code") or ""
+            if code.startswith("clippy::") and msg.get("level") == "warning":
+                counts[code] += 1
+
+    total = sum(counts.values())
+    out = [f"# Clippy pedantic+nursery measurement", "", f"Total warnings: {total}", ""]
+    out.append("## Recommend PROMOTE (staged, signal > churn)")
+    for l, n in counts.most_common():
+        if l.replace("clippy::", "") in PROMOTE:
+            out.append(f"- {n:6d}  {l}")
+    out.append("\n## Recommend ALLOW/DEFER (mostly intentional in a compiler)")
+    for l, n in counts.most_common():
+        if l.replace("clippy::", "") in DEFER:
+            out.append(f"- {n:6d}  {l}")
+    out.append("\n## Uncategorized (judge per repo)")
+    for l, n in counts.most_common():
+        k = l.replace("clippy::", "")
+        if k not in PROMOTE and k not in DEFER:
+            out.append(f"- {n:6d}  {l}")
+    text = "\n".join(out)
+    with open(os.path.join(a.out, "clippy-triage.md"), "w") as f:
+        f.write(text + "\n")
+    print(text)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/agents/hygiene-audit-workflow.mjs
+++ b/scripts/agents/hygiene-audit-workflow.mjs
@@ -1,0 +1,215 @@
+export const meta = {
+  name: 'tsz-hygiene-audit',
+  description: 'Audit tsz for DRY violations + code-hygiene debt; emit verified, deduped, hierarchical GitHub issue specs',
+  whenToUse: 'Deep codebase hygiene sweep producing parent/child tech-debt issue specs',
+  phases: [
+    { title: 'Survey', detail: 'per-crate DRY auditors + cross-cutting concern auditors' },
+    { title: 'Cluster', detail: 'dedup vs open issues, bucket into epic taxonomy' },
+    { title: 'Verify', detail: 'adversarially confirm each finding against real code' },
+    { title: 'Author', detail: 'write full techdebt-template bodies for survivors' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+const WT = '/Users/mohsen/code/tsz-pr12885' // worktree pinned to origin/main
+const ISSUES = '/tmp/tsz-hygiene/open-issues.json' // dedup corpus (number,title,labels)
+
+const PERSONA = [
+  'You are a deeply senior Rust compiler engineer. Simplicity, DRY, and clean',
+  'code are your religion: you prize zero-cost abstractions, eliminating',
+  'boilerplate via macros / derive_more / newtypes, small focused modules,',
+  'idiomatic error handling, and a tight Clippy posture. You are skeptical and',
+  'EVIDENCE-DRIVEN: every finding MUST carry a real `file:line` citation you',
+  'verified by reading the code in this repo. You never report vague smells,',
+  'cosmetic nits, or anything a formatter/clippy already auto-fixes trivially.',
+  '',
+  `All analysis targets the worktree at ${WT} (pinned to origin/main).`,
+  'Use absolute paths under that root. Use ripgrep (rg), wc, and Read.',
+  '',
+  'IMPORTANT architecture context (from .claude/CLAUDE.md):',
+  '- Pipeline: scanner -> parser -> binder -> checker -> solver -> emitter.',
+  '- Identity handles are u32 newtypes: TypeId, SymbolId, FlowNodeId, Atom, DefId.',
+  '- Hard 2000-physical-line cap per source/test file (no local allowlists).',
+  '- Anti-hardcoding gate: no identifier/file-name string checks in compiler logic.',
+  '- A separate agent is actively paying down ARCHITECTURE-BOUNDARY debt',
+  '  (checker/binder/solver god-objects, TypeEnvironment dup, option engines).',
+  '  Do NOT propose architecture-boundary refactors that overlap those; focus on',
+  '  DRY/boilerplate/hygiene/lint-posture that those issues do not cover.',
+  '',
+  `DEDUP: read ${ISSUES} (JSON array of {number,title,labels}). If a finding`,
+  'overlaps an existing OPEN issue, still report it but set duplicate_of_existing',
+  'to that issue number so synthesis can drop or merge it.',
+].join('\n')
+
+const FINDING_PROPS = {
+  title: { type: 'string', description: 'Proposed issue title, format: techdebt(scope): <imperative>' },
+  concern: { type: 'string', enum: ['dry', 'derive', 'file-size', 'clippy', 'error-handling', 'naming', 'dead-code', 'api'] },
+  crate: { type: 'string' },
+  structural_rule: { type: 'string', description: 'When <condition>, idiomatic Rust does X; tsz does Y at <location>.' },
+  evidence: { type: 'array', items: { type: 'string' }, description: 'file:line citations w/ short quote; at least 2 distinct sites for a DRY claim' },
+  why_it_matters: { type: 'string' },
+  proposed_fix: { type: 'string', description: 'Concrete idiomatic fix (macro, derive_more, newtype, split, lint).' },
+  size: { type: 'string', enum: ['S', 'M', 'L'] },
+  duplicate_of_existing: { type: ['integer', 'null'] },
+}
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: { type: 'object', additionalProperties: false, required: ['title', 'concern', 'crate', 'structural_rule', 'evidence', 'why_it_matters', 'proposed_fix', 'size', 'duplicate_of_existing'], properties: FINDING_PROPS },
+    },
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 — Survey
+// ---------------------------------------------------------------------------
+phase('Survey')
+
+const CRATES = [
+  { name: 'tsz-solver', hint: 'relations, evaluation, inference, instantiation, narrowing, type construction, caches' },
+  { name: 'tsz-checker', hint: 'AST orchestration, diagnostics, error_reporter, type computation, query_boundaries' },
+  { name: 'tsz-emitter', hint: 'JS/DTS emit transforms, declaration emitter, printers, helpers' },
+  { name: 'tsz-binder', hint: 'symbols, scopes, flow graph, atom migration' },
+  { name: 'tsz-core', hint: 'module_resolver, config/options, parallel driver, source files' },
+  { name: 'tsz-parser', hint: 'AST in arenas, recovery, jsdoc' },
+  { name: 'tsz-lsp', hint: 'providers, hover, completions, workspace symbols' },
+  { name: 'tsz-cli', hint: 'driver, tsz_server binary, plan' },
+  { name: 'tsz-common + tsz-scanner + tsz-lowering', hint: 'interning, perf_counters, lexing, lowering shared utilities' },
+]
+
+const CONCERNS = [
+  { key: 'derive', label: 'derive-bloat', task:
+    'Audit derive & trait-impl BOILERPLATE across all crates. Specifically: (1) the ~15 `pub struct XxxId(u32)` identity newtypes (TypeId, SymbolId, DefId, FlowNodeId, Atom, SourceId, TypeListId, ObjectShapeId, ...) that each repeat the same Copy/Clone/Debug/PartialEq/Eq/Hash[/Ord] derive cluster plus hand-written Display/From/index helpers — propose a single `define_id!` macro or small internal proc-macro crate. (2) ~334 derive sites with >=5 traits and the 99x `Clone, Debug, Serialize, Deserialize` cluster — where can derive_more (From/Into/Deref/Display/Add) or a shared derive alias remove boilerplate? (3) ~51 hand-written `impl Default` that are derivable (clippy::derivable_impls). (4) repeated manual trait impls (Hash/PartialEq/Ord) that could be derived or macro-generated. Cite concrete structs.' },
+  { key: 'file-size', label: 'split-debt', task:
+    'Audit MODULARIZATION debt. Find: (1) files OVER the hard 2000-line cap (contract violation) — there are ~6. (2) files parked in 1900-2000 lines (~131) that are deferred splits; identify the worst offenders by responsibility-count, not just length. (3) god-modules / core.rs files that aggregate unrelated concerns. Propose concrete module decompositions. Do NOT just list lengths — name the distinct responsibilities that should split out.' },
+  { key: 'clippy', label: 'clippy-posture', task:
+    `Audit the LINT POSTURE for prevention. Read ${WT}/Cargo.toml [workspace.lints] and ${WT}/crates/clippy.toml. Today: correctness/style/perf/complexity=deny + ~6 hand-picked warns; pedantic and nursery are OFF; no unwrap_used/expect_used discipline; nothing lints derive bloat or file size. Propose a CONCRETE, staged lint-tightening plan: which pedantic/nursery lints to promote (e.g. derivable_impls, use_self, redundant_clone[on], equatable_if_let, needless_pass_by_value, trivially_copy_pass_by_ref, semicolon_if_nothing_returned, manual_let_else, explicit_iter_loop), which to allow, unwrap/expect discipline outside tests aligned with the existing allow-unwrap-in-tests=false philosophy, and whether a CI file-size ratchet should back the 2000-line rule. Justify each promotion by what class of future bug/debt it prevents. Note any lints that would create churn and should be deferred.` },
+  { key: 'error-handling', label: 'error-handling', task:
+    'Audit ERROR-HANDLING & panic discipline. Find: unwrap()/expect()/panic!/unreachable!/todo! in non-test library paths that could be Result/Option flows; repeated ad-hoc error construction that should share an error type; inconsistent Result vs Option vs sentinel returns for the same kind of failure; .clone() that masks borrow issues (redundant_clone is already a warn — look for ones it misses). Cite sites and propose idiomatic fixes.' },
+  { key: 'dry-cross', label: 'cross-crate-dry', task:
+    'Audit CROSS-CRATTE / shared-utility duplication: helper functions, constants, small algorithms (string interning helpers, span math, name mangling, hashing, small visitors) re-implemented in multiple crates that should live once in tsz-common. Find copy-pasted utility blocks across crate boundaries. Cite >=2 sites per claim.' },
+  { key: 'dead-code', label: 'dead-code-api', task:
+    'Audit DEAD/REDUNDANT abstraction & API surface: pub items with no external users, dead struct fields (e.g. the known dead IdentifierData.type_arguments), feature flags that are always-on/off, duplicate type aliases, wrapper types that only forward, and over-broad pub(crate) surfaces. Cite sites. Avoid overlap with the active architecture-boundary agent.' },
+]
+
+const surveyTasks = []
+for (const c of CRATES) {
+  surveyTasks.push(() => agent(
+    `${PERSONA}\n\nTASK: Audit crate ${c.name} (${c.hint}) ONLY for DRY violations and code-hygiene debt that is LOCAL to this crate's domain: copy-pasted logic across functions/modules, parallel/near-duplicate match arms, repeated boilerplate, duplicated small algorithms, near-identical structs, and modules doing too much. For each DRY claim cite at least two distinct file:line sites. Report your 4-8 highest-value findings only. Skip architecture-boundary refactors owned by other agents.`,
+    { label: `survey:${c.name.split(' ')[0]}`, phase: 'Survey', schema: FINDINGS_SCHEMA }
+  ))
+}
+for (const c of CONCERNS) {
+  surveyTasks.push(() => agent(
+    `${PERSONA}\n\nTASK (cross-cutting concern = ${c.label}): ${c.task}\n\nReport your 4-10 highest-value findings only, each with verified file:line evidence.`,
+    { label: `survey:${c.label}`, phase: 'Survey', schema: FINDINGS_SCHEMA }
+  ))
+}
+
+const surveyResults = await parallel(surveyTasks)
+const allFindings = surveyResults.filter(Boolean).flatMap(r => r.findings || [])
+log(`Survey collected ${allFindings.length} raw findings from ${surveyTasks.length} auditors`)
+
+// ---------------------------------------------------------------------------
+// Phase 2 — Cluster + dedup (barrier: needs all findings + the open-issue corpus)
+// ---------------------------------------------------------------------------
+phase('Cluster')
+
+const EPICS = [
+  { key: 'clippy-posture', title: 'techdebt(repo): tighten the Clippy/lint posture to prevent hygiene regressions' },
+  { key: 'derive-boilerplate', title: 'techdebt(repo): eliminate derive bloat and identity/serde/Default boilerplate' },
+  { key: 'module-split', title: 'techdebt(repo): modularize oversized and near-cap files' },
+  { key: 'dry-logic', title: 'techdebt(repo): eliminate duplicated compiler logic (DRY sweep)' },
+  { key: 'general-hygiene', title: 'techdebt(repo): general hygiene — error handling, dead code, shared utilities' },
+]
+
+const CLUSTER_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['children', 'dropped'],
+  properties: {
+    children: { type: 'array', items: { type: 'object', additionalProperties: false,
+      required: ['epic_key', 'title', 'concern', 'crate', 'structural_rule', 'evidence', 'why_it_matters', 'proposed_fix', 'size'],
+      properties: {
+        epic_key: { type: 'string', enum: EPICS.map(e => e.key) },
+        ...FINDING_PROPS,
+      } } },
+    dropped: { type: 'array', items: { type: 'object', additionalProperties: false, required: ['title', 'reason'], properties: { title: { type: 'string' }, reason: { type: 'string' } } } },
+  },
+}
+
+const cluster = await agent(
+  `${PERSONA}\n\nYou are the SYNTHESIS lead. Below are ${allFindings.length} raw findings from a fan-out audit (JSON). ` +
+  `Read the open-issue corpus at ${ISSUES} and DROP any finding that materially overlaps an existing OPEN issue (record it in "dropped" with the existing issue number in the reason). ` +
+  `MERGE near-duplicate findings into one strong child. Then assign every surviving child to exactly one epic from this taxonomy: ` +
+  EPICS.map(e => `${e.key} = "${e.title}"`).join('; ') + '. ' +
+  `Prefer FEWER, STRONGER children (merge aggressively); each child must be independently actionable and PR-sized. Keep the best evidence when merging. ` +
+  `Output children (with merged evidence) and the dropped list.\n\nRAW FINDINGS:\n` + JSON.stringify(allFindings),
+  { label: 'cluster:synthesis', phase: 'Cluster', schema: CLUSTER_SCHEMA }
+)
+const candidates = (cluster?.children || [])
+log(`Clustered into ${candidates.length} candidate children (${(cluster?.dropped || []).length} dropped as dup/weak)`)
+
+// ---------------------------------------------------------------------------
+// Phase 3+4 — Verify (adversarial) then Author (pipeline per child)
+// ---------------------------------------------------------------------------
+const VERIFY_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['keep', 'confidence', 'verified_evidence', 'notes'],
+  properties: {
+    keep: { type: 'boolean' },
+    confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+    verified_evidence: { type: 'array', items: { type: 'string' }, description: 'corrected/confirmed file:line citations actually read' },
+    notes: { type: 'string' },
+  },
+}
+const AUTHOR_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['title', 'labels', 'size', 'epic_key', 'body_md'],
+  properties: {
+    title: { type: 'string' },
+    labels: { type: 'array', items: { type: 'string' } },
+    size: { type: 'string', enum: ['S', 'M', 'L'] },
+    epic_key: { type: 'string', enum: EPICS.map(e => e.key) },
+    body_md: { type: 'string', description: 'Full GitHub issue body in markdown following the techdebt template' },
+  },
+}
+
+const authored = await pipeline(
+  candidates,
+  // Stage 1: adversarial verification against the real code
+  (child) => agent(
+    `${PERSONA}\n\nADVERSARIAL VERIFY. Try to REFUTE this candidate tech-debt issue. Open the cited files in ${WT} and check: ` +
+    `(a) does the code actually exhibit the claimed duplication/bloat/debt at those lines? (b) is it already idiomatic / auto-fixed by existing lints? ` +
+    `(c) is it actually a duplicate of an existing OPEN issue in ${ISSUES}? (d) for a DRY claim, are there genuinely >=2 real duplicated sites? ` +
+    `Correct or tighten the evidence to what you actually verified. Default keep=false if evidence is weak, stale, or unverifiable.\n\nCANDIDATE:\n` + JSON.stringify(child),
+    { label: `verify:${child.concern}/${child.crate}`.slice(0, 48), phase: 'Verify', schema: VERIFY_SCHEMA }
+  ).then(v => ({ child, v })),
+  // Stage 2: author the full issue body for survivors only
+  (res, child) => {
+    if (!res || !res.v || !res.v.keep || res.v.confidence === 'low') return null
+    const verified = { ...child, evidence: res.v.verified_evidence?.length ? res.v.verified_evidence : child.evidence, verify_notes: res.v.notes }
+    return agent(
+      `${PERSONA}\n\nAUTHOR the GitHub issue body for this VERIFIED tech-debt finding. Follow this exact template (markdown), matching the repo's existing techdebt issues:\n` +
+      '\n## Summary\n<one paragraph + the structural rule: "When <condition>, idiomatic Rust does X; tsz does Y at <owner>.">\n' +
+      '\n## Evidence\n<bulleted file:line citations with short quotes — only the verified ones>\n' +
+      '\n## Why it matters\n<concrete maintenance/correctness/perf cost; reference DRY/boilerplate counts>\n' +
+      '\n## Proposed fix\n<concrete idiomatic Rust: macro/derive_more/newtype/module split/lint promotion; sized S/M/L; multi-PR if L>\n' +
+      '\n## Risks / coordination\n<behavior-preservation, ordering, overlap with other agents, verification commands>\n' +
+      `\nDo NOT invent evidence beyond what is provided. Set labels to ["tech-debt"] plus at most one crate/area label from this set if clearly applicable: solver, checker, binder, parser, emitter, emit, lsp, cli, scanner, performance, ci, chore. Set epic_key=${child.epic_key}.\n\nVERIFIED FINDING:\n` + JSON.stringify(verified),
+      { label: `author:${child.concern}`.slice(0, 48), phase: 'Author', schema: AUTHOR_SCHEMA }
+    )
+  }
+)
+
+const children = authored.filter(Boolean)
+log(`Authored ${children.length} verified issue bodies`)
+
+return {
+  epics: EPICS,
+  children,
+  dropped: cluster?.dropped || [],
+  stats: { raw_findings: allFindings.length, candidates: candidates.length, authored: children.length },
+}


### PR DESCRIPTION
## Summary

Adds a repo-local skill `rust-hygiene-audit` that codifies the DRY + code-hygiene audit workflow, plus the reusable fan-out workflow it drives. This is tooling/process, not a behavior change — no crate source is touched.

What it captures (the workflow run that produced it filed epics #13409–#13413 with 29 verified children and assigned Priority/Effort across all open issues):

1. **Measure clippy posture** — `scripts/measure_clippy.py` runs `pedantic`+`nursery` libs-only and triages warnings into promote-vs-defer (the audit found 13,615 warnings the current floor lets through).
2. **Fan-out audit** — `scripts/agents/hygiene-audit-workflow.mjs`: per-crate DRY auditors + cross-cutting concern auditors → dedup vs open issues → **adversarial verification of every finding against source** → authored issue bodies.
3. **Create hierarchy** — `scripts/create_issues.py`: epics + children with native parent/child sub-issues + child-map fallback.
4. **Assign Fields** — `scripts/assign_fields.py`: discovers Priority/Effort single-select fields and assigns by rule (correctness > speed > tech-debt; effort from size).

References bundle the lint-triage rationale, the tech-debt issue template, and the GitHub sub-issues/Issue-Fields API gotchas (`-F` integer for `sub_issue_id`; `setIssueFieldValue` needs only `repo` scope; `createIssueField` needs `admin:org`).

Goal: hold

This serves **hold**: it is prevention/maintainability tooling that backs the parity floor and structures tech-debt paydown into evidence-backed, non-duplicating issues. It changes no compiler behavior.

## Provenance

Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- `python3 -m py_compile .agents/skills/rust-hygiene-audit/scripts/*.py` — all compile.
- `create_issues.py --specs result.json` (dry-run) reproduces the epic/child tree.
- `assign_fields.py` discovers fields and produces the expected Priority/Effort distribution.
- `python3 scripts/agents/llm-context-audit.py` — `status=pass`, `finding_count=0` (SKILL.md 119 lines, under the 120 budget).
- The bundled workflow already executed end-to-end (77 agents → 29 verified issues), proving the script runs under the Workflow runtime.
- No Rust source changed; pre-commit `cargo fmt` reported no staged Rust files.
