### PR TITLE
perf(checker): delay function-shape param rebuild (#13480)

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -190,37 +190,45 @@ pub(crate) fn map_function_shape_types(
     shape: &FunctionShape,
     mut map_type: impl FnMut(FunctionShapeTypeSlot, TypeId) -> TypeId,
 ) -> Option<FunctionShape> {
-    let mut changed = false;
-    let mut visit = |slot: FunctionShapeTypeSlot, type_id: TypeId| {
-        let mapped = map_type(slot, type_id);
-        if mapped != type_id {
-            changed = true;
+    let mut params = None;
+    for (index, param) in shape.params.iter().enumerate() {
+        let mapped = map_type(FunctionShapeTypeSlot::Param, param.type_id);
+        if let Some(params) = &mut params {
+            params.push(ParamInfo {
+                type_id: mapped,
+                ..*param
+            });
+        } else if mapped != param.type_id {
+            let mut changed_params = Vec::with_capacity(shape.params.len());
+            changed_params.extend(shape.params[..index].iter().copied());
+            changed_params.push(ParamInfo {
+                type_id: mapped,
+                ..*param
+            });
+            params = Some(changed_params);
         }
-        mapped
-    };
+    }
 
-    let params: Vec<ParamInfo> = shape
-        .params
-        .iter()
-        .map(|param| ParamInfo {
-            type_id: visit(FunctionShapeTypeSlot::Param, param.type_id),
-            ..*param
-        })
-        .collect();
-    let this_type = shape
-        .this_type
-        .map(|this_type| visit(FunctionShapeTypeSlot::This, this_type));
-    let return_type = visit(FunctionShapeTypeSlot::Return, shape.return_type);
+    let mut changed = params.is_some();
+    let this_type = shape.this_type.map(|this_type| {
+        let mapped = map_type(FunctionShapeTypeSlot::This, this_type);
+        changed |= mapped != this_type;
+        mapped
+    });
+    let return_type = map_type(FunctionShapeTypeSlot::Return, shape.return_type);
+    changed |= return_type != shape.return_type;
     let type_predicate = shape.type_predicate.map(|predicate| TypePredicate {
-        type_id: predicate
-            .type_id
-            .map(|type_id| visit(FunctionShapeTypeSlot::PredicateTarget, type_id)),
+        type_id: predicate.type_id.map(|type_id| {
+            let mapped = map_type(FunctionShapeTypeSlot::PredicateTarget, type_id);
+            changed |= mapped != type_id;
+            mapped
+        }),
         ..predicate
     });
 
     changed.then_some(FunctionShape {
         type_params: shape.type_params.clone(),
-        params,
+        params: params.unwrap_or_else(|| shape.params.clone()),
         this_type,
         return_type,
         type_predicate,

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -190,7 +190,7 @@ pub(crate) fn map_function_shape_types(
     shape: &FunctionShape,
     mut map_type: impl FnMut(FunctionShapeTypeSlot, TypeId) -> TypeId,
 ) -> Option<FunctionShape> {
-    let mut params = None;
+    let mut params: Option<Vec<ParamInfo>> = None;
     for (index, param) in shape.params.iter().enumerate() {
         let mapped = map_type(FunctionShapeTypeSlot::Param, param.type_id);
         if let Some(params) = &mut params {

--- a/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
+++ b/crates/tsz-checker/src/query_boundaries/construct_signatures.rs
@@ -226,7 +226,7 @@ pub(crate) fn map_function_shape_types(
         ..predicate
     });
 
-    changed.then_some(FunctionShape {
+    changed.then(|| FunctionShape {
         type_params: shape.type_params.clone(),
         params: params.unwrap_or_else(|| shape.params.clone()),
         this_type,


### PR DESCRIPTION
Goal: fast

## Summary
- Delay `map_function_shape_types` parameter-vector allocation until the first mapped parameter type actually changes.
- Preserve the existing no-change return contract so callers can keep the original interned function/callable type.
- Keep visiting parameter, `this`, return, and predicate target slots in the same order; only the identity-path allocation changes.

## Structural Rule
When every component mapper result is the original `TypeId`, tsc observes no function-shape semantic change; tsz should return `None` from the checker signature-construction query boundary without allocating a replacement parameter vector. If any component changes, tsz rebuilds the same `FunctionShape` metadata with the changed component. Solver remains the owner of function/callable interning and relation semantics.

## Owner Layer
Checker query-boundary housekeeping only: `crates/tsz-checker/src/query_boundaries/construct_signatures.rs`. No solver relation, inference, display, or diagnostic policy changes.

## Adjacent Matrix
- Positive no-op path: unchanged parameter mappings allocate no replacement parameter vector and return `None` after all slots are visited.
- Changed-parameter path: unchanged prefixes are copied only when a later parameter changes.
- Changed non-parameter path: params are cloned only when rebuilding for changed `this`, return, or predicate target slots.
- Fallback behavior: all existing changed-slot rebuild semantics and metadata preservation stay intact.

## Verification
- No local tests run per user instruction.
- Pre-commit formatting hook ran during commit.
- Branch was fast-forward-synced with `origin/main` before push.
- Draft/light CI passed at exact head `32fd0af4c43bccc84bdfbc0d4477fed2608e0775` (`CI Light Summary`, run `27489104142`).
- Ready-review CI is now expected to run the full PR-head gates before merge queue.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: medium
