### PR TITLE
perf(solver): delay shallow-this signature rebuilds (#13242)

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate/signatures.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/signatures.rs
@@ -212,66 +212,55 @@ impl<'a> TypeInstantiator<'a> {
                     id
                 }
             };
-            let rewrite_sig = |sig: &CallSignature| -> Option<CallSignature> {
-                let new_this_slot = sig.this_type.map(sub_top_level);
+            let rewrite_sig = |sig: &CallSignature| -> (CallSignature, bool) {
+                let mut changed = false;
+                let new_this_slot = sig.this_type.map(|s| {
+                    let n = sub_top_level(s);
+                    if n != s {
+                        changed = true;
+                    }
+                    n
+                });
                 let new_return = sub_top_level(sig.return_type);
-                let mut new_params: Option<Vec<_>> = None;
-                for (index, p) in sig.params.iter().enumerate() {
+                if new_return != sig.return_type {
+                    changed = true;
+                }
+                let mut new_params = Vec::with_capacity(sig.params.len());
+                for p in sig.params.iter() {
                     let new_t = sub_top_level(p.type_id);
-                    if let Some(new_params) = &mut new_params {
+                    if new_t != p.type_id {
+                        changed = true;
                         let mut np = *p;
                         np.type_id = new_t;
                         new_params.push(np);
-                    } else if new_t != p.type_id {
-                        let mut changed = Vec::with_capacity(sig.params.len());
-                        changed.extend_from_slice(&sig.params[..index]);
-                        let mut np = *p;
-                        np.type_id = new_t;
-                        changed.push(np);
-                        new_params = Some(changed);
                     } else {
-                        // Leave the unchanged prefix borrowed until a later
-                        // slot changes.
+                        new_params.push(*p);
                     }
                 }
-                let this_changed = new_this_slot != sig.this_type;
-                let return_changed = new_return != sig.return_type;
-                if new_params.is_none() && !this_changed && !return_changed {
-                    return None;
-                }
-                Some(CallSignature {
-                    type_params: sig.type_params.clone(),
-                    params: new_params.unwrap_or_else(|| sig.params.clone()),
-                    this_type: new_this_slot,
-                    return_type: new_return,
-                    type_predicate: sig.type_predicate,
-                    is_method: sig.is_method,
-                })
+                let mut new_sig = sig.clone();
+                new_sig.this_type = new_this_slot;
+                new_sig.return_type = new_return;
+                new_sig.params = new_params;
+                (new_sig, changed)
             };
 
-            let rewrite_signatures = |signatures: &[CallSignature]| -> Option<Vec<CallSignature>> {
-                let mut updated: Option<Vec<CallSignature>> = None;
-                for (index, signature) in signatures.iter().enumerate() {
-                    let signature = rewrite_sig(signature);
-                    if let Some(updated) = &mut updated {
-                        updated.push(signature.unwrap_or_else(|| signatures[index].clone()));
-                    } else if let Some(signature) = signature {
-                        let mut changed = Vec::with_capacity(signatures.len());
-                        changed.extend_from_slice(&signatures[..index]);
-                        changed.push(signature);
-                        updated = Some(changed);
-                    }
-                }
-                updated
-            };
-
-            let updated_call = rewrite_signatures(&shape.call_signatures);
-            let updated_construct = rewrite_signatures(&shape.construct_signatures);
-            if updated_call.is_some() || updated_construct.is_some() {
+            let mut updated_call = Vec::with_capacity(shape.call_signatures.len());
+            let mut any_changed = false;
+            for sig in shape.call_signatures.iter() {
+                let (new_sig, changed) = rewrite_sig(sig);
+                any_changed |= changed;
+                updated_call.push(new_sig);
+            }
+            let mut updated_construct = Vec::with_capacity(shape.construct_signatures.len());
+            for sig in shape.construct_signatures.iter() {
+                let (new_sig, changed) = rewrite_sig(sig);
+                any_changed |= changed;
+                updated_construct.push(new_sig);
+            }
+            if any_changed {
                 return self.interner.callable(CallableShape {
-                    call_signatures: updated_call.unwrap_or_else(|| shape.call_signatures.clone()),
-                    construct_signatures: updated_construct
-                        .unwrap_or_else(|| shape.construct_signatures.clone()),
+                    call_signatures: updated_call,
+                    construct_signatures: updated_construct,
                     properties: shape.properties.clone(),
                     string_index: shape.string_index,
                     number_index: shape.number_index,

--- a/crates/tsz-solver/src/instantiation/instantiate/signatures.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/signatures.rs
@@ -109,17 +109,23 @@ impl<'a> TypeInstantiator<'a> {
             };
             let new_this_slot = shape.this_type.map(sub_top_level);
             let new_return_type = sub_top_level(shape.return_type);
-            let mut new_params = Vec::with_capacity(shape.params.len());
-            let mut params_changed = false;
-            for p in shape.params.iter() {
+            let mut new_params: Option<Vec<_>> = None;
+            for (index, p) in shape.params.iter().enumerate() {
                 let new_t = sub_top_level(p.type_id);
-                if new_t != p.type_id {
-                    params_changed = true;
+                if let Some(new_params) = &mut new_params {
                     let mut np = *p;
                     np.type_id = new_t;
                     new_params.push(np);
+                } else if new_t != p.type_id {
+                    let mut changed = Vec::with_capacity(shape.params.len());
+                    changed.extend_from_slice(&shape.params[..index]);
+                    let mut np = *p;
+                    np.type_id = new_t;
+                    changed.push(np);
+                    new_params = Some(changed);
                 } else {
-                    new_params.push(*p);
+                    // Leave the unchanged prefix borrowed until the first
+                    // changed slot proves a replacement vector is needed.
                 }
             }
             let this_changed = match (shape.this_type, new_this_slot) {
@@ -127,10 +133,10 @@ impl<'a> TypeInstantiator<'a> {
                 (None, None) => false,
                 _ => true,
             };
-            if params_changed || this_changed || new_return_type != shape.return_type {
+            if new_params.is_some() || this_changed || new_return_type != shape.return_type {
                 return self.interner.function(FunctionShape {
                     type_params: shape.type_params.clone(),
-                    params: new_params,
+                    params: new_params.unwrap_or_else(|| shape.params.clone()),
                     this_type: new_this_slot,
                     return_type: new_return_type,
                     type_predicate: shape.type_predicate,
@@ -206,55 +212,69 @@ impl<'a> TypeInstantiator<'a> {
                     id
                 }
             };
-            let rewrite_sig = |sig: &CallSignature| -> (CallSignature, bool) {
-                let mut changed = false;
+            let rewrite_sig = |sig: &CallSignature| -> Option<CallSignature> {
                 let new_this_slot = sig.this_type.map(|s| {
                     let n = sub_top_level(s);
-                    if n != s {
-                        changed = true;
-                    }
                     n
                 });
                 let new_return = sub_top_level(sig.return_type);
-                if new_return != sig.return_type {
-                    changed = true;
-                }
-                let mut new_params = Vec::with_capacity(sig.params.len());
-                for p in sig.params.iter() {
+                let mut new_params: Option<Vec<_>> = None;
+                for (index, p) in sig.params.iter().enumerate() {
                     let new_t = sub_top_level(p.type_id);
-                    if new_t != p.type_id {
-                        changed = true;
+                    if let Some(new_params) = &mut new_params {
                         let mut np = *p;
                         np.type_id = new_t;
                         new_params.push(np);
+                    } else if new_t != p.type_id {
+                        let mut changed = Vec::with_capacity(sig.params.len());
+                        changed.extend_from_slice(&sig.params[..index]);
+                        let mut np = *p;
+                        np.type_id = new_t;
+                        changed.push(np);
+                        new_params = Some(changed);
                     } else {
-                        new_params.push(*p);
+                        // Leave the unchanged prefix borrowed until a later
+                        // slot changes.
                     }
                 }
-                let mut new_sig = sig.clone();
-                new_sig.this_type = new_this_slot;
-                new_sig.return_type = new_return;
-                new_sig.params = new_params;
-                (new_sig, changed)
+                let this_changed = new_this_slot != sig.this_type;
+                let return_changed = new_return != sig.return_type;
+                if new_params.is_none() && !this_changed && !return_changed {
+                    return None;
+                }
+                Some(CallSignature {
+                    type_params: sig.type_params.clone(),
+                    params: new_params.unwrap_or_else(|| sig.params.clone()),
+                    this_type: new_this_slot,
+                    return_type: new_return,
+                    type_predicate: sig.type_predicate,
+                    is_method: sig.is_method,
+                })
             };
 
-            let mut updated_call = Vec::with_capacity(shape.call_signatures.len());
-            let mut any_changed = false;
-            for sig in shape.call_signatures.iter() {
-                let (new_sig, changed) = rewrite_sig(sig);
-                any_changed |= changed;
-                updated_call.push(new_sig);
-            }
-            let mut updated_construct = Vec::with_capacity(shape.construct_signatures.len());
-            for sig in shape.construct_signatures.iter() {
-                let (new_sig, changed) = rewrite_sig(sig);
-                any_changed |= changed;
-                updated_construct.push(new_sig);
-            }
-            if any_changed {
+            let rewrite_signatures = |signatures: &[CallSignature]| -> Option<Vec<CallSignature>> {
+                let mut updated: Option<Vec<CallSignature>> = None;
+                for (index, signature) in signatures.iter().enumerate() {
+                    let signature = rewrite_sig(signature);
+                    if let Some(updated) = &mut updated {
+                        updated.push(signature.unwrap_or_else(|| signatures[index].clone()));
+                    } else if let Some(signature) = signature {
+                        let mut changed = Vec::with_capacity(signatures.len());
+                        changed.extend_from_slice(&signatures[..index]);
+                        changed.push(signature);
+                        updated = Some(changed);
+                    }
+                }
+                updated
+            };
+
+            let updated_call = rewrite_signatures(&shape.call_signatures);
+            let updated_construct = rewrite_signatures(&shape.construct_signatures);
+            if updated_call.is_some() || updated_construct.is_some() {
                 return self.interner.callable(CallableShape {
-                    call_signatures: updated_call,
-                    construct_signatures: updated_construct,
+                    call_signatures: updated_call.unwrap_or_else(|| shape.call_signatures.clone()),
+                    construct_signatures: updated_construct
+                        .unwrap_or_else(|| shape.construct_signatures.clone()),
                     properties: shape.properties.clone(),
                     string_index: shape.string_index,
                     number_index: shape.number_index,

--- a/crates/tsz-solver/src/instantiation/instantiate/signatures.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/signatures.rs
@@ -213,10 +213,7 @@ impl<'a> TypeInstantiator<'a> {
                 }
             };
             let rewrite_sig = |sig: &CallSignature| -> Option<CallSignature> {
-                let new_this_slot = sig.this_type.map(|s| {
-                    let n = sub_top_level(s);
-                    n
-                });
+                let new_this_slot = sig.this_type.map(sub_top_level);
                 let new_return = sub_top_level(sig.return_type);
                 let mut new_params: Option<Vec<_>> = None;
                 for (index, p) in sig.params.iter().enumerate() {


### PR DESCRIPTION
Goal: fast

## Summary
- Delay shallow-`this` function parameter vector allocation until a top-level parameter slot actually changes.
- Preserve the prior shallow-`this` callable-signature rebuild path after draft unit CI exposed a failure and the raw unit log artifact was unavailable (`BlobNotFound`).
- Preserve existing unchanged-type identity and rebuild behavior when function `this`, return, or parameter slots change.

## Structural Rule
When shallow-`this` substitution visits a function and every top-level `this`/parameter/return slot remains the original `TypeId`, tsc observes no concrete materialization change; tsz should keep the original interned function type instead of allocating an equivalent replacement parameter vector. When any visited function slot changes, tsz rebuilds the same solver-owned function metadata with only the changed component values. Callable shallow-`this` handling remains on the prior rebuild path in this PR.

## Owner Layer
Solver instantiation only: `crates/tsz-solver/src/instantiation/instantiate/signatures.rs`. This does not change relation semantics, lazy-materialization policy, checker behavior, diagnostic display, or cross-file cache residency.

## Cache And Complexity Invariant
- Request scope: one `TypeInstantiator` shallow-`this` walk.
- Key/fallback: no new cache; unchanged function walks return the existing interned `TypeId` as before.
- Complexity: removes identity-path parameter-vector allocation/copy work for shallow-`this` function walks; changed paths still allocate and rebuild as before.
- Scope boundary: callable shallow-`this` signature rebuilding is left behaviorally unchanged after draft unit CI rejected the broader allocation deferral.
- Safety: no blanket #12142-style deferral, no fixture-name shortcuts, and no display-string predicates.

## Verification
- No local tests or benchmarks run per user instruction.
- Pre-commit formatting hook ran during commits.
- Initial draft/light CI failed at head `584cd4985c17268b3c599a7d62738ab8c23cf155` in `unit`; GitHub Actions raw unit log retrieval returned `BlobNotFound`, but the CI summary identified `tsz-solver` unit as the failing package.
- Follow-up repair commit preserves the prior callable shallow-`this` rebuild path while keeping the narrower function parameter allocation optimization.
- Branch was merged with current `origin/main` before push; current head is `c186a67aa4791281bc1b34325e57e6e0e9f554e4`.
- Exact-head draft/light CI passed on `c186a67aa4791281bc1b34325e57e6e0e9f554e4`; ready-review CI is expected after promotion.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: medium
