### PR TITLE
perf(tools): expose unattributed reset-cache bytes (#13246)

### DIFF
--- a/scripts/perf/query-perf-counters.py
+++ b/scripts/perf/query-perf-counters.py
@@ -87,7 +87,7 @@ def reset_cache_value(checker: dict, suffix: str) -> Optional[int]:
     return checker.get(f"file_session_reset_{suffix}_max")
 
 
-def reset_cache_rows(checker: dict) -> list:
+def reset_cache_rows(checker: dict, include_unattributed=False) -> list:
     rows = []
     for name, entries_suffix, bytes_suffix in RESET_CACHE_FIELDS:
         entries = reset_cache_value(checker, entries_suffix)
@@ -101,13 +101,26 @@ def reset_cache_rows(checker: dict) -> list:
                 "bytes": size or 0,
             }
         )
+    if include_unattributed:
+        total_bytes = checker.get("file_session_reset_cache_bytes_max")
+        if total_bytes is not None:
+            known_bytes = sum(row["bytes"] for row in rows)
+            unattributed_bytes = total_bytes - known_bytes
+            if unattributed_bytes > 0:
+                rows.append(
+                    {
+                        "name": "unattributed",
+                        "entries": 0,
+                        "bytes": unattributed_bytes,
+                    }
+                )
     return rows
 
 
 def print_reset_cache_high_water(checker: dict, indent: str = "  ") -> None:
     entries = checker.get("file_session_reset_cache_entries_max")
     size = checker.get("file_session_reset_cache_bytes_max")
-    rows = reset_cache_rows(checker)
+    rows = reset_cache_rows(checker, include_unattributed=True)
     if entries is None and size is None and not rows:
         return
 
@@ -385,8 +398,8 @@ def print_diff(post: dict, base: dict) -> None:
         "compute_type_of_symbol_cache_hits",
     ):
         print(f"  {delta(post['checker'], base['checker'], k)}")
-    post_rows = reset_cache_rows(post["checker"])
-    base_rows = reset_cache_rows(base["checker"])
+    post_rows = reset_cache_rows(post["checker"], include_unattributed=True)
+    base_rows = reset_cache_rows(base["checker"], include_unattributed=True)
     if post_rows or base_rows:
         post_by_name = {row["name"]: row for row in post_rows}
         base_by_name = {row["name"]: row for row in base_rows}

--- a/scripts/perf/test_query_perf_counters.py
+++ b/scripts/perf/test_query_perf_counters.py
@@ -167,6 +167,34 @@ class QueryPerfCountersTests(unittest.TestCase):
         self.assertIn("env_eval", result.stdout)
         self.assertIn("share  40.6% →  40.6%", result.stdout)
 
+    def test_reset_cache_summary_reports_unattributed_bytes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            payload = sample_snapshot()
+            payload["checker"]["file_session_reset_cache_bytes_max"] = 8192
+            path = self.write_json(Path(temp_dir), "snap.json", payload)
+            result = self.run_tool("--json", path)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("unattributed", result.stdout)
+        self.assertIn("bytes=     4,096", result.stdout)
+        self.assertIn("byte_share= 50.0%", result.stdout)
+        self.assertIn("dominant=unattributed", result.stdout)
+
+    def test_reset_cache_diff_reports_unattributed_bytes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            baseline_payload = sample_snapshot()
+            current_payload = sample_snapshot()
+            current_payload["checker"]["file_session_reset_cache_bytes_max"] = 8192
+            baseline = self.write_json(root, "baseline.json", baseline_payload)
+            current = self.write_json(root, "current.json", current_payload)
+            result = self.run_tool("--json", current, "--baseline", baseline)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("unattributed", result.stdout)
+        self.assertIn("bytes          0 →      4,096 (+4,096)", result.stdout)
+        self.assertIn("share   0.0% →  50.0%", result.stdout)
+
     def test_by_reason_requires_by_reason_rows(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             payload = sample_snapshot()


### PR DESCRIPTION
Goal: fast

## Summary
- Report an explicit `unattributed` file-session reset-cache high-water row when aggregate retained bytes exceed the sum of known cache-family counters.
- Include the same `unattributed` row in baseline diff output so #13246 accumulation runs expose unknown retained state instead of hiding it in the total.
- Cover both summary and diff output in `scripts/perf/test_query_perf_counters.py`.

## Structural Rule
When the file-session reset cache total is larger than the sum of named cache-family high-water byte counters, tsz performance tooling should surface the residual as unattributed retained state. This keeps #13246 root-cause evidence honest: known cache families remain attributed by their existing counters, and any missing family/counter coverage becomes visible before bounded checker-partition design work.

## Owner Layer
Performance tooling only: `scripts/perf/query-perf-counters.py` and `scripts/perf/test_query_perf_counters.py`. No checker, solver, scheduler, cache invalidation, or compiler semantic behavior changes.

## Cache And Complexity Invariant
- Semantic question: none; this is post-run attribution reporting over an existing perf-counter JSON artifact.
- Key/reset behavior: no new cache and no changed counter reset behavior.
- Scope: one report invocation; residual bytes are computed as `file_session_reset_cache_bytes_max - sum(named_family_bytes)` when positive.
- Fallback: artifacts without reset-cache totals keep the existing no-report behavior.

## Verification
- No local tests or benchmarks run per user instruction.
- Pre-commit formatting hook ran during commit and reported no staged Rust files changed.
- Branch was synced with `origin/main` before push.
- Draft/light CI passed at exact head `34d3ef97fea1ea383fd4d7e228ec7f09697831a5` (`CI Light Summary`, run `27490334127`).
- Ready-review CI is now expected to run the full PR-head gates before merge queue.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: medium
