### PR TITLE
fix(solver): instantiate generic signature in context of target (#13232)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -241,6 +241,9 @@ mod generic_method_override_variance_tests;
 #[path = "tests/generic_mixed_inheritance_chain_tests.rs"]
 mod generic_mixed_inheritance_chain_tests;
 #[cfg(test)]
+#[path = "tests/generic_signature_context_instantiation_tests.rs"]
+mod generic_signature_context_instantiation_tests;
+#[cfg(test)]
 #[path = "tests/global_augmentation_structural_lookup_arch_tests.rs"]
 mod global_augmentation_structural_lookup_arch_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/generic_signature_context_instantiation_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_signature_context_instantiation_tests.rs
@@ -1,0 +1,134 @@
+//! Regression tests for issue #13232 — relating two same-arity generic
+//! signatures whose target expresses a source type parameter through a type
+//! *function* (a conditional / indexed-access / mapped alias application).
+//!
+//! When an un-annotated, contextually-typed generic function expression is
+//! assigned to a generic signature whose return type wraps the function's own
+//! type parameter in a deferred alias application, tsc relates the two via
+//! `instantiateSignatureInContextOf`: the source's type parameter is inferred
+//! from the target so the two signatures become identical. tsz previously
+//! alpha-renamed the parameters and compared `Box<T>` against
+//! `Box<MappedResponseType<R, T>>` directly, producing a false `TS2322`:
+//!
+//! ```ts
+//! type MRT<R extends RT, J = any> = R extends keyof RM ? RM[R] : J;
+//! interface Box<T> { _data?: T; }
+//! interface Api { raw<T = any, R extends RT = "json">(): Box<MRT<R, T>>; }
+//! // assigning `() => Box<T>` here is clean in tsc; tsz reported TS2322
+//! const impl: Api["raw"] = function <T, R extends RT>() { /* return Box<T> */ };
+//! ```
+//!
+//! The fix adds a tsc-style contextual-instantiation fallback to the generic
+//! signature relation (see
+//! `relations/subtype/rules/functions/checking/context_instantiation.rs`). It
+//! only relaxes a comparison that already failed and is gated to ordinary
+//! assignability, so genuine mismatches (concrete sources, explicitly annotated
+//! returns) still report `TS2322`.
+//!
+//! Real-world witness: the `ofetch` `$fetchRaw` assignment to
+//! `$Fetch["raw"]` (`MappedResponseType` mapped over `ResponseType`).
+//!
+//! Issue: <https://github.com/mohsen1/tsz/issues/13232>
+
+use crate::test_utils::check_source_codes;
+
+fn assert_no(code: u32, src: &str) {
+    let codes = check_source_codes(src);
+    assert!(
+        !codes.contains(&code),
+        "unexpected TS{code} (false positive). Got: {codes:?}\nSource:\n{src}"
+    );
+}
+
+fn assert_has(code: u32, src: &str) {
+    let codes = check_source_codes(src);
+    assert!(
+        codes.contains(&code),
+        "expected TS{code}, got none. Got: {codes:?}\nSource:\n{src}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Core witness: un-annotated generic function expression whose inferred return
+// `Box<T>` must relate to the contextual `Box<MRT<R, T>>`. Clean in tsc.
+// ---------------------------------------------------------------------------
+
+const WITNESS: &str = "
+interface RM { blob: number; text: string; }
+type RT = keyof RM | \"json\";
+type MRT<R extends RT, J = any> = R extends keyof RM ? RM[R] : J;
+interface Box<T> { _data?: T; }
+interface Ctx<T = any, R extends RT = RT> { box?: Box<T>; }
+interface Api { raw<T = any, R extends RT = \"json\">(): Box<MRT<R, T>>; }
+const impl: Api[\"raw\"] = function <T = any, R extends RT = \"json\">() {
+  const ctx: Ctx<T, R> = undefined as any;
+  return ctx.box!;
+};
+";
+
+#[test]
+fn generic_signature_context_instantiation_no_false_2322() {
+    assert_no(2322, WITNESS);
+}
+
+// The rule is structural, not identifier-keyed: renaming every binder must not
+// change the outcome.
+#[test]
+fn generic_signature_context_instantiation_no_false_2322_renamed() {
+    let renamed = "
+interface Kinds { a: number; b: string; }
+type Sel = keyof Kinds | \"json\";
+type Pick<S extends Sel, D = any> = S extends keyof Kinds ? Kinds[S] : D;
+interface Cell<V> { _value?: V; }
+interface Holder<V = any, S extends Sel = Sel> { cell?: Cell<V>; }
+interface Provider { load<V = any, S extends Sel = \"json\">(): Cell<Pick<S, V>>; }
+const provider: Provider[\"load\"] = function <V = any, S extends Sel = \"json\">() {
+  const holder: Holder<V, S> = undefined as any;
+  return holder.cell!;
+};
+";
+    assert_no(2322, renamed);
+}
+
+// ---------------------------------------------------------------------------
+// Guardrails — the fallback only relaxes a comparison that should succeed in
+// tsc. These mismatches must still report TS2322.
+// ---------------------------------------------------------------------------
+
+// A *concrete* source return (`Box<string>`) does not relate to the deferred
+// `Box<MRT<R, T>>`; there is no source type parameter to infer.
+#[test]
+fn concrete_source_return_still_reports_2322() {
+    assert_has(
+        2322,
+        "
+interface RM { blob: number; text: string; }
+type RT = keyof RM | \"json\";
+type MRT<R extends RT, J = any> = R extends keyof RM ? RM[R] : J;
+interface Box<T> { _data?: T; }
+declare const make: <T, R extends RT>() => Box<string>;
+const bad: <T, R extends RT>() => Box<MRT<R, T>> = make;
+",
+    );
+}
+
+// With an *explicit* return-type annotation, tsc checks the return against the
+// annotation directly (`T` is not assignable to `MRT<R, T>`), so TS2322 stays.
+#[test]
+fn explicit_return_annotation_still_reports_2322() {
+    assert_has(
+        2322,
+        "
+interface RM { blob: number; text: string; }
+type RT = keyof RM | \"json\";
+type MRT<R extends RT, J = any> = R extends keyof RM ? RM[R] : J;
+interface Box<T> { _data?: T; }
+interface Ctx<T = any, R extends RT = RT> { box?: Box<T>; }
+interface Api { raw<T = any, R extends RT = \"json\">(): Box<MRT<R, T>>; }
+const impl: Api[\"raw\"] = function <T = any, R extends RT = \"json\">(): Box<MRT<R, T>> {
+  const ctx: Ctx<T, R> = undefined as any;
+  return ctx.box!;
+};
+",
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -15,6 +15,7 @@ use crate::visitor::callable_shape_id;
 use super::super::super::{SubtypeChecker, SubtypeResult, TypeResolver};
 use super::erase_type_params_to_constraints;
 
+mod context_instantiation;
 mod generic_constraints;
 mod overloads;
 mod params;
@@ -29,7 +30,16 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
     ) -> SubtypeResult {
         let allow_constructor_bivariance =
             !Self::constructor_signatures_need_strict_params(source, target);
-        self.check_function_subtype_impl(source, target, allow_constructor_bivariance)
+        let result = self.check_function_subtype_impl(source, target, allow_constructor_bivariance);
+        if result.is_true() {
+            return result;
+        }
+        if let Some(retry) =
+            self.retry_generic_signature_with_context_instantiation(source, target, result)
+        {
+            return retry;
+        }
+        result
     }
 
     /// True when any of `candidate_tp_ids` occurs *free* in `shape`'s parameter

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/context_instantiation.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/context_instantiation.rs
@@ -1,0 +1,127 @@
+//! tsc-style `instantiateSignatureInContextOf` fallback for relating two
+//! same-arity generic signatures.
+//!
+//! tsz's primary same-arity generic-vs-generic path alpha-renames the target's
+//! type parameters onto the source's and compares structurally. That is correct
+//! when each source type parameter appears *bare* on both sides, but it diverges
+//! from tsc when the target expresses a source type parameter through a type
+//! *function* (a conditional, indexed-access, mapped, or other deferred alias
+//! application). In that case tsc instead infers the source's type parameters
+//! from the target (`compareSignaturesRelated` -> `instantiateSignatureInContextOf`)
+//! before comparing, so the two signatures can relate by identity.
+
+use crate::relations::subtype::{SubtypeChecker, SubtypeResult, TypeResolver};
+use crate::types::FunctionShape;
+
+impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
+    /// tsc parity: `instantiateSignatureInContextOf` for two same-arity generic
+    /// signatures.
+    ///
+    /// When relating a generic source signature to a generic target whose
+    /// parameter/return types express the source's type parameters through a type
+    /// *function*, the same-arity alpha-rename path compares the source type
+    /// parameter directly against that expression and fails. tsc instead INFERS the
+    /// source's type parameters from the target before comparing, so e.g.
+    ///
+    /// ```ignore
+    /// <T, R extends K>() => Box<T>
+    ///   ≤  <T, R extends K>() => Box<MappedResponseType<R, T>>
+    /// ```
+    ///
+    /// relates because the source `T` is inferred to `MappedResponseType<R, T>`,
+    /// making the two return types identical. This mirrors `compareSignaturesRelated`
+    /// calling `instantiateSignatureInContextOf(source, target)` for the generic
+    /// case.
+    ///
+    /// Applied only as a fallback after the direct comparison failed, so it can only
+    /// turn a non-`True` result into `True` (never the reverse). It is gated to
+    /// ordinary assignability (`erase_generics`): strict member-compatibility checks
+    /// (TS2416/TS2430) keep their existing opaque-marker comparison, matching tsc's
+    /// stricter handling there.
+    pub(super) fn retry_generic_signature_with_context_instantiation(
+        &mut self,
+        source: &FunctionShape,
+        target: &FunctionShape,
+        direct_result: SubtypeResult,
+    ) -> Option<SubtypeResult> {
+        if direct_result.is_true() {
+            return None;
+        }
+        if !self.erase_generics {
+            return None;
+        }
+        if source.type_params.is_empty() || source.type_params.len() != target.type_params.len() {
+            return None;
+        }
+        if source.is_constructor != target.is_constructor {
+            return None;
+        }
+        // Only worth retrying when the target actually references its own type
+        // parameters through a non-bare (type-function) occurrence, since a bare
+        // alpha-rename already handles the identity case. Without such an
+        // occurrence the inference is an identity operation and the re-comparison
+        // would fail again.
+        if !self.target_references_own_type_params_non_bare(target) {
+            return None;
+        }
+        // Inference matches the source's free parameters positionally against the
+        // target. The source signature is normalised to evaluated (structural)
+        // shapes before inference, so the target's parameter/return/`this` types
+        // must be evaluated to the same representation — otherwise a deferred
+        // `Application` on the target (e.g. `Box<MappedResponseType<R, T>>`) cannot
+        // be matched against the source's already-evaluated object shape and no
+        // candidate is collected.
+        let target_for_inference = self.evaluate_function_shape_types(target);
+        let substitution = self
+            .infer_source_type_param_substitution(source, &target_for_inference)
+            .ok()?;
+        let inferred_source = self.instantiate_function_shape(source, &substitution);
+        let allow_constructor_bivariance =
+            !Self::constructor_signatures_need_strict_params(&inferred_source, target);
+        let retry = self.check_function_subtype_impl(
+            &inferred_source,
+            target,
+            allow_constructor_bivariance,
+        );
+        retry.is_true().then_some(retry)
+    }
+
+    /// True when any of `target`'s own type parameters occurs in a parameter,
+    /// `this`, or return position through something other than a bare reference —
+    /// i.e. inside a type-function application (`Foo<T>`, `T[K]`, a conditional, a
+    /// mapped type, …). This is the shape where inference-based contextual
+    /// instantiation differs from a plain alpha-rename.
+    fn target_references_own_type_params_non_bare(&self, target: &FunctionShape) -> bool {
+        let own_ids = self.own_type_param_identity_ids(target);
+        if own_ids.is_empty() {
+            return false;
+        }
+        let mentions_non_bare = |type_id| -> bool {
+            own_ids.iter().any(|&tp_id| {
+                crate::visitor::contains_type_parameters(self.interner, type_id)
+                    && !self.type_param_appears_bare(type_id, tp_id)
+                    && crate::visitor::collect_all_types(self.interner, type_id)
+                        .into_iter()
+                        .any(|ty| ty == tp_id)
+            })
+        };
+        target.params.iter().any(|p| mentions_non_bare(p.type_id))
+            || target.this_type.is_some_and(mentions_non_bare)
+            || mentions_non_bare(target.return_type)
+    }
+
+    /// Return a copy of `shape` with its parameter, `this`, and return types
+    /// evaluated to their structural form. The type-parameter list and parameter
+    /// metadata are preserved. Used to align the target's representation with the
+    /// source before contextual type-parameter inference (which normalises the
+    /// source to evaluated shapes).
+    fn evaluate_function_shape_types(&mut self, shape: &FunctionShape) -> FunctionShape {
+        let mut evaluated = shape.clone();
+        for param in &mut evaluated.params {
+            param.type_id = self.evaluate_type(param.type_id);
+        }
+        evaluated.this_type = evaluated.this_type.map(|t| self.evaluate_type(t));
+        evaluated.return_type = self.evaluate_type(evaluated.return_type);
+        evaluated
+    }
+}


### PR DESCRIPTION
Goal: green

Fixes the false `TS2322` in #13232.

## Structural rule

When relating two **same-arity generic** call signatures and the target
expresses one of the source's type parameters through a type *function* (a
conditional, indexed-access, mapped, or other deferred alias application),
`tsc` infers the source's type parameters from the target
(`compareSignaturesRelated` → `instantiateSignatureInContextOf`) so the
signatures relate by identity. `tsz` instead alpha-renamed the target's type
parameters onto the source and compared structurally, so it compared the bare
source parameter against the target's type-function expression and reported a
false `TS2322`.

Concretely (the `ofetch` `$Fetch["raw"]` shape):

```ts
type MRT<R extends RT, J = any> = R extends keyof RM ? RM[R] : J;
interface Box<T> { _data?: T; }
interface Api { raw<T = any, R extends RT = "json">(): Box<MRT<R, T>>; }
// inferred return `Box<T>` vs contextual `Box<MRT<R, T>>` — clean in tsc,
// tsz reported TS2322 because it compared `T` against `MRT<R, T>` directly
const impl: Api["raw"] = function <T, R extends RT>() { /* returns Box<T> */ };
```

## Owner layer

Solver generic signature relation —
`relations/subtype/rules/functions/checking/context_instantiation.rs`. The
checker/query boundary is unchanged; this is a pure relation-parity fix routed
through the existing `infer_source_type_param_substitution` /
`instantiate_function_shape` machinery.

## Fix

A tsc-style contextual-instantiation **fallback** in `check_function_subtype`:

- Runs only after the direct comparison already failed, so it can only relax a
  failing comparison to success — never the reverse.
- Gated to ordinary assignability (`erase_generics`): strict
  member-compatibility checks (`TS2416`/`TS2430`) keep their opaque-marker
  comparison, matching tsc's stricter handling there.
- Requires the target to reference its own type parameters through a *non-bare*
  occurrence (otherwise alpha-rename already covers the identity case).
- Evaluates the target's parameter/return/`this` types before inference so a
  deferred `Application` target matches the source's already-evaluated shape.

## Adjacent matrix

- Renamed binders (rule is structural, not identifier-keyed): clean.
- Concrete source return (`Box<string>` ≤ `Box<MRT<R, T>>`): still `TS2322`.
- Explicit return annotation: still `TS2322` (tsc checks the return against the
  annotation directly).
- A pre-existing checker test
  (`...source_option_bag_tests::delegate_cross_arena_source_option_bag_lowers_directly_via_cross_file_index`)
  now passes.

## Known follow-up (out of scope)

The issue's literal witness is an **async** function expression. The async
return path additionally checks each `return` against the *contextual* awaited
return type (`function_type_helpers.rs:310`), so the async manifestation still
reports the per-return `TS2322`; the non-async form and the underlying relation
are fixed here. Tracked as a follow-up checker change.

## Verification

- `cargo build -p tsz-solver` / `-p tsz-cli` clean; `cargo clippy -p tsz-solver`
  and `-p tsz-checker --lib` clean.
- New regression tests pass:
  `cargo test -p tsz-checker --lib generic_signature_context_instantiation_tests`
  (4/4: core witness, renamed binders, concrete-source guardrail,
  explicit-annotation guardrail).
- No new failures: `tsz-solver --lib` and `tsz-checker --lib` failure sets are
  identical to `origin/main` except this change *fixes* one pre-existing checker
  test (62 vs 63 failed). `tsz-cli --lib check_tests` delta is one pre-existing
  failure, unchanged.
- Witness behavior matches `tsc` 6.0.2 on the minimal repros (clean witness;
  `TS2322` retained for concrete-source and explicitly-annotated forms).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4.8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01X98mNNWsu1oYZHEjtDvsB5)_