### PR TITLE
fix(checker): recognize `keyof X & string` idiom in indexed-access key-space checks (#13326)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/state/checking.rs
+++ b/crates/tsz-checker/src/query_boundaries/state/checking.rs
@@ -22,6 +22,35 @@ pub(crate) fn keyof_target(db: &dyn TypeDatabase, type_id: TypeId) -> Option<Typ
     tsz_solver::type_queries::get_keyof_type(db, type_id)
 }
 
+/// Collect the operands of every `keyof X` denoted by `type_id`, seeing through
+/// the common `keyof X & string` (also `& number` / `& symbol` /
+/// `& PropertyKey`) intersection idiom.
+///
+/// A key-space constraint is frequently narrowed to string keys by writing
+/// `keyof X & string` instead of a bare `keyof X`. Both forms denote keys drawn
+/// from the same object `X`, so key-space reasoning must treat the `keyof X`
+/// member of such an intersection exactly like a bare `keyof X`; the other
+/// members (`string`/`number`/`symbol`) are key filters that do not change
+/// which object the keys come from. [`keyof_target`] alone returns `None` for
+/// the intersection form because the underlying `get_keyof_type` query matches
+/// only a bare `KeyOf`.
+pub(crate) fn keyof_operands_through_filters(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Vec<TypeId> {
+    if let Some(operand) = keyof_target(db, type_id) {
+        return vec![operand];
+    }
+    intersection_members(db, type_id)
+        .map(|members| {
+            members
+                .iter()
+                .filter_map(|member| keyof_target(db, *member))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 pub(crate) fn unwrap_readonly_deep(db: &dyn TypeDatabase, type_id: TypeId) -> TypeId {
     tsz_solver::type_queries::unwrap_readonly_deep(db, type_id)
 }

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -84,8 +84,16 @@ impl<'a> CheckerState<'a> {
         object_type: TypeId,
         object_type_for_check: TypeId,
     ) -> bool {
-        crate::query_boundaries::state::checking::keyof_target(self.ctx.types, ty).is_some_and(
-            |operand| {
+        // `K extends keyof T[U] & string` (the common string-key-filtered idiom)
+        // must be recognized as keying its own object, not just the bare
+        // `keyof T[U]` form — otherwise indexing the deferred object `T[U]` (e.g.
+        // the three-level `Registry[Scope][Sub]` shape) raises a spurious
+        // `TS2536`. The per-operand key-space comparison below keeps genuinely
+        // foreign `keyof A` constraints (where `A` is a different object)
+        // reporting `TS2536`.
+        crate::query_boundaries::state::checking::keyof_operands_through_filters(self.ctx.types, ty)
+            .into_iter()
+            .any(|operand| {
                 let evaluated_operand = self.evaluate_type_with_env(operand);
                 same_object_key_space(self.ctx.types, operand, object_type)
                     || same_object_key_space(self.ctx.types, operand, object_type_for_check)
@@ -95,8 +103,7 @@ impl<'a> CheckerState<'a> {
                         evaluated_operand,
                         object_type_for_check,
                     )
-            },
-        )
+            })
     }
 
     /// Resolve a type parameter's constraint from its AST declaration when the TypeId

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -84,13 +84,6 @@ impl<'a> CheckerState<'a> {
         object_type: TypeId,
         object_type_for_check: TypeId,
     ) -> bool {
-        // `K extends keyof T[U] & string` (the common string-key-filtered idiom)
-        // must be recognized as keying its own object, not just the bare
-        // `keyof T[U]` form — otherwise indexing the deferred object `T[U]` (e.g.
-        // the three-level `Registry[Scope][Sub]` shape) raises a spurious
-        // `TS2536`. The per-operand key-space comparison below keeps genuinely
-        // foreign `keyof A` constraints (where `A` is a different object)
-        // reporting `TS2536`.
         crate::query_boundaries::state::checking::keyof_operands_through_filters(self.ctx.types, ty)
             .into_iter()
             .any(|operand| {

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -295,28 +295,18 @@ impl<'a> CheckerState<'a> {
         };
         let index_constraint_eval = self.evaluate_type_with_env(index_constraint);
 
-        // Collect keyof operands from each candidate. A candidate may be a direct
-        // `keyof X` or an intersection like `keyof X & string` — in the latter case
-        // we extract the `keyof X` members from the intersection so the index operand
-        // can still be matched against the mapped constraint's key space.
-        let mut keyof_operands: Vec<TypeId> = Vec::new();
-        for candidate in [index_constraint, index_constraint_eval] {
-            if let Some(operand) =
-                crate::query_boundaries::state::checking::keyof_target(self.ctx.types, candidate)
-            {
-                keyof_operands.push(operand);
-            } else if let Some(members) =
-                crate::query_boundaries::common::intersection_members(self.ctx.types, candidate)
-            {
-                for m in members {
-                    if let Some(operand) =
-                        crate::query_boundaries::state::checking::keyof_target(self.ctx.types, m)
-                    {
-                        keyof_operands.push(operand);
-                    }
-                }
-            }
-        }
+        // Collect keyof operands from each candidate, seeing through the
+        // `keyof X & string` intersection idiom so the index operand can still be
+        // matched against the mapped constraint's key space.
+        let keyof_operands: Vec<TypeId> = [index_constraint, index_constraint_eval]
+            .into_iter()
+            .flat_map(|candidate| {
+                crate::query_boundaries::state::checking::keyof_operands_through_filters(
+                    self.ctx.types,
+                    candidate,
+                )
+            })
+            .collect();
 
         keyof_operands.into_iter().any(|index_operand| {
             crate::query_boundaries::state::checking::keyof_target(

--- a/crates/tsz-checker/tests/template_literal_generic_call_indexed_keyof_constraint_tests.rs
+++ b/crates/tsz-checker/tests/template_literal_generic_call_indexed_keyof_constraint_tests.rs
@@ -179,6 +179,107 @@ function f2<
     );
 }
 
+/// Adjacent shape: four-level dependency, to prove the rule is not capped at
+/// three levels — each `keyof Registry[..][..] & string` constraint must be
+/// recognized as keying its own (deferred) indexed-access object.
+#[test]
+fn nested_keyof_indexed_constraint_four_levels() {
+    let result = codes(
+        r#"
+type Registry = {
+  a: { x: { p: { p1: number } } };
+};
+declare function f1<S extends string, T extends string, U extends string, V extends string>(
+  p: `${S}.${T}.${U}.${V}`,
+): void;
+function f2<
+  Scope extends keyof Registry & string,
+  Sub extends keyof Registry[Scope] & string,
+  Leaf extends keyof Registry[Scope][Sub] & string,
+  Twig extends keyof Registry[Scope][Sub][Leaf] & string,
+>(s: Scope, t: Sub, l: Leaf, w: Twig) {
+  f1(`${s}.${t}.${l}.${w}`);
+}
+"#,
+    );
+    assert!(
+        result.is_empty(),
+        "expected no diagnostics, got: {result:?}"
+    );
+}
+
+/// Adjacent shape: the `& string` key filter is what previously broke the
+/// recognition. The bare `keyof Registry[Scope]` form (no intersection) must
+/// keep passing, isolating the intersection idiom as the only difference.
+#[test]
+fn bare_keyof_indexed_constraint_without_string_filter() {
+    let result = codes(
+        r#"
+type Registry = {
+  a: { x: { x1: number }; y: { y1: number } };
+  b: { z: { z1: number } };
+};
+declare function f1<S extends string, T extends string, U extends string>(p: `${S}.${T}.${U}`): void;
+function f2<
+  Scope extends keyof Registry,
+  Sub extends keyof Registry[Scope],
+  Leaf extends keyof Registry[Scope][Sub],
+>(s: Scope, t: Sub, l: Leaf) {
+  f1(`${s as string}.${t as string}.${l as string}`);
+}
+"#,
+    );
+    assert!(
+        result.is_empty(),
+        "expected no diagnostics, got: {result:?}"
+    );
+}
+
+/// Adjacent shape: the key filter is `& number` rather than `& string`. The
+/// fix must see through any primitive key filter, not just `string`.
+#[test]
+fn nested_keyof_indexed_constraint_number_filter() {
+    let result = codes(
+        r#"
+type Registry = {
+  a: { 0: { x1: number }; 1: { y1: number } };
+};
+function read<
+  Scope extends keyof Registry,
+  Sub extends keyof Registry[Scope] & number,
+>(reg: Registry, s: Scope, t: Sub): Registry[Scope][Sub] {
+  return reg[s][t];
+}
+"#,
+    );
+    assert!(
+        result.is_empty(),
+        "expected no diagnostics, got: {result:?}"
+    );
+}
+
+/// Negative adjacent case: a `keyof A & string` constraint used to index a
+/// DIFFERENT object `B` (`B[K]`) must still report TS2536. This guards the fix
+/// against over-suppression — seeing through the `& string` key filter must
+/// recover the keyof *operand* `A`, and `A` is a different key space than `B`,
+/// so the index stays invalid. Both the bare and `& string` forms are checked.
+#[test]
+fn foreign_keyof_indexed_constraint_still_reports_ts2536() {
+    let result = codes(
+        r#"
+type A = { a1: number; a2: number };
+type B = { b1: number; b2: number };
+type BadBare<K extends keyof A> = B[K];
+type BadFiltered<K extends keyof A & string> = B[K];
+"#,
+    );
+    let ts2536 = result.iter().filter(|&&c| c == 2536).count();
+    assert_eq!(
+        ts2536, 2,
+        "expected TS2536 for both `B[K]` forms keyed by a foreign object, got: {result:?}"
+    );
+}
+
 /// Negative adjacent case: a literal that does NOT satisfy the prefix shape
 /// must still be rejected, proving we are not silently widening keyof to
 /// `string` everywhere.


### PR DESCRIPTION
Goal: hold

Fixes #13326.

## Summary
A type parameter whose constraint is the string-key-filtered idiom `keyof X & string` (also `& number` / `& symbol`) was not recognized as keying its own object when `X` is a **deferred generic indexed access**, producing a spurious **TS2536**. The witness is the three-level `Registry[Scope][Sub]` shape: indexing `Registry[Scope]` (a deferred `IndexAccess`) with `Sub extends keyof Registry[Scope] & string` raised `Type 'Sub' cannot be used to index type 'Registry[Scope]'.`, where `tsc` is clean.

Root cause: the underlying `get_keyof_type` query matches only a bare `TypeData::KeyOf(_)`, so the TS2536 suppression gate `is_keyof_for_current_object` returned `None` for the `keyof X & string` intersection and never compared the keyof *operand* `X` against the object being indexed. The two-level case happened to be rescued by a concrete-keyof relation path; the deferred three-level case had no such fallback.

## Structural rule
When an index type's constraint is `keyof X & <primitive key filter>` (`string` / `number` / `symbol`), `tsc` treats it as keying object `X` exactly like a bare `keyof X` — the filter members narrow the *type* of allowed keys but do not change which object the keys come from. tsz must extract the `keyof X` operand from such intersections when deciding indexed-access validity, through the solver-backed query boundary, regardless of whether `X` is concrete, a type parameter, or a deferred `IndexAccess`.

## Owner layer
Checker indexed-access key-space validation (`is_keyof_for_current_object`), backed by a new shared query-boundary helper `keyof_operands_through_filters` placed next to `keyof_target`. The mapped-constraint matcher `index_constraint_keyof_matches_mapped_constraint` previously inlined the identical intersection-unwrapping; it now routes through the same helper, removing the duplication (net −8 lines in `indexed_access_helpers.rs`).

## Adjacent matrix
- three-level `Registry[Scope][Sub]` (the witness) — now clean
- four-level `Registry[Scope][Sub][Leaf]` — proves it is not capped at three levels
- bare `keyof Registry[Scope]` (no filter) — isolates the intersection idiom as the only difference
- `& number` key filter — proves it is not `string`-specific
- renamed binders (existing `renamed_type_params_preserve_structural_rule`, `alias_wrapping_keyof_indexed_constraint`) — structural, not name-keyed
- **negative / fallback**: type-level `B[K]` with `K extends keyof A` and `K extends keyof A & string` (foreign object) must still report TS2536 — guards against over-suppression; both forms verified to still error.

## Verification
- CI lint follow-up on head `33b833c671`: trimmed comment-only lines in `indexed_access.rs` after architecture guard reported 2007 lines (limit 2000); no compiler behavior change.
- No local tests run for this lint-only follow-up per current instruction; pre-commit formatting hook ran during commit.
- `cargo test -p tsz-checker --test template_literal_generic_call_indexed_keyof_constraint_tests` → 11 passed (was 1 failing: `nested_keyof_indexed_constraint_three_levels`).
- Related suites green: `keyof_operand_indexed_access_validation_tests` (7), `deferred_keyof_index_access_assignability_tests` (17), `intersection_indexed_access_source_suppression_tests` (11), `enum_indexed_access_tests` (17), `tuple_index_access_tests` (16), `indexed_access_resolved_union_property_tests` (4), `ts2862_keyof_tparam_tests` (3), `keyof_naked_priority_tests` (5), `indexed_access_unconstrained_param_tests` (5); `cargo test -p tsz-checker --lib indexed_access` → 84 passed.
- `cargo clippy -p tsz-checker` clean; `cargo fmt` applied.
- Two pre-existing failures observed (`test_computed_unique_prefix_property_stays_string_key`, `keyof_keeps_computed_unique_like_string_property_as_string_key`) are the unrelated `__unique_*` symbol-key family (#13402); confirmed failing on pristine `main` without this change.
- Broad conformance/emit/project gates: deferred to ready-review CI per repo policy.

## Anti-hardcoding
No identifier/alias/file-name literals or rendered-string predicates drive the decision; the helper is a structural solver-backed query over `KeyOf` / intersection members. Tests vary binder names and include positive, deeper-nesting, alternate-filter, bare, and negative/foreign cases.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01EptDwNZz82SZpk1MuQwiqj)_