### PR TITLE
fix(solver): bound literal-widening recursion on cyclic union origins (#13507)

### DIFF
--- a/crates/tsz-solver/tests/widening_tests.rs
+++ b/crates/tsz-solver/tests/widening_tests.rs
@@ -1342,3 +1342,42 @@ fn annotation_widen_reports_display_residue() {
         "literal spellings live only in display provenance"
     );
 }
+
+// -------- recursive union-origin termination (issue #13507) ------------------
+//
+// `widen_literal_type` follows a union's display-origin member list when one is
+// recorded. A few generic-heavy projects (mobx's observable/computed generics)
+// produce a union whose origin members reach the union again, forming a cycle
+// in the member graph. Before the path-scoped cycle guard, widening such a union
+// recursed until the worker stack overflowed (SIGABRT, exit 134). These tests
+// pin the termination — they abort the whole test binary on regression.
+
+/// A union whose display origin references the union itself must terminate.
+#[test]
+fn widen_literal_type_self_referential_union_origin_terminates() {
+    let interner = TypeInterner::new();
+    let lit = interner.literal_string("a");
+    let union = interner.union(vec![lit, TypeId::NUMBER]);
+    // Poison the display origin so a member of the union is the union itself.
+    interner.store_union_origin(union, vec![union, lit]);
+
+    let widened = widen_literal_type(&interner, union);
+    // Reaching here proves no stack overflow. Widening still happened (the
+    // non-cyclic literal member became `string`), so the result stays a union.
+    assert!(matches!(interner.lookup(widened), Some(TypeData::Union(_))));
+}
+
+/// Two unions whose display origins reference each other must terminate.
+#[test]
+fn widen_literal_type_mutually_recursive_union_origins_terminate() {
+    let interner = TypeInterner::new();
+    let a = interner.literal_string("a");
+    let b = interner.literal_string("b");
+    let u1 = interner.union(vec![a, TypeId::NUMBER]);
+    let u2 = interner.union(vec![b, TypeId::BOOLEAN]);
+    interner.store_union_origin(u1, vec![u2, a]);
+    interner.store_union_origin(u2, vec![u1, b]);
+
+    let widened = widen_literal_type(&interner, u1);
+    assert!(matches!(interner.lookup(widened), Some(TypeData::Union(_))));
+}


### PR DESCRIPTION
Goal: green

Closes the last stack-overflow witness of #13507. The earlier merged PR #13518
fixed two checker-side recursive walks (trpc + remeda no longer overflow); the
**mobx** row still aborted with a Rust stack overflow (SIGABRT, exit 134). This
PR fixes that third site at its root in the solver.

> **Rebase note (post #13585):** the source-side cycle guard described below
> landed independently on `main` via #13585 (commit `cbbcce7a81`), which uses a
> semantically equivalent on-stack ancestor set in `widen_literal_type`. After
> rebasing onto that `main`, this PR's source change is fully subsumed, so its
> remaining contribution is the **additional regression coverage** below — in
> particular the **mutually-recursive** union-origin case, which #13585's single
> self-referential test does not exercise. The structural-rule narrative still
> describes the in-tree fix that both PRs implement.

## Structural rule

When a `TypeData::Union` carries display **union-origin provenance**,
`widen_literal_type` (`crates/tsz-solver/src/operations/widening.rs`) follows the
origin member list and recurses through each member. mobx's observable/computed
generics produce a union whose origin members reach the union again, so the
member graph contains a cycle. `widen_literal_type` had **no cycle guard at all**
and recursed until the worker stack overflowed.

`tsc` resolves recursive structural questions coinductively (it assumes the
recursive position) and never overflows. tsz now does the same here: a
**lazily-allocated, path-scoped visiting set** keyed on the union `TypeId` cuts
back-edges — a union already on the recursion path widens to itself (the
coinductive identity, which never changes a non-cyclic result). The union is
removed from the set once its subtree completes, so a union shared across
sibling (non-ancestor) branches of a DAG is still widened on each branch rather
than mistaken for a back-edge. The set is created only when the first union is
entered, so the dominant literal/intrinsic leaf path (this function is called
from dozens of hot checker sites) allocates nothing.

Because the member lists are drawn from the finite universe of interned types
and no freshly-built type is recursed into, cutting true back-edges alone
guarantees termination — no depth cap or magic number needed.

Owner layer: solver widening operation. No checker/binder/emit changes; no
fixture-name or printer-string predicates. Mirrors the cycle sentinels the
sibling walks `widen_type_cached` / `widen_annotation_walk` already use in this
same module.

## Adjacent matrix

- Self-referential union origin (`origin(U) ⊇ {U}`) — regression test, aborted
  the test binary before the fix, passes after.
- Mutually-recursive union origins (`origin(U1) ⊇ {U2}`, `origin(U2) ⊇ {U1}`) —
  regression test, same.
- Non-cyclic unions / literals / intrinsics — behavior unchanged (the guard only
  engages on a true back-edge; existing `widen`/`widen_literal_type` suites stay
  green).
- DAG-shared non-cyclic union — still widened on every branch (the path-scoped
  `remove` is load-bearing, documented in code).

## Verification

- Rebased onto `main` (which already carries the equivalent source fix #13585);
  the post-rebase diff vs `main` is exactly the two new regression tests in
  `crates/tsz-solver/tests/widening_tests.rs`. `widening.rs` is byte-identical to
  `main`.
- `cargo build -p tsz-solver` — clean.
- `cargo nextest run -p tsz-solver --lib widen_literal_type` → **12 passed**,
  including this PR's
  `widen_literal_type_self_referential_union_origin_terminates` and
  `widen_literal_type_mutually_recursive_union_origins_terminate`, plus #13585's
  `widen_literal_type_terminates_on_cyclic_union_origin`. Reaching the assertions
  proves no stack overflow on the cyclic origin graphs.
- `cargo nextest run -p tsz-solver --lib widen` → 128 passed, 1 failed. The one
  failure, `operations::tests::test_generic_call_widening_applies_when_constraint_satisfied`,
  lives in `operations_tests_parts/part_00.rs` (untouched by this PR) and
  reproduces **identically on `origin/main`** — the only delta vs `main` is the
  two added widening tests, so it is pre-existing and independent of this change.
- Original corpus witnesses (release binary, pinned refs, `RAYON_NUM_THREADS=1`):
  mobx @ 2a069e41 was `exit 134` (stack overflow), now completes; trpc @ f8f0c0e3
  `exit 2`, 0 overflow; remeda @ 53d22a60 no overflow (hits 90s wall, separate
  family #13508). These verified the in-tree fix shared by #13585 and this PR.
- Broad conformance / emit / fourslash / project-compile owned by ready-review CI.

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01DSnsjh4aT7zordduMeXwWW)_
