### PR TITLE
perf(cli): report batch residency cleanup action (#13249)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz.rs
+++ b/crates/tsz-cli/src/bin/tsz.rs
@@ -328,6 +328,12 @@ fn write_batch_residency_report(
         stdout,
         "Batch estimated eviction savings: {eviction_savings_kb:.1}K"
     )?;
+    let cleanup_action = if batch_residency_should_clear(pressure) {
+        "clear finished-project thread-local state"
+    } else {
+        "observe only"
+    };
+    writeln!(stdout, "Batch residency cleanup action: {cleanup_action}")?;
     Ok(Some(pressure))
 }
 


### PR DESCRIPTION
Goal: fast

## Summary
- Report the batch residency cleanup action in the hidden `--batchResidencyBudget` CLI report.
- Derive the reported action from the existing `batch_residency_should_clear(pressure)` predicate.
- Keep default behavior and cleanup policy unchanged; this is observability for the residency-budget lane.

## Structural Rule / Owner Layer
When batch residency pressure crosses the existing cleanup threshold, the CLI report should expose the same cleanup decision the driver already uses: observe-only below the threshold, clear finished-project thread-local state above it.

Owner layer: CLI reporting over existing checker/project residency policy. No semantic checker/solver behavior changes.

## Verification
- Not run locally per current instruction.
- Pre-commit formatting hook ran during commit `22bf992507`.
- Draft/light CI passed at exact head `22bf9925072980e892253d921fbd7d090aca6468`: `CI Light Summary` and `premerge-microbench` succeeded.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
