### PR TITLE
fix(solver): guard widen_literal_type against cyclic union origin (mobx crash)

### DIFF
--- a/crates/tsz-solver/src/operations/widening.rs
+++ b/crates/tsz-solver/src/operations/widening.rs
@@ -19,6 +19,7 @@ use crate::diagnostics::display_provenance::{
     FreshObjectLiteralDisplayProvenance, UnionOriginProvenance,
 };
 use crate::types::{ObjectFlags, TypeData, TypeId};
+use rustc_hash::FxHashSet;
 
 /// Propagate `display_alias` from the original type to the widened type.
 ///
@@ -918,6 +919,26 @@ pub fn get_base_type_for_comparison(
 /// Used for binary operator error messages where tsc shows widened types
 /// for literal operands but preserves enum type names.
 pub fn widen_literal_type(db: &dyn crate::construction::TypeDatabase, type_id: TypeId) -> TypeId {
+    // `FxHashSet::default()` does not allocate until the first insert, and only
+    // the union arm inserts, so the common non-union inputs stay allocation-free.
+    widen_literal_type_tracked(db, type_id, &mut FxHashSet::default())
+}
+
+/// `widen_literal_type` with an on-stack ancestor set guarding union recursion.
+///
+/// A union's display-origin provenance can transitively reference the union
+/// itself (a cyclic origin chain). Recursing into such members through the
+/// `Union` arm would otherwise overflow the stack. `on_stack` records the
+/// unions currently being widened on this call path; revisiting one returns it
+/// unchanged (it is already being widened by an ancestor frame). Entries are
+/// inserted on enter and removed on exit so non-cyclic diamonds — the same
+/// union reached by two independent member paths — are still widened on each
+/// path.
+fn widen_literal_type_tracked(
+    db: &dyn crate::construction::TypeDatabase,
+    type_id: TypeId,
+    on_stack: &mut FxHashSet<TypeId>,
+) -> TypeId {
     if type_id == TypeId::BOOLEAN_TRUE || type_id == TypeId::BOOLEAN_FALSE {
         return TypeId::BOOLEAN;
     }
@@ -932,41 +953,60 @@ pub fn widen_literal_type(db: &dyn crate::construction::TypeDatabase, type_id: T
         Some(TypeData::Literal(ref value)) => value.primitive_type_id(),
 
         Some(TypeData::Union(list_id)) => {
-            let canonical_members = db.type_list(list_id);
-            let origin_members = db.get_union_origin(type_id);
-            let members = origin_members
-                .as_deref()
-                .map_or(canonical_members.as_ref(), Vec::as_slice);
-            let mut mapped = None;
-            for (index, &member) in members.iter().enumerate() {
-                let widened = widen_literal_type(db, member);
-                if widened != member && mapped.is_none() {
-                    let mut out = Vec::with_capacity(members.len());
-                    out.extend_from_slice(&members[..index]);
-                    mapped = Some(out);
-                }
-                if let Some(mapped) = mapped.as_mut() {
-                    mapped.push(widened);
-                }
-            }
-
-            let Some(mapped) = mapped else {
+            if !on_stack.insert(type_id) {
+                // Cyclic union origin: this union is an ancestor on the current
+                // widening path. Returning it unchanged breaks the cycle.
                 return type_id;
-            };
-
-            let result = db.union(mapped.clone());
-            display_provenance::record_union_origin(
-                db,
-                UnionOriginProvenance {
-                    union_type_id: result,
-                    origin_members: mapped,
-                },
-            );
+            }
+            let result = widen_union_literal_members(db, type_id, list_id, on_stack);
+            on_stack.remove(&type_id);
             result
         }
 
         _ => type_id,
     }
+}
+
+/// Widen the members of a literal-bearing union, threading the on-stack
+/// ancestor set so nested unions stay cycle-guarded. Returns the union
+/// unchanged when no member widened.
+fn widen_union_literal_members(
+    db: &dyn crate::construction::TypeDatabase,
+    type_id: TypeId,
+    list_id: crate::types::TypeListId,
+    on_stack: &mut FxHashSet<TypeId>,
+) -> TypeId {
+    let canonical_members = db.type_list(list_id);
+    let origin_members = db.get_union_origin(type_id);
+    let members = origin_members
+        .as_deref()
+        .map_or(canonical_members.as_ref(), Vec::as_slice);
+    let mut mapped = None;
+    for (index, &member) in members.iter().enumerate() {
+        let widened = widen_literal_type_tracked(db, member, on_stack);
+        if widened != member && mapped.is_none() {
+            let mut out = Vec::with_capacity(members.len());
+            out.extend_from_slice(&members[..index]);
+            mapped = Some(out);
+        }
+        if let Some(mapped) = mapped.as_mut() {
+            mapped.push(widened);
+        }
+    }
+
+    let Some(mapped) = mapped else {
+        return type_id;
+    };
+
+    let result = db.union(mapped.clone());
+    display_provenance::record_union_origin(
+        db,
+        UnionOriginProvenance {
+            union_type_id: result,
+            origin_members: mapped,
+        },
+    );
+    result
 }
 
 /// Combine the source constituents of a union that did not match any structured

--- a/crates/tsz-solver/tests/widening_tests.rs
+++ b/crates/tsz-solver/tests/widening_tests.rs
@@ -908,6 +908,34 @@ fn test_widen_literal_type_bigint_literal() {
 }
 
 #[test]
+fn widen_literal_type_terminates_on_cyclic_union_origin() {
+    let interner = TypeInterner::new();
+    let db = &interner as &dyn crate::construction::TypeDatabase;
+    let lit1 = interner.literal_number(1.0);
+    let lit2 = interner.literal_number(2.0);
+    let union = interner.union(vec![lit1, lit2]);
+
+    // Record a self-referential display origin: the union lists itself as one of
+    // its origin members. `widen_literal_type` recurses through origin members,
+    // so before the on-stack cycle guard this overflowed the stack (the mobx
+    // project-compile crash). It must now terminate.
+    display_provenance::record_union_origin(
+        db,
+        UnionOriginProvenance {
+            union_type_id: union,
+            origin_members: vec![union, lit1, lit2],
+        },
+    );
+
+    let widened = widen_literal_type(db, union);
+
+    // Terminated (no stack overflow). The self-reference is returned unchanged
+    // rather than recursed into, and the number literals widen to `number`;
+    // unioning the widened members collapses to `number`.
+    assert_eq!(widened, TypeId::NUMBER);
+}
+
+#[test]
 fn test_widen_literal_type_union_maps_each_member() {
     let interner = TypeInterner::new();
     let s = interner.literal_string("x");


### PR DESCRIPTION
Goal: green

## Summary

The **mobx** project-compile canary crashed the compiler — `fatal runtime error:
stack overflow, aborting` (exit 134) after ~58 files in the check phase. A gdb
backtrace showed `tsz_solver::operations::widening::widen_literal_type`
self-recursing without bound (frames #3..#59 the identical recursive call site).

## Structural rule

`widen_literal_type`'s `Union` arm widens each member by recursing
(`widen_literal_type(db, member)`), and it iterates a union's **display-origin
members** (`get_union_origin`) when present rather than the canonical (flat)
member list. Origin provenance is a tree that can form a **cycle**: an origin
member transitively references the union itself. With no on-stack guard the
recursion never terminates and overflows the stack.

When a union's origin members transitively include the union itself, `tsc`
widens it in bounded time; tsz must not recurse into the self-reference.

## Fix / owner layer

Thread an on-stack ancestor set (`FxHashSet<TypeId>`) through the union arm
(`crates/tsz-solver/src/operations/widening.rs`):

- insert the union id on enter, remove on exit (classic DFS cycle detection);
- revisiting a union already on the current path returns it unchanged (it is
  already being widened by an ancestor frame), breaking the cycle;
- because entries are removed on exit, a non-cyclic **diamond** — the same union
  reached by two independent member paths — still widens on each path, so
  results are unchanged for all non-cyclic inputs.

The common non-union inputs stay **allocation-free**: `FxHashSet::default()` does
not allocate until the first insert, and only the union arm inserts. The union
body moves into a small `widen_union_literal_members` helper so the
insert/remove bracket has a single owner.

Owner: solver widening operation. No identifier/file-name/printer-string
predicates; the guard keys purely on type identity.

## Result

| project | before | after |
|---|---|---|
| mobx | **crash** (exit 134, stack overflow) | exits check phase (exit 2) |

mobx moves RED (crash) → YELLOW; its remaining diagnostics are separate,
pre-existing deltas now reachable because the compiler no longer aborts.

## Verification

- `cargo test -p tsz-solver --lib widening::tests` — 71/71, including the new
  `widen_literal_type_terminates_on_cyclic_union_origin` regression (records a
  self-referential union origin; asserts termination — it overflowed the stack
  before this change).
- Re-ran the mobx fixture via the project-compile-guard `dist-fast` binary: no
  stack overflow; exit 134 → exit 2.
- `cargo clippy -p tsz-solver --lib` and `cargo fmt` — clean.
- The one solver lib failure (`test_generic_call_widening_applies_when_constraint_satisfied`)
  is **pre-existing on `main`** (verified by stashing this change), not caused
  here.
- Broad conformance / emit / fourslash / project-compile parity owned by
  ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZ8cdofmotV5hhW6NUuBBe)_