### PR TITLE
perf(cli): report batch residency savings (#13249)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -318,10 +318,15 @@ fn write_batch_residency_report(
         MemoryPressure::Medium => "medium",
         MemoryPressure::High => "high",
     };
+    let eviction_savings_kb = ResidencyBudget::eviction_savings(stats) as f64 / 1024.0;
     writeln!(stdout, "Batch retained file state:     {retained_kb:.1}K")?;
     writeln!(
         stdout,
         "Batch retained residency pressure: {pressure_label}"
+    )?;
+    writeln!(
+        stdout,
+        "Batch estimated eviction savings: {eviction_savings_kb:.1}K"
     )?;
     Ok(Some(pressure))
 }


### PR DESCRIPTION
Goal: fast

## Summary
- extend the hidden batch residency probe report with `ResidencyBudget::eviction_savings` in KB
- keep the existing pressure assessment and cleanup decision unchanged
- make #13249 runs distinguish retained pressure from the amount of pre-merge bind state that a future eviction path could reclaim

## Structural rule
When the explicit batch residency probe is enabled, tsz should report both retained file-state pressure and estimated reclaimable eviction savings after a project has finished diagnostics. Default batch behavior remains unchanged, and cleanup still only runs after diagnostics are rendered.

## Owner layer
CLI batch/probe reporting only. No checker, solver, scheduler, or semantic behavior changes.

## Adjacent matrix
- Low pressure: still report pressure and savings; cleanup decision remains observe-only.
- Medium/high pressure: existing cleanup decision remains unchanged, with savings now visible in the probe output.
- No residency stats: existing no-report path remains unchanged.

## Verification
- Pre-commit formatting hook ran during commit.
- No local tests or benchmarks run per user instruction.
- Draft/light CI passed at exact head `4354b16f128f720652efbb84e95102f35b25f861` (`CI Light Summary`, run `27489287723`).
- Ready-review CI is now expected to run the full PR-head gates before merge queue.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: medium
