### PR TITLE
fix(checker): default imported alias constraints

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -11,7 +11,7 @@ use tsz_parser::parser::{NodeIndex, NodeList, syntax_kind_ext};
 use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
-impl<'a> CheckerState<'a> {
+impl CheckerState<'_> {
     pub(crate) fn resolve_type_only_import_alias_target_symbol(
         &mut self,
         name: &str,
@@ -143,12 +143,10 @@ impl<'a> CheckerState<'a> {
                         // TS2314 and treats the erroneous annotation as any-like. Type aliases
                         // keep the old resolution-set skip because tsc handles those through
                         // circularity detection.
-                        let is_class_or_interface = self
-                            .ctx
-                            .binder
-                            .get_symbol(sym_id)
-                            .map(|s| s.has_any_flags(symbol_flags::CLASS | symbol_flags::INTERFACE))
-                            .unwrap_or(false);
+                        let is_class_or_interface =
+                            self.ctx.binder.get_symbol(sym_id).is_some_and(|s| {
+                                s.has_any_flags(symbol_flags::CLASS | symbol_flags::INTERFACE)
+                            });
                         let should_emit_ts2314 = !self.ctx.symbol_resolution_set.contains(&sym_id)
                             || is_class_or_interface;
                         if should_emit_ts2314 {
@@ -365,16 +363,12 @@ impl<'a> CheckerState<'a> {
         let def_id = self.ctx.get_or_create_def_id(sym_id);
 
         // Step 2: extract and cache type parameters if not already cached.
-        let should_extract_params = self
-            .ctx
-            .get_def_type_params(def_id)
-            .map(|cached| {
-                !cached.is_empty()
-                    && cached
-                        .iter()
-                        .all(|param| param.constraint.is_none() && param.default.is_none())
-            })
-            .unwrap_or(true);
+        let should_extract_params = self.ctx.get_def_type_params(def_id).is_none_or(|cached| {
+            !cached.is_empty()
+                && cached
+                    .iter()
+                    .all(|param| param.constraint.is_none() && param.default.is_none())
+        });
         if should_extract_params {
             let params = self
                 .extract_declared_type_params_for_reference_symbol(sym_id, name)
@@ -396,8 +390,7 @@ impl<'a> CheckerState<'a> {
                 .ctx
                 .type_env
                 .try_borrow()
-                .map(|env| env.get_def(def_id).is_some())
-                .unwrap_or(false);
+                .is_ok_and(|env| env.get_def(def_id).is_some());
             if !has_body {
                 let _ = self.resolve_lib_type_by_name(name);
             }
@@ -659,7 +652,7 @@ impl<'a> CheckerState<'a> {
                     };
                     Some(self.apply_omitted_defaults_to_cross_file_param_constraints(
                         decl_arena,
-                        &type_alias.type_parameters,
+                        type_alias.type_parameters.as_ref(),
                         params,
                         effective_file_idx,
                     ))
@@ -757,7 +750,7 @@ impl<'a> CheckerState<'a> {
                     };
                     Some(self.apply_omitted_defaults_to_cross_file_param_constraints(
                         decl_arena,
-                        &iface.type_parameters,
+                        iface.type_parameters.as_ref(),
                         params,
                         effective_file_idx,
                     ))
@@ -865,7 +858,7 @@ impl<'a> CheckerState<'a> {
                         .collect_type_parameters(type_parameters);
                         Some(self.apply_omitted_defaults_to_cross_file_param_constraints(
                             decl_arena,
-                            &class.type_parameters,
+                            class.type_parameters.as_ref(),
                             params,
                             effective_file_idx,
                         ))
@@ -968,7 +961,7 @@ impl<'a> CheckerState<'a> {
     fn apply_omitted_defaults_to_cross_file_param_constraints(
         &mut self,
         decl_arena: &NodeArena,
-        type_parameters: &Option<NodeList>,
+        type_parameters: Option<&NodeList>,
         mut params: Vec<tsz_solver::TypeParamInfo>,
         effective_file_idx: Option<usize>,
     ) -> Vec<tsz_solver::TypeParamInfo> {
@@ -1027,8 +1020,7 @@ impl<'a> CheckerState<'a> {
             .get_symbol_from_registered_file_target(target_sym_id)
             .or_else(|| self.get_cross_file_symbol(target_sym_id))
             .or_else(|| self.ctx.binder.get_symbol(target_sym_id))
-            .map(|symbol| symbol.escaped_name.clone())
-            .unwrap_or_else(|| name.to_string());
+            .map_or_else(|| name.to_string(), |symbol| symbol.escaped_name.clone());
         let type_params = self.get_reference_type_params_for_symbol(target_sym_id, &target_name);
         if type_params.is_empty() {
             return None;

--- a/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
+++ b/crates/tsz-checker/src/state/type_resolution/reference_helpers.rs
@@ -657,7 +657,12 @@ impl<'a> CheckerState<'a> {
                         .prefer_name_def_id_resolution()
                         .collect_type_alias_type_parameters(type_alias)
                     };
-                    Some(params)
+                    Some(self.apply_omitted_defaults_to_cross_file_param_constraints(
+                        decl_arena,
+                        &type_alias.type_parameters,
+                        params,
+                        effective_file_idx,
+                    ))
                 } else if let Some(iface) = decl_arena.get_interface(node) {
                     if let Some(name_node) = decl_arena.get(iface.name)
                         && let Some(ident) = decl_arena.get_identifier(name_node)
@@ -750,7 +755,12 @@ impl<'a> CheckerState<'a> {
                         .prefer_name_def_id_resolution()
                         .collect_merged_interface_type_parameters(&[(decl_idx, decl_arena)])
                     };
-                    Some(params)
+                    Some(self.apply_omitted_defaults_to_cross_file_param_constraints(
+                        decl_arena,
+                        &iface.type_parameters,
+                        params,
+                        effective_file_idx,
+                    ))
                 } else if !mixed_class_interface && let Some(class) = decl_arena.get_class(node) {
                     if let Some(name_node) = decl_arena.get(class.name)
                         && let Some(ident) = decl_arena.get_identifier(name_node)
@@ -853,7 +863,12 @@ impl<'a> CheckerState<'a> {
                         .with_name_def_id_resolver(&name_resolver)
                         .prefer_name_def_id_resolution()
                         .collect_type_parameters(type_parameters);
-                        Some(params)
+                        Some(self.apply_omitted_defaults_to_cross_file_param_constraints(
+                            decl_arena,
+                            &class.type_parameters,
+                            params,
+                            effective_file_idx,
+                        ))
                     } else {
                         None
                     }
@@ -948,6 +963,91 @@ impl<'a> CheckerState<'a> {
                     .and_then(|class| class.type_parameters.as_ref())
             })
             .is_some_and(|type_parameters| !type_parameters.nodes.is_empty())
+    }
+
+    fn apply_omitted_defaults_to_cross_file_param_constraints(
+        &mut self,
+        decl_arena: &NodeArena,
+        type_parameters: &Option<NodeList>,
+        mut params: Vec<tsz_solver::TypeParamInfo>,
+        effective_file_idx: Option<usize>,
+    ) -> Vec<tsz_solver::TypeParamInfo> {
+        let Some(type_parameters) = type_parameters else {
+            return params;
+        };
+        for (i, &param_idx) in type_parameters.nodes.iter().enumerate() {
+            let Some(param) = params.get_mut(i) else {
+                break;
+            };
+            let Some(param_node) = decl_arena.get(param_idx) else {
+                continue;
+            };
+            let Some(param_data) = decl_arena.get_type_parameter(param_node) else {
+                continue;
+            };
+            if param_data.constraint == NodeIndex::NONE {
+                continue;
+            }
+            if let Some(defaulted_constraint) = self
+                .cross_file_omitted_default_constraint_reference(
+                    decl_arena,
+                    param_data.constraint,
+                    effective_file_idx,
+                )
+            {
+                param.constraint = Some(defaulted_constraint);
+            }
+        }
+        params
+    }
+
+    fn cross_file_omitted_default_constraint_reference(
+        &mut self,
+        decl_arena: &NodeArena,
+        constraint_idx: NodeIndex,
+        effective_file_idx: Option<usize>,
+    ) -> Option<TypeId> {
+        let node = decl_arena.get(constraint_idx)?;
+        if node.kind != syntax_kind_ext::TYPE_REFERENCE {
+            return None;
+        }
+        let type_ref = decl_arena.get_type_ref(node)?;
+        if type_ref
+            .type_arguments
+            .as_ref()
+            .is_some_and(|args| !args.nodes.is_empty())
+        {
+            return None;
+        }
+
+        let name = decl_arena.get_identifier_text(type_ref.type_name)?;
+        let target_sym_id =
+            self.resolve_declaration_file_type_symbol_for_lowering(name, effective_file_idx)?;
+        let target_name = self
+            .get_symbol_from_registered_file_target(target_sym_id)
+            .or_else(|| self.get_cross_file_symbol(target_sym_id))
+            .or_else(|| self.ctx.binder.get_symbol(target_sym_id))
+            .map(|symbol| symbol.escaped_name.clone())
+            .unwrap_or_else(|| name.to_string());
+        let type_params = self.get_reference_type_params_for_symbol(target_sym_id, &target_name);
+        if type_params.is_empty() {
+            return None;
+        }
+        let default_args = crate::query_boundaries::type_defaults::fill_application_defaults(
+            self.ctx.types,
+            &[],
+            &type_params,
+        )?;
+
+        self.ensure_def_ready_for_lowering(target_sym_id, &target_name);
+        let def_id = self
+            .resolve_declaration_file_type_def_id_for_lowering(name, effective_file_idx)
+            .unwrap_or_else(|| {
+                self.ctx
+                    .get_or_create_def_id_for_symbol_name(target_sym_id, &target_name)
+            });
+        let base = self.ctx.types.factory().lazy(def_id);
+        Some(self.ctx.types.factory().application(base, default_args))
     }
 
     /// Read leading JSDoc on a JS class declaration and synthesize

--- a/crates/tsz-cli/Cargo.toml
+++ b/crates/tsz-cli/Cargo.toml
@@ -131,6 +131,10 @@ path = "tests/declaration_type_walk_boundary_dts_emit_tests.rs"
 name = "lib_target_suggestion_ts2550_tests"
 path = "tests/lib_target_suggestion_ts2550_tests.rs"
 
+[[test]]
+name = "imported_infer_readonly_alias_cli_tests"
+path = "tests/imported_infer_readonly_alias_cli_tests.rs"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/crates/tsz-cli/tests/imported_infer_readonly_alias_cli_tests.rs
+++ b/crates/tsz-cli/tests/imported_infer_readonly_alias_cli_tests.rs
@@ -1,0 +1,75 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+fn find_tsz_binary() -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_tsz") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    let current_exe = std::env::current_exe().ok()?;
+    let debug_dir = current_exe.parent()?.parent()?;
+    let candidate = debug_dir.join("tsz");
+    candidate.exists().then_some(candidate)
+}
+
+#[test]
+fn imported_infer_result_array_satisfies_imported_readonly_alias_constraint() {
+    let Some(tsz_bin) = find_tsz_binary() else {
+        println!("skipping: tsz binary not found");
+        return;
+    };
+    let dir = tempfile::tempdir().expect("temp dir");
+
+    std::fs::write(
+        dir.path().join("list.ts"),
+        r#"
+export type Seq<Item = any> = readonly Item[];
+"#,
+    )
+    .expect("write list.ts");
+    std::fs::write(
+        dir.path().join("length.ts"),
+        r#"
+import { Seq } from "./list";
+export type Size<Items extends Seq> = Items["length"];
+"#,
+    )
+    .expect("write length.ts");
+    std::fs::write(
+        dir.path().join("split.ts"),
+        r#"
+type Split<Text extends string> =
+    string[] extends infer Parts
+        ? Parts
+        : never;
+export type Pieces<Text extends string> = Split<Text>;
+"#,
+    )
+    .expect("write split.ts");
+    std::fs::write(
+        dir.path().join("main.ts"),
+        r#"
+import { Size } from "./length";
+import { Pieces } from "./split";
+
+export type Use<Text extends string> = Size<Pieces<Text>>;
+"#,
+    )
+    .expect("write main.ts");
+
+    let output = Command::new(tsz_bin)
+        .args(["--noEmit", "--pretty", "false", "main.ts"])
+        .current_dir(dir.path())
+        .output()
+        .expect("run tsz");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "imported infer result `string[]` should satisfy imported readonly-array alias constraint.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Goal: hold

## Summary
Fix cross-file extraction of type parameter constraints so bare references to imported generic aliases receive omitted default type arguments before they are stored as constraints. This prevents an imported conditional-infer result like `string[]` from being checked against a leaked raw alias parameter such as `readonly Item[]`.

## Structural Rule
When a type parameter constraint references a generic alias with omitted type arguments and that alias has defaults, `tsc` applies the defaults at the constraint declaration. TSZ now applies the same defaulting while extracting cross-file reference type parameters, before assignability validates later applications.

Owner layer: checker cross-file reference type-parameter metadata extraction. The TS2344 relation path remains the existing relation -> reason -> diagnostic gateway.

## Adjacent Matrix
- Imported alias constraint: `Items extends Seq` where `Seq<Item = any> = readonly Item[]`.
- Conditional-infer input: `string[] extends infer Parts ? Parts : never` applied through an imported alias.
- Renamed binders: regression test uses `Seq`, `Size`, `Pieces`, `Item`, `Parts`, and `Text` rather than the original witness names.
- Project smoke: ts-toolbelt canary guard compiles against the failed merge-group fixture.

## Fallback / Hardcoding Check
- No user-chosen identifier, filename, rendered diagnostic, or printer-output predicate drives compiler behavior.
- Explicit type arguments remain unchanged.
- Bare references to generics without fillable defaults remain unchanged.
- Non-type-reference constraints continue through existing lowering unchanged.

## Verification
- `cargo fmt --check`
- `scripts/safe-run.sh cargo nextest run -p tsz-cli --test imported_infer_readonly_alias_cli_tests imported_infer_result_array_satisfies_imported_readonly_alias_constraint`
- `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli --bin tsz`
- `TSZ_PROJECT_COMPILE_RESULT_CACHE=0 TSZ_PROJECT_COMPILE_FIXTURE_ROOT=/Users/mohsen/code/tsz-mg-13548-13541-debug/.target/project-compile-guard TSZ_PROJECT_COMPILE_FILTER=ts-toolbelt-project TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_INCLUDE_GENERATED_APPS=0 TSZ_PROJECT_COMPILE_TIMEOUT=120 scripts/safe-run.sh scripts/ci/project-compile-guard.sh`

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: GPT-5
Effort: high