### PR TITLE
fix(checker): consume method-bearing cross-file interface heritage (#13554)

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/heritage_publication.rs
+++ b/crates/tsz-checker/src/state/type_resolution/heritage_publication.rs
@@ -114,16 +114,32 @@ impl<'a> CheckerState<'a> {
             return None;
         }
         let published = self.ctx.definition_store.get_body(def_id)?;
+        // The published body feeds contextual-inference paths only when it
+        // carries a conditional that can surface still-generic during union
+        // normalization (the #13232 resolver-less defect). A callable member
+        // with no conditional in its signature — directly or behind an applied
+        // alias — is inference-inert, so consuming it lets an importing file
+        // resolve members inherited through a method-bearing generic interface
+        // (`interface D<T> extends Base<T>` with a method on `Base`). Detect the
+        // conditional *through* alias applications, since the standard content
+        // walk treats an applied alias base as an opaque leaf.
+        let published_feeds_conditional_inference = {
+            let db = self.ctx.types.as_type_database();
+            let def_store = &self.ctx.definition_store;
+            let mut resolve_lazy = |d: tsz_solver::DefId| def_store.get_body(d);
+            tsz_solver::type_queries::contains_conditional_through_aliases(
+                db,
+                published,
+                &mut resolve_lazy,
+            )
+        };
         if published == TypeId::ERROR
             || published == TypeId::UNKNOWN
             || published == merged
             || crate::query_boundaries::common::lazy_def_id(self.ctx.types, published)
                 == Some(def_id)
             || !self.published_body_covers_local_members(published, merged)
-            || tsz_solver::type_queries::contains_callable_or_conditional(
-                self.ctx.types.as_type_database(),
-                published,
-            )
+            || published_feeds_conditional_inference
         {
             return None;
         }

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part4.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part4.rs
@@ -56,6 +56,102 @@ d.pulp;
         );
     }
 
+    // ------------------------------------------------------------------
+    // #13554: a cross-module *generic* interface that `extends` a base
+    // carrying a METHOD member dropped every inherited member when imported.
+    //
+    // Root cause: the importing file's local heritage merge is a no-op for a
+    // foreign declaration, so it relies on consuming the declaring checker's
+    // published heritage-merged body. The consumption gate refused any body
+    // `contains_callable_or_conditional` — a method makes the body "contain a
+    // callable" — to avoid unmasking the #13232 resolver-less *conditional*
+    // defect. That over-broad guard also blocked inert method-bearing bodies.
+    //
+    // Fix: gate on a conditional reachable *through* applied aliases instead of
+    // on any callable. Plain methods (no conditional, even behind an alias) are
+    // consumed; conditional-bearing bodies stay gated. Binder names vary across
+    // cases so the behavior follows the type shape, not a spelling.
+    // ------------------------------------------------------------------
+
+    fn assert_no_2339(diagnostics: &[Diagnostic], ctx: &str) {
+        let bogus: Vec<_> = diagnostics
+            .iter()
+            .filter(|diag| diag.code == 2339)
+            .map(|diag| diag.message_text.to_string())
+            .collect();
+        assert!(bogus.is_empty(), "{ctx}: unexpected TS2339: {bogus:?}");
+    }
+
+    #[test]
+    fn repro13554_method_shorthand_base_keeps_inherited() {
+        let options = project_mode_es2015_strict_options();
+        let diagnostics = collect_test_diagnostics_with_options(
+            &[
+                (
+                    "/p/base.ts",
+                    r#"
+export interface Base<T> {
+  m(): void;
+  v?: T;
+}
+export interface Derived<T> extends Base<T> {}
+"#,
+                ),
+                (
+                    "/p/main.ts",
+                    r#"
+import type { Derived } from "./base";
+declare const d: Derived<number>;
+d.v;
+d.m();
+"#,
+                ),
+            ],
+            &options,
+            Path::new("/p"),
+        );
+        assert_no_2339(&diagnostics, "method-shorthand base, generic derived");
+    }
+
+    #[test]
+    fn repro13554_renamed_binders_and_nested_method_keep_inherited() {
+        // Every binder renamed; the method shorthand is nested inside a base
+        // member's object type, and the derived interface re-declares one of
+        // its own members. Inherited members (`payload`, `kind`) must resolve.
+        let options = project_mode_es2015_strict_options();
+        let diagnostics = collect_test_diagnostics_with_options(
+            &[
+                (
+                    "/p/shapes.ts",
+                    r#"
+export interface Envelope<Kind, Payload> {
+  meta: { stamp(): string };
+  payload?: Payload;
+  kind?: Kind;
+}
+export interface SealedEnvelope<Kind, Payload>
+  extends Envelope<Kind, Payload> {
+  meta: { stamp(): string };
+}
+"#,
+                ),
+                (
+                    "/p/station.ts",
+                    r#"
+import type { SealedEnvelope } from "./shapes";
+declare const e: SealedEnvelope<"json", { id: number }>;
+const p = e.payload;
+const k = e.kind;
+const s = e.meta.stamp();
+"#,
+                ),
+            ],
+            &options,
+            Path::new("/p"),
+        );
+        assert_no_2339(&diagnostics, "renamed binders, nested method shorthand");
+    }
+
     #[test]
     fn program_mode_imported_generic_interface_heritage_reversed_file_order_resolves() {
         let options = project_mode_es2015_strict_options();

--- a/crates/tsz-solver/src/type_queries/data/content_predicates.rs
+++ b/crates/tsz-solver/src/type_queries/data/content_predicates.rs
@@ -258,21 +258,96 @@ pub fn contains_conditional_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool
     contains_content_cached(db, type_id, &ConditionalPredicate)
 }
 
-/// Whether the alias-opaque structure of `type_id` contains a `Callable`
-/// or a `Conditional` node.
+/// Whether the body contains a `Conditional` node reachable through its full
+/// content surface, **resolving alias `Application`/`Lazy` bases** via
+/// `resolve_lazy`.
 ///
-/// Used by the cross-module interface-heritage consumption gate: a published
-/// definition body carrying call/construct signatures or conditional members
-/// feeds contextual-inference paths where a pre-existing resolver-less
-/// evaluation defect (still-generic conditionals mis-distributed during union
-/// normalization) produces false relation failures. Only inference-inert
-/// (data-shaped) bodies are consumed until that defect is fixed. Treats
-/// nested `Lazy`/`Application` bases as opaque leaves, mirroring
-/// [`contains_conditional_type`].
-pub fn contains_callable_or_conditional(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
-    crate::visitors::visitor_predicates::contains_type_matching(db, type_id, |key| {
-        matches!(key, TypeData::Callable(_) | TypeData::Conditional(_))
-    })
+/// Unlike [`contains_conditional_type`] — which treats `Lazy`/`Application`
+/// bases as opaque leaves — this walk follows an applied alias
+/// (`MappedResponseType<R, T>`) into its registered body so a conditional
+/// buried behind a generic alias *inside a method signature* is still detected.
+///
+/// Used by the cross-module interface-heritage consumption gate: the #13232
+/// resolver-less union-normalization defect is triggered specifically by a
+/// still-generic conditional surfacing during contextual inference. A published
+/// body whose callable members carry no conditional (directly or through an
+/// applied alias) cannot feed that path, so it is safe to consume — which is
+/// what lets an importing file resolve members inherited through a method-
+/// bearing generic interface (`interface D<T> extends Base<T>` where `Base` has
+/// a method member). Bodies that do reach a conditional stay gated.
+///
+/// `resolve_lazy` maps an alias/interface `DefId` to its registered body; it
+/// returns `None` when no body is registered (treated as "no conditional behind
+/// this alias"). The walk is bounded by a visited set and a depth limit so
+/// recursive aliases terminate.
+pub fn contains_conditional_through_aliases(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    resolve_lazy: &mut dyn FnMut(crate::def::DefId) -> Option<TypeId>,
+) -> bool {
+    let mut visited = FxHashSet::default();
+    contains_conditional_through_aliases_inner(db, type_id, resolve_lazy, &mut visited, 0)
+}
+
+const CONDITIONAL_THROUGH_ALIAS_DEPTH_LIMIT: usize = 64;
+
+fn contains_conditional_through_aliases_inner(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+    resolve_lazy: &mut dyn FnMut(crate::def::DefId) -> Option<TypeId>,
+    visited: &mut FxHashSet<TypeId>,
+    depth: usize,
+) -> bool {
+    if depth > CONDITIONAL_THROUGH_ALIAS_DEPTH_LIMIT || type_id.is_intrinsic() {
+        return false;
+    }
+    if !visited.insert(type_id) {
+        return false;
+    }
+    let Some(data) = db.lookup(type_id) else {
+        return false;
+    };
+    if matches!(data, TypeData::Conditional(_)) {
+        return true;
+    }
+    // Follow an applied alias / bare lazy reference into its registered body so
+    // a conditional hidden behind `Alias<Args>` is not missed (the standard
+    // content child policy treats application bases as opaque leaves).
+    let alias_base_def = match &data {
+        TypeData::Application(app_id) => {
+            crate::visitors::visitor_extract::lazy_def_id(db, db.type_application(*app_id).base)
+        }
+        TypeData::Lazy(def_id) => Some(*def_id),
+        _ => None,
+    };
+    if let Some(def_id) = alias_base_def
+        && let Some(body) = resolve_lazy(def_id)
+        && contains_conditional_through_aliases_inner(db, body, resolve_lazy, visited, depth + 1)
+    {
+        return true;
+    }
+    // Descend the standard content surface (object properties, callable/function
+    // signature params + returns, application args, union/intersection members,
+    // conditional arms), short-circuiting on the first conditional found.
+    try_for_each_child_with_policy::<(), _>(
+        db,
+        &data,
+        &ChildPolicy::CONTENT_PREDICATE,
+        &mut |child| {
+            if contains_conditional_through_aliases_inner(
+                db,
+                child,
+                resolve_lazy,
+                visited,
+                depth + 1,
+            ) {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        },
+    )
+    .is_break()
 }
 
 /// Whether `superset`'s named object properties include every named property
@@ -1554,5 +1629,94 @@ pub fn union_has_direct_type_parameter(db: &dyn TypeDatabase, type_id: TypeId) -
             })
         }
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod conditional_through_aliases_tests {
+    use super::contains_conditional_through_aliases;
+    use crate::construction::TypeInterner;
+    use crate::def::DefId;
+    use crate::types::{ConditionalType, FunctionShape, PropertyInfo, TypeId};
+
+    // A generic interface body shaped like `{ m(): void; v?: T }`: a method
+    // member plus a data member, no conditional anywhere. This is the #13554
+    // case that must be consumable cross-file, so the gate must report `false`.
+    #[test]
+    fn plain_method_object_body_has_no_conditional() {
+        let interner = TypeInterner::new();
+        let m = interner.intern_string("m");
+        let v = interner.intern_string("v");
+        let method = interner.function(FunctionShape::new(vec![], TypeId::VOID));
+        let body = interner.object(vec![
+            PropertyInfo::method(m, method),
+            PropertyInfo::opt(v, TypeId::NUMBER),
+        ]);
+        let mut resolve = |_: DefId| None;
+        assert!(!contains_conditional_through_aliases(
+            &interner,
+            body,
+            &mut resolve
+        ));
+    }
+
+    // A method whose return type applies an alias whose body is a conditional
+    // (`read(): MappedResponseType<R, T>`). The standard content walk treats
+    // the application base as an opaque leaf, so resolution must follow the
+    // alias to find the conditional. Detected through both the object property
+    // and the applied alias.
+    #[test]
+    fn method_returning_alias_to_conditional_is_detected() {
+        let interner = TypeInterner::new();
+        let cond = interner.conditional(ConditionalType {
+            check_type: TypeId::STRING,
+            extends_type: TypeId::STRING,
+            true_type: TypeId::NUMBER,
+            false_type: TypeId::BOOLEAN,
+            is_distributive: false,
+        });
+        let def = DefId(7);
+        let alias_app = interner.application(interner.lazy(def), vec![TypeId::STRING]);
+        let method = interner.function(FunctionShape::new(vec![], alias_app));
+        let read = interner.intern_string("read");
+        let body = interner.object(vec![PropertyInfo::method(read, method)]);
+
+        let mut resolve = |d: DefId| (d == def).then_some(cond);
+        assert!(contains_conditional_through_aliases(
+            &interner,
+            body,
+            &mut resolve
+        ));
+
+        // When the alias body is unavailable, the conditional behind it cannot
+        // be observed and the body is treated as inert (no false gating).
+        let mut unresolved = |_: DefId| None;
+        assert!(!contains_conditional_through_aliases(
+            &interner,
+            body,
+            &mut unresolved
+        ));
+    }
+
+    // A directly-present conditional member is detected without alias
+    // resolution.
+    #[test]
+    fn direct_conditional_member_is_detected() {
+        let interner = TypeInterner::new();
+        let cond = interner.conditional(ConditionalType {
+            check_type: TypeId::STRING,
+            extends_type: TypeId::STRING,
+            true_type: TypeId::NUMBER,
+            false_type: TypeId::BOOLEAN,
+            is_distributive: false,
+        });
+        let p = interner.intern_string("p");
+        let body = interner.object(vec![PropertyInfo::new(p, cond)]);
+        let mut resolve = |_: DefId| None;
+        assert!(contains_conditional_through_aliases(
+            &interner,
+            body,
+            &mut resolve
+        ));
     }
 }


### PR DESCRIPTION
Goal: green

Fixes #13554.

## Summary

A cross-module **generic** interface that `extends` a base carrying a **method**
member dropped every inherited member when imported into another file, emitting
false `TS2339` (the ofetch canary's dominant cluster, ~22 sites).

## Structural rule

When interface `D<…>` is declared in file A, `extends` a base, and is imported
into file B, B's local heritage merge is a no-op (`merge_interface_heritage_types`
reads B's arena, which lacks A's declaration nodes). B therefore **consumes the
declaring checker's published heritage-merged body** through the shared
`DefinitionStore` (`try_consume_published_heritage_body`).

That consumption was gated by `contains_callable_or_conditional(published)`: a
method makes the body "contain a callable", so the gate refused the body and B
fell back to the own-members-only seed → inherited members dropped. The gate was
a deliberately broad guard against unmasking the #13232 resolver-less
**conditional** defect ("Lift once that defect is fixed"). It also over-blocked
inert method-bearing bodies.

`tsc` binds the full member set; tsz now does too for the inert case.

## Fix / owner layer

Narrow the consumption gate from "any callable" to "a **conditional reachable
through applied aliases**". A new solver query
`contains_conditional_through_aliases` (`crates/tsz-solver/.../content_predicates.rs`)
walks the full content surface (object properties, callable/function signatures)
**and resolves alias `Application`/`Lazy` bases** via a `resolve_lazy` closure —
because the existing `contains_conditional_type` treats those bases as opaque
leaves, which is exactly why the broad callable check was load-bearing for
#13232 (the conditional hides behind `MappedResponseType<R, T>` inside a method
return). Plain method bodies (no conditional, even through an alias) are now
consumed; conditional-bearing bodies stay gated. Owner: solver type-shape query
consumed by the checker's cross-file heritage-consumption gate.

No identifier/file-name/printer-string predicates; the decision is purely on
type shape.

## Adjacent matrix

| case | tsc | tsz (PR) |
|---|---|---|
| generic derived `extends` method-bearing base, cross-file | clean | clean |
| renamed binders + nested method shorthand + own re-decl | clean | clean |
| property-function base (not a method) | clean | clean (unchanged) |
| non-generic derived | clean | clean (unchanged) |
| conditional-through-alias in a method signature | (residual) | stays gated (#13232 guard preserved) |

## Verification

- `cargo test -p tsz-cli --lib repro13554` — new driver regression tests
  (method-shorthand base + renamed-binder/nested-method) pass; the original
  2-file witness and all controls are clean via the CLI.
- `cargo test -p tsz-solver --lib conditional_through_aliases` — 3 new unit
  tests for the query (plain method = inert; method→alias→conditional detected;
  unresolved alias = inert; direct conditional detected).
- `cargo test -p tsz-checker --lib` and `cargo test -p tsz-solver --lib`:
  **0 new failures** vs the branch base (the one differing checker test is a
  global perf-counter flake that passes in isolation; solver has the same 3
  pre-existing failures on base and branch). The #13232-family zod/async tests
  are unchanged — the alias-resolving narrowing does not re-expose that defect,
  unlike a blanket `contains_conditional_type` narrowing.
- `cargo clippy -p tsz-solver -p tsz-checker --lib`: clean.
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvA9xTDcM1VTsHAy1PfDPh)_