### PR TITLE
perf(solver): cache constrained template captures (#13508)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_template_match.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/infer_pattern_template_match.rs
@@ -39,6 +39,14 @@ struct TemplateStringCursor {
 struct TemplateStringMatchScratch {
     failed_states: FxHashSet<TemplateStringMatchState>,
     capture_ends: FxHashMap<(usize, usize), Vec<usize>>,
+    constrained_captures: FxHashMap<TemplateStringCaptureKey, Option<TypeId>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct TemplateStringCaptureKey {
+    start: usize,
+    end: usize,
+    constraint: u32,
 }
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
@@ -120,28 +128,6 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             }
             _ => None,
         }
-    }
-
-    fn bind_template_infer_capture(
-        &self,
-        info: &TypeParamInfo,
-        captured: &str,
-        bindings: &mut FxHashMap<Atom, TypeId>,
-        checker: &mut SubtypeChecker<'_, R>,
-    ) -> bool {
-        let captured_type = self.interner().literal_string(captured);
-        let inferred = if let Some(constraint) = info.constraint {
-            let Some(converted) =
-                self.template_capture_for_constraint(captured, captured_type, constraint, checker)
-            else {
-                return false;
-            };
-            converted
-        } else {
-            captured_type
-        };
-
-        self.bind_infer(info, inferred, bindings, checker)
     }
 
     /// Match a template literal string against a pattern.
@@ -290,6 +276,56 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         let ends = self.candidate_template_capture_ends(source, pos, pattern, index);
         scratch.capture_ends.insert(key, ends.clone());
         ends
+    }
+
+    fn cached_template_capture_for_constraint(
+        &self,
+        source: &str,
+        start: usize,
+        end: usize,
+        constraint: TypeId,
+        checker: &mut SubtypeChecker<'_, R>,
+        scratch: &mut TemplateStringMatchScratch,
+    ) -> Option<TypeId> {
+        let key = TemplateStringCaptureKey {
+            start,
+            end,
+            constraint: constraint.0,
+        };
+        if let Some(cached) = scratch.constrained_captures.get(&key) {
+            return *cached;
+        }
+
+        let captured = &source[start..end];
+        let captured_type = self.interner().literal_string(captured);
+        let result =
+            self.template_capture_for_constraint(captured, captured_type, constraint, checker);
+        scratch.constrained_captures.insert(key, result);
+        result
+    }
+
+    fn bind_cached_template_infer_capture(
+        &self,
+        info: &TypeParamInfo,
+        source: &str,
+        start: usize,
+        end: usize,
+        bindings: &mut FxHashMap<Atom, TypeId>,
+        checker: &mut SubtypeChecker<'_, R>,
+        scratch: &mut TemplateStringMatchScratch,
+    ) -> bool {
+        let inferred = if let Some(constraint) = info.constraint {
+            let Some(converted) = self.cached_template_capture_for_constraint(
+                source, start, end, constraint, checker, scratch,
+            ) else {
+                return false;
+            };
+            converted
+        } else {
+            self.interner().literal_string(&source[start..end])
+        };
+
+        self.bind_infer(info, inferred, bindings, checker)
     }
 
     /// Match an intrinsic-typed span at position `pos` in the infer-pattern path.
@@ -474,12 +510,14 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         source, pos, pattern, index, scratch,
                     ) {
                         let mut next_bindings = bindings.clone();
-                        let captured = &source[pos..end];
-                        if !self.bind_template_infer_capture(
+                        if !self.bind_cached_template_infer_capture(
                             &info,
-                            captured,
+                            source,
+                            pos,
+                            end,
                             &mut next_bindings,
                             checker,
+                            scratch,
                         ) {
                             continue;
                         }
@@ -530,10 +568,10 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 for end in self
                     .cached_candidate_template_capture_ends(source, pos, pattern, index, scratch)
                 {
-                    let captured = &source[pos..end];
-                    let captured_type = self.interner().literal_string(captured);
                     if self
-                        .template_capture_for_constraint(captured, captured_type, type_id, checker)
+                        .cached_template_capture_for_constraint(
+                            source, pos, end, type_id, checker, scratch,
+                        )
                         .is_some()
                         && self.match_template_literal_string_from(
                             source,


### PR DESCRIPTION
Goal: fast

## Summary
- Add request-local caching for constrained template-literal captures in solver infer-pattern matching.
- Reuse the result for the same `(source start, source end, constraint TypeId)` during one template string match request.
- Keep the existing binding-sensitive failed-state cache unchanged, so successful/failed branch answers still depend on current infer bindings.

## Structural Rule / Owner Layer
When recursive template/infer matching revisits the same source substring under the same constraint within one request, `tsc` treats the capture conversion as the same semantic question; tsz now reuses that solver-owned constrained-capture result instead of redoing literal interning, subtype checks, numeric/bigint parsing, and union-constraint walks.

Owner layer: solver evaluation / infer-pattern template matching.

Cache invariant: the cache is request-local, keyed by source byte range plus constraint `TypeId`, and stores only the converted captured type or failed conversion for that exact match request. It does not widen cross-file, cross-session, or cross-interner state.

## Adjacent Matrix
- Renamed binders: cache key uses the structural constraint and source span, not infer variable names.
- Alias/wrapper/nesting: constrained conversion still delegates to `template_capture_for_constraint` and existing subtype checks.
- Generic/concrete: cache is local to the active instantiated pattern/source match.
- Positive/fallback: successful conversions and failed conversions are both reused only for the same substring/constraint pair.

## Verification
- Not run locally per current instruction.
- Pre-commit formatting hook ran during commit `8fdbfe84ec`.
- Draft/light CI passed at exact head `8fdbfe84eca674767575f383129dbe79f0a803a6`: `CI Light Summary` and `premerge-microbench` succeeded.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
