### PR TITLE
perf(cli): gate batch residency cleanup on pressure (#13249)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -307,19 +307,27 @@ fn clear_batch_iteration_state() {
 fn write_batch_residency_report(
     stdout: &mut impl std::io::Write,
     result: &driver::CompilationResult,
-) -> Result<()> {
+) -> Result<Option<MemoryPressure>> {
     let Some(stats) = result.residency_stats.as_ref() else {
-        return Ok(());
+        return Ok(None);
     };
     let retained_kb = stats.retained_file_state_bytes_est() as f64 / 1024.0;
-    let pressure = match ResidencyBudget::default().assess(stats) {
+    let pressure = ResidencyBudget::default().assess(stats);
+    let pressure_label = match pressure {
         MemoryPressure::Low => "low",
         MemoryPressure::Medium => "medium",
         MemoryPressure::High => "high",
     };
     writeln!(stdout, "Batch retained file state:     {retained_kb:.1}K")?;
-    writeln!(stdout, "Batch retained residency pressure: {pressure}")?;
-    Ok(())
+    writeln!(
+        stdout,
+        "Batch retained residency pressure: {pressure_label}"
+    )?;
+    Ok(Some(pressure))
+}
+
+const fn batch_residency_should_clear(pressure: MemoryPressure) -> bool {
+    matches!(pressure, MemoryPressure::Medium | MemoryPressure::High)
 }
 
 /// Batch compilation mode: read project directory paths from stdin (one per line),
@@ -400,9 +408,11 @@ fn run_batch_mode(residency_budget: bool) -> Result<()> {
                     }
                 }
                 if residency_budget {
-                    write_batch_residency_report(&mut stdout, &result)?;
+                    let pressure = write_batch_residency_report(&mut stdout, &result)?;
                     drop(result);
-                    clear_batch_iteration_state();
+                    if pressure.is_some_and(batch_residency_should_clear) {
+                        clear_batch_iteration_state();
+                    }
                 }
             }
             Err(e) => {


### PR DESCRIPTION
Goal: fast

## Summary
- Make hidden `--batchResidencyBudget` cleanup use `ResidencyBudget` pressure instead of clearing on every probe-enabled batch item.
- Keep default batch behavior unchanged; the hidden probe still opts into `--extendedDiagnostics` for residency stats.
- Preserve the post-diagnostics ordering: report retained residency first, drop the finished result, then clear only under Medium/High pressure.

## Structural Rule
When hidden batch residency probing is enabled, finished-project cleanup belongs at the CLI batch boundary after diagnostics and residency reporting are complete. `ResidencyBudget` owns the pressure decision: Low pressure observes only, Medium/High pressure clears finished-project thread-local checker/solver state. Default batch mode remains unchanged.

## Owner Layer
CLI batch orchestration owns the hidden probe and post-project cleanup gate. Core `ResidencyBudget` owns pressure classification. Checker and solver semantics are unchanged.

## Adjacent Matrix
- Default `--batch`: unchanged; no hidden flag, no extra diagnostics, no cleanup behavior change.
- Hidden probe with Low pressure: report retained bytes/pressure and keep finished-project cleanup off.
- Hidden probe with Medium/High pressure: report retained bytes/pressure, drop the finished `CompilationResult`, then clear thread-local checker/solver caches.
- Compile errors before residency stats: existing error path still clears probe-mode thread-local state conservatively.

## Verification
- Local: pre-commit formatting hook ran during commit.
- CI: draft/light PR checks passed at head `9017bea4d7840b5917eb3b83d3b0331bc9d12138` in run `27468873939` (`gate`, `lint`, `cargo-deny`, `cargo-shear`, `unit`, `unit-checker-integration`, `unit-cloudbuild`, `dist-binaries`, `project-row-drift`, `premerge-microbench`, `CI Light Summary`).
- Not run locally per current instruction: `cargo nextest`, benchmarks, conformance, emit, fourslash.
- Expected CI after ready: full PR-head `CI Summary` at head `9017bea4d7840b5917eb3b83d3b0331bc9d12138`.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
