### PR TITLE
refactor(repo): derive Default for trivially-derivable structs (#13416)

### DIFF
--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -219,7 +219,7 @@ pub struct SharedConstraintProofCache {
 /// [`Self::merge`], [`Self::merge_owned`]) intentionally see only the overlay
 /// layer, so the existing "restore caller map, merge winner entries" restore
 /// choreography is unchanged.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct NodeTypeCache {
     data: Arc<FxHashMap<u32, TypeId>>,
     /// Read-only fallback consulted on `data` misses. `None` for plain caches.
@@ -408,14 +408,8 @@ impl NodeTypeCache {
     }
 }
 
-impl Default for NodeTypeCache {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Dense tristate cache for `is_narrowable_identifier` results.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct NarrowableIdentifierCache {
     data: Vec<u8>,
 }
@@ -461,19 +455,13 @@ impl NarrowableIdentifierCache {
     }
 }
 
-impl Default for NarrowableIdentifierCache {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// Sparse cache for `SymbolId -> TypeId` lookups.
 ///
 /// `SymbolId`s are global after program merge, so a dense per-checker vector
 /// scales with total program symbols even when a checker touches only a small
 /// subset. Keep the cache sparse and Arc-backed so child checkers can inherit a
 /// read snapshot cheaply; writes copy-on-write only the populated entries.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SymbolTypeCache {
     data: Arc<FxHashMap<SymbolId, TypeId>>,
     /// Monotonic mutation counter. Consumers (the assignability evaluation
@@ -741,12 +729,6 @@ impl AssignabilityFailureMemo {
     pub fn clear(&mut self) {
         self.stamp = None;
         self.entries.clear();
-    }
-}
-
-impl Default for SymbolTypeCache {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/tsz-checker/src/context/cross_file_delegation_cache.rs
+++ b/crates/tsz-checker/src/context/cross_file_delegation_cache.rs
@@ -5,7 +5,7 @@ use tsz_parser::parser::{NodeArena, NodeIndex};
 use tsz_solver::{TypeId, TypeParamInfo};
 
 /// File-local caches for cross-file/lib delegation helpers.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct CrossFileDelegationCache {
     symbol_types: FxHashMap<SymbolId, (TypeId, Vec<TypeParamInfo>)>,
     declaration_node_types: Arc<dashmap::DashMap<(usize, NodeIndex, u8), TypeId>>,
@@ -13,16 +13,6 @@ pub struct CrossFileDelegationCache {
     /// (via `Arc` clone in `with_parent_cache`) with every transient child
     /// checker in the same file-check session. See [`CrossArenaSessionMemo`].
     session_memo: Arc<CrossArenaSessionMemo>,
-}
-
-impl Default for CrossFileDelegationCache {
-    fn default() -> Self {
-        Self {
-            symbol_types: FxHashMap::default(),
-            declaration_node_types: Arc::new(dashmap::DashMap::new()),
-            session_memo: Arc::new(CrossArenaSessionMemo::default()),
-        }
-    }
 }
 
 impl CrossFileDelegationCache {

--- a/crates/tsz-checker/src/flow/flow_analyzer.rs
+++ b/crates/tsz-checker/src/flow/flow_analyzer.rs
@@ -54,7 +54,7 @@ impl AssignmentState {
 /// A mapping of variables to their assignment states at a point in the program.
 ///
 /// Variables are indexed by their declaration node ID (`NodeIndex`).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct AssignmentStateMap {
     states: FxHashMap<u32, AssignmentState>,
 }
@@ -108,12 +108,6 @@ impl AssignmentStateMap {
             .states
             .values()
             .any(|&s| s == AssignmentState::MaybeAssigned)
-    }
-}
-
-impl Default for AssignmentStateMap {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/tsz-checker/src/statements.rs
+++ b/crates/tsz-checker/src/statements.rs
@@ -430,14 +430,10 @@ pub trait StatementCheckCallbacks {
 /// This is a zero-sized struct that only provides the dispatching logic.
 /// All state and type checking operations are delegated back to the
 /// implementation of `StatementCheckCallbacks` (typically `CheckerState`).
+#[derive(Default)]
 pub struct StatementChecker;
 
 impl StatementChecker {
-    /// Create a new statement checker.
-    pub const fn new() -> Self {
-        Self
-    }
-
     /// Check a statement node.
     ///
     /// This dispatches to specialized handlers based on statement kind.
@@ -1170,11 +1166,5 @@ impl StatementChecker {
         }
 
         false
-    }
-}
-
-impl Default for StatementChecker {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/crates/tsz-emitter/src/context/transform.rs
+++ b/crates/tsz-emitter/src/context/transform.rs
@@ -365,7 +365,7 @@ pub enum ModuleFormat {
 }
 
 /// Transform context maps node indices to their transform directives
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct TransformContext {
     /// Map of `NodeIndex` -> `TransformDirective`
     /// Only contains entries for nodes that need transformation
@@ -478,12 +478,6 @@ impl TransformContext {
     /// Check if the context is empty
     pub fn is_empty(&self) -> bool {
         self.directives.is_empty()
-    }
-}
-
-impl Default for TransformContext {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/tsz-emitter/src/transforms/arrow_es5.rs
+++ b/crates/tsz-emitter/src/transforms/arrow_es5.rs
@@ -46,24 +46,13 @@ use tsz_parser::parser::node::NodeArena;
 pub use tsz_parser::syntax::transform_utils::contains_this_reference;
 
 /// Context for arrow function transformation
+#[derive(Default)]
 pub struct ArrowTransformContext {
     /// Whether we need to capture `this` as `_this`
     pub needs_this_capture: bool,
 }
 
-impl Default for ArrowTransformContext {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl ArrowTransformContext {
-    pub const fn new() -> Self {
-        Self {
-            needs_this_capture: false,
-        }
-    }
-
     /// Analyze an arrow function to determine if `this` capture is needed
     pub fn analyze_arrow(&mut self, arena: &NodeArena, func_idx: NodeIndex) {
         let Some(func_node) = arena.get(func_idx) else {

--- a/crates/tsz-lsp/src/highlighting/semantic_tokens.rs
+++ b/crates/tsz-lsp/src/highlighting/semantic_tokens.rs
@@ -65,6 +65,7 @@ pub mod semantic_token_modifiers {
 /// Builder for LSP semantic tokens response (delta encoding).
 ///
 /// Tokens must be pushed in order of appearance in the file (by line, then by column).
+#[derive(Default)]
 pub struct SemanticTokensBuilder {
     data: Vec<u32>,
     prev_line: u32,
@@ -111,12 +112,6 @@ impl SemanticTokensBuilder {
     /// Build the final token array.
     pub fn build(self) -> Vec<u32> {
         self.data
-    }
-}
-
-impl Default for SemanticTokensBuilder {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/tsz-lsp/src/rename/mod.rs
+++ b/crates/tsz-lsp/src/rename/mod.rs
@@ -102,7 +102,7 @@ impl RenameTextEdit {
 }
 
 /// A workspace edit (changes across multiple files).
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct WorkspaceEdit {
     /// Map of file path -> list of edits.
     pub changes: FxHashMap<String, Vec<TextEdit>>,
@@ -122,15 +122,9 @@ impl WorkspaceEdit {
     }
 }
 
-impl Default for WorkspaceEdit {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 /// A rename-specific workspace edit that preserves prefix/suffix metadata.
 /// Use `to_workspace_edit()` to convert to a standard `WorkspaceEdit`.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct RenameWorkspaceEdit {
     /// Map of file path -> list of rich rename edits.
     pub changes: FxHashMap<String, Vec<RenameTextEdit>>,
@@ -157,12 +151,6 @@ impl RenameWorkspaceEdit {
             }
         }
         ws
-    }
-}
-
-impl Default for RenameWorkspaceEdit {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/tsz-solver/src/caches/instantiation_cache.rs
+++ b/crates/tsz-solver/src/caches/instantiation_cache.rs
@@ -147,6 +147,7 @@ impl InstantiationCacheKey {
 /// for the same reason as the surrounding caches: a per-file `QueryCache`
 /// is borrowed for the duration of a check and never crossed by Rayon
 /// workers.
+#[derive(Default)]
 pub struct InstantiationCache {
     inner: RefCell<FxHashMap<InstantiationCacheKey, TypeId>>,
 }
@@ -195,12 +196,6 @@ impl InstantiationCache {
     #[must_use]
     pub fn capacity(&self) -> usize {
         self.inner.borrow().capacity()
-    }
-}
-
-impl Default for InstantiationCache {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/tsz-solver/src/caches/subtype_reduction_cache.rs
+++ b/crates/tsz-solver/src/caches/subtype_reduction_cache.rs
@@ -120,6 +120,7 @@ impl SubtypeReductionKey {
 ///
 /// The value side is `Arc<[TypeId]>` so cache hits return a cheap clone of
 /// a heap-allocated slice instead of re-allocating a `Vec`.
+#[derive(Default)]
 pub struct SubtypeReductionCache {
     inner: RefCell<FxHashMap<SubtypeReductionKey, Arc<[TypeId]>>>,
 }
@@ -166,12 +167,6 @@ impl SubtypeReductionCache {
     #[must_use]
     pub fn capacity(&self) -> usize {
         self.inner.borrow().capacity()
-    }
-}
-
-impl Default for SubtypeReductionCache {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/tsz-solver/src/classes/inheritance.rs
+++ b/crates/tsz-solver/src/classes/inheritance.rs
@@ -24,18 +24,12 @@ struct ClassNode {
     mro: Option<Vec<SymbolId>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct InheritanceGraph {
     /// Map from `SymbolId` to graph node data
     nodes: RefCell<FxHashMap<SymbolId, ClassNode>>,
     /// Maximum `SymbolId` seen so far (for `BitSet` sizing)
     max_symbol_id: Cell<usize>,
-}
-
-impl Default for InheritanceGraph {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl InheritanceGraph {

--- a/crates/tsz-solver/src/evaluation/session.rs
+++ b/crates/tsz-solver/src/evaluation/session.rs
@@ -29,6 +29,7 @@ const MAX_GLOBAL_INSTANTIATION_FUEL: u32 = crate::limits::MAX_GLOBAL_INSTANTIATI
 /// per-context counters, but the session counters are shared via `Rc`).
 ///
 /// Uses `Cell` for interior mutability since all access is single-threaded.
+#[derive(Default)]
 pub struct EvaluationSession {
     /// Cross-context instantiation depth (nesting of `evaluate_application_type`).
     global_instantiation_depth: Cell<u32>,
@@ -86,12 +87,6 @@ impl EvaluationSession {
     #[inline]
     pub const fn global_instantiation_fuel(&self) -> u32 {
         self.global_instantiation_fuel.get()
-    }
-}
-
-impl Default for EvaluationSession {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -1222,7 +1222,7 @@ bitflags::bitflags! {
 /// NOTE: The `symbol` field affects BOTH Hash and `PartialEq` for nominal discrimination.
 /// This ensures that different classes get different `TypeIds` in the interner.
 /// Structural subtyping is computed explicitly in the Solver, not via `PartialEq`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ObjectShape {
     /// Object-level flags (e.g. fresh literal tracking).
     pub flags: ObjectFlags,
@@ -1274,18 +1274,6 @@ impl ObjectShape {
     /// Use this instead of importing `ObjectFlags::HAS_LATE_BOUND_MEMBERS` directly.
     pub fn mark_has_late_bound_members(&mut self) {
         self.flags |= ObjectFlags::HAS_LATE_BOUND_MEMBERS;
-    }
-}
-
-impl Default for ObjectShape {
-    fn default() -> Self {
-        Self {
-            flags: ObjectFlags::empty(),
-            properties: Vec::new(),
-            string_index: None,
-            number_index: None,
-            symbol: None,
-        }
     }
 }
 


### PR DESCRIPTION
Goal: hold

Fixes #13416.

## Summary

Replace 16 hand-written `Default` impls with `#[derive(Default)]` across
`tsz-solver` / `tsz-checker` / `tsz-emitter` / `tsz-lsp`, deleting the
genuinely-derivable subset of `fn default() -> Self { Self::new() }` shims and
field-literal `Default` impls. `clippy::derivable_impls` does not flag these
(it does not fire on `Self::new()`-delegating bodies nor on literals built from
`RefCell::new(..)` / `Cell::new(0)` / `Arc::new(..)` / `ObjectFlags::empty()`),
so this is a real, non-autofixed hygiene win.

## Structural rule

When a struct's `Default` is exactly its field-wise `Default` — every field set
to that field type's own default (`Vec::new`, `None`, `0`, `FxHashMap::default`,
`RefCell::new(<default>)`, `Cell::new(0)`, `Arc::new(<default>)`,
`ObjectFlags::empty()` which is `ObjectFlags::default()`) — the manual impl is
redundant boilerplate that silently drifts from the struct definition when a
field is added. Use `#[derive(Default)]` so the default tracks the definition.

## Converted (behavior-identical)

- solver: `InheritanceGraph`, `ObjectShape`, `InstantiationCache`,
  `SubtypeReductionCache`, `EvaluationSession`
- checker: `NodeTypeCache`, `NarrowableIdentifierCache`, `SymbolTypeCache`,
  `CrossFileDelegationCache`, `AssignmentStateMap`, `StatementChecker`
- emitter: `TransformContext`, `ArrowTransformContext`
- lsp: `WorkspaceEdit`, `RenameWorkspaceEdit`, `SemanticTokensBuilder`

Also removes two `new()` methods (`StatementChecker`, `ArrowTransformContext`)
whose only caller was the removed `Default` impl.

## Left hand-written (audited as genuinely stateful — NOT touched)

`ShardedInterner`, `BinderState`, `EmitContext`, `Tracer`, `SourceWriter`,
`ContentAddressedDefIds`, `DefinitionStore`, `TypeInterner`, `AliasCycleTracker`,
`AnyPropagationRules`, `UnsoundnessAudit`, `IRPrinter`, `FlowSharedCaches`,
`FlowGraph`, `SharedQueryCache`, and the `WasmProgram` family — each has
capacity preallocation, `DashMap::with_hasher`, env-driven values, side effects
(`Instant::now`, arena node allocation), sentinel/non-default literals, or a
`&'static str` field, so `#[derive(Default)]` would change behavior or not
compile. Per-impl audit; no `sed`/mass-delete. `clippy::derivable_impls` is NOT
enabled repo-wide.

## Owner layer

Pure boilerplate cleanup; no checker/solver/emitter semantic behavior changes,
no diagnostic/emit policy touched. A derived `Default` produces a value
byte-identical to the prior `new()`/literal for every converted struct.

## Verification

- `cargo build -p tsz-solver -p tsz-checker -p tsz-emitter -p tsz-lsp` — clean
- `cargo clippy -p tsz-solver -p tsz-checker -p tsz-emitter -p tsz-lsp` — clean
  (no `derivable_impls` / `new_without_default`)
- `cargo fmt --check` — clean
- `cargo test -p tsz-lsp --lib` — 4044 passed
- `cargo test -p tsz-emitter --lib` — 3735 passed; the 3 pre-existing
  `declaration_emitter` failures reproduce identically on clean `main` (verified
  via stash) and are unrelated to this change
- Broad conformance / emit / fourslash owned by ready-review CI (parity floor —
  behavior unchanged)

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbsCF1UyyLTnoa36a4y6FV)_