### PR TITLE
green(bench): promote ts-toolbelt canary -> required compile-guard row

### DIFF
--- a/scripts/bench/project-rows.mjs
+++ b/scripts/bench/project-rows.mjs
@@ -75,7 +75,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref_env: "TS_TOOLBELT_REF",
     repo: "https://github.com/millsp/ts-toolbelt.git",
     ref: "b8a49285e3ed3a7d8bb8e0b433389eac46a5f140",
-    guard_set: "canary",
+    guard_set: "required",
     benchmark_set: "required",
     category: "external",
   },

--- a/scripts/bench/test-merge-results.mjs
+++ b/scripts/bench/test-merge-results.mjs
@@ -300,9 +300,13 @@ withTempDir((dir) => {
 });
 
 withTempDir((dir) => {
-  const requiredCanaryRow = "ts-toolbelt-project";
-  assert.ok(COMPILE_CANARY_PROJECT_ROWS.includes(requiredCanaryRow));
-  assert.ok(REQUIRED_PROJECT_ROWS.includes(requiredCanaryRow));
+  const requiredCanaryRow = REQUIRED_PROJECT_ROWS.find((name) => (
+    COMPILE_CANARY_PROJECT_ROWS.includes(name)
+  ));
+  assert.ok(
+    requiredCanaryRow,
+    "test fixture expects at least one required benchmark row still guarded by compile-canary CI",
+  );
   const slowdownCompatibility = {
     ...SAMPLE_COMPATIBILITY,
     state: "red",


### PR DESCRIPTION
AgentName: opus48-canary-green

Goal: green

Promote **ts-toolbelt** from a `guard_set: "canary"` row to a `guard_set: "required"` compile-guard row. It already compiles like `tsc`: under the strict guard tsconfig the tsz binary emits **0 diagnostics**, and the `tsc` oracle (`typescript/lib/tsc.js`) is likewise clean at the pinned ref `b8a49285`. Wall time is **0.94s** against the 90s guard timeout (~100x headroom), so this is not a timeout-flake risk. Issue #8356 (ts-toolbelt perf-vs-tsgo regression) is a Fast-goal benchmark concern, not an absolute-timeout one, and does not block green promotion.

This is a one-line `guard_set` flip: `benchmark_set` was already `required`, so the row stays in `allTrackedRows`, the runtime row-group sync (`tsz_sync_project_row_groups`) re-derives the groups from `project-rows.mjs`, and the shared compile-guard / bench `case` arms need no edits. ts-toolbelt's bench function is not behind `should_run_compile_canary_project`, so there is no canary gate to remove.

## Project Corpus Impact
- Row: ts-toolbelt-project (canary -> required, green)
- Bug family: n/a (graduation of an already-green canary; no compiler change)
- Evidence: tsz `--noEmit -p tsconfig.tsz-guard.json` => 0 diagnostics; `node typescript/lib/tsc.js --noEmit -p` => 0 diagnostics; 0.94s check

## Verification
- `node scripts/bench/validate-project-metadata.mjs` => PASS
- `node scripts/bench/test-project-rows.mjs` (drift) => PASS
- `python3 scripts/arch/test_arch_guard_project.py` => 63 tests OK
- Derived groups: `COMPILE_GUARD_REQUIRED_ROWS` includes `ts-toolbelt-project`; `COMPILE_CANARY_PROJECT_ROWS` excludes it
- Local guard run (canary set, fresh main binary): ts-toolbelt-project state=green, files=242

## Provenance
Machine: Mac.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max
