### PR TITLE
perf(checker): skip unchanged return-type rollback (#13243)

### DIFF
--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -251,6 +251,22 @@ impl NodeTypeCache {
         }
     }
 
+    /// `true` when both caches share the same visible backing storage.
+    ///
+    /// Speculation rollback uses this to prove a return-type inference probe did
+    /// not write to `node_types` before skipping the restore path. Require both
+    /// overlay layers to match: a changed overlay can expose different visible
+    /// entries even when the base snapshot is unchanged.
+    #[inline]
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.data, &other.data)
+            && match (&self.base, &other.base) {
+                (None, None) => true,
+                (Some(left), Some(right)) => Arc::ptr_eq(left, right),
+                _ => false,
+            }
+    }
+
     /// Create an empty speculative write layer whose reads fall through to
     /// this cache's current visible entries. See the type-level docs.
     pub fn overlay(&self) -> Self {

--- a/crates/tsz-checker/src/context/speculation.rs
+++ b/crates/tsz-checker/src/context/speculation.rs
@@ -328,6 +328,39 @@ impl<'a> CheckerContext<'a> {
             && self.request_node_types.ptr_eq(&snap.request_node_types)
     }
 
+    /// True when a return-type speculation snapshot has observed no writes that
+    /// rollback needs to undo.
+    ///
+    /// Return-type inference snapshots include heavier checker caches in
+    /// addition to diagnostics. The no-op fast path is intentionally strict:
+    /// every COW-backed cache must still share its original backing storage and
+    /// the global lazy-resolution fuel counter must be unchanged. If a
+    /// speculative pass wrote and later restored equal contents, the normal
+    /// rollback path still owns restoration.
+    fn return_type_snapshot_unchanged(&self, snap: &ReturnTypeSnapshot) -> bool {
+        self.full_snapshot_unchanged(&snap.full)
+            && self.node_types.ptr_eq(&snap.cache.node_types)
+            && self
+                .type_reference_validation_caches
+                .type_node_scope_types
+                .ptr_eq(&snap.cache.type_node_scope_types)
+            && self
+                .flow_shared
+                .flow_analysis_cache
+                .borrow()
+                .ptr_eq(&snap.cache.flow_analysis_cache)
+            && self
+                .flow_narrowed_nodes
+                .ptr_eq(&snap.cache.flow_narrowed_nodes)
+            && self.daa_error_nodes.ptr_eq(&snap.cache.daa_error_nodes)
+            && self
+                .symbol_flow_confirmed
+                .borrow()
+                .ptr_eq(&snap.cache.symbol_flow_confirmed)
+            && crate::state_domain::type_environment::lazy::global_resolution_fuel_value()
+                == snap.cache.global_resolution_fuel
+    }
+
     /// Roll back to a diagnostic-only snapshot, discarding all speculative
     /// diagnostics and restoring the dedup set.
     ///
@@ -396,6 +429,10 @@ impl<'a> CheckerContext<'a> {
     /// Roll back to a return-type snapshot, discarding speculative diagnostics,
     /// dedup state, and cache entries added during speculation.
     fn rollback_return_type(&mut self, snap: &ReturnTypeSnapshot) {
+        if self.return_type_snapshot_unchanged(snap) {
+            return;
+        }
+
         tracing::trace!(
             node_types_now = self.node_types.len(),
             node_types_restored = snap.cache.node_types.len(),


### PR DESCRIPTION
Goal: fast

## Summary
- Add pointer-identity detection for checker NodeTypeCache snapshots.
- Skip return-type speculation rollback when diagnostics, checker COW caches, node type cache layers, flow caches, and global lazy-resolution fuel are all unchanged.
- Leave changed-state rollback behavior untouched.

## Structural Rule
When return-type speculative checking writes no diagnostic, cache, or lazy-resolution fuel state, tsc observes no semantic effect and tsz can skip restoring identical checker bookkeeping through CheckerContext speculation rollback. If any tracked state diverges, tsz keeps the existing rollback path. Relation decisions and failure reasons remain owned by solver/query-boundary assignability.

## Owner Layer
Checker orchestration only. This does not add type semantics, relation logic, or diagnostic rendering policy.

## Adjacent Matrix
- Positive no-op path: all tracked snapshot backings are pointer-identical and fuel is unchanged.
- Fallback mutation path: any cache COW detaches, node-type layer changes, diagnostics change, or fuel changes, and the existing restore path runs.
- Overlay safety: NodeTypeCache requires both data and base backing pointers to match before treating snapshots as unchanged.

## Verification
- No local tests run per user instruction.
- Pre-commit formatting hook ran during commit.
- Draft CI Light Summary passed for head 84d945b0e3a2d5235be51ace42004077bc789519.
- Ready PR CI Summary is expected to cover the targeted checks.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: medium
