### PR TITLE
perf(solver): borrow conditional app args during structural resolve (#8356)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -75,14 +75,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 && !type_params.is_empty()
                 && type_params.len() == app.args.len()
             {
-                let args = app.args.clone();
-                let expanded_args = self.expand_type_args(&args);
+                let expanded_args = self.expand_type_args(&app.args);
                 let instantiated = instantiate_generic_cached(
                     self.interner(),
                     self.query_db(),
                     resolved_base,
                     &type_params,
-                    &expanded_args,
+                    expanded_args.as_ref(),
                 );
                 let resolved = self.evaluate(instantiated);
                 if resolved != check_type {


### PR DESCRIPTION
Goal: fast

## Summary
- Avoid an unconditional `Vec<TypeId>` clone when conditional evaluation structurally resolves an unresolvable `TypeQuery` application.
- Borrow the application argument slice and rely on the existing copy-on-write `expand_type_args` helper.
- Keep instantiated arguments identical by passing `expanded_args.as_ref()` into `instantiate_generic_cached`.

## Structural Rule
When conditional evaluation resolves a `TypeQuery`-backed application into a structural base, the application argument list is read-only input to type-argument expansion. The evaluator should borrow that list and allocate only if an argument actually needs expansion; solver semantics and instantiation order remain unchanged.

## Owner Layer
Solver conditional evaluation owns this structural-resolution path. Instantiation still goes through `instantiate_generic_cached`; checker and emitter behavior are unchanged.

## Adjacent Matrix
- No type argument needs expansion: borrow the existing application args; no vector clone.
- One or more type arguments need expansion: existing `expand_type_args` allocates the expanded vector and instantiation sees the same slice contents as before.
- Non-`TypeQuery` application bases and already-resolved conditional operands: unchanged.
- Raw interner/test contexts: unchanged; this path still uses the existing evaluator/interner/resolver gates.

## Verification
- Draft/light CI at head `81d9e6f38ac9a650ac6923e9bdbc5d26a6b16e74`: gate, lint, cargo-deny, cargo-shear, dist-binaries, unit, unit-checker-integration, unit-cloudbuild, project-row-drift, and premerge-microbench passed.
- Patch review: allocation-only change; `expand_type_args(&app.args)` returns a borrowed slice when unchanged and an owned slice when expansion is needed; `expanded_args.as_ref()` preserves the instantiated argument sequence.
- Full ready-review CI will run after draft promotion.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5-codex
Effort: medium
