### PR TITLE
perf(checker): budget finite mapped display materialization (#13040)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -636,6 +636,9 @@ impl<'a> CheckerState<'a> {
         let ty = self
             .materialize_finite_mapped_type_for_display(ty)
             .unwrap_or(ty);
+        if crate::error_reporter::display_budget::is_exhausted() {
+            return ty;
+        }
 
         if depth >= MAX_ASSIGNABILITY_DISPLAY_DEPTH || !visiting.insert(ty) {
             return ty;
@@ -1261,6 +1264,9 @@ impl<'a> CheckerState<'a> {
         // overflow the stack while materializing a finite mapped type for
         // display (issue #12455).
         let _display_guard = DisplayRecursionGuard::enter()?;
+        if !crate::error_reporter::display_budget::try_consume_visit() {
+            return None;
+        }
         if let Some((mapped_id, mapped)) = query::mapped_type(self.ctx.types, ty) {
             let names =
                 crate::query_boundaries::state::checking::collect_finite_mapped_property_names(
@@ -1277,6 +1283,9 @@ impl<'a> CheckerState<'a> {
 
             let mut properties = Vec::with_capacity(names.len());
             for name in names {
+                if crate::error_reporter::display_budget::is_exhausted() {
+                    return None;
+                }
                 let property_name = self.ctx.types.resolve_atom_ref(name).to_string();
                 let type_id =
                     crate::query_boundaries::state::checking::get_finite_mapped_property_type(
@@ -1299,6 +1308,9 @@ impl<'a> CheckerState<'a> {
             let remapped: Vec<_> = members
                 .iter()
                 .map(|&member| {
+                    if crate::error_reporter::display_budget::is_exhausted() {
+                        return member;
+                    }
                     if let Some(materialized) =
                         self.materialize_finite_mapped_type_for_display(member)
                     {
@@ -1315,6 +1327,9 @@ impl<'a> CheckerState<'a> {
             let remapped: Vec<_> = members
                 .iter()
                 .map(|&member| {
+                    if crate::error_reporter::display_budget::is_exhausted() {
+                        return member;
+                    }
                     if let Some(materialized) =
                         self.materialize_finite_mapped_type_for_display(member)
                     {


### PR DESCRIPTION
Goal: fast

## Summary
- Extend the existing #13040 diagnostic-display budget to finite mapped-type materialization used during assignability display normalization.
- Truncate immediately if the helper exhausts the per-rendered-type visit budget before the caller continues deeper normalization.
- Preserve semantic relation/evaluation paths: the budget helpers remain inert outside display scopes.

## Structural rule
When diagnostic display materializes finite mapped/intersection/union shapes only for rendering, tsz should charge that recursive display-only work to the same per-rendered-type budget as assignability display normalization. Once the budget is exhausted, display truncates at the current frame instead of continuing sibling/member expansion.

Owner layer: checker diagnostic display. Relation decisions and type evaluation semantics remain owned by the existing solver/query paths.

Adjacent matrix:
- Active display-budget scope: finite mapped materialization consumes display visit budget and falls back to the original display type after exhaustion.
- No display-budget scope: helpers are inert, so non-display and semantic paths keep existing behavior.
- Intersection/union materialization siblings: stop additional display-only materialization once exhaustion is observed.
- Mapped property materialization: return no display materialization after exhaustion, preserving the original type for fallback rendering.

Fallback:
- Exhaustion returns the existing type rather than synthesizing a new display shape.
- If finite mapped materialization is not available, the previous formatting fallback remains unchanged.

Performance notes:
- This is a bounded-work guard for the #13040 effect diagnostic-display churn family; no timing claim is made without benchmark evidence.

## Verification
- Not run locally; no local tests or benchmarks run per current agent instruction.
- Exact-head draft CI passed for `2795668bc201a9e4b77fa504e5f585c96450a06e`: `CI Light Summary`, `lint`, `unit`, `unit-cloudbuild`, `unit-checker-integration`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `premerge-microbench`, and `gate`.
- Ready PR CI is expected to run the full `CI Summary` gate before queueing.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium

Refs #13040
