### PR TITLE
perf(checker): memo pass-through defer gates (#13311)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -170,6 +170,7 @@ impl<'a> FlowAnalyzer<'a> {
                 },
                 visited,
                 results,
+                &mut antecedent_defer_memo,
                 &mut passthrough_run,
             );
             // If the chase spliced out the entry `flow_id` itself, remember the node
@@ -1208,6 +1209,7 @@ impl<'a> FlowAnalyzer<'a> {
         gate: PassthroughGate,
         visited: &FxHashSet<FlowNodeId>,
         results: &FxHashMap<FlowNodeId, TypeId>,
+        antecedent_defer_memo: &mut FxHashMap<FlowNodeId, bool>,
         run: &mut Vec<FlowNodeId>,
     ) -> FlowNodeId {
         let PassthroughGate {
@@ -1309,8 +1311,12 @@ impl<'a> FlowAnalyzer<'a> {
             // Never skip past an antecedent that carries pending narrowing, and
             // never skip one already finalized/cached (let the worklist reuse the
             // existing answer for it).
-            if self.antecedent_requires_defer(ant, reference, symbol_id)
-                || visited.contains(&ant)
+            if self.antecedent_requires_defer_cached(
+                ant,
+                reference,
+                symbol_id,
+                antecedent_defer_memo,
+            ) || visited.contains(&ant)
                 || results.contains_key(&ant)
             {
                 return current;


### PR DESCRIPTION
Goal: fast

## Summary
- Reuse the existing per-`check_flow` antecedent-defer memo inside the linear pass-through chase.
- Avoid recomputing the same defer gate while scanning pure assignment runs for one reference/symbol walk.
- Keep the optimization bounded to `FlowAnalyzer`; no fixture-name shortcuts or semantic special cases.

## Structural Rule
When a concrete `check_flow` walk chases a straight-line run of pure non-targeting assignment flow nodes, tsz must make the same defer-or-process decision for each antecedent as the normal worklist path. That decision is a pure property of `(antecedent, reference, symbol_id)` within one walk, so the existing per-walk `antecedent_defer_memo` can answer both the worklist path and the pass-through chase.

## Owner Layer
Checker `FlowAnalyzer` owns flow traversal, deferral gates, and narrowing-preserving pass-through collapse. Solver semantics are unchanged.

## Adjacent Matrix
- Concrete straight-line assignment runs: share the per-walk defer memo while preserving existing pass-through gates.
- Deferrable antecedents: still stop the chase and fall back to normal worklist processing.
- Generic, `any`, `unknown`, and `error` walks: unchanged because the chase remains disabled by the existing gates.
- Merge, condition, call, loop, switch, array mutation, destructuring, and targeting/affecting assignments: unchanged fallback to existing processing.

## Verification
- Draft/light PR-head CI passed at exact head `731c2228b1f899c4e1f39081a6e7234f0ae4a813`: `CI Light Summary`, `gate`, `project-row-drift`, `lint`, `cargo-deny`, `cargo-shear`, `dist-binaries`, `unit`, `unit-checker-integration`, and `unit-cloudbuild`.
- Local: pre-commit formatting hook ran during commit.
- Not run locally per current instruction: `cargo nextest`, benchmarks, conformance, emit, fourslash.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
