### PR TITLE
perf(checker): reuse flow cache borrow in passthrough chase (#13311)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -1239,6 +1239,8 @@ impl<'a> FlowAnalyzer<'a> {
         {
             return entry;
         }
+        let flow_cache = self.flow_cache();
+        let flow_cache = flow_cache.as_ref().map(|cache| cache.borrow());
 
         // Only pure non-merge ASSIGNMENT flow flags are skippable. Any other flag
         // means the node can apply or merge narrowing and must be processed.
@@ -1321,10 +1323,9 @@ impl<'a> FlowAnalyzer<'a> {
             {
                 return current;
             }
-            if let Some(cache) = self.flow_cache()
-                && cache
-                    .borrow()
-                    .contains_key(&(ant, cache_symbol, initial_type))
+            if flow_cache
+                .as_ref()
+                .is_some_and(|cache| cache.contains_key(&(ant, cache_symbol, initial_type)))
             {
                 return current;
             }


### PR DESCRIPTION
Goal: fast

## Summary
- borrow the shared flow cache once for a linear pass-through chase instead of reacquiring it for every skipped assignment node
- keep the existing pure-pass-through gates, cache key, and fallback behavior unchanged
- reduce per-node hot-path overhead in the single-large-function FlowAnalyzer path tracked by #13311

Refs #13311.

## Structural Rule
When a concrete `check_flow` walk scans a straight-line run of pure non-targeting assignment flow nodes, tsz must stop at the same landed flow node as before. The shared flow-cache lookup for `(antecedent, cache_symbol, initial_type)` is a read-only gate over the immutable per-walk inputs, so the chase can hold one immutable cache borrow while scanning the run instead of reacquiring the same cache handle per node.

## Owner Layer
Checker `FlowAnalyzer` owns the pass-through traversal shortcut and the flow-cache read gate. Solver semantics, narrowing decisions, and flow-cache contents are unchanged.

## Adjacent Matrix
- Pure pass-through assignment runs: reuse one immutable flow-cache borrow for the whole chase.
- Antecedents already present in the flow cache: still stop the chase and let the normal worklist/cache path reuse the existing answer.
- Generic, `any`, `unknown`, `error`, destructuring, targeting/affecting assignments, merge, condition, call, loop, switch, array mutation, and start nodes: unchanged fallback through the existing gates.
- Analyzers without a shared flow cache: unchanged; the optional borrow is absent and the chase behaves as before.

## Performance Notes
- This removes repeated `self.flow_cache()` + `RefCell::borrow()` work inside the linear pass-through scan.
- No timing claim is made; this is a small repeated-operation reduction in the #13311 FlowAnalyzer hot path.

## Verification
- Not run locally; no local tests or benchmarks run per current agent instruction.
- Exact-head draft CI passed for `cee993bee933a4f9b2c3847837b3d572e8407462`: `CI Light Summary`, `lint`, `unit`, `unit-cloudbuild`, `unit-checker-integration`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `premerge-microbench`, and `gate`.
- Ready PR CI is expected to run the full `CI Summary` gate before queueing.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: high
