### PR TITLE
perf(checker): stop display union siblings after budget exhaustion (#13040)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/core/type_display.rs
+++ b/crates/tsz-checker/src/error_reporter/core/type_display.rs
@@ -679,12 +679,18 @@ impl<'a> CheckerState<'a> {
                 // not `{ fooProp: string; } & Bar`.
                 ty
             } else if let Some(members) = query::union_members(self.ctx.types, ty) {
-                let normalized: Vec<_> = members
-                    .iter()
-                    .map(|&member| {
-                        self.normalize_assignability_display_type_inner(member, visiting, depth + 1)
-                    })
-                    .collect();
+                let mut normalized = Vec::with_capacity(members.len());
+                for &member in members.iter() {
+                    normalized.push(self.normalize_assignability_display_type_inner(
+                        member,
+                        visiting,
+                        depth + 1,
+                    ));
+                    if crate::error_reporter::display_budget::is_exhausted() {
+                        visiting.remove(&ty);
+                        return ty;
+                    }
+                }
                 if normalized == members {
                     ty
                 } else {


### PR DESCRIPTION
Goal: fast

## Summary
- Stop assignability-display union sibling normalization immediately after the shared display budget exhausts in the intersection/union branch.
- Preserve the current display frame instead of continuing breadth work over remaining union members after a child burns the per-rendered-type budget.

## Structural rule
When diagnostic display normalization exhausts the per-rendered-type budget while normalizing a union nested in an intersection display path, tsz should truncate at the current display frame instead of walking the remaining union siblings. Relation and semantic evaluation paths remain unchanged because the display budget is inert outside diagnostic display scopes.

## Owner layer
Checker diagnostic display only. Solver relation/evaluation policy is unchanged.

## Adjacent matrix
- Budget not exhausted: union members normalize and preserve/rebuild as before.
- Budget exhausted by a child union member: return the current display type and skip remaining siblings.
- Non-display scopes: `display_budget::is_exhausted()` remains false, so behavior is unchanged.
- Existing evaluated union/intersection branches already stop after each child; this aligns the earlier intersection/union branch with that policy.

## Fallback and risk
The fallback is the original/current display type for this frame, matching the rest of the display-budget truncation strategy. No fixture names, source text, rendered strings, or semantic predicates were added.

## Verification
- Not run locally per current instruction to avoid local validation; draft/light CI is the first gate.
- Pre-commit formatting hook ran during `git commit`.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: codex
Model: GPT-5
Effort: medium
