### PR TITLE
perf(cli): report batch residency probe pressure (#13249)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -6,6 +6,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use std::io::IsTerminal;
 
+use tsz::parallel::residency::{MemoryPressure, ResidencyBudget};
 use tsz_cli::args::CliArgs;
 use tsz_cli::help::{self, TSC_VERSION};
 use tsz_cli::{driver, locale, reporter::Reporter, watch};
@@ -303,6 +304,24 @@ fn clear_batch_iteration_state() {
     tsz::checker::clear_all_thread_local_state();
 }
 
+fn write_batch_residency_report(
+    stdout: &mut impl std::io::Write,
+    result: &driver::CompilationResult,
+) -> Result<()> {
+    let Some(stats) = result.residency_stats.as_ref() else {
+        return Ok(());
+    };
+    let retained_kb = stats.retained_file_state_bytes_est() as f64 / 1024.0;
+    let pressure = match ResidencyBudget::default().assess(stats) {
+        MemoryPressure::Low => "low",
+        MemoryPressure::Medium => "medium",
+        MemoryPressure::High => "high",
+    };
+    writeln!(stdout, "Batch retained file state:     {retained_kb:.1}K")?;
+    writeln!(stdout, "Batch retained residency pressure: {pressure}")?;
+    Ok(())
+}
+
 /// Batch compilation mode: read project directory paths from stdin (one per line),
 /// compile each with `--project <path> --noEmit --pretty false`, print diagnostics,
 /// then print a sentinel line so the caller can demarcate output boundaries.
@@ -381,6 +400,7 @@ fn run_batch_mode(residency_budget: bool) -> Result<()> {
                     }
                 }
                 if residency_budget {
+                    write_batch_residency_report(&mut stdout, &result)?;
                     drop(result);
                     clear_batch_iteration_state();
                 }


### PR DESCRIPTION
Goal: fast

## Summary
- Print retained file-state bytes and default `ResidencyBudget` pressure when hidden `--batchResidencyBudget` mode is enabled.
- Reuse `CompilationResult.residency_stats` already collected by `--extendedDiagnostics`.
- Keep default batch behavior unchanged; no eviction, scheduler, checker, or solver semantic changes.

## Structural rule
When the hidden batch residency probe finishes a project, retained `MergedProgram` pressure should be observable before finished-project state is cleared. `tsz` owns this at the CLI batch boundary; default batch mode and live checker/type state stay unchanged.

## Verification
- PR-head CI on `99611f20e726c261a04e7f3f01358b2294efeaae`: `CI Summary`, `conformance-*`, `conformance-aggregate`, `emit`, `fourslash-*`, `fourslash-aggregate`, `project-compile-canary`, `project-compile-guard`, `unit`, `unit-checker-integration`, `lint`, `cargo-deny`, `cargo-shear`, `dist-binaries`, `wasm`, `lsp-e2e`, `premerge-microbench`, `pr-body-gate`, `project-row-drift`, and `gate` passed.
- Pre-commit formatting hook ran during commit.
- Local tests/benchmarks not run in this continuation.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium