### PR TITLE
refactor(solver,checker): centralize lock-poison policy and table-back protected-property elaboration

### DIFF
--- a/crates/tsz-checker/src/classes/class_checker.rs
+++ b/crates/tsz-checker/src/classes/class_checker.rs
@@ -3,7 +3,9 @@
 use std::borrow::Cow;
 
 use crate::classes_domain::class_summary::ClassChainSummary;
-use crate::diagnostics::{diagnostic_codes, diagnostic_messages};
+use crate::diagnostics::{
+    diagnostic_codes, diagnostic_messages, format_message, internal_elaboration_messages,
+};
 use crate::query_boundaries::class::{
     should_report_member_type_mismatch, should_report_member_type_mismatch_bivariant,
 };
@@ -132,11 +134,13 @@ pub(crate) fn visibility_conflict_elaboration(
 ) -> Option<String> {
     use MemberVisibility::*;
     match (derived_visibility, base_visibility) {
-        (Private, Private) => Some(format!(
-            "Types have separate declarations of a private property '{display_name}'."
+        (Private, Private) => Some(format_message(
+            diagnostic_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PRIVATE_PROPERTY,
+            &[display_name],
         )),
-        (Protected, Protected) => Some(format!(
-            "Types have separate declarations of a protected property '{display_name}'."
+        (Protected, Protected) => Some(format_message(
+            internal_elaboration_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PROTECTED_PROPERTY,
+            &[display_name],
         )),
         (_, Private) => Some(format!(
             "Property '{display_name}' is private in type '{base_class_name}' but not in type '{derived_class_name}'."

--- a/crates/tsz-checker/src/classes/class_implements_checker/core.rs
+++ b/crates/tsz-checker/src/classes/class_implements_checker/core.rs
@@ -1403,7 +1403,13 @@ impl<'a> CheckerState<'a> {
                                     } else {
                                         self.error_at_node(
                                                 class_error_idx,
-                                                &format!("Class '{class_name}' incorrectly implements interface '{interface_display_name}'.\n  Types have separate declarations of a private property '{member_name}'."),
+                                                &format!(
+                                                    "Class '{class_name}' incorrectly implements interface '{interface_display_name}'.\n  {}",
+                                                    crate::diagnostics::format_message(
+                                                        diagnostic_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PRIVATE_PROPERTY,
+                                                        &[&member_name],
+                                                    ),
+                                                ),
                                                 diagnostic_codes::CLASS_INCORRECTLY_IMPLEMENTS_INTERFACE,
                                             );
                                     }

--- a/crates/tsz-checker/src/classes/private_checker.rs
+++ b/crates/tsz-checker/src/classes/private_checker.rs
@@ -1,6 +1,6 @@
 //! Private field access and brand checking for nominal class typing.
 
-use crate::diagnostics::{diagnostic_messages, format_message};
+use crate::diagnostics::{diagnostic_messages, format_message, internal_elaboration_messages};
 use crate::state::CheckerState;
 use tsz_solver::TypeId;
 
@@ -99,11 +99,10 @@ impl<'a> CheckerState<'a> {
                     diagnostic_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PRIVATE_PROPERTY,
                     &[&source_member],
                 ),
-                tsz_solver::Visibility::Protected => {
-                    format!(
-                        "Types have separate declarations of a protected property '{source_member}'."
-                    )
-                }
+                tsz_solver::Visibility::Protected => format_message(
+                    internal_elaboration_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PROTECTED_PROPERTY,
+                    &[&source_member],
+                ),
                 tsz_solver::Visibility::Public => {
                     unreachable!("public members do not create nominal brands")
                 }

--- a/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability_helpers.rs
@@ -1,7 +1,9 @@
 //! Helper methods for assignability error reporting.
 //! Extracted from `assignability.rs` for maintainability.
 
-use crate::diagnostics::{diagnostic_codes, diagnostic_messages, format_message};
+use crate::diagnostics::{
+    diagnostic_codes, diagnostic_messages, format_message, internal_elaboration_messages,
+};
 use crate::error_reporter::assignability::is_object_prototype_method;
 use crate::error_reporter::fingerprint_policy::{
     DiagnosticAnchorKind, DiagnosticRenderRequest, RelatedInformationPolicy,
@@ -839,8 +841,9 @@ impl<'a> CheckerState<'a> {
                 diagnostic_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PRIVATE_PROPERTY,
                 &[&prop_name],
             )),
-            tsz_solver::Visibility::Protected => Some(format!(
-                "Types have separate declarations of a protected property '{prop_name}'."
+            tsz_solver::Visibility::Protected => Some(format_message(
+                internal_elaboration_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PROTECTED_PROPERTY,
+                &[&prop_name],
             )),
             tsz_solver::Visibility::Public => None,
         }

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -78,8 +78,8 @@ pub use types_domain::{
 pub mod diagnostics {
     pub use tsz_common::diagnostics::{
         Diagnostic, DiagnosticCategory, DiagnosticRelatedInformation, diagnostic_codes,
-        diagnostic_messages, format_message, is_js_grammar_diagnostic,
-        is_parser_grammar_diagnostic,
+        diagnostic_messages, format_message, internal_elaboration_messages,
+        is_js_grammar_diagnostic, is_parser_grammar_diagnostic,
     };
 }
 

--- a/crates/tsz-common/src/diagnostics/mod.rs
+++ b/crates/tsz-common/src/diagnostics/mod.rs
@@ -49,6 +49,27 @@ pub mod diagnostic_codes {
     pub use super::data::diagnostic_codes::*;
 }
 
+/// tsz-internal diagnostic elaboration templates that have **no** dedicated tsc
+/// diagnostic number.
+///
+/// Some elaboration sentences tsc renders inline (during error elaboration)
+/// have a numbered twin in the generated [`diagnostic_messages`] table while
+/// their sibling variant does not. For example the *private*-property
+/// "separate declarations" elaboration is numbered diagnostic 2442
+/// ([`diagnostic_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PRIVATE_PROPERTY`]),
+/// but the adjacent *protected*-property sentence has no code of its own (2443
+/// is already taken by `Property '{0}' is protected but type '{1}' is not a
+/// class derived from '{2}'.`). These constants give such codeless
+/// elaborations a single source of truth so the wording cannot drift between
+/// the checker modules that emit them; route them through [`format_message`]
+/// exactly like their numbered twins.
+pub mod internal_elaboration_messages {
+    /// Protected-property sibling of the numbered private twin
+    /// [`super::diagnostic_messages::TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PRIVATE_PROPERTY`].
+    pub const TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PROTECTED_PROPERTY: &str =
+        "Types have separate declarations of a protected property '{0}'.";
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiagnosticRelatedInformation {
     pub category: DiagnosticCategory,

--- a/crates/tsz-solver/src/caches/query_trace.rs
+++ b/crates/tsz-solver/src/caches/query_trace.rs
@@ -159,6 +159,7 @@ mod tests {
         // Concurrent increments from N threads must produce N distinct
         // values (Relaxed ordering on a single counter is sufficient for
         // uniqueness, which is the contract callers rely on).
+        use crate::utils::MutexExt;
         use std::collections::HashSet;
         use std::sync::Arc;
         use std::sync::Mutex;
@@ -176,13 +177,15 @@ mod tests {
                 for _ in 0..PER_THREAD {
                     local.push(next_query_id());
                 }
-                collected.lock().expect("lock poisoned").extend(local);
+                collected
+                    .lock_unpoisoned("query_trace.collected")
+                    .extend(local);
             }));
         }
         for h in handles {
             h.join().expect("thread panicked");
         }
-        let all = collected.lock().expect("lock poisoned");
+        let all = collected.lock_unpoisoned("query_trace.collected");
         let unique: HashSet<u64> = all.iter().copied().collect();
         assert_eq!(
             unique.len(),

--- a/crates/tsz-solver/src/def/core.rs
+++ b/crates/tsz-solver/src/def/core.rs
@@ -23,6 +23,7 @@ use super::publication_census;
 #[cfg(test)]
 use crate::types::ObjectFlags;
 use crate::types::{ObjectShape, PropertyInfo, TypeId, TypeParamInfo};
+use crate::utils::MutexExt;
 use dashmap::{DashMap, DashSet};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use std::hash::{Hash, Hasher};
@@ -714,8 +715,7 @@ impl DefinitionStore {
             Entry::Vacant(vacant) => {
                 vacant.insert(def_id);
                 self.symbol_mappings_log
-                    .lock()
-                    .expect("symbol mappings log lock poisoned")
+                    .lock_unpoisoned("def.symbol_mappings_log")
                     .push((symbol_id, def_id));
             }
             Entry::Occupied(_) => {}
@@ -1570,12 +1570,10 @@ impl DefinitionStore {
         if !self.symbol_mappings_log_invalid.load(Ordering::Relaxed) {
             let log = self
                 .symbol_mappings_log
-                .lock()
-                .expect("symbol mappings log lock poisoned");
+                .lock_unpoisoned("def.symbol_mappings_log");
             let mut cached = self
                 .symbol_mappings_log_snapshot
-                .lock()
-                .expect("symbol mappings log snapshot lock poisoned");
+                .lock_unpoisoned("def.symbol_mappings_log_snapshot");
             if let Some((cached_len, snapshot)) = cached.as_ref()
                 && *cached_len == log.len()
             {
@@ -1606,8 +1604,7 @@ impl DefinitionStore {
 
             let mut cached = self
                 .symbol_mappings_snapshot
-                .lock()
-                .expect("symbol mappings snapshot lock poisoned");
+                .lock_unpoisoned("def.symbol_mappings_snapshot");
             if let Some((cached_generation, snapshot)) = cached.as_ref()
                 && *cached_generation == generation_after
             {
@@ -1622,8 +1619,7 @@ impl DefinitionStore {
     fn cached_symbol_mappings_snapshot(&self, generation: u64) -> Option<SymbolMappingsSnapshot> {
         let cached = self
             .symbol_mappings_snapshot
-            .lock()
-            .expect("symbol mappings snapshot lock poisoned");
+            .lock_unpoisoned("def.symbol_mappings_snapshot");
         cached.as_ref().and_then(|(cached_generation, snapshot)| {
             (*cached_generation == generation).then(|| Arc::clone(snapshot))
         })

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -16,6 +16,7 @@ use crate::types::{
     TupleElement, TupleListId, TypeApplication, TypeApplicationId, TypeData, TypeId, TypeListId,
     TypeParamInfo,
 };
+use crate::utils::RwLockExt;
 use crate::visitor::is_identity_comparable_type;
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
@@ -1029,16 +1030,10 @@ impl TypeInterner {
         let order = self.alloc_counter.fetch_add(1, Ordering::Relaxed);
         {
             let mut vec = tsz_common::perf_counters::time_shard_write(shard_idx as u32, || {
-                inner
-                    .index_to_key
-                    .write()
-                    .expect("interner index_to_key lock poisoned")
+                inner.index_to_key.write_unpoisoned("interner.index_to_key")
             });
             let mut ord = tsz_common::perf_counters::time_shard_write(shard_idx as u32, || {
-                inner
-                    .alloc_order
-                    .write()
-                    .expect("interner alloc_order lock poisoned")
+                inner.alloc_order.write_unpoisoned("interner.alloc_order")
             });
             write_id_slot(&mut vec, local_index as usize, key, || TypeData::Error);
             write_id_slot(&mut ord, local_index as usize, order, || u32::MAX);
@@ -1106,17 +1101,11 @@ impl TypeInterner {
                     // no `Instant::now()`, no atomic touch.
                     let mut vec =
                         tsz_common::perf_counters::time_shard_write(shard_idx as u32, || {
-                            inner
-                                .index_to_key
-                                .write()
-                                .expect("interner index_to_key lock poisoned")
+                            inner.index_to_key.write_unpoisoned("interner.index_to_key")
                         });
                     let mut ord =
                         tsz_common::perf_counters::time_shard_write(shard_idx as u32, || {
-                            inner
-                                .alloc_order
-                                .write()
-                                .expect("interner alloc_order lock poisoned")
+                            inner.alloc_order.write_unpoisoned("interner.alloc_order")
                         });
                     write_id_slot(&mut vec, local_index as usize, key, || TypeData::Error);
                     write_id_slot(&mut ord, local_index as usize, order, || u32::MAX);

--- a/crates/tsz-solver/src/intern/core/interner/storage.rs
+++ b/crates/tsz-solver/src/intern/core/interner/storage.rs
@@ -11,6 +11,7 @@
 //! these locks directly rather than through accessor methods.
 
 use crate::types::{TypeData, TypeId};
+use crate::utils::RwLockExt;
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
 use rustc_hash::FxBuildHasher;
@@ -197,7 +198,7 @@ where
                     // TypeData writes. With `perf-counters-timing` OFF this
                     // wrapper compiles to a direct closure call.
                     let mut vec = tsz_common::perf_counters::time_shard_write(0, || {
-                        inner.items.write().expect("interner items lock poisoned")
+                        inner.items.write_unpoisoned("interner.items")
                     });
                     // Gap slots get an empty slice.
                     write_id_slot(&mut vec, id as usize, temp_arc, || Arc::from(Vec::new()));
@@ -227,7 +228,7 @@ where
     #[inline]
     pub(in crate::intern::core) fn empty(&self) -> Arc<[T]> {
         let inner = self.get_inner();
-        let vec = inner.items.read().expect("interner items lock poisoned");
+        let vec = inner.items.read_unpoisoned("interner.items");
         vec.first()
             .cloned()
             .unwrap_or_else(|| Arc::from(Vec::new()))
@@ -292,7 +293,7 @@ where
                     // `ConcurrentSliceInterner::intern`. Same rationale,
                     // same zero-cost-when-feature-off contract.
                     let mut vec = tsz_common::perf_counters::time_shard_write(0, || {
-                        inner.items.write().expect("interner items lock poisoned")
+                        inner.items.write_unpoisoned("interner.items")
                     });
                     // No empty value exists for arbitrary `T`; gap slots get
                     // this value's `Arc` and rightful owners overwrite their

--- a/crates/tsz-solver/src/utils/lock.rs
+++ b/crates/tsz-solver/src/utils/lock.rs
@@ -1,0 +1,63 @@
+//! Lock-poison recovery policy for the solver's internal synchronization
+//! primitives.
+//!
+//! The solver guards a handful of internal `RwLock`/`Mutex` fields (the type
+//! interner shards, the slice interner's `items` vector, the definition
+//! store's append-only symbol-mappings log and its snapshots). A poisoned lock
+//! means another thread panicked while holding it — the protected state is in
+//! an unknown, unrecoverable condition, so the only correct policy is to
+//! propagate the panic rather than silently observe torn state.
+//!
+//! Historically each call site inlined `.expect("... lock poisoned")` with its
+//! own wording, so the recover-by-panic policy was copy-pasted with four
+//! different messages across 14 sites. Funnelling every acquisition through
+//! these extension traits gives one uniform panic message keyed off the lock
+//! name and makes a future synchronization change (e.g. switching to
+//! `parking_lot`, or to `PoisonError::into_inner` recovery) a one-line edit
+//! instead of a crate-wide sweep.
+
+use std::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+/// Single source of truth for the "an internal solver lock was poisoned"
+/// panic. Cold and never inlined so the acquisition fast paths stay lean.
+#[cold]
+#[inline(never)]
+fn lock_poisoned(lock_name: &str) -> ! {
+    panic!("solver lock poisoned: {lock_name}");
+}
+
+/// Acquire an internal [`RwLock`] whose poisoning is treated as unrecoverable.
+///
+/// Both methods panic with a uniform message keyed off `lock_name` when the
+/// lock is poisoned, preserving the original panic-on-poison semantics.
+pub(crate) trait RwLockExt<T: ?Sized> {
+    /// Acquire a shared read guard, panicking uniformly on poison.
+    fn read_unpoisoned(&self, lock_name: &'static str) -> RwLockReadGuard<'_, T>;
+    /// Acquire an exclusive write guard, panicking uniformly on poison.
+    fn write_unpoisoned(&self, lock_name: &'static str) -> RwLockWriteGuard<'_, T>;
+}
+
+impl<T: ?Sized> RwLockExt<T> for RwLock<T> {
+    #[inline]
+    fn read_unpoisoned(&self, lock_name: &'static str) -> RwLockReadGuard<'_, T> {
+        self.read().unwrap_or_else(|_| lock_poisoned(lock_name))
+    }
+
+    #[inline]
+    fn write_unpoisoned(&self, lock_name: &'static str) -> RwLockWriteGuard<'_, T> {
+        self.write().unwrap_or_else(|_| lock_poisoned(lock_name))
+    }
+}
+
+/// Acquire an internal [`Mutex`] whose poisoning is treated as unrecoverable.
+pub(crate) trait MutexExt<T: ?Sized> {
+    /// Acquire the mutex guard, panicking uniformly on poison.
+    fn lock_unpoisoned(&self, lock_name: &'static str) -> MutexGuard<'_, T>;
+}
+
+impl<T: ?Sized> MutexExt<T> for Mutex<T> {
+    #[inline]
+    fn lock_unpoisoned(&self, lock_name: &'static str) -> MutexGuard<'_, T> {
+        self.lock().unwrap_or_else(|_| lock_poisoned(lock_name))
+    }
+}

--- a/crates/tsz-solver/src/utils/mod.rs
+++ b/crates/tsz-solver/src/utils/mod.rs
@@ -536,6 +536,9 @@ pub(crate) fn expand_tuple_rest(db: &dyn TypeDatabase, type_id: TypeId) -> Tuple
     }
 }
 
+mod lock;
+pub(crate) use lock::{MutexExt, RwLockExt};
+
 #[cfg(test)]
 #[path = "../../tests/utils_tests.rs"]
 mod tests;


### PR DESCRIPTION
Goal: hold

Closes #13441. Two independent, behavior-preserving DRY/hygiene wins. The fix is broad: every site in each family is converted, not just the cited lines.

## 1. Lock-poison policy (`tsz-solver`)
The recover-by-panic policy for unrecoverable internal `RwLock`/`Mutex` poisoning was copy-pasted as inline `.expect("... lock poisoned")` across **14 sites with 4 different wordings**. Added internal extension traits in `crates/tsz-solver/src/utils/lock.rs`:

- `RwLockExt::read_unpoisoned(name)` / `write_unpoisoned(name)`
- `MutexExt::lock_unpoisoned(name)`

Each funnels through a single `#[cold] #[inline(never)] lock_poisoned(name) -> !` helper that panics with a uniform, lock-named message. All 14 sites converted (interner shards, slice-interner `items`, definition-store symbol-mappings log/snapshots, query-trace test). Panic-on-poison semantics are preserved exactly; the `#[inline]` methods compile to identical hot-path code (the `&'static str` and closure are only touched on the cold panic path). A future `parking_lot` or `PoisonError::into_inner` switch is now a one-line change instead of a 14-site sweep.

## 2. Protected-property elaboration (`tsz-checker` / `tsz-common`)
The *private*-property "separate declarations" elaboration is table-backed (numbered diagnostic 2442) but its adjacent *protected* twin was hand-written as a raw `format!` literal across 3+ checker modules, with no table constant. Since the protected sentence has **no** tsc number (2443 is taken by a different message), added a tsz-internal codeless-elaboration constant `TYPES_HAVE_SEPARATE_DECLARATIONS_OF_A_PROTECTED_PROPERTY` in a new `internal_elaboration_messages` module (`crates/tsz-common/src/diagnostics/mod.rs`), re-exported through the checker's `diagnostics` module.

Routed all protected sites (`private_checker`, `class_checker`, `assignability_helpers`) through `format_message`, and also routed the adjacent raw *private* "separate declarations" literals (`class_checker`, `class_implements_checker/core`) through their existing 2442 constant. Emitted strings are **byte-identical** — guarded by the existing `private_brands` assertions.

## Structural rule
When acquiring an internal solver lock whose poisoning is unrecoverable, the recover-by-panic policy is owned by one helper (uniform message keyed off the lock name); when a diagnostic elaboration has a table-backed twin, both sibling variants route through a message-table constant via `format_message` rather than diverging raw literals.

## Verification
- `cargo test -p tsz-checker --test private_brands` — 35 passed (protected/private elaboration strings byte-identical)
- `cargo test -p tsz-solver --lib intern` + `query_trace` — 289 passed (interner/query-trace lock paths)
- `cargo test -p tsz-solver --lib def::` — 95 passed (definition-store lock paths)
- `cargo clippy -p tsz-solver -p tsz-checker -p tsz-common` — clean
- Rebased on `origin/main` (8f6584a); `cargo check` clean post-rebase.

(nextest unavailable in this environment; used `cargo test` with the same filters. Ready-review CI owns the broad suites.)

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPGjccJN8vn8vbpQ7fG4HH)_