### PR TITLE
perf(solver): preserve unchanged conditional instantiations

### DIFF
--- a/crates/tsz-solver/src/caches/instantiation_cache_test.rs
+++ b/crates/tsz-solver/src/caches/instantiation_cache_test.rs
@@ -22,12 +22,12 @@
 
 use crate::caches::query_cache::QueryCache;
 use crate::instantiation::instantiate::{
-    MAX_INSTANTIATION_DEPTH, TypeSubstitution, instantiate_generic_cached, instantiate_type_cached,
-    instantiate_type_preserving_cached, substitute_this_type_at_return_position,
-    substitute_this_type_cached,
+    MAX_INSTANTIATION_DEPTH, TypeSubstitution, instantiate_generic_cached, instantiate_type,
+    instantiate_type_cached, instantiate_type_preserving_cached,
+    substitute_this_type_at_return_position, substitute_this_type_cached,
 };
 use crate::intern::TypeInterner;
-use crate::types::{PropertyInfo, TypeId, TypeParamInfo, Visibility};
+use crate::types::{ConditionalType, PropertyInfo, TypeId, TypeParamInfo, Visibility};
 
 fn param_info(atom: tsz_common::interner::Atom) -> TypeParamInfo {
     TypeParamInfo {
@@ -640,6 +640,87 @@ fn instantiate_generic_cached_identity_short_circuits() {
         stats1.instantiation_cache_misses, stats0.instantiation_cache_misses,
         "identity substitution must not probe the cache"
     );
+}
+
+#[test]
+fn unchanged_conditional_instantiation_skips_conditional_reintern() {
+    // Conditional types are meta-types, so they still need to be walked under a
+    // non-empty substitution. If all four arms remain unchanged, though, the
+    // walk should return the original `TypeId` without probing the conditional
+    // interner again.
+    tsz_common::perf_counters::force_enable_perf_counters_for_tests();
+
+    let interner = TypeInterner::new();
+    let (u_atom, _u_id) = type_param(&interner, "U");
+    let conditional = interner.conditional(ConditionalType {
+        check_type: TypeId::STRING,
+        extends_type: TypeId::STRING,
+        true_type: TypeId::NUMBER,
+        false_type: TypeId::BOOLEAN,
+        is_distributive: false,
+    });
+
+    let mut subst = TypeSubstitution::new();
+    subst.insert(u_atom, TypeId::STRING);
+
+    let before = tsz_common::perf_counters::PerfCounters::snapshot()
+        .interner
+        .conditional_intern_calls;
+    let result = instantiate_type(&interner, conditional, &subst);
+    let after = tsz_common::perf_counters::PerfCounters::snapshot()
+        .interner
+        .conditional_intern_calls;
+
+    assert_eq!(
+        result, conditional,
+        "unchanged conditional instantiation should preserve identity"
+    );
+    assert_eq!(
+        after, before,
+        "unchanged conditional instantiation should not re-intern the conditional"
+    );
+}
+
+#[test]
+fn changed_conditional_instantiation_still_rebuilds_conditional() {
+    tsz_common::perf_counters::force_enable_perf_counters_for_tests();
+
+    let interner = TypeInterner::new();
+    let (t_atom, t_id) = type_param(&interner, "T");
+    let conditional = interner.conditional(ConditionalType {
+        check_type: TypeId::STRING,
+        extends_type: TypeId::STRING,
+        true_type: t_id,
+        false_type: TypeId::BOOLEAN,
+        is_distributive: false,
+    });
+
+    let mut subst = TypeSubstitution::new();
+    subst.insert(t_atom, TypeId::NUMBER);
+
+    let before = tsz_common::perf_counters::PerfCounters::snapshot()
+        .interner
+        .conditional_intern_calls;
+    let result = instantiate_type(&interner, conditional, &subst);
+    let after = tsz_common::perf_counters::PerfCounters::snapshot()
+        .interner
+        .conditional_intern_calls;
+
+    assert_ne!(
+        result, conditional,
+        "changed conditional instantiation must not preserve the old identity"
+    );
+    assert!(
+        after > before,
+        "changed conditional instantiation should re-intern the rebuilt conditional"
+    );
+    let result_id = match interner.lookup(result) {
+        Some(crate::types::TypeData::Conditional(id)) => id,
+        other => panic!("expected rebuilt conditional, got {other:?}"),
+    };
+    let rebuilt = interner.get_conditional(result_id);
+    assert_eq!(rebuilt.true_type, TypeId::NUMBER);
+    assert_eq!(rebuilt.false_type, TypeId::BOOLEAN);
 }
 
 #[test]

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -822,7 +822,7 @@ impl<'a> TypeInstantiator<'a> {
             TypeData::Callable(shape_id) => self.instantiate_callable(shape_id, key),
 
             // Conditional: instantiate all parts
-            TypeData::Conditional(cond_id) => self.instantiate_conditional(cond_id),
+            TypeData::Conditional(cond_id) => self.instantiate_conditional(type_id, cond_id),
 
             // Mapped: instantiate constraint and template
             TypeData::Mapped(mapped_id) => self.instantiate_mapped(mapped_id),

--- a/crates/tsz-solver/src/instantiation/instantiate/conditional.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/conditional.rs
@@ -8,7 +8,11 @@ use super::{TypeInstantiator, instantiate_type, instantiate_type_preserving};
 
 impl<'a> TypeInstantiator<'a> {
     /// Instantiate a conditional type: instantiate all parts.
-    pub(super) fn instantiate_conditional(&mut self, cond_id: &ConditionalTypeId) -> TypeId {
+    pub(super) fn instantiate_conditional(
+        &mut self,
+        type_id: TypeId,
+        cond_id: &ConditionalTypeId,
+    ) -> TypeId {
         let cond = self.interner.get_conditional(*cond_id);
         if cond.is_distributive
             && let Some(TypeData::TypeParameter(info)) = self.interner.lookup(cond.check_type)
@@ -107,6 +111,9 @@ impl<'a> TypeInstantiator<'a> {
             false_type: self.instantiate(cond.false_type),
             is_distributive: cond.is_distributive,
         };
+        if instantiated == cond {
+            return type_id;
+        }
         self.interner.conditional(instantiated)
     }
 }


### PR DESCRIPTION
Refs #13242

Goal: fast

## Summary
- Preserve the existing conditional TypeId when instantiation walks all four conditional arms and none changes.
- Keep changed conditional arms rebuilding through the normal conditional interner path.
- Add counter-backed solver tests for unchanged and changed conditional instantiation.

## Structural Rule
When a non-distributive conditional instantiation leaves check_type, extends_type, true_type, and false_type unchanged, tsc-equivalent semantics are unchanged; tsz should return the original solver TypeId through solver instantiation instead of re-interning an equivalent conditional. When any arm changes, solver instantiation rebuilds the conditional normally.

Owner layer: solver instantiation.
Adjacent matrix: unchanged conditional with unrelated substitution skips re-intern; changed true branch rebuilds and substitutes.
Fallback: distributive substitution paths and meta-type walking behavior are unchanged.
Performance: removes one conditional interner probe for no-op conditional instantiation walks, verified by conditional_intern_calls delta.

## Verification
- scripts/safe-run.sh cargo nextest run -p tsz-solver --lib unchanged_conditional_instantiation_skips_conditional_reintern
- scripts/safe-run.sh cargo nextest run -p tsz-solver --lib instantiation_cache_wiring_tests
- cargo fmt --check
- git diff --check
- python3 scripts/arch/arch_guard.py

## Provenance
Machine: Mac.fritz.box
Assistant: codex
Model: gpt-5
Effort: medium