### PR TITLE
fix(checker): bind type arguments when an interface extends a generic type-alias application (#13470)

### DIFF
--- a/crates/tsz-checker/src/types/interface_type.rs
+++ b/crates/tsz-checker/src/types/interface_type.rs
@@ -809,6 +809,7 @@ impl<'a> CheckerState<'a> {
                         base_symbol_declarations,
                         base_symbol_value_declaration,
                         base_symbol_name,
+                        base_symbol_flags,
                     )) = self
                         .get_cross_file_symbol(base_sym_id)
                         .or_else(|| self.ctx.binder.get_symbol(base_sym_id))
@@ -817,6 +818,7 @@ impl<'a> CheckerState<'a> {
                                 symbol.declarations.clone(),
                                 symbol.value_declaration,
                                 symbol.escaped_name.clone(),
+                                symbol.flags,
                             )
                         })
                     else {
@@ -921,9 +923,62 @@ impl<'a> CheckerState<'a> {
                         })
                     });
 
-                    let substitution =
-                        TypeSubstitution::from_args(self.ctx.types, &base_type_params, &type_args);
-                    base_type = instantiate_type(self.ctx.types, base_type, &substitution);
+                    // A generic type alias is referenced nominally as `Lazy(DefId)`,
+                    // which carries no inline type-parameter occurrences, so
+                    // `instantiate_type` is a no-op that silently drops the heritage
+                    // type arguments. Cross-file (multi-arena) resolution of a generic
+                    // alias commonly yields exactly that bare `Lazy` here — e.g.
+                    // `interface I extends Omit<Base, K>` / `Pick<…>` / `Partial<…>` /
+                    // `Record<…>` — and without the arguments the base collapses to an
+                    // argument-less `Lazy` that resolves to `unknown` and is then dropped
+                    // by the merge, losing every inherited member.
+                    //
+                    // Form the generic application `Alias<args>` (mirroring the canonical
+                    // `Name<args>` type-reference lowering) and then resolve it env-aware
+                    // to its concrete apparent shape. Resolving here — rather than leaving
+                    // a deferred `Application` for the merge to wrap in an intersection —
+                    // is what lets the inherited members compose through a *second* level
+                    // of generic-interface inheritance (`interface R<…> extends I<…>`):
+                    // an `Object & Application` intersection base does not merge cleanly
+                    // through `merge_with_intersection`, but a plain `Object` does. When
+                    // the application stays generic (its arguments still depend on the
+                    // deriving interface's own type parameters) evaluation makes no
+                    // progress and the deferred application is kept, preserving the
+                    // existing single-level behaviour.
+                    //
+                    // Scoped to type-alias bases: interface/class heritage resolves to an
+                    // already-expanded object/callable (or class instance) body whose
+                    // member signatures embed the base's own type-parameter `TypeId`s, so
+                    // those keep going through `instantiate_type`, which substitutes them
+                    // directly (and aliases whose body the resolver does expand inline
+                    // are not `Lazy`, so they are unaffected too).
+                    let base_is_lazy_alias_ref = base_symbol_flags
+                        & tsz_binder::symbol_flags::TYPE_ALIAS
+                        != 0
+                        && crate::query_boundaries::common::lazy_def_id(self.ctx.types, base_type)
+                            .is_some();
+                    base_type = if base_is_lazy_alias_ref && !type_args.is_empty() {
+                        let application = self.ctx.types.application(base_type, type_args.clone());
+                        let resolved = self.evaluate_type_with_env(application);
+                        if resolved != application
+                            && crate::query_boundaries::common::classify_for_interface_merge(
+                                self.ctx.types,
+                                resolved,
+                            )
+                            .is_structurally_mergeable()
+                        {
+                            resolved
+                        } else {
+                            application
+                        }
+                    } else {
+                        let substitution = TypeSubstitution::from_args(
+                            self.ctx.types,
+                            &base_type_params,
+                            &type_args,
+                        );
+                        instantiate_type(self.ctx.types, base_type, &substitution)
+                    };
                     let is_builtin_array_heritage =
                         matches!(base_symbol_name.as_str(), "Array" | "ReadonlyArray");
                     let requires_self = !is_builtin_array_heritage

--- a/crates/tsz-cli/src/lib.rs
+++ b/crates/tsz-cli/src/lib.rs
@@ -47,6 +47,9 @@ mod dual_package_exports_tests;
 #[path = "../tests/fs_tests.rs"]
 mod fs_tests;
 #[cfg(test)]
+#[path = "../tests/interface_extends_generic_alias_cli_tests.rs"]
+mod interface_extends_generic_alias_cli_tests;
+#[cfg(test)]
 #[path = "../tests/lib_heritage_import_order_cli_tests.rs"]
 mod lib_heritage_import_order_cli_tests;
 #[cfg(test)]

--- a/crates/tsz-cli/tests/interface_extends_generic_alias_cli_tests.rs
+++ b/crates/tsz-cli/tests/interface_extends_generic_alias_cli_tests.rs
@@ -1,0 +1,290 @@
+//! Cross-file interface heritage that `extends` a generic *type-alias
+//! application* (`Omit<…>` / `Pick<…>` / `Partial<…>` / `Record<…>`).
+//!
+//! Structural rule: when `interface I extends Alias<Args>` and `Alias` is a
+//! generic type alias resolved across modules/arenas (so the heritage symbol
+//! resolves to a nominal `Lazy(DefId)` reference), tsc binds the arguments and
+//! inherits the alias's apparent members; tsz must form the generic
+//! application `Alias<Args>` and resolve it env-aware to those members.
+//!
+//! The previous code applied `instantiate_type` to the bare `Lazy`, a no-op
+//! that silently dropped the type arguments. The base then degraded to an
+//! argument-less `unknown` and the heritage merge discarded it, so cross-file
+//! property access on `I` reported every inherited member as missing (TS2339).
+//! The defect was cross-file only — single-file resolution expands the alias
+//! body inline, so substitution worked there. This is the general form behind
+//! the ofetch canary (`FetchOptions extends Omit<RequestInit, "body">`,
+//! #13470); it needs the real multi-module driver to reproduce (the in-crate
+//! `check_multi_file_with_libs` harness expands lib aliases inline and cannot
+//! host it).
+//!
+//! Cases vary the utility type, the alias base (lib vs user), the root-file
+//! order, and the inheritance depth, plus renamed binders and a
+//! genuine-missing negative control so the rule follows the type shape rather
+//! than identifier names.
+
+use crate::args::CliArgs;
+use clap::Parser;
+use tsz_checker::diagnostics::Diagnostic;
+
+/// Compile `files` (written into one temp dir) with the given root-file order.
+fn compile_in_order(files: &[(&str, &str)], root_order: &[&str]) -> Vec<Diagnostic> {
+    let dir = tempfile::tempdir().expect("temp dir");
+    for (name, contents) in files {
+        std::fs::write(dir.path().join(name), contents).expect("write repro file");
+    }
+
+    let mut argv: Vec<&str> = vec![
+        "tsz",
+        "--ignoreConfig",
+        "--noEmit",
+        "--strict",
+        "--target",
+        "es2022",
+        "--lib",
+        "es2022,dom,dom.iterable",
+    ];
+    argv.extend_from_slice(root_order);
+
+    let args = CliArgs::try_parse_from(argv).expect("parse args");
+    crate::driver::compile(&args, dir.path())
+        .expect("compile should succeed")
+        .diagnostics
+}
+
+fn missing_property_messages(diagnostics: &[Diagnostic]) -> Vec<String> {
+    diagnostics
+        .iter()
+        .filter(|d| d.code == 2339)
+        .map(|d| d.message_text.clone())
+        .collect()
+}
+
+/// Assert no TS2339 "property does not exist" in either root-file order
+/// (consumer-first is the cross-file regression direction).
+fn assert_no_missing_property_both_orders(files: &[(&str, &str)]) {
+    let names: Vec<&str> = files.iter().map(|(name, _)| *name).collect();
+    let forward = missing_property_messages(&compile_in_order(files, &names));
+    assert!(
+        forward.is_empty(),
+        "expected no TS2339 in forward root order {names:?}, got: {forward:?}"
+    );
+    let reversed: Vec<&str> = names.iter().rev().copied().collect();
+    let backward = missing_property_messages(&compile_in_order(files, &reversed));
+    assert!(
+        backward.is_empty(),
+        "expected no TS2339 in reversed root order {reversed:?}, got: {backward:?}"
+    );
+}
+
+#[test]
+fn imported_interface_extending_omit_keeps_inherited_members() {
+    assert_no_missing_property_both_orders(&[
+        (
+            "consumer.ts",
+            r#"
+import type { FetchOptions } from './shapes';
+export function read(o: FetchOptions) {
+    o.method;
+    o.baseURL;
+}
+"#,
+        ),
+        (
+            "shapes.ts",
+            r#"
+interface Base { method?: string; cache?: string; }
+export interface FetchOptions extends Omit<Base, "cache"> {
+    baseURL?: string;
+}
+"#,
+        ),
+    ]);
+}
+
+#[test]
+fn imported_interface_extending_record_keeps_inherited_member() {
+    assert_no_missing_property_both_orders(&[
+        (
+            "consumer.ts",
+            r#"
+import type { FetchOptions } from './shapes';
+export function read(o: FetchOptions) {
+    o.method;
+    o.baseURL;
+}
+"#,
+        ),
+        (
+            "shapes.ts",
+            r#"
+export interface FetchOptions extends Record<"method", string> {
+    baseURL?: string;
+}
+"#,
+        ),
+    ]);
+}
+
+#[test]
+fn imported_interface_extending_partial_keeps_inherited_members() {
+    assert_no_missing_property_both_orders(&[
+        (
+            "consumer.ts",
+            r#"
+import type { FetchOptions } from './shapes';
+export function read(o: FetchOptions) {
+    o.method;
+    o.cache;
+    o.baseURL;
+}
+"#,
+        ),
+        (
+            "shapes.ts",
+            r#"
+interface Base { method: string; cache: string; }
+export interface FetchOptions extends Partial<Base> {
+    baseURL?: string;
+}
+"#,
+        ),
+    ]);
+}
+
+/// Two levels of generic-interface inheritance over a utility-type heritage
+/// base must compose: `R<…> extends I<…>` where `I<…> extends Omit<…>`. This
+/// is the exact ofetch shape (`ResolvedFetchOptions<R, T> extends
+/// FetchOptions<R, T>`). A deferred `Object & Application` intersection base
+/// does not survive the second-level merge, so the alias application is
+/// resolved to a plain object before merging.
+#[test]
+fn imported_two_level_generic_interface_keeps_all_members() {
+    assert_no_missing_property_both_orders(&[
+        (
+            "consumer.ts",
+            r#"
+import type { ResolvedFetchOptions } from './shapes';
+export function read(o: ResolvedFetchOptions) {
+    o.body;
+    o.method;
+    o.baseURL;
+    o.headers;
+}
+"#,
+        ),
+        (
+            "shapes.ts",
+            r#"
+interface Base { method?: string; cache?: string; }
+export interface FetchOptions<R = string, T = unknown> extends Omit<Base, "cache"> {
+    baseURL?: string;
+    body?: string;
+}
+export interface ResolvedFetchOptions<R = string, T = unknown> extends FetchOptions<R, T> {
+    headers: string;
+}
+"#,
+        ),
+    ]);
+}
+
+/// Anti-hardcoding: the rule follows the type shape, not the identifier
+/// spellings.
+#[test]
+fn imported_interface_extending_omit_renamed_binders_keeps_members() {
+    assert_no_missing_property_both_orders(&[
+        (
+            "consumer.ts",
+            r#"
+import type { Widget } from './shapes';
+export function read(w: Widget) {
+    w.alpha;
+    w.gamma;
+}
+"#,
+        ),
+        (
+            "shapes.ts",
+            r#"
+interface Shape { alpha?: string; beta?: string; }
+export interface Widget extends Omit<Shape, "beta"> {
+    gamma?: string;
+}
+"#,
+        ),
+    ]);
+}
+
+/// The inherited members are genuinely present, not silently widened to
+/// `any`: `Record<"method", string>` makes `method` required, so an object
+/// literal that omits it is rejected cross-file with TS2741.
+#[test]
+fn imported_interface_extending_record_member_is_required() {
+    let files = &[
+        (
+            "consumer.ts",
+            r#"
+import type { FetchOptions } from './shapes';
+export const bad: FetchOptions = { baseURL: "a" };
+export const good: FetchOptions = { method: "GET", baseURL: "a" };
+"#,
+        ),
+        (
+            "shapes.ts",
+            r#"
+export interface FetchOptions extends Record<"method", string> {
+    baseURL?: string;
+}
+"#,
+        ),
+    ];
+    let diags = compile_in_order(files, &["consumer.ts", "shapes.ts"]);
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.code == 2741 && d.message_text.contains("method")),
+        "omitting the required inherited `method` must report TS2741, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+/// Negative control: a property on neither the interface nor the utility-type
+/// heritage base must still report TS2339 (no over-broadening to `any`).
+#[test]
+fn imported_interface_extending_omit_genuinely_missing_property_still_errors() {
+    let files = &[
+        (
+            "consumer.ts",
+            r#"
+import type { FetchOptions } from './shapes';
+export function read(o: FetchOptions) {
+    o.cache;
+    o.nonexistent;
+}
+"#,
+        ),
+        (
+            "shapes.ts",
+            r#"
+interface Base { method?: string; cache?: string; }
+export interface FetchOptions extends Omit<Base, "cache"> {
+    baseURL?: string;
+}
+"#,
+        ),
+    ];
+    let missing =
+        missing_property_messages(&compile_in_order(files, &["consumer.ts", "shapes.ts"]));
+    assert!(
+        missing.iter().any(|m| m.contains("nonexistent")),
+        "a genuinely-absent property must still report TS2339, got: {missing:?}"
+    );
+    assert!(
+        missing.iter().any(|m| m.contains("cache")),
+        "the Omit-excluded `cache` must still report TS2339, got: {missing:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes #13470.

## Summary

A cross-file interface that `extends` a **generic type-alias application** —
`Omit<…>`, `Pick<…>`, `Partial<…>`, `Record<…>`, or any generic `type` alias
applied with arguments in a heritage clause — silently dropped **every
inherited member**, so property access on the interface from another module
reported them as missing (`TS2339`). This is the general root cause behind the
ofetch canary's second blocker (`FetchOptions extends Omit<RequestInit, "body">`,
27× false `TS2339` on `.body`/`.method`, #13470). The issue's hypothesised
mechanism ("an unresolvable `InstanceType` member poisons sibling lookup") is
**refuted**: the `undici`/`InstanceType` member is irrelevant — the minimal
witness is `interface I extends Record<"method", string>` accessed from another
file, with no error member anywhere.

## Structural rule

When `interface I extends Alias<Args>` and `Alias` is a generic type alias,
`tsc` binds `Args` and inherits the alias's apparent members. tsz now forms the
generic application `Alias<Args>` in the heritage base and resolves it env-aware
to its concrete apparent shape, through the checker's interface-heritage merge
(`merge_interface_heritage_types`).

Cross-file resolution of a generic alias yields a nominal `Lazy(DefId)` from
`get_type_of_symbol`. The old code applied `instantiate_type(Lazy, substitution)`,
which is a **no-op** on a bare `Lazy` (it has no inline type-parameter
occurrences), so the heritage type arguments were silently dropped. The base
then degraded to an argument-less reference that resolves to `unknown` and was
discarded by the merge (`(_, Other) => derived`), losing all inherited members.
Single-file resolution expands the alias body inline, so `instantiate_type`
substituted correctly there — the defect was **cross-file only** (multi-arena),
which is why every minimal single-file reduction in #13470 looked clean.

## Owner layer

Checker interface-heritage merge. The fix mirrors the canonical `Name<args>`
type-reference lowering (`get_type_from_type_reference` →
`types.application(resolved, type_args)`): build `Application(Lazy(alias), args)`
and evaluate it env-aware. Resolving to a concrete object **here** — rather than
leaving a deferred `Application` for the merge to wrap in an `Object & Application`
intersection — is what lets the inherited members compose through a *second*
level of generic-interface inheritance (`interface R<…> extends I<…>`, the
ofetch `ResolvedFetchOptions<R,T> extends FetchOptions<R,T>` shape); the
intersection base does not survive `merge_with_intersection`, but a plain
`Object` does. When the application stays generic (its arguments still depend on
the deriving interface's own type parameters) evaluation makes no progress and
the deferred application is kept, preserving the existing single-level behaviour.

Scoped to type-alias bases (`symbol_flags::TYPE_ALIAS` + `Lazy(_)`):
interface/class heritage already resolves to an expanded object/callable/class
body whose member signatures embed the base's own type-parameter `TypeId`s, so
those keep going through `instantiate_type`. Applying the application path to
generic *interface* bases was tried and regressed a two-level inheritance case,
so it is deliberately not broadened. No diagnostic-string predicates, no
user-name/file-name literals — the gate is the binder's `TYPE_ALIAS` flag plus a
structural `Lazy` check.

## Adjacent-case matrix

New CLI-driver regression tests
(`crates/tsz-cli/tests/interface_extends_generic_alias_cli_tests.rs`). The
in-crate `check_multi_file_with_libs` harness expands lib aliases inline and
cannot host the witness, so the real multi-module driver is used (same gap class
noted on #13165); each case is verified to fail on base and pass with the fix:

- `extends Omit<Base, K>` — inherited member resolves cross-file (both root
  orders).
- `extends Record<"method", string>` — inherited member resolves.
- `extends Partial<Base>` — inherited members resolve.
- Two-level generic: `ResolvedFetchOptions<R,T> extends FetchOptions<R,T> extends Omit<Base,"cache">`
  — own and inherited members all resolve through both levels.
- Renamed binders — clean (anti-hardcoding control).
- Required-member positive: `Record<"k", string>` keeps `k` **required**, so an
  object literal omitting it is rejected with `TS2741` (members genuinely
  present, not widened to `any`).
- Negative control: a property on neither the interface nor the heritage base
  still reports `TS2339` (no over-broadening).

## Verification

- `cargo test -p tsz-cli --lib interface_extends_generic_alias` — 7/7 pass; the
  6 positive/required cases fail on the base commit (fix reverted) and pass with
  the fix (non-vacuous).
- Real-CLI repro of the ofetch shape (`types.ts` + consumer, `--lib dom`): the
  false `TS2339` family on `ResolvedFetchOptions`/`FetchOptions` members is
  cleared; only the legitimate `TS2307` (`undici` not installed) remains, as
  `tsc` reports.
- No new failures vs base on `cargo test -p tsz-cli --test tsc_compat_tests`
  (4 failures identical to base), `cargo test -p tsz-checker --lib`
  filters `heritage`/`extends`/`interface` (1 pre-existing fail),
  `augment` (clean), `alias` (2 pre-existing), `mapped` (7 pre-existing) — all
  pre-existing and identical with/without the change.
- `cargo clippy -p tsz-checker` clean; `cargo fmt` applied.
- Broad conformance/emit/project gates deferred to ready-review CI per repo
  policy; the ofetch project-compile guard (#13470 acceptance) is the corpus
  regression gate.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdJQWRwAFU7nGpR54eeeFN)_