### PR TITLE
refactor(emitter): retire post-print first-generic-arg parenthesization from DTS printer path (#13048)

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_text.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_inference_source_text.rs
@@ -237,6 +237,15 @@ impl<'a> DeclarationEmitter<'a> {
             })
     }
 
+    /// Parenthesize a generic-function type that appears as the first type
+    /// argument (`X<<T>() => T>` -> `X<(<T>() => T)>`) so the rendered text does
+    /// not begin a type-argument list with a `<<` token.
+    ///
+    /// For types printed from a `TypeId` this is owned structurally by
+    /// [`TypePrinter::print_type_argument`](crate::emitter::type_printer); this
+    /// string pass survives only for the class-(d) source-text fallback paths in
+    /// `type_inference_return_normalization`, which re-emit a function's declared
+    /// return annotation directly from source syntax rather than from a `TypeId`.
     pub(in crate::declaration_emitter) fn parenthesize_first_generic_function_type_argument_text(
         type_text: &str,
     ) -> String {

--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
@@ -711,7 +711,11 @@ impl<'a> DeclarationEmitter<'a> {
         let printed = self
             .expand_imported_indexed_access_type_text(&printed)
             .unwrap_or(printed);
-        let printed = Self::parenthesize_first_generic_function_type_argument_text(&printed);
+        // Parenthesization of a generic-function first type argument (`X<<T>() => T>`
+        // -> `X<(<T>() => T)>`, needed to avoid a `<<` token) is owned structurally by
+        // `TypePrinter::print_type_argument`; this output is already correct, so no
+        // post-print text pass is applied here. The text-surgery helper survives only
+        // for the source-text (class-d) fallback in `type_inference_return_normalization`.
         if Self::contains_portable_mapped_object_text(&printed)
             && let Some(expanded) =
                 self.expand_portable_intersection_type_text(self.arena, &printed)


### PR DESCRIPTION
Goal: hold

Campaign slice of #13048 (replace DTS type-text string surgery with TypeId-level transforms / printer policy applied before printing). The principled printer-output path no longer post-processes its own rendering for first-generic-argument parenthesization.

(Note: angle-bracket glyphs are stripped by the PR-body sanitizer, so the type examples below are described in words; the exact rendered glyphs live in the cited test file.)

## Structural rule

When a generic-function type (its own type-parameter list, then a parameter list, then an arrow) is rendered as the **first** type argument of a type-argument list, the rendered text opens the argument list with a double-left-angle token, which re-lexes as a left-shift and is invalid. `tsc` (and tsz) wrap that first argument in parentheses. tsz already owns this **structurally** in the emitter's `TypePrinter::print_type_argument` (`crates/tsz-emitter/src/emitter/types/printer/type_printing.rs:1053`), which parenthesizes when: the argument is first, `type_needs_parentheses_in_composition(type_id)` holds (true for any function shape), and the printed text starts with a left-angle. Owner layer: emitter type printer (printer policy applied while printing a `TypeId`), not post-print text.

## Why the post-print pass was redundant

- `print_type_argument` is the single choke point for type-argument rendering; the only path that can open an argument list with a double-left-angle is the application arg list at `type_printing.rs:839`. `print_string_intrinsic` (`:1298`) only takes string-like args, and type-parameter lists never place a left-angle immediately after the opening left-angle.
- The inferred-**predicate** declaration path (`helpers/type_printing.rs:725`) already omitted the post-print pass, relying solely on the printer — corroborating the printer as the structural owner.
- Therefore `parenthesize_first_generic_function_type_argument_text` chained onto `print_type_id_for_inferred_declaration*` output was a redundant safety net over already-correct printer text. Its trigger condition is equivalent to the printer's (first argument, function shape, printed starts with a left-angle), and on already-parenthesized text it is a no-op — so removing it is byte-identical.

## Change

- Remove the redundant `parenthesize_first_generic_function_type_argument_text` call from `print_type_id_for_inferred_declaration_with_optional_setter_names` (`helpers/type_printing.rs`).
- Document the helper as the **class-(d) source-text residual lane**: it survives only for `type_inference_return_normalization`, which re-emits a function's declared return annotation directly from source syntax rather than from a `TypeId` (the printer is not involved there). This matches #13048's plan, which anticipates a residual syntax-text lane for class (d).

No behavior change on the principled printer paths; no new text-surgery; no output surgery. Diff: +14 / -1 across 2 files.

## Adjacent matrix (existing end-to-end DTS tests, unchanged, now gated solely by the printer)

Both tests in `crates/tsz-emitter/src/declaration_emitter/tests/type_info.rs` carry the exact glyphs:

- `test_first_generic_function_type_argument_is_parenthesized`: a class `X` applied to a generic arrow as its single argument is parenthesized; the same explicitly-parenthesized form is idempotent; an **inferred** function return (`function f1() { return prop11; }`) parenthesizes through the edited path; and a class `Y` applied to two generic arrows parenthesizes **only the first** argument (the second is unaffected).
- `test_declared_generic_call_return_preserves_wrapper_for_generic_function_argument`: an **inferred** generic-call return (`const value = fn(...)` where the call argument is a generic arrow) keeps the wrapper parentheses through the edited path.

The inferred `f1()` and `value` cases both flow through `print_type_id_for_inferred_declaration`, so they fail if the printer alone (without the removed pass) does not parenthesize — they pass.

## Verification

- `cargo test -p tsz-emitter --lib first_generic_function_type_argument` -> 2 passed (the inferred `f1()` case exercises the edited path).
- `cargo test -p tsz-emitter --lib` -> 3748 passed; the 3 failures (`fix_generic_rest_identity_preserves_parameters_tuple_labels`, two `..._ts2883_...`) reproduce identically on the parent commit — they depend on local lib fixtures from `scripts/setup/setup.sh` not present in this sandbox, and are not introduced by this change. Ready-review CI runs the full emit/conformance/fourslash suites with libs present.
- `cargo clippy -p tsz-emitter --lib` -> clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: medium