### PR TITLE
fix(checker): fold self-module augmentations into exported interfaces before keyof

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -506,6 +506,9 @@ path = "tests/ambient_module_value_export_tests.rs"
 name = "export_star_module_augmentation_tests"
 path = "tests/export_star_module_augmentation_tests.rs"
 [[test]]
+name = "hkt_self_augmentation_keyof_repro"
+path = "tests/hkt_self_augmentation_keyof_repro.rs"
+[[test]]
 name = "cjs_object_export_module_augmentation_merge_tests"
 path = "tests/cjs_object_export_module_augmentation_merge_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -202,6 +202,10 @@ impl<'a> CheckerState<'a> {
                         );
                     }
 
+                    // Step 1.26: fold in augmentations targeting this interface's
+                    // own module (fp-ts HKT `URItoKind` pattern, #13509).
+                    structural_type = self.apply_self_module_augmentations(sym_id, structural_type);
+
                     // Cache generic interface params with canonical symbol extraction;
                     // local NodeIndex lookups can collide with lib/cross-file nodes.
                     let def_id = self.ctx.get_or_create_def_id(sym_id);
@@ -1005,6 +1009,8 @@ impl<'a> CheckerState<'a> {
                 };
             }
             if merged != TypeId::ERROR {
+                // Self-module augmentations before caching, so `keyof` sees them (#13509).
+                merged = self.apply_self_module_augmentations(sym_id, merged);
                 self.ctx.symbol_instance_types.insert(sym_id, merged);
             }
             return merged;
@@ -1149,6 +1155,9 @@ impl<'a> CheckerState<'a> {
         let _ = params; // params are not needed for this path
 
         let merged = self.merge_interface_heritage_types(&declarations, interface_type);
+        // Self-module augmentations so the canonical DefId type that `keyof`
+        // evaluation reads carries cross-file augmented members (#13509).
+        let merged = self.apply_self_module_augmentations(sym_id, merged);
         self.ctx.symbol_instance_types.insert(sym_id, merged);
         let def_id = self.ctx.get_or_create_def_id(sym_id);
         self.ctx

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -1327,6 +1327,66 @@ impl<'a> CheckerState<'a> {
         result
     }
 
+    /// Merge `declare module "./home" { interface I { ... } }` augmentations into
+    /// the type of interface `I` declared (and exported) in its own home module,
+    /// even when `I` is reached by reference within its declaring file rather than
+    /// through an import alias.
+    ///
+    /// This is the fp-ts higher-kinded-types pattern: a central `URItoKind`
+    /// interface in `./HKT` is augmented from many sibling files via
+    /// `declare module "./HKT" { interface URItoKind<A> { readonly Foo: ... } }`.
+    /// Computing `keyof URItoKind` (for the `Kind`/`URIS` constraint) must see the
+    /// cross-file registered members. The import-driven augmentation path only
+    /// fires for symbols carrying an `import_module()` specifier, so a self-module
+    /// interface reference never picked them up.
+    ///
+    /// Gated on `is_exported`: a file-local (non-exported) interface is not part
+    /// of the module's augmentable export surface, so a same-file
+    /// `declare module "./self"` augmentation stays an independent symbol and must
+    /// not merge into it (#6164). Symbols already reached through an import alias
+    /// are left to the import path to avoid double application.
+    pub(crate) fn apply_self_module_augmentations(
+        &mut self,
+        sym_id: tsz_binder::SymbolId,
+        base_type: TypeId,
+    ) -> TypeId {
+        if base_type == TypeId::ERROR
+            || base_type == TypeId::UNKNOWN
+            || !self.ctx.program_has_module_augmentations()
+        {
+            return base_type;
+        }
+        let Some(symbol) = self.ctx.binder.get_symbol(sym_id) else {
+            return base_type;
+        };
+        // The import-driven path (`type_reference_symbol_type`) already applies
+        // augmentations for symbols reached through an import alias.
+        if symbol.import_module().is_some() {
+            return base_type;
+        }
+        // Only exported interfaces participate in their module's augmentable
+        // surface; a non-exported file-local interface keeps its self-module
+        // augmentation as a separate symbol (#6164).
+        if !symbol.is_exported {
+            return base_type;
+        }
+        let interface_name = symbol.escaped_name.clone();
+        let home_idx = self
+            .ctx
+            .resolve_symbol_file_index(sym_id)
+            .unwrap_or(self.ctx.current_file_idx);
+        let Some(home_file_name) = self
+            .ctx
+            .get_arena_for_file(home_idx as u32)
+            .source_files
+            .first()
+            .map(|sf| sf.file_name.clone())
+        else {
+            return base_type;
+        };
+        self.apply_module_augmentations(&home_file_name, &interface_name, base_type)
+    }
+
     /// Update `symbol_types` and `type_env` for augmentation-local interface symbols
     /// so self-referential type references resolve to the merged type.
     /// Searches both the current binder and `all_binders` since the augmentation

--- a/crates/tsz-checker/tests/hkt_self_augmentation_keyof_repro.rs
+++ b/crates/tsz-checker/tests/hkt_self_augmentation_keyof_repro.rs
@@ -1,0 +1,226 @@
+//! Repro + adjacent matrix for #13509: a cross-file `declare module` interface
+//! augmentation must be folded into the interface BEFORE `keyof` / constraint
+//! satisfaction, even when the interface is referenced within its own declaring
+//! file (the fp-ts higher-kinded-types pattern).
+//!
+//! Structural rule: when an exported interface `I` declared in module `M` is
+//! augmented via `declare module "M" { interface I { ... } }` from any file,
+//! `keyof I` (and constraint satisfaction against it) must include every merged
+//! member. Gated on export-ness so non-exported file-local interfaces keep their
+//! self-module augmentation isolated (#6164).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_multi_file_with_global_index;
+
+fn diagnostics(files: &[(&str, &str)], entry: &str) -> Vec<(u32, String)> {
+    check_multi_file_with_global_index(
+        files,
+        entry,
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn count_code(diags: &[(u32, String)], expected: u32) -> usize {
+    diags.iter().filter(|(code, _)| *code == expected).count()
+}
+
+/// Core fp-ts HKT witness: `Kind<URI, A>` where `URI = "Array"` is registered
+/// into the central `URItoKind` interface via a cross-file `declare module`.
+#[test]
+fn fp_ts_hkt_keyof_sees_cross_file_self_augmentation() {
+    let diags = diagnostics(
+        &[
+            (
+                "HKT.ts",
+                r#"
+export interface URItoKind<A> {}
+export type URIS = keyof URItoKind<unknown>;
+export type Kind<U extends URIS, A> = URItoKind<A>[U];
+"#,
+            ),
+            (
+                "Array.ts",
+                r#"
+import { Kind } from "./HKT";
+declare module "./HKT" {
+    interface URItoKind<A> {
+        readonly Array: Array<A>;
+    }
+}
+export const URI = "Array";
+export type URI = typeof URI;
+export const of = <A>(a: A): Kind<URI, A> => [a];
+"#,
+            ),
+        ],
+        "Array.ts",
+    );
+
+    assert_eq!(
+        count_code(&diags, 2344),
+        0,
+        "unexpected TS2344 (keyof missed cross-file self-augmentation); got {diags:#?}"
+    );
+}
+
+/// Anti-hardcoding: the rule is structural, not name-driven. Every binder is
+/// renamed (module, registry interface, key, alias) and the behavior holds.
+#[test]
+fn keyof_self_augmentation_rule_is_binder_name_independent() {
+    let diags = diagnostics(
+        &[
+            (
+                "registry.ts",
+                r#"
+export interface Slots<T> {}
+export type Tags = keyof Slots<unknown>;
+export type Pick2<K extends Tags, T> = Slots<T>[K];
+"#,
+            ),
+            (
+                "widget.ts",
+                r#"
+import { Pick2 } from "./registry";
+declare module "./registry" {
+    interface Slots<T> {
+        readonly Widget: ReadonlyArray<T>;
+    }
+}
+export const TAG = "Widget";
+export type TAG = typeof TAG;
+export const wrap = <T>(t: T): Pick2<TAG, T> => [t];
+"#,
+            ),
+        ],
+        "widget.ts",
+    );
+
+    assert_eq!(
+        count_code(&diags, 2344),
+        0,
+        "renamed-binder HKT registry should also see the augmented key; got {diags:#?}"
+    );
+}
+
+/// Two type-parameter registry (`URItoKind2<E, A>`): the 2-ary form must merge
+/// the same way.
+#[test]
+fn keyof_self_augmentation_two_arity_registry() {
+    let diags = diagnostics(
+        &[
+            (
+                "HKT.ts",
+                r#"
+export interface URItoKind2<E, A> {}
+export type URIS2 = keyof URItoKind2<unknown, unknown>;
+export type Kind2<U extends URIS2, E, A> = URItoKind2<E, A>[U];
+"#,
+            ),
+            (
+                "Either.ts",
+                r#"
+import { Kind2 } from "./HKT";
+declare module "./HKT" {
+    interface URItoKind2<E, A> {
+        readonly Either: { left: E; right: A };
+    }
+}
+export const URI = "Either";
+export type URI = typeof URI;
+export const right = <E, A>(a: A): Kind2<URI, E, A> => ({ left: undefined as any, right: a });
+"#,
+            ),
+        ],
+        "Either.ts",
+    );
+
+    assert_eq!(
+        count_code(&diags, 2344),
+        0,
+        "2-ary HKT registry should see the augmented key; got {diags:#?}"
+    );
+}
+
+/// Multiple sibling files registering distinct URIs all land in `keyof`.
+#[test]
+fn keyof_self_augmentation_accumulates_across_many_files() {
+    let diags = diagnostics(
+        &[
+            (
+                "HKT.ts",
+                r#"
+export interface URItoKind<A> {}
+export type URIS = keyof URItoKind<unknown>;
+export type Kind<U extends URIS, A> = URItoKind<A>[U];
+"#,
+            ),
+            (
+                "Array.ts",
+                r#"
+import { Kind } from "./HKT";
+declare module "./HKT" { interface URItoKind<A> { readonly Array: Array<A>; } }
+export const URI = "Array";
+export type URI = typeof URI;
+export const ofA = <A>(a: A): Kind<URI, A> => [a];
+"#,
+            ),
+            (
+                "Option.ts",
+                r#"
+import { Kind } from "./HKT";
+declare module "./HKT" { interface URItoKind<A> { readonly Option: { value: A }; } }
+export const URI = "Option";
+export type URI = typeof URI;
+export const ofO = <A>(a: A): Kind<URI, A> => ({ value: a });
+"#,
+            ),
+        ],
+        "Option.ts",
+    );
+
+    assert_eq!(
+        count_code(&diags, 2344),
+        0,
+        "every sibling-registered URI should satisfy the keyof constraint; got {diags:#?}"
+    );
+}
+
+/// Negative control (#6164): a NON-exported file-local interface that is
+/// self-augmented via `declare module "./self"` must NOT absorb the augmented
+/// member, so an object literal carrying that member is still an excess property
+/// (TS2353). Guards against over-merging.
+#[test]
+fn non_exported_self_augmented_interface_does_not_merge() {
+    let diags = diagnostics(
+        &[(
+            "test.ts",
+            r#"
+interface Local {
+    a: number;
+}
+
+declare module "./test" {
+    interface Local {
+        b: string;
+    }
+}
+
+const v: Local = { a: 1, b: "x" };
+export {};
+"#,
+        )],
+        "test.ts",
+    );
+
+    assert_eq!(
+        count_code(&diags, 2353),
+        1,
+        "non-exported local interface must keep its self-augmentation isolated; got {diags:#?}"
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes #13509.

## Structural rule

When an exported interface `I` declared in module `M` is augmented via
`declare module "M" { interface I { ... } }` from any file, the computed type of
`I` — and therefore `keyof I` and constraint satisfaction against it — must
include every merged member. tsz previously merged augmentations only when the
interface symbol was reached through an **import alias** (`symbol.import_module()`
was `Some`). An interface referenced within (or cross-file from) its own
declaring module never picked up the augmentations, so `keyof URItoKind` excluded
every cross-file-registered key.

This is the fp-ts higher-kinded-types registry pattern: a central `URItoKind`
interface in `./HKT` is augmented from many sibling files via
`declare module "./HKT" { interface URItoKind<A> { readonly Foo: ... } }`. The
`Kind`/`URIS` constraint computes `keyof URItoKind`, which missed the keys and
emitted a spurious `TS2344: Type 'typeof URI' does not satisfy the constraint
'keyof URItoKind'` (fp-ts row: 853 × TS2344 + the downstream TS2322 cascade).

## Owner layer

Checker interface-type computation (`tsz_checker::state::type_resolution`),
backed by the existing solver-side augmentation merge
(`apply_module_augmentations`). New helper
`apply_self_module_augmentations(sym_id, base_type)` resolves the interface
symbol's own home-module specifier and folds in augmentations targeting it.

- Gated on `is_exported`: a non-exported file-local interface is not part of the
  module's augmentable export surface, so a same-file `declare module "./self"`
  augmentation stays an independent symbol and must not merge (#6164).
- Defers to the import-driven path for symbols already carrying an
  `import_module()` specifier, to avoid double application.
- Applied at the three interface-type computation chokepoints in
  `symbol_types.rs` (the import-resolution site in `type_reference_symbol_type`
  plus both return points of `compute_interface_type_from_declarations`) so the
  canonical `DefId` type that keyof evaluation reads carries the augmented
  members.

## Anti-hardcoding

No identifier/file-name/printer-string predicates. The gate is the structural
`is_exported` boundary; the module specifier is resolved from the symbol's home
file index. A renamed-binder test (`registry`/`Slots`/`Tags`/`Widget`) and a
2-ary registry test prove the rule is name-independent.

## Adjacent matrix

- Positive: cross-file self-augmentation merges into `keyof` (core fp-ts witness;
  renamed binders; 2-ary `URItoKind2`; accumulation across multiple sibling
  files).
- Negative/fallback: a non-exported file-local interface self-augmented via
  `declare module "./self"` still does **not** merge (excess property remains
  `TS2353`) — guards against over-merging and preserves #6164.

## Verification

- `cargo fmt -p tsz-checker -- --check`
- `scripts/arch/check-checker-boundaries.sh` (passes; `symbol_types.rs` kept
  under the 2000-line cap)
- `cargo test -p tsz-checker --test hkt_self_augmentation_keyof_repro` — 5/5
  (new fp-ts HKT matrix + negative control)
- `cargo test -p tsz-checker --test self_module_augmentation_isolation_tests
  --test module_augmentation_isolation_tests
  --test export_star_module_augmentation_tests
  --test cjs_object_export_module_augmentation_merge_tests` — all pass (#6164
  isolation + `export *` merge regressions preserved)
- `cargo test -p tsz-checker --lib` — no new failures vs `main` baseline
  (baseline 66 pre-existing debug-mode failures → 65 with this change; the diff
  is +1 fixed test, 0 new failures)

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01QLeY9exWnzBut1d2GLT4HU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLeY9exWnzBut1d2GLT4HU)_