### PR TITLE
fix(bench/ci): make benchmark orchestration resilient to transient GitHub API errors (#13306)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -59,6 +59,31 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          # Retry read-only gh/curl calls so a transient GitHub API blip (5xx,
+          # rate limit, dropped connection) cannot fail Bench orchestration.
+          # Echoes the successful attempt's stdout; returns non-zero only after
+          # all attempts fail, so each caller keeps its own safe-default branch.
+          gh_retry() {
+            local attempt=1 max_attempts=5 delay=4 out rc
+            while :; do
+              if out="$("$@" 2>/dev/null)"; then
+                printf '%s' "$out"
+                return 0
+              else
+                rc=$?
+              fi
+              if [[ "$attempt" -ge "$max_attempts" ]]; then
+                echo "gh_retry: '$1' failed after ${max_attempts} attempts (rc=${rc})." >&2
+                return "$rc"
+              fi
+              echo "gh_retry: '$1' attempt ${attempt}/${max_attempts} failed (rc=${rc}); retrying in ${delay}s." >&2
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
           should_run=true
 
           if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
@@ -107,7 +132,7 @@ jobs:
           if [[ "$should_run" == "true" &&
                 "$release_only" != "true" &&
                 "${{ github.event_name }}" == "workflow_run" ]]; then
-            active_runs_raw="$(
+            list_other_active_runs() {
               {
                 gh run list --repo "${{ github.repository }}" --workflow bench.yml --branch main --status in_progress --limit 20 \
                   --json databaseId,headSha,url \
@@ -116,7 +141,12 @@ jobs:
                   --json databaseId,headSha,url \
                   --jq '.[] | select(.databaseId != ${{ github.run_id }}) | [.databaseId, .headSha, .url] | @tsv'
               } | sort -u
-            )"
+            }
+            if ! active_runs_raw="$(gh_retry list_other_active_runs)"; then
+              echo "bench-gate: could not list active Bench runs after retries; failing closed (skipping this run) to avoid two concurrent benches."
+              should_run=false
+              active_runs_raw=""
+            fi
             active_runs=""
             while IFS=$'\t' read -r run_id run_sha run_url; do
               [[ -n "${run_id:-}" ]] || continue
@@ -1502,7 +1532,9 @@ jobs:
           set -euo pipefail
 
           TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
-          MAIN_SHA="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
+          # Informational only (the "behind main" log below); never let a transient
+          # git ls-remote failure abort the publish that already produced results.
+          MAIN_SHA="$(git ls-remote origin refs/heads/main 2>/dev/null | awk '{print $1}' || true)"
           TARGET_SHA="${BENCH_TARGET_SHA:-${GITHUB_SHA}}"
 
           gsutil -q cp "$GITHUB_WORKSPACE/bench-results.json" \
@@ -1646,13 +1678,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -fsSL \
+          # The gh-pages redeploy dispatch is idempotent, so retry aggressively to
+          # ride out transient API errors. Results are already published to GCS by
+          # the preceding step; if the redeploy ultimately fails, warn but do NOT
+          # fail bench-publish (a job failure here would flip needs.publish.result
+          # and trigger a wasteful catch-up bench). The next publish redeploys.
+          if ! curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 15 \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/gh-pages.yml/dispatches" \
-            -d '{"ref":"main"}'
+            -d '{"ref":"main"}'; then
+            echo "::warning::Website redeploy dispatch failed after retries; benchmark data is published to GCS and will redeploy on the next publish."
+          fi
 
   catch-up:
     name: bench-catch-up
@@ -1671,6 +1710,30 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Retry read-only gh/curl calls so a transient GitHub API blip (5xx,
+          # rate limit, dropped connection) cannot fail Bench orchestration.
+          # Echoes the successful attempt's stdout; returns non-zero only after
+          # all attempts fail, so each caller keeps its own safe-default branch.
+          gh_retry() {
+            local attempt=1 max_attempts=5 delay=4 out rc
+            while :; do
+              if out="$("$@" 2>/dev/null)"; then
+                printf '%s' "$out"
+                return 0
+              else
+                rc=$?
+              fi
+              if [[ "$attempt" -ge "$max_attempts" ]]; then
+                echo "gh_retry: '$1' failed after ${max_attempts} attempts (rc=${rc})." >&2
+                return "$rc"
+              fi
+              echo "gh_retry: '$1' attempt ${attempt}/${max_attempts} failed (rc=${rc}); retrying in ${delay}s." >&2
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
           target_sha="${{ env.BENCH_TARGET_SHA }}"
           main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha' 2>/dev/null || true)"
           if [[ -z "${main_sha}" ]]; then
@@ -1682,7 +1745,7 @@ jobs:
             exit 0
           fi
 
-          active_runs="$(
+          list_other_active_runs() {
             {
               gh run list --repo "${GITHUB_REPOSITORY}" --workflow bench.yml --branch main --status in_progress --limit 20 \
                 --json databaseId,headSha,url \
@@ -1691,7 +1754,11 @@ jobs:
                 --json databaseId,headSha,url \
                 --jq '.[] | select(.databaseId != ${{ github.run_id }}) | [.databaseId, .headSha, .url] | @tsv'
             } | sort -u
-          )"
+          }
+          if ! active_runs="$(gh_retry list_other_active_runs)"; then
+            echo "Could not list active Bench runs after retries; skipping catch-up dispatch (fail closed) to avoid two concurrent benches."
+            exit 0
+          fi
           if [[ -n "${active_runs}" ]]; then
             echo "Another Bench run is already active; skipping catch-up dispatch."
             printf '%s\n' "${active_runs}"
@@ -1703,11 +1770,12 @@ jobs:
             min_catch_up_interval_hours=4
           fi
           min_catch_up_interval_seconds=$((min_catch_up_interval_hours * 3600))
-          recent_dispatches="$(
-            gh run list --repo "${GITHUB_REPOSITORY}" --workflow bench.yml --branch main --limit 20 \
+          if ! recent_dispatches="$(gh_retry gh run list --repo "${GITHUB_REPOSITORY}" --workflow bench.yml --branch main --limit 20 \
               --json databaseId,event,createdAt,status,conclusion,headSha,url \
-              --jq '.[] | select(.databaseId != ${{ github.run_id }} and .event == "workflow_dispatch") | [.databaseId, .createdAt, .status, .conclusion, .headSha, .url] | @tsv'
-          )"
+              --jq '.[] | select(.databaseId != ${{ github.run_id }} and .event == "workflow_dispatch") | [.databaseId, .createdAt, .status, .conclusion, .headSha, .url] | @tsv')"; then
+            echo "Could not read recent Bench dispatches after retries; skipping catch-up dispatch (fail closed) to respect the dispatch throttle."
+            exit 0
+          fi
           now_epoch="$(date -u +%s)"
           while IFS=$'\t' read -r run_id created_at status conclusion run_sha run_url; do
             [[ -n "${run_id:-}" ]] || continue
@@ -1721,13 +1789,20 @@ jobs:
           done <<< "${recent_dispatches}"
 
           echo "Bench target ${target_sha} did not publish and main is now ${main_sha}; dispatching one catch-up Bench run."
-          curl -fsSL \
+          # workflow_dispatch is not idempotent, so retry only transient transport/5xx
+          # (no --retry-all-errors) and never fail the job on exhaustion: a missed
+          # dispatch is recovered by the next main event, and bench-gate de-dups any
+          # double dispatch. This keeps a transient API blip from reddening Bench.
+          if ! curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 15 \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/bench.yml/dispatches" \
-            -d '{"ref":"main","inputs":{"publish_latest_pgo":false}}'
+            -d '{"ref":"main","inputs":{"publish_latest_pgo":false}}'; then
+            echo "Catch-up dispatch request failed after retries; the next main Bench event will re-evaluate catch-up."
+            exit 0
+          fi
 
   catch-up-after-active:
     name: bench-catch-up-after-active
@@ -1749,6 +1824,30 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          # Retry read-only gh/curl calls so a transient GitHub API blip (5xx,
+          # rate limit, dropped connection) cannot fail Bench orchestration.
+          # Echoes the successful attempt's stdout; returns non-zero only after
+          # all attempts fail, so each caller keeps its own safe-default branch.
+          gh_retry() {
+            local attempt=1 max_attempts=5 delay=4 out rc
+            while :; do
+              if out="$("$@" 2>/dev/null)"; then
+                printf '%s' "$out"
+                return 0
+              else
+                rc=$?
+              fi
+              if [[ "$attempt" -ge "$max_attempts" ]]; then
+                echo "gh_retry: '$1' failed after ${max_attempts} attempts (rc=${rc})." >&2
+                return "$rc"
+              fi
+              echo "gh_retry: '$1' attempt ${attempt}/${max_attempts} failed (rc=${rc}); retrying in ${delay}s." >&2
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
 
           target_sha="${{ env.BENCH_TARGET_SHA }}"
           max_active_minutes=180
@@ -1772,10 +1871,16 @@ jobs:
             sleep 60
           done
 
-          active_published="$(
-            gh run view "${ACTIVE_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --json jobs \
-              --jq '[.jobs[] | select(.name == "bench-publish" and .conclusion == "success")] | length'
-          )"
+          # This query (gh run view --json jobs) hit an HTTP 502 on 2026-06-14 and,
+          # being unguarded under set -euo pipefail, failed the whole job so no
+          # catch-up was dispatched. Retry, and on exhaustion assume the active run
+          # published (fail closed) so a transient blip neither reds Bench nor
+          # triggers a redundant catch-up bench.
+          if ! active_published="$(gh_retry gh run view "${ACTIVE_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --json jobs \
+              --jq '[.jobs[] | select(.name == "bench-publish" and .conclusion == "success")] | length')"; then
+            echo "Could not read active Bench run ${ACTIVE_RUN_ID} publish status after retries; assuming it published (fail closed)."
+            active_published=1
+          fi
 
           main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha' 2>/dev/null || true)"
           if [[ -z "${main_sha}" ]]; then
@@ -1794,14 +1899,18 @@ jobs:
             echo "Active Bench run ${ACTIVE_RUN_ID} published ${ACTIVE_RUN_SHA}, but skipped target ${target_sha} is still current main; dispatching catch-up."
           fi
 
-          active_dispatches="$(
+          list_other_active_dispatches() {
             gh run list --repo "${GITHUB_REPOSITORY}" --workflow bench.yml --branch main --status in_progress --limit 20 \
               --json databaseId,event,headSha,url \
               --jq '.[] | select(.databaseId != ${{ github.run_id }} and .databaseId != '"${ACTIVE_RUN_ID}"' and .event == "workflow_dispatch") | [.databaseId, .headSha, .url] | @tsv'
             gh run list --repo "${GITHUB_REPOSITORY}" --workflow bench.yml --branch main --status queued --limit 20 \
               --json databaseId,event,headSha,url \
               --jq '.[] | select(.databaseId != ${{ github.run_id }} and .databaseId != '"${ACTIVE_RUN_ID}"' and .event == "workflow_dispatch") | [.databaseId, .headSha, .url] | @tsv'
-          )"
+          }
+          if ! active_dispatches="$(gh_retry list_other_active_dispatches)"; then
+            echo "Could not list dispatched Bench catch-ups after retries; skipping dispatch (fail closed) to avoid two concurrent benches."
+            exit 0
+          fi
           if [[ -n "${active_dispatches}" ]]; then
             echo "A dispatched Bench catch-up is already active; skipping duplicate dispatch."
             printf '%s\n' "${active_dispatches}"
@@ -1813,11 +1922,12 @@ jobs:
             min_catch_up_interval_hours=4
           fi
           min_catch_up_interval_seconds=$((min_catch_up_interval_hours * 3600))
-          recent_dispatches="$(
-            gh run list --repo "${GITHUB_REPOSITORY}" --workflow bench.yml --branch main --limit 20 \
+          if ! recent_dispatches="$(gh_retry gh run list --repo "${GITHUB_REPOSITORY}" --workflow bench.yml --branch main --limit 20 \
               --json databaseId,event,createdAt,status,conclusion,headSha,url \
-              --jq '.[] | select(.databaseId != ${{ github.run_id }} and .databaseId != '"${ACTIVE_RUN_ID}"' and .event == "workflow_dispatch") | [.databaseId, .createdAt, .status, .conclusion, .headSha, .url] | @tsv'
-          )"
+              --jq '.[] | select(.databaseId != ${{ github.run_id }} and .databaseId != '"${ACTIVE_RUN_ID}"' and .event == "workflow_dispatch") | [.databaseId, .createdAt, .status, .conclusion, .headSha, .url] | @tsv')"; then
+            echo "Could not read recent Bench dispatches after retries; skipping dispatch (fail closed) to respect the dispatch throttle."
+            exit 0
+          fi
           now_epoch="$(date -u +%s)"
           while IFS=$'\t' read -r run_id created_at status conclusion run_sha run_url; do
             [[ -n "${run_id:-}" ]] || continue
@@ -1831,10 +1941,17 @@ jobs:
           done <<< "${recent_dispatches}"
 
           echo "Active Bench run ${ACTIVE_RUN_ID} completed without bench-publish; dispatching one fresh main Bench run for ${main_sha}."
-          curl -fsSL \
+          # workflow_dispatch is not idempotent, so retry only transient transport/5xx
+          # (no --retry-all-errors) and never fail the job on exhaustion: a missed
+          # dispatch is recovered by the next main event, and bench-gate de-dups any
+          # double dispatch. This keeps a transient API blip from reddening Bench.
+          if ! curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 15 \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/bench.yml/dispatches" \
-            -d '{"ref":"main","inputs":{"publish_latest_pgo":false}}'
+            -d '{"ref":"main","inputs":{"publish_latest_pgo":false}}'; then
+            echo "Catch-up dispatch request failed after retries; the next main Bench event will re-evaluate catch-up."
+            exit 0
+          fi


### PR DESCRIPTION
## Summary

A transient **HTTP 502** on the unguarded `gh run view --json jobs` (`active_published`) query in `bench-catch-up-after-active` failed the entire job under `set -euo pipefail` on 2026-06-14 ([run 27498435715](https://github.com/tsz-org/tsz/actions/runs/27498435715)), painting **Bench red on main** and dropping the catch-up that keeps the public benchmark scoreboard fresh. This is the latest symptom in the catch-up-loop fragility family of #13306 (its Cloud-Build-starvation root causes were fixed in #13307).

This change makes **every** read-only orchestration network call resilient so a momentary GitHub API blip can neither red the Bench workflow nor break the one-bench-at-a-time / catch-up-to-latest serialization the public scoreboard depends on.

## Structural rule

When a transient GitHub API error (5xx / rate-limit / dropped connection) hits a Bench orchestration query, `tsc`-equivalent behavior is: retry, then fall **closed** (assume work is already in-progress/published/throttled) so the workflow never starts a second concurrent bench and never reds main — recovery comes from the next `main` event. Owner: the `Bench` workflow's `bench-gate`, `catch-up`, `catch-up-after-active`, and `bench-publish` jobs.

## Changes

A small inline `gh_retry` helper (5× exponential backoff; echoes stdout, returns non-zero only after exhaustion) wraps each query, and each caller keeps an explicit safe-default branch:

| Site | Fix | Fallback on exhaustion |
|---|---|---|
| `bench-gate` active-runs | retry | `should_run=false` (skip — never two benches) |
| `catch-up` active-runs / recent-dispatches | retry | skip dispatch (fail closed) |
| `catch-up-after-active` **active_published** (today's crash) | retry | assume published → skip redundant catch-up |
| `catch-up-after-active` active-dispatches / recent-dispatches | retry | skip dispatch (fail closed) |
| `bench-publish` `MAIN_SHA` git ls-remote (informational log) | `2>/dev/null \|\| true` | empty (never aborts an already-produced publish) |
| redeploy curl (idempotent gh-pages dispatch) | `--retry 5 --retry-all-errors` | warn, do **not** fail publish (a failure would trigger a wasteful catch-up) |
| self-dispatch curls | `--retry 3` (no `--retry-all-errors`; `workflow_dispatch` is not idempotent, gate de-dups) | warn + `exit 0` |

The helper captures `rc` in an `else` branch — an `if/fi` with a false condition leaves `$?` = 0, which a unit test caught (it would otherwise report exhaustion as success-with-empty-output).

Inline (not an extracted script) because the three orchestration jobs intentionally run with **no `actions/checkout`**; sourcing a helper would add a clone dependency to the very jobs meant to survive API flakiness. Follow-up: extract to `scripts/ci/gh-retry.sh` with tests + checkout if a fourth call site appears.

A **follow-up PR** will harden the serialization *semantics* surfaced while verifying this (4h throttle counting failed dispatches; "newer main owns catch-up" deferral gap) — out of scope here to keep the red-CI hotfix focused.

## Verification

- `python3 -c yaml.safe_load` — YAML well-formed.
- `bash -n` on every extracted `run:` block — all OK.
- `actionlint` (with shellcheck) — warning set **byte-identical** to pristine `main` (no new issues; remaining items are the pre-existing `tsz-cloud-run` self-hosted label and unrelated SC2129/SC2140).
- `gh_retry` unit-tested: success / empty-success / exhaustion-returns-rc / pipe-producer-failure / eventual-recovery / fail-closed-branch — all pass.
- `node scripts/bench/test-bench-workflow-{cloudbuild-prep,cloudbuild-shards,micro-coverage}.mjs` — all pass.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: max

Goal: fast
