### PR TITLE
perf(solver): memo conditional branch containment (#12271)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate.rs
@@ -97,6 +97,14 @@ pub struct TypeEvaluator<'a, R: TypeResolver = NoopResolver> {
     /// pattern thousands of times while checking whether the application-level
     /// infer fast path applies.
     contains_infer_cache: FxHashMap<TypeId, bool>,
+    /// PERF: Cache exact `TypeId` containment checks within this evaluator.
+    ///
+    /// Distributive conditional evaluation asks whether each branch references
+    /// the original distribution source before deciding whether substitution is
+    /// necessary. Recursive utility aliases can revisit the same branch/source
+    /// pair across tail-recursive conditional iterations; this memo keeps that
+    /// pure solver predicate O(1) after the first walk.
+    contains_type_by_id_cache: FxHashMap<(TypeId, TypeId), bool>,
     /// Ceiling for eager mapped-key expansion before bailing out.
     max_mapped_keys: usize,
     /// When true, flag `depth_exceeded` on Application cycle detection.
@@ -216,6 +224,8 @@ pub struct TypeEvaluatorCacheStatistics {
     pub conditional_subtype_entries: usize,
     /// Entries in the `contains infer` predicate memo keyed by `TypeId`.
     pub contains_infer_entries: usize,
+    /// Entries in the exact `contains_type_by_id(root, target)` memo.
+    pub contains_type_by_id_entries: usize,
     estimated_size_bytes: usize,
 }
 
@@ -265,6 +275,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             suppress_this_binding: false,
             conditional_subtype_cache: FxHashMap::default(),
             contains_infer_cache: FxHashMap::default(),
+            contains_type_by_id_cache: FxHashMap::default(),
             max_mapped_keys: DEFAULT_MAX_MAPPED_KEYS,
             flag_depth_on_app_cycle: false,
             expand_application_display_alias_args: false,
@@ -288,15 +299,21 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     pub fn cache_statistics(&self) -> TypeEvaluatorCacheStatistics {
         let conditional_subtype_entries = self.conditional_subtype_cache.len();
         let contains_infer_entries = self.contains_infer_cache.len();
+        let contains_type_by_id_entries = self.contains_type_by_id_cache.len();
         let type_evaluator_cache_estimated_size_bytes = conditional_subtype_entries
             .saturating_mul(std::mem::size_of::<((TypeId, TypeId), bool)>())
             .saturating_add(
                 contains_infer_entries.saturating_mul(std::mem::size_of::<(TypeId, bool)>()),
+            )
+            .saturating_add(
+                contains_type_by_id_entries
+                    .saturating_mul(std::mem::size_of::<((TypeId, TypeId), bool)>()),
             );
 
         TypeEvaluatorCacheStatistics {
             conditional_subtype_entries,
             contains_infer_entries,
+            contains_type_by_id_entries,
             estimated_size_bytes: type_evaluator_cache_estimated_size_bytes,
         }
     }
@@ -492,6 +509,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     pub fn reset(&mut self) {
         self.cache.clear();
         self.tainted.clear();
+        self.contains_type_by_id_cache.clear();
         self.guard.reset();
         self.def_depth.clear();
         self.real_instantiation_depth_count = 0;
@@ -570,6 +588,21 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     #[inline]
     pub(crate) fn cache_contains_infer(&mut self, type_id: TypeId, result: bool) {
         self.contains_infer_cache.insert(type_id, result);
+    }
+
+    /// PERF: Exact `TypeId` containment with an evaluator-local memo.
+    #[inline]
+    pub(crate) fn cached_contains_type_by_id(&mut self, root: TypeId, target: TypeId) -> bool {
+        if root == target {
+            return true;
+        }
+        if let Some(cached) = self.contains_type_by_id_cache.get(&(root, target)) {
+            return *cached;
+        }
+        let result = crate::visitor::contains_type_by_id(self.interner, root, target);
+        self.contains_type_by_id_cache
+            .insert((root, target), result);
+        result
     }
 
     /// Check if `no_unchecked_indexed_access` is enabled.

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -1625,17 +1625,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // the substitution walk's children (it also descends `Mapped` and
         // type-parameter internals), so a `false` answer here is always safe
         // to skip on.
-        let branch_references_check = |evaluator: &Self, branch: TypeId| {
-            branch == original_check_type
-                || crate::visitor::contains_type_by_id(
-                    evaluator.interner(),
-                    branch,
-                    original_check_type,
-                )
-        };
-        let extends_needs_subst = branch_references_check(self, extends_type);
-        let true_needs_subst = branch_references_check(self, true_type);
-        let false_needs_subst = branch_references_check(self, false_type);
+        let branch_references_check = |branch: TypeId| branch == original_check_type;
+        let extends_needs_subst = branch_references_check(extends_type)
+            || self.cached_contains_type_by_id(extends_type, original_check_type);
+        let true_needs_subst = branch_references_check(true_type)
+            || self.cached_contains_type_by_id(true_type, original_check_type);
+        let false_needs_subst = branch_references_check(false_type)
+            || self.cached_contains_type_by_id(false_type, original_check_type);
 
         for &member in members {
             // Check if depth was exceeded during previous iterations


### PR DESCRIPTION
Goal: fast

## Summary
- Add an evaluator-local memo for exact `contains_type_by_id(root, target)` branch-containment checks.
- Use the memo in distributive conditional evaluation before deciding whether each branch needs per-member substitution.
- Keep the cache scoped to one solver evaluator request; no checker boundary changes, fixture-name gates, or semantic result changes.

## Structural rule
When distributive conditional evaluation repeatedly asks whether a branch references the original distribution source, `tsz` should answer that pure solver predicate from an evaluator-local `(branch, source)` memo after the first structural walk. The owner is the solver evaluator; substitution, relation, and branch-selection semantics are unchanged.

## Verification
- PR-head CI on `2da3c1923ead5ee70f8bdcde64959620ba4ff659`: `CI Summary`, conformance shards + aggregate, emit, fourslash shards + aggregate, project-compile-canary, project-compile-guard, unit, unit-checker-integration, unit-cloudbuild, lint, cargo-deny, cargo-shear, dist-binaries, wasm, wasm-web, premerge-microbench, project-row-drift, gate, and pr-body-gate passed.
- Draft PR-head CI on `2da3c1923ead5ee70f8bdcde64959620ba4ff659`: `CI Light Summary`, `unit`, `unit-checker-integration`, `lint`, `cargo-deny`, `cargo-shear`, `dist-binaries`, `premerge-microbench`, `project-row-drift`, `gate` passed.
- Pre-commit formatting hook ran during commit.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium