### PR TITLE
perf(checker): skip flow walk for call-rooted non-narrowable references — indexed-access to tsgo parity (#13393)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core/flow_query.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_query.rs
@@ -102,6 +102,26 @@ impl<'a> FlowAnalyzer<'a> {
                 }
             });
 
+        // Non-narrowable reference short-circuit (mirrors tsc's
+        // `getFlowTypeOfReference`, which only walks the flow graph for
+        // narrowable references). When the reference carries no binder symbol AND
+        // is not a narrowable member access — its receiver chain bottoms out at a
+        // call result / non-narrowable expression (e.g. `readIndexed('p').a.b`,
+        // the indexed-access hotspot) — no flow node can `is_matching_reference`-
+        // match it, so the backward walk provably returns the declared type
+        // unchanged at every node. Skipping it is byte-identical and removes the
+        // O(N^2) per-antecedent enumeration the worklist would otherwise perform
+        // over preceding statements (each call/condition/assignment node re-runs
+        // `is_matching_reference` against the call-rooted reference). Bare
+        // identifiers, `this`/`super`, and any narrowable member path still walk.
+        if symbol_id.is_none()
+            && self.is_member_like_reference(reference)
+            && self.reference_root_symbol(reference).is_none()
+            && !self.is_narrowable_member_reference(reference)
+        {
+            return initial_type;
+        }
+
         self.check_flow(
             reference,
             initial_type,

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_query.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_query.rs
@@ -117,7 +117,7 @@ impl<'a> FlowAnalyzer<'a> {
         if symbol_id.is_none()
             && self.is_member_like_reference(reference)
             && self.reference_root_symbol(reference).is_none()
-            && !self.is_narrowable_member_reference(reference)
+            && self.reference_bottoms_at_call_result(reference)
         {
             return initial_type;
         }

--- a/crates/tsz-checker/src/flow/control_flow/references.rs
+++ b/crates/tsz-checker/src/flow/control_flow/references.rs
@@ -426,6 +426,39 @@ impl<'a> FlowAnalyzer<'a> {
         self.reference_is_narrowable(leaf)
     }
 
+    /// True when a member-access reference's receiver chain bottoms out at a
+    /// `CallExpression` result (e.g. `readIndexed('p').a.b`). Such a reference
+    /// has no narrowable storage root — no flow node can `is_matching_reference`-
+    /// match it — so the backward flow walk provably returns the declared type
+    /// unchanged. This is the *positive* counterpart used to gate the
+    /// non-narrowable short-circuit: only call-rooted member paths are skipped,
+    /// so `this`/`super`/identifier/meta-property roots (which are narrowable and
+    /// participate in `typeof`-query and discriminant narrowing) always walk.
+    pub(crate) fn reference_bottoms_at_call_result(&self, idx: NodeIndex) -> bool {
+        let idx = self.skip_parenthesized(idx);
+        let Some(node) = self.arena.get(idx) else {
+            return false;
+        };
+        if node.kind == syntax_kind_ext::CALL_EXPRESSION {
+            return true;
+        }
+        if node.kind == syntax_kind_ext::NON_NULL_EXPRESSION {
+            return self
+                .arena
+                .get_unary_expr_ex(node)
+                .is_some_and(|u| self.reference_bottoms_at_call_result(u.expression));
+        }
+        if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
+            || node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
+        {
+            return self
+                .arena
+                .get_access_expr(node)
+                .is_some_and(|a| self.reference_bottoms_at_call_result(a.expression));
+        }
+        false
+    }
+
     fn reference_is_narrowable(&self, idx: NodeIndex) -> bool {
         let idx = self.skip_parenthesized(idx);
         let Some(node) = self.arena.get(idx) else {

--- a/crates/tsz-checker/src/flow/control_flow/references.rs
+++ b/crates/tsz-checker/src/flow/control_flow/references.rs
@@ -861,7 +861,7 @@ impl<'a> FlowAnalyzer<'a> {
         assignment_root == reference_root
     }
 
-    fn reference_root_symbol(&self, idx: NodeIndex) -> Option<SymbolId> {
+    pub(crate) fn reference_root_symbol(&self, idx: NodeIndex) -> Option<SymbolId> {
         let idx = self.skip_parenthesized(idx);
         let node = self.arena.get(idx)?;
 

--- a/crates/tsz-checker/tests/flow_property_reference_cache_tests.rs
+++ b/crates/tsz-checker/tests/flow_property_reference_cache_tests.rs
@@ -581,3 +581,106 @@ function classify(token: unknown) {
         "unknown switch-case narrowing must survive a pass-through run, got: {codes:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Non-narrowable (call-rooted) reference flow-walk short-circuit.
+//
+// A reference rooted at a pure call result (`reader('k').a.b`) carries no binder
+// symbol and is not a narrowable member access, so no flow node can
+// `is_matching_reference`-match it. `get_flow_type` short-circuits to the
+// declared type without walking the flow graph (mirroring tsc's
+// `getFlowTypeOfReference`, which only walks for narrowable references). This
+// removes the O(N^2) backward enumeration over preceding call/condition/
+// assignment statements (the indexed-access hotspot). These witnesses pin that
+// the short-circuit is narrowing-exact: the call-rooted reference itself stays
+// unnarrowed (tsc parity), while ANY const the call result flows INTO, or a
+// DIFFERENT const narrowed between the reads, still narrows correctly — the
+// short-circuit keys on the reference's own root, not the surrounding run.
+// Binder names are varied so it cannot be keyed on identifier text.
+// ---------------------------------------------------------------------------
+
+/// A long straight-line run of call-rooted member reads (the exact hotspot
+/// shape: `reader('k').leaf.flag`) with a DIFFERENT, genuinely narrowed `const`
+/// reference interleaved. The call-rooted reads short-circuit the flow walk, but
+/// the interleaved guard on the real `const` must still narrow: `parcel.detail`
+/// narrows to present, so `.amount` is a `number` and no diagnostic is expected.
+/// If the call-rooted short-circuit wrongly suppressed the guard, the read would
+/// stay `{ amount: number } | undefined` and trip an error.
+#[test]
+fn intervening_const_narrows_despite_call_rooted_passthrough_run() {
+    let codes = check_source_strict_codes(
+        r#"
+interface Cells { alpha: { leaf: { flag: boolean }; value: number }; }
+declare function reader<K extends keyof Cells>(key: K): Cells[K];
+function survey(parcel: { detail?: { amount: number } }) {
+  const c0 = reader('alpha').leaf.flag ? reader('alpha').value : 0;
+  const c1 = reader('alpha').leaf.flag ? reader('alpha').value : 0;
+  const c2 = reader('alpha').leaf.flag ? reader('alpha').value : 0;
+  if (parcel.detail) {
+    const amount: number = parcel.detail.amount;
+  }
+  const c3 = reader('alpha').leaf.flag ? reader('alpha').value : 0;
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "a different const must still narrow across a call-rooted pass-through run, got: {codes:?}"
+    );
+}
+
+/// A call-rooted member read assigned to a `const` that IS then narrowed: the
+/// call result itself is not narrowable (parity), but the `const` it flows into
+/// is an ordinary binder symbol whose type guard must still narrow. `captured`
+/// holds `{ amount: number } | undefined`; the guard narrows it, so `.amount`
+/// reads as a `number`. The call-rooted early-out applies only to the
+/// call-rooted reference, never to the narrowable `const` that captures it.
+#[test]
+fn call_result_flowing_into_narrowed_const_still_narrows() {
+    let codes = check_source_strict_codes(
+        r#"
+interface Cells { beta: { detail?: { amount: number } }; }
+declare function reader<K extends keyof Cells>(key: K): Cells[K];
+function survey() {
+  const noise1 = reader('beta');
+  const noise2 = reader('beta');
+  const captured = reader('beta').detail;
+  if (captured) {
+    const amount: number = captured.amount;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "a const capturing a call result must still narrow under its own guard, got: {codes:?}"
+    );
+}
+
+/// Negative parity guard for the early-out: a call-rooted member reference is
+/// never narrowed by a preceding straight-line guard, even when many unrelated
+/// `const` reads precede it (the spliced run). `reader('gamma').slot` is
+/// `number | undefined`; the guard on a *fresh* call result does not narrow the
+/// next *fresh* call result (distinct call expressions), so annotating it
+/// `number` trips TS2322 — exactly tsc's behavior, preserved by the O(1) skip.
+#[test]
+fn call_rooted_reference_stays_unnarrowed_after_passthrough_run() {
+    let codes = check_source_strict_codes(
+        r#"
+interface Cells { gamma: { slot: number | undefined }; }
+declare function reader<K extends keyof Cells>(key: K): Cells[K];
+function survey() {
+  const f1 = reader('gamma').slot;
+  const f2 = reader('gamma').slot;
+  const f3 = reader('gamma').slot;
+  if (reader('gamma').slot !== undefined) {
+    const used: number = reader('gamma').slot;
+  }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&2322),
+        "call-rooted reference must stay unnarrowed (tsc parity), expected TS2322, got: {codes:?}"
+    );
+}


### PR DESCRIPTION
Goal: fast

Completes #13393's flow-narrowing O(N²) fix for the last victim row (Indexed access hotspot), building on the merged pass-through splice (#13457).

## Structural rule
The splice's O(1) root pre-filter (`assignment_root_symbols_may_overlap`, #13404) degrades for CALL-ROOTED references. The witness has N lines of `const indexedValueI = readIndexed('propI').nested.flag ? readIndexed('propI').value : 0;` — the `.nested.flag` / `.value` references bottom out at a `CallExpression`, so `reference_root_symbol` returns `None` and the pre-filter hits its conservative `else { return true }`. The worklist then runs the deep `is_matching_reference` AST predicate against the call-rooted reference at every preceding flow node → Σ O(i) = O(N²); `get_flow_type` was 84% of samples.

A member-access reference whose receiver chain bottoms out at a call result has NO narrowable storage root — no flow node can `is_matching_reference`-match it — so the backward walk provably returns the declared type unchanged (mirrors tsc's `getFlowTypeOfReference`, which only walks for narrowable references). `get_flow_type` now short-circuits to the declared type for such references without entering `check_flow`.

## Parity: a positive predicate, not a negative one
The gate is `reference_bottoms_at_call_result(reference)` — it fires ONLY when the receiver chain provably bottoms at a `CallExpression`. This is deliberately the *positive* form: an earlier negative formulation (`!is_narrowable_member_reference`) let the short-circuit fire for some `this`-rooted member references and regressed `typeofThis.ts`; the positive predicate cannot touch any `this`/`super`/identifier/meta-property root, so those (which participate in `typeof`-query and discriminant narrowing) always walk. The regression was caught by the full conformance gate and the predicate tightened to eliminate it with no loss of the win.

## Performance (release; tsgo flat ~155ms)
| N | main | this PR |
|---|---|---|
| 200 | 160ms | **50ms** |
| 400 | 590ms | **140ms** (4.2x — beats tsgo) |
Flattened from O(N²) toward linear; N=400 now faster than tsgo.

## Verification
- Full local conformance (release): 12583/12585, zero new vs accepted regressions (only the 2 accepted Mac-delta cases) — typeofThis no longer regresses.
- Byte-identical diagnostics on the indexed-access witness fixtures (N=50/100/200/400).
- 24/24 flow property-reference cache + passthrough tests pass (incl. call-rooted witnesses).
- clippy --all-targets clean; no new `#[allow]`; arch_guard + 2000-line caps pass.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: max
