### PR TITLE
perf(solver): use a visited set in exact containment

### DIFF
--- a/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
+++ b/crates/tsz-solver/src/visitors/visitor_predicates/content.rs
@@ -393,18 +393,17 @@ pub fn contains_type_by_id(types: &dyn TypeDatabase, root: TypeId, target: TypeI
     if root == target {
         return true;
     }
-    let mut visited = FxHashMap::default();
+    let mut visited = FxHashSet::default();
     let mut stack = vec![root];
     while let Some(current) = stack.pop() {
         if current == target {
             return true;
         }
-        if visited.contains_key(&current) {
+        if !visited.insert(current) {
             continue;
         }
-        visited.insert(current, true);
         crate::visitors::visitor::for_each_child_by_id(types, current, |child| {
-            if !visited.contains_key(&child) {
+            if !visited.contains(&child) {
                 stack.push(child);
             }
         });


### PR DESCRIPTION
Goal: fast

## Summary
- Replace the exact `contains_type_by_id` traversal's `FxHashMap<TypeId, bool>` visited table with an `FxHashSet<TypeId>`.
- The walk only needs membership, so this removes dummy boolean writes and narrows per-node visited storage in a predicate used by conditional/generic evaluation paths.
- This is a small #8356 residue slice after the recent query-backed inference and conditional-application allocation PRs.

## Performance invariant
The semantic question is unchanged: `contains_type_by_id(root, target)` returns true iff `target` is reachable from `root` through `for_each_child_by_id`. The traversal order, early target check, and child-pruning logic are preserved; only the operation-local visited representation changes from map membership to set membership. Cache/request scope is unchanged: evaluator-local `cached_contains_type_by_id(root, target)` still owns cross-call reuse.

## Adjacent matrix
- Direct hit: `root == target` still returns immediately without allocating visited state.
- Recursive miss/hit: visited membership still prevents revisiting cycles/shared subgraphs.
- Conditional distribution path: branch substitution gating still calls the same evaluator-local cache before this raw walker.
- Fallback: no shared/global cache is added, so there is no invalidation or cross-interner identity risk.

## Verification
- Not run locally per user instruction.
- Pre-commit formatting hook ran during commit `4312bd64c4`.
- Branch synced with current `origin/main` before push; pushed head `d3caf8f93863276b4f2b2e932985e0744dcc1737`.
- GitHub draft/light CI passed for head `d3caf8f93863276b4f2b2e932985e0744dcc1737`, including `CI Light Summary`, `lint`, `unit`, `unit-checker-integration`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `premerge-microbench`.
- Ready-review CI is expected to run broader gates after this PR leaves draft.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
