### PR TITLE
perf(checker): charge mapped display properties to budget (#13040)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -1283,7 +1283,7 @@ impl<'a> CheckerState<'a> {
 
             let mut properties = Vec::with_capacity(names.len());
             for name in names {
-                if crate::error_reporter::display_budget::is_exhausted() {
+                if !crate::error_reporter::display_budget::try_consume_visit() {
                     return None;
                 }
                 let property_name = self.ctx.types.resolve_atom_ref(name).to_string();


### PR DESCRIPTION
Goal: fast

## Summary
- Charge finite mapped-display property synthesis to the existing per-rendered-type display visit budget.
- Keep the materialization fallback behavior unchanged: once the display budget exhausts, the helper returns no display-only materialization and callers render the current/original type.
- Leave relation, evaluation, and semantic paths untouched.

## Structural Rule
When diagnostic display materializes a finite mapped type only to render an error message, every synthesized display property is display work and should be bounded by the same per-rendered-type visit budget as recursive display normalization. tsc truncates long displays; tsz should stop display-only property construction when the display budget is exhausted, while semantic relation/evaluation remains unchanged.

## Owner Layer
Checker diagnostic display only. No solver semantics, relation policy, type evaluation policy, source-text predicates, fixture-name checks, or rendered-string semantic decisions are added.

## Cache And Complexity Invariant
- Request scope: one rendered diagnostic type inside DisplayBudgetScope.
- Key/fallback: no new cache; existing budget and fallback-to-original display behavior are reused.
- Complexity: finite mapped display property synthesis now consumes one display visit per property instead of potentially constructing an unbounded property list after a single mapped-type visit.

## Verification
- No local tests or benchmarks run per user instruction.
- Pre-commit formatting hook ran during commit.
- Draft CI Light Summary passed for head 7477f40103426b123640385a77068fd0bb58b28a.
- Ready PR CI Summary is expected to cover full required gates before queue.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: medium
