### PR TITLE
fix(ci): smoke perf shell-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,10 +206,10 @@ jobs:
                 bench_shell_only=true
               fi
             fi
-            # Perf-tool Python script-only changes do not need Rust compiler CI.
+            # Perf-tool Python/shell script-only changes do not need Rust compiler CI.
             # Keep the required CI Summary alive, but replace lint/unit/dist/wasm
-            # jobs with a cheap Python smoke job below. CI workflow edits, Cargo
-            # files, Rust crates, shell scripts, and non-perf scripts still take
+            # jobs with a cheap tool smoke job below. CI workflow edits, Cargo
+            # files, Rust crates, and non-perf scripts still take
             # the normal path.
             if [[ "$should_run" == "true" && -n "${path_classification:-}" ]]; then
               perf_tool_only_classified=$(printf '%s' "$path_classification" | jq -r '.perfToolOnly')
@@ -514,11 +514,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Check perf Python tools
+      - name: Check perf tools
         shell: bash
         run: |
           set -euo pipefail
-          python3 -m py_compile scripts/perf/*.py
+          shopt -s nullglob
+          perf_python_tools=(scripts/perf/*.py)
+          perf_shell_tools=(scripts/perf/*.sh)
+          if [[ "${#perf_python_tools[@]}" -gt 0 ]]; then
+            python3 -m py_compile "${perf_python_tools[@]}"
+          fi
+          if [[ "${#perf_shell_tools[@]}" -gt 0 ]]; then
+            bash -n "${perf_shell_tools[@]}"
+          fi
           tests=()
           while IFS= read -r test_file; do
             tests+=("$test_file")

--- a/scripts/ci/gate-path-classifier.mjs
+++ b/scripts/ci/gate-path-classifier.mjs
@@ -23,7 +23,7 @@ const COMPILER_PATH_PATTERN =
   /^(Cargo\.(lock|toml)|\.cargo\/|rust-toolchain|\.github\/workflows\/(ci|bench)\.yml|crates\/clippy\.toml|crates\/(conformance|tsz-(binder|checker|cli|common|core|emitter|lowering|lsp|parser|scanner|solver|wasm))(\/|$)|benches\/|tests\/|TypeScript\/|scripts\/(conformance|emit|fourslash|tsc|dts|snapshot)|scripts\/ci\/gate-path-classifier\.mjs|scripts\/ci\/lib\/[^/]+\.sh|scripts\/ci\/(ci-resources|gcp-full-ci|github-suite|gcp-cache|suite-metadata|build-dist|dist|wasm)[^/]*\.sh)/;
 
 const BENCH_SHELL_PATTERN = /^scripts\/bench\/[^/]+\.sh$/;
-const PERF_TOOL_PATTERN = /^scripts\/perf\/[^/]+\.py$/;
+const PERF_TOOL_PATTERN = /^scripts\/perf\/[^/]+\.(py|sh)$/;
 const ARCH_TOOL_PATTERN = /^scripts\/arch\/[^/]+\.py$/;
 const CACHE_KEY_INPUT_PATTERN = /^(Cargo\.lock|Cargo\.toml|\.cargo\/config\.toml)$/;
 

--- a/scripts/ci/test-gate-path-classifier.mjs
+++ b/scripts/ci/test-gate-path-classifier.mjs
@@ -54,6 +54,15 @@ assert.equal(
   false,
 );
 assert.equal(classify(["scripts/perf/collect.py", "docs/perf.md"]).perfToolOnly, true);
+assert.equal(
+  classify(["scripts/perf/forced-parallel-project-determinism.sh", "docs/perf.md"]).perfToolOnly,
+  true,
+  "perf shell harness changes should run the perf tool smoke path",
+);
+assert.equal(
+  classify(["scripts/perf/collect.py", "scripts/perf/forced-parallel-project-determinism.sh"]).perfToolOnly,
+  true,
+);
 assert.equal(classify(["scripts/arch/guard.py", "docs/arch.md"]).archToolOnly, true);
 
 {


### PR DESCRIPTION
Goal: hold

## Summary
- Treat `scripts/perf/*.sh` changes as perf-tool-only CI changes instead of generic non-compiler diffs.
- Extend `perf-tool-smoke` to run `bash -n` over perf shell scripts while preserving Python compile/test coverage.
- Add classifier coverage for the #13448 witness path, `scripts/perf/forced-parallel-project-determinism.sh`.

## Evidence
- PR #13448 did not get stuck: draft produced `CI Light Summary`, ready-review produced `CI Summary`, and the metadata run correctly deferred to the active exact-head suite.
- Its heavy compiler jobs were skipped because the single changed perf shell path was classified as non-compiler, but it was not routed to any targeted smoke job.
- This patch keeps compiler-heavy jobs skipped for perf harness-only diffs while making the targeted smoke signal explicit.

## Verification
- `node scripts/ci/test-gate-path-classifier.mjs`
- `node scripts/ci/test-pr-ready-state.mjs`
- `bash -n scripts/perf/*.sh`
- `git diff --check`

## Provenance
Machine: Mohsens-MacBook-Pro.local
Assistant: codex
Model: gpt-5
Effort: high

Refs #13448.
