### PR TITLE
ci: run full CI on every open PR (remove draft two-phase)

### DIFF
--- a/.agents/skills/tsz-ci-pr/SKILL.md
+++ b/.agents/skills/tsz-ci-pr/SKILL.md
@@ -15,7 +15,7 @@ Use for PR checks, CI triage, ready state, queue evidence, and landing. Use
   high`).
 - The PR author lands their own PR; never idle-wait on CI between pushes.
 - Never merge draft/WIP PRs (`draft`, `WIP`, `[WIP]`, or body/branch says WIP).
-- Ready PRs run heavy CI. Draft PRs intentionally run light CI.
+- Every open PR runs the full CI suite (draft or not); path-based content skips apply only to docs-only or tooling-only diffs.
 - Ready PRs land through GitHub's native merge queue.
 - If asked to land, verify `state: MERGED`; an armed queue request alone is not enough.
 

--- a/.agents/skills/tsz-pr-coordination/SKILL.md
+++ b/.agents/skills/tsz-pr-coordination/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tsz-pr-coordination
-description: Create, refresh, and publish TSZ pull requests with correct body and state. Use when opening a draft PR, updating a PR body, changing WIP/draft/ready state, acknowledging review, or making sure a TSZ PR satisfies the Goal, Verification, Provenance, and overlap rules.
+description: Create, refresh, and publish TSZ pull requests with correct body and state. Use when opening a PR, updating a PR body, changing WIP/draft/ready state, acknowledging review, or making sure a TSZ PR satisfies the Goal, Verification, Provenance, and overlap rules.
 ---
 
 # TSZ PR Coordination

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,8 @@ narrowing, emit, edge cases, and project-row behavior.
 - Do not update the roadmap for routine status, small fixes, cleanup, or PR
   bookkeeping. Use PR bodies, PR/review comments, or issues.
 - Inspect open PRs, recent merged PRs, and relevant issues before coding.
-- Open or update a draft PR early for roadmap-adjacent implementation.
+- Open or update a PR early for roadmap-adjacent implementation. Every open PR
+  runs the full CI suite; do not open a draft to dodge heavy CI.
 
 ## Architecture
 - Pipeline: `scanner -> parser -> binder -> checker -> solver -> emitter`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft, edited]
+    types: [opened, reopened, synchronize, ready_for_review, edited]
   merge_group:
   push:
     branches:
@@ -42,7 +42,6 @@ jobs:
       metadata_only_skip: ${{ steps.gate.outputs.metadata_only_skip }}
       metadata_active_suite_found: ${{ steps.gate.outputs.metadata_active_suite_found }}
       compiler_checks_required: ${{ steps.gate.outputs.compiler_checks_required }}
-      unit_packages: ${{ steps.gate.outputs.unit_packages }}
     steps:
       - id: metadata-active-suite
         if: github.event_name == 'pull_request' && github.event.action == 'edited'
@@ -101,7 +100,6 @@ jobs:
           perf_tool_only=false
           arch_tool_only=false
           compiler_checks_required=true
-          unit_packages=""
           if [[ "${{ github.event_name }}" == "merge_group" ]]; then
             # Native merge queue validates a GitHub-owned synthetic merge
             # commit. Run the same Cloud Run-backed compiler suite here so
@@ -139,12 +137,9 @@ jobs:
               should_run=false
               metadata_only_skip=true
             fi
-            if [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
-              # Draft PRs still run the light CI suite (lint, build, unit).
-              # Heavy suites wait until the PR is marked ready for review.
-              full_run=false
-              required_summary=false
-            fi
+            # Two-phase CI removed: every open PR (draft or not) runs the full
+            # CI suite and reports the required "CI Summary". Path-based content
+            # skips (docs-only / *-tool-only) below still trim jobs.
             # Docs-only PRs cannot affect cargo build/test/conformance, so
             # skip CI jobs when every changed path matches
             # one of the docs-only patterns. The gate job itself + the
@@ -236,38 +231,8 @@ jobs:
                 arch_tool_only=true
               fi
             fi
-            # P4 — draft-phase fast-fail: narrow the unit job to the touched
-            # crates' tests when the diff is safely localized. Ready-for-review
-            # PRs always run the full unit suite (correctness gate); only draft
-            # PRs use the narrow set.
-            #
-            # Narrowing is "safe" when EVERY changed file is either:
-            #   * under `crates/<known-unit-crate>/src|tests|benches|examples/`
-            #   * a `.md`/docs path (already filtered by docs-only above)
-            # And NONE of these "blast-radius" paths is touched:
-            #   * root `Cargo.{toml,lock}`, `.cargo/`, `rust-toolchain*`
-            #   * `crates/*/Cargo.toml`, `crates/*/build.rs`
-            #   * `scripts/ci/`, `.github/workflows/`
-            #   * a non-unit-tested crate (tsz-cli, tsz-conformance, tsz-lowering,
-            #     tsz-wasm, tsz-website) — these can transitively affect unit
-            #     test behavior via integration points
-            #
-            # When a blast-radius path is touched, fall back to the full unit
-            # suite even on drafts. Lint always runs across the full workspace
-            # regardless, so compile breakage in any crate still surfaces fast.
-            if [[ "$should_run" == "true" \
-                  && "${{ github.event.pull_request.draft }}" == "true" \
-                  && -n "${path_classification:-}" ]]; then
-              unit_packages=$(printf '%s' "$path_classification" | jq -r '.draftUnitNarrow.unitPackages | join(" ")')
-              if [[ -n "$unit_packages" ]]; then
-                echo "P4 draft fast-fail: narrowing unit to: ${unit_packages}"
-                printf '%s' "$path_classification" | jq -r '.draftUnitNarrow.cratePaths[]' | sed 's/^/  touched: /'
-              fi
-              if [[ -z "$unit_packages" ]]; then
-                reasons=$(printf '%s' "$path_classification" | jq -r '.draftUnitNarrow.reason')
-                echo "P4 draft fast-fail: NOT narrowing (${reasons:-no eligible crates})"
-              fi
-            fi
+            # Draft-phase unit narrowing removed with the two-phase CI: every
+            # open PR runs the full unit suite. Path-based skips above still apply.
             if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
               # Fork PRs cannot use self-hosted runners by default (untrusted
               # code on shared infra). A maintainer must add the
@@ -427,12 +392,11 @@ jobs:
           echo "metadata_only_skip=${metadata_only_skip}" >> "$GITHUB_OUTPUT"
           echo "metadata_active_suite_found=${METADATA_ACTIVE_SUITE_FOUND:-false}" >> "$GITHUB_OUTPUT"
           echo "compiler_checks_required=${compiler_checks_required}" >> "$GITHUB_OUTPUT"
-          echo "unit_packages=${unit_packages}" >> "$GITHUB_OUTPUT"
 
   pr-body-gate:
     name: pr-body-gate
     needs: gate
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,9 +10,9 @@ cd tsz
 ./scripts/setup/setup.sh   # installs hooks, initializes TypeScript submodule
 ```
 
-Open a draft PR to run the light CI suite: lint, dist-fast build, and unit
-tests. Mark the PR ready for review when it should run the heavy suites:
-WASM, conformance, emit, fourslash, and snapshot gates.
+Open a PR to run CI. Every open PR runs the full suite: lint, build, unit
+tests, WASM, conformance, emit, fourslash, and snapshot gates. Path-based
+skips still apply for docs-only or tooling-only changes.
 
 When a ready PR's exact head has passed the PR-head gates (`CI Summary`,
 and any review/body checks), the PR author
@@ -59,14 +59,14 @@ python3 scripts/conformance/query-conformance.py --dashboard
 
 ### Workflow For Semantic Changes
 
-1. **Check active work** — inspect draft PRs, open PRs, recent merged PRs, and relevant issues before starting
-2. **Claim the scope** — open a draft PR early; a GitHub issue is optional
+1. **Check active work** — inspect open PRs, recent merged PRs, and relevant issues before starting
+2. **Claim the scope** — open a PR early; a GitHub issue is optional
 3. **Research** — use offline analysis tools and existing tests before running heavy commands
 4. **Understand the root cause** — read the relevant checker/solver code
 5. **Fix the root cause** — not a symptom. Follow architecture rules
 6. **Verify narrowly** — run only targeted local checks needed for debugging
-7. **Push updates to the draft PR** — let CI run build, lint, and unit tests; do not wait idle
-8. **Mark ready for review** — triggers conformance, emit, fourslash, WASM, and snapshot gates
+7. **Push updates to the PR** — every push runs the full CI suite; do not wait idle
+8. **Mark ready for review** — when the change is complete; CI already ran the full suite on every push
 9. **Land your own PR** — after exact-head PR-head gates pass,
    queue the PR yourself with
    `gh pr merge <pr> --match-head-commit <sha>`; native queue admission and
@@ -75,7 +75,7 @@ python3 scripts/conformance/query-conformance.py --dashboard
 Every PR body must include a `Goal: <green|fast|grow|hold>` line, a
 `## Verification` section, and a `## Provenance` block with `Machine:`,
 `Assistant:`, `Model:`, and `Effort:` lines reporting your actual runtime
-values; the `pr-body-gate` CI job enforces these. Use the draft PR body for
+values; the `pr-body-gate` CI job enforces these. Use the PR body for
 scope, invariants, findings, and verification.
 
 When adding or re-adding WIP state, leave a PR comment with the reason WIP
@@ -117,7 +117,8 @@ Hooks run automatically and check:
 - TypeScript submodule guard
 
 Build, lint, unit, WASM, conformance, emit, and fourslash verification runs in
-CI. Draft PRs get the light CI suite; ready-for-review PRs get the full suite.
+CI. Every open PR gets the full CI suite; path-based skips apply only to
+docs-only or tooling-only changes.
 
 To skip hooks in emergencies: `TSZ_SKIP_HOOKS=1 git commit -m "message"`
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -23,9 +23,8 @@ cheap and enforce:
 - TypeScript submodule guard — prevents accidental submodule edits
 
 Build, lint, unit tests, WASM, conformance, emit, and fourslash run in CI.
-Draft PRs run the light suite: lint, dist-fast build, and unit tests. Marking
-a PR ready for review runs the heavy suites: WASM, conformance, emit,
-fourslash, and snapshot gates.
+Every open PR runs the full suite on each push; path-based skips trim jobs
+for docs-only or tooling-only changes.
 
 To manually install hooks:
 ```bash
@@ -116,7 +115,7 @@ Conformance tests compare tsz diagnostics against the official TypeScript compil
 # Run one filtered test while debugging
 ./scripts/conformance/conformance.sh run --filter "testName" --verbose
 
-# Full conformance runs in CI when a PR is marked ready for review
+# Full conformance runs in CI on every open PR
 ```
 
 ### Conformance Analysis (Offline)

--- a/docs/HOW_TO_CODE.md
+++ b/docs/HOW_TO_CODE.md
@@ -245,7 +245,7 @@ Likewise, if two visitors share identical helper logic (e.g. extracting a parame
 
 Use `docs/plan/ROADMAP.md` Track 10 for current refactor/tooling priorities.
 Historical audit files and claim documents are not the coordination surface;
-open a draft PR and keep the PR body current instead.
+open a PR and keep the PR body current instead.
 
 ---
 

--- a/docs/plan/LSP_ROADMAP.md
+++ b/docs/plan/LSP_ROADMAP.md
@@ -6,7 +6,7 @@ standalone reason to start broad LSP work while project-corpus correctness is
 still the primary gate.
 
 Do not use this file as an LSP issue inventory or run log. Put current issue
-state in GitHub issues, draft PR bodies, PR comments, and CI artifacts.
+state in GitHub issues, PR bodies, PR comments, and CI artifacts.
 
 ## Mission
 

--- a/docs/plan/ROADMAP.md
+++ b/docs/plan/ROADMAP.md
@@ -145,7 +145,7 @@ and no reviewer role.
    queue with `gh pr merge <pr> --match-head-commit <sha>`.
 3. Land-and-continue: do not idle-wait on CI. Push, start the next task, and
    return to queue the merge when checks resolve.
-4. Check open PRs and recent merges for overlap before starting. A draft PR
+4. Check open PRs and recent merges for overlap before starting. A PR
    with a clear body claims active work; drain owned PRs before unrelated new
    work.
 5. Never merge WIP: draft state, `WIP` label, `[WIP]` title, or a body that


### PR DESCRIPTION
## Summary

Removes the **two-phase CI** (drafts ran a reduced "light" suite; heavy suites — WASM/conformance/emit/fourslash/snapshot — waited until `ready_for_review`). Now **every open PR, draft or not, runs the full CI suite** and reports the branch-protection-required `CI Summary`.

Concretely in `.github/workflows/ci.yml` gate:
- Removed the `pull_request.draft == true → full_run=false; required_summary=false` branch (drafts now inherit the `full_run=true` default).
- Removed the P4 `draftUnitNarrow` block (drafts ran a narrowed unit set).
- `pr-body-gate` now runs on drafts too (`if: github.event_name == 'pull_request'`), so a draft's Goal/Provenance body is actually enforced.
- Dropped the now-no-op `converted_to_draft` trigger and the dead `unit_packages` plumbing (producer-only; never consumed).

**Preserved** (verified separate, correct semantics): the `merge_group` path, the metadata-edit branch + its "CI Light Summary", the labeled-event skip, and the four **path-based content skips** (docs-only / bench-shell-only / perf-tool-only / arch-tool-only) — those are efficiency optimizations, not the draft two-phase, and still trim jobs for docs/tooling-only diffs.

Also updates agent/contributor instructions to stop recommending proactive draft PRs and the light-CI model (CLAUDE.md, CONTRIBUTING, DEVELOPMENT, HOW_TO_CODE, ROADMAP, LSP_ROADMAP, `tsz-ci-pr` + `tsz-pr-coordination` skills). The **never-merge-WIP/draft** merge-safety rules are kept unchanged.

Goal: hold

## Provenance

Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — valid; no `pull_request.draft`/`draftUnitNarrow`/`unit_packages`/`converted_to_draft` references remain in the gate.
- `python3 scripts/agents/llm-context-audit.py` — `status=pass`, `finding_count=0`.
- Merge-safety rules retained: `Never merge WIP` (ROADMAP), never-merge-draft (`tsz-ci-pr` skill) unchanged.
- Behavioral check (post-merge / on this PR): because this PR edits `.github/workflows/**`, the gate runs the full suite; a follow-up draft PR touching a crate should now run conformance/emit/fourslash/dist-binaries and post `CI Summary` (not `CI Light Summary`), while a docs-only draft still skips heavy jobs and posts `CI Summary`.
