### PR TITLE
perf(checker): atom-key lazy lib member cache (#12101)

### DIFF
--- a/crates/tsz-checker/src/context/cache_statistics.rs
+++ b/crates/tsz-checker/src/context/cache_statistics.rs
@@ -222,9 +222,7 @@ impl<'a> CheckerContext<'a> {
                 ),
             lazy_lib_member_resolution_cache_entries: lazy_lib_member_resolution_cache.len(),
             lazy_lib_member_resolution_cache_estimated_size_bytes:
-                string_atom_option_type_cache_estimated_size_bytes(
-                    &lazy_lib_member_resolution_cache,
-                ),
+                atom_atom_option_type_cache_estimated_size_bytes(&lazy_lib_member_resolution_cache),
             symbol_name_candidates_cache_entries: symbol_name_candidates_cache.len(),
             symbol_name_candidates_cache_estimated_size_bytes:
                 string_symbol_vec_cache_estimated_size_bytes(&symbol_name_candidates_cache),
@@ -340,11 +338,10 @@ fn string_option_type_cache_estimated_size_bytes(
         .saturating_add(cache.keys().map(String::len).sum::<usize>())
 }
 
-fn string_atom_option_type_cache_estimated_size_bytes(
-    cache: &FxHashMap<(String, Atom), Option<TypeId>>,
+fn atom_atom_option_type_cache_estimated_size_bytes(
+    cache: &FxHashMap<(Atom, Atom), Option<TypeId>>,
 ) -> usize {
     fx_hash_map_estimated_size_bytes(cache)
-        .saturating_add(cache.keys().map(|(name, _)| name.len()).sum::<usize>())
 }
 
 fn string_symbol_vec_cache_estimated_size_bytes(cache: &FxHashMap<String, Vec<SymbolId>>) -> usize {

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -151,12 +151,12 @@ pub struct LibTypeResolutionCaches {
     pub types: FxHashMap<String, Option<TypeId>>,
 
     /// Per-checker cache for lazy single-member lib-interface property reads.
-    /// Keyed by `(interface_name, property_name)` and stores both hits and
+    /// Keyed by `(interface_name, property_name)` atoms and stores both hits and
     /// conservative misses after the existing lazy-member resolver has decided
     /// whether it can lower only the requested member. This keeps repeated DOM
     /// reads from rescanning declaration and heritage lists while preserving the
     /// same full-materialization fallback on cached misses.
-    pub lazy_members: RefCell<FxHashMap<(String, Atom), Option<TypeId>>>,
+    pub lazy_members: RefCell<FxHashMap<(Atom, Atom), Option<TypeId>>>,
 }
 
 /// Maximum depth for nested `get_type_of_symbol` calls before giving up.

--- a/crates/tsz-checker/src/types/queries/lib_resolution_member.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution_member.rs
@@ -62,8 +62,9 @@ impl CheckerState<'_> {
         name: &str,
         prop_name: &str,
     ) -> Option<TypeId> {
+        let name_atom = self.ctx.types.intern_string(name);
         let prop_atom = self.ctx.types.intern_string(prop_name);
-        let key = (name.to_string(), prop_atom);
+        let key = (name_atom, prop_atom);
         if let Some(cached) = self
             .ctx
             .lib_type_resolution_caches


### PR DESCRIPTION
Goal: fast

## Summary
- atom-key the lazy lib-interface single-member cache as `(interface_atom, property_atom)` instead of cloning an interface `String` on every lookup
- preserve the existing hit/miss semantics: the cache still records the same `(interface name, property name)` answer and still falls back to full materialization on conservative misses
- update cache statistics sizing for the atom-keyed entry shape

## Structural rule
When a lazy lib-interface receiver/member lookup has already been classified by the checker-owned single-member resolver, repeated lookups should reuse the cached hit or miss without allocating a fresh interface-name `String`; unresolved, ambiguous, generic, indexed, augmented, shadowed, or consumer-needs-full-shape cases continue through the existing full-materialization fallback.

## Owner layer
Checker/type-environment query path only. No solver semantic policy changes, no DOM/property-name allowlists, no display-string predicates, and no fixture-specific shortcuts.

## Adjacent matrix
- Positive: repeated simple lib receiver/member lookups reuse the same cached hit with atom keys.
- Fallback: cached misses still represent the existing conservative resolver decision and route callers to full materialization.
- Safety: interface and property identity remain interned source text atoms in the same checker context.

## Verification
- Pre-commit formatting hook ran during commit.
- No local tests or benchmarks run per user instruction.
- Draft/light CI passed at exact head `7d3b970293671c79de3ea5ed6eed49aa24ec5fd6` (`CI Light Summary`, run `27489205462`).
- Ready-review CI is now expected to run the full PR-head gates before merge queue.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: medium
