### PR TITLE
fix(checker): publish delegated class instances (#13480)

### DIFF
--- a/crates/tsz-checker/src/context/cross_file_query.rs
+++ b/crates/tsz-checker/src/context/cross_file_query.rs
@@ -392,7 +392,7 @@ impl<'a> CheckerContext<'a> {
 
     /// Whether a class symbol's INSTANCE type is recoverable in this checker:
     /// already registered in `symbol_instance_types`, or available in the
-    /// cross-file `ClassInstance` bucket (in which case it is registered now).
+    /// cross-file `ClassInstance` bucket.
     ///
     /// The SYMBOL bucket stores only a class's value-side (constructor) type.
     /// Serving that entry while no instance side is recoverable leaves every
@@ -417,7 +417,16 @@ impl<'a> CheckerContext<'a> {
         else {
             return false;
         };
-        self.symbol_instance_types.insert(sym_id, inst);
+        let owner_is_declaration_file = self
+            .all_arenas
+            .as_ref()
+            .and_then(|arenas| arenas.get(file_idx as usize))
+            .and_then(|arena| arena.source_files.first())
+            .map(|source_file| source_file.is_declaration_file)
+            .unwrap_or(true);
+        if owner_is_declaration_file {
+            self.symbol_instance_types.insert(sym_id, inst);
+        }
         true
     }
 

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -694,6 +694,9 @@ mod contextual_return_wrapper_tests;
 #[path = "../tests/contextual_typing_tests.rs"]
 mod contextual_typing_tests;
 #[cfg(test)]
+#[path = "tests/cross_file_class_instance_publication_tests.rs"]
+mod cross_file_class_instance_publication_tests;
+#[cfg(test)]
 #[path = "../tests/cross_file_class_merge_tests.rs"]
 mod cross_file_class_merge_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -1195,7 +1195,7 @@ impl<'a> CheckerState<'a> {
         }
         checker.propagate_class_delegation_setup(self, sym_id);
         if !delegated_class_is_ambient {
-            self.clear_delegated_symbol_cache_collisions(&mut checker, delegate_binder);
+            self.clear_delegated_symbol_cache_collisions(&mut checker, delegate_binder, sym_id);
         }
 
         let result = checker.class_instance_type_with_params_from_symbol(sym_id);

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_delegation.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_delegation.rs
@@ -27,6 +27,7 @@ impl<'a> CheckerState<'a> {
         &self,
         checker: &mut CheckerState<'_>,
         delegate_binder: &tsz_binder::BinderState,
+        preserve_class_sym: SymbolId,
     ) {
         for delegate_symbol in delegate_binder.symbols.iter() {
             let sym_id = delegate_symbol.id;
@@ -44,7 +45,9 @@ impl<'a> CheckerState<'a> {
                 checker.ctx.symbol_instance_types.remove(&sym_id);
                 checker.ctx.symbol_to_def.borrow_mut().remove(&sym_id);
                 checker.ctx.symbol_resolution_set.remove(&sym_id);
-                checker.ctx.class_instance_resolution_set.remove(&sym_id);
+                if sym_id != preserve_class_sym {
+                    checker.ctx.class_instance_resolution_set.remove(&sym_id);
+                }
                 checker.ctx.class_constructor_resolution_set.remove(&sym_id);
             }
         }

--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -1253,15 +1253,37 @@ impl<'a> CheckerState<'a> {
         &mut self,
         sym_id: SymbolId,
     ) -> Option<(TypeId, Vec<tsz_solver::TypeParamInfo>)> {
+        if let Some(&instance_type) = self.ctx.symbol_instance_types.get(&sym_id)
+            && !instance_type.is_any_unknown_or_error()
+        {
+            let params = self
+                .class_instance_def_id_for_symbol(sym_id)
+                .and_then(|def_id| self.ctx.get_def_type_params(def_id))
+                .unwrap_or_default();
+            return Some((instance_type, params));
+        }
+        if self.ctx.class_instance_resolution_set.contains(&sym_id) {
+            let fallback = self.ctx.create_lazy_type_ref(sym_id);
+            return Some((fallback, Vec::new()));
+        }
+
         if self
             .get_symbol_from_registered_file_target(sym_id)
             .is_some_and(|symbol| symbol.has_any_flags(symbol_flags::CLASS))
-            && self
-                .ctx
-                .resolve_symbol_file_index(sym_id)
-                .is_some_and(|file_idx| file_idx != self.ctx.current_file_idx)
+            && let Some(owner_file_idx) = self.ctx.resolve_symbol_file_index(sym_id)
+            && owner_file_idx != self.ctx.current_file_idx
             && let Some(result) = self.delegate_cross_arena_class_instance_type(sym_id)
         {
+            // Source modules still need the delegated instance memoized for
+            // type-position class references, but registering their `DefId` as
+            // an instance type corrupts value/static namespace comparisons like
+            // `typeof import("./mod")`. Declaration files lack the source
+            // checker writer, so they still publish both caches.
+            if self.file_index_is_declaration_file(owner_file_idx) {
+                self.publish_delegated_class_instance_type(sym_id, result.0, &result.1);
+            } else {
+                self.publish_delegated_class_instance_symbol_type(sym_id, result.0);
+            }
             return Some(result);
         }
 
@@ -1382,6 +1404,71 @@ impl<'a> CheckerState<'a> {
         // Cross-file fallback: class declaration is not in the current arena.
         // Delegate to a child checker with the symbol's arena.
         self.delegate_cross_arena_class_instance_type(sym_id)
+    }
+
+    fn publish_delegated_class_instance_type(
+        &mut self,
+        sym_id: SymbolId,
+        instance_type: TypeId,
+        params: &[tsz_solver::TypeParamInfo],
+    ) {
+        if instance_type.is_any_unknown_or_error() {
+            return;
+        }
+
+        self.publish_delegated_class_instance_symbol_type(sym_id, instance_type);
+        self.publish_delegated_class_instance_env_type(sym_id, instance_type, params);
+    }
+
+    fn publish_delegated_class_instance_symbol_type(
+        &mut self,
+        sym_id: SymbolId,
+        instance_type: TypeId,
+    ) {
+        if instance_type.is_any_unknown_or_error() {
+            return;
+        }
+
+        self.ctx.symbol_instance_types.insert(sym_id, instance_type);
+    }
+
+    fn publish_delegated_class_instance_env_type(
+        &mut self,
+        sym_id: SymbolId,
+        instance_type: TypeId,
+        params: &[tsz_solver::TypeParamInfo],
+    ) {
+        if instance_type.is_any_unknown_or_error() {
+            return;
+        }
+
+        let symbol_name = self
+            .get_symbol_from_registered_file_target(sym_id)
+            .or_else(|| self.get_cross_file_symbol(sym_id))
+            .map(|symbol| symbol.escaped_name.clone());
+        let def_id = symbol_name.as_deref().map_or_else(
+            || self.ctx.get_or_create_def_id(sym_id),
+            |name| self.ctx.get_or_create_def_id_for_symbol_name(sym_id, name),
+        );
+        if !params.is_empty() && self.ctx.get_def_type_params(def_id).is_none() {
+            self.ctx.insert_def_type_params(def_id, params.to_vec());
+        }
+        self.ctx
+            .definition_store
+            .register_type_to_def(instance_type, def_id);
+        self.ctx
+            .register_class_instance_in_envs(def_id, instance_type);
+    }
+
+    fn class_instance_def_id_for_symbol(&self, sym_id: SymbolId) -> Option<tsz_solver::def::DefId> {
+        let symbol_name = self
+            .get_symbol_from_registered_file_target(sym_id)
+            .or_else(|| self.get_cross_file_symbol(sym_id))
+            .map(|symbol| symbol.escaped_name.as_str());
+        Some(symbol_name.map_or_else(
+            || self.ctx.get_or_create_def_id(sym_id),
+            |name| self.ctx.get_or_create_def_id_for_symbol_name(sym_id, name),
+        ))
     }
 
     /// Check if a type alias declaration has a mapped type body that

--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -1274,15 +1274,8 @@ impl<'a> CheckerState<'a> {
             && owner_file_idx != self.ctx.current_file_idx
             && let Some(result) = self.delegate_cross_arena_class_instance_type(sym_id)
         {
-            // Source modules still need the delegated instance memoized for
-            // type-position class references, but registering their `DefId` as
-            // an instance type corrupts value/static namespace comparisons like
-            // `typeof import("./mod")`. Declaration files lack the source
-            // checker writer, so they still publish both caches.
             if self.file_index_is_declaration_file(owner_file_idx) {
                 self.publish_delegated_class_instance_type(sym_id, result.0, &result.1);
-            } else {
-                self.publish_delegated_class_instance_symbol_type(sym_id, result.0);
             }
             return Some(result);
         }

--- a/crates/tsz-checker/src/tests/cross_file_class_instance_publication_tests.rs
+++ b/crates/tsz-checker/src/tests/cross_file_class_instance_publication_tests.rs
@@ -8,8 +8,10 @@
 use std::sync::Arc;
 
 use crate::context::CheckerOptions;
+use crate::diagnostics::diagnostic_codes;
 use crate::module_resolution::build_module_resolution_maps;
 use crate::state::CheckerState;
+use crate::test_utils::check_all_multi_file_with_global_index;
 use tsz_binder::BinderState;
 use tsz_common::common::ModuleKind;
 use tsz_parser::parser::ParserState;
@@ -171,15 +173,17 @@ let item: BoxThing | undefined;
                 .type_env
                 .borrow()
                 .snapshot_class_instance_types();
+            let symbol_cache_before = checker.ctx.symbol_instance_types.get(&sym_id).copied();
 
             let (instance_type, params) = checker
                 .class_instance_type_with_params_from_symbol(sym_id)
                 .expect("cross-file class instance should delegate");
+            assert!(!instance_type.is_any_unknown_or_error());
             assert!(params.is_empty());
             assert_eq!(
                 checker.ctx.symbol_instance_types.get(&sym_id).copied(),
-                Some(instance_type),
-                "source class delegation should memoize the requester symbol instance"
+                symbol_cache_before,
+                "source class delegation must not publish the requester symbol instance"
             );
 
             let env_after = checker
@@ -192,6 +196,70 @@ let item: BoxThing | undefined;
                 "source class delegation must not mutate the requester class-instance env"
             );
         },
+    );
+}
+
+#[test]
+fn delegated_source_class_instance_does_not_poison_commonjs_namespace_static_side() {
+    let diagnostics = check_all_multi_file_with_global_index(
+        &[
+            (
+                "extendingClassFromAliasAndUsageInIndexer_backbone.ts",
+                r#"
+export class Model {
+    public someData: string;
+}
+"#,
+            ),
+            (
+                "extendingClassFromAliasAndUsageInIndexer_moduleA.ts",
+                r#"
+import Backbone = require("./extendingClassFromAliasAndUsageInIndexer_backbone");
+export class VisualizationModel extends Backbone.Model {}
+"#,
+            ),
+            (
+                "extendingClassFromAliasAndUsageInIndexer_moduleB.ts",
+                r#"
+import Backbone = require("./extendingClassFromAliasAndUsageInIndexer_backbone");
+export class VisualizationModel extends Backbone.Model {}
+"#,
+            ),
+            (
+                "extendingClassFromAliasAndUsageInIndexer_main.ts",
+                r#"
+import Backbone = require("./extendingClassFromAliasAndUsageInIndexer_backbone");
+import moduleA = require("./extendingClassFromAliasAndUsageInIndexer_moduleA");
+import moduleB = require("./extendingClassFromAliasAndUsageInIndexer_moduleB");
+
+interface IHasVisualizationModel {
+    VisualizationModel: typeof Backbone.Model;
+}
+
+var moduleATyped: IHasVisualizationModel = moduleA;
+var moduleMap: { [key: string]: IHasVisualizationModel } = {
+    "first": moduleA,
+    "second": moduleB,
+};
+var moduleName: string;
+var visModel = new moduleMap[moduleName].VisualizationModel();
+"#,
+            ),
+        ],
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    );
+
+    let assignability_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .collect();
+    assert!(
+        assignability_errors.is_empty(),
+        "source class instance publication must not make a CommonJS module namespace expose the instance side: {assignability_errors:?}"
     );
 }
 

--- a/crates/tsz-checker/src/tests/cross_file_class_instance_publication_tests.rs
+++ b/crates/tsz-checker/src/tests/cross_file_class_instance_publication_tests.rs
@@ -1,0 +1,340 @@
+//! Cross-file class-instance publication invariants.
+//!
+//! Direct class-instance delegation returns the owner file's instance type to a
+//! requesting checker. Declaration-file owners must also publish that result
+//! into the requester so later `Lazy(DefId)` resolution can reuse the delegated
+//! instance instead of reconstructing the child checker.
+
+use std::sync::Arc;
+
+use crate::context::CheckerOptions;
+use crate::module_resolution::build_module_resolution_maps;
+use crate::state::CheckerState;
+use tsz_binder::BinderState;
+use tsz_common::common::ModuleKind;
+use tsz_parser::parser::ParserState;
+use tsz_solver::construction::TypeInterner;
+use tsz_solver::relations::subtype::TypeResolver;
+use tsz_solver::{TypeId, TypeParamInfo};
+
+fn with_two_file_state<F>(files: &[(&str, &str)], entry_file: &str, f: F)
+where
+    F: FnOnce(&mut CheckerState<'_>, usize),
+{
+    let mut arenas = Vec::with_capacity(files.len());
+    let mut binders = Vec::with_capacity(files.len());
+    let mut roots = Vec::with_capacity(files.len());
+    let file_names: Vec<String> = files.iter().map(|(name, _)| (*name).to_string()).collect();
+
+    for (name, source) in files {
+        let mut parser = ParserState::new((*name).to_string(), (*source).to_string());
+        let root = parser.parse_source_file();
+        let mut binder = BinderState::new();
+        binder.bind_source_file(parser.get_arena(), root);
+        arenas.push(Arc::new(parser.get_arena().clone()));
+        binders.push(Arc::new(binder));
+        roots.push(root);
+    }
+
+    let entry_idx = file_names
+        .iter()
+        .position(|name| name == entry_file)
+        .expect("entry file must exist");
+    let (resolved_module_paths, resolved_modules) = build_module_resolution_maps(&file_names);
+    let all_arenas = Arc::new(arenas);
+    let all_binders = Arc::new(binders);
+
+    let mut symbol_file_index = rustc_hash::FxHashMap::default();
+    for (file_idx, binder) in all_binders.iter().enumerate() {
+        for symbol in binder.symbols.iter() {
+            symbol_file_index.entry(symbol.id).or_insert(file_idx);
+        }
+    }
+
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        all_arenas[entry_idx].as_ref(),
+        all_binders[entry_idx].as_ref(),
+        &types,
+        file_names[entry_idx].clone(),
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    );
+    checker.ctx.set_all_arenas(Arc::clone(&all_arenas));
+    checker.ctx.set_all_binders(Arc::clone(&all_binders));
+    checker.ctx.set_current_file_idx(entry_idx);
+    checker.ctx.set_lib_contexts(Vec::new());
+    checker
+        .ctx
+        .set_resolved_module_paths(Arc::new(resolved_module_paths));
+    checker.ctx.set_resolved_modules(resolved_modules);
+    checker
+        .ctx
+        .set_global_symbol_file_index(Arc::new(symbol_file_index));
+    checker.ctx.share_owner_symbol_type_results = true;
+    checker.check_source_file(roots[entry_idx]);
+
+    f(&mut checker, entry_idx);
+}
+
+#[test]
+fn delegated_cross_file_class_instance_is_published_to_requester_env() {
+    with_two_file_state(
+        &[
+            (
+                "model.d.ts",
+                r#"
+export declare class BoxThing {
+    readonly value: number;
+}
+"#,
+            ),
+            (
+                "entry.ts",
+                r#"
+import { BoxThing } from "./model";
+let item: BoxThing | undefined;
+"#,
+            ),
+        ],
+        "entry.ts",
+        |checker, entry_idx| {
+            let sym_id = checker
+                .resolve_cross_file_export_from_file("./model", "BoxThing", Some(entry_idx))
+                .expect("exported class symbol should resolve");
+            let owner_file = checker
+                .ctx
+                .resolve_symbol_file_index(sym_id)
+                .expect("exported class should have an owner file");
+            assert_ne!(owner_file, checker.ctx.current_file_idx);
+
+            let (instance_type, params) = checker
+                .class_instance_type_with_params_from_symbol(sym_id)
+                .expect("cross-file class instance should delegate");
+            assert!(!instance_type.is_any_unknown_or_error());
+            assert!(
+                params.is_empty(),
+                "non-generic class should not publish params"
+            );
+
+            let def_id = checker
+                .ctx
+                .get_or_create_def_id_for_symbol_name(sym_id, "BoxThing");
+            let resolved = {
+                let env = checker.ctx.type_env.borrow();
+                TypeResolver::resolve_lazy(&*env, def_id, checker.ctx.types)
+            };
+            assert_eq!(
+                resolved,
+                Some(instance_type),
+                "requester env should resolve the class DefId to the delegated instance"
+            );
+            assert_eq!(
+                checker.ctx.symbol_instance_types.get(&sym_id).copied(),
+                Some(instance_type),
+                "requester should memoize the delegated class instance by symbol"
+            );
+        },
+    );
+}
+
+#[test]
+fn delegated_source_class_instance_skips_requester_env_publication() {
+    with_two_file_state(
+        &[
+            (
+                "model.ts",
+                r#"
+export class BoxThing {
+    readonly value: number = 1;
+}
+"#,
+            ),
+            (
+                "entry.ts",
+                r#"
+import { BoxThing } from "./model";
+let item: BoxThing | undefined;
+"#,
+            ),
+        ],
+        "entry.ts",
+        |checker, entry_idx| {
+            let sym_id = checker
+                .resolve_cross_file_export_from_file("./model", "BoxThing", Some(entry_idx))
+                .expect("exported class symbol should resolve");
+            let env_before = checker
+                .ctx
+                .type_env
+                .borrow()
+                .snapshot_class_instance_types();
+
+            let (instance_type, params) = checker
+                .class_instance_type_with_params_from_symbol(sym_id)
+                .expect("cross-file class instance should delegate");
+            assert!(params.is_empty());
+            assert_eq!(
+                checker.ctx.symbol_instance_types.get(&sym_id).copied(),
+                Some(instance_type),
+                "source class delegation should memoize the requester symbol instance"
+            );
+
+            let env_after = checker
+                .ctx
+                .type_env
+                .borrow()
+                .snapshot_class_instance_types();
+            assert_eq!(
+                env_after, env_before,
+                "source class delegation must not mutate the requester class-instance env"
+            );
+        },
+    );
+}
+
+#[test]
+fn cross_file_class_instance_with_params_uses_published_requester_cache_first() {
+    with_two_file_state(
+        &[
+            (
+                "model.ts",
+                r#"
+export class BoxThing<Value> {
+    readonly value!: Value;
+}
+"#,
+            ),
+            (
+                "entry.ts",
+                r#"
+import { BoxThing } from "./model";
+let item: BoxThing<number> | undefined;
+"#,
+            ),
+        ],
+        "entry.ts",
+        |checker, entry_idx| {
+            let sym_id = checker
+                .resolve_cross_file_export_from_file("./model", "BoxThing", Some(entry_idx))
+                .expect("exported generic class symbol should resolve");
+            let def_id = checker
+                .ctx
+                .get_or_create_def_id_for_symbol_name(sym_id, "BoxThing");
+            let param = TypeParamInfo::simple(checker.ctx.types.intern_string("Value"));
+            checker.ctx.insert_def_type_params(def_id, vec![param]);
+            checker
+                .ctx
+                .symbol_instance_types
+                .insert(sym_id, TypeId::STRING);
+
+            let (instance_type, params) = checker
+                .class_instance_type_with_params_from_symbol(sym_id)
+                .expect("published requester class instance should be reused");
+
+            assert_eq!(
+                instance_type,
+                TypeId::STRING,
+                "requester symbol-instance cache should win before cross-file delegation"
+            );
+            assert_eq!(params, vec![param]);
+        },
+    );
+}
+
+#[test]
+fn in_progress_cross_file_class_instance_returns_lazy_placeholder() {
+    with_two_file_state(
+        &[
+            (
+                "model.ts",
+                r#"
+export class BoxThing {
+    make(): BoxThing {
+        return new BoxThing();
+    }
+}
+"#,
+            ),
+            (
+                "entry.ts",
+                r#"
+import { BoxThing } from "./model";
+let item: BoxThing | undefined;
+"#,
+            ),
+        ],
+        "entry.ts",
+        |checker, entry_idx| {
+            let sym_id = checker
+                .resolve_cross_file_export_from_file("./model", "BoxThing", Some(entry_idx))
+                .expect("exported class symbol should resolve");
+            let def_id = checker
+                .ctx
+                .get_or_create_def_id_for_symbol_name(sym_id, "BoxThing");
+            checker.ctx.symbol_instance_types.remove(&sym_id);
+            checker.ctx.class_instance_resolution_set.insert(sym_id);
+
+            let (instance_type, params) = checker
+                .class_instance_type_with_params_from_symbol(sym_id)
+                .expect("in-progress class should return a lazy placeholder");
+
+            assert!(params.is_empty());
+            assert_eq!(
+                crate::query_boundaries::common::lazy_def_id(checker.ctx.types, instance_type),
+                Some(def_id),
+                "in-progress cross-file class read should not delegate recursively"
+            );
+        },
+    );
+}
+
+#[test]
+fn delegated_cross_file_class_instance_preserves_active_target_guard_after_collision_cleanup() {
+    with_two_file_state(
+        &[
+            (
+                "model.ts",
+                r#"
+export class BoxThing {
+    make(): BoxThing {
+        return new BoxThing();
+    }
+}
+"#,
+            ),
+            (
+                "entry.ts",
+                r#"
+import { BoxThing } from "./model";
+class LocalThing {}
+let item: BoxThing | undefined;
+"#,
+            ),
+        ],
+        "entry.ts",
+        |checker, entry_idx| {
+            let sym_id = checker
+                .resolve_cross_file_export_from_file("./model", "BoxThing", Some(entry_idx))
+                .expect("exported class symbol should resolve");
+            let def_id = checker
+                .ctx
+                .get_or_create_def_id_for_symbol_name(sym_id, "BoxThing");
+            checker.ctx.symbol_instance_types.remove(&sym_id);
+            checker.ctx.class_instance_resolution_set.insert(sym_id);
+
+            let (instance_type, params) = checker
+                .delegate_cross_arena_class_instance_type(sym_id)
+                .expect("cross-file delegation should preserve active target guard");
+
+            assert!(params.is_empty());
+            assert_eq!(
+                crate::query_boundaries::common::lazy_def_id(checker.ctx.types, instance_type),
+                Some(def_id),
+                "delegation cleanup should not drop the active class guard for the target symbol"
+            );
+        },
+    );
+}

--- a/crates/tsz-cli/tests/driver_tests.rs
+++ b/crates/tsz-cli/tests/driver_tests.rs
@@ -104,3 +104,4 @@ include!("driver_tests_parts/part_09.rs");
 include!("driver_tests_parts/part_10.rs");
 include!("driver_tests_parts/part_11.rs");
 include!("driver_tests_parts/part_12.rs");
+include!("driver_tests_parts/part_13.rs");

--- a/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
@@ -1,0 +1,80 @@
+#[test]
+fn compile_import_alias_indexer_does_not_leak_instance_side_into_namespace_static_side() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "es2015",
+            "module": "commonjs",
+            "strict": true,
+            "noEmit": true
+          },
+          "include": [
+            "*.ts", "*.tsx", "*.js", "*.jsx",
+            "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"
+          ],
+          "exclude": ["node_modules"]
+        }"#,
+    );
+    write_file(
+        &base.join("extendingClassFromAliasAndUsageInIndexer_backbone.ts"),
+        r#"export class Model {
+    public someData: string;
+}
+"#,
+    );
+    write_file(
+        &base.join("extendingClassFromAliasAndUsageInIndexer_moduleA.ts"),
+        r#"import Backbone = require("./extendingClassFromAliasAndUsageInIndexer_backbone");
+export class VisualizationModel extends Backbone.Model {
+}
+"#,
+    );
+    write_file(
+        &base.join("extendingClassFromAliasAndUsageInIndexer_moduleB.ts"),
+        r#"import Backbone = require("./extendingClassFromAliasAndUsageInIndexer_backbone");
+export class VisualizationModel extends Backbone.Model {
+}
+"#,
+    );
+    write_file(
+        &base.join("extendingClassFromAliasAndUsageInIndexer_main.ts"),
+        r#"import Backbone = require("./extendingClassFromAliasAndUsageInIndexer_backbone");
+import moduleA = require("./extendingClassFromAliasAndUsageInIndexer_moduleA");
+import moduleB = require("./extendingClassFromAliasAndUsageInIndexer_moduleB");
+interface IHasVisualizationModel {
+    VisualizationModel: typeof Backbone.Model;
+}
+var moduleATyped: IHasVisualizationModel = moduleA;
+var moduleMap: { [key: string]: IHasVisualizationModel } = {
+    "moduleA": moduleA,
+    "moduleB": moduleB
+};
+var moduleName: string;
+var visModel = new moduleMap[moduleName].VisualizationModel();
+"#,
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    let mut codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+    codes.sort_unstable();
+
+    assert_eq!(
+        codes,
+        vec![2454, 2564],
+        "Expected only TS2454 and TS2564 for alias indexer usage. Diagnostics: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|diag| diag.code != diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "Expected no TS2322 from instance-side leakage into module namespace static side. Diagnostics: {:?}",
+        result.diagnostics
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary
- publish delegated cross-file class instances back into requester state only for declaration-file owner classes, where no source checker writer can recover the instance later
- keep source-file delegated class instances out of requester `symbol_instance_types`/`DefId` publication so `typeof import("./mod")` and CommonJS namespace static comparisons keep constructor-side shapes
- preserve the active target class guard while clearing delegated symbol cache collisions
- add focused cross-file publication, requester-cache, lazy-placeholder, source/declaration split, guard-preservation, and include-order namespace regression tests

## Structural Rule
When a class instance is resolved through cross-file delegation, `tsc` treats type-position references in the requester as the imported class instance without letting that instance side contaminate value/static namespace comparisons. `tsz` now lets source-file owner instances remain recoverable through cross-file delegation/shared `ClassInstance` evidence, but only declaration-file owner classes hydrate requester-local `symbol_instance_types` and requester `DefId` environments. Source owners already have normal checker writers; publishing their instance side into requester symbol state can make `typeof Backbone.Model` require instance members such as `someData`.

## Adjacent Matrix
- declaration-file imported class instance publishes into requester env for later `Lazy(DefId)` resolution
- source-file imported class instance returns through delegation without mutating requester symbol-instance or class-instance env state
- generic imported class instance honors existing requester cache and published type params
- in-progress cross-file class resolution returns a lazy placeholder instead of recursive delegation
- delegated collision cleanup preserves the active target class guard
- conformance-style include-order CommonJS namespace/indexer fixture keeps parity with `tsc` and does not emit extra `TS2322`

## Verification
- `cargo fmt --check`
- `git diff --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib cross_file_class_instance_publication_tests` -> 6/6 passed
- `scripts/safe-run.sh cargo nextest run -p tsz-cli --lib compile_import_alias_indexer_does_not_leak_instance_side_into_namespace_static_side` -> 1/1 passed
- `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "extendingClassFromAliasAndUsageInIndexer" --verbose` -> 1/1 passed, 0 fingerprint-only
- earlier on this branch: `scripts/safe-run.sh ./scripts/conformance/conformance.sh run --filter "aliasUsage" --verbose` -> 9/9 passed, 0 fingerprint-only
- earlier on this branch: `scripts/safe-run.sh scripts/bench/measure-tsz.sh --timeout 120 --json-file /tmp/tsz-drizzle-main-crossfile-symbol-only-measure.json --label drizzle-main-crossfile-symbol-only -- --noEmit -p /Users/mohsen/code/tsz-drizzle-assignability-13480-20260614/.target/project-compile-guard/drizzle-orm/tsconfig.tsz-bisect-pg-core-single-boolean.json` -> exit 2, 1513 `error TS` lines; wall 41s under unusable CPU accounting (`cpu_s=0.000`, share 0%)

## Notes
- This is partial Drizzle parity progress, not a green-row or timing win. The bisect config still exits with diagnostics.
- The final source-owner rule is intentionally narrower than the first revision: source class instances are recoverable, but not published into requester symbol/env caches. That restores `extendingClassFromAliasAndUsageInIndexer` parity under conformance include-order checking.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: high
