### PR TITLE
fix(checker): keep unique-symbol value identity through value/type name-merge (#13402)

### DIFF
--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_merged_value.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_merged_value.rs
@@ -30,6 +30,13 @@ impl<'a> CheckerState<'a> {
 
         if var_decl.type_annotation.is_some() {
             let ann_type = self.get_type_from_type_node(var_decl.type_annotation);
+            // A `const X: unique symbol` declaration carries a `unique symbol` value
+            // identity (`typeof X`), even when `X` is name-merged with a same-named
+            // type alias. Apply the same upgrade `get_type_of_variable_declaration`
+            // uses so the merged value type keeps the symbol's own identity instead
+            // of degrading to the general `symbol` type.
+            let ann_type =
+                self.const_unique_symbol_value_type(decl, var_decl.type_annotation, ann_type);
             if ann_type != TypeId::ERROR && ann_type != TypeId::ANY {
                 return Some(ann_type);
             }

--- a/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/type_alias_variable_alias.rs
@@ -532,17 +532,11 @@ impl<'a> CheckerState<'a> {
                             self.get_type_from_type_node(var_decl.type_annotation);
                         // `const k: unique symbol = Symbol()` — create a proper UniqueSymbol
                         // type using the variable's binder symbol as identity.
-                        if annotation_type == TypeId::SYMBOL
-                            && self.is_const_variable_declaration(resolved_value_decl)
-                            && self.is_unique_symbol_type_annotation(var_decl.type_annotation)
-                        {
-                            return (
-                                self.ctx
-                                    .types
-                                    .unique_symbol(tsz_solver::SymbolRef(sym_id.0)),
-                                Vec::new(),
-                            );
-                        }
+                        let annotation_type = self.const_unique_symbol_value_type(
+                            resolved_value_decl,
+                            var_decl.type_annotation,
+                            annotation_type,
+                        );
                         return (annotation_type, Vec::new());
                     }
                     if let Some(jsdoc_type) =

--- a/crates/tsz-checker/src/tests/synthetic_unique_atom_union_display_tests.rs
+++ b/crates/tsz-checker/src/tests/synthetic_unique_atom_union_display_tests.rs
@@ -68,6 +68,121 @@ const lit: "__unique_1" = key;
     );
 }
 
+// Regression coverage for #13402: a `unique symbol` const that is name-merged
+// with a same-named `type X = typeof X` alias must still key a computed member
+// `[X]` by the symbol's own value identity. Before the fix, value-position
+// resolution of `X` degraded to the general `symbol` type, so the interface
+// member and the object literal minted disagreeing keys and produced a spurious
+// TS2322 / phantom `__unique_NNNNN` member.
+
+fn assert_clean(diags: &[crate::diagnostics::Diagnostic], context: &str) {
+    assert!(
+        diags.is_empty(),
+        "{context}; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn namemerged_unique_symbol_method_key_is_symbol_keyed() {
+    let diags = check_source_diagnostics(
+        r#"
+declare const tag: unique symbol;
+type tag = typeof tag;
+interface Protocol { [tag](): number; }
+const impl: Protocol = { [tag]: () => 1 };
+"#,
+    );
+    assert_clean(
+        &diags,
+        "name-merged unique-symbol method key should be clean",
+    );
+}
+
+#[test]
+fn namemerged_unique_symbol_property_key_is_symbol_keyed() {
+    let diags = check_source_diagnostics(
+        r#"
+declare const t2: unique symbol;
+type t2 = typeof t2;
+interface HA2 { [t2]: number; }
+const ha2: HA2 = { [t2]: 1 };
+"#,
+    );
+    assert_clean(
+        &diags,
+        "name-merged unique-symbol property key should be clean",
+    );
+}
+
+#[test]
+fn unique_symbol_key_without_alias_is_symbol_keyed() {
+    // Control: same shape with no `type X = typeof X` merge. Isolates the
+    // defect to the value/type name-merge rather than unique-symbol keys.
+    let diags = check_source_diagnostics(
+        r#"
+declare const k2: unique symbol;
+interface H2 { [k2](): number; }
+const h2: H2 = { [k2]: () => 1 };
+"#,
+    );
+    assert_clean(&diags, "unique-symbol key without an alias should be clean");
+}
+
+#[test]
+fn namemerged_unique_symbol_renamed_binder_is_symbol_keyed() {
+    // Structural, not name-keyed: a differently named binder behaves the same.
+    let diags = check_source_diagnostics(
+        r#"
+declare const brandKey: unique symbol;
+type brandKey = typeof brandKey;
+interface Brand { [brandKey](): string; }
+const b: Brand = { [brandKey]: () => "x" };
+"#,
+    );
+    assert_clean(
+        &diags,
+        "renamed name-merged unique-symbol key should be clean",
+    );
+}
+
+#[test]
+fn namemerged_unique_symbol_value_read_keeps_unique_identity() {
+    // The value identity must survive the merge: `tag` read as a value keeps
+    // its own `typeof tag` identity, so it is assignable to the alias type and
+    // not to a foreign `unique symbol`.
+    let diags = check_source_diagnostics(
+        r#"
+declare const tag: unique symbol;
+type tag = typeof tag;
+declare const other: unique symbol;
+const ok: tag = tag;
+const bad: typeof other = tag;
+"#,
+    );
+    let codes: Vec<u32> = diags.iter().map(|d| d.code).collect();
+    assert!(
+        codes.contains(&2322),
+        "assigning `tag` to a foreign unique symbol must still fail (TS2322); got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        codes.iter().filter(|&&c| c == 2322).count(),
+        1,
+        "only the foreign assignment should fail; `const ok: tag = tag` must be clean; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
 #[test]
 fn keyof_keeps_computed_unique_like_string_property_as_string_key() {
     let source = r#"

--- a/crates/tsz-checker/src/types/computation/call_helpers.rs
+++ b/crates/tsz-checker/src/types/computation/call_helpers.rs
@@ -632,6 +632,16 @@ impl<'a> CheckerState<'a> {
         if let Some(var_decl) = self.ctx.arena.get_variable_declaration(node) {
             if var_decl.type_annotation.is_some() {
                 let annotated = self.get_type_from_type_node(var_decl.type_annotation);
+                // `const X: unique symbol` has the value identity `typeof X`; apply the
+                // upgrade so value-position references resolve the symbol's own unique
+                // identity rather than the general `symbol` type the annotation lowers
+                // to. Without this, a `const X: unique symbol` that is also name-merged
+                // with a `type X = typeof X` alias would type `X` as `symbol` here.
+                let annotated = self.const_unique_symbol_value_type(
+                    decl_idx,
+                    var_decl.type_annotation,
+                    annotated,
+                );
                 return self.resolve_ref_type(annotated);
             }
             if self.ctx.is_js_file()

--- a/crates/tsz-checker/src/types/computation/helpers.rs
+++ b/crates/tsz-checker/src/types/computation/helpers.rs
@@ -867,6 +867,40 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Upgrade the annotation type of a `const X: unique symbol` declaration to a
+    /// proper `UniqueSymbol` type keyed on the variable's own binder symbol.
+    ///
+    /// A `unique symbol` annotation lowers to the general `symbol` type, but a
+    /// `const` declaration that owns it has the distinct value identity `typeof X`.
+    /// Centralizing the upgrade here keeps every value-typing path — direct
+    /// variable typing and the merged type-alias/value path — agreed on that
+    /// identity, so `[X]` keys minted from either side intern to the same member.
+    /// Returns `annotation_type` unchanged when the declaration does not own a
+    /// `unique symbol`.
+    pub(crate) fn const_unique_symbol_value_type(
+        &mut self,
+        decl_idx: NodeIndex,
+        annotation: NodeIndex,
+        annotation_type: TypeId,
+    ) -> TypeId {
+        if annotation_type == TypeId::SYMBOL
+            && self.is_const_variable_declaration(decl_idx)
+            && self.is_unique_symbol_type_annotation(annotation)
+            && let Some(var_decl) = self
+                .ctx
+                .arena
+                .get(decl_idx)
+                .and_then(|node| self.ctx.arena.get_variable_declaration(node))
+            && let Some(sym_id) = self.get_symbol_id_for_variable_name(var_decl.name)
+        {
+            return self
+                .ctx
+                .types
+                .unique_symbol(tsz_solver::SymbolRef(sym_id.0));
+        }
+        annotation_type
+    }
+
     /// Get type of variable declaration.
     ///
     /// Computes the type of variable declarations like `let x: number = 5` or `const y = "hello"`.
@@ -885,17 +919,11 @@ impl<'a> CheckerState<'a> {
             let annotation_type = self.get_type_from_type_node(var_decl.type_annotation);
             // `const k: unique symbol = Symbol()` — create a proper UniqueSymbol type
             // using the variable's binder symbol as the identity.
-            if annotation_type == TypeId::SYMBOL
-                && self.is_const_variable_declaration(idx)
-                && self.is_unique_symbol_type_annotation(var_decl.type_annotation)
-                && let Some(sym_id) = self.get_symbol_id_for_variable_name(var_decl.name)
-            {
-                return self
-                    .ctx
-                    .types
-                    .unique_symbol(tsz_solver::SymbolRef(sym_id.0));
-            }
-            return annotation_type;
+            return self.const_unique_symbol_value_type(
+                idx,
+                var_decl.type_annotation,
+                annotation_type,
+            );
         }
 
         if self.is_catch_clause_variable_declaration(idx) {


### PR DESCRIPTION
Goal: green

Fixes #13402.

## Summary
A `const X: unique symbol` declaration that is **name-merged** with a same-named `type X = typeof X` alias resolved, in **value position**, to the general `symbol` type instead of its own `unique symbol` identity. Used as a computed property key `[X]`, the interface member and an object literal then minted **disagreeing** keys (one a degenerate `__symbol_*` / phantom `__unique_NNNNN` member), so any object literal that legitimately provides `[X]` failed structural assignability with a spurious **TS2322** (and **TS2464** at the declaration site). `tsc` accepts this. This is the root cause behind the `ts-pattern` canary row (`matcher = Symbol.for(...)` + `type matcher = typeof matcher` keyed on `interface Matcher { [matcher](): ... }`).

Minimal repro (clean in `tsc`, was TS2322 in tsz):
```ts
declare const tag: unique symbol;   // (or: const tag = Symbol.for('@demo/tag'))
type tag = typeof tag;
interface Protocol { [tag](): number; }
const impl: Protocol = { [tag]: () => 1 };
```
The control with **no** alias (`interface H2 { [k2](): number }`) was already clean — isolating the defect to the value/type name-merge.

## Structural rule
When a `const X: unique symbol` is referenced as a **value**, `tsc` types it by the symbol's own `typeof X` identity, regardless of a co-merged type alias. tsz did this only in `get_type_of_variable_declaration`; the other value-typing entry points reached for a value+type-alias merge re-lowered the `unique symbol` annotation (which lowers to the general `symbol` type) **without** the const-ownership upgrade, so value-position references degraded to `symbol` and computed keys interned as a different member than the symbol-keyed interface slot.

## Owner layer
Checker value-declaration typing. The `unique symbol` → `UniqueSymbol(typeof X)` upgrade is centralized in a new shared helper `const_unique_symbol_value_type` and applied at every value-typing entry point:
- `get_type_of_variable_declaration` (`types/computation/helpers.rs`) — was the only site with the upgrade; refactored to the helper.
- `type_of_value_declaration_with_mode` (`types/computation/call_helpers.rs`) — the canonical value-declaration typing used by value-identifier resolution.
- `compute_value_type_for_merged_alias` (`state/type_analysis/computed/type_alias_merged_value.rs`) — the merged value cache read by `typeof X`.
- the merged type-alias/value variable path (`state/type_analysis/computed/type_alias_variable_alias.rs`) — previously a fourth inline duplicate, now routed through the helper.

The printer's `__unique_NNNNN` rendering was the visible symptom, not the defect; no printer/display change is needed.

## Adjacent matrix
- method-form `[tag](): number` and property-form `[t2]: number` computed keys under the merge — now clean.
- no-alias control (`unique_symbol_key_without_alias_is_symbol_keyed`) — stays clean, isolates the trigger.
- renamed binder (`brandKey`) — structural, not name-keyed.
- value-read identity (`namemerged_unique_symbol_value_read_keeps_unique_identity`): `const ok: tag = tag` is clean, while `const bad: typeof other = tag` still reports TS2322 — the merge keeps `X`'s own identity and does not collapse distinct unique symbols.

## Anti-hardcoding
No identifier/alias/file-name literals or rendered-string predicates drive the decision; the helper is a structural check (`annotation_type == SYMBOL` + `is_const_variable_declaration` + `is_unique_symbol_type_annotation`) keyed on the binder symbol. Tests vary binder names and include positive, control, renamed, and negative/foreign cases.

## Out of scope
The pre-existing failures `keyof_keeps_computed_unique_like_string_property_as_string_key` and `test_computed_unique_prefix_property_stays_string_key` are a **distinct** internal-encoding collision (a user string key literally spelled `"__unique_1"` colliding with the synthetic symbol-key encoding); confirmed red on pristine `main` and unaffected by this change.

## Verification
- `cargo test -p tsz-checker --lib synthetic_unique_atom_union_display_tests::` — the 5 new `namemerged_*` / `unique_symbol_key_without_alias` tests pass (was TS2322 before).
- Full `cargo test -p tsz-checker --lib` A/B vs pristine `main`: failure-set delta is **empty in the new-failure direction** (6541 passed; the ~62 pre-existing failures are identical to main and known-red — the lib suite is not the CI gate), and this change incidentally fixes one pre-existing failure (`delegate_cross_arena_source_option_bag_lowers_directly_via_cross_file_index`).
- `cargo clippy -p tsz-checker` clean; `cargo fmt` applied.
- Broad conformance/emit/project gates: deferred to ready-review CI per repo policy.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01TMwQxSqiALwvB2yaRAkSRf)_