### PR TITLE
refactor(solver): reuse string intrinsic transform helper (#13423)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/string_intrinsic.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/string_intrinsic.rs
@@ -59,38 +59,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             // String literal types - apply the transformation
             TypeData::Literal(LiteralValue::String(atom)) => {
                 let s = self.interner().resolve_atom_ref(atom);
-                let transformed = match kind {
-                    StringIntrinsicKind::Uppercase => s.to_uppercase(),
-                    StringIntrinsicKind::Lowercase => s.to_lowercase(),
-                    StringIntrinsicKind::Capitalize => {
-                        if s.is_empty() {
-                            s.to_string()
-                        } else {
-                            let mut chars = s.chars();
-                            match chars.next() {
-                                Some(first) => {
-                                    let upper: String = first.to_uppercase().collect();
-                                    upper + chars.as_str()
-                                }
-                                None => s.to_string(),
-                            }
-                        }
-                    }
-                    StringIntrinsicKind::Uncapitalize => {
-                        if s.is_empty() {
-                            s.to_string()
-                        } else {
-                            let mut chars = s.chars();
-                            match chars.next() {
-                                Some(first) => {
-                                    let lower: String = first.to_lowercase().collect();
-                                    lower + chars.as_str()
-                                }
-                                None => s.to_string(),
-                            }
-                        }
-                    }
-                };
+                let transformed = self.apply_string_transform(kind, &s);
                 self.interner().literal_string(&transformed)
             }
 


### PR DESCRIPTION
Goal: hold

## Summary
- Reuse the existing solver-owned string transform helper for string literal intrinsic evaluation.
- Remove the duplicated Uppercase/Lowercase/Capitalize/Uncapitalize match from the literal path.
- Keep behavior unchanged while shrinking #13423's duplicated string intrinsic surface.

## Structural Rule
When a string intrinsic transform is applied to literal or template text, tsc applies the same string-mapping operation; tsz now does that through the solver's shared `apply_string_transform` helper.

Owner layer: solver evaluation.

## Verification
- Draft/light CI: `CI Light Summary` SUCCESS on head `a4c3445b2a75328fa9c447eaa83a365464fe563c`.
- Not run locally per session instruction to avoid local validation.
- Ready-review CI expected after promotion.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: medium
