### PR TITLE
refactor(emitter): consolidate DTS export-prefix disk scans; AST export check in visibility (#13437)

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/dts_export_text_scan.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/dts_export_text_scan.rs
@@ -1,0 +1,52 @@
+//! Shared text predicates for scanning third-party `.d.ts` files on disk.
+//!
+//! These helpers exist for one narrow situation: deciding export-ness of a
+//! declaration that lives in an external dependency's emitted `.d.ts`, for
+//! which tsz has no in-memory AST or symbol graph (the file is read straight
+//! from disk via `std::fs::read_to_string`). For declarations that tsz parsed
+//! itself, the idiomatic check is the AST modifier list
+//! (`stmt_has_export_modifier`) — never these text predicates.
+//!
+//! Centralizing the `export `-prefix scan removes the copy-pasted predicate
+//! that previously lived inline at each disk-reading call site, so the brittle
+//! string contract is stated once.
+
+/// A `.d.ts` line begins an exported declaration when, after trimming leading
+/// whitespace, it starts with the `export ` keyword (the trailing space rules
+/// out the `exports` identifier). Trailing whitespace and a trailing `;` do not
+/// affect the prefix, so callers may pass either a raw or pre-trimmed line.
+pub(crate) fn dts_line_has_export_prefix(line: &str) -> bool {
+    line.trim_start().starts_with("export ")
+}
+
+/// Whether a `.d.ts` source re-exports an entire module via an
+/// `export * from` clause anywhere in the file. Used to decide whether a
+/// package root forwards its members through a wildcard re-export.
+pub(crate) fn dts_text_has_export_star(text: &str) -> bool {
+    text.contains("export * from")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn export_prefix_matches_leading_keyword_only() {
+        assert!(dts_line_has_export_prefix("export const x = 1;"));
+        assert!(dts_line_has_export_prefix("    export function f(): void;"));
+        assert!(dts_line_has_export_prefix("export { a, b } from \"./m\";"));
+        // `exports` (CJS identifier) must not be mistaken for the keyword.
+        assert!(!dts_line_has_export_prefix("exports.foo = 1;"));
+        assert!(!dts_line_has_export_prefix("const exported = 1;"));
+        assert!(!dts_line_has_export_prefix("declare const x: number;"));
+    }
+
+    #[test]
+    fn export_star_detects_wildcard_reexport() {
+        assert!(dts_text_has_export_star(
+            "export * from \"./a\";\nexport * from \"./b\";"
+        ));
+        assert!(!dts_text_has_export_star("export { a } from \"./a\";"));
+        assert!(!dts_text_has_export_star("declare const x: number;"));
+    }
+}

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/mod.rs
@@ -227,6 +227,7 @@ mod computed_declarations;
 mod correlated_union;
 mod correlated_union_mapped_arrays;
 mod default_import_alias_rewrite;
+mod dts_export_text_scan;
 mod emit_node;
 mod function_analysis;
 mod generic_call_literal;

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_imported_calls.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_imported_calls.rs
@@ -1,4 +1,5 @@
 use super::super::DeclarationEmitter;
+use super::dts_export_text_scan::dts_line_has_export_prefix;
 use tsz_binder::BinderState;
 use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -121,7 +122,7 @@ impl<'a> DeclarationEmitter<'a> {
     fn module_text_reexports_parent_root(content: &str) -> bool {
         content.lines().any(|line| {
             let trimmed = line.trim().trim_end_matches(';').trim();
-            if !trimmed.starts_with("export ") {
+            if !dts_line_has_export_prefix(trimmed) {
                 return false;
             }
             let Some((_, module_specifier)) = trimmed.rsplit_once(" from ") else {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_public_packages.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_public_packages.rs
@@ -2,6 +2,7 @@
 
 #[allow(unused_imports)]
 use super::super::{DeclarationEmitter, ImportPlan, PlannedImportModule, PlannedImportSymbol};
+use super::dts_export_text_scan::{dts_line_has_export_prefix, dts_text_has_export_star};
 #[allow(unused_imports)]
 use crate::emitter::type_printer::TypePrinter;
 #[allow(unused_imports)]
@@ -191,13 +192,13 @@ impl<'a> DeclarationEmitter<'a> {
             .unwrap_or_else(|| package_root.join("index.d.ts"));
         std::fs::read_to_string(root_dts)
             .ok()
-            .is_some_and(|text| text.contains("export * from"))
+            .is_some_and(|text| dts_text_has_export_star(&text))
     }
 
     fn dts_text_explicitly_exports_name(text: &str, export_name: &str) -> bool {
         text.lines().any(|line| {
             let trimmed = line.trim();
-            if !trimmed.starts_with("export ") || !trimmed.contains('{') {
+            if !dts_line_has_export_prefix(trimmed) || !trimmed.contains('{') {
                 return false;
             }
             let Some(named) = trimmed

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/visibility.rs
@@ -381,11 +381,10 @@ impl<'a> DeclarationEmitter<'a> {
         let Some(var_stmt) = self.arena.get_variable(stmt_node) else {
             return false;
         };
-        let has_export_modifier = self.stmt_has_export_modifier(stmt_node)
-            || self
-                .get_source_slice(stmt_node.pos, stmt_node.end)
-                .is_some_and(|text| text.trim_start().starts_with("export "));
-        if !has_export_modifier {
+        // Export-ness is decided from the AST modifier list. `stmt_node` is a
+        // parsed `VARIABLE_STATEMENT` (checked above), so an `export` keyword is
+        // present as a modifier on the node — no source-text scan is needed.
+        if !self.stmt_has_export_modifier(stmt_node) {
             return false;
         }
         var_stmt


### PR DESCRIPTION
Goal: hold

Closes #13437.

## Structural rule
When deciding export-ness of a declaration tsz parsed itself, idiomatic emit inspects the AST modifier list, not rendered/source text. When deciding export-ness of a declaration that lives only in a third-party `.d.ts` on disk (no in-memory AST/symbol graph), a text scan is the realistic ceiling — but the brittle predicate must be stated once, not copy-pasted at each disk-reading call site. Owner layer: `tsz-emitter` declaration emitter helpers.

## What changed (behavior-preserving)
This lands the genuinely-novel, non-#13048 slice of #13437.

1. **New shared helper module** `crates/tsz-emitter/src/declaration_emitter/helpers/dts_export_text_scan.rs` with two documented predicates for the disk-`.d.ts` scan sites:
   - `dts_line_has_export_prefix(line)` — `trim_start().starts_with("export ")` (the trailing space rules out the `exports` CJS identifier).
   - `dts_text_has_export_star(text)` — `contains("export * from")` wildcard re-export detection.
   - Routed the three previously copy-pasted disk-scan call sites through it (`type_inference_public_packages.rs` ×2, `type_inference_imported_calls.rs` ×1). These read third-party `.d.ts` from disk via `std::fs::read_to_string`, where no AST exists, so a shared text predicate is the correct ceiling.

2. **AST conversion** in `visibility.rs::exported_variable_statement_initializer_references_name`: replaced the `stmt_has_export_modifier(stmt_node) || get_source_slice(..).starts_with("export ")` source-text fallback with the pure AST check `stmt_has_export_modifier(stmt_node)`. The node is a parsed `VARIABLE_STATEMENT` (checked immediately above), so the `export` keyword is present as a modifier on the node — the text fallback was redundant.

## Scope notes
- `portability_resolve.rs` is **1997 lines** on current `main` (the audit cited 2002; since reduced), so the file is already under the 2000-line cap — the split called for in #13437 is moot and intentionally omitted.
- The portability text-rewrite half (`printed_type_uses_private_import_type_root`, `rewrite_leading_import_type_member`, `default_type_arguments_for_import_type_text`, `is_plain_identifier_text`) is, as #13437 states, #13048's job (route through `TypeId`-level transforms) and is **not** touched here.
- `imports.rs::namespace_has_prior_import_equals_alias` (the `strip_prefix("export ")` site) is a JS-emit namespace-IIFE dedup that scans a brace-delimited *prior* source region rather than a single node; converting it to an AST statement-walk is a larger, regression-prone change in namespace emit and is deferred rather than risked here.

## Anti-hardcoding
No identifier/file-name/printer-output predicate drives compiler logic. The helpers operate on third-party disk text only; the parsed-AST path uses the binder/AST modifier list. Unit tests vary the input text rather than keying on fixture names.

## Verification
- `cargo test -p tsz-emitter --lib dts_export_text_scan` — 2/2 pass (new predicate unit tests).
- `cargo test -p tsz-emitter` declaration/import emit targets pass: `cjs_clause_export_live_binding_tests` (33), `cjs_import_equals_export_tests` (3), `export_equals_type_only_namespace` (4), `import_use_before_decl_3597_tests` (3), `script_mode_import_equals_interface_alias_tests` (6), `variable_declaration_emit_tests` (12).
- `crates/tsz-emitter` builds clean (no unused-import / dead-code warnings).
- 3 unrelated lib test failures (`take_diagnostics_*_ts2883_*`, `fix_generic_rest_identity_*`) were confirmed pre-existing on clean `main` (`f64c8a3`), not introduced here.
- Broad emit/conformance/fourslash parity owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: medium

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6eagVAQrbS9QpaBhcJeSH)_