### PR TITLE
fix(solver): defer conditionals over an unresolved cross-file reference

### DIFF
--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part4.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part4.rs
@@ -246,3 +246,129 @@ export function tend(p: Plant) {
         );
     }
 
+    // ------------------------------------------------------------------
+    // A conditional whose check type is an unresolvable cross-file
+    // reference must DEFER, not fabricate `error` (#8432 /
+    // propTypeValidatorInference family).
+    //
+    // Under a namespace import, an imported generic interface member typed
+    // by a sibling type (`isRequired: Validator<NonNullable<T>>`) is read
+    // off an inferred `typeof` object. The member reference lowers to
+    // `Application(UnresolvedTypeName("Validator"), …)` because the bare
+    // name `Validator` is not in the consuming file's scope (it is
+    // `P.Validator` there). `is_error_type` folds `UnresolvedTypeName` into
+    // "error", so the homomorphic mapped body's conditional
+    // `V[K] extends P.Validator<any> ? K : never` used to collapse the
+    // property to `error`, minting `{ str: error }` and a false TS2322.
+    // The conditional now defers on an unresolved reference, matching the
+    // equivalent named-import behavior. Binder names vary across cases.
+    // ------------------------------------------------------------------
+
+    /// Library declaring a generic interface whose member is typed by a sibling
+    /// generic type (`isRequired: Validator<NonNullable<T>>`). Imported as a
+    /// namespace, the bare `Validator` reference is not in the consumer's scope.
+    const UNRESOLVED_MEMBER_VLIB: &str = r#"
+export interface Validator<T> {
+  (props: object): boolean;
+  brand?: T;
+}
+export interface Requireable<T> extends Validator<T> {
+  isRequired: Validator<NonNullable<T>>;
+}
+export declare const str: Requireable<string>;
+"#;
+
+    fn check_unresolved_member_conditional(vlib: &str, main: &str) -> Vec<Diagnostic> {
+        collect_test_diagnostics_with_options(
+            &[("/p/vlib.ts", vlib), ("/p/main.ts", main)],
+            &project_mode_es2015_strict_options(),
+            Path::new("/p"),
+        )
+    }
+
+    #[test]
+    fn program_mode_conditional_over_unresolved_namespace_member_defers_not_error() {
+        let diagnostics = check_unresolved_member_conditional(
+            UNRESOLVED_MEMBER_VLIB,
+            r#"
+import * as P from "./vlib";
+const lit = { str: P.str.isRequired };
+type V = typeof lit;
+type Mc = { [K in keyof V]: V[K] extends P.Validator<any> ? K : never };
+const ok: Mc = { str: "str" };
+"#,
+        );
+        // No diagnostic, and in particular nothing that rendered a property
+        // as the internal `error` type (which the false TS2322 did).
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diag| diag.code != 2322 && diag.code != 2741),
+            "valid assignment to the mapped type must not error; got: {diagnostics:?}"
+        );
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|diag| diag.message_text.contains("error")),
+            "no diagnostic may render a mapped property as the internal `error` type: {:?}",
+            diagnostics
+                .iter()
+                .map(|d| d.message_text.to_string())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn program_mode_conditional_over_unresolved_namespace_member_still_reports_mismatch() {
+        let diagnostics = check_unresolved_member_conditional(
+            UNRESOLVED_MEMBER_VLIB,
+            r#"
+import * as P from "./vlib";
+const lit = { str: P.str.isRequired };
+type V = typeof lit;
+type Mc = { [K in keyof V]: V[K] extends P.Validator<any> ? K : never };
+const bad: Mc = { str: 123 };
+"#,
+        );
+        // The mapped type still resolves to a usable key type, so a genuine
+        // value mismatch is reported — proving the conditional deferred to a
+        // real type instead of collapsing to `error` (which would silently
+        // accept everything).
+        assert!(
+            diagnostics.iter().any(|diag| diag.code == 2322),
+            "a genuine mismatch against the resolved mapped key type must error; got: {diagnostics:?}"
+        );
+    }
+
+    /// Same shape with different binder names (anti-hardcoding): the behavior
+    /// follows the structural pattern, not the spellings
+    /// `Validator`/`Requireable`/`str`/`P`.
+    #[test]
+    fn program_mode_conditional_over_unresolved_namespace_member_renamed_binders() {
+        let diagnostics = check_unresolved_member_conditional(
+            r#"
+export interface Checker<U> {
+  (value: object): boolean;
+  tag?: U;
+}
+export interface Mandatory<U> extends Checker<U> {
+  required: Checker<NonNullable<U>>;
+}
+export declare const field: Mandatory<string>;
+"#,
+            r#"
+import * as Lib from "./vlib";
+const shape = { field: Lib.field.required };
+type S = typeof shape;
+type Keys = { [K in keyof S]: S[K] extends Lib.Checker<any> ? K : never };
+const ok: Keys = { field: "field" };
+"#,
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diag| diag.code != 2322 && diag.code != 2741),
+            "renamed-binder witness must not fabricate `error`; got: {diagnostics:?}"
+        );
+    }
+

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -1192,10 +1192,22 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     fn visit_conditional(&mut self, cond_id: ConditionalTypeId) -> TypeId {
         let cond = self.interner.get_conditional(cond_id);
         // tsc propagates the error type through conditionals: when the check type
-        // resolves to an error (e.g. a failed indexed access `O[number]`), the whole
-        // conditional resolves to the error type so neither branch is selected and
-        // downstream diagnostics stay suppressed instead of cascading.
-        if crate::visitor::is_error_type(self.interner, self.evaluate(cond.check_type)) {
+        // resolves to a genuine error (e.g. a failed indexed access `O[number]`),
+        // the whole conditional resolves to the error type so neither branch is
+        // selected and downstream diagnostics stay suppressed instead of cascading.
+        //
+        // An `UnresolvedTypeName` is NOT a genuine error — it is a display-preserving
+        // reference the current resolver could not bind to a `DefId` (e.g. a cross-
+        // file interface member typed by a sibling type whose bare name is not in the
+        // consuming file's scope under a namespace import). The broad `is_error_type`
+        // folds `UnresolvedTypeName` into "error", so bailing on it would fabricate
+        // `error` for the whole conditional (and, through a homomorphic mapped body,
+        // mint `{ k: error }`). `is_genuine_error_type` excludes it, so the check side
+        // instead defers to `evaluate_conditional`. (Note: the *extends*-side
+        // unresolved-name handling still folds one layer down; the durable fix is the
+        // cross-arena member-type lowering campaign in #13044 / #13484.)
+        let evaluated_check = self.evaluate(cond.check_type);
+        if crate::visitor::is_genuine_error_type(self.interner, evaluated_check) {
             return TypeId::ERROR;
         }
         self.evaluate_conditional(&cond)

--- a/crates/tsz-solver/src/visitors/visitor_extract.rs
+++ b/crates/tsz-solver/src/visitors/visitor_extract.rs
@@ -869,6 +869,31 @@ pub fn is_this_type(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
 /// display-preserving unresolved type names, including applications whose base
 /// is an unresolved type name.
 pub fn is_error_type(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    error_type_through_application_bases(types, type_id, true)
+}
+
+/// Like [`is_error_type`] but does NOT treat an `UnresolvedTypeName` as an error.
+///
+/// An `UnresolvedTypeName` is a display-preserving reference the current resolver
+/// could not bind to a `DefId` (cross-file / namespace-import lowering residue),
+/// not a definitive `error`. Callers that must distinguish a *deferrable*
+/// unresolved reference from a genuine failure — e.g. conditional branch
+/// selection, where a failed indexed access (`error`) suppresses the conditional
+/// but an unresolved reference must defer — use this variant.
+pub fn is_genuine_error_type(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    error_type_through_application_bases(types, type_id, false)
+}
+
+/// Shared `Application`-base walk for the error-type predicates: descend through
+/// `Application` bases (bounded) looking for `TypeId::ERROR` / `TypeData::Error`.
+/// `treat_unresolved_as_error` decides whether a reached `UnresolvedTypeName`
+/// counts as an error (`is_error_type`) or is a deferrable reference
+/// (`is_genuine_error_type`).
+fn error_type_through_application_bases(
+    types: &dyn TypeDatabase,
+    type_id: TypeId,
+    treat_unresolved_as_error: bool,
+) -> bool {
     let mut current = type_id;
 
     for _ in 0..16 {
@@ -877,7 +902,8 @@ pub fn is_error_type(types: &dyn TypeDatabase, type_id: TypeId) -> bool {
         }
 
         match types.lookup(current) {
-            Some(TypeData::Error | TypeData::UnresolvedTypeName(_)) => return true,
+            Some(TypeData::Error) => return true,
+            Some(TypeData::UnresolvedTypeName(_)) => return treat_unresolved_as_error,
             Some(TypeData::Application(app_id)) => {
                 current = types.type_application(app_id).base;
             }


### PR DESCRIPTION
Goal: hold

Fixes the concrete slice of #8432 diagnosed in the 2026-06-13 19:03Z comment
(the `propTypeValidatorInference` / deterministic `vlib` witness).

## Structural rule

When a conditional type's check type evaluates to an `Application` whose base is
an **`UnresolvedTypeName`**, `tsc` keeps the nominal reference and selects a real
branch; `tsz` collapsed the conditional to the internal `error` type because
`is_error_type` folds `UnresolvedTypeName` into "error". Through a homomorphic
mapped body `{ [K in keyof V]: V[K] extends Validator<any> ? K : never }` that
minted `{ k: error }` and a **false `TS2322`/`TS2741`**.

`UnresolvedTypeName` is a display-preserving reference the current resolver could
not bind to a `DefId` — under `import * as P from "vlib"`, an imported interface
member typed `Validator<…>` lowers to a bare `UnresolvedTypeName("Validator")`
because that name is not in the consuming file's scope (it is `P.Validator`
there). It is a *deferrable* reference, not a definitive `error`.

## Owner layer

Solver evaluation — conditional branch selection (`visit_conditional`). The fix
adds `is_genuine_error_type`, which **shares the bounded `Application`-base walk
with `is_error_type`** (one helper, `error_type_through_application_bases`,
parameterized by `treat_unresolved_as_error`) and excludes `UnresolvedTypeName`.
`is_error_type`'s existing behavior — and all ~18 relation/compat/cache/printer
callers that intentionally fold unresolved names into "error" — is byte-for-byte
unchanged; only the one conditional decision point uses the new variant.

A genuine failed indexed access (`TypeData::Error`) still suppresses the
conditional as before. Only an unresolved *reference* now defers, matching the
behavior of the equivalent **named** import.

## Scope / adjacent matrix

- Positive: a valid assignment to the mapped type no longer errors and no member
  renders as `error`.
- Negative control: a genuine value mismatch (`{ str: 123 }`) still raises
  `TS2322`, proving the conditional deferred to a real key type instead of
  collapsing to error-relates-to-everything.
- Renamed binders: the same shape with different identifiers
  (`Checker`/`Mandatory`/`field`) behaves identically — the rule follows the
  type shape, not the spelling.

The durable fix for the residue itself — cross-arena member-type lowering that
preserves `Lazy(DefId)` instead of emitting a bare `UnresolvedTypeName`, and the
symmetric *extends*-side handling — stays with the WIP campaign in #13044 /
#13484; this PR removes the fabricated-`error` symptom at the conditional layer.

`scripts/conformance/conformance-accepted-regressions.txt` is intentionally left
untouched: per the repo's stale-entry policy, the `propTypeValidatorInference.ts`
entry should only be retired after exact-head aggregate CI confirms it no longer
fails.

## Verification

- New regression tests (CLI driver, real program-mode module resolution),
  fail on `main`, pass with the fix:
  - `program_mode_conditional_over_unresolved_namespace_member_defers_not_error`
  - `program_mode_conditional_over_unresolved_namespace_member_still_reports_mismatch`
  - `program_mode_conditional_over_unresolved_namespace_member_renamed_binders`
- `is_error_type` default-behavior guard unchanged:
  `cargo test -p tsz-solver --lib is_error_type` (passes).
- No new failures across the touched surfaces (all pre-existing failures present
  on clean `main`): `cargo test -p tsz-solver --lib {conditional,mapped,index_access,keyof,visitor_tests,compat,relations,subtype}`,
  `cargo test -p tsz-checker --lib {conditional,indexed_access}`.
- `cargo fmt --check` and `cargo clippy -p tsz-solver -p tsz-cli` clean.
- Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_018kHAfy6rFdYoVX8JQNxfdr)_