### PR TITLE
fix(checker): stop suppressing TS2322 on deferred keyof type-param targets

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -710,6 +710,9 @@ path = "tests/contextual_ts2345_conformance_tests.rs"
 name = "co_contra_inference_tests"
 path = "tests/co_contra_inference_tests.rs"
 [[test]]
+name = "keyof_type_param_target_diagnostic_tests"
+path = "tests/keyof_type_param_target_diagnostic_tests.rs"
+[[test]]
 name = "keyof_naked_priority_tests"
 path = "tests/keyof_naked_priority_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -725,6 +725,15 @@ impl<'a> CheckerState<'a> {
                         candidate,
                     )
                     || crate::query_boundaries::common::is_mapped_type(self.ctx.types, candidate)
+                    // A deferred `keyof T` target is a structural key-space
+                    // relation the solver decides directly (contravariantly:
+                    // `keyof S <: keyof T` iff `T <: S`), and a concrete-key
+                    // `keyof` target is already handled by the literal-membership
+                    // suppression above. Either way it must not take the
+                    // complex-generic suppression, which would hide a legitimate
+                    // TS2322 (e.g. `keyof X` assigned to `keyof A` for distinct
+                    // type parameters, which `tsc` reports).
+                    || crate::query_boundaries::common::is_keyof_type(self.ctx.types, candidate)
                     || crate::query_boundaries::common::intersection_members(
                         self.ctx.types,
                         candidate,

--- a/crates/tsz-checker/tests/keyof_type_param_target_diagnostic_tests.rs
+++ b/crates/tsz-checker/tests/keyof_type_param_target_diagnostic_tests.rs
@@ -1,0 +1,135 @@
+//! Regression tests for TS2322 over-suppression on `keyof <type parameter>`
+//! targets.
+//!
+//! `should_suppress_assignability_diagnostic`'s "complex generic" carve-out
+//! suppressed any target that merely *contained* a type parameter and was not
+//! itself a bare type parameter. A deferred `keyof T` target satisfies that
+//! shape, so a genuine key-space mismatch the solver had already rejected
+//! (`keyof S <: keyof T` iff `T <: S`) was silently dropped — `tsc` reports
+//! TS2322 there. A deferred `keyof T` is a structural key-space relation the
+//! solver decides directly, so it must not take the complex-generic
+//! suppression (concrete-key `keyof` targets are handled by the separate
+//! literal-membership suppression).
+//!
+//! The rule is structural (`keyof` of a type-parameter-bearing operand), not
+//! keyed on any identifier, so the renamed-binder variants below must behave
+//! identically.
+
+use tsz_checker::test_utils::check_source_codes;
+
+const TYPE_NOT_ASSIGNABLE: u32 = 2322;
+
+#[test]
+fn keyof_of_distinct_type_params_reports_ts2322() {
+    // `keyof X` is not assignable to `keyof A` for unrelated `A`, `X`
+    // (contravariant: it would require `A <: X`). tsc reports TS2322.
+    let source = r#"
+function f<A, X>(t: keyof A, s: keyof X): void {
+    t = s;
+}
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&TYPE_NOT_ASSIGNABLE),
+        "keyof X assigned to keyof A (distinct params) must report TS2322; got {codes:?}"
+    );
+}
+
+#[test]
+fn keyof_of_distinct_type_params_renamed_binders_reports_ts2322() {
+    // Same structural shape, different binder names: the decision must not be
+    // name-keyed.
+    let source = r#"
+function relate<Schema, Other>(left: keyof Schema, right: keyof Other): void {
+    left = right;
+}
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&TYPE_NOT_ASSIGNABLE),
+        "renamed-binder keyof mismatch must still report TS2322; got {codes:?}"
+    );
+}
+
+#[test]
+fn keyof_variable_declaration_initializer_reports_ts2322() {
+    // The same defect reached through a variable-declaration initializer.
+    let source = r#"
+function f<A, X>(s: keyof X): void {
+    const t: keyof A = s;
+}
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&TYPE_NOT_ASSIGNABLE),
+        "keyof X initializer for a keyof A binding must report TS2322; got {codes:?}"
+    );
+}
+
+#[test]
+fn keyof_of_indexed_access_type_params_reports_ts2322() {
+    // The kysely `AnyColumn` shape: `keyof DB[TB]`. The deferred indexed-keyof
+    // target must stay non-suppressible.
+    let source = r#"
+function f<A, BK extends keyof A, X, YK extends keyof X>(
+    t: keyof A[BK],
+    s: keyof X[YK],
+): void {
+    t = s;
+}
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&TYPE_NOT_ASSIGNABLE),
+        "keyof X[YK] assigned to keyof A[BK] must report TS2322; got {codes:?}"
+    );
+}
+
+#[test]
+fn keyof_subset_override_direction_reports_ts2322() {
+    // `A extends X` makes `keyof A` a *superset* of `keyof X`, so
+    // `keyof A <: keyof X` is false (it would require `X <: A`). tsc reports
+    // TS2322; the suppression must not hide it.
+    let source = r#"
+function f<X, A extends X>(t: keyof X, s: keyof A): void {
+    t = s;
+}
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        codes.contains(&TYPE_NOT_ASSIGNABLE),
+        "keyof A assigned to keyof X (A extends X) must report TS2322; got {codes:?}"
+    );
+}
+
+#[test]
+fn keyof_self_assignment_stays_clean() {
+    // Negative control: `keyof A <: keyof A` is trivially assignable. The fix
+    // must not start manufacturing a spurious TS2322 here.
+    let source = r#"
+function f<A>(t: keyof A, s: keyof A): void {
+    t = s;
+}
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        !codes.contains(&TYPE_NOT_ASSIGNABLE),
+        "keyof A assigned to keyof A must stay clean; got {codes:?}"
+    );
+}
+
+#[test]
+fn keyof_constraint_subtype_direction_stays_clean() {
+    // Negative control / adjacent direction: `A extends X` means
+    // `keyof X <: keyof A`, so assigning `keyof X` to `keyof A` is allowed.
+    let source = r#"
+function f<X, A extends X>(t: keyof A, s: keyof X): void {
+    t = s;
+}
+"#;
+    let codes = check_source_codes(source);
+    assert!(
+        !codes.contains(&TYPE_NOT_ASSIGNABLE),
+        "keyof X assigned to keyof A (A extends X) must stay clean; got {codes:?}"
+    );
+}


### PR DESCRIPTION
Goal: hold

Refs #13044 (found while investigating the kysely keyof family; this is an adjacent keyof-relation parity fix, not the `whereRef` TS2416 false-positive itself — see the investigation note on #13044).

## Summary
The checker's `should_suppress_assignability_diagnostic` "complex generic" carve-out suppressed **any** assignability target that merely *contained* a type parameter and was not a bare type parameter. A deferred `keyof T` target satisfies that shape, so a genuine key-space mismatch the solver had **already rejected** was silently dropped, producing a false negative: tsz accepted `keyof X` assigned to `keyof A` for unrelated `A`/`X`, while `tsc` reports **TS2322**.

Minimal witness (clean in tsz before, TS2322 in `tsc` 6.0.2):
```ts
function f<A, X>(t: keyof A, s: keyof X): void { t = s; } // tsc: TS2322; tsz (before): clean
```

## Structural rule
When the target is a deferred `keyof T`, `tsc` decides the relation **contravariantly** (`keyof S <: keyof T` iff `T <: S`) and reports TS2322 on a mismatch. The solver already computes this correctly (the keyof contravariant dispatch returns `False` for distinct params); the diagnostic was being thrown away by the suppression. So a deferred `keyof T` target must not take the complex-generic suppression. Concrete-key `keyof` targets are unaffected — they are handled by the separate literal-membership suppression and never carry free type parameters, so they never reach this path.

## Owner layer
Checker assignability diagnostic suppression: `is_structural_target_that_must_not_be_suppressed` in `crates/tsz-checker/src/assignability/assignability_checker.rs`. `keyof` now joins the sibling structural predicates (`is_conditional_type` / `is_string_intrinsic_type` / `is_mapped_type` / `intersection_members`) that the solver decides directly. No solver/relation change — the relation was already correct; only the diagnostic-suppression gate over-fired.

## Adjacent matrix (every case matched against `tsc` 6.0.2)
| Case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `keyof X` -> `keyof A` (distinct params) | TS2322 | clean | TS2322 |
| renamed binders (`keyof Schema` -> `keyof Other`) | TS2322 | clean | TS2322 |
| variable-declaration initializer form | TS2322 | clean | TS2322 |
| `keyof X[YK]` -> `keyof A[BK]` (indexed-keyof) | TS2322 | clean | TS2322 |
| `keyof A` -> `keyof X` with `A extends X` (superset) | TS2322 | clean | TS2322 |
| `keyof A` -> `keyof A` (negative) | clean | clean | clean |
| `keyof X` -> `keyof A` with `A extends X` (subset, negative) | clean | clean | clean |

## Anti-hardcoding
No identifier/alias/file-name literals or rendered-string predicates drive the decision; the predicate is a structural `keyof`-shape check reusing the existing `is_keyof_type` query-boundary helper (the same predicate used by the sibling clauses). The new tests vary binder names and include positive, renamed, indexed, superset, and two negative/subset controls.

## Out of scope
The kysely `whereRef`/`havingRef`/`groupBy` TS2416 **false positives** tracked by #13044 are a distinct defect (cross-file `ReferenceExpression` union relation, false-positive direction). The `ReferenceExpression`-shaped false **negative** (`(keyof T & string) | <sibling>` union over-acceptance) is a separate solver-relation bug also left out of scope here; both are documented in the #13044 investigation note.

## Verification
- New regression suite passes: `cargo test -p tsz-checker --test keyof_type_param_target_diagnostic_tests` (7/7).
- No regression in adjacent suites: `cargo test -p tsz-checker --test deferred_keyof_index_access_assignability_tests --test ts2862_keyof_tparam_tests --test assignability_final_relation_gate_tests` (all green). The one failure in `ts2344_keyof_bare_tparam_defer_tests` (`test_computed_unique_prefix_property_stays_string_key`) is pre-existing on clean `main` (the `__unique_*` symbol-key encoding family, #13402) — confirmed by A/B stash.
- `cargo clippy -p tsz-checker` clean; pre-commit fmt applied.
- Every matrix row above verified against `tsc` 6.0.2.
- Broad conformance/emit/project gates deferred to ready-review CI per repo policy.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_012BtNiePnHD5ibYTHBdtUKU)_