### PR TITLE
bench: publish project hotspot micro rows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1045,6 +1045,9 @@ jobs:
           - label: synthetic
             timeout: 120
             filter: '[0-9]+ classes|[0-9]+ generic functions|DeepPartial optional-chain|Shallow optional-chain|[0-9]+ union members'
+          - label: project-hotspots
+            timeout: 120
+            filter: 'Recursive utility aliases|Indexed access hotspot|Remapped accessor hotspot|Conditional infer hotspot|Object spread hotspot|Contextual callback hotspot'
           - label: solver-stress
             timeout: 120
             filter: 'Recursive generic depth|Conditional dist N|Mapped type keys|Template literal N|Deep subtype depth|Intersection N|Infer stress N|CFA branches'
@@ -1377,7 +1380,7 @@ jobs:
         run: |
           set -euo pipefail
           mapfile -t json_files < <(find bench-artifacts -name 'bench-results-*.json' -type f | sort)
-          expected_shards=8
+          expected_shards=9
           echo "json_count=${#json_files[@]}" >> "$GITHUB_OUTPUT"
           echo "expected_json_count=${expected_shards}" >> "$GITHUB_OUTPUT"
           if [[ "${#json_files[@]}" -eq 0 ]]; then

--- a/crates/tsz-website/src/_data/benchmark_data.js
+++ b/crates/tsz-website/src/_data/benchmark_data.js
@@ -880,6 +880,9 @@ function categoryFor(name, lines) {
   if (name.startsWith("ts-toolbelt/")) return "Single file: ts-toolbelt";
   if (name.startsWith("ts-essentials/")) return "Single file: ts-essentials";
   if (isTinyBenchmark(lines)) return "Tiny File Benchmarks";
+  if (/Recursive utility aliases|Indexed access hotspot|Remapped accessor hotspot|Conditional infer hotspot|Object spread hotspot|Contextual callback hotspot/i.test(name)) {
+    return "Project Hotspot Microbenchmarks";
+  }
   if (/Recursive generic|Conditional dist|Mapped type/i.test(name)) return "Solver Stress Tests";
   if (/\d+\s+classes|\d+\s+generic functions|\d+\s+union members|DeepPartial|Shallow optional/i.test(name)) {
     return "Synthetic Type Workloads";
@@ -960,6 +963,10 @@ function categoryMeta(category) {
       title: "Generated type workloads",
       description: "Generated stress tests that isolate specific type-system patterns.",
     },
+    "Project Hotspot Microbenchmarks": {
+      title: "Project hotspot probes",
+      description: "Focused synthetic rows that isolate hot patterns found in real project benchmark regressions.",
+    },
     "Solver Stress Tests": {
       title: "Solver stress",
       description: "Upper-bound tests for recursive, mapped, and conditional type complexity.",
@@ -1029,6 +1036,7 @@ function benchmarkKind(category) {
   if (isProjectCategory(category)) return "project";
   if (isExternalLibraryCategory(category)) return "library file";
   if (category === "Tiny File Benchmarks") return "startup";
+  if (category === "Project Hotspot Microbenchmarks") return "hotspot";
   if (category === "Solver Stress Tests") return "solver stress";
   if (category === "Synthetic Type Workloads") return "synthetic";
   return "benchmark";
@@ -1074,6 +1082,24 @@ function benchmarkFocus(row, category) {
   }
   if (name.includes("union members")) {
     return "Union construction, reduction, and assignability checks.";
+  }
+  if (name.includes("Recursive utility aliases")) {
+    return "Recursive utility alias applications that stress generic instantiation, substitution, and cache reuse.";
+  }
+  if (name.includes("Indexed access hotspot")) {
+    return "Indexed access over mapped reader helpers, a reduced shape from project-row property access pressure.";
+  }
+  if (name.includes("Remapped accessor hotspot")) {
+    return "Mapped-type key remapping with accessor-like property surfaces.";
+  }
+  if (name.includes("Conditional infer hotspot")) {
+    return "Conditional infer extraction chains that probe repeated evaluation and inference reuse.";
+  }
+  if (name.includes("Object spread hotspot")) {
+    return "Object spread inference and property merging from project-style update pipelines.";
+  }
+  if (name.includes("Contextual callback hotspot")) {
+    return "Contextual typing through callback dispatch tables with repeated generic payload shapes.";
   }
   if (name.includes("classes")) {
     return "Class declaration binding plus constructor/member shape checking.";
@@ -1417,6 +1443,7 @@ function buildGroupedBenchmarks(data) {
     "Single file: ts-essentials",
     "General Benchmarks",
     "Synthetic Type Workloads",
+    "Project Hotspot Microbenchmarks",
     "Solver Stress Tests",
     "Tiny File Benchmarks",
   ];

--- a/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
+++ b/scripts/bench/test-bench-workflow-cloudbuild-prep.mjs
@@ -225,7 +225,7 @@ assert.match(
 
 assert.match(
   workflow,
-  /- id: merge[\s\S]+expected_shards=8[\s\S]+echo "complete=false" >> "\$GITHUB_OUTPUT"[\s\S]+node scripts\/bench\/merge-results\.mjs/,
+  /- id: merge[\s\S]+expected_shards=9[\s\S]+echo "complete=false" >> "\$GITHUB_OUTPUT"[\s\S]+node scripts\/bench\/merge-results\.mjs/,
   "bench publish should merge partial shard sets into a diagnostic artifact instead of discarding completed shard JSON",
 );
 

--- a/scripts/bench/test-bench-workflow-micro-coverage.mjs
+++ b/scripts/bench/test-bench-workflow-micro-coverage.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const workflow = fs.readFileSync(".github/workflows/bench.yml", "utf8");
+const runner = fs.readFileSync("scripts/bench/bench-vs-tsgo.sh", "utf8");
+const websiteData = fs.readFileSync(
+  "crates/tsz-website/src/_data/benchmark_data.js",
+  "utf8",
+);
+
+function workflowShardFilters() {
+  return [...workflow.matchAll(/^\s+- label: ([^\n]+)\n\s+timeout: \d+\n\s+filter: '([^']+)'/gm)]
+    .map((match) => ({
+      label: match[1].trim(),
+      pattern: match[2],
+      regex: new RegExp(match[2]),
+    }));
+}
+
+function expandNameTemplate(template, frames) {
+  if (template.includes("$(") || template.includes("${rel") || template.includes("$label")) {
+    return [];
+  }
+
+  const envs = frames.reduce((acc, frame) => (
+    acc.flatMap((env) => frame.values.map((value) => ({ ...env, [frame.name]: value })))
+  ), [{}]);
+
+  return envs.flatMap((env) => {
+    let name = template;
+    for (const [key, value] of Object.entries(env)) {
+      name = name
+        .replaceAll(`\${${key}}`, value)
+        .replaceAll(`$${key}`, value);
+    }
+    return name.includes("$") ? [] : [name];
+  });
+}
+
+function parseBenchmarkNames() {
+  const names = new Set();
+  const frames = [];
+
+  for (const line of runner.split(/\r?\n/)) {
+    const loop = line.match(/^\s*for\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+in\s+([0-9 ]+);\s+do\s*$/);
+    if (loop) {
+      frames.push({
+        name: loop[1],
+        values: loop[2].trim().split(/\s+/),
+      });
+      continue;
+    }
+
+    if (/^\s*done\s*$/.test(line) && frames.length > 0) {
+      frames.pop();
+      continue;
+    }
+
+    const benchmark = line.match(/\brun_benchmark\s+"([^"]*)"/);
+    if (!benchmark) continue;
+    for (const name of expandNameTemplate(benchmark[1], frames)) {
+      names.add(name);
+    }
+  }
+
+  return [...names].sort();
+}
+
+const shardFilters = workflowShardFilters();
+
+assert.deepEqual(
+  shardFilters.map((filter) => filter.label),
+  [
+    "compiler-files",
+    "synthetic",
+    "project-hotspots",
+    "solver-stress",
+    "algorithmic-bct",
+    "algorithmic-constraint",
+    "algorithmic-mapped",
+    "projects",
+    "large-ts-repo",
+  ],
+  "bench workflow shard labels should stay explicit when adding timed benchmark families",
+);
+
+const benchmarkNames = parseBenchmarkNames();
+const missing = benchmarkNames.filter((name) => (
+  !shardFilters.some((filter) => filter.regex.test(name))
+));
+
+assert.deepEqual(
+  missing,
+  [],
+  "bench workflow shard filters should cover every statically named bench-vs-tsgo benchmark",
+);
+
+const projectHotspotFilter = shardFilters.find((filter) => filter.label === "project-hotspots");
+assert.ok(projectHotspotFilter, "bench workflow should have a dedicated project-hotspots shard");
+
+const projectHotspotRows = benchmarkNames.filter((name) => projectHotspotFilter.regex.test(name));
+assert.deepEqual(
+  projectHotspotRows,
+  [
+    "Conditional infer hotspot N=100",
+    "Conditional infer hotspot N=200",
+    "Conditional infer hotspot N=25",
+    "Conditional infer hotspot N=50",
+    "Contextual callback hotspot N=100",
+    "Contextual callback hotspot N=200",
+    "Contextual callback hotspot N=25",
+    "Contextual callback hotspot N=50",
+    "Indexed access hotspot N=100",
+    "Indexed access hotspot N=200",
+    "Indexed access hotspot N=25",
+    "Indexed access hotspot N=50",
+    "Object spread hotspot N=100",
+    "Object spread hotspot N=200",
+    "Object spread hotspot N=25",
+    "Object spread hotspot N=50",
+    "Recursive utility aliases N=120",
+    "Recursive utility aliases N=240",
+    "Recursive utility aliases N=30",
+    "Remapped accessor hotspot N=100",
+    "Remapped accessor hotspot N=200",
+    "Remapped accessor hotspot N=25",
+    "Remapped accessor hotspot N=50",
+  ],
+  "project-hotspots shard should publish all current project-derived micro rows",
+);
+
+assert.match(
+  websiteData,
+  /Project Hotspot Microbenchmarks/,
+  "website benchmark data should classify project-derived micro rows separately",
+);
+assert.match(
+  websiteData,
+  /Recursive utility aliases\|Indexed access hotspot\|Remapped accessor hotspot\|Conditional infer hotspot\|Object spread hotspot\|Contextual callback hotspot/,
+  "website benchmark category logic should recognize every project-hotspots shard row family",
+);
+
+console.log("bench workflow micro coverage tests passed");

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -410,6 +410,8 @@ run_lint() {
   node scripts/bench/test-benchmark-artifact-selection.mjs || return $?
   node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs || return $?
   node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs || return $?
+  node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs || return $?
+  node scripts/bench/test-bench-workflow-micro-coverage.mjs || return $?
   for script in scripts/ci/*type-challenges*.mjs; do
     node --check "$script" || return $?
   done


### PR DESCRIPTION
Goal: fast

## Summary
- Add a dedicated `project-hotspots` benchmark shard so project-derived micro rows from `bench-vs-tsgo.sh` are included in published benchmark artifacts.
- Classify those hotspot rows separately on the benchmark website instead of letting them fall into the generic bucket.
- Add a workflow coverage test that parses statically named `bench-vs-tsgo.sh` rows and fails when the benchmark matrix filters stop selecting them.

## Verification
- `node scripts/bench/test-bench-workflow-micro-coverage.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs`
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs`
- `node scripts/bench/test-merge-results.mjs`
- `node scripts/bench/test-gh-pages-benchmark-artifact-gate.mjs`
- `node scripts/bench/test-benchmark-artifact-selection.mjs`
- `node --check scripts/bench/test-bench-workflow-micro-coverage.mjs`
- `git diff --check`

## Provenance
Machine: Mohsens-MacBook-Pro.local
Assistant: codex
Model: gpt-5
Effort: high
