### PR TITLE
perf(solver): memoize failed template string matches

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_template_match.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_template_match.rs
@@ -29,6 +29,12 @@ impl TemplateStringMatchState {
     }
 }
 
+#[derive(Clone, Copy)]
+struct TemplateStringCursor {
+    pos: usize,
+    index: usize,
+}
+
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     fn parse_template_number_capture(&self, captured: &str) -> Option<TypeId> {
         let value = if let Some(digits) = captured.strip_prefix("0x") {
@@ -272,8 +278,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         &self,
         source: &str,
         pattern: &[TemplateSpan],
-        pos: usize,
-        index: usize,
+        cursor: TemplateStringCursor,
         type_id: TypeId,
         bindings: &mut FxHashMap<Atom, TypeId>,
         checker: &mut SubtypeChecker<'_, R>,
@@ -283,7 +288,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             find_integer_length, find_number_length, is_valid_number,
         };
 
-        let remaining = &source[pos..];
+        let remaining = &source[cursor.pos..];
 
         match self.interner().lookup(type_id)? {
             TypeData::Intrinsic(kind) => match kind {
@@ -299,8 +304,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             && self.match_template_literal_string_from(
                                 source,
                                 pattern,
-                                pos + len,
-                                index + 1,
+                                cursor.pos + len,
+                                cursor.index + 1,
                                 bindings,
                                 checker,
                                 failed_states,
@@ -321,8 +326,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         if self.match_template_literal_string_from(
                             source,
                             pattern,
-                            pos + len,
-                            index + 1,
+                            cursor.pos + len,
+                            cursor.index + 1,
                             bindings,
                             checker,
                             failed_states,
@@ -337,8 +342,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         && self.match_template_literal_string_from(
                             source,
                             pattern,
-                            pos + 4,
-                            index + 1,
+                            cursor.pos + 4,
+                            cursor.index + 1,
                             bindings,
                             checker,
                             failed_states,
@@ -350,8 +355,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         && self.match_template_literal_string_from(
                             source,
                             pattern,
-                            pos + 5,
-                            index + 1,
+                            cursor.pos + 5,
+                            cursor.index + 1,
                             bindings,
                             checker,
                             failed_states,
@@ -366,8 +371,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         && self.match_template_literal_string_from(
                             source,
                             pattern,
-                            pos + 4,
-                            index + 1,
+                            cursor.pos + 4,
+                            cursor.index + 1,
                             bindings,
                             checker,
                             failed_states,
@@ -383,8 +388,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         && self.match_template_literal_string_from(
                             source,
                             pattern,
-                            pos + 9,
-                            index + 1,
+                            cursor.pos + 9,
+                            cursor.index + 1,
                             bindings,
                             checker,
                             failed_states,
@@ -484,8 +489,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 if let Some(result) = self.match_intrinsic_span_from(
                     source,
                     pattern,
-                    pos,
-                    index,
+                    TemplateStringCursor { pos, index },
                     type_id,
                     bindings,
                     checker,

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_template_match.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_template_match.rs
@@ -2,10 +2,32 @@
 
 use crate::relations::subtype::{SubtypeChecker, TypeResolver};
 use crate::types::{IntrinsicKind, LiteralValue, TemplateSpan, TypeData, TypeId, TypeParamInfo};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tsz_common::interner::Atom;
 
 use super::super::evaluate::TypeEvaluator;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct TemplateStringMatchState {
+    pos: usize,
+    index: usize,
+    bindings: Vec<(u32, u32)>,
+}
+
+impl TemplateStringMatchState {
+    fn new(pos: usize, index: usize, bindings: &FxHashMap<Atom, TypeId>) -> Self {
+        let mut bindings: Vec<_> = bindings
+            .iter()
+            .map(|(name, type_id)| (name.0, type_id.0))
+            .collect();
+        bindings.sort_unstable();
+        Self {
+            pos,
+            index,
+            bindings,
+        }
+    }
+}
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
     fn parse_template_number_capture(&self, captured: &str) -> Option<TypeId> {
@@ -118,7 +140,16 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         bindings: &mut FxHashMap<Atom, TypeId>,
         checker: &mut SubtypeChecker<'_, R>,
     ) -> bool {
-        self.match_template_literal_string_from(source, pattern, 0, 0, bindings, checker)
+        let mut failed_states = FxHashSet::default();
+        self.match_template_literal_string_from(
+            source,
+            pattern,
+            0,
+            0,
+            bindings,
+            checker,
+            &mut failed_states,
+        )
     }
 
     fn match_template_segment_prefix(
@@ -246,6 +277,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         type_id: TypeId,
         bindings: &mut FxHashMap<Atom, TypeId>,
         checker: &mut SubtypeChecker<'_, R>,
+        failed_states: &mut FxHashSet<TemplateStringMatchState>,
     ) -> Option<bool> {
         use crate::relations::subtype::rules::literals::{
             find_integer_length, find_number_length, is_valid_number,
@@ -271,6 +303,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                                 index + 1,
                                 bindings,
                                 checker,
+                                failed_states,
                             )
                         {
                             return Some(true);
@@ -292,6 +325,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             index + 1,
                             bindings,
                             checker,
+                            failed_states,
                         ) {
                             return Some(true);
                         }
@@ -307,6 +341,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             index + 1,
                             bindings,
                             checker,
+                            failed_states,
                         )
                     {
                         return Some(true);
@@ -319,6 +354,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             index + 1,
                             bindings,
                             checker,
+                            failed_states,
                         )
                     {
                         return Some(true);
@@ -334,6 +370,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             index + 1,
                             bindings,
                             checker,
+                            failed_states,
                         )
                     {
                         Some(true)
@@ -350,6 +387,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             index + 1,
                             bindings,
                             checker,
+                            failed_states,
                         )
                     {
                         Some(true)
@@ -372,26 +410,34 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         index: usize,
         bindings: &mut FxHashMap<Atom, TypeId>,
         checker: &mut SubtypeChecker<'_, R>,
+        failed_states: &mut FxHashSet<TemplateStringMatchState>,
     ) -> bool {
         if index == pattern.len() {
             return pos == source.len();
         }
 
-        match pattern[index] {
+        let state = TemplateStringMatchState::new(pos, index, bindings);
+        if failed_states.contains(&state) {
+            return false;
+        }
+
+        let matched = match pattern[index] {
             TemplateSpan::Text(text) => {
                 let text_value = self.interner().resolve_atom_ref(text);
                 let text_value = text_value.as_ref();
                 if !source[pos..].starts_with(text_value) {
-                    return false;
+                    false
+                } else {
+                    self.match_template_literal_string_from(
+                        source,
+                        pattern,
+                        pos + text_value.len(),
+                        index + 1,
+                        bindings,
+                        checker,
+                        failed_states,
+                    )
                 }
-                self.match_template_literal_string_from(
-                    source,
-                    pattern,
-                    pos + text_value.len(),
-                    index + 1,
-                    bindings,
-                    checker,
-                )
             }
             TemplateSpan::Type(type_id) => {
                 if let Some(TypeData::Infer(info)) = self.interner().lookup(type_id) {
@@ -413,11 +459,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             index + 1,
                             &mut next_bindings,
                             checker,
+                            failed_states,
                         ) {
                             *bindings = next_bindings;
                             return true;
                         }
                     }
+                    failed_states.insert(state);
                     return false;
                 }
 
@@ -429,12 +477,23 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         index + 1,
                         bindings,
                         checker,
+                        failed_states,
                     );
                 }
 
                 if let Some(result) = self.match_intrinsic_span_from(
-                    source, pattern, pos, index, type_id, bindings, checker,
+                    source,
+                    pattern,
+                    pos,
+                    index,
+                    type_id,
+                    bindings,
+                    checker,
+                    failed_states,
                 ) {
+                    if !result {
+                        failed_states.insert(state);
+                    }
                     return result;
                 }
 
@@ -451,6 +510,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                             index + 1,
                             bindings,
                             checker,
+                            failed_states,
                         )
                     {
                         return true;
@@ -458,7 +518,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 }
                 false
             }
+        };
+        if !matched {
+            failed_states.insert(state);
         }
+        matched
     }
 
     /// Capture value for a bare single-placeholder `` `${infer V}` `` pattern


### PR DESCRIPTION
Goal: green

## Summary
- Add a request-local negative memo for literal-string template infer matching.
- Key failed states by source cursor, pattern cursor, and the current infer-binding fingerprint.
- Preserve successful capture order and existing fallback behavior; this only skips retrying states that already failed under the same bindings.

## Structural rule
When template-literal infer matching revisits the same `(source position, pattern index)` with the same already-bound infer variables, a previous failed match is deterministic for that request. tsz should reuse that failed state instead of re-exploring the same capture-end backtracking tree.

Owner layer: solver evaluation / infer-pattern template matching. This does not add fixture-name shortcuts, display-string predicates, cross-file cache widening, or checker-local semantic policy.

## Adjacent matrix
- Repeated failed string-template cursor state with identical infer bindings: return `false` from the request-local memo.
- Same cursor state with different infer bindings: recompute, because repeated `infer` names and constraints can change success.
- Successful candidate capture: preserve existing first-success behavior and copy the successful bindings back to the caller.
- Non-template infer matching and template-span structural matching: unchanged.
- Fallback invariant: relation and subtype decisions remain owned by the existing `SubtypeChecker` calls.

## Verification
- Not run locally per user instruction.
- Pre-commit formatting hook ran during commits `0e4b250a743cb955db8ae0452c07871fd10fd37f` and `ac69a27373be8d8f52ca95e5118f249df32db881`.
- Draft CI at `0e4b250a743cb955db8ae0452c07871fd10fd37f` found `lint` failed on `clippy::too_many_arguments`; fixed by bundling the template string cursor in `ac69a27373be8d8f52ca95e5118f249df32db881`.
- Draft CI is expected to prove formatting/lint/unit compatibility before ready-review.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium
