### PR TITLE
refactor(common): generalize atom_handle! into a define_id! macro for the 17 u32 newtypes

### DIFF
--- a/crates/tsz-binder/src/flow.rs
+++ b/crates/tsz-binder/src/flow.rs
@@ -3,6 +3,7 @@
 //! Provides `FlowNode`, `FlowNodeId`, `FlowNodeArena`, and `flow_flags`.
 
 use serde::{Deserialize, Serialize};
+use tsz_common::define_id;
 use tsz_parser::NodeIndex;
 
 // =============================================================================
@@ -32,22 +33,11 @@ pub mod flow_flags {
     pub const CONDITION: u32 = TRUE_CONDITION | FALSE_CONDITION;
 }
 
-/// Unique identifier for a flow node.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct FlowNodeId(pub u32);
-
-impl FlowNodeId {
-    pub const NONE: Self = Self(u32::MAX);
-
-    #[must_use]
-    pub const fn is_none(&self) -> bool {
-        self.0 == u32::MAX
-    }
-
-    #[must_use]
-    pub const fn is_some(&self) -> bool {
-        self.0 != u32::MAX
-    }
+define_id! {
+    /// Unique identifier for a flow node.
+    pub struct FlowNodeId;
+    derive: Serialize, Deserialize;
+    sentinel: max
 }
 
 /// A node in the control flow graph.

--- a/crates/tsz-binder/src/scopes.rs
+++ b/crates/tsz-binder/src/scopes.rs
@@ -3,6 +3,7 @@
 //! Provides `Scope`, `ScopeId`, and `ContainerKind`.
 
 use serde::{Deserialize, Serialize};
+use tsz_common::define_id;
 use tsz_parser::NodeIndex;
 
 use crate::symbols::SymbolTable;
@@ -11,22 +12,11 @@ use crate::symbols::SymbolTable;
 // Persistent Scope System
 // =============================================================================
 
-/// Unique identifier for a persistent scope.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ScopeId(pub u32);
-
-impl ScopeId {
-    pub const NONE: Self = Self(u32::MAX);
-
-    #[must_use]
-    pub const fn is_none(&self) -> bool {
-        self.0 == u32::MAX
-    }
-
-    #[must_use]
-    pub const fn is_some(&self) -> bool {
-        self.0 != u32::MAX
-    }
+define_id! {
+    /// Unique identifier for a persistent scope.
+    pub struct ScopeId;
+    derive: Serialize, Deserialize;
+    sentinel: max
 }
 
 /// Container kind - tracks what kind of scope we're in

--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -5,6 +5,7 @@
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tsz_common::define_id;
 use tsz_parser::NodeIndex;
 
 // =============================================================================
@@ -219,22 +220,11 @@ impl Default for StableLocation {
 // Symbol
 // =============================================================================
 
-/// Unique identifier for a symbol in the symbol table.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct SymbolId(pub u32);
-
-impl SymbolId {
-    pub const NONE: Self = Self(u32::MAX);
-
-    #[must_use]
-    pub const fn is_none(&self) -> bool {
-        self.0 == u32::MAX
-    }
-
-    #[must_use]
-    pub const fn is_some(&self) -> bool {
-        self.0 != u32::MAX
-    }
+define_id! {
+    /// Unique identifier for a symbol in the symbol table.
+    pub struct SymbolId;
+    derive: PartialOrd, Ord, Serialize, Deserialize;
+    sentinel: max
 }
 
 /// A symbol represents a named entity in the program.

--- a/crates/tsz-common/src/id/mod.rs
+++ b/crates/tsz-common/src/id/mod.rs
@@ -1,0 +1,147 @@
+//! Declarative generator for `u32` identity newtypes.
+//!
+//! tsz threads a family of `u32` "handle" newtypes through every layer:
+//! interned string atoms, solver `TypeId`/shape ids, binder
+//! `SymbolId`/`ScopeId`/`FlowNodeId`, the parser `NodeIndex`, and the core
+//! `SourceId`. They all share the same skeleton — a `pub struct N(pub u32)`
+//! with the `Copy, Clone, Debug, PartialEq, Eq, Hash` derive cluster — and
+//! several share a null/sentinel helper block (`NONE`, `is_none`, …).
+//!
+//! [`define_id!`] is the single source of truth for that skeleton so the
+//! derive surface and the sentinel helpers cannot drift from handle to handle.
+//! Type-specific associated items (`TypeId::ERROR`, `DefId::INVALID`,
+//! `SourceId::new`, …) stay in adjacent inherent `impl` blocks; the macro only
+//! emits the boilerplate shared across handles.
+
+/// Declare a `u32` identity newtype (an interned handle or arena index).
+///
+/// Every handle gets the base derive cluster
+/// `Copy, Clone, Debug, PartialEq, Eq, Hash`. Additional derives — serde,
+/// `Default`, `Ord` — are listed after `derive:`. Attributes written before the
+/// `struct` keyword (doc comments, `#[wasm_bindgen]`, `cfg_attr`, …) are passed
+/// through verbatim, preserving their order relative to the generated
+/// `#[derive(...)]`.
+///
+/// An optional `sentinel:` clause emits the shared null-handle helpers,
+/// parameterized by the family's null convention:
+///
+/// - `sentinel: zero` — `NONE = Self(0)` plus `none()` (a serde-default
+///   helper), `is_none()`, and the `index()` accessor (the interned-string
+///   atom convention).
+/// - `sentinel: max` — `NONE = Self(u32::MAX)` plus `is_none()` / `is_some()`
+///   (the binder/parser arena-index convention).
+/// - `sentinel: max + into_option` — as `max`, plus `into_option()`.
+///
+/// # Examples
+///
+/// ```ignore
+/// define_id!(/// A plain interned shape id.
+///     pub struct ObjectShapeId);
+///
+/// define_id!(/// An arena node index.
+///     pub struct NodeIndex; derive: Default, Serialize, Deserialize;
+///     sentinel: max + into_option);
+/// ```
+#[macro_export]
+macro_rules! define_id {
+    // --- With a sentinel helper block (always carries extra derives) ---
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident
+        ; derive: $($extra:path),+ $(,)?
+        ; sentinel: $($sentinel:tt)+
+    ) => {
+        $crate::define_id!(@emit $(#[$meta])* $vis struct $name : $($extra),+ );
+        $crate::define_id!(@sentinel $name; $($sentinel)+);
+    };
+
+    // --- Without a sentinel helper block; extra derives optional ---
+    (
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident
+        $(; derive: $($extra:path),+ $(,)?)?
+        $(;)?
+    ) => {
+        $crate::define_id!(@emit $(#[$meta])* $vis struct $name $(: $($extra),+)? );
+    };
+
+    // --- Internal: emit the struct with the base + extra derive cluster ---
+    (@emit
+        $(#[$meta:meta])*
+        $vis:vis struct $name:ident $(: $($extra:path),+)?
+    ) => {
+        $(#[$meta])*
+        #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash $($(, $extra)+)?)]
+        $vis struct $name(pub u32);
+    };
+
+    // --- Internal: zero-valued sentinel (interned-string atom convention) ---
+    (@sentinel $name:ident; zero) => {
+        impl $name {
+            #[doc = concat!(
+                "Sentinel value representing no `", stringify!($name),
+                "` / the empty atom."
+            )]
+            pub const NONE: Self = Self(0);
+
+            /// Returns the `NONE` sentinel — used as a serde default.
+            #[must_use]
+            #[inline]
+            pub const fn none() -> Self {
+                Self::NONE
+            }
+
+            /// Whether this handle is the `NONE` sentinel.
+            #[must_use]
+            #[inline]
+            pub const fn is_none(self) -> bool {
+                self.0 == 0
+            }
+
+            /// The raw `u32` index value.
+            #[must_use]
+            #[inline]
+            pub const fn index(self) -> u32 {
+                self.0
+            }
+        }
+    };
+
+    // --- Internal: max-valued sentinel (binder/parser arena-index convention) ---
+    (@sentinel $name:ident; max) => {
+        impl $name {
+            #[doc = concat!("Sentinel value representing no `", stringify!($name), "`.")]
+            pub const NONE: Self = Self(u32::MAX);
+
+            /// Whether this handle is the `NONE` sentinel.
+            #[must_use]
+            #[inline]
+            pub const fn is_none(&self) -> bool {
+                self.0 == u32::MAX
+            }
+
+            /// Whether this handle is a real (non-`NONE`) handle.
+            #[must_use]
+            #[inline]
+            pub const fn is_some(&self) -> bool {
+                self.0 != u32::MAX
+            }
+        }
+    };
+
+    // --- Internal: max-valued sentinel plus `into_option` ---
+    (@sentinel $name:ident; max + into_option) => {
+        $crate::define_id!(@sentinel $name; max);
+        impl $name {
+            #[doc = concat!(
+                "Convert a sentinel-based optional `", stringify!($name),
+                "` into an `Option`."
+            )]
+            #[must_use]
+            #[inline]
+            pub const fn into_option(self) -> Option<$name> {
+                if self.0 == u32::MAX { None } else { Some(self) }
+            }
+        }
+    };
+}

--- a/crates/tsz-common/src/interner/mod.rs
+++ b/crates/tsz-common/src/interner/mod.rs
@@ -12,48 +12,12 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, RwLock};
 
-/// Declare an interned string handle type.
-///
-/// Each handle type names a distinct atom namespace: handles minted by one
-/// interner kind must not be resolved by or compared against another, and
-/// the distinct types make such cross-namespace use a compile error.
-macro_rules! atom_handle {
-    ($(#[$doc:meta])* $name:ident) => {
-        $(#[$doc])*
-        #[derive(
-            Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default, PartialOrd, Ord,
-        )]
-        pub struct $name(pub u32);
-
-        impl $name {
-            /// A sentinel value representing no atom / empty string.
-            pub const NONE: Self = Self(0);
-
-            /// Returns the `NONE` sentinel - used for serde default.
-            #[must_use]
-            #[inline]
-            pub const fn none() -> Self {
-                Self::NONE
-            }
-
-            /// Check if this is the empty/none atom.
-            #[must_use]
-            #[inline]
-            pub const fn is_none(self) -> bool {
-                self.0 == 0
-            }
-
-            /// Get the raw index value.
-            #[must_use]
-            #[inline]
-            pub const fn index(self) -> u32 {
-                self.0
-            }
-        }
-    };
-}
-
-atom_handle! {
+// Interned string handle types. Each handle type names a distinct atom
+// namespace: handles minted by one interner kind must not be resolved by or
+// compared against another, and the distinct types make such cross-namespace
+// use a compile error. Both share the program-wide `u32` handle skeleton
+// emitted by `define_id!` with the zero-valued (empty-string) sentinel.
+crate::define_id! {
     /// An interned string identifier in the program-wide (solver) namespace.
     ///
     /// Atoms are cheap to copy (just a u32) and can be compared with == in O(1).
@@ -65,10 +29,12 @@ atom_handle! {
     /// per-file [`Interner`] instead; the two namespaces use incompatible
     /// encodings, so the same string gets unrelated raw values in each. Bridge
     /// by resolving the string and re-interning, never by copying raw indices.
-    Atom
+    pub struct Atom;
+    derive: Serialize, Deserialize, Default, PartialOrd, Ord;
+    sentinel: zero
 }
 
-atom_handle! {
+crate::define_id! {
     /// An interned string identifier in a per-file AST namespace.
     ///
     /// `AstAtom`s are minted sequentially by the per-file [`Interner`] that the
@@ -77,7 +43,9 @@ atom_handle! {
     /// interner: comparing or resolving them against another file's arena, or
     /// against the program-wide [`Atom`] namespace, is a logic error (and a
     /// compile error thanks to this distinct type).
-    AstAtom
+    pub struct AstAtom;
+    derive: Serialize, Deserialize, Default, PartialOrd, Ord;
+    sentinel: zero
 }
 
 const SHARD_BITS: u32 = 6;

--- a/crates/tsz-common/src/lib.rs
+++ b/crates/tsz-common/src/lib.rs
@@ -9,6 +9,9 @@
 //! - Source map generation
 //! - Comment parsing utilities
 
+// Declarative `u32` identity-newtype generator (shared by all crates).
+pub mod id;
+
 // String interning for identifier deduplication
 pub mod interner;
 pub use interner::{AstAtom, Atom, Interner, ShardedInterner};

--- a/crates/tsz-core/src/source_file/mod.rs
+++ b/crates/tsz-core/src/source_file/mod.rs
@@ -20,6 +20,7 @@
 use crate::lsp::position::{LineMap, Position, Range};
 use crate::span::Span;
 use std::sync::Arc;
+use tsz_common::define_id;
 
 const SOURCE_FILE_LEN_OVERFLOW_MESSAGE: &str =
     "source file text length exceeds u32; large file support requires a larger span type";
@@ -333,12 +334,13 @@ impl<'a> From<&'a SourceFile> for SourceFileRef<'a> {
 // SourceId - Interned source file identifier
 // =============================================================================
 
-/// An interned identifier for a source file.
-///
-/// This is used in multi-file compilation to efficiently reference
-/// source files without cloning strings.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
-pub struct SourceId(pub u32);
+define_id! {
+    /// An interned identifier for a source file.
+    ///
+    /// This is used in multi-file compilation to efficiently reference
+    /// source files without cloning strings.
+    pub struct SourceId; derive: Default
+}
 
 impl SourceId {
     /// The invalid/unknown source ID.

--- a/crates/tsz-parser/src/parser/base.rs
+++ b/crates/tsz-parser/src/parser/base.rs
@@ -4,6 +4,7 @@
 //! available even if the legacy fat AST is disabled.
 
 use serde::{Deserialize, Serialize};
+use tsz_common::define_id;
 use wasm_bindgen::prelude::wasm_bindgen;
 
 /// A text range with start and end positions.
@@ -54,33 +55,12 @@ impl TextRange {
     }
 }
 
-/// Index into an arena. Used instead of pointers/references for serialization-friendly graphs.
-#[wasm_bindgen]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize, Hash)]
-pub struct NodeIndex(pub u32);
-
-impl NodeIndex {
-    pub const NONE: Self = Self(u32::MAX);
-
-    #[inline]
-    #[must_use]
-    pub const fn is_none(&self) -> bool {
-        self.0 == u32::MAX
-    }
-
-    #[inline]
-    #[must_use]
-    pub const fn is_some(&self) -> bool {
-        self.0 != u32::MAX
-    }
-
-    /// Convert a sentinel-based optional `NodeIndex` into `Option<NodeIndex>`.
-    /// Returns `None` if `self` is `NONE`, otherwise `Some(self)`.
-    #[inline]
-    #[must_use]
-    pub const fn into_option(self) -> Option<NodeIndex> {
-        if self.0 == u32::MAX { None } else { Some(self) }
-    }
+define_id! {
+    /// Index into an arena. Used instead of pointers/references for serialization-friendly graphs.
+    #[wasm_bindgen]
+    pub struct NodeIndex;
+    derive: Default, Serialize, Deserialize;
+    sentinel: max + into_option
 }
 
 /// A list of node indices, representing children or a node array.

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -30,6 +30,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use tracing::trace;
+use tsz_common::define_id;
 use tsz_common::interner::Atom;
 
 /// Global counter for assigning unique instance IDs to `DefinitionStore` instances.
@@ -46,6 +47,7 @@ type SymbolMappingsSnapshot = Arc<[(u32, DefId)]>;
 // DefId - Solver-Owned Definition Identifier
 // =============================================================================
 
+define_id! {
 /// Solver-owned definition identifier.
 ///
 /// Unlike `SymbolRef` which references Binder symbols, `DefId` is owned by
@@ -59,8 +61,7 @@ type SymbolMappingsSnapshot = Arc<[(u32, DefId)]>;
 /// | Stable across edits | No | Yes (with content-hash) |
 /// | Requires Binder | Yes | No |
 /// | Supports testing | Limited | Full |
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct DefId(pub u32);
+pub struct DefId; }
 
 impl DefId {
     /// Sentinel value for invalid `DefId`.

--- a/crates/tsz-solver/src/types.rs
+++ b/crates/tsz-solver/src/types.rs
@@ -6,6 +6,7 @@
 use crate::def::DefId;
 use serde::Serialize;
 use tsz_binder::SymbolId;
+use tsz_common::define_id;
 use tsz_common::interner::Atom;
 
 /// Hand-maintained `PartialEq`/`Eq`/`Hash` impls for the interned shape types
@@ -13,6 +14,7 @@ use tsz_common::interner::Atom;
 /// per-field identity decisions made explicit via exhaustive destructuring.
 mod shape_identity;
 
+define_id! {
 /// A lightweight handle to an interned type.
 /// Equality check is O(1) - just compare the u32 values.
 ///
@@ -82,8 +84,8 @@ mod shape_identity;
 /// | Empty array literal `[]`          | `any[]`       |
 /// | Function never returns            | `NEVER`       |
 /// | Exhaustive narrowing remainder    | `NEVER`       |
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Default)]
-pub struct TypeId(pub u32);
+pub struct TypeId; derive: Serialize, Default
+}
 
 impl TypeId {
     /// Internal placeholder - no valid type.
@@ -662,41 +664,32 @@ impl InferencePriority {
     pub const LOWEST: Self = Self::LowPriority;
 }
 
-/// Interned list of `TypeId` values (e.g., unions/intersections).
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct TypeListId(pub u32);
+define_id!(/// Interned list of `TypeId` values (e.g., unions/intersections).
+    pub struct TypeListId);
 
-/// Interned object shape (properties + index signatures).
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ObjectShapeId(pub u32);
+define_id!(/// Interned object shape (properties + index signatures).
+    pub struct ObjectShapeId);
 
-/// Interned tuple element list.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct TupleListId(pub u32);
+define_id!(/// Interned tuple element list.
+    pub struct TupleListId);
 
-/// Interned function shape.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct FunctionShapeId(pub u32);
+define_id!(/// Interned function shape.
+    pub struct FunctionShapeId);
 
-/// Interned callable shape.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct CallableShapeId(pub u32);
+define_id!(/// Interned callable shape.
+    pub struct CallableShapeId);
 
-/// Interned type application (Base<Args>).
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct TypeApplicationId(pub u32);
+define_id!(/// Interned type application (Base<Args>).
+    pub struct TypeApplicationId);
 
-/// Interned template literal span list.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct TemplateLiteralId(pub u32);
+define_id!(/// Interned template literal span list.
+    pub struct TemplateLiteralId);
 
-/// Interned conditional type.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct ConditionalTypeId(pub u32);
+define_id!(/// Interned conditional type.
+    pub struct ConditionalTypeId);
 
-/// Interned mapped type.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct MappedTypeId(pub u32);
+define_id!(/// Interned mapped type.
+    pub struct MappedTypeId);
 /// The structural "shape" of a type.
 /// This is the key used for interning - structurally identical types
 /// will have the same `TypeData` and therefore the same `TypeId`.
@@ -1611,9 +1604,8 @@ impl TypeParamInfo {
     }
 }
 
-/// Reference to a symbol (for named types)
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct SymbolRef(pub u32);
+define_id!(/// Reference to a symbol (for named types)
+    pub struct SymbolRef);
 
 /// Conditional type structure
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Goal: hold

Closes #13414.

Behavior-preserving DRY/hygiene sweep over the `u32` identity-newtype boilerplate. No type-algorithm, diagnostic, inference, or emit change, so this defends the conformance/emit parity floor.

## Structural rule

When a crate declares a `u32` identity handle (an interned atom, a solver `TypeId`/shape id, a binder `SymbolId`/`ScopeId`/`FlowNodeId`, the parser `NodeIndex`, the core `SourceId`), idiomatic Rust generates the derive cluster and the shared null/sentinel helpers once via a declarative macro. tsz hand-wrote the `struct` + derive cluster at **17 sites** and copy-pasted near-identical `NONE`/`is_none`/`is_some`/`into_option` sentinel blocks across **four** of them, and the derive surfaces had drifted incoherently (derive ordering alternated, serde/`Default`/`Ord` present at some sites and not others). `tsz-common` already shipped an `atom_handle!` macro doing exactly this for the `Atom`/`AstAtom` namespaces, so this **generalizes the existing macro** rather than adding a new one. Owner layer: `tsz-common` is the single source of truth; every affected crate already depends on it, so consolidation adds no coupling.

## What changed

New `crates/tsz-common/src/id/mod.rs` exports `define_id!`:

- base derive cluster `Copy, Clone, Debug, PartialEq, Eq, Hash` for every handle;
- opt-in extra derives after `derive:` (serde, `Default`, `Ord`);
- attributes before the `struct` keyword (doc comments, `#[wasm_bindgen]`, `cfg_attr`) passed through verbatim, preserving order relative to the generated `#[derive(...)]`;
- an opt-in `sentinel:` clause parameterized by the family's null convention:
  - `zero` — `NONE = Self(0)` + `none()` (serde default) + `is_none()` + `index()` (the interned-atom convention),
  - `max` — `NONE = Self(u32::MAX)` + `is_none()`/`is_some()` (the binder/parser arena-index convention),
  - `max + into_option` — as `max`, plus `into_option()`.

Migrated all 17 newtypes + the 4 sentinel blocks, and removed the old `atom_handle!`:

- `Atom`, `AstAtom` — `zero` sentinel.
- `TypeId`, the nine solver shape ids (`TypeListId`, `ObjectShapeId`, `TupleListId`, `FunctionShapeId`, `CallableShapeId`, `TypeApplicationId`, `TemplateLiteralId`, `ConditionalTypeId`, `MappedTypeId`), `SymbolRef`, `DefId` — struct + derives only; type-specific consts (`TypeId::ERROR`/`NONE`/…, `DefId::INVALID`/`is_valid`) stay in adjacent inherent `impl` blocks.
- `SymbolId`, `ScopeId`, `FlowNodeId` — `max` sentinel.
- `NodeIndex` — `max + into_option`, `#[wasm_bindgen]` preserved.
- `SourceId` — struct + derive via the macro; its bespoke `UNKNOWN`/`is_unknown`/`new`/`From` (a distinct value-space null convention) stays inherent.

Removes **~84 lines** of hand-written per-site boilerplate, replaced by the single ~147-line `define_id!` source of truth (placed under `id/` per the crate-root-file policy).

## Behavior preservation

Each invocation reproduces its existing derive surface and method signatures exactly (including deliberate pre-existing divergences such as `TypeId` deriving `Serialize` but not `Deserialize`, and the `is_none(self)` vs `is_none(&self)` receiver split between the zero/max families). No serde, `Default`, or `Ord` was silently added or removed; that remains a separate reviewable decision. The only incidental change is that `FlowNodeId`/`ScopeId`/`SymbolId` sentinel checks are now `#[inline]` like every other handle.

## Anti-hardcoding

No user-name/file-name/printer-string predicates introduced; the macro keys only on the structural handle skeleton. No single-test suppressions.

## Verification

- `cargo build --workspace` — clean, no errors/warnings.
- `cargo clippy -p tsz-common -p tsz-solver -p tsz-binder -p tsz-core -p tsz-parser --lib` — clean.
- `scripts/check-crate-root-files.sh` — passes (macro lives under `id/mod.rs`, not a root file).
- `cargo test -p tsz-common --lib` (537 pass), `-p tsz-binder --lib` (412 pass, incl. `symbol_size_is_pinned` — layout unchanged), `-p tsz-parser --lib` (1425 pass), `-p tsz-solver --lib` (6682 pass). The 4 failures observed locally (`tsz-common` `perf_counters::json_tests::wired_keys_match_snapshot_struct_fields`; `tsz-solver` `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`, `test_generic_call_widening_applies_when_constraint_satisfied`, `test_solver_oversized_file_size_ceilings`) reproduce identically on clean `origin/main` with this change stashed — pre-existing, untouched by this refactor.
- Branch rebased on `origin/main` (clean, no conflicts) and rebuilt green.
- Broad conformance/emit/fourslash parity owned by ready-review CI (conformance/emit/fourslash/unit/wasm all green on the prior PR-head run; only the crate-root lint needed the `id/` move).

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high