### PR TITLE
refactor(core): centralize tsconfig key diagnostics and list trim filter (#13435)

### DIFF
--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -518,6 +518,25 @@ fn find_key_offset_in_source(source: &str, key: &str) -> u32 {
     }
 }
 
+/// Push an error diagnostic anchored at a tsconfig key, spanning the key text
+/// plus its surrounding quotes.
+///
+/// Centralizes the `find_key_offset_in_source` + `key.len() + 2` quote-width
+/// anchoring that config validation repeats at every key-anchored diagnostic
+/// site, so an anchoring or off-by-one correction is a single-place change.
+fn push_key_diagnostic(
+    diagnostics: &mut Vec<Diagnostic>,
+    file_path: &str,
+    stripped: &str,
+    key: &str,
+    message: impl Into<String>,
+    code: u32,
+) {
+    let start = find_key_offset_in_source(stripped, key);
+    let length = key.len() as u32 + 2; // include surrounding quotes
+    diagnostics.push(Diagnostic::error(file_path, start, length, message, code));
+}
+
 /// Find the byte offset of a JSON value within the source text.
 /// Searches for `"key":` after `compilerOptions`, then finds the value start.
 fn find_value_offset_in_source(source: &str, key: &str) -> u32 {

--- a/crates/tsz-core/src/config/parse.rs
+++ b/crates/tsz-core/src/config/parse.rs
@@ -61,45 +61,46 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
             if let Some(canonical) = known_compiler_option(&key_lower) {
                 if key.as_str() != canonical {
                     // Miscased option — emit TS5025 and schedule rename
-                    let start = find_key_offset_in_source(&stripped, key);
                     let msg = format_message(
                         diagnostic_messages::UNKNOWN_COMPILER_OPTION_DID_YOU_MEAN,
                         &[key, canonical],
                     );
-                    diagnostics.push(Diagnostic::error(
+                    push_key_diagnostic(
+                        &mut diagnostics,
                         file_path,
-                        start,
-                        key.len() as u32 + 2, // include quotes
+                        &stripped,
+                        key,
                         msg,
                         diagnostic_codes::UNKNOWN_COMPILER_OPTION_DID_YOU_MEAN,
-                    ));
+                    );
                     renames.push((key.clone(), canonical.to_string()));
                 }
                 // else: exact match, no diagnostic needed
             } else {
                 // Truly unknown option — emit TS5023
-                let start = find_key_offset_in_source(&stripped, key);
                 if let Some(suggestion) = unknown_compiler_option_suggestion(&key_lower) {
                     let msg = format_message(
                         diagnostic_messages::UNKNOWN_COMPILER_OPTION_DID_YOU_MEAN,
                         &[key, suggestion],
                     );
-                    diagnostics.push(Diagnostic::error(
+                    push_key_diagnostic(
+                        &mut diagnostics,
                         file_path,
-                        start,
-                        key.len() as u32 + 2,
+                        &stripped,
+                        key,
                         msg,
                         diagnostic_codes::UNKNOWN_COMPILER_OPTION_DID_YOU_MEAN,
-                    ));
+                    );
                 } else {
                     let msg = format_message(diagnostic_messages::UNKNOWN_COMPILER_OPTION, &[key]);
-                    diagnostics.push(Diagnostic::error(
+                    push_key_diagnostic(
+                        &mut diagnostics,
                         file_path,
-                        start,
-                        key.len() as u32 + 2,
+                        &stripped,
+                        key,
                         msg,
                         diagnostic_codes::UNKNOWN_COMPILER_OPTION,
-                    ));
+                    );
                 }
                 unknown_keys.push(key.clone());
             }
@@ -124,18 +125,18 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
         let mut cli_only_keys: Vec<String> = Vec::new();
         for key in compiler_opts.keys().cloned().collect::<Vec<_>>() {
             if cli_only_options.contains(&key.as_str()) {
-                let start = find_key_offset_in_source(&stripped, &key);
                 let msg = format_message(
                     diagnostic_messages::OPTION_CAN_ONLY_BE_SPECIFIED_ON_COMMAND_LINE,
                     &[&key],
                 );
-                diagnostics.push(Diagnostic::error(
+                push_key_diagnostic(
+                    &mut diagnostics,
                     file_path,
-                    start,
-                    key.len() as u32 + 2,
+                    &stripped,
+                    &key,
                     msg,
                     diagnostic_codes::OPTION_CAN_ONLY_BE_SPECIFIED_ON_COMMAND_LINE,
-                ));
+                );
                 cli_only_keys.push(key);
             }
         }
@@ -160,18 +161,18 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
                     Some(_) => true,
                 };
                 if is_set {
-                    let start = find_key_offset_in_source(&stripped, &key);
                     let msg = format_message(
                         diagnostic_messages::OPTION_HAS_BEEN_REMOVED_PLEASE_REMOVE_IT_FROM_YOUR_CONFIGURATION,
                         &[&key],
                     );
-                    diagnostics.push(Diagnostic::error(
+                    push_key_diagnostic(
+                        &mut diagnostics,
                         file_path,
-                        start,
-                        key.len() as u32 + 2, // include quotes
+                        &stripped,
+                        &key,
                         msg,
                         diagnostic_codes::OPTION_HAS_BEEN_REMOVED_PLEASE_REMOVE_IT_FROM_YOUR_CONFIGURATION,
-                    ));
+                    );
                 }
                 removed_keys.push(key);
             }
@@ -440,19 +441,18 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
         let command_line_only_options = ["listFilesOnly"];
         for key in &command_line_only_options {
             if compiler_opts.contains_key(*key) {
-                let start = find_key_offset_in_source(&stripped, key);
-                let key_len = key.len() as u32 + 2; // include quotes
                 let msg = format_message(
                     diagnostic_messages::OPTION_CAN_ONLY_BE_SPECIFIED_ON_COMMAND_LINE,
                     &[key],
                 );
-                diagnostics.push(Diagnostic::error(
+                push_key_diagnostic(
+                    &mut diagnostics,
                     file_path,
-                    start,
-                    key_len,
+                    &stripped,
+                    key,
                     msg,
                     diagnostic_codes::OPTION_CAN_ONLY_BE_SPECIFIED_ON_COMMAND_LINE,
-                ));
+                );
                 // Remove the option so it doesn't affect compilation
                 compiler_opts.remove(*key);
             }
@@ -670,25 +670,23 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
                     &["outFile"],
                 );
                 // Emit at the "module" key (matching tsc behavior)
-                let start_module = find_key_offset_in_source(&stripped, "module");
-                let module_key_len = "module".len() as u32 + 2; // include quotes
-                diagnostics.push(Diagnostic::error(
+                push_key_diagnostic(
+                    &mut diagnostics,
                     file_path,
-                    start_module,
-                    module_key_len,
+                    &stripped,
+                    "module",
                     msg.clone(),
                     diagnostic_codes::ONLY_AMD_AND_SYSTEM_MODULES_ARE_SUPPORTED_ALONGSIDE,
-                ));
+                );
                 // Emit at the "outFile" key (matching tsc behavior)
-                let start_outfile = find_key_offset_in_source(&stripped, "outFile");
-                let outfile_key_len = "outFile".len() as u32 + 2;
-                diagnostics.push(Diagnostic::error(
+                push_key_diagnostic(
+                    &mut diagnostics,
                     file_path,
-                    start_outfile,
-                    outfile_key_len,
+                    &stripped,
+                    "outFile",
                     msg,
                     diagnostic_codes::ONLY_AMD_AND_SYSTEM_MODULES_ARE_SUPPORTED_ALONGSIDE,
-                ));
+                );
             }
         }
 
@@ -704,15 +702,14 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
                 false
             };
             if module_bad {
-                let start = find_key_offset_in_source(&stripped, "verbatimModuleSyntax");
-                let key_len = "verbatimModuleSyntax".len() as u32 + 2;
-                diagnostics.push(Diagnostic::error(
+                push_key_diagnostic(
+                    &mut diagnostics,
                     file_path,
-                    start,
-                    key_len,
-                    diagnostic_messages::OPTION_VERBATIMMODULESYNTAX_CANNOT_BE_USED_WHEN_MODULE_IS_SET_TO_UMD_AMD_OR_SYST.to_string(),
+                    &stripped,
+                    "verbatimModuleSyntax",
+                    diagnostic_messages::OPTION_VERBATIMMODULESYNTAX_CANNOT_BE_USED_WHEN_MODULE_IS_SET_TO_UMD_AMD_OR_SYST,
                     diagnostic_codes::OPTION_VERBATIMMODULESYNTAX_CANNOT_BE_USED_WHEN_MODULE_IS_SET_TO_UMD_AMD_OR_SYST,
-                ));
+                );
             }
         }
 
@@ -746,15 +743,14 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
                     related_keys.push("composite");
                 }
                 for key in related_keys {
-                    let start = find_key_offset_in_source(&stripped, key);
-                    let key_len = key.len() as u32 + 2; // include quotes
-                    diagnostics.push(Diagnostic::error(
+                    push_key_diagnostic(
+                        &mut diagnostics,
                         file_path,
-                        start,
-                        key_len,
+                        &stripped,
+                        key,
                         msg.clone(),
                         code,
-                    ));
+                    );
                 }
             }
         }
@@ -789,19 +785,18 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
             && !option_is_effectively_enabled(compiler_opts, &ts5024_keys, "sourceMap")
             && !option_is_effectively_enabled(compiler_opts, &ts5024_keys, "declarationMap")
         {
-            let start = find_key_offset_in_source(&stripped, "mapRoot");
-            let key_len = "mapRoot".len() as u32 + 2;
             let msg = format_message(
                 diagnostic_messages::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION_OR_OPTION,
                 &["mapRoot", "sourceMap", "declarationMap"],
             );
-            diagnostics.push(Diagnostic::error(
+            push_key_diagnostic(
+                &mut diagnostics,
                 file_path,
-                start,
-                key_len,
+                &stripped,
+                "mapRoot",
                 msg,
                 diagnostic_codes::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION_OR_OPTION,
-            ));
+            );
         }
 
         // TS5091: preserveConstEnums cannot be disabled when isolatedModules is enabled.
@@ -813,29 +808,27 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
             let enablers: &[&str] = &["isolatedModules", "isolatedDeclarations"];
             for enabler in enablers {
                 if option_is_effectively_enabled(compiler_opts, &ts5024_keys, enabler) {
-                    let start = find_key_offset_in_source(&stripped, "preserveConstEnums");
-                    let key_len = "preserveConstEnums".len() as u32 + 2;
                     let msg = format_message(
                         diagnostic_messages::OPTION_PRESERVECONSTENUMS_CANNOT_BE_DISABLED_WHEN_IS_ENABLED,
                         &[enabler],
                     );
-                    diagnostics.push(Diagnostic::error(
+                    push_key_diagnostic(
+                        &mut diagnostics,
                         file_path,
-                        start,
-                        key_len,
+                        &stripped,
+                        "preserveConstEnums",
                         msg.clone(),
                         diagnostic_codes::OPTION_PRESERVECONSTENUMS_CANNOT_BE_DISABLED_WHEN_IS_ENABLED,
-                    ));
+                    );
                     // tsc also emits at the enabler key position
-                    let enabler_start = find_key_offset_in_source(&stripped, enabler);
-                    let enabler_key_len = enabler.len() as u32 + 2;
-                    diagnostics.push(Diagnostic::error(
+                    push_key_diagnostic(
+                        &mut diagnostics,
                         file_path,
-                        enabler_start,
-                        enabler_key_len,
+                        &stripped,
+                        enabler,
                         msg,
                         diagnostic_codes::OPTION_PRESERVECONSTENUMS_CANNOT_BE_DISABLED_WHEN_IS_ENABLED,
-                    ));
+                    );
                 }
             }
         }
@@ -848,16 +841,14 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
                 Some(serde_json::Value::Bool(false))
             )
         {
-            let start = find_key_offset_in_source(&stripped, "declaration");
-            let key_len = "declaration".len() as u32 + 2;
-            diagnostics.push(Diagnostic::error(
+            push_key_diagnostic(
+                &mut diagnostics,
                 file_path,
-                start,
-                key_len,
-                diagnostic_messages::COMPOSITE_PROJECTS_MAY_NOT_DISABLE_DECLARATION_EMIT
-                    .to_string(),
+                &stripped,
+                "declaration",
+                diagnostic_messages::COMPOSITE_PROJECTS_MAY_NOT_DISABLE_DECLARATION_EMIT,
                 diagnostic_codes::COMPOSITE_PROJECTS_MAY_NOT_DISABLE_DECLARATION_EMIT,
-            ));
+            );
         }
 
         // TS6379: Composite projects may not disable incremental compilation.
@@ -896,27 +887,25 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
             );
 
             // Always emit at the checkJs key.
-            let check_js_start = find_key_offset_in_source(&stripped, "checkJs");
-            let check_js_len = "checkJs".len() as u32 + 2;
-            diagnostics.push(Diagnostic::error(
+            push_key_diagnostic(
+                &mut diagnostics,
                 file_path,
-                check_js_start,
-                check_js_len,
+                &stripped,
+                "checkJs",
                 msg.clone(),
                 diagnostic_codes::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION,
-            ));
+            );
 
             // If allowJs is explicitly present, emit at allowJs too (tsc parity).
             if compiler_opts.contains_key("allowJs") {
-                let allow_js_start = find_key_offset_in_source(&stripped, "allowJs");
-                let allow_js_len = "allowJs".len() as u32 + 2;
-                diagnostics.push(Diagnostic::error(
+                push_key_diagnostic(
+                    &mut diagnostics,
                     file_path,
-                    allow_js_start,
-                    allow_js_len,
+                    &stripped,
+                    "allowJs",
                     msg,
                     diagnostic_codes::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION,
-                ));
+                );
             }
         }
 
@@ -924,19 +913,18 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
         if option_is_truthy(compiler_opts.get("emitDecoratorMetadata"))
             && !option_is_effectively_enabled(compiler_opts, &ts5024_keys, "experimentalDecorators")
         {
-            let start = find_key_offset_in_source(&stripped, "emitDecoratorMetadata");
-            let key_len = "emitDecoratorMetadata".len() as u32 + 2;
             let msg = format_message(
                 diagnostic_messages::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION,
                 &["emitDecoratorMetadata", "experimentalDecorators"],
             );
-            diagnostics.push(Diagnostic::error(
+            push_key_diagnostic(
+                &mut diagnostics,
                 file_path,
-                start,
-                key_len,
+                &stripped,
+                "emitDecoratorMetadata",
                 msg,
                 diagnostic_codes::OPTION_CANNOT_BE_SPECIFIED_WITHOUT_SPECIFYING_OPTION,
-            ));
+            );
         }
 
         // TS5053: Option '{0}' cannot be specified with option '{1}'.
@@ -977,29 +965,27 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
                 let key_b = resolve(opt_b);
                 // Emit at the resolved-key position (issue #3732 anchors at
                 // `checkJs` when allowJs is implied).
-                let start = find_key_offset_in_source(&stripped, key_a);
-                let key_len = key_a.len() as u32 + 2;
                 let msg = format_message(
                     diagnostic_messages::OPTION_CANNOT_BE_SPECIFIED_WITH_OPTION,
                     &[opt_a, opt_b],
                 );
-                diagnostics.push(Diagnostic::error(
+                push_key_diagnostic(
+                    &mut diagnostics,
                     file_path,
-                    start,
-                    key_len,
+                    &stripped,
+                    key_a,
                     msg.clone(),
                     diagnostic_codes::OPTION_CANNOT_BE_SPECIFIED_WITH_OPTION,
-                ));
+                );
                 // Emit at opt_b's position (same message, different location)
-                let start_b = find_key_offset_in_source(&stripped, key_b);
-                let key_len_b = key_b.len() as u32 + 2;
-                diagnostics.push(Diagnostic::error(
+                push_key_diagnostic(
+                    &mut diagnostics,
                     file_path,
-                    start_b,
-                    key_len_b,
+                    &stripped,
+                    key_b,
                     msg,
                     diagnostic_codes::OPTION_CANNOT_BE_SPECIFIED_WITH_OPTION,
-                ));
+                );
             }
         }
 
@@ -1079,15 +1065,14 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
             };
 
             if resolve_json_explicit && effective_mr == "classic" {
-                let start = find_key_offset_in_source(&stripped, "resolveJsonModule");
-                let key_len = "resolveJsonModule".len() as u32 + 2;
-                diagnostics.push(Diagnostic::error(
+                push_key_diagnostic(
+                    &mut diagnostics,
                     file_path,
-                    start,
-                    key_len,
-                    diagnostic_messages::OPTION_RESOLVEJSONMODULE_CANNOT_BE_SPECIFIED_WHEN_MODULERESOLUTION_IS_SET_TO_CLA.to_string(),
+                    &stripped,
+                    "resolveJsonModule",
+                    diagnostic_messages::OPTION_RESOLVEJSONMODULE_CANNOT_BE_SPECIFIED_WHEN_MODULERESOLUTION_IS_SET_TO_CLA,
                     diagnostic_codes::OPTION_RESOLVEJSONMODULE_CANNOT_BE_SPECIFIED_WHEN_MODULERESOLUTION_IS_SET_TO_CLA,
-                ));
+                );
             }
 
             // TS5071: fires when module=none/system/umd but ONLY when effective_mr is NOT
@@ -1099,27 +1084,26 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
                 let mod_normalized =
                     normalize_enum_option_value(mod_value.split(',').next().unwrap_or(mod_value));
                 if matches!(mod_normalized.as_str(), "none" | "system" | "umd") {
-                    let emit_ts5071 = |diagnostics: &mut Vec<Diagnostic>,
-                                       error_key: &str,
-                                       key_len: u32| {
-                        let start = find_key_offset_in_source(&stripped, error_key);
-                        diagnostics.push(Diagnostic::error(
-                            file_path,
-                            start,
-                            key_len,
-                            diagnostic_messages::OPTION_RESOLVEJSONMODULE_CANNOT_BE_SPECIFIED_WHEN_MODULE_IS_SET_TO_NONE_SYSTEM_O.to_string(),
-                            diagnostic_codes::OPTION_RESOLVEJSONMODULE_CANNOT_BE_SPECIFIED_WHEN_MODULE_IS_SET_TO_NONE_SYSTEM_O,
-                        ));
-                    };
-
+                    let msg = diagnostic_messages::OPTION_RESOLVEJSONMODULE_CANNOT_BE_SPECIFIED_WHEN_MODULE_IS_SET_TO_NONE_SYSTEM_O;
+                    let code = diagnostic_codes::OPTION_RESOLVEJSONMODULE_CANNOT_BE_SPECIFIED_WHEN_MODULE_IS_SET_TO_NONE_SYSTEM_O;
                     // tsc reports the invalid pairing on both participating options when
                     // resolveJsonModule is explicitly present in the config.
-                    emit_ts5071(&mut diagnostics, "module", "module".len() as u32 + 2);
+                    push_key_diagnostic(
+                        &mut diagnostics,
+                        file_path,
+                        &stripped,
+                        "module",
+                        msg,
+                        code,
+                    );
                     if resolve_json_explicit {
-                        emit_ts5071(
+                        push_key_diagnostic(
                             &mut diagnostics,
+                            file_path,
+                            &stripped,
                             "resolveJsonModule",
-                            "resolveJsonModule".len() as u32 + 2,
+                            msg,
+                            code,
                         );
                     }
                 }
@@ -1176,19 +1160,18 @@ pub fn parse_tsconfig_with_diagnostics(source: &str, file_path: &str) -> Result<
         if !mr_is_modern {
             for &opt in requires_modern_mr {
                 if option_is_truthy(compiler_opts.get(opt)) {
-                    let start = find_key_offset_in_source(&stripped, opt);
-                    let key_len = opt.len() as u32 + 2;
                     let msg = format_message(
                         diagnostic_messages::OPTION_CAN_ONLY_BE_USED_WHEN_MODULERESOLUTION_IS_SET_TO_NODE16_NODENEXT_OR_BUNDL,
                         &[opt],
                     );
-                    diagnostics.push(Diagnostic::error(
+                    push_key_diagnostic(
+                        &mut diagnostics,
                         file_path,
-                        start,
-                        key_len,
+                        &stripped,
+                        opt,
                         msg,
                         diagnostic_codes::OPTION_CAN_ONLY_BE_USED_WHEN_MODULERESOLUTION_IS_SET_TO_NODE16_NODENEXT_OR_BUNDL,
-                    ));
+                    );
                 }
             }
         }

--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -306,6 +306,17 @@ impl ResolvedCompilerOptions {
     }
 }
 
+/// Trim a configured string-list entry, dropping it when nothing remains.
+///
+/// Shared by the `types` / `typeRoots` / `rootDirs` normalizers, which differ
+/// only in the final `String` vs `PathBuf` constructor applied to the trimmed
+/// slice (`trimmed_non_empty(v).map(String::from)` /
+/// `trimmed_non_empty(v).map(PathBuf::from)`).
+fn trimmed_non_empty(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
 pub fn resolve_compiler_options(
     options: Option<&CompilerOptions>,
 ) -> Result<ResolvedCompilerOptions> {
@@ -438,14 +449,7 @@ pub fn resolve_compiler_options(
     if let Some(types) = options.types.as_ref() {
         let list: Vec<String> = types
             .iter()
-            .filter_map(|value| {
-                let trimmed = value.trim();
-                if trimmed.is_empty() {
-                    None
-                } else {
-                    Some(trimmed.to_string())
-                }
-            })
+            .filter_map(|value| trimmed_non_empty(value).map(String::from))
             .collect();
         resolved.types = Some(list);
         resolved.checker.types_explicitly_set = true;
@@ -454,14 +458,7 @@ pub fn resolve_compiler_options(
     if let Some(type_roots) = options.type_roots.as_ref() {
         let roots: Vec<PathBuf> = type_roots
             .iter()
-            .filter_map(|value| {
-                let trimmed = value.trim();
-                if trimmed.is_empty() {
-                    None
-                } else {
-                    Some(PathBuf::from(trimmed))
-                }
-            })
+            .filter_map(|value| trimmed_non_empty(value).map(PathBuf::from))
             .collect();
         resolved.type_roots = Some(roots);
     }
@@ -552,14 +549,7 @@ pub fn resolve_compiler_options(
     if let Some(root_dirs) = options.root_dirs.as_ref() {
         resolved.root_dirs = root_dirs
             .iter()
-            .filter_map(|value| {
-                let trimmed = value.trim();
-                if trimmed.is_empty() {
-                    None
-                } else {
-                    Some(PathBuf::from(trimmed))
-                }
-            })
+            .filter_map(|value| trimmed_non_empty(value).map(PathBuf::from))
             .collect();
     }
 


### PR DESCRIPTION
Goal: hold

Closes #13435.

## Summary
Pure intra-crate DRY cleanup in `tsz_core::config`. No behavior change: every
diagnostic computes the identical `start`/`length`/`code`, and the normalized
option lists keep the same trim/empty filtering.

Two behavior-preserving helpers replace hand-inlined boilerplate:

- **`push_key_diagnostic`** (`crates/tsz-core/src/config/mod.rs`, beside
  `find_key_offset_in_source`): collapses the key-anchored diagnostic triple —
  `find_key_offset_in_source` + `key.len() as u32 + 2` (quote-width fudge) +
  `Diagnostic::error` — into one call. Applied at every key-anchored validation
  site in `parse.rs` (TS5023/TS5025/TS5102/TS6266/TS5069/TS5070/TS5071/TS5091/
  TS5052/TS5053/TS5098/TS6304/TS6082 and friends). The bespoke `emit_ts5071`
  closure is dropped in favor of the shared helper.
- **`trimmed_non_empty(&str) -> Option<&str>`** (`resolved_options.rs`):
  collapses the three byte-identical trim/drop-empty `filter_map` closures for
  `types` / `typeRoots` / `rootDirs`, which differed only by the final
  constructor — now `.map(String::from)` / `.map(PathBuf::from)`.

## Structural rule
When emitting a tsconfig key diagnostic or normalizing a string-option list by
trimming and dropping empties, there is now one helper instead of ~20 inlined
copies. Centralizing the `+2` quote-width makes an anchoring/off-by-one fix a
one-line change. Owner layer: `tsz-core` config parsing — no checker/solver/
binder boundary is touched.

## Scope / fallback
Value-anchored diagnostics (`find_value_offset_in_source`) and the custom-offset
sites — `compilerOptions`-scoped deprecation anchoring, the TS6379
`compilerOptions`-key anchor, and the `paths` substitution element offsets — are
intentionally left unchanged; they do not share the key-anchored shape.

## Verification
- `cargo test -p tsz-core config` → `216 passed; 0 failed` (covers
  TS5023/TS5025/TS6266/TS5095 and the rest of the config-diagnostic anchoring
  and option-list normalization suites).
- `cargo check -p tsz-core` → clean.
- `cargo clippy -p tsz-core -- -D warnings` → clean.
- Rebased onto current `origin/main`; no conflicts.
- Ready-review CI owns the broad conformance/emit/fourslash gates.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vb4N2dvZNMTTVfhiUxzqVh)_