### PR TITLE
refactor(parser): dedupe identifier text reader and drop dead IdentifierData.type_arguments (#13055)

### DIFF
--- a/crates/tsz-core/src/parallel/lib_snapshot.rs
+++ b/crates/tsz-core/src/parallel/lib_snapshot.rs
@@ -57,7 +57,7 @@ use tsz_parser::parser::node::NodeArena;
 
 /// Magic header. Trailing byte is the format version. Bump on layout
 /// changes that break round-trip.
-const SNAPSHOT_MAGIC: &[u8; 8] = b"TSZSNAP\x06";
+const SNAPSHOT_MAGIC: &[u8; 8] = b"TSZSNAP\x07";
 
 /// Environment variable that controls the lib snapshot cache.
 const ENV_VAR: &str = "TSZ_LIB_CACHE";

--- a/crates/tsz-emitter/src/declaration_emitter/exports/parameters_and_heritage.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/exports/parameters_and_heritage.rs
@@ -1103,12 +1103,12 @@ impl<'a> DeclarationEmitter<'a> {
             return false;
         };
         if self.get_identifier_text(type_idx).as_deref() == Some("Array")
-            && let Some(identifier) = self.arena.get_identifier(type_node)
+            && self.arena.get_identifier(type_node).is_some()
         {
-            return identifier
-                .type_arguments
-                .as_ref()
-                .is_none_or(|args| args.nodes.is_empty());
+            // A bare `Array` identifier reference carries no type arguments of
+            // its own (those live on the surrounding type-reference node), so
+            // an identifier-only `Array` is always argument-free here.
+            return true;
         }
 
         let Some(expr) = self.arena.get_expr_type_args(type_node) else {

--- a/crates/tsz-parser/src/parser/node.rs
+++ b/crates/tsz-parser/src/parser/node.rs
@@ -209,7 +209,6 @@ pub struct IdentifierData {
     /// The identifier text (DEPRECATED: kept for backward compatibility during migration)
     pub escaped_text: String,
     pub original_text: Option<String>,
-    pub type_arguments: Option<NodeList>,
 }
 
 /// Data for string literals (`StringLiteral`, template parts)

--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -1682,7 +1682,6 @@ mod is_missing_recovery_identifier_tests {
                 atom: AstAtom::NONE,
                 escaped_text: String::new(),
                 original_text: None,
-                type_arguments: None,
             },
         );
         assert!(arena.is_missing_recovery_identifier(idx));
@@ -1701,7 +1700,6 @@ mod is_missing_recovery_identifier_tests {
                 atom: AstAtom(1),
                 escaped_text: "foo".to_string(),
                 original_text: None,
-                type_arguments: None,
             },
         );
         assert!(!arena.is_missing_recovery_identifier(idx));
@@ -1718,7 +1716,6 @@ mod is_missing_recovery_identifier_tests {
                 atom: AstAtom(1),
                 escaped_text: String::new(),
                 original_text: None,
-                type_arguments: None,
             },
         );
         assert!(!arena.is_missing_recovery_identifier(idx));
@@ -1735,7 +1732,6 @@ mod is_missing_recovery_identifier_tests {
                 atom: AstAtom::NONE,
                 escaped_text: "x".to_string(),
                 original_text: None,
-                type_arguments: None,
             },
         );
         assert!(!arena.is_missing_recovery_identifier(idx));

--- a/crates/tsz-parser/src/parser/node_arena/mod.rs
+++ b/crates/tsz-parser/src/parser/node_arena/mod.rs
@@ -327,7 +327,6 @@ mod tests {
             atom: stale_atom,
             escaped_text: "uniquely_named_identifier".to_string(),
             original_text: None,
-            type_arguments: None,
         };
 
         assert_eq!(
@@ -361,7 +360,6 @@ mod tests {
             // can confirm which branch was taken.
             escaped_text: "stale_escaped_form".to_string(),
             original_text: None,
-            type_arguments: None,
         };
 
         assert_eq!(arena.resolve_identifier_text(&data), "stale_escaped_form");

--- a/crates/tsz-parser/src/parser/speculation.rs
+++ b/crates/tsz-parser/src/parser/speculation.rs
@@ -171,7 +171,6 @@ mod tests {
             atom: AstAtom::NONE,
             escaped_text: text.to_string(),
             original_text: None,
-            type_arguments: None,
         }
     }
 

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -810,7 +810,6 @@ impl ParserState {
                 atom: AstAtom::NONE,
                 escaped_text: recovered,
                 original_text: None,
-                type_arguments: None,
             },
         )
     }

--- a/crates/tsz-parser/src/parser/state_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_declarations.rs
@@ -117,7 +117,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             )
         } else {
@@ -1227,7 +1226,6 @@ impl ParserState {
                     atom,
                     escaped_text: text,
                     original_text: None,
-                    type_arguments: None,
                 },
             )
         } else if self.is_token(SyntaxKind::NumericLiteral) {
@@ -1251,7 +1249,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             )
         } else {
@@ -1391,7 +1388,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             );
         }

--- a/crates/tsz-parser/src/parser/state_declarations_modules.rs
+++ b/crates/tsz-parser/src/parser/state_declarations_modules.rs
@@ -36,7 +36,6 @@ impl ParserState {
                     atom: self.scanner.interner_mut().intern("global"),
                     escaped_text: "global".to_string(),
                     original_text: None,
-                    type_arguments: None,
                 },
             )
         } else {
@@ -61,7 +60,6 @@ impl ParserState {
                         atom: AstAtom::NONE,
                         escaped_text: String::new(),
                         original_text: None,
-                        type_arguments: None,
                     },
                 )
             } else if self.is_token(SyntaxKind::StringLiteral) {
@@ -87,7 +85,6 @@ impl ParserState {
                         atom: AstAtom::NONE,
                         escaped_text: String::new(),
                         original_text: None,
-                        type_arguments: None,
                     },
                 )
             } else {
@@ -135,7 +132,6 @@ impl ParserState {
                             atom: AstAtom::NONE,
                             escaped_text: String::new(),
                             original_text: None,
-                            type_arguments: None,
                         },
                     )
                 } else {
@@ -216,7 +212,6 @@ impl ParserState {
                     atom: self.scanner.interner_mut().intern("global"),
                     escaped_text: "global".to_string(),
                     original_text: None,
-                    type_arguments: None,
                 },
             )
         } else {
@@ -241,7 +236,6 @@ impl ParserState {
                         atom: AstAtom::NONE,
                         escaped_text: String::new(),
                         original_text: None,
-                        type_arguments: None,
                     },
                 )
             } else if self.is_token(SyntaxKind::StringLiteral) {
@@ -267,7 +261,6 @@ impl ParserState {
                         atom: AstAtom::NONE,
                         escaped_text: String::new(),
                         original_text: None,
-                        type_arguments: None,
                     },
                 )
             } else {
@@ -302,7 +295,6 @@ impl ParserState {
                             atom: AstAtom::NONE,
                             escaped_text: String::new(),
                             original_text: None,
-                            type_arguments: None,
                         },
                     )
                 } else {
@@ -936,7 +928,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             )
         } else {
@@ -1175,7 +1166,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             );
         }
@@ -1190,7 +1180,6 @@ impl ParserState {
                 atom: AstAtom::NONE,
                 escaped_text: String::new(),
                 original_text: None,
-                type_arguments: None,
             },
         )
     }

--- a/crates/tsz-parser/src/parser/state_exports_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_exports_recovery.rs
@@ -220,7 +220,6 @@ impl ParserState {
                     atom: tsz_common::interner::AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             )
         } else {

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -113,7 +113,6 @@ impl ParserState {
                                 atom: AstAtom::NONE,
                                 escaped_text: String::new(),
                                 original_text: None,
-                                type_arguments: None,
                             },
                         )
                     } else {

--- a/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
@@ -1111,7 +1111,6 @@ impl ParserState {
                                 atom: self.scanner.interner_mut().intern(""),
                                 escaped_text: String::new(),
                                 original_text: None,
-                                type_arguments: None,
                             },
                         );
                     }
@@ -1151,7 +1150,6 @@ impl ParserState {
                         atom,
                         escaped_text: text,
                         original_text,
-                        type_arguments: None,
                     },
                 )
             }

--- a/crates/tsz-parser/src/parser/state_expressions_literals_object.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals_object.rs
@@ -128,7 +128,6 @@ impl ParserState {
                 atom,
                 escaped_text: String::new(),
                 original_text: None,
-                type_arguments: None,
             },
         )
     }

--- a/crates/tsz-parser/src/parser/state_expressions_tail.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_tail.rs
@@ -70,7 +70,6 @@ impl ParserState {
                 atom: AstAtom::NONE,
                 escaped_text: String::from("#"),
                 original_text: None,
-                type_arguments: None,
             },
         )
     }
@@ -88,7 +87,6 @@ impl ParserState {
                 atom: AstAtom::NONE,
                 escaped_text: String::from("#"),
                 original_text: None,
-                type_arguments: None,
             },
         )
     }
@@ -756,6 +754,42 @@ impl ParserState {
         }
     }
 
+    /// Read the cooked text of the current identifier/keyword token and advance
+    /// past it. Returns the interned `atom`, the identifier `text`, and the
+    /// `original_text` source slice when the scanner detected unicode escapes
+    /// (tsc preserves escape sequences in emitted identifiers).
+    ///
+    /// The caller must have already verified [`Self::is_identifier_or_keyword`].
+    /// Shared by [`Self::parse_identifier`] and [`Self::parse_identifier_name`]
+    /// so identifier text/escape handling stays a single source of truth.
+    #[inline]
+    fn read_cooked_identifier_text(&mut self) -> (AstAtom, String, Option<String>) {
+        // OPTIMIZATION: Capture atom for O(1) comparison
+        let atom = self.scanner.get_token_atom();
+        let has_unicode_escape =
+            (self.scanner.get_token_flags() & TokenFlags::UnicodeEscape as u32) != 0;
+        let src = self.scanner.source_text();
+        let start = self.scanner.get_token_start();
+        let end = self.scanner.get_token_end();
+        let source_slice = (start < end && end <= src.len()).then(|| &src[start..end]);
+
+        // Without escapes the raw source slice is the cooked text; otherwise
+        // fall back to the scanner's already-cooked token value.
+        let text = match source_slice {
+            Some(slice) if !has_unicode_escape => slice.to_string(),
+            _ => self.scanner.get_token_value_ref().to_string(),
+        };
+        // tsc preserves unicode escape sequences in emitted identifiers: when the
+        // scanner detected escapes, keep the original source slice if it differs
+        // from the cooked text.
+        let original_text = match source_slice {
+            Some(slice) if has_unicode_escape && slice != text => Some(slice.to_string()),
+            _ => None,
+        };
+        self.next_token();
+        (atom, text, original_text)
+    }
+
     // Parse identifier
     // Uses zero-copy accessor and only clones when storing
     pub(crate) fn parse_identifier(&mut self) -> NodeIndex {
@@ -776,7 +810,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             );
         }
@@ -785,43 +818,7 @@ impl ParserState {
         // This allows contextual keywords (type, interface, package, etc.) to be used as identifiers
         // in appropriate contexts (e.g., type aliases, interface names)
         let (atom, text, original_text) = if self.is_identifier_or_keyword() {
-            // OPTIMIZATION: Capture atom for O(1) comparison
-            let atom = self.scanner.get_token_atom();
-            let has_unicode_escape =
-                (self.scanner.get_token_flags() & TokenFlags::UnicodeEscape as u32) != 0;
-            let text = if !has_unicode_escape {
-                let src = self.scanner.source_text();
-                let start = self.scanner.get_token_start();
-                let end = self.scanner.get_token_end();
-                if start < end && end <= src.len() {
-                    src[start..end].to_string()
-                } else {
-                    self.scanner.get_token_value_ref().to_string()
-                }
-            } else {
-                self.scanner.get_token_value_ref().to_string()
-            };
-            // tsc preserves unicode escape sequences in emitted identifiers.
-            // Capture the original source text when the scanner detected escapes.
-            let original_text = if has_unicode_escape {
-                let src = self.scanner.source_text();
-                let start = self.scanner.get_token_start();
-                let end = self.scanner.get_token_end();
-                if start < end && end <= src.len() {
-                    let slice = &src[start..end];
-                    if slice != text {
-                        Some(slice.to_string())
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-            self.next_token();
-            (atom, text, original_text)
+            self.read_cooked_identifier_text()
         } else {
             self.error_identifier_expected();
             (AstAtom::NONE, String::new(), None)
@@ -835,7 +832,6 @@ impl ParserState {
                 atom,
                 escaped_text: text,
                 original_text,
-                type_arguments: None,
             },
         )
     }
@@ -863,22 +859,10 @@ impl ParserState {
             }
         }
         let (atom, text, original_text) = if self.is_identifier_or_keyword() {
-            // OPTIMIZATION: Capture atom for O(1) comparison
-            let atom = self.scanner.get_token_atom();
-            let has_unicode_escape =
-                (self.scanner.get_token_flags() & TokenFlags::UnicodeEscape as u32) != 0;
-            let text = if !has_unicode_escape {
-                let src = self.scanner.source_text();
-                let start = self.scanner.get_token_start();
-                let end = self.scanner.get_token_end();
-                if start < end && end <= src.len() {
-                    src[start..end].to_string()
-                } else {
-                    self.scanner.get_token_value_ref().to_string()
-                }
-            } else {
-                self.scanner.get_token_value_ref().to_string()
-            };
+            let (atom, text, original_text) = self.read_cooked_identifier_text();
+            // Identifier-name positions (declaration names) additionally reject
+            // astral-plane characters when targeting pre-ES2015, which cannot
+            // represent them in an identifier.
             if !self.language_version.supports_es2015()
                 && let Some((offset, ch)) =
                     text.char_indices().find(|(_, ch)| (*ch as u32) > 0xFFFF)
@@ -890,25 +874,6 @@ impl ParserState {
                     diagnostic_codes::INVALID_CHARACTER,
                 );
             }
-            // Preserve unicode escape sequences for emission parity with tsc
-            let original_text = if has_unicode_escape {
-                let src = self.scanner.source_text();
-                let start = self.scanner.get_token_start();
-                let end = self.scanner.get_token_end();
-                if start < end && end <= src.len() {
-                    let slice = &src[start..end];
-                    if slice != text {
-                        Some(slice.to_string())
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-            self.next_token();
             (atom, text, original_text)
         } else {
             self.error_identifier_expected();
@@ -923,7 +888,6 @@ impl ParserState {
                 atom,
                 escaped_text: text,
                 original_text,
-                type_arguments: None,
             },
         )
     }
@@ -946,7 +910,6 @@ impl ParserState {
                 atom,
                 escaped_text: text,
                 original_text: None,
-                type_arguments: None,
             },
         )
     }

--- a/crates/tsz-parser/src/parser/state_expressions_unary.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_unary.rs
@@ -217,7 +217,6 @@ impl ParserState {
                         atom,
                         escaped_text: String::from("await"),
                         original_text: None,
-                        type_arguments: None,
                     },
                 );
             }
@@ -405,7 +404,6 @@ impl ParserState {
                     atom,
                     escaped_text: String::from("yield"),
                     original_text: None,
-                    type_arguments: None,
                 },
             );
         }

--- a/crates/tsz-parser/src/parser/state_recovery_helpers.rs
+++ b/crates/tsz-parser/src/parser/state_recovery_helpers.rs
@@ -516,7 +516,6 @@ impl ParserState {
                 atom: AstAtom::NONE,
                 escaped_text: String::new(),
                 original_text: None,
-                type_arguments: None,
             },
         )
     }

--- a/crates/tsz-parser/src/parser/state_statements_class.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class.rs
@@ -1032,7 +1032,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             )
         } else if self.is_token(SyntaxKind::ThisKeyword) {
@@ -1092,7 +1091,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             )
         } else if self.is_identifier_or_keyword() {
@@ -1118,7 +1116,6 @@ impl ParserState {
                         atom: AstAtom::NONE,
                         escaped_text: String::new(),
                         original_text: None,
-                        type_arguments: None,
                     },
                 )
             } else if parameter_name_is_reserved_word {
@@ -1141,7 +1138,6 @@ impl ParserState {
                         atom: AstAtom::NONE,
                         escaped_text: String::new(),
                         original_text: None,
-                        type_arguments: None,
                     },
                 )
             } else {

--- a/crates/tsz-parser/src/parser/state_statements_class_members.rs
+++ b/crates/tsz-parser/src/parser/state_statements_class_members.rs
@@ -1754,7 +1754,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             )
         } else {

--- a/crates/tsz-parser/src/parser/state_statements_keywords.rs
+++ b/crates/tsz-parser/src/parser/state_statements_keywords.rs
@@ -884,7 +884,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             )
         } else {

--- a/crates/tsz-parser/src/parser/state_type_parameters.rs
+++ b/crates/tsz-parser/src/parser/state_type_parameters.rs
@@ -102,7 +102,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             )
         } else if self.is_strict_mode_future_reserved_word() {

--- a/crates/tsz-parser/src/parser/state_types.rs
+++ b/crates/tsz-parser/src/parser/state_types.rs
@@ -478,7 +478,6 @@ impl ParserState {
                         atom: AstAtom::NONE,
                         escaped_text: String::new(),
                         original_text: None,
-                        type_arguments: None,
                     },
                 );
             }
@@ -529,7 +528,6 @@ impl ParserState {
                         atom: tsz_common::interner::AstAtom::NONE,
                         escaped_text: String::new(),
                         original_text: None,
-                        type_arguments: None,
                     },
                 );
             }
@@ -584,7 +582,6 @@ impl ParserState {
                     atom: tsz_common::interner::AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             );
         }
@@ -606,7 +603,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             );
         }
@@ -800,7 +796,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: format!("arg{index}"),
                     original_text: None,
-                    type_arguments: None,
                 },
             );
             let param_end = self.token_full_start();

--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -1495,7 +1495,6 @@ impl ParserState {
                     atom: tsz_common::interner::AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             );
         }
@@ -1516,7 +1515,6 @@ impl ParserState {
                     atom: tsz_common::interner::AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             );
         }

--- a/crates/tsz-parser/src/parser/state_types_jsx.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx.rs
@@ -400,7 +400,6 @@ impl ParserState {
                     atom,
                     escaped_text: text,
                     original_text: None,
-                    type_arguments: None,
                 },
             );
         }
@@ -420,7 +419,6 @@ impl ParserState {
                 atom,
                 escaped_text: text,
                 original_text: None,
-                type_arguments: None,
             },
         )
     }
@@ -503,7 +501,6 @@ impl ParserState {
                                 atom: tsz_common::interner::AstAtom::NONE,
                                 escaped_text: String::new(),
                                 original_text: None,
-                                type_arguments: None,
                             },
                         )
                     } else {

--- a/crates/tsz-parser/src/parser/state_types_jsx_elements.rs
+++ b/crates/tsz-parser/src/parser/state_types_jsx_elements.rs
@@ -783,7 +783,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             );
         }
@@ -892,7 +891,6 @@ impl ParserState {
                         atom: AstAtom::NONE,
                         escaped_text: String::new(),
                         original_text: None,
-                        type_arguments: None,
                     },
                 )
             } else {

--- a/crates/tsz-parser/src/parser/state_variable_declarations.rs
+++ b/crates/tsz-parser/src/parser/state_variable_declarations.rs
@@ -104,7 +104,6 @@ impl ParserState {
                     atom: AstAtom::NONE,
                     escaped_text: String::new(),
                     original_text: None,
-                    type_arguments: None,
                 },
             )
         } else {
@@ -390,7 +389,6 @@ impl ParserState {
                     atom,
                     escaped_text: text,
                     original_text: None,
-                    type_arguments: None,
                 },
             )
         } else if self.is_identifier_or_keyword() {

--- a/crates/tsz-parser/tests/node_tests.rs
+++ b/crates/tsz-parser/tests/node_tests.rs
@@ -37,7 +37,6 @@ fn test_node_arena_basic() {
             atom: AstAtom::NONE,
             escaped_text: "hello".to_string(),
             original_text: None,
-            type_arguments: None,
         },
     );
     assert_eq!(ident.0, 1);
@@ -89,7 +88,6 @@ fn test_node_view() {
             atom: AstAtom::NONE,
             escaped_text: "myVar".to_string(),
             original_text: None,
-            type_arguments: None,
         },
     );
 
@@ -144,7 +142,6 @@ fn test_node_access_trait() {
             atom: AstAtom::NONE,
             escaped_text: "testVar".to_string(),
             original_text: None,
-            type_arguments: None,
         },
     );
 
@@ -197,7 +194,6 @@ fn test_parent_mapping() {
             atom: AstAtom::NONE,
             escaped_text: "a".to_string(),
             original_text: None,
-            type_arguments: None,
         },
     );
 
@@ -209,7 +205,6 @@ fn test_parent_mapping() {
             atom: AstAtom::NONE,
             escaped_text: "b".to_string(),
             original_text: None,
-            type_arguments: None,
         },
     );
 
@@ -323,7 +318,6 @@ fn test_parent_mapping_nested() {
             atom: AstAtom::NONE,
             escaped_text: "a".to_string(),
             original_text: None,
-            type_arguments: None,
         },
     );
     let b = arena.add_identifier(
@@ -334,7 +328,6 @@ fn test_parent_mapping_nested() {
             atom: AstAtom::NONE,
             escaped_text: "b".to_string(),
             original_text: None,
-            type_arguments: None,
         },
     );
     let add = arena.add_binary_expr(
@@ -356,7 +349,6 @@ fn test_parent_mapping_nested() {
             atom: AstAtom::NONE,
             escaped_text: "c".to_string(),
             original_text: None,
-            type_arguments: None,
         },
     );
     let multiply = arena.add_binary_expr(
@@ -425,7 +417,6 @@ fn test_parent_mapping_function() {
             atom: AstAtom::NONE,
             escaped_text: "foo".to_string(),
             original_text: None,
-            type_arguments: None,
         },
     );
 
@@ -583,7 +574,6 @@ fn estimated_size_bytes_grows_with_identifiers() {
                 atom: AstAtom::NONE,
                 escaped_text: name,
                 original_text: None,
-                type_arguments: None,
             },
         );
     }


### PR DESCRIPTION
Goal: hold

Stages 1-2 of #13055 (the independently-landable portion). Behavior-preserving parser cleanup.

1. **Dedupe the identifier-text reader.** The atom capture + source-slice cooking + unicode-escape `original_text` preservation was copy-pasted across `parse_identifier` and `parse_identifier_name` (~25 identical lines each, already drifting). Extracted into one `read_cooked_identifier_text` helper — a single source of truth. The ES5 astral-plane-character check stays only in `parse_identifier_name` (declaration names), preserving exact current diagnostics; the check reads only the already-captured `text`/`start_pos`, so moving it after `next_token()` is behavior-identical.
2. **Delete the dead `IdentifierData::type_arguments` field.** Every one of the 68 construction sites wrote `None`, and the sole reader (DTS `Array`-heritage arity check) constant-folded to `true`. Removing the `Option<NodeList>` slot shrinks the arena's largest typed pool; the compiler confirms no remaining reader.

Stage 3 (drop `escaped_text: String` and migrate the ~1703 `.escaped_text` consumer sites to an arena accessor) is intentionally out of scope — the issue flags it as wide and dependent on hardening the atom round-trip invariant first. It stays tracked on #13055.

Structural rule: identifier text cooking has one owner; the two parse entry points differ only in the declaration-name astral-char check. An `IdentifierData` node carries no type-argument slot — type arguments live on the surrounding type-reference node, never on the identifier itself.

The lib-snapshot magic byte is bumped (`\x06` -> `\x07`) because dropping a field changes the positional bincode layout, per the documented round-trip-break protocol in `crates/tsz-core/src/parallel/lib_snapshot.rs`.

## Verification
- `cargo build --workspace` — clean; the compiler confirms no remaining reader of the removed field.
- `cargo test -p tsz-parser` — 1425 passed, 0 failed (incl. `node_tests` size/pool assertions and unicode-escape recovery tests). (nextest is unavailable in this environment; CI runs the mandated `cargo nextest`.)
- `cargo clippy -p tsz-parser -p tsz-core` — clean.
- Behavior preserved: the extracted helper is logically equivalent to the prior inlined code; the DTS `Array` branch returns the same value it previously constant-folded to.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: medium

---
_Generated by [Claude Code](https://claude.ai/code/session_015LjbyazxEjDcxhU26pnCTN)_