### PR TITLE
perf(checker): cache lazy lib receiver eligibility (#12101)

### DIFF
--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -157,6 +157,15 @@ pub struct LibTypeResolutionCaches {
     /// reads from rescanning declaration and heritage lists while preserving the
     /// same full-materialization fallback on cached misses.
     pub lazy_members: RefCell<FxHashMap<(Atom, Atom), Option<TypeId>>>,
+
+    /// Per-checker cache for lazy single-member receiver eligibility.
+    /// Keyed by the bare receiver `Lazy(DefId)`. Stores both eligible and
+    /// ineligible decisions after the conservative receiver predicate has
+    /// inspected symbol provenance, generic parameters, shadowing, global
+    /// augmentations, and heritage bases. This keeps repeated DOM/lib property
+    /// reads from re-walking the same heritage/augmentation graph before they
+    /// can hit the member cache.
+    pub lazy_member_receivers: RefCell<FxHashMap<tsz_solver::def::DefId, bool>>,
 }
 
 /// Maximum depth for nested `get_type_of_symbol` calls before giving up.

--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -145,47 +145,65 @@ impl CheckerState<'_> {
         }
 
         let def_id = crate::query_boundaries::common::lazy_def_id(self.ctx.types, object_type)?;
-
-        // Must resolve to a concrete lib interface symbol.
-        let sym_id = self.ctx.def_to_symbol_id_with_fallback(def_id)?;
-        let symbol = self.ctx.binder.get_symbol(sym_id)?;
-        if !symbol.has_any_flags(symbol_flags::INTERFACE) {
-            return None;
-        }
-
-        // Non-generic only: a generic interface body would need its receiver's
-        // type arguments substituted into the member type, which the bare-Lazy
-        // path cannot supply.
-        if self
+        if let Some(&eligible) = self
             .ctx
-            .get_def_type_params(def_id)
-            .is_some_and(|p| !p.is_empty())
+            .lib_type_resolution_caches
+            .lazy_member_receivers
+            .borrow()
+            .get(&def_id)
         {
-            return None;
+            return eligible.then_some(def_id);
         }
 
-        let name = symbol.escaped_name.clone();
-        if crate::query_boundaries::type_predicates::is_compiler_managed_type(&name) {
-            return None;
-        }
-        if self.ctx.file_local_type_shadow_for_lib_name(&name) {
-            return None;
-        }
-        // The symbol must come from the actual/cloned lib — user interfaces (even
-        // sharing a lib name) take the normal path so augmentation/merging stays
-        // correct.
-        if !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id) {
-            return None;
-        }
+        let eligible = (|| {
+            // Must resolve to a concrete lib interface symbol.
+            let sym_id = self.ctx.def_to_symbol_id_with_fallback(def_id)?;
+            let symbol = self.ctx.binder.get_symbol(sym_id)?;
+            if !symbol.has_any_flags(symbol_flags::INTERFACE) {
+                return None;
+            }
 
-        // A globally-augmented or user-shadowed interface/base may gain members
-        // from a separate declaration. Fall back to full materialization so
-        // merge state and diagnostic source locations stay authoritative.
-        if self.lib_interface_or_heritage_is_augmented_or_shadowed(sym_id, &name) {
-            return None;
-        }
+            // Non-generic only: a generic interface body would need its receiver's
+            // type arguments substituted into the member type, which the bare-Lazy
+            // path cannot supply.
+            if self
+                .ctx
+                .get_def_type_params(def_id)
+                .is_some_and(|p| !p.is_empty())
+            {
+                return None;
+            }
 
-        Some(def_id)
+            let name = symbol.escaped_name.clone();
+            if crate::query_boundaries::type_predicates::is_compiler_managed_type(&name) {
+                return None;
+            }
+            if self.ctx.file_local_type_shadow_for_lib_name(&name) {
+                return None;
+            }
+            // The symbol must come from the actual/cloned lib — user interfaces (even
+            // sharing a lib name) take the normal path so augmentation/merging stays
+            // correct.
+            if !self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id) {
+                return None;
+            }
+
+            // A globally-augmented or user-shadowed interface/base may gain members
+            // from a separate declaration. Fall back to full materialization so
+            // merge state and diagnostic source locations stay authoritative.
+            if self.lib_interface_or_heritage_is_augmented_or_shadowed(sym_id, &name) {
+                return None;
+            }
+
+            Some(def_id)
+        })()
+        .is_some();
+        self.ctx
+            .lib_type_resolution_caches
+            .lazy_member_receivers
+            .borrow_mut()
+            .insert(def_id, eligible);
+        eligible.then_some(def_id)
     }
 
     /// Whether a lib interface `name` has any global augmentation declarations


### PR DESCRIPTION
Goal: fast

## Summary
- Cache lazy lib-interface receiver eligibility by bare `Lazy(DefId)` inside the existing lib type resolution cache bundle.
- Keep the existing member cache and conservative eligibility predicate unchanged.
- Avoid re-walking the same symbol provenance, type-parameter, shadowing, global-augmentation, and heritage-base checks before repeated DOM/lib member lookups can hit the member cache.

## Structural Rule / Owner Layer
When a lazy lib-interface receiver has already been classified by the checker-owned eligibility predicate, repeated property accesses on the same bare `Lazy(DefId)` should reuse that stable file-session decision. If the receiver is generic, indexed, merged, receiver-specific augmented, shadowed, compiler-managed, user-owned, or otherwise ambiguous, the cached decision remains ineligible and tsz takes the existing full-materialization fallback.

Owner layer: checker state / lazy lib-member property-access fast path.

Cache invariant: the key is the receiver's stable `DefId` inside one checker context. The cache stores only the predicate result for the existing fast path; it does not cache member types, diagnostics, rendered names, source text, or cross-session state.

## Adjacent Matrix
- Renamed binders: decisions use `DefId` plus existing symbol provenance, not user-chosen property or local variable names.
- Alias/wrapper/nesting: only bare `Lazy(DefId)` receivers enter the cache; applications and materialized objects still use existing paths.
- Positive/fallback: eligible lib receivers continue into the existing member resolver/cache; ineligible receivers still fall back to full materialization.
- Augmentation/shadowing: the existing augmentation and shadow checks are preserved before caching the decision.

## Verification
- Not run locally per current instruction.
- Pre-commit formatting hook ran during commit `af50ce7234`.
- Draft/light CI passed at exact head `af50ce723487d808a47db86aaba1df0dc23594dc`: `CI Light Summary` and `premerge-microbench` succeeded.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
