### PR TITLE
perf(server): reuse project state across navigation requests

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_implement_interface_tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_implement_interface_tests.rs
@@ -19,6 +19,7 @@ fn make_server() -> Server {
         open_files: FxHashMap::default(),
         external_project_files: FxHashMap::default(),
         completion_project_cache: None,
+        project_cache: std::cell::RefCell::new(None),
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_nested_pkg_tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_nested_pkg_tests.rs
@@ -32,6 +32,7 @@ fn make_server() -> Server {
         open_files: FxHashMap::default(),
         external_project_files: FxHashMap::default(),
         completion_project_cache: None,
+        project_cache: std::cell::RefCell::new(None),
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests.rs
@@ -22,6 +22,7 @@ fn make_server() -> Server {
         open_files: FxHashMap::default(),
         external_project_files: FxHashMap::default(),
         completion_project_cache: None,
+        project_cache: std::cell::RefCell::new(None),
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests_part2.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests_part2.rs
@@ -23,6 +23,7 @@ fn make_server() -> Server {
         open_files: FxHashMap::default(),
         external_project_files: FxHashMap::default(),
         completion_project_cache: None,
+        project_cache: std::cell::RefCell::new(None),
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_completions_project.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_completions_project.rs
@@ -122,7 +122,7 @@ impl Server {
             .unwrap_or_default()
     }
 
-    fn completion_project_file_fingerprints(
+    pub(super) fn completion_project_file_fingerprints(
         files: &FxHashMap<String, String>,
     ) -> Vec<(String, u64)> {
         let mut fingerprints: Vec<_> = files

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -697,7 +697,7 @@ impl Server {
     }
 
     fn build_quoted_alias_referenced_symbols(
-        &mut self,
+        &self,
         project: &mut Project,
         file: &str,
         arena: &tsz::parser::node::NodeArena,

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -949,7 +949,7 @@ impl Server {
     }
 
     fn build_alias_definition_from_location(
-        &mut self,
+        &self,
         loc: &tsz_common::position::Location,
     ) -> (serde_json::Value, String, u32, u32) {
         fn extract_alias_rhs(display: &str) -> Option<String> {

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_info.rs
@@ -1,6 +1,6 @@
 //! Navigation, definition, and reference handlers for tsz-server.
 
-use super::{Server, TsServerRequest, TsServerResponse};
+use super::{Server, ServerProjectCache, ServerProjectCacheKey, TsServerRequest, TsServerResponse};
 use tsz::binder::SymbolId;
 use tsz::lsp::definition::GoToDefinition;
 use tsz::lsp::highlighting::DocumentHighlightProvider;
@@ -314,7 +314,7 @@ fn sort_symbols_deep(symbols: &mut [tsz::lsp::symbols::document_symbols::Documen
 }
 
 impl Server {
-    fn build_project_for_file(&self, file_name: &str) -> Option<Project> {
+    fn build_project_for_file(&self, file_name: &str) -> Option<std::cell::RefMut<'_, Project>> {
         let mut files = self.open_files.clone();
         for project_files in self.external_project_files.values() {
             for path in project_files {
@@ -336,6 +336,26 @@ impl Server {
             return None;
         }
 
+        let key = ServerProjectCacheKey {
+            files: Self::completion_project_file_fingerprints(&files),
+            allow_importing_ts_extensions: self.allow_importing_ts_extensions,
+            auto_imports_allowed_without_tsconfig: self.auto_imports_allowed_for_inferred_projects,
+            import_module_specifier_ending: self.completion_import_module_specifier_ending.clone(),
+            import_module_specifier_preference: self.import_module_specifier_preference.clone(),
+            auto_import_file_exclude_patterns: self.auto_import_file_exclude_patterns.clone(),
+            auto_import_specifier_exclude_regexes: self
+                .auto_import_specifier_exclude_regexes
+                .clone(),
+        };
+
+        let mut cache = self.project_cache.borrow_mut();
+        let cache_matches = cache.as_ref().is_some_and(|cache| cache.key == key);
+        if cache_matches {
+            return Some(std::cell::RefMut::map(cache, |cache| {
+                &mut cache.as_mut().expect("project cache must exist").project
+            }));
+        }
+
         let mut project = Project::new();
         project.set_allow_importing_ts_extensions(self.allow_importing_ts_extensions);
         project.set_auto_imports_allowed_without_tsconfig(
@@ -355,7 +375,10 @@ impl Server {
         for (path, text) in files {
             project.set_file(path, text);
         }
-        Some(project)
+        *cache = Some(ServerProjectCache { key, project });
+        Some(std::cell::RefMut::map(cache, |cache| {
+            &mut cache.as_mut().expect("project cache must exist").project
+        }))
     }
 
     pub(super) fn find_ancestor_of_kind(

--- a/crates/tsz-cli/src/bin/tsz_server/main.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/main.rs
@@ -63,6 +63,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -89,6 +90,22 @@ pub(crate) struct CompletionProjectCacheKey {
 
 pub(crate) struct CompletionProjectCache {
     pub(crate) key: CompletionProjectCacheKey,
+    pub(crate) project: tsz::lsp::Project,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ServerProjectCacheKey {
+    pub(crate) files: Vec<(String, u64)>,
+    pub(crate) allow_importing_ts_extensions: bool,
+    pub(crate) auto_imports_allowed_without_tsconfig: bool,
+    pub(crate) import_module_specifier_ending: Option<String>,
+    pub(crate) import_module_specifier_preference: Option<String>,
+    pub(crate) auto_import_file_exclude_patterns: Vec<String>,
+    pub(crate) auto_import_specifier_exclude_regexes: Vec<String>,
+}
+
+pub(crate) struct ServerProjectCache {
+    pub(crate) key: ServerProjectCacheKey,
     pub(crate) project: tsz::lsp::Project,
 }
 
@@ -592,6 +609,10 @@ pub(crate) struct Server {
     /// inputs. Avoids rebuilding `tsz_lsp::Project` when completion/detail
     /// requests repeat over the same server file snapshot and preferences.
     pub(crate) completion_project_cache: Option<CompletionProjectCache>,
+    /// General project state for the most recent identical request inputs.
+    /// Reused by project-backed navigation operations such as references,
+    /// type-definition, implementations, and file references.
+    pub(crate) project_cache: RefCell<Option<ServerProjectCache>>,
     /// Completion preference: import module specifier ending (e.g. "js")
     pub(crate) completion_import_module_specifier_ending: Option<String>,
     /// Completion/codefix preference: import module specifier preference.
@@ -705,6 +726,7 @@ impl Server {
             open_files: FxHashMap::default(),
             external_project_files: FxHashMap::default(),
             completion_project_cache: None,
+            project_cache: RefCell::new(None),
             completion_import_module_specifier_ending: None,
             import_module_specifier_preference: None,
             organize_imports_type_order: None,
@@ -777,6 +799,7 @@ impl Server {
 
     pub(crate) fn clear_completion_project_cache(&mut self) {
         self.completion_project_cache = None;
+        self.project_cache.borrow_mut().take();
     }
 
     fn handle_reset(&mut self, seq: u64, request: &TsServerRequest) -> TsServerResponse {

--- a/crates/tsz-cli/src/bin/tsz_server/tests_support.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/tests_support.rs
@@ -16,6 +16,7 @@ pub(super) fn make_server() -> Server {
         open_files: FxHashMap::default(),
         external_project_files: FxHashMap::default(),
         completion_project_cache: None,
+        project_cache: std::cell::RefCell::new(None),
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,


### PR DESCRIPTION
Goal: fast

## Summary
- Add a general `tsz-server` project cache for the most recent identical file snapshot and project preferences.
- Reuse the cached `Project` through `build_project_for_file` for project-backed navigation operations.
- Keep existing file/preference invalidation by clearing the general cache alongside the completion project cache.

## Structural rule
When a server request needs project-backed navigation over the same open/external file snapshot and the same project preferences, tsserver can reuse resident project state; tsz now does this through the tsz-server project-building boundary instead of rebuilding a fresh `tsz_lsp::Project` for every definition/reference/type-definition/implementation/file-reference request.

Owner layer: `tsz-server` request orchestration owns cache residency and invalidation; `tsz_lsp::Project` continues to own semantic project operations.

Adjacent matrix:
- Same files and same preferences: reuse the cached `Project`.
- Changed open file, external project, legacy check input, reset, or preference/configure change: clear project caches.
- Different file snapshot or project preference fingerprint: rebuild and replace the cached `Project`.
- Completion-specific module-export dependency expansion remains owned by the existing completion project cache.

Fallback:
- If no files can be assembled for the request, behavior stays `None`/empty as before.
- If the key does not match, the builder constructs a fresh `Project` exactly as before.

Performance notes:
- This removes repeated parse/bind/project construction for consecutive project-backed navigation requests over the same server snapshot.
- Local perf numbers were not collected; ready-review CI should provide the broad guardrails.

## Verification
- Not run locally per agent instruction.
- Remote draft light CI passed at exact head `675da98d4132c0449d78c7146b92b9e73dbfa76a`: `CI Light Summary`, `premerge-microbench`, `unit`, `dist-binaries`, `unit-cloudbuild`, `unit-checker-integration`, `lint`, `cargo-deny`, `cargo-shear`, `project-row-drift`, and `gate`.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium

Refs #13114
