### PR TITLE
refactor(tsz-core): unify duplicated Node module-resolution helpers (#13426)

### DIFF
--- a/crates/tsz-core/src/config/resolved_options.rs
+++ b/crates/tsz-core/src/config/resolved_options.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use crate::checker::context::CheckerOptions;
 use crate::emitter::{ModuleKind, PrinterOptions, ScriptTarget};
+use crate::module_resolver_helpers::match_prefix_suffix;
 use tsz_common::options::strict_family::{StrictFamilyOverrides, apply_strict_family};
 
 use super::{
@@ -216,18 +217,10 @@ impl PathMapping {
         // Keys with more than one `*` are rejected up front by
         // `build_path_mappings` (mirroring tsc's `tryParsePattern`), so every
         // mapping that reaches here has exactly one `*` and a well-formed
-        // `prefix`/`suffix`.
-        if !specifier.starts_with(&self.prefix) || !specifier.ends_with(&self.suffix) {
-            return None;
-        }
-
-        let start = self.prefix.len();
-        let end = specifier.len().saturating_sub(self.suffix.len());
-        if end < start {
-            return None;
-        }
-
-        Some(specifier[start..end].to_string())
+        // `prefix`/`suffix`. The capture itself shares the single-`*` matcher
+        // with the `exports`/`imports` resolvers (this carries precomputed
+        // `prefix`/`suffix` fields rather than re-splitting the pattern).
+        match_prefix_suffix(&self.prefix, &self.suffix, specifier)
     }
 
     pub const fn specificity(&self) -> usize {

--- a/crates/tsz-core/src/lib.rs
+++ b/crates/tsz-core/src/lib.rs
@@ -210,14 +210,12 @@ pub mod config;
 // Module Resolution Infrastructure (non-wasm targets only - requires file system access)
 #[cfg(not(target_arch = "wasm32"))]
 pub mod module_resolver;
-#[cfg(not(target_arch = "wasm32"))]
 mod resolution;
 #[cfg(not(target_arch = "wasm32"))]
 pub use module_resolver::{
     ModuleExtension, ModuleLookupError, ModuleLookupOutcome, ModuleLookupRequest,
     ModuleLookupResult, ModuleResolver, ResolutionFailure, ResolvedModule,
 };
-#[cfg(not(target_arch = "wasm32"))]
 pub(crate) use resolution::helpers as module_resolver_helpers;
 
 // =============================================================================

--- a/crates/tsz-core/src/module_resolver/file_probing.rs
+++ b/crates/tsz-core/src/module_resolver/file_probing.rs
@@ -28,6 +28,34 @@ impl ModuleResolver {
         path: &Path,
         package_type: Option<PackageType>,
     ) -> Option<PathBuf> {
+        self.try_file_inner(path, package_type, true)
+    }
+
+    /// Like [`Self::try_file`], but does NOT try directory index resolution
+    /// (`path/index.{ext}`). Used for ESM packages in Node16/NodeNext where
+    /// directory index resolution is not allowed by Node.js.
+    pub(super) fn try_file_no_index(
+        &self,
+        path: &Path,
+        package_type: Option<PackageType>,
+    ) -> Option<PathBuf> {
+        self.try_file_inner(path, package_type, false)
+    }
+
+    /// Shared body of [`Self::try_file`] and [`Self::try_file_no_index`]. The
+    /// two differ only in the trailing directory-index probe, gated on
+    /// `try_index`: `try_file` passes `true`, `try_file_no_index` passes
+    /// `false` (ESM packages in Node16/NodeNext, where Node.js forbids
+    /// directory index resolution). Everything before that — normalization,
+    /// arbitrary-extension declaration probing, `node16_extension_substitution`,
+    /// the `rewriteRelativeImportExtensions` declaration remap, and the
+    /// original-extension fallback — is identical between the two callers.
+    fn try_file_inner(
+        &self,
+        path: &Path,
+        package_type: Option<PackageType>,
+        try_index: bool,
+    ) -> Option<PathBuf> {
         // Canonicalize `.`/`..` before probing so the returned `PathBuf` is
         // the same across alias branches that point at the same file.
         let path = &normalize_path_segments(path);
@@ -55,18 +83,12 @@ impl ModuleResolver {
 
             // When rewriteRelativeImportExtensions is true, .ts/.tsx/.mts/.cts imports
             // should resolve to their declaration file equivalents (.d.ts/.d.mts/.d.cts).
-            if self.rewrite_relative_import_extensions {
-                let decl_ext = match extension {
-                    "ts" | "tsx" => Some("d.ts"),
-                    "mts" => Some("d.mts"),
-                    "cts" => Some("d.cts"),
-                    _ => None,
-                };
-                if let Some(decl_ext) = decl_ext {
-                    let candidate = base.with_extension(decl_ext);
-                    if let Some(resolved) = try_file_with_suffixes(&candidate, suffixes) {
-                        return Some(resolved);
-                    }
+            if self.rewrite_relative_import_extensions
+                && let Some(decl_ext) = ts_extension_to_declaration(extension)
+            {
+                let candidate = base.with_extension(decl_ext);
+                if let Some(resolved) = try_file_with_suffixes(&candidate, suffixes) {
+                    return Some(resolved);
                 }
             }
 
@@ -86,72 +108,16 @@ impl ModuleResolver {
             }
         }
 
-        let index = path.join("index");
-        for ext in extensions {
-            if let Some(resolved) = try_file_with_suffixes_and_extension(&index, ext, suffixes) {
-                return Some(resolved);
-            }
-        }
-
-        None
-    }
-
-    /// Like [`Self::try_file`], but does NOT try directory index resolution
-    /// (`path/index.{ext}`). Used for ESM packages in Node16/NodeNext where
-    /// directory index resolution is not allowed by Node.js.
-    pub(super) fn try_file_no_index(
-        &self,
-        path: &Path,
-        package_type: Option<PackageType>,
-    ) -> Option<PathBuf> {
-        let path = &normalize_path_segments(path);
-        let suffixes = &self.module_suffixes;
-        if let Some(extension) = path.extension().and_then(|ext| ext.to_str())
-            && split_path_extension(path).is_none()
-        {
-            // Always probe for .d.*.ts declaration files regardless of allowArbitraryExtensions.
-            // When the flag is off, the caller (lookup) emits TS6263 for the resolved file.
-            if let Some(resolved) = try_arbitrary_extension_declaration(path, extension) {
-                return Some(resolved);
-            }
-            return None;
-        }
-        if let Some((base, extension)) = split_path_extension(path) {
-            if let Some(rewritten) = node16_extension_substitution(path, extension) {
-                for candidate in &rewritten {
-                    if let Some(resolved) = try_file_with_suffixes(candidate, suffixes) {
-                        return Some(resolved);
-                    }
+        if try_index {
+            let index = path.join("index");
+            for ext in extensions {
+                if let Some(resolved) = try_file_with_suffixes_and_extension(&index, ext, suffixes)
+                {
+                    return Some(resolved);
                 }
             }
-            if self.rewrite_relative_import_extensions {
-                let decl_ext = match extension {
-                    "ts" | "tsx" => Some("d.ts"),
-                    "mts" => Some("d.mts"),
-                    "cts" => Some("d.cts"),
-                    _ => None,
-                };
-                if let Some(decl_ext) = decl_ext {
-                    let candidate = base.with_extension(decl_ext);
-                    if let Some(resolved) = try_file_with_suffixes(&candidate, suffixes) {
-                        return Some(resolved);
-                    }
-                }
-            }
-            if let Some(resolved) = try_file_with_suffixes_and_extension(&base, extension, suffixes)
-            {
-                return Some(resolved);
-            }
-            return None;
         }
 
-        let extensions = self.extension_candidates_for_package_type(package_type);
-        for ext in extensions {
-            if let Some(resolved) = try_file_with_suffixes_and_extension(path, ext, suffixes) {
-                return Some(resolved);
-            }
-        }
-        // No index fallback -- that's the whole point
         None
     }
 

--- a/crates/tsz-core/src/resolution/helpers.rs
+++ b/crates/tsz-core/src/resolution/helpers.rs
@@ -133,6 +133,43 @@ pub(crate) fn types_package_name(package_name: &str) -> String {
     format!("@types/{}", stripped.replace('/', "__"))
 }
 
+/// Match `input` against a single-`*` pattern already split into its
+/// `prefix`/`suffix` halves, returning the substring the `*` captured.
+///
+/// Shared inner step of [`match_single_star`] (which splits the pattern on
+/// `*` first) and `PathMapping::match_specifier` (which carries precomputed
+/// `prefix`/`suffix` fields). Mirrors Node's `PATTERN_KEY_COMPARE` capture:
+/// `input` must start with `prefix` and end with `suffix`, and the matched
+/// region is what sits between them (empty when they abut). Routing all three
+/// callers through one body keeps the parity-sensitive capture rule from
+/// drifting between resolvers.
+pub(crate) fn match_prefix_suffix(prefix: &str, suffix: &str, input: &str) -> Option<String> {
+    if !input.starts_with(prefix) || !input.ends_with(suffix) {
+        return None;
+    }
+
+    let start = prefix.len();
+    let end = input.len().saturating_sub(suffix.len());
+
+    if end < start {
+        return None;
+    }
+
+    Some(input[start..end].to_string())
+}
+
+/// Match `input` against a single-`*` `pattern`, returning the captured
+/// wildcard text. Patterns that do not contain exactly one `*` (the
+/// `parts.len() != 2` guard) are rejected, mirroring Node's single-`*`
+/// `PATTERN_KEY_COMPARE` contract.
+pub(crate) fn match_single_star(pattern: &str, input: &str) -> Option<String> {
+    let parts: Vec<&str> = pattern.split('*').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+    match_prefix_suffix(parts[0], parts[1], input)
+}
+
 /// Match an export pattern against a subpath
 pub(crate) fn match_export_pattern(pattern: &str, subpath: &str) -> Option<String> {
     if !pattern.contains('*') {
@@ -150,26 +187,7 @@ pub(crate) fn match_export_pattern(pattern: &str, subpath: &str) -> Option<Strin
         return None;
     }
 
-    let parts: Vec<&str> = pattern.split('*').collect();
-    if parts.len() != 2 {
-        return None;
-    }
-
-    let prefix = parts[0];
-    let suffix = parts[1];
-
-    if !subpath.starts_with(prefix) || !subpath.ends_with(suffix) {
-        return None;
-    }
-
-    let start = prefix.len();
-    let end = subpath.len().saturating_sub(suffix.len());
-
-    if end < start {
-        return None;
-    }
-
-    Some(subpath[start..end].to_string())
+    match_single_star(pattern, subpath)
 }
 
 /// Specificity ranking key for an `exports`/`imports` subpath key.
@@ -242,26 +260,7 @@ pub(crate) fn match_imports_pattern(pattern: &str, specifier: &str) -> Option<St
     let pattern = pattern.strip_prefix('#').unwrap_or(pattern);
     let specifier = specifier.strip_prefix('#').unwrap_or(specifier);
 
-    let parts: Vec<&str> = pattern.split('*').collect();
-    if parts.len() != 2 {
-        return None;
-    }
-
-    let prefix = parts[0];
-    let suffix = parts[1];
-
-    if !specifier.starts_with(prefix) || !specifier.ends_with(suffix) {
-        return None;
-    }
-
-    let start = prefix.len();
-    let end = specifier.len().saturating_sub(suffix.len());
-
-    if end < start {
-        return None;
-    }
-
-    Some(specifier[start..end].to_string())
+    match_single_star(pattern, specifier)
 }
 
 // The `typesVersions` / semver algorithm is owned by
@@ -324,13 +323,7 @@ pub(crate) fn substitute_wildcard_in_exports(
 ) -> PackageExports {
     match value {
         PackageExports::String(s) => {
-            if s.contains('*') {
-                PackageExports::String(s.replacen('*', wildcard, 1))
-            } else if is_directory_match && s.ends_with('/') {
-                PackageExports::String(format!("{s}{wildcard}"))
-            } else {
-                PackageExports::String(s.clone())
-            }
+            PackageExports::String(apply_wildcard_substitution(s, wildcard, is_directory_match))
         }
         PackageExports::Conditional(entries) => PackageExports::Conditional(
             entries
@@ -490,6 +483,24 @@ pub(crate) fn declaration_substitution_for_main(path: &Path) -> Option<PathBuf> 
         "js" | "jsx" => Some(path.with_extension("d.ts")),
         "mjs" => Some(path.with_extension("d.mts")),
         "cjs" => Some(path.with_extension("d.cts")),
+        _ => None,
+    }
+}
+
+/// Map a TS implementation extension to its declaration-file extension
+/// (`ts`/`tsx` -> `d.ts`, `mts` -> `d.mts`, `cts` -> `d.cts`); returns `None`
+/// for any other extension.
+///
+/// This is the inverse direction of [`declaration_substitution_for_main`],
+/// which maps JS *output* extensions (`js`/`jsx`/`mjs`/`cjs`) to their
+/// declaration equivalents. The TS-to-declaration direction is used by the
+/// `rewriteRelativeImportExtensions` probe, where a `.ts`/`.mts`/`.cts`
+/// specifier resolves to its `.d.ts`/`.d.mts`/`.d.cts` declaration file.
+pub(crate) fn ts_extension_to_declaration(extension: &str) -> Option<&'static str> {
+    match extension {
+        "ts" | "tsx" => Some("d.ts"),
+        "mts" => Some("d.mts"),
+        "cts" => Some("d.cts"),
         _ => None,
     }
 }


### PR DESCRIPTION
Goal: hold

Closes #13426.

## Summary

The `tsz-core` module resolver re-implemented several Node.js resolution
algorithms as independent copies across the file-probing, exports/imports, and
paths resolvers. The surrounding comments repeatedly warn these copies "cannot
drift between them" — yet a parity fix landed in one copy would silently
diverge from the others. This is a pure, behavior-preserving intra-crate DRY
sweep that gives each algorithm one owner.

## Changes

- **`module_resolver/file_probing.rs`** — collapse `try_file` and
  `try_file_no_index` (~110 lines of line-for-line copy-paste) into a shared
  `try_file_inner(.., try_index: bool)`. The trailing directory-index probe is
  the only behavioral difference and is now gated on the flag; `try_file`
  passes `true`, `try_file_no_index` passes `false`.
- **`resolution/helpers.rs`** — extract `match_prefix_suffix` (the
  prefix/suffix single-`*` capture) and `match_single_star` (split-on-`*` +
  capture); route `match_export_pattern` and `match_imports_pattern` through
  them.
- **`config/resolved_options.rs`** — route `PathMapping::match_specifier`
  (which carries precomputed `prefix`/`suffix` fields) through
  `match_prefix_suffix`, so the single-`*` capture rule has one owner across
  the `exports`/`imports`/`paths` resolvers.
- **`resolution/helpers.rs`** — `substitute_wildcard_in_exports`' `String` arm
  now calls the existing `apply_wildcard_substitution` helper instead of
  re-inlining its three branches.
- **`resolution/helpers.rs`** — add `ts_extension_to_declaration`
  (`ts`/`tsx` -> `d.ts`, `mts` -> `d.mts`, `cts` -> `d.cts`) next to its
  JS-direction inverse `declaration_substitution_for_main`, replacing the
  inline TS-to-declaration map that was duplicated in both `try_file` bodies.

**Out of scope (deliberately):** `PathMapping::substitute_target` stays
separate per its own doc — tsconfig-`paths` substitution is a distinct
Node-spec concern from `exports`/`imports` substitution, and folding it in
would cross a documented boundary.

## Structural rule

When matching a single-`*` specifier, probing a file with/without a directory
index fallback, mapping a TS extension to its declaration extension, or
substituting a captured wildcard, there is now exactly one helper and every
caller routes through it. Owner layer: `tsz-core` module resolution helpers;
no checker/solver/emitter surface changes. Behavior is byte-equivalent to the
prior copies — the extracted bodies are identical to one of the originals, and
the index-fallback branch stays gated so ESM-package callers still skip it.

## Anti-hardcoding

No user-name/file-name/printer-string predicates introduced; the helpers key
only on Node-spec structural inputs (pattern shape, file extension). No
single-test suppressions.

## Verification

- Post-ready wasm fix: CI wasm job 81245140169 failed with E0432 because `config/resolved_options.rs` imported the shared resolver helper while the re-export was gated out on `wasm32`; commit `37e31057563cc9b3f891d6b433d0fa7046a1ea1e` exposes the pure helper module to wasm builds while keeping the filesystem resolver gated.
- No local tests run for the post-ready wasm fix per current instruction; pre-commit formatting hook ran during commit.
- `cargo build -p tsz-core` — clean.
- `cargo test -p tsz-core` resolution/`module_resolver`/`path_mapping`/
  `file_probing`/`match_*`/`wildcard` filter — **671 passed, 0 failed**.
- `cargo clippy -p tsz-core --lib -- -D warnings` — clean.
- `cargo fmt -p tsz-core -- --check` — clean.
- The 32 unrelated failures in the full `tsz-core` suite (ES5 async-emitter
  source-map panics, parallel-residency, scanner) reproduce identically on the
  clean tree with this change stashed — they are pre-existing and untouched by
  this refactor.
- Broad resolution/conformance/emit/fourslash parity gates owned by
  ready-review CI.

## Provenance

Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: medium

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5GiEgtLPy85Z5Phg5xuvg)_
