### PR TITLE
bench(perf): add DOM gate determinism smoke rows (#13245)

### DIFF
--- a/scripts/perf/forced-parallel-project-determinism.sh
+++ b/scripts/perf/forced-parallel-project-determinism.sh
@@ -11,7 +11,8 @@ Usage:
 
 Options:
   --row NAME        Project row to check (default: ts-toolbelt-project).
-                    Supported: ts-toolbelt-project, utility-types-project.
+                    Supported: ts-toolbelt-project, utility-types-project,
+                    dom-smoke, webworker-smoke, dom-webworker-smoke.
   --tsconfig PATH   Existing tsconfig to check instead of materializing a row.
                     Uses custom-tsconfig as the output label unless --row is
                     also provided as a descriptive label.
@@ -129,6 +130,52 @@ tsz_sync_project_row_groups
 
 mkdir -p "$FIXTURE_ROOT" "$OUT_ROOT"
 
+write_global_lib_smoke_fixture() {
+  local name="$1"
+  local libs_json="$2"
+  local global_interface="$3"
+  local global_object="$4"
+  local global_property="$5"
+  local root="$FIXTURE_ROOT/$name"
+
+  rm -rf "$root"
+  mkdir -p "$root"
+
+  cat >"$root/tsconfig.json" <<EOF
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": $libs_json
+  },
+  "files": ["augment.ts", "use.ts"]
+}
+EOF
+
+  cat >"$root/augment.ts" <<EOF
+declare global {
+  interface $global_interface {
+    $global_property: string;
+  }
+
+  interface Console {
+    ${global_property}Log(value: string): void;
+  }
+}
+
+export {};
+EOF
+
+  cat >"$root/use.ts" <<EOF
+$global_object.$global_property = "stable";
+console.${global_property}Log($global_object.$global_property);
+EOF
+
+  printf '%s\n' "$root/tsconfig.json"
+}
+
 prepare_row() {
   if [[ -n "$TSCONFIG_INPUT" ]]; then
     if [[ ! -f "$TSCONFIG_INPUT" ]]; then
@@ -149,6 +196,30 @@ prepare_row() {
       tsz_ensure_git_fixture "utility-types" "$UTILITY_TYPES_REPO" "$UTILITY_TYPES_REF" "$FIXTURE_ROOT/utility-types"
       tsz_write_utility_types_config "$FIXTURE_ROOT/utility-types/tsconfig.tsz-guard.json"
       printf '%s\n' "$FIXTURE_ROOT/utility-types/tsconfig.tsz-guard.json"
+      ;;
+    dom-smoke)
+      write_global_lib_smoke_fixture \
+        "dom-smoke" \
+        '["es2020", "dom"]' \
+        "Window" \
+        "window" \
+        "tszDomGateSmoke"
+      ;;
+    webworker-smoke)
+      write_global_lib_smoke_fixture \
+        "webworker-smoke" \
+        '["es2020", "webworker"]' \
+        "WorkerGlobalScope" \
+        "self" \
+        "tszWebworkerGateSmoke"
+      ;;
+    dom-webworker-smoke)
+      write_global_lib_smoke_fixture \
+        "dom-webworker-smoke" \
+        '["es2020", "dom", "webworker"]' \
+        "Window" \
+        "window" \
+        "tszDomWebworkerGateSmoke"
       ;;
     *)
       echo "error: unsupported row: $ROW" >&2


### PR DESCRIPTION
Goal: fast

## Summary
- Add built-in `dom-smoke`, `webworker-smoke`, and `dom-webworker-smoke` rows to `scripts/perf/forced-parallel-project-determinism.sh`.
- Each smoke row materializes a tiny two-file project with lib-backed global augmentation plus `Console`/global-object use.
- Keep the DOM/webworker single-worker gate unchanged; this only improves the exit-criteria harness for #13245.

## Structural rule
When a DOM or webworker-lib project is checked with forced parallel fresh checkers, tsz should produce byte-identical diagnostics to the sequential baseline before the global-lib gate can be narrowed or removed. The harness now includes minimal DOM/webworker witnesses for that determinism proof instead of requiring every check to use a large external project row.

## Owner layer
Benchmark/performance harness only. No checker, solver, binder, emitter, CLI dispatch policy, diagnostic, or semantic behavior change.

## Adjacent matrix
- `dom-smoke` covers `lib.dom.d.ts`, `Window`, and `Console` augmentation/use.
- `webworker-smoke` covers `lib.webworker.d.ts`, `WorkerGlobalScope`, `self`, and `Console` augmentation/use.
- `dom-webworker-smoke` covers the combined lib set called out by #13245.
- Existing `ts-toolbelt-project`, `utility-types-project`, and `--tsconfig` harness paths are unchanged.
- The forced-parallel env var remains diagnosis-only; this PR does not lift or narrow the gate.

## Verification
- No local tests or harness runs per current instruction.
- Pre-commit hook ran during commit; no staged Rust files changed.
- Draft CI Light Summary passed for head `27886747e08193541ea68e4ca375f0a780ee7104`.
- Ready-review CI is expected to provide full `CI Summary` before merge queue.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium

Refs #13245.
Refs #13250.
