### PR TITLE
perf(solver): short-circuit nonlocal-type-param checks in generic fn subtype (#13395)

### DIFF
--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking.rs
@@ -161,18 +161,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         //    usage (e.g., `<S extends {p:string}[]>(x: S)` vs `<T extends {p:string}>(x: T[])`).
         let signature_mentions_nonlocal_type_params =
             |shape: &crate::types::FunctionShape| -> bool {
-                let local_tp_ids: Vec<TypeId> = shape
+                let local_tp_ids: rustc_hash::FxHashSet<TypeId> = shape
                     .type_params
                     .iter()
                     .map(|tp| self.interner.type_param(*tp))
                     .collect();
                 let refs_nonlocal_type_param = |type_id: TypeId| {
-                    crate::visitor::collect_all_types(self.interner, type_id)
-                        .into_iter()
-                        .any(|ty| {
-                            type_param_info(self.interner, ty).is_some()
-                                && !local_tp_ids.contains(&ty)
-                        })
+                    crate::visitors::visitor_predicates::references_type_param_outside_id_set(
+                        self.interner,
+                        type_id,
+                        &local_tp_ids,
+                    )
                 };
 
                 shape
@@ -368,18 +367,17 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         }
 
         let source_mentions_nonlocal_type_params = {
-            let local_source_tp_ids: Vec<TypeId> = source_instantiated
+            let local_source_tp_ids: rustc_hash::FxHashSet<TypeId> = source_instantiated
                 .type_params
                 .iter()
                 .map(|tp| self.interner.type_param(*tp))
                 .collect();
             let refs_nonlocal_type_param = |type_id: TypeId| {
-                crate::visitor::collect_all_types(self.interner, type_id)
-                    .into_iter()
-                    .any(|ty| {
-                        type_param_info(self.interner, ty).is_some()
-                            && !local_source_tp_ids.contains(&ty)
-                    })
+                crate::visitors::visitor_predicates::references_type_param_outside_id_set(
+                    self.interner,
+                    type_id,
+                    &local_source_tp_ids,
+                )
             };
             source_instantiated
                 .params

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/mod.rs
@@ -147,29 +147,11 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         type_id: TypeId,
         param_name: tsz_common::interner::Atom,
     ) -> bool {
-        crate::visitor::collect_all_types(self.interner, type_id)
-            .into_iter()
-            .any(|candidate| match self.interner.lookup(candidate) {
-                Some(TypeData::Mapped(mapped_id)) => {
-                    let mapped = self.interner.get_mapped(mapped_id);
-                    crate::visitor::contains_type_parameter_named(
-                        self.interner,
-                        mapped.constraint,
-                        param_name,
-                    ) || crate::visitor::contains_type_parameter_named(
-                        self.interner,
-                        mapped.template,
-                        param_name,
-                    ) || mapped.name_type.is_some_and(|name_type| {
-                        crate::visitor::contains_type_parameter_named(
-                            self.interner,
-                            name_type,
-                            param_name,
-                        )
-                    })
-                }
-                _ => false,
-            })
+        crate::visitors::visitor_predicates::mapped_context_references_type_param_named(
+            self.interner,
+            type_id,
+            param_name,
+        )
     }
 
     pub(crate) fn has_conflicting_contextual_param_candidates(

--- a/crates/tsz-solver/src/visitors/visitor_predicates.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates.rs
@@ -567,5 +567,6 @@ pub use content::{
     contains_free_type_parameters_except_name, contains_infer_types, contains_this_type,
     contains_type_by_id, contains_type_matching, contains_type_parameter_identity_shallow,
     contains_type_parameter_named, contains_type_parameter_named_shallow, contains_type_parameters,
-    free_type_parameter_ids_in, references_any_type_param_named,
+    free_type_parameter_ids_in, mapped_context_references_type_param_named,
+    references_any_type_param_named, references_type_param_outside_id_set,
 };

--- a/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
@@ -244,6 +244,60 @@ pub fn references_any_type_param_named(
     )
 }
 
+/// Check if a type's full structural surface references any `TypeParameter`/
+/// `Infer` whose interned `TypeId` is *not* one of `local_param_ids`.
+///
+/// This is the short-circuiting, allocation-free replacement for the former
+/// `collect_all_types(..).into_iter().any(..)` pattern in the generic
+/// function-subtype rules: it answers "does this signature position mention a
+/// type parameter outside its own locally-bound set?". The reachability is the
+/// same `ChildPolicy::EVERYTHING` surface `collect_all_types` walks (generic
+/// signature bodies, type-parameter constraints, and defaults all included),
+/// and the positive match is the same `TypeData::TypeParameter | Infer` test
+/// the old code applied via `type_param_info`, so the boolean answer is
+/// identical — but the worklist stops at the first non-local occurrence and
+/// reuses pooled buffers instead of materializing the full reachable set into a
+/// fresh `FxHashSet` per query.
+pub fn references_type_param_outside_id_set(
+    types: &dyn TypeDatabase,
+    type_id: TypeId,
+    local_param_ids: &rustc_hash::FxHashSet<TypeId>,
+) -> bool {
+    worklist_contains_matching(types, type_id, &ChildPolicy::EVERYTHING, |id, data| {
+        matches!(data, Some(TypeData::TypeParameter(_) | TypeData::Infer(_)))
+            && !local_param_ids.contains(&id)
+    })
+}
+
+/// Check whether any `Mapped` node in `type_id`'s full structural surface has a
+/// `constraint`, `template`, or `name_type` that references the type parameter
+/// named `param_name`.
+///
+/// Short-circuiting, allocation-free replacement for the former
+/// `collect_all_types(..).into_iter().any(|c| matches Mapped && ..)` pattern in
+/// the generic function-subtype rules. The reachability is the same
+/// `ChildPolicy::EVERYTHING` surface `collect_all_types` walked, and the
+/// per-`Mapped` predicate is identical, so the boolean answer matches; the
+/// worklist stops at the first qualifying mapped node and reuses pooled buffers
+/// rather than materializing the full reachable set.
+pub fn mapped_context_references_type_param_named(
+    types: &dyn TypeDatabase,
+    type_id: TypeId,
+    param_name: Atom,
+) -> bool {
+    worklist_contains_matching(types, type_id, &ChildPolicy::EVERYTHING, |_, data| {
+        let Some(TypeData::Mapped(mapped_id)) = data else {
+            return false;
+        };
+        let mapped = types.get_mapped(*mapped_id);
+        contains_type_parameter_named(types, mapped.constraint, param_name)
+            || contains_type_parameter_named(types, mapped.template, param_name)
+            || mapped.name_type.is_some_and(|name_type| {
+                contains_type_parameter_named(types, name_type, param_name)
+            })
+    })
+}
+
 /// Check if a constraint type references a type parameter along the base-constraint
 /// resolution path. This mimics tsc's `getBaseConstraint` recursion, which only
 /// follows certain structural paths:


### PR DESCRIPTION
Goal: fast

Eliminates an unmemoized full-structural type-walk used as a boolean predicate in the generic function/callable subtype rules (the residual superlinear cost on the "Conditional infer hotspot" bench row after the #13457 flow fix).

## Structural rule
On every generic function/callable subtype comparison, the rule answered "does this signature mention a type parameter outside its own local set?" by calling `collect_all_types(interner, type_id).into_iter().any(...)` — spinning a fresh `RecursiveTypeCollector` + `FxHashSet` and walking the ENTIRE reachable type surface, for each parameter / `this` / return type of BOTH the source and target signatures. The answer is a pure predicate over the type structure, but it was recomputed by full-set materialization every time.

Replaced with short-circuiting, allocation-free pooled-buffer worklist predicates (`references_type_param_outside_id_set`, `mapped_context_references_type_param_named` in `crates/tsz-solver/src/visitors/visitor_predicates/content.rs`), driven by the existing `worklist_contains_matching` over `ChildPolicy::EVERYTHING`. Three call sites rewired: `functions/checking.rs:170`, `:377`, and `type_param_appears_in_mapped_context` in `functions/mod.rs:150`.

## Behavior preservation (deliberate)
The new predicates walk the SAME `ChildPolicy::EVERYTHING` reachability and match the SAME `TypeData::TypeParameter | Infer` ids as the prior `collect_all_types`-based code (which matched via `type_param_info(...).is_some()`), so the boolean result is identical — only short-circuiting earlier and reusing a pooled buffer. I deliberately did NOT switch to the `free_type_parameter_ids_in` free-variable semantics (which skip generic-signature bodies and type-param constraints/defaults) — that is a real semantic change that could flip generic-function directionality, whereas the `EVERYTHING`-policy worklist gives the perf win with provably identical answers.

## Performance
On the synthetic witness the `RecursiveTypeCollector::visit` frames from this path go 211 → 0 (eliminated), replaced by ~9 frames of the short-circuiting predicate; ~9–16% wall on the (instantiation-bound) synthetic at N=200–400. The larger payoff is on real generic-function-subtype-heavy corpus code where this predicate fires per-comparison and the eliminated per-query `FxHashSet` allocation + full-surface walk compounds.

## Verification
- Full local conformance (release): 12583/12585, zero new vs accepted regressions (only the 2 accepted Mac-delta cases).
- Byte-identical diagnostics on the conditional-infer witness fixtures (N=50/100/200/400).
- `cargo nextest run -p tsz-solver`: only the 3 known pre-existing failures (A/B-identical on clean main).
- clippy --all-targets clean; no new `#[allow]` (the new helpers take 3 params each — no suppression needed); arch_guard + 2000-line caps pass.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: max
