### PR TITLE
refactor(emitter): collapse duplicated ES5-transformer scaffolding (#13431)

### DIFF
--- a/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
+++ b/crates/tsz-emitter/src/emitter/module_emission/core/mod.rs
@@ -572,15 +572,10 @@ impl<'a> Printer<'a> {
                                     && let Some(prop) = self.arena.get_property_decl(member_node)
                                     && prop.initializer.is_some()
                                     && self.arena.is_static(&prop.modifiers)
-                                    && !self
-                                        .arena
-                                        .has_modifier(&prop.modifiers, SyntaxKind::AccessorKeyword)
-                                    && !self
-                                        .arena
-                                        .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
-                                    && !self
-                                        .arena
-                                        .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
+                                    && !crate::transforms::emit_utils::is_runtime_omitted_member(
+                                        self.arena,
+                                        &prop.modifiers,
+                                    )
                                 {
                                     true
                                 } else {

--- a/crates/tsz-emitter/src/transforms/async_es5.rs
+++ b/crates/tsz-emitter/src/transforms/async_es5.rs
@@ -68,6 +68,7 @@
 use crate::transforms::async_es5_ir::AsyncES5Transformer;
 use crate::transforms::ir::IRNode;
 use crate::transforms::ir_printer::IRPrinter;
+use crate::transforms::tslib_helper_naming::TslibHelperNaming;
 use tsz_common::common::ModuleKind;
 use tsz_common::source_map::Mapping;
 use tsz_parser::parser::NodeIndex;
@@ -95,11 +96,8 @@ pub struct AsyncES5Emitter<'a> {
     /// already-allocated hoisted vars for the purpose of `generator_state_name_for_hoisted`,
     /// so the state-name picker skips past them.
     outer_reserved_for_generator_state: Vec<String>,
-    /// When true, prefix runtime helper calls with `tslib_1.` (for CJS importHelpers).
-    tslib_prefix: bool,
-    tslib_import_binding: String,
-    /// Per-file helper import renames (e.g. `__awaiter` -> `__awaiter_1`).
-    helper_import_aliases: rustc_hash::FxHashMap<String, String>,
+    /// Naming of runtime helpers under `importHelpers` (CommonJS prefix / ESM alias).
+    tslib_helpers: TslibHelperNaming,
     system_import_meta: bool,
     generator_this_arg: String,
 }
@@ -116,9 +114,7 @@ impl<'a> AsyncES5Emitter<'a> {
             this_capture_depth: 0,
             class_name: None,
             outer_reserved_for_generator_state: Vec::new(),
-            tslib_prefix: false,
-            tslib_import_binding: "tslib_1".to_string(),
-            helper_import_aliases: rustc_hash::FxHashMap::default(),
+            tslib_helpers: TslibHelperNaming::default(),
             system_import_meta: false,
             generator_this_arg: "this".to_string(),
         }
@@ -129,16 +125,16 @@ impl<'a> AsyncES5Emitter<'a> {
     }
 
     pub const fn set_tslib_prefix(&mut self, enable: bool) {
-        self.tslib_prefix = enable;
+        self.tslib_helpers.set_prefix(enable);
     }
 
     pub fn set_tslib_import_binding(&mut self, binding: String) {
-        self.tslib_import_binding = binding;
+        self.tslib_helpers.set_binding(binding);
     }
 
     /// Set per-file helper import renames (e.g. `__awaiter` -> `__awaiter_1`).
     pub fn set_helper_import_aliases(&mut self, aliases: rustc_hash::FxHashMap<String, String>) {
-        self.helper_import_aliases = aliases;
+        self.tslib_helpers.set_aliases(aliases);
     }
 
     pub const fn set_system_import_meta(&mut self, enabled: bool) {
@@ -248,8 +244,8 @@ impl<'a> AsyncES5Emitter<'a> {
             printer.set_source_text(text);
         }
         printer.set_indent_level(self.indent_level);
-        printer.set_tslib_prefix(self.tslib_prefix);
-        printer.set_tslib_import_binding(self.tslib_import_binding.clone());
+        printer.set_tslib_prefix(self.tslib_helpers.prefix());
+        printer.set_tslib_import_binding(self.tslib_helpers.binding().to_string());
         printer.set_system_import_meta(self.system_import_meta);
         printer.set_generator_this_arg(self.generator_this_arg.clone());
         printer.emit(&ir);
@@ -266,8 +262,8 @@ impl<'a> AsyncES5Emitter<'a> {
             printer.set_source_text(text);
         }
         printer.set_indent_level(self.indent_level);
-        printer.set_tslib_prefix(self.tslib_prefix);
-        printer.set_tslib_import_binding(self.tslib_import_binding.clone());
+        printer.set_tslib_prefix(self.tslib_helpers.prefix());
+        printer.set_tslib_import_binding(self.tslib_helpers.binding().to_string());
         printer.set_system_import_meta(self.system_import_meta);
         printer.set_generator_this_arg(self.generator_this_arg.clone());
         printer.emit(&ir);
@@ -337,8 +333,8 @@ impl<'a> AsyncES5Emitter<'a> {
             printer.set_source_text(text);
         }
         printer.set_indent_level(self.indent_level);
-        printer.set_tslib_prefix(self.tslib_prefix);
-        printer.set_tslib_import_binding(self.tslib_import_binding.clone());
+        printer.set_tslib_prefix(self.tslib_helpers.prefix());
+        printer.set_tslib_import_binding(self.tslib_helpers.binding().to_string());
         printer.set_system_import_meta(self.system_import_meta);
         printer.set_generator_this_arg(self.generator_this_arg.clone());
         let hoisted_names: Vec<&str> = hoisted
@@ -405,9 +401,9 @@ impl<'a> AsyncES5Emitter<'a> {
             printer.set_source_text(text);
         }
         printer.set_indent_level(self.indent_level);
-        printer.set_tslib_prefix(self.tslib_prefix);
-        printer.set_tslib_import_binding(self.tslib_import_binding.clone());
-        printer.set_helper_import_aliases(self.helper_import_aliases.clone());
+        printer.set_tslib_prefix(self.tslib_helpers.prefix());
+        printer.set_tslib_import_binding(self.tslib_helpers.binding().to_string());
+        printer.set_helper_import_aliases(self.tslib_helpers.aliases().clone());
         printer.set_system_import_meta(self.system_import_meta);
         printer.set_generator_this_arg(self.generator_this_arg.clone());
         printer.set_outer_reserved_for_generator_state(
@@ -462,8 +458,8 @@ impl<'a> AsyncES5Emitter<'a> {
             printer.set_source_text(text);
         }
         printer.set_indent_level(self.indent_level);
-        printer.set_tslib_prefix(self.tslib_prefix);
-        printer.set_tslib_import_binding(self.tslib_import_binding.clone());
+        printer.set_tslib_prefix(self.tslib_helpers.prefix());
+        printer.set_tslib_import_binding(self.tslib_helpers.binding().to_string());
         printer.set_system_import_meta(self.system_import_meta);
         printer.emit(&ir);
         printer.take_output()

--- a/crates/tsz-emitter/src/transforms/class_es5.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5.rs
@@ -35,6 +35,7 @@ use crate::context::transform::TransformContext;
 use crate::transforms::class_es5_ir::ES5ClassTransformer;
 use crate::transforms::ir::IRNode;
 use crate::transforms::ir_printer::IRPrinter;
+use crate::transforms::tslib_helper_naming::TslibHelperNaming;
 use tsz_common::common::ModuleKind;
 use tsz_common::source_map::Mapping;
 use tsz_parser::parser::NodeIndex;
@@ -80,9 +81,8 @@ pub struct ClassES5Emitter<'a> {
     leading_comment: Option<String>,
     /// When true, suppress `/** @class */` annotation and leading comments.
     remove_comments: bool,
-    /// When true, prefix runtime helper calls with `tslib_1.` (for CJS importHelpers).
-    tslib_prefix: bool,
-    tslib_import_binding: String,
+    /// Naming of runtime helpers under `importHelpers` (CommonJS prefix / ESM alias).
+    tslib_helpers: TslibHelperNaming,
     commonjs_import_substitutions: rustc_hash::FxHashMap<String, String>,
     printer_options: Option<crate::emitter::PrinterOptions>,
     externally_hoisted_decls: rustc_hash::FxHashSet<String>,
@@ -110,8 +110,7 @@ impl<'a> ClassES5Emitter<'a> {
             tc39_decorators: false,
             leading_comment: None,
             remove_comments: false,
-            tslib_prefix: false,
-            tslib_import_binding: "tslib_1".to_string(),
+            tslib_helpers: TslibHelperNaming::default(),
             commonjs_import_substitutions: rustc_hash::FxHashMap::default(),
             printer_options: None,
             externally_hoisted_decls: rustc_hash::FxHashSet::default(),
@@ -124,13 +123,13 @@ impl<'a> ClassES5Emitter<'a> {
     }
 
     pub const fn set_tslib_prefix(&mut self, enable: bool) {
-        self.tslib_prefix = enable;
+        self.tslib_helpers.set_prefix(enable);
         self.transformer.set_tslib_prefix(enable);
     }
 
     pub fn set_tslib_import_binding(&mut self, binding: String) {
         self.transformer.set_tslib_import_binding(binding.clone());
-        self.tslib_import_binding = binding;
+        self.tslib_helpers.set_binding(binding);
     }
 
     pub fn set_block_scope_shadowed_names(&mut self, names: Vec<String>) {
@@ -537,8 +536,8 @@ impl<'a> ClassES5Emitter<'a> {
         let mut printer = IRPrinter::with_arena(self.arena);
         printer.set_indent_level(self.indent_level);
         printer.set_remove_comments(self.remove_comments);
-        printer.set_tslib_prefix(self.tslib_prefix);
-        printer.set_tslib_import_binding(self.tslib_import_binding.clone());
+        printer.set_tslib_prefix(self.tslib_helpers.prefix());
+        printer.set_tslib_import_binding(self.tslib_helpers.binding().to_string());
         printer.set_target_es5(true);
         if let Some(source_text) = self.source_text {
             printer.set_source_text(source_text);

--- a/crates/tsz-emitter/src/transforms/class_es5_ir.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir.rs
@@ -99,6 +99,7 @@ use crate::transforms::private_fields_es5::{
     collect_private_fields_with_reserved, collect_private_methods_with_reserved,
     make_unique_private_name, private_helper_base,
 };
+use crate::transforms::tslib_helper_naming::TslibHelperNaming;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cell::{Cell, RefCell};
 use tsz_common::common::ModuleKind;
@@ -194,10 +195,8 @@ pub struct ES5ClassTransformer<'a> {
     /// Whether static field initializer assignments are emitted by the surrounding expression emitter.
     skip_static_field_initializers: bool,
     use_define_for_class_fields: bool,
-    /// When true, prefix helper names like `__decorate` with the tslib import binding.
-    tslib_prefix: bool,
-    /// The tslib import binding name (e.g. `tslib_1`) used when `tslib_prefix` is true.
-    tslib_import_binding: String,
+    /// Naming of runtime helpers under `importHelpers` (CommonJS prefix / ESM alias).
+    tslib_helpers: TslibHelperNaming,
     commonjs_import_substitutions: FxHashMap<String, String>,
     module_kind: ModuleKind,
     target_es5: bool,
@@ -261,8 +260,7 @@ impl<'a> ES5ClassTransformer<'a> {
             extends_this_captured: false,
             skip_static_field_initializers: false,
             use_define_for_class_fields: false,
-            tslib_prefix: false,
-            tslib_import_binding: "tslib_1".to_string(),
+            tslib_helpers: TslibHelperNaming::default(),
             commonjs_import_substitutions: FxHashMap::default(),
             module_kind: ModuleKind::None,
             target_es5: false,
@@ -327,11 +325,11 @@ impl<'a> ES5ClassTransformer<'a> {
     }
 
     pub const fn set_tslib_prefix(&mut self, enable: bool) {
-        self.tslib_prefix = enable;
+        self.tslib_helpers.set_prefix(enable);
     }
 
     pub fn set_tslib_import_binding(&mut self, binding: String) {
-        self.tslib_import_binding = binding;
+        self.tslib_helpers.set_binding(binding);
     }
 
     pub const fn set_module_kind(&mut self, module_kind: ModuleKind) {

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_decorators.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_decorators.rs
@@ -196,11 +196,7 @@ impl<'a> ES5ClassTransformer<'a> {
     }
 
     fn helper_name(&self, name: &str) -> String {
-        if self.tslib_prefix {
-            format!("{}.{name}", self.tslib_import_binding)
-        } else {
-            name.to_string()
-        }
+        self.tslib_helpers.helper_name(name)
     }
 
     /// Render a single decorator expression as a string using the IR printer.

--- a/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
+++ b/crates/tsz-emitter/src/transforms/class_es5_ir_members.rs
@@ -706,16 +706,11 @@ impl<'a> ES5ClassTransformer<'a> {
                     return self
                         .arena
                         .has_modifier(&prop_data.modifiers, SyntaxKind::StaticKeyword)
-                        && !self
-                            .arena
-                            .has_modifier(&prop_data.modifiers, SyntaxKind::AbstractKeyword)
-                        && !self
-                            .arena
-                            .has_modifier(&prop_data.modifiers, SyntaxKind::DeclareKeyword)
+                        && !crate::transforms::emit_utils::is_runtime_omitted_member(
+                            self.arena,
+                            &prop_data.modifiers,
+                        )
                         && !is_private_identifier(self.arena, prop_data.name)
-                        && !self
-                            .arena
-                            .has_modifier(&prop_data.modifiers, SyntaxKind::AccessorKeyword)
                         && self.property_initializer_has_equals(m_node, prop_data);
                 }
             } else if (m_node.kind == syntax_kind_ext::GET_ACCESSOR
@@ -1267,7 +1262,11 @@ impl<'a> ES5ClassTransformer<'a> {
                         });
                         continue;
                     }
-                    if is_abstract || is_declare || is_private_field || is_accessor_keyword {
+                    if crate::transforms::emit_utils::is_runtime_omitted_member(
+                        self.arena,
+                        &prop_data.modifiers,
+                    ) || is_private_field
+                    {
                         continue;
                     }
                     if !self.property_initializer_has_equals(member_node, prop_data) {

--- a/crates/tsz-emitter/src/transforms/emit_utils.rs
+++ b/crates/tsz-emitter/src/transforms/emit_utils.rs
@@ -3,6 +3,23 @@ use tsz_parser::parser::syntax_kind_ext;
 use tsz_parser::parser::{NodeIndex, node_flags};
 use tsz_scanner::{SyntaxKind, is_ecmascript_identifier_part, is_ecmascript_identifier_start};
 
+/// True when a class member is omitted from runtime materialization purely by
+/// its modifiers. `abstract` and `declare` members have no runtime presence at
+/// all, and `accessor` (auto-accessor) members are lowered to getter/setter
+/// pairs rather than emitted as plain runtime fields. Static-ness, private
+/// identifiers, and initializer presence are orthogonal and remain the
+/// responsibility of each call site. This is the single definition of "omitted
+/// at runtime by modifier" shared by the field-collect and emit passes so they
+/// cannot drift.
+pub(crate) fn is_runtime_omitted_member(
+    arena: &NodeArena,
+    modifiers: &Option<tsz_parser::parser::NodeList>,
+) -> bool {
+    arena.has_modifier(modifiers, SyntaxKind::AbstractKeyword)
+        || arena.has_modifier(modifiers, SyntaxKind::DeclareKeyword)
+        || arena.has_modifier(modifiers, SyntaxKind::AccessorKeyword)
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ForOfUsingInfo {
     pub binding_name: String,

--- a/crates/tsz-emitter/src/transforms/es_decorators.rs
+++ b/crates/tsz-emitter/src/transforms/es_decorators.rs
@@ -28,6 +28,7 @@ mod node_utils;
 mod private_members;
 
 use crate::transforms::emit_utils::hygienic_temp_name;
+use crate::transforms::tslib_helper_naming::TslibHelperNaming;
 
 struct ClassDecoratorVars<'a> {
     class_descriptor: &'a str,
@@ -166,9 +167,8 @@ pub struct TC39DecoratorEmitter<'a> {
     indent: usize,
     /// When true, uses `static { }` blocks (ES2022+) instead of IIFE pattern (ES2015).
     use_static_blocks: bool,
-    /// When true, prefix helper calls with `tslib_1.` (importHelpers + commonjs).
-    tslib_prefix: bool,
-    tslib_import_binding: String,
+    /// Naming of runtime helpers under `importHelpers` (CommonJS prefix / ESM alias).
+    tslib_helpers: TslibHelperNaming,
     /// When true, emit as an expression (no `let C = ` wrapper) for class expressions.
     expression_mode: bool,
     /// Function name for class expression named evaluation (__setFunctionName).
@@ -219,8 +219,7 @@ impl<'a> TC39DecoratorEmitter<'a> {
             source_text: None,
             indent: 0,
             use_static_blocks: false,
-            tslib_prefix: false,
-            tslib_import_binding: "tslib_1".to_string(),
+            tslib_helpers: TslibHelperNaming::default(),
             expression_mode: false,
             function_name: None,
             function_name_is_expression: false,
@@ -250,11 +249,11 @@ impl<'a> TC39DecoratorEmitter<'a> {
     }
 
     pub const fn set_tslib_prefix(&mut self, prefix: bool) {
-        self.tslib_prefix = prefix;
+        self.tslib_helpers.set_prefix(prefix);
     }
 
     pub fn set_tslib_import_binding(&mut self, binding: String) {
-        self.tslib_import_binding = binding;
+        self.tslib_helpers.set_binding(binding);
     }
 
     pub const fn set_expression_mode(&mut self, expr: bool) {
@@ -319,11 +318,7 @@ impl<'a> TC39DecoratorEmitter<'a> {
 
     /// Returns the helper function name with optional tslib prefix.
     fn helper(&self, name: &str) -> String {
-        if self.tslib_prefix {
-            format!("{}.{name}", self.tslib_import_binding)
-        } else {
-            name.to_string()
-        }
+        self.tslib_helpers.helper_name(name)
     }
 
     fn function_name_arg(&self, fallback: &str) -> String {

--- a/crates/tsz-emitter/src/transforms/es_decorators_collect_fields.rs
+++ b/crates/tsz-emitter/src/transforms/es_decorators_collect_fields.rs
@@ -11,7 +11,7 @@ use super::{
     EsDecorateVars, PlainComputedInstanceFieldInfo,
 };
 #[allow(unused_imports)]
-use crate::transforms::emit_utils::hygienic_temp_name;
+use crate::transforms::emit_utils::{hygienic_temp_name, is_runtime_omitted_member};
 #[allow(unused_imports)]
 use rustc_hash::FxHashMap;
 #[allow(unused_imports)]
@@ -84,15 +84,7 @@ impl<'a> TC39DecoratorEmitter<'a> {
                 continue;
             };
             if self.arena.is_static(&prop.modifiers)
-                || self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::AccessorKeyword)
-                || self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
-                || self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
+                || is_runtime_omitted_member(self.arena, &prop.modifiers)
             {
                 continue;
             }
@@ -342,15 +334,7 @@ impl<'a> TC39DecoratorEmitter<'a> {
             let Some(prop) = self.arena.get_property_decl(member_node) else {
                 continue;
             };
-            if self
-                .arena
-                .has_modifier(&prop.modifiers, SyntaxKind::AccessorKeyword)
-                || self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
-                || self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
+            if is_runtime_omitted_member(self.arena, &prop.modifiers)
                 || !self.arena.is_static(&prop.modifiers)
             {
                 continue;
@@ -404,15 +388,7 @@ impl<'a> TC39DecoratorEmitter<'a> {
                 continue;
             };
             if self.arena.is_static(&prop.modifiers)
-                || self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::AccessorKeyword)
-                || self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
-                || self
-                    .arena
-                    .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
+                || is_runtime_omitted_member(self.arena, &prop.modifiers)
             {
                 continue;
             }

--- a/crates/tsz-emitter/src/transforms/es_decorators_node_utils.rs
+++ b/crates/tsz-emitter/src/transforms/es_decorators_node_utils.rs
@@ -11,7 +11,7 @@ use super::{
     EsDecorateVars, PlainComputedInstanceFieldInfo,
 };
 #[allow(unused_imports)]
-use crate::transforms::emit_utils::hygienic_temp_name;
+use crate::transforms::emit_utils::{hygienic_temp_name, is_runtime_omitted_member};
 #[allow(unused_imports)]
 use rustc_hash::FxHashMap;
 #[allow(unused_imports)]
@@ -54,15 +54,7 @@ impl<'a> TC39DecoratorEmitter<'a> {
         }
         let prop = self.arena.get_property_decl(member_node)?;
         if !self.arena.is_static(&prop.modifiers)
-            || self
-                .arena
-                .has_modifier(&prop.modifiers, SyntaxKind::AbstractKeyword)
-            || self
-                .arena
-                .has_modifier(&prop.modifiers, SyntaxKind::DeclareKeyword)
-            || self
-                .arena
-                .has_modifier(&prop.modifiers, SyntaxKind::AccessorKeyword)
+            || is_runtime_omitted_member(self.arena, &prop.modifiers)
         {
             return None;
         }

--- a/crates/tsz-emitter/src/transforms/ir_printer.rs
+++ b/crates/tsz-emitter/src/transforms/ir_printer.rs
@@ -44,6 +44,7 @@ use crate::transforms::ir::{
     EnumMember, EnumMemberValue, IRMethodName, IRNode, IRParam, IRProperty, IRPropertyKey,
     IRPropertyKind, IRSwitchCase,
 };
+use crate::transforms::tslib_helper_naming::TslibHelperNaming;
 use tsz_parser::parser::base::NodeIndex;
 use tsz_parser::parser::node::NodeArena;
 
@@ -78,12 +79,8 @@ pub struct IRPrinter<'a> {
     target_es5: bool,
     /// When true, comments like `/** @class */` are suppressed in output.
     remove_comments: bool,
-    /// CommonJS `tslib` binding used to prefix runtime helper calls for importHelpers.
-    tslib_prefix: bool,
-    tslib_import_binding: String,
-    /// Per-file helper import renames (e.g. `__awaiter` -> `__awaiter_1`)
-    /// applied when ESM importHelpers renamed a helper at the import site.
-    helper_import_aliases: rustc_hash::FxHashMap<String, String>,
+    /// Naming of runtime helpers under `importHelpers` (CommonJS prefix / ESM alias).
+    tslib_helpers: TslibHelperNaming,
     commonjs_import_substitutions: rustc_hash::FxHashMap<String, String>,
     system_import_meta: bool,
     pub(crate) base_printer_options: Option<PrinterOptions>,
@@ -263,9 +260,7 @@ impl<'a> IRPrinter<'a> {
             in_namespace_iife_body: false,
             target_es5: false,
             remove_comments: false,
-            tslib_prefix: false,
-            tslib_import_binding: "tslib_1".to_string(),
-            helper_import_aliases: rustc_hash::FxHashMap::default(),
+            tslib_helpers: TslibHelperNaming::default(),
             commonjs_import_substitutions: rustc_hash::FxHashMap::default(),
             system_import_meta: false,
             base_printer_options: None,
@@ -297,9 +292,7 @@ impl<'a> IRPrinter<'a> {
             in_namespace_iife_body: false,
             target_es5: false,
             remove_comments: false,
-            tslib_prefix: false,
-            tslib_import_binding: "tslib_1".to_string(),
-            helper_import_aliases: rustc_hash::FxHashMap::default(),
+            tslib_helpers: TslibHelperNaming::default(),
             commonjs_import_substitutions: rustc_hash::FxHashMap::default(),
             system_import_meta: false,
             base_printer_options: None,
@@ -331,9 +324,7 @@ impl<'a> IRPrinter<'a> {
             in_namespace_iife_body: false,
             target_es5: false,
             remove_comments: false,
-            tslib_prefix: false,
-            tslib_import_binding: "tslib_1".to_string(),
-            helper_import_aliases: rustc_hash::FxHashMap::default(),
+            tslib_helpers: TslibHelperNaming::default(),
             commonjs_import_substitutions: rustc_hash::FxHashMap::default(),
             system_import_meta: false,
             base_printer_options: None,
@@ -372,17 +363,17 @@ impl<'a> IRPrinter<'a> {
 
     /// Enable `tslib_1.` prefix for runtime helper calls (importHelpers + CJS).
     pub const fn set_tslib_prefix(&mut self, enable: bool) {
-        self.tslib_prefix = enable;
+        self.tslib_helpers.set_prefix(enable);
     }
 
     pub fn set_tslib_import_binding(&mut self, binding: String) {
-        self.tslib_import_binding = binding;
+        self.tslib_helpers.set_binding(binding);
     }
 
     /// Set per-file helper import renames (e.g. `__awaiter` -> `__awaiter_1`)
     /// so helper references printed from IR match the import-site aliases.
     pub fn set_helper_import_aliases(&mut self, aliases: rustc_hash::FxHashMap<String, String>) {
-        self.helper_import_aliases = aliases;
+        self.tslib_helpers.set_aliases(aliases);
     }
 
     pub fn set_commonjs_import_substitutions(
@@ -460,18 +451,7 @@ impl<'a> IRPrinter<'a> {
     /// active, or substituting the import-site alias (e.g. `__awaiter_1`) when ESM
     /// importHelpers renamed the helper. Mirrors `Printer::write_helper`.
     fn write_helper(&mut self, name: &str) {
-        if self.tslib_prefix {
-            self.output.push_str(&self.tslib_import_binding);
-            self.output.push('.');
-            self.output.push_str(name);
-            return;
-        }
-        if let Some(alias) = self.helper_import_aliases.get(name) {
-            let alias_owned = alias.clone();
-            self.output.push_str(&alias_owned);
-            return;
-        }
-        self.output.push_str(name);
+        self.tslib_helpers.write_into(&mut self.output, name);
     }
 
     /// Set the source text for `ASTRef` emission
@@ -1695,8 +1675,8 @@ impl<'a> IRPrinter<'a> {
                     let mut es5_emitter = ClassES5Emitter::new(arena);
                     es5_emitter.set_indent_level(0);
                     es5_emitter.set_remove_comments(self.remove_comments);
-                    es5_emitter.set_tslib_prefix(self.tslib_prefix);
-                    es5_emitter.set_tslib_import_binding(self.tslib_import_binding.clone());
+                    es5_emitter.set_tslib_prefix(self.tslib_helpers.prefix());
+                    es5_emitter.set_tslib_import_binding(self.tslib_helpers.binding().to_string());
                     es5_emitter.set_inherited_computed_name_super(super_name.to_string());
                     es5_emitter.set_printer_options(self.make_ast_printer_options());
                     if let Some(source_text) = self.source_text {

--- a/crates/tsz-emitter/src/transforms/mod.rs
+++ b/crates/tsz-emitter/src/transforms/mod.rs
@@ -70,6 +70,7 @@ pub mod namespace_es5_ir;
 pub mod namespace_iife_binding_scan;
 pub mod private_fields_es5;
 pub mod spread_es5;
+pub(crate) mod tslib_helper_naming;
 
 // Re-export concrete emitter types for use by the emitter module
 // This breaks the dependency on internal submodules (transforms::class_es5)

--- a/crates/tsz-emitter/src/transforms/private_fields_es5.rs
+++ b/crates/tsz-emitter/src/transforms/private_fields_es5.rs
@@ -529,10 +529,10 @@ pub fn collect_private_members_with_reserved(
                 let Some(prop_data) = arena.get_property_decl(member_node) else {
                     continue;
                 };
-                if arena.has_modifier(&prop_data.modifiers, SyntaxKind::AccessorKeyword)
-                    || arena.has_modifier(&prop_data.modifiers, SyntaxKind::AbstractKeyword)
-                    || arena.has_modifier(&prop_data.modifiers, SyntaxKind::DeclareKeyword)
-                    || !is_private_identifier(arena, prop_data.name)
+                if crate::transforms::emit_utils::is_runtime_omitted_member(
+                    arena,
+                    &prop_data.modifiers,
+                ) || !is_private_identifier(arena, prop_data.name)
                 {
                     continue;
                 }

--- a/crates/tsz-emitter/src/transforms/tslib_helper_naming.rs
+++ b/crates/tsz-emitter/src/transforms/tslib_helper_naming.rs
@@ -1,0 +1,146 @@
+//! Single source of truth for naming runtime helper functions under
+//! `importHelpers`.
+//!
+//! Several ES5/decorator/async transformers need to turn a bare runtime-helper
+//! name (e.g. `__decorate`, `__awaiter`) into the token actually emitted at the
+//! call site. The rules are identical everywhere:
+//!
+//! - under CommonJS `importHelpers`, the helper is reached through the tslib
+//!   import binding, so the call is `<binding>.<name>` (e.g. `tslib_1.__decorate`);
+//! - under ESM `importHelpers`, the helper may have been imported under a renamed
+//!   local alias (e.g. `__awaiter` -> `__awaiter_1`), so the call uses the alias;
+//! - otherwise the helper is referenced by its bare name.
+//!
+//! These rules used to be copy-pasted as a `tslib_prefix: bool` +
+//! `tslib_import_binding: String` (+ sometimes `helper_import_aliases`) field
+//! triple with byte-identical prefixing methods across five transformer structs,
+//! and the copies had already drifted (only the IR printer consulted the ESM
+//! alias map). This type collapses them onto one value so every transformer
+//! resolves helper names the same way.
+
+use rustc_hash::FxHashMap;
+
+/// Resolves runtime-helper call names for `importHelpers` emit.
+#[derive(Clone, Debug)]
+pub(crate) struct TslibHelperNaming {
+    /// When true, prefix helper calls with `<binding>.` (CommonJS `importHelpers`).
+    prefix: bool,
+    /// The tslib import binding name (e.g. `tslib_1`) used when `prefix` is true.
+    binding: String,
+    /// ESM `importHelpers` renamed-helper aliases (e.g. `__awaiter` -> `__awaiter_1`).
+    aliases: FxHashMap<String, String>,
+}
+
+impl Default for TslibHelperNaming {
+    fn default() -> Self {
+        Self {
+            prefix: false,
+            binding: "tslib_1".to_string(),
+            aliases: FxHashMap::default(),
+        }
+    }
+}
+
+impl TslibHelperNaming {
+    /// Enable/disable the CommonJS `<binding>.` prefix.
+    pub(crate) const fn set_prefix(&mut self, prefix: bool) {
+        self.prefix = prefix;
+    }
+
+    /// Set the tslib import binding name used by the CommonJS prefix.
+    pub(crate) fn set_binding(&mut self, binding: String) {
+        self.binding = binding;
+    }
+
+    /// Set the ESM renamed-helper alias map.
+    pub(crate) fn set_aliases(&mut self, aliases: FxHashMap<String, String>) {
+        self.aliases = aliases;
+    }
+
+    /// Whether the CommonJS `<binding>.` prefix is active.
+    pub(crate) const fn prefix(&self) -> bool {
+        self.prefix
+    }
+
+    /// The tslib import binding name used by the CommonJS prefix.
+    pub(crate) fn binding(&self) -> &str {
+        &self.binding
+    }
+
+    /// The ESM renamed-helper alias map.
+    pub(crate) const fn aliases(&self) -> &FxHashMap<String, String> {
+        &self.aliases
+    }
+
+    /// Resolve the runtime call token for `name` as an owned `String`.
+    pub(crate) fn helper_name(&self, name: &str) -> String {
+        let mut buf = String::new();
+        self.write_into(&mut buf, name);
+        buf
+    }
+
+    /// Append the runtime call token for `name` into `buf` without an
+    /// intermediate allocation.
+    pub(crate) fn write_into(&self, buf: &mut String, name: &str) {
+        if self.prefix {
+            buf.push_str(&self.binding);
+            buf.push('.');
+            buf.push_str(name);
+            return;
+        }
+        if let Some(alias) = self.aliases.get(name) {
+            buf.push_str(alias);
+            return;
+        }
+        buf.push_str(name);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_name_when_no_prefix_or_alias() {
+        let naming = TslibHelperNaming::default();
+        assert_eq!(naming.helper_name("__decorate"), "__decorate");
+        let mut buf = String::new();
+        naming.write_into(&mut buf, "__decorate");
+        assert_eq!(buf, "__decorate");
+    }
+
+    #[test]
+    fn commonjs_prefix_takes_precedence_over_alias() {
+        let mut naming = TslibHelperNaming::default();
+        naming.set_prefix(true);
+        naming.set_binding("tslib_1".to_string());
+        let mut aliases = FxHashMap::default();
+        aliases.insert("__awaiter".to_string(), "__awaiter_1".to_string());
+        naming.set_aliases(aliases);
+        assert_eq!(naming.helper_name("__awaiter"), "tslib_1.__awaiter");
+        let mut buf = String::new();
+        naming.write_into(&mut buf, "__awaiter");
+        assert_eq!(buf, "tslib_1.__awaiter");
+    }
+
+    #[test]
+    fn esm_alias_used_when_present_and_unprefixed() {
+        let mut naming = TslibHelperNaming::default();
+        let mut aliases = FxHashMap::default();
+        aliases.insert("__awaiter".to_string(), "__awaiter_1".to_string());
+        naming.set_aliases(aliases);
+        assert_eq!(naming.helper_name("__awaiter"), "__awaiter_1");
+        assert_eq!(naming.helper_name("__generator"), "__generator");
+        let mut buf = String::new();
+        naming.write_into(&mut buf, "__awaiter");
+        assert_eq!(buf, "__awaiter_1");
+    }
+
+    #[test]
+    fn custom_binding_is_honored() {
+        let mut naming = TslibHelperNaming::default();
+        naming.set_prefix(true);
+        naming.set_binding("tslib_42".to_string());
+        assert_eq!(naming.helper_name("__extends"), "tslib_42.__extends");
+    }
+}


### PR DESCRIPTION
Goal: hold

Closes #13431.

Behavior-preserving DRY/hygiene over the ES5/decorator/async transformers in `tsz-emitter`. No type-algorithm, diagnostic, inference, or emit change, so this defends the conformance/emit parity floor.

## Failure family

Two pieces of shared emit scaffolding were re-implemented by copy-paste, and both had already drifted into multiple sources of truth.

### 1. `importHelpers` helper-name prefixing

Five transformer structs each carried a `tslib_prefix: bool` + `tslib_import_binding: String` (+ sometimes `helper_import_aliases`) field set, identical default, identical setters, and a byte-identical prefixing method under different names:

- `TC39DecoratorEmitter::helper` (`es_decorators.rs`)
- `ES5ClassTransformer::helper_name` (`class_es5_ir_decorators.rs`) — byte-identical body, different name
- `IRPrinter::write_helper` (`ir_printer.rs`) — same logic **plus** an ESM renamed-helper alias branch the other two lacked (the documented drift)

### 2. "member omitted at runtime by its modifiers"

The `abstract || declare || accessor` skip rule was open-coded across the collect and emit passes (`es_decorators_collect_fields.rs`, `es_decorators_node_utils.rs`, `class_es5_ir_members.rs`, `module_emission/core/mod.rs`, `private_fields_es5.rs`), with non-identical phrasings, so the collect pass could silently diverge from the emit pass.

## Owner layer / structural rule

- New `transforms::tslib_helper_naming::TslibHelperNaming` value type (`prefix` + `binding` + alias-aware `helper_name`/`write_into`) is the single source of truth for resolving a runtime-helper call token under `importHelpers`. The five transformer structs hold one of these in place of the loose field set; the three prefixing methods now delegate to it, so the rule (CommonJS `<binding>.` prefix → ESM alias → bare name) has exactly one body and the alias branch is honored everywhere. `helper_name` delegates to the alloc-free `write_into`.
- New `transforms::emit_utils::is_runtime_omitted_member(arena, modifiers)` is the single definition of "omitted at runtime by modifier". Every exact-match call site routes through it; site-specific `is_static` / private-identifier / initializer checks stay at the call site exactly as before.

## Behavior preservation

- The transformers that never set helper aliases keep an empty alias map, so the now-alias-aware prefixing resolves identically to the old prefix-or-bare logic. The four async forwarding sites that propagated only prefix+binding still do so; the one site that also propagated aliases still does (a blanket bundle setter was deliberately **not** introduced, since it would leak aliases to the prefix-only sites).
- The main `Printer::write_helper` (in `emitter/`) is intentionally left out of scope: it derives the prefix flag on-demand from `ctx.options` and writes through a mapping-aware `self.write()`, so folding it in would change its write path / risk a stale prefix flag. The issue references it only as the behavioral mirror.
- `is_runtime_omitted_member` performs the same three `has_modifier` checks the inline chains did (cost-neutral); only sites whose composition was an exact match were migrated. Inverse-polarity chains (e.g. auto-accessor collection that *requires* `accessor`) were left untouched.

Net: −149 / +239 lines (the new file + its unit tests account for the additions; the migrated sites are a net reduction).

## Verification

- `cargo build -p tsz-emitter` — clean.
- `cargo clippy -p tsz-emitter --lib` — 0 warnings.
- `cargo test -p tsz-emitter --lib` — 3739 passed (incl. 4 new `tslib_helper_naming` unit tests covering bare/CJS-prefix-precedence/ESM-alias/custom-binding for both `helper_name` and `write_into`). The only 3 failures (`declaration_emitter::tests::…ts2883…`, `…fix_generic_rest_identity…`) reproduce identically on clean `origin/main` with this change stashed — pre-existing, unrelated DTS declaration-emitter tests, untouched by this refactor.
- Public setter signatures (`set_tslib_prefix`, `set_tslib_import_binding`, `set_helper_import_aliases`) are unchanged, so emitter consumers are unaffected.
- Branch is on current `origin/main` (33a11c5), no conflicts.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5MtvjwfWwy9ZCf7EWDd6A)_