### PR TITLE
perf(checker): reuse call parameter type refs (#8773)

### DIFF
--- a/crates/tsz-checker/src/types/computation/call_inference.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference.rs
@@ -1407,6 +1407,18 @@ impl<'a> CheckerState<'a> {
         for tp in &orig_shape.type_params {
             constraint_default.insert(tp.name, tp.constraint.unwrap_or(TypeId::UNKNOWN));
         }
+        let param_type_param_refs: Vec<_> = orig_shape
+            .params
+            .iter()
+            .map(|param| {
+                common::collect_referenced_types(self.ctx.types, param.type_id)
+                    .into_iter()
+                    .filter_map(|ty| {
+                        common::type_param_info(self.ctx.types, ty).map(|info| info.name)
+                    })
+                    .collect::<rustc_hash::FxHashSet<_>>()
+            })
+            .collect();
         let mut solver_defaulted = rustc_hash::FxHashSet::default();
         for tp in &orig_shape.type_params {
             // Build a substitution that maps THIS tp to its constraint and
@@ -1436,13 +1448,9 @@ impl<'a> CheckerState<'a> {
                 if i >= params.len() {
                     break;
                 }
-                let referenced =
-                    common::collect_referenced_types(self.ctx.types, orig_param.type_id)
-                        .into_iter()
-                        .any(|ty| {
-                            common::type_param_info(self.ctx.types, ty)
-                                .is_some_and(|info| info.name == tp.name)
-                        });
+                let referenced = param_type_param_refs
+                    .get(i)
+                    .is_some_and(|refs| refs.contains(&tp.name));
                 if !referenced {
                     continue;
                 }


### PR DESCRIPTION
Goal: fast

## Summary
- precompute the type-parameter names referenced by each original call parameter once during checker-side generic call refinement
- reuse that reference map while probing which type parameters the solver defaulted
- avoid re-walking the same parameter type graph for each type parameter in chained generic calls

Fixes #8773.

## Structural Rule
When a generic call refinement needs to know whether an original parameter mentions a type parameter, the answer is a structural property of that parameter type graph. `tsc` does not repeatedly re-expand the same schema-shaped parameter graph per type parameter; tsz should preserve that through checker orchestration over solver type facts, without recognizing project, identifier, or property names.

## Owner Layer
Checker call inference owns this refinement pass. Solver remains the owner of type construction, relation outcomes, and referenced-type traversal; the checker now memoizes only the per-parameter referenced type-parameter names inside the request-local refinement.

## Adjacent Cases
- multiple type parameters sharing one large parameter type reuse the same referenced-name set
- unrelated parameters still skip probes when their referenced-name set does not contain the current type parameter
- solver-provided non-default bindings still win through the existing mutual-assignability gate
- checker overrides remain filtered to solver-defaulted type parameters only

## Performance Notes
- complexity for the defaulting probe changes from repeated `type_params * params * collect_referenced_types(param)` graph walks to `params * collect_referenced_types(param)` plus set lookups
- residency is request-local to `refine_instantiated_params_with_checker_substitution`; no cross-call cache or invalidation contract is introduced
- no timing claim yet; this is a focused repeated-operation reduction for the Kysely contextual generic chain blocker

## Verification
- Remote draft/light CI passed at exact head `42ae156a07aa522354c0e5730bbf95a0de301bff`: `CI Light Summary`, `premerge-microbench`, `unit-cloudbuild`, `project-row-drift`, `cargo-shear`, `cargo-deny`, `lint`, `unit-checker-integration`, `unit`, `dist-binaries`, and `gate`.
- Not run locally; no local tests or benchmarks run per current agent instruction.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: high
