### PR TITLE
perf(binder): nest reexport resolution caches (#13073)

### DIFF
--- a/crates/tsz-binder/src/state/mod.rs
+++ b/crates/tsz-binder/src/state/mod.rs
@@ -53,15 +53,16 @@ pub type FileReexportsMap = FxHashMap<String, FileReexports>;
 /// Maps `current_file` -> `Vec<(source_module, is_type_only)>`.
 /// The `is_type_only` flag is `true` for `export type * from "X"` chains.
 pub type WildcardReexportsMap = FxHashMap<String, Vec<(String, bool)>>;
-type ExportCache = FxHashMap<(String, String), Option<SymbolId>>;
+type ExportCache = FxHashMap<String, FxHashMap<String, Option<SymbolId>>>;
 /// Cache for the type-only re-export resolver. Mirrors [`ExportCache`] but also
 /// records whether the resolution path crossed an `export type * from ...`
-/// wildcard (the `bool` in the value). Keyed by `(module_specifier,
-/// export_name)`. The result is a pure function of the request plus the
-/// binder's immutable re-export tables, so it is safe to memoize for the
-/// lifetime of the binder and is cleared alongside [`ExportCache`] whenever
-/// resolution caches are invalidated.
-type ExportTypeOnlyCache = FxHashMap<(String, String), Option<(SymbolId, bool)>>;
+/// wildcard (the `bool` in the value). Keyed first by `module_specifier`, then
+/// by `export_name`, so repeated probes can borrow request strings instead of
+/// allocating a composite key before a cache hit. The result is a pure function
+/// of the request plus the binder's immutable re-export tables, so it is safe
+/// to memoize for the lifetime of the binder and is cleared alongside
+/// [`ExportCache`] whenever resolution caches are invalidated.
+type ExportTypeOnlyCache = FxHashMap<String, FxHashMap<String, Option<(SymbolId, bool)>>>;
 type IdentifierCache = FxHashMap<(usize, u32), Option<SymbolId>>;
 /// Cache for [`BinderState::find_enclosing_scope`], keyed by
 /// `(arena_pointer, node_index)` -> the resolved enclosing [`ScopeId`].
@@ -1105,12 +1106,16 @@ impl BinderState {
                 .resolved_export_cache
                 .read()
                 .expect("resolved_export_cache RwLock poisoned")
-                .len(),
+                .values()
+                .map(FxHashMap::len)
+                .sum(),
             export_type_only_cache_entries: self
                 .resolved_export_type_only_cache
                 .read()
                 .expect("resolved_export_type_only_cache RwLock poisoned")
-                .len(),
+                .values()
+                .map(FxHashMap::len)
+                .sum(),
             identifier_cache_entries: self
                 .resolved_identifier_cache
                 .read()

--- a/crates/tsz-binder/src/state/resolution.rs
+++ b/crates/tsz-binder/src/state/resolution.rs
@@ -642,12 +642,12 @@ impl BinderState {
         export_name: &str,
     ) -> Option<SymbolId> {
         // Check cache first for fast path
-        let cache_key = (module_specifier.to_string(), export_name.to_string());
         if let Some(&cached) = self
             .resolved_export_cache
             .read()
             .expect("RwLock not poisoned")
-            .get(&cache_key)
+            .get(module_specifier)
+            .and_then(|module_exports| module_exports.get(export_name))
         {
             return cached;
         }
@@ -666,7 +666,9 @@ impl BinderState {
         self.resolved_export_cache
             .write()
             .expect("resolved_export_cache RwLock poisoned")
-            .insert(cache_key, result);
+            .entry(module_specifier.to_string())
+            .or_default()
+            .insert(export_name.to_string(), result);
         result
     }
 
@@ -698,12 +700,12 @@ impl BinderState {
             );
         }
 
-        let cache_key = (module_specifier.to_string(), export_name.to_string());
         if let Some(&cached) = self
             .resolved_export_type_only_cache
             .read()
             .expect("resolved_export_type_only_cache RwLock poisoned")
-            .get(&cache_key)
+            .get(module_specifier)
+            .and_then(|module_exports| module_exports.get(export_name))
         {
             return cached;
         }
@@ -719,7 +721,9 @@ impl BinderState {
         self.resolved_export_type_only_cache
             .write()
             .expect("resolved_export_type_only_cache RwLock poisoned")
-            .insert(cache_key, result);
+            .entry(module_specifier.to_string())
+            .or_default()
+            .insert(export_name.to_string(), result);
         result
     }
 

--- a/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
+++ b/crates/tsz-binder/src/state/tests/exports_jsdoc.rs
@@ -1305,7 +1305,8 @@ fn type_only_reexport_resolution_is_cached_and_stable() {
             .resolved_export_type_only_cache
             .read()
             .expect("cache lock")
-            .get(&("./entry".to_string(), "Widget".to_string()))
+            .get("./entry")
+            .and_then(|module_exports| module_exports.get("Widget"))
             .copied(),
         Some(Some((leaf_sym, false))),
         "type-only resolution should be memoized per (module, export)"
@@ -1348,7 +1349,8 @@ fn type_only_reexport_cache_missing_export_is_cached_as_none() {
             .resolved_export_type_only_cache
             .read()
             .expect("cache lock")
-            .get(&("./entry".to_string(), "DoesNotExist".to_string()))
+            .get("./entry")
+            .and_then(|module_exports| module_exports.get("DoesNotExist"))
             .copied(),
         Some(None),
         "negative type-only results must also be memoized"

--- a/crates/tsz-binder/src/state/tests/state_storage.rs
+++ b/crates/tsz-binder/src/state/tests/state_storage.rs
@@ -510,7 +510,9 @@ fn seed_resolution_caches(binder: &mut BinderState) {
         .resolved_export_cache
         .write()
         .expect("not poisoned")
-        .insert(("stub.ts".to_string(), "x".to_string()), Some(SymbolId(99)));
+        .entry("stub.ts".to_string())
+        .or_default()
+        .insert("x".to_string(), Some(SymbolId(99)));
     binder
         .resolved_identifier_cache
         .write()
@@ -520,10 +522,9 @@ fn seed_resolution_caches(binder: &mut BinderState) {
         .resolved_export_type_only_cache
         .write()
         .expect("not poisoned")
-        .insert(
-            ("stub.ts".to_string(), "T".to_string()),
-            Some((SymbolId(88), true)),
-        );
+        .entry("stub.ts".to_string())
+        .or_default()
+        .insert("T".to_string(), Some((SymbolId(88), true)));
     binder
         .find_enclosing_scope_cache
         .write()


### PR DESCRIPTION
Goal: fast

## Summary
- change binder re-export resolution caches from `(module_specifier, export_name)` tuple keys to nested module -> export-name maps
- keep the cache question and invalidation unchanged while allowing cache hits to borrow request `&str`s instead of allocating composite keys first
- keep resolution statistics reporting logical cached export entries by summing nested export-name buckets

Refs #13073.

## Structural Rule
When binder re-export resolution answers the same `(module_specifier, export_name)` request, tsz must reuse the same cached `Option<SymbolId>` / type-only provenance result as before. Binder owns this re-export cache; the storage layout can group by module specifier first as long as the request identity, cache lifetime, and `clear_resolution_caches` invalidation boundary stay unchanged.

## Owner Layer
Binder owns module export/re-export resolution and these memo tables. Checker, solver, and display paths are unchanged.

## Adjacent Matrix
- Direct value import resolution: same request identity, nested cache hit avoids tuple-key allocation before lookup.
- Type-position re-export resolution: same nested layout while preserving the `(SymbolId, is_type_only)` result.
- Negative lookups: still cache `None` under the same module/export-name request.
- Cache clearing and binder cloning: unchanged `RwLock` storage and clear paths; nested maps are cleared as one table.
- Statistics: logical entry counts still count cached export-name requests rather than only module buckets.

## Performance Notes
- This removes repeated composite tuple `String` key construction on re-export cache hits; storage now clones the module/export strings only when inserting a missed request.
- No timing claim is made; this is a small repeated-operation reduction in the #13073 binder/export-resolution string-key path.

## Verification
- Not run locally; no local tests or benchmarks run per current agent instruction.
- Exact-head draft CI passed for `b8c1b5ec74279a064c603e0aab82c28777ed779e`: `CI Light Summary`, `lint`, `unit`, `unit-cloudbuild`, `unit-checker-integration`, `dist-binaries`, `cargo-deny`, `cargo-shear`, `project-row-drift`, `premerge-microbench`, and `gate`.
- Ready PR CI is expected to run the full `CI Summary` gate before queueing.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: high
