### PR TITLE
perf(bench): print project aggregate row count

### DIFF
--- a/scripts/bench/bench-readiness-banner.mjs
+++ b/scripts/bench/bench-readiness-banner.mjs
@@ -64,7 +64,7 @@ export function benchReadinessMessages(readiness, winnerReport = null) {
     const speedupText = Number.isFinite(speedup) && speedup > 0
       ? `${speedup.toFixed(2)}x`
       : "unknown speedup";
-    const projectRows = Number(projectAggregate.rows ?? 0);
+    const projectRows = Number(projectAggregate.measured_rows ?? 0);
     const rowText = projectRows > 0 ? ` across ${projectRows} project row(s)` : "";
     messages.push(
       `Benchmark companion report project-row aggregate is ${speedupText}${rowText}, below the 2x tsgo target; public speed claims are not launch-ready.`,

--- a/scripts/bench/test-bench-readiness-banner.mjs
+++ b/scripts/bench/test-bench-readiness-banner.mjs
@@ -43,7 +43,7 @@ assert.match(
       rows_below_target: 0,
       missing_attribution_rows: [],
       project_rows_aggregate: {
-        rows: 3,
+        measured_rows: 3,
         tsz_speedup_vs_tsgo: 1.42,
         target_met: false,
       },

--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -211,6 +211,7 @@ withTempDir((dir) => {
   assert.deepEqual(report.totals.missing_attribution_rows, ["single-file-loss", "vite-vanilla-ts-app"]);
   assert.equal(report.totals.incomplete_compat_excluded, 0);
   assert.match(result.stdout, /2x target gaps with attribution commands: 2\/3/);
+  assert.match(result.stdout, /project-row aggregate speedup: 0\.15x \(below 2x target; 2 row\(s\)\)/);
   assert.deepEqual(report.two_x_target, {
     tsz_speedup_target: 2,
     eligible_green_rows: 4,

--- a/scripts/bench/test-tsgo-winner-report.mjs
+++ b/scripts/bench/test-tsgo-winner-report.mjs
@@ -810,6 +810,7 @@ withTempDir((dir) => {
   });
   assert.equal(result.status, 0, result.stderr || result.stdout);
   assert.match(result.stdout, /2x target gaps: 2\/3/);
+  assert.match(result.stdout, /startup-floor target gaps: 1\/2/);
 
   const report = JSON.parse(fs.readFileSync(output, "utf8"));
   assert.equal(report.two_x_target.rows_meeting_target, 1);

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -908,10 +908,10 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     `2x target gaps with attribution commands: ${report.two_x_target.rows_with_attribution_command}/${report.two_x_target.rows_below_target}`,
   ];
   const projectAggregate = report.two_x_target.project_rows_aggregate;
-  if (projectAggregate?.rows > 0) {
+  if (projectAggregate?.measured_rows > 0) {
     const targetState = projectAggregate.target_met ? "meets" : "below";
     outputLines.push(
-      `project-row aggregate speedup: ${formatNumber(projectAggregate.tsz_speedup_vs_tsgo)}x (${targetState} 2x target; ${projectAggregate.rows} row(s))`,
+      `project-row aggregate speedup: ${formatNumber(projectAggregate.tsz_speedup_vs_tsgo)}x (${targetState} 2x target; ${projectAggregate.measured_rows} row(s))`,
     );
   }
   outputLines.push(`report: ${path.relative(process.cwd(), outputPath).split(path.sep).join("/")}`);

--- a/scripts/bench/tsgo-winner-report.mjs
+++ b/scripts/bench/tsgo-winner-report.mjs
@@ -906,6 +906,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     `2x target gaps: ${report.two_x_target.rows_below_target}/${report.two_x_target.eligible_green_rows}`,
     `2x target gaps with attribution: ${report.two_x_target.rows_with_attribution}/${report.two_x_target.rows_below_target}`,
     `2x target gaps with attribution commands: ${report.two_x_target.rows_with_attribution_command}/${report.two_x_target.rows_below_target}`,
+    `startup-floor target gaps: ${report.target_gaps.filter((row) => row.startup_floor_win).length}/${report.two_x_target.rows_below_target}`,
   ];
   const projectAggregate = report.two_x_target.project_rows_aggregate;
   if (projectAggregate?.measured_rows > 0) {


### PR DESCRIPTION
Goal: fast

## Summary
- Print the project-row aggregate speedup line when the aggregate has measured rows.
- Use the existing `measured_rows` field instead of the nonexistent `rows` field in CLI output and readiness-banner messaging.
- Surface startup-floor-shaped 2x target gaps in CLI output from the existing per-row `startup_floor_win` tag.
- Add/update regression assertions so reporting surfaces use the current project aggregate schema and expose startup-floor target-gap pressure.

## Reporting rule
When Fast-goal reporting computes a project-row aggregate with measured rows, the CLI summary and benchmark readiness banner should show that project-weighted 2x context. The report JSON already carries `measured_rows`; this PR fixes text gates/output that were silently looking for a stale `rows` field. When target-gap rows are tagged as startup-floor wins, the CLI should also summarize that count so startup-floor-shaped 2x misses are visible without manually inspecting row JSON.

## Verification
- Pre-commit formatting hook ran during commits; no staged Rust files changed.
- Exact-head draft/light CI passed on `e89d054f15f978e3d9343d2012d5f8ca83ecf86a`.
- Not run locally: targeted Node tests intentionally left to CI.

## Provenance
Machine: MacBookPro
Assistant: codex
Model: GPT-5
Effort: medium
