### PR TITLE
fix(tsz-lsp): remove fixture-scoped dob/Date hover string-surgery hack (#13442)

### DIFF
--- a/crates/tsz-lsp/src/hover/core.rs
+++ b/crates/tsz-lsp/src/hover/core.rs
@@ -888,7 +888,6 @@ impl<'a> HoverProvider<'a> {
             {
                 type_string = array_type;
             }
-            type_string = self.rewrite_date_constructor_error_types(decl_node_idx, type_string);
             type_string = format::format_hover_variable_type(&type_string);
             let keyword = self.get_variable_keyword(decl_node_idx);
             if self.is_local_variable(decl_node_idx) {
@@ -922,7 +921,6 @@ impl<'a> HoverProvider<'a> {
             {
                 type_string = array_type;
             }
-            type_string = self.rewrite_date_constructor_error_types(decl_node_idx, type_string);
             type_string = format::format_hover_variable_type(&type_string);
             if self.is_parameter_declaration(decl_node_idx) {
                 return format!("(parameter) {display_name}: {type_string}");
@@ -1417,20 +1415,6 @@ impl<'a> HoverProvider<'a> {
         }
 
         Some("any[]".to_string())
-    }
-
-    fn rewrite_date_constructor_error_types(
-        &self,
-        decl_node_idx: NodeIndex,
-        type_string: String,
-    ) -> String {
-        if !type_string.contains("dob: error")
-            || !self.source_text.contains("new Date(")
-            || !decl_node_idx.is_some()
-        {
-            return type_string;
-        }
-        type_string.replace("dob: error", "dob: Date")
     }
 
     /// Get the tsserver-compatible kind string for the symbol.

--- a/crates/tsz-lsp/tests/hover_tests.rs
+++ b/crates/tsz-lsp/tests/hover_tests.rs
@@ -351,13 +351,77 @@ fn test_hover_union_array_precedence_preserved() {
     );
 }
 
+/// Hover infrastructure helper that loads `lib_source` as an ambient lib file so
+/// constructor-return inference (`new Date()` -> `Date`) resolves through the real
+/// checker, not a display-layer string patch.
+fn get_hover_at_with_lib(lib_source: &str, source: &str, line: u32, col: u32) -> Option<HoverInfo> {
+    let lib = Arc::new(LibFile::from_source(
+        "lib.test.d.ts".to_string(),
+        lib_source.to_string(),
+    ));
+    let mut parser = ParserState::new("test.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+
+    let mut binder = BinderState::new();
+    binder.bind_source_file_with_libs(parser.get_arena(), root, &[Arc::clone(&lib)]);
+
+    let interner = TypeInterner::new();
+    let line_map = LineMap::build(source);
+    let lib_contexts = vec![LibContext {
+        arena: Arc::clone(&lib.arena),
+        binder: Arc::clone(&lib.binder),
+    }];
+    let provider = HoverProvider::with_options_and_lib_contexts(
+        parser.get_arena(),
+        &binder,
+        &line_map,
+        &interner,
+        source,
+        "test.ts".to_string(),
+        FullProviderOptions {
+            strict: true,
+            sound_mode: false,
+            checker_options: None,
+            lib_contexts: &lib_contexts,
+        },
+    );
+
+    let mut cache = None;
+    provider.get_hover(root, Position::new(line, col), &mut cache)
+}
+
+/// Minimal `Date`/`DateConstructor` ambient lib so `new Date()` resolves its
+/// construct-signature return type through the real checker.
+const DATE_LIB: &str = "interface Date { getTime(): number; }\ninterface DateConstructor { new (): Date; }\ndeclare var Date: DateConstructor;";
+
 #[test]
-fn test_hover_date_constructor_rewrites_error_property_type() {
+fn test_hover_constructor_return_property_type_infers_through_checker() {
+    // `new Date()` infers `Date` from the `DateConstructor` `new()` signature.
+    // The hover type string flows from the real checker (`format_type`), so the
+    // member must render `Date` structurally — no display-layer string surgery.
     let source = "var a2 = { name: 'bob', age: 18, address: 'springfield' };\nvar b2 = { name: 'jim', age: 20, dob: new Date() };\nvar c2 = [a2, b2];\nc2;";
-    let info = get_hover_at(source, 3, 0).expect("Should find hover info for c2");
+    let info =
+        get_hover_at_with_lib(DATE_LIB, source, 3, 0).expect("Should find hover info for c2");
     assert!(
         info.display_string.contains("dob: Date"),
-        "Quick-info display should normalize constructor-based error property type to Date, got: {}",
+        "Constructor-return inference should render the property type as Date, got: {}",
+        info.display_string
+    );
+}
+
+#[test]
+fn test_hover_constructor_return_property_type_is_not_keyed_to_dob() {
+    // The deleted string-surgery hack only rewrote the literal `dob: error`.
+    // Using a different property name (`created`) for `new Date()` proves the
+    // member now renders `Date` through real constructor-return inference rather
+    // than a name-keyed display patch. p1/p2 carry distinct extra members
+    // (label vs created) so union subtype-reduction keeps both element members.
+    let source = "var p1 = { name: 'bob', age: 18, label: 'home' };\nvar p2 = { name: 'jim', age: 20, created: new Date() };\nvar items = [p1, p2];\nitems;";
+    let info =
+        get_hover_at_with_lib(DATE_LIB, source, 3, 0).expect("Should find hover info for items");
+    assert!(
+        info.display_string.contains("created: Date"),
+        "Constructor-return inference should render the property type as Date for a non-`dob` member, got: {}",
         info.display_string
     );
 }


### PR DESCRIPTION
Goal: hold

Closes #13442.

## Summary
Removes the `rewrite_date_constructor_error_types` hover helper, an anti-hardcoding-gate violation that patched rendered type text by literally `replace`-ing `"dob: error"` with `"dob: Date"`, gated on the source containing `"new Date("`. It keyed compiler output on a user-chosen identifier (`dob`), ran `contains`/`replace` over type-printer output, and inspected a raw source-text substring — all to green a single hover test, while masking the real behavior and silently corrupting any legitimate member that genuinely renders `dob: error`.

## Structural rule
When a hover renders a variable's type, tsz computes the displayed string from the real checker (`checker.format_type`, `crates/tsz-lsp/src/hover/core.rs:154`); the property type of `new Date()` must come from the `DateConstructor` `new()` construct-signature return type through normal inference, not from a display-layer string patch. The sole exerciser test set up the checker with **no lib files**, so `Date`/`DateConstructor` were genuinely undefined and `new Date()` correctly resolved to `error` — the hack then faked `Date`.

Owner layer: `tsz-lsp` hover display. No solver/checker change was needed — constructor-return inference already produces `Date` once the ambient lib is present; the hover was only ever wrong because the test ran without a lib.

## Changes
- Delete `rewrite_date_constructor_error_types` and both call sites (`BLOCK_SCOPED_VARIABLE` and `FUNCTION_SCOPED_VARIABLE` paths).
- Rewrite the test to load a minimal `Date`/`DateConstructor` ambient lib (same `LibFile`/`with_options_and_lib_contexts` pattern as `test_hover_global_from_lib_uses_lib_context_type`) so the member renders `Date` through real inference.
- No replacement rendered-text predicate.

## Adjacent matrix
- Positive: `{ dob: new Date() }` in a nested array-of-union renders `dob: Date` via real inference (`test_hover_constructor_return_property_type_infers_through_checker`).
- Structural / not name-keyed: the same `new Date()` under a different property name (`created`) — which the deleted hack only ever matched as the literal `dob: error` — still renders `created: Date` (`test_hover_constructor_return_property_type_is_not_keyed_to_dob`).
- Fallback unchanged: the structurally-driven `array_constructor_initializer_display_type` path (gated on `type_string == "error"`, no identifier key) is left intact per the issue scope.

## Verification
- `cargo test -p tsz-lsp --lib hover::hover_tests` -> 125 passed, 0 failed.
- `cargo clippy -p tsz-lsp --all-targets -- -D warnings` -> clean.
- `cargo fmt -p tsz-lsp -- --check` -> clean.
- `rg rewrite_date_constructor_error_types crates/` -> no remaining callers.
- Rebased onto `origin/main` (`379d5de`); no conflicts.
- Ready-review CI owns the broader gates.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: low

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3sVRGqV3NAP2rT46B8DUD)_