### PR TITLE
fix(bench): ofetch guard config sets allowImportingTsExtensions to match upstream tsconfig

### DIFF
--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -566,6 +566,11 @@ JSON
 tsz_write_basic_external_project_config() {
   local output="$1"
   local source_dir="$2"
+  # Optional 3rd arg: extra compilerOptions JSON lines (each must include its
+  # own trailing comma) injected verbatim. Used by sources whose real tsconfig
+  # enables options the shared baseline omits (e.g. allowImportingTsExtensions
+  # for projects that import sibling modules with explicit `.ts` extensions).
+  local extra_compiler_options="${3:-}"
   cat > "$output" <<JSON
 {
   "compilerOptions": {
@@ -580,7 +585,7 @@ tsz_write_basic_external_project_config() {
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true
+${extra_compiler_options}    "resolveJsonModule": true
   },
   "include": ["${source_dir}/**/*.ts", "${source_dir}/**/*.tsx"],
   "exclude": [
@@ -622,7 +627,15 @@ tsz_write_ts_rest_config() {
 }
 
 tsz_write_ofetch_config() {
-  tsz_write_basic_external_project_config "$1" "src"
+  # ofetch's source imports sibling modules with explicit `.ts` extensions
+  # (e.g. `export * from "./base.ts";`), which its real tsconfig.json permits
+  # via allowImportingTsExtensions: true (paired with noEmit, as here). Without
+  # the option tsc emits TS5097 on every such import and cascades into
+  # TS2304/TS2339; tsz matches that tsc behavior, so the guard config must
+  # carry the option the upstream project actually sets.
+  tsz_write_basic_external_project_config "$1" "src" \
+    '    "allowImportingTsExtensions": true,
+'
 }
 
 tsz_write_ts_pattern_config() {


### PR DESCRIPTION
Fixes the first ofetch canary blocker: the synthesized `tsconfig.tsz-guard.json`
omitted `allowImportingTsExtensions`, while ofetch's real `tsconfig.json` (pinned
ref) enables it. ofetch's source imports sibling modules with explicit `.ts`
extensions (e.g. `export * from "./base.ts";`), so without the option the project
cannot compile cleanly.

Goal: green

## Structural rule
When a relative import specifier ends with a `.ts`-family extension and
`allowImportingTsExtensions` is **not** enabled, `tsc` emits **TS5097** on that
import and the unresolved binding cascades into TS2304/TS2339; **tsz reproduces
this exactly** through the module resolver (`crates/tsz-core/src/module_resolver`).
The divergence was therefore not in the compiler but in the guard-config writer
(`scripts/bench/project-fixtures.sh`), which synthesized a config that did not
match the option set the upstream project actually compiles under. The guard
must mirror the upstream `allowImportingTsExtensions: true` (paired with the
`noEmit: true` the guard already sets, satisfying the TS5096 chain rule).

Verified directly against `tsc` 6.0.3 (oracle), not assumed:
- Guard config **without** the option: `tsc` emits `TS5097` + cascade (tsz matches).
- Guard config **with** the option (+`noEmit`): `TS5097` gone (tsz matches).
- Option **with** `allowImportingTsExtensions` but **without** `noEmit`/`emitDeclarationOnly`/`rewriteRelativeImportExtensions`: `tsc` emits the `TS5096` chain error (tsz matches).

## Adjacent-case matrix
| Config | tsc | tsz | parity |
| --- | --- | --- | --- |
| `.ts` import, no `allowImportingTsExtensions` | TS5097 + cascade | TS5097 + cascade | match |
| `.ts` import, `allowImportingTsExtensions:true` + `noEmit` | no TS5097 | no TS5097 | match |
| `allowImportingTsExtensions:true`, no `noEmit`/`emitDeclarationOnly` | TS5096 | TS5096 | match |

Only ofetch opts into the new option; the shared `basic-external` writer gains an
optional extra-compilerOptions parameter and all other projects emit
byte-identical config (verified `msw` output unchanged, JSON re-validated).

## Verification
```
# tsc oracle on the exact guard config (cloned fixture), 6.0.3:
tsc --noEmit -p .target/project-compile-guard/ofetch/tsconfig.tsz-guard.json
#   -> 5 errors (Node/undici type-resolution only): TS2591, TS2503, 2x TS2339, TS2307

# tsz on the same config:
TSZ_BIN="$PWD/.target/dist-fast/tsz" TSZ_PROJECT_COMPILE_SET=canary \
  TSZ_PROJECT_COMPILE_FILTER='^ofetch-project$' scripts/ci/project-compile-guard.sh
```

ofetch error counts (tsz, identical config):
- Before this change: **7x TS5097** + ~29 cascading TS2339 (imports unresolved).
- After this change: **0x TS5097**; `.ts` imports resolve. Remaining tsz errors: 42.

## Scope / remaining blocker (NOT in this PR)
ofetch is **not yet green**. After removing TS5097, the guard config still
legitimately produces 5 `tsc` errors (missing `@types/node` / `undici`:
`node:stream`, `Error.captureStackTrace`, `NodeJS` namespace, `undici` module).
Beyond those, **tsz over-reports ~37 errors that tsc does not** (27x TS2339
`Property 'X' does not exist on type 'ResolvedFetchOptions<ResponseType>'`, plus
TS18048/TS2322/TS2345/TS7053/TS2454, and tsz uses TS2580/TS2833 where tsc uses
TS2591/TS2503 for `node:stream`/`NodeJS`).

The TS2339 family points at a distinct tsz checker bug: property lookup on a
generic interface (`FetchOptions<R,T>` -> `ResolvedFetchOptions<R>`) appears to
degrade when one member's type annotation references an unresolvable
`InstanceType<typeof import("undici").Dispatcher>`. A minimal one-property repro
does **not** reproduce it, so the trigger is the specific combination of
`Omit<RequestInit,...>` + intersection (`FetchHooks`) + generic instantiation +
unresolvable import-type. This is a separate, deeper property-lookup / import-type
evaluation investigation and should be filed as its own issue, not force-fit here.

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
