### PR TITLE
refactor(binder): out-of-line import-alias payload on Symbol (PR 2, #13072)

### DIFF
--- a/crates/tsz-binder/src/binding/declaration.rs
+++ b/crates/tsz-binder/src/binding/declaration.rs
@@ -964,7 +964,7 @@ impl BinderState {
                     .current_scope
                     .get(name)
                     .and_then(|sym_id| self.symbols.get(sym_id))
-                    .is_some_and(|sym| sym.import_module.is_some());
+                    .is_some_and(|sym| sym.import_module().is_some());
                 if name_conflicts_with_import {
                     self.record_module_augmentation_entry(&module_spec, name, idx);
                     return;

--- a/crates/tsz-binder/src/modules/import_export.rs
+++ b/crates/tsz-binder/src/modules/import_export.rs
@@ -60,10 +60,10 @@ impl BinderState {
                 sym.is_type_only = clause_type_only;
                 // Track module for cross-file resolution
                 if let Some(ref specifier) = module_specifier {
-                    sym.import_module = Some(specifier.clone());
+                    sym.set_import_module(Some(specifier.clone()));
                     // Default imports (`import X from "mod"`) resolve the module's
                     // **default** export, regardless of the local binding name.
-                    sym.import_name = Some("default".to_string());
+                    sym.set_import_name(Some("default".to_string()));
                 }
             }
             Arc::make_mut(&mut self.node_symbols).insert(clause.name.0, sym_id);
@@ -86,7 +86,7 @@ impl BinderState {
                         sym.is_type_only = clause_type_only;
                         // Track module for cross-file resolution
                         if let Some(ref specifier) = module_specifier {
-                            sym.import_module = Some(specifier.clone());
+                            sym.set_import_module(Some(specifier.clone()));
                         }
                     }
                     Arc::make_mut(&mut self.node_symbols).insert(clause.named_bindings.0, sym_id);
@@ -108,10 +108,10 @@ impl BinderState {
                         sym.is_type_only = clause_type_only;
                         // Track module for cross-file resolution
                         if let Some(ref specifier) = module_specifier {
-                            sym.import_module = Some(specifier.clone());
+                            sym.set_import_module(Some(specifier.clone()));
                             // Namespace import: mark as `*` so type display
                             // renders `typeof import("mod")` instead of `typeof ns`.
-                            sym.import_name = Some("*".to_string());
+                            sym.set_import_name(Some("*".to_string()));
                         }
                     }
                     Arc::make_mut(&mut self.node_symbols).insert(named.name.0, sym_id);
@@ -149,15 +149,15 @@ impl BinderState {
                         sym.is_type_only = spec_type_only;
                         // Track module and original name for cross-file resolution
                         if let Some(ref specifier) = module_specifier {
-                            sym.import_module = Some(specifier.clone());
+                            sym.set_import_module(Some(specifier.clone()));
                             // For renamed imports (import { foo as bar }), track original name
                             if let Some(prop_name) = prop_name {
-                                sym.import_name = Some(prop_name.to_string());
+                                sym.set_import_name(Some(prop_name.to_string()));
                             } else {
                                 // For non-renamed imports (import { foo }), still set
                                 // import_name so the checker can distinguish named
                                 // imports from namespace imports (import * as ns).
-                                sym.import_name = Some(name.to_string());
+                                sym.set_import_name(Some(name.to_string()));
                             }
                         }
                     }
@@ -220,7 +220,7 @@ impl BinderState {
                         // For valid merges (if any), this logic might need refinement,
                         // but for duplicates it doesn't matter much which one wins for resolution
                         // as long as we report the error.
-                        sym.import_module = Some(specifier.clone());
+                        sym.set_import_module(Some(specifier.clone()));
                     }
 
                     // Propagate type-only flag from `import type X = require('...')`
@@ -697,13 +697,13 @@ impl BinderState {
                                 if let Some(sym) = self.symbols.get_mut(sym_id) {
                                     sym.is_exported = true;
                                     sym.is_type_only = spec.is_type_only;
-                                    sym.import_module = Some(source_module.clone());
-                                    sym.import_name = Some(
+                                    sym.set_import_module(Some(source_module.clone()));
+                                    sym.set_import_name(Some(
                                         spec.original
                                             .as_deref()
                                             .unwrap_or(&spec.exported)
                                             .to_string(),
-                                    );
+                                    ));
                                 }
                                 Arc::make_mut(&mut self.node_symbols)
                                     .insert(spec.spec_idx.0, sym_id);
@@ -759,15 +759,15 @@ impl BinderState {
                         if is_umd {
                             // `export as namespace Foo` creates a global alias to the
                             // current file's external-module export surface.
-                            sym.import_module = Some(self.debugger.current_file.clone());
-                            sym.import_name = Some("*".to_string());
+                            sym.set_import_module(Some(self.debugger.current_file.clone()));
+                            sym.set_import_name(Some("*".to_string()));
                         } else if export.module_specifier.is_some()
                             && let Some(spec_node) = arena.get(export.module_specifier)
                             && let Some(lit) = arena.get_literal(spec_node)
                         {
-                            sym.import_module = Some(lit.text.clone());
+                            sym.set_import_module(Some(lit.text.clone()));
                             // Use '*' to indicate it's a namespace export, similar to namespace imports
-                            sym.import_name = Some("*".to_string());
+                            sym.set_import_name(Some("*".to_string()));
                         }
                     }
 
@@ -849,7 +849,7 @@ impl BinderState {
     ) -> Option<crate::SymbolId> {
         let candidate = self.current_scope.get(name)?;
         let sym = self.symbols.get(candidate)?;
-        if (sym.flags & symbol_flags::ALIAS) == 0 || sym.import_module.is_none() {
+        if (sym.flags & symbol_flags::ALIAS) == 0 || sym.import_module().is_none() {
             return None;
         }
         let first_decl = sym.declarations.first().copied()?;

--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -1292,7 +1292,7 @@ impl BinderState {
                         && let Some(existing_id) = file_exports.get(name)
                         && self.symbols.get(existing_id).is_some_and(|s| {
                             (s.flags & symbol_flags::ALIAS) != 0
-                                && s.import_name.as_deref() == Some("*")
+                                && s.import_name() == Some("*")
                                 && !s.is_umd_export
                         })
                     {

--- a/crates/tsz-binder/src/state/core_jsdoc.rs
+++ b/crates/tsz-binder/src/state/core_jsdoc.rs
@@ -410,9 +410,9 @@ impl BinderState {
                     if let Some(sym) = self.symbols.get_mut(sym_id) {
                         // JSDoc @import bindings are type-only aliases that target a module member.
                         sym.is_type_only = true;
-                        sym.import_module = Some(specifier.clone());
-                        sym.import_name = Some(import_name);
-                        sym.import_resolution_mode = resolution_mode;
+                        sym.set_import_module(Some(specifier.clone()));
+                        sym.set_import_name(Some(import_name));
+                        sym.set_import_resolution_mode(resolution_mode);
                     }
                 }
             }

--- a/crates/tsz-binder/src/state/resolution.rs
+++ b/crates/tsz-binder/src/state/resolution.rs
@@ -606,19 +606,19 @@ impl BinderState {
     pub(crate) fn resolve_import_if_needed(&self, sym_id: SymbolId) -> Option<SymbolId> {
         // Get the symbol to check if it's an import
         let sym = self.symbols.get(sym_id)?;
-        let module_specifier = sym.import_module.as_ref()?;
+        let module_specifier = sym.import_module()?;
 
         // For namespace/require imports (`import * as X from "m"` or
         // `import X = require("m")`), import_name is None. These resolve to the
         // module namespace, NOT to a specific named export. Only try `export=`.
-        if sym.import_name.is_none() {
+        if sym.import_name().is_none() {
             return self.resolve_import_with_reexports(module_specifier, "export=");
         }
 
         // Determine the export name:
         // - If import_name is set, use it (for renamed imports like `import { foo as bar }`)
         // - Otherwise use the symbol's escaped_name
-        let export_name = sym.import_name.as_ref().unwrap_or(&sym.escaped_name);
+        let export_name = sym.import_name().unwrap_or(&sym.escaped_name);
 
         // Try to resolve the import, following re-export chains
         if let Some(resolved) = self.resolve_import_with_reexports(module_specifier, export_name) {

--- a/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
+++ b/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
@@ -117,8 +117,8 @@ export type { Foo } from './a';
 
     // The visible binding keeps the first-bound spec's metadata so downstream
     // import resolution still routes through the original module specifier.
-    assert_eq!(foo_sym.import_module.as_deref(), Some("./a"));
-    assert_eq!(foo_sym.import_name.as_deref(), Some("Foo"));
+    assert_eq!(foo_sym.import_module(), Some("./a"));
+    assert_eq!(foo_sym.import_name(), Some("Foo"));
     assert!(
         !foo_sym.is_type_only,
         "first-bound spec was value-only — the merge must not escalate to type-only"
@@ -151,7 +151,7 @@ export { Bar as X } from './a';
         "expected two spec declarations on the shared re-export symbol, got: {:?}",
         x_sym.declarations
     );
-    assert_eq!(x_sym.import_name.as_deref(), Some("Foo"));
+    assert_eq!(x_sym.import_name(), Some("Foo"));
 }
 
 /// Aliased re-exports with DISTINCT exported names must remain separate
@@ -176,8 +176,8 @@ export type { Foo } from './a';
     let foo_sym = binder.symbols.get(foo).expect("Foo symbol data");
     assert_eq!(bar_sym.declarations.len(), 1);
     assert_eq!(foo_sym.declarations.len(), 1);
-    assert_eq!(bar_sym.import_name.as_deref(), Some("Foo"));
-    assert_eq!(foo_sym.import_name.as_deref(), Some("Foo"));
+    assert_eq!(bar_sym.import_name(), Some("Foo"));
+    assert_eq!(foo_sym.import_name(), Some("Foo"));
     assert!(foo_sym.is_type_only);
     assert!(!bar_sym.is_type_only);
 }
@@ -211,8 +211,8 @@ export { type Renamed as Aliased } from './mod';
         foo_sym.is_type_only,
         "per-specifier `type Foo` must mark the re-export alias type-only"
     );
-    assert_eq!(foo_sym.import_module.as_deref(), Some("./mod"));
-    assert_eq!(foo_sym.import_name.as_deref(), Some("Foo"));
+    assert_eq!(foo_sym.import_module(), Some("./mod"));
+    assert_eq!(foo_sym.import_name(), Some("Foo"));
 
     let bar_sym = lookup("Bar");
     assert!(
@@ -225,7 +225,7 @@ export { type Renamed as Aliased } from './mod';
         aliased_sym.is_type_only,
         "renamed per-spec `type Renamed as Aliased` must also be type-only"
     );
-    assert_eq!(aliased_sym.import_name.as_deref(), Some("Renamed"));
+    assert_eq!(aliased_sym.import_name(), Some("Renamed"));
 }
 
 #[test]
@@ -247,8 +247,8 @@ export type { D as E } from './b';
         .symbols
         .get(a_sym_id)
         .expect("expected symbol data for A");
-    assert_eq!(a_symbol.import_module.as_deref(), Some("./a"));
-    assert_eq!(a_symbol.import_name.as_deref(), Some("A"));
+    assert_eq!(a_symbol.import_module(), Some("./a"));
+    assert_eq!(a_symbol.import_name(), Some("A"));
     assert!(!a_symbol.is_type_only);
 
     let c_sym_id = binder
@@ -259,8 +259,8 @@ export type { D as E } from './b';
         .symbols
         .get(c_sym_id)
         .expect("expected symbol data for C");
-    assert_eq!(c_symbol.import_module.as_deref(), Some("./a"));
-    assert_eq!(c_symbol.import_name.as_deref(), Some("B"));
+    assert_eq!(c_symbol.import_module(), Some("./a"));
+    assert_eq!(c_symbol.import_name(), Some("B"));
     assert!(!c_symbol.is_type_only);
 
     let e_sym_id = binder
@@ -271,8 +271,8 @@ export type { D as E } from './b';
         .symbols
         .get(e_sym_id)
         .expect("expected symbol data for E");
-    assert_eq!(e_symbol.import_module.as_deref(), Some("./b"));
-    assert_eq!(e_symbol.import_name.as_deref(), Some("D"));
+    assert_eq!(e_symbol.import_module(), Some("./b"));
+    assert_eq!(e_symbol.import_name(), Some("D"));
     assert!(e_symbol.is_type_only);
 }
 
@@ -302,8 +302,8 @@ class C {}
         .expect("expected symbol data for NS");
     assert_ne!(ns_sym.flags & symbol_flags::ALIAS, 0);
     assert!(ns_sym.is_type_only);
-    assert_eq!(ns_sym.import_module.as_deref(), Some("./a"));
-    assert_eq!(ns_sym.import_name.as_deref(), Some("*"));
+    assert_eq!(ns_sym.import_module(), Some("./a"));
+    assert_eq!(ns_sym.import_name(), Some("*"));
 
     let renamed_i_sym_id = binder
         .file_locals
@@ -315,8 +315,8 @@ class C {}
         .expect("expected symbol data for RenamedI");
     assert_ne!(renamed_i_sym.flags & symbol_flags::ALIAS, 0);
     assert!(renamed_i_sym.is_type_only);
-    assert_eq!(renamed_i_sym.import_module.as_deref(), Some("./a"));
-    assert_eq!(renamed_i_sym.import_name.as_deref(), Some("I"));
+    assert_eq!(renamed_i_sym.import_module(), Some("./a"));
+    assert_eq!(renamed_i_sym.import_name(), Some("I"));
 
     let default_sym_id = binder
         .file_locals
@@ -328,8 +328,8 @@ class C {}
         .expect("expected symbol data for DefaultThing");
     assert_ne!(default_sym.flags & symbol_flags::ALIAS, 0);
     assert!(default_sym.is_type_only);
-    assert_eq!(default_sym.import_module.as_deref(), Some("./a"));
-    assert_eq!(default_sym.import_name.as_deref(), Some("default"));
+    assert_eq!(default_sym.import_module(), Some("./a"));
+    assert_eq!(default_sym.import_name(), Some("default"));
 
     assert!(
         binder.file_import_sources.iter().any(|spec| spec == "./a"),
@@ -368,8 +368,8 @@ class C {}
         .expect("expected symbol data for `types`");
     assert_ne!(ns_sym.flags & symbol_flags::ALIAS, 0);
     assert!(ns_sym.is_type_only);
-    assert_eq!(ns_sym.import_module.as_deref(), Some("./types"));
-    assert_eq!(ns_sym.import_name.as_deref(), Some("*"));
+    assert_eq!(ns_sym.import_module(), Some("./types"));
+    assert_eq!(ns_sym.import_name(), Some("*"));
 }
 
 #[test]
@@ -398,8 +398,8 @@ class C {}
             .unwrap_or_else(|| panic!("expected symbol data for {local_name}"));
         assert_ne!(symbol.flags & symbol_flags::ALIAS, 0);
         assert!(symbol.is_type_only);
-        assert_eq!(symbol.import_module.as_deref(), Some("./dep"));
-        assert_eq!(symbol.import_name.as_deref(), Some(import_name));
+        assert_eq!(symbol.import_module(), Some("./dep"));
+        assert_eq!(symbol.import_name(), Some(import_name));
     }
 
     assert!(
@@ -443,23 +443,23 @@ class C {}
     let imp = lookup("ImpAlias");
     assert_ne!(imp.flags & symbol_flags::ALIAS, 0);
     assert!(imp.is_type_only);
-    assert_eq!(imp.import_module.as_deref(), Some("pkg"));
-    assert_eq!(imp.import_name.as_deref(), Some("Esm"));
+    assert_eq!(imp.import_module(), Some("pkg"));
+    assert_eq!(imp.import_name(), Some("Esm"));
     assert_eq!(
-        imp.import_resolution_mode,
+        imp.import_resolution_mode(),
         Some(tsz_common::ImportResolutionMode::Import)
     );
 
     let req = lookup("ReqAlias");
-    assert_eq!(req.import_name.as_deref(), Some("Cjs"));
+    assert_eq!(req.import_name(), Some("Cjs"));
     assert_eq!(
-        req.import_resolution_mode,
+        req.import_resolution_mode(),
         Some(tsz_common::ImportResolutionMode::Require)
     );
 
     // No attribute clause → no override.
     let plain = lookup("Plain");
-    assert_eq!(plain.import_resolution_mode, None);
+    assert_eq!(plain.import_resolution_mode(), None);
 }
 
 #[test]
@@ -486,8 +486,8 @@ export as namespace Foo;
 
     assert_ne!(foo_symbol.flags & symbol_flags::ALIAS, 0);
     assert!(foo_symbol.is_umd_export);
-    assert_eq!(foo_symbol.import_module.as_deref(), Some("foo.d.ts"));
-    assert_eq!(foo_symbol.import_name.as_deref(), Some("*"));
+    assert_eq!(foo_symbol.import_module(), Some("foo.d.ts"));
+    assert_eq!(foo_symbol.import_name(), Some("*"));
 }
 
 #[test]
@@ -521,8 +521,8 @@ let ns = { a: 1 };
         .expect("expected symbol data for exported ns");
 
     assert_ne!(export_ns.flags & symbol_flags::ALIAS, 0);
-    assert_eq!(export_ns.import_module.as_deref(), Some("./mod"));
-    assert_eq!(export_ns.import_name.as_deref(), Some("*"));
+    assert_eq!(export_ns.import_module(), Some("./mod"));
+    assert_eq!(export_ns.import_name(), Some("*"));
     assert_ne!(export_ns_id, local_ns_id);
 }
 
@@ -553,8 +553,8 @@ export type Foo = { x: number };
         .get(alias_id)
         .expect("expected alias partner symbol data");
     assert_ne!(alias_symbol.flags & symbol_flags::ALIAS, 0);
-    assert_eq!(alias_symbol.import_module.as_deref(), Some("./mod"));
-    assert_eq!(alias_symbol.import_name.as_deref(), Some("*"));
+    assert_eq!(alias_symbol.import_module(), Some("./mod"));
+    assert_eq!(alias_symbol.import_name(), Some("*"));
 
     let export_foo_id = binder
         .module_exports
@@ -812,7 +812,7 @@ declare module "b" {
         .expect("expected symbol data for alias a");
 
     assert_ne!(a_symbol.flags & symbol_flags::ALIAS, 0);
-    assert_eq!(a_symbol.import_module.as_deref(), Some("a"));
+    assert_eq!(a_symbol.import_module(), Some("a"));
 
     let module_exports = binder
         .module_exports
@@ -1144,8 +1144,8 @@ fn assert_ns_module_alias_partner(source: &str, ns_name: &str) {
         .get(alias_id)
         .unwrap_or_else(|| panic!("expected alias partner symbol data for {ns_name}"));
     assert_ne!(alias_sym.flags & symbol_flags::ALIAS, 0);
-    assert_eq!(alias_sym.import_module.as_deref(), Some("./mod"));
-    assert_eq!(alias_sym.import_name.as_deref(), Some("*"));
+    assert_eq!(alias_sym.import_module(), Some("./mod"));
+    assert_eq!(alias_sym.import_name(), Some("*"));
 }
 
 /// `export * as N from './mod'` followed by `namespace N { ... }`:
@@ -1220,7 +1220,7 @@ export * as Ns from './mod';
         .expect("expected symbol data for Ns");
     // Should be ALIAS, not MODULE
     assert_ne!(ns_sym.flags & symbol_flags::ALIAS, 0);
-    assert_eq!(ns_sym.import_module.as_deref(), Some("./mod"));
+    assert_eq!(ns_sym.import_module(), Some("./mod"));
     // No alias_partners entry for a lone ALIAS
     assert!(
         !binder.alias_partners.contains_key(&ns_id),

--- a/crates/tsz-binder/src/state/tests/hoisting_scopes_flow.rs
+++ b/crates/tsz-binder/src/state/tests/hoisting_scopes_flow.rs
@@ -802,7 +802,7 @@ import { foo } from './bar';
         "imported foo should have ALIAS flag"
     );
     assert_eq!(
-        foo_symbol.import_module.as_deref(),
+        foo_symbol.import_module(),
         Some("./bar"),
         "import_module should be './bar'"
     );
@@ -824,8 +824,8 @@ import { foo as bar } from './baz';
         .expect("expected import symbol bar");
     let bar_symbol = binder.symbols.get(bar_sym_id).unwrap();
     assert!(bar_symbol.flags & symbol_flags::ALIAS != 0);
-    assert_eq!(bar_symbol.import_module.as_deref(), Some("./baz"));
-    assert_eq!(bar_symbol.import_name.as_deref(), Some("foo"));
+    assert_eq!(bar_symbol.import_module(), Some("./baz"));
+    assert_eq!(bar_symbol.import_name(), Some("foo"));
 }
 
 #[test]
@@ -846,7 +846,7 @@ import * as ns from './mod';
         ns_symbol.flags & symbol_flags::ALIAS != 0,
         "namespace import should have ALIAS flag"
     );
-    assert_eq!(ns_symbol.import_module.as_deref(), Some("./mod"));
+    assert_eq!(ns_symbol.import_module(), Some("./mod"));
 }
 
 #[test]
@@ -908,7 +908,7 @@ import Foo from './mod';
         foo_symbol.flags & symbol_flags::ALIAS != 0,
         "default import should have ALIAS flag"
     );
-    assert_eq!(foo_symbol.import_module.as_deref(), Some("./mod"));
+    assert_eq!(foo_symbol.import_module(), Some("./mod"));
 }
 
 // =============================================================================

--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -282,6 +282,32 @@ pub struct Symbol {
     /// This indicates which file's arena contains this symbol's declarations.
     /// Value of `u32::MAX` means single-file mode (use current arena).
     pub decl_file_idx: u32,
+    /// Out-of-lined import-alias payload.
+    ///
+    /// Fewer than ~5% of symbols are import aliases, yet the module specifier,
+    /// renamed export name, and explicit `resolution-mode` override are
+    /// per-import data. Storing them inline taxed every `Symbol` (millions per
+    /// large project) with ~50 unused bytes. They now live behind a heap
+    /// allocation that only import-alias symbols pay for (#13072 PR 2). Use the
+    /// [`Symbol::import_module`], [`Symbol::import_name`], and
+    /// [`Symbol::import_resolution_mode`] accessors to read, and
+    /// [`Symbol::set_import_module`], [`Symbol::set_import_name`], and
+    /// [`Symbol::set_import_resolution_mode`] to populate.
+    pub import_alias: Option<Box<ImportAliasData>>,
+    /// Whether this symbol is a UMD namespace export (`export as namespace Foo`).
+    /// UMD exports are ALIAS symbols that should be globally visible across files,
+    /// unlike regular import aliases which are file-local.
+    pub is_umd_export: bool,
+}
+
+/// Out-of-lined import-alias payload for [`Symbol`].
+///
+/// Only import-alias symbols allocate this box, so the common `Symbol` stays
+/// small (#13072). The checker and LSP read these through the accessors on
+/// [`Symbol`]; nothing constructs an `ImportAliasData` directly outside the
+/// `Symbol` setters.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct ImportAliasData {
     /// Import module specifier for ES6 imports (e.g., './file' for `import { X } from './file'`)
     /// This enables resolving imported symbols to their actual exports from other files.
     pub import_module: Option<String>,
@@ -296,10 +322,6 @@ pub struct Symbol {
     /// inferred module mode. The checker maps this onto the resolution request
     /// so package `exports`/`imports` conditions pick the right target file.
     pub import_resolution_mode: Option<tsz_common::ImportResolutionMode>,
-    /// Whether this symbol is a UMD namespace export (`export as namespace Foo`).
-    /// UMD exports are ALIAS symbols that should be globally visible across files,
-    /// unlike regular import aliases which are file-local.
-    pub is_umd_export: bool,
 }
 
 impl Symbol {
@@ -320,11 +342,89 @@ impl Symbol {
             is_exported: false,
             is_type_only: false,
             decl_file_idx: u32::MAX,
-            import_module: None,
-            import_name: None,
-            import_resolution_mode: None,
+            import_alias: None,
             is_umd_export: false,
         }
+    }
+
+    /// Import module specifier for ES6 imports (e.g., `./file` for
+    /// `import { X } from './file'`), if this symbol is an import alias.
+    ///
+    /// Reads through the out-of-lined [`Self::import_alias`] payload (#13072).
+    #[inline]
+    #[must_use]
+    pub fn import_module(&self) -> Option<&str> {
+        self.import_alias
+            .as_ref()
+            .and_then(|data| data.import_module.as_deref())
+    }
+
+    /// Original export name for renamed imports (e.g., `foo` for
+    /// `import { foo as bar }`), if this symbol is an import alias.
+    ///
+    /// `None` means the import name matches [`Self::escaped_name`]. Reads
+    /// through the out-of-lined [`Self::import_alias`] payload (#13072).
+    #[inline]
+    #[must_use]
+    pub fn import_name(&self) -> Option<&str> {
+        self.import_alias
+            .as_ref()
+            .and_then(|data| data.import_name.as_deref())
+    }
+
+    /// Explicit `resolution-mode` override declared on this import alias, if any.
+    ///
+    /// Reads through the out-of-lined [`Self::import_alias`] payload (#13072).
+    #[inline]
+    #[must_use]
+    pub fn import_resolution_mode(&self) -> Option<tsz_common::ImportResolutionMode> {
+        self.import_alias
+            .as_ref()
+            .and_then(|data| data.import_resolution_mode)
+    }
+
+    /// True when this symbol carries an import module specifier.
+    #[inline]
+    #[must_use]
+    pub fn has_import_module(&self) -> bool {
+        self.import_module().is_some()
+    }
+
+    /// Mutable handle to the out-of-lined import-alias payload, allocating it
+    /// on first use. Only import-alias symbols ever allocate the box (#13072).
+    #[inline]
+    fn import_alias_mut(&mut self) -> &mut ImportAliasData {
+        self.import_alias.get_or_insert_with(Box::default)
+    }
+
+    /// Set the import module specifier, allocating the import-alias payload if
+    /// needed.
+    #[inline]
+    pub fn set_import_module(&mut self, module: Option<String>) {
+        if module.is_none() && self.import_alias.is_none() {
+            return;
+        }
+        self.import_alias_mut().import_module = module;
+    }
+
+    /// Set the renamed-import original name, allocating the import-alias payload
+    /// if needed.
+    #[inline]
+    pub fn set_import_name(&mut self, name: Option<String>) {
+        if name.is_none() && self.import_alias.is_none() {
+            return;
+        }
+        self.import_alias_mut().import_name = name;
+    }
+
+    /// Set the explicit `resolution-mode` override, allocating the import-alias
+    /// payload if needed.
+    #[inline]
+    pub fn set_import_resolution_mode(&mut self, mode: Option<tsz_common::ImportResolutionMode>) {
+        if mode.is_none() && self.import_alias.is_none() {
+            return;
+        }
+        self.import_alias_mut().import_resolution_mode = mode;
     }
 
     /// Estimate the heap bytes owned by this symbol beyond
@@ -343,11 +443,14 @@ impl Symbol {
         if let Some(members) = &self.members {
             size += std::mem::size_of::<SymbolTable>() + members.estimated_size_bytes();
         }
-        if let Some(module) = &self.import_module {
-            size += module.capacity();
-        }
-        if let Some(name) = &self.import_name {
-            size += name.capacity();
+        if let Some(alias) = &self.import_alias {
+            size += std::mem::size_of::<ImportAliasData>();
+            if let Some(module) = &alias.import_module {
+                size += module.capacity();
+            }
+            if let Some(name) = &alias.import_name {
+                size += name.capacity();
+            }
         }
         size
     }
@@ -1194,12 +1297,15 @@ mod tests {
     }
 
     /// Pin the size of `Symbol` so accidental field growth is caught in
-    /// review. Dropping the redundant `first_declaration_span` /
-    /// `value_declaration_span` fields (#13072) brought this from 200 to
-    /// 176 bytes; every interned symbol pays this footprint.
+    /// review; every interned symbol pays this footprint. Dropping the
+    /// redundant span fields (#13072 PR 1) brought this from 200 to 176 bytes;
+    /// out-of-lining the import-alias payload behind `Option<Box<ImportAliasData>>`
+    /// (#13072 PR 2) brought it from 176 to 136 bytes, since only the
+    /// fewer-than-5% import-alias symbols now pay for the module specifier,
+    /// renamed name, and resolution-mode fields.
     #[test]
     fn symbol_size_is_pinned() {
-        assert_eq!(std::mem::size_of::<Symbol>(), 176);
+        assert_eq!(std::mem::size_of::<Symbol>(), 136);
     }
 
     /// The derived span accessors must reproduce the semantics of the

--- a/crates/tsz-binder/tests/symbols_tests.rs
+++ b/crates/tsz-binder/tests/symbols_tests.rs
@@ -81,8 +81,9 @@ mod symbol_tests {
         assert!(symbol.members.is_none());
         assert!(!symbol.is_exported);
         assert!(!symbol.is_type_only);
-        assert!(symbol.import_module.is_none());
-        assert!(symbol.import_name.is_none());
+        assert!(symbol.import_module().is_none());
+        assert!(symbol.import_name().is_none());
+        assert!(symbol.import_alias.is_none());
         assert!(!symbol.is_umd_export);
     }
 

--- a/crates/tsz-checker/src/assignability/assignment_checker/commonjs_assignment.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/commonjs_assignment.rs
@@ -385,7 +385,7 @@ impl<'a> CheckerState<'a> {
             return false;
         };
 
-        if root_symbol.has_any_flags(symbol_flags::ALIAS) && root_symbol.import_module.is_some() {
+        if root_symbol.has_any_flags(symbol_flags::ALIAS) && root_symbol.import_module().is_some() {
             return false;
         }
         if root_symbol.has_any_flags(symbol_flags::CLASS) {

--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_syntax_instantiation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_syntax_instantiation.rs
@@ -177,11 +177,8 @@ impl<'a> CheckerState<'a> {
             .is_some_and(|symbol| symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS))
         {
             let imported_target = self.get_cross_file_symbol(sym_id).and_then(|symbol| {
-                let module_name = symbol.import_module.as_ref()?;
-                let import_name = symbol
-                    .import_name
-                    .as_deref()
-                    .unwrap_or(&symbol.escaped_name);
+                let module_name = symbol.import_module()?;
+                let import_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
                 let source_file_idx = (symbol.decl_file_idx != u32::MAX)
                     .then_some(symbol.decl_file_idx as usize)
                     .or_else(|| self.ctx.resolve_symbol_file_index(sym_id))
@@ -292,10 +289,10 @@ impl<'a> CheckerState<'a> {
             if symbol.flags & tsz_binder::symbol_flags::ALIAS == 0 {
                 return None;
             }
-            let module_name = symbol.import_module.clone()?;
+            let module_name = symbol.import_module()?.to_string();
             let import_name = symbol
-                .import_name
-                .clone()
+                .import_name()
+                .map(str::to_string)
                 .unwrap_or_else(|| symbol.escaped_name.clone());
             (module_name, import_name)
         };

--- a/crates/tsz-checker/src/checkers/generic_checker/infer_conditional_constraints.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/infer_conditional_constraints.rs
@@ -375,8 +375,8 @@ impl<'a> CheckerState<'a> {
             if symbol.flags & tsz_binder::symbol_flags::ALIAS == 0 {
                 None
             } else {
-                let module_name = symbol.import_module.clone()?;
-                let import_name = symbol.import_name.clone()?;
+                let module_name = symbol.import_module()?.to_string();
+                let import_name = symbol.import_name()?.to_string();
                 let source_file_idx = (symbol.decl_file_idx != u32::MAX)
                     .then_some(symbol.decl_file_idx as usize)
                     .or_else(|| self.ctx.resolve_symbol_file_index(sym_id));

--- a/crates/tsz-checker/src/checkers/generic_checker/mod.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/mod.rs
@@ -957,13 +957,13 @@ impl<'a> CheckerState<'a> {
                     self.ctx
                         .binder
                         .get_symbol(alias_sym_id)
-                        .and_then(|alias_sym| alias_sym.import_module.as_ref())
+                        .and_then(|alias_sym| alias_sym.import_module())
                         .is_some_and(|module_spec| {
                             let import_name = self
                                 .ctx
                                 .binder
                                 .get_symbol(alias_sym_id)
-                                .and_then(|s| s.import_name.clone())
+                                .and_then(|s| s.import_name().map(str::to_string))
                                 .unwrap_or_else(|| base_name.clone());
                             self.module_augmentation_has_type_params(module_spec, &import_name)
                         })

--- a/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
+++ b/crates/tsz-checker/src/checkers/jsx/orchestration/resolution.rs
@@ -1578,8 +1578,8 @@ impl<'a> CheckerState<'a> {
                     return Some(sym_id);
                 }
                 (
-                    symbol.import_module.clone(),
-                    symbol.import_name.clone(),
+                    symbol.import_module().map(str::to_string),
+                    symbol.import_name().map(str::to_string),
                     symbol.escaped_name.clone(),
                     symbol.primary_declaration()?,
                 )
@@ -1590,8 +1590,8 @@ impl<'a> CheckerState<'a> {
                     return Some(sym_id);
                 }
                 (
-                    symbol.import_module.clone(),
-                    symbol.import_name.clone(),
+                    symbol.import_module().map(str::to_string),
+                    symbol.import_name().map(str::to_string),
                     symbol.escaped_name.clone(),
                     symbol.primary_declaration()?,
                 )

--- a/crates/tsz-checker/src/checkers/jsx/runtime.rs
+++ b/crates/tsz-checker/src/checkers/jsx/runtime.rs
@@ -635,7 +635,7 @@ impl<'a> CheckerState<'a> {
         if symbol.is_umd_export {
             return true;
         }
-        if symbol.is_exported || symbol.import_module.is_some() {
+        if symbol.is_exported || symbol.import_module().is_some() {
             return false;
         }
         let Some(owner_binder) = self.ctx.get_binder_for_file(symbol.decl_file_idx as usize) else {
@@ -869,7 +869,7 @@ impl<'a> CheckerState<'a> {
             return Some(sym_id);
         }
 
-        if let Some(module_name) = root_symbol.import_module.as_deref() {
+        if let Some(module_name) = root_symbol.import_module() {
             let source_file_idx = self
                 .ctx
                 .resolve_symbol_file_index(root_sym)

--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -1741,7 +1741,7 @@ impl<'a> CheckerState<'a> {
             }
 
             self.ctx.binder.get_symbol(sym_id).is_some_and(|symbol| {
-                symbol.import_module.is_some() && symbol.has_any_flags(symbol_flags::ALIAS)
+                symbol.import_module().is_some() && symbol.has_any_flags(symbol_flags::ALIAS)
             })
         }) || self.current_file_import_binds_name(name)
     }

--- a/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/jsdoc_heritage.rs
@@ -770,8 +770,8 @@ impl<'a> CheckerState<'a> {
     ) -> Vec<tsz_solver::TypeParamInfo> {
         let import_target = self.ctx.binder.get_symbol(sym_id).and_then(|symbol| {
             Some((
-                symbol.import_module.as_ref()?.clone(),
-                symbol.import_name.as_ref()?.clone(),
+                symbol.import_module()?.to_string(),
+                symbol.import_name()?.to_string(),
             ))
         });
 
@@ -793,13 +793,9 @@ impl<'a> CheckerState<'a> {
             }
         }
         if type_params.is_empty()
-            && let Some((module_specifier, import_name)) =
-                self.get_cross_file_symbol(sym_id).and_then(|symbol| {
-                    Some((
-                        symbol.import_module.as_ref()?,
-                        symbol.import_name.as_deref()?,
-                    ))
-                })
+            && let Some((module_specifier, import_name)) = self
+                .get_cross_file_symbol(sym_id)
+                .and_then(|symbol| Some((symbol.import_module()?, symbol.import_name()?)))
             && import_name != "*"
             && import_name != "default"
             && let Some(export_sym) = self.resolve_cross_file_export(module_specifier, import_name)

--- a/crates/tsz-checker/src/context/core.rs
+++ b/crates/tsz-checker/src/context/core.rs
@@ -1376,8 +1376,8 @@ impl<'a> CheckerContext<'a> {
         if (symbol.flags & tsz_binder::symbol_flags::ALIAS) == 0 {
             return None;
         }
-        let module_specifier = symbol.import_module.as_ref()?;
-        let import_name = symbol.import_name.as_ref().unwrap_or(&symbol.escaped_name);
+        let module_specifier = symbol.import_module()?;
+        let import_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
 
         let source_file_idx = if self
             .binder
@@ -1416,8 +1416,8 @@ impl<'a> CheckerContext<'a> {
         if (symbol.flags & tsz_binder::symbol_flags::ALIAS) == 0 {
             return None;
         }
-        let module_specifier = symbol.import_module.as_ref()?;
-        let import_name = symbol.import_name.as_ref().unwrap_or(&symbol.escaped_name);
+        let module_specifier = symbol.import_module()?;
+        let import_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
 
         let source_file_idx = if self
             .binder

--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -156,7 +156,7 @@ impl<'a> CheckerContext<'a> {
             let authoritative_is_current =
                 authoritative_file_idx.is_none_or(|file_idx| file_idx == self.current_file_idx);
             authoritative_is_current
-                && symbol.import_module.is_none()
+                && symbol.import_module().is_none()
                 && !symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
         });
         let symbol_name = self

--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -173,8 +173,8 @@ impl<'a> CheckerContext<'a> {
         if !symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS) {
             return None;
         }
-        let module_specifier = symbol.import_module.as_ref()?;
-        let import_name = symbol.import_name.as_ref().unwrap_or(&symbol.escaped_name);
+        let module_specifier = symbol.import_module()?;
+        let import_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
 
         if let Some(target_idx) =
             self.resolve_import_target_from_file(source_file_idx, module_specifier)
@@ -1340,10 +1340,10 @@ impl<'a> TypeResolver for CheckerContext<'a> {
                         .and_then(|members| members.get(segment))
                 })
                 .or_else(|| {
-                    if symbol.import_name.as_deref() != Some("*") {
+                    if symbol.import_name() != Some("*") {
                         return None;
                     }
-                    let module = symbol.import_module.as_deref()?;
+                    let module = symbol.import_module()?;
                     let source_file_idx = self
                         .resolve_symbol_file_index_stable(current_sym)
                         .or_else(|| {

--- a/crates/tsz-checker/src/declarations/declarations.rs
+++ b/crates/tsz-checker/src/declarations/declarations.rs
@@ -1332,11 +1332,8 @@ impl<'a, 'ctx> DeclarationChecker<'a, 'ctx> {
         if !symbol.has_any_flags(symbol_flags::ALIAS) {
             return Some(sym_id);
         }
-        let module_specifier = symbol.import_module.as_ref()?;
-        let target_name = symbol
-            .import_name
-            .as_deref()
-            .unwrap_or(&symbol.escaped_name);
+        let module_specifier = symbol.import_module()?;
+        let target_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
         let source_file_idx = if symbol.decl_file_idx == u32::MAX {
             self.ctx.current_file_idx
         } else {

--- a/crates/tsz-checker/src/declarations/import/core/helpers.rs
+++ b/crates/tsz-checker/src/declarations/import/core/helpers.rs
@@ -404,8 +404,8 @@ impl<'a> CheckerState<'a> {
         // module namespace, so treat them as module-like for TS2497 purposes.
         if !is_module_or_variable
             && target.has_any_flags(symbol_flags::ALIAS)
-            && target.import_module.is_some()
-            && target.import_name.as_deref() == Some("*")
+            && target.import_module().is_some()
+            && target.import_name() == Some("*")
         {
             return false;
         }

--- a/crates/tsz-checker/src/declarations/import/core/import_members.rs
+++ b/crates/tsz-checker/src/declarations/import/core/import_members.rs
@@ -1426,7 +1426,7 @@ impl<'a> CheckerState<'a> {
         if sym.has_any_flags(PURE_TYPE) && !sym.has_any_flags(VALUE) {
             return true;
         }
-        if sym.has_any_flags(symbol_flags::ALIAS) && sym.import_module.is_none() {
+        if sym.has_any_flags(symbol_flags::ALIAS) && sym.import_module().is_none() {
             let arena = self.ctx.get_arena_for_file(owner_file_idx as u32);
             if sym.all_declarations().into_iter().any(|decl_idx| {
                 arena.get(decl_idx).is_some_and(|node| {

--- a/crates/tsz-checker/src/declarations/import/declaration_resolution.rs
+++ b/crates/tsz-checker/src/declarations/import/declaration_resolution.rs
@@ -380,8 +380,8 @@ impl<'a> CheckerState<'a> {
                                 import_has_type = true;
                             }
                             if resolved_sym.has_any_flags(symbol_flags::ALIAS)
-                                && sym.import_module.is_some()
-                                && sym.import_name.is_none()
+                                && sym.import_module().is_some()
+                                && sym.import_name().is_none()
                             {
                                 import_has_value = true;
                             }
@@ -391,9 +391,9 @@ impl<'a> CheckerState<'a> {
                         // itself (can't resolve cross-file), check the exported symbol's
                         // flags directly in the target file's binder.
                         if (!import_has_value || !import_has_type)
-                            && let Some(ref module_name) = sym.import_module
+                            && let Some(module_name) = sym.import_module()
                         {
-                            let export_name = sym.import_name.as_deref().unwrap_or(&name);
+                            let export_name = sym.import_name().unwrap_or(name.as_str());
                             // Try declared modules (module_exports)
                             // Use global_module_binder_index for O(1) lookup instead of O(N) binder scan
                             if let Some(binders) = &self.ctx.all_binders {
@@ -401,15 +401,13 @@ impl<'a> CheckerState<'a> {
                                     .ctx
                                     .global_module_binder_index
                                     .as_ref()
-                                    .and_then(|idx| idx.get(module_name.as_str()));
+                                    .and_then(|idx| idx.get(module_name));
                                 if let Some(indices) = candidate_indices {
                                     for &binder_idx in indices {
                                         if let Some(binder) = binders.get(binder_idx)
-                                            && let Some(exports) =
-                                                self.ctx.module_exports_for_module(
-                                                    binder,
-                                                    module_name.as_str(),
-                                                )
+                                            && let Some(exports) = self
+                                                .ctx
+                                                .module_exports_for_module(binder, module_name)
                                             && let Some(target_sym_id) = exports.get(export_name)
                                             && let Some(target_sym) =
                                                 binder.symbols.get(target_sym_id)
@@ -429,9 +427,8 @@ impl<'a> CheckerState<'a> {
                                     }
                                 } else {
                                     for binder in binders.iter() {
-                                        if let Some(exports) = self
-                                            .ctx
-                                            .module_exports_for_module(binder, module_name.as_str())
+                                        if let Some(exports) =
+                                            self.ctx.module_exports_for_module(binder, module_name)
                                             && let Some(target_sym_id) = exports.get(export_name)
                                             && let Some(target_sym) =
                                                 binder.symbols.get(target_sym_id)
@@ -498,12 +495,10 @@ impl<'a> CheckerState<'a> {
                                                 resolved_binder.symbols.get(partner_id)
                                             && partner.has_any_flags(symbol_flags::ALIAS)
                                             && !partner.is_type_only
-                                            && let Some(ref src_module) = partner.import_module
+                                            && let Some(src_module) = partner.import_module()
                                         {
-                                            let src_name = partner
-                                                .import_name
-                                                .as_deref()
-                                                .unwrap_or(export_name);
+                                            let src_name =
+                                                partner.import_name().unwrap_or(export_name);
                                             if let Some(src_idx) =
                                                 self.ctx.resolve_import_target_from_file(
                                                     resolved_file_idx,

--- a/crates/tsz-checker/src/declarations/import/equals.rs
+++ b/crates/tsz-checker/src/declarations/import/equals.rs
@@ -1298,7 +1298,7 @@ impl<'a> CheckerState<'a> {
             // (before alias resolution) which may have import_module set.
             let orig_left_symbol = self.ctx.binder.get_symbol_with_libs(left_sym, &lib_binders);
             if let Some(orig) = orig_left_symbol
-                && let Some(ref module_specifier) = orig.import_module
+                && let Some(module_specifier) = orig.import_module()
             {
                 let mut reexport_visited = AliasCycleTracker::new();
                 if let Some(resolved) = self.resolve_reexported_member_symbol(
@@ -1355,7 +1355,7 @@ impl<'a> CheckerState<'a> {
 
         if symbol.is_type_only {
             // Symbol is directly marked type-only — determine if it was via import or export
-            return if symbol.import_module.is_some() {
+            return if symbol.import_module().is_some() {
                 Some(TypeOnlyKind::ImportType)
             } else {
                 Some(TypeOnlyKind::ExportType)
@@ -1395,7 +1395,7 @@ impl<'a> CheckerState<'a> {
                 };
                 // Check directly: is the resolved target type-only?
                 if check_sym.is_type_only {
-                    return if check_sym.import_module.is_some() {
+                    return if check_sym.import_module().is_some() {
                         Some(TypeOnlyKind::ImportType)
                     } else {
                         Some(TypeOnlyKind::ExportType)
@@ -1471,7 +1471,7 @@ impl<'a> CheckerState<'a> {
             if is_same_arena && let Some(sym_id) = self.resolve_identifier_symbol(rhs_idx) {
                 let sym = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)?;
                 if sym.is_type_only {
-                    return if sym.import_module.is_some() {
+                    return if sym.import_module().is_some() {
                         Some(TypeOnlyKind::ImportType)
                     } else {
                         Some(TypeOnlyKind::ExportType)
@@ -1500,7 +1500,7 @@ impl<'a> CheckerState<'a> {
                 for &(_file_idx, sym_id) in entries {
                     if let Some(sym) = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders) {
                         if sym.is_type_only {
-                            return if sym.import_module.is_some() {
+                            return if sym.import_module().is_some() {
                                 Some(TypeOnlyKind::ImportType)
                             } else {
                                 Some(TypeOnlyKind::ExportType)
@@ -1519,7 +1519,7 @@ impl<'a> CheckerState<'a> {
                             self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)
                     {
                         if sym.is_type_only {
-                            return if sym.import_module.is_some() {
+                            return if sym.import_module().is_some() {
                                 Some(TypeOnlyKind::ImportType)
                             } else {
                                 Some(TypeOnlyKind::ExportType)
@@ -1555,7 +1555,7 @@ impl<'a> CheckerState<'a> {
                     self.ctx.binder.get_symbol_with_libs(alias_id, &lib_binders)
                     && alias_sym.is_type_only
                 {
-                    return if alias_sym.import_module.is_some() {
+                    return if alias_sym.import_module().is_some() {
                         TypeOnlyKind::ImportType
                     } else {
                         TypeOnlyKind::ExportType
@@ -1566,7 +1566,7 @@ impl<'a> CheckerState<'a> {
             if let Some(target_sym) = self.ctx.binder.get_symbol_with_libs(target, &lib_binders)
                 && target_sym.is_type_only
             {
-                return if target_sym.import_module.is_some() {
+                return if target_sym.import_module().is_some() {
                     TypeOnlyKind::ImportType
                 } else {
                     TypeOnlyKind::ExportType

--- a/crates/tsz-checker/src/declarations/import/exports.rs
+++ b/crates/tsz-checker/src/declarations/import/exports.rs
@@ -16,7 +16,7 @@ impl<'a> CheckerState<'a> {
         let Some(symbol) = binder.symbols.get(sym_id) else {
             return false;
         };
-        if !symbol.is_exported || symbol.import_module.is_some() {
+        if !symbol.is_exported || symbol.import_module().is_some() {
             return false;
         }
         symbol.decl_file_idx == file_idx as u32
@@ -155,9 +155,9 @@ impl<'a> CheckerState<'a> {
             // If this is an alias, follow it to the source module
             if let Some(sym) = target_binder.symbols.get(sym_id)
                 && sym.has_any_flags(tsz_binder::symbol_flags::ALIAS)
-                && let Some(ref import_module) = sym.import_module
+                && let Some(import_module) = sym.import_module()
             {
-                let import_name = sym.import_name.as_deref().unwrap_or(export_name);
+                let import_name = sym.import_name().unwrap_or(export_name);
                 if let Some(source_idx) = self
                     .ctx
                     .resolve_import_target_from_file(file_idx, import_module)

--- a/crates/tsz-checker/src/declarations/import/verbatim.rs
+++ b/crates/tsz-checker/src/declarations/import/verbatim.rs
@@ -52,8 +52,8 @@ impl<'a> CheckerState<'a> {
         // empty. Follow `import_module` to check the target module's
         // top-level exports for any runtime value before short-circuiting.
         let is_namespace_style_alias = sym.has_any_flags(symbol_flags::ALIAS)
-            && sym.import_module.is_some()
-            && sym.import_name.as_deref() == Some("*");
+            && sym.import_module().is_some()
+            && sym.import_name() == Some("*");
         if !sym.has_any_flags(symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE)
             && !is_namespace_style_alias
         {
@@ -83,7 +83,7 @@ impl<'a> CheckerState<'a> {
         // exports/members are empty — the runtime exports live in the target
         // module. Follow the import_module pointer to check that module's
         // top-level exports for any runtime value.
-        if let Some(ref module_specifier) = sym.import_module
+        if let Some(module_specifier) = sym.import_module()
             && let Some(target_idx) = self.ctx.resolve_import_target(module_specifier)
             && let Some(target_binder) = self.ctx.get_binder_for_file(target_idx)
         {
@@ -402,7 +402,7 @@ impl<'a> CheckerState<'a> {
                             && let Some(default_sym_id) = exports.get(candidate_name)
                             && let Some(default_sym) = target_binder.get_symbol(default_sym_id)
                             && default_sym.has_any_flags(symbol_flags::ALIAS)
-                            && default_sym.import_module.is_none()
+                            && default_sym.import_module().is_none()
                             && let Some(target_decl_idx) = default_sym.primary_declaration()
                             && let Some(target_decl_node) = target_arena.get(target_decl_idx)
                             && let Some(target_ident) =

--- a/crates/tsz-checker/src/declarations/module_checker.rs
+++ b/crates/tsz-checker/src/declarations/module_checker.rs
@@ -1112,9 +1112,9 @@ impl<'a> CheckerState<'a> {
                     true
                 } else if let Some(sym) = sym
                     && sym.has_any_flags(symbol_flags::ALIAS)
-                    && let Some(ref module_spec) = sym.import_module
+                    && let Some(module_spec) = sym.import_module()
                 {
-                    let import_name = sym.import_name.as_deref().unwrap_or(&name_str);
+                    let import_name = sym.import_name().unwrap_or(&name_str);
                     self.import_binding_is_type_only(module_spec, import_name)
                 } else {
                     self.is_local_symbol_type_only(&name_str)
@@ -1511,11 +1511,10 @@ impl<'a> CheckerState<'a> {
 
                 // For import aliases with import_module, use cross-file resolution
                 // to properly track which file we're resolving from.
-                if let Some(ref module_name) = curr_sym.import_module {
+                if let Some(module_name) = curr_sym.import_module() {
                     let export_name = curr_sym
-                        .import_name
-                        .as_deref()
-                        .unwrap_or(&curr_sym.escaped_name);
+                        .import_name()
+                        .unwrap_or(curr_sym.escaped_name.as_str());
 
                     // Use checker's cross-file module resolution first.
                     // This correctly resolves relative specifiers from the
@@ -1530,7 +1529,7 @@ impl<'a> CheckerState<'a> {
                             .resolve_import_with_reexports_type_only(module_name, export_name)
                             .map(|(sym_id, _)| sym_id)
                             .or_else(|| {
-                                (curr_sym.import_name.is_none())
+                                (curr_sym.import_name().is_none())
                                     .then(|| {
                                         target_binder
                                             .resolve_import_with_reexports_type_only(

--- a/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
+++ b/crates/tsz-checker/src/declarations/module_checker/verbatim_module_syntax.rs
@@ -224,9 +224,9 @@ impl<'a> CheckerState<'a> {
                 return false;
             }
             if sym.has_any_flags(symbol_flags::ALIAS)
-                && let Some(ref module_spec) = sym.import_module
+                && let Some(module_spec) = sym.import_module()
             {
-                let import_name = sym.import_name.as_deref().unwrap_or(name);
+                let import_name = sym.import_name().unwrap_or(name);
                 return self.is_export_type_only_across_binders(module_spec, import_name);
             }
         }
@@ -248,9 +248,9 @@ impl<'a> CheckerState<'a> {
                 return false;
             }
             if sym.has_any_flags(symbol_flags::ALIAS)
-                && let Some(ref module_spec) = sym.import_module
+                && let Some(module_spec) = sym.import_module()
             {
-                let import_name = sym.import_name.as_deref().unwrap_or(name);
+                let import_name = sym.import_name().unwrap_or(name);
                 return self.is_export_type_only_syntax_across_binders(module_spec, import_name);
             }
         }
@@ -311,9 +311,9 @@ impl<'a> CheckerState<'a> {
                 return true;
             }
             if sym.has_any_flags(symbol_flags::ALIAS)
-                && let Some(ref module_spec) = sym.import_module
+                && let Some(module_spec) = sym.import_module()
             {
-                let import_name = sym.import_name.as_deref().unwrap_or(name);
+                let import_name = sym.import_name().unwrap_or(name);
                 return self.is_import_specifier_type_only(module_spec, import_name);
             }
         }
@@ -476,14 +476,10 @@ impl<'a> CheckerState<'a> {
                 // current file, suppressing TS1292.
                 return;
             }
-            let Some(ref module_spec) = alias_sym.import_module else {
+            let Some(module_spec) = alias_sym.import_module() else {
                 return;
             };
-            let import_name = alias_sym
-                .import_name
-                .as_deref()
-                .unwrap_or(name.as_str())
-                .to_string();
+            let import_name = alias_sym.import_name().unwrap_or(name.as_str()).to_string();
 
             // Resolve the imported target's flags. If the target is type-only
             // (Type but not Value), TS1292 applies.

--- a/crates/tsz-checker/src/declarations/namespace_checker.rs
+++ b/crates/tsz-checker/src/declarations/namespace_checker.rs
@@ -696,8 +696,8 @@ impl<'a> CheckerState<'a> {
                 && symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
             {
                 // Follow the alias
-                if let Some(ref import_module) = symbol.import_module {
-                    let export_name = symbol.import_name.as_deref().unwrap_or(member_name);
+                if let Some(import_module) = symbol.import_module() {
+                    let export_name = symbol.import_name().unwrap_or(member_name);
                     return self.resolve_reexported_member(import_module, export_name, lib_binders);
                 }
             }

--- a/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
+++ b/crates/tsz-checker/src/error_reporter/properties/diagnostic_methods_tail.rs
@@ -181,8 +181,8 @@ impl<'a> CheckerState<'a> {
         let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
             return false;
         };
-        let symbol_is_namespace_import = symbol.import_module.is_some()
-            && (symbol.import_name.is_none() || symbol.import_name.as_deref() == Some("*"));
+        let symbol_is_namespace_import = symbol.import_module().is_some()
+            && (symbol.import_name().is_none() || symbol.import_name() == Some("*"));
         if symbol_is_namespace_import {
             return true;
         }
@@ -191,9 +191,9 @@ impl<'a> CheckerState<'a> {
             if let Some(resolved_sym_id) = self.resolve_alias_symbol(sym_id, &mut visited)
                 && let Some(resolved_symbol) = self.ctx.binder.get_symbol(resolved_sym_id)
             {
-                let resolved_is_namespace_import = resolved_symbol.import_module.is_some()
-                    && (resolved_symbol.import_name.is_none()
-                        || resolved_symbol.import_name.as_deref() == Some("*"));
+                let resolved_is_namespace_import = resolved_symbol.import_module().is_some()
+                    && (resolved_symbol.import_name().is_none()
+                        || resolved_symbol.import_name() == Some("*"));
                 if resolved_is_namespace_import {
                     return true;
                 }

--- a/crates/tsz-checker/src/error_reporter/type_value.rs
+++ b/crates/tsz-checker/src/error_reporter/type_value.rs
@@ -666,7 +666,7 @@ impl<'a> CheckerState<'a> {
                 None => continue,
             };
 
-            if let Some(module_specifier) = symbol.import_module.as_deref() {
+            if let Some(module_specifier) = symbol.import_module() {
                 let Some((export_name, is_namespace_binding)) =
                     self.effective_import_binding_name(symbol)
                 else {
@@ -708,7 +708,7 @@ impl<'a> CheckerState<'a> {
                 Some(s) => s,
                 None => continue,
             };
-            if let Some(module_specifier) = symbol.import_module.as_deref()
+            if let Some(module_specifier) = symbol.import_module()
                 && let Some(target_idx) = self.ctx.resolve_import_target(module_specifier)
                 && let Some(target_binder) = self.ctx.get_binder_for_file(target_idx)
             {
@@ -726,14 +726,12 @@ impl<'a> CheckerState<'a> {
                         // Also check if the export= symbol is an alias that
                         // resolves to a type-only import
                         if eq_sym.has_any_flags(symbol_flags::ALIAS)
-                            && let Some(ref eq_import_module) = eq_sym.import_module
+                            && let Some(eq_import_module) = eq_sym.import_module()
                         {
-                            let eq_name = eq_sym
-                                .import_name
-                                .as_deref()
-                                .unwrap_or(&eq_sym.escaped_name);
-                            let is_ns = eq_sym.import_name.is_none()
-                                || eq_sym.import_name.as_deref() == Some("*");
+                            let eq_name =
+                                eq_sym.import_name().unwrap_or(eq_sym.escaped_name.as_str());
+                            let is_ns =
+                                eq_sym.import_name().is_none() || eq_sym.import_name() == Some("*");
                             // For namespace imports, check the main binder's
                             // merged symbol for is_type_only
                             if is_ns {

--- a/crates/tsz-checker/src/flow/flow_analysis/tdz.rs
+++ b/crates/tsz-checker/src/flow/flow_analysis/tdz.rs
@@ -299,7 +299,7 @@ impl<'a> CheckerState<'a> {
 
         // Skip check for cross-file symbols (imported from another file).
         // Position comparison only makes sense within the same file.
-        if symbol.import_module.is_some() {
+        if symbol.import_module().is_some() {
             return false;
         }
         let is_cross_file = symbol.decl_file_idx != u32::MAX

--- a/crates/tsz-checker/src/jsdoc/lookup.rs
+++ b/crates/tsz-checker/src/jsdoc/lookup.rs
@@ -860,7 +860,7 @@ impl<'a> CheckerState<'a> {
         // CommonJS `var mod = require("./x")` binds `mod` to the module's
         // exports. Qualified references like `{mod.Foo}` resolve through the
         // imported module and must not be flagged here.
-        if symbol.import_module.is_some() {
+        if symbol.import_module().is_some() {
             return;
         }
         // Detect `var mod = require("./x")` in JS salsa mode, which is

--- a/crates/tsz-checker/src/jsdoc/params_type_strings.rs
+++ b/crates/tsz-checker/src/jsdoc/params_type_strings.rs
@@ -436,7 +436,7 @@ impl<'a> CheckerState<'a> {
                 | symbol_flags::NAMESPACE_MODULE
                 | symbol_flags::VALUE_MODULE
                 | symbol_flags::MODULE_EXPORTS,
-        ) || symbol.import_module.is_some()
+        ) || symbol.import_module().is_some()
     }
 
     const fn is_jsdoc_identifier_start(byte: u8) -> bool {

--- a/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
+++ b/crates/tsz-checker/src/jsdoc/resolution/name_resolution.rs
@@ -1126,7 +1126,7 @@ impl<'a> CheckerState<'a> {
                 .get_symbol_with_libs(current_sym, &lib_binders)
         })?;
 
-        if let Some(module_specifier) = symbol.import_module.as_deref()
+        if let Some(module_specifier) = symbol.import_module()
             && self.jsdoc_module_specifier_prefers_direct_type_exports(module_specifier)
         {
             return self.resolve_jsdoc_import_member(module_specifier, segment);
@@ -1394,7 +1394,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            if let Some(ref module_specifier) = symbol.import_module {
+            if let Some(module_specifier) = symbol.import_module() {
                 let mut visited_aliases = AliasCycleTracker::new();
                 if let Some(member_sym) = self.resolve_reexported_member_symbol(
                     module_specifier,

--- a/crates/tsz-checker/src/state/state_checking/heritage.rs
+++ b/crates/tsz-checker/src/state/state_checking/heritage.rs
@@ -30,7 +30,7 @@ impl<'a> CheckerState<'a> {
             return None;
         }
 
-        let module_specifier = alias.import_module.as_deref()?;
+        let module_specifier = alias.import_module()?;
         let exports = self.resolve_effective_module_exports_from_file(
             module_specifier,
             Some(self.ctx.current_file_idx),
@@ -444,7 +444,7 @@ impl<'a> CheckerState<'a> {
                                 // The namespace object from an import is always usable as a value
                                 // reference, even if the module has no value exports or failed to resolve.
                                 let has_alias = symbol.has_any_flags(symbol_flags::ALIAS);
-                                if has_alias && symbol.import_module.is_some() {
+                                if has_alias && symbol.import_module().is_some() {
                                     // Skip TS2708 for import aliases - this handles cases like
                                     // `import * as A from ""` where the module fails to resolve.
                                     continue;
@@ -1663,7 +1663,7 @@ impl<'a> CheckerState<'a> {
 
         // Skip check for cross-file symbols (imported from another file).
         // Position comparison only makes sense within the same file.
-        if symbol.import_module.is_some() {
+        if symbol.import_module().is_some() {
             return;
         }
         // If decl_file_idx is set and differs from the current file, the declaration

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -116,10 +116,10 @@ impl<'a> CheckerState<'a> {
             // (import_name = None) and `import * as X from M`
             // (import_name = "*"). Named and default imports flow through
             // their own type-resolution paths.
-            if !matches!(symbol.import_name.as_deref(), None | Some("*")) {
+            if !matches!(symbol.import_name(), None | Some("*")) {
                 return None;
             }
-            let module_name = symbol.import_module.as_deref()?;
+            let module_name = symbol.import_module()?;
             if !self.current_file_uses_module_exports_require_interop(module_name) {
                 return None;
             }
@@ -519,7 +519,7 @@ impl<'a> CheckerState<'a> {
             let should_try_default_reexport = self
                 .get_cross_file_symbol(export_sym_id)
                 .or_else(|| self.ctx.binder.get_symbol(export_sym_id))
-                .is_some_and(|symbol| symbol.import_module.is_some());
+                .is_some_and(|symbol| symbol.import_module().is_some());
             let default_reexport_type = if should_try_default_reexport {
                 self.namespace_default_reexport_property_type(
                     module_name,
@@ -830,8 +830,8 @@ impl<'a> CheckerState<'a> {
                     symbol.flags,
                     symbol.value_declaration,
                     symbol.declarations.clone(),
-                    symbol.import_module.clone(),
-                    symbol.import_name.clone(),
+                    symbol.import_module().map(str::to_string),
+                    symbol.import_name().map(str::to_string),
                     symbol.escaped_name.clone(),
                 )
             }
@@ -846,8 +846,8 @@ impl<'a> CheckerState<'a> {
                             symbol.flags,
                             symbol.value_declaration,
                             symbol.declarations.clone(),
-                            symbol.import_module.clone(),
-                            symbol.import_name.clone(),
+                            symbol.import_module().map(str::to_string),
+                            symbol.import_name().map(str::to_string),
                             symbol.escaped_name.clone(),
                         )
                     }

--- a/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed_helpers_binding.rs
@@ -103,8 +103,8 @@ impl<'a> CheckerState<'a> {
             .or_else(|| self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders))?;
 
         let is_namespace_import =
-            symbol.import_name.is_none() || symbol.import_name.as_deref() == Some("*");
-        if is_namespace_import && let Some(module_name) = symbol.import_module.as_deref() {
+            symbol.import_name().is_none() || symbol.import_name() == Some("*");
+        if is_namespace_import && let Some(module_name) = symbol.import_module() {
             return Some(self.imported_namespace_display_module_name(module_name));
         }
 
@@ -1216,7 +1216,7 @@ impl<'a> CheckerState<'a> {
                 if let Some(local_sym_id) = self.ctx.binder.file_locals.get(ident_text)
                     && let Some(symbol) = self.ctx.binder.get_symbol(local_sym_id)
                     && symbol.has_any_flags(symbol_flags::ALIAS)
-                    && let Some(ref import_module) = symbol.import_module
+                    && let Some(import_module) = symbol.import_module()
                 {
                     let last_segment = import_module.rsplit('/').next().unwrap_or(import_module);
                     if last_segment == file_stem {

--- a/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_type_query.rs
@@ -1167,7 +1167,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Must be an import-equals declaration (import a = X), not an ES import
-        if symbol.import_module.is_some() {
+        if symbol.import_module().is_some() {
             return false;
         }
 

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_alias_shortcut.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_alias_shortcut.rs
@@ -28,13 +28,13 @@ impl<'a> CheckerState<'a> {
                 );
                 return None;
             }
-            let Some(module_name) = symbol.import_module.clone() else {
+            let Some(module_name) = symbol.import_module().map(str::to_string) else {
                 tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
                     AliasOutcome::MissingModule,
                 );
                 return None;
             };
-            let Some(import_name) = symbol.import_name.clone() else {
+            let Some(import_name) = symbol.import_name().map(str::to_string) else {
                 tsz_common::perf_counters::record_cross_arena_alias_shortcut_outcome(
                     AliasOutcome::MissingImportName,
                 );

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain.rs
@@ -1386,11 +1386,8 @@ impl<'a> CheckerState<'a> {
         if symbol.flags & symbol_flags::ALIAS == 0 {
             return None;
         }
-        let module_specifier = symbol.import_module.as_ref()?;
-        let import_name = symbol
-            .import_name
-            .as_deref()
-            .unwrap_or(symbol.escaped_name.as_str());
+        let module_specifier = symbol.import_module()?;
+        let import_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
         if import_name == "*" {
             return None;
         }
@@ -1433,11 +1430,8 @@ impl<'a> CheckerState<'a> {
                 sym_id,
             });
         }
-        let module_specifier = symbol.import_module.as_ref()?;
-        let import_name = symbol
-            .import_name
-            .as_deref()
-            .unwrap_or(symbol.escaped_name.as_str());
+        let module_specifier = symbol.import_module()?;
+        let import_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
         if import_name == "*" {
             return None;
         }

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_alias_chain_tests.rs
@@ -955,8 +955,8 @@ fn direct_source_file_type_alias_lowers_same_binder_export_alias_symbol() {
         .alloc(symbol_flags::ALIAS, "Alias".to_string());
     {
         let alias_symbol = binder.symbols.get_mut(alias_sym).expect("Alias symbol");
-        alias_symbol.import_module = Some("./target".to_string());
-        alias_symbol.import_name = Some("Leaf".to_string());
+        alias_symbol.set_import_module(Some("./target".to_string()));
+        alias_symbol.set_import_name(Some("Leaf".to_string()));
         alias_symbol.is_type_only = true;
     }
     binder.file_locals.set("Alias".to_string(), alias_sym);
@@ -1004,8 +1004,8 @@ fn direct_source_file_type_alias_lowers_renamed_same_binder_alias_with_type_args
         .alloc(symbol_flags::ALIAS, "Renamed".to_string());
     {
         let alias_symbol = binder.symbols.get_mut(alias_sym).expect("Renamed symbol");
-        alias_symbol.import_module = Some("./target".to_string());
-        alias_symbol.import_name = Some("Wrap".to_string());
+        alias_symbol.set_import_module(Some("./target".to_string()));
+        alias_symbol.set_import_name(Some("Wrap".to_string()));
         alias_symbol.is_type_only = true;
     }
     binder.file_locals.set("Renamed".to_string(), alias_sym);
@@ -1054,8 +1054,8 @@ fn direct_source_file_type_alias_rejects_alias_symbol_to_typeof_body() {
         .alloc(symbol_flags::ALIAS, "Alias".to_string());
     {
         let alias_symbol = binder.symbols.get_mut(alias_sym).expect("Alias symbol");
-        alias_symbol.import_module = Some("./target".to_string());
-        alias_symbol.import_name = Some("Flow".to_string());
+        alias_symbol.set_import_module(Some("./target".to_string()));
+        alias_symbol.set_import_name(Some("Flow".to_string()));
         alias_symbol.is_type_only = true;
     }
     binder.file_locals.set("Alias".to_string(), alias_sym);

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_import_alias_pin.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_import_alias_pin.rs
@@ -22,6 +22,7 @@ impl<'a> CheckerState<'a> {
     /// Local import alias (`ALIAS` + `import_module`) at `sym_id`, if any.
     pub(crate) fn local_import_alias(&self, sym_id: SymbolId) -> Option<&tsz_binder::Symbol> {
         let local = self.ctx.binder.get_symbol(sym_id)?;
-        (local.has_any_flags(symbol_flags::ALIAS) && local.import_module.is_some()).then_some(local)
+        (local.has_any_flags(symbol_flags::ALIAS) && local.import_module().is_some())
+            .then_some(local)
     }
 }

--- a/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
+++ b/crates/tsz-checker/src/state/type_analysis/qualified_names.rs
@@ -325,7 +325,7 @@ impl<'a> CheckerState<'a> {
             if let Some(sym_id) = self.resolve_identifier_symbol_as_qualified_type_anchor(qn.left) {
                 if let Some(symbol) = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders) {
                     left_sym_for_missing = Some(sym_id);
-                    left_module_specifier = symbol.import_module.clone();
+                    left_module_specifier = symbol.import_module().map(str::to_string);
                     let mut result = self.resolve_symbol_export_for(
                         Some(sym_id),
                         symbol,
@@ -351,7 +351,7 @@ impl<'a> CheckerState<'a> {
                                 .as_ref()
                                 .and_then(|exports| exports.get(&right_name));
                             if result.is_none()
-                                && let Some(module) = alias_sym.import_module.as_ref()
+                                && let Some(module) = alias_sym.import_module()
                             {
                                 // Resolve from ALIAS's source file, then
                                 // fall back to current-file resolution.
@@ -615,7 +615,7 @@ impl<'a> CheckerState<'a> {
             } else if node.kind == SyntaxKind::Identifier as u16 {
                 let sym_id = self.resolve_identifier_symbol_as_qualified_type_anchor(idx)?;
                 let symbol = self.ctx.binder.get_symbol_with_libs(sym_id, lib_binders)?;
-                return symbol.import_module.clone();
+                return symbol.import_module().map(str::to_string);
             } else {
                 return None;
             }
@@ -753,7 +753,7 @@ impl<'a> CheckerState<'a> {
 
         // If not found in direct exports, check for re-exports
         // The member might be re-exported from another module
-        if let Some(ref module_specifier) = symbol.import_module {
+        if let Some(module_specifier) = symbol.import_module() {
             if self
                 .ctx
                 .namespace_import_alias_has_local_namespace_conflict(symbol)

--- a/crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs
+++ b/crates/tsz-checker/src/state/type_analysis/source_alias_attribution.rs
@@ -485,8 +485,8 @@ fn resolve_import_symbol_for_attribution_no_cache(
     sym_id: tsz_binder::SymbolId,
 ) -> Option<tsz_binder::SymbolId> {
     let symbol = binder.get_symbol(sym_id)?;
-    let module_specifier = symbol.import_module.as_ref()?;
-    let export_name = symbol.import_name.as_deref().unwrap_or("export=");
+    let module_specifier = symbol.import_module()?;
+    let export_name = symbol.import_name().unwrap_or("export=");
     let mut visited = HashSet::new();
     resolve_import_with_reexports_for_attribution_no_cache(
         binder,
@@ -654,8 +654,8 @@ mod tests {
             .symbols
             .alloc(symbol_flags::ALIAS, "Alias".to_string());
         let alias_symbol = binder.symbols.get_mut(alias_sym).expect("alias symbol");
-        alias_symbol.import_module = Some("./target".to_string());
-        alias_symbol.import_name = Some("Target".to_string());
+        alias_symbol.set_import_module(Some("./target".to_string()));
+        alias_symbol.set_import_name(Some("Target".to_string()));
         binder.file_locals.set("Alias".to_string(), alias_sym);
         let mut exports = SymbolTable::new();
         exports.set("Target".to_string(), target_sym);
@@ -706,8 +706,8 @@ mod tests {
             .symbols
             .alloc(symbol_flags::ALIAS, "Array".to_string());
         let alias_symbol = binder.symbols.get_mut(alias_sym).expect("alias symbol");
-        alias_symbol.import_module = Some("./target".to_string());
-        alias_symbol.import_name = Some("Array".to_string());
+        alias_symbol.set_import_module(Some("./target".to_string()));
+        alias_symbol.set_import_name(Some("Array".to_string()));
         binder.file_locals.set("Array".to_string(), alias_sym);
         let mut exports = SymbolTable::new();
         exports.set("Array".to_string(), target_sym);

--- a/crates/tsz-checker/src/state/type_environment/core.rs
+++ b/crates/tsz-checker/src/state/type_environment/core.rs
@@ -1429,7 +1429,7 @@ impl<'a> CheckerState<'a> {
                     .ctx
                     .binder
                     .get_symbol(sym_id)
-                    .is_some_and(|s| s.import_module.is_some());
+                    .is_some_and(|s| s.import_module().is_some());
                 if is_import {
                     continue;
                 }

--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -1137,12 +1137,11 @@ impl<'a> CheckerState<'a> {
                 continue;
             };
             // Must be a star namespace import: `import * as L from "..."`
-            if !ns_symbol.has_any_flags(symbol_flags::ALIAS)
-                || ns_symbol.import_name.as_deref() != Some("*")
+            if !ns_symbol.has_any_flags(symbol_flags::ALIAS) || ns_symbol.import_name() != Some("*")
             {
                 continue;
             }
-            let Some(module_name) = ns_symbol.import_module.as_deref() else {
+            let Some(module_name) = ns_symbol.import_module() else {
                 continue;
             };
 

--- a/crates/tsz-checker/src/state/type_resolution/core.rs
+++ b/crates/tsz-checker/src/state/type_resolution/core.rs
@@ -184,8 +184,8 @@ impl<'a> CheckerState<'a> {
                 .get_symbol(local_sym_id)
                 .is_some_and(|symbol| {
                     symbol.has_any_flags(symbol_flags::ALIAS)
-                        && symbol.import_module.is_some()
-                        && symbol.import_name.as_deref() != Some("*")
+                        && symbol.import_module().is_some()
+                        && symbol.import_name() != Some("*")
                 })
         {
             // `import { X } from ...` referenced in plain type position.
@@ -731,7 +731,7 @@ impl<'a> CheckerState<'a> {
                         self.ctx
                             .binder
                             .get_symbol_with_libs(left_sym_id, &lib_binders)
-                            .and_then(|s| s.import_module.clone())
+                            .and_then(|s| s.import_module().map(str::to_string))
                     } else {
                         // Nested qualified name (e.g., ns.Root.Foo) — walk to
                         // root identifier to extract the module specifier.
@@ -770,12 +770,12 @@ impl<'a> CheckerState<'a> {
                         .binder
                         .get_symbol_with_libs(sym_id, &lib_binders)
                         .and_then(|symbol| {
-                            symbol.import_module.as_ref().map(|module_specifier| {
+                            symbol.import_module().map(|module_specifier| {
                                 (
-                                    module_specifier.clone(),
+                                    module_specifier.to_string(),
                                     symbol
-                                        .import_name
-                                        .clone()
+                                        .import_name()
+                                        .map(str::to_string)
                                         .unwrap_or_else(|| symbol.escaped_name.clone()),
                                 )
                             })
@@ -1628,12 +1628,12 @@ impl<'a> CheckerState<'a> {
                         .binder
                         .get_symbol_with_libs(sym_id, &lib_binders)
                         .and_then(|symbol| {
-                            symbol.import_module.as_ref().map(|module_specifier| {
+                            symbol.import_module().map(|module_specifier| {
                                 (
-                                    module_specifier.clone(),
+                                    module_specifier.to_string(),
                                     symbol
-                                        .import_name
-                                        .clone()
+                                        .import_name()
+                                        .map(str::to_string)
                                         .unwrap_or_else(|| symbol.escaped_name.clone()),
                                 )
                             })

--- a/crates/tsz-checker/src/state/type_resolution/cross_file_export.rs
+++ b/crates/tsz-checker/src/state/type_resolution/cross_file_export.rs
@@ -69,7 +69,7 @@ impl<'a> CheckerState<'a> {
         let is_reexport_alias = |sym_id: tsz_binder::SymbolId| {
             target_binder
                 .get_symbol(sym_id)
-                .is_some_and(|symbol| symbol.import_module.is_some())
+                .is_some_and(|symbol| symbol.import_module().is_some())
         };
 
         if let Some(exports_table) = self

--- a/crates/tsz-checker/src/state/type_resolution/module.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module.rs
@@ -379,8 +379,8 @@ impl<'a> CheckerState<'a> {
         if !symbol.has_any_flags(symbol_flags::ALIAS) {
             return None;
         }
-        let module_name = symbol.import_module.as_ref()?;
-        let import_name = symbol.import_name.as_ref()?;
+        let module_name = symbol.import_module()?;
+        let import_name = symbol.import_name()?;
         if import_name == "default" {
             return None;
         }

--- a/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
@@ -213,17 +213,17 @@ impl<'a> CheckerState<'a> {
                 .get_binder_for_file(actual_file)
                 .and_then(|binder| binder.get_symbol(sym_id))
                 .and_then(|sym| {
-                    sym.import_module.as_ref().map(|m| {
+                    sym.import_module().map(|m| {
                         let next_name = sym
-                            .import_name
-                            .clone()
+                            .import_name()
+                            .map(str::to_string)
                             .unwrap_or_else(|| current_name.clone());
                         let decl_file = if sym.decl_file_idx == u32::MAX {
                             actual_file
                         } else {
                             sym.decl_file_idx as usize
                         };
-                        (m.clone(), next_name, decl_file)
+                        (m.to_string(), next_name, decl_file)
                     })
                 });
             match next_hop {

--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -21,12 +21,8 @@ impl<'a> CheckerState<'a> {
         if !alias_symbol.has_any_flags(symbol_flags::ALIAS) || !alias_symbol.is_type_only {
             return None;
         }
-        let module_name = alias_symbol.import_module.clone()?;
-        let import_name = alias_symbol
-            .import_name
-            .as_deref()
-            .unwrap_or(name)
-            .to_owned();
+        let module_name = alias_symbol.import_module().map(str::to_string)?;
+        let import_name = alias_symbol.import_name().unwrap_or(name).to_owned();
         let target_sym_id = self.resolve_cross_file_export_from_file(
             &module_name,
             &import_name,
@@ -457,7 +453,7 @@ impl<'a> CheckerState<'a> {
             .and_then(|alias_sym_id| self.ctx.binder.get_symbol(alias_sym_id))
             .or_else(|| self.ctx.binder.get_symbol(sym_id))
             .filter(|alias_symbol| self.reference_symbol_is_import_alias(alias_symbol))
-            .and_then(|alias_symbol| alias_symbol.import_name.clone());
+            .and_then(|alias_symbol| alias_symbol.import_name().map(str::to_string));
         let mixed_class_interface = symbol.has_any_flags(symbol_flags::CLASS)
             && symbol.has_any_flags(symbol_flags::INTERFACE);
 
@@ -961,7 +957,7 @@ impl<'a> CheckerState<'a> {
 
                 let target_sym_id = self.resolve_alias_symbol(sym_id, visited_aliases);
 
-                if matches!(symbol.import_name.as_deref(), Some("*")) && target_sym_id.is_some() {
+                if matches!(symbol.import_name(), Some("*")) && target_sym_id.is_some() {
                     if symbol.is_umd_export {
                         if let Some(target_sym_id) = target_sym_id
                             && target_sym_id != sym_id
@@ -991,13 +987,9 @@ impl<'a> CheckerState<'a> {
                 // If the module has `export =`, resolve_alias_symbol would have succeeded
                 // above. If the module isn't in our exports table at all (unresolved
                 // cross-file reference), we can't assume it's namespace-only.
-                if let Some(ref module_name) = symbol.import_module
-                    && matches!(symbol.import_name.as_deref(), None | Some("*"))
-                    && self
-                        .ctx
-                        .binder
-                        .module_exports
-                        .contains_key(module_name.as_str())
+                if let Some(module_name) = symbol.import_module()
+                    && matches!(symbol.import_name(), None | Some("*"))
+                    && self.ctx.binder.module_exports.contains_key(module_name)
                 {
                     return true;
                 }

--- a/crates/tsz-checker/src/state/type_resolution/reference_type_params.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_type_params.rs
@@ -47,9 +47,9 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         if symbol.has_any_flags(symbol_flags::ALIAS)
-            && let Some(module_name) = symbol.import_module.as_ref()
+            && let Some(module_name) = symbol.import_module()
         {
-            let import_name = symbol.import_name.as_deref().unwrap_or(name);
+            let import_name = symbol.import_name().unwrap_or(name);
             let target_sym_id =
                 self.resolve_cross_file_export_from_file(module_name, import_name, Some(file_idx))?;
             if let Some(target_file_idx) = self
@@ -201,8 +201,8 @@ impl<'a> CheckerState<'a> {
         alias_symbol: &tsz_binder::Symbol,
         expected_name: &str,
     ) -> Option<(SymbolId, Option<usize>)> {
-        let module_specifier = alias_symbol.import_module.as_ref()?;
-        let import_name = alias_symbol.import_name.as_deref().unwrap_or(expected_name);
+        let module_specifier = alias_symbol.import_module()?;
+        let import_name = alias_symbol.import_name().unwrap_or(expected_name);
         let source_file_idx = if alias_symbol.decl_file_idx == u32::MAX {
             self.ctx.current_file_idx
         } else {
@@ -242,7 +242,7 @@ impl<'a> CheckerState<'a> {
             self.ctx.get_arena_for_file(symbol.decl_file_idx)
         };
         symbol.has_any_flags(symbol_flags::ALIAS)
-            && symbol.import_module.is_some()
+            && symbol.import_module().is_some()
             && symbol
                 .declarations
                 .iter()

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -190,12 +190,11 @@ impl<'a> CheckerState<'a> {
                     if structural_type != TypeId::ERROR
                         && structural_type != TypeId::UNKNOWN
                         && let Some(local_sym) = self.ctx.binder.get_symbol(sym_id)
-                        && let Some(module_specifier) = local_sym.import_module.as_ref()
+                        && let Some(module_specifier) = local_sym.import_module()
                     {
                         let aug_name = local_sym
-                            .import_name
-                            .as_deref()
-                            .unwrap_or(&local_sym.escaped_name);
+                            .import_name()
+                            .unwrap_or(local_sym.escaped_name.as_str());
                         structural_type = self.apply_module_augmentations(
                             module_specifier,
                             aug_name,
@@ -460,7 +459,7 @@ impl<'a> CheckerState<'a> {
             let alias_result = self.resolve_alias_symbol(sym_id, &mut visited);
             let is_default_import_alias = self
                 .get_cross_file_symbol(sym_id)
-                .and_then(|symbol| symbol.import_name.as_deref())
+                .and_then(|symbol| symbol.import_name())
                 == Some("default");
             if let Some(target_sym_id) = alias_result
                 && target_sym_id != sym_id
@@ -505,13 +504,12 @@ impl<'a> CheckerState<'a> {
                     }
                     let alias_augmentation_target =
                         local_alias_for_augmentation.and_then(|alias_symbol| {
-                            alias_symbol.import_module.as_ref().map(|module_specifier| {
+                            alias_symbol.import_module().map(|module_specifier| {
                                 let aug_name = alias_symbol
-                                    .import_name
-                                    .as_deref()
-                                    .unwrap_or(&alias_symbol.escaped_name)
+                                    .import_name()
+                                    .unwrap_or(alias_symbol.escaped_name.as_str())
                                     .to_string();
-                                (module_specifier.clone(), aug_name)
+                                (module_specifier.to_string(), aug_name)
                             })
                         });
                     self.ctx.leave_recursion();
@@ -911,11 +909,8 @@ impl<'a> CheckerState<'a> {
         if !symbol.has_any_flags(symbol_flags::ALIAS) {
             return None;
         }
-        let module_specifier = symbol.import_module.as_ref()?;
-        let import_name = symbol
-            .import_name
-            .as_deref()
-            .unwrap_or(&symbol.escaped_name);
+        let module_specifier = symbol.import_module()?;
+        let import_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
 
         // Local import aliases resolve relative to the current file even if a
         // same-number cross-file target has already been registered for `sym_id`.

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit.rs
@@ -912,7 +912,7 @@ impl<'a> CheckerState<'a> {
         // The parent package is between the FIRST node_modules and the second.
         if nm_positions.len() >= 2
             && symbol.has_any_flags(symbol_flags::ALIAS)
-            && let Some(import_module) = &symbol.import_module
+            && let Some(import_module) = symbol.import_module()
             && !import_module.starts_with('.')
             && !import_module.starts_with('/')
         {

--- a/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit_symbol_access.rs
+++ b/crates/tsz-checker/src/state/variable_checking/variable_helpers/declaration_emit_symbol_access.rs
@@ -82,7 +82,7 @@ impl<'a> CheckerState<'a> {
             if local_sym.flags & tsz_binder::symbol_flags::ALIAS == 0 {
                 continue;
             }
-            let Some(specifier) = local_sym.import_module.as_deref() else {
+            let Some(specifier) = local_sym.import_module() else {
                 continue;
             };
             if !tried.insert(specifier.to_string()) {

--- a/crates/tsz-checker/src/symbols/symbol_resolver.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver.rs
@@ -1181,13 +1181,12 @@ impl<'a> CheckerState<'a> {
             };
 
             if let Some(alias_symbol) = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)
-                && let Some(module_name) = alias_symbol.import_module.as_ref()
-                && alias_symbol.import_name.is_some()
+                && let Some(module_name) = alias_symbol.import_module()
+                && alias_symbol.import_name().is_some()
             {
                 let expected_name = alias_symbol
-                    .import_name
-                    .as_deref()
-                    .unwrap_or(&alias_symbol.escaped_name);
+                    .import_name()
+                    .unwrap_or(alias_symbol.escaped_name.as_str());
                 let source_file_idx = self
                     .ctx
                     .resolve_symbol_file_index(sym_id)
@@ -1246,12 +1245,11 @@ impl<'a> CheckerState<'a> {
                 .map(|target_sym_id| {
                     if let Some(alias_symbol) =
                         self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)
-                        && let Some(module_name) = alias_symbol.import_module.as_ref()
+                        && let Some(module_name) = alias_symbol.import_module()
                     {
                         let expected_name = alias_symbol
-                            .import_name
-                            .as_deref()
-                            .unwrap_or(&alias_symbol.escaped_name);
+                            .import_name()
+                            .unwrap_or(alias_symbol.escaped_name.as_str());
                         self.record_cross_file_symbol_if_needed(
                             target_sym_id,
                             expected_name,
@@ -1271,8 +1269,8 @@ impl<'a> CheckerState<'a> {
             }
 
             let has_local_type_meaning = self.symbol_has_declared_type_meaning(sym_id);
-            let is_namespace_import_alias = symbol.import_module.is_some()
-                && matches!(symbol.import_name.as_deref(), Some("*"));
+            let is_namespace_import_alias =
+                symbol.import_module().is_some() && matches!(symbol.import_name(), Some("*"));
 
             has_local_type_meaning || is_namespace_import_alias
         };
@@ -1663,7 +1661,7 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
-            if let Some(ref module_specifier) = symbol.import_module {
+            if let Some(module_specifier) = symbol.import_module() {
                 let mut visited_aliases = AliasCycleTracker::new();
                 if let Some(member_sym) = self.resolve_reexported_member_symbol(
                     module_specifier,
@@ -1798,8 +1796,8 @@ impl<'a> CheckerState<'a> {
                     self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)
                     && alias_symbol.has_any_flags(symbol_flags::ALIAS)
                     && alias_symbol.is_type_only
-                    && let Some(module_name) = alias_symbol.import_module.as_ref()
-                    && let Some(import_name) = alias_symbol.import_name.as_deref()
+                    && let Some(module_name) = alias_symbol.import_module()
+                    && let Some(import_name) = alias_symbol.import_name()
                 {
                     let source_file_idx = self
                         .ctx

--- a/crates/tsz-checker/src/symbols/symbol_resolver_qualified.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_qualified.rs
@@ -200,8 +200,8 @@ impl<'a> CheckerState<'a> {
                 .binder
                 .get_symbol_with_libs(original_left_sym, &lib_binders);
             let module_specifier = unresolved_left_symbol
-                .and_then(|symbol| symbol.import_module.clone())
-                .or_else(|| left_symbol.import_module.clone())
+                .and_then(|symbol| symbol.import_module().map(str::to_string))
+                .or_else(|| left_symbol.import_module().map(str::to_string))
                 .or_else(|| {
                     self.ctx
                         .arena
@@ -416,8 +416,8 @@ impl<'a> CheckerState<'a> {
             || unresolved_left_has_local_namespace_conflict
             || left_name_has_import_conflict;
         let module_specifier = unresolved_left_symbol
-            .and_then(|symbol| symbol.import_module.clone())
-            .or_else(|| left_symbol.import_module.clone())
+            .and_then(|symbol| symbol.import_module().map(str::to_string))
+            .or_else(|| left_symbol.import_module().map(str::to_string))
             .or_else(|| {
                 self.ctx
                     .arena
@@ -475,12 +475,13 @@ impl<'a> CheckerState<'a> {
             return TypeSymbolResolution::Type(reexported_sym);
         }
 
-        let augmentation_module_specifier = left_symbol.import_module.clone().or_else(|| {
-            self.ctx
-                .binder
-                .get_symbol_with_libs(original_left_sym, &lib_binders)
-                .and_then(|symbol| symbol.import_module.clone())
-        });
+        let augmentation_module_specifier =
+            left_symbol.import_module().map(str::to_string).or_else(|| {
+                self.ctx
+                    .binder
+                    .get_symbol_with_libs(original_left_sym, &lib_binders)
+                    .and_then(|symbol| symbol.import_module().map(str::to_string))
+            });
         if !left_has_local_namespace_conflict
             && let Some(ref module_specifier) = augmentation_module_specifier
             && let Some(augmented_sym) = self.resolve_module_augmentation_member_symbol(
@@ -565,7 +566,7 @@ impl<'a> CheckerState<'a> {
                 self.ctx
                     .binder
                     .get_symbol_with_libs(parent_sym_id, &lib_binders)
-                    .and_then(|symbol| symbol.import_module.as_deref())
+                    .and_then(|symbol| symbol.import_module())
                     .and_then(|module_specifier| self.ctx.resolve_import_target(module_specifier))
             });
 
@@ -1044,7 +1045,7 @@ impl<'a> CheckerState<'a> {
                 );
             }
 
-            if let Some(ref module_specifier) = left_symbol.import_module {
+            if let Some(module_specifier) = left_symbol.import_module() {
                 if left_symbol.has_any_flags(symbol_flags::ALIAS)
                     && self
                         .ctx
@@ -1127,7 +1128,7 @@ impl<'a> CheckerState<'a> {
 
         // If not found in direct exports, check for re-exports
         // This handles cases like: export { foo } from './bar'
-        if let Some(ref module_specifier) = left_symbol.import_module {
+        if let Some(module_specifier) = left_symbol.import_module() {
             if left_symbol.has_any_flags(symbol_flags::ALIAS)
                 && self
                     .ctx

--- a/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
@@ -327,7 +327,7 @@ impl<'a> CheckerState<'a> {
 
                 // For import aliases (import X = require("./module")), X represents
                 // the entire module namespace. Look up the member in module_exports.
-                if let Some(ref module_specifier) = left_symbol.import_module {
+                if let Some(module_specifier) = left_symbol.import_module() {
                     if left_symbol.has_any_flags(symbol_flags::ALIAS)
                         && self
                             .ctx
@@ -372,7 +372,7 @@ impl<'a> CheckerState<'a> {
                     return Some(member_sym);
                 }
                 // Also check module_exports on the resolved symbol
-                if let Some(ref module_specifier) = resolved_symbol.import_module
+                if let Some(module_specifier) = resolved_symbol.import_module()
                     && let Some(member_sym) = self.resolve_reexported_member_symbol(
                         module_specifier,
                         &name,
@@ -462,7 +462,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Check if it has an import_module - if so, check if that module is resolved
-        if let Some(ref module_name) = symbol.import_module {
+        if let Some(module_name) = symbol.import_module() {
             // Check various ways a module can be resolved
             if self
                 .ctx
@@ -863,7 +863,7 @@ impl<'a> CheckerState<'a> {
 
         // Check for re-exports from other modules
         // This handles cases like: export { foo } from './bar'
-        if let Some(ref module_specifier) = left_symbol.import_module {
+        if let Some(module_specifier) = left_symbol.import_module() {
             if left_symbol.has_any_flags(symbol_flags::ALIAS)
                 && self
                     .ctx
@@ -900,7 +900,7 @@ impl<'a> CheckerState<'a> {
             }
         }
 
-        if from_typeof && left_symbol.import_module.is_none() {
+        if from_typeof && left_symbol.import_module().is_none() {
             let left_text = self
                 .entity_name_text(qn.left)
                 .unwrap_or_else(|| left_symbol.escaped_name.clone());

--- a/crates/tsz-checker/src/types/computation/access_super.rs
+++ b/crates/tsz-checker/src/types/computation/access_super.rs
@@ -197,7 +197,7 @@ impl<'a> CheckerState<'a> {
             }
             // Same-file classes only — cross-file references have no runtime
             // ordering relationship worth TDZ-checking here.
-            if symbol.import_module.is_some() {
+            if symbol.import_module().is_some() {
                 continue;
             }
             if symbol.decl_file_idx != u32::MAX

--- a/crates/tsz-checker/src/types/computation/complex_new_target.rs
+++ b/crates/tsz-checker/src/types/computation/complex_new_target.rs
@@ -23,8 +23,8 @@ impl<'a> CheckerState<'a> {
                 self.get_cross_file_symbol(sym_id)
                     .or_else(|| self.ctx.binder.get_symbol(sym_id))
                     .and_then(|symbol| {
-                        (symbol.import_name.as_deref() == Some("default"))
-                            .then(|| symbol.import_module.clone())
+                        (symbol.import_name() == Some("default"))
+                            .then(|| symbol.import_module().map(str::to_string))
                             .flatten()
                     })
             })
@@ -334,8 +334,8 @@ impl<'a> CheckerState<'a> {
             );
             return Some(TypeId::ERROR);
         }
-        if let Some(module_name) = symbol.import_module.as_deref() {
-            let export_name = symbol.import_name.as_deref().unwrap_or(class_name);
+        if let Some(module_name) = symbol.import_module() {
+            let export_name = symbol.import_name().unwrap_or(class_name);
             if self.imported_value_is_abstract_class(module_name, export_name) {
                 self.error_at_node(
                     new_idx,

--- a/crates/tsz-checker/src/types/computation/identifier/core.rs
+++ b/crates/tsz-checker/src/types/computation/identifier/core.rs
@@ -221,7 +221,7 @@ impl<'a> CheckerState<'a> {
             if candidate.escaped_name != type_symbol.escaped_name
                 || (candidate.flags & tsz_binder::symbol_flags::VALUE) == 0
                 || (candidate.flags & tsz_binder::symbol_flags::ALIAS) != 0
-                || candidate.import_module.is_some()
+                || candidate.import_module().is_some()
                 || !candidate.value_declaration.is_some()
             {
                 continue;
@@ -661,12 +661,12 @@ impl<'a> CheckerState<'a> {
                     .get_cross_file_symbol(sym_id)
                     .or_else(|| self.ctx.binder.get_symbol(sym_id))
                     .and_then(|symbol| {
-                        symbol.import_module.as_ref().map(|module_spec| {
+                        symbol.import_module().map(|module_spec| {
                             (
-                                module_spec.clone(),
+                                module_spec.to_string(),
                                 symbol
-                                    .import_name
-                                    .clone()
+                                    .import_name()
+                                    .map(str::to_string)
                                     .unwrap_or_else(|| name.to_string()),
                             )
                         })
@@ -896,8 +896,8 @@ impl<'a> CheckerState<'a> {
                     .get_cross_file_symbol(sym_id)
                     .or_else(|| self.ctx.binder.get_symbol(sym_id))
                     .and_then(|symbol| {
-                        (symbol.import_name.as_deref() == Some("default"))
-                            .then(|| symbol.import_module.clone())
+                        (symbol.import_name() == Some("default"))
+                            .then(|| symbol.import_module().map(str::to_string))
                             .flatten()
                     })
                     .or_else(|| self.source_file_default_import_module_named(idx, name))
@@ -942,9 +942,8 @@ impl<'a> CheckerState<'a> {
                         let lib_binders = self.get_lib_binders();
                         if let Some(symbol) =
                             self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)
-                            && symbol.import_module.is_some()
-                            && (symbol.import_name.is_none()
-                                || symbol.import_name.as_deref() == Some("*"))
+                            && symbol.import_module().is_some()
+                            && (symbol.import_name().is_none() || symbol.import_name() == Some("*"))
                         {
                             return self.get_type_of_symbol(sym_id);
                         }
@@ -1213,9 +1212,9 @@ impl<'a> CheckerState<'a> {
                         // binder to reach the underlying merged symbol.
                         if let Some(target) = self.get_symbol_globally(target_sym_id)
                             && (target.flags & tsz_binder::symbol_flags::ALIAS) != 0
-                            && target.import_module.is_none()
+                            && target.import_module().is_none()
                             && (target.escaped_name == "default"
-                                || target.import_name.as_deref() == Some("default"))
+                                || target.import_name() == Some("default"))
                             && let Some(decl_idx) = target.primary_declaration()
                             && let Some(target_file_idx) =
                                 self.ctx.resolve_symbol_file_index(target_sym_id)
@@ -1241,7 +1240,7 @@ impl<'a> CheckerState<'a> {
                             != 0
                             && (tflags & tsz_binder::symbol_flags::VALUE) != 0
                             && (tflags & tsz_binder::symbol_flags::ALIAS) == 0
-                            && target.import_module.is_none()
+                            && target.import_module().is_none()
                             && target.value_declaration.is_some()
                         {
                             let target_value_decl = target.value_declaration;
@@ -1505,8 +1504,8 @@ impl<'a> CheckerState<'a> {
                     self.get_cross_file_symbol(sym_id)
                         .or_else(|| self.ctx.binder.get_symbol(sym_id))
                         .and_then(|symbol| {
-                            (symbol.import_name.as_deref() == Some("default"))
-                                .then(|| symbol.import_module.clone())
+                            (symbol.import_name() == Some("default"))
+                                .then(|| symbol.import_module().map(str::to_string))
                                 .flatten()
                         })
                 })

--- a/crates/tsz-checker/src/types/property_access_helpers/expando.rs
+++ b/crates/tsz-checker/src/types/property_access_helpers/expando.rs
@@ -55,7 +55,7 @@ impl<'a> CheckerState<'a> {
             .or_else(|| self.ctx.binder.resolve_identifier(self.ctx.arena, root_idx))
             && let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
             && symbol.has_any_flags(symbol_flags::ALIAS)
-            && symbol.import_module.is_some()
+            && symbol.import_module().is_some()
         {
             return true;
         }
@@ -1073,7 +1073,7 @@ impl<'a> CheckerState<'a> {
             && let Some(root_sym_id) = self.resolve_identifier_symbol(root_idx)
             && let Some(root_symbol) = self.ctx.binder.get_symbol(root_sym_id)
             && root_symbol.has_any_flags(symbol_flags::ALIAS)
-            && root_symbol.import_module.is_some()
+            && root_symbol.import_module().is_some()
         {
             return false;
         }
@@ -1139,7 +1139,7 @@ impl<'a> CheckerState<'a> {
             && let Some(root_sym_id) = self.resolve_identifier_symbol(object_access.expression)
             && let Some(root_symbol) = self.ctx.binder.get_symbol(root_sym_id)
             && root_symbol.has_any_flags(symbol_flags::ALIAS)
-            && root_symbol.import_module.is_some()
+            && root_symbol.import_module().is_some()
         {
             return false;
         }

--- a/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
+++ b/crates/tsz-checker/src/types/property_access_type/identifier_resolution.rs
@@ -68,11 +68,8 @@ impl<'a> CheckerState<'a> {
         if let Some(base_sym_id) = self.resolve_identifier_symbol(access.expression)
             && let Some(base_symbol) = self.ctx.binder.get_symbol(base_sym_id)
             && base_symbol.has_any_flags(symbol_flags::ALIAS)
-            && base_symbol.import_module.is_some()
-            && base_symbol
-                .import_name
-                .as_ref()
-                .is_none_or(|name| name == "*")
+            && base_symbol.import_module().is_some()
+            && base_symbol.import_name().is_none_or(|name| name == "*")
         {
             if let Some(member_type) =
                 self.resolve_namespace_value_member_from_symbol(base_sym_id, property_name)
@@ -87,16 +84,13 @@ impl<'a> CheckerState<'a> {
 
             if self.is_in_type_only_position(idx)
                 && let Some(member_sym_id) =
-                    base_symbol
-                        .import_module
-                        .as_deref()
-                        .and_then(|module_specifier| {
-                            self.resolve_effective_module_exports_from_file(
-                                module_specifier,
-                                Some(base_symbol.decl_file_idx as usize),
-                            )
-                            .and_then(|exports| exports.get(property_name))
-                        })
+                    base_symbol.import_module().and_then(|module_specifier| {
+                        self.resolve_effective_module_exports_from_file(
+                            module_specifier,
+                            Some(base_symbol.decl_file_idx as usize),
+                        )
+                        .and_then(|exports| exports.get(property_name))
+                    })
             {
                 let member_type = self.get_type_of_symbol(member_sym_id);
                 if member_type != TypeId::ERROR && member_type != TypeId::UNKNOWN {
@@ -426,7 +420,7 @@ impl<'a> CheckerState<'a> {
                     .resolve_identifier_symbol(access.expression)
                     .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
                     .is_some_and(|sym| {
-                        sym.has_any_flags(symbol_flags::ALIAS) && sym.import_module.is_some()
+                        sym.has_any_flags(symbol_flags::ALIAS) && sym.import_module().is_some()
                     })
             {
                 return TypeId::ANY;
@@ -1303,7 +1297,7 @@ impl<'a> CheckerState<'a> {
                         .resolve_identifier_symbol(access.expression)
                         .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
                         .is_some_and(|sym| {
-                            sym.has_any_flags(symbol_flags::ALIAS) && sym.import_module.is_some()
+                            sym.has_any_flags(symbol_flags::ALIAS) && sym.import_module().is_some()
                         })
                 {
                     return TypeId::ANY;

--- a/crates/tsz-checker/src/types/property_access_type/value_import.rs
+++ b/crates/tsz-checker/src/types/property_access_type/value_import.rs
@@ -58,11 +58,11 @@ impl<'a> CheckerState<'a> {
         if alias.flags & symbol_flags::ALIAS == 0 {
             return None;
         }
-        let module_specifier = alias.import_module.as_deref()?;
+        let module_specifier = alias.import_module()?;
         // Namespace / `export=` imports (`import * as ns`) bind the module
         // object, not a single named value export, so there is no value-space
         // target to recover here.
-        let import_name = alias.import_name.as_deref()?;
+        let import_name = alias.import_name()?;
         if import_name == "*" {
             return None;
         }

--- a/crates/tsz-checker/src/types/queries/lib.rs
+++ b/crates/tsz-checker/src/types/queries/lib.rs
@@ -460,8 +460,8 @@ impl<'a> CheckerState<'a> {
             .get_cross_file_symbol(member_id)
             .or_else(|| self.ctx.binder.get_symbol(member_id))
             && member_symbol.has_any_flags(symbol_flags::ALIAS)
-            && member_symbol.import_name.is_none()
-            && let Some(module_specifier) = member_symbol.import_module.clone()
+            && member_symbol.import_name().is_none()
+            && let Some(module_specifier) = member_symbol.import_module().map(str::to_string)
         {
             let source_file_idx = if member_symbol.decl_file_idx == u32::MAX {
                 self.ctx.current_file_idx
@@ -479,8 +479,8 @@ impl<'a> CheckerState<'a> {
             .get_cross_file_symbol(member_id)
             .or_else(|| self.ctx.binder.get_symbol(member_id))
             && member_symbol.has_any_flags(symbol_flags::ALIAS)
-            && member_symbol.import_name.as_deref() == Some("default")
-            && let Some(module_specifier) = member_symbol.import_module.clone()
+            && member_symbol.import_name() == Some("default")
+            && let Some(module_specifier) = member_symbol.import_module().map(str::to_string)
             && let Some(namespace_type) =
                 self.node_esm_cjs_default_import_namespace_type(&module_specifier)
         {
@@ -541,10 +541,10 @@ impl<'a> CheckerState<'a> {
             if let Some(sym_id) = binder.file_locals.get(namespace_name)
                 && let Some(symbol) = binder.get_symbol(sym_id)
                 && symbol.is_umd_export
-                && let Some(module_spec) = symbol.import_module.as_ref()
+                && let Some(module_spec) = symbol.import_module()
                 && !module_specs.iter().any(|existing| existing == module_spec)
             {
-                module_specs.push(module_spec.clone());
+                module_specs.push(module_spec.to_string());
             }
         };
 
@@ -675,9 +675,8 @@ impl<'a> CheckerState<'a> {
             .get_cross_file_symbol(sym_id)
             .or_else(|| self.ctx.binder.get_symbol(sym_id))?;
         if !symbol.has_any_flags(symbol_flags::ALIAS)
-            || symbol.import_module.is_some()
-            || !(symbol.escaped_name == "default"
-                || symbol.import_name.as_deref() == Some("default"))
+            || symbol.import_module().is_some()
+            || !(symbol.escaped_name == "default" || symbol.import_name() == Some("default"))
         {
             return None;
         }
@@ -818,7 +817,7 @@ impl<'a> CheckerState<'a> {
                         symbol.escaped_name.clone(),
                         direct_member_id,
                         module_export_member_id,
-                        symbol.import_module.clone(),
+                        symbol.import_module().map(str::to_string),
                     )
                 };
 
@@ -960,12 +959,11 @@ impl<'a> CheckerState<'a> {
                     }
 
                     let module_name = symbol
-                        .import_module
-                        .as_deref()
+                        .import_module()
                         .unwrap_or(symbol.escaped_name.as_str())
                         .to_string();
 
-                    let import_module = symbol.import_module.clone();
+                    let import_module = symbol.import_module().map(str::to_string);
 
                     let direct_member_id = symbol
                         .exports
@@ -1446,7 +1444,7 @@ impl<'a> CheckerState<'a> {
                 symbol.escaped_name.clone(),
                 direct_member_id,
                 module_export_member_id,
-                symbol.import_module.clone(),
+                symbol.import_module().map(str::to_string),
                 symbol.decl_file_idx as usize,
             )
         };

--- a/crates/tsz-checker/src/types/queries/lib_aliases.rs
+++ b/crates/tsz-checker/src/types/queries/lib_aliases.rs
@@ -103,11 +103,8 @@ impl<'a> CheckerState<'a> {
             // Prevent infinite loops in re-export chains
             if !visited_aliases.contains(&resolved_sym_id) {
                 let mut preferred_target = resolved_sym_id;
-                if let Some(module_name) = symbol.import_module.as_ref() {
-                    let export_name = symbol
-                        .import_name
-                        .as_deref()
-                        .unwrap_or(symbol.escaped_name.as_str());
+                if let Some(module_name) = symbol.import_module() {
+                    let export_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
                     if export_name != "*"
                         && self.symbol_is_namespace_only_tracked(resolved_sym_id, visited_aliases)
                         && let Some(member_sym_id) = self
@@ -127,17 +124,14 @@ impl<'a> CheckerState<'a> {
         // Fallback to direct module_exports lookup for backward compatibility
         // Handle ES6 imports: import { X } from 'module' or import X from 'module'
         // The binder sets import_module and import_name for these
-        if let Some(ref module_name) = symbol.import_module {
-            let export_name = symbol
-                .import_name
-                .as_deref()
-                .unwrap_or(&symbol.escaped_name);
+        if let Some(module_name) = symbol.import_module() {
+            let export_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
             // An explicit `resolution-mode` (from a JSDoc `@import ... with
             // { "resolution-mode": ... }` attribute) routes the specifier
             // through the requested package condition so members resolve from
             // the matching ESM/CJS declaration file, mirroring tsc.
             let resolution_mode_override: Option<crate::context::ResolutionModeOverride> =
-                symbol.import_resolution_mode.map(Into::into);
+                symbol.import_resolution_mode().map(Into::into);
             if export_name == "default"
                 && self.ctx.compiler_options.module.is_node_module()
                 && self.ctx.file_is_esm == Some(true)
@@ -159,7 +153,7 @@ impl<'a> CheckerState<'a> {
             // import_name is None and escaped_name could accidentally match
             // a specific export, resolving the alias to that export instead
             // of the module namespace.
-            if symbol.import_name.is_some() {
+            if symbol.import_name().is_some() {
                 let export_equals_member = self.resolve_named_export_via_export_equals_tracked(
                     module_name,
                     export_name,
@@ -241,7 +235,7 @@ impl<'a> CheckerState<'a> {
                 }
             }
 
-            if symbol.import_name.is_some()
+            if symbol.import_name().is_some()
                 && let Some(target_sym_id) = self.resolve_named_export_via_export_equals_tracked(
                     module_name,
                     export_name,
@@ -257,7 +251,7 @@ impl<'a> CheckerState<'a> {
             // module's `export =` value (key `"export="`), falling back to
             // `"module.exports"` for Node20/NodeNext CJS-of-ESM consumers —
             // see `export_equals_target_for_require_consumer`.
-            if symbol.import_name.is_none() {
+            if symbol.import_name().is_none() {
                 let lookup = |binder: &tsz_binder::BinderState| {
                     binder.module_exports.get(module_name).and_then(|exports| {
                         self.export_equals_target_for_require_consumer(exports, module_name)
@@ -306,7 +300,7 @@ impl<'a> CheckerState<'a> {
                     // The symbol itself acts as the namespace container; record
                     // all target exports for cross-file member resolution.
                     let is_namespace_import = export_name == "*"
-                        || (symbol.import_name.is_none() && symbol.escaped_name != "default");
+                        || (symbol.import_name().is_none() && symbol.escaped_name != "default");
                     if is_namespace_import {
                         if let Some(exports) =
                             self.ctx.module_exports_for_module(target_binder, file_name)
@@ -344,7 +338,7 @@ impl<'a> CheckerState<'a> {
                         // Node20/NodeNext CJS-of-ESM `"module.exports"` fallback
                         // when applicable (see
                         // `export_equals_target_for_require_consumer`).
-                        if symbol.import_name.is_none()
+                        if symbol.import_name().is_none()
                             && let Some(target_sym_id) =
                                 self.export_equals_target_for_require_consumer(exports, module_name)
                         {
@@ -437,7 +431,7 @@ impl<'a> CheckerState<'a> {
             return self
                 .resolve_require_call_symbol(import.module_specifier, Some(visited_aliases));
         }
-        if symbol.import_module.is_none() {
+        if symbol.import_module().is_none() {
             return Some(sym_id);
         }
         // For other alias symbols (not ES6 imports or import equals), return None

--- a/crates/tsz-checker/src/types/queries/type_only.rs
+++ b/crates/tsz-checker/src/types/queries/type_only.rs
@@ -18,8 +18,8 @@ impl<'a> CheckerState<'a> {
         &self,
         symbol: &tsz_binder::Symbol,
     ) -> Option<(String, bool)> {
-        let module_specifier = symbol.import_module.as_deref()?;
-        let import_name = symbol.import_name.as_deref();
+        let module_specifier = symbol.import_module()?;
+        let import_name = symbol.import_name();
         let is_namespace_binding = import_name.is_none() || import_name == Some("*");
 
         if self.module_uses_module_exports_interop(
@@ -482,7 +482,7 @@ impl<'a> CheckerState<'a> {
             let Some(sym) = self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders) else {
                 continue;
             };
-            let Some(ref import_module) = sym.import_module else {
+            let Some(import_module) = sym.import_module() else {
                 continue;
             };
             // Check if the member is type-only in the target module
@@ -719,7 +719,7 @@ impl<'a> CheckerState<'a> {
         if self
             .resolve_identifier_symbol(root_idx)
             .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
-            .is_some_and(|symbol| symbol.import_module.is_some())
+            .is_some_and(|symbol| symbol.import_module().is_some())
         {
             return None;
         }
@@ -797,7 +797,7 @@ impl<'a> CheckerState<'a> {
         if symbol.is_type_only {
             return true;
         }
-        if let Some(module_specifier) = symbol.import_module.as_deref() {
+        if let Some(module_specifier) = symbol.import_module() {
             let Some((export_name, is_namespace_binding)) =
                 self.effective_import_binding_name(symbol)
             else {
@@ -873,7 +873,7 @@ impl<'a> CheckerState<'a> {
         }
 
         // Namespace imports (`import * as ns`) are always values.
-        if symbol.import_name.as_deref() == Some("*") {
+        if symbol.import_name() == Some("*") {
             return false;
         }
 
@@ -901,7 +901,7 @@ impl<'a> CheckerState<'a> {
         // namespace.
         if !target_sym.has_any_flags(symbol_flags::NAMESPACE_MODULE)
             && target_sym.has_any_flags(symbol_flags::ALIAS)
-            && target_sym.import_module.is_none()
+            && target_sym.import_module().is_none()
             && let Some(file_idx) = target_file_idx
         {
             let target_arena = self.ctx.get_arena_for_file(file_idx as u32);
@@ -912,13 +912,12 @@ impl<'a> CheckerState<'a> {
             {
                 let ident_name = target_ident.escaped_text.as_str();
                 let import_module = symbol
-                    .import_module
-                    .as_deref()
+                    .import_module()
                     .unwrap_or("")
                     .trim_matches('"')
                     .trim_matches('\'');
                 let module_keys = [
-                    symbol.import_module.as_deref().unwrap_or(""),
+                    symbol.import_module().unwrap_or(""),
                     import_module,
                     target_file_name.as_str(),
                 ];
@@ -1631,8 +1630,8 @@ impl<'a> CheckerState<'a> {
                         }
                     }
 
-                    if let Some(ref import_module) = sym.import_module {
-                        let import_name = sym.import_name.as_deref().unwrap_or(&sym.escaped_name);
+                    if let Some(import_module) = sym.import_module() {
+                        let import_name = sym.import_name().unwrap_or(sym.escaped_name.as_str());
                         if self.is_export_type_only_in_file(
                             target_file_idx,
                             import_module,
@@ -1651,7 +1650,7 @@ impl<'a> CheckerState<'a> {
                 // type-only for cross-file import/value checks.
                 if export_name == "default"
                     && sym.has_any_flags(symbol_flags::ALIAS)
-                    && sym.import_module.is_none()
+                    && sym.import_module().is_none()
                     && let Some(target_decl_idx) = sym.primary_declaration()
                     && let Some(target_decl_node) = target_arena.get(target_decl_idx)
                     && let Some(target_ident) = target_arena.get_identifier(target_decl_node)

--- a/crates/tsz-checker/src/types/queries/type_only_module_exports.rs
+++ b/crates/tsz-checker/src/types/queries/type_only_module_exports.rs
@@ -45,9 +45,9 @@ impl<'a> CheckerState<'a> {
             return false;
         }
 
-        if let Some(module_specifier) = symbol.import_module.as_deref() {
+        if let Some(module_specifier) = symbol.import_module() {
             let is_namespace_binding =
-                symbol.import_name.is_none() || symbol.import_name.as_deref() == Some("*");
+                symbol.import_name().is_none() || symbol.import_name() == Some("*");
             if is_namespace_binding
                 && self
                     .classify_cross_file_type_only_kind(module_specifier, "module.exports")

--- a/crates/tsz-checker/src/types/queries/type_only_reexports.rs
+++ b/crates/tsz-checker/src/types/queries/type_only_reexports.rs
@@ -61,9 +61,9 @@ impl<'a> CheckerState<'a> {
                 }
 
                 if sym.has_any_flags(symbol_flags::ALIAS)
-                    && let Some(ref import_module) = sym.import_module
+                    && let Some(import_module) = sym.import_module()
                 {
-                    let import_name = sym.import_name.as_deref().unwrap_or(&sym.escaped_name);
+                    let import_name = sym.import_name().unwrap_or(sym.escaped_name.as_str());
                     if self.is_export_type_only_syntax_in_file(
                         target_file_idx,
                         import_module,

--- a/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_export_surface.rs
+++ b/crates/tsz-checker/src/types/type_checking/duplicate_identifiers_export_surface.rs
@@ -473,8 +473,8 @@ impl<'a> CheckerState<'a> {
         if node.kind == syntax_kind_ext::IMPORT_SPECIFIER
             && let Some(symbol) = binder.get_symbol(sym_id)
             && let (Some(module_name), Some(export_name), Some(source_file_idx)) = (
-                symbol.import_module.as_deref(),
-                symbol.import_name.as_deref(),
+                symbol.import_module(),
+                symbol.import_name(),
                 self.ctx.get_file_idx_for_arena(arena),
             )
             && let Some(target_sym_id) = self.resolve_cross_file_export_from_file(

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -207,8 +207,8 @@ impl<'a> CheckerState<'a> {
                                 .binder
                                 .get_symbol(sym_id)
                                 .and_then(|symbol| {
-                                    symbol.import_module.as_ref().and_then(|module_name| {
-                                        symbol.import_name.as_deref().and_then(|import_name| {
+                                    symbol.import_module().and_then(|module_name| {
+                                        symbol.import_name().and_then(|import_name| {
                                             self.resolve_cross_file_export_from_file(
                                                 module_name,
                                                 import_name,
@@ -235,8 +235,8 @@ impl<'a> CheckerState<'a> {
                         .binder
                         .get_symbol(sym_id)
                         .and_then(|symbol| {
-                            symbol.import_module.as_ref().and_then(|module_name| {
-                                symbol.import_name.as_deref().and_then(|import_name| {
+                            symbol.import_module().and_then(|module_name| {
+                                symbol.import_name().and_then(|import_name| {
                                     self.resolve_cross_file_export_from_file(
                                         module_name,
                                         import_name,
@@ -627,8 +627,8 @@ impl<'a> CheckerState<'a> {
                     .binder
                     .get_symbol(sym_id)
                     .and_then(|symbol| {
-                        symbol.import_module.as_ref().and_then(|module_name| {
-                            symbol.import_name.as_deref().and_then(|import_name| {
+                        symbol.import_module().and_then(|module_name| {
+                            symbol.import_name().and_then(|import_name| {
                                 self.resolve_cross_file_export_from_file(
                                     module_name,
                                     import_name,

--- a/crates/tsz-checker/src/types/type_node_resolution.rs
+++ b/crates/tsz-checker/src/types/type_node_resolution.rs
@@ -56,8 +56,8 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         if !symbol.is_type_only {
             return None;
         }
-        let module_name = symbol.import_module.as_ref()?;
-        let import_name = symbol.import_name.as_deref()?;
+        let module_name = symbol.import_module()?;
+        let import_name = symbol.import_name()?;
         if import_name == "*" {
             return None;
         }
@@ -118,8 +118,8 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
         if !symbol.is_type_only {
             return None;
         }
-        let module_name = symbol.import_module.as_ref()?;
-        let import_name = symbol.import_name.as_deref()?;
+        let module_name = symbol.import_module()?;
+        let import_name = symbol.import_name()?;
         if import_name == "*" {
             return None;
         }
@@ -246,7 +246,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                             // Follow the ALIAS's import_module, resolving from the
                             // ALIAS's source file perspective (cross-file), then
                             // falling back to the merged binder (same-file).
-                            let module = alias_sym.import_module.as_ref()?;
+                            let module = alias_sym.import_module()?;
                             self.ctx
                                 .resolve_alias_import_member(alias_id, module, segment)
                                 .or_else(|| {
@@ -262,10 +262,10 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     // namespace alias has no populated `exports` map, so all
                     // prior branches miss.  Resolve `segment` directly from
                     // the target module's binder (refs #12951).
-                    if symbol.import_name.as_deref() != Some("*") {
+                    if symbol.import_name() != Some("*") {
                         return None;
                     }
-                    let module = symbol.import_module.as_deref()?;
+                    let module = symbol.import_module()?;
                     let source_file_idx = self
                         .ctx
                         .resolve_symbol_file_index(current_sym)
@@ -352,10 +352,10 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     // object is not materialised until runtime, so the ALIAS symbol has
                     // no `exports` map.  Look up `segment` directly in the target
                     // module's binder using the declared module specifier (refs #12951).
-                    if symbol.import_name.as_deref() != Some("*") {
+                    if symbol.import_name() != Some("*") {
                         return None;
                     }
-                    let module = symbol.import_module.as_deref()?;
+                    let module = symbol.import_module()?;
                     let target_idx = self
                         .ctx
                         .resolve_import_target_from_file(self.ctx.current_file_idx, module)?;
@@ -1529,7 +1529,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 if !self
                     .ctx
                     .namespace_import_alias_has_local_namespace_conflict(alias_sym)
-                    && let Some(module_name) = alias_sym.import_module.as_ref()
+                    && let Some(module_name) = alias_sym.import_module()
                 {
                     let member = self
                         .ctx
@@ -1558,7 +1558,7 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 && !self
                     .ctx
                     .namespace_import_alias_has_local_namespace_conflict(left_sym)
-                && let Some(module_name) = left_sym.import_module.as_ref()
+                && let Some(module_name) = left_sym.import_module()
             {
                 // Use the current file's index to resolve the import target, since `left_sym`
                 // is a local alias declared in the current file.

--- a/crates/tsz-checker/src/types/utilities/core.rs
+++ b/crates/tsz-checker/src/types/utilities/core.rs
@@ -951,10 +951,7 @@ impl<'a> CheckerState<'a> {
 
         // symbol_is_value_only already checks TYPE flags and declarations
         // No need for redundant declaration check here
-        let target_name = symbol
-            .import_name
-            .as_deref()
-            .unwrap_or(symbol.escaped_name.as_str());
+        let target_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
         self.symbol_is_value_only(target, Some(target_name))
     }
 

--- a/crates/tsz-cli/tests/driver_tests_parts/part_01.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_01.rs
@@ -1718,8 +1718,8 @@ fn symbol_snapshot_by_id(binder: &BinderState, sym_id: SymbolId) -> Option<Symbo
         members,
         is_exported: sym.is_exported,
         is_type_only: sym.is_type_only,
-        import_module: sym.import_module.clone(),
-        import_name: sym.import_name.clone(),
+        import_module: sym.import_module().map(str::to_string),
+        import_name: sym.import_name().map(str::to_string),
         is_umd_export: sym.is_umd_export,
     })
 }

--- a/crates/tsz-core/src/parallel/core/parse_and_libs.rs
+++ b/crates/tsz-core/src/parallel/core/parse_and_libs.rs
@@ -703,11 +703,11 @@ impl BindResult {
                 size += std::mem::size_of::<SymbolTable>();
                 size += members.len() * (32 + std::mem::size_of::<SymbolId>());
             }
-            if let Some(ref s) = sym.import_module {
-                size += s.capacity();
+            if let Some(s) = sym.import_module() {
+                size += s.len();
             }
-            if let Some(ref s) = sym.import_name {
-                size += s.capacity();
+            if let Some(s) = sym.import_name() {
+                size += s.len();
             }
         }
 

--- a/crates/tsz-core/src/parallel/skeleton/mod.rs
+++ b/crates/tsz-core/src/parallel/skeleton/mod.rs
@@ -300,7 +300,7 @@ pub fn extract_skeleton(result: &BindResult) -> FileSkeleton {
                 has_members: sym.members.is_some(),
                 is_lib_origin: result.lib_symbol_ids.contains(&sym_id),
                 is_import_alias: (sym.flags & crate::binder::symbol_flags::ALIAS) != 0,
-                import_module: sym.import_module.clone(),
+                import_module: sym.import_module().map(str::to_string),
                 heritage_fingerprint,
                 heritage_count,
             });
@@ -327,7 +327,7 @@ pub fn extract_skeleton(result: &BindResult) -> FileSkeleton {
                     has_members: sym.members.is_some(),
                     is_lib_origin: result.lib_symbol_ids.contains(&sym_id),
                     is_import_alias: (sym.flags & crate::binder::symbol_flags::ALIAS) != 0,
-                    import_module: sym.import_module.clone(),
+                    import_module: sym.import_module().map(str::to_string),
                     heritage_fingerprint,
                     heritage_count,
                 });

--- a/crates/tsz-core/tests/binder_state_tests_parts/part_01.rs
+++ b/crates/tsz-core/tests/binder_state_tests_parts/part_01.rs
@@ -803,13 +803,13 @@ const y = bar;
 
     // Verify import_module is set correctly
     assert_eq!(
-        foo_import_sym.import_module,
-        Some("./file1".to_string()),
+        foo_import_sym.import_module(),
+        Some("./file1"),
         "foo import should have import_module set"
     );
     assert_eq!(
-        bar_import_sym.import_module,
-        Some("./file1".to_string()),
+        bar_import_sym.import_module(),
+        Some("./file1"),
         "bar import should have import_module set"
     );
 }
@@ -881,13 +881,13 @@ const x = aliasedValue;
 
     // Verify import_module and import_name are set correctly
     assert_eq!(
-        import_sym.import_module,
-        Some("./file1".to_string()),
+        import_sym.import_module(),
+        Some("./file1"),
         "import should have import_module set"
     );
     assert_eq!(
-        import_sym.import_name,
-        Some("originalValue".to_string()),
+        import_sym.import_name(),
+        Some("originalValue"),
         "import should have import_name set to original name"
     );
     assert_eq!(
@@ -942,11 +942,11 @@ function localFunction() { return localValue; }
         .expect("localFunction symbol should exist");
 
     assert_eq!(
-        value_sym.import_module, None,
+        value_sym.import_module(), None,
         "localValue should not have import_module set"
     );
     assert_eq!(
-        func_sym.import_module, None,
+        func_sym.import_module(), None,
         "localFunction should not have import_module set"
     );
 

--- a/crates/tsz-core/tests/module_resolution_tests_parts/part_00.rs
+++ b/crates/tsz-core/tests/module_resolution_tests_parts/part_00.rs
@@ -860,8 +860,8 @@ const x = value;
         "Import symbol should be ALIAS"
     );
     assert_eq!(
-        import_sym.import_module,
-        Some("./file1".to_string()),
+        import_sym.import_module(),
+        Some("./file1"),
         "Import symbol should have import_module set"
     );
 }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_check.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_check.rs
@@ -243,7 +243,7 @@ impl<'a> DeclarationEmitter<'a> {
                 // same-named symbol in the specific module this alias imports from.
                 // Restricting to `import_module` prevents false positives from
                 // same-named exports in unrelated modules.
-                let import_module = symbol.import_module.as_deref().unwrap_or("");
+                let import_module = symbol.import_module().unwrap_or("");
                 let mut found = None;
                 for (path, table) in binder.module_exports.iter() {
                     // Only search in modules whose path ends with the import specifier.
@@ -465,7 +465,7 @@ impl<'a> DeclarationEmitter<'a> {
                             if !candidate.has_any_flags(tsz_binder::symbol_flags::ALIAS) {
                                 return None;
                             }
-                            let import_mod = candidate.import_module.as_deref()?;
+                            let import_mod = candidate.import_module()?;
                             // Only bare specifiers can point to nested node_modules.
                             if import_mod.is_empty()
                                 || import_mod.starts_with('.')
@@ -879,7 +879,7 @@ impl<'a> DeclarationEmitter<'a> {
             {
                 if let Some(binder) = self.binder
                     && let Some(symbol) = binder.symbols.get(sym_id)
-                    && let Some(import_module) = symbol.import_module.as_deref()
+                    && let Some(import_module) = symbol.import_module()
                     && let Some(current_file_path) = self.current_file_path.as_deref()
                 {
                     let mut module_paths =

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_export_paths.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_export_paths.rs
@@ -14,11 +14,8 @@ impl<'a> DeclarationEmitter<'a> {
             return None;
         }
 
-        let module_specifier = symbol.import_module.as_deref()?;
-        let export_name = symbol
-            .import_name
-            .as_deref()
-            .unwrap_or(symbol.escaped_name.as_str());
+        let module_specifier = symbol.import_module()?;
+        let export_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
         let current_path = self.current_file_path.as_deref()?;
 
         for module_path in self.matching_module_export_paths(binder, current_path, module_specifier)
@@ -69,7 +66,7 @@ impl<'a> DeclarationEmitter<'a> {
         binder
             .symbols
             .get(sym_id)
-            .and_then(|symbol| symbol.import_name.as_deref())
+            .and_then(|symbol| symbol.import_name())
             .unwrap_or(fallback)
     }
 

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_resolve.rs
@@ -719,7 +719,7 @@ impl<'a> DeclarationEmitter<'a> {
         if let Some(sym_id) = self.find_symbol_in_arena_by_name(arena, &left_name) {
             let binder = self.binder?;
             let symbol = binder.symbols.get(sym_id)?;
-            if let Some(import_module) = symbol.import_module.as_deref() {
+            if let Some(import_module) = symbol.import_module() {
                 if import_module.starts_with('.') || import_module.starts_with('/') {
                     return None;
                 }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/portability_symbols.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/portability_symbols.rs
@@ -130,7 +130,7 @@ impl<'a> DeclarationEmitter<'a> {
             .count();
         if nm_count_in_original >= 2
             && original_symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
-            && let Some(import_module) = original_symbol.import_module.as_deref()
+            && let Some(import_module) = original_symbol.import_module()
             && !import_module.starts_with('.')
             && !import_module.starts_with('/')
             && self
@@ -221,7 +221,7 @@ impl<'a> DeclarationEmitter<'a> {
         // The "from" path is "foo/node_modules/nested".
         if nm_positions.len() >= 2
             && symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
-            && let Some(import_module) = &symbol.import_module
+            && let Some(import_module) = symbol.import_module()
             && !import_module.starts_with('.')
             && !import_module.starts_with('/')
         {
@@ -780,7 +780,7 @@ impl<'a> DeclarationEmitter<'a> {
             for (_, &exported_sym_id) in exports.iter() {
                 if let Some(symbol) = binder.symbols.get(exported_sym_id)
                     && symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
-                    && let Some(import_module) = &symbol.import_module
+                    && let Some(import_module) = symbol.import_module()
                     && import_module.starts_with('.')
                 {
                     // Normalize the joined path to remove `.` components
@@ -1053,11 +1053,8 @@ impl<'a> DeclarationEmitter<'a> {
         binder: &BinderState,
     ) -> Option<SymbolId> {
         let symbol = binder.symbols.get(sym_id)?;
-        let module_specifier = symbol.import_module.as_deref()?;
-        let export_name = symbol
-            .import_name
-            .as_deref()
-            .unwrap_or(symbol.escaped_name.as_str());
+        let module_specifier = symbol.import_module()?;
+        let export_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
         let current_path = self.current_file_path.as_deref()?;
 
         for module_path in self.matching_module_export_paths(binder, current_path, module_specifier)
@@ -1089,11 +1086,8 @@ impl<'a> DeclarationEmitter<'a> {
         if !symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS) {
             return None;
         }
-        let module_specifier = symbol.import_module.as_deref()?;
-        let export_name = symbol
-            .import_name
-            .as_deref()
-            .unwrap_or(symbol.escaped_name.as_str());
+        let module_specifier = symbol.import_module()?;
+        let export_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
 
         // Use the alias symbol's own source file as the resolution base.
         let source_path = self.get_symbol_source_path(sym_id, binder)?;
@@ -1170,7 +1164,7 @@ impl<'a> DeclarationEmitter<'a> {
         if !symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS) {
             return None;
         }
-        let import_module = symbol.import_module.as_deref()?;
+        let import_module = symbol.import_module()?;
         // Only bare specifiers can point to nested node_modules.
         if import_module.is_empty()
             || import_module.starts_with('.')

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
@@ -1572,10 +1572,13 @@ impl<'a> DeclarationEmitter<'a> {
         sym_id: SymbolId,
         binder: &BinderState,
     ) -> Option<String> {
-        self.import_symbol_map
-            .get(&sym_id)
-            .cloned()
-            .or_else(|| binder.symbols.get(sym_id)?.import_module.clone())
+        self.import_symbol_map.get(&sym_id).cloned().or_else(|| {
+            binder
+                .symbols
+                .get(sym_id)?
+                .import_module()
+                .map(|s| s.to_string())
+        })
     }
 
     pub(in crate::declaration_emitter) fn imported_value_module_specifier_from_syntax(

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_enum_access.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_enum_access.rs
@@ -123,7 +123,7 @@ impl<'a> DeclarationEmitter<'a> {
 
         if !parts.is_empty()
             && root_symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
-            && let Some(module_specifier) = root_symbol.import_module.as_deref()
+            && let Some(module_specifier) = root_symbol.import_module()
             && let Some(current_path) = self.current_file_path.as_deref()
         {
             for module_path in
@@ -132,7 +132,7 @@ impl<'a> DeclarationEmitter<'a> {
                 let Some(exports) = binder.module_exports.get(module_path) else {
                     continue;
                 };
-                let export_name = root_symbol.import_name.as_deref();
+                let export_name = root_symbol.import_name();
                 let (mut current, start_index) = match export_name {
                     Some("*") | Some("export=") | None => {
                         let Some(current) = exports.get(&parts[0]) else {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_foreign_names.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_foreign_names.rs
@@ -138,7 +138,7 @@ impl<'a> DeclarationEmitter<'a> {
                 {
                     continue;
                 }
-                let Some(module_path) = symbol.import_module.as_deref() else {
+                let Some(module_path) = symbol.import_module() else {
                     continue;
                 };
                 let Some(module_specifier) =

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing_paths.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing_paths.rs
@@ -36,7 +36,7 @@ impl<'a> DeclarationEmitter<'a> {
 
         if let Some(symbol) = binder.symbols.get(sym_id)
             && symbol.has_any_flags(symbol_flags::ALIAS)
-            && let Some(import_module) = symbol.import_module.as_deref()
+            && let Some(import_module) = symbol.import_module()
             && !import_module.starts_with('.')
             && !import_module.starts_with('/')
         {
@@ -80,7 +80,11 @@ impl<'a> DeclarationEmitter<'a> {
             return Some(module_specifier.clone());
         }
 
-        binder.symbols.get(sym_id)?.import_module.clone()
+        binder
+            .symbols
+            .get(sym_id)?
+            .import_module()
+            .map(|s| s.to_string())
     }
 
     fn resolve_public_export_module_path(
@@ -219,10 +223,9 @@ impl<'a> DeclarationEmitter<'a> {
             // link them (e.g. cross-file merges).
             if let Some(alias_symbol) = binder.symbols.get(alias_sym_id) {
                 let alias_import_name = alias_symbol
-                    .import_name
-                    .as_deref()
+                    .import_name()
                     .unwrap_or(&alias_symbol.escaped_name);
-                if alias_import_name == target_name && alias_symbol.import_module.is_some() {
+                if alias_import_name == target_name && alias_symbol.import_module().is_some() {
                     // Verify the alias points to the same foreign module.
                     if let Some(current_path) = &self.current_file_path
                         && let Some(source_arena) = binder.symbol_arenas.get(&original_sym_id)
@@ -231,9 +234,8 @@ impl<'a> DeclarationEmitter<'a> {
                         if let Some(source_path) = self.arena_to_path.get(&arena_addr) {
                             let rel = self.calculate_relative_path(current_path, source_path);
                             let stripped = self.strip_module_path_extension(&rel);
-                            if alias_symbol.import_module.as_deref() == Some(&stripped)
-                                || alias_symbol.import_module.as_deref()
-                                    == Some(source_path.as_str())
+                            if alias_symbol.import_module() == Some(&stripped)
+                                || alias_symbol.import_module() == Some(source_path.as_str())
                             {
                                 return true;
                             }
@@ -266,7 +268,8 @@ impl<'a> DeclarationEmitter<'a> {
         };
 
         // Import aliases are never "global" in this sense.
-        if symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS) && symbol.import_module.is_some() {
+        if symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS) && symbol.import_module().is_some()
+        {
             return false;
         }
 
@@ -443,8 +446,8 @@ impl<'a> DeclarationEmitter<'a> {
         };
 
         symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
-            && symbol.import_module.is_some()
-            && (symbol.import_name.is_none() || symbol.import_name.as_deref() == Some("*"))
+            && symbol.import_module().is_some()
+            && (symbol.import_name().is_none() || symbol.import_name() == Some("*"))
     }
 
     /// When `sym_id` is the resolved target of a single in-scope
@@ -577,7 +580,7 @@ impl<'a> DeclarationEmitter<'a> {
             if !self.is_namespace_import_alias_symbol(import_sym_id) {
                 continue;
             }
-            if symbol.import_module.as_deref() == Some(module_path.as_str()) {
+            if symbol.import_module() == Some(module_path.as_str()) {
                 return Some(symbol.escaped_name.clone());
             }
         }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/variable_decl.rs
@@ -1477,12 +1477,9 @@ impl<'a> DeclarationEmitter<'a> {
             // produce a false positive.
             if let Some(symbol) = binder.symbols.get(sym_id)
                 && symbol.has_any_flags(symbol_flags::ALIAS)
-                && let Some(module_specifier) = symbol.import_module.as_deref()
+                && let Some(module_specifier) = symbol.import_module()
             {
-                let export_name = symbol
-                    .import_name
-                    .as_deref()
-                    .unwrap_or(symbol.escaped_name.as_str());
+                let export_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
                 if self.ambient_module_contains_class(module_specifier, export_name) {
                     return true;
                 }

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
@@ -1322,8 +1322,8 @@ impl<'a> DeclarationEmitter<'a> {
             .copied()
             .or_else(|| binder.file_locals.get(local_name))?;
         let symbol = binder.symbols.get(sym_id)?;
-        let import_module = symbol.import_module.as_deref()?;
-        let import_name = symbol.import_name.as_deref()?;
+        let import_module = symbol.import_module()?;
+        let import_name = symbol.import_name()?;
 
         if import_name == "*"
             || import_name == local_name
@@ -1339,7 +1339,7 @@ impl<'a> DeclarationEmitter<'a> {
         let canonical_sym_id = self.import_name_map.get(import_name).copied()?;
         let canonical_symbol = binder.symbols.get(canonical_sym_id)?;
         if canonical_symbol.escaped_name != import_name
-            || canonical_symbol.import_module.as_deref() != Some(import_module)
+            || canonical_symbol.import_module() != Some(import_module)
         {
             return None;
         }
@@ -1443,14 +1443,11 @@ impl<'a> DeclarationEmitter<'a> {
         let Some(symbol) = binder.symbols.get(sym_id) else {
             return false;
         };
-        let Some(import_module) = symbol.import_module.as_deref() else {
+        let Some(import_module) = symbol.import_module() else {
             return false;
         };
         let local_name = symbol.escaped_name.as_str();
-        let import_name = symbol
-            .import_name
-            .as_deref()
-            .unwrap_or(&symbol.escaped_name);
+        let import_name = symbol.import_name().unwrap_or(&symbol.escaped_name);
 
         if local_name != import_name {
             return false;
@@ -1462,7 +1459,7 @@ impl<'a> DeclarationEmitter<'a> {
             };
 
             if used_symbol.escaped_name != import_name
-                && used_symbol.import_name.as_deref() != Some(import_name)
+                && used_symbol.import_name() != Some(import_name)
             {
                 return false;
             }
@@ -1471,7 +1468,7 @@ impl<'a> DeclarationEmitter<'a> {
                 return false;
             }
 
-            used_symbol.import_module.as_deref() == Some(import_module)
+            used_symbol.import_module() == Some(import_module)
                 || self.resolve_symbol_module_path(used_sym_id).as_deref() == Some(import_module)
         })
     }

--- a/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/symbol_references.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/symbol_references.rs
@@ -75,7 +75,8 @@ impl UsageAnalyzer<'_> {
     pub(super) fn type_query_value_dependency_symbol(&self, sym_id: SymbolId) -> Option<SymbolId> {
         let symbol = self.binder.symbols.get(sym_id)?;
 
-        if symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS) && symbol.import_module.is_some() {
+        if symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS) && symbol.import_module().is_some()
+        {
             let Some(resolved_sym_id) = self.resolve_import_alias_target_symbol(sym_id) else {
                 // If the module graph is unavailable, preserve the source import.
                 return Some(sym_id);
@@ -95,11 +96,8 @@ impl UsageAnalyzer<'_> {
         }
 
         let symbol = self.binder.symbols.get(sym_id)?;
-        let module_specifier = symbol.import_module.as_deref()?;
-        let export_name = symbol
-            .import_name
-            .as_deref()
-            .unwrap_or(symbol.escaped_name.as_str());
+        let module_specifier = symbol.import_module()?;
+        let export_name = symbol.import_name().unwrap_or(symbol.escaped_name.as_str());
 
         for module_key in self.relative_module_export_keys(module_specifier) {
             if let Some(exports) = self.binder.module_exports.get(&module_key)
@@ -263,7 +261,7 @@ impl UsageAnalyzer<'_> {
         let Some(symbol) = self.binder.symbols.get(sym_id) else {
             return false;
         };
-        if symbol.import_module.as_deref() != Some(module_specifier) {
+        if symbol.import_module() != Some(module_specifier) {
             return false;
         }
 
@@ -271,11 +269,7 @@ impl UsageAnalyzer<'_> {
         // inside `declare module "observable"` because the declaration body is
         // already scoped to that ambient module. Aliased imports still need to
         // count as usages because the alias is not introduced by the module body.
-        symbol
-            .import_name
-            .as_deref()
-            .unwrap_or(&symbol.escaped_name)
-            == ident
+        symbol.import_name().unwrap_or(&symbol.escaped_name) == ident
             && symbol.escaped_name == ident
     }
 

--- a/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/value_references.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/usage_analyzer/value_references.rs
@@ -37,7 +37,7 @@ impl UsageAnalyzer<'_> {
             return false;
         };
         let resolved_sym_id = if source_symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
-            && source_symbol.import_module.is_some()
+            && source_symbol.import_module().is_some()
         {
             self.resolve_import_alias_target_symbol(sym_id)
                 .unwrap_or(sym_id)
@@ -65,8 +65,8 @@ impl UsageAnalyzer<'_> {
         };
 
         symbol.has_any_flags(tsz_binder::symbol_flags::ALIAS)
-            && symbol.import_module.is_some()
-            && (symbol.import_name.is_none() || symbol.import_name.as_deref() == Some("*"))
+            && symbol.import_module().is_some()
+            && (symbol.import_name().is_none() || symbol.import_name() == Some("*"))
     }
 
     fn entity_access_root_symbol(&self, expr_idx: NodeIndex) -> Option<SymbolId> {

--- a/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/symbol_resolution.rs
@@ -493,7 +493,7 @@ impl<'a> TypePrinter<'a> {
         self.symbol_arena
             .and_then(|arena| arena.get(sym_id))
             .is_some_and(|symbol| {
-                symbol.has_any_flags(symbol_flags::ALIAS) && symbol.import_module.is_some()
+                symbol.has_any_flags(symbol_flags::ALIAS) && symbol.import_module().is_some()
             })
     }
 
@@ -621,7 +621,7 @@ impl<'a> TypePrinter<'a> {
             return true;
         };
 
-        if symbol.has_any_flags(symbol_flags::ALIAS) && symbol.import_module.is_some() {
+        if symbol.has_any_flags(symbol_flags::ALIAS) && symbol.import_module().is_some() {
             return true;
         }
 

--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing_references.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing_references.rs
@@ -833,7 +833,7 @@ impl<'a> TypePrinter<'a> {
         symbol.declarations.is_empty()
             && !symbol.parent.is_some()
             && self.resolve_symbol_module_path(sym_id).is_none()
-            && !(symbol.has_any_flags(symbol_flags::ALIAS) && symbol.import_module.is_some())
+            && !(symbol.has_any_flags(symbol_flags::ALIAS) && symbol.import_module().is_some())
     }
 
     pub(crate) fn intersection_member_priority(&self, type_id: TypeId) -> u8 {

--- a/crates/tsz-emitter/tests/type_printer.rs
+++ b/crates/tsz-emitter/tests/type_printer.rs
@@ -163,7 +163,7 @@ fn local_import_alias_uses_bare_name_when_alias_is_emitted() {
     symbols
         .get_mut(thing)
         .expect("missing alias symbol")
-        .import_module = Some("pkg".to_string());
+        .set_import_module(Some("pkg".to_string()));
 
     let module_path_resolver = |sym_id| (sym_id == thing).then(|| "pkg".to_string());
     let alias_name_resolver = |sym_id| sym_id == thing;
@@ -187,7 +187,7 @@ fn local_import_alias_falls_back_to_import_qualified_name_when_elided() {
     symbols
         .get_mut(thing)
         .expect("missing alias symbol")
-        .import_module = Some("inner/other.js".to_string());
+        .set_import_module(Some("inner/other.js".to_string()));
 
     let module_path_resolver = |sym_id| (sym_id == thing).then(|| "inner/other".to_string());
     let alias_name_resolver = |_sym_id| false;

--- a/crates/tsz-lsp/src/hover/core.rs
+++ b/crates/tsz-lsp/src/hover/core.rs
@@ -753,7 +753,7 @@ impl<'a> HoverProvider<'a> {
                     symbol.escaped_name
                 );
             }
-            if let Some(module_name) = symbol.import_module.as_deref() {
+            if let Some(module_name) = symbol.import_module() {
                 if decl_node_idx.is_some()
                     && let Some(decl_node) = self.arena.get(decl_node_idx)
                     && decl_node.kind == tsz_parser::syntax_kind_ext::IMPORT_EQUALS_DECLARATION

--- a/crates/tsz-lsp/src/project/core/project_file.rs
+++ b/crates/tsz-lsp/src/project/core/project_file.rs
@@ -431,11 +431,11 @@ impl ProjectFile {
             if let Some(ref members) = sym.members {
                 size += members.len() * (32 + std::mem::size_of::<SymbolId>());
             }
-            if let Some(ref s) = sym.import_module {
-                size += s.capacity();
+            if let Some(s) = sym.import_module() {
+                size += s.len();
             }
-            if let Some(ref s) = sym.import_name {
-                size += s.capacity();
+            if let Some(s) = sym.import_name() {
+                size += s.len();
             }
         }
 

--- a/crates/tsz-lsp/src/symbols/symbol_index.rs
+++ b/crates/tsz-lsp/src/symbols/symbol_index.rs
@@ -453,11 +453,11 @@ impl SymbolIndex {
         for (local_name, symbol_id) in binder.file_locals.iter() {
             if let Some(symbol) = binder.symbols.get(*symbol_id)
                 && symbol.has_any_flags(symbol_flags::ALIAS)
-                && let Some(ref source_module) = symbol.import_module
+                && let Some(source_module) = symbol.import_module()
             {
                 let exported_name = symbol
-                    .import_name
-                    .clone()
+                    .import_name()
+                    .map(|s| s.to_string())
                     .unwrap_or_else(|| local_name.clone());
 
                 let kind = if exported_name == "*" {
@@ -470,7 +470,7 @@ impl SymbolIndex {
 
                 let info = ImportInfo {
                     local_name: local_name.clone(),
-                    source_module: source_module.clone(),
+                    source_module: source_module.to_string(),
                     exported_name,
                     kind,
                 };
@@ -481,7 +481,7 @@ impl SymbolIndex {
                     .push(info);
 
                 self.importers
-                    .entry(source_module.clone())
+                    .entry(source_module.to_string())
                     .or_default()
                     .insert(file_name_owned.clone());
             }

--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -555,8 +555,8 @@ impl<'a> TypeFormatter<'a> {
                 // — tsc displays these as `typeof import("mod")` rather than `typeof X`.
                 if let Some(arena) = self.symbol_arena
                     && let Some(symbol) = arena.get(SymbolId(sym.0))
-                    && symbol.import_name.as_deref() == Some("*")
-                    && let Some(ref module_specifier) = symbol.import_module
+                    && symbol.import_name() == Some("*")
+                    && let Some(module_specifier) = symbol.import_module()
                 {
                     let display_name = Self::strip_module_extension(
                         module_specifier


### PR DESCRIPTION
Goal: hold

Closes #13072 (PR 2 of 2): out-of-lines the import-alias payload on `Symbol` behind an `Option<Box<ImportAliasData>>`, so only import-alias symbols pay for those fields. Combined with PR 1's span-field removal (#13401), `Symbol` shrinks from 200 -> 136 bytes. Zero behavior change — import-alias resolution is identical, pinned by the binder suite and the updated size test.

Structural rule: `Symbol` carries only the fields every symbol needs; rare per-kind payloads (import-alias data) are out-of-lined so the common case stays small.

Closes #13072

## Verification
- `cargo nextest run -p tsz-binder`
- `cargo nextest run -p tsz-checker -E 'test(/import|alias|symbol|module/)'`
- `cargo clippy -p tsz-binder -- -D warnings`
- `cargo check --workspace`

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: max