### PR TITLE
perf(bench): record premerge microbench noise (#13247)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -854,11 +854,25 @@ jobs:
           console.log("");
           console.log(`Status: ${report.status}`);
           console.log(`Runs: ${report.runs}, warmup: ${report.warmup}`);
+          if (report.noise_summary?.max_case) {
+            const maxCase = report.noise_summary.max_case;
+            console.log(
+              `Max within-run spread: \`${maxCase.name}\` ${maxCase.relative_spread_pct.toFixed(2)}% (${maxCase.spread_ms.toFixed(2)}ms)`
+            );
+          }
+          if (report.run_context?.git_sha || report.run_context?.github_run_id) {
+            const sha = report.run_context.git_sha ? report.run_context.git_sha.slice(0, 12) : "unknown";
+            const runId = report.run_context.github_run_id || "local";
+            const attempt = report.run_context.github_run_attempt || "1";
+            console.log(`Run context: sha \`${sha}\`, run \`${runId}\`, attempt \`${attempt}\``);
+          }
           console.log("");
-          console.log("| Case | Median | Mean |");
-          console.log("| --- | ---: | ---: |");
+          console.log("| Case | Median | Mean | Spread |");
+          console.log("| --- | ---: | ---: | ---: |");
           for (const [name, data] of Object.entries(report.cases || {})) {
-            console.log(`| \`${name}\` | ${data.median_ms.toFixed(2)}ms | ${data.mean_ms.toFixed(2)}ms |`);
+            const spread = data.noise?.relative_spread_pct;
+            const spreadCell = typeof spread === "number" ? `${spread.toFixed(2)}%` : "";
+            console.log(`| \`${name}\` | ${data.median_ms.toFixed(2)}ms | ${data.mean_ms.toFixed(2)}ms | ${spreadCell} |`);
           }
           if ((report.regressions || []).length > 0) {
             console.log("");

--- a/scripts/bench/precommit-microbench.mjs
+++ b/scripts/bench/precommit-microbench.mjs
@@ -107,6 +107,53 @@ function median(values) {
   return sorted[mid];
 }
 
+function sampleSpread(samples, medianMs) {
+  const minMs = Math.min(...samples);
+  const maxMs = Math.max(...samples);
+  const spreadMs = maxMs - minMs;
+  return {
+    min_ms: minMs,
+    max_ms: maxMs,
+    spread_ms: spreadMs,
+    relative_spread_pct: medianMs > 0 ? (spreadMs / medianMs) * 100 : 0,
+  };
+}
+
+function summarizeNoise(measurements) {
+  let maxCase = null;
+  for (const [name, data] of Object.entries(measurements)) {
+    const spread = data.noise?.relative_spread_pct;
+    if (typeof spread !== "number") continue;
+    if (!maxCase || spread > maxCase.relative_spread_pct) {
+      maxCase = {
+        name,
+        relative_spread_pct: spread,
+        spread_ms: data.noise.spread_ms,
+      };
+    }
+  }
+  return {
+    kind: "within_run_sample_spread",
+    method: "(max(sample_ms) - min(sample_ms)) / median_ms",
+    cases: Object.keys(measurements).length,
+    max_case: maxCase,
+  };
+}
+
+function runContext() {
+  return {
+    git_sha: process.env.GITHUB_SHA || null,
+    github_run_id: process.env.GITHUB_RUN_ID || null,
+    github_run_attempt: process.env.GITHUB_RUN_ATTEMPT || null,
+    github_workflow: process.env.GITHUB_WORKFLOW || null,
+    github_job: process.env.GITHUB_JOB || null,
+    github_ref: process.env.GITHUB_REF || null,
+    runner_name: process.env.RUNNER_NAME || null,
+    runner_os: process.env.RUNNER_OS || null,
+    runner_arch: process.env.RUNNER_ARCH || null,
+  };
+}
+
 function readBaseline(filePath) {
   if (!fs.existsSync(filePath)) {
     return null;
@@ -161,6 +208,7 @@ function main() {
       median_ms: median(samples),
       samples_ms: samples,
     };
+    entry.noise = sampleSpread(samples, entry.median_ms);
     measurements[testCase.name] = entry;
     console.log(
       `   - ${testCase.name}: mean ${formatMs(entry.mean_ms)} | median ${formatMs(entry.median_ms)}`
@@ -198,6 +246,8 @@ function main() {
       warmup: opts.warmup,
       baseline_file: opts.baseline,
       generated_at: nextBaseline.updated_at,
+      run_context: runContext(),
+      noise_summary: summarizeNoise(measurements),
       cases: measurements,
       regressions: [],
     });
@@ -253,6 +303,8 @@ function main() {
     baseline_file: opts.baseline,
     baseline_updated_at: baseline.updated_at,
     generated_at: nextBaseline.updated_at,
+    run_context: runContext(),
+    noise_summary: summarizeNoise(measurements),
     cases: measurements,
     regressions,
   });


### PR DESCRIPTION
Goal: fast

## Summary
- Add explicit within-run spread metadata to `premerge-microbench.json` so #13247 noise-band calibration does not have to reverse-engineer raw samples.
- Add GitHub run context (`sha`, run id/attempt, runner fields) to the advisory artifact so same-sha reruns can be grouped later.
- Surface max spread and per-case spread in the advisory `premerge-microbench` step summary.

## Verification
- Draft/light CI passed at exact head `6e92f3cb6124c4a35c14721bddc9ed5dc8286ec0`: `premerge-microbench` and `CI Light Summary`.
- Not run locally per current instruction.
- Pre-commit formatting hook ran during `git commit`.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
