### PR TITLE
refactor(checker): move in-operator RHS classification to query boundary

### DIFF
--- a/crates/tsz-checker/src/query_boundaries/type_computation/in_operator.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/in_operator.rs
@@ -1,0 +1,380 @@
+//! Reusable `in`-operator right-operand classification rules.
+//!
+//! These are the `WHAT` half of the `in`-operator checks: pure set-theoretic
+//! rules over `TypeId` shapes that decide which diagnostic family a right
+//! operand belongs to (TS2361 valid-RHS, TS2638 may-represent-primitive, and
+//! the TS2322-vs-TS2638 routing for type-parameter-shaped operands). The
+//! checker keeps the `WHERE` half — AST iteration, diagnostic anchoring, and
+//! apparent-type display.
+//!
+//! Two leaf capabilities cannot be answered from the type database alone:
+//! resolver-backed single-step evaluation (alias/application expansion) and the
+//! dedicated TS2638 primitive-constraint relation outcome. The checker supplies
+//! both through [`InOperatorRhsClassifier`], so the relation still routes
+//! through the canonical `in_operator_primitive_constraint` request.
+
+use crate::query_boundaries::state::checking;
+use crate::query_boundaries::{common, dispatch as query};
+use tsz_solver::TypeId;
+use tsz_solver::construction::{QueryDatabase, TypeDatabase};
+
+/// Checker-supplied capabilities the `in`-operator RHS classifier needs beyond
+/// pure type-database queries.
+pub(crate) trait InOperatorRhsClassifier {
+    /// The interned type database used for structural shape queries.
+    fn types(&self) -> &dyn QueryDatabase;
+
+    /// Resolver-backed single-step evaluation. Returns the input unchanged when
+    /// the type cannot be reduced further.
+    fn evaluate(&mut self, type_id: TypeId) -> TypeId;
+
+    /// Whether `source` relates to `target` through the dedicated `in`-operator
+    /// primitive-constraint relation request (TS2638 routing). Callers pass
+    /// `string` as the probing source and a type-parameter constraint as the
+    /// target.
+    fn primitive_constraint_relates(&mut self, source: TypeId, target: TypeId) -> bool;
+}
+
+/// Whether `ty` is a valid right operand for `in` (assignable to `object`).
+///
+/// `any`/`error`/`object` and object-like types are valid; type parameters
+/// defer to their constraint (unconstrained ones are invalid); unions require
+/// every member valid; intersections require any member valid; otherwise a
+/// single evaluation step is attempted before rejecting.
+pub(crate) fn is_valid_in_operator_rhs(cx: &mut dyn InOperatorRhsClassifier, ty: TypeId) -> bool {
+    if matches!(ty, TypeId::ANY | TypeId::ERROR | TypeId::OBJECT) {
+        return true;
+    }
+
+    // For type parameters, check if their constraint is assignable to object.
+    // Unconstrained type params are NOT valid (could be primitive) → TS2322.
+    if common::is_type_parameter_like(cx.types(), ty) {
+        return match checking::type_parameter_constraint(cx.types(), ty) {
+            Some(c) => is_valid_in_operator_rhs(cx, c),
+            None => false,
+        };
+    }
+
+    if query::is_object_like_type(cx.types(), ty) {
+        return true;
+    }
+
+    if let Some(members) = query::union_members(cx.types(), ty) {
+        return members
+            .iter()
+            .all(|&member| is_valid_in_operator_rhs(cx, member));
+    }
+
+    if let Some(members) = query::intersection_members(cx.types(), ty) {
+        return members
+            .iter()
+            .any(|&member| is_valid_in_operator_rhs(cx, member));
+    }
+
+    let evaluated = cx.evaluate(ty);
+    if evaluated != ty {
+        return is_valid_in_operator_rhs(cx, evaluated);
+    }
+
+    false
+}
+
+/// Whether `ty` "may represent a primitive value" for TS2638.
+///
+/// In tsc, this fires for "instantiable" types (type parameters, conditional
+/// types) whose constraint is missing or could accept primitive values.
+/// Concrete object types like `{}` do NOT trigger TS2638 on their own — only
+/// when they appear as the constraint of a type parameter that could be
+/// instantiated with a primitive.
+pub(crate) fn type_may_represent_primitive(
+    cx: &mut dyn InOperatorRhsClassifier,
+    ty: TypeId,
+) -> bool {
+    // The intrinsic `object` type excludes primitives by definition.
+    if ty == TypeId::OBJECT {
+        return false;
+    }
+
+    // `unknown` can represent any value including primitives — TS2638.
+    if ty == TypeId::UNKNOWN {
+        return true;
+    }
+
+    // Type parameters: check if constraint is missing or could be primitive.
+    // A type param with no constraint or constraint `{}` may represent a
+    // primitive because it could be instantiated with string, number, etc.
+    if common::is_type_parameter_like(cx.types(), ty) {
+        return match checking::type_parameter_constraint(cx.types(), ty) {
+            None => true,                            // Unconstrained type param may be primitive
+            Some(c) if c == TypeId::OBJECT => false, // `extends object` excludes primitives
+            Some(c) => {
+                // Check if the constraint itself could accept primitives.
+                // This handles `T extends {}` (may represent primitive) vs
+                // `T extends object` (may not) vs `T extends { a: number }`
+                // (may not).
+                if type_may_represent_primitive(cx, c) {
+                    return true;
+                }
+                // For concrete constraints, check if a primitive is assignable.
+                cx.primitive_constraint_relates(TypeId::STRING, c)
+            }
+        };
+    }
+
+    // Union: any member may represent primitive.
+    if let Some(members) = common::union_members(cx.types(), ty) {
+        return members.iter().any(|&m| type_may_represent_primitive(cx, m));
+    }
+
+    // Intersection: `T & {}` still may represent a primitive because `{}`
+    // only removes nullish values. However, `T & object`, `T & { x: ... }`,
+    // and `T & Interface` exclude primitives through the object-like member.
+    if let Some(members) = common::intersection_members(cx.types(), ty) {
+        let has_instantiable_primitive_member = members.iter().any(|&member| {
+            common::is_type_parameter_like(cx.types(), member)
+                && type_may_represent_primitive(cx, member)
+        });
+        if has_instantiable_primitive_member
+            && !members.iter().any(|&member| {
+                in_operator_intersection_member_excludes_primitive(cx.types(), member)
+            })
+        {
+            return true;
+        }
+
+        return members.iter().all(|&m| type_may_represent_primitive(cx, m));
+    }
+
+    let evaluated = cx.evaluate(ty);
+    if evaluated != ty {
+        return type_may_represent_primitive(cx, evaluated);
+    }
+
+    // Concrete object types are NOT considered "may represent primitive" —
+    // only type parameters can be instantiated with primitives at runtime.
+    false
+}
+
+/// True when `ty` is an `in`-operator RHS shape that tsc reports via TS2322
+/// (assignability to `object`) rather than TS2638 (primitive runtime warning).
+///
+/// tsc routes these to the assignability gateway:
+/// - bare type parameters (`T`)
+/// - unions that contain a type parameter/primitive assignability member
+///   (`T | U`, `string | number | T`, `T | { a: string }`)
+/// - intersections whose every member is a type parameter or primitive
+///   constraint (`T & U`, `T & (0 | 1 | 2)`)
+///
+/// It keeps TS2638 for shapes whose apparent type is reported with a
+/// `NonNullable<T>`-style message — typically intersections with `{}`-shaped
+/// object constraints. For those, the empty-object member excludes some nullish
+/// cases without committing to the `object` constraint, and tsc emits TS2638
+/// with the `NonNullable<T>` apparent-type display.
+pub(crate) fn in_rhs_is_type_parameter_assignability_shape(
+    db: &dyn TypeDatabase,
+    ty: TypeId,
+) -> bool {
+    if common::is_type_parameter_like(db, ty) {
+        return true;
+    }
+    if let Some(members) = common::union_members(db, ty) {
+        // A union containing a bare generic or primitive constituent is
+        // reported through assignability to `object`, even when other
+        // constituents are object-like. This is the shape produced by a
+        // false branch of `("a" in x && "b" in x)`: `T | (T & Record<...>)`.
+        return members
+            .iter()
+            .any(|&m| in_rhs_is_type_parameter_assignability_shape(db, m));
+    }
+    if let Some(members) = common::intersection_members(db, ty) {
+        // Intersections with an empty-object-constraint member (e.g. `T & {}`,
+        // `T & EmptyAlias`) collapse to `NonNullable<T>` in tsc's apparent-type
+        // rendering and stay on the TS2638 path. Recognize that by requiring
+        // every member to be either a type parameter or a primitive — if any
+        // member is an empty-object shape, defer to TS2638.
+        if members.iter().any(|&m| {
+            common::object_shape_for_type(db, m).is_some_and(|shape| shape.properties.is_empty())
+        }) {
+            return false;
+        }
+        return members
+            .iter()
+            .all(|&m| in_rhs_is_type_parameter_assignability_shape(db, m));
+    }
+    // Concrete primitives (string, number, ...) are also routed to the
+    // assignability gateway when they're combined with type parameters in a
+    // union / intersection that we already verified above. A bare primitive (no
+    // generics involved) keeps the TS2638 path because the user can fix it
+    // without touching a generic position.
+    common::is_primitive_type(db, ty)
+}
+
+/// Whether `ty` contains an empty-object (`{}`) shape, recursing through unions
+/// and a single evaluation step.
+pub(crate) fn in_operator_type_contains_empty_object_shape(
+    cx: &mut dyn InOperatorRhsClassifier,
+    ty: TypeId,
+) -> bool {
+    if common::is_empty_object_type(cx.types(), ty) {
+        return true;
+    }
+
+    if let Some(members) = common::union_members(cx.types(), ty) {
+        return members
+            .iter()
+            .any(|&member| in_operator_type_contains_empty_object_shape(cx, member));
+    }
+
+    let evaluated = cx.evaluate(ty);
+    evaluated != ty && in_operator_type_contains_empty_object_shape(cx, evaluated)
+}
+
+/// Whether an intersection member excludes primitives (an object-like, non-empty
+/// shape, `object`, or a type parameter/composite that reduces to one).
+pub(crate) fn in_operator_intersection_member_excludes_primitive(
+    db: &dyn TypeDatabase,
+    ty: TypeId,
+) -> bool {
+    if ty == TypeId::OBJECT {
+        return true;
+    }
+
+    if common::is_type_parameter_like(db, ty) {
+        return checking::type_parameter_constraint(db, ty).is_some_and(|constraint| {
+            in_operator_intersection_member_excludes_primitive(db, constraint)
+        });
+    }
+
+    if let Some(members) = query::union_members(db, ty) {
+        return members
+            .iter()
+            .all(|&member| in_operator_intersection_member_excludes_primitive(db, member));
+    }
+
+    if let Some(members) = query::intersection_members(db, ty) {
+        return members
+            .iter()
+            .any(|&member| in_operator_intersection_member_excludes_primitive(db, member));
+    }
+
+    query::is_object_like_type(db, ty) && !common::is_empty_object_type(db, ty)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tsz_solver::PropertyInfo;
+    use tsz_solver::construction::TypeInterner;
+
+    /// Test classifier with identity evaluation and a configurable
+    /// primitive-constraint relation. The structural rules under test do not
+    /// require resolver-backed evaluation, so identity evaluation is sufficient.
+    struct TestClassifier<'a> {
+        db: &'a TypeInterner,
+        string_relates_to: Vec<TypeId>,
+    }
+
+    impl InOperatorRhsClassifier for TestClassifier<'_> {
+        fn types(&self) -> &dyn QueryDatabase {
+            self.db
+        }
+        fn evaluate(&mut self, type_id: TypeId) -> TypeId {
+            type_id
+        }
+        fn primitive_constraint_relates(&mut self, source: TypeId, target: TypeId) -> bool {
+            source == TypeId::STRING && self.string_relates_to.contains(&target)
+        }
+    }
+
+    fn classifier(db: &TypeInterner) -> TestClassifier<'_> {
+        TestClassifier {
+            db,
+            string_relates_to: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn object_and_object_like_are_valid_rhs() {
+        let db = TypeInterner::new();
+        let mut cx = classifier(&db);
+        assert!(is_valid_in_operator_rhs(&mut cx, TypeId::OBJECT));
+        assert!(is_valid_in_operator_rhs(&mut cx, TypeId::ANY));
+        let obj = db.object_fresh(vec![]);
+        assert!(is_valid_in_operator_rhs(&mut cx, obj));
+    }
+
+    #[test]
+    fn bare_primitive_is_not_valid_rhs() {
+        let db = TypeInterner::new();
+        let mut cx = classifier(&db);
+        assert!(!is_valid_in_operator_rhs(&mut cx, TypeId::STRING));
+        assert!(!is_valid_in_operator_rhs(&mut cx, TypeId::NUMBER));
+    }
+
+    #[test]
+    fn union_requires_every_member_valid() {
+        let db = TypeInterner::new();
+        let mut cx = classifier(&db);
+        let obj = db.object_fresh(vec![]);
+        let all_valid = db.union(vec![obj, TypeId::OBJECT]);
+        assert!(is_valid_in_operator_rhs(&mut cx, all_valid));
+        let mixed = db.union(vec![obj, TypeId::STRING]);
+        assert!(!is_valid_in_operator_rhs(&mut cx, mixed));
+    }
+
+    #[test]
+    fn intersection_requires_any_member_valid() {
+        let db = TypeInterner::new();
+        let mut cx = classifier(&db);
+        let obj = db.object_fresh(vec![]);
+        let inter = db.intersection(vec![TypeId::STRING, obj]);
+        assert!(is_valid_in_operator_rhs(&mut cx, inter));
+    }
+
+    #[test]
+    fn unknown_may_represent_primitive() {
+        let db = TypeInterner::new();
+        let mut cx = classifier(&db);
+        assert!(type_may_represent_primitive(&mut cx, TypeId::UNKNOWN));
+        assert!(!type_may_represent_primitive(&mut cx, TypeId::OBJECT));
+    }
+
+    #[test]
+    fn concrete_object_does_not_represent_primitive() {
+        let db = TypeInterner::new();
+        let mut cx = classifier(&db);
+        let obj = db.object_fresh(vec![]);
+        assert!(!type_may_represent_primitive(&mut cx, obj));
+    }
+
+    #[test]
+    fn empty_object_shape_detection_walks_unions() {
+        let db = TypeInterner::new();
+        let mut cx = classifier(&db);
+        let empty = db.object_fresh(vec![]);
+        let with_empty = db.union(vec![TypeId::NUMBER, empty]);
+        assert!(in_operator_type_contains_empty_object_shape(
+            &mut cx, with_empty
+        ));
+        assert!(!in_operator_type_contains_empty_object_shape(
+            &mut cx,
+            TypeId::NUMBER
+        ));
+    }
+
+    #[test]
+    fn bare_primitive_keeps_ts2638_path_not_assignability_shape() {
+        let db = TypeInterner::new();
+        // A bare primitive is an assignability-shape only inside a generic
+        // union/intersection; on its own `is_primitive_type` returns true.
+        assert!(in_rhs_is_type_parameter_assignability_shape(
+            &db,
+            TypeId::STRING
+        ));
+        let obj = db.object_fresh(vec![PropertyInfo::new(
+            db.intern_string("a"),
+            TypeId::NUMBER,
+        )]);
+        assert!(!in_rhs_is_type_parameter_assignability_shape(&db, obj));
+    }
+}

--- a/crates/tsz-checker/src/query_boundaries/type_computation/mod.rs
+++ b/crates/tsz-checker/src/query_boundaries/type_computation/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod access;
 pub(crate) mod complex;
 pub(crate) mod core;
+pub(crate) mod in_operator;

--- a/crates/tsz-checker/src/tests/in_operator_relation_routing_arch_tests.rs
+++ b/crates/tsz-checker/src/tests/in_operator_relation_routing_arch_tests.rs
@@ -49,26 +49,42 @@ fn in_operator_lhs_key_diagnostic_uses_relation_outcome_boundary() {
 
 #[test]
 fn in_operator_rhs_primitive_constraint_uses_relation_outcome_boundary() {
-    let source = fs::read_to_string("src/types/computation/binary_support.rs")
-        .expect("failed to read binary support source");
+    // The pure TS2638 classification lives in the query boundary; it probes the
+    // primitive constraint only through the checker-supplied
+    // `primitive_constraint_relates` callback, never a raw assignability gate.
+    let boundary = fs::read_to_string("src/query_boundaries/type_computation/in_operator.rs")
+        .expect("failed to read in_operator boundary source");
     let body = function_body_until(
-        &source,
-        "fn type_may_represent_primitive(",
-        "\n    /// True when `ty` is an `in`-operator RHS shape",
+        &boundary,
+        "pub(crate) fn type_may_represent_primitive(",
+        "\n/// True when `ty` is an `in`-operator RHS shape",
+    );
+    assert!(
+        body.contains("cx.primitive_constraint_relates(TypeId::STRING, c)"),
+        "`in` operator TS2638 primitive constraint check should route through the classifier callback"
+    );
+    assert!(
+        !body.contains("is_assignable_to(TypeId::STRING, c)")
+            && !body.contains("assign_relation_outcome(TypeId::STRING, c)"),
+        "`in` operator TS2638 primitive constraint check should not use a raw or generic assignability gate"
     );
 
+    // The checker-side callback keeps the routing on the dedicated
+    // `in_operator_primitive_constraint` relation request.
+    let source = fs::read_to_string("src/types/computation/binary_support.rs")
+        .expect("failed to read binary support source");
+    let impl_body = function_body_until(&source, "fn primitive_constraint_relates(", "\n}");
+    let compact_impl = compact(impl_body);
     assert!(
-        body.contains("self.in_operator_primitive_constraint_relation_outcome(TypeId::STRING, c)")
-            && body.contains(".related"),
-        "`in` operator TS2638 primitive constraint check should route through the dedicated relation outcome"
+        compact_impl
+            .contains("self.in_operator_primitive_constraint_relation_outcome(source,target)")
+            && compact_impl.contains(".related"),
+        "the classifier callback should route through the dedicated relation outcome"
     );
     assert!(
-        !body.contains("self.assign_relation_outcome(TypeId::STRING, c)"),
-        "`in` operator TS2638 primitive constraint check should not use the generic assign relation outcome"
-    );
-    assert!(
-        !body.contains("ctx.types.is_assignable_to(TypeId::STRING, c)"),
-        "`in` operator TS2638 primitive constraint check should not use a raw solver relation gate"
+        !compact_impl.contains("self.assign_relation_outcome(source,target)")
+            && !compact_impl.contains("is_assignable_to(source,target)"),
+        "the classifier callback should not use the generic or raw assignability gate"
     );
 }
 

--- a/crates/tsz-checker/src/types/computation/binary_support.rs
+++ b/crates/tsz-checker/src/types/computation/binary_support.rs
@@ -28,7 +28,7 @@ enum SyntacticNullishness {
     Never,
 }
 
-impl<'a> CheckerState<'a> {
+impl CheckerState<'_> {
     /// Recover the un-widened literal type of a logical-operator (`&&`/`||`/`??`)
     /// operand for the result union, when a literal-preserving context requested
     /// it (`ctx.preserve_logical_operand_literals`).
@@ -1426,7 +1426,7 @@ impl<'a> CheckerState<'a> {
 /// primitive-constraint relation outcome. The pure structural rules live in
 /// [`in_operator`]; this keeps the relation routed through the canonical
 /// `in_operator_primitive_constraint` request.
-impl<'a> InOperatorRhsClassifier for CheckerState<'a> {
+impl InOperatorRhsClassifier for CheckerState<'_> {
     fn types(&self) -> &dyn tsz_solver::construction::QueryDatabase {
         self.ctx.types
     }

--- a/crates/tsz-checker/src/types/computation/binary_support.rs
+++ b/crates/tsz-checker/src/types/computation/binary_support.rs
@@ -6,6 +6,7 @@ use crate::context::TypingRequest;
 use crate::query_boundaries::type_computation::core::{
     WriteTargetLogicalOperator, WriteTargetLogicalResult,
 };
+use crate::query_boundaries::type_computation::in_operator::{self, InOperatorRhsClassifier};
 use crate::state::CheckerState;
 use tsz_binder::symbol_flags;
 use tsz_parser::parser::NodeIndex;
@@ -381,53 +382,6 @@ impl<'a> CheckerState<'a> {
         // etc.) are never nullish.
         SyntacticNullishness::Never
     }
-    fn is_valid_in_operator_rhs(&mut self, ty: TypeId) -> bool {
-        use crate::query_boundaries::dispatch as query;
-
-        if matches!(ty, TypeId::ANY | TypeId::ERROR | TypeId::OBJECT) {
-            return true;
-        }
-
-        // For type parameters, check if their constraint is assignable to object.
-        // Unconstrained type params are NOT valid (could be primitive) → TS2322.
-        if crate::query_boundaries::common::is_type_parameter_like(self.ctx.types, ty) {
-            return match crate::query_boundaries::state::checking::type_parameter_constraint(
-                self.ctx.types,
-                ty,
-            ) {
-                Some(c) => self.is_valid_in_operator_rhs(c),
-                None => false,
-            };
-        }
-
-        if query::is_object_like_type(self.ctx.types, ty) {
-            return true;
-        }
-
-        if let Some(members) = query::union_members(self.ctx.types, ty) {
-            return members
-                .iter()
-                .all(|&member| self.is_valid_in_operator_rhs(member));
-        }
-
-        if let Some(members) = query::intersection_members(self.ctx.types, ty) {
-            return members
-                .iter()
-                .any(|&member| self.is_valid_in_operator_rhs(member));
-        }
-
-        let evaluated = crate::query_boundaries::dispatch::evaluate_type_with_resolver(
-            self.ctx.types,
-            &self.ctx,
-            ty,
-        );
-        if evaluated != ty {
-            return self.is_valid_in_operator_rhs(evaluated);
-        }
-
-        false
-    }
-
     /// Check if an AST node is a nullish coalescing expression (`??`) or a
     /// literal value (string, number, boolean, bigint, template), unwrapping
     /// parentheses. TSC only emits TS2869 for these syntactic forms; general
@@ -468,203 +422,6 @@ impl<'a> CheckerState<'a> {
             || kind == SyntaxKind::TrueKeyword as u16
             || kind == SyntaxKind::FalseKeyword as u16
             || kind == syntax_kind_ext::TEMPLATE_EXPRESSION
-    }
-
-    /// Check if a type "may represent a primitive value" for TS2638.
-    ///
-    /// In tsc, this fires for "instantiable" types (type parameters, conditional types)
-    /// whose constraint is missing or could accept primitive values. Concrete object
-    /// types like `{}` do NOT trigger TS2638 on their own — only when they appear as
-    /// the constraint of a type parameter that could be instantiated with a primitive.
-    fn type_may_represent_primitive(&mut self, ty: TypeId) -> bool {
-        // The intrinsic `object` type excludes primitives by definition
-        if ty == TypeId::OBJECT {
-            return false;
-        }
-
-        // `unknown` can represent any value including primitives — TS2638
-        if ty == TypeId::UNKNOWN {
-            return true;
-        }
-
-        // Type parameters: check if constraint is missing or could be primitive.
-        // A type param with no constraint or constraint `{}` may represent a primitive
-        // because it could be instantiated with string, number, etc.
-        if crate::query_boundaries::common::is_type_parameter_like(self.ctx.types, ty) {
-            return match crate::query_boundaries::state::checking::type_parameter_constraint(
-                self.ctx.types,
-                ty,
-            ) {
-                None => true,                            // Unconstrained type param may be primitive
-                Some(c) if c == TypeId::OBJECT => false, // `extends object` excludes primitives
-                Some(c) => {
-                    // Check if the constraint itself could accept primitives.
-                    // This handles `T extends {}` (may represent primitive) vs
-                    // `T extends object` (may not) vs `T extends { a: number }` (may not).
-                    if self.type_may_represent_primitive(c) {
-                        return true;
-                    }
-                    // For concrete constraints, check if a primitive is assignable.
-                    self.in_operator_primitive_constraint_relation_outcome(TypeId::STRING, c)
-                        .related
-                }
-            };
-        }
-
-        // Union: any member may represent primitive
-        if let Some(members) = crate::query_boundaries::common::union_members(self.ctx.types, ty) {
-            return members
-                .iter()
-                .any(|&m| self.type_may_represent_primitive(m));
-        }
-
-        // Intersection: `T & {}` still may represent a primitive because `{}`
-        // only removes nullish values. However, `T & object`, `T & { x: ... }`,
-        // and `T & Interface` exclude primitives through the object-like member.
-        if let Some(members) =
-            crate::query_boundaries::common::intersection_members(self.ctx.types, ty)
-        {
-            let has_instantiable_primitive_member = members.iter().any(|&member| {
-                crate::query_boundaries::common::is_type_parameter_like(self.ctx.types, member)
-                    && self.type_may_represent_primitive(member)
-            });
-            if has_instantiable_primitive_member
-                && !members
-                    .iter()
-                    .any(|&member| self.in_operator_intersection_member_excludes_primitive(member))
-            {
-                return true;
-            }
-
-            return members
-                .iter()
-                .all(|&m| self.type_may_represent_primitive(m));
-        }
-
-        let evaluated = crate::query_boundaries::dispatch::evaluate_type_with_resolver(
-            self.ctx.types,
-            &self.ctx,
-            ty,
-        );
-        if evaluated != ty {
-            return self.type_may_represent_primitive(evaluated);
-        }
-
-        // Concrete object types are NOT considered "may represent primitive" —
-        // only type parameters can be instantiated with primitives at runtime.
-        false
-    }
-
-    /// True when `ty` is an `in`-operator RHS shape that tsc reports via
-    /// TS2322 (assignability to `object`) rather than TS2638 (primitive
-    /// runtime warning).
-    ///
-    /// tsc routes these to the assignability gateway:
-    /// - bare type parameters (`T`)
-    /// - unions that contain a type parameter/primitive assignability member
-    ///   (`T | U`, `string | number | T`, `T | { a: string }`)
-    /// - intersections whose every member is a type parameter or
-    ///   primitive constraint (`T & U`, `T & (0 | 1 | 2)`)
-    ///
-    /// It keeps TS2638 for shapes whose apparent type is reported with a
-    /// `NonNullable<T>`-style message — typically intersections with
-    /// `{}`-shaped object constraints. For those, the empty-object
-    /// member excludes some nullish cases without committing to the
-    /// `object` constraint, and tsc emits TS2638 with the
-    /// `NonNullable<T>` apparent-type display.
-    fn in_rhs_is_type_parameter_assignability_shape(&self, ty: TypeId) -> bool {
-        use crate::query_boundaries::common;
-
-        if common::is_type_parameter_like(self.ctx.types, ty) {
-            return true;
-        }
-        if let Some(members) = common::union_members(self.ctx.types, ty) {
-            // A union containing a bare generic or primitive constituent is
-            // reported through assignability to `object`, even when other
-            // constituents are object-like. This is the shape produced by a
-            // false branch of `("a" in x && "b" in x)`: `T | (T & Record<...>)`.
-            return members
-                .iter()
-                .any(|&m| self.in_rhs_is_type_parameter_assignability_shape(m));
-        }
-        if let Some(members) = common::intersection_members(self.ctx.types, ty) {
-            // Intersections with an empty-object-constraint member
-            // (e.g. `T & {}`, `T & EmptyAlias`) collapse to
-            // `NonNullable<T>` in tsc's apparent-type rendering and stay
-            // on the TS2638 path. Recognize that by requiring every
-            // member to be either a type parameter or a primitive — if
-            // any member is an empty-object shape, defer to TS2638.
-            if members.iter().any(|&m| {
-                common::object_shape_for_type(self.ctx.types, m)
-                    .is_some_and(|shape| shape.properties.is_empty())
-            }) {
-                return false;
-            }
-            return members
-                .iter()
-                .all(|&m| self.in_rhs_is_type_parameter_assignability_shape(m));
-        }
-        // Concrete primitives (string, number, ...) are also routed to
-        // the assignability gateway when they're combined with type
-        // parameters in a union / intersection that we already verified
-        // above. A bare primitive (no generics involved) keeps the
-        // TS2638 path because the user can fix it without touching a
-        // generic position.
-        common::is_primitive_type(self.ctx.types, ty)
-    }
-
-    fn in_operator_type_contains_empty_object_shape(&self, ty: TypeId) -> bool {
-        use crate::query_boundaries::common;
-
-        if common::is_empty_object_type(self.ctx.types, ty) {
-            return true;
-        }
-
-        if let Some(members) = common::union_members(self.ctx.types, ty) {
-            return members
-                .iter()
-                .any(|&member| self.in_operator_type_contains_empty_object_shape(member));
-        }
-
-        let evaluated = crate::query_boundaries::dispatch::evaluate_type_with_resolver(
-            self.ctx.types,
-            &self.ctx,
-            ty,
-        );
-        evaluated != ty && self.in_operator_type_contains_empty_object_shape(evaluated)
-    }
-
-    fn in_operator_intersection_member_excludes_primitive(&self, ty: TypeId) -> bool {
-        use crate::query_boundaries::{common, dispatch as query};
-
-        if ty == TypeId::OBJECT {
-            return true;
-        }
-
-        if common::is_type_parameter_like(self.ctx.types, ty) {
-            return crate::query_boundaries::state::checking::type_parameter_constraint(
-                self.ctx.types,
-                ty,
-            )
-            .is_some_and(|constraint| {
-                self.in_operator_intersection_member_excludes_primitive(constraint)
-            });
-        }
-
-        if let Some(members) = query::union_members(self.ctx.types, ty) {
-            return members
-                .iter()
-                .all(|&member| self.in_operator_intersection_member_excludes_primitive(member));
-        }
-
-        if let Some(members) = query::intersection_members(self.ctx.types, ty) {
-            return members
-                .iter()
-                .any(|&member| self.in_operator_intersection_member_excludes_primitive(member));
-        }
-
-        query::is_object_like_type(self.ctx.types, ty)
-            && !common::is_empty_object_type(self.ctx.types, ty)
     }
 
     /// Format the apparent type for display in TS2638 error messages.
@@ -712,7 +469,7 @@ impl<'a> CheckerState<'a> {
         // First check if the narrowed type includes the empty object `{}`.
         // After previous `in` checks, flow can preserve both the truthiness-
         // narrowed unknown branch and the record branch as a union.
-        if !self.in_operator_type_contains_empty_object_shape(narrowed_type) {
+        if !in_operator::in_operator_type_contains_empty_object_shape(self, narrowed_type) {
             return false;
         }
 
@@ -1566,14 +1323,17 @@ impl<'a> CheckerState<'a> {
         if right_type == TypeId::UNKNOWN {
             self.error_is_of_type_unknown(right_idx);
         } else {
-            let type_may_represent_primitive = self.type_may_represent_primitive(right_type);
+            let type_may_represent_primitive =
+                in_operator::type_may_represent_primitive(self, right_type);
             let truthiness_narrowed_unknown = self
                 .truthiness_narrowed_from_unknown(right_idx, right_type)
                 && !self.in_rhs_has_typeof_object_guard(right_idx);
             if type_may_represent_primitive || truthiness_narrowed_unknown {
-                let truthiness_guarded_type_parameter = self
-                    .in_rhs_is_type_parameter_assignability_shape(right_type)
-                    && self.in_rhs_has_direct_truthiness_guard(right_idx);
+                let truthiness_guarded_type_parameter =
+                    in_operator::in_rhs_is_type_parameter_assignability_shape(
+                        self.ctx.types,
+                        right_type,
+                    ) && self.in_rhs_has_direct_truthiness_guard(right_idx);
                 // tsc reports TS2322 ("Type 'T' is not assignable to type
                 // 'object'") rather than TS2638 ("may represent a primitive
                 // value") for type-parameter-shaped RHS values: bare `T`,
@@ -1585,8 +1345,10 @@ impl<'a> CheckerState<'a> {
                 // keep the existing TS2638 path because tsc emits that code
                 // with a `NonNullable<T>`-style message rather than a bare
                 // assignability failure.
-                if self.in_rhs_is_type_parameter_assignability_shape(right_type)
-                    && !truthiness_guarded_type_parameter
+                if in_operator::in_rhs_is_type_parameter_assignability_shape(
+                    self.ctx.types,
+                    right_type,
+                ) && !truthiness_guarded_type_parameter
                 {
                     let _ = self.check_assignable_or_report_at_exact_anchor(
                         right_type,
@@ -1603,7 +1365,7 @@ impl<'a> CheckerState<'a> {
                     let code = tsz_common::diagnostics::diagnostic_codes::TYPE_MAY_REPRESENT_A_PRIMITIVE_VALUE_WHICH_IS_NOT_PERMITTED_AS_THE_RIGHT_OPERAND;
                     self.error_at_node_msg(right_idx, code, &[&type_str]);
                 }
-            } else if !self.is_valid_in_operator_rhs(right_type) {
+            } else if !in_operator::is_valid_in_operator_rhs(self, right_type) {
                 // Route through the check_assignable_or_report(...) gateway family
                 // so computation-layer mismatches stay on the centralized path.
                 let _ = self.check_assignable_or_report_at_exact_anchor(
@@ -1656,5 +1418,29 @@ impl<'a> CheckerState<'a> {
             }
             _ => false,
         }
+    }
+}
+
+/// Supplies the checker-side leaf capabilities the `in`-operator RHS
+/// classifier needs: resolver-backed evaluation and the dedicated TS2638
+/// primitive-constraint relation outcome. The pure structural rules live in
+/// [`in_operator`]; this keeps the relation routed through the canonical
+/// `in_operator_primitive_constraint` request.
+impl<'a> InOperatorRhsClassifier for CheckerState<'a> {
+    fn types(&self) -> &dyn tsz_solver::construction::QueryDatabase {
+        self.ctx.types
+    }
+
+    fn evaluate(&mut self, type_id: TypeId) -> TypeId {
+        crate::query_boundaries::dispatch::evaluate_type_with_resolver(
+            self.ctx.types,
+            &self.ctx,
+            type_id,
+        )
+    }
+
+    fn primitive_constraint_relates(&mut self, source: TypeId, target: TypeId) -> bool {
+        self.in_operator_primitive_constraint_relation_outcome(source, target)
+            .related
     }
 }


### PR DESCRIPTION
Goal: hold

Advances #8226 (move reusable type-computation semantics out of `CheckerState`). One behavior-preserving slice.

## Structural rule

When the checker classifies the right operand of an `in` expression, the reusable set-theoretic rules — TS2361 valid-RHS (assignable to `object`), TS2638 may-represent-primitive, the TS2322-vs-TS2638 routing for type-parameter-shaped operands, the empty-object shape walk, and the intersection-member primitive-exclusion rule — are pure `WHAT` logic over `TypeId` shapes. tsc decides these from type structure alone; tsz now owns them in a query boundary instead of as `CheckerState` methods.

## What changed

- New module `crates/tsz-checker/src/query_boundaries/type_computation/in_operator.rs` holds the five extracted predicates as free functions:
  - `is_valid_in_operator_rhs`
  - `type_may_represent_primitive`
  - `in_rhs_is_type_parameter_assignability_shape`
  - `in_operator_type_contains_empty_object_shape`
  - `in_operator_intersection_member_excludes_primitive`
- The checker keeps the `WHERE` half (AST iteration, diagnostic anchoring, apparent-type display) in `types/computation/binary_support.rs`, which shrinks by ~225 lines.
- Two leaf capabilities that need checker state — resolver-backed single-step evaluation and the dedicated TS2638 primitive-constraint relation outcome — are supplied through the new `InOperatorRhsClassifier` trait (impl on `CheckerState`). This keeps the relation routed through the canonical `in_operator_primitive_constraint` request and resolves the borrow split (immutable resolver evaluation vs `&mut self` relation outcome can't be two live closures), matching the established `query_boundaries::type_computation::core` convention where pure-db functions take `db` and resolver/relation functions take a context.

## Owner layer

`query_boundaries::type_computation` (the `WHAT` boundary, in `tsz-checker`), consistent with prior #8226 slices (#8261, #8319, #8408/#8851, #8413, #8414/#8813, #8911). No logic moved into the checker; no semantics changed.

## Anti-hardcoding

No identifier/file-name/printer-string predicates. Classification is purely structural over `TypeId` shapes via existing `common`/`dispatch` solver-backed helpers.

## Verification

- `cargo build -p tsz-checker` — clean
- `cargo clippy -p tsz-checker --lib` — clean
- `cargo test -p tsz-checker --lib in_operator` — 18 passed (8 new boundary unit tests + updated relation-routing arch test + existing `in`-operator behavior tests)
- `python3 scripts/arch/arch_guard.py` — architecture guardrails passed
- Ready-review CI owns broad conformance/emit/fourslash parity (the `hold` floor).

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_01Mc3suUxYAJ1U7djkvdyzaa

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mc3suUxYAJ1U7djkvdyzaa)_