### PR TITLE
bench(perf): warn on project aggregate target gap (#13247)

### DIFF
--- a/scripts/bench/bench-readiness-banner.mjs
+++ b/scripts/bench/bench-readiness-banner.mjs
@@ -58,6 +58,19 @@ export function benchReadinessMessages(readiness, winnerReport = null) {
     );
   }
 
+  const projectAggregate = target?.project_rows_aggregate;
+  if (projectAggregate?.target_met === false) {
+    const speedup = Number(projectAggregate.tsz_speedup_vs_tsgo);
+    const speedupText = Number.isFinite(speedup) && speedup > 0
+      ? `${speedup.toFixed(2)}x`
+      : "unknown speedup";
+    const projectRows = Number(projectAggregate.rows ?? 0);
+    const rowText = projectRows > 0 ? ` across ${projectRows} project row(s)` : "";
+    messages.push(
+      `Benchmark companion report project-row aggregate is ${speedupText}${rowText}, below the 2x tsgo target; public speed claims are not launch-ready.`,
+    );
+  }
+
   const missingAttribution = Array.isArray(target?.missing_attribution_rows)
     ? target.missing_attribution_rows.length
     : 0;

--- a/scripts/bench/test-bench-readiness-banner.mjs
+++ b/scripts/bench/test-bench-readiness-banner.mjs
@@ -37,6 +37,22 @@ assert.match(
 );
 
 assert.match(
+  benchReadinessMessages(null, {
+    two_x_target: {
+      eligible_green_rows: 4,
+      rows_below_target: 0,
+      missing_attribution_rows: [],
+      project_rows_aggregate: {
+        rows: 3,
+        tsz_speedup_vs_tsgo: 1.42,
+        target_met: false,
+      },
+    },
+  }).join(" "),
+  /project-row aggregate is 1\.42x across 3 project row\(s\), below the 2x tsgo target/,
+);
+
+assert.match(
   benchReadinessMessages({ artifact_absent: true }).join(" "),
   /No recent benchmark artifact/,
 );

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -906,8 +906,15 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     `2x target gaps: ${report.two_x_target.rows_below_target}/${report.two_x_target.eligible_green_rows}`,
     `2x target gaps with attribution: ${report.two_x_target.rows_with_attribution}/${report.two_x_target.rows_below_target}`,
     `2x target gaps with attribution commands: ${report.two_x_target.rows_with_attribution_command}/${report.two_x_target.rows_below_target}`,
-    `report: ${path.relative(process.cwd(), outputPath).split(path.sep).join("/")}`,
   ];
+  const projectAggregate = report.two_x_target.project_rows_aggregate;
+  if (projectAggregate?.rows > 0) {
+    const targetState = projectAggregate.target_met ? "meets" : "below";
+    outputLines.push(
+      `project-row aggregate speedup: ${formatNumber(projectAggregate.tsz_speedup_vs_tsgo)}x (${targetState} 2x target; ${projectAggregate.rows} row(s))`,
+    );
+  }
+  outputLines.push(`report: ${path.relative(process.cwd(), outputPath).split(path.sep).join("/")}`);
   if (attributionPlanPath) {
     outputLines.push(
       `missing attribution plan: ${path.relative(process.cwd(), attributionPlanPath).split(path.sep).join("/")}`,


### PR DESCRIPTION
Goal: fast

## Summary
- Warn in the benchmark readiness banner when the companion report's project-row aggregate is below the 2x tsgo target.
- Print the same project-row aggregate speedup/target status from `tsgo-winner-report.mjs` so CI/log consumers see the real-project aggregate gap directly.
- Include the aggregate speedup and project-row count so README/dashboard speed claims cannot look launch-ready from per-row counts alone.
- Keep benchmark data generation, compiler behavior, and compatibility semantics unchanged.

## Structural rule
When green project rows collectively miss the 2x tsgo target, `tsz` should surface that aggregate Fast-goal failure at the benchmark readiness/reporting boundary. The owner is the benchmark reporting/readiness layer; compiler behavior, row eligibility, and measured timings are unchanged.

## Verification
- Draft PR-head CI on `cfb4ad579b7c367a8497a231b08e307a2865cbe3`: `CI Light Summary`, `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `gate` passed.
- Pre-commit formatting hook ran during commits.
- Ready-review CI will run the broad PR-head gates after draft promotion.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium