### PR TITLE
perf(solver): preserve unchanged infer instantiation (#13242)

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -878,20 +878,16 @@ impl<'a> TypeInstantiator<'a> {
                 // Instantiate the constraint if it references type parameters being substituted.
                 // e.g., `infer A extends keyof T` when T is being substituted with Obj
                 // needs the constraint updated to `keyof Obj`.
-                let new_info = if let Some(constraint) = info.constraint {
+                if let Some(constraint) = info.constraint {
                     let new_constraint = self.instantiate(constraint);
                     if new_constraint != constraint {
-                        TypeParamInfo {
+                        return self.interner.infer(TypeParamInfo {
                             constraint: Some(new_constraint),
                             ..*info
-                        }
-                    } else {
-                        *info
+                        });
                     }
-                } else {
-                    *info
-                };
-                self.interner.infer(new_info)
+                }
+                self.interner.intern(*key)
             }
         }
     }


### PR DESCRIPTION
Goal: fast

## Summary
- Preserve the original `Infer` `TypeId` when instantiation neither substitutes the inference variable nor changes its constraint.
- Only build and intern replacement `TypeParamInfo` when the constraint actually changes.

## Structural rule
When an `Infer` type has no active inference substitution and its constraint instantiates to the same `TypeId` or is absent, `tsc` observes the same deferred infer node; tsz now preserves the existing interned `Infer` identity through solver instantiation instead of re-interning an equivalent shape.

## Owner layer
Solver instantiation. Checker diagnostics, relation policy, and concrete materialization policy are unchanged.

## Adjacent matrix
- `Infer` without a constraint: return the existing `TypeId`.
- `Infer` with an unchanged constraint: return the existing `TypeId`.
- `Infer` with a changed constraint: intern the replacement `TypeParamInfo` as before.
- `Infer` with an active substitution binding: still returns the substituted type before constraint handling.

## Fallback and risk
The fallback path for changed constraints is the previous interner path. The unchanged path is identity preservation only; it does not add laziness, widen caches, or alter inference-variable substitution.

## Performance note
This removes avoidable same-shape `Infer` re-interning during concrete instantiation walks where inference constraints are absent or unchanged. No local benchmark was run.

## Verification
- Not run locally per current instruction to avoid local validation; ready-review CI owns broad checks.
- Pre-commit formatting hook ran during `git commit`.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
