### PR TITLE
perf(checker): keep lazy lib access with unrelated augmentations

### DIFF
--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -171,9 +171,6 @@ impl CheckerState<'_> {
         if self.ctx.file_local_type_shadow_for_lib_name(&name) {
             return None;
         }
-        if self.program_has_global_augmentations() {
-            return None;
-        }
         // The symbol must come from the actual/cloned lib — user interfaces (even
         // sharing a lib name) take the normal path so augmentation/merging stays
         // correct.
@@ -200,15 +197,11 @@ impl CheckerState<'_> {
             .global_augmentations
             .get(name)
             .is_some_and(|decls| !decls.is_empty())
-    }
-
-    fn program_has_global_augmentations(&self) -> bool {
-        !self.ctx.binder.global_augmentations.is_empty()
             || self
                 .ctx
                 .global_augmentation_targets_index
                 .as_ref()
-                .is_some_and(|index| !index.is_empty())
+                .is_some_and(|index| index.get(name).is_some())
     }
 
     fn lib_interface_or_heritage_is_augmented_or_shadowed(


### PR DESCRIPTION
Goal: fast

## Summary

Narrow the lazy lib-interface member eligibility gate from "no global augmentations anywhere in the program" to "the receiver interface or one of its declared lib heritage bases is not globally augmented or shadowed."

This keeps the existing safe fallback for augmented/shadowed DOM/lib interfaces, but avoids disabling the single-member fast path for unrelated global augmentations elsewhere in a project.

Fixes/Refs: #12101

## Structural rule

When resolving `recv.p` where `recv` is a bare lazy standard-library interface, unrelated global augmentations should not force full receiver materialization. If the receiver interface itself, or one of its declared lib heritage bases, is augmented or shadowed, tsz still falls back to the full materialization path so merged members and diagnostic sources stay authoritative.

Owner layer: checker lazy lib-member receiver eligibility.

## Adjacent cases and fallback

- Preserves full fallback for file-local shadows of the receiver name.
- Preserves full fallback for receiver or heritage names present in `global_augmentations`.
- Preserves full fallback for receiver or heritage names present in `global_augmentation_targets_index`.
- Preserves existing generic, compiler-managed, user-defined, and non-lib receiver exclusions.
- Does not introduce fixture-name, property-name, file-name, or rendered-type predicates.

## Verification

Not run locally per user instruction. Pre-commit formatting hook ran during commit `d43fc72cc5`.

Expected CI coverage: draft/light CI should prove build/lint compatibility; ready-review CI should own broader compatibility.

## Provenance

Machine: MacBookPro.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium
