### PR TITLE
perf(checker): linear pass-through splice for O(N²) flow narrowing — object-spread to tsgo parity (#13393)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -94,14 +94,58 @@ impl<'a> FlowAnalyzer<'a> {
         let mut condition_antecedent_defer_memo: FxHashMap<FlowNodeId, bool> = FxHashMap::default();
         condition_dp_memos.clear();
 
+        // Reusable scratch buffer for the linear pass-through chase below: the run
+        // of pure pass-through ASSIGNMENT nodes spliced out in O(1) per node, each
+        // aliased to the landed node's result.
+        let mut passthrough_run: Vec<FlowNodeId> = Vec::new();
+
         // Process worklist until empty
-        while let Some((current_flow, current_type)) = worklist.pop_front() {
+        while let Some((entry_flow, current_type)) = worklist.pop_front() {
             steps += 1;
             if steps > step_budget {
                 // Bail out conservatively to avoid unbounded traversal in pathological CFGs.
                 return results.get(&flow_id).copied().unwrap_or(initial_type);
             }
-            in_worklist.remove(&current_flow);
+            in_worklist.remove(&entry_flow);
+
+            // O(N²) → O(N) linear pass-through short-circuit.
+            //
+            // A straight-line run of ASSIGNMENT flow nodes that neither *target*
+            // nor *affect* the reference (the prior top-level `const x_j = …`
+            // statements when narrowing `x_i`/`x_i.prop`) carries no narrowing:
+            // each node's flow type equals its antecedent's. The plain worklist
+            // would still pop, cache-probe, hashset-track, and re-push the
+            // antecedent for every one of them — Σ O(i) per reference, O(N²) total.
+            // The #13404 root pre-filter made each visit cheap to *reject* but the
+            // worklist still ENUMERATED all N, so it stayed O(N²) with a smaller
+            // constant.
+            //
+            // Splice the whole run out in O(1) per node by chasing the single
+            // antecedent in place, landing on the first node that is NOT a pure
+            // pass-through (a merge/condition/call/loop/switch, a targeting or
+            // affecting assignment, a node needing defer, or one already
+            // finalized/cached). Only that landed node is processed; its result is
+            // then aliased back to every skipped node so `results[flow_id]` (the
+            // only result read outside this walk) stays correct when the entry was
+            // itself spliced. Skipped nodes are pure pass-throughs with a single
+            // antecedent and single straight-line successor, so no surviving merge
+            // point reads their now-absent result within this traversal, and the
+            // distinct-reference flow cache keys make caching them useless to later
+            // references anyway. Falls back to the full per-node walk whenever any
+            // gate is uncertain, so narrowing stays byte-identical.
+            passthrough_run.clear();
+            let current_flow = self.chase_linear_passthrough(
+                entry_flow,
+                reference,
+                symbol_id,
+                initial_type,
+                initial_has_type_params,
+                skip_cache_for_control_flow_typed_any,
+                cache_symbol,
+                visited,
+                results,
+                &mut passthrough_run,
+            );
 
             // Check global cache first to avoid redundant traversals.
             // Skip cache for SWITCH_CLAUSE nodes — they must be processed to
@@ -141,15 +185,30 @@ impl<'a> FlowAnalyzer<'a> {
             {
                 let key = (current_flow, cache_symbol, initial_type);
                 if let Some(&cached_type) = cache.borrow().get(&key) {
-                    // Use cached result and skip processing this node
+                    // Use cached result and skip processing this node. Alias the
+                    // cached type to every pass-through node the chase spliced out:
+                    // those nodes are pure pass-throughs whose flow type equals this
+                    // (landed) node's, so `results[flow_id]` stays correct even when
+                    // the landed node was already cached by a prior walk.
                     results.insert(current_flow, cached_type);
                     visited.insert(current_flow);
+                    for &skipped in &passthrough_run {
+                        results.insert(skipped, cached_type);
+                        visited.insert(skipped);
+                    }
                     continue;
                 }
             }
 
-            // Skip if we've already finalized this node
+            // Skip if we've already finalized this node. Propagate its result to
+            // the spliced pass-through run for the same reason as the cache-hit path.
             if visited.contains(&current_flow) {
+                if let Some(&done) = results.get(&current_flow) {
+                    for &skipped in &passthrough_run {
+                        results.insert(skipped, done);
+                        visited.insert(skipped);
+                    }
+                }
                 continue;
             }
 
@@ -1014,6 +1073,19 @@ impl<'a> FlowAnalyzer<'a> {
             results.insert(current_flow, final_type);
             visited.insert(current_flow);
 
+            // Alias the landed node's result to every pure pass-through node spliced
+            // out by `chase_linear_passthrough`: their flow type is exactly this
+            // antecedent result (they neither target nor affect the reference), so
+            // finalizing them here keeps `results[flow_id]` correct when the entry
+            // node was itself spliced, and prevents a redundant re-walk if reached
+            // again. These are not written to the global flow cache: each pass-through
+            // node's cached entry would be keyed by this reference's `cache_symbol`,
+            // which no other reference shares, so it could never be reused.
+            for &skipped in &passthrough_run {
+                results.insert(skipped, final_type);
+                visited.insert(skipped);
+            }
+
             // Store result in global cache for future calls
             // CRITICAL: Only cache if BOTH initial and final types are concrete (no type parameters).
             // This prevents the "Generic Result" bug where narrowing introduces type parameters.
@@ -1063,6 +1135,143 @@ impl<'a> FlowAnalyzer<'a> {
             initial_type
         } else {
             result
+        }
+    }
+
+    /// Linear pass-through short-circuit for the `check_flow` worklist.
+    ///
+    /// Starting at `entry`, chases the single antecedent in place across a run of
+    /// *pure pass-through* ASSIGNMENT flow nodes — nodes that neither target nor
+    /// affect `reference` — collapsing a straight-line `const`/assignment segment
+    /// (the `Σ O(i)` independent-assignment narrowing hotspot) into one landed
+    /// node. Every node skipped this way is pushed onto `run` so the caller can
+    /// alias the landed node's result back to it (their flow type equals the
+    /// antecedent result by construction).
+    ///
+    /// A node is only spliced when ALL of these hold, so narrowing is byte
+    /// identical to the full walk:
+    /// - it is an ASSIGNMENT with no other flow flags (not a merge label, switch
+    ///   clause, loop label, call, condition, array mutation, or start);
+    /// - it has exactly one antecedent (no join to union);
+    /// - it neither targets nor affects `reference`, checked with the same
+    ///   `assignment_root_symbols_may_overlap` pre-filter (#13404) plus the symbol
+    ///   and `assignment_targets_reference_node` / `assignment_affects_reference_node`
+    ///   AST predicates the worklist's own ASSIGNMENT branch uses, so it is neither
+    ///   a killing definition, a base reassignment, nor a property mutation of the
+    ///   reference;
+    /// - its antecedent does not `antecedent_requires_defer` (so we never skip past
+    ///   a node carrying pending narrowing such as a condition, call, loop, branch,
+    ///   or a targeting assignment); and
+    /// - the antecedent is not already finalized/cached for this walk (so we never
+    ///   bypass an existing `results`/`visited`/flow-cache answer).
+    ///
+    /// The chase is disabled for type-parameter-bearing or control-flow-`any`
+    /// initial types, mirroring the worklist's own cache-eligibility gate, so it
+    /// cannot perturb loop fixed-point or generic-result caching. On any node that
+    /// fails a gate the chase stops and returns that node for normal processing.
+    #[allow(clippy::too_many_arguments)]
+    fn chase_linear_passthrough(
+        &self,
+        entry: FlowNodeId,
+        reference: NodeIndex,
+        symbol_id: Option<SymbolId>,
+        initial_type: TypeId,
+        initial_has_type_params: bool,
+        skip_cache_for_control_flow_typed_any: bool,
+        cache_symbol: SymbolId,
+        visited: &FxHashSet<FlowNodeId>,
+        results: &FxHashMap<FlowNodeId, TypeId>,
+        run: &mut Vec<FlowNodeId>,
+    ) -> FlowNodeId {
+        // Gate: only collapse when the worklist treats this walk as
+        // cacheable/concrete. Generic or control-flow-`any` walks keep the full
+        // per-node path so loop fixed-point and generic-result invariants are
+        // untouched.
+        if initial_has_type_params
+            || skip_cache_for_control_flow_typed_any
+            || initial_type == TypeId::ANY
+            || initial_type == TypeId::ERROR
+        {
+            return entry;
+        }
+
+        // Only pure non-merge ASSIGNMENT flow flags are skippable. Any other flag
+        // means the node can apply or merge narrowing and must be processed.
+        let pure_assignment_only = |flags: u32| -> bool {
+            flags & flow_flags::ASSIGNMENT != 0
+                && flags
+                    & (flow_flags::BRANCH_LABEL
+                        | flow_flags::LOOP_LABEL
+                        | flow_flags::SWITCH_CLAUSE
+                        | flow_flags::CONDITION
+                        | flow_flags::CALL
+                        | flow_flags::ARRAY_MUTATION
+                        | flow_flags::START)
+                    == 0
+        };
+
+        let mut current = entry;
+        loop {
+            let Some(flow) = self.binder.flow_nodes.get(current) else {
+                return current;
+            };
+            if !pure_assignment_only(flow.flags) {
+                return current;
+            }
+            // Exactly one antecedent: a join/merge must be processed so its
+            // antecedents union correctly.
+            let [ant] = flow.antecedent.as_slice() else {
+                return current;
+            };
+            let ant = *ant;
+
+            // The assignment must neither target nor affect the reference. Reuse
+            // the #13404 O(1) root pre-filter (`assignment_root_symbols_may_overlap`):
+            // when the assignment's root symbol is provably disjoint from the
+            // reference's, it is irrelevant and skippable. Only fall back to the
+            // deep AST predicates (which the worklist's ASSIGNMENT branch also runs)
+            // when the roots may overlap.
+            let relevant =
+                if !self.assignment_root_symbols_may_overlap(flow.node, reference, symbol_id) {
+                    false
+                } else if let Some(target_sym) = symbol_id {
+                    let assignment_sym = self.reference_symbol(flow.node);
+                    if assignment_sym.is_some() && assignment_sym != Some(target_sym) {
+                        // Different binder symbol: cannot target the reference. It may
+                        // still *affect* a property/element path of the reference.
+                        self.assignment_affects_reference_node(flow.node, reference)
+                    } else {
+                        self.assignment_targets_reference_node(flow.node, reference)
+                            || self.assignment_affects_reference_node(flow.node, reference)
+                    }
+                } else {
+                    self.assignment_targets_reference_node(flow.node, reference)
+                        || self.assignment_affects_reference_node(flow.node, reference)
+                };
+            if relevant {
+                return current;
+            }
+
+            // Never skip past an antecedent that carries pending narrowing, and
+            // never skip one already finalized/cached (let the worklist reuse the
+            // existing answer for it).
+            if self.antecedent_requires_defer(ant, reference, symbol_id)
+                || visited.contains(&ant)
+                || results.contains_key(&ant)
+            {
+                return current;
+            }
+            if let Some(cache) = self.flow_cache()
+                && cache
+                    .borrow()
+                    .contains_key(&(ant, cache_symbol, initial_type))
+            {
+                return current;
+            }
+
+            // `current` is a pure pass-through: record it and advance.
+            run.push(current);
+            current = ant;
         }
     }
 

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -6,6 +6,18 @@ use tsz_binder::{FlowNodeId, SymbolId, flow_flags};
 use tsz_parser::parser::{NodeIndex, syntax_kind_ext};
 use tsz_solver::TypeId;
 
+/// Immutable per-walk parameters for [`FlowAnalyzer::chase_linear_passthrough`],
+/// bundled so the chase helper stays within the argument-count budget.
+#[derive(Clone, Copy)]
+struct PassthroughGate {
+    reference: NodeIndex,
+    symbol_id: Option<SymbolId>,
+    initial_type: TypeId,
+    initial_has_type_params: bool,
+    skip_cache_for_control_flow_typed_any: bool,
+    cache_symbol: SymbolId,
+}
+
 impl<'a> FlowAnalyzer<'a> {
     /// Iterative flow graph traversal using a worklist algorithm.
     ///
@@ -148,12 +160,14 @@ impl<'a> FlowAnalyzer<'a> {
             passthrough_run.clear();
             let current_flow = self.chase_linear_passthrough(
                 entry_flow,
-                reference,
-                symbol_id,
-                initial_type,
-                initial_has_type_params,
-                skip_cache_for_control_flow_typed_any,
-                cache_symbol,
+                PassthroughGate {
+                    reference,
+                    symbol_id,
+                    initial_type,
+                    initial_has_type_params,
+                    skip_cache_for_control_flow_typed_any,
+                    cache_symbol,
+                },
                 visited,
                 results,
                 &mut passthrough_run,
@@ -1188,20 +1202,22 @@ impl<'a> FlowAnalyzer<'a> {
     /// initial types, mirroring the worklist's own cache-eligibility gate, so it
     /// cannot perturb loop fixed-point or generic-result caching. On any node that
     /// fails a gate the chase stops and returns that node for normal processing.
-    #[allow(clippy::too_many_arguments)]
     fn chase_linear_passthrough(
         &self,
         entry: FlowNodeId,
-        reference: NodeIndex,
-        symbol_id: Option<SymbolId>,
-        initial_type: TypeId,
-        initial_has_type_params: bool,
-        skip_cache_for_control_flow_typed_any: bool,
-        cache_symbol: SymbolId,
+        gate: PassthroughGate,
         visited: &FxHashSet<FlowNodeId>,
         results: &FxHashMap<FlowNodeId, TypeId>,
         run: &mut Vec<FlowNodeId>,
     ) -> FlowNodeId {
+        let PassthroughGate {
+            reference,
+            symbol_id,
+            initial_type,
+            initial_has_type_params,
+            skip_cache_for_control_flow_typed_any,
+            cache_symbol,
+        } = gate;
         // Gate: only collapse when the worklist treats this walk as
         // cacheable/concrete. Generic or control-flow-`any` walks keep the full
         // per-node path so loop fixed-point and generic-result invariants are

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -94,9 +94,20 @@ impl<'a> FlowAnalyzer<'a> {
         let mut condition_antecedent_defer_memo: FxHashMap<FlowNodeId, bool> = FxHashMap::default();
         condition_dp_memos.clear();
 
-        // Reusable scratch buffer for the linear pass-through chase below: the run
-        // of pure pass-through ASSIGNMENT nodes spliced out in O(1) per node, each
-        // aliased to the landed node's result.
+        // Landed nodes whose spliced pass-through run CONTAINS the entry `flow_id`.
+        // When the chase splices out the very node we must return a result for, the
+        // landed node's finalized type IS that result (the run is pure pass-through,
+        // so `flow_id`'s flow type equals the antecedent result). The landed node may
+        // DEFER and re-pop any number of times before finalizing, so we cannot alias
+        // eagerly; instead we record the landed node here and write `results[flow_id]`
+        // at whichever finalize site (cache hit, visited skip, or final write) resolves
+        // it. We deliberately alias ONLY `flow_id`, never interior spliced nodes: an
+        // interior node can still be a live antecedent of a surviving merge point that
+        // re-schedules and finalizes it on its own; overwriting that with the landed
+        // result would corrupt the merge (the `jsxComplexSignature` family). `flow_id`
+        // is the sole result read outside the walk, so aliasing it alone is sufficient
+        // and never overwrites an independently-computed merge result.
+        let mut flow_id_landed_on: Option<FlowNodeId> = None;
         let mut passthrough_run: Vec<FlowNodeId> = Vec::new();
 
         // Process worklist until empty
@@ -124,15 +135,16 @@ impl<'a> FlowAnalyzer<'a> {
             // antecedent in place, landing on the first node that is NOT a pure
             // pass-through (a merge/condition/call/loop/switch, a targeting or
             // affecting assignment, a node needing defer, or one already
-            // finalized/cached). Only that landed node is processed; its result is
-            // then aliased back to every skipped node so `results[flow_id]` (the
-            // only result read outside this walk) stays correct when the entry was
-            // itself spliced. Skipped nodes are pure pass-throughs with a single
-            // antecedent and single straight-line successor, so no surviving merge
-            // point reads their now-absent result within this traversal, and the
-            // distinct-reference flow cache keys make caching them useless to later
-            // references anyway. Falls back to the full per-node walk whenever any
-            // gate is uncertain, so narrowing stays byte-identical.
+            // finalized/cached). Only that landed node is processed. If the entry
+            // `flow_id` itself was among the spliced nodes, its result is aliased
+            // from the landed node's once that resolves (`flow_id_landed_on`).
+            // `flow_id` is the only result read outside this walk, so we alias it
+            // alone and never touch interior spliced nodes: an interior node may
+            // still be a live antecedent of a surviving merge that re-schedules and
+            // finalizes it independently, and overwriting that would corrupt the
+            // merge. Re-scheduling an interior node simply re-runs the cheap chase.
+            // Falls back to the full per-node walk whenever any gate is uncertain,
+            // so narrowing stays byte-identical.
             passthrough_run.clear();
             let current_flow = self.chase_linear_passthrough(
                 entry_flow,
@@ -146,6 +158,14 @@ impl<'a> FlowAnalyzer<'a> {
                 results,
                 &mut passthrough_run,
             );
+            // If the chase spliced out the entry `flow_id` itself, remember the node
+            // it landed on so the final result can be aliased to `flow_id` once that
+            // node resolves (possibly after deferrals). Interior spliced nodes are
+            // intentionally left untracked so a surviving merge can re-derive them.
+            if current_flow != flow_id && passthrough_run.contains(&flow_id) {
+                flow_id_landed_on = Some(current_flow);
+            }
+            passthrough_run.clear();
 
             // Check global cache first to avoid redundant traversals.
             // Skip cache for SWITCH_CLAUSE nodes — they must be processed to
@@ -192,22 +212,22 @@ impl<'a> FlowAnalyzer<'a> {
                     // the landed node was already cached by a prior walk.
                     results.insert(current_flow, cached_type);
                     visited.insert(current_flow);
-                    for &skipped in &passthrough_run {
-                        results.insert(skipped, cached_type);
-                        visited.insert(skipped);
+                    if flow_id_landed_on == Some(current_flow) {
+                        results.insert(flow_id, cached_type);
+                        visited.insert(flow_id);
                     }
                     continue;
                 }
             }
 
             // Skip if we've already finalized this node. Propagate its result to
-            // the spliced pass-through run for the same reason as the cache-hit path.
+            // `flow_id` if the chase spliced `flow_id` onto this landed node.
             if visited.contains(&current_flow) {
-                if let Some(&done) = results.get(&current_flow) {
-                    for &skipped in &passthrough_run {
-                        results.insert(skipped, done);
-                        visited.insert(skipped);
-                    }
+                if flow_id_landed_on == Some(current_flow)
+                    && let Some(&done) = results.get(&current_flow)
+                {
+                    results.insert(flow_id, done);
+                    visited.insert(flow_id);
                 }
                 continue;
             }
@@ -1073,17 +1093,16 @@ impl<'a> FlowAnalyzer<'a> {
             results.insert(current_flow, final_type);
             visited.insert(current_flow);
 
-            // Alias the landed node's result to every pure pass-through node spliced
-            // out by `chase_linear_passthrough`: their flow type is exactly this
-            // antecedent result (they neither target nor affect the reference), so
-            // finalizing them here keeps `results[flow_id]` correct when the entry
-            // node was itself spliced, and prevents a redundant re-walk if reached
-            // again. These are not written to the global flow cache: each pass-through
-            // node's cached entry would be keyed by this reference's `cache_symbol`,
-            // which no other reference shares, so it could never be reused.
-            for &skipped in &passthrough_run {
-                results.insert(skipped, final_type);
-                visited.insert(skipped);
+            // If the chase spliced the entry `flow_id` onto this landed node, write
+            // its result now: the spliced run is pure pass-through, so `flow_id`'s
+            // flow type equals this antecedent result. Only `flow_id` is aliased
+            // (never interior spliced nodes — see `flow_id_landed_on`), so a surviving
+            // merge that re-derives an interior node is never overwritten. This is not
+            // written to the global flow cache: `flow_id`'s cached entry would be keyed
+            // by this reference's `cache_symbol`, which no other reference shares.
+            if flow_id_landed_on == Some(current_flow) {
+                results.insert(flow_id, final_type);
+                visited.insert(flow_id);
             }
 
             // Store result in global cache for future calls
@@ -1186,11 +1205,19 @@ impl<'a> FlowAnalyzer<'a> {
         // Gate: only collapse when the worklist treats this walk as
         // cacheable/concrete. Generic or control-flow-`any` walks keep the full
         // per-node path so loop fixed-point and generic-result invariants are
-        // untouched.
+        // untouched. `UNKNOWN` is excluded too: the worklist gives UNKNOWN
+        // references dedicated switch-clause and exhaustive-typeof handling
+        // (`skip_cache_for_explicit_unknown_switch` /
+        // `skip_cache_for_exhaustive_unknown_typeof`) whose narrowing flows
+        // through the very pass-through `const` nodes the chase would splice, so
+        // collapsing them would drop switch/typeof narrowing (e.g. `unknownType2`).
+        // UNKNOWN references are catch-clause / explicit-`unknown` shaped, not the
+        // concrete member-typed `const` hotspot, so this costs no perf.
         if initial_has_type_params
             || skip_cache_for_control_flow_typed_any
             || initial_type == TypeId::ANY
             || initial_type == TypeId::ERROR
+            || initial_type == TypeId::UNKNOWN
         {
             return entry;
         }
@@ -1216,6 +1243,17 @@ impl<'a> FlowAnalyzer<'a> {
                 return current;
             };
             if !pure_assignment_only(flow.flags) {
+                return current;
+            }
+            // A destructuring assignment is never spliced: it has dedicated
+            // worklist handling (`is_const_destructuring` defers to the antecedent
+            // and re-derives the binding from the narrowed source). The targeting
+            // predicates below compare against the binding *pattern* node, not the
+            // bound element, so a destructuring node that DOES define the reference
+            // (e.g. `const { nested: { b: text } } = aFoo` defining `text` after a
+            // guard, `destructuringTypeGuardFlow`) would read as non-targeting and
+            // be wrongly skipped, dropping the narrowing. Let the worklist own it.
+            if self.is_destructuring_assignment(flow.node) {
                 return current;
             }
             // Exactly one antecedent: a join/merge must be processed so its

--- a/crates/tsz-checker/tests/flow_property_reference_cache_tests.rs
+++ b/crates/tsz-checker/tests/flow_property_reference_cache_tests.rs
@@ -518,3 +518,66 @@ const useA2: number = recA.v;
         "sequential distinct member reads must not cross-contaminate, got: {codes:?}"
     );
 }
+
+/// Destructuring binding after a type guard, with intervening pass-through
+/// `const` reads between the destructuring and the use. The destructuring
+/// `const { nested: { b: text } } = src` is never spliced (it has dedicated
+/// worklist handling), and the intervening reads that the chase DOES splice
+/// must not orphan the guarded property read: `src.nested.b` is narrowed to
+/// `string` by the guard, so `text` (and direct `src.member` reads) stay
+/// narrowed. Mirrors `destructuringTypeGuardFlow`; binder names varied.
+#[test]
+fn destructuring_after_guard_with_intervening_passthrough_keeps_narrowing() {
+    let codes = check_source_strict_codes(
+        r#"
+type Holder = {
+  count: number | null;
+  label: string;
+  inner: { idx: number; tag: string | null };
+};
+const src: Holder = { count: 3, label: "b", inner: { idx: 1, tag: "y" } };
+if (src.count && src.inner.tag) {
+  const { count, label, inner: { idx, tag: text } } = src;
+  const okCount: number = src.count;
+  const okIdx: number = idx;
+  const okLabel: string = label;
+  const okText: string = text;
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "guarded narrowing must survive a destructuring + intervening pass-through run, got: {codes:?}"
+    );
+}
+
+/// A `switch` over an `unknown` reference narrows each case body, with leading
+/// pass-through `const` statements that the chase must NOT splice (UNKNOWN
+/// initial types are excluded from the chase because the worklist gives them
+/// dedicated switch/typeof handling). Mirrors the `switchTestCollectEnum`
+/// family of `unknownType2`; binder names varied.
+#[test]
+fn unknown_switch_case_narrowing_survives_passthrough_run() {
+    let codes = check_source_strict_codes(
+        r#"
+enum Hue { Red = "red", Green = "green", Blue = "blue" }
+function classify(token: unknown) {
+  const lead1 = 0;
+  const lead2 = 0;
+  const lead3 = 0;
+  switch (token) {
+    case Hue.Red:
+      const r: Hue.Red = token;
+      break;
+    case Hue.Green:
+      const g: Hue.Green = token;
+      break;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "unknown switch-case narrowing must survive a pass-through run, got: {codes:?}"
+    );
+}

--- a/crates/tsz-checker/tests/flow_property_reference_cache_tests.rs
+++ b/crates/tsz-checker/tests/flow_property_reference_cache_tests.rs
@@ -349,3 +349,172 @@ export function read() {
         "import.meta.value member access must narrow, got: {codes:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Linear pass-through short-circuit (`chase_linear_passthrough`).
+//
+// A straight-line run of `const`/assignment statements that do not target or
+// affect a reference is spliced out of the backward flow walk in O(1) per node.
+// These witnesses pin that the splice is narrowing-exact: it must NOT fire (or
+// must land correctly) whenever a node between the declaration and the use
+// carries narrowing — type guards, mid-chain reassignment, discriminant
+// branches, captured/aliased roots, and optional-chain roots all still narrow.
+// Binder names are deliberately varied from the usual `x`/`y` so the short
+// circuit cannot be keyed on identifier text.
+// ---------------------------------------------------------------------------
+
+/// A narrowed `const` with a type guard between its declaration and use must
+/// still narrow: the CONDITION node is not a pure pass-through, so the chase
+/// stops there. Many unrelated leading `const` statements (the spliced run) must
+/// not swallow the guard. `payload` narrows to the `"text"` arm, so reading
+/// `.body` as a `string` is fine and reading it as a `number` trips TS2322.
+#[test]
+fn type_guard_between_decl_and_use_still_narrows_after_passthrough_run() {
+    let codes = check_source_strict_codes(
+        r#"
+type Message =
+  | { channel: "text"; body: string }
+  | { channel: "code"; body: number };
+function handle(payload: Message) {
+  const alpha = 1;
+  const bravo = 2;
+  const charlie = 3;
+  const delta = 4;
+  if (payload.channel === "text") {
+    const ok: string = payload.body;
+    const bad: number = payload.body;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "type-guard narrowing after a pass-through run must hold (TS2322 on number), got: {codes:?}"
+    );
+}
+
+/// A reference reassigned mid-chain is NOT a pure pass-through at the reassigning
+/// node, so the chase stops and the killing definition wins. `subject` starts as
+/// a `string` union, is narrowed to `"a"`, then reassigned to a number — the
+/// later read must see `number`, so annotating it `string` trips TS2322.
+#[test]
+fn reassigned_mid_chain_reference_stops_passthrough_chase() {
+    let codes = check_source_strict_codes(
+        r#"
+function process(subject: string | number) {
+  const lead1 = 10;
+  const lead2 = 20;
+  if (typeof subject === "string") {
+    subject = 99;
+    const wrong: string = subject;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "mid-chain reassignment must stop the pass-through chase (TS2322), got: {codes:?}"
+    );
+}
+
+/// An aliased/captured reference still narrows across a long pass-through run:
+/// the alias binding is itself a pass-through, but the guard on the alias must
+/// survive the splice. `clone.detail` narrows to present, so `.value` is a
+/// `number` and no diagnostic is expected.
+#[test]
+fn aliased_captured_reference_narrows_through_passthrough_run() {
+    let codes = check_source_strict_codes(
+        r#"
+function inspect(origin: { detail?: { value: number } }) {
+  const noise1 = "a";
+  const noise2 = "b";
+  const noise3 = "c";
+  const clone = origin;
+  const noise4 = "d";
+  if (clone.detail) {
+    const v: number = clone.detail.value;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "aliased reference must keep narrowing through a pass-through run, got: {codes:?}"
+    );
+}
+
+/// An optional-chain member reference (root resolves to `Unknown`) still narrows
+/// after a long pass-through run; the chase falls back to the full walk for the
+/// guard node. No diagnostic expected.
+#[test]
+fn optional_chain_reference_narrows_after_passthrough_run() {
+    let codes = check_source_strict_codes(
+        r#"
+function read(box?: { inner?: { count: number } }) {
+  const s1 = 0;
+  const s2 = 0;
+  const s3 = 0;
+  const s4 = 0;
+  if (box?.inner) {
+    const c: number = box.inner.count;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "optional-chain narrowing must survive a pass-through run, got: {codes:?}"
+    );
+}
+
+/// A discriminated union narrowed inside a branch, with the discriminant check
+/// preceded by a pass-through run, must still expose the branch-only member.
+/// `node.kind === "leaf"` narrows to the leaf arm; reading `.weight` (leaf only)
+/// is fine, and reading `.children` (branch only) trips TS2339.
+#[test]
+fn discriminated_union_branch_narrows_after_passthrough_run() {
+    let codes = check_source_strict_codes(
+        r#"
+type Tree =
+  | { kind: "leaf"; weight: number }
+  | { kind: "branch"; children: number };
+function walk(node: Tree) {
+  const pre1 = 1;
+  const pre2 = 2;
+  const pre3 = 3;
+  if (node.kind === "leaf") {
+    const w: number = node.weight;
+    const oops = node.children;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&2339),
+        "discriminated-union branch narrowing after a pass-through run must hold (TS2339), got: {codes:?}"
+    );
+}
+
+/// Many independent top-level-style `const` member reads in sequence (the exact
+/// `Σ O(i)` hotspot shape) must each see their own value and not leak narrowing
+/// from a sibling — the splice must not alias distinct references. None of these
+/// reads is illegal, so no diagnostic is expected; this pins that the spliced
+/// run finalizes each reference correctly rather than collapsing them.
+#[test]
+fn sequential_member_reads_do_not_cross_contaminate_under_passthrough() {
+    let codes = check_source_strict_codes(
+        r#"
+declare const recA: { v: number };
+declare const recB: { v: string };
+declare const recC: { v: boolean };
+const useA: number = recA.v;
+const useB: string = recB.v;
+const useC: boolean = recC.v;
+const useA2: number = recA.v;
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "sequential distinct member reads must not cross-contaminate, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Goal: fast

Implements the second (algorithmic) half of #13393: control-flow narrowing was O(N²) on long straight-line code. The O(1) root-receiver pre-filter landed via #13404 — but it only makes each antecedent O(1) to *reject*; the flow worklist still *enumerates* all N prior assignment nodes per reference, so the total stays O(N²) (Σ O(i)). This PR adds walk **splicing** to make it ~O(N).

## Structural rule
When the backward flow walk reaches a straight-line run of pure pass-through ASSIGNMENT nodes that provably cannot affect the reference, `chase_linear_passthrough` splices the whole run out in O(1) per node and aliases the surviving node's result back to the walk entry, instead of popping/cache-probing/visiting each one. A node is spliced only when ALL hold (else fall back to the full per-node walk → byte-identical narrowing):
- ASSIGNMENT flag with no other flow flag (not branch/loop/switch/condition/call/array-mutation/start);
- exactly one antecedent; not a destructuring assignment (it has dedicated worklist handling);
- provably does NOT target or affect the reference — via main's `assignment_root_symbols_may_overlap` (#13404) pre-filter, then the same symbol + `assignment_targets_reference_node`/`assignment_affects_reference_node` AST predicates the worklist's ASSIGNMENT branch uses;
- the antecedent does not `antecedent_requires_defer` (reused, not duplicated — coexists with the #13359/#13378 defer memos);
- not already finalized/visited/flow-cached.
Disabled for type-parameter-bearing, control-flow-`any`, `ANY`, `ERROR`, and `UNKNOWN` initial types (mirrors the worklist's own cache-eligibility gate). Only the entry `flow_id` is aliased to the landed result (across deferrals); interior spliced nodes are never aliased, since an interior node can still be a live antecedent of a surviving merge that re-derives it independently.

"Never reassigned" ≠ "never narrowed": a const can be narrowed by a type guard between its declaration and use — those antecedents (CONDITION/branch/call) are never spliced.

## Performance (release, ms mean; tsgo ~155ms flat)
| Row | N=50 | N=100 | N=200 | N=400 | speedup@400 |
|---|---|---|---|---|---|
| Object spread hotspot | 39→29 | 129→37 | 379→65 | 867→**152** | **5.7x — at tsgo parity** |
| Recursive utility aliases | 129→125 | 263→229 | 710→412 | 1695→**811** | **2.1x** |
| Conditional infer hotspot | 134→133 | 206→202 | 502→449 | 1188→992 | 1.2x (residual is type-construction, not flow) |

Object-spread flattens toward linear and reaches tsgo parity; recursive-alias halves at N=400. Diagnostics byte-identical before/after on all 3 rows × 4 N.

## Verification
- Full local conformance (release): 12583/12585, zero new vs accepted regressions (only the 2 accepted Mac-delta cases). Three real narrowing regressions were caught *by conformance* during development (deferred-finalization aliasing, destructuring-pattern targeting, UNKNOWN-type switch handling) and each became a tightened splice clause + a witness — the gate did its job.
- nextest A/B vs clean main (tsz-checker, TS fixtures symlinked both sides): failure-set delta EMPTY both directions.
- 8 renamed-binder parity witnesses (type-guard-between-decl-and-use, mid-chain-reassignment-stops-chase, aliased/captured-root, optional-chain-root, discriminated-union-branch, sequential-distinct-reads, destructuring-after-guard-with-intervening-passthrough, unknown-switch-case); 14/14 flow cache + passthrough tests pass.
- clippy --all-targets clean; **no new `#[allow]`** (the chase helper's params are bundled into a `Copy` `PassthroughGate` struct to stay within the argument-count budget — no suppression); arch_guard + 2000-line caps pass.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: max
