### PR TITLE
fix(checker): count defaulted namespace class arity from syntax

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/reference_type_params.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_type_params.rs
@@ -112,6 +112,13 @@ impl<'a> CheckerState<'a> {
         expected_name: &str,
     ) -> usize {
         let cache_key = self.reference_type_params_cache_key(sym_id, expected_name);
+        if let Some(required) = self.count_required_reference_type_params_from_syntax(
+            cache_key.0,
+            cache_key.1,
+            expected_name,
+        ) {
+            return required;
+        }
         if let Some(cached) = self
             .ctx
             .type_reference_validation_caches
@@ -134,6 +141,139 @@ impl<'a> CheckerState<'a> {
             return count;
         }
         self.count_required_type_params(cache_key.0)
+    }
+
+    fn count_required_reference_type_params_from_syntax(
+        &self,
+        sym_id: SymbolId,
+        file_idx: Option<usize>,
+        expected_name: &str,
+    ) -> Option<usize> {
+        let symbol = if file_idx.is_some() {
+            self.get_symbol_from_registered_file_target(sym_id)
+                .or_else(|| self.get_cross_file_symbol(sym_id))
+        } else {
+            self.ctx
+                .binder
+                .get_symbol(sym_id)
+                .or_else(|| self.get_symbol_from_registered_file_target(sym_id))
+                .or_else(|| self.get_cross_file_symbol(sym_id))
+        }?;
+        let flags = symbol.flags;
+        let expected_leaf_name = expected_name.rsplit('.').next().unwrap_or(expected_name);
+        let mut best_required: Option<usize> = None;
+
+        for decl_idx in symbol.all_declarations() {
+            if let Some(file_idx) = file_idx {
+                let arena = self.ctx.get_arena_for_file(file_idx as u32);
+                if let Some(required) = Self::count_required_reference_params_in_arena(
+                    arena,
+                    flags,
+                    decl_idx,
+                    expected_name,
+                    expected_leaf_name,
+                ) {
+                    best_required = Some(best_required.map_or(required, |prev| prev.min(required)));
+                }
+                continue;
+            }
+
+            if let Some(required) = Self::count_required_reference_params_in_arena(
+                self.ctx.arena,
+                flags,
+                decl_idx,
+                expected_name,
+                expected_leaf_name,
+            ) {
+                best_required = Some(best_required.map_or(required, |prev| prev.min(required)));
+                continue;
+            }
+            if let Some(arenas) = self.ctx.binder.declaration_arenas.get(&(sym_id, decl_idx)) {
+                for arena in arenas {
+                    if let Some(required) = Self::count_required_reference_params_in_arena(
+                        arena.as_ref(),
+                        flags,
+                        decl_idx,
+                        expected_name,
+                        expected_leaf_name,
+                    ) {
+                        best_required =
+                            Some(best_required.map_or(required, |prev| prev.min(required)));
+                    }
+                }
+            }
+            if let Some(required) = self
+                .ctx
+                .binder
+                .symbol_arenas
+                .get(&sym_id)
+                .and_then(|arena| {
+                    Self::count_required_reference_params_in_arena(
+                        arena.as_ref(),
+                        flags,
+                        decl_idx,
+                        expected_name,
+                        expected_leaf_name,
+                    )
+                })
+            {
+                best_required = Some(best_required.map_or(required, |prev| prev.min(required)));
+            }
+        }
+
+        best_required
+    }
+
+    fn count_required_reference_params_in_arena(
+        arena: &NodeArena,
+        flags: u32,
+        decl_idx: NodeIndex,
+        expected_name: &str,
+        expected_leaf_name: &str,
+    ) -> Option<usize> {
+        let node = arena.get(decl_idx)?;
+        let type_params = if flags & symbol_flags::INTERFACE != 0 {
+            let iface = arena.get_interface(node)?;
+            Self::reference_decl_name_matches(arena, iface.name, expected_name, expected_leaf_name)
+                .then_some(iface.type_parameters.as_ref())?
+        } else if flags & symbol_flags::TYPE_ALIAS != 0 {
+            let alias = arena.get_type_alias(node)?;
+            Self::reference_decl_name_matches(arena, alias.name, expected_name, expected_leaf_name)
+                .then_some(alias.type_parameters.as_ref())?
+        } else if flags & symbol_flags::CLASS != 0 {
+            let class = arena.get_class(node)?;
+            Self::reference_decl_name_matches(arena, class.name, expected_name, expected_leaf_name)
+                .then_some(class.type_parameters.as_ref())?
+        } else {
+            return None;
+        }?;
+
+        Some(
+            type_params
+                .nodes
+                .iter()
+                .filter(|&&param_idx| {
+                    arena
+                        .get(param_idx)
+                        .and_then(|node| arena.get_type_parameter(node))
+                        .is_some_and(|param| param.default == NodeIndex::NONE)
+                })
+                .count(),
+        )
+    }
+
+    fn reference_decl_name_matches(
+        arena: &NodeArena,
+        name_idx: NodeIndex,
+        expected_name: &str,
+        expected_leaf_name: &str,
+    ) -> bool {
+        arena
+            .get(name_idx)
+            .and_then(|node| arena.get_identifier(node))
+            .is_some_and(|ident| {
+                ident.escaped_text == expected_name || ident.escaped_text == expected_leaf_name
+            })
     }
 
     fn reference_type_params_cache_key(

--- a/crates/tsz-checker/tests/type_arg_count_mismatch_tests.rs
+++ b/crates/tsz-checker/tests/type_arg_count_mismatch_tests.rs
@@ -5,8 +5,30 @@
 //! the incorrectly-instantiated signature. This prevents spurious TS2345
 //! (argument not assignable) errors.
 
+use tsz_checker::context::CheckerOptions;
 use tsz_checker::diagnostics::Diagnostic;
-use tsz_checker::test_utils::{check_source_codes, check_source_diagnostics};
+use tsz_checker::test_utils::{
+    check_multi_file_with_libs, check_source_codes, check_source_diagnostics, load_lib_files,
+};
+use tsz_common::common::ModuleKind;
+
+fn check_namespace_import_codes(lib: &str, main: &str) -> Vec<u32> {
+    let libs = load_lib_files(&["es5.d.ts"]);
+    check_multi_file_with_libs(
+        &[("query.ts", lib), ("main.ts", main)],
+        "main.ts",
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+        &libs,
+    )
+    .into_iter()
+    .filter(|diag| diag.code != 2318)
+    .map(|diag| diag.code)
+    .collect()
+}
 
 /// When calling a generic function with too few type arguments,
 /// only TS2558 should be emitted — no spurious TS2345.
@@ -128,6 +150,48 @@ type Alias = Box<Pair<string>>;
     assert!(
         codes.contains(&2314),
         "Expected TS2314 for nested Pair<string>, got: {codes:?}"
+    );
+}
+
+#[test]
+fn namespace_import_defaulted_class_type_reference_allows_omitted_type_arg() {
+    let lib = r#"
+export namespace SQL {
+  export class Aliased<T = unknown> {
+    value!: T
+  }
+}
+"#;
+    let main = r#"
+import * as Query from './query'
+export type Bare = Query.SQL.Aliased
+"#;
+    let codes = check_namespace_import_codes(lib, main);
+
+    assert!(
+        !codes.contains(&2314),
+        "defaulted namespace-imported class should not require a type argument, got {codes:?}"
+    );
+}
+
+#[test]
+fn namespace_import_required_class_type_reference_still_requires_type_arg() {
+    let lib = r#"
+export namespace SQL {
+  export class Required<T> {
+    value!: T
+  }
+}
+"#;
+    let main = r#"
+import * as Query from './query'
+export type Bare = Query.SQL.Required
+"#;
+    let codes = check_namespace_import_codes(lib, main);
+
+    assert!(
+        codes.contains(&2314),
+        "required namespace-imported class should still emit TS2314, got {codes:?}"
     );
 }
 


### PR DESCRIPTION
Goal: green

Fixes one Drizzle #13480 false-positive family: bare references to namespace-imported classes with defaulted type parameters, such as `Query.SQL.Aliased<T = unknown>`, should not emit `TS2314` when the type argument is omitted.

## Structural rule

When a type reference names a namespace-imported class and the referenced declaration has defaulted type parameters, `tsc` computes the required arity from declaration syntax before reporting `TS2314`. `tsz` now answers that diagnostic-only required-count question from the referenced declaration syntax without storing the default type in the extracted `TypeParamInfo` list.

## Owner layer

Checker type-reference validation / reference type-parameter lookup. The change is intentionally count-only: it does not lower default types, does not instantiate default arguments, and does not change solver relation/evaluation semantics. This avoids the stale patch failure mode where setting `default: Some(TypeId::UNKNOWN)` or lowering real Drizzle defaults unlocked recursive default expansion and stack-overflowed the row.

## Adjacent matrix

- Positive: `import * as Query; type Bare = Query.SQL.Aliased` with `class Aliased<T = unknown>` no longer emits `TS2314`.
- Negative: the same namespace-imported class shape with `class Required<T>` still emits `TS2314`.
- Fallback: ordinary unconstrained outer type references still check nested type-argument arity.
- Remaining Drizzle state: the full project-compile guard still times out CPU-bound; this PR only removes the namespace-defaulted arity false-positive family before the next #13480 blocker.

## Verification

- `scripts/safe-run.sh cargo fmt --check`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli --bin tsz`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --test type_arg_count_mismatch_tests -E 'test(namespace_import_defaulted_class_type_reference_allows_omitted_type_arg) or test(namespace_import_required_class_type_reference_still_requires_type_arg) or test(unconstrained_outer_type_ref_still_checks_nested_type_arg_arity)'`
- `scripts/safe-run.sh scripts/bench/measure-tsz.sh --timeout 80 --json-file /tmp/drizzle-guard-syntax-required-count-rebased.json --label drizzle-guard-syntax-required-count-rebased -- --noEmit -p /Users/mohsen/code/tsz-drizzle-13480/.target/project-compile-guard/drizzle-orm/tsconfig.tsz-guard.json` (expected remaining #13480 blocker: CPU-bound timeout, no passing smoke claim)

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5-codex
Effort: high