### PR TITLE
fix(bench/ci): exempt successfully-published catch-up dispatches from the throttle (#13306)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1779,6 +1779,13 @@ jobs:
           now_epoch="$(date -u +%s)"
           while IFS=$'\t' read -r run_id created_at status conclusion run_sha run_url; do
             [[ -n "${run_id:-}" ]] || continue
+            # A catch-up dispatch that already published (conclusion=success)
+            # advanced freshness, so it must not throttle a fresh catch-up for a
+            # newer main — otherwise a successful-but-now-stale dispatch blocks
+            # "catch up no matter how many commits land" for up to the interval.
+            # Failed/cancelled/running dispatches still keep the cooldown,
+            # preserving the anti-loop-burn intent of #13306 rec 4.
+            [[ "${conclusion}" == "success" ]] && continue
             created_epoch="$(date -u -d "${created_at}" +%s 2>/dev/null || true)"
             if [[ "${created_epoch}" =~ ^[0-9]+$ &&
                   $((now_epoch - created_epoch)) -lt "${min_catch_up_interval_seconds}" ]]; then
@@ -1931,6 +1938,13 @@ jobs:
           now_epoch="$(date -u +%s)"
           while IFS=$'\t' read -r run_id created_at status conclusion run_sha run_url; do
             [[ -n "${run_id:-}" ]] || continue
+            # A catch-up dispatch that already published (conclusion=success)
+            # advanced freshness, so it must not throttle a fresh catch-up for a
+            # newer main — otherwise a successful-but-now-stale dispatch blocks
+            # "catch up no matter how many commits land" for up to the interval.
+            # Failed/cancelled/running dispatches still keep the cooldown,
+            # preserving the anti-loop-burn intent of #13306 rec 4.
+            [[ "${conclusion}" == "success" ]] && continue
             created_epoch="$(date -u -d "${created_at}" +%s 2>/dev/null || true)"
             if [[ "${created_epoch}" =~ ^[0-9]+$ &&
                   $((now_epoch - created_epoch)) -lt "${min_catch_up_interval_seconds}" ]]; then


### PR DESCRIPTION
## Summary

Follow-up to #13591 closing one of the serialization gaps documented on #13306. The catch-up dispatch throttle (`BENCH_CATCH_UP_MIN_INTERVAL_HOURS=4`) counts **every** recent `workflow_dispatch` run with **no conclusion filter**, so a catch-up dispatch that **already published** still suppresses a fresh catch-up for up to 4h. When `main` moves again after a successful-but-now-stale catch-up, the next genuinely-needed catch-up is blocked — directly contradicting the "catch up no matter how many commits land" requirement and leaving `latest.json` stale.

## Structural rule

When deciding whether to throttle a catch-up dispatch, a prior dispatch that **succeeded** (`conclusion == "success"`) already advanced public benchmark freshness, so it must not block a new catch-up for a newer `main`. Only **failed/cancelled/running** dispatches keep the cooldown — preserving the anti-loop-burn intent of #13306 rec 4 (a failing dispatch must not be re-fired in a tight loop that burns Cloud Build capacity). Owner: the `catch-up` and `catch-up-after-active` throttle loops in `.github/workflows/bench.yml`.

## Change

One line added to **both** throttle loops, immediately after the empty-row guard:

```bash
[[ "${conclusion}" == "success" ]] && continue
```

- **Success dispatch within window** → not counted → a fresh catch-up for newer `main` is allowed (each catch-up is still a full bench run serialized by `bench-gate`, so this is freshness, not loop-burn).
- **Failed/cancelled/running dispatch within window** → still throttles (anti-loop-burn intact).

## Why it does not loop-burn

Each catch-up dispatch is a full benchmark run gated one-at-a-time by `bench-gate` and takes a bench-duration (~30–90 min). Exempting *successful* dispatches lets freshness track `main` at most once per bench-duration, each run producing fresh public data. A *failing* dispatch still cools down for the full interval, so a broken dispatch cannot be re-fired rapidly.

## Verification

- Decision logic **unit-tested** (6 cases): recent-failed throttles · recent-success allows · recent-cancelled throttles · old-failed allows · mixed (a failure still throttles) · empty allows — all pass.
- `python3 yaml.safe_load` — YAML well-formed.
- `bash -n` on every extracted `run:` block — all OK.
- `actionlint` warning set **byte-identical** to pristine `main` (no new issues).
- `node scripts/bench/test-bench-workflow-{cloudbuild-prep,cloudbuild-shards,micro-coverage}.mjs` — all pass.

Remaining serialization gaps (multi-commit deferral; 180-min stale-break concurrency) stay documented on #13306 for separate, individually-tested follow-ups.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: max

Goal: fast
