### PR TITLE
test(cli): guard scope registry parallel agreement (#13255)

### DIFF
--- a/crates/tsz-cli/tests/fixtures/parallel_agreement_scope_registry/alias-consumer.ts
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement_scope_registry/alias-consumer.ts
@@ -1,0 +1,40 @@
+import type { BrandInfo } from './brands';
+import type {
+  StepDefinition,
+  StepInput,
+  StepName,
+  StepOutput,
+  StepView,
+  StepsByName,
+} from './scope-registry';
+import type { Pairwise } from './tuple-utils';
+
+export type StepAudit<
+  TDefinitions extends readonly StepDefinition[],
+  TTarget extends keyof StepsByName<TDefinitions> & string,
+> = {
+  readonly key: `audit:${TTarget}`;
+  readonly view: StepView<TDefinitions, TTarget>;
+  readonly input: StepInput<TDefinitions, TTarget>;
+  readonly output: Awaited<StepOutput<TDefinitions, TTarget>>;
+};
+
+export type AuditByName<TDefinitions extends readonly StepDefinition[]> = {
+  [Name in keyof StepsByName<TDefinitions> & string as `audit:${Name}`]: StepAudit<
+    TDefinitions,
+    Name
+  >;
+};
+
+export type DependencyPairs<
+  TNames extends readonly StepName[],
+  TDeps extends readonly StepName[],
+> = Pairwise<TNames, TDeps>;
+
+export type BrandedAuditMarker<TDefinitions extends readonly StepDefinition[]> =
+  BrandInfo<keyof AuditByName<TDefinitions> & string>;
+
+export const toAuditKeys = <TDefinitions extends readonly StepDefinition[]>(
+  definitions: TDefinitions,
+): readonly (keyof AuditByName<TDefinitions> & string)[] =>
+  definitions.map((definition) => `audit:${definition.name}`) as readonly (keyof AuditByName<TDefinitions> & string)[];

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement_scope_registry/brands.ts
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement_scope_registry/brands.ts
@@ -1,0 +1,12 @@
+export type Brand<TValue, TMarker extends string = string> = TValue & {
+  readonly __brand: TMarker;
+};
+
+export type BrandInfo<TValue> = TValue extends Brand<infer Raw, infer Marker>
+  ? { readonly value: Raw; readonly marker: Marker }
+  : never;
+
+export const asBrand = <TValue extends string, TMarker extends string>(
+  value: TValue,
+  _marker: TMarker,
+): Brand<TValue, TMarker> => value as Brand<TValue, TMarker>;

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement_scope_registry/registry-consumer.ts
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement_scope_registry/registry-consumer.ts
@@ -1,0 +1,99 @@
+import { asBrand } from './brands';
+import { toAuditKeys, type AuditByName } from './alias-consumer';
+import {
+  runAllSteps,
+  StepRegistry,
+  type StepDefinition,
+  type StepDependency,
+} from './scope-registry';
+
+type LoadInput = {
+  readonly value: number;
+  readonly tenant: string;
+};
+
+type LoadOutput = {
+  readonly normalized: string;
+  readonly score: number;
+};
+
+type StoreInput = {
+  readonly normalized: string;
+  readonly score: number;
+};
+
+type StoreOutput = {
+  readonly stored: true;
+  readonly receipt: `receipt:${string}`;
+};
+
+type LoadStep = StepDefinition<LoadInput, LoadOutput, 'step:load', readonly []>;
+type StoreStep = StepDefinition<
+  StoreInput,
+  StoreOutput,
+  'step:store',
+  readonly ['dep:step:load']
+>;
+
+const definitions: readonly [LoadStep, StoreStep] = [
+  {
+    id: 'load',
+    name: 'step:load',
+    phase: 'phase:prepare',
+    dependsOn: [],
+    async run(input: LoadInput) {
+      return {
+        state: 'success',
+        output: {
+          normalized: input.tenant.toUpperCase(),
+          score: input.value + 1,
+        },
+        notes: ['loaded'],
+      };
+    },
+  },
+  {
+    id: 'store',
+    name: 'step:store',
+    phase: 'phase:commit',
+    dependsOn: ['dep:step:load'],
+    async run(input: StoreInput) {
+      return {
+        state: 'success',
+        output: {
+          stored: true,
+          receipt: `receipt:${input.normalized}`,
+        },
+        notes: ['stored'],
+      };
+    },
+  },
+];
+
+const dependencyProbe: readonly StepDependency[] = definitions[1].dependsOn;
+
+const registry = new StepRegistry(definitions);
+const space = asBrand('space:fixture', 'SpaceId');
+
+export const registryNames = registry.names();
+
+export const auditKeys: readonly (keyof AuditByName<typeof definitions> & string)[] =
+  toAuditKeys(definitions);
+
+export const knownDependencies = dependencyProbe;
+
+export const runLoad = () =>
+  registry.run('step:load', { value: 41, tenant: 'north' }, space);
+
+export const runStore = () =>
+  registry.run('step:store', { normalized: 'NORTH', score: 42 }, space);
+
+export const runEverything = () =>
+  runAllSteps({
+    definitions,
+    space,
+    inputByName: {
+      'step:load': { value: 1, tenant: 'south' },
+      'step:store': { normalized: 'SOUTH', score: 2 },
+    },
+  });

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement_scope_registry/scope-registry.ts
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement_scope_registry/scope-registry.ts
@@ -1,0 +1,207 @@
+import type { Brand } from './brands';
+import type { Expand, NoInfer } from './tuple-utils';
+
+export type SpaceId = Brand<string, 'SpaceId'>;
+export type PhaseName = `phase:${string}`;
+export type StepName = `step:${string}`;
+export type StepDependency = `dep:${StepName}`;
+
+export type StepContext<TInput> = {
+  readonly executionId: string;
+  readonly space: SpaceId;
+  readonly phase: PhaseName;
+  readonly attempt: number;
+  readonly input: NoInfer<TInput>;
+};
+
+export type StepSuccess<TOutput> = {
+  readonly state: 'success';
+  readonly output: TOutput;
+  readonly notes: readonly string[];
+};
+
+export type StepFailure = {
+  readonly state: 'failure';
+  readonly reason: string;
+  readonly notes: readonly string[];
+};
+
+export type StepResult<TOutput> = StepSuccess<TOutput> | StepFailure;
+
+export type StepDefinition<
+  TInput = any,
+  TOutput = any,
+  TName extends StepName = StepName,
+  TDependencies extends readonly StepDependency[] = readonly StepDependency[],
+> = {
+  readonly id: string;
+  readonly name: TName;
+  readonly phase: PhaseName;
+  readonly dependsOn: TDependencies;
+  readonly run: (
+    input: NoInfer<TInput>,
+    context: StepContext<TInput>,
+  ) => Promise<StepResult<TOutput>>;
+};
+
+export type StepsByName<TDefinitions extends readonly StepDefinition[]> = {
+  [Step in TDefinitions[number] as Step['name']]: Step;
+};
+
+export type StepByName<
+  TDefinitions extends readonly StepDefinition[],
+  TTarget extends keyof StepsByName<TDefinitions> & string,
+> = StepsByName<TDefinitions>[TTarget];
+
+export type StepInput<
+  TDefinitions extends readonly StepDefinition[],
+  TTarget extends keyof StepsByName<TDefinitions> & string,
+> = TTarget extends keyof StepsByName<TDefinitions>
+  ? StepByName<TDefinitions, TTarget> extends StepDefinition<infer TInput>
+    ? TInput
+    : never
+  : never;
+
+export type StepOutput<
+  TDefinitions extends readonly StepDefinition[],
+  TTarget extends keyof StepsByName<TDefinitions> & string,
+> = TTarget extends keyof StepsByName<TDefinitions>
+  ? StepByName<TDefinitions, TTarget> extends StepDefinition<any, infer TOutput>
+    ? TOutput
+    : never
+  : never;
+
+export type StepView<
+  TDefinitions extends readonly StepDefinition[],
+  TTarget extends keyof StepsByName<TDefinitions> & string,
+> = Expand<{
+  readonly name: TTarget;
+  readonly input: StepInput<TDefinitions, TTarget>;
+  readonly output: StepOutput<TDefinitions, TTarget>;
+}>;
+
+type StepRecord = {
+  readonly name: StepName;
+  readonly index: number;
+};
+
+export class StepRegistry<TDefinitions extends readonly StepDefinition[]> {
+  readonly #definitions = new Map<StepName, StepDefinition>();
+  readonly #records: StepRecord[] = [];
+
+  public constructor(private readonly definitions: TDefinitions) {
+    for (const definition of definitions) {
+      this.#definitions.set(definition.name, definition);
+      this.#records.push({
+        name: definition.name,
+        index: this.#records.length,
+      });
+    }
+  }
+
+  public names(): readonly StepName[] {
+    return this.#records.map((record) => record.name);
+  }
+
+  public get<TName extends keyof StepsByName<TDefinitions> & string>(
+    name: TName,
+  ): StepsByName<TDefinitions>[TName] | undefined {
+    return this.#definitions.get(name as StepName) as
+      | StepsByName<TDefinitions>[TName]
+      | undefined;
+  }
+
+  public dependenciesOf<TName extends StepName>(
+    name: TName,
+  ): readonly StepDependency[] {
+    return (this.#definitions.get(name)?.dependsOn ?? []) as readonly StepDependency[];
+  }
+
+  public async run<TName extends keyof StepsByName<TDefinitions> & string>(
+    name: TName,
+    input: StepInput<TDefinitions, TName>,
+    space: SpaceId,
+  ): Promise<StepResult<StepOutput<TDefinitions, TName>>> {
+    const definition = this.get(name);
+    if (!definition) {
+      throw new Error(`missing step ${name}`);
+    }
+
+    const typedDefinition = definition as unknown as StepDefinition<
+      StepInput<TDefinitions, TName>,
+      StepOutput<TDefinitions, TName>,
+      TName,
+      readonly StepDependency[]
+    >;
+    return typedDefinition.run(input, {
+      executionId: `exec:${String(name)}`,
+      space,
+      phase: typedDefinition.phase,
+      attempt: 0,
+      input,
+    });
+  }
+}
+
+export const createRunOrder = <TDefinitions extends readonly StepDefinition[]>(
+  definitions: TDefinitions,
+): readonly (keyof StepsByName<TDefinitions> & string)[] => {
+  const byName = new Map<StepName, StepDefinition>();
+  const indegree = new Map<StepName, number>();
+  const outgoing = new Map<StepName, StepName[]>();
+
+  for (const definition of definitions) {
+    byName.set(definition.name, definition);
+    indegree.set(definition.name, definition.dependsOn.length);
+    outgoing.set(definition.name, []);
+  }
+
+  for (const definition of definitions) {
+    for (const dependency of definition.dependsOn) {
+      const normalized = (dependency as string).replace('dep:', '') as StepName;
+      outgoing.get(normalized)?.push(definition.name);
+    }
+  }
+
+  const ready: StepName[] = [...byName.keys()].filter(
+    (name) => (indegree.get(name) ?? 0) === 0,
+  );
+  const ordered: StepName[] = [];
+
+  while (ready.length > 0) {
+    const current = ready.shift();
+    if (!current) {
+      break;
+    }
+    ordered.push(current);
+    for (const next of outgoing.get(current) ?? []) {
+      const nextDegree = (indegree.get(next) ?? 0) - 1;
+      indegree.set(next, nextDegree);
+      if (nextDegree <= 0) {
+        ready.push(next);
+      }
+    }
+  }
+
+  return ordered as readonly (keyof StepsByName<TDefinitions> & string)[];
+};
+
+export const runAllSteps = async <TDefinitions extends readonly StepDefinition[]>({
+  definitions,
+  inputByName,
+  space,
+}: {
+  definitions: TDefinitions;
+  inputByName: Partial<Record<keyof StepsByName<TDefinitions> & string, unknown>>;
+  space: SpaceId;
+}): Promise<Record<string, StepResult<unknown>>> => {
+  const registry = new StepRegistry(definitions);
+  const outputs: Record<string, StepResult<unknown>> = {};
+
+  for (const name of createRunOrder(definitions)) {
+    const input = inputByName[name] as never;
+    outputs[name] = await registry.run(name, input, space);
+  }
+
+  return outputs;
+};

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement_scope_registry/tsconfig.json
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement_scope_registry/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "files": [
+    "src/registry-consumer.ts",
+    "src/alias-consumer.ts",
+    "src/scope-registry.ts",
+    "src/brands.ts",
+    "src/tuple-utils.ts"
+  ]
+}

--- a/crates/tsz-cli/tests/fixtures/parallel_agreement_scope_registry/tuple-utils.ts
+++ b/crates/tsz-cli/tests/fixtures/parallel_agreement_scope_registry/tuple-utils.ts
@@ -1,0 +1,15 @@
+export type NoInfer<TValue> = [TValue][TValue extends any ? 0 : never];
+
+export type Expand<TValue> = TValue extends infer Inner
+  ? { readonly [Key in keyof Inner]: Inner[Key] }
+  : never;
+
+export type Pairwise<
+  TLeft extends readonly unknown[],
+  TRight extends readonly unknown[],
+  TOut extends readonly [unknown, unknown][] = readonly [],
+> = TLeft extends readonly [infer LHead, ...infer LTail]
+  ? TRight extends readonly [infer RHead, ...infer RTail]
+    ? Pairwise<LTail, RTail, readonly [...TOut, [LHead, RHead]]>
+    : TOut
+  : TOut;

--- a/crates/tsz-cli/tests/parallel_sequential_agreement_tests.rs
+++ b/crates/tsz-cli/tests/parallel_sequential_agreement_tests.rs
@@ -175,6 +175,38 @@ const DISPOSABLE_FIXTURE_FILES: &[(&str, &str)] = &[
 const DISPOSABLE_FIXTURE_TSCONFIG: &str =
     include_str!("fixtures/parallel_agreement_disposable/tsconfig.json");
 
+/// Fourth witness family (#13255 program-def alias republication remainder):
+/// consumers are listed before the declaring module and force fresh per-file
+/// checkers to derive the same generic registry aliases through the shared
+/// `DefinitionStore`. Parallel and sequential schedules must agree even when
+/// remapped tuple-union aliases and conditional `infer` wrappers are first
+/// requested from importers rather than the declaring file.
+const SCOPE_REGISTRY_FIXTURE_FILES: &[(&str, &str)] = &[
+    (
+        "src/alias-consumer.ts",
+        include_str!("fixtures/parallel_agreement_scope_registry/alias-consumer.ts"),
+    ),
+    (
+        "src/brands.ts",
+        include_str!("fixtures/parallel_agreement_scope_registry/brands.ts"),
+    ),
+    (
+        "src/registry-consumer.ts",
+        include_str!("fixtures/parallel_agreement_scope_registry/registry-consumer.ts"),
+    ),
+    (
+        "src/scope-registry.ts",
+        include_str!("fixtures/parallel_agreement_scope_registry/scope-registry.ts"),
+    ),
+    (
+        "src/tuple-utils.ts",
+        include_str!("fixtures/parallel_agreement_scope_registry/tuple-utils.ts"),
+    ),
+];
+
+const SCOPE_REGISTRY_FIXTURE_TSCONFIG: &str =
+    include_str!("fixtures/parallel_agreement_scope_registry/tsconfig.json");
+
 fn run_project(tsz_bin: &Path, project_dir: &Path, force_parallel: bool) -> String {
     let mut cmd = Command::new(tsz_bin);
     cmd.args(["-p", "tsconfig.json", "--pretty", "false"])
@@ -253,5 +285,18 @@ fn forced_parallel_disposable_delegation_matches_sequential() {
         DISPOSABLE_FIXTURE_FILES,
         DISPOSABLE_FIXTURE_TSCONFIG,
         5,
+    );
+}
+
+/// Generic program aliases published through the shared definition store must
+/// be schedule-independent when importers request them before the declaring
+/// module finishes its own publication pass.
+#[test]
+fn forced_parallel_scope_registry_alias_republication_matches_sequential() {
+    assert_parallel_matches_sequential(
+        "scope_registry",
+        SCOPE_REGISTRY_FIXTURE_FILES,
+        SCOPE_REGISTRY_FIXTURE_TSCONFIG,
+        7,
     );
 }


### PR DESCRIPTION
Goal: fast

## Summary
- Adds a renamed scope-registry agreement fixture for the remaining #13255 program-def alias-republication shape.
- Extends the real-binary parallel-vs-sequential CLI integration suite with `forced_parallel_scope_registry_alias_republication_matches_sequential`.
- Records current-main exit evidence that the named `typed-orchestration-core` seed is byte-stable in both forced and default parallel modes after the merged DefinitionStore publication fixes.

## Structural rule
When importers request remapped tuple-union registry aliases and conditional `infer` wrappers before the declaring module finishes its publication pass, `tsc` observes one completed semantic identity. `tsz` must produce the same diagnostics through the shared solver `DefinitionStore` regardless of whether the aliases are first evaluated by sequential or parallel fresh checkers.

## Adjacent Matrix
- Importer-before-declaration ordering: `registry-consumer.ts` and `alias-consumer.ts` precede `scope-registry.ts` in `files`.
- Generic and concrete forms: `StepDefinition<TInput, TOutput, TName, TDependencies>` is instantiated as a concrete readonly tuple and rewrapped through generic aliases.
- Alias/wrapper forms: `StepsByName`, `StepInput`, `StepOutput`, `StepView`, `AuditByName`, and template-key audit wrappers all cross module boundaries.
- Fallback path: the materialized fixture exits cleanly, so any future failure is schedule disagreement rather than fixture-local strictness noise.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-cli --test parallel_sequential_agreement_tests`
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- Materialized new fixture with `.target/debug/tsz -p <tmp>/tsconfig.json --pretty false` exits 0.
- `scripts/safe-run.sh env TSZ_BIN=/Users/mohsen/code/tsz-shared-cache-witness-13240/.target/debug/tsz TSZ_DETERMINISM_TIMEOUT=90 scripts/perf/forced-parallel-project-determinism.sh --row typed-orchestration-core --tsconfig /Users/mohsen/code/large-ts-repo/packages/shared/typed-orchestration-core/tsconfig.json --runs 2 --workers 8,16 --mode both --baseline-workers 1 --out .target/forced-parallel-determinism-scope` passed; output dir `.target/forced-parallel-determinism-scope/typed-orchestration-core/20260614T104401Z`.

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high

Head: f90fca068caaa1f1c2895c23f5fb9872c8541cbc