### PR TITLE
perf(checker): avoid passthrough run membership scan (#13311)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -120,7 +120,6 @@ impl<'a> FlowAnalyzer<'a> {
         // is the sole result read outside the walk, so aliasing it alone is sufficient
         // and never overwrites an independently-computed merge result.
         let mut flow_id_landed_on: Option<FlowNodeId> = None;
-        let mut passthrough_run: Vec<FlowNodeId> = Vec::new();
 
         // Process worklist until empty
         while let Some((entry_flow, current_type)) = worklist.pop_front() {
@@ -157,7 +156,6 @@ impl<'a> FlowAnalyzer<'a> {
             // merge. Re-scheduling an interior node simply re-runs the cheap chase.
             // Falls back to the full per-node walk whenever any gate is uncertain,
             // so narrowing stays byte-identical.
-            passthrough_run.clear();
             let mut passthrough_run_contains_flow_id = false;
             let current_flow = self.chase_linear_passthrough(
                 entry_flow,
@@ -172,7 +170,6 @@ impl<'a> FlowAnalyzer<'a> {
                 visited,
                 results,
                 &mut antecedent_defer_memo,
-                &mut passthrough_run,
                 flow_id,
                 &mut passthrough_run_contains_flow_id,
             );
@@ -183,7 +180,6 @@ impl<'a> FlowAnalyzer<'a> {
             if current_flow != flow_id && passthrough_run_contains_flow_id {
                 flow_id_landed_on = Some(current_flow);
             }
-            passthrough_run.clear();
 
             // Check global cache first to avoid redundant traversals.
             // Skip cache for SWITCH_CLAUSE nodes — they must be processed to
@@ -1181,9 +1177,9 @@ impl<'a> FlowAnalyzer<'a> {
     /// *pure pass-through* ASSIGNMENT flow nodes — nodes that neither target nor
     /// affect `reference` — collapsing a straight-line `const`/assignment segment
     /// (the `Σ O(i)` independent-assignment narrowing hotspot) into one landed
-    /// node. Every node skipped this way is pushed onto `run` so the caller can
-    /// alias the landed node's result back to it (their flow type equals the
-    /// antecedent result by construction).
+    /// node. If the original queried flow node is skipped this way, the chase
+    /// records that fact so the caller can alias its result from the landed node
+    /// once the landed node resolves.
     ///
     /// A node is only spliced when ALL of these hold, so narrowing is byte
     /// identical to the full walk:
@@ -1213,7 +1209,6 @@ impl<'a> FlowAnalyzer<'a> {
         visited: &FxHashSet<FlowNodeId>,
         results: &FxHashMap<FlowNodeId, TypeId>,
         antecedent_defer_memo: &mut FxHashMap<FlowNodeId, bool>,
-        run: &mut Vec<FlowNodeId>,
         alias_flow_id: FlowNodeId,
         run_contains_alias_flow_id: &mut bool,
     ) -> FlowNodeId {
@@ -1393,7 +1388,6 @@ impl<'a> FlowAnalyzer<'a> {
             if current == alias_flow_id {
                 *run_contains_alias_flow_id = true;
             }
-            run.push(current);
             current = ant;
         }
     }

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -1312,7 +1312,9 @@ impl<'a> FlowAnalyzer<'a> {
                 {
                     return current;
                 }
-                run.push(current);
+                if current == alias_flow_id {
+                    *run_contains_alias_flow_id = true;
+                }
                 current = ant;
                 continue;
             }

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -158,6 +158,7 @@ impl<'a> FlowAnalyzer<'a> {
             // Falls back to the full per-node walk whenever any gate is uncertain,
             // so narrowing stays byte-identical.
             passthrough_run.clear();
+            let mut passthrough_run_contains_flow_id = false;
             let current_flow = self.chase_linear_passthrough(
                 entry_flow,
                 PassthroughGate {
@@ -172,12 +173,14 @@ impl<'a> FlowAnalyzer<'a> {
                 results,
                 &mut antecedent_defer_memo,
                 &mut passthrough_run,
+                flow_id,
+                &mut passthrough_run_contains_flow_id,
             );
             // If the chase spliced out the entry `flow_id` itself, remember the node
             // it landed on so the final result can be aliased to `flow_id` once that
             // node resolves (possibly after deferrals). Interior spliced nodes are
             // intentionally left untracked so a surviving merge can re-derive them.
-            if current_flow != flow_id && passthrough_run.contains(&flow_id) {
+            if current_flow != flow_id && passthrough_run_contains_flow_id {
                 flow_id_landed_on = Some(current_flow);
             }
             passthrough_run.clear();
@@ -1211,6 +1214,8 @@ impl<'a> FlowAnalyzer<'a> {
         results: &FxHashMap<FlowNodeId, TypeId>,
         antecedent_defer_memo: &mut FxHashMap<FlowNodeId, bool>,
         run: &mut Vec<FlowNodeId>,
+        alias_flow_id: FlowNodeId,
+        run_contains_alias_flow_id: &mut bool,
     ) -> FlowNodeId {
         let PassthroughGate {
             reference,
@@ -1385,6 +1390,9 @@ impl<'a> FlowAnalyzer<'a> {
             }
 
             // `current` is a pure pass-through: record it and advance.
+            if current == alias_flow_id {
+                *run_contains_alias_flow_id = true;
+            }
             run.push(current);
             current = ant;
         }


### PR DESCRIPTION
Goal: fast

## Summary
- Avoid a post-chase linear membership scan over the pass-through run in FlowAnalyzer.
- Drop the now-unused skipped-run scratch vector and record whether the original queried flow node was spliced while the chase already visits each skipped assignment node.
- Keep pass-through gates, flow cache keys, and fallback behavior unchanged.

## Structural Rule
When FlowAnalyzer collapses a pure pass-through assignment run, tsz must alias the original queried flow node to the landed node only if that queried flow node was actually spliced. The chase already observes each spliced node, so it can record that fact during traversal instead of storing a skipped-node list and scanning it afterward. Unsupported or non-pass-through shapes still fall back to the existing worklist path.

## Owner Layer
Checker FlowAnalyzer traversal only. No solver semantics, relation policy, narrowing rules, or diagnostic rendering behavior move layers.

## Cache And Complexity Invariant
- Request scope: one check_flow walk for one reference/symbol/initial-type query.
- Key/fallback: no new resident cache; existing pass-through gates and flow cache keys are unchanged.
- Complexity: removes the per-chase O(pass-through-run length) contains scan and the scratch vector pushes by recording one alias flag during the existing O(run length) chase.

## Verification
- No local tests or benchmarks run per user instruction.
- Pre-commit formatting hook ran during both commits.
- Draft CI Light Summary passed for head 15ec3a0a281d987136c6c3be68f3cdf9b4a09349.
- Ready PR CI Summary is expected to cover full required gates before queue.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: medium
