### PR TITLE
fix(checker): exclude ambient modules from typeof globalThis indexed access (#13363)

### DIFF
--- a/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
@@ -7,9 +7,60 @@ use tracing::trace;
 use tsz_binder::symbol_flags::CLASS;
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::node::{Node, NodeArena};
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
+
+/// Whether `node` is a string-literal ("external") ambient module declaration
+/// such as `declare module "foo"` (or, defensively, a template-literal name).
+///
+/// String-literal ambient modules are not part of the global scope: `tsc`
+/// records them in a separate ambient-module table, so they never seed
+/// `program.globals` and never become properties of `typeof globalThis`.
+/// Identifier-named namespaces (`declare module M {}`, `namespace M {}`) are
+/// genuine globals and must be retained, so the test keys on the declaration's
+/// *name* node being a string literal rather than on any module symbol flag,
+/// which cannot distinguish the two forms.
+fn declaration_is_string_literal_module(arena: &NodeArena, node: &Node) -> bool {
+    if node.kind != syntax_kind_ext::MODULE_DECLARATION {
+        return false;
+    }
+    let Some(module) = arena.get_module(node) else {
+        return false;
+    };
+    arena.get(module.name).is_some_and(|name_node| {
+        name_node.kind == SyntaxKind::StringLiteral as u16
+            || name_node.kind == SyntaxKind::NoSubstitutionTemplateLiteral as u16
+    })
+}
+
+/// Whether every (resolvable) declaration of `symbol` is a string-literal
+/// ("external") ambient module. Such a symbol contributes no global value, so
+/// it must not appear on the `typeof globalThis` surface and indexing the
+/// surface by its name is a `TS2339`. A symbol that also carries a genuine
+/// value declaration is not module-only and stays on the surface.
+///
+/// `arena` must be the arena owning `symbol`'s declarations. For symbols whose
+/// declarations span lib arenas, prefer the per-declaration
+/// [`CheckerState::symbol_has_globalable_declaration`] gate, which resolves the
+/// arena for each declaration.
+pub(crate) fn symbol_is_string_literal_module_only(
+    arena: &NodeArena,
+    symbol: &tsz_binder::Symbol,
+) -> bool {
+    let mut saw_decl = false;
+    for &decl_idx in &symbol.declarations {
+        let Some(node) = arena.get(decl_idx) else {
+            continue;
+        };
+        saw_decl = true;
+        if !declaration_is_string_literal_module(arena, node) {
+            return false;
+        }
+    }
+    saw_decl
+}
 
 impl<'a> CheckerState<'a> {
     /// Find a VALUE symbol for a name across all lib binders.

--- a/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs
@@ -260,20 +260,27 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                     if key.as_str() == "globalThis" {
                         return object_type;
                     }
-                    let not_in_locals = self.ctx.binder.file_locals.get(key.as_str()).is_none();
-                    let is_block_scoped = self
+                    // A key is absent from the `typeof globalThis` surface when it
+                    // binds to no global local, to a block-scoped `let`/`const`
+                    // (not a `var`/`function`), or to a string-literal ambient
+                    // module (`declare module "x"`) — modules seed a separate
+                    // ambient table in `tsc`, never `globalThis`.
+                    let key_absent_from_surface = self
                         .ctx
                         .binder
                         .file_locals
                         .get(key.as_str())
                         .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
-                        .is_some_and(|symbol| {
-                            symbol.has_any_flags(tsz_binder::symbol_flags::BLOCK_SCOPED_VARIABLE)
-                                && !symbol.has_any_flags(
-                                    tsz_binder::symbol_flags::FUNCTION_SCOPED_VARIABLE,
-                                )
-                        });
-                    if not_in_locals || is_block_scoped {
+                        .is_none_or(|symbol| {
+                        (symbol.has_any_flags(tsz_binder::symbol_flags::BLOCK_SCOPED_VARIABLE)
+                            && !symbol
+                                .has_any_flags(tsz_binder::symbol_flags::FUNCTION_SCOPED_VARIABLE))
+                            || crate::symbols_domain::symbol_resolver_utils::symbol_is_string_literal_module_only(
+                                self.ctx.arena,
+                                symbol,
+                            )
+                    });
+                    if key_absent_from_surface {
                         if let Some(idx_node) = self.ctx.arena.get(indexed_access.index_type) {
                             let message = crate::diagnostics::format_message(
                                 crate::diagnostics::diagnostic_messages::PROPERTY_DOES_NOT_EXIST_ON_TYPE,

--- a/crates/tsz-checker/tests/global_this_property_access_diagnostics_tests.rs
+++ b/crates/tsz-checker/tests/global_this_property_access_diagnostics_tests.rs
@@ -111,6 +111,87 @@ type Missing = (typeof globalThis)["\"ambientModule\""];
     );
 }
 
+/// A string-literal ambient module (`declare module "x"`) is not part of the
+/// global scope: `tsc` records it in a separate ambient-module table, so it
+/// never becomes a property of `typeof globalThis`. Indexing the surface by the
+/// module name — even though the name *is* bound in the file's locals — must
+/// still report TS2339 against the canonical `typeof globalThis` receiver.
+/// Before the fix the module surfaced as a `typeof <module>` property, so the
+/// access resolved instead of erroring.
+#[test]
+fn typeof_globalthis_indexed_access_declared_ambient_module_reports_ts2339() {
+    let source = r#"
+declare module "ambientModule" {
+    export const x: number;
+}
+type Bad = (typeof globalThis)["ambientModule"];
+"#;
+    let diags = check_with_no_implicit_any(source);
+    let ts2339: Vec<_> = diags.iter().filter(|diag| diag.code == 2339).collect();
+    assert_eq!(
+        ts2339.len(),
+        1,
+        "indexing typeof globalThis by a declared ambient module name should emit one TS2339; got: {diags:#?}"
+    );
+    assert!(
+        ts2339[0]
+            .message_text
+            .contains("Property 'ambientModule' does not exist on type 'typeof globalThis'"),
+        "TS2339 must use the canonical typeof globalThis receiver; got: {}",
+        ts2339[0].message_text
+    );
+}
+
+/// `tsc` keys ambient modules under their quoted name, so the conformance
+/// witness indexes `typeof globalThis` by the *quoted* form `"ambientModule"`.
+/// That key must also miss the surface. Renamed module binder to prove the
+/// rule is structural, not keyed to a specific module name.
+#[test]
+fn typeof_globalthis_indexed_access_quoted_declared_module_name_reports_ts2339() {
+    let source = r#"
+declare module "renamedAmbientMod" {
+    export type typ = 1;
+    export var val: typ;
+}
+type Bad = (typeof globalThis)["\"renamedAmbientMod\""];
+"#;
+    let diags = check_with_no_implicit_any(source);
+    assert!(
+        diags.iter().any(|d| d.code == 2339
+            && d.message_text
+                .contains("does not exist on type 'typeof globalThis'")),
+        "quoted ambient module name must miss the typeof globalThis surface; got: {diags:#?}"
+    );
+}
+
+/// Companion: a string-literal ambient module and an identifier value
+/// namespace declared side by side. The ambient module is excluded; the value
+/// namespace stays a genuine global and indexes cleanly. Guards against the
+/// exclusion over-reaching to identifier namespaces.
+#[test]
+fn typeof_globalthis_surface_excludes_ambient_module_but_keeps_value_namespace() {
+    let source = r#"
+declare module "someAmbientMod" {
+    export const x: number;
+}
+namespace keptValueNs { export var v = 1; }
+type Bad = (typeof globalThis)["someAmbientMod"];
+type Ok = (typeof globalThis)["keptValueNs"];
+"#;
+    let diags = check_with_no_implicit_any(source);
+    let ts2339: Vec<_> = diags.iter().filter(|diag| diag.code == 2339).collect();
+    assert_eq!(
+        ts2339.len(),
+        1,
+        "only the ambient module key should miss the surface; the value namespace stays; got: {diags:#?}"
+    );
+    assert!(
+        ts2339[0].message_text.contains("someAmbientMod"),
+        "the surviving TS2339 must be the ambient module, not the value namespace; got: {}",
+        ts2339[0].message_text
+    );
+}
+
 #[test]
 fn typeof_globalthis_indexed_access_keeps_declared_namespace_keys_valid() {
     let source = r#"


### PR DESCRIPTION
Goal: hold

Refs #13363 (closed once the aggregate drift cleared via #13365). The conformance witness `globalThisAmbientModules.ts` accesses `typeof globalThis` by the **quoted** ambient-module name `"\"ambientModule\""`, a key that misses the surface regardless. This PR closes the residual, real divergence the witness did not cover — indexing `typeof globalThis` by the **bare** ambient-module name — and locks the whole family with regression tests.

## Structural rule
When a string-literal ("external") ambient module (`declare module "x"`) is indexed off `typeof globalThis`, `tsc` reports **TS2339**: ambient external modules are recorded in a separate ambient-module table and never become global properties. tsz instead resolved the module name to a `typeof <module>` property, so `(typeof globalThis)["x"]` type-checked successfully (e.g. `TS2322: Type 'number' is not assignable to type 'typeof foo'` against a downstream annotation) instead of erroring. Identifier-named namespaces (`declare module M {}`, `namespace M {}`) **are** genuine globals and must stay on the surface.

`When the key of a typeof-globalThis indexed access binds to a string-literal ambient module symbol, tsc reports TS2339; tsz now does too, through the type-node indexed-access TS2339 gate.`

## Owner layer
Checker type-node indexed-access TS2339 emission (`TypeNodeChecker` in `crates/tsz-checker/src/types/type_node_advanced/indexed_access_type.rs`). The exclusion sits beside the existing not-in-locals / block-scoped checks for the canonical `typeof globalThis` receiver, so the missing key reuses the same `Property '<key>' does not exist on type 'typeof globalThis'` message and short-circuits to `TypeId::ERROR`. The decision is keyed on a new shared solver-free predicate `symbol_is_string_literal_module_only` (in `symbols_domain::symbol_resolver_utils`) that inspects the module declaration's **name node** (string literal), not a module symbol flag — flags cannot distinguish identifier namespaces, which must be retained.

## Scope / altitude
Scoped deliberately to the direct type-level indexed-access emitter. Excluding ambient modules in the shared `typeof globalThis` *surface-object* builder was prototyped but rejected: it shifted the type-alias indexed-access path (`type G = typeof globalThis; G["x"]`) from a silent resolution to a **new** TS2536 divergence (tsc reports TS2339 there too — a separate, orthogonal alias-missing-key gap), trading one divergence for another. The plain value-space `globalThis.x` path is unchanged.

## Adjacent matrix
- bare-key `(typeof globalThis)["ambientModule"]` — now TS2339 with `typeof globalThis` receiver (was a resolved `typeof <module>`).
- quoted-key `(typeof globalThis)["\"renamedAmbientMod\""]` (the conformance witness shape, renamed binder) — TS2339.
- module + identifier value namespace side by side — only the module key errors; the namespace stays a valid global (guards against over-reach).
- existing `declare var` / namespace / block-scoped-local cases — unchanged (full existing suite green).

## Anti-hardcoding
No identifier/module-name/file-name literals or rendered-string predicates drive the decision; the predicate is a structural check over the declaration's `MODULE_DECLARATION` name node. Tests vary the module binder name (`ambientModule`, `renamedAmbientMod`, `someAmbientMod`) and include positive, quoted, and negative (kept-namespace) cases.

## Verification
- `cargo test -p tsz-checker --test global_this_property_access_diagnostics_tests` — 16 passed (3 new + 13 existing).
- `cargo test -p tsz-checker --test global_this_const_property_tests --test global_this_block_scoped_local_tests --test ts2540_readonly_tests` — 42 passed.
- Reproduced the real conformance test `globalThisAmbientModules.ts` (es2015): tsz output byte-identical to `tsc 6.0.2` (2× TS2339, `valueModule`/`namespaceModule` clean).
- `cargo clippy -p tsz-checker` clean; `cargo fmt` applied; `python3 scripts/arch/arch_guard.py` + `scripts/arch/check-checker-boundaries.sh` pass.
- Rebased on current `origin/main`; rebuilt and re-ran the above green. Broad conformance/emit/project gates deferred to ready-review CI per repo policy.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01AESbJb2ibwQVVxZGhhXoUp)_