### PR TITLE
perf(checker): avoid unchanged function-shape rebuilds

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -191,40 +191,134 @@ pub(crate) fn map_function_shape_types(
     mut map_type: impl FnMut(FunctionShapeTypeSlot, TypeId) -> TypeId,
 ) -> Option<FunctionShape> {
     let mut changed = false;
-    let mut visit = |slot: FunctionShapeTypeSlot, type_id: TypeId| {
-        let mapped = map_type(slot, type_id);
-        if mapped != type_id {
+
+    let mut params = None;
+    for (index, param) in shape.params.iter().enumerate() {
+        let mapped_type = map_type(FunctionShapeTypeSlot::Param, param.type_id);
+        if mapped_type != param.type_id {
             changed = true;
+            if params.is_none() {
+                let mut mapped_params = Vec::with_capacity(shape.params.len());
+                mapped_params.extend_from_slice(&shape.params[..index]);
+                params = Some(mapped_params);
+            }
         }
+        if let Some(params) = params.as_mut() {
+            params.push(ParamInfo {
+                type_id: mapped_type,
+                ..*param
+            });
+        }
+    }
+
+    let this_type = shape.this_type.map(|this_type| {
+        let mapped = map_type(FunctionShapeTypeSlot::This, this_type);
+        changed |= mapped != this_type;
+        mapped
+    });
+
+    let return_type = {
+        let mapped = map_type(FunctionShapeTypeSlot::Return, shape.return_type);
+        changed |= mapped != shape.return_type;
         mapped
     };
 
-    let params: Vec<ParamInfo> = shape
-        .params
-        .iter()
-        .map(|param| ParamInfo {
-            type_id: visit(FunctionShapeTypeSlot::Param, param.type_id),
-            ..*param
-        })
-        .collect();
-    let this_type = shape
-        .this_type
-        .map(|this_type| visit(FunctionShapeTypeSlot::This, this_type));
-    let return_type = visit(FunctionShapeTypeSlot::Return, shape.return_type);
-    let type_predicate = shape.type_predicate.map(|predicate| TypePredicate {
-        type_id: predicate
-            .type_id
-            .map(|type_id| visit(FunctionShapeTypeSlot::PredicateTarget, type_id)),
-        ..predicate
+    let type_predicate = shape.type_predicate.map(|predicate| {
+        let type_id = predicate.type_id.map(|type_id| {
+            let mapped = map_type(FunctionShapeTypeSlot::PredicateTarget, type_id);
+            changed |= mapped != type_id;
+            mapped
+        });
+        TypePredicate {
+            type_id,
+            ..predicate
+        }
     });
 
     changed.then_some(FunctionShape {
         type_params: shape.type_params.clone(),
-        params,
+        params: params.unwrap_or_else(|| shape.params.clone()),
         this_type,
         return_type,
         type_predicate,
         is_constructor: shape.is_constructor,
         is_method: shape.is_method,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsz_solver::TypePredicateTarget;
+
+    fn sample_shape() -> FunctionShape {
+        FunctionShape {
+            type_params: Vec::new(),
+            params: vec![
+                ParamInfo {
+                    type_id: TypeId::STRING,
+                    ..ParamInfo::default()
+                },
+                ParamInfo {
+                    type_id: TypeId::NUMBER,
+                    optional: true,
+                    ..ParamInfo::default()
+                },
+            ],
+            this_type: Some(TypeId::OBJECT),
+            return_type: TypeId::BOOLEAN,
+            type_predicate: Some(TypePredicate {
+                asserts: false,
+                target: TypePredicateTarget::This,
+                type_id: Some(TypeId::STRING),
+                parameter_index: None,
+            }),
+            is_constructor: true,
+            is_method: true,
+        }
+    }
+
+    #[test]
+    fn map_function_shape_types_returns_none_for_identity_map_after_visiting_all_slots() {
+        let shape = sample_shape();
+        let mut visited = Vec::new();
+
+        let mapped = map_function_shape_types(&shape, |slot, type_id| {
+            visited.push((slot, type_id));
+            type_id
+        });
+
+        assert!(mapped.is_none());
+        assert_eq!(
+            visited,
+            vec![
+                (FunctionShapeTypeSlot::Param, TypeId::STRING),
+                (FunctionShapeTypeSlot::Param, TypeId::NUMBER),
+                (FunctionShapeTypeSlot::This, TypeId::OBJECT),
+                (FunctionShapeTypeSlot::Return, TypeId::BOOLEAN),
+                (FunctionShapeTypeSlot::PredicateTarget, TypeId::STRING),
+            ]
+        );
+    }
+
+    #[test]
+    fn map_function_shape_types_rebuilds_changed_slots_preserving_metadata() {
+        let shape = sample_shape();
+
+        let mapped = map_function_shape_types(&shape, |slot, type_id| {
+            if slot == FunctionShapeTypeSlot::Return {
+                TypeId::NUMBER
+            } else {
+                type_id
+            }
+        })
+        .expect("return type change should rebuild the shape");
+
+        assert_eq!(mapped.params, shape.params);
+        assert_eq!(mapped.this_type, shape.this_type);
+        assert_eq!(mapped.return_type, TypeId::NUMBER);
+        assert_eq!(mapped.type_predicate, shape.type_predicate);
+        assert_eq!(mapped.is_constructor, shape.is_constructor);
+        assert_eq!(mapped.is_method, shape.is_method);
+    }
 }


### PR DESCRIPTION
Goal: fast

## Summary
- make `map_function_shape_types` allocate a replacement parameter vector only after the first changed parameter type
- keep identity mappings on the no-rebuild path while still visiting params, `this`, return, and predicate target slots in order
- add focused query-boundary tests for identity and changed-slot behavior

## Stacking
Draft stacked on #13517 (`perf(solver): index application eval invalidations`). Retarget/rebase after #13517 lands.

## Structural Rule
When a function-shape component mapper returns every original component `TypeId`, the checker should preserve the existing interned function/callable type and avoid constructing replacement shape vectors. When any component changes, the helper rebuilds the shape with the changed component while preserving signature metadata. Owner layer: checker signature-construction query boundary; solver remains the owner of function/callable interning.

## Adjacent Cases
- identity mapping over params/this/return/predicate target returns `None` after visiting every slot
- changed return slot rebuilds the shape and preserves params, `this`, predicate, constructor, and method metadata
- unchanged parameter prefixes are copied only if a later parameter changes
- no user-name, property-name, file-name, or rendered-type predicates

## Performance Notes
- Drizzle sampler after #13517 showed callable/function shape allocation and interning under assignability normalization
- this patch removes eager param-vector construction on identity normalization, but it is a micro-optimization: Drizzle still times out CPU-bound at 80s
- `/tmp/drizzle-callable-shape-map-20260614.json`: timeout-cpu-bound, wall `80.00s`, CPU `80.19s`, share `100%`
- `/tmp/drizzle-callable-shape-map-sample-20260614.txt` showed the targeted callable/shape frames lower, but the dominant cost remains deep containment and assignability recursion

## Verification
- `cargo fmt --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib query_boundaries::construct_signatures::tests::`
- `scripts/safe-run.sh cargo clippy --profile ci-lint -p tsz-checker --lib -- -D warnings`
- `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli --bin tsz`
- `TSZ_BIN=/Users/mohsen/code/tsz-drizzle-assignability-13480-20260614/.target/dist-fast/tsz TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_FILTER='^drizzle-orm-project$' TSZ_PROJECT_COMPILE_TIMEOUT=80 TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 scripts/safe-run.sh scripts/ci/project-compile-guard.sh` (timeout-cpu-bound, allowed failure)
- `scripts/safe-run.sh scripts/bench/measure-tsz.sh --timeout 80 --json-file /tmp/drizzle-callable-shape-map-20260614.json --label drizzle-callable-shape-map -- --noEmit -p /Users/mohsen/code/tsz-drizzle-assignability-13480-20260614/.target/project-compile-guard/drizzle-orm/tsconfig.tsz-guard.json` (timeout-cpu-bound, wall `80.00s`, CPU `80.19s`, share `100%`)

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
