### PR TITLE
fix(solver): evaluate both signatures before contextual instantiation (#13232)

### DIFF
--- a/crates/tsz-checker/src/tests/generic_signature_context_instantiation_tests.rs
+++ b/crates/tsz-checker/src/tests/generic_signature_context_instantiation_tests.rs
@@ -132,3 +132,87 @@ const impl: Api[\"raw\"] = function <T = any, R extends RT = \"json\">(): Box<MR
 ",
     );
 }
+
+// ---------------------------------------------------------------------------
+// Residual of #13232 after #13467: the source return is itself an *explicit*
+// `Box<T>` annotation that stays a deferred `Application` (not the materialized
+// object shape the `ctx.box!` indirection produced above). Contextual
+// instantiation must evaluate BOTH signatures to the same structural form before
+// inferring; evaluating only the target left the source's `Box<T>` `Application`
+// unmatched, so `T` defaulted to `unknown` and the re-comparison still failed.
+// tsc is clean on all of these. See the gate matrix in the issue.
+// ---------------------------------------------------------------------------
+
+// Single-conditional alias, source return annotated `Box<T>` (deferred form).
+#[test]
+fn deferred_application_source_return_no_false_2322() {
+    assert_no(
+        2322,
+        "
+type M<R extends string, J = any> = R extends \"a\" ? number : J;
+interface Box<T> { data?: T; }
+type Raw = <T = any, R extends string = \"a\">() => Box<M<R, T>>;
+const f: Raw = <T = any, R extends string = \"a\">(): Box<T> => (undefined as any);
+",
+    );
+}
+
+// Structural, not identifier-keyed: renaming every binder keeps it clean.
+#[test]
+fn deferred_application_source_return_no_false_2322_renamed() {
+    assert_no(
+        2322,
+        "
+type Pick<S extends string, D = any> = S extends \"a\" ? number : D;
+interface Cell<V> { value?: V; }
+type Load = <V = any, S extends string = \"a\">() => Cell<Pick<S, V>>;
+const g: Load = <V = any, S extends string = \"a\">(): Cell<V> => (undefined as any);
+",
+    );
+}
+
+// The target conditional need not even mention the source type parameter: tsc
+// still infers the (free/covariant) source `T` to the target's demanded type.
+#[test]
+fn target_result_without_source_type_param_no_false_2322() {
+    assert_no(
+        2322,
+        "
+type M<R extends string, J = any> = R extends \"a\" ? number : string;
+interface Box<T> { data?: T; }
+type Raw = <T = any, R extends string = \"a\">() => Box<M<R, T>>;
+const f: Raw = <T = any, R extends string = \"a\">(): Box<T> => (undefined as any);
+",
+    );
+}
+
+// Guardrail: a *concrete* source return (`Box<number>`) has nothing to infer and
+// must still report TS2322 (matches tsc).
+#[test]
+fn concrete_source_return_deferred_target_still_reports_2322() {
+    assert_has(
+        2322,
+        "
+type M<R extends string, J = any> = R extends \"a\" ? number : J;
+interface Box<T> { data?: T; }
+type Raw = <T = any, R extends string = \"a\">() => Box<M<R, T>>;
+const f: Raw = <T = any, R extends string = \"a\">(): Box<number> => (undefined as any);
+",
+    );
+}
+
+// Guardrail: when the source type parameter also occurs *contravariantly* (in a
+// parameter), inference is pinned back to the bare parameter and the relation
+// must still fail, exactly as tsc reports it.
+#[test]
+fn invariant_source_type_param_occurrence_still_reports_2322() {
+    assert_has(
+        2322,
+        "
+type M<R extends string, J = any> = R extends \"a\" ? number : J;
+interface Box<T> { data?: T; }
+type Raw = <T = any, R extends string = \"a\">(p: Box<T>) => Box<M<R, T>>;
+const f: Raw = <T = any, R extends string = \"a\">(p: Box<T>): Box<T> => (undefined as any);
+",
+    );
+}

--- a/crates/tsz-solver/src/relations/subtype/rules/functions/checking/context_instantiation.rs
+++ b/crates/tsz-solver/src/relations/subtype/rules/functions/checking/context_instantiation.rs
@@ -64,23 +64,31 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
         if !self.target_references_own_type_params_non_bare(target) {
             return None;
         }
-        // Inference matches the source's free parameters positionally against the
-        // target. The source signature is normalised to evaluated (structural)
-        // shapes before inference, so the target's parameter/return/`this` types
-        // must be evaluated to the same representation — otherwise a deferred
-        // `Application` on the target (e.g. `Box<MappedResponseType<R, T>>`) cannot
-        // be matched against the source's already-evaluated object shape and no
-        // candidate is collected.
+        // Contextual inference matches the source's type parameters positionally
+        // against the target. For that match to find candidates, source and target
+        // must be compared in the *same* representation: evaluating only one side
+        // (e.g. the target's `Box<MappedResponseType<R, T>>` to its `{ data?: … }`
+        // object shape) while the other stays a deferred `Application` leaves the
+        // inference with nothing to unify, so the source type parameter silently
+        // defaults to `unknown` and the re-comparison fails. Evaluate BOTH shapes
+        // to their structural form, infer in that form, instantiate the evaluated
+        // source, and re-compare against the evaluated target — all four steps in
+        // one representation. This mirrors tsc, where
+        // `instantiateSignatureInContextOf` works over the (resolved) apparent
+        // types of both signatures.
+        let source_for_inference = self.evaluate_function_shape_types(source);
         let target_for_inference = self.evaluate_function_shape_types(target);
         let substitution = self
-            .infer_source_type_param_substitution(source, &target_for_inference)
+            .infer_source_type_param_substitution(&source_for_inference, &target_for_inference)
             .ok()?;
-        let inferred_source = self.instantiate_function_shape(source, &substitution);
-        let allow_constructor_bivariance =
-            !Self::constructor_signatures_need_strict_params(&inferred_source, target);
+        let inferred_source = self.instantiate_function_shape(&source_for_inference, &substitution);
+        let allow_constructor_bivariance = !Self::constructor_signatures_need_strict_params(
+            &inferred_source,
+            &target_for_inference,
+        );
         let retry = self.check_function_subtype_impl(
             &inferred_source,
-            target,
+            &target_for_inference,
             allow_constructor_bivariance,
         );
         retry.is_true().then_some(retry)
@@ -112,9 +120,9 @@ impl<'a, R: TypeResolver> SubtypeChecker<'a, R> {
 
     /// Return a copy of `shape` with its parameter, `this`, and return types
     /// evaluated to their structural form. The type-parameter list and parameter
-    /// metadata are preserved. Used to align the target's representation with the
-    /// source before contextual type-parameter inference (which normalises the
-    /// source to evaluated shapes).
+    /// metadata are preserved. The caller evaluates *both* the source and target
+    /// signatures with this before contextual type-parameter inference, so the two
+    /// are compared in the same representation.
     fn evaluate_function_shape_types(&mut self, shape: &FunctionShape) -> FunctionShape {
         let mut evaluated = shape.clone();
         for param in &mut evaluated.params {


### PR DESCRIPTION
Goal: green

Fixes the residual of #13232 left after #13467.

## Summary

The `instantiateSignatureInContextOf` fallback for relating two same-arity generic
signatures (added in #13467) evaluated only the **target** shape before inference
while leaving the **source** as a deferred `Application`. When the source return is
itself a deferred application — e.g. an explicit `() => Box<T>` annotation rather
than the materialized object shape an indirection like `ctx.box!` produced — the
inference engine had nothing to unify the target's `{ data?: … }` object shape
against, so the source type parameter silently defaulted to `unknown` and the
re-comparison failed. Result: a false `TS2322`.

Minimal witness (tsc 5.9.3 / 6.0.2 clean; tsz emitted `TS2322` before this PR):

```ts
type M<R extends string, J = any> = R extends "a" ? number : J;
interface Box<T> { data?: T; }
type Raw = <T = any, R extends string = "a">() => Box<M<R, T>>;
const f: Raw = <T = any, R extends string = "a">(): Box<T> => (undefined as any);
```

## Structural rule

When tsc relates `<T,R>() => Box<T>` to `<T,R>() => Box<M<R,T>>` via
`compareSignaturesRelated` → `instantiateSignatureInContextOf`, it infers the
source's type parameters from the target over the **resolved apparent types of
both signatures**. tsz now evaluates *both* source and target to their structural
form, infers in that form, instantiates the evaluated source, and re-compares
against the evaluated target — all four steps in one representation. Evaluating
only one side left source and target in mismatched representations (deferred
`Application` vs object shape), which is what defeated the inference.

Owner layer: solver function subtype relation, contextual-instantiation fallback
(`crates/tsz-solver/src/relations/subtype/rules/functions/checking/context_instantiation.rs`).
No fixture-name, identifier, property-name, file-name, or rendered-type predicates.

## Adjacent matrix / fallback

The fallback still only relaxes a comparison that already failed and stays gated to
ordinary assignability, so genuine mismatches keep reporting `TS2322`:

| case | shape | tsc | tsz (this PR) |
|---|---|---|---|
| deferred source return | `() => Box<T>` vs `() => Box<M<R,T>>` | clean | clean |
| renamed binders | same, every binder renamed | clean | clean |
| target result omits source param | `M<R,_> = R extends "a" ? number : string` | clean | clean |
| concrete source return | `() => Box<number>` | error | error |
| invariant occurrence | `(p: Box<T>) => Box<T>` | error | error |
| direct relation (control) | `(x: T): M<R,T>` return-stmt | error | error |

Regression tests added to
`crates/tsz-checker/src/tests/generic_signature_context_instantiation_tests.rs`
cover all of the above (the prior #13467 tests, which exercised the materialized
object-shape source, stay green).

## Verification

- `cargo test -p tsz-checker --lib generic_signature_context_instantiation` — 9 passed (4 existing + 5 new).
- `cargo test -p tsz-checker --lib` and `cargo test -p tsz-solver --lib`: deterministic before/after diff over the full lib suites shows **0 new failures** introduced by this change (1 checker test additionally passes); the remaining failures are pre-existing on the branch base (= `main` HEAD `6a39d99`) and are lib-cache / pre-existing-ceiling related, not touched here.
- `cargo fmt` + `cargo clippy -p tsz-solver --lib` clean.
- CLI gate matrix on a `dist`-style build matches the table above; the original #13232 two-file ofetch witness (`$fetchRaw` / `MappedResponseType`) is clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_013shYiBXVmtbr8Ey1EC2VW2)_