### PR TITLE
fix(conformance): deterministically pin corpus lib dir for local/CI parity (#13400)

### DIFF
--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -438,6 +438,7 @@ run_lint() {
   python3 scripts/ci/test_refresh_readme.py || return $?
   python3 scripts/conformance/test_query_conformance.py || return $?
   python3 scripts/conformance/test_check_accepted_regression_growth.py || return $?
+  python3 scripts/conformance/test_corpus_lib_dir.py || return $?
   python3 scripts/conformance/lib/test_accepted_regressions.py || return $?
   python3 scripts/emit/test_query_emit_families.py || return $?
   # Use the dedicated ci-lint profile (debug=false, incremental=false,

--- a/scripts/conformance/conformance.sh
+++ b/scripts/conformance/conformance.sh
@@ -23,13 +23,10 @@ RUNNER_BIN="$REPO_ROOT/.target/dist-fast/tsz-conformance"
 
 WORKERS=16
 
-# The checked-in TSC cache is generated against the pinned TypeScript
-# checkout's lib files. Point tsz at the same lib directory during
-# conformance runs so fingerprint comparisons use the same source
-# line/column mapping instead of the embedded stripped libs.
-if [ -z "${TSZ_LIB_DIR:-}" ] && [ -d "$REPO_ROOT/TypeScript/lib" ]; then
-    export TSZ_LIB_DIR="$REPO_ROOT/TypeScript/lib"
-fi
+# TSZ_LIB_DIR (the pinned-version lib.*.d.ts set tsz must type-check against so
+# its fingerprints match the cache) is resolved inside run_tests via
+# corpus-lib-dir.sh, after ensure_scripts_deps installs
+# scripts/node_modules/typescript as a fallback (#13400).
 
 # Colors
 GREEN='\033[0;32m'
@@ -404,6 +401,18 @@ EOF
 run_tests() {
     # TypeScript lib files are needed for type checking (resolved via scripts/node_modules/typescript/lib)
     ensure_scripts_deps
+
+    # Pin tsz to the same pinned-version lib.*.d.ts set the cache was generated
+    # against, deterministically, so local and CI produce identical fingerprints
+    # (#13400). Done here (not at script top) so the scripts/node_modules
+    # fallback installed by ensure_scripts_deps above is visible to the resolver.
+    if [ -z "${TSZ_LIB_DIR:-}" ]; then
+        local resolved_lib_dir
+        resolved_lib_dir="$("$REPO_ROOT/scripts/conformance/corpus-lib-dir.sh" --repo-root "$REPO_ROOT")" \
+            || { echo "error: conformance could not resolve the pinned TypeScript lib directory (see above)." >&2; exit 1; }
+        export TSZ_LIB_DIR="$resolved_lib_dir"
+    fi
+    echo "Lib dir: ${TSZ_LIB_DIR}"
 
     echo -e "${GREEN}Running conformance tests...${NC}"
     echo "Cache file: $CACHE_FILE"

--- a/scripts/conformance/corpus-lib-dir.sh
+++ b/scripts/conformance/corpus-lib-dir.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Resolve the corpus lib directory whose built `lib.*.d.ts` files match the
+# pinned TypeScript version recorded in
+# `scripts/conformance/typescript-versions.json` and used to generate
+# `scripts/conformance/tsc-cache-full.json`.
+#
+# Why this exists (#13400):
+# Conformance fingerprints (`file:line:col`) are only stable when tsz
+# type-checks against the EXACT same lib set `tsc` used to produce the cache.
+# When `TSZ_LIB_DIR` is unset, tsz falls back to `default_lib_dir()`
+# auto-discovery, whose candidate priority list is environment-dependent — a
+# stray root `node_modules/typescript/lib` at a different TS version can win
+# over the pinned corpus libs. That made the SAME commit produce different
+# diagnostics locally vs in CI (e.g. tsz resolving `DateTimeFormatPart` locally
+# but not in CI). This resolver removes that ambiguity.
+#
+# It prints the resolved absolute directory to stdout and exits 0, or prints an
+# actionable message to stderr and exits 1 when no pinned-version corpus lib
+# directory is present. The candidates all carry the built `lib.*.d.ts` layout
+# the cache fingerprints expect — `TypeScript/src/lib` is intentionally NOT a
+# candidate, because its files lack the `lib.` prefix and would mismatch every
+# cached fingerprint. All candidates resolve to the same pinned TS version, so
+# whichever exists first yields identical fingerprints; the ordering only fixes
+# WHICH directory is chosen so local and CI agree.
+#
+# Usage:
+#   corpus-lib-dir.sh [--repo-root DIR]
+#
+# A caller-provided `TSZ_LIB_DIR` wins, but it must be an existing directory: a
+# stale override would silently reintroduce the divergence this resolver exists
+# to prevent, so it is rejected with a clear error instead.
+
+set -u
+
+repo_root=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo-root)
+            repo_root="${2:-}"
+            if [ -z "$repo_root" ]; then
+                echo "corpus-lib-dir.sh: --repo-root requires a value" >&2
+                exit 2
+            fi
+            shift 2
+            ;;
+        *)
+            echo "corpus-lib-dir.sh: unknown argument '$1'" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "$repo_root" ]; then
+    repo_root="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)"
+fi
+
+# Explicit override wins — but only if it actually points at a directory.
+if [ -n "${TSZ_LIB_DIR:-}" ]; then
+    if [ -d "$TSZ_LIB_DIR" ]; then
+        printf '%s\n' "$TSZ_LIB_DIR"
+        exit 0
+    fi
+    echo "corpus-lib-dir.sh: TSZ_LIB_DIR is set but is not a directory: $TSZ_LIB_DIR" >&2
+    exit 1
+fi
+
+for candidate in \
+    "$repo_root/TypeScript/built/local" \
+    "$repo_root/TypeScript/lib" \
+    "$repo_root/scripts/node_modules/typescript/lib"; do
+    if [ -d "$candidate" ]; then
+        printf '%s\n' "$candidate"
+        exit 0
+    fi
+done
+
+cat >&2 <<EOF
+corpus-lib-dir.sh: no pinned-version TypeScript lib directory found under
+  $repo_root
+Conformance requires the built lib.*.d.ts set used to generate tsc-cache-full.json.
+Provide one of (checked in this order):
+  - TypeScript/built/local                 (build the pinned submodule)
+  - TypeScript/lib
+  - scripts/node_modules/typescript/lib    (run: cd scripts && npm install)
+or set TSZ_LIB_DIR to that directory explicitly.
+EOF
+exit 1

--- a/scripts/conformance/test_corpus_lib_dir.py
+++ b/scripts/conformance/test_corpus_lib_dir.py
@@ -1,0 +1,129 @@
+"""Tests for `corpus-lib-dir.sh` — the deterministic conformance lib resolver.
+
+Conformance fingerprints only match the checked-in tsc cache when tsz checks
+against the same pinned-version `lib.*.d.ts` set. `corpus-lib-dir.sh` picks that
+directory deterministically so local and CI agree (#13400). These tests pin the
+candidate priority order, the fail-loud behavior, and the `TSZ_LIB_DIR`
+override contract without needing the full TypeScript corpus.
+"""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).with_name("corpus-lib-dir.sh")
+
+
+def run_resolver(repo_root, env_overrides=None):
+    """Invoke the resolver against `repo_root`. Returns (returncode, stdout, stderr)."""
+    env = dict(os.environ)
+    # Start from a clean slate so an ambient TSZ_LIB_DIR can't leak into cases
+    # that mean to leave it unset.
+    env.pop("TSZ_LIB_DIR", None)
+    if env_overrides:
+        env.update(env_overrides)
+    proc = subprocess.run(
+        ["bash", str(SCRIPT_PATH), "--repo-root", str(repo_root)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return proc.returncode, proc.stdout.strip(), proc.stderr
+
+
+def make_dir(root, rel):
+    path = Path(root) / rel
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+class CorpusLibDirTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_prefers_built_local(self):
+        built = make_dir(self.root, "TypeScript/built/local")
+        # Lower-priority candidates also present; built/local must still win.
+        make_dir(self.root, "TypeScript/lib")
+        make_dir(self.root, "scripts/node_modules/typescript/lib")
+        code, out, _ = run_resolver(self.root)
+        self.assertEqual(code, 0)
+        self.assertEqual(out, str(built))
+
+    def test_falls_back_to_typescript_lib(self):
+        lib = make_dir(self.root, "TypeScript/lib")
+        make_dir(self.root, "scripts/node_modules/typescript/lib")
+        code, out, _ = run_resolver(self.root)
+        self.assertEqual(code, 0)
+        self.assertEqual(out, str(lib))
+
+    def test_falls_back_to_scripts_node_modules(self):
+        scripts_lib = make_dir(self.root, "scripts/node_modules/typescript/lib")
+        code, out, _ = run_resolver(self.root)
+        self.assertEqual(code, 0)
+        self.assertEqual(out, str(scripts_lib))
+
+    def test_ignores_stray_root_node_modules(self):
+        # A root node_modules/typescript at an arbitrary version is the exact
+        # divergence source from #13400: it must NOT be selected. With no real
+        # corpus candidate present, the resolver fails loudly instead.
+        make_dir(self.root, "node_modules/typescript/lib")
+        code, out, err = run_resolver(self.root)
+        self.assertEqual(code, 1, msg=err)
+        self.assertEqual(out, "")
+        self.assertIn("no pinned-version TypeScript lib directory", err)
+
+    def test_fails_loudly_when_nothing_present(self):
+        code, out, err = run_resolver(self.root)
+        self.assertEqual(code, 1)
+        self.assertEqual(out, "")
+        # Message is actionable: it names the three candidates and the npm hint.
+        self.assertIn("TypeScript/built/local", err)
+        self.assertIn("scripts/node_modules/typescript/lib", err)
+        self.assertIn("cd scripts && npm install", err)
+
+    def test_does_not_select_src_lib(self):
+        # src/lib uses the unprefixed `es2021.intl.d.ts` layout and would
+        # mismatch every cached `lib.*.d.ts` fingerprint, so it is not a
+        # candidate even when it is the only TypeScript dir present.
+        make_dir(self.root, "TypeScript/src/lib")
+        code, _, err = run_resolver(self.root)
+        self.assertEqual(code, 1, msg=err)
+
+    def test_explicit_override_wins(self):
+        override = make_dir(self.root, "custom-lib")
+        # built/local is present but the explicit override must take precedence.
+        make_dir(self.root, "TypeScript/built/local")
+        code, out, _ = run_resolver(
+            self.root, env_overrides={"TSZ_LIB_DIR": str(override)}
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(out, str(override))
+
+    def test_stale_override_is_rejected(self):
+        # A TSZ_LIB_DIR pointing at a missing path must fail loudly rather than
+        # silently falling back (which would reintroduce the divergence).
+        code, out, err = run_resolver(
+            self.root,
+            env_overrides={"TSZ_LIB_DIR": str(self.root / "does-not-exist")},
+        )
+        self.assertEqual(code, 1)
+        self.assertEqual(out, "")
+        self.assertIn("not a directory", err)
+
+    def test_rejects_unknown_argument(self):
+        proc = subprocess.run(
+            ["bash", str(SCRIPT_PATH), "--bogus"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("unknown argument", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Goal: hold

Closes #13400.

## Problem

Conformance diagnostics diverged between local runs and CI **on the same commit**: `temporal.ts` reported two `Cannot find name 'DateTimeFormatPart'` diagnostics as *missing* locally while passing in CI.

Root cause (confirmed by code archaeology, not yet reproduced end-to-end in this cloud container — see Verification caveat): the checked-in `tsc-cache-full.json` is pinned to **TypeScript 6.0.3** and its fingerprints reference the built `lib.*.d.ts` layout (`lib.es2021.intl.d.ts`, …). `conformance.sh` only pinned `TSZ_LIB_DIR` when `TypeScript/lib` existed — a directory absent in **both** environments:

- CI builds `TypeScript/built/local`;
- a typical local checkout has only `scripts/node_modules/typescript/lib` (installed by `ensure_scripts_deps`), plus possibly a stray root `node_modules/typescript` at a *different* TS version.

So `TSZ_LIB_DIR` stayed unset and tsz fell through to `default_lib_dir()` / `lib_dir_from_root` auto-discovery (`crates/tsz-core/src/config/lib_resolution.rs`), whose candidate priority list is environment-dependent: a stray root `node_modules/typescript/lib` (#3) wins over `scripts/node_modules/typescript/lib` (#4). A newer TS there resolves `DateTimeFormatPart` differently, so the same commit produced different diagnostics locally vs in CI. (`TypeScript/src/lib` cannot be the CI source — its unprefixed `es2021.intl.d.ts` filenames would mismatch the cache's `lib.es2021.intl.d.ts` fingerprints.)

## Structural rule

When conformance runs, tsz must type-check against the *exact* pinned-version `lib.*.d.ts` set the tsc cache was generated against — deterministically, independent of incidentally-present `node_modules` installs — or fingerprints diverge. The harness owns that contract; it must pin it explicitly and fail loudly rather than silently inheriting an environment-dependent auto-discovery result.

## Owner layer

Conformance harness, not the compiler. `default_lib_dir()` is intentionally general (dev / standalone / emit / bench flows legitimately want root-`node_modules` or embedded libs), so the determinism belongs at the harness boundary via `TSZ_LIB_DIR`, the existing override the compiler already honors.

## Change

- New `scripts/conformance/corpus-lib-dir.sh`: resolves the corpus lib dir to the first existing of `TypeScript/built/local` → `TypeScript/lib` → `scripts/node_modules/typescript/lib` (all the same pinned version; ordering only fixes *which* is chosen so local and CI agree). Honors an explicit `TSZ_LIB_DIR` (must be an existing dir, else rejected), and **fails loudly** with an actionable message when no candidate exists instead of letting tsz auto-discover a mismatched set. `src/lib` is deliberately excluded.
- `scripts/conformance/conformance.sh`: resolves + exports `TSZ_LIB_DIR` inside `run_tests` after `ensure_scripts_deps` (so the `scripts/node_modules` fallback is visible), replacing the fragile `[ -d TypeScript/lib ]` guard.
- `scripts/conformance/test_corpus_lib_dir.py`: 9 unit tests pinning candidate priority, the stray-root-`node_modules` exclusion (the #13400 divergence source), `src/lib` exclusion, fail-loud messaging, and the override contract. Wired into `scripts/ci/gcp-full-ci.sh`'s lint test list.

This mirrors CI's current auto-discovery pick (`built/local`/`scripts/node_modules`, both 6.0.3) → **no CI behavior change** → conformance stays green, while making local `@lib`-directive runs reproducible.

## Verification

- `python3 scripts/conformance/test_corpus_lib_dir.py` → 9 passed.
- `bash -n` on `conformance.sh`, `corpus-lib-dir.sh`, `gcp-full-ci.sh` → clean.
- Resolver against a fresh checkout with no corpus libs → exits 1 with the actionable message (fail-loud verified).
- CI-simulation: with a fixture `TypeScript/built/local` present, resolver selects it first (CI no-op confirmed).
- `conformance.sh --help` no longer triggers lib resolution (moved out of script top).
- Caveat: the full `temporal.ts` narrow filter (`conformance.sh run --filter compiler/temporal`) requires the pinned TypeScript corpus + a dist-fast build, which aren't provisioned in this container; the ready-review conformance gate exercises it end-to-end.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDMXz13RK2Ghh8jZbS3ibH)_