### PR TITLE
perf(checker): skip no-op speculative diagnostic extraction (#13243)

### DIFF
--- a/crates/tsz-checker/src/context/speculation.rs
+++ b/crates/tsz-checker/src/context/speculation.rs
@@ -483,6 +483,10 @@ impl<'a> CheckerContext<'a> {
         &mut self,
         snap: &DiagnosticSnapshot,
     ) -> Vec<Diagnostic> {
+        if self.diagnostic_snapshot_unchanged(snap) {
+            return Vec::new();
+        }
+
         let split_at = self.clamped_diag_len(snap);
         let taken = self.diagnostics.split_off(split_at);
         // Clean up TS2454 dedup entries for taken diagnostics.
@@ -504,6 +508,10 @@ impl<'a> CheckerContext<'a> {
         snap: &DiagnosticSnapshot,
         replacement: Vec<Diagnostic>,
     ) {
+        if replacement.is_empty() && self.diagnostic_snapshot_unchanged(snap) {
+            return;
+        }
+
         // Clean up emitted_ts2454_errors for discarded TS2454 diagnostics
         // that are not in the replacement set.
         let truncate_at = self.clamped_diag_len(snap);


### PR DESCRIPTION
Goal: fast

## Summary
- Add no-op fast paths for speculative diagnostic extraction/replacement when a DiagnosticSnapshot proves the diagnostic state never changed.
- Avoid split_off, TS2454 cleanup, COW restores, and auxiliary-index rebuilds in the hot speculative-probe path that emitted no diagnostics.
- Leave rollback/replacement behavior unchanged whenever diagnostics, dedup indices, overload markers, or deferred TS2454 state diverged.

## Structural Rule
When a speculative checker probe emits no diagnostics and leaves diagnostic bookkeeping unchanged, tsz should not rebuild or restore diagnostic state. This slice is checker orchestration only: relation decisions stay in the assignability/query-boundary path, and rendered diagnostic text is unchanged.

## Owner Layer
Checker diagnostic lifecycle / speculation rollback: crates/tsz-checker/src/context/speculation.rs. No solver semantics, type-shape recursion, diagnostic-string predicates, or fixture/name checks.

## Verification
- Draft CI at 28a1b178968ef9794a5b9d7116eec5f23aff0c78: CI Light Summary, gate, lint, cargo-deny, cargo-shear, unit, unit-checker-integration, unit-cloudbuild, dist-binaries, project-row-drift, and premerge-microbench passed in run 27468164083.
- Reviewed exact-head patch: one-file checker speculation change that returns early only when diagnostic_snapshot_unchanged proves diagnostic state is unchanged, and replacement is empty for the replace path.
- Ready-review CI should cover pr-body-gate and the full ready PR-head CI Summary before queueing.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high

## Issue
- Part of #13243 step 5 follow-up toward #13250.
