### PR TITLE
fix(checker): emit tsc's type-parameter-target assignment caveats (TS5082/TS5075)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1180,69 +1180,6 @@ impl<'a> CheckerState<'a> {
         (source_str, target_str)
     }
 
-    pub(in crate::error_reporter) fn unrelated_type_parameter_target_related_info(
-        &mut self,
-        source: TypeId,
-        target: TypeId,
-        source_display: &str,
-        target_display: &str,
-        start: u32,
-        length: u32,
-    ) -> Option<DiagnosticRelatedInformation> {
-        if !self.target_is_bare_type_parameter(target) {
-            return None;
-        }
-        // Mirror tsc's `isRelatedTo` type-parameter-target elaboration: when a
-        // concrete source is assigned to a bare type-parameter target and the
-        // relation fails, tsc attaches one of two notes.
-        //
-        //   * If the parameter has a meaningful constraint (not `any`/`unknown`)
-        //     that the source *satisfies*, the failure is that the parameter
-        //     could still be instantiated with a narrower type, so tsc reports
-        //     TS5075 ("'{src}' is assignable to the constraint of type '{T}',
-        //     but '{T}' could be instantiated with a different subtype of
-        //     constraint '{constraint}'.").
-        //   * Otherwise — the parameter is unconstrained (or top-constrained),
-        //     or the source does not satisfy the constraint — the parameter
-        //     could be instantiated with something entirely unrelated, so tsc
-        //     reports TS5082 ("'{T}' could be instantiated with an arbitrary
-        //     type which could be unrelated to '{src}'.").
-        let file = self.ctx.file_name.clone();
-        let elaboration = |code, message_text| DiagnosticRelatedInformation {
-            category: DiagnosticCategory::Message,
-            code,
-            file: file.clone(),
-            start,
-            length,
-            message_text,
-            depth: 0,
-        };
-        let constraint =
-            crate::query_boundaries::diagnostics::type_parameter_constraint(self.ctx.types, target)
-                .filter(|&c| c != TypeId::ANY && c != TypeId::UNKNOWN);
-        if let Some(constraint) = constraint
-            && self
-                .type_parameter_constraint_elaboration_relation_outcome(source, constraint)
-                .related
-        {
-            let constraint_display = self.format_type_diagnostic(constraint);
-            return Some(elaboration(
-                diagnostic_codes::IS_ASSIGNABLE_TO_THE_CONSTRAINT_OF_TYPE_BUT_COULD_BE_INSTANTIATED_WITH_A_DIFFERE,
-                format_message(
-                    diagnostic_messages::IS_ASSIGNABLE_TO_THE_CONSTRAINT_OF_TYPE_BUT_COULD_BE_INSTANTIATED_WITH_A_DIFFERE,
-                    &[source_display, target_display, &constraint_display],
-                ),
-            ));
-        }
-        Some(elaboration(
-            diagnostic_codes::COULD_BE_INSTANTIATED_WITH_AN_ARBITRARY_TYPE_WHICH_COULD_BE_UNRELATED_TO,
-            format_message(
-                diagnostic_messages::COULD_BE_INSTANTIATED_WITH_AN_ARBITRARY_TYPE_WHICH_COULD_BE_UNRELATED_TO,
-                &[target_display, source_display],
-            ),
-        ))
-    }
-
     /// Whether `ty` (or its assignability-evaluated form `evaluated`) carries
     /// fresh object-literal `display_properties` — the provenance marker that
     /// distinguishes a fresh expression literal (whose canonical shape is

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -1192,31 +1192,55 @@ impl<'a> CheckerState<'a> {
         if !self.target_is_bare_type_parameter(target) {
             return None;
         }
-        let constraint = crate::query_boundaries::diagnostics::type_parameter_constraint(
-            self.ctx.types,
-            target,
-        )?;
-        if constraint == TypeId::ANY
-            || constraint == TypeId::UNKNOWN
-            || self
+        // Mirror tsc's `isRelatedTo` type-parameter-target elaboration: when a
+        // concrete source is assigned to a bare type-parameter target and the
+        // relation fails, tsc attaches one of two notes.
+        //
+        //   * If the parameter has a meaningful constraint (not `any`/`unknown`)
+        //     that the source *satisfies*, the failure is that the parameter
+        //     could still be instantiated with a narrower type, so tsc reports
+        //     TS5075 ("'{src}' is assignable to the constraint of type '{T}',
+        //     but '{T}' could be instantiated with a different subtype of
+        //     constraint '{constraint}'.").
+        //   * Otherwise — the parameter is unconstrained (or top-constrained),
+        //     or the source does not satisfy the constraint — the parameter
+        //     could be instantiated with something entirely unrelated, so tsc
+        //     reports TS5082 ("'{T}' could be instantiated with an arbitrary
+        //     type which could be unrelated to '{src}'.").
+        let file = self.ctx.file_name.clone();
+        let elaboration = |code, message_text| DiagnosticRelatedInformation {
+            category: DiagnosticCategory::Message,
+            code,
+            file: file.clone(),
+            start,
+            length,
+            message_text,
+            depth: 0,
+        };
+        let constraint =
+            crate::query_boundaries::diagnostics::type_parameter_constraint(self.ctx.types, target)
+                .filter(|&c| c != TypeId::ANY && c != TypeId::UNKNOWN);
+        if let Some(constraint) = constraint
+            && self
                 .type_parameter_constraint_elaboration_relation_outcome(source, constraint)
                 .related
         {
-            return None;
+            let constraint_display = self.format_type_diagnostic(constraint);
+            return Some(elaboration(
+                diagnostic_codes::IS_ASSIGNABLE_TO_THE_CONSTRAINT_OF_TYPE_BUT_COULD_BE_INSTANTIATED_WITH_A_DIFFERE,
+                format_message(
+                    diagnostic_messages::IS_ASSIGNABLE_TO_THE_CONSTRAINT_OF_TYPE_BUT_COULD_BE_INSTANTIATED_WITH_A_DIFFERE,
+                    &[source_display, target_display, &constraint_display],
+                ),
+            ));
         }
-        let message = format_message(
-            diagnostic_messages::COULD_BE_INSTANTIATED_WITH_AN_ARBITRARY_TYPE_WHICH_COULD_BE_UNRELATED_TO,
-            &[target_display, source_display],
-        );
-        Some(DiagnosticRelatedInformation {
-            category: DiagnosticCategory::Message,
-            code: diagnostic_codes::COULD_BE_INSTANTIATED_WITH_AN_ARBITRARY_TYPE_WHICH_COULD_BE_UNRELATED_TO,
-            file: self.ctx.file_name.clone(),
-            start,
-            length,
-            message_text: message,
-            depth: 0,
-        })
+        Some(elaboration(
+            diagnostic_codes::COULD_BE_INSTANTIATED_WITH_AN_ARBITRARY_TYPE_WHICH_COULD_BE_UNRELATED_TO,
+            format_message(
+                diagnostic_messages::COULD_BE_INSTANTIATED_WITH_AN_ARBITRARY_TYPE_WHICH_COULD_BE_UNRELATED_TO,
+                &[target_display, source_display],
+            ),
+        ))
     }
 
     /// Whether `ty` (or its assignability-evaluated form `evaluated`) carries

--- a/crates/tsz-checker/src/error_reporter/assignability_type_parameter_target.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_type_parameter_target.rs
@@ -1,0 +1,78 @@
+//! Elaboration notes for assignments whose target is a bare type parameter.
+//!
+//! Mirrors `tsc`'s `isRelatedTo` type-parameter-target handling: when a
+//! concrete source fails to relate to a bare type-parameter target, the
+//! failure is annotated with one of two notes (`TS5082`/`TS5075`).
+
+use crate::diagnostics::{
+    DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes, diagnostic_messages,
+    format_message,
+};
+use crate::state::CheckerState;
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Build `tsc`'s type-parameter-target elaboration for a failed assignment
+    /// to a bare type-parameter `target`. When a concrete source is assigned to
+    /// a bare type-parameter target and the relation fails, `tsc` attaches one
+    /// of two notes:
+    ///
+    ///   * If the parameter has a meaningful constraint (not `any`/`unknown`)
+    ///     that the source *satisfies*, the failure is that the parameter could
+    ///     still be instantiated with a narrower type, so `tsc` reports `TS5075`
+    ///     ("`'{src}'` is assignable to the constraint of type `'{T}'`, but
+    ///     `'{T}'` could be instantiated with a different subtype of constraint
+    ///     `'{constraint}'`.").
+    ///   * Otherwise — the parameter is unconstrained (or top-constrained), or
+    ///     the source does not satisfy the constraint — the parameter could be
+    ///     instantiated with something entirely unrelated, so `tsc` reports
+    ///     `TS5082` ("`'{T}'` could be instantiated with an arbitrary type which
+    ///     could be unrelated to `'{src}'`.").
+    pub(in crate::error_reporter) fn unrelated_type_parameter_target_related_info(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+        source_display: &str,
+        target_display: &str,
+        start: u32,
+        length: u32,
+    ) -> Option<DiagnosticRelatedInformation> {
+        if !self.target_is_bare_type_parameter(target) {
+            return None;
+        }
+        let file = self.ctx.file_name.clone();
+        let elaboration = |code, message_text| DiagnosticRelatedInformation {
+            category: DiagnosticCategory::Message,
+            code,
+            file: file.clone(),
+            start,
+            length,
+            message_text,
+            depth: 0,
+        };
+        let constraint =
+            crate::query_boundaries::diagnostics::type_parameter_constraint(self.ctx.types, target)
+                .filter(|&c| c != TypeId::ANY && c != TypeId::UNKNOWN);
+        if let Some(constraint) = constraint
+            && self
+                .type_parameter_constraint_elaboration_relation_outcome(source, constraint)
+                .related
+        {
+            let constraint_display = self.format_type_diagnostic(constraint);
+            return Some(elaboration(
+                diagnostic_codes::IS_ASSIGNABLE_TO_THE_CONSTRAINT_OF_TYPE_BUT_COULD_BE_INSTANTIATED_WITH_A_DIFFERE,
+                format_message(
+                    diagnostic_messages::IS_ASSIGNABLE_TO_THE_CONSTRAINT_OF_TYPE_BUT_COULD_BE_INSTANTIATED_WITH_A_DIFFERE,
+                    &[source_display, target_display, &constraint_display],
+                ),
+            ));
+        }
+        Some(elaboration(
+            diagnostic_codes::COULD_BE_INSTANTIATED_WITH_AN_ARBITRARY_TYPE_WHICH_COULD_BE_UNRELATED_TO,
+            format_message(
+                diagnostic_messages::COULD_BE_INSTANTIATED_WITH_AN_ARBITRARY_TYPE_WHICH_COULD_BE_UNRELATED_TO,
+                &[target_display, source_display],
+            ),
+        ))
+    }
+}

--- a/crates/tsz-checker/src/error_reporter/mod.rs
+++ b/crates/tsz-checker/src/error_reporter/mod.rs
@@ -24,6 +24,7 @@ mod assignability_normalized_union;
 mod assignability_numeric_display;
 mod assignability_satisfies;
 mod assignability_type_helpers;
+mod assignability_type_parameter_target;
 mod call_errors;
 mod call_errors_anchors;
 mod conditional_alias_display;

--- a/crates/tsz-checker/tests/type_parameter_source_constraint_chain_tests.rs
+++ b/crates/tsz-checker/tests/type_parameter_source_constraint_chain_tests.rs
@@ -222,3 +222,63 @@ fn type_parameter_target_keeps_instantiation_caveat() {
         related_messages(&diag)
     );
 }
+
+/// An *unconstrained* type-parameter target keeps `tsc`'s TS5082 caveat: the
+/// parameter could be instantiated with an arbitrary type unrelated to the
+/// concrete source. Previously the caveat was dropped whenever the parameter
+/// had no constraint (the `?` short-circuit on the missing constraint), so the
+/// bare headline was emitted alone.
+#[test]
+fn unconstrained_type_parameter_target_keeps_arbitrary_type_caveat() {
+    let diag = ts2322(
+        "function emit<Out>(value: number): Out {\n\
+         return value;\n\
+         }\n",
+    );
+    assert!(
+        diag.message_text
+            .contains("Type 'number' is not assignable to type 'Out'"),
+        "headline is the bare parameter mismatch; got: {}",
+        diag.message_text
+    );
+    assert!(
+        has_related(
+            &diag,
+            "'Out' could be instantiated with an arbitrary type which could be unrelated to 'number'",
+        ),
+        "an unconstrained type-parameter target keeps tsc's arbitrary-type caveat; got: {:?}",
+        related_messages(&diag)
+    );
+}
+
+/// A *constrained* type-parameter target whose constraint the source satisfies
+/// gets `tsc`'s TS5075 note instead of the arbitrary-type caveat: the source is
+/// assignable to the constraint, but the parameter could still be instantiated
+/// with a different, narrower subtype of that constraint.
+#[test]
+fn constrained_type_parameter_target_with_satisfied_constraint_reports_different_subtype() {
+    let diag = ts2322(
+        "function shape<Acc extends object>(value: { tag: number }): Acc {\n\
+         return value;\n\
+         }\n",
+    );
+    assert!(
+        diag.message_text
+            .contains("is not assignable to type 'Acc'"),
+        "headline relates the source to the bare parameter; got: {}",
+        diag.message_text
+    );
+    assert!(
+        has_related(
+            &diag,
+            "is assignable to the constraint of type 'Acc', but 'Acc' could be instantiated with a different subtype of constraint 'object'",
+        ),
+        "a satisfied constraint reports tsc's different-subtype note; got: {:?}",
+        related_messages(&diag)
+    );
+    assert!(
+        !has_related(&diag, "could be instantiated with an arbitrary type"),
+        "the arbitrary-type caveat must not stack on the different-subtype note; got: {:?}",
+        related_messages(&diag)
+    );
+}


### PR DESCRIPTION
Goal: hold

## Summary

When a concrete source is assigned to a **bare type-parameter target** and the relation fails, `tsc` attaches one of two elaboration notes that tsz was dropping. This reworks `unrelated_type_parameter_target_related_info` to mirror tsc's `isRelatedTo` type-parameter-target elaboration.

## Structural rule

When the assignment target is a bare type parameter `T` and a concrete source `S` is not assignable to it, `tsc` reports:
- **TS5082** `'T' could be instantiated with an arbitrary type which could be unrelated to 'S'.` — when `T` is unconstrained (or top-constrained `any`/`unknown`), **or** `S` does not satisfy `T`'s constraint;
- **TS5075** `'S' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'C'.` — when `T` has a meaningful constraint `C` that `S` satisfies.

tsz does this through the checker error-reporter (`crates/tsz-checker/src/error_reporter/assignability.rs`, `unrelated_type_parameter_target_related_info`).

## Bug / owner layer

`unrelated_type_parameter_target_related_info` previously:
1. bailed out via `?` when the parameter had **no** constraint, so unconstrained targets lost the caveat entirely; and
2. returned `None` whenever the source satisfied the constraint, so the **TS5075** "different subtype of constraint" note was never produced in the general assignment path (only the indexed-access path emitted it).

Net effect: tsz emitted only the bare `Type 'S' is not assignable to type 'T'.` headline where tsc adds the instantiation caveat. Surfaced while triaging `deeplyNestedMappedTypes.ts` (`problematicFunction2`, `<T extends Output[]>`). Owner layer: checker assignability diagnostic elaboration. Related-information is not conformance-fingerprinted (diagnostic code 5082/5075 do not appear in the tsc expectation cache), so this is diagnostic parity, not an aggregate move.

## Adjacent matrix (all verified against tsc semantics)

| Target | Source vs constraint | Note |
|---|---|---|
| `<T>` (unconstrained) | n/a | TS5082 arbitrary type |
| `<T extends object>` | `{ a: number }` satisfies | TS5075 different subtype of `object` |
| `<T extends string>` | `number` fails | TS5082 arbitrary type |
| `<T extends string>` | `"a"` satisfies | TS5075 different subtype of `string` |

Existing constraint-fail behavior (TS5082) is preserved; the source-side constraint chain (`type_parameter_source_constraint_chain_tests`) is unaffected.

## Not in scope

The deeper `deeplyNestedMappedTypes.ts` divergence (`Input[]` wrongly assignable to `Output[]` because the recursive TypeBox `Static<typeof X>` evaluation leaks `unique symbol` under full-project/resolver-less evaluation) is a separate solver-evaluation defect (#13232-adjacent) and is **not** addressed here; the accepted-regression ledger entry is left in place.

## Verification

- `cargo test -p tsz-checker --test type_parameter_source_constraint_chain_tests` — 9 passed (incl. 2 new regression tests: `unconstrained_type_parameter_target_keeps_arbitrary_type_caveat`, `constrained_type_parameter_target_with_satisfied_constraint_reports_different_subtype`).
- `cargo test -p tsz-checker --lib -- ts2352_constrained_type_param_target assignment_checker_template_display` — 21 passed.
- `ts2322_tests` suite: identical pass/fail set before and after this change (the 7 failures present are pre-existing on the base branch in a plain debug build, unrelated to this change).
- Manual: `function f<T>(x: number): T { return x; }` and `function f<T extends object>(x: { a: number }): T { return x; }` now emit the TS5082 / TS5075 caveats matching tsc.

Refs #8432.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgLZopXmL7NmABSebYXNV8)_