### PR TITLE
fix(checker): narrow discriminated unions through member-rooted references (#13553)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -401,6 +401,9 @@ path = "tests/lazy_class_constructor_type_tests.rs"
 name = "this_type_tests"
 path = "tests/this_type_tests.rs"
 [[test]]
+name = "this_rooted_discriminant_narrowing_tests"
+path = "tests/this_rooted_discriminant_narrowing_tests.rs"
+[[test]]
 name = "ts2725_tests"
 path = "tests/ts2725_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -287,7 +287,7 @@ impl<'a> FlowAnalyzer<'a> {
                         type_id,
                         &excluded_types,
                     )
-                } else if let Some((ref path, _, _)) = discriminant_info {
+                } else if let Some((ref path, _)) = discriminant_info {
                     flow_query::narrow_by_excluding_discriminant_values_in_context(
                         narrowing,
                         type_id,
@@ -453,11 +453,11 @@ impl<'a> FlowAnalyzer<'a> {
         let mut discriminant_info = None;
 
         if !target_is_switch_expr {
+            // A discriminant path is only reported when it is accessed directly
+            // on `target` (e.g. `switch (x.kind)` narrowing `x`); its absence
+            // means this switch cannot affect `target`'s type.
             discriminant_info = self.discriminant_property_info(switch_expr, target);
-            let switch_targets_base = discriminant_info
-                .as_ref()
-                .is_some_and(|(_, _, base)| self.is_matching_reference(*base, target));
-            if !switch_targets_base {
+            if discriminant_info.is_none() {
                 return type_id;
             }
         }
@@ -510,7 +510,7 @@ impl<'a> FlowAnalyzer<'a> {
                         type_id,
                         &excluded_types,
                     );
-                } else if let Some((path, is_optional, _)) = discriminant_info {
+                } else if let Some((path, is_optional)) = discriminant_info {
                     if is_optional && excluded_types.contains(&TypeId::UNDEFINED) {
                         return type_id;
                     }

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -1546,9 +1546,8 @@ impl<'a> FlowAnalyzer<'a> {
         // extract the property path and narrow the parent object by discriminant.
         if let Some(predicate_type) = resolved_predicate.type_id
             && query::is_unit_type(self.interner, predicate_type)
-            && let Some((property_path, _is_optional, base)) =
+            && let Some((property_path, _is_optional)) =
                 self.discriminant_property_info(predicate_target, reference)
-            && self.is_matching_reference(base, reference)
         {
             let env_borrow;
             let mut narrowing = self.make_narrowing_context();

--- a/crates/tsz-checker/src/flow/control_flow/narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/narrowing.rs
@@ -1158,18 +1158,11 @@ impl<'a> FlowAnalyzer<'a> {
         expr: NodeIndex,
         target: NodeIndex,
     ) -> Option<Vec<Atom>> {
+        // `discriminant_property_info` already requires the discriminant be
+        // accessed directly on `target`; only the non-optional case narrows by
+        // truthiness here.
         self.discriminant_property_info(expr, target)
-            .and_then(|(path, is_optional, base)| {
-                if is_optional {
-                    return None;
-                }
-                // Only apply discriminant narrowing if the base of the property
-                // access matches the target being narrowed. For example, if narrowing
-                // `x` based on `x.kind`, the base `x` must match target `x`.
-                // Without this check, narrowing `x.prop` based on `x.kind` would
-                // incorrectly try to find `kind` on the type of `x.prop`.
-                self.is_matching_reference(base, target).then_some(path)
-            })
+            .and_then(|(path, is_optional)| (!is_optional).then_some(path))
     }
 
     /// For a const-declared identifier that is a destructuring alias, return
@@ -1262,88 +1255,36 @@ impl<'a> FlowAnalyzer<'a> {
     pub(crate) fn discriminant_property_info(
         &self,
         expr: NodeIndex,
-        _target: NodeIndex,
-    ) -> Option<(Vec<Atom>, bool, NodeIndex)> {
-        let expr = self.skip_parenthesized(expr);
-        self.arena.get(expr)?;
-
-        // Collect the property path by walking up the access chain
-        // For action.payload.kind, we want ["payload", "kind"]
-        let mut path: Vec<Atom> = Vec::new();
-        let mut is_optional = false;
-        let mut current = expr;
-
-        loop {
-            let current_node = self.arena.get(current)?;
-            let access = if current_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
-                || current_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
-            {
-                self.arena.get_access_expr(current_node)?
-            } else {
-                // Not a property/element access - we've reached the base
-                break;
-            };
-
-            // Track if any segment uses optional chaining
-            if access.question_dot_token {
-                is_optional = true;
-            }
-
-            // Get the property name for this segment
-            let prop_name = if current_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
-                let ident = self.arena.get_identifier_at(access.name_or_argument)?;
-                self.interner.intern_string(&ident.escaped_text)
-            } else {
-                // Element access
-                self.literal_atom_from_node_or_type(access.name_or_argument)?
-            };
-
-            // Add to path (will be reversed later)
-            path.push(prop_name);
-
-            // Move to the next level up
-            let access_target = access.expression;
-            let access_target = self.skip_parenthesized(access_target);
-            let access_target_node = self.arena.get(access_target)?;
-
-            // Unwrap assignment and comma expressions to get the actual target
-            let effective_target = if access_target_node.kind == syntax_kind_ext::BINARY_EXPRESSION
-            {
-                let binary = self.arena.get_binary_expr(access_target_node)?;
-                if binary.operator_token == SyntaxKind::EqualsToken as u16 {
-                    // (x = y).prop -> unwrap to x.prop
-                    binary.left
-                } else if binary.operator_token == SyntaxKind::CommaToken as u16 {
-                    // (a, b).prop -> unwrap to b.prop
-                    binary.right
-                } else {
-                    access_target
-                }
-            } else {
-                access_target
-            };
-
-            current = effective_target;
-        }
-
-        // Discriminant narrowing only applies to a *direct* property of the
-        // narrowed reference. `tsc` narrows a union by `x.kind === "a"` (a
-        // discriminant property accessed directly on `x`), but it does NOT
-        // narrow the outer union through a nested access such as
-        // `x.meta.kind === "a"` — there the only references narrowed are
-        // `x.meta` and `x.meta.kind`, never `x`. Requiring a single-segment
-        // path keeps every consumer (truthiness, switch, assertion predicate)
-        // aligned with that rule; nested references are narrowed when they are
-        // themselves the target via the relative-path producers.
+        target: NodeIndex,
+    ) -> Option<(Vec<Atom>, bool)> {
+        // A discriminant property must be accessed *directly* on the narrowed
+        // reference: the guard `target.prop` narrows `target` by `prop`. The
+        // property path is therefore measured *relative to `target`*, not to
+        // the syntactic root of the access chain.
         //
-        // A single collected segment needs no reversal, so reject multi-segment
-        // paths before paying for `Vec::reverse`.
+        // Measuring relative to the root (the previous behavior) only worked
+        // when `target` itself was the root — a bare identifier, `this`, or
+        // `super`. For a member-rooted reference such as `this.state`, the path
+        // from the root `this` to `this.state.matched` is two segments
+        // (`["state", "matched"]`), so a single-segment gate rejected it and the
+        // discriminant guard `if (this.state.matched)` failed to narrow
+        // `this.state`. `relative_discriminant_path` walks from `expr` toward
+        // `target` (following `const alias = target` proxies) and yields exactly
+        // the segments between them, so `this.state.matched` relative to
+        // `this.state` is the single segment `["matched"]`.
+        //
+        // The single-segment requirement is preserved: `tsc` narrows a union by
+        // a discriminant accessed *directly* on the reference, never through a
+        // nested access (`x.meta.kind` narrows `x.meta`, never the outer `x`).
+        // This mirrors `discriminant_comparison` / `typeof_discriminant_path`,
+        // which already key their paths off `relative_discriminant_path`. The
+        // base is necessarily `target`, so only the path and optional flag are
+        // reported.
+        let (path, is_optional) = self.relative_discriminant_path(expr, target)?;
         if path.len() != 1 {
             return None;
         }
-
-        // current is now the base (e.g., "action" in action.kind)
-        Some((path, is_optional, current))
+        Some((path, is_optional))
     }
 
     pub(crate) fn discriminant_comparison(
@@ -1352,25 +1293,18 @@ impl<'a> FlowAnalyzer<'a> {
         right: NodeIndex,
         target: NodeIndex,
     ) -> Option<(Vec<Atom>, TypeId, bool, NodeIndex)> {
-        // Use relative_discriminant_path to find the property path from target to left.
-        // This correctly handles both:
-        //   - Direct: `t.kind === "a"` narrowing `t` → path=["kind"], base=t
-        //   - Nested: `this.test.type === "a"` narrowing `this.test` → path=["type"], base=this.test
-        // (discriminant_property_info returns the full path from the root, which is wrong when
-        //  target is not the root — e.g., returns path=["test","type"] base=this for `this.test.type`
-        //  when we need path=["type"] base=this.test relative to target=this.test)
-        // Single-segment relative path only (see `discriminant_property_info`):
-        // a nested access narrows the inner reference, never the outer `target`.
+        // `discriminant_property_info` reports the single-segment path of a
+        // discriminant accessed directly on `target` (e.g. `t.kind === "a"`
+        // narrowing `t`, or `this.test.type === "a"` narrowing `this.test`). A
+        // nested access narrows the inner reference, never the outer `target`.
         if let Some(literal) = self.discriminant_literal_candidate(right)
-            && let Some((rel_path, is_optional)) = self.relative_discriminant_path(left, target)
-            && rel_path.len() == 1
+            && let Some((rel_path, is_optional)) = self.discriminant_property_info(left, target)
         {
             return Some((rel_path, literal, is_optional, target));
         }
 
         if let Some(literal) = self.discriminant_literal_candidate(left)
-            && let Some((rel_path, is_optional)) = self.relative_discriminant_path(right, target)
-            && rel_path.len() == 1
+            && let Some((rel_path, is_optional)) = self.discriminant_property_info(right, target)
         {
             return Some((rel_path, literal, is_optional, target));
         }
@@ -1468,11 +1402,10 @@ impl<'a> FlowAnalyzer<'a> {
             if init_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION
                 || init_node.kind == syntax_kind_ext::ELEMENT_ACCESS_EXPRESSION
             {
-                // Walk from `init_expr` towards the root, collecting segments until we hit `target`.
-                // Single-segment path only: `const k = s.meta.kind` does not narrow `s` in `tsc`.
+                // Single-segment discriminant directly on `target`: `const k =
+                // s.meta.kind` does not narrow `s` in `tsc`.
                 if let Some((rel_path, is_optional)) =
-                    self.relative_discriminant_path(init_expr, target)
-                    && rel_path.len() == 1
+                    self.discriminant_property_info(init_expr, target)
                 {
                     return Some((rel_path, literal, is_optional, target));
                 }
@@ -1583,20 +1516,19 @@ impl<'a> FlowAnalyzer<'a> {
         right: NodeIndex,
         target: NodeIndex,
     ) -> Option<(Vec<Atom>, bool, &str)> {
-        // Single-segment path only (see `discriminant_property_info`):
-        // `typeof s.meta.x === "string"` narrows `s.meta`, never the outer union `s`.
+        // Single-segment discriminant directly on `target` (see
+        // `discriminant_property_info`): `typeof s.meta.x === "string"` narrows
+        // `s.meta`, never the outer union `s`.
         // Try left = typeof expr, right = string literal
         if let Some(operand) = self.get_typeof_operand(self.skip_parenthesized(left))
-            && let Some((path, is_optional)) = self.relative_discriminant_path(operand, target)
-            && path.len() == 1
+            && let Some((path, is_optional)) = self.discriminant_property_info(operand, target)
             && let Some(lit) = self.literal_string_from_node(right)
         {
             return Some((path, is_optional, lit));
         }
         // Try right = typeof expr, left = string literal
         if let Some(operand) = self.get_typeof_operand(self.skip_parenthesized(right))
-            && let Some((path, is_optional)) = self.relative_discriminant_path(operand, target)
-            && path.len() == 1
+            && let Some((path, is_optional)) = self.discriminant_property_info(operand, target)
             && let Some(lit) = self.literal_string_from_node(left)
         {
             return Some((path, is_optional, lit));

--- a/crates/tsz-checker/tests/this_rooted_discriminant_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/this_rooted_discriminant_narrowing_tests.rs
@@ -1,0 +1,202 @@
+//! Regression coverage for discriminated-union narrowing of a **member-rooted**
+//! reference — most importantly a `this.`-rooted property-access reference.
+//!
+//! Structural rule (matches TypeScript 6.0.x): a discriminant guard accessed
+//! *directly* on a reference narrows that reference. The narrowed reference need
+//! not be a bare identifier — `this.state.matched` narrows `this.state`, exactly
+//! as `s.matched` narrows a local `s`. Previously tsz measured the discriminant
+//! property path from the *syntactic root* (`this`) and required a single
+//! segment, so any member-rooted target (two or more hops from the root) was
+//! silently skipped: the guard `if (this.state.matched)` left `this.state` typed
+//! as the full union and produced false `TS2322`/`TS2339`.
+//!
+//! The fix measures the path *relative to the narrowed reference*, so the rule
+//! is uniform across truthiness, `===`, `switch`, and assertion-predicate
+//! discriminants, and applies whether the reference is `s`, `this.state`, or a
+//! deeper `this.a.b` chain. The "direct property only" guarantee is preserved:
+//! a nested access (`x.meta.kind`) still narrows `x.meta`, never the outer `x`.
+//!
+//! Binder names are varied per case so the coverage is structural, not keyed to
+//! a particular identifier.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+const TS2322: u32 = 2322; // Type not assignable
+const TS2339: u32 = 2339; // Property does not exist on type
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_strict_codes(source)
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases: a discriminant directly on a `this.`-rooted reference narrows.
+// `tsc` is clean on all of these.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn truthiness_discriminant_on_this_param_property_generic() {
+    // The ts-pattern witness: a generic constructor-parameter property.
+    let diags = codes(
+        r#"
+type MatchState<out> = { matched: true; value: out } | { matched: false; value: undefined };
+class Matcher<inp, out> {
+  constructor(private input: inp, private state: MatchState<out>) {}
+  otherwise(handler: (v: inp) => out): out {
+    if (this.state.matched) return this.state.value;
+    return handler(this.input);
+  }
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2322),
+        "`if (this.state.matched)` must narrow `this.state`, got {diags:?}"
+    );
+}
+
+#[test]
+fn truthiness_discriminant_on_this_plain_field_nongeneric() {
+    // Plain field (not a parameter property), concrete value type.
+    let diags = codes(
+        r#"
+type Result = { ok: true; data: number } | { ok: false; data: undefined };
+class Box {
+  private slot: Result;
+  constructor(seed: Result) { this.slot = seed; }
+  read(): number { if (this.slot.ok) return this.slot.data; throw 0; }
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2322),
+        "plain `this.`-field truthiness discriminant must narrow, got {diags:?}"
+    );
+}
+
+#[test]
+fn equality_discriminant_on_this_field() {
+    let diags = codes(
+        r#"
+type Figure = { tag: "round"; radius: number } | { tag: "square"; edge: number };
+class Drawing {
+  constructor(private figure: Figure) {}
+  metric(): number {
+    if (this.figure.tag === "round") return this.figure.radius;
+    return this.figure.edge;
+  }
+}
+"#,
+    );
+    assert!(
+        !diags.iter().any(|c| *c == TS2322 || *c == TS2339),
+        "`this.figure.tag === \"round\"` must narrow `this.figure`, got {diags:?}"
+    );
+}
+
+#[test]
+fn switch_discriminant_on_this_field() {
+    let diags = codes(
+        r#"
+type Node = { sort: "leaf"; weight: number } | { sort: "branch"; span: number };
+class Tree {
+  constructor(private node: Node) {}
+  size(): number {
+    switch (this.node.sort) {
+      case "leaf": return this.node.weight;
+      case "branch": return this.node.span;
+    }
+  }
+}
+"#,
+    );
+    assert!(
+        !diags.iter().any(|c| *c == TS2322 || *c == TS2339),
+        "`switch (this.node.sort)` must narrow `this.node`, got {diags:?}"
+    );
+}
+
+#[test]
+fn truthiness_discriminant_on_deeper_this_chain() {
+    // The narrowed reference is itself two hops deep: `this.wrap.cell.flag`
+    // narrows `this.wrap.cell`.
+    let diags = codes(
+        r#"
+type Cell = { flag: true; payload: number } | { flag: false; payload: undefined };
+class Holder {
+  constructor(private wrap: { cell: Cell }) {}
+  fetch(): number { if (this.wrap.cell.flag) return this.wrap.cell.payload; throw 0; }
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2322),
+        "`this.wrap.cell.flag` must narrow `this.wrap.cell`, got {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Control: narrowing the identical union through a local copy already worked and
+// must keep working (isolates the defect to member-rooted references).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn local_copy_discriminant_still_narrows() {
+    let diags = codes(
+        r#"
+type Outcome = { hit: true; value: number } | { hit: false; value: undefined };
+class Runner {
+  constructor(private outcome: Outcome) {}
+  resolve(): number { const local = this.outcome; if (local.hit) return local.value; throw 0; }
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2322),
+        "local-copy discriminant narrowing must keep working, got {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative cases: a discriminant on a *nested* access must NOT narrow the outer
+// union. `tsc` reports the noted error; tsz must too (no over-narrowing).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nested_access_does_not_narrow_outer_union_equality() {
+    // `pair.lead.key === "x"` narrows `pair.lead`, never the outer `pair`, so
+    // `pair.first` (present on only one member) is still a union-wide access.
+    let diags = codes(
+        r#"
+type Pair = { lead: { key: "x" }; first: number } | { lead: { key: "y" }; second: number };
+function pick(pair: Pair): number {
+  if (pair.lead.key === "x") { return pair.first; }
+  return 0;
+}
+"#,
+    );
+    assert!(
+        diags.contains(&TS2339),
+        "nested discriminant must not narrow the outer union, expected TS2339, got {diags:?}"
+    );
+}
+
+#[test]
+fn nested_access_does_not_narrow_outer_union_on_this() {
+    // `this.frame.inner.matched` narrows `this.frame.inner`, never `this.frame`.
+    let diags = codes(
+        r#"
+type Inner = { matched: true; value: number } | { matched: false; value: undefined };
+class Stage {
+  constructor(private frame: { inner: Inner; tail: number } | { inner: Inner; head: number }) {}
+  run(): number {
+    if (this.frame.inner.matched) { return this.frame.tail; }
+    return 0;
+  }
+}
+"#,
+    );
+    assert!(
+        diags.contains(&TS2339),
+        "nested `this.frame.inner` discriminant must not narrow `this.frame`, expected TS2339, got {diags:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

Closes #13553.

## Summary

Discriminated-union narrowing was not applied when the narrowed reference was a **member access** such as `this.state` rather than a bare identifier. After a guard `if (this.state.matched)`, tsz left `this.state.value` typed as the full union value type (`output | undefined`) instead of narrowing `this.state` to the `matched: true` member, producing false **TS2322** (and **TS2339** in the `===`/property-not-found shapes). Narrowing the identical union through a local copy (`const s = this.state`) already worked, which isolated the defect to flow narrowing of member-rooted property-access references. Witnessed by the **ts-pattern** canary (~2 false TS2322 at the `MatchState`/`otherwise` sites).

## Structural rule

When a discriminant guard is accessed **directly** on a reference, `tsc` narrows that reference by the discriminant property: `target.prop` narrows `target` by `prop`. The narrowed reference need not be a bare identifier — `this.state.matched` narrows `this.state`, exactly as `s.matched` narrows a local `s`. The discriminant property path must therefore be measured **relative to the narrowed reference**, never to the syntactic root of the access chain.

## Owner layer / root cause

Checker flow narrowing (`crates/tsz-checker/src/flow/control_flow`).

The truthiness / `switch` / assertion-predicate discriminant path used `discriminant_property_info`, which walked the access chain to the **syntactic root** and required a single-segment path. That only matched when the reference *was* the root (`s`, `this`, `super`); for `this.state` the root path is the two segments `["state", "matched"]`, so the single-segment gate rejected it and the guard failed to narrow. The `===` and `typeof` discriminant paths already measured the path **relative to the target** via `relative_discriminant_path`.

The fix routes `discriminant_property_info` through that same target-relative primitive (`relative_discriminant_path(expr, target)` + single-segment gate), unifying every discriminant family (truthiness, `===`, `typeof`, `switch`, assertion predicate) on one mechanism. The "direct property only" guarantee is preserved: a nested access (`x.meta.kind`) still narrows `x.meta`, never the outer `x`.

DRY follow-through (from `/simplify`): the now-redundant base `NodeIndex` is dropped from `discriminant_property_info`'s return (it always equalled `target`), the trivial `is_matching_reference(base, target)` checks at all four callers are removed, and `discriminant_comparison` / `typeof_discriminant_path` / the const-alias discriminant now reuse `discriminant_property_info` instead of re-inlining the `relative_discriminant_path` + single-segment check.

## Anti-hardcoding

The fix keys only on the structural flow-reference relationship (`relative_discriminant_path` + single-segment length), with no identifier/field/file-name or printer-string predicate. Tests vary binder names per case.

## Adjacent matrix (all clean in `tsc` 6.0.x; now clean in tsz)

| Form | before | after |
|---|---|---|
| `if (this.state.matched)` truthiness, generic ctor-param property (ts-pattern witness) | false TS2322 | narrows ✅ |
| truthiness on a plain `this.`-field, concrete value type | false TS2322 | narrows ✅ |
| `this.figure.tag === "round"` (`===`) | false TS2322/TS2339 | narrows ✅ |
| `switch (this.node.sort)` | false TS2322/TS2339 | narrows ✅ |
| `typeof this.o.v === "string"` | (typeof path) | narrows ✅ |
| deeper `this.wrap.cell.flag` (target two hops deep) | false TS2322 | narrows ✅ |
| local-copy control (`const s = this.state`) | already correct | unchanged ✅ |
| **negative:** nested `pair.lead.key === "x"` must NOT narrow outer `pair` | TS2339 | TS2339 preserved ✅ |
| **negative:** nested `this.frame.inner.matched` must NOT narrow `this.frame` | TS2339 | TS2339 preserved ✅ |

## Verification

- New regression suite `crates/tsz-checker/tests/this_rooted_discriminant_narrowing_tests.rs` (8 cases, binder names varied, incl. the two negative controls): `8 passed`.
- `cargo test -p tsz-checker` discriminant/narrowing integration suites green: `nested_discriminant_narrowing_tests`, `const_alias_discriminant_narrowing_tests`, `discriminant_literal_reference_narrowing_tests`, `discriminant_narrow_function_lazy_preserved_tests`, `unique_symbol_discriminant_narrowing_tests`, `enum_equality_narrowing_tests`, `imported_ctor_alias_predicate_narrowing_tests`, `closure_boundary_property_narrowing_tests`, `flow_property_reference_cache_tests`, `assignment_branch_merge_narrowing_tests`, `type_guard_mutable_field_probe_tests`, `ts2339_union_narrow_display_tests`.
- `cargo test -p tsz-checker --lib`: `504 passed`; the only 3 failures (`flow_assignment_and_predicate_exclusion_use_relation_outcome_boundary`, `test_typeof_after_logical_assignment_local_and_parameter_scopes`, `mapped_enum_discriminant_application_exposes_member_property`) reproduce **identically on clean `origin/main`** with this change stashed — pre-existing and unrelated.
- CLI on the witness/controls (bundled `es5` lib): witness, local-copy control, broad (`===`/`switch`/deeper-`this`), and `typeof`/`===`-on-`this` extras all emit 0 diagnostics; the nested-over-narrowing negative still reports TS2339.
- `cargo fmt -p tsz-checker --check` clean; `cargo clippy -p tsz-checker --lib` clean.
- Branch is on current `origin/main`; broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCy9uTJYDd42XivVegLUYu)_