### PR TITLE
perf(solver): preserve unchanged unary wrappers

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -838,13 +838,21 @@ impl<'a> TypeInstantiator<'a> {
             // ReadonlyType: instantiate the operand
             TypeData::ReadonlyType(operand) => {
                 let inst_operand = self.instantiate(*operand);
-                self.interner.readonly_type(inst_operand)
+                if inst_operand == *operand {
+                    self.interner.intern(*key)
+                } else {
+                    self.interner.readonly_type(inst_operand)
+                }
             }
 
             // NoInfer: preserve wrapper, instantiate inner
             TypeData::NoInfer(inner) => {
                 let inst_inner = self.instantiate(*inner);
-                self.interner.no_infer(inst_inner)
+                if inst_inner == *inner {
+                    self.interner.intern(*key)
+                } else {
+                    self.interner.no_infer(inst_inner)
+                }
             }
 
             // Template literal: instantiate embedded types


### PR DESCRIPTION
Goal: fast

## Summary
- Preserve existing `TypeId` identity when solver instantiation walks a `ReadonlyType` wrapper whose operand does not change.
- Preserve existing `TypeId` identity when solver instantiation walks a `NoInfer` wrapper whose inner type does not change.
- Leave changed-inner wrapper instantiation on the existing interner paths.

## Performance invariant
When a solver-owned concrete instantiation walk visits a unary wrapper and recursive substitution returns the same inner `TypeId`, the wrapper's semantic shape is unchanged. tsz can return the existing interned wrapper instead of allocating/re-interning an equivalent `ReadonlyType` or `NoInfer` shape.

Owner layer: solver instantiation. This does not add checker-local semantic logic, change lazy materialization policy, widen cross-file caches, or introduce fixture-name shortcuts.

## Adjacent matrix
- Unchanged `ReadonlyType<T>`: return the original wrapper `TypeId`.
- Changed `ReadonlyType<T>`: keep existing `readonly_type(instantiated)` path.
- Unchanged `NoInfer<T>`: return the original wrapper `TypeId`.
- Changed `NoInfer<T>`: keep existing `no_infer(instantiated)` path.
- Fallback invariant: relation behavior, diagnostics, wrapper semantics, and interner canonicalization remain owned by the existing solver paths.

## Verification
- Not run locally per user instruction.
- Pre-commit formatting hook ran during commit `a4e39536284975a32a150b46166f8829613770b5`.
- Branch synced with current `origin/main` at head `c7b204e43c6ca748ee1d6a8e0300a894a69229fa` after #13485, #13500, and #13502 landed.
- Draft/light CI passed on exact head `c7b204e43c6ca748ee1d6a8e0300a894a69229fa`: `CI Light Summary`, `gate`, `cargo-deny`, `project-row-drift`, `unit-cloudbuild`, `lint`, `premerge-microbench`, `unit`, `dist-binaries`, `unit-checker-integration`, and `cargo-shear`.
- Ready-review CI is expected to prove broad conformance, fourslash, emit, project compile, WASM, and PR body gates.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium
