### PR TITLE
fix(cli): lay implicit-rootDir emit output relative to common source directory

### DIFF
--- a/crates/tsz-cli/src/driver/core.rs
+++ b/crates/tsz-cli/src/driver/core.rs
@@ -1561,9 +1561,10 @@ mod plan;
 pub use plan::apply_cli_overrides;
 use plan::{
     apply_cli_overrides_with_config_options, cli_ignore_deprecations_silences_6_0,
-    display_relative_to_dir, find_latest_dts_file, implicit_common_source_directory,
-    is_deprecation_diagnostic_code, is_removed_option_diagnostic_code,
-    is_removed_option_value_diagnostic_code, validate_cli_compiler_option_diagnostics,
+    display_relative_to_dir, emit_common_source_directory, find_latest_dts_file,
+    implicit_common_source_directory, is_deprecation_diagnostic_code,
+    is_removed_option_diagnostic_code, is_removed_option_value_diagnostic_code,
+    validate_cli_compiler_option_diagnostics,
 };
 
 #[cfg(test)]

--- a/crates/tsz-cli/src/driver/core_diagnostics.rs
+++ b/crates/tsz-cli/src/driver/core_diagnostics.rs
@@ -1111,6 +1111,28 @@ pub(super) fn compile_inner(
         }
     }
 
+    // Output layout follows tsc's `getCommonSourceDirectory()`. When `rootDir`
+    // is set, that is the root. In project (tsconfig) mode tsc 6.0 anchors the
+    // layout at the config directory (the `base_dir` fallback used inside the
+    // emitter, see TS5011), so nothing extra is needed there. But when
+    // compilation is driven by an explicit file list with no tsconfig, tsc lays
+    // output out relative to the longest common directory of the emittable
+    // source files — not the cwd. Compute that implicit root so a single input
+    // `src/a.ts --outDir out` emits to `out/a.js` (like tsc) rather than
+    // `out/src/a.js`.
+    let emit_root_dir = if root_dir.is_some() || tsconfig_path.is_some() {
+        root_dir
+    } else {
+        emit_common_source_directory(
+            program
+                .files
+                .iter()
+                .map(|file| PathBuf::from(&file.file_name)),
+            &base_dir,
+            &cwd,
+        )
+    };
+
     let emit_outputs_start = Instant::now();
     let emitted_files = if !should_emit && !should_run_declaration_emit_check {
         Vec::new()
@@ -1120,7 +1142,7 @@ pub(super) fn compile_inner(
             options: &resolved,
             base_dir: &base_dir,
             root_file_paths: &root_file_paths,
-            root_dir: root_dir.as_deref(),
+            root_dir: emit_root_dir.as_deref(),
             out_dir: out_dir.as_deref(),
             declaration_dir: declaration_dir.as_deref(),
             dirty_paths: dirty_paths.as_ref(),

--- a/crates/tsz-cli/src/driver/plan.rs
+++ b/crates/tsz-cli/src/driver/plan.rs
@@ -1125,6 +1125,35 @@ fn longest_common_directory(a: &Path, b: &Path) -> PathBuf {
         .collect()
 }
 
+/// Compute tsc's `getCommonSourceDirectory()` for the emit layout when no
+/// explicit `rootDir` is in play: the longest common directory of the emittable
+/// source files, with declaration files and `node_modules` sources excluded so
+/// they cannot drag the inferred root upward.
+///
+/// This is the root tsc lays output out against for an explicit file list with
+/// no tsconfig, so `tsz src/a.ts --outDir out` emits `out/a.js` like tsc rather
+/// than the cwd-relative `out/src/a.js`. Returns `None` when that directory
+/// coincides with `base_dir` (the emitter's `base_dir` fallback already
+/// produces the right layout) or when there are no emittable files.
+pub(super) fn emit_common_source_directory<I>(
+    program_file_paths: I,
+    base_dir: &Path,
+    cwd: &Path,
+) -> Option<PathBuf>
+where
+    I: IntoIterator<Item = PathBuf>,
+{
+    let emittable: Vec<PathBuf> = program_file_paths
+        .into_iter()
+        .filter(|path| {
+            !path
+                .components()
+                .any(|component| component.as_os_str() == "node_modules")
+        })
+        .collect();
+    implicit_common_source_directory(&emittable, base_dir, cwd)
+}
+
 /// Format `path` for display relative to `dir`, using forward slashes and a
 /// leading `./` when the result is a non-parent relative path. Falls back to
 /// the path's own string representation when it cannot be expressed under
@@ -1178,6 +1207,47 @@ mod tests {
         assert!(!is_valid_jsx_factory_expression("my-lib.create"));
         assert!(!is_valid_jsx_factory_expression(".leading"));
         assert!(!is_valid_jsx_factory_expression("trailing."));
+    }
+
+    #[test]
+    fn emit_common_source_directory_single_file_uses_file_directory() {
+        // `tsz src/a.ts --outDir out` (no tsconfig, no rootDir): tsc lays output
+        // relative to the file's directory, not the cwd, so the root is src.
+        let files = vec![PathBuf::from("/proj/src/a.ts")];
+        let got = emit_common_source_directory(files, Path::new("/proj"), Path::new("/proj"));
+        assert_eq!(got, Some(PathBuf::from("/proj/src")));
+    }
+
+    #[test]
+    fn emit_common_source_directory_multi_file_uses_longest_common_directory() {
+        let files = vec![
+            PathBuf::from("/proj/src/a.ts"),
+            PathBuf::from("/proj/src/sub/c.ts"),
+        ];
+        let got = emit_common_source_directory(files, Path::new("/proj"), Path::new("/proj"));
+        assert_eq!(got, Some(PathBuf::from("/proj/src")));
+    }
+
+    #[test]
+    fn emit_common_source_directory_none_when_common_equals_base_dir() {
+        // Common directory coincides with base_dir: the base_dir fallback already
+        // produces the right layout, so there is nothing to override.
+        let files = vec![PathBuf::from("/proj/a.ts"), PathBuf::from("/proj/b.ts")];
+        let got = emit_common_source_directory(files, Path::new("/proj"), Path::new("/proj"));
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn emit_common_source_directory_excludes_node_modules_and_declaration_sources() {
+        // node_modules and `.d.ts` sources must not drag the common directory up.
+        let files = vec![
+            PathBuf::from("/proj/src/a.ts"),
+            PathBuf::from("/proj/src/sub/c.ts"),
+            PathBuf::from("/proj/node_modules/dep/index.ts"),
+            PathBuf::from("/proj/types/global.d.ts"),
+        ];
+        let got = emit_common_source_directory(files, Path::new("/proj"), Path::new("/proj"));
+        assert_eq!(got, Some(PathBuf::from("/proj/src")));
     }
 
     #[test]

--- a/scripts/emit/src/cli-transpiler.ts
+++ b/scripts/emit/src/cli-transpiler.ts
@@ -78,6 +78,23 @@ interface CompilerFlagOptions {
   rootDir?: string;
 }
 
+// Longest common directory of a set of POSIX-style relative file paths,
+// returned as a slash-joined prefix without a trailing slash (empty when the
+// files share no directory beyond the root). Mirrors tsc's
+// `getCommonSourceDirectory` component-wise comparison.
+function longestCommonSourceDir(relPaths: string[]): string {
+  if (relPaths.length === 0) return '';
+  const dirComponents = relPaths.map(p => p.split('/').slice(0, -1));
+  let common = dirComponents[0];
+  for (const comps of dirComponents.slice(1)) {
+    let i = 0;
+    while (i < common.length && i < comps.length && common[i] === comps[i]) i++;
+    common = common.slice(0, i);
+    if (common.length === 0) break;
+  }
+  return common.join('/');
+}
+
 // Append shared compiler-option flags onto a tsz CLI args array. Used by both
 // the primary emit invocation and the declaration-emit retry path so that the
 // two stay in lockstep — previously the retry path silently dropped
@@ -348,6 +365,28 @@ export class CliTranspiler {
     const inputFiles: string[] = [];
     const expectedOutputs: OutputPaths[] = [];
 
+    // When `rootDir` is unset, tsz (like tsc) lays output out relative to the
+    // common source directory of the emittable inputs, not the test root. So a
+    // test whose files all live under `src/` emits to `<outDir>/a.js`, not
+    // `<outDir>/src/a.js`. Compute that common directory (over non-declaration,
+    // non-node_modules sources) so the stripped output path is offered as an
+    // output-location candidate below.
+    const emittableRelNames = files
+      .map(f => f.name.replace(/^\/+/, '').replace(/\\/g, '/'))
+      .filter(
+        rel =>
+          !rel.endsWith('package.json') &&
+          !rel.endsWith('tsconfig.json') &&
+          !rel.endsWith('.d.ts') &&
+          !rel.split('/').includes('node_modules'),
+      );
+    const commonSourceDir = rootDir ? '' : longestCommonSourceDir(emittableRelNames);
+    const stripCommonSourceDir = (relStem: string): string =>
+      commonSourceDir &&
+      (relStem === commonSourceDir || relStem.startsWith(`${commonSourceDir}/`))
+        ? relStem.slice(commonSourceDir.length).replace(/^\/+/, '')
+        : relStem;
+
     for (const file of files) {
       const relName = file.name.replace(/^\/+/, '');
       const normalizedRelName = relName.replace(/\\/g, '/');
@@ -379,6 +418,15 @@ export class CliTranspiler {
         }
         return path.join(testDir, outDir.replace(/^[/\\]+/, ''), relStem);
       })();
+      // Same path with the implicit common source directory stripped (the
+      // layout tsz actually emits when `rootDir` is unset).
+      const outputRelStemCommon = (() => {
+        if (!outDir || rootDir) return null;
+        const relStem = stripCommonSourceDir(
+          relName.replace(/\\/g, '/').replace(/\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/, ''),
+        );
+        return path.join(testDir, outDir.replace(/^[/\\]+/, ''), relStem);
+      })();
       const declarationRelStem = (() => {
         const declarationOutputDir = declarationDir ?? outDir;
         if (!declarationOutputDir) return null;
@@ -387,6 +435,14 @@ export class CliTranspiler {
         if (normalizedRoot && (relStem === normalizedRoot || relStem.startsWith(`${normalizedRoot}/`))) {
           relStem = relStem.slice(normalizedRoot.length).replace(/^\/+/, '');
         }
+        return path.join(testDir, declarationOutputDir.replace(/^[/\\]+/, ''), relStem);
+      })();
+      const declarationRelStemCommon = (() => {
+        const declarationOutputDir = declarationDir ?? outDir;
+        if (!declarationOutputDir || rootDir) return null;
+        const relStem = stripCommonSourceDir(
+          relName.replace(/\\/g, '/').replace(/\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/, ''),
+        );
         return path.join(testDir, declarationOutputDir.replace(/^[/\\]+/, ''), relStem);
       })();
       // For TS→JS: .ts→.js, .tsx→.jsx, .mts→.mjs, .cts→.cjs
@@ -401,12 +457,14 @@ export class CliTranspiler {
         jsPath: sourceDefaultJsPath,
         jsCandidates: [
           ...(outputFilePath ? [outputFilePath] : []),
-          ...(outputRelStem ? [
-            ext === '.tsx' || ext === '.jsx' ? `${outputRelStem}.jsx` :
-            ext === '.mts' || ext === '.mjs' ? `${outputRelStem}.mjs` :
-            ext === '.cts' || ext === '.cjs' ? `${outputRelStem}.cjs` :
-            `${outputRelStem}.js`,
-          ] : []),
+          ...([outputRelStem, outputRelStemCommon]
+            .filter((stem): stem is string => stem !== null)
+            .map(stem =>
+              ext === '.tsx' || ext === '.jsx' ? `${stem}.jsx` :
+              ext === '.mts' || ext === '.mjs' ? `${stem}.mjs` :
+              ext === '.cts' || ext === '.cjs' ? `${stem}.cjs` :
+              `${stem}.js`,
+            )),
           sourceDefaultJsPath,
           `${stem}.js`,
           `${stem}.jsx`,
@@ -416,11 +474,13 @@ export class CliTranspiler {
         dtsPath: `${stem}.d.ts`,
         dtsCandidates: [
           ...(outputDtsPath ? [outputDtsPath] : []),
-          ...(declarationRelStem ? [
-            `${declarationRelStem}.d.ts`,
-            `${declarationRelStem}.d.mts`,
-            `${declarationRelStem}.d.cts`,
-          ] : []),
+          ...([declarationRelStem, declarationRelStemCommon]
+            .filter((relStem): relStem is string => relStem !== null)
+            .flatMap(relStem => [
+              `${relStem}.d.ts`,
+              `${relStem}.d.mts`,
+              `${relStem}.d.cts`,
+            ])),
           `${stem}.d.ts`,
           `${stem}.d.mts`,
           `${stem}.d.cts`,


### PR DESCRIPTION
Goal: hold

Closes #13496

## Summary

When compilation is driven by an explicit file list with **no tsconfig** and **no explicit `rootDir`**, tsc lays emit output out relative to `getCommonSourceDirectory()` — the longest common directory of the emittable source files — not the cwd. tsz was stripping `base_dir` (the cwd), so `tsz src/a.ts --outDir out` emitted `out/src/a.js` where tsc emits `out/a.js`. Found via differential testing against `tsc` 6.0.2.

## Structural rule

When `rootDir` is unset, `tsc` lays output out relative to `getCommonSourceDirectory()`. For an explicit file list with no tsconfig that is the longest common directory of the emittable (non-`.d.ts`, non-`node_modules`) source files, computed over **all** emittable program files — so a file reached through an import that escapes the root files' directory still contributes to the common root. tsz instead stripped `base_dir` (the cwd), nesting the cwd-relative path under `outDir`.

In project (tsconfig) mode `tsc` 6.0 anchors the layout at the config directory and emits TS5011; tsz already matches that through the emitter's `base_dir` fallback, so this PR leaves project mode untouched.

## Owner layer

CLI driver emit planning. `crates/tsz-cli/src/driver/core_diagnostics.rs` (`compile_inner`) computes the effective root passed into `EmitOutputsContext.root_dir`; the new `emit_common_source_directory` helper sits in `crates/tsz-cli/src/driver/plan.rs` beside the existing `implicit_common_source_directory` (which it reuses). No emitter/solver semantic change — only the implicit root fed to the existing `output_relative_path` layout logic. The allocation happens only in the explicit-file/no-tsconfig branch.

## Adjacent matrix (every row verified against `tsc` 6.0.2)

| Case (`--outDir out`) | tsc | tsz before | tsz after |
|---|---|---|---|
| `src/a.ts` (no tsconfig, no rootDir) | `out/a.js` | `out/src/a.js` | `out/a.js` |
| `src/a.ts src/sub/c.ts` | `out/a.js`, `out/sub/c.js` | nested under `src/` | matches |
| `src/a.ts lib/b.ts` (common = cwd) | `out/src/a.js`, `out/lib/b.js` | same | same |
| `src/a.ts` importing `../lib/b.ts` | `out/src/a.js`, `out/lib/b.js` | `a.js` mis-placed at `out/a.js` | matches |
| explicit `--rootDir .` | `out/src/a.js` | honored | honored |
| project (tsconfig) mode | config-dir layout + TS5011 | matches | matches (unchanged) |
| `node_modules` / `.d.ts` sources | excluded from common dir | n/a | excluded |

## Anti-hardcoding

Structural path computation only — no identifier/file-name/printer-string predicates. Reuses the existing set-theoretic longest-common-directory helper (`implicit_common_source_directory`).

## Verification

- `cargo test -p tsz-cli --lib emit_common_source_directory` — 4 new unit tests pass (single file, longest-common-directory, common-equals-base, node_modules/`.d.ts` exclusion).
- `cargo test -p tsz-cli --lib 'driver::'` — 483 pass; the one pre-existing failure (`project_mode_imported_class_with_then_method_is_promise_like`, a PromiseLike/lib-target issue) fails identically on the base branch (confirmed by A/B stash) and is unrelated.
- Differential vs `tsc` 6.0.2: 6/6 integration cases (above matrix) match output trees; JS/DTS bytes identical on the single-file case.
- `cargo fmt --check`, `cargo clippy -p tsz-cli --lib` (clean), `python3 scripts/arch/arch_guard.py` (passed); no file exceeds the 2000-line cap.
- Broad conformance/emit/fourslash deferred to ready-review CI per repo policy.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01G18zxXAvp8NxPbhAUFGgrT)_