### PR TITLE
fix(checker): append-only diagnostics buffer — one finalize boundary, build-before-push elaboration

### DIFF
--- a/crates/tsz-checker/src/assignability/assignment_checker/js_global_fallback.rs
+++ b/crates/tsz-checker/src/assignability/assignment_checker/js_global_fallback.rs
@@ -105,17 +105,25 @@ impl<'a> CheckerState<'a> {
         let target_display =
             self.checked_js_global_element_access_fallback_target_display(fallback_idx);
 
-        for diag in &mut self.ctx.diagnostics[diag_count_before..] {
-            if matches!(
-                diag.code,
-                diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE
-                    | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE
-                    | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE
-            ) && diag.start >= fallback_node.pos
-                && diag.start < fallback_node.end
-            {
-                diag.start = anchor.start;
-                diag.length = anchor.length;
+        let fallback_pos = fallback_node.pos;
+        let fallback_end = fallback_node.end;
+        let anchor_start = anchor.start;
+        let anchor_length = anchor.length;
+
+        self.ctx
+            .finalize_recent_diagnostics(diag_count_before, |diag| {
+                if !matches!(
+                    diag.code,
+                    diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE
+                        | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE
+                        | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE
+                ) || diag.start < fallback_pos
+                    || diag.start >= fallback_end
+                {
+                    return;
+                }
+                diag.start = anchor_start;
+                diag.length = anchor_length;
                 if let Some(display) = target_display.as_deref()
                     && let Some(name) = display.strip_prefix("typeof ")
                 {
@@ -123,8 +131,7 @@ impl<'a> CheckerState<'a> {
                     let qualified = format!("required in type '{display}'");
                     diag.message_text = diag.message_text.replace(&bare, &qualified);
                 }
-            }
-        }
+            });
     }
 
     pub(crate) fn checked_js_global_element_access_fallback_target_display(

--- a/crates/tsz-checker/src/checkers/jsx/children.rs
+++ b/crates/tsz-checker/src/checkers/jsx/children.rs
@@ -1337,22 +1337,23 @@ impl<'a> CheckerState<'a> {
     fn rewrite_recent_jsx_element_source_display(&mut self, diagnostics_start: usize) {
         use crate::diagnostics::diagnostic_codes;
 
-        for diagnostic in self.ctx.diagnostics.iter_mut().skip(diagnostics_start) {
-            if diagnostic.code
-                != diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE
-                && diagnostic.code
-                    != diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE
-                && diagnostic.code
-                    != diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE
-            {
-                continue;
-            }
+        self.ctx
+            .finalize_recent_diagnostics(diagnostics_start, |diagnostic| {
+                if diagnostic.code
+                    != diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE
+                    && diagnostic.code
+                        != diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE
+                    && diagnostic.code
+                        != diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE
+                {
+                    return;
+                }
 
-            diagnostic.message_text =
-                diagnostic
-                    .message_text
-                    .replacen("Type 'Element'", "Type 'ReactElement<any>'", 1);
-        }
+                diagnostic.message_text =
+                    diagnostic
+                        .message_text
+                        .replacen("Type 'Element'", "Type 'ReactElement<any>'", 1);
+            });
     }
 
     fn report_jsx_multiple_children_individual_assignability(
@@ -1462,11 +1463,12 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
-        for diagnostic in self.ctx.diagnostics.iter_mut().skip(diagnostics_start) {
-            diagnostic.message_text = diagnostic
-                .message_text
-                .replace(raw_target_display, normalized_target_display);
-        }
+        self.ctx
+            .finalize_recent_diagnostics(diagnostics_start, |diagnostic| {
+                diagnostic.message_text = diagnostic
+                    .message_text
+                    .replace(raw_target_display, normalized_target_display);
+            });
     }
 
     fn jsx_multiple_children_expected_union_for_display(&mut self, type_id: TypeId) -> TypeId {

--- a/crates/tsz-checker/src/context/diagnostic_push.rs
+++ b/crates/tsz-checker/src/context/diagnostic_push.rs
@@ -267,6 +267,47 @@ impl<'a> CheckerContext<'a> {
         self.diagnostics.push(diag);
     }
 
+    /// Read-only view of the diagnostics emitted since the buffer held `start`
+    /// entries.
+    ///
+    /// Checker paths that inspect their own freshly emitted diagnostics (to
+    /// decide a downgrade, detect an excess-property report, etc.) should go
+    /// through this accessor rather than indexing `diagnostics` directly, so
+    /// the buffer's `Vec` representation stays an implementation detail of the
+    /// context. `start` is clamped, so a speculative shrink between capture and
+    /// read cannot panic the slice.
+    pub(crate) fn recent_diagnostics(&self, start: usize) -> &[Diagnostic] {
+        &self.diagnostics[start.min(self.diagnostics.len())..]
+    }
+
+    /// Finalize the diagnostics emitted since the buffer held `start` entries.
+    ///
+    /// Some checker paths can only compute a diagnostic's final span, code, or
+    /// message after the sub-check that emitted it has run — for example,
+    /// repositioning a missing-property error onto an initializer anchor, or
+    /// downgrading TS2739 to TS2322 once the relation outcome is known. Routing
+    /// every such finalization through this one boundary keeps the buffer's
+    /// `Vec` representation an implementation detail of the context instead of
+    /// scattering raw `diagnostics[start..]` index patching across the checker,
+    /// and confines the "the tail may still be rewritten" window to a single,
+    /// documented place. `start` is clamped, so a speculative shrink between
+    /// emission and finalization cannot panic the slice.
+    ///
+    /// The `diagnostic_indices` aux state is intentionally left untouched: the
+    /// tail was already deduplicated and indexed when it was first pushed, so
+    /// finalizing in place reproduces exactly what the prior scattered in-place
+    /// patching produced.
+    pub(crate) fn finalize_recent_diagnostics(
+        &mut self,
+        start: usize,
+        mut finalize: impl FnMut(&mut Diagnostic),
+    ) {
+        let len = self.diagnostics.len();
+        for diag in &mut self.diagnostics[start.min(len)..] {
+            finalize(diag);
+        }
+    }
+
     /// Reconcile precedence between the name-resolution diagnostics that can
     /// collide at one span: TS2301 ("Initializer of instance member cannot
     /// reference identifier declared in constructor") outranks TS2304 ("Cannot

--- a/crates/tsz-checker/src/error_reporter/assignability.rs
+++ b/crates/tsz-checker/src/error_reporter/assignability.rs
@@ -328,15 +328,26 @@ impl<'a> CheckerState<'a> {
 
         use crate::diagnostics::diagnostic_codes;
 
-        // When a value anchor is supplied, reposition missing-property codes
-        // (TS2741/TS2739/TS2740) to anchor on the property value — matching
-        // tsc's `elaborateElementwise` behavior that uses the initializer as
-        // the error node for missing-property elaborations.
-        if let Some(value_anchor_src) = value_anchor_idx {
+        // The missing-property elaboration codes (TS2741/TS2739/TS2740) whose
+        // span and code are finalized below once the value anchor and downgrade
+        // decision are known.
+        let is_missing_property = |code: u32| {
+            matches!(
+                code,
+                diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE
+                    | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE
+                    | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE
+            )
+        };
+
+        // When a value anchor is supplied, missing-property codes are
+        // repositioned to anchor on the property value — matching tsc's
+        // `elaborateElementwise` behavior that uses the initializer as the error
+        // node for missing-property elaborations.
+        let value_span = value_anchor_idx.and_then(|value_anchor_src| {
             let resolved_value_anchor =
                 self.resolve_diagnostic_anchor_node(value_anchor_src, DiagnosticAnchorKind::Exact);
-            let value_span = self
-                .resolve_diagnostic_anchor(resolved_value_anchor, DiagnosticAnchorKind::Exact)
+            self.resolve_diagnostic_anchor(resolved_value_anchor, DiagnosticAnchorKind::Exact)
                 .map(|anchor| (anchor.start, anchor.length))
                 .or_else(|| {
                     self.get_node_span(resolved_value_anchor).map(|(pos, end)| {
@@ -346,55 +357,47 @@ impl<'a> CheckerState<'a> {
                             end.saturating_sub(pos),
                         )
                     })
-                });
-            if let Some((start, length)) = value_span {
-                for diag in &mut self.ctx.diagnostics[diag_count_before..] {
-                    if matches!(
-                        diag.code,
-                        diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE
-                            | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE
-                            | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE
-                    ) {
-                        diag.start = start;
-                        diag.length = length;
-                    }
-                }
-            }
-        }
-
-        if !downgrade_missing_to_2322 {
-            return;
-        }
-
-        let needs_downgrade = self.ctx.diagnostics[diag_count_before..].iter().any(|d| {
-            matches!(
-                d.code,
-                diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE
-                    | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE
-                    | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE
-            )
+                })
         });
-        if needs_downgrade {
+
+        // Downgrade missing-property elaborations to TS2322 when the caller asks
+        // for it and at least one such diagnostic was emitted. The replacement
+        // message is built before the buffer tail is finalized.
+        let downgrade_message = (downgrade_missing_to_2322
+            && self
+                .ctx
+                .recent_diagnostics(diag_count_before)
+                .iter()
+                .any(|d| is_missing_property(d.code)))
+        .then(|| {
             let src_str = "this".to_string();
             let tgt_str = self.format_type_for_assignability_message(target);
             let (src_str, tgt_str) =
                 self.finalize_pair_display_for_diagnostic(source, target, src_str, tgt_str);
-            let new_message = crate::diagnostics::format_message(
+            crate::diagnostics::format_message(
                 crate::diagnostics::diagnostic_messages::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE,
                 &[&src_str, &tgt_str],
-            );
-            for diag in &mut self.ctx.diagnostics[diag_count_before..] {
-                if matches!(
-                    diag.code,
-                    diagnostic_codes::PROPERTY_IS_MISSING_IN_TYPE_BUT_REQUIRED_IN_TYPE
-                        | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE
-                        | diagnostic_codes::TYPE_IS_MISSING_THE_FOLLOWING_PROPERTIES_FROM_TYPE_AND_MORE
-                ) {
+            )
+        });
+
+        if value_span.is_none() && downgrade_message.is_none() {
+            return;
+        }
+
+        self.ctx
+            .finalize_recent_diagnostics(diag_count_before, |diag| {
+                if !is_missing_property(diag.code) {
+                    return;
+                }
+                if let Some((start, length)) = value_span {
+                    diag.start = start;
+                    diag.length = length;
+                }
+                if let Some(new_message) = &downgrade_message {
                     diag.code = diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE;
                     diag.message_text = new_message.clone();
                 }
-            }
-        }
+            });
     }
     /// Diagnose why an assignment failed and report a detailed error.
     pub fn diagnose_assignment_failure(&mut self, source: TypeId, target: TypeId, idx: NodeIndex) {

--- a/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
+++ b/crates/tsz-checker/src/error_reporter/call_errors/elaboration_object_properties.rs
@@ -125,10 +125,11 @@ impl<'a> CheckerState<'a> {
         self.check_object_literal_excess_properties(source_type, effective_param_type, arg_idx);
         // `check_object_literal_excess_properties` can trigger a contextual-type
         // refresh that retains/drops earlier implicit-any diagnostics (see
-        // object_literal_support.rs). Clamp to the current length so an
-        // unrelated shrink doesn't panic the slice.
-        let scan_start = diagnostics_before_epc.min(self.ctx.diagnostics.len());
-        let had_excess_property = self.ctx.diagnostics[scan_start..]
+        // object_literal_support.rs). `recent_diagnostics` clamps its start, so
+        // an unrelated shrink cannot panic the slice.
+        let had_excess_property = self
+            .ctx
+            .recent_diagnostics(diagnostics_before_epc)
             .iter()
             .any(|diag| {
                 matches!(

--- a/crates/tsz-checker/src/error_reporter/emitters.rs
+++ b/crates/tsz-checker/src/error_reporter/emitters.rs
@@ -24,6 +24,36 @@ impl<'a> CheckerState<'a> {
         }
     }
 
+    /// Report an error at a node with its `related_information` already attached,
+    /// built as one complete `Diagnostic` value before it is pushed.
+    ///
+    /// This is the build-before-push counterpart to emitting with
+    /// [`Self::error_at_node`] and then appending related entries to the
+    /// buffer's last diagnostic: the latter silently attaches the elaboration to
+    /// the wrong entry whenever `(start, code)` deduplication drops the just
+    /// emitted diagnostic (so the previous, unrelated entry becomes `last`).
+    /// Routing the full value through [`CheckerContext::push_diagnostic`] keeps
+    /// the related-information collision reconciliation authoritative and the
+    /// buffer append-only. The main-diagnostic span is normalized exactly as
+    /// [`Self::error_at_node`] does; callers supply `related` built against
+    /// whatever spans they need.
+    pub(crate) fn error_at_node_with_related(
+        &mut self,
+        node_idx: NodeIndex,
+        message: &str,
+        code: u32,
+        related: Vec<crate::diagnostics::DiagnosticRelatedInformation>,
+    ) {
+        if let Some((start, end)) = self.get_node_span(node_idx) {
+            let raw_length = end.saturating_sub(start);
+            let (start, length) = self.normalized_anchor_span(node_idx, start, raw_length);
+            let mut diag =
+                Diagnostic::error(self.ctx.file_name.clone(), start, length, message, code);
+            diag.related_information = related;
+            self.ctx.push_diagnostic(diag);
+        }
+    }
+
     /// Report an error using a shared diagnostic anchor policy.
     pub(crate) fn error_at_anchor(
         &mut self,

--- a/crates/tsz-checker/src/state/state_checking/core.rs
+++ b/crates/tsz-checker/src/state/state_checking/core.rs
@@ -228,29 +228,34 @@ impl<'a> CheckerState<'a> {
                 self.report_isolated_decl_computed_name_dependency(name_idx);
             }
 
-            self.error_at_node(
+            // Build the "add a type annotation" elaboration as part of the
+            // diagnostic value, then emit it in one push, so the related entry
+            // can never attach to a different diagnostic that happens to be last
+            // in the buffer after `(start, code)` dedup drops this one.
+            let related = self
+                .get_node_span(name_idx)
+                .map(|(start, length)| {
+                    vec![crate::diagnostics::DiagnosticRelatedInformation {
+                        category: crate::diagnostics::DiagnosticCategory::Message,
+                        code: diagnostic_codes::ADD_A_TYPE_ANNOTATION_TO_THE_VARIABLE,
+                        file: self.ctx.file_name.clone(),
+                        start,
+                        length,
+                        message_text: crate::diagnostics::format_message(
+                            diagnostic_messages::ADD_A_TYPE_ANNOTATION_TO_THE_VARIABLE,
+                            &[&var_name],
+                        ),
+                        depth: 0,
+                    }]
+                })
+                .unwrap_or_default();
+
+            self.error_at_node_with_related(
                 name_idx,
                 diagnostic_messages::COMPUTED_PROPERTY_NAMES_ON_CLASS_OR_OBJECT_LITERALS_CANNOT_BE_INFERRED_WITH_ISOL,
                 diagnostic_codes::COMPUTED_PROPERTY_NAMES_ON_CLASS_OR_OBJECT_LITERALS_CANNOT_BE_INFERRED_WITH_ISOL,
+                related,
             );
-
-            if let Some((start, length)) = self.get_node_span(name_idx) {
-                let related = crate::diagnostics::DiagnosticRelatedInformation {
-                    category: crate::diagnostics::DiagnosticCategory::Message,
-                    code: diagnostic_codes::ADD_A_TYPE_ANNOTATION_TO_THE_VARIABLE,
-                    file: self.ctx.file_name.clone(),
-                    start,
-                    length,
-                    message_text: crate::diagnostics::format_message(
-                        diagnostic_messages::ADD_A_TYPE_ANNOTATION_TO_THE_VARIABLE,
-                        &[&var_name],
-                    ),
-                    depth: 0,
-                };
-                if let Some(last) = self.ctx.diagnostics.last_mut() {
-                    last.related_information.push(related);
-                }
-            }
 
             reported = true;
         }

--- a/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
+++ b/crates/tsz-checker/src/state/variable_checking/initializer_policy.rs
@@ -488,7 +488,8 @@ impl<'a> CheckerState<'a> {
                         let func = self.ctx.arena.get_function(init_node)?;
                         let body_node = self.ctx.arena.get(func.body)?;
                         Some(
-                            self.ctx.diagnostics[init_diagnostics_len..]
+                            self.ctx
+                                .recent_diagnostics(init_diagnostics_len)
                                 .iter()
                                 .any(|diag| {
                                     diag.start >= body_node.pos

--- a/crates/tsz-checker/src/types/computation/object_literal_support.rs
+++ b/crates/tsz-checker/src/types/computation/object_literal_support.rs
@@ -173,7 +173,9 @@ impl<'a> CheckerState<'a> {
 
         // Check if the refresh pass re-emitted any implicit-any diagnostics.
         // If so, contextual typing didn't help — keep everything.
-        let refreshed_still_has_implicit_any = self.ctx.diagnostics[pre_refresh.diagnostics_len..]
+        let refreshed_still_has_implicit_any = self
+            .ctx
+            .recent_diagnostics(pre_refresh.diagnostics_len)
             .iter()
             .any(|diag| {
                 Self::implicit_any_like_diagnostic_code(diag.code)


### PR DESCRIPTION
Goal: hold

## Summary

Closes #13080.

Several checker paths emitted a diagnostic and then reached back into
`ctx.diagnostics[start..]` (or `diagnostics.last_mut()`) to reposition, downgrade,
or rewrite it after the fact. That made the buffer's `Vec` slot layout
load-bearing, scattered raw index patching across four files, and — in one case —
attached a related-information entry to the **wrong** diagnostic.

### Structural rule

When a checker path can only finalize a diagnostic's span/code/message after the
sub-check that emitted it has run, `tsc` builds the final value and the buffer
stays append-only. tsz now does the same through a single owner boundary on
`CheckerContext` instead of scattered in-place index patching.

### What changed

- New `CheckerContext::recent_diagnostics(start)` — clamped read-only view of the
  just-emitted tail (replaces raw `diagnostics[start..]` reads).
- New `CheckerContext::finalize_recent_diagnostics(start, |d| …)` — the single,
  documented place that finalizes the tail. The `diagnostic_indices` aux/dedup
  state is intentionally left untouched, so the result is **byte-identical** to
  the prior in-place patching.
- Migrated onto the boundary: missing-property reposition/downgrade
  (`error_reporter/assignability.rs`), the JS global-element fallback relocation
  (`assignment_checker/js_global_fallback.rs`), and the two JSX display rewrites
  (`checkers/jsx/children.rs`). Range-read sites in
  `object_literal_support.rs`, `elaboration_object_properties.rs`, and
  `initializer_policy.rs` now use the accessor.
- New `error_at_node_with_related` (build-before-push): the isolatedDeclarations
  computed-property elaboration is now built as one `Diagnostic` value routed
  through `push_diagnostic`, instead of `error_at_node` followed by
  `diagnostics.last_mut().related_information.push(...)`. The old pattern silently
  attached the "add a type annotation" related entry to whatever diagnostic
  happened to be last whenever `(start, code)` dedup dropped the just-emitted one;
  `push_diagnostic` now reconciles the related information correctly.

Owner layer: checker diagnostic emission/finalization (`tsz_checker::context` /
`error_reporter`). No solver or relation semantics touched. The printer/types
boundary is unchanged.

## Goal rationale (hold)

Behavior-preserving checker hygiene that removes a latent ordering/attachment
hazard; protects the conformance/emit parity floor.

## Verification

- `cargo check -p tsz-checker` — clean.
- `cargo clippy -p tsz-checker` — no warnings.
- Full `cargo test -p tsz-checker --lib` run, diffed against the branch baseline:
  **zero net-new failures** (the only run-to-run delta was two `cross_file_direct`
  `source_option_bag` tests that flap on the clean branch too — the #13255
  parallel-schedule family — confirmed by running them in isolation on both
  branches).
- Targeted suites green and unchanged vs baseline: `isolated` (4/4),
  `ts2739` (9/9), `excess_propert` (105/3 — same 3 pre-existing
  `ts2353_generic_constraint` failures on clean), `jsx` (405/3 — same 3
  pre-existing failures on clean).
- ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high