### PR TITLE
perf(checker): skip unused TS2454 replacement set (#13243)

### DIFF
--- a/crates/tsz-checker/src/context/speculation.rs
+++ b/crates/tsz-checker/src/context/speculation.rs
@@ -587,15 +587,20 @@ impl<'a> CheckerContext<'a> {
         // Clean up emitted_ts2454_errors for discarded TS2454 diagnostics
         // that are not in the replacement set.
         let truncate_at = self.clamped_diag_len(snap);
-        let replacement_ts2454_positions: rustc_hash::FxHashSet<u32> = replacement
+        let discarded_has_ts2454 = self.diagnostics[truncate_at..]
             .iter()
-            .filter(|d| d.code == 2454)
-            .map(|d| d.start)
-            .collect();
-        for diag in &self.diagnostics[truncate_at..] {
-            if diag.code == 2454 && !replacement_ts2454_positions.contains(&diag.start) {
-                self.emitted_ts2454_errors
-                    .retain(|&(pos, _)| pos != diag.start);
+            .any(|diag| diag.code == 2454);
+        if discarded_has_ts2454 {
+            let replacement_ts2454_positions: rustc_hash::FxHashSet<u32> = replacement
+                .iter()
+                .filter(|d| d.code == 2454)
+                .map(|d| d.start)
+                .collect();
+            for diag in &self.diagnostics[truncate_at..] {
+                if diag.code == 2454 && !replacement_ts2454_positions.contains(&diag.start) {
+                    self.emitted_ts2454_errors
+                        .retain(|&(pos, _)| pos != diag.start);
+                }
             }
         }
         self.diagnostics.truncate(truncate_at);


### PR DESCRIPTION
Goal: fast

## Summary
- Avoid building the `replacement_ts2454_positions` set during diagnostic replacement unless the discarded speculative diagnostic tail actually contains TS2454 entries.
- Keep existing rollback and replacement behavior unchanged for TS2454 by building the set only on the path that needs TS2454 dedup cleanup.

## Structural rule
When speculative diagnostic replacement discards no TS2454 diagnostics, `tsc` observes no definite-assignment dedup cleanup effect; tsz now skips the checker-owned TS2454 replacement-position allocation and preserves the existing diagnostic rollback result through `CheckerContext::rollback_and_replace_diagnostics`.

## Owner layer
Checker diagnostic speculation lifecycle. Relation semantics and solver assignability behavior are unchanged.

## Adjacent matrix
- Non-TS2454 speculative diagnostics: skip the replacement-position set and use the existing truncate/dedup restore path.
- Discarded TS2454 diagnostics with no replacement TS2454: retain existing cleanup behavior.
- Discarded TS2454 diagnostics with replacement TS2454 at the same start: retain existing preservation behavior.
- Empty replacement with changed diagnostic state: retain existing rollback behavior.

## Fallback and risk
If the discarded speculative tail contains TS2454, the old cleanup logic still runs with the same replacement-position membership check. The change is allocation gating only and does not alter diagnostic filtering, ordering, or relation failure reasons.

## Performance note
This removes one temporary `FxHashSet` allocation from the common diagnostic-replacement path where assignment/call failure speculation has no TS2454 diagnostics. No local benchmark was run.

## Verification
- Not run locally per current instruction to avoid local validation; ready-review CI owns broad checks.
- Pre-commit formatting hook ran during `git commit`.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
