### PR TITLE
fix(solver): guard shared def body publication (#13255)

### DIFF
--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -960,60 +960,56 @@ impl DefinitionStore {
         params: Option<Vec<TypeParamInfo>>,
         finalize: bool,
     ) {
-        // Mutation-isolation: defs frozen after their finalized
-        // materialization keep that body; a later attempt to overwrite it
-        // with a *different* body form is dropped (the shared store stays
-        // immutable for that def). Identical republication is allowed
-        // through (it is a no-op write).
-        let prev_body = self.definitions.get(&id).and_then(|entry| entry.body);
-        let is_different_overwrite = prev_body.is_some_and(|prev| prev != body);
-        let suppressed = is_different_overwrite
-            && !self.publish_once_defs.is_empty()
-            && self.publish_once_defs.contains(&id);
-        // Deferred-publication experiment: pre-finalize different-body
-        // overwrites of marked defs are dropped; only the finalize entry
-        // point may replace the first published form.
-        let deferred = !suppressed
-            && !finalize
-            && is_different_overwrite
-            && !self.deferred_publish_defs.is_empty()
-            && self.deferred_publish_defs.contains(&id);
-        // Mutation-isolation campaign census (env-gated, see
-        // `publication_census`): classify this publication against the
-        // pre-write entry state with caller attribution.
-        if publication_census::census_enabled() {
-            let caller = std::panic::Location::caller();
-            let (outcome, kind, name, file_id) = match self.definitions.get(&id) {
-                Some(entry) => {
-                    let params_changed = params
-                        .as_ref()
-                        .is_some_and(|new_params| *new_params != entry.type_params);
-                    (
-                        if suppressed {
-                            publication_census::PublicationOutcome::SuppressedDifferentBody
-                        } else if deferred {
-                            publication_census::PublicationOutcome::DeferredDifferentBody
-                        } else {
-                            publication_census::classify(entry.body, body, params_changed, true)
-                        },
-                        Some(entry.kind),
-                        entry.name,
-                        entry.file_id,
-                    )
-                }
-                None => (
-                    publication_census::classify(None, body, false, false),
-                    None,
-                    Atom::NONE,
-                    None,
-                ),
-            };
-            publication_census::record_publication(id, kind, name, file_id, body, outcome, caller);
-        }
-        if suppressed || deferred {
-            return;
-        }
         if let Some(mut entry) = self.definitions.get_mut(&id) {
+            // Mutation-isolation: defs frozen after their finalized
+            // materialization keep that body; a later attempt to overwrite it
+            // with a *different* body form is dropped (the shared store stays
+            // immutable for that def). Compute this under the same entry guard
+            // that owns the write: a pre-lock body probe can race with a
+            // sibling checker publication and turn a stale "no body yet"
+            // observation into a different-body overwrite.
+            let is_different_overwrite = entry.body.is_some_and(|prev| prev != body);
+            let suppressed = is_different_overwrite
+                && !self.publish_once_defs.is_empty()
+                && self.publish_once_defs.contains(&id);
+            // Deferred-publication experiment: pre-finalize different-body
+            // overwrites of marked defs are dropped; only the finalize entry
+            // point may replace the first published form.
+            let deferred = !suppressed
+                && !finalize
+                && is_different_overwrite
+                && !self.deferred_publish_defs.is_empty()
+                && self.deferred_publish_defs.contains(&id);
+
+            // Mutation-isolation campaign census (env-gated, see
+            // `publication_census`): classify this publication against the
+            // guarded pre-write entry state with caller attribution.
+            if publication_census::census_enabled() {
+                let caller = std::panic::Location::caller();
+                let params_changed = params
+                    .as_ref()
+                    .is_some_and(|new_params| *new_params != entry.type_params);
+                let outcome = if suppressed {
+                    publication_census::PublicationOutcome::SuppressedDifferentBody
+                } else if deferred {
+                    publication_census::PublicationOutcome::DeferredDifferentBody
+                } else {
+                    publication_census::classify(entry.body, body, params_changed, true)
+                };
+                publication_census::record_publication(
+                    id,
+                    Some(entry.kind),
+                    entry.name,
+                    entry.file_id,
+                    body,
+                    outcome,
+                    caller,
+                );
+            }
+            if suppressed || deferred {
+                return;
+            }
+
             // Identical republication is a no-op: nothing a reader can
             // observe changes, so consumers keyed on `generation()` must not
             // see a bump for it.
@@ -1042,6 +1038,18 @@ impl DefinitionStore {
             }
             self.bump_generation();
         } else {
+            if publication_census::census_enabled() {
+                let caller = std::panic::Location::caller();
+                publication_census::record_publication(
+                    id,
+                    None,
+                    Atom::NONE,
+                    None,
+                    body,
+                    publication_census::classify(None, body, false, false),
+                    caller,
+                );
+            }
             // Create a minimal entry for DefIds created via get_or_create_def_id
             // (which only populates symbol_to_def/def_to_symbol, not definitions).
             // This ensures cross-file delegation results survive child-checker

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -985,25 +985,14 @@ impl DefinitionStore {
             // `publication_census`): classify this publication against the
             // guarded pre-write entry state with caller attribution.
             if publication_census::census_enabled() {
-                let caller = std::panic::Location::caller();
-                let params_changed = params
-                    .as_ref()
-                    .is_some_and(|new_params| *new_params != entry.type_params);
-                let outcome = if suppressed {
-                    publication_census::PublicationOutcome::SuppressedDifferentBody
-                } else if deferred {
-                    publication_census::PublicationOutcome::DeferredDifferentBody
-                } else {
-                    publication_census::classify(entry.body, body, params_changed, true)
-                };
-                publication_census::record_publication(
+                publication_census::record_existing_publication(
                     id,
-                    Some(entry.kind),
-                    entry.name,
-                    entry.file_id,
+                    &entry,
                     body,
-                    outcome,
-                    caller,
+                    params.as_deref(),
+                    suppressed,
+                    deferred,
+                    std::panic::Location::caller(),
                 );
             }
             if suppressed || deferred {
@@ -1039,15 +1028,10 @@ impl DefinitionStore {
             self.bump_generation();
         } else {
             if publication_census::census_enabled() {
-                let caller = std::panic::Location::caller();
-                publication_census::record_publication(
+                publication_census::record_minted_minimal_publication(
                     id,
-                    None,
-                    Atom::NONE,
-                    None,
                     body,
-                    publication_census::classify(None, body, false, false),
-                    caller,
+                    std::panic::Location::caller(),
                 );
             }
             // Create a minimal entry for DefIds created via get_or_create_def_id

--- a/crates/tsz-solver/src/def/publication_census.rs
+++ b/crates/tsz-solver/src/def/publication_census.rs
@@ -22,9 +22,9 @@
 //! (~10^3..10^4 publications per project run). Output is rendered by
 //! [`dump_to_string`]; the CLI driver owns file IO and name resolution.
 
-use super::{DefId, DefKind};
+use super::{DefId, DefKind, DefinitionInfo};
 use crate::intern::TypeInterner;
-use crate::types::{TypeData, TypeId};
+use crate::types::{TypeData, TypeId, TypeParamInfo};
 use rustc_hash::FxHashMap;
 use std::panic::Location;
 use std::sync::{Mutex, OnceLock};
@@ -189,6 +189,52 @@ pub fn record_publication(
             entry.bodies_overflowed = true;
         }
     }
+}
+
+/// Record an update against an existing guarded definition entry.
+pub fn record_existing_publication(
+    def_id: DefId,
+    entry: &DefinitionInfo,
+    new_body: TypeId,
+    new_params: Option<&[TypeParamInfo]>,
+    suppressed: bool,
+    deferred: bool,
+    caller: &'static Location<'static>,
+) {
+    let params_changed = new_params.is_some_and(|params| params != entry.type_params.as_slice());
+    let outcome = if suppressed {
+        PublicationOutcome::SuppressedDifferentBody
+    } else if deferred {
+        PublicationOutcome::DeferredDifferentBody
+    } else {
+        classify(entry.body, new_body, params_changed, true)
+    };
+    record_publication(
+        def_id,
+        Some(entry.kind),
+        entry.name,
+        entry.file_id,
+        new_body,
+        outcome,
+        caller,
+    );
+}
+
+/// Record publication of a body for a `DefId` that had no definition entry yet.
+pub fn record_minted_minimal_publication(
+    def_id: DefId,
+    new_body: TypeId,
+    caller: &'static Location<'static>,
+) {
+    record_publication(
+        def_id,
+        None,
+        Atom::NONE,
+        None,
+        new_body,
+        PublicationOutcome::MintedMinimal,
+        caller,
+    );
 }
 
 /// Classify a publication against the pre-write entry state.


### PR DESCRIPTION
Goal: fast

## Summary
- Fixes a schedule-sensitive shared DefinitionStore publication window for #13255.
- Moves different-body suppress/defer decisions under the same definition entry guard that performs the body write.
- Preserves identical republication as a no-op and keeps publication-census attribution intact.
- Synced with current origin/main after #13454 landed; refreshed code head is merge commit 68ed4856680117a88d678fa69783208335d10944.
- Adds empty queue-refresh commit 349545d9e85cec8afa795cf837434629da88db8a so the newest check suite on the PR head is full CI, not the metadata-only light run.

## Structural rule
When sibling parallel fresh checkers publish a shared program definition body, tsc observes one completed semantic identity for that definition. tsz owns that identity in the solver DefinitionStore; suppress/defer publication policy must compare against the guarded current entry state, not a stale pre-lock body probe.

## Verification
- Draft CI Light Summary passed on 86d667f09261e0f1a30fe7b2cc3f60dba858b584 before the main-sync merge.
- Previous ready-review CI on 98f6b5e251cd4e026706905254be8d626e08e933 ran the heavy gates and failed only lint on the def/core.rs size ratchet.
- Ratchet fix on 5fbc6e4659454bd2e083f9f0dc54b5e3705d2d35: `cargo fmt --check`; `git diff --check`; `python3 scripts/arch/arch_guard.py`; `scripts/arch/check-checker-boundaries.sh`; `scripts/safe-run.sh cargo check -p tsz-solver`.
- Refreshed current-main merge head 68ed4856680117a88d678fa69783208335d10944: `cargo fmt --check`; `git diff --check HEAD~1..HEAD`; `python3 scripts/arch/arch_guard.py`; `scripts/safe-run.sh cargo check -p tsz-solver`; PR-head CI Summary passed on run 27467268673.
- Queue-refresh head 349545d9e85cec8afa795cf837434629da88db8a is tree-identical to 68ed4856680117a88d678fa69783208335d10944; `git diff --stat HEAD~1..HEAD` is empty.
- Ready-review CI must validate pr-body-gate, lint, unit, conformance, emit, and project gates on 349545d9e85cec8afa795cf837434629da88db8a before queueing.

## Provenance
Machine: Mohsens-MacBook-Pro.local
Assistant: codex
Model: gpt-5
Effort: high

Head: 349545d9e85cec8afa795cf837434629da88db8a
