### PR TITLE
refactor(tsz-common): hoist byte-level source-text scanning primitives (#13430)

### DIFF
--- a/crates/tsz-binder/src/state/core_jsdoc.rs
+++ b/crates/tsz-binder/src/state/core_jsdoc.rs
@@ -279,7 +279,7 @@ impl BinderState {
     }
 
     pub(super) const fn is_jsdoc_import_keyword_part(ch: char) -> bool {
-        ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()
+        tsz_common::text_scan::is_ascii_identifier_continue_char(ch)
     }
 
     /// Collapse `@import` tag continuations onto a single line so the

--- a/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/destructuring.rs
@@ -1083,7 +1083,7 @@ impl<'a> CheckerState<'a> {
     }
 
     const fn is_inline_type_identifier_char(ch: u8) -> bool {
-        ch.is_ascii_alphanumeric() || ch == b'_' || ch == b'$'
+        tsz_common::text_scan::is_ascii_identifier_continue(ch)
     }
 
     fn property_name_text(&self, name_idx: NodeIndex) -> Option<String> {

--- a/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_alias_display.rs
@@ -15,7 +15,7 @@ impl<'a> CheckerState<'a> {
         (!name.is_empty()
             && name
                 .chars()
-                .all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()))
+                .all(tsz_common::text_scan::is_ascii_identifier_continue_char))
         .then_some(name)
     }
 

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -1060,10 +1060,10 @@ impl<'a> CheckerState<'a> {
         let name = head.rsplit_once('.').map(|(_, name)| name).unwrap_or(head);
         let mut chars = name.chars();
         let first = chars.next()?;
-        if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
+        if !tsz_common::text_scan::is_ascii_identifier_start_char(first) {
             return None;
         }
-        if !chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()) {
+        if !chars.all(tsz_common::text_scan::is_ascii_identifier_continue_char) {
             return None;
         }
 

--- a/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
+++ b/crates/tsz-checker/src/error_reporter/fingerprint_policy.rs
@@ -1097,13 +1097,13 @@ impl<'a> CheckerState<'a> {
         let text = sf.text.get(start as usize..)?;
         let mut chars = text.chars();
         let first = chars.next()?;
-        if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
+        if !tsz_common::text_scan::is_ascii_identifier_start_char(first) {
             return None;
         }
 
         let mut len = first.len_utf8() as u32;
         for ch in chars {
-            if ch == '_' || ch == '$' || ch.is_ascii_alphanumeric() {
+            if tsz_common::text_scan::is_ascii_identifier_continue_char(ch) {
                 len += ch.len_utf8() as u32;
             } else {
                 break;

--- a/crates/tsz-checker/src/jsdoc/parsing.rs
+++ b/crates/tsz-checker/src/jsdoc/parsing.rs
@@ -1293,7 +1293,7 @@ impl<'a> CheckerState<'a> {
     }
 
     const fn is_jsdoc_import_keyword_part(ch: char) -> bool {
-        ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()
+        tsz_common::text_scan::is_ascii_identifier_continue_char(ch)
     }
 
     fn is_jsdoc_import_identifier_name(name: &str) -> bool {

--- a/crates/tsz-checker/src/types/queries/class.rs
+++ b/crates/tsz-checker/src/types/queries/class.rs
@@ -566,7 +566,7 @@ impl<'a> CheckerState<'a> {
 
     fn jsdoc_type_expr_mentions_name(type_expr: &str, name: &str) -> bool {
         const fn is_ident_char(ch: char) -> bool {
-            ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()
+            tsz_common::text_scan::is_ascii_identifier_continue_char(ch)
         }
 
         let mut cursor = 0usize;

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_quickinfo_text.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_quickinfo_text.rs
@@ -6,7 +6,7 @@
 
 /// Check if a byte is a valid JS identifier character (ASCII alphanumeric, `_`, or `$`).
 pub(super) const fn is_js_identifier_char(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+    tsz_common::text_scan::is_ascii_identifier_continue(byte)
 }
 
 /// Extract a trailing type name from a display string like `"(var) x: Foo"` → `"Foo"`.

--- a/crates/tsz-cli/src/driver/resolution/discovery.rs
+++ b/crates/tsz-cli/src/driver/resolution/discovery.rs
@@ -391,11 +391,7 @@ pub(crate) fn collect_jsdoc_module_requests(
     requests
 }
 
-/// True for bytes that can appear inside a JS identifier (so the byte before an
-/// `import` keyword can be checked for a word boundary).
-const fn is_identifier_part_byte(byte: u8) -> bool {
-    byte == b'_' || byte == b'$' || byte.is_ascii_alphanumeric()
-}
+use tsz_common::text_scan::is_ascii_identifier_continue as is_identifier_part_byte;
 
 /// Append every `import(<quote>specifier<quote>)` specifier found in `text` to
 /// `out`. Requires a word boundary before `import` so identifiers ending in
@@ -570,7 +566,7 @@ pub(crate) fn find_jsdoc_import_from_keyword(rest: &str) -> Option<usize> {
 }
 
 pub(crate) const fn is_jsdoc_import_keyword_part(ch: char) -> bool {
-    ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()
+    tsz_common::text_scan::is_ascii_identifier_continue_char(ch)
 }
 
 #[cfg(test)]

--- a/crates/tsz-common/src/comments/mod.rs
+++ b/crates/tsz-common/src/comments/mod.rs
@@ -339,22 +339,11 @@ fn skip_template_literal(bytes: &[u8], start: usize) -> usize {
     pos
 }
 
-fn skip_quoted_string(bytes: &[u8], start: usize, quote: u8) -> usize {
-    let mut pos = start + 1;
-    while pos < bytes.len() {
-        match bytes[pos] {
-            b'\\' => pos = (pos + 2).min(bytes.len()),
-            ch if ch == quote => return pos + 1,
-            // JS/TS single-line string literals cannot contain raw newlines.
-            // If we hit one, treat the string as terminated and let the main
-            // scanner resume at the newline so subsequent comments are still
-            // detected.
-            b'\n' | b'\r' => return pos,
-            _ => pos += 1,
-        }
-    }
-    pos
-}
+// Quoted-string skipping for the comment scanner routes through the shared
+// `text_scan` primitive (single-line string literals terminate on a raw
+// newline; the comment scanner only ever passes `'`/`"` quotes). Template
+// literals are handled separately by `scan_template_literal_comments`.
+use crate::text_scan::skip_quoted_literal as skip_quoted_string;
 
 fn can_start_regex_at(bytes: &[u8], slash_pos: usize) -> bool {
     let mut pos = slash_pos;

--- a/crates/tsz-common/src/common/mod.rs
+++ b/crates/tsz-common/src/common/mod.rs
@@ -327,9 +327,7 @@ impl ImportResolutionMode {
 /// JSDoc attribute grammar has a single source of truth.
 #[must_use]
 pub fn parse_jsdoc_resolution_mode_attribute_clause(text: &str) -> Option<ImportResolutionMode> {
-    const fn is_word_byte(b: u8) -> bool {
-        b == b'_' || b == b'$' || b.is_ascii_alphanumeric()
-    }
+    use crate::text_scan::is_ascii_identifier_continue as is_word_byte;
     let bytes = text.as_bytes();
 
     // Locate the attribute keyword (`with`/`assert`) at a word boundary.

--- a/crates/tsz-common/src/text_scan.rs
+++ b/crates/tsz-common/src/text_scan.rs
@@ -1,4 +1,20 @@
-//! Char-boundary-safe text windowing helpers.
+//! Byte-level source-text scanning primitives.
+//!
+//! Phases that scan raw source or display text at the byte level all need the
+//! same handful of leaf operations: "is this byte/char an ASCII identifier
+//! char", "skip past a quoted literal", "is this needle a standalone
+//! (whole-word) token", and "skip ASCII whitespace". This module is the single
+//! source of truth for those primitives so the emitter, CLI, parser, binder,
+//! checker, and LSP stop re-deriving (and silently drifting) their own copies.
+//!
+//! The identifier predicates are the ASCII fast path mirroring
+//! `tsz_scanner`'s Unicode `is_ecmascript_identifier_*`: an identifier *start*
+//! is `_`, `$`, or an ASCII letter; an identifier *continue* additionally
+//! admits ASCII digits. Callers that need full Unicode identifier semantics
+//! must use the scanner helpers; these cover the ASCII-only byte/char scans
+//! that walk already-emitted text or display strings.
+//!
+//! # Char-boundary-safe text windowing
 //!
 //! Several phases scan only the leading portion of a source file — JSX pragma
 //! detection (`@jsx`, `@jsxImportSource`, `@jsxRuntime`, `@jsxFrag`) caps the
@@ -69,9 +85,234 @@ pub fn leading_window(text: &str, max_bytes: usize) -> &str {
     &text[..limit]
 }
 
+/// True when `b` can begin an ASCII identifier: `_`, `$`, or an ASCII letter.
+///
+/// The ASCII fast path for `tsz_scanner`'s Unicode `is_ecmascript_identifier_start`.
+#[inline]
+#[must_use]
+pub const fn is_ascii_identifier_start(b: u8) -> bool {
+    b == b'_' || b == b'$' || b.is_ascii_alphabetic()
+}
+
+/// True when `b` can continue an ASCII identifier: an identifier-start byte or
+/// an ASCII digit.
+///
+/// The ASCII fast path for `tsz_scanner`'s Unicode `is_ecmascript_identifier_part`.
+#[inline]
+#[must_use]
+pub const fn is_ascii_identifier_continue(b: u8) -> bool {
+    is_ascii_identifier_start(b) || b.is_ascii_digit()
+}
+
+/// `char` variant of [`is_ascii_identifier_start`]: `_`, `$`, or an ASCII letter.
+///
+/// Non-ASCII characters return `false`; callers that need Unicode identifier
+/// semantics must use the scanner helpers instead.
+#[inline]
+#[must_use]
+pub const fn is_ascii_identifier_start_char(c: char) -> bool {
+    c == '_' || c == '$' || c.is_ascii_alphabetic()
+}
+
+/// `char` variant of [`is_ascii_identifier_continue`]: an identifier-start char
+/// or an ASCII digit.
+#[inline]
+#[must_use]
+pub const fn is_ascii_identifier_continue_char(c: char) -> bool {
+    is_ascii_identifier_start_char(c) || c.is_ascii_digit()
+}
+
+/// Advance past a quoted literal that opens at `start` (the opening `quote`
+/// byte) and return the index just after its closing quote.
+///
+/// Policy (one source of truth for every byte-level quoted-literal skip):
+/// - A backslash escapes the next byte (the escape pair is consumed, clamped at
+///   end-of-input).
+/// - A matching `quote` byte closes the literal; the returned index points just
+///   past it.
+/// - A raw line terminator (`\n`/`\r`) terminates a single-line string literal
+///   (`'`/`"`): the literal is treated as closed and the returned index points
+///   *at* the terminator, so the caller resumes scanning there. This matches
+///   the TS grammar (single-line strings cannot contain raw newlines) and lets
+///   an unterminated string fail gracefully instead of consuming to EOF.
+/// - Template literals (`` ` ``) may span newlines, so raw line terminators do
+///   not terminate them.
+///
+/// When the literal is unterminated, the input length is returned.
+#[inline]
+#[must_use]
+pub fn skip_quoted_literal(bytes: &[u8], start: usize, quote: u8) -> usize {
+    let mut pos = start + 1;
+    while pos < bytes.len() {
+        match bytes[pos] {
+            b'\\' => pos = (pos + 2).min(bytes.len()),
+            b if b == quote => return pos + 1,
+            b'\n' | b'\r' if quote != b'`' => return pos,
+            _ => pos += 1,
+        }
+    }
+    pos
+}
+
+/// Skip ASCII inline/line-terminator whitespace (`' '`, `'\t'`, `'\r'`, `'\n'`)
+/// starting at `from`, returning the index of the first non-whitespace byte (or
+/// `bytes.len()`).
+///
+/// This is the explicit, single whitespace set for byte-level source-text
+/// scans; it deliberately excludes form-feed/vertical-tab so every scanner
+/// agrees on what "skip whitespace" means.
+#[inline]
+#[must_use]
+pub fn skip_ascii_whitespace(bytes: &[u8], from: usize) -> usize {
+    let mut pos = from;
+    while pos < bytes.len() && matches!(bytes[pos], b' ' | b'\t' | b'\r' | b'\n') {
+        pos += 1;
+    }
+    pos
+}
+
+/// Return the byte offset of the first occurrence of `needle` in `haystack`
+/// that appears as a standalone (whole-word) ASCII identifier token — i.e. not
+/// flanked by identifier-continue bytes on either side.
+///
+/// Returns `None` when `needle` is empty or never appears as a whole word.
+#[inline]
+#[must_use]
+pub fn find_standalone_token(haystack: &str, needle: &str) -> Option<usize> {
+    let bytes = haystack.as_bytes();
+    let needle_bytes = needle.as_bytes();
+    if needle_bytes.is_empty() || needle_bytes.len() > bytes.len() {
+        return None;
+    }
+    let mut i = 0;
+    while i + needle_bytes.len() <= bytes.len() {
+        if &bytes[i..i + needle_bytes.len()] == needle_bytes {
+            let prev_ok = i == 0 || !is_ascii_identifier_continue(bytes[i - 1]);
+            let next_ok = i + needle_bytes.len() == bytes.len()
+                || !is_ascii_identifier_continue(bytes[i + needle_bytes.len()]);
+            if prev_ok && next_ok {
+                return Some(i);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// True when `haystack` contains `needle` as a standalone (whole-word) ASCII
+/// identifier token. See [`find_standalone_token`].
+#[inline]
+#[must_use]
+pub fn contains_standalone_token(haystack: &str, needle: &str) -> bool {
+    find_standalone_token(haystack, needle).is_some()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::leading_window;
+    use super::{
+        contains_standalone_token, find_standalone_token, is_ascii_identifier_continue,
+        is_ascii_identifier_continue_char, is_ascii_identifier_start,
+        is_ascii_identifier_start_char, leading_window, skip_ascii_whitespace, skip_quoted_literal,
+    };
+
+    #[test]
+    fn identifier_start_admits_underscore_dollar_and_letters_only() {
+        for b in [b'_', b'$', b'a', b'Z'] {
+            assert!(is_ascii_identifier_start(b));
+        }
+        for b in [b'0', b'9', b' ', b'.', b'-'] {
+            assert!(!is_ascii_identifier_start(b));
+        }
+        // Non-ASCII bytes are never identifier-start under the ASCII fast path.
+        assert!(!is_ascii_identifier_start(0xC3));
+    }
+
+    #[test]
+    fn identifier_continue_additionally_admits_digits() {
+        for b in [b'_', b'$', b'a', b'Z', b'0', b'9'] {
+            assert!(is_ascii_identifier_continue(b));
+        }
+        for b in [b' ', b'.', b'-', b'('] {
+            assert!(!is_ascii_identifier_continue(b));
+        }
+    }
+
+    #[test]
+    fn char_variants_match_byte_variants_for_ascii() {
+        for c in ['_', '$', 'a', 'Z', '0', '9', ' ', '.', '-'] {
+            assert_eq!(
+                is_ascii_identifier_start_char(c),
+                is_ascii_identifier_start(c as u8)
+            );
+            assert_eq!(
+                is_ascii_identifier_continue_char(c),
+                is_ascii_identifier_continue(c as u8)
+            );
+        }
+        // Non-ASCII chars are rejected by the ASCII fast path.
+        assert!(!is_ascii_identifier_start_char('é'));
+        assert!(!is_ascii_identifier_continue_char('é'));
+    }
+
+    #[test]
+    fn skip_quoted_basic_string_returns_past_close() {
+        let s = b"'abc' rest";
+        // Opens at 0, closes at index 4; returns 5 (the space).
+        assert_eq!(skip_quoted_literal(s, 0, b'\''), 5);
+    }
+
+    #[test]
+    fn skip_quoted_honors_backslash_escape() {
+        let s = br#""a\"b" rest"#;
+        // The escaped quote does not close the literal; real close is index 5.
+        assert_eq!(skip_quoted_literal(s, 0, b'"'), 6);
+    }
+
+    #[test]
+    fn skip_quoted_trailing_backslash_at_eof_clamps() {
+        let s = b"'ab\\";
+        assert_eq!(skip_quoted_literal(s, 0, b'\''), s.len());
+    }
+
+    #[test]
+    fn skip_quoted_single_line_terminates_on_raw_newline() {
+        let s = b"'unterminated\nnext";
+        // Returns the index *at* the newline (13), not EOF.
+        assert_eq!(skip_quoted_literal(s, 0, b'\''), 13);
+        assert_eq!(s[13], b'\n');
+    }
+
+    #[test]
+    fn skip_quoted_template_spans_newlines() {
+        let s = b"`line1\nline2` rest";
+        // Backtick literals are not terminated by raw newlines.
+        let end = skip_quoted_literal(s, 0, b'`');
+        assert_eq!(s[end - 1], b'`');
+        assert_eq!(end, 13);
+    }
+
+    #[test]
+    fn skip_whitespace_skips_inline_and_line_terminators_only() {
+        let s = b" \t\r\nx";
+        assert_eq!(skip_ascii_whitespace(s, 0), 4);
+        // Form-feed (0x0C) is deliberately not part of the set.
+        let ff = b"\x0Cx";
+        assert_eq!(skip_ascii_whitespace(ff, 0), 0);
+        // From past the end is a no-op clamp.
+        assert_eq!(skip_ascii_whitespace(s, s.len()), s.len());
+    }
+
+    #[test]
+    fn standalone_token_requires_word_boundaries() {
+        assert!(contains_standalone_token("a + react + b", "react"));
+        assert!(!contains_standalone_token("react_2 = 1", "react"));
+        assert!(!contains_standalone_token("preact", "react"));
+        assert_eq!(find_standalone_token("x react y", "react"), Some(2));
+        // Token at the very start and end of input.
+        assert!(contains_standalone_token("react", "react"));
+        // Empty needle never matches.
+        assert!(!contains_standalone_token("anything", ""));
+    }
 
     #[test]
     fn ascii_caps_exactly_at_budget() {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/jsdoc.rs
@@ -502,7 +502,7 @@ impl<'a> DeclarationEmitter<'a> {
     }
 
     const fn is_jsdoc_tag_name_continuation(ch: char) -> bool {
-        ch.is_ascii_alphanumeric() || ch == '_' || ch == '$'
+        tsz_common::text_scan::is_ascii_identifier_continue_char(ch)
     }
 
     pub(in crate::declaration_emitter) fn normalize_jsdoc_type_text(
@@ -1341,7 +1341,7 @@ impl<'a> DeclarationEmitter<'a> {
     }
 
     const fn is_jsdoc_identifier_part(ch: char) -> bool {
-        ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()
+        tsz_common::text_scan::is_ascii_identifier_continue_char(ch)
     }
 
     fn format_jsdoc_object_type_text(type_text: &str) -> Option<String> {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference.rs
@@ -399,27 +399,7 @@ impl<'a> DeclarationEmitter<'a> {
     }
 
     fn protected_type_text_literal_spans(text: &str) -> Vec<(usize, usize)> {
-        fn skip_quoted(bytes: &[u8], mut i: usize, quote: u8) -> usize {
-            i += 1;
-            let mut escaped = false;
-            while i < bytes.len() {
-                if escaped {
-                    escaped = false;
-                    i += 1;
-                    continue;
-                }
-                if bytes[i] == b'\\' {
-                    escaped = true;
-                    i += 1;
-                    continue;
-                }
-                i += 1;
-                if bytes[i - 1] == quote {
-                    break;
-                }
-            }
-            i
-        }
+        use tsz_common::text_scan::skip_quoted_literal as skip_quoted;
 
         fn scan_template(bytes: &[u8], start: usize, spans: &mut Vec<(usize, usize)>) -> usize {
             let mut segment_start = start;
@@ -504,7 +484,7 @@ impl<'a> DeclarationEmitter<'a> {
     }
 
     pub(super) const fn is_ident_char_in_text(b: u8) -> bool {
-        b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
+        tsz_common::text_scan::is_ascii_identifier_continue(b)
     }
 
     pub(in crate::declaration_emitter) fn object_rest_binding_excluded_names(

--- a/crates/tsz-emitter/src/emitter/declarations/class/mod.rs
+++ b/crates/tsz-emitter/src/emitter/declarations/class/mod.rs
@@ -177,7 +177,7 @@ fn text_contains_identifier(text: &str, name: &str) -> bool {
 }
 
 pub(super) const fn is_ident_char(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
+    tsz_common::text_scan::is_ascii_identifier_continue(b)
 }
 
 #[cfg(test)]

--- a/crates/tsz-emitter/src/emitter/helpers.rs
+++ b/crates/tsz-emitter/src/emitter/helpers.rs
@@ -22,9 +22,7 @@ fn strip_keyword_token<'a>(text: &'a str, keyword: &str) -> Option<&'a str> {
     })
 }
 
-const fn is_identifier_continue(byte: u8) -> bool {
-    byte == b'_' || byte == b'$' || byte.is_ascii_alphanumeric()
-}
+use tsz_common::text_scan::is_ascii_identifier_continue as is_identifier_continue;
 
 fn previous_identifier_token(text: &str, mut end: usize) -> Option<(&str, usize)> {
     let bytes = text.as_bytes();

--- a/crates/tsz-emitter/src/emitter/source_file/recovery.rs
+++ b/crates/tsz-emitter/src/emitter/source_file/recovery.rs
@@ -1110,7 +1110,11 @@ impl<'a> Printer<'a> {
         let line = crate::safe_slice::slice(text, start, line_end).ok()?;
         let trimmed = line.trim_start();
         let rest = trimmed.strip_prefix("declare namespace debugger")?;
-        if rest.as_bytes().first().is_some_and(is_identifier_continue) {
+        if rest
+            .as_bytes()
+            .first()
+            .is_some_and(|&b| tsz_common::text_scan::is_ascii_identifier_continue(b))
+        {
             return None;
         }
 
@@ -1121,13 +1125,13 @@ impl<'a> Printer<'a> {
     }
 }
 
-const fn is_identifier_continue(byte: &u8) -> bool {
-    byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'$'
-}
-
 fn strip_recovery_keyword<'a>(text: &'a str, keyword: &str) -> Option<&'a str> {
     let rest = text.strip_prefix(keyword)?;
-    if rest.as_bytes().first().is_some_and(is_identifier_continue) {
+    if rest
+        .as_bytes()
+        .first()
+        .is_some_and(|&b| tsz_common::text_scan::is_ascii_identifier_continue(b))
+    {
         return None;
     }
     Some(rest)

--- a/crates/tsz-emitter/src/emitter/statements/recovered_expression_statement_helpers.rs
+++ b/crates/tsz-emitter/src/emitter/statements/recovered_expression_statement_helpers.rs
@@ -203,6 +203,6 @@ impl<'a> Printer<'a> {
     }
 
     const fn is_ascii_identifier_part(byte: u8) -> bool {
-        byte == b'_' || byte == b'$' || byte.is_ascii_alphanumeric()
+        tsz_common::text_scan::is_ascii_identifier_continue(byte)
     }
 }

--- a/crates/tsz-emitter/src/emitter/types/printer/type_printing_references.rs
+++ b/crates/tsz-emitter/src/emitter/types/printer/type_printing_references.rs
@@ -331,7 +331,7 @@ impl<'a> TypePrinter<'a> {
     }
 
     const fn is_identifier_continue(byte: u8) -> bool {
-        byte == b'_' || byte == b'$' || byte.is_ascii_alphanumeric()
+        tsz_common::text_scan::is_ascii_identifier_continue(byte)
     }
 
     /// Print a type parameter declaration with constraint and default.

--- a/crates/tsz-emitter/src/import_usage.rs
+++ b/crates/tsz-emitter/src/import_usage.rs
@@ -181,20 +181,9 @@ const fn is_ident_or_member_access_char(ch: char) -> bool {
     ch == '_' || ch == '$' || ch == '.' || ch.is_ascii_alphanumeric()
 }
 
-fn skip_ascii_ws(bytes: &[u8], mut i: usize) -> usize {
-    while i < bytes.len() && matches!(bytes[i], b' ' | b'\t' | b'\r' | b'\n') {
-        i += 1;
-    }
-    i
-}
-
-const fn is_ident_start(byte: u8) -> bool {
-    byte == b'_' || byte == b'$' || byte.is_ascii_alphabetic()
-}
-
-const fn is_ident_continue(byte: u8) -> bool {
-    is_ident_start(byte) || byte.is_ascii_digit()
-}
+use tsz_common::text_scan::is_ascii_identifier_continue as is_ident_continue;
+use tsz_common::text_scan::is_ascii_identifier_start as is_ident_start;
+use tsz_common::text_scan::skip_ascii_whitespace as skip_ascii_ws;
 
 fn push_non_code_blank(result: &mut String, byte: u8) {
     if byte == b'\t' {
@@ -1218,19 +1207,7 @@ fn scan_balanced_parens(bytes: &[u8], start: usize) -> Option<usize> {
     None
 }
 
-fn skip_quoted_bytes(bytes: &[u8], mut i: usize, quote: u8) -> usize {
-    i += 1;
-    while i < bytes.len() {
-        if bytes[i] == b'\\' && i + 1 < bytes.len() {
-            i += 2;
-        } else if bytes[i] == quote {
-            return i + 1;
-        } else {
-            i += 1;
-        }
-    }
-    i
-}
+use tsz_common::text_scan::skip_quoted_literal as skip_quoted_bytes;
 
 fn scan_past_decorator(bytes: &[u8], start: usize) -> Option<usize> {
     if start >= bytes.len() || bytes[start] != b'@' {

--- a/crates/tsz-emitter/src/transforms/emit_utils.rs
+++ b/crates/tsz-emitter/src/transforms/emit_utils.rs
@@ -1222,29 +1222,10 @@ pub(crate) fn skip_trivia_forward(source_text: Option<&str>, start: u32, end: u3
 /// ASCII identifier alphabet — used by transforms that need to detect
 /// user bindings before allocating helper-temp names.
 pub(crate) fn contains_identifier_token(haystack: &str, needle: &str) -> bool {
-    let bytes = haystack.as_bytes();
-    let needle_bytes = needle.as_bytes();
-    if needle_bytes.is_empty() || needle_bytes.len() > bytes.len() {
-        return false;
-    }
-    let mut i = 0;
-    while i + needle_bytes.len() <= bytes.len() {
-        if &bytes[i..i + needle_bytes.len()] == needle_bytes {
-            let prev_ok = i == 0 || !is_identifier_part(bytes[i - 1]);
-            let next_ok = i + needle_bytes.len() == bytes.len()
-                || !is_identifier_part(bytes[i + needle_bytes.len()]);
-            if prev_ok && next_ok {
-                return true;
-            }
-        }
-        i += 1;
-    }
-    false
+    tsz_common::text_scan::contains_standalone_token(haystack, needle)
 }
 
-const fn is_identifier_part(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
-}
+use tsz_common::text_scan::is_ascii_identifier_continue as is_identifier_part;
 
 /// Pick a temporary name that doesn't collide with any identifier reference
 /// in `source_text`. Returns `base` when the base itself is free, otherwise

--- a/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/namespace_es5_ir.rs
@@ -85,9 +85,7 @@ fn starts_with_keyword_token(text: &str, keyword: &str) -> bool {
     })
 }
 
-const fn is_identifier_continue(byte: u8) -> bool {
-    byte == b'_' || byte == b'$' || byte.is_ascii_alphanumeric()
-}
+use tsz_common::text_scan::is_ascii_identifier_continue as is_identifier_continue;
 
 fn previous_identifier_token(text: &str, mut end: usize) -> Option<(&str, usize)> {
     let bytes = text.as_bytes();

--- a/crates/tsz-lsp/src/completions/string_literals.rs
+++ b/crates/tsz-lsp/src/completions/string_literals.rs
@@ -429,7 +429,7 @@ impl<'a> Completions<'a> {
     }
 
     const fn is_identifier_char(ch: char) -> bool {
-        ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()
+        tsz_common::text_scan::is_ascii_identifier_continue_char(ch)
     }
 
     fn collect_string_literals_from_type_node(

--- a/crates/tsz-lsp/src/fourslash_variants.rs
+++ b/crates/tsz-lsp/src/fourslash_variants.rs
@@ -162,13 +162,8 @@ pub fn apply_variant(source: &str, variant: &ShapeVariant) -> String {
 // Internal lexing helpers.
 // -----------------------------------------------------------------------------
 
-const fn is_ident_start(b: u8) -> bool {
-    b.is_ascii_alphabetic() || b == b'_' || b == b'$'
-}
-
-const fn is_ident_continue(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
-}
+use tsz_common::text_scan::is_ascii_identifier_continue as is_ident_continue;
+use tsz_common::text_scan::is_ascii_identifier_start as is_ident_start;
 
 /// If `bytes[i..]` starts with a marker comment `/*name*/`, return the byte
 /// offset just past the closing `*/`. Delegates to

--- a/crates/tsz-lsp/src/highlighting/document.rs
+++ b/crates/tsz-lsp/src/highlighting/document.rs
@@ -304,12 +304,7 @@ impl<'a> DocumentHighlightProvider<'a> {
 
     /// Skip whitespace forward from an offset and return the new offset.
     fn skip_whitespace_forward(&self, offset: usize) -> usize {
-        let bytes = self.source_text.as_bytes();
-        let mut i = offset;
-        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
-            i += 1;
-        }
-        i
+        tsz_common::text_scan::skip_ascii_whitespace(self.source_text.as_bytes(), offset)
     }
 
     /// Highlight if/else keyword pairs.

--- a/crates/tsz-lsp/src/utils/mod.rs
+++ b/crates/tsz-lsp/src/utils/mod.rs
@@ -228,7 +228,7 @@ pub fn should_backtrack_to_previous_symbol(source_text: &str, offset: u32) -> bo
     }
 
     let prev = bytes[idx - 1];
-    if !(prev.is_ascii_alphanumeric() || prev == b'_' || prev == b'$') {
+    if !tsz_common::text_scan::is_ascii_identifier_continue(prev) {
         return false;
     }
 
@@ -236,8 +236,7 @@ pub fn should_backtrack_to_previous_symbol(source_text: &str, offset: u32) -> bo
         return true;
     }
 
-    let current = bytes[idx];
-    !(current.is_ascii_alphanumeric() || current == b'_' || current == b'$')
+    !tsz_common::text_scan::is_ascii_identifier_continue(bytes[idx])
 }
 
 /// Check if a node is the `import` keyword (for dynamic import expressions).

--- a/crates/tsz-parser/src/parser/incomplete_call.rs
+++ b/crates/tsz-parser/src/parser/incomplete_call.rs
@@ -54,10 +54,7 @@ const DECLARATION_KEYWORDS: [&str; 7] = [
     "module",
 ];
 
-#[inline]
-const fn is_ident_byte(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
-}
+use tsz_common::text_scan::is_ascii_identifier_continue as is_ident_byte;
 
 #[inline]
 fn is_less_than_or_equal(bytes: &[u8], idx: usize) -> bool {


### PR DESCRIPTION
Goal: hold

Closes #13430.

Behavior-preserving DRY/hygiene over shared leaf primitives in `tsz-common`; no
type-algorithm change, so this defends the conformance/emit parity floor.

## Structural rule

When scanning raw source or display text at the byte level for one of four
operations — "is this byte/char an ASCII identifier char", "skip past a quoted
literal", "is this needle a standalone (whole-word) token", "skip ASCII
whitespace" — idiomatic Rust calls one shared `tsz-common` primitive. tsz
instead re-derived each primitive locally across the emitter, CLI, parser,
binder, checker, and LSP under 20+ distinct private names, and two of the four
had already drifted in semantically observable ways. Owner layer: a new
`tsz_common::text_scan` module is the single source of truth; every crate
involved already depends on `tsz-common`, so consolidation adds no coupling.

## What changed

New primitives in `crates/tsz-common/src/text_scan.rs` (the existing
`leading_window` home), with full unit coverage including the drifted edge
cases:

- `is_ascii_identifier_start` / `is_ascii_identifier_continue` (+ `_char`
  variants) — the ASCII fast path mirroring `tsz_scanner`'s Unicode
  `is_ecmascript_identifier_*`.
- `skip_quoted_literal(bytes, start, quote)` — **quote-aware** policy, picking
  the correct TS grammar semantics: single-line string literals (`'`/`"`)
  terminate on a raw newline; template literals (`` ` ``) span newlines;
  backslash escapes consume the next byte, clamped at EOF.
- `skip_ascii_whitespace(bytes, from)` — one explicit set (`' '`, `\t`, `\r`,
  `\n`).
- `find_standalone_token` / `contains_standalone_token` — whole-word identifier
  search built on the identifier-continue predicate.

Migrated the private copies to call them:

- **tsz-common**: `common::is_word_byte`, `comments::skip_quoted_string`.
- **tsz-emitter**: `emit_utils` (`is_identifier_part`,
  `contains_identifier_token`), `import_usage` (`skip_quoted_bytes`,
  `skip_ascii_ws`, `is_ident_start`/`is_ident_continue`), `type_inference`
  (`skip_quoted`, `is_ident_char_in_text`), plus the identifier-predicate
  copies in `emitter/helpers`, `source_file/recovery`,
  `types/printer/type_printing_references`, `transforms/namespace_es5_ir`,
  `statements/recovered_expression_statement_helpers`,
  `declarations/class/mod`, and `declaration_emitter/helpers/jsdoc`.
- **tsz-cli**: `discovery` (`is_identifier_part_byte`,
  `is_jsdoc_import_keyword_part`), `tsz_server` quickinfo `is_js_identifier_char`.
- **tsz-parser**: `incomplete_call::is_ident_byte`.
- **tsz-binder**: `core_jsdoc::is_jsdoc_import_keyword_part`.
- **tsz-checker**: `core_formatting`, `assignability_alias_display`,
  `fingerprint_policy`, `jsdoc/parsing`, `types/queries/class`,
  `assignment_checker/destructuring`.
- **tsz-lsp**: `highlighting/document::skip_whitespace_forward`,
  `fourslash_variants`, `utils`, `completions/string_literals`.

## Behavior notes

- The identifier-predicate migrations are strictly behavior-preserving
  (identical predicate, new owner).
- `skip_quoted_literal` and `skip_ascii_whitespace` deliberately unify the two
  drifted primitives onto one documented policy. The drift only differed on
  malformed/exotic input (an unterminated single-line string consuming to EOF;
  form-feed/vertical-tab in the whitespace set), which is not reachable on
  valid TS that `tsc` accepts, so emit/scan output is unchanged for valid
  programs. Edge cases are covered by new `text_scan` unit tests.
- Predicates that are genuinely *different* were left alone (e.g.
  `signature_help/display::is_ident_char`, which excludes `$`; qualified-name
  scanners that also admit `.`).

## Anti-hardcoding

No user-name/file-name/printer-string predicates introduced; the primitives key
only on structural byte/char classes. No single-test suppressions.

## Verification

- `cargo build` — clean across tsz-common, tsz-emitter, tsz-cli, tsz-checker,
  tsz-lsp, tsz-parser, tsz-binder (and tsz-core).
- `cargo clippy --lib --bins` on all touched crates — **0** warnings.
- `cargo test -p tsz-common --lib text_scan` — 17 passed (new primitives +
  drifted edge cases).
- `cargo test` filtered runs green: tsz-common `comments` (94), tsz-emitter
  `import_usage` (56) / `emit_utils` (28), tsz-lsp `highlighting` (206) /
  `fourslash_variants` (16), tsz-cli `discovery` (29).
- Branch rebased on `origin/main` (clean, no conflicts) and rebuilt green.
- Broad conformance/emit/fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZ8ewk3apqA31zZee1ZMNQ)_