### PR TITLE
refactor(solver): scope inference dead-code allows, drop blanket module allows (#13440)

### DIFF
--- a/crates/tsz-solver/src/inference/infer.rs
+++ b/crates/tsz-solver/src/inference/infer.rs
@@ -142,7 +142,10 @@ impl UnifyValue for InferenceInfo {
 
 /// Inference error
 #[derive(Clone, Debug)]
-#[allow(dead_code)] // Variants/fields reserved for full inference error reporting
+// Constructed throughout inference as a control-flow signal; the variant
+// payload is retained for `Debug`/future error reporting, and only the variant
+// kind and `BoundsViolation.lower` are read today.
+#[allow(dead_code)]
 pub(crate) enum InferenceError {
     /// Two incompatible types were unified
     Conflict(TypeId, TypeId),
@@ -167,7 +170,6 @@ pub(crate) enum InferenceError {
 /// Constraint set for an inference variable.
 /// Tracks both lower bounds (L <: α) and upper bounds (α <: U).
 #[derive(Clone, Debug, Default)]
-#[allow(dead_code)] // Methods reserved for constraint-based inference resolution
 pub(crate) struct ConstraintSet {
     /// Lower bounds: types that must be subtypes of this variable
     /// e.g., from argument types being assigned to a parameter
@@ -177,15 +179,7 @@ pub(crate) struct ConstraintSet {
     pub(crate) upper_bounds: Vec<TypeId>,
 }
 
-#[allow(dead_code)] // Methods reserved for constraint-based inference resolution
 impl ConstraintSet {
-    pub const fn new() -> Self {
-        Self {
-            lower_bounds: Vec::new(),
-            upper_bounds: Vec::new(),
-        }
-    }
-
     pub fn from_info(info: &InferenceInfo) -> Self {
         let mut lower_bounds = Vec::new();
         let mut upper_bounds = Vec::new();
@@ -210,20 +204,6 @@ impl ConstraintSet {
         }
     }
 
-    /// Add a lower bound constraint: L <: α
-    pub fn add_lower_bound(&mut self, ty: TypeId) {
-        if !self.lower_bounds.contains(&ty) {
-            self.lower_bounds.push(ty);
-        }
-    }
-
-    /// Add an upper bound constraint: α <: U
-    pub fn add_upper_bound(&mut self, ty: TypeId) {
-        if !self.upper_bounds.contains(&ty) {
-            self.upper_bounds.push(ty);
-        }
-    }
-
     /// Check if there are any constraints
     pub const fn is_empty(&self) -> bool {
         self.lower_bounds.is_empty() && self.upper_bounds.is_empty()
@@ -234,7 +214,6 @@ impl ConstraintSet {
 pub(crate) const MAX_CONSTRAINT_ITERATIONS: usize = 100;
 
 /// Maximum recursion depth for type containment checks.
-#[allow(dead_code)] // Used by conditional type inference (not yet wired up)
 pub(crate) const MAX_TYPE_RECURSION_DEPTH: usize = 100;
 
 /// Operation-local cache statistics for [`InferenceContext`].
@@ -242,6 +221,7 @@ pub(crate) const MAX_TYPE_RECURSION_DEPTH: usize = 100;
 /// Owner: one inference request. The subtype memo is scoped to that request
 /// and is dropped with the context.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[allow(dead_code)] // Inference cache accounting; consumed by inference unit tests
 pub(crate) struct InferenceContextCacheStatistics {
     /// Entries in the inference subtype memo keyed by source and target `TypeId`.
     pub(crate) subtype_entries: usize,
@@ -251,6 +231,7 @@ pub(crate) struct InferenceContextCacheStatistics {
 impl InferenceContextCacheStatistics {
     /// Estimated heap bytes owned by inference memo tables.
     #[must_use]
+    #[allow(dead_code)] // Inference cache accounting; consumed by inference unit tests
     pub(crate) const fn estimated_size_bytes(self) -> usize {
         self.estimated_size_bytes
     }
@@ -387,34 +368,6 @@ impl<'a> InferenceContext<'a> {
         }
     }
 
-    pub fn with_resolver(
-        interner: &'a dyn TypeDatabase,
-        resolver: &'a dyn crate::relations::subtype::TypeResolver,
-    ) -> Self {
-        InferenceContext {
-            interner,
-            resolver: Some(resolver),
-            query_db: None,
-            subtype_cache: RefCell::new(FxHashMap::default()),
-            active_subtype_checks: RefCell::new(FxHashSet::default()),
-            table: InPlaceUnificationTable::new(),
-            type_params: Vec::new(),
-            declared_constraints: FxHashMap::default(),
-            literal_preserving_declared_constraints: FxHashSet::default(),
-            app_expansion_depth: 0,
-            in_contra_mode: false,
-            reverse_mapped_properties: FxHashMap::default(),
-            source_is_type_annotation: false,
-            infer_depth: 0,
-            infer_visited: FxHashSet::default(),
-            top_level_in_return_type_unfixed: FxHashSet::default(),
-            vars_with_substituted_candidates: FxHashSet::default(),
-            in_array_element_context: false,
-            in_readonly_source_context: false,
-            implied_arities: FxHashMap::default(),
-        }
-    }
-
     pub fn with_query_db(query_db: &'a dyn QueryDatabase) -> Self {
         InferenceContext {
             interner: query_db.as_type_database(),
@@ -442,6 +395,7 @@ impl<'a> InferenceContext<'a> {
 
     /// Return entry and size accounting for this context's operation-local caches.
     #[must_use]
+    #[allow(dead_code)] // Inference cache accounting; consumed by inference unit tests
     pub(crate) fn cache_statistics(&self) -> InferenceContextCacheStatistics {
         let subtype_entries = self.subtype_cache.borrow().len();
         let estimated_size_bytes =
@@ -1475,6 +1429,7 @@ impl<'a> InferenceContext<'a> {
     /// concrete (non-TypeParameter) type. `TypeParameter` types in `contra_candidates`
     /// are typically unresolved source inference placeholders from generic function
     /// arguments and should not drive the resolution gate.
+    #[allow(dead_code)] // Reserved contra-candidate resolution-gate query
     pub fn has_concrete_contra_candidates(
         &mut self,
         var: InferenceVar,

--- a/crates/tsz-solver/src/inference/infer_resolve.rs
+++ b/crates/tsz-solver/src/inference/infer_resolve.rs
@@ -1238,6 +1238,7 @@ impl<'a> InferenceContext<'a> {
     }
 
     /// Infer type parameters from a type by traversing its structure.
+    #[allow(dead_code)] // Reserved for conditional type inference (paired with `infer_from_conditional`)
     fn infer_from_type(&mut self, var: InferenceVar, ty: TypeId) {
         let root = self.table.find(var);
 

--- a/crates/tsz-solver/src/inference/mod.rs
+++ b/crates/tsz-solver/src/inference/mod.rs
@@ -1,10 +1,8 @@
-#[allow(dead_code)]
 pub(crate) mod infer;
 pub(crate) mod infer_bct;
 pub(crate) mod infer_candidate_kinds;
 pub(crate) mod infer_matching;
 pub(crate) mod infer_matching_tuples;
-#[allow(dead_code)]
 pub(crate) mod infer_resolve;
 pub(crate) mod infer_variance;
 mod partially_inferable;


### PR DESCRIPTION
Goal: hold

Addresses the solver portion of #13440 (stop lying about dead code; idiomatic per-item allows instead of blanket allows). Behavior-preserving lint-posture cleanup — no type-algorithm change, so this defends the parity floor.

## Structural rule

When code is unused but deliberately retained, idiomatic Rust scopes `#[allow(dead_code)]` to that single item with a truthful reason. The inference module instead relied on two **bare module-level** `#[allow(dead_code)]` (`inference/mod.rs` on `mod infer` and `mod infer_resolve`), which defeated `dead_code` for the whole module — making the per-item allows inert and letting real orphans accumulate undetected. Owner layer: `tsz-solver` inference module (lint posture only).

## What changed

- **Remove the two blanket module-level allows** in `inference/mod.rs` so `dead_code` is active for the inference module again. This is the change that makes the rest meaningful — with the blanket in place, removing any item-level allow in `infer.rs`/`infer_resolve.rs` was cosmetic.
- **Delete confirmed orphans** surfaced once the blanket was lifted (zero callers in production *and* tests):
  - `ConstraintSet::new` and the two single-arg `ConstraintSet` mutators (`add_lower_bound`/`add_upper_bound`),
  - the unused `InferenceContext::with_resolver` constructor.
- **Drop the false allow on `MAX_TYPE_RECURSION_DEPTH`** — its comment claimed "not yet wired up", but it is used by `contains_inference_var_inner`.
- **Replace blanket coverage with narrowly-scoped item allows carrying truthful reasons** for items that are dead-in-production but legitimately retained:
  - the test-only cache-statistics accounting (`InferenceContextCacheStatistics`, `estimated_size_bytes`, `cache_statistics` — consumed by inference unit tests via `infer.rs`'s `#[cfg(test)] mod tests`),
  - the reserved conditional-inference traversal `infer_from_conditional` / `infer_from_type`,
  - the reserved `has_concrete_contra_candidates` resolution-gate query,
  - the `InferenceError` payload retained for `Debug`/future inference error reporting.

## Corrections to the issue's findings (verified against source before coding)

- The issue lists `ConstraintSet::is_empty` as a zero-caller orphan to delete. It is **live** — read at `operations/generic_call/resolve/finalize.rs` (`matches!(&constraints, Some(c) if !c.is_empty())`). Kept, no allow. `ConstraintSet::from_info` is likewise live and kept.
- The issue asks to *delete* the `InferenceError` allow as a false label. The enum is indeed constructed in production, but once the **module** blanket is removed its variant **payload fields** are genuinely unread (only the variant kind and `BoundsViolation.lower` are consumed). Rather than strip the reserved payload across ~13 construction sites in `infer.rs`/`infer_resolve.rs` (which would touch lines under active WIP #13232 and discard intentionally-reserved error-reporting context), the enum keeps a single honest, scoped allow — exactly the idiomatic pattern the issue advocates.

## Scope / split

Per the issue's guidance ("if removing the blanket allow surfaces a large orphan set, split into two PRs"), this is **PR1 (solver, self-contained)**. The checker crate-wide `#[allow(dead_code)]` removal is a large orphan set (149 warnings across ~93 files in the most actively-developed crate) and is left to a follow-up to avoid a high-conflict diff.

## Verification

- `cargo build -p tsz-solver` — clean, **0** `dead_code` warnings.
- `cargo clippy --profile ci-lint -p tsz-solver --lib -- -D warnings` — clean (the relevant CI lint gate; `dead_code` is now active for the module).
- `cargo test -p tsz-solver --no-run` — all registered targets + the lib `#[cfg(test)]` tree compile (the deleted items have no test callers; the retained cache-statistics items do).
- `cargo test -p tsz-solver --lib` filtered runs: `cache_statistics` (24 passed), `bct` (112 passed), `infer_from` (9 passed), `conditional_infer_tuple_numeric_key_tests` (6 passed) — all green.
- Broad conformance/emit/fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyC9GAtp6mjq95JeQDMwZZ)_