### PR TITLE
perf(solver): skip unchanged application instantiation (#13242)

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -611,8 +611,13 @@ impl<'a> TypeInstantiator<'a> {
             TypeData::Application(app_id) => {
                 let app = self.interner.type_application(*app_id);
                 let base = self.instantiate(app.base);
-                let args: Vec<TypeId> = app.args.iter().map(|&arg| self.instantiate(arg)).collect();
-                self.interner.application(base, args)
+                let args = self.instantiate_type_list_if_changed(&app.args);
+                if base == app.base && args.is_none() {
+                    self.interner.intern(*key)
+                } else {
+                    self.interner
+                        .application(base, args.unwrap_or_else(|| app.args.clone()))
+                }
             }
 
             // This type: substitute with concrete this_type if provided


### PR DESCRIPTION
Goal: fast

## Summary
- Skip rebuilding type-application argument vectors when instantiation leaves both the base and all arguments unchanged.
- Keep the optimization inside solver instantiation, preserving existing interner identity and fallback behavior.

## Structural rule
When a type application is instantiated and both the base type and every argument instantiate to the same `TypeId`, `tsc` observes no semantic materialization change; tsz should return the existing interned application through solver instantiation instead of allocating a replacement argument vector and re-interning the same shape.

Owner layer: solver instantiation (`crates/tsz-solver/src/instantiation/instantiate.rs`).

Adjacent matrix:
- Positive: unchanged application base and unchanged args reuse the existing interned type.
- Positive: changed application base still materializes an application with the original args.
- Positive: changed application args still materializes an application with the instantiated args.
- Fallback: intrinsic/leaf, shadowed type-parameter, constraint fallback, union/intersection origin propagation, and diagnostics remain unchanged.

Performance note:
- This removes one avoidable `Vec<TypeId>` allocation/copy on unchanged application-instantiation paths.
- No fixture-name or source-text fast path is introduced.

## Verification
- PR-head CI on `ca6ae2c734fdb80554107fb36e64db0406669975`: `CI Summary`, conformance shards + aggregate, emit, fourslash shards + aggregate, project-compile-canary, project-compile-guard, unit, unit-checker-integration, unit-cloudbuild, lint, cargo-deny, cargo-shear, dist-binaries, wasm, wasm-web, premerge-microbench, project-row-drift, gate, and pr-body-gate passed.
- Pre-commit formatting hook ran during commit.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium