### PR TITLE
perf(checker): cache lazy lib member lookup by receiver def (#12101)

### DIFF
--- a/crates/tsz-checker/src/context/cache_statistics.rs
+++ b/crates/tsz-checker/src/context/cache_statistics.rs
@@ -158,6 +158,10 @@ impl<'a> CheckerContext<'a> {
 
         let lazy_lib_member_resolution_cache =
             self.lib_type_resolution_caches.lazy_members.borrow();
+        let lazy_lib_member_receiver_property_cache = self
+            .lib_type_resolution_caches
+            .lazy_member_receiver_properties
+            .borrow();
         let symbol_name_candidates_cache = self.symbol_name_candidates_cache.borrow();
         let namespace_member_resolution_cache = self.namespace_member_resolution_cache.borrow();
         let export_equals_named_cache = self.export_equals_named_cache.borrow();
@@ -220,9 +224,14 @@ impl<'a> CheckerContext<'a> {
                 string_option_type_cache_estimated_size_bytes(
                     &self.lib_type_resolution_caches.types,
                 ),
-            lazy_lib_member_resolution_cache_entries: lazy_lib_member_resolution_cache.len(),
+            lazy_lib_member_resolution_cache_entries: lazy_lib_member_resolution_cache
+                .len()
+                .saturating_add(lazy_lib_member_receiver_property_cache.len()),
             lazy_lib_member_resolution_cache_estimated_size_bytes:
-                atom_atom_option_type_cache_estimated_size_bytes(&lazy_lib_member_resolution_cache),
+                atom_atom_option_type_cache_estimated_size_bytes(&lazy_lib_member_resolution_cache)
+                    .saturating_add(def_atom_option_type_cache_estimated_size_bytes(
+                        &lazy_lib_member_receiver_property_cache,
+                    )),
             symbol_name_candidates_cache_entries: symbol_name_candidates_cache.len(),
             symbol_name_candidates_cache_estimated_size_bytes:
                 string_symbol_vec_cache_estimated_size_bytes(&symbol_name_candidates_cache),
@@ -340,6 +349,12 @@ fn string_option_type_cache_estimated_size_bytes(
 
 fn atom_atom_option_type_cache_estimated_size_bytes(
     cache: &FxHashMap<(Atom, Atom), Option<TypeId>>,
+) -> usize {
+    fx_hash_map_estimated_size_bytes(cache)
+}
+
+fn def_atom_option_type_cache_estimated_size_bytes(
+    cache: &FxHashMap<(DefId, Atom), Option<TypeId>>,
 ) -> usize {
     fx_hash_map_estimated_size_bytes(cache)
 }

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -158,6 +158,14 @@ pub struct LibTypeResolutionCaches {
     /// same full-materialization fallback on cached misses.
     pub lazy_members: RefCell<FxHashMap<(Atom, Atom), Option<TypeId>>>,
 
+    /// Per-checker cache for lazy single-member property reads once a receiver
+    /// has already been classified as an eligible bare `Lazy(DefId)`.
+    /// Keyed by `(receiver_def_id, property_name)` and stores the same hit/miss
+    /// result as `lazy_members`, but lets the receiver hot path avoid mapping
+    /// the cached `DefId` back to a symbol name before a repeated lookup.
+    pub lazy_member_receiver_properties:
+        RefCell<FxHashMap<(tsz_solver::def::DefId, Atom), Option<TypeId>>>,
+
     /// Per-checker cache for lazy single-member receiver eligibility.
     /// Keyed by the bare receiver `Lazy(DefId)`. Stores both eligible and
     /// ineligible decisions after the conservative receiver predicate has

--- a/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
+++ b/crates/tsz-checker/src/state/state_checking/lazy_lib_member.rs
@@ -341,12 +341,33 @@ impl CheckerState<'_> {
         prop_name: &str,
     ) -> Option<tsz_solver::operations::property::PropertyAccessResult> {
         let def_id = self.lazy_lib_member_receiver_def_id(object_type)?;
+        let prop_atom = self.ctx.types.intern_string(prop_name);
+        let key = (def_id, prop_atom);
+        if let Some(cached) = self
+            .ctx
+            .lib_type_resolution_caches
+            .lazy_member_receiver_properties
+            .borrow()
+            .get(&key)
+            .copied()
+        {
+            return cached.map(tsz_solver::operations::property::PropertyAccessResult::simple);
+        }
 
-        let sym_id = self.ctx.def_to_symbol_id_with_fallback(def_id)?;
-        let name = self.ctx.binder.get_symbol(sym_id)?.escaped_name.clone();
-        let member_type = self.resolve_simple_lib_interface_own_property(&name, prop_name)?;
+        let member_type = self
+            .ctx
+            .def_to_symbol_id_with_fallback(def_id)
+            .and_then(|sym_id| self.ctx.binder.get_symbol(sym_id))
+            .map(|symbol| symbol.escaped_name.clone())
+            .and_then(|name| self.resolve_simple_lib_interface_own_property(&name, prop_name));
 
-        Some(tsz_solver::operations::property::PropertyAccessResult::simple(member_type))
+        self.ctx
+            .lib_type_resolution_caches
+            .lazy_member_receiver_properties
+            .borrow_mut()
+            .insert(key, member_type);
+
+        member_type.map(tsz_solver::operations::property::PropertyAccessResult::simple)
     }
 
     /// Resolve a property-access receiver to its property-access-ready form,

--- a/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file_direct_actual_lib_tests.rs
@@ -804,6 +804,137 @@ interface Wrapper {
 }
 
 #[test]
+fn lazy_lib_member_lookup_caches_by_receiver_def_id() {
+    let lib_files = load_compiled_lib_files(&[
+        "lib.es5.d.ts",
+        "lib.es2015.core.d.ts",
+        "lib.es2015.collection.d.ts",
+        "lib.es2015.generator.d.ts",
+        "lib.es2015.iterable.d.ts",
+        "lib.es2015.promise.d.ts",
+        "lib.es2015.proxy.d.ts",
+        "lib.es2015.reflect.d.ts",
+        "lib.es2015.symbol.d.ts",
+        "lib.es2015.symbol.wellknown.d.ts",
+        "lib.es2016.array.include.d.ts",
+        "lib.es2016.d.ts",
+        "lib.es2017.object.d.ts",
+        "lib.es2017.sharedmemory.d.ts",
+        "lib.es2017.string.d.ts",
+        "lib.es2017.intl.d.ts",
+        "lib.es2017.typedarrays.d.ts",
+        "lib.es2018.asyncgenerator.d.ts",
+        "lib.es2018.asynciterable.d.ts",
+        "lib.es2018.intl.d.ts",
+        "lib.es2018.promise.d.ts",
+        "lib.es2018.regexp.d.ts",
+        "lib.es2018.d.ts",
+        "lib.es2019.array.d.ts",
+        "lib.es2019.object.d.ts",
+        "lib.es2019.string.d.ts",
+        "lib.es2019.symbol.d.ts",
+        "lib.es2019.intl.d.ts",
+        "lib.es2019.d.ts",
+        "lib.es2020.bigint.d.ts",
+        "lib.es2020.date.d.ts",
+        "lib.es2020.promise.d.ts",
+        "lib.es2020.sharedmemory.d.ts",
+        "lib.es2020.string.d.ts",
+        "lib.es2020.symbol.wellknown.d.ts",
+        "lib.es2020.intl.d.ts",
+        "lib.es2020.number.d.ts",
+        "lib.es2020.d.ts",
+        "lib.dom.d.ts",
+        "lib.dom.iterable.d.ts",
+    ]);
+    let mut parser = ParserState::new("fixture.ts".to_string(), "let value;".to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file_with_libs(parser.get_arena(), root, &lib_files);
+    let arena = Arc::new(parser.get_arena().clone());
+    let binder = Arc::new(binder);
+    let types = TypeInterner::new();
+    let ctx = CheckerContext::new(
+        arena.as_ref(),
+        binder.as_ref(),
+        &types,
+        "fixture.ts".to_string(),
+        CheckerOptions::default(),
+    );
+    let mut state = CheckerState { ctx };
+    let lib_contexts: Vec<LibContext> = lib_files
+        .iter()
+        .map(|lib| LibContext {
+            arena: Arc::clone(&lib.arena),
+            binder: Arc::clone(&lib.binder),
+        })
+        .collect();
+    state.ctx.set_lib_contexts(lib_contexts);
+    state.ctx.set_actual_lib_file_count(lib_files.len());
+
+    let document_value_sym_id = state
+        .ctx
+        .binder
+        .file_locals
+        .get("document")
+        .expect("document should resolve to a lib value symbol");
+    let document_value_arena = state
+        .ctx
+        .binder
+        .symbol_arenas
+        .get(&document_value_sym_id)
+        .map(std::convert::AsRef::as_ref);
+    let (document_value, _) = state
+        .direct_actual_lib_symbol_type(
+            document_value_sym_id,
+            CrossArenaSymbolMissSource::SymbolArena,
+            document_value_arena,
+            false,
+        )
+        .expect("document should lower to its annotated lazy lib interface");
+
+    let first = state
+        .try_lazy_lib_member_property_access(document_value, "title")
+        .expect("Document.title should resolve through the lazy member fast path");
+    let entries_after_first = state
+        .ctx
+        .lib_type_resolution_caches
+        .lazy_member_receiver_properties
+        .borrow()
+        .len();
+    let second = state
+        .try_lazy_lib_member_property_access(document_value, "title")
+        .expect("cached Document.title should still resolve through the fast path");
+
+    let first_type = match first {
+        tsz_solver::operations::property::PropertyAccessResult::Success { type_id, .. } => type_id,
+        other => panic!("first lazy member lookup should succeed, got {other:?}"),
+    };
+    let second_type = match second {
+        tsz_solver::operations::property::PropertyAccessResult::Success { type_id, .. } => type_id,
+        other => panic!("cached lazy member lookup should succeed, got {other:?}"),
+    };
+    assert_eq!(
+        first_type, second_type,
+        "cached lazy member lookup should return the same property-access result",
+    );
+    assert_eq!(
+        entries_after_first, 1,
+        "first lazy member lookup should record one receiver/property cache entry",
+    );
+    assert_eq!(
+        state
+            .ctx
+            .lib_type_resolution_caches
+            .lazy_member_receiver_properties
+            .borrow()
+            .len(),
+        entries_after_first,
+        "repeating the same receiver/property lookup should hit the DefId-keyed cache",
+    );
+}
+
+#[test]
 fn value_merged_builtin_dom_interface_type_argument_keeps_inherited_members() {
     let lib_files = load_compiled_lib_files(&[
         "lib.es5.d.ts",


### PR DESCRIPTION
Goal: fast

## Summary
- Add a per-checker `(Lazy receiver DefId, property Atom)` cache for the lazy lib-interface single-member path.
- Keep the existing name-based resolver and full-materialization fallback unchanged for first lookups, misses, ambiguous members, generic/indexed/augmented/shadowed receivers, and structural consumers.
- Include the new cache in retained cache statistics so residency reports see the extra entries.

## Structural Rule
When a property access receiver is already classified as an eligible bare `Lazy(DefId)` lib interface and the same property is looked up again in the same checker context, tsz should reuse the cached single-member hit/miss by receiver `DefId` and property atom. If the cached result is a miss or the receiver is not eligible, tsz continues through the existing materialization fallback.

Owner layer: checker/type-environment lazy lib-member path. This is cache/key plumbing around an existing checker-owned resolver; it does not add solver semantics or DOM/property-name special cases.

## Verification
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib lazy_lib_member_lookup_caches_by_receiver_def_id`
- `scripts/safe-run.sh cargo nextest run -p tsz-checker --lib lazy_lib_member_access_tests`
- `cargo fmt --check`
- `git diff --check`
- `python3 scripts/arch/arch_guard.py`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high