### PR TITLE
refactor(parser): table-drive arena append + typed getters, centralize keyword length

### DIFF
--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -657,23 +657,6 @@ impl NodeArenaInner {
         (self.get_variable_declaration_flags(node_idx) & node_flags::CONST) != 0
     }
 
-    /// Get function data.
-    /// Returns None if node is not a function-like node or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_function(&self, node: &Node) -> Option<&FunctionData> {
-        if node.has_data()
-            && matches!(
-                node.kind,
-                FUNCTION_DECLARATION | FUNCTION_EXPRESSION | ARROW_FUNCTION
-            )
-        {
-            self.functions.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
     /// Get accessor data (get/set accessor).
     #[inline]
     #[must_use]
@@ -1089,6 +1072,10 @@ define_kind_getters! {
     /// Get extended unary expression data (await/yield/non-null/spread).
     /// Returns None if node is not an await/yield/non-null/spread expression or has no data.
     get_unary_expr_ex => unary_exprs_ex -> UnaryExprDataEx, [AWAIT_EXPRESSION, YIELD_EXPRESSION, NON_NULL_EXPRESSION, SPREAD_ELEMENT];
+
+    /// Get function data.
+    /// Returns None if node is not a function-like node or has no data.
+    get_function => functions -> FunctionData, [FUNCTION_DECLARATION, FUNCTION_EXPRESSION, ARROW_FUNCTION];
 
     /// Get class data.
     /// Returns None if node is not a class declaration/expression or has no data.

--- a/crates/tsz-parser/src/parser/node_access.rs
+++ b/crates/tsz-parser/src/parser/node_access.rs
@@ -38,6 +38,36 @@ use super::syntax_kind_ext::{
     TYPE_PREDICATE, VARIABLE_DECLARATION, VARIABLE_DECLARATION_LIST, VARIABLE_STATEMENT,
 };
 
+/// Generate the single-condition typed getter bodies (`get_X(&Node) ->
+/// Option<&XData>`) that were previously hand-written ~per node kind. Each
+/// arm checks `has_data()` and that the node's kind is one of `[KIND, ..]`
+/// before indexing the typed side-pool — the exact shape `define_at_accessors!`
+/// wrappers delegate to.
+macro_rules! define_kind_getters {
+    ($(
+        $(#[$meta:meta])*
+        $name:ident => $field:ident -> $ret:ty, [$($kind:ident),+ $(,)?]
+    );* $(;)?) => {
+        impl NodeArenaInner {
+            $(
+                $(#[$meta])*
+                #[inline]
+                #[must_use]
+                pub fn $name(&self, node: &Node) -> Option<&$ret> {
+                    if node.has_data()
+                        && ($(node.kind == $crate::parser::syntax_kind_ext::$kind)||+)
+                    {
+                        self.$field.get(node.data_index as usize)
+                    } else {
+                        None
+                    }
+                }
+            )*
+        }
+    };
+}
+pub(crate) use define_kind_getters;
+
 impl NodeArenaInner {
     /// Get a thin node by index
     #[inline]
@@ -238,32 +268,6 @@ impl NodeArenaInner {
             )
         {
             self.literals.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get binary expression data.
-    /// Returns None if node is not a binary expression or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_binary_expr(&self, node: &Node) -> Option<&BinaryExprData> {
-        use super::syntax_kind_ext::BINARY_EXPRESSION;
-        if node.has_data() && node.kind == BINARY_EXPRESSION {
-            self.binary_exprs.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get call expression data.
-    /// Returns None if node is not a call/new expression or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_call_expr(&self, node: &Node) -> Option<&CallExprData> {
-        use super::syntax_kind_ext::{CALL_EXPRESSION, NEW_EXPRESSION};
-        if node.has_data() && (node.kind == CALL_EXPRESSION || node.kind == NEW_EXPRESSION) {
-            self.call_exprs.get(node.data_index as usize)
         } else {
             None
         }
@@ -653,131 +657,6 @@ impl NodeArenaInner {
         (self.get_variable_declaration_flags(node_idx) & node_flags::CONST) != 0
     }
 
-    /// Get access expression data (property access or element access).
-    /// Returns None if node is not an access expression or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_access_expr(&self, node: &Node) -> Option<&AccessExprData> {
-        use super::syntax_kind_ext::{
-            ELEMENT_ACCESS_EXPRESSION, META_PROPERTY, PROPERTY_ACCESS_EXPRESSION,
-        };
-        if node.has_data()
-            && (node.kind == PROPERTY_ACCESS_EXPRESSION
-                || node.kind == ELEMENT_ACCESS_EXPRESSION
-                || node.kind == META_PROPERTY)
-        {
-            self.access_exprs.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get conditional expression data (ternary: a ? b : c).
-    /// Returns None if node is not a conditional expression or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_conditional_expr(&self, node: &Node) -> Option<&ConditionalExprData> {
-        use super::syntax_kind_ext::CONDITIONAL_EXPRESSION;
-        if node.has_data() && node.kind == CONDITIONAL_EXPRESSION {
-            self.conditional_exprs.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get qualified name data (A.B syntax).
-    /// Returns None if node is not a qualified name or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_qualified_name(&self, node: &Node) -> Option<&QualifiedNameData> {
-        use super::syntax_kind_ext::QUALIFIED_NAME;
-        if node.has_data() && node.kind == QUALIFIED_NAME {
-            self.qualified_names.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get literal expression data (array or object literal).
-    /// Returns None if node is not a literal expression or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_literal_expr(&self, node: &Node) -> Option<&LiteralExprData> {
-        use super::syntax_kind_ext::{ARRAY_LITERAL_EXPRESSION, OBJECT_LITERAL_EXPRESSION};
-        if node.has_data()
-            && (node.kind == ARRAY_LITERAL_EXPRESSION || node.kind == OBJECT_LITERAL_EXPRESSION)
-        {
-            self.literal_exprs.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get property assignment data.
-    /// Returns None if node is not a property assignment or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_property_assignment(&self, node: &Node) -> Option<&PropertyAssignmentData> {
-        use super::syntax_kind_ext::PROPERTY_ASSIGNMENT;
-        if node.has_data() && node.kind == PROPERTY_ASSIGNMENT {
-            self.property_assignments.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get type assertion data (as/satisfies/type assertion).
-    /// Returns None if node is not a type assertion or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_type_assertion(&self, node: &Node) -> Option<&TypeAssertionData> {
-        use super::syntax_kind_ext::{AS_EXPRESSION, SATISFIES_EXPRESSION, TYPE_ASSERTION};
-        if node.has_data()
-            && (node.kind == TYPE_ASSERTION
-                || node.kind == AS_EXPRESSION
-                || node.kind == SATISFIES_EXPRESSION)
-        {
-            self.type_assertions.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get unary expression data (prefix or postfix).
-    /// Returns None if node is not a unary expression or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_unary_expr(&self, node: &Node) -> Option<&UnaryExprData> {
-        use super::syntax_kind_ext::{POSTFIX_UNARY_EXPRESSION, PREFIX_UNARY_EXPRESSION};
-        if node.has_data()
-            && (node.kind == PREFIX_UNARY_EXPRESSION || node.kind == POSTFIX_UNARY_EXPRESSION)
-        {
-            self.unary_exprs.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get extended unary expression data (await/yield/non-null/spread).
-    /// Returns None if node is not an await/yield/non-null/spread expression or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_unary_expr_ex(&self, node: &Node) -> Option<&UnaryExprDataEx> {
-        use super::syntax_kind_ext::{
-            AWAIT_EXPRESSION, NON_NULL_EXPRESSION, SPREAD_ELEMENT, YIELD_EXPRESSION,
-        };
-        if node.has_data()
-            && (node.kind == AWAIT_EXPRESSION
-                || node.kind == YIELD_EXPRESSION
-                || node.kind == NON_NULL_EXPRESSION
-                || node.kind == SPREAD_ELEMENT)
-        {
-            self.unary_exprs_ex.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
     /// Get function data.
     /// Returns None if node is not a function-like node or has no data.
     #[inline]
@@ -795,576 +674,12 @@ impl NodeArenaInner {
         }
     }
 
-    /// Get class data.
-    /// Returns None if node is not a class declaration/expression or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_class(&self, node: &Node) -> Option<&ClassData> {
-        use super::syntax_kind_ext::{CLASS_DECLARATION, CLASS_EXPRESSION};
-        if node.has_data() && (node.kind == CLASS_DECLARATION || node.kind == CLASS_EXPRESSION) {
-            self.classes.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get block data.
-    /// Returns None if node is not a block or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_block(&self, node: &Node) -> Option<&BlockData> {
-        use super::syntax_kind_ext::{BLOCK, CASE_BLOCK, CLASS_STATIC_BLOCK_DECLARATION};
-        if node.has_data()
-            && (node.kind == BLOCK
-                || node.kind == CLASS_STATIC_BLOCK_DECLARATION
-                || node.kind == CASE_BLOCK)
-        {
-            self.blocks.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get source file data.
-    /// Returns None if node is not a source file or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_source_file(&self, node: &Node) -> Option<&SourceFileData> {
-        use super::syntax_kind_ext::SOURCE_FILE;
-        if node.has_data() && node.kind == SOURCE_FILE {
-            self.source_files.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get variable data (`VariableStatement` or `VariableDeclarationList`).
-    #[inline]
-    #[must_use]
-    pub fn get_variable(&self, node: &Node) -> Option<&VariableData> {
-        use super::syntax_kind_ext::{VARIABLE_DECLARATION_LIST, VARIABLE_STATEMENT};
-        if node.has_data()
-            && (node.kind == VARIABLE_STATEMENT || node.kind == VARIABLE_DECLARATION_LIST)
-        {
-            self.variables.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get variable declaration data.
-    #[inline]
-    #[must_use]
-    pub fn get_variable_declaration(&self, node: &Node) -> Option<&VariableDeclarationData> {
-        use super::syntax_kind_ext::VARIABLE_DECLARATION;
-        if node.has_data() && node.kind == VARIABLE_DECLARATION {
-            self.variable_declarations.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get interface data.
-    #[inline]
-    #[must_use]
-    pub fn get_interface(&self, node: &Node) -> Option<&InterfaceData> {
-        use super::syntax_kind_ext::INTERFACE_DECLARATION;
-        if node.has_data() && node.kind == INTERFACE_DECLARATION {
-            self.interfaces.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get type alias data.
-    #[inline]
-    #[must_use]
-    pub fn get_type_alias(&self, node: &Node) -> Option<&TypeAliasData> {
-        use super::syntax_kind_ext::TYPE_ALIAS_DECLARATION;
-        if node.has_data() && node.kind == TYPE_ALIAS_DECLARATION {
-            self.type_aliases.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get enum data.
-    #[inline]
-    #[must_use]
-    pub fn get_enum(&self, node: &Node) -> Option<&EnumData> {
-        use super::syntax_kind_ext::ENUM_DECLARATION;
-        if node.has_data() && node.kind == ENUM_DECLARATION {
-            self.enums.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get enum member data.
-    #[inline]
-    #[must_use]
-    pub fn get_enum_member(&self, node: &Node) -> Option<&EnumMemberData> {
-        use super::syntax_kind_ext::ENUM_MEMBER;
-        if node.has_data() && node.kind == ENUM_MEMBER {
-            self.enum_members.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get module data.
-    #[inline]
-    #[must_use]
-    pub fn get_module(&self, node: &Node) -> Option<&ModuleData> {
-        use super::syntax_kind_ext::MODULE_DECLARATION;
-        if node.has_data() && node.kind == MODULE_DECLARATION {
-            self.modules.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get module block data.
-    #[inline]
-    #[must_use]
-    pub fn get_module_block(&self, node: &Node) -> Option<&ModuleBlockData> {
-        use super::syntax_kind_ext::MODULE_BLOCK;
-        if node.has_data() && node.kind == MODULE_BLOCK {
-            self.module_blocks.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get if statement data.
-    #[inline]
-    #[must_use]
-    pub fn get_if_statement(&self, node: &Node) -> Option<&IfStatementData> {
-        use super::syntax_kind_ext::IF_STATEMENT;
-        if node.has_data() && node.kind == IF_STATEMENT {
-            self.if_statements.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get loop data (while, for, do-while).
-    #[inline]
-    #[must_use]
-    pub fn get_loop(&self, node: &Node) -> Option<&LoopData> {
-        use super::syntax_kind_ext::{DO_STATEMENT, FOR_STATEMENT, WHILE_STATEMENT};
-        if node.has_data()
-            && (node.kind == WHILE_STATEMENT
-                || node.kind == DO_STATEMENT
-                || node.kind == FOR_STATEMENT)
-        {
-            self.loops.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get for-in/for-of data.
-    #[inline]
-    #[must_use]
-    pub fn get_for_in_of(&self, node: &Node) -> Option<&ForInOfData> {
-        use super::syntax_kind_ext::{FOR_IN_STATEMENT, FOR_OF_STATEMENT};
-        if node.has_data() && (node.kind == FOR_IN_STATEMENT || node.kind == FOR_OF_STATEMENT) {
-            self.for_in_of.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get switch data.
-    #[inline]
-    #[must_use]
-    pub fn get_switch(&self, node: &Node) -> Option<&SwitchData> {
-        use super::syntax_kind_ext::SWITCH_STATEMENT;
-        if node.has_data() && node.kind == SWITCH_STATEMENT {
-            self.switch_data.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get case clause data.
-    #[inline]
-    #[must_use]
-    pub fn get_case_clause(&self, node: &Node) -> Option<&CaseClauseData> {
-        use super::syntax_kind_ext::{CASE_CLAUSE, DEFAULT_CLAUSE};
-        if node.has_data() && (node.kind == CASE_CLAUSE || node.kind == DEFAULT_CLAUSE) {
-            self.case_clauses.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get try data.
-    #[inline]
-    #[must_use]
-    pub fn get_try(&self, node: &Node) -> Option<&TryData> {
-        use super::syntax_kind_ext::TRY_STATEMENT;
-        if node.has_data() && node.kind == TRY_STATEMENT {
-            self.try_data.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get catch clause data.
-    #[inline]
-    #[must_use]
-    pub fn get_catch_clause(&self, node: &Node) -> Option<&CatchClauseData> {
-        use super::syntax_kind_ext::CATCH_CLAUSE;
-        if node.has_data() && node.kind == CATCH_CLAUSE {
-            self.catch_clauses.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get labeled statement data.
-    #[inline]
-    #[must_use]
-    pub fn get_labeled_statement(&self, node: &Node) -> Option<&LabeledData> {
-        use super::syntax_kind_ext::LABELED_STATEMENT;
-        if node.has_data() && node.kind == LABELED_STATEMENT {
-            self.labeled_data.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get jump data (break/continue statements).
-    #[inline]
-    #[must_use]
-    pub fn get_jump_data(&self, node: &Node) -> Option<&JumpData> {
-        use super::syntax_kind_ext::{BREAK_STATEMENT, CONTINUE_STATEMENT};
-        if node.has_data() && (node.kind == BREAK_STATEMENT || node.kind == CONTINUE_STATEMENT) {
-            self.jump_data.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get with statement data (stored in if statement pool).
-    #[inline]
-    #[must_use]
-    pub fn get_with_statement(&self, node: &Node) -> Option<&IfStatementData> {
-        use super::syntax_kind_ext::WITH_STATEMENT;
-        if node.has_data() && node.kind == WITH_STATEMENT {
-            self.if_statements.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get import declaration data (handles both `IMPORT_DECLARATION` and `IMPORT_EQUALS_DECLARATION`).
-    #[inline]
-    #[must_use]
-    pub fn get_import_decl(&self, node: &Node) -> Option<&ImportDeclData> {
-        use super::syntax_kind_ext::{IMPORT_DECLARATION, IMPORT_EQUALS_DECLARATION};
-        if node.has_data()
-            && (node.kind == IMPORT_DECLARATION || node.kind == IMPORT_EQUALS_DECLARATION)
-        {
-            self.import_decls.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get import clause data.
-    #[inline]
-    #[must_use]
-    pub fn get_import_clause(&self, node: &Node) -> Option<&ImportClauseData> {
-        use super::syntax_kind_ext::IMPORT_CLAUSE;
-        if node.has_data() && node.kind == IMPORT_CLAUSE {
-            self.import_clauses.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get named imports/exports data.
-    /// Works for `NAMED_IMPORTS`, `NAMESPACE_IMPORT`, and `NAMED_EXPORTS` (they share the same data structure).
-    #[inline]
-    #[must_use]
-    pub fn get_named_imports(&self, node: &Node) -> Option<&NamedImportsData> {
-        use super::syntax_kind_ext::{NAMED_EXPORTS, NAMED_IMPORTS, NAMESPACE_IMPORT};
-        if node.has_data()
-            && (node.kind == NAMED_IMPORTS
-                || node.kind == NAMED_EXPORTS
-                || node.kind == NAMESPACE_IMPORT)
-        {
-            self.named_imports.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get import/export specifier data.
-    #[inline]
-    #[must_use]
-    pub fn get_specifier(&self, node: &Node) -> Option<&SpecifierData> {
-        use super::syntax_kind_ext::{EXPORT_SPECIFIER, IMPORT_SPECIFIER};
-        if node.has_data() && (node.kind == IMPORT_SPECIFIER || node.kind == EXPORT_SPECIFIER) {
-            self.specifiers.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get export declaration data.
-    #[inline]
-    #[must_use]
-    pub fn get_export_decl(&self, node: &Node) -> Option<&ExportDeclData> {
-        use super::syntax_kind_ext::{EXPORT_DECLARATION, NAMESPACE_EXPORT_DECLARATION};
-        if node.has_data()
-            && (node.kind == EXPORT_DECLARATION || node.kind == NAMESPACE_EXPORT_DECLARATION)
-        {
-            self.export_decls.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get export assignment data (export = expr).
-    #[inline]
-    #[must_use]
-    pub fn get_export_assignment(&self, node: &Node) -> Option<&ExportAssignmentData> {
-        use super::syntax_kind_ext::EXPORT_ASSIGNMENT;
-        if node.has_data() && node.kind == EXPORT_ASSIGNMENT {
-            self.export_assignments.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get import attributes data (`with { ... }` or `assert { ... }`).
-    #[inline]
-    #[must_use]
-    pub fn get_import_attributes_data(&self, node: &Node) -> Option<&ImportAttributesData> {
-        use super::syntax_kind_ext::IMPORT_ATTRIBUTES;
-        if node.has_data() && node.kind == IMPORT_ATTRIBUTES {
-            self.import_attributes.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get single import attribute data (name: value pair).
-    #[inline]
-    #[must_use]
-    pub fn get_import_attribute_data(&self, node: &Node) -> Option<&ImportAttributeData> {
-        use super::syntax_kind_ext::IMPORT_ATTRIBUTE;
-        if node.has_data() && node.kind == IMPORT_ATTRIBUTE {
-            self.import_attribute.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get parameter data.
-    #[inline]
-    #[must_use]
-    pub fn get_parameter(&self, node: &Node) -> Option<&ParameterData> {
-        use super::syntax_kind_ext::PARAMETER;
-        if node.has_data() && node.kind == PARAMETER {
-            self.parameters.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get property declaration data.
-    #[inline]
-    #[must_use]
-    pub fn get_property_decl(&self, node: &Node) -> Option<&PropertyDeclData> {
-        use super::syntax_kind_ext::PROPERTY_DECLARATION;
-        if node.has_data() && node.kind == PROPERTY_DECLARATION {
-            self.property_decls.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get method declaration data.
-    #[inline]
-    #[must_use]
-    pub fn get_method_decl(&self, node: &Node) -> Option<&MethodDeclData> {
-        use super::syntax_kind_ext::METHOD_DECLARATION;
-        if node.has_data() && node.kind == METHOD_DECLARATION {
-            self.method_decls.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get constructor data.
-    #[inline]
-    #[must_use]
-    pub fn get_constructor(&self, node: &Node) -> Option<&ConstructorData> {
-        use super::syntax_kind_ext::CONSTRUCTOR;
-        if node.has_data() && node.kind == CONSTRUCTOR {
-            self.constructors.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
     /// Get accessor data (get/set accessor).
     #[inline]
     #[must_use]
     pub fn get_accessor(&self, node: &Node) -> Option<&AccessorData> {
         if node.has_data() && node.is_accessor() {
             self.accessors.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get decorator data.
-    #[inline]
-    #[must_use]
-    pub fn get_decorator(&self, node: &Node) -> Option<&DecoratorData> {
-        use super::syntax_kind_ext::DECORATOR;
-        if node.has_data() && node.kind == DECORATOR {
-            self.decorators.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get type reference data.
-    #[inline]
-    #[must_use]
-    pub fn get_type_ref(&self, node: &Node) -> Option<&TypeRefData> {
-        use super::syntax_kind_ext::TYPE_REFERENCE;
-        if node.has_data() && node.kind == TYPE_REFERENCE {
-            self.type_refs.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get expression statement data (returns the expression node index).
-    #[inline]
-    #[must_use]
-    pub fn get_expression_statement(&self, node: &Node) -> Option<&ExprStatementData> {
-        use super::syntax_kind_ext::EXPRESSION_STATEMENT;
-        if node.has_data() && node.kind == EXPRESSION_STATEMENT {
-            self.expr_statements.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get return statement data (returns the expression node index).
-    #[inline]
-    #[must_use]
-    pub fn get_return_statement(&self, node: &Node) -> Option<&ReturnData> {
-        use super::syntax_kind_ext::{RETURN_STATEMENT, THROW_STATEMENT};
-        if node.has_data() && (node.kind == RETURN_STATEMENT || node.kind == THROW_STATEMENT) {
-            self.return_data.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get JSX element data.
-    #[inline]
-    #[must_use]
-    pub fn get_jsx_element(&self, node: &Node) -> Option<&JsxElementData> {
-        use super::syntax_kind_ext::JSX_ELEMENT;
-        if node.has_data() && node.kind == JSX_ELEMENT {
-            self.jsx_elements.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get JSX opening/self-closing element data.
-    #[inline]
-    #[must_use]
-    pub fn get_jsx_opening(&self, node: &Node) -> Option<&JsxOpeningData> {
-        use super::syntax_kind_ext::{JSX_OPENING_ELEMENT, JSX_SELF_CLOSING_ELEMENT};
-        if node.has_data()
-            && (node.kind == JSX_OPENING_ELEMENT || node.kind == JSX_SELF_CLOSING_ELEMENT)
-        {
-            self.jsx_opening.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get JSX closing element data.
-    #[inline]
-    #[must_use]
-    pub fn get_jsx_closing(&self, node: &Node) -> Option<&JsxClosingData> {
-        use super::syntax_kind_ext::JSX_CLOSING_ELEMENT;
-        if node.has_data() && node.kind == JSX_CLOSING_ELEMENT {
-            self.jsx_closing.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get JSX fragment data.
-    #[inline]
-    #[must_use]
-    pub fn get_jsx_fragment(&self, node: &Node) -> Option<&JsxFragmentData> {
-        use super::syntax_kind_ext::JSX_FRAGMENT;
-        if node.has_data() && node.kind == JSX_FRAGMENT {
-            self.jsx_fragments.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get JSX attributes data.
-    #[inline]
-    #[must_use]
-    pub fn get_jsx_attributes(&self, node: &Node) -> Option<&JsxAttributesData> {
-        use super::syntax_kind_ext::JSX_ATTRIBUTES;
-        if node.has_data() && node.kind == JSX_ATTRIBUTES {
-            self.jsx_attributes.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get JSX attribute data.
-    #[inline]
-    #[must_use]
-    pub fn get_jsx_attribute(&self, node: &Node) -> Option<&JsxAttributeData> {
-        use super::syntax_kind_ext::JSX_ATTRIBUTE;
-        if node.has_data() && node.kind == JSX_ATTRIBUTE {
-            self.jsx_attribute.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get JSX spread attribute data.
-    #[inline]
-    #[must_use]
-    pub fn get_jsx_spread_attribute(&self, node: &Node) -> Option<&JsxSpreadAttributeData> {
-        use super::syntax_kind_ext::JSX_SPREAD_ATTRIBUTE;
-        if node.has_data() && node.kind == JSX_SPREAD_ATTRIBUTE {
-            self.jsx_spread_attributes.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get JSX expression data.
-    #[inline]
-    #[must_use]
-    pub fn get_jsx_expression(&self, node: &Node) -> Option<&JsxExpressionData> {
-        use super::syntax_kind_ext::JSX_EXPRESSION;
-        if node.has_data() && node.kind == JSX_EXPRESSION {
-            self.jsx_expressions.get(node.data_index as usize)
         } else {
             None
         }
@@ -1377,18 +692,6 @@ impl NodeArenaInner {
         use tsz_scanner::SyntaxKind;
         if node.has_data() && node.kind == SyntaxKind::JsxText as u16 {
             self.jsx_text.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get JSX namespaced name data.
-    #[inline]
-    #[must_use]
-    pub fn get_jsx_namespaced_name(&self, node: &Node) -> Option<&JsxNamespacedNameData> {
-        use super::syntax_kind_ext::JSX_NAMESPACED_NAME;
-        if node.has_data() && node.kind == JSX_NAMESPACED_NAME {
-            self.jsx_namespaced_names.get(node.data_index as usize)
         } else {
             None
         }
@@ -1743,4 +1046,189 @@ mod is_missing_recovery_identifier_tests {
         // Default-init NodeIndex points at nothing — get() returns None.
         assert!(!arena.is_missing_recovery_identifier(NodeIndex::NONE));
     }
+}
+
+// Single-kind / small-fixed-kind typed getters, table-driven.
+define_kind_getters! {
+    /// Get binary expression data.
+    /// Returns None if node is not a binary expression or has no data.
+    get_binary_expr => binary_exprs -> BinaryExprData, [BINARY_EXPRESSION];
+
+    /// Get call expression data.
+    /// Returns None if node is not a call/new expression or has no data.
+    get_call_expr => call_exprs -> CallExprData, [CALL_EXPRESSION, NEW_EXPRESSION];
+
+    /// Get access expression data (property access or element access).
+    /// Returns None if node is not an access expression or has no data.
+    get_access_expr => access_exprs -> AccessExprData, [PROPERTY_ACCESS_EXPRESSION, ELEMENT_ACCESS_EXPRESSION, META_PROPERTY];
+
+    /// Get conditional expression data (ternary: a ? b : c).
+    /// Returns None if node is not a conditional expression or has no data.
+    get_conditional_expr => conditional_exprs -> ConditionalExprData, [CONDITIONAL_EXPRESSION];
+
+    /// Get qualified name data (A.B syntax).
+    /// Returns None if node is not a qualified name or has no data.
+    get_qualified_name => qualified_names -> QualifiedNameData, [QUALIFIED_NAME];
+
+    /// Get literal expression data (array or object literal).
+    /// Returns None if node is not a literal expression or has no data.
+    get_literal_expr => literal_exprs -> LiteralExprData, [ARRAY_LITERAL_EXPRESSION, OBJECT_LITERAL_EXPRESSION];
+
+    /// Get property assignment data.
+    /// Returns None if node is not a property assignment or has no data.
+    get_property_assignment => property_assignments -> PropertyAssignmentData, [PROPERTY_ASSIGNMENT];
+
+    /// Get type assertion data (as/satisfies/type assertion).
+    /// Returns None if node is not a type assertion or has no data.
+    get_type_assertion => type_assertions -> TypeAssertionData, [TYPE_ASSERTION, AS_EXPRESSION, SATISFIES_EXPRESSION];
+
+    /// Get unary expression data (prefix or postfix).
+    /// Returns None if node is not a unary expression or has no data.
+    get_unary_expr => unary_exprs -> UnaryExprData, [PREFIX_UNARY_EXPRESSION, POSTFIX_UNARY_EXPRESSION];
+
+    /// Get extended unary expression data (await/yield/non-null/spread).
+    /// Returns None if node is not an await/yield/non-null/spread expression or has no data.
+    get_unary_expr_ex => unary_exprs_ex -> UnaryExprDataEx, [AWAIT_EXPRESSION, YIELD_EXPRESSION, NON_NULL_EXPRESSION, SPREAD_ELEMENT];
+
+    /// Get class data.
+    /// Returns None if node is not a class declaration/expression or has no data.
+    get_class => classes -> ClassData, [CLASS_DECLARATION, CLASS_EXPRESSION];
+
+    /// Get block data.
+    /// Returns None if node is not a block or has no data.
+    get_block => blocks -> BlockData, [BLOCK, CLASS_STATIC_BLOCK_DECLARATION, CASE_BLOCK];
+
+    /// Get source file data.
+    /// Returns None if node is not a source file or has no data.
+    get_source_file => source_files -> SourceFileData, [SOURCE_FILE];
+
+    /// Get variable data (`VariableStatement` or `VariableDeclarationList`).
+    get_variable => variables -> VariableData, [VARIABLE_STATEMENT, VARIABLE_DECLARATION_LIST];
+
+    /// Get variable declaration data.
+    get_variable_declaration => variable_declarations -> VariableDeclarationData, [VARIABLE_DECLARATION];
+
+    /// Get interface data.
+    get_interface => interfaces -> InterfaceData, [INTERFACE_DECLARATION];
+
+    /// Get type alias data.
+    get_type_alias => type_aliases -> TypeAliasData, [TYPE_ALIAS_DECLARATION];
+
+    /// Get enum data.
+    get_enum => enums -> EnumData, [ENUM_DECLARATION];
+
+    /// Get enum member data.
+    get_enum_member => enum_members -> EnumMemberData, [ENUM_MEMBER];
+
+    /// Get module data.
+    get_module => modules -> ModuleData, [MODULE_DECLARATION];
+
+    /// Get module block data.
+    get_module_block => module_blocks -> ModuleBlockData, [MODULE_BLOCK];
+
+    /// Get if statement data.
+    get_if_statement => if_statements -> IfStatementData, [IF_STATEMENT];
+
+    /// Get loop data (while, for, do-while).
+    get_loop => loops -> LoopData, [WHILE_STATEMENT, DO_STATEMENT, FOR_STATEMENT];
+
+    /// Get for-in/for-of data.
+    get_for_in_of => for_in_of -> ForInOfData, [FOR_IN_STATEMENT, FOR_OF_STATEMENT];
+
+    /// Get switch data.
+    get_switch => switch_data -> SwitchData, [SWITCH_STATEMENT];
+
+    /// Get case clause data.
+    get_case_clause => case_clauses -> CaseClauseData, [CASE_CLAUSE, DEFAULT_CLAUSE];
+
+    /// Get try data.
+    get_try => try_data -> TryData, [TRY_STATEMENT];
+
+    /// Get catch clause data.
+    get_catch_clause => catch_clauses -> CatchClauseData, [CATCH_CLAUSE];
+
+    /// Get labeled statement data.
+    get_labeled_statement => labeled_data -> LabeledData, [LABELED_STATEMENT];
+
+    /// Get jump data (break/continue statements).
+    get_jump_data => jump_data -> JumpData, [BREAK_STATEMENT, CONTINUE_STATEMENT];
+
+    /// Get with statement data (stored in if statement pool).
+    get_with_statement => if_statements -> IfStatementData, [WITH_STATEMENT];
+
+    /// Get import declaration data (handles both `IMPORT_DECLARATION` and `IMPORT_EQUALS_DECLARATION`).
+    get_import_decl => import_decls -> ImportDeclData, [IMPORT_DECLARATION, IMPORT_EQUALS_DECLARATION];
+
+    /// Get import clause data.
+    get_import_clause => import_clauses -> ImportClauseData, [IMPORT_CLAUSE];
+
+    /// Get named imports/exports data.
+    /// Works for `NAMED_IMPORTS`, `NAMESPACE_IMPORT`, and `NAMED_EXPORTS` (they share the same data structure).
+    get_named_imports => named_imports -> NamedImportsData, [NAMED_IMPORTS, NAMED_EXPORTS, NAMESPACE_IMPORT];
+
+    /// Get import/export specifier data.
+    get_specifier => specifiers -> SpecifierData, [IMPORT_SPECIFIER, EXPORT_SPECIFIER];
+
+    /// Get export declaration data.
+    get_export_decl => export_decls -> ExportDeclData, [EXPORT_DECLARATION, NAMESPACE_EXPORT_DECLARATION];
+
+    /// Get export assignment data (export = expr).
+    get_export_assignment => export_assignments -> ExportAssignmentData, [EXPORT_ASSIGNMENT];
+
+    /// Get import attributes data (`with { ... }` or `assert { ... }`).
+    get_import_attributes_data => import_attributes -> ImportAttributesData, [IMPORT_ATTRIBUTES];
+
+    /// Get single import attribute data (name: value pair).
+    get_import_attribute_data => import_attribute -> ImportAttributeData, [IMPORT_ATTRIBUTE];
+
+    /// Get parameter data.
+    get_parameter => parameters -> ParameterData, [PARAMETER];
+
+    /// Get property declaration data.
+    get_property_decl => property_decls -> PropertyDeclData, [PROPERTY_DECLARATION];
+
+    /// Get method declaration data.
+    get_method_decl => method_decls -> MethodDeclData, [METHOD_DECLARATION];
+
+    /// Get constructor data.
+    get_constructor => constructors -> ConstructorData, [CONSTRUCTOR];
+
+    /// Get decorator data.
+    get_decorator => decorators -> DecoratorData, [DECORATOR];
+
+    /// Get type reference data.
+    get_type_ref => type_refs -> TypeRefData, [TYPE_REFERENCE];
+
+    /// Get expression statement data (returns the expression node index).
+    get_expression_statement => expr_statements -> ExprStatementData, [EXPRESSION_STATEMENT];
+
+    /// Get return statement data (returns the expression node index).
+    get_return_statement => return_data -> ReturnData, [RETURN_STATEMENT, THROW_STATEMENT];
+
+    /// Get JSX element data.
+    get_jsx_element => jsx_elements -> JsxElementData, [JSX_ELEMENT];
+
+    /// Get JSX opening/self-closing element data.
+    get_jsx_opening => jsx_opening -> JsxOpeningData, [JSX_OPENING_ELEMENT, JSX_SELF_CLOSING_ELEMENT];
+
+    /// Get JSX closing element data.
+    get_jsx_closing => jsx_closing -> JsxClosingData, [JSX_CLOSING_ELEMENT];
+
+    /// Get JSX fragment data.
+    get_jsx_fragment => jsx_fragments -> JsxFragmentData, [JSX_FRAGMENT];
+
+    /// Get JSX attributes data.
+    get_jsx_attributes => jsx_attributes -> JsxAttributesData, [JSX_ATTRIBUTES];
+
+    /// Get JSX attribute data.
+    get_jsx_attribute => jsx_attribute -> JsxAttributeData, [JSX_ATTRIBUTE];
+
+    /// Get JSX spread attribute data.
+    get_jsx_spread_attribute => jsx_spread_attributes -> JsxSpreadAttributeData, [JSX_SPREAD_ATTRIBUTE];
+
+    /// Get JSX expression data.
+    get_jsx_expression => jsx_expressions -> JsxExpressionData, [JSX_EXPRESSION];
+
+    /// Get JSX namespaced name data.
+    get_jsx_namespaced_name => jsx_namespaced_names -> JsxNamespacedNameData, [JSX_NAMESPACED_NAME];
 }

--- a/crates/tsz-parser/src/parser/node_access_typed_getters.rs
+++ b/crates/tsz-parser/src/parser/node_access_typed_getters.rs
@@ -12,390 +12,15 @@ use super::node::{
     TypeLiteralData, TypeOperatorData, TypeParameterData, TypePredicateData, TypeQueryData,
     WrappedTypeData,
 };
+use super::node_access::define_kind_getters;
 
 impl NodeArenaInner {
-    /// Get signature data (call, construct, method, property signatures).
-    #[inline]
-    #[must_use]
-    pub fn get_signature(&self, node: &Node) -> Option<&SignatureData> {
-        use super::syntax_kind_ext::{
-            CALL_SIGNATURE, CONSTRUCT_SIGNATURE, METHOD_SIGNATURE, PROPERTY_SIGNATURE,
-        };
-        if node.has_data()
-            && (node.kind == CALL_SIGNATURE
-                || node.kind == CONSTRUCT_SIGNATURE
-                || node.kind == METHOD_SIGNATURE
-                || node.kind == PROPERTY_SIGNATURE)
-        {
-            self.signatures.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get index signature data.
-    #[inline]
-    #[must_use]
-    pub fn get_index_signature(&self, node: &Node) -> Option<&IndexSignatureData> {
-        use super::syntax_kind_ext::INDEX_SIGNATURE;
-        if node.has_data() && node.kind == INDEX_SIGNATURE {
-            self.index_signatures.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get heritage clause data.
-    #[inline]
-    #[must_use]
-    pub fn get_heritage_clause(&self, node: &Node) -> Option<&HeritageData> {
-        use super::syntax_kind_ext::HERITAGE_CLAUSE;
-        if node.has_data() && node.kind == HERITAGE_CLAUSE {
-            self.heritage_clauses.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get composite type data (union or intersection).
-    #[inline]
-    #[must_use]
-    pub fn get_composite_type(&self, node: &Node) -> Option<&CompositeTypeData> {
-        use super::syntax_kind_ext::{INTERSECTION_TYPE, UNION_TYPE};
-        if node.has_data() && (node.kind == UNION_TYPE || node.kind == INTERSECTION_TYPE) {
-            self.composite_types.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get array type data.
-    #[inline]
-    #[must_use]
-    pub fn get_array_type(&self, node: &Node) -> Option<&ArrayTypeData> {
-        use super::syntax_kind_ext::ARRAY_TYPE;
-        if node.has_data() && node.kind == ARRAY_TYPE {
-            self.array_types.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get tuple type data.
-    #[inline]
-    #[must_use]
-    pub fn get_tuple_type(&self, node: &Node) -> Option<&TupleTypeData> {
-        use super::syntax_kind_ext::TUPLE_TYPE;
-        if node.has_data() && node.kind == TUPLE_TYPE {
-            self.tuple_types.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get function type data.
-    #[inline]
-    #[must_use]
-    pub fn get_function_type(&self, node: &Node) -> Option<&FunctionTypeData> {
-        use super::syntax_kind_ext::{CONSTRUCTOR_TYPE, FUNCTION_TYPE};
-        if node.has_data() && (node.kind == FUNCTION_TYPE || node.kind == CONSTRUCTOR_TYPE) {
-            self.function_types.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get type literal data.
-    #[inline]
-    #[must_use]
-    pub fn get_type_literal(&self, node: &Node) -> Option<&TypeLiteralData> {
-        use super::syntax_kind_ext::TYPE_LITERAL;
-        if node.has_data() && node.kind == TYPE_LITERAL {
-            self.type_literals.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get conditional type data.
-    #[inline]
-    #[must_use]
-    pub fn get_conditional_type(&self, node: &Node) -> Option<&ConditionalTypeData> {
-        use super::syntax_kind_ext::CONDITIONAL_TYPE;
-        if node.has_data() && node.kind == CONDITIONAL_TYPE {
-            self.conditional_types.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get mapped type data.
-    #[inline]
-    #[must_use]
-    pub fn get_mapped_type(&self, node: &Node) -> Option<&MappedTypeData> {
-        use super::syntax_kind_ext::MAPPED_TYPE;
-        if node.has_data() && node.kind == MAPPED_TYPE {
-            self.mapped_types.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get indexed access type data.
-    #[inline]
-    #[must_use]
-    pub fn get_indexed_access_type(&self, node: &Node) -> Option<&IndexedAccessTypeData> {
-        use super::syntax_kind_ext::INDEXED_ACCESS_TYPE;
-        if node.has_data() && node.kind == INDEXED_ACCESS_TYPE {
-            self.indexed_access_types.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get literal type data.
-    #[inline]
-    #[must_use]
-    pub fn get_literal_type(&self, node: &Node) -> Option<&LiteralTypeData> {
-        use super::syntax_kind_ext::LITERAL_TYPE;
-        if node.has_data() && node.kind == LITERAL_TYPE {
-            self.literal_types.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get wrapped type data (parenthesized, optional, rest types).
-    #[inline]
-    #[must_use]
-    pub fn get_wrapped_type(&self, node: &Node) -> Option<&WrappedTypeData> {
-        use super::syntax_kind_ext::{OPTIONAL_TYPE, PARENTHESIZED_TYPE, REST_TYPE};
-        if node.has_data()
-            && (node.kind == PARENTHESIZED_TYPE
-                || node.kind == OPTIONAL_TYPE
-                || node.kind == REST_TYPE)
-        {
-            self.wrapped_types.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get heritage clause data.
-    #[inline]
-    #[must_use]
-    pub fn get_heritage(&self, node: &Node) -> Option<&HeritageData> {
-        use super::syntax_kind_ext::HERITAGE_CLAUSE;
-        if node.has_data() && node.kind == HERITAGE_CLAUSE {
-            self.heritage_clauses.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get expression with type arguments data (e.g., `extends Base<T>`).
-    #[inline]
-    #[must_use]
-    pub fn get_expr_type_args(&self, node: &Node) -> Option<&ExprWithTypeArgsData> {
-        use super::syntax_kind_ext::EXPRESSION_WITH_TYPE_ARGUMENTS;
-        if node.has_data() && node.kind == EXPRESSION_WITH_TYPE_ARGUMENTS {
-            self.expr_with_type_args.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get type query data (typeof in type position).
-    #[inline]
-    #[must_use]
-    pub fn get_type_query(&self, node: &Node) -> Option<&TypeQueryData> {
-        use super::syntax_kind_ext::TYPE_QUERY;
-        if node.has_data() && node.kind == TYPE_QUERY {
-            self.type_queries.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get type operator data (keyof, unique, readonly).
-    #[inline]
-    #[must_use]
-    pub fn get_type_operator(&self, node: &Node) -> Option<&TypeOperatorData> {
-        use super::syntax_kind_ext::TYPE_OPERATOR;
-        if node.has_data() && node.kind == TYPE_OPERATOR {
-            self.type_operators.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get infer type data.
-    #[inline]
-    #[must_use]
-    pub fn get_infer_type(&self, node: &Node) -> Option<&InferTypeData> {
-        use super::syntax_kind_ext::INFER_TYPE;
-        if node.has_data() && node.kind == INFER_TYPE {
-            self.infer_types.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get template literal type data.
-    #[inline]
-    #[must_use]
-    pub fn get_template_literal_type(&self, node: &Node) -> Option<&TemplateLiteralTypeData> {
-        use super::syntax_kind_ext::TEMPLATE_LITERAL_TYPE;
-        if node.has_data() && node.kind == TEMPLATE_LITERAL_TYPE {
-            self.template_literal_types.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get named tuple member data.
-    #[inline]
-    #[must_use]
-    pub fn get_named_tuple_member(&self, node: &Node) -> Option<&NamedTupleMemberData> {
-        use super::syntax_kind_ext::NAMED_TUPLE_MEMBER;
-        if node.has_data() && node.kind == NAMED_TUPLE_MEMBER {
-            self.named_tuple_members.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get type predicate data.
-    #[inline]
-    #[must_use]
-    pub fn get_type_predicate(&self, node: &Node) -> Option<&TypePredicateData> {
-        use super::syntax_kind_ext::TYPE_PREDICATE;
-        if node.has_data() && node.kind == TYPE_PREDICATE {
-            self.type_predicates.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get type parameter data.
-    #[inline]
-    #[must_use]
-    pub fn get_type_parameter(&self, node: &Node) -> Option<&TypeParameterData> {
-        use super::syntax_kind_ext::TYPE_PARAMETER;
-        if node.has_data() && node.kind == TYPE_PARAMETER {
-            self.type_parameters.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get parenthesized expression data.
-    /// Returns None if node is not a parenthesized expression or has no data.
-    #[inline]
-    #[must_use]
-    pub fn get_parenthesized(&self, node: &Node) -> Option<&ParenthesizedData> {
-        use super::syntax_kind_ext::PARENTHESIZED_EXPRESSION;
-        if node.has_data() && node.kind == PARENTHESIZED_EXPRESSION {
-            self.parenthesized.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get template expression data.
-    #[inline]
-    #[must_use]
-    pub fn get_template_expr(&self, node: &Node) -> Option<&TemplateExprData> {
-        use super::syntax_kind_ext::TEMPLATE_EXPRESSION;
-        if node.has_data() && node.kind == TEMPLATE_EXPRESSION {
-            self.template_exprs.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get template span data. Accepts both `TEMPLATE_SPAN` (expression-level)
-    /// and `TEMPLATE_LITERAL_TYPE_SPAN` (type-level) since both store data in
-    /// the same `template_spans` array.
-    #[inline]
-    #[must_use]
-    pub fn get_template_span(&self, node: &Node) -> Option<&TemplateSpanData> {
-        use super::syntax_kind_ext::{TEMPLATE_LITERAL_TYPE_SPAN, TEMPLATE_SPAN};
-        if node.has_data()
-            && (node.kind == TEMPLATE_SPAN || node.kind == TEMPLATE_LITERAL_TYPE_SPAN)
-        {
-            self.template_spans.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get tagged template expression data.
-    #[inline]
-    #[must_use]
-    pub fn get_tagged_template(&self, node: &Node) -> Option<&TaggedTemplateData> {
-        use super::syntax_kind_ext::TAGGED_TEMPLATE_EXPRESSION;
-        if node.has_data() && node.kind == TAGGED_TEMPLATE_EXPRESSION {
-            self.tagged_templates.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get spread element/assignment data.
-    #[inline]
-    #[must_use]
-    pub fn get_spread(&self, node: &Node) -> Option<&SpreadData> {
-        use super::syntax_kind_ext::{SPREAD_ASSIGNMENT, SPREAD_ELEMENT};
-        if node.has_data() && (node.kind == SPREAD_ELEMENT || node.kind == SPREAD_ASSIGNMENT) {
-            self.spread_data.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get shorthand property assignment data.
-    #[inline]
-    #[must_use]
-    pub fn get_shorthand_property(&self, node: &Node) -> Option<&ShorthandPropertyData> {
-        use super::syntax_kind_ext::SHORTHAND_PROPERTY_ASSIGNMENT;
-        if node.has_data() && node.kind == SHORTHAND_PROPERTY_ASSIGNMENT {
-            self.shorthand_properties.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
     /// Get binding pattern data (`ObjectBindingPattern` or `ArrayBindingPattern`).
     #[inline]
     #[must_use]
     pub fn get_binding_pattern(&self, node: &Node) -> Option<&BindingPatternData> {
         if node.has_data() && node.is_binding_pattern() {
             self.binding_patterns.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get binding element data.
-    #[inline]
-    #[must_use]
-    pub fn get_binding_element(&self, node: &Node) -> Option<&BindingElementData> {
-        use super::syntax_kind_ext::BINDING_ELEMENT;
-        if node.has_data() && node.kind == BINDING_ELEMENT {
-            self.binding_elements.get(node.data_index as usize)
-        } else {
-            None
-        }
-    }
-
-    /// Get computed property name data
-    #[inline]
-    #[must_use]
-    pub fn get_computed_property(&self, node: &Node) -> Option<&ComputedPropertyData> {
-        use super::syntax_kind_ext::COMPUTED_PROPERTY_NAME;
-        if node.has_data() && node.kind == COMPUTED_PROPERTY_NAME {
-            self.computed_properties.get(node.data_index as usize)
         } else {
             None
         }
@@ -438,4 +63,100 @@ impl NodeArenaInner {
             .is_some_and(|raw| raw.starts_with('\''));
         (true, single_quoted)
     }
+}
+
+// Type/signature/binding typed getters, table-driven.
+define_kind_getters! {
+    /// Get signature data (call, construct, method, property signatures).
+    get_signature => signatures -> SignatureData, [CALL_SIGNATURE, CONSTRUCT_SIGNATURE, METHOD_SIGNATURE, PROPERTY_SIGNATURE];
+
+    /// Get index signature data.
+    get_index_signature => index_signatures -> IndexSignatureData, [INDEX_SIGNATURE];
+
+    /// Get heritage clause data.
+    get_heritage_clause => heritage_clauses -> HeritageData, [HERITAGE_CLAUSE];
+
+    /// Get composite type data (union or intersection).
+    get_composite_type => composite_types -> CompositeTypeData, [UNION_TYPE, INTERSECTION_TYPE];
+
+    /// Get array type data.
+    get_array_type => array_types -> ArrayTypeData, [ARRAY_TYPE];
+
+    /// Get tuple type data.
+    get_tuple_type => tuple_types -> TupleTypeData, [TUPLE_TYPE];
+
+    /// Get function type data.
+    get_function_type => function_types -> FunctionTypeData, [FUNCTION_TYPE, CONSTRUCTOR_TYPE];
+
+    /// Get type literal data.
+    get_type_literal => type_literals -> TypeLiteralData, [TYPE_LITERAL];
+
+    /// Get conditional type data.
+    get_conditional_type => conditional_types -> ConditionalTypeData, [CONDITIONAL_TYPE];
+
+    /// Get mapped type data.
+    get_mapped_type => mapped_types -> MappedTypeData, [MAPPED_TYPE];
+
+    /// Get indexed access type data.
+    get_indexed_access_type => indexed_access_types -> IndexedAccessTypeData, [INDEXED_ACCESS_TYPE];
+
+    /// Get literal type data.
+    get_literal_type => literal_types -> LiteralTypeData, [LITERAL_TYPE];
+
+    /// Get wrapped type data (parenthesized, optional, rest types).
+    get_wrapped_type => wrapped_types -> WrappedTypeData, [PARENTHESIZED_TYPE, OPTIONAL_TYPE, REST_TYPE];
+
+    /// Get heritage clause data.
+    get_heritage => heritage_clauses -> HeritageData, [HERITAGE_CLAUSE];
+
+    /// Get expression with type arguments data (e.g., `extends Base<T>`).
+    get_expr_type_args => expr_with_type_args -> ExprWithTypeArgsData, [EXPRESSION_WITH_TYPE_ARGUMENTS];
+
+    /// Get type query data (typeof in type position).
+    get_type_query => type_queries -> TypeQueryData, [TYPE_QUERY];
+
+    /// Get type operator data (keyof, unique, readonly).
+    get_type_operator => type_operators -> TypeOperatorData, [TYPE_OPERATOR];
+
+    /// Get infer type data.
+    get_infer_type => infer_types -> InferTypeData, [INFER_TYPE];
+
+    /// Get template literal type data.
+    get_template_literal_type => template_literal_types -> TemplateLiteralTypeData, [TEMPLATE_LITERAL_TYPE];
+
+    /// Get named tuple member data.
+    get_named_tuple_member => named_tuple_members -> NamedTupleMemberData, [NAMED_TUPLE_MEMBER];
+
+    /// Get type predicate data.
+    get_type_predicate => type_predicates -> TypePredicateData, [TYPE_PREDICATE];
+
+    /// Get type parameter data.
+    get_type_parameter => type_parameters -> TypeParameterData, [TYPE_PARAMETER];
+
+    /// Get parenthesized expression data.
+    /// Returns None if node is not a parenthesized expression or has no data.
+    get_parenthesized => parenthesized -> ParenthesizedData, [PARENTHESIZED_EXPRESSION];
+
+    /// Get template expression data.
+    get_template_expr => template_exprs -> TemplateExprData, [TEMPLATE_EXPRESSION];
+
+    /// Get template span data. Accepts both `TEMPLATE_SPAN` (expression-level)
+    /// and `TEMPLATE_LITERAL_TYPE_SPAN` (type-level) since both store data in
+    /// the same `template_spans` array.
+    get_template_span => template_spans -> TemplateSpanData, [TEMPLATE_SPAN, TEMPLATE_LITERAL_TYPE_SPAN];
+
+    /// Get tagged template expression data.
+    get_tagged_template => tagged_templates -> TaggedTemplateData, [TAGGED_TEMPLATE_EXPRESSION];
+
+    /// Get spread element/assignment data.
+    get_spread => spread_data -> SpreadData, [SPREAD_ELEMENT, SPREAD_ASSIGNMENT];
+
+    /// Get shorthand property assignment data.
+    get_shorthand_property => shorthand_properties -> ShorthandPropertyData, [SHORTHAND_PROPERTY_ASSIGNMENT];
+
+    /// Get binding element data.
+    get_binding_element => binding_elements -> BindingElementData, [BINDING_ELEMENT];
+
+    /// Get computed property name data
+    get_computed_property => computed_properties -> ComputedPropertyData, [COMPUTED_PROPERTY_NAME];
 }

--- a/crates/tsz-parser/src/parser/node_arena/declarations.rs
+++ b/crates/tsz-parser/src/parser/node_arena/declarations.rs
@@ -2,57 +2,35 @@
 //! functions, classes, interfaces, type aliases, enums, modules, and the
 //! variable-statement / individual-variable-declaration pair.
 
+use super::push_data_node;
 use crate::parser::base::NodeIndex;
 use crate::parser::node::{
-    ClassData, EnumData, EnumMemberData, ExtendedNodeInfo, FunctionData, InterfaceData,
-    ModuleBlockData, ModuleData, Node, NodeArenaInner, TypeAliasData, VariableData,
-    VariableDeclarationData,
+    ClassData, EnumData, EnumMemberData, FunctionData, InterfaceData, ModuleBlockData, ModuleData,
+    NodeArenaInner, TypeAliasData, VariableData, VariableDeclarationData,
 };
 
 impl NodeArenaInner {
     /// Add a function node
     pub fn add_function(&mut self, kind: u16, pos: u32, end: u32, data: FunctionData) -> NodeIndex {
-        let name = data.name;
-        let type_annotation = data.type_annotation;
-        let body = data.body;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
+        self.set_parent(data.name, parent);
         self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
         self.set_parent_list(&data.parameters, parent);
-        self.set_parent(type_annotation, parent);
-        self.set_parent(body, parent);
-
-        let data_index = self.len_u32(self.functions.len());
-        self.functions.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        self.set_parent(data.type_annotation, parent);
+        self.set_parent(data.body, parent);
+        push_data_node!(self, parent, kind, pos, end, functions, data)
     }
 
     /// Add a class node
     pub fn add_class(&mut self, kind: u16, pos: u32, end: u32, data: ClassData) -> NodeIndex {
-        let name = data.name;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
+        self.set_parent(data.name, parent);
         self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
         self.set_parent_opt_list(data.heritage_clauses.as_ref(), parent);
         self.set_parent_list(&data.members, parent);
-
-        let data_index = self.len_u32(self.classes.len());
-        self.classes.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        push_data_node!(self, parent, kind, pos, end, classes, data)
     }
 
     /// Add an interface declaration node
@@ -63,23 +41,13 @@ impl NodeArenaInner {
         end: u32,
         data: InterfaceData,
     ) -> NodeIndex {
-        let name = data.name;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
+        self.set_parent(data.name, parent);
         self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
         self.set_parent_opt_list(data.heritage_clauses.as_ref(), parent);
         self.set_parent_list(&data.members, parent);
-
-        let data_index = self.len_u32(self.interfaces.len());
-        self.interfaces.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        push_data_node!(self, parent, kind, pos, end, interfaces, data)
     }
 
     /// Add a type alias declaration node
@@ -90,42 +58,21 @@ impl NodeArenaInner {
         end: u32,
         data: TypeAliasData,
     ) -> NodeIndex {
-        let name = data.name;
-        let type_node = data.type_node;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
+        self.set_parent(data.name, parent);
         self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
-        self.set_parent(type_node, parent);
-
-        let data_index = self.len_u32(self.type_aliases.len());
-        self.type_aliases.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        self.set_parent(data.type_node, parent);
+        push_data_node!(self, parent, kind, pos, end, type_aliases, data)
     }
 
     /// Add an enum declaration node
     pub fn add_enum(&mut self, kind: u16, pos: u32, end: u32, data: EnumData) -> NodeIndex {
-        let name = data.name;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
+        self.set_parent(data.name, parent);
         self.set_parent_list(&data.members, parent);
-
-        let data_index = self.len_u32(self.enums.len());
-        self.enums.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        push_data_node!(self, parent, kind, pos, end, enums, data)
     }
 
     /// Add an enum member node
@@ -136,40 +83,19 @@ impl NodeArenaInner {
         end: u32,
         data: EnumMemberData,
     ) -> NodeIndex {
-        let name = data.name;
-        let initializer = data.initializer;
-
-        let data_index = self.len_u32(self.enum_members.len());
-        self.enum_members.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(name, parent);
-        self.set_parent(initializer, parent);
-
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.name, parent);
+        self.set_parent(data.initializer, parent);
+        push_data_node!(self, parent, kind, pos, end, enum_members, data)
     }
 
     /// Add a module declaration node
     pub fn add_module(&mut self, kind: u16, pos: u32, end: u32, data: ModuleData) -> NodeIndex {
-        let name = data.name;
-        let body = data.body;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent(body, parent);
-
-        let data_index = self.len_u32(self.modules.len());
-        self.modules.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        self.set_parent(data.name, parent);
+        self.set_parent(data.body, parent);
+        push_data_node!(self, parent, kind, pos, end, modules, data)
     }
 
     /// Add a module block node: { statements }
@@ -180,18 +106,9 @@ impl NodeArenaInner {
         end: u32,
         data: ModuleBlockData,
     ) -> NodeIndex {
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.statements.as_ref(), parent);
-
-        let data_index = self.len_u32(self.module_blocks.len());
-        self.module_blocks.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        push_data_node!(self, parent, kind, pos, end, module_blocks, data)
     }
 
     /// Add a variable statement/declaration list node
@@ -208,20 +125,10 @@ impl NodeArenaInner {
         data: VariableData,
         flags: u16,
     ) -> NodeIndex {
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
         self.set_parent_list(&data.declarations, parent);
-
-        let data_index = self.len_u32(self.variables.len());
-        self.variables.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes
-            .push(Node::with_data_and_flags(kind, pos, end, data_index, flags));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        push_data_node!(self, parent, kind, pos, end, variables, data, flags = flags)
     }
 
     /// Add a variable declaration node (individual)
@@ -232,21 +139,10 @@ impl NodeArenaInner {
         end: u32,
         data: VariableDeclarationData,
     ) -> NodeIndex {
-        let name = data.name;
-        let type_annotation = data.type_annotation;
-        let initializer = data.initializer;
-
-        let data_index = self.len_u32(self.variable_declarations.len());
-        self.variable_declarations.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(name, parent);
-        self.set_parent(type_annotation, parent);
-        self.set_parent(initializer, parent);
-
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.name, parent);
+        self.set_parent(data.type_annotation, parent);
+        self.set_parent(data.initializer, parent);
+        push_data_node!(self, parent, kind, pos, end, variable_declarations, data)
     }
 }

--- a/crates/tsz-parser/src/parser/node_arena/expressions.rs
+++ b/crates/tsz-parser/src/parser/node_arena/expressions.rs
@@ -2,12 +2,13 @@
 //! that appear inside expressions: qualified names, computed property names,
 //! and expression-with-type-arguments).
 
+use super::push_data_node;
 use crate::parser::base::NodeIndex;
 use crate::parser::node::{
     AccessExprData, BinaryExprData, CallExprData, ComputedPropertyData, ConditionalExprData,
-    ExprWithTypeArgsData, ExtendedNodeInfo, LiteralExprData, Node, NodeArenaInner,
-    ParenthesizedData, QualifiedNameData, SpreadData, TaggedTemplateData, TemplateExprData,
-    TemplateSpanData, TypeAssertionData, UnaryExprData, UnaryExprDataEx,
+    ExprWithTypeArgsData, LiteralExprData, NodeArenaInner, ParenthesizedData, QualifiedNameData,
+    SpreadData, TaggedTemplateData, TemplateExprData, TemplateSpanData, TypeAssertionData,
+    UnaryExprData, UnaryExprDataEx,
 };
 
 impl NodeArenaInner {
@@ -19,20 +20,10 @@ impl NodeArenaInner {
         end: u32,
         data: QualifiedNameData,
     ) -> NodeIndex {
-        let left = data.left;
-        let right = data.right;
-
-        let data_index = self.len_u32(self.qualified_names.len());
-        self.qualified_names.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(left, parent);
-        self.set_parent(right, parent);
-
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.left, parent);
+        self.set_parent(data.right, parent);
+        push_data_node!(self, parent, kind, pos, end, qualified_names, data)
     }
 
     /// Add a computed property name node
@@ -43,16 +34,9 @@ impl NodeArenaInner {
         end: u32,
         data: ComputedPropertyData,
     ) -> NodeIndex {
-        let expression = data.expression;
-
-        let data_index = self.len_u32(self.computed_properties.len());
-        self.computed_properties.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        push_data_node!(self, parent, kind, pos, end, computed_properties, data)
     }
 
     /// Add a binary expression
@@ -63,20 +47,10 @@ impl NodeArenaInner {
         end: u32,
         data: BinaryExprData,
     ) -> NodeIndex {
-        let left = data.left;
-        let right = data.right;
-
-        let data_index = self.len_u32(self.binary_exprs.len());
-        self.binary_exprs.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(left, parent);
-        self.set_parent(right, parent);
-
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.left, parent);
+        self.set_parent(data.right, parent);
+        push_data_node!(self, parent, kind, pos, end, binary_exprs, data)
     }
 
     /// Add a call expression
@@ -87,21 +61,11 @@ impl NodeArenaInner {
         end: u32,
         data: CallExprData,
     ) -> NodeIndex {
-        let expression = data.expression;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
-        self.set_parent(expression, parent);
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
         self.set_parent_opt_list(data.type_arguments.as_ref(), parent);
         self.set_parent_opt_list(data.arguments.as_ref(), parent);
-
-        let data_index = self.len_u32(self.call_exprs.len());
-        self.call_exprs.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        push_data_node!(self, parent, kind, pos, end, call_exprs, data)
     }
 
     /// Add a unary expression node
@@ -112,18 +76,9 @@ impl NodeArenaInner {
         end: u32,
         data: UnaryExprData,
     ) -> NodeIndex {
-        let operand = data.operand;
-
-        let data_index = self.len_u32(self.unary_exprs.len());
-        self.unary_exprs.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(operand, parent);
-
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.operand, parent);
+        push_data_node!(self, parent, kind, pos, end, unary_exprs, data)
     }
 
     /// Add a property/element access expression node
@@ -134,20 +89,10 @@ impl NodeArenaInner {
         end: u32,
         data: AccessExprData,
     ) -> NodeIndex {
-        let expression = data.expression;
-        let name_or_argument = data.name_or_argument;
-
-        let data_index = self.len_u32(self.access_exprs.len());
-        self.access_exprs.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        self.set_parent(name_or_argument, parent);
-
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        self.set_parent(data.name_or_argument, parent);
+        push_data_node!(self, parent, kind, pos, end, access_exprs, data)
     }
 
     /// Add a conditional expression node (a ? b : c)
@@ -158,20 +103,11 @@ impl NodeArenaInner {
         end: u32,
         data: ConditionalExprData,
     ) -> NodeIndex {
-        let condition = data.condition;
-        let when_true = data.when_true;
-        let when_false = data.when_false;
-
-        let data_index = self.len_u32(self.conditional_exprs.len());
-        self.conditional_exprs.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(condition, parent);
-        self.set_parent(when_true, parent);
-        self.set_parent(when_false, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.condition, parent);
+        self.set_parent(data.when_true, parent);
+        self.set_parent(data.when_false, parent);
+        push_data_node!(self, parent, kind, pos, end, conditional_exprs, data)
     }
 
     /// Add an object/array literal expression node
@@ -182,17 +118,9 @@ impl NodeArenaInner {
         end: u32,
         data: LiteralExprData,
     ) -> NodeIndex {
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_list(&data.elements, parent);
-
-        let data_index = self.len_u32(self.literal_exprs.len());
-        self.literal_exprs.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, literal_exprs, data)
     }
 
     /// Add a parenthesized expression node
@@ -203,15 +131,9 @@ impl NodeArenaInner {
         end: u32,
         data: ParenthesizedData,
     ) -> NodeIndex {
-        let expression = data.expression;
-        let data_index = self.len_u32(self.parenthesized.len());
-        self.parenthesized.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        push_data_node!(self, parent, kind, pos, end, parenthesized, data)
     }
 
     /// Add a spread/await/yield expression node
@@ -222,15 +144,9 @@ impl NodeArenaInner {
         end: u32,
         data: UnaryExprDataEx,
     ) -> NodeIndex {
-        let expression = data.expression;
-        let data_index = self.len_u32(self.unary_exprs_ex.len());
-        self.unary_exprs_ex.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        push_data_node!(self, parent, kind, pos, end, unary_exprs_ex, data)
     }
 
     /// Add a type assertion expression node
@@ -241,18 +157,10 @@ impl NodeArenaInner {
         end: u32,
         data: TypeAssertionData,
     ) -> NodeIndex {
-        let expression = data.expression;
-        let type_node = data.type_node;
-        let data_index = self.len_u32(self.type_assertions.len());
-        self.type_assertions.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        self.set_parent(type_node, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        self.set_parent(data.type_node, parent);
+        push_data_node!(self, parent, kind, pos, end, type_assertions, data)
     }
 
     /// Add a template expression node
@@ -263,20 +171,10 @@ impl NodeArenaInner {
         end: u32,
         data: TemplateExprData,
     ) -> NodeIndex {
-        let head = data.head;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
-        self.set_parent(head, parent);
+        let parent = self.reserve_parent();
+        self.set_parent(data.head, parent);
         self.set_parent_list(&data.template_spans, parent);
-
-        let data_index = self.len_u32(self.template_exprs.len());
-        self.template_exprs.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        push_data_node!(self, parent, kind, pos, end, template_exprs, data)
     }
 
     /// Add a template span node
@@ -287,20 +185,10 @@ impl NodeArenaInner {
         end: u32,
         data: TemplateSpanData,
     ) -> NodeIndex {
-        let expression = data.expression;
-        let literal = data.literal;
-
-        let data_index = self.len_u32(self.template_spans.len());
-        self.template_spans.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        self.set_parent(literal, parent);
-
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        self.set_parent(data.literal, parent);
+        push_data_node!(self, parent, kind, pos, end, template_spans, data)
     }
 
     /// Add a tagged template expression node
@@ -311,22 +199,11 @@ impl NodeArenaInner {
         end: u32,
         data: TaggedTemplateData,
     ) -> NodeIndex {
-        let tag = data.tag;
-        let template = data.template;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
-        self.set_parent(tag, parent);
+        let parent = self.reserve_parent();
+        self.set_parent(data.tag, parent);
         self.set_parent_opt_list(data.type_arguments.as_ref(), parent);
-        self.set_parent(template, parent);
-
-        let data_index = self.len_u32(self.tagged_templates.len());
-        self.tagged_templates.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        self.set_parent(data.template, parent);
+        push_data_node!(self, parent, kind, pos, end, tagged_templates, data)
     }
 
     /// Add an expression with type arguments node
@@ -337,32 +214,16 @@ impl NodeArenaInner {
         end: u32,
         data: ExprWithTypeArgsData,
     ) -> NodeIndex {
-        let expression = data.expression;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
-        self.set_parent(expression, parent);
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
         self.set_parent_opt_list(data.type_arguments.as_ref(), parent);
-
-        let data_index = self.len_u32(self.expr_with_type_args.len());
-        self.expr_with_type_args.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, expr_with_type_args, data)
     }
 
     /// Add a spread assignment node
     pub fn add_spread(&mut self, kind: u16, pos: u32, end: u32, data: SpreadData) -> NodeIndex {
-        let expression = data.expression;
-
-        let data_index = self.len_u32(self.spread_data.len());
-        self.spread_data.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        push_data_node!(self, parent, kind, pos, end, spread_data, data)
     }
 }

--- a/crates/tsz-parser/src/parser/node_arena/imports_exports.rs
+++ b/crates/tsz-parser/src/parser/node_arena/imports_exports.rs
@@ -2,11 +2,11 @@
 //! export declarations, import clauses, named imports, specifiers,
 //! export assignments, and import attributes).
 
+use super::push_data_node;
 use crate::parser::base::NodeIndex;
 use crate::parser::node::{
-    ExportAssignmentData, ExportDeclData, ExtendedNodeInfo, ImportAttributeData,
-    ImportAttributesData, ImportClauseData, ImportDeclData, NamedImportsData, Node, NodeArenaInner,
-    SpecifierData,
+    ExportAssignmentData, ExportDeclData, ImportAttributeData, ImportAttributesData,
+    ImportClauseData, ImportDeclData, NamedImportsData, NodeArenaInner, SpecifierData,
 };
 
 impl NodeArenaInner {
@@ -18,23 +18,12 @@ impl NodeArenaInner {
         end: u32,
         data: ImportDeclData,
     ) -> NodeIndex {
-        let import_clause = data.import_clause;
-        let module_specifier = data.module_specifier;
-        let attributes = data.attributes;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(import_clause, parent);
-        self.set_parent(module_specifier, parent);
-        self.set_parent(attributes, parent);
-
-        let data_index = self.len_u32(self.import_decls.len());
-        self.import_decls.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        self.set_parent(data.import_clause, parent);
+        self.set_parent(data.module_specifier, parent);
+        self.set_parent(data.attributes, parent);
+        push_data_node!(self, parent, kind, pos, end, import_decls, data)
     }
 
     /// Add an import clause node
@@ -45,18 +34,10 @@ impl NodeArenaInner {
         end: u32,
         data: ImportClauseData,
     ) -> NodeIndex {
-        let name = data.name;
-        let named_bindings = data.named_bindings;
-
-        let data_index = self.len_u32(self.import_clauses.len());
-        self.import_clauses.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(name, parent);
-        self.set_parent(named_bindings, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.name, parent);
+        self.set_parent(data.named_bindings, parent);
+        push_data_node!(self, parent, kind, pos, end, import_clauses, data)
     }
 
     /// Add a namespace/named imports node
@@ -67,19 +48,10 @@ impl NodeArenaInner {
         end: u32,
         data: NamedImportsData,
     ) -> NodeIndex {
-        let name = data.name;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
-        self.set_parent(name, parent);
+        let parent = self.reserve_parent();
+        self.set_parent(data.name, parent);
         self.set_parent_list(&data.elements, parent);
-
-        let data_index = self.len_u32(self.named_imports.len());
-        self.named_imports.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, named_imports, data)
     }
 
     /// Add an import/export specifier node
@@ -90,18 +62,10 @@ impl NodeArenaInner {
         end: u32,
         data: SpecifierData,
     ) -> NodeIndex {
-        let property_name = data.property_name;
-        let name = data.name;
-
-        let data_index = self.len_u32(self.specifiers.len());
-        self.specifiers.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(property_name, parent);
-        self.set_parent(name, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.property_name, parent);
+        self.set_parent(data.name, parent);
+        push_data_node!(self, parent, kind, pos, end, specifiers, data)
     }
 
     /// Add an export declaration node
@@ -112,23 +76,12 @@ impl NodeArenaInner {
         end: u32,
         data: ExportDeclData,
     ) -> NodeIndex {
-        let export_clause = data.export_clause;
-        let module_specifier = data.module_specifier;
-        let attributes = data.attributes;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(export_clause, parent);
-        self.set_parent(module_specifier, parent);
-        self.set_parent(attributes, parent);
-
-        let data_index = self.len_u32(self.export_decls.len());
-        self.export_decls.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        self.set_parent(data.export_clause, parent);
+        self.set_parent(data.module_specifier, parent);
+        self.set_parent(data.attributes, parent);
+        push_data_node!(self, parent, kind, pos, end, export_decls, data)
     }
 
     /// Add an export assignment node
@@ -139,19 +92,10 @@ impl NodeArenaInner {
         end: u32,
         data: ExportAssignmentData,
     ) -> NodeIndex {
-        let expression = data.expression;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(expression, parent);
-
-        let data_index = self.len_u32(self.export_assignments.len());
-        self.export_assignments.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        self.set_parent(data.expression, parent);
+        push_data_node!(self, parent, kind, pos, end, export_assignments, data)
     }
 
     /// Add an import attributes node
@@ -162,17 +106,9 @@ impl NodeArenaInner {
         end: u32,
         data: ImportAttributesData,
     ) -> NodeIndex {
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_list(&data.elements, parent);
-
-        let data_index = self.len_u32(self.import_attributes.len());
-        self.import_attributes.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, import_attributes, data)
     }
 
     /// Add an import attribute node
@@ -183,17 +119,9 @@ impl NodeArenaInner {
         end: u32,
         data: ImportAttributeData,
     ) -> NodeIndex {
-        let name = data.name;
-        let value = data.value;
-
-        let data_index = self.len_u32(self.import_attribute.len());
-        self.import_attribute.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(name, parent);
-        self.set_parent(value, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.name, parent);
+        self.set_parent(data.value, parent);
+        push_data_node!(self, parent, kind, pos, end, import_attribute, data)
     }
 }

--- a/crates/tsz-parser/src/parser/node_arena/jsx.rs
+++ b/crates/tsz-parser/src/parser/node_arena/jsx.rs
@@ -2,11 +2,12 @@
 //! closing tags, attributes, spread attributes, expressions, text, and
 //! namespaced names).
 
+use super::push_data_node;
 use crate::parser::base::NodeIndex;
 use crate::parser::node::{
-    ExtendedNodeInfo, JsxAttributeData, JsxAttributesData, JsxClosingData, JsxElementData,
-    JsxExpressionData, JsxFragmentData, JsxNamespacedNameData, JsxOpeningData,
-    JsxSpreadAttributeData, JsxTextData, Node, NodeArenaInner,
+    JsxAttributeData, JsxAttributesData, JsxClosingData, JsxElementData, JsxExpressionData,
+    JsxFragmentData, JsxNamespacedNameData, JsxOpeningData, JsxSpreadAttributeData, JsxTextData,
+    NodeArenaInner,
 };
 
 impl NodeArenaInner {
@@ -18,21 +19,11 @@ impl NodeArenaInner {
         end: u32,
         data: JsxElementData,
     ) -> NodeIndex {
-        let opening_element = data.opening_element;
-        let closing_element = data.closing_element;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
-        self.set_parent(opening_element, parent);
+        let parent = self.reserve_parent();
+        self.set_parent(data.opening_element, parent);
         self.set_parent_list(&data.children, parent);
-        self.set_parent(closing_element, parent);
-
-        let data_index = self.len_u32(self.jsx_elements.len());
-        self.jsx_elements.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        self.set_parent(data.closing_element, parent);
+        push_data_node!(self, parent, kind, pos, end, jsx_elements, data)
     }
 
     /// Add a JSX opening/self-closing element node
@@ -43,21 +34,11 @@ impl NodeArenaInner {
         end: u32,
         data: JsxOpeningData,
     ) -> NodeIndex {
-        let tag_name = data.tag_name;
-        let attributes = data.attributes;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
-        self.set_parent(tag_name, parent);
+        let parent = self.reserve_parent();
+        self.set_parent(data.tag_name, parent);
         self.set_parent_opt_list(data.type_arguments.as_ref(), parent);
-        self.set_parent(attributes, parent);
-
-        let data_index = self.len_u32(self.jsx_opening.len());
-        self.jsx_opening.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        self.set_parent(data.attributes, parent);
+        push_data_node!(self, parent, kind, pos, end, jsx_opening, data)
     }
 
     /// Add a JSX closing element node
@@ -68,17 +49,9 @@ impl NodeArenaInner {
         end: u32,
         data: JsxClosingData,
     ) -> NodeIndex {
-        let tag_name = data.tag_name;
-
-        let data_index = self.len_u32(self.jsx_closing.len());
-        self.jsx_closing.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(tag_name, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.tag_name, parent);
+        push_data_node!(self, parent, kind, pos, end, jsx_closing, data)
     }
 
     /// Add a JSX fragment node
@@ -89,21 +62,11 @@ impl NodeArenaInner {
         end: u32,
         data: JsxFragmentData,
     ) -> NodeIndex {
-        let opening_fragment = data.opening_fragment;
-        let closing_fragment = data.closing_fragment;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
-        self.set_parent(opening_fragment, parent);
+        let parent = self.reserve_parent();
+        self.set_parent(data.opening_fragment, parent);
         self.set_parent_list(&data.children, parent);
-        self.set_parent(closing_fragment, parent);
-
-        let data_index = self.len_u32(self.jsx_fragments.len());
-        self.jsx_fragments.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        self.set_parent(data.closing_fragment, parent);
+        push_data_node!(self, parent, kind, pos, end, jsx_fragments, data)
     }
 
     /// Add a JSX attributes node
@@ -114,17 +77,9 @@ impl NodeArenaInner {
         end: u32,
         data: JsxAttributesData,
     ) -> NodeIndex {
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_list(&data.properties, parent);
-
-        let data_index = self.len_u32(self.jsx_attributes.len());
-        self.jsx_attributes.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, jsx_attributes, data)
     }
 
     /// Add a JSX attribute node
@@ -135,19 +90,10 @@ impl NodeArenaInner {
         end: u32,
         data: JsxAttributeData,
     ) -> NodeIndex {
-        let name = data.name;
-        let initializer = data.initializer;
-
-        let data_index = self.len_u32(self.jsx_attribute.len());
-        self.jsx_attribute.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(name, parent);
-        self.set_parent(initializer, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.name, parent);
+        self.set_parent(data.initializer, parent);
+        push_data_node!(self, parent, kind, pos, end, jsx_attribute, data)
     }
 
     /// Add a JSX spread attribute node
@@ -158,17 +104,9 @@ impl NodeArenaInner {
         end: u32,
         data: JsxSpreadAttributeData,
     ) -> NodeIndex {
-        let expression = data.expression;
-
-        let data_index = self.len_u32(self.jsx_spread_attributes.len());
-        self.jsx_spread_attributes.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        push_data_node!(self, parent, kind, pos, end, jsx_spread_attributes, data)
     }
 
     /// Add a JSX expression node
@@ -179,27 +117,16 @@ impl NodeArenaInner {
         end: u32,
         data: JsxExpressionData,
     ) -> NodeIndex {
-        let expression = data.expression;
-
-        let data_index = self.len_u32(self.jsx_expressions.len());
-        self.jsx_expressions.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        push_data_node!(self, parent, kind, pos, end, jsx_expressions, data)
     }
 
     /// Add a JSX text node
     pub fn add_jsx_text(&mut self, kind: u16, pos: u32, end: u32, data: JsxTextData) -> NodeIndex {
-        let data_index = self.len_u32(self.jsx_text.len());
-        self.jsx_text.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        NodeIndex(index)
+        // Leaf node: no children to parent, but still data-bearing.
+        let parent = self.reserve_parent();
+        push_data_node!(self, parent, kind, pos, end, jsx_text, data)
     }
 
     /// Add a JSX namespaced name node
@@ -210,18 +137,9 @@ impl NodeArenaInner {
         end: u32,
         data: JsxNamespacedNameData,
     ) -> NodeIndex {
-        let namespace = data.namespace;
-        let name = data.name;
-
-        let data_index = self.len_u32(self.jsx_namespaced_names.len());
-        self.jsx_namespaced_names.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(namespace, parent);
-        self.set_parent(name, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.namespace, parent);
+        self.set_parent(data.name, parent);
+        push_data_node!(self, parent, kind, pos, end, jsx_namespaced_names, data)
     }
 }

--- a/crates/tsz-parser/src/parser/node_arena/members.rs
+++ b/crates/tsz-parser/src/parser/node_arena/members.rs
@@ -3,11 +3,11 @@
 //! declarations, parameters, type parameters, decorators, and heritage
 //! clauses).
 
+use super::push_data_node;
 use crate::parser::base::NodeIndex;
 use crate::parser::node::{
-    AccessorData, ConstructorData, DecoratorData, ExtendedNodeInfo, HeritageData,
-    IndexSignatureData, MethodDeclData, Node, NodeArenaInner, ParameterData, PropertyDeclData,
-    SignatureData, TypeParameterData,
+    AccessorData, ConstructorData, DecoratorData, HeritageData, IndexSignatureData, MethodDeclData,
+    NodeArenaInner, ParameterData, PropertyDeclData, SignatureData, TypeParameterData,
 };
 
 impl NodeArenaInner {
@@ -19,24 +19,13 @@ impl NodeArenaInner {
         end: u32,
         data: SignatureData,
     ) -> NodeIndex {
-        let name = data.name;
-        let type_annotation = data.type_annotation;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
+        self.set_parent(data.name, parent);
         self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
         self.set_parent_opt_list(data.parameters.as_ref(), parent);
-        self.set_parent(type_annotation, parent);
-
-        let data_index = self.len_u32(self.signatures.len());
-        self.signatures.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        self.set_parent(data.type_annotation, parent);
+        push_data_node!(self, parent, kind, pos, end, signatures, data)
     }
 
     /// Add an index signature node
@@ -47,21 +36,11 @@ impl NodeArenaInner {
         end: u32,
         data: IndexSignatureData,
     ) -> NodeIndex {
-        let type_annotation = data.type_annotation;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
         self.set_parent_list(&data.parameters, parent);
-        self.set_parent(type_annotation, parent);
-
-        let data_index = self.len_u32(self.index_signatures.len());
-        self.index_signatures.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        self.set_parent(data.type_annotation, parent);
+        push_data_node!(self, parent, kind, pos, end, index_signatures, data)
     }
 
     /// Add a property declaration node
@@ -72,23 +51,12 @@ impl NodeArenaInner {
         end: u32,
         data: PropertyDeclData,
     ) -> NodeIndex {
-        let name = data.name;
-        let type_annotation = data.type_annotation;
-        let initializer = data.initializer;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent(type_annotation, parent);
-        self.set_parent(initializer, parent);
-
-        let data_index = self.len_u32(self.property_decls.len());
-        self.property_decls.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        self.set_parent(data.name, parent);
+        self.set_parent(data.type_annotation, parent);
+        self.set_parent(data.initializer, parent);
+        push_data_node!(self, parent, kind, pos, end, property_decls, data)
     }
 
     /// Add a method declaration node
@@ -99,25 +67,14 @@ impl NodeArenaInner {
         end: u32,
         data: MethodDeclData,
     ) -> NodeIndex {
-        let name = data.name;
-        let type_annotation = data.type_annotation;
-        let body = data.body;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
+        self.set_parent(data.name, parent);
         self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
         self.set_parent_list(&data.parameters, parent);
-        self.set_parent(type_annotation, parent);
-        self.set_parent(body, parent);
-
-        let data_index = self.len_u32(self.method_decls.len());
-        self.method_decls.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        self.set_parent(data.type_annotation, parent);
+        self.set_parent(data.body, parent);
+        push_data_node!(self, parent, kind, pos, end, method_decls, data)
     }
 
     /// Add a constructor declaration node
@@ -128,45 +85,24 @@ impl NodeArenaInner {
         end: u32,
         data: ConstructorData,
     ) -> NodeIndex {
-        let body = data.body;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
         self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
         self.set_parent_list(&data.parameters, parent);
-        self.set_parent(body, parent);
-
-        let data_index = self.len_u32(self.constructors.len());
-        self.constructors.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        self.set_parent(data.body, parent);
+        push_data_node!(self, parent, kind, pos, end, constructors, data)
     }
 
     /// Add an accessor declaration node (get/set)
     pub fn add_accessor(&mut self, kind: u16, pos: u32, end: u32, data: AccessorData) -> NodeIndex {
-        let name = data.name;
-        let type_annotation = data.type_annotation;
-        let body = data.body;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
+        self.set_parent(data.name, parent);
         self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
         self.set_parent_list(&data.parameters, parent);
-        self.set_parent(type_annotation, parent);
-        self.set_parent(body, parent);
-
-        let data_index = self.len_u32(self.accessors.len());
-        self.accessors.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        self.set_parent(data.type_annotation, parent);
+        self.set_parent(data.body, parent);
+        push_data_node!(self, parent, kind, pos, end, accessors, data)
     }
 
     /// Add a parameter declaration node
@@ -177,24 +113,13 @@ impl NodeArenaInner {
         end: u32,
         data: ParameterData,
     ) -> NodeIndex {
-        let name = data.name;
-        let type_annotation = data.type_annotation;
-        let initializer = data.initializer;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         // Set parent pointers for children
-        self.set_parent(name, parent);
-        self.set_parent(type_annotation, parent);
-        self.set_parent(initializer, parent);
+        self.set_parent(data.name, parent);
+        self.set_parent(data.type_annotation, parent);
+        self.set_parent(data.initializer, parent);
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-
-        let data_index = self.len_u32(self.parameters.len());
-        self.parameters.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, parameters, data)
     }
 
     /// Add a type parameter declaration node
@@ -205,24 +130,12 @@ impl NodeArenaInner {
         end: u32,
         data: TypeParameterData,
     ) -> NodeIndex {
-        let name = data.name;
-        let constraint = data.constraint;
-        let default = data.default;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent(constraint, parent);
-        self.set_parent(default, parent);
-
-        let data_index = self.len_u32(self.type_parameters.len());
-        self.type_parameters.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        self.set_parent(data.name, parent);
+        self.set_parent(data.constraint, parent);
+        self.set_parent(data.default, parent);
+        push_data_node!(self, parent, kind, pos, end, type_parameters, data)
     }
 
     /// Add a decorator node
@@ -233,29 +146,15 @@ impl NodeArenaInner {
         end: u32,
         data: DecoratorData,
     ) -> NodeIndex {
-        let expression = data.expression;
-        let data_index = self.len_u32(self.decorators.len());
-        self.decorators.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        push_data_node!(self, parent, kind, pos, end, decorators, data)
     }
 
     /// Add a heritage clause node
     pub fn add_heritage(&mut self, kind: u16, pos: u32, end: u32, data: HeritageData) -> NodeIndex {
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_list(&data.types, parent);
-
-        let data_index = self.len_u32(self.heritage_clauses.len());
-        self.heritage_clauses.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, heritage_clauses, data)
     }
 }

--- a/crates/tsz-parser/src/parser/node_arena/mod.rs
+++ b/crates/tsz-parser/src/parser/node_arena/mod.rs
@@ -67,24 +67,20 @@ for_each_node_pool!(impl_clear_pools);
 /// of being open-coded (and silently dropped) per constructor.
 ///
 /// `$pool` is the typed side-pool field that stores `$data`. The optional
-/// `flags = <expr>` tail routes through `Node::with_data_and_flags` for the
-/// node kinds that carry node-level flags (e.g. variable statements).
+/// `flags = <expr>` tail supplies node-level flags for the kinds that carry
+/// them (e.g. variable statements); it defaults to `0`, which matches
+/// `Node::with_data`.
 macro_rules! push_data_node {
-    ($arena:expr, $parent:expr, $kind:expr, $pos:expr, $end:expr, $pool:ident, $data:expr) => {{
-        let parent: $crate::parser::base::NodeIndex = $parent;
-        let data_index = $arena.len_u32($arena.$pool.len());
-        $arena.$pool.push($data);
-        let index = $arena.len_u32($arena.nodes.len());
-        debug_assert_eq!(parent.0, index, "NodeArena parent/index invariant violated");
-        $arena.nodes.push($crate::parser::node::Node::with_data(
-            $kind, $pos, $end, data_index,
-        ));
-        $arena
-            .extended_info
-            .push($crate::parser::node::ExtendedNodeInfo::default());
-        parent
-    }};
-    ($arena:expr, $parent:expr, $kind:expr, $pos:expr, $end:expr, $pool:ident, $data:expr, flags = $flags:expr) => {{
+    // Resolve the optional `flags = <expr>` tail to a `u16` (defaulting to 0).
+    // Only the user expression / literal crosses this expansion boundary, so
+    // there is no macro-hygiene hazard with the `let` bindings below.
+    (@flags) => {
+        0u16
+    };
+    (@flags $flags:expr) => {
+        $flags
+    };
+    ($arena:expr, $parent:expr, $kind:expr, $pos:expr, $end:expr, $pool:ident, $data:expr $(, flags = $flags:expr)?) => {{
         let parent: $crate::parser::base::NodeIndex = $parent;
         let data_index = $arena.len_u32($arena.$pool.len());
         $arena.$pool.push($data);
@@ -93,7 +89,11 @@ macro_rules! push_data_node {
         $arena
             .nodes
             .push($crate::parser::node::Node::with_data_and_flags(
-                $kind, $pos, $end, data_index, $flags,
+                $kind,
+                $pos,
+                $end,
+                data_index,
+                $crate::parser::node_arena::push_data_node!(@flags $($flags)?),
             ));
         $arena
             .extended_info
@@ -237,24 +237,13 @@ impl NodeArenaInner {
     }
 
     /// Create a modifier token (static, public, private, etc.)
+    ///
+    /// Modifiers are simple tokens whose kind IS the modifier type; the end
+    /// position is `pos + keyword length`, derived from the single
+    /// source-of-truth [`tsz_scanner::keyword_text_len`] rather than a
+    /// hand-maintained length table.
     pub fn create_modifier(&mut self, kind: tsz_scanner::SyntaxKind, pos: u32) -> NodeIndex {
-        // Modifiers are simple tokens, their kind IS the modifier type
-        // End position is pos + keyword length
-        let end = pos
-            + match kind {
-                tsz_scanner::SyntaxKind::AsyncKeyword | tsz_scanner::SyntaxKind::ConstKeyword => 5,
-                tsz_scanner::SyntaxKind::StaticKeyword
-                | tsz_scanner::SyntaxKind::PublicKeyword
-                | tsz_scanner::SyntaxKind::ExportKeyword => 6,
-                tsz_scanner::SyntaxKind::PrivateKeyword
-                | tsz_scanner::SyntaxKind::DefaultKeyword
-                | tsz_scanner::SyntaxKind::DeclareKeyword => 7,
-                tsz_scanner::SyntaxKind::ReadonlyKeyword
-                | tsz_scanner::SyntaxKind::AbstractKeyword
-                | tsz_scanner::SyntaxKind::OverrideKeyword => 8,
-                tsz_scanner::SyntaxKind::ProtectedKeyword => 9,
-                _ => 0,
-            };
+        let end = pos + tsz_scanner::keyword_text_len(kind);
         self.add_token(kind as u16, pos, end)
     }
 

--- a/crates/tsz-parser/src/parser/node_arena/mod.rs
+++ b/crates/tsz-parser/src/parser/node_arena/mod.rs
@@ -54,6 +54,55 @@ macro_rules! impl_clear_pools {
 }
 for_each_node_pool!(impl_clear_pools);
 
+/// Append a data-bearing node to the arena, centralizing the
+/// `data` / `nodes` / `extended_info` lockstep push and the
+/// `parent == nodes.len()` invariant in one place.
+///
+/// Every data-bearing `add_*` constructor reserves the node's eventual index
+/// up front with [`NodeArenaInner::reserve_parent`], wires up its children's
+/// parent pointers against that index, then hands the typed payload to this
+/// macro. The macro performs the three-step `data` / `nodes` / `extended_info`
+/// push in lockstep and asserts the reserved `parent` still equals the index
+/// the node actually lands at — so the invariant is enforced uniformly instead
+/// of being open-coded (and silently dropped) per constructor.
+///
+/// `$pool` is the typed side-pool field that stores `$data`. The optional
+/// `flags = <expr>` tail routes through `Node::with_data_and_flags` for the
+/// node kinds that carry node-level flags (e.g. variable statements).
+macro_rules! push_data_node {
+    ($arena:expr, $parent:expr, $kind:expr, $pos:expr, $end:expr, $pool:ident, $data:expr) => {{
+        let parent: $crate::parser::base::NodeIndex = $parent;
+        let data_index = $arena.len_u32($arena.$pool.len());
+        $arena.$pool.push($data);
+        let index = $arena.len_u32($arena.nodes.len());
+        debug_assert_eq!(parent.0, index, "NodeArena parent/index invariant violated");
+        $arena.nodes.push($crate::parser::node::Node::with_data(
+            $kind, $pos, $end, data_index,
+        ));
+        $arena
+            .extended_info
+            .push($crate::parser::node::ExtendedNodeInfo::default());
+        parent
+    }};
+    ($arena:expr, $parent:expr, $kind:expr, $pos:expr, $end:expr, $pool:ident, $data:expr, flags = $flags:expr) => {{
+        let parent: $crate::parser::base::NodeIndex = $parent;
+        let data_index = $arena.len_u32($arena.$pool.len());
+        $arena.$pool.push($data);
+        let index = $arena.len_u32($arena.nodes.len());
+        debug_assert_eq!(parent.0, index, "NodeArena parent/index invariant violated");
+        $arena
+            .nodes
+            .push($crate::parser::node::Node::with_data_and_flags(
+                $kind, $pos, $end, data_index, $flags,
+            ));
+        $arena
+            .extended_info
+            .push($crate::parser::node::ExtendedNodeInfo::default());
+        parent
+    }};
+}
+pub(crate) use push_data_node;
+
 impl NodeArenaInner {
     /// Maximum pre-allocation to avoid capacity overflow in huge files.
     const MAX_NODE_PREALLOC: usize = 5_000_000;
@@ -128,6 +177,18 @@ impl NodeArenaInner {
         u32::try_from(len).expect(
             "node arena length exceeds u32::MAX; large AST support requires a larger span type",
         )
+    }
+
+    /// Reserve the index the next pushed node will occupy.
+    ///
+    /// Children are created before their parent (bottom-up), so a constructor
+    /// can take this index, set it as its children's parent, and then push the
+    /// parent node itself; [`push_data_node`] re-checks the reservation still
+    /// holds when the node lands.
+    #[inline]
+    #[must_use]
+    pub(super) fn reserve_parent(&self) -> NodeIndex {
+        NodeIndex(self.len_u32(self.nodes.len()))
     }
 
     // ============================================================================
@@ -205,42 +266,25 @@ impl NodeArenaInner {
         end: u32,
         data: IdentifierData,
     ) -> NodeIndex {
-        let data_index = self.len_u32(self.identifiers.len());
-        self.identifiers.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        NodeIndex(index)
+        let parent = self.reserve_parent();
+        push_data_node!(self, parent, kind, pos, end, identifiers, data)
     }
 
     /// Add a literal node
     pub fn add_literal(&mut self, kind: u16, pos: u32, end: u32, data: LiteralData) -> NodeIndex {
-        let data_index = self.len_u32(self.literals.len());
-        self.literals.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        NodeIndex(index)
+        let parent = self.reserve_parent();
+        push_data_node!(self, parent, kind, pos, end, literals, data)
     }
 
     /// Add a source file node
     pub fn add_source_file(&mut self, pos: u32, end: u32, data: SourceFileData) -> NodeIndex {
         use super::syntax_kind_ext::SOURCE_FILE;
-        let end_of_file_token = data.end_of_file_token;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
+        let parent = self.reserve_parent();
 
         self.set_parent_list(&data.statements, parent);
-        self.set_parent(end_of_file_token, parent);
+        self.set_parent(data.end_of_file_token, parent);
 
-        let data_index = self.len_u32(self.source_files.len());
-        self.source_files.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes
-            .push(Node::with_data(SOURCE_FILE, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        push_data_node!(self, parent, SOURCE_FILE, pos, end, source_files, data)
     }
 }
 

--- a/crates/tsz-parser/src/parser/node_arena/patterns.rs
+++ b/crates/tsz-parser/src/parser/node_arena/patterns.rs
@@ -1,10 +1,11 @@
 //! `NodeArena` constructors for destructuring binding patterns and
 //! object-literal property assignments / shorthand properties.
 
+use super::push_data_node;
 use crate::parser::base::NodeIndex;
 use crate::parser::node::{
-    BindingElementData, BindingPatternData, ExtendedNodeInfo, Node, NodeArenaInner,
-    PropertyAssignmentData, ShorthandPropertyData,
+    BindingElementData, BindingPatternData, NodeArenaInner, PropertyAssignmentData,
+    ShorthandPropertyData,
 };
 
 impl NodeArenaInner {
@@ -16,17 +17,9 @@ impl NodeArenaInner {
         end: u32,
         data: BindingPatternData,
     ) -> NodeIndex {
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_list(&data.elements, parent);
-
-        let data_index = self.len_u32(self.binding_patterns.len());
-        self.binding_patterns.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, binding_patterns, data)
     }
 
     /// Add a binding element node
@@ -37,20 +30,11 @@ impl NodeArenaInner {
         end: u32,
         data: BindingElementData,
     ) -> NodeIndex {
-        let property_name = data.property_name;
-        let name = data.name;
-        let initializer = data.initializer;
-
-        let data_index = self.len_u32(self.binding_elements.len());
-        self.binding_elements.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(property_name, parent);
-        self.set_parent(name, parent);
-        self.set_parent(initializer, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.property_name, parent);
+        self.set_parent(data.name, parent);
+        self.set_parent(data.initializer, parent);
+        push_data_node!(self, parent, kind, pos, end, binding_elements, data)
     }
 
     /// Add a property assignment node
@@ -61,21 +45,11 @@ impl NodeArenaInner {
         end: u32,
         data: PropertyAssignmentData,
     ) -> NodeIndex {
-        let name = data.name;
-        let initializer = data.initializer;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent(initializer, parent);
-
-        let data_index = self.len_u32(self.property_assignments.len());
-        self.property_assignments.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        self.set_parent(data.name, parent);
+        self.set_parent(data.initializer, parent);
+        push_data_node!(self, parent, kind, pos, end, property_assignments, data)
     }
 
     /// Add a shorthand property assignment node
@@ -86,20 +60,10 @@ impl NodeArenaInner {
         end: u32,
         data: ShorthandPropertyData,
     ) -> NodeIndex {
-        let name = data.name;
-        let object_assignment_initializer = data.object_assignment_initializer;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.modifiers.as_ref(), parent);
-        self.set_parent(name, parent);
-        self.set_parent(object_assignment_initializer, parent);
-
-        let data_index = self.len_u32(self.shorthand_properties.len());
-        self.shorthand_properties.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        self.set_parent(data.name, parent);
+        self.set_parent(data.object_assignment_initializer, parent);
+        push_data_node!(self, parent, kind, pos, end, shorthand_properties, data)
     }
 }

--- a/crates/tsz-parser/src/parser/node_arena/statements.rs
+++ b/crates/tsz-parser/src/parser/node_arena/statements.rs
@@ -1,28 +1,19 @@
 //! `NodeArena` constructors for control-flow statement nodes (blocks,
 //! conditionals, loops, switch, try/catch, labeled, jump, with).
 
+use super::push_data_node;
 use crate::parser::base::NodeIndex;
 use crate::parser::node::{
-    BlockData, CaseClauseData, CatchClauseData, ExprStatementData, ExtendedNodeInfo, ForInOfData,
-    IfStatementData, JumpData, LabeledData, LoopData, Node, NodeArenaInner, ReturnData, SwitchData,
-    TryData, WithData,
+    BlockData, CaseClauseData, CatchClauseData, ExprStatementData, ForInOfData, IfStatementData,
+    JumpData, LabeledData, LoopData, NodeArenaInner, ReturnData, SwitchData, TryData, WithData,
 };
 
 impl NodeArenaInner {
     /// Add a block node
     pub fn add_block(&mut self, kind: u16, pos: u32, end: u32, data: BlockData) -> NodeIndex {
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_list(&data.statements, parent);
-
-        let data_index = self.len_u32(self.blocks.len());
-        self.blocks.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        push_data_node!(self, parent, kind, pos, end, blocks, data)
     }
 
     /// Add an if statement node
@@ -33,74 +24,37 @@ impl NodeArenaInner {
         end: u32,
         data: IfStatementData,
     ) -> NodeIndex {
-        let expression = data.expression;
-        let then_statement = data.then_statement;
-        let else_statement = data.else_statement;
-
-        let data_index = self.len_u32(self.if_statements.len());
-        self.if_statements.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        self.set_parent(then_statement, parent);
-        self.set_parent(else_statement, parent);
-
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        self.set_parent(data.then_statement, parent);
+        self.set_parent(data.else_statement, parent);
+        push_data_node!(self, parent, kind, pos, end, if_statements, data)
     }
 
     /// Add a loop node (for/while/do)
     pub fn add_loop(&mut self, kind: u16, pos: u32, end: u32, data: LoopData) -> NodeIndex {
-        let initializer = data.initializer;
-        let condition = data.condition;
-        let incrementor = data.incrementor;
-        let statement = data.statement;
-        let data_index = self.len_u32(self.loops.len());
-        self.loops.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(initializer, parent);
-        self.set_parent(condition, parent);
-        self.set_parent(incrementor, parent);
-        self.set_parent(statement, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.initializer, parent);
+        self.set_parent(data.condition, parent);
+        self.set_parent(data.incrementor, parent);
+        self.set_parent(data.statement, parent);
+        push_data_node!(self, parent, kind, pos, end, loops, data)
     }
 
     /// Add a for-in/for-of statement node
     pub fn add_for_in_of(&mut self, kind: u16, pos: u32, end: u32, data: ForInOfData) -> NodeIndex {
-        let initializer = data.initializer;
-        let expression = data.expression;
-        let statement = data.statement;
-        let data_index = self.len_u32(self.for_in_of.len());
-        self.for_in_of.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(initializer, parent);
-        self.set_parent(expression, parent);
-        self.set_parent(statement, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.initializer, parent);
+        self.set_parent(data.expression, parent);
+        self.set_parent(data.statement, parent);
+        push_data_node!(self, parent, kind, pos, end, for_in_of, data)
     }
 
     /// Add a return/throw statement node
     pub fn add_return(&mut self, kind: u16, pos: u32, end: u32, data: ReturnData) -> NodeIndex {
-        let expression = data.expression;
-
-        let data_index = self.len_u32(self.return_data.len());
-        self.return_data.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        push_data_node!(self, parent, kind, pos, end, return_data, data)
     }
 
     /// Add an expression statement node
@@ -111,30 +65,17 @@ impl NodeArenaInner {
         end: u32,
         data: ExprStatementData,
     ) -> NodeIndex {
-        let expression = data.expression;
-        let data_index = self.len_u32(self.expr_statements.len());
-        self.expr_statements.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        push_data_node!(self, parent, kind, pos, end, expr_statements, data)
     }
 
     /// Add a switch statement node
     pub fn add_switch(&mut self, kind: u16, pos: u32, end: u32, data: SwitchData) -> NodeIndex {
-        let expression = data.expression;
-        let case_block = data.case_block;
-        let data_index = self.len_u32(self.switch_data.len());
-        self.switch_data.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        self.set_parent(case_block, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        self.set_parent(data.case_block, parent);
+        push_data_node!(self, parent, kind, pos, end, switch_data, data)
     }
 
     /// Add a case/default clause node
@@ -145,37 +86,19 @@ impl NodeArenaInner {
         end: u32,
         data: CaseClauseData,
     ) -> NodeIndex {
-        let expression = data.expression;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
-        self.set_parent(expression, parent);
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
         self.set_parent_list(&data.statements, parent);
-
-        let data_index = self.len_u32(self.case_clauses.len());
-        self.case_clauses.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, case_clauses, data)
     }
 
     /// Add a try statement node
     pub fn add_try(&mut self, kind: u16, pos: u32, end: u32, data: TryData) -> NodeIndex {
-        let try_block = data.try_block;
-        let catch_clause = data.catch_clause;
-        let finally_block = data.finally_block;
-        let data_index = self.len_u32(self.try_data.len());
-        self.try_data.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(try_block, parent);
-        self.set_parent(catch_clause, parent);
-        self.set_parent(finally_block, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.try_block, parent);
+        self.set_parent(data.catch_clause, parent);
+        self.set_parent(data.finally_block, parent);
+        push_data_node!(self, parent, kind, pos, end, try_data, data)
     }
 
     /// Add a catch clause node
@@ -186,64 +109,32 @@ impl NodeArenaInner {
         end: u32,
         data: CatchClauseData,
     ) -> NodeIndex {
-        let variable_declaration = data.variable_declaration;
-        let block = data.block;
-        let data_index = self.len_u32(self.catch_clauses.len());
-        self.catch_clauses.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(variable_declaration, parent);
-        self.set_parent(block, parent);
-
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.variable_declaration, parent);
+        self.set_parent(data.block, parent);
+        push_data_node!(self, parent, kind, pos, end, catch_clauses, data)
     }
 
     /// Add a labeled statement node
     pub fn add_labeled(&mut self, kind: u16, pos: u32, end: u32, data: LabeledData) -> NodeIndex {
-        let label = data.label;
-        let statement = data.statement;
-        let data_index = self.len_u32(self.labeled_data.len());
-        self.labeled_data.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(label, parent);
-        self.set_parent(statement, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.label, parent);
+        self.set_parent(data.statement, parent);
+        push_data_node!(self, parent, kind, pos, end, labeled_data, data)
     }
 
     /// Add a break/continue statement node
     pub fn add_jump(&mut self, kind: u16, pos: u32, end: u32, data: JumpData) -> NodeIndex {
-        let label = data.label;
-        let data_index = self.len_u32(self.jump_data.len());
-        self.jump_data.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(label, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.label, parent);
+        push_data_node!(self, parent, kind, pos, end, jump_data, data)
     }
 
     /// Add a with statement node
     pub fn add_with(&mut self, kind: u16, pos: u32, end: u32, data: WithData) -> NodeIndex {
-        let expression = data.expression;
-        let statement = data.statement;
-        let data_index = self.len_u32(self.with_data.len());
-        self.with_data.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        let parent = NodeIndex(index);
-        self.set_parent(expression, parent);
-        self.set_parent(statement, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.expression, parent);
+        self.set_parent(data.statement, parent);
+        push_data_node!(self, parent, kind, pos, end, with_data, data)
     }
 }

--- a/crates/tsz-parser/src/parser/node_arena/types.rs
+++ b/crates/tsz-parser/src/parser/node_arena/types.rs
@@ -3,30 +3,22 @@
 //! types, conditional/infer/operator/indexed-access/mapped types, literal and
 //! template-literal types, named tuple members, and type predicates).
 
+use super::push_data_node;
 use crate::parser::base::NodeIndex;
 use crate::parser::node::{
-    ArrayTypeData, CompositeTypeData, ConditionalTypeData, ExtendedNodeInfo, FunctionTypeData,
-    IndexedAccessTypeData, InferTypeData, LiteralTypeData, MappedTypeData, NamedTupleMemberData,
-    Node, NodeArenaInner, TemplateLiteralTypeData, TupleTypeData, TypeLiteralData,
-    TypeOperatorData, TypePredicateData, TypeQueryData, TypeRefData, WrappedTypeData,
+    ArrayTypeData, CompositeTypeData, ConditionalTypeData, FunctionTypeData, IndexedAccessTypeData,
+    InferTypeData, LiteralTypeData, MappedTypeData, NamedTupleMemberData, NodeArenaInner,
+    TemplateLiteralTypeData, TupleTypeData, TypeLiteralData, TypeOperatorData, TypePredicateData,
+    TypeQueryData, TypeRefData, WrappedTypeData,
 };
 
 impl NodeArenaInner {
     /// Add a type reference node
     pub fn add_type_ref(&mut self, kind: u16, pos: u32, end: u32, data: TypeRefData) -> NodeIndex {
-        let type_name = data.type_name;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
-        self.set_parent(type_name, parent);
+        let parent = self.reserve_parent();
+        self.set_parent(data.type_name, parent);
         self.set_parent_opt_list(data.type_arguments.as_ref(), parent);
-
-        let data_index = self.len_u32(self.type_refs.len());
-        self.type_refs.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, type_refs, data)
     }
 
     /// Add a union/intersection type node
@@ -37,18 +29,9 @@ impl NodeArenaInner {
         end: u32,
         data: CompositeTypeData,
     ) -> NodeIndex {
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_list(&data.types, parent);
-
-        let data_index = self.len_u32(self.composite_types.len());
-        self.composite_types.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        push_data_node!(self, parent, kind, pos, end, composite_types, data)
     }
 
     /// Add a function/constructor type node
@@ -59,21 +42,11 @@ impl NodeArenaInner {
         end: u32,
         data: FunctionTypeData,
     ) -> NodeIndex {
-        let type_annotation = data.type_annotation;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_opt_list(data.type_parameters.as_ref(), parent);
         self.set_parent_list(&data.parameters, parent);
-        self.set_parent(type_annotation, parent);
-
-        let data_index = self.len_u32(self.function_types.len());
-        self.function_types.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-
-        parent
+        self.set_parent(data.type_annotation, parent);
+        push_data_node!(self, parent, kind, pos, end, function_types, data)
     }
 
     /// Add a type query node (typeof)
@@ -84,19 +57,10 @@ impl NodeArenaInner {
         end: u32,
         data: TypeQueryData,
     ) -> NodeIndex {
-        let expr_name = data.expr_name;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
-        self.set_parent(expr_name, parent);
+        let parent = self.reserve_parent();
+        self.set_parent(data.expr_name, parent);
         self.set_parent_opt_list(data.type_arguments.as_ref(), parent);
-
-        let data_index = self.len_u32(self.type_queries.len());
-        self.type_queries.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, type_queries, data)
     }
 
     /// Add a type literal node
@@ -107,17 +71,9 @@ impl NodeArenaInner {
         end: u32,
         data: TypeLiteralData,
     ) -> NodeIndex {
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_list(&data.members, parent);
-
-        let data_index = self.len_u32(self.type_literals.len());
-        self.type_literals.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, type_literals, data)
     }
 
     /// Add an array type node
@@ -128,15 +84,9 @@ impl NodeArenaInner {
         end: u32,
         data: ArrayTypeData,
     ) -> NodeIndex {
-        let element_type = data.element_type;
-        let data_index = self.len_u32(self.array_types.len());
-        self.array_types.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(element_type, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.element_type, parent);
+        push_data_node!(self, parent, kind, pos, end, array_types, data)
     }
 
     /// Add a tuple type node
@@ -147,17 +97,9 @@ impl NodeArenaInner {
         end: u32,
         data: TupleTypeData,
     ) -> NodeIndex {
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
+        let parent = self.reserve_parent();
         self.set_parent_list(&data.elements, parent);
-
-        let data_index = self.len_u32(self.tuple_types.len());
-        self.tuple_types.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, tuple_types, data)
     }
 
     /// Add an optional/rest type node
@@ -168,15 +110,9 @@ impl NodeArenaInner {
         end: u32,
         data: WrappedTypeData,
     ) -> NodeIndex {
-        let type_node = data.type_node;
-        let data_index = self.len_u32(self.wrapped_types.len());
-        self.wrapped_types.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(type_node, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.type_node, parent);
+        push_data_node!(self, parent, kind, pos, end, wrapped_types, data)
     }
 
     /// Add a conditional type node
@@ -187,21 +123,12 @@ impl NodeArenaInner {
         end: u32,
         data: ConditionalTypeData,
     ) -> NodeIndex {
-        let check_type = data.check_type;
-        let extends_type = data.extends_type;
-        let true_type = data.true_type;
-        let false_type = data.false_type;
-        let data_index = self.len_u32(self.conditional_types.len());
-        self.conditional_types.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(check_type, parent);
-        self.set_parent(extends_type, parent);
-        self.set_parent(true_type, parent);
-        self.set_parent(false_type, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.check_type, parent);
+        self.set_parent(data.extends_type, parent);
+        self.set_parent(data.true_type, parent);
+        self.set_parent(data.false_type, parent);
+        push_data_node!(self, parent, kind, pos, end, conditional_types, data)
     }
 
     /// Add an infer type node
@@ -212,15 +139,9 @@ impl NodeArenaInner {
         end: u32,
         data: InferTypeData,
     ) -> NodeIndex {
-        let type_parameter = data.type_parameter;
-        let data_index = self.len_u32(self.infer_types.len());
-        self.infer_types.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(type_parameter, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.type_parameter, parent);
+        push_data_node!(self, parent, kind, pos, end, infer_types, data)
     }
 
     /// Add a type operator node (keyof, unique, readonly)
@@ -231,15 +152,9 @@ impl NodeArenaInner {
         end: u32,
         data: TypeOperatorData,
     ) -> NodeIndex {
-        let type_node = data.type_node;
-        let data_index = self.len_u32(self.type_operators.len());
-        self.type_operators.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(type_node, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.type_node, parent);
+        push_data_node!(self, parent, kind, pos, end, type_operators, data)
     }
 
     /// Add an indexed access type node
@@ -250,17 +165,10 @@ impl NodeArenaInner {
         end: u32,
         data: IndexedAccessTypeData,
     ) -> NodeIndex {
-        let object_type = data.object_type;
-        let index_type = data.index_type;
-        let data_index = self.len_u32(self.indexed_access_types.len());
-        self.indexed_access_types.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(object_type, parent);
-        self.set_parent(index_type, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.object_type, parent);
+        self.set_parent(data.index_type, parent);
+        push_data_node!(self, parent, kind, pos, end, indexed_access_types, data)
     }
 
     /// Add a mapped type node
@@ -271,27 +179,14 @@ impl NodeArenaInner {
         end: u32,
         data: MappedTypeData,
     ) -> NodeIndex {
-        let readonly_token = data.readonly_token;
-        let type_parameter = data.type_parameter;
-        let name_type = data.name_type;
-        let question_token = data.question_token;
-        let type_node = data.type_node;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
-        self.set_parent(readonly_token, parent);
-        self.set_parent(type_parameter, parent);
-        self.set_parent(name_type, parent);
-        self.set_parent(question_token, parent);
-        self.set_parent(type_node, parent);
+        let parent = self.reserve_parent();
+        self.set_parent(data.readonly_token, parent);
+        self.set_parent(data.type_parameter, parent);
+        self.set_parent(data.name_type, parent);
+        self.set_parent(data.question_token, parent);
+        self.set_parent(data.type_node, parent);
         self.set_parent_opt_list(data.members.as_ref(), parent);
-
-        let data_index = self.len_u32(self.mapped_types.len());
-        self.mapped_types.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, mapped_types, data)
     }
 
     /// Add a literal type node
@@ -302,15 +197,9 @@ impl NodeArenaInner {
         end: u32,
         data: LiteralTypeData,
     ) -> NodeIndex {
-        let literal = data.literal;
-        let data_index = self.len_u32(self.literal_types.len());
-        self.literal_types.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(literal, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.literal, parent);
+        push_data_node!(self, parent, kind, pos, end, literal_types, data)
     }
 
     /// Add a template literal type node
@@ -321,19 +210,10 @@ impl NodeArenaInner {
         end: u32,
         data: TemplateLiteralTypeData,
     ) -> NodeIndex {
-        let head = data.head;
-        let parent = NodeIndex(self.len_u32(self.nodes.len()));
-
-        self.set_parent(head, parent);
+        let parent = self.reserve_parent();
+        self.set_parent(data.head, parent);
         self.set_parent_list(&data.template_spans, parent);
-
-        let data_index = self.len_u32(self.template_literal_types.len());
-        self.template_literal_types.push(data);
-        let index = self.len_u32(self.nodes.len());
-        debug_assert_eq!(parent.0, index);
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        parent
+        push_data_node!(self, parent, kind, pos, end, template_literal_types, data)
     }
 
     /// Add a named tuple member node
@@ -344,18 +224,10 @@ impl NodeArenaInner {
         end: u32,
         data: NamedTupleMemberData,
     ) -> NodeIndex {
-        let name = data.name;
-        let type_node = data.type_node;
-
-        let data_index = self.len_u32(self.named_tuple_members.len());
-        self.named_tuple_members.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(name, parent);
-        self.set_parent(type_node, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.name, parent);
+        self.set_parent(data.type_node, parent);
+        push_data_node!(self, parent, kind, pos, end, named_tuple_members, data)
     }
 
     /// Add a type predicate node
@@ -366,17 +238,9 @@ impl NodeArenaInner {
         end: u32,
         data: TypePredicateData,
     ) -> NodeIndex {
-        let parameter_name = data.parameter_name;
-        let type_node = data.type_node;
-
-        let data_index = self.len_u32(self.type_predicates.len());
-        self.type_predicates.push(data);
-        let index = self.len_u32(self.nodes.len());
-        self.nodes.push(Node::with_data(kind, pos, end, data_index));
-        self.extended_info.push(ExtendedNodeInfo::default());
-        let parent = NodeIndex(index);
-        self.set_parent(parameter_name, parent);
-        self.set_parent(type_node, parent);
-        parent
+        let parent = self.reserve_parent();
+        self.set_parent(data.parameter_name, parent);
+        self.set_parent(data.type_node, parent);
+        push_data_node!(self, parent, kind, pos, end, type_predicates, data)
     }
 }

--- a/crates/tsz-parser/src/parser/state.rs
+++ b/crates/tsz-parser/src/parser/state.rs
@@ -27,7 +27,7 @@ use rustc_hash::FxHashMap;
 use tracing::warn;
 use tsz_common::interner::AstAtom;
 use tsz_scanner::scanner_impl::{ScannerState, TokenFlags};
-use tsz_scanner::{SyntaxKind, token_is_keyword};
+use tsz_scanner::{SyntaxKind, keyword_text_len, token_is_keyword};
 // =============================================================================
 // Parser Context Flags
 // =============================================================================
@@ -705,6 +705,17 @@ impl ParserState {
         self.u32_from_usize(self.scanner.get_token_end())
     }
 
+    /// Synthesize a keyword token spanning `start .. start + len(kw)`.
+    ///
+    /// Used by error-recovery paths that fabricate a keyword/modifier token
+    /// at a known start. The span end is derived from the single
+    /// source-of-truth [`keyword_text_len`] instead of hardcoding the byte
+    /// length (e.g. `+ 6` for `"export"`) at each call site.
+    pub(crate) fn synth_keyword_token(&mut self, kw: SyntaxKind, start: u32) -> NodeIndex {
+        let end = start + keyword_text_len(kw);
+        self.arena.add_token(kw as u16, start, end)
+    }
+
     /// Advance to next token
     pub(crate) fn next_token(&mut self) -> SyntaxKind {
         self.current_token = self.scanner.scan();
@@ -833,7 +844,7 @@ impl ParserState {
         if (flags & TokenFlags::UnicodeEscape as u32) != 0 {
             use tsz_common::diagnostics::diagnostic_codes;
             self.parse_error_at(
-                self.u32_from_usize(self.scanner.get_token_start()),
+                self.token_pos(),
                 self.u32_from_usize(self.scanner.get_token_end() - self.scanner.get_token_start()),
                 "Keywords cannot contain escape characters.",
                 diagnostic_codes::KEYWORDS_CANNOT_CONTAIN_ESCAPE_CHARACTERS,

--- a/crates/tsz-parser/src/parser/state_diagnostics.rs
+++ b/crates/tsz-parser/src/parser/state_diagnostics.rs
@@ -14,8 +14,8 @@ impl ParserState {
         {
             return;
         }
-        let start = self.u32_from_usize(self.scanner.get_token_start());
-        let end = self.u32_from_usize(self.scanner.get_token_end());
+        let start = self.token_pos();
+        let end = self.token_end();
         self.parse_error_at(start, end - start, message, code);
     }
 
@@ -23,8 +23,8 @@ impl ParserState {
     /// deduplication.  Use when TSC emits multiple distinct error codes at the same
     /// position (e.g. TS1042 + TS1184 for object-literal modifiers).
     pub(crate) fn parse_companion_error_at_current_token(&mut self, message: &str, code: u32) {
-        let start = self.u32_from_usize(self.scanner.get_token_start());
-        let end = self.u32_from_usize(self.scanner.get_token_end());
+        let start = self.token_pos();
+        let end = self.token_end();
         let length = end - start;
         self.parse_companion_error_at(start, length, message, code);
     }

--- a/crates/tsz-parser/src/parser/state_exports_recovery.rs
+++ b/crates/tsz-parser/src/parser/state_exports_recovery.rs
@@ -78,11 +78,7 @@ impl ParserState {
             | SyntaxKind::UsingKeyword
             | SyntaxKind::AwaitKeyword => {
                 use tsz_scanner::SyntaxKind;
-                let export_node = self.arena.add_token(
-                    SyntaxKind::ExportKeyword as u16,
-                    start_pos,
-                    start_pos + 6,
-                );
+                let export_node = self.synth_keyword_token(SyntaxKind::ExportKeyword, start_pos);
                 let modifiers = Self::make_node_list(vec![export_node]);
                 self.parse_variable_statement_with_modifiers(Some(start_pos), Some(modifiers))
             }
@@ -93,15 +89,12 @@ impl ParserState {
                 } else {
                     self.parse_error_at(
                         start_pos,
-                        6,
+                        keyword_text_len(SyntaxKind::ExportKeyword),
                         "An import declaration cannot have modifiers.",
                         diagnostic_codes::AN_IMPORT_DECLARATION_CANNOT_HAVE_MODIFIERS,
                     );
-                    let export_modifier = self.arena.add_token(
-                        SyntaxKind::ExportKeyword as u16,
-                        start_pos,
-                        start_pos + keyword_text_len(SyntaxKind::ExportKeyword),
-                    );
+                    let export_modifier =
+                        self.synth_keyword_token(SyntaxKind::ExportKeyword, start_pos);
                     let modifiers = Some(Self::make_node_list(vec![export_modifier]));
                     self.parse_import_declaration_with_modifiers(start_pos, modifiers)
                 }
@@ -136,7 +129,9 @@ impl ParserState {
                     use tsz_common::diagnostics::diagnostic_messages;
                     self.parse_error_at(
                         start_pos,
-                        second_export_pos + 6 - start_pos, // span covers "export export"
+                        // span covers "export export": from the first `export`
+                        // start to the end of the second `export` keyword.
+                        second_export_pos + keyword_text_len(SyntaxKind::ExportKeyword) - start_pos,
                         diagnostic_messages::AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS,
                         diagnostic_codes::AN_EXPORT_ASSIGNMENT_CANNOT_HAVE_MODIFIERS,
                     );
@@ -167,7 +162,7 @@ impl ParserState {
             _ => {
                 self.parse_error_at(
                     start_pos,
-                    6,
+                    keyword_text_len(SyntaxKind::ExportKeyword),
                     "Declaration or statement expected.",
                     diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
                 );
@@ -188,7 +183,7 @@ impl ParserState {
         if should_report {
             self.parse_error_at(
                 export_pos,
-                6,
+                keyword_text_len(SyntaxKind::ExportKeyword),
                 "Declaration or statement expected.",
                 diagnostic_codes::DECLARATION_OR_STATEMENT_EXPECTED,
             );

--- a/crates/tsz-parser/src/parser/state_expressions_call_member.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_call_member.rs
@@ -145,12 +145,12 @@ impl ParserState {
                     if (self.context_flags & crate::parser::state::CONTEXT_FLAG_IN_DECORATOR) != 0 {
                         break;
                     }
-                    let missing_argument_start = self.u32_from_usize(self.scanner.get_token_end());
+                    let missing_argument_start = self.token_end();
                     self.next_token();
                     let argument = self.parse_expression();
                     if argument.is_none() {
                         // TS1011: An element access expression should take an argument
-                        let current_start = self.u32_from_usize(self.scanner.get_token_start());
+                        let current_start = self.token_pos();
                         self.parse_error_at(
                             missing_argument_start,
                             (current_start.saturating_sub(missing_argument_start)).max(1),

--- a/crates/tsz-parser/src/parser/state_expressions_literals.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals.rs
@@ -943,9 +943,8 @@ impl ParserState {
                             let mut outer_close_paren = None;
 
                             if self.is_token(SyntaxKind::CloseParenToken) {
-                                let inner_start =
-                                    self.u32_from_usize(self.scanner.get_token_start());
-                                let inner_end = self.u32_from_usize(self.scanner.get_token_end());
+                                let inner_start = self.token_pos();
+                                let inner_end = self.token_end();
                                 inner_close_paren =
                                     Some((inner_start, inner_end.saturating_sub(inner_start)));
 
@@ -960,10 +959,8 @@ impl ParserState {
                                         if self.is_token(SyntaxKind::CloseParenToken)
                                             && !self.scanner.has_preceding_line_break()
                                         {
-                                            let outer_start =
-                                                self.u32_from_usize(self.scanner.get_token_start());
-                                            let outer_end =
-                                                self.u32_from_usize(self.scanner.get_token_end());
+                                            let outer_start = self.token_pos();
+                                            let outer_end = self.token_end();
                                             outer_close_paren = Some((
                                                 outer_start,
                                                 outer_end.saturating_sub(outer_start),
@@ -1181,7 +1178,7 @@ impl ParserState {
                     );
                 } else {
                     let start = self.u32_from_usize(self.scanner.get_token_full_start());
-                    let end = self.u32_from_usize(self.scanner.get_token_end());
+                    let end = self.token_end();
                     self.parse_error_at(
                         start,
                         end.saturating_sub(start),
@@ -1651,9 +1648,7 @@ impl ParserState {
         // Handle new.target meta-property
         if self.is_token(SyntaxKind::DotToken) {
             self.next_token(); // consume '.'
-            let new_node =
-                self.arena
-                    .add_token(SyntaxKind::NewKeyword as u16, start_pos, start_pos + 3);
+            let new_node = self.synth_keyword_token(SyntaxKind::NewKeyword, start_pos);
             let name = self.parse_identifier_name();
             // TS17012: Check that the meta-property is 'target', not a misspelling
             if let Some(name_node) = self.arena.get(name)
@@ -1777,12 +1772,12 @@ impl ParserState {
                     );
                 }
                 SyntaxKind::OpenBracketToken => {
-                    let missing_argument_start = self.u32_from_usize(self.scanner.get_token_end());
+                    let missing_argument_start = self.token_end();
                     self.next_token();
                     let argument = self.parse_expression();
                     if argument.is_none() {
                         // TS1011: An element access expression should take an argument
-                        let current_start = self.u32_from_usize(self.scanner.get_token_start());
+                        let current_start = self.token_pos();
                         self.parse_error_at(
                             missing_argument_start,
                             (current_start.saturating_sub(missing_argument_start)).max(1),

--- a/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_literals/object_members.rs
@@ -236,7 +236,7 @@ impl ParserState {
         // TSC emits TS1162: "An object member cannot be declared optional."
         let question_pos = if self.is_token(SyntaxKind::QuestionToken) {
             use tsz_common::diagnostics::diagnostic_codes;
-            let pos = self.u32_from_usize(self.scanner.get_token_start());
+            let pos = self.token_pos();
             self.parse_error_at_current_token(
                 "An object member cannot be declared optional.",
                 diagnostic_codes::AN_OBJECT_MEMBER_CANNOT_BE_DECLARED_OPTIONAL,
@@ -264,7 +264,7 @@ impl ParserState {
         // suppress downstream semantic checks. We skip the '!' here for error recovery
         // and let the checker emit TS1255 based on the exclamation_token_pos field.
         let exclamation_pos = if self.is_token(SyntaxKind::ExclamationToken) {
-            let pos = self.u32_from_usize(self.scanner.get_token_start());
+            let pos = self.token_pos();
             self.next_token(); // Skip the '!' for error recovery
             pos
         } else {

--- a/crates/tsz-parser/src/parser/state_expressions_tail.rs
+++ b/crates/tsz-parser/src/parser/state_expressions_tail.rs
@@ -721,7 +721,7 @@ impl ParserState {
             // to match tsc's parseErrorAtPosition(scanner.getTokenStart()). When there's
             // leading whitespace, the positions differ and both errors are emitted.
             let full_start = self.u32_from_usize(self.scanner.get_token_full_start());
-            let end = self.u32_from_usize(self.scanner.get_token_end());
+            let end = self.token_end();
             self.parse_error_at(
                 full_start,
                 end.saturating_sub(full_start),

--- a/crates/tsz-parser/src/parser/state_import_attributes.rs
+++ b/crates/tsz-parser/src/parser/state_import_attributes.rs
@@ -79,8 +79,8 @@ impl ParserState {
                     && !self.is_token(SyntaxKind::EndOfFileToken)
                 {
                     if semicolon_recovery.is_none() && self.is_token(SyntaxKind::ColonToken) {
-                        let start = self.u32_from_usize(self.scanner.get_token_start());
-                        let end = self.u32_from_usize(self.scanner.get_token_end());
+                        let start = self.token_pos();
+                        let end = self.token_end();
                         semicolon_recovery = Some((start, end - start));
                     }
                     self.next_token();

--- a/crates/tsz-parser/src/parser/state_types_advanced.rs
+++ b/crates/tsz-parser/src/parser/state_types_advanced.rs
@@ -1419,8 +1419,8 @@ impl ParserState {
     /// Handles compound `<<` by splitting into two `<` tokens.
     pub(crate) fn parse_type_arguments(&mut self) -> NodeList {
         // Save the `<` position before consuming it so TS1099 points at `<`, not `>`
-        let less_than_start = self.u32_from_usize(self.scanner.get_token_start());
-        let less_than_end = self.u32_from_usize(self.scanner.get_token_end());
+        let less_than_start = self.token_pos();
+        let less_than_end = self.token_end();
         self.parse_expected_less_than();
 
         let mut args = Vec::new();
@@ -1562,8 +1562,8 @@ impl ParserState {
         let checkpoint = self.speculation_checkpoint();
 
         // Save the `<` position before consuming it so TS1099 points at `<`, not `>`
-        let less_than_start = self.u32_from_usize(self.scanner.get_token_start());
-        let less_than_end = self.u32_from_usize(self.scanner.get_token_end());
+        let less_than_start = self.token_pos();
+        let less_than_end = self.token_end();
 
         // Consume `<` (handles `<<` by splitting into two `<` tokens)
         self.parse_expected_less_than();


### PR DESCRIPTION
Closes #13429.

Goal: hold

## Summary

The `tsz-parser` node arena hand-wrote four families of mechanically identical
boilerplate. This collapses all four onto shared, table-driven mechanisms with
no behavior change — and re-establishes one invariant that had silently drifted.

### Structural rule

When a data-bearing AST node is appended, `tsc`/tsz must push the typed payload,
the thin `nodes` header, and the `extended_info` entry in lockstep, and the
node's reserved parent index must equal the index it actually lands at. tsz now
enforces this in **one** place (`push_data_node!`) instead of open-coding it
~90 times — where two divergent orderings had already dropped the
`parent == nodes.len()` `debug_assert` in the post-push constructors.

### What changed (owner layer: `tsz-parser` only — pure intra-crate DRY)

1. **`push_data_node!` macro + `reserve_parent()`** (`node_arena/mod.rs`).
   Every data-bearing `add_*` constructor now reserves its index up front,
   wires children's parents against it, and hands the payload to the macro,
   which performs the lockstep push and asserts the invariant uniformly. The
   constructors that previously pushed first and derived the parent afterward
   (skipping the assert) are converted to the reserve-first form, so the
   invariant is now enforced everywhere. Single-arm macro with an optional
   `flags = <expr>` tail (defaulting to `0`, identical to `Node::with_data`)
   resolved through an `@flags` helper arm.
2. **`define_kind_getters!` macro** (`node_access.rs`, used there and in
   `node_access_typed_getters.rs`). The ~87 single/small-fixed-kind `get_*`
   bodies are migrated to `name => field -> Type, [KIND, ..]` entries, matching
   the sibling `define_at_accessors!` precedent. Predicate-based and
   scanner-`SyntaxKind`-cast getters (`get_accessor`, `get_binding_pattern`,
   `get_identifier`, `get_literal`, `get_jsx_text`) stay hand-written.
3. **`token_pos()` / `token_end()` accessors** replace the 23 inline
   `u32_from_usize(self.scanner.get_token_start()/end())` respellings.
4. **`synth_keyword_token()` + `keyword_text_len`-backed `create_modifier()`**
   eliminate the magic keyword lengths: the `+ 6` ("export") and `+ 3` ("new")
   span literals and the hand-maintained `5/6/7/8/9` modifier-length table all
   derive from the single source of truth `keyword_text_len`.

### Adjacent cases

Both append orderings (parent-first-with-assert and post-push-without-assert)
are unified; leaf data nodes (`add_jsx_text`), flag-carrying nodes
(`add_variable_with_flags`), and multi-kind getters (`get_function`,
`get_signature`, …) all route through the shared mechanisms. Diagnostic span
sites for both synthetic (`export`, `new`) and real-position keyword tokens are
covered.

## Verification

- `cargo check -p tsz-parser` — clean.
- `cargo clippy -p tsz-parser --all-targets` — clean.
- `cargo test -p tsz-parser` — 1425 passed, 0 failed (debug build exercises the
  newly-uniform `debug_assert_eq!(parent.0, index)`; it does not fire).
- `cargo check --workspace` — all crates build (public getter API unchanged).
- Rebased on `origin/main`; no file overlap, no conflicts.
- Ready-review CI owns the broad conformance/emit/fourslash suites (`hold` floor).

Net: 20 files, ~+900/−2400 lines; `node_access.rs` 1746→~1230, the arena
submodules roughly halved.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRyW4hzL7tkzBU1HFT8QWS)_
