### PR TITLE
fix(checker): resolve value lazy refs for relation prep

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -1670,6 +1670,13 @@ impl<'a> CheckerState<'a> {
                             })
                     })
                     .unwrap_or_else(|| self.get_type_of_symbol(sym_id))
+            } else if symbol.has_any_flags(symbol_flags::VARIABLE) {
+                // `typeof value` can be represented as a Lazy(value DefId) once it
+                // flows through aliases/mapped types instead of as a direct
+                // TypeQuery(SymbolRef). Relation prep must register the value-space
+                // type for that DefId so solver-side mapped/keyof evaluation does not
+                // classify the unresolved Lazy as a non-object.
+                self.type_of_value_declaration_for_symbol(sym_id, symbol.value_declaration)
             } else {
                 self.get_type_of_symbol(sym_id)
             }

--- a/crates/tsz-checker/src/state/type_environment/lazy.rs
+++ b/crates/tsz-checker/src/state/type_environment/lazy.rs
@@ -1670,12 +1670,17 @@ impl<'a> CheckerState<'a> {
                             })
                     })
                     .unwrap_or_else(|| self.get_type_of_symbol(sym_id))
-            } else if symbol.has_any_flags(symbol_flags::VARIABLE) {
+            } else if symbol.has_any_flags(symbol_flags::VARIABLE)
+                && !symbol.has_any_flags(symbol_flags::TYPE)
+            {
                 // `typeof value` can be represented as a Lazy(value DefId) once it
                 // flows through aliases/mapped types instead of as a direct
                 // TypeQuery(SymbolRef). Relation prep must register the value-space
-                // type for that DefId so solver-side mapped/keyof evaluation does not
-                // classify the unresolved Lazy as a non-object.
+                // type for value-only DefIds so solver-side mapped/keyof evaluation
+                // does not classify the unresolved Lazy as a non-object. Merged
+                // interface/var symbols still have type-space meaning, so bare type
+                // references like `HTMLDivElement` must continue resolving to the
+                // instance type instead of the constructor value.
                 self.type_of_value_declaration_for_symbol(sym_id, symbol.value_declaration)
             } else {
                 self.get_type_of_symbol(sym_id)

--- a/crates/tsz-checker/tests/mapped_keyof_index_access_tests.rs
+++ b/crates/tsz-checker/tests/mapped_keyof_index_access_tests.rs
@@ -13,6 +13,7 @@
 
 use tsz_checker::context::CheckerOptions;
 use tsz_checker::diagnostics::Diagnostic;
+use tsz_common::common::ModuleKind;
 
 fn check_strict(source: &str) -> Vec<Diagnostic> {
     let lib_files = tsz_checker::test_utils::load_lib_files(&["es5.d.ts"]);
@@ -35,6 +36,90 @@ fn has_code(diags: &[Diagnostic], code: u32) -> bool {
 
 const fn no_errors(diags: &[Diagnostic]) -> bool {
     diags.is_empty()
+}
+
+/// A `typeof value` alias whose value type was inferred must stay resolvable
+/// when a mapped/keyof type is evaluated inside a relation path.
+///
+/// Before #13484, relation-driven mapped evaluation saw `V = typeof lit` as an
+/// unresolved value-symbol `Lazy(DefId)`, classified it as a non-object, and
+/// collapsed the mapped property body to `error`.
+#[test]
+fn mapped_keyof_typeof_inferred_value_resolves_in_relation_path() {
+    let diagnostics = tsz_checker::test_utils::check_multi_file_with_global_index(
+        &[
+            (
+                "/node_modules/vlib/index.d.ts",
+                r#"
+export interface Validator<T> { (props: object): any; brand?: T; }
+export interface Requireable<T> extends Validator<T> { isRequired: Validator<T & {}>; }
+export declare const str: Requireable<string>;
+"#,
+            ),
+            (
+                "file.ts",
+                r#"
+import * as P from "vlib";
+const lit = { str: P.str.isRequired };
+type V = typeof lit;
+type Mc = { [K in keyof V]: V[K] extends P.Validator<any> ? K : never };
+const ok: { str: "str" } = (null as any as Mc);
+"#,
+            ),
+        ],
+        "file.ts",
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            module: ModuleKind::CommonJS,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        no_errors(&diagnostics),
+        "expected inferred typeof mapped keys to resolve without diagnostics, got: {diagnostics:#?}"
+    );
+}
+
+/// Same structure with renamed binders and an explicit negative assignment so
+/// the test is not tied to the original repro's property/type-parameter names.
+#[test]
+fn mapped_keyof_typeof_inferred_value_resolves_with_renamed_binders() {
+    let diagnostics = tsz_checker::test_utils::check_multi_file_with_global_index(
+        &[
+            (
+                "/node_modules/vlib/index.d.ts",
+                r#"
+export interface CheckBox<T> { (props: object): any; marker?: T; }
+export interface Needed<T> extends CheckBox<T> { must: CheckBox<T & {}>; }
+export declare const title: Needed<string>;
+"#,
+            ),
+            (
+                "consumer.ts",
+                r#"
+import * as Q from "vlib";
+const shape = { title: Q.title.must };
+type ShapeType = typeof shape;
+type Picked = { [Field in keyof ShapeType]: ShapeType[Field] extends Q.CheckBox<any> ? Field : never };
+const bad: { title: "other" } = (null as any as Picked);
+"#,
+            ),
+        ],
+        "consumer.ts",
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            module: ModuleKind::CommonJS,
+            ..CheckerOptions::default()
+        },
+    );
+
+    assert!(
+        has_code(&diagnostics, 2322),
+        "expected TS2322 for the wrong literal target, got: {diagnostics:#?}"
+    );
 }
 
 // ============================================================================

--- a/crates/tsz-checker/tests/mapped_keyof_index_access_tests.rs
+++ b/crates/tsz-checker/tests/mapped_keyof_index_access_tests.rs
@@ -122,6 +122,26 @@ const bad: { title: "other" } = (null as any as Picked);
     );
 }
 
+/// Merged interface/constructor symbols carry value flags for `typeof`, but a
+/// bare type reference must still resolve to the instance side in relation prep.
+#[test]
+fn merged_interface_var_type_reference_stays_instance_in_relation_path() {
+    let diagnostics = check_strict(
+        r#"
+interface ElementLike { innerHTML: string; }
+declare var ElementLike: { new (): ElementLike; prototype: ElementLike };
+type Mirror<T> = { [K in keyof T]: T[K] };
+declare const node: Mirror<ElementLike>;
+node.innerHTML = "";
+"#,
+    );
+
+    assert!(
+        no_errors(&diagnostics),
+        "expected merged interface/var type reference to stay instance-shaped, got: {diagnostics:#?}"
+    );
+}
+
 // ============================================================================
 // Core: mapped-type keyof index access evaluates to the template
 // ============================================================================


### PR DESCRIPTION
Goal: green

## Summary
- Resolve variable-backed value `Lazy(DefId)` refs through the value-declaration path during relation input preparation.
- This lets relation-driven mapped/keyof evaluation resolve `typeof <inferred value>` aliases instead of treating the unresolved lazy value ref as a non-object and collapsing mapped bodies to `error`.
- Add two mapped/keyof regression witnesses covering the #8432/#13484 two-file shape plus renamed binders and a negative literal assignment.

## Structural rule
When a relation or assignability path evaluates a mapped/keyof type whose source is `typeof <value-symbol>` represented as a value-symbol `Lazy(DefId)`, `tsc` resolves the inferred value object before collecting keys/properties. tsz now resolves that value `DefId` through the checker-owned value-declaration resolver and registers it in the relation `TypeEnvironment`, so solver object collection sees the object shape rather than an unresolved lazy non-object.

Owner layer: checker query-boundary/type-environment preparation for relation inputs; solver `collect_properties` remains structural and does not special-case fixture names, property names, or rendered diagnostics.

## Adjacent matrix
- Positive: imported validator module, inferred object `lit`, `type V = typeof lit`, mapped conditional over `keyof V` assigns to `{ str: "str" }` without diagnostics.
- Renamed binders: same shape with `shape`, `ShapeType`, `Field`, and `CheckBox`/`Needed` names.
- Negative/fallback: renamed case assigns `Picked` to the wrong literal target and should still report TS2322 instead of being broadly accepted.
- Fallback invariant: class/interface lazy resolution stays on the existing instance-type branch; only variable-backed value lazy refs use the value-declaration resolver.

## Verification
- Not run locally per user instruction.
- Pre-commit formatting hook ran during commit `a8528e22cb`.
- GitHub draft/light CI passed for head `a8528e22cbfec742c422bf8b3f92cf03c2734046`, including `CI Light Summary`, `lint`, `unit`, `unit-checker-integration`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `premerge-microbench`.
- Ready-review CI is expected to run the broader conformance/project/emit gates.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
