### PR TITLE
fix(solver): keep numeric-string mapped keys string-named (#13510)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1558,6 +1558,9 @@ path = "tests/property_chain_elaboration_collapse_tests.rs"
 name = "nested_infer_extends_scope_tests"
 path = "tests/nested_infer_extends_scope_tests.rs"
 [[test]]
+name = "mapped_numeric_string_key_index_tests"
+path = "tests/mapped_numeric_string_key_index_tests.rs"
+[[test]]
 name = "homomorphic_indexed_access_tests"
 path = "tests/homomorphic_indexed_access_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/mapped_numeric_string_key_index_tests.rs
+++ b/crates/tsz-checker/tests/mapped_numeric_string_key_index_tests.rs
@@ -1,0 +1,147 @@
+//! Regression tests for issue #13510: a mapped type whose keys are numeric
+//! *string* literals (e.g. `"0" | "1" | "2"`) must keep those keys as string
+//! literals, so `keyof` reproduces `"0" | "1" | "2"` rather than the numeric
+//! `0 | 1 | 2`.
+//!
+//! Structural rule: when a mapped type `{ [K in U]: V }` is instantiated, a
+//! property materialized from a string-literal key whose text is numeric is
+//! string-named — independent of whether the mapping is homomorphic. Without
+//! this, indexing `M[P]` with `P extends U` spuriously reported TS2536 because
+//! the `"0" | "1" | "2"`-constrained index could not index a `0 | 1 | 2`
+//! key space. Owner: mapped-type instantiation / `keyof` in the solver.
+//!
+//! The hotscript witness is `DigitCompareTable[D1][D2]`; the matrix below also
+//! exercises the single-level form, the `Record<...>` form, varied binder
+//! names, the bare-numeric-key control (must stay numeric), and a negative
+//! case that must still report a genuinely-missing key.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::diagnostics::Diagnostic;
+
+fn check_es5(source: &str) -> Vec<Diagnostic> {
+    let lib_files = tsz_checker::test_utils::load_lib_files(&["es5.d.ts"]);
+    assert!(!lib_files.is_empty(), "es5.d.ts lib file not loaded");
+    tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions {
+            strict: true,
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+        &lib_files,
+    )
+}
+
+fn ts2536(diags: &[Diagnostic]) -> Vec<&Diagnostic> {
+    diags.iter().filter(|d| d.code == 2536).collect()
+}
+
+#[test]
+fn nested_digit_compare_table_no_ts2536() {
+    // The hotscript witness, reduced: a mapped table whose value is itself a
+    // mapped table, both keyed by a numeric-string union, indexed two levels
+    // deep by constrained type parameters.
+    let diags = check_es5(
+        r#"
+type Digit = "0" | "1" | "2";
+type DigitCompareTable = {
+  [D1 in Digit]: {
+    [D2 in Digit]: boolean;
+  };
+};
+type Compare<A extends Digit, B extends Digit> = DigitCompareTable[A][B];
+"#,
+    );
+    assert!(
+        ts2536(&diags).is_empty(),
+        "nested numeric-string mapped table indexed by constrained params must not emit TS2536: {diags:?}"
+    );
+}
+
+#[test]
+fn single_level_numeric_string_mapped_index_no_ts2536() {
+    let diags = check_es5(
+        r#"
+type Keys = "0" | "1" | "2";
+type Table = { [K in Keys]: number };
+type At<P extends Keys> = Table[P];
+"#,
+    );
+    assert!(
+        ts2536(&diags).is_empty(),
+        "single-level numeric-string mapped index must not emit TS2536: {diags:?}"
+    );
+}
+
+#[test]
+fn record_with_numeric_string_keys_index_no_ts2536() {
+    // `Record<K, V>` is the homomorphic `{ [P in K]: V }`; numeric-string keys
+    // must survive it too.
+    let diags = check_es5(
+        r#"
+type Keys = "0" | "1";
+type R = Record<Keys, string>;
+type At<Q extends Keys> = R[Q];
+"#,
+    );
+    assert!(
+        ts2536(&diags).is_empty(),
+        "Record<numeric-string-union, V> indexed by a constrained param must not emit TS2536: {diags:?}"
+    );
+}
+
+#[test]
+fn keyof_numeric_string_mapped_is_string_literal() {
+    // `keyof` of the instantiated mapped type must be the string literals, so a
+    // string-literal index is a valid key and assignment through it type-checks.
+    let diags = check_es5(
+        r#"
+type Keys = "0" | "1";
+type Table = { [K in Keys]: number };
+const ok: Table["0"] = 1;
+const k: keyof Table = "1";
+"#,
+    );
+    assert!(
+        ts2536(&diags).is_empty(),
+        "string-literal index into a numeric-string mapped type must be a valid key: {diags:?}"
+    );
+}
+
+#[test]
+fn bare_numeric_literal_keys_stay_numeric() {
+    // Control: bare numeric-literal keys (`0 | 1`, not `"0" | "1"`) must remain
+    // number-named. Indexing by a parameter constrained to the same numeric
+    // union stays valid and emits no TS2536.
+    let diags = check_es5(
+        r#"
+type NumKeys = 0 | 1;
+type Table = { [K in NumKeys]: string };
+type At<P extends NumKeys> = Table[P];
+"#,
+    );
+    assert!(
+        ts2536(&diags).is_empty(),
+        "numeric-literal mapped keys indexed by a matching numeric param must not emit TS2536: {diags:?}"
+    );
+}
+
+#[test]
+fn missing_numeric_string_key_still_reported() {
+    // The fix must not silence a genuinely-out-of-range key: indexing by a
+    // parameter constrained to a wider union than the table's keys must still
+    // be rejected (tsc reports TS2536 here).
+    let diags = check_es5(
+        r#"
+type TableKeys = "0" | "1";
+type WideKeys = "0" | "1" | "2";
+type Table = { [K in TableKeys]: number };
+type At<P extends WideKeys> = Table[P];
+"#,
+    );
+    assert!(
+        !ts2536(&diags).is_empty(),
+        "indexing a numeric-string mapped table by a wider key union must still emit TS2536: {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -589,25 +589,22 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 Ok(None) => continue,
                 Err(()) => return self.interner().mapped(*mapped),
             };
-            // Extract property name(s) from the remapped key. The no-`as`-clause
-            // path is the common case (Partial / Readonly / Required / Pick
-            // expansions) and skips a lookup + numeric-atom intern.
-            // Unions arise from `as \`${K}1\` | \`${K}2\`` producing multiple
-            // properties per source key.
-            let remapped_names: smallvec::SmallVec<[Atom; 1]> = if remapped == key_literal {
-                smallvec::smallvec![key_name]
+            // Property key(s) from the remapped key. Each `MappedKey` carries the
+            // naming key literal (string- vs number-named; see `is_string_named`).
+            let remapped_keys: smallvec::SmallVec<[MappedKey; 1]> = if remapped == key_literal {
+                smallvec::smallvec![mapped_key]
             } else if let Some(entry) = self.mapped_key_from_literal(remapped) {
-                smallvec::smallvec![entry.name]
+                smallvec::smallvec![entry]
             } else if let Some(TypeData::Union(list_id)) = self.interner().lookup(remapped) {
                 let members = self.interner().type_list(list_id);
-                let names: smallvec::SmallVec<[Atom; 1]> = members
+                let keys: smallvec::SmallVec<[MappedKey; 1]> = members
                     .iter()
-                    .filter_map(|&m| self.mapped_key_from_literal(m).map(|k| k.name))
+                    .filter_map(|&m| self.mapped_key_from_literal(m))
                     .collect();
-                if names.is_empty() {
+                if keys.is_empty() {
                     return self.interner().mapped(*mapped);
                 }
-                names
+                keys
             } else {
                 return self.interner().mapped(*mapped);
             };
@@ -679,19 +676,21 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 remove_optional_with_declared && source_optional,
             );
 
-            for remapped_name in remapped_names {
-                let is_string_named = source_info
-                    .is_some_and(|(_, _, _, source_is_string_named, _, _)| *source_is_string_named)
-                    && remapped_name == key_name;
-                let single_quoted_name =
-                    source_info.is_some_and(|(_, _, _, _, _, source_single_quoted_name)| {
-                        *source_single_quoted_name
-                    }) && remapped_name == key_name;
-                let is_symbol_named = source_info
-                    .is_some_and(|(_, _, _, _, source_is_symbol_named, _)| *source_is_symbol_named)
-                    && remapped_name == key_name;
+            // Naming flags an identity key inherits from its homomorphic source.
+            let (src_string_named, src_symbol_named, src_single_quoted) =
+                source_info.map_or((false, false, false), |&(_, _, _, s, y, q)| (s, y, q));
+            for mk in remapped_keys {
+                let identity = mk.name == key_name;
+                // Numeric-named string-literal key (`"0"`) stays string-named so `keyof` yields `"0"`, not `0`.
+                let is_string_named = (src_string_named && identity)
+                    || crate::utils::type_is_numeric_string_literal(
+                        self.interner(),
+                        mk.key_literal,
+                    );
+                let single_quoted_name = src_single_quoted && identity;
+                let is_symbol_named = src_symbol_named && identity;
                 properties.push(PropertyInfo {
-                    name: remapped_name,
+                    name: mk.name,
                     type_id: property_type,
                     write_type: property_type,
                     optional,

--- a/crates/tsz-solver/src/utils/mod.rs
+++ b/crates/tsz-solver/src/utils/mod.rs
@@ -98,6 +98,22 @@ pub(crate) fn literal_key_for_property_name(
     interner.literal_string_atom(name)
 }
 
+/// Returns `true` when `type_id` is a string-literal type whose text is a
+/// numeric property name (e.g. `"0"`, `"42"`).
+///
+/// Such a key names a string-named property: a mapped type iterating over
+/// `"0" | "1"` must keep those keys as the string literals `"0" | "1"` so that
+/// `keyof` reproduces them, instead of collapsing to the numeric literals
+/// `0 | 1`. A `LiteralValue::Number` key (authored as bare `0`) is intentionally
+/// excluded.
+pub(crate) fn type_is_numeric_string_literal(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
+    matches!(
+        db.lookup(type_id),
+        Some(crate::types::TypeData::Literal(crate::types::LiteralValue::String(atom)))
+            if atom_as_numeric_key(db, atom).is_some()
+    )
+}
+
 /// If `atom` is a numeric property name, returns the parsed `f64` value.
 /// Returns `None` for string-named atoms, `NaN`/`Infinity` identifiers used as property names,
 /// and any atom that is not a valid JavaScript numeric literal.


### PR DESCRIPTION
Goal: green

Fixes #13510. The hotscript `hotscript-project` row emitted spurious `TS2536`
("Type 'D2' cannot be used to index type 'DigitCompareTable[D1]'") on type-level
lookup tables keyed by a numeric-string union.

## Structural rule

When a mapped type `{ [K in U]: V }` is instantiated and `U` contains a numeric
*string* literal key (e.g. `"0"`), `tsc` materializes a **string-named**
property, so `keyof` reproduces `"0" | "1" | "2"` rather than the numeric
`0 | 1 | 2`. `tsz` only set `is_string_named` when the key was inherited from a
homomorphic source property; a non-homomorphic mapped type (no source) left the
flag false, so the keys collapsed to numeric literals. Indexing such a table
with a type parameter constrained to the string union (`P extends "0" | "1" | "2"`)
then failed the key-space relation — the `"0" | "1" | "2"` index could not index
a `0 | 1 | 2` key space — and reported `TS2536`.

`tsz` now derives `is_string_named` from the **naming key literal**: a
string-literal key whose text is numeric stays string-named, independent of
whether the mapped type is homomorphic.

## Owner layer

Solver — mapped-type instantiation (`evaluation/evaluate_rules/mapped.rs`) and
the shared `keyof` literal-key reconstruction it feeds. The fix is intentionally
scoped to numeric-string keys: a string-literal key with a numeric text becomes
string-named; bare numeric-literal keys (`0`) stay numeric; non-numeric
identifier keys keep their existing flag (which participates in shape identity,
so widening it there would perturb interning). The per-key naming literal is
threaded through the existing `MappedKey` (name + `key_literal`), and the check
lives in `tsz_solver::utils::type_is_numeric_string_literal`.

## Adjacent matrix

- Positive: nested `DigitCompareTable[A][B]` (hotscript witness), single-level
  `{ [K in "0"|"1"|"2"]: V }[P]`, and `Record<"0"|"1", V>[Q]` — no `TS2536`.
- `keyof`: `keyof { [K in "0"|"1"]: V }` is `"0" | "1"`, so a string-literal
  index is a valid key.
- Control: bare numeric-literal keys `{ [K in 0|1]: V }` stay numeric and index
  by a numeric-constrained parameter without error.
- Negative/fallback: indexing the table by a *wider* key union than its keys
  still reports `TS2536` (the fix does not silence genuinely-missing keys).
- Binder names varied across cases (`A`/`B`, `P`, `Q`) so no name-driven logic.

Note: the secondary `TS2694` namespace-member resolution mentioned in #13510 is a
separate gap and is out of scope here.

## Verification

- `cargo test -p tsz-checker --test mapped_numeric_string_key_index_tests` — 6 passed (new regression suite)
- `cargo test -p tsz-checker --test homomorphic_indexed_access_tests` (28) / `homomorphic_indexed_access_edge_cases` (12) / `ts7053_record_constrained_type_param_index_tests` (10) / `ts7053_record_constraint_index_tests` (7) / `ts7053_template_mapped_tests` (9) / `keyof_mapped_as_clause_tests` (22) / `tuple_index_access_tests` (16) / `ts2536_keyof_string_index_signature_tests` (14) — all green
- `cargo test -p tsz-solver --lib` — only pre-existing failures remain (`def/core.rs` size ratchet and two `operations::tests` generic-call cases reproduce identically on `main`); `mapped.rs` stays at its 1982-line baseline
- `cargo fmt --check` clean; `cargo clippy -p tsz-solver -p tsz-checker` clean

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuYaRSJz7uFowe1PJUmwFE)_