### PR TITLE
fix(checker): render excess-property target annotation from lowered TypeId (#13076)

### DIFF
--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -206,8 +206,7 @@ impl<'a> CheckerState<'a> {
             // source text (issue #13076). Source-text rendering bypasses
             // type-level stripping (non-object union members, optional-property
             // `| undefined`) and breaks on multiline / aliased annotations.
-            // Fall back to source text only when no annotation node is available
-            // (e.g. the JSDoc `@satisfies` path returns no type node).
+            // Fall back to source text when no annotation node is available (e.g. JSDoc `@satisfies`).
             let annotation_display = match annotation_type_node {
                 Some(type_node) => {
                     let annotation_type = self.get_type_from_type_node(type_node);

--- a/crates/tsz-checker/src/error_reporter/properties.rs
+++ b/crates/tsz-checker/src/error_reporter/properties.rs
@@ -202,7 +202,19 @@ impl<'a> CheckerState<'a> {
         if let Some((annotation_text, annotation_from_nested_container, annotation_type_node)) =
             self.excess_property_target_annotation_for_site(idx)
         {
-            let annotation_display = self.format_annotation_like_type(&annotation_text);
+            // Format the annotation's lowered TypeId instead of slicing raw
+            // source text (issue #13076). Source-text rendering bypasses
+            // type-level stripping (non-object union members, optional-property
+            // `| undefined`) and breaks on multiline / aliased annotations.
+            // Fall back to source text only when no annotation node is available
+            // (e.g. the JSDoc `@satisfies` path returns no type node).
+            let annotation_display = match annotation_type_node {
+                Some(type_node) => {
+                    let annotation_type = self.get_type_from_type_node(type_node);
+                    self.format_excess_property_target_type(annotation_type)
+                }
+                None => self.format_annotation_like_type(&annotation_text),
+            };
             if self.excess_property_site_is_nested_in_nested_array_literal(idx) {
                 return annotation_display;
             }

--- a/crates/tsz-checker/tests/ts2353_tests.rs
+++ b/crates/tsz-checker/tests/ts2353_tests.rs
@@ -1879,3 +1879,74 @@ outer = { branch: { keep: "ok", noise: 1 } };
         "No spurious TS2322 expected, got: {diags:?}"
     );
 }
+
+// Issue #13076: the excess-property target display must be formatted from the
+// annotation's lowered TypeId, not sliced from raw source text. Source-text
+// slicing keeps non-object union members (`string`) that tsc strips, and breaks
+// on multiline annotations and generic aliases.
+
+#[test]
+fn excess_property_union_annotation_strips_non_object_member_for_display() {
+    // tsc checks the object literal against the only object-like union member
+    // (`Book`) and displays `Book`, dropping the `string` member. The source-text
+    // pipeline used to echo the written `Book | string`.
+    let source = r#"
+interface Book { title: string }
+const b: Book | string = { title: "x", extra: 1 };
+"#;
+    let diags = get_diagnostics(source);
+    let ts2353 = diags.iter().find(|d| d.0 == 2353).expect("expected TS2353");
+    assert!(
+        ts2353.1.contains("'Book'") && !ts2353.1.contains("string"),
+        "Expected TS2353 to display the stripped object member 'Book', got: {}",
+        ts2353.1
+    );
+}
+
+#[test]
+fn excess_property_multiline_generic_alias_annotation_renders_canonically() {
+    // A generic alias annotation spread across lines must render as the
+    // canonical `Wrap<number>` rather than a source slice that carries the
+    // newline/whitespace of the written `Wrap<\n  number\n>`.
+    let source = "
+type Wrap<T> = { value: T };
+const x: Wrap<
+  number
+> = { value: 1, extra: 2 };
+";
+    let diags = get_diagnostics(source);
+    let ts2353 = diags.iter().find(|d| d.0 == 2353).expect("expected TS2353");
+    assert!(
+        ts2353.1.contains("'Wrap<number>'"),
+        "Expected canonical generic alias display, got: {}",
+        ts2353.1
+    );
+    assert!(
+        !ts2353.1.contains('\n'),
+        "Expected no embedded newline from source slicing, got: {}",
+        ts2353.1
+    );
+}
+
+#[test]
+fn excess_property_multiline_object_annotation_renders_single_line_display() {
+    // A multiline inline object annotation must render as the canonical
+    // single-line `{ a: number; }`, not the raw multiline source slice.
+    let source = "
+const x: {
+  a: number;
+} = { a: 1, b: 2 };
+";
+    let diags = get_diagnostics(source);
+    let ts2353 = diags.iter().find(|d| d.0 == 2353).expect("expected TS2353");
+    assert!(
+        ts2353.1.contains("'{ a: number; }'"),
+        "Expected canonical single-line object display, got: {}",
+        ts2353.1
+    );
+    assert!(
+        !ts2353.1.contains('\n'),
+        "Expected no embedded newline from source slicing, got: {}",
+        ts2353.1
+    );
+}


### PR DESCRIPTION
Goal: hold

Fixes #13076 (first slice: the documented excess-property root case).

## Structural rule
When a TS2353/TS2561 excess-property diagnostic displays the *target* type and
that target is driven by a variable/property annotation, tsc formats the
annotation's resolved type. tsz did this through `excess_property_target_display_for_site`
by slicing the annotation's **raw source text** and re-massaging it with
`format_annotation_like_type` — a string pipeline that bypasses type-level
stripping and breaks on multiline / aliased annotations. This change routes the
annotation display through the solver-backed type formatter
`format_excess_property_target_type(get_type_from_type_node(node))`, the same
formatter already used for the inferred display, so the annotation is rendered
from its lowered `TypeId` (owner: checker `error_reporter`).

## What changed
- `crates/tsz-checker/src/error_reporter/properties.rs`:
  `excess_property_target_display_for_site` now formats the annotation's lowered
  `TypeId` when a type node is available; the raw source-text path
  (`format_annotation_like_type`) is kept only for the nodeless JSDoc
  `@satisfies` fallback (no reified type node to lower).
- The annotation-vs-inferred *precedence* heuristics are intentionally left
  intact: they decide **which** type to show (annotation vs resolved/narrowed
  target), not **how** to render it. Both displays now flow through the same
  formatter, so the comparison is apples-to-apples instead of mixed-altitude.

## Why it matters
Active parity divergence. Source-text slicing:
- kept non-object union members tsc strips (`Book | string` vs tsc `Book`);
- carried embedded newlines/whitespace from multiline annotations
  (`Wrap<\n  number\n>` vs tsc `Wrap<number>`);
- bypassed optional-property `| undefined` insertion.

It is also an anti-hardcoding-gate smell (regex/`contains`/`starts_with` over
rendered output); this removes one rendering source for that site.

## Adjacent-case matrix (new regression tests in `ts2353_tests.rs`)
- union annotation with a non-object member → object member only
  (`Book | string` → `Book`);
- multiline generic-alias annotation → canonical `Wrap<number>` (no newline);
  **proven to fail on pre-fix code, pass after**;
- multiline inline-object annotation → canonical `{ a: number; }` (no newline).

## Scope note
This is the documented root case from `feedback_excess_property_union_display.md`
(excess-property TS2353/TS2561). The return-type/namespace-qualified
disambiguation site (`render_failure/type_mismatch.rs`) and the TS2339
receiver-display site (`properties.rs`, entangled with multi-level alias
provenance / #13082) are left for follow-up to keep this change parity-safe.

## Verification
- `cargo test -p tsz-checker --test ts2353_tests` — 79 passed (76 prior + 3 new).
- No regressions in adjacent display suites run locally:
  `ts2322_property_decl_annotation_tests`, `jsdoc_class_property_target_display`,
  `satisfies_object_property_position_tests`,
  `object_literal_property_target_display_tests`,
  `ts2353_generic_constraint_excess_property_tests`,
  `ts2353_omit_pick_excess_property_tests`,
  `ts2353_mapped_template_literal_key_tests`,
  `excess_property_check_recursive_intersection_tests`,
  `jsx_excess_attr_with_spread_source_display_tests`.
- Broad conformance/emit suites owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_016391oRgcSDWQiREbf1Jvib)_