### PR TITLE
chore(conformance): retire deeplyNestedMappedTypes + propTypeValidatorInference accepted-regressions (#8432)

### DIFF
--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -65,38 +65,21 @@
 #      existing leading-zero exception). Covered by
 #      parser_improvement_class_member_recovery_tests::misplaced_case_clause_* and
 #      parser_improvement_expression_recovery_tests::empty_element_access_*.
-TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
-TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
-# deeplyNestedMappedTypes.ts: RE-JUSTIFIED (failure mode corrected). Earlier
-# evidence described spurious TS2344/TS2464; tsz no longer emits those. Verified
-# against the authoritative tsc baseline
-# (`deeplyNestedMappedTypes.errors.txt`, TypeScript 6.0.3): tsc emits exactly 5
-# TS2322 errors — `foo2` (Id), `foo4` (Id2), and the three `problematicFunction`
-# returns. Notably tsc emits NO error on the `bar2` NestedRecord line despite the
-# fixture's `// Error expected` comment: the recursion-identity / deeply-nested
-# bailout treats the deep path-splitting conditional alias as related after three
-# object hops. tsz currently emits 3 of the 5 expected TS2322 (`foo2`, `foo4`,
-# `problematicFunction2`) and correctly matches tsc on `bar2` (no error).
-# REMAINING GAP: tsz MISSES TS2322 on `problematicFunction1` and
-# `problematicFunction3` (`Input[]` not assignable to `Output[]`). Root cause
-# (verified by one-variable isolation): the fixture declares
-# `const Readonly: unique symbol`, whose name collides with the global lib
-# `Readonly<T>` utility type. When the deferred generic `PropertiesReducer` body
-# instantiates `Readonly<Pick<R, ...>>` (R/T still free type parameters), tsz
-# mis-resolves the `Readonly` reference to the shadowing value instead of the lib
-# type, corrupting the reduced object so `Input.static`/`Output.static` both lose
-# the `bar` discriminator and compare as assignable. Renaming ONLY the `Readonly`
-# unique symbol (to a non-lib name) restores the expected TS2322. A simple
-# `type Foo = Readonly<{ a: string }>` with `const Readonly` in scope resolves
-# correctly, so the divergence is specific to lazy instantiation of a
-# globally-shadowed lib utility type inside a generic alias body. Owner layer:
-# type-vs-value name resolution for shadowed global lib types (checker/binder),
-# NOT the solver index-access path. The minimal unit-test lib lacks the lib
-# utility types this repro needs, so the runnable parity gate is this conformance
-# row; the inline witness is the ignored
-# `deeply_nested_mapped_types_tests::readonly_pick_never_under_evaluate_loses_property_mismatch`.
-# Reproduce with the full lib via `tsz` on that snippet (renaming the `Readonly`
-# unique symbol to a non-lib name flips the result to the expected TS2322).
+# deeplyNestedMappedTypes.ts: RESOLVED. The five expected TS2322 diagnostics
+# (recursive Id/Id2 mapped-type leaf mismatch + the three `problematicFunction`
+# returns) now match tsc on exact-head against the pinned TypeScript 6.0.3
+# corpus. The prior `Readonly` unique-symbol shadowing divergence (value-symbol
+# mis-resolution during lazy instantiation) was fixed by the self-module
+# augmentation folding in #13515 and the value-lazy-ref resolution in #13500.
+# Verified in upstream/chore/retire-deeply-nested-prop-type-regressions and in
+# #13513 aggregate CI (6/6 shards, conformance-aggregate PASS).
+# propTypeValidatorInference.ts: RESOLVED. PR #13513 (fix(solver): defer
+# conditionals over an unresolved cross-file reference) stopped the fabricated
+# `error` in mapped bodies over namespace-imported members: a conditional whose
+# check type evaluates to `Application(UnresolvedTypeName, …)` now defers
+# instead of collapsing to `error`, so `InferProps<typeof propTypes>` with
+# `Validator`/`Requireable` from a namespace import resolves correctly (zero
+# diagnostics, matching tsc). Verified in #13513 merge-queue aggregate CI.
 # intersectionsOfLargeUnions.ts: RESOLVED. Two-part fix: (1) IndexAccess structural
 # comparison (PR #13146) distinguishes `ElementTagNameMap[T]` from
 # `HTMLElementTagNameMap[T]` when both sides are IndexAccess types; (2)


### PR DESCRIPTION
Goal: hold

Authored by **Thomas Metcalfe** (@MetcalfeTom); landed from https://github.com/MetcalfeTom/tsz PR #3.

Removes the last two entries from `scripts/conformance/conformance-accepted-regressions.txt` — `deeplyNestedMappedTypes.ts` and `propTypeValidatorInference.ts` — now that their underlying fixes have landed on main (incl. the self-module-augmentation/HKT keyof fix, commit 39e4858f). Restores the accepted-regression ledger toward empty per the Hold floor.

Structural rule: the accepted-regression ledger stays empty or every entry carries fresh exact-head CI evidence; these two are now fixed, so they leave the ledger.

Closes #8432

## Verification
- conformance-snapshot-gate + conformance-aggregate on the merge-group head must show both tests passing (the gate fails if either regresses)
- ledger entries: 2 -> 0

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-fable-5
Effort: high

Co-authored-by: Thomas Metcalfe <tommetcalfe@live.com>