### PR TITLE
perf(solver): index application eval invalidations

### DIFF
--- a/crates/tsz-solver/src/caches/application_eval_index.rs
+++ b/crates/tsz-solver/src/caches/application_eval_index.rs
@@ -1,0 +1,42 @@
+use crate::caches::shared_instantiation::collect_application_eval_entry_def_dependencies;
+use crate::caches::shared_query_cache::ApplicationEvalCacheKey;
+use crate::def::DefId;
+use crate::intern::TypeInterner;
+use crate::types::TypeId;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::cell::RefCell;
+
+pub(super) type ApplicationEvalDependencyIndex =
+    RefCell<FxHashMap<DefId, FxHashSet<ApplicationEvalCacheKey>>>;
+
+pub(super) fn record_dependencies(
+    interner: &TypeInterner,
+    index: &ApplicationEvalDependencyIndex,
+    key: &ApplicationEvalCacheKey,
+    result: TypeId,
+) {
+    let deps = collect_application_eval_entry_def_dependencies(interner, key, result);
+    let mut index = index.borrow_mut();
+    for def_id in deps {
+        index.entry(def_id).or_default().insert(key.clone());
+    }
+}
+
+pub(super) fn invalidate_for_def(
+    index: &ApplicationEvalDependencyIndex,
+    cache: &RefCell<FxHashMap<ApplicationEvalCacheKey, TypeId>>,
+    def_id: DefId,
+) {
+    let Some(keys) = index.borrow_mut().remove(&def_id) else {
+        return;
+    };
+    let mut cache = cache.borrow_mut();
+    for key in keys {
+        cache.remove(&key);
+    }
+}
+
+#[cfg(test)]
+pub(super) fn key_count(index: &ApplicationEvalDependencyIndex, def_id: DefId) -> usize {
+    index.borrow().get(&def_id).map_or(0, FxHashSet::len)
+}

--- a/crates/tsz-solver/src/caches/mod.rs
+++ b/crates/tsz-solver/src/caches/mod.rs
@@ -1,3 +1,4 @@
+mod application_eval_index;
 pub(crate) mod db;
 pub(crate) mod instantiation_cache;
 pub(crate) mod query_cache;

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -4,6 +4,7 @@
 //! relation, property, and element access queries. This is the concrete
 //! database implementation used by the checker at runtime.
 
+use crate::caches::application_eval_index::{self, ApplicationEvalDependencyIndex};
 use crate::caches::db::{
     QueryDatabase, TypeApplicationEvalCache, TypeCompilerOptions, TypeDatabase,
     TypeDisplayProvenance, TypePredicateCache, TypeTupleLimitSignal,
@@ -11,7 +12,6 @@ use crate::caches::db::{
 use crate::caches::instantiation_cache::{InstantiationCache, InstantiationCacheKey};
 use crate::caches::query_cache_statistics::{QueryCacheStatistics, RelationCacheStats};
 use crate::caches::query_trace;
-use crate::caches::shared_instantiation::application_eval_entry_references_def;
 use crate::caches::shared_query_cache::ApplicationEvalCacheKey;
 pub use crate::caches::shared_query_cache::SharedQueryCache;
 use crate::caches::subtype_reduction_cache::{SubtypeReductionCache, SubtypeReductionKey};
@@ -224,6 +224,7 @@ pub struct QueryCache<'a> {
     /// in `evaluate`). Keyed by `(TypeId, no_unchecked_indexed_access)`.
     closed_eval_cache: RefCell<FxHashMap<EvaluationCacheKey, TypeId>>,
     application_eval_cache: RefCell<FxHashMap<ApplicationEvalCacheKey, TypeId>>,
+    application_eval_dependency_index: ApplicationEvalDependencyIndex,
     element_access_cache: RefCell<FxHashMap<ElementAccessTypeCacheKey, TypeId>>,
     object_spread_properties_cache: RefCell<FxHashMap<TypeId, Vec<PropertyInfo>>>,
     subtype_cache: RefCell<FxHashMap<RelationCacheKey, RelationCacheValue>>,
@@ -294,6 +295,7 @@ impl<'a> QueryCache<'a> {
             eval_cache: RefCell::new(FxHashMap::default()),
             closed_eval_cache: RefCell::new(FxHashMap::default()),
             application_eval_cache: RefCell::new(FxHashMap::default()),
+            application_eval_dependency_index: RefCell::new(FxHashMap::default()),
             element_access_cache: RefCell::new(FxHashMap::default()),
             object_spread_properties_cache: RefCell::new(FxHashMap::default()),
             subtype_cache: RefCell::new(FxHashMap::default()),
@@ -321,6 +323,7 @@ impl<'a> QueryCache<'a> {
         self.closed_eval_cache.borrow_mut().clear();
         self.element_access_cache.borrow_mut().clear();
         self.application_eval_cache.borrow_mut().clear();
+        self.application_eval_dependency_index.borrow_mut().clear();
         self.object_spread_properties_cache.borrow_mut().clear();
         self.subtype_cache.borrow_mut().clear();
         self.assignability_cache.borrow_mut().clear();
@@ -613,7 +616,15 @@ impl<'a> QueryCache<'a> {
             && shared.shares_instantiation_family()
         {
             if let Some(result) = shared.application_eval_cache.get(&key).map(|entry| *entry) {
-                self.application_eval_cache.borrow_mut().insert(key, result);
+                self.application_eval_cache
+                    .borrow_mut()
+                    .insert(key.clone(), result);
+                application_eval_index::record_dependencies(
+                    self.interner,
+                    &self.application_eval_dependency_index,
+                    &key,
+                    result,
+                );
                 self.application_eval_cache_stats.record_hit();
                 self.application_eval_cache_stats.record_shared_hit();
                 tsz_common::perf_counters::record_shared_application_eval_cache_hit();
@@ -630,11 +641,24 @@ impl<'a> QueryCache<'a> {
         if let Some(shared) = self.shared
             && shared.shares_instantiation_family()
         {
-            shared.application_eval_cache.insert(key.clone(), result);
+            shared.insert_application_eval_cache(self.interner, key.clone(), result);
             self.application_eval_cache_stats.record_shared_insert();
             tsz_common::perf_counters::record_shared_application_eval_cache_insert();
         }
-        self.application_eval_cache.borrow_mut().insert(key, result);
+        self.application_eval_cache
+            .borrow_mut()
+            .insert(key.clone(), result);
+        application_eval_index::record_dependencies(
+            self.interner,
+            &self.application_eval_dependency_index,
+            &key,
+            result,
+        );
+    }
+
+    #[cfg(test)]
+    pub(crate) fn application_eval_dependency_key_count(&self, def_id: DefId) -> usize {
+        application_eval_index::key_count(&self.application_eval_dependency_index, def_id)
     }
 
     fn check_object_spread_properties_cache(&self, key: TypeId) -> Option<Vec<PropertyInfo>> {
@@ -1015,17 +1039,15 @@ impl TypeApplicationEvalCache for QueryCache<'_> {
     }
 
     fn invalidate_application_eval_cache_for_def(&self, def_id: DefId) {
-        let mut cache = self.application_eval_cache.borrow_mut();
-        cache.retain(|key, &mut result| {
-            !application_eval_entry_references_def(self.interner, key, result, def_id)
-        });
+        application_eval_index::invalidate_for_def(
+            &self.application_eval_dependency_index,
+            &self.application_eval_cache,
+            def_id,
+        );
         if let Some(shared) = self.shared
             && shared.shares_instantiation_family()
-            && !shared.application_eval_cache.is_empty()
         {
-            shared.application_eval_cache.retain(|key, result| {
-                !application_eval_entry_references_def(self.interner, key, *result, def_id)
-            });
+            shared.invalidate_application_eval_cache_for_def(def_id);
         }
     }
 

--- a/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
+++ b/crates/tsz-solver/src/caches/query_cache_statistics_test.rs
@@ -189,6 +189,53 @@ fn application_eval_cache_stats_visible_in_display() {
 }
 
 #[test]
+fn application_eval_cache_invalidation_uses_recorded_def_dependencies() {
+    // Structural rule: a definition-body rewrite invalidates exactly the
+    // application-eval entries whose base, arguments, or result mention the
+    // rewritten `DefId`. The cache records those dependencies at insertion so
+    // invalidation is keyed by `DefId`, not by a full cache sweep.
+    let interner = TypeInterner::new();
+    let db = QueryCache::new(&interner);
+
+    let base_def = DefId(10);
+    let arg_def = DefId(20);
+    let result_def = DefId(30);
+    let unrelated_def = DefId(40);
+    let arg_ref = interner.lazy(arg_def);
+    let result_ref = interner.lazy(result_def);
+
+    db.insert_application_eval_cache(base_def, &[TypeId::STRING], false, TypeId::NUMBER);
+    db.insert_application_eval_cache(DefId(11), &[arg_ref], false, TypeId::BOOLEAN);
+    db.insert_application_eval_cache(DefId(12), &[TypeId::NUMBER], false, result_ref);
+    db.insert_application_eval_cache(unrelated_def, &[TypeId::BOOLEAN], false, TypeId::STRING);
+
+    assert_eq!(db.application_eval_dependency_key_count(base_def), 1);
+    assert_eq!(db.application_eval_dependency_key_count(arg_def), 1);
+    assert_eq!(db.application_eval_dependency_key_count(result_def), 1);
+    assert_eq!(db.statistics().application_eval_cache_entries, 4);
+
+    db.invalidate_application_eval_cache_for_def(arg_def);
+
+    assert_eq!(
+        db.lookup_application_eval_cache(DefId(11), &[arg_ref], false),
+        None
+    );
+    assert_eq!(
+        db.lookup_application_eval_cache(base_def, &[TypeId::STRING], false),
+        Some(TypeId::NUMBER)
+    );
+    assert_eq!(
+        db.lookup_application_eval_cache(DefId(12), &[TypeId::NUMBER], false),
+        Some(result_ref)
+    );
+    assert_eq!(
+        db.lookup_application_eval_cache(unrelated_def, &[TypeId::BOOLEAN], false),
+        Some(TypeId::STRING)
+    );
+    assert_eq!(db.application_eval_dependency_key_count(arg_def), 0);
+}
+
+#[test]
 fn instantiation_cache_is_per_file_isolated() {
     // Structural rule: `instantiation_cache` is intentionally NOT shared
     // cross-file. The same class of ordering-sensitivity that affects

--- a/crates/tsz-solver/src/caches/shared_instantiation.rs
+++ b/crates/tsz-solver/src/caches/shared_instantiation.rs
@@ -1,21 +1,38 @@
 use crate::caches::shared_query_cache::ApplicationEvalCacheKey;
 use crate::def::DefId;
 use crate::types::TypeId;
+use rustc_hash::FxHashSet;
 
 pub(super) fn shared_instantiation_family_requested() -> bool {
     std::env::var_os("TSZ_SHARE_INSTANTIATION_CACHES").is_some_and(|value| value != "0")
 }
 
-pub(super) fn application_eval_entry_references_def(
+pub(super) fn collect_application_eval_entry_def_dependencies(
     interner: &dyn crate::construction::TypeDatabase,
     key: &ApplicationEvalCacheKey,
     result: TypeId,
-    def_id: DefId,
-) -> bool {
+) -> Vec<DefId> {
     let (key_def, key_args, _, _) = key;
-    *key_def == def_id
-        || key_args
-            .iter()
-            .any(|&arg| crate::visitors::visitor::contains_lazy_def_id(interner, arg, def_id))
-        || crate::visitors::visitor::contains_lazy_def_id(interner, result, def_id)
+    let mut seen = FxHashSet::default();
+    let mut deps = Vec::new();
+
+    if seen.insert(*key_def) {
+        deps.push(*key_def);
+    }
+
+    for &arg in key_args {
+        for def_id in crate::visitors::visitor::collect_lazy_def_ids(interner, arg) {
+            if seen.insert(def_id) {
+                deps.push(def_id);
+            }
+        }
+    }
+
+    for def_id in crate::visitors::visitor::collect_lazy_def_ids(interner, result) {
+        if seen.insert(def_id) {
+            deps.push(def_id);
+        }
+    }
+
+    deps
 }

--- a/crates/tsz-solver/src/caches/shared_query_cache.rs
+++ b/crates/tsz-solver/src/caches/shared_query_cache.rs
@@ -1,12 +1,14 @@
 //! Thread-safe shared query cache for cross-file type checking.
 
 use crate::caches::instantiation_cache::InstantiationCacheKey;
+use crate::caches::shared_instantiation::collect_application_eval_entry_def_dependencies;
 use crate::caches::shared_instantiation::shared_instantiation_family_requested;
 use crate::def::DefId;
 use crate::evaluation::request::EvaluationCacheKey;
+use crate::intern::TypeInterner;
 use crate::types::{RelationCacheKey, RelationCacheValue, TypeId};
 use dashmap::DashMap;
-use rustc_hash::FxBuildHasher;
+use rustc_hash::{FxBuildHasher, FxHashSet};
 
 // The trailing two `bool`s are `no_unchecked_indexed_access` and
 // `exact_optional_property_types`. Evaluating a generic application can expand
@@ -53,6 +55,8 @@ pub struct SharedQueryCache {
     pub(super) subtype_cache: DashMap<RelationCacheKey, RelationCacheValue, FxBuildHasher>,
     pub(super) assignability_cache: DashMap<RelationCacheKey, RelationCacheValue, FxBuildHasher>,
     pub(super) application_eval_cache: DashMap<ApplicationEvalCacheKey, TypeId, FxBuildHasher>,
+    pub(super) application_eval_dependency_index:
+        DashMap<DefId, FxHashSet<ApplicationEvalCacheKey>, FxBuildHasher>,
     pub(super) instantiation_cache: DashMap<InstantiationCacheKey, TypeId, FxBuildHasher>,
     share_instantiation_family: bool,
 }
@@ -64,6 +68,7 @@ impl SharedQueryCache {
             subtype_cache: DashMap::with_hasher(FxBuildHasher),
             assignability_cache: DashMap::with_hasher(FxBuildHasher),
             application_eval_cache: DashMap::with_hasher(FxBuildHasher),
+            application_eval_dependency_index: DashMap::with_hasher(FxBuildHasher),
             instantiation_cache: DashMap::with_hasher(FxBuildHasher),
             share_instantiation_family: shared_instantiation_family_requested(),
         }
@@ -88,6 +93,30 @@ impl SharedQueryCache {
     #[inline]
     pub(super) const fn shares_instantiation_family(&self) -> bool {
         self.share_instantiation_family
+    }
+
+    pub(super) fn insert_application_eval_cache(
+        &self,
+        interner: &TypeInterner,
+        key: ApplicationEvalCacheKey,
+        result: TypeId,
+    ) {
+        self.application_eval_cache.insert(key.clone(), result);
+        for def_id in collect_application_eval_entry_def_dependencies(interner, &key, result) {
+            self.application_eval_dependency_index
+                .entry(def_id)
+                .or_default()
+                .insert(key.clone());
+        }
+    }
+
+    pub(super) fn invalidate_application_eval_cache_for_def(&self, def_id: DefId) {
+        let Some((_, keys)) = self.application_eval_dependency_index.remove(&def_id) else {
+            return;
+        };
+        for key in keys {
+            self.application_eval_cache.remove(&key);
+        }
     }
 
     /// Estimate the resident heap bytes of the shared cache maps.


### PR DESCRIPTION
Goal: fast

## Summary
- add a `DefId -> application eval key` dependency index for local and shared application-eval caches
- invalidate application-eval entries from the recorded dependency bucket instead of sweeping the full cache
- record dependencies from the application base, lazy defs inside arguments, and lazy defs inside the cached result
- keep the local dependency-index bookkeeping in a focused cache helper so `query_cache.rs` stays under the architecture ratchet

## Structural Rule
When a definition body is rewritten, any application-eval cache entry whose base `DefId`, argument graph, or result graph mentions that `DefId` is stale; entries that do not mention it remain valid. The owner layer is `tsz-solver` query-cache invalidation, with the checker continuing to consume solver cache APIs.

## Adjacent Cases
- base `DefId` dependency invalidates the matching application entry
- lazy `DefId` inside an argument invalidates that entry
- lazy `DefId` inside a cached result invalidates that entry
- unrelated entries survive the invalidation
- shared-cache opt-in path records and invalidates through the same dependency collector

## Performance Notes
- before this patch, the Drizzle sampler was dominated by `HashMap::retain` in `QueryCache::invalidate_application_eval_cache_for_def` while repeatedly registering definitions
- after this patch, that retain stack disappeared from the top sample; the remaining row still times out in assignability normalization/instantiation work
- Drizzle rebased-head measurement remains a real CPU-bound timeout: `/tmp/drizzle-indexed-app-eval-rebased-20260614.json` recorded wall `80.00s`, CPU `80.24s`, CPU share `100%`

## Verification
- `cargo fmt --check`
- `git diff --check`
- `scripts/arch/check-checker-boundaries.sh`
- `scripts/safe-run.sh cargo nextest run -p tsz-solver query_cache_statistics_tests::`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-common -p tsz-scanner -p tsz-parser -p tsz-binder -p tsz-solver -p tsz-checker -p tsz-emitter -p tsz-lowering -p tsz-lsp --all-targets -- -D warnings`
- `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli --bin tsz`
- `scripts/safe-run.sh scripts/bench/measure-tsz.sh --timeout 80 --json-file /tmp/drizzle-indexed-app-eval-rebased-20260614.json --label drizzle-indexed-app-eval-rebased -- --noEmit -p /Users/mohsen/code/tsz-drizzle-13480/.target/project-compile-guard/drizzle-orm/tsconfig.tsz-guard.json` (timeout-cpu-bound, wall `80.00s`, CPU `80.24s`, share `100%`)

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high
