### PR TITLE
perf(checker): memoize switch-case-clause literal types — O(N²)→O(N) interns in discriminated-union narrowing

### DIFF
--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -555,6 +555,21 @@ pub struct FlowSharedCaches {
     /// Reused across `FlowAnalyzer` instances within a single file check.
     pub flow_numeric_atom_cache: RefCell<FxHashMap<u64, Atom>>,
 
+    /// Cache the literal `TypeId` of a switch-case clause expression.
+    /// Key: clause-expression `NodeIndex.0` -> its literal `TypeId` (or `None`
+    /// when the expression is not a recognized literal). `literal_type_from_node`
+    /// is a pure function of the immutable post-bind AST node, so entries are
+    /// stable for the whole file check and need no invalidation within a pass.
+    ///
+    /// Reused across `FlowAnalyzer` instances within a single file check. Without
+    /// this, `narrow_by_switch_case_clause` re-derives (and re-interns) every
+    /// predecessor case label on every case, giving O(N^2) string interns for an
+    /// N-arm literal switch (each case body's flow re-walk scans all earlier
+    /// clauses). The cache collapses the per-switch literal materialization to
+    /// O(N) total: each clause expression is interned once, then read as an O(1)
+    /// hash hit.
+    pub flow_switch_case_literal_cache: RefCell<FxHashMap<u32, Option<TypeId>>>,
+
     /// Shared reference-equivalence cache used by flow narrowing.
     /// Key: (`node_a`, `node_b`) -> whether they reference the same symbol/property chain.
     /// Reused across `FlowAnalyzer` instances within a single file check.
@@ -585,6 +600,7 @@ impl FlowSharedCaches {
             narrowing_cache: tsz_solver::narrowing::NarrowingCache::new(),
             flow_switch_reference_cache: RefCell::new(FxHashMap::default()),
             flow_numeric_atom_cache: RefCell::new(FxHashMap::default()),
+            flow_switch_case_literal_cache: RefCell::new(FxHashMap::default()),
             flow_reference_match_cache: RefCell::new(FxHashMap::default()),
             symbol_flow_memo: SymbolFlowMemoCaches::default(),
             call_type_predicates: crate::control_flow::CallPredicateMap::default(),

--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -211,7 +211,7 @@ impl<'a> FlowAnalyzer<'a> {
 
         if target_is_switch_expr || discriminant_info.is_some() {
             if !has_fallthrough
-                && let Some(current_lit_type) = self.literal_type_from_node(case_expr)
+                && let Some(current_lit_type) = self.cached_case_clause_literal_type(case_expr)
             {
                 let mut previous_cases_are_distinct_literals = true;
                 for &idx in &case_block_data.statements.nodes {
@@ -228,7 +228,9 @@ impl<'a> FlowAnalyzer<'a> {
                         previous_cases_are_distinct_literals = false;
                         break;
                     }
-                    let Some(prev_lit_type) = self.literal_type_from_node(clause.expression) else {
+                    let Some(prev_lit_type) =
+                        self.cached_case_clause_literal_type(clause.expression)
+                    else {
                         previous_cases_are_distinct_literals = false;
                         break;
                     };
@@ -266,7 +268,7 @@ impl<'a> FlowAnalyzer<'a> {
                     continue; // Skip default clause
                 }
 
-                if let Some(lit_type) = self.literal_type_from_node(clause.expression) {
+                if let Some(lit_type) = self.cached_case_clause_literal_type(clause.expression) {
                     excluded_types.push(lit_type);
                 } else if let Some(node_types) = self.node_types
                     && let Some(&expr_type) = node_types.get(&clause.expression.0)

--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -738,6 +738,39 @@ impl<'a> FlowAnalyzer<'a> {
         self.shared.map(|s| &s.flow_numeric_atom_cache)
     }
 
+    /// Shared switch-case-clause literal-type cache, when wired.
+    #[inline]
+    pub(crate) fn shared_switch_case_literal_cache(
+        &self,
+    ) -> Option<&'a RefCell<FxHashMap<u32, Option<TypeId>>>> {
+        self.shared.map(|s| &s.flow_switch_case_literal_cache)
+    }
+
+    /// Literal `TypeId` of a switch-case clause expression, memoized.
+    ///
+    /// `literal_type_from_node` is a pure function of the immutable post-bind
+    /// AST node, so this caches its result keyed by the clause-expression
+    /// `NodeIndex`. `narrow_by_switch_case_clause` scans every earlier clause on
+    /// every case, so without memoization an N-arm literal switch re-derives (and
+    /// re-interns) O(N^2) case labels; the shared cache makes the per-switch
+    /// literal materialization O(N) total.
+    ///
+    /// When the shared bundle is absent (isolated unit-test analyzers), this
+    /// falls through to direct computation and preserves identical behavior — it
+    /// only skips the memo.
+    #[inline]
+    pub(crate) fn cached_case_clause_literal_type(&self, idx: NodeIndex) -> Option<TypeId> {
+        let Some(cache) = self.shared_switch_case_literal_cache() else {
+            return self.literal_type_from_node(idx);
+        };
+        if let Some(&hit) = cache.borrow().get(&idx.0) {
+            return hit;
+        }
+        let computed = self.literal_type_from_node(idx);
+        cache.borrow_mut().insert(idx.0, computed);
+        computed
+    }
+
     /// Shared alias path-assignment memo, when wired.
     /// Key: (`alias_symbol`, `target_reference_node`, `antecedent_flow`) ->
     /// whether the backward path from the antecedent to the alias declaration


### PR DESCRIPTION
Goal: fast

Removes an O(N²) term in discriminated-union switch narrowing: `narrow_by_switch_case_clause` re-derives every *predecessor* case-label literal on every case, so an N-case switch performs Σ_{K=0..N} O(K) = O(N²) string interns.

## Structural rule
For `case 'eventK':`, `narrow_by_switch_case_clause` (`crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs:217-239`) walks ALL K previous case clauses and calls `literal_type_from_node(clause.expression)` → `interner.literal_string("eventJ")` for each (to build the distinct-literal / excluded-type sets). Each of the N cases triggers its own flow re-narrow that re-runs this predecessor scan, giving O(N²) literal interns — the single dominant frame at large N (`sample` on a 3200-case switch: `intern_string` 255 samples, `literal_type_from_node` 210, reached only via `narrow_by_switch_case_clause`).

`literal_type_from_node(clause.expression)` is a pure function of the (immutable, post-bind) clause-expression `NodeIndex`. This PR memoizes it in a per-`CheckerContext` `FlowSharedCaches.flow_switch_case_literal_cache` (`FxHashMap<NodeIndex, Option<TypeId>>`), collapsing the predecessor scans from O(K) interns to O(K) cached hits and the per-switch literal materialization from O(N²) to O(N).

## Cache contract (per PERFORMANCE_PLAN.md)
- **Key**: clause-expression `NodeIndex.0` (u32) → `Option<TypeId>`.
- **Invalidation**: none needed within a check pass — literals are immutable post-bind AST; the cache is constructed fresh per `CheckerContext` (one per file check) and dropped at file-check end.
- **Semantic modes in key**: none — `literal_type_from_node` has no compiler-option dependence; it returns the literal type of an AST node.
- **Behavior when absent/disabled**: identical — the memo returns the exact value the function would compute; a cold cache just recomputes once.
- **Memory**: one small entry per switch-case-label node per file check; bounded by case-label count, freed at file boundary.

## Performance (timing mode, counters OFF; best-of-N, source release build)
| Fixture | clean-main | this PR | speedup |
|---|---|---|---|
| discriminated-union switch, N=800 | 0.18s | 0.16s | 1.12x |
| N=1600 | 0.75s | 0.62s | 1.21x |
| N=3200 | 2.91s | 2.35s | **1.24x** |

The speedup grows with N — the signature of removing an O(N²) term. On intern-dominated switches (cases that don't co-trigger heavy property-access) the structural win is larger: a literal-only switch's `intern_string` self-time drops from 255 `sample` frames to 2. The remaining N=3200 cost is a *separate* O(N²) in per-case property-access/widening over the N-member union (filed as a follow-up); this PR removes the literal-intern quadratic only.

## Diagnostic status / verification
- Full local conformance (release): 12583/12585, zero new vs accepted regressions (only the 2 accepted Mac-delta cases).
- Byte-identical diagnostics (empty diff) clean-main vs this PR on the union witness and ts-toolbelt-flat.
- `cargo nextest run -p tsz-checker` A/B vs clean main: identical failure set (zero new, zero newly-fixed); switch/narrow/discriminant subset 649/654 (the 5 fails pre-exist on main). Solver untouched.
- ts-toolbelt-flat: 0.44s → 0.43s (within noise — it has no large-N literal switches; no regression).
- clippy --all-targets clean; no new `#[allow]`; arch_guard + 2000-line caps pass.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: max
