### PR TITLE
perf(ci): shard project-compile-canary 3-way with aggregate recombiner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -718,18 +718,33 @@ jobs:
         run: node scripts/ci/project-compatibility.mjs format-step-summary >> "${GITHUB_STEP_SUMMARY}"
 
   project-compile-canary:
-    name: project-compile-canary
+    # Canary rows run serially per shard. Sharding the row set 3-way (mirrors
+    # the conformance shard fan-out) lets three self-hosted runners share the
+    # canary set in parallel, cutting ~9-10 min off the wave-2 CI tail. The
+    # per-shard partition is keyed on each row's stable index in
+    # TSZ_COMPILE_GUARD_CANARY_ROWS (see scripts/ci/project-compile-guard.sh),
+    # so the union of all shards is the full set with no overlap. The
+    # project-compile-canary-aggregate job recombines the per-shard
+    # compatibility jsonl/summary into the same project-compile-canary-logs
+    # artifact the single job produced.
+    name: project-compile-canary-${{ matrix.shard }}
     needs: [gate, dist-binaries]
     if: needs.gate.outputs.full_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true'
     runs-on: [self-hosted, tsz-cloud-run]
     timeout-minutes: 45
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2]
     env:
       npm_config_cache: ${{ github.workspace }}/.ci-cache/npm-project-compile-canary
       TSZ_CI_CACHE_SAVE: "0"
       TSZ_PROJECT_COMPILE_SET: canary
       TSZ_PROJECT_COMPILE_ALLOW_FAILURES: "1"
       TSZ_PROJECT_COMPILE_INCLUDE_GENERATED_APPS: "0"
+      _TSZ_CI_CANARY_SHARD_INDEX: ${{ matrix.shard }}
+      _TSZ_CI_CANARY_SHARD_COUNT: 3
     steps:
       - uses: actions/checkout@v4
         with:
@@ -743,6 +758,120 @@ jobs:
         run: mkdir -p .target/dist-fast && tar -C .target/dist-fast -xf dist-fast-binaries.tar
       - name: Run compile canaries
         run: scripts/ci/project-compile-guard.sh
+      - name: Upload compile canary logs
+        if: always()
+        id: project_compile_canary_artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: project-compile-canary-logs-${{ matrix.shard }}
+          path: |
+            .target/project-compile-guard/*.log
+            .target/project-compile-guard/project-compatibility.jsonl
+            .target/project-compile-guard/project-compatibility-summary.json
+            .target/project-compile-guard/type-challenges-readiness-pairing.json
+            .target/project-compile-guard/type-challenges-assertions/type-challenges-assertions-classification.json
+            .target/project-compile-guard/type-challenges-assertions/type-challenges-assertions-manifest.json
+            .target/project-compile-guard/type-challenges-assertions-tsc-clean/**
+            .target/project-compile-guard/type-challenges-solutions/.tsz-compile/type-challenges-solutions-manifest.json
+          retention-days: 7
+          if-no-files-found: warn
+          compression-level: 1
+      - name: Summarize compile canary compatibility artifact
+        if: always()
+        env:
+          SUMMARY_INPUT_FILE: .target/project-compile-guard/project-compatibility-summary.json
+          SUMMARY_TITLE: Compile canary compatibility artifact (shard ${{ matrix.shard }})
+          SUMMARY_ARTIFACT_NAME: project-compile-canary-logs-${{ matrix.shard }}
+          SUMMARY_ARTIFACT_URL: ${{ steps.project_compile_canary_artifact.outputs.artifact-url }}
+          SUMMARY_JSONL_PATH: .target/project-compile-guard/project-compatibility.jsonl
+        run: node scripts/ci/project-compatibility.mjs format-step-summary >> "${GITHUB_STEP_SUMMARY}"
+
+  project-compile-canary-aggregate:
+    # Recombine the per-shard canary compatibility data into the single
+    # project-compile-canary-logs artifact the downstream consumers expect.
+    # Mirrors conformance-aggregate: wait for the shard artifacts to index,
+    # download them, concatenate the per-shard project-compatibility.jsonl
+    # rows into one combined jsonl, and regenerate
+    # project-compatibility-summary.json from the combined rows so the summary
+    # is byte-shape-identical to the pre-shard single-job output.
+    name: project-compile-canary-aggregate
+    needs: [gate, project-compile-canary]
+    if: needs.gate.outputs.full_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true' && !cancelled() && needs.project-compile-canary.result != 'skipped' && needs.project-compile-canary.result != 'cancelled'
+    runs-on: [self-hosted, tsz-cloud-run]
+    timeout-minutes: 15
+    continue-on-error: true
+    env:
+      TSZ_CI_CACHE_SAVE: "0"
+      TSZ_PROJECT_COMPILE_SET: canary
+      TSZ_PROJECT_COMPILE_ALLOW_FAILURES: "1"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Wait for canary shard artifacts to be indexed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          EXPECTED=3
+          MAX_WAIT=180
+          INTERVAL=10
+          elapsed=0
+          count=0
+          echo "Polling for all ${EXPECTED} project-compile-canary-logs-* artifacts (max ${MAX_WAIT}s)..."
+          while [ "$elapsed" -lt "$MAX_WAIT" ]; do
+            api_response=$(curl -sf \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}/artifacts?per_page=100" \
+              2>/dev/null || echo '{}')
+            count=$(echo "$api_response" | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          c = sum(1 for a in data.get('artifacts', []) if a['name'].startswith('project-compile-canary-logs-'))
+          print(c)
+          " 2>/dev/null || echo 0)
+            echo "  ${count}/${EXPECTED} shard artifacts indexed (${elapsed}s elapsed)"
+            if [ "${count}" -ge "${EXPECTED}" ]; then
+              echo "All ${EXPECTED} shard artifacts indexed after ${elapsed}s."
+              break
+            fi
+            jobs_response=$(curl -sf \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+              2>/dev/null || echo '{}')
+            shard_summary=$(echo "$jobs_response" | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          jobs = [j for j in data.get('jobs', []) if j.get('name','').startswith('project-compile-canary-')]
+          done = [j for j in jobs if j.get('status') == 'completed']
+          failed = [j['name'] for j in done if j.get('conclusion') not in ('success','skipped')]
+          print(f'done={len(done)} failed={len(failed)} names={failed}')
+          " 2>/dev/null || echo 'done=0 failed=0 names=[]')
+            echo "  shard jobs: ${shard_summary}"
+            done_count=$(echo "$shard_summary" | grep -oP 'done=\K[0-9]+' || echo 0)
+            failed_count=$(echo "$shard_summary" | grep -oP 'failed=\K[0-9]+' || echo 0)
+            if [ "${done_count}" -ge "${EXPECTED}" ] && [ "${failed_count}" -gt 0 ]; then
+              echo "warning: ${failed_count} shard job(s) failed (runner issue); artifact(s) will not appear — proceeding with ${count} available" >&2
+              break
+            fi
+            sleep "${INTERVAL}"
+            elapsed=$(( elapsed + INTERVAL ))
+          done
+          if [ "${count}" -lt "${EXPECTED}" ]; then
+            echo "warning: only ${count}/${EXPECTED} shard artifacts indexed after ${elapsed}s; proceeding" >&2
+          fi
+      - name: Download canary shard results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: project-compile-canary-logs-*
+          path: .canary-shards
+          merge-multiple: false
+      - name: Aggregate canary compatibility results
+        id: project_compile_canary_aggregate
+        run: scripts/ci/project-compile-canary-aggregate.sh
       - name: Upload compile canary logs
         if: always()
         id: project_compile_canary_artifact
@@ -1356,7 +1485,7 @@ jobs:
       - dist-binaries
       - lsp-e2e
       - project-compile-guard
-      - project-compile-canary
+      - project-compile-canary-aggregate
       - wasm
       - wasm-web
       - node-harness-prep
@@ -1519,7 +1648,7 @@ jobs:
           if full_run and compiler_checks_required:
               required.update({
                   "project-compile-guard",
-                  "project-compile-canary",
+                  "project-compile-canary-aggregate",
                   "conformance-snapshot-gate",
               })
               required.update({

--- a/scripts/ci/project-compile-canary-aggregate.sh
+++ b/scripts/ci/project-compile-canary-aggregate.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Recombine the per-shard project-compile-canary artifacts into the single
+# project-compile-canary-logs payload the downstream consumers expect.
+#
+# The canary job is sharded N-way (see ci.yml project-compile-canary matrix and
+# scripts/ci/project-compile-guard.sh run_canary_projects). Each shard runs a
+# disjoint, ordered subset of TSZ_COMPILE_GUARD_CANARY_ROWS and uploads its own
+# project-compile-canary-logs-<shard> artifact. This script merges those shard
+# artifacts back into a single .target/project-compile-guard tree:
+#
+#   * the per-shard project-compatibility.jsonl files are concatenated (in
+#     shard order) into one combined project-compatibility.jsonl, exactly the
+#     row set the pre-shard single job produced;
+#   * project-compatibility-summary.json is regenerated from the combined jsonl
+#     via project-compatibility.mjs summary, so it is byte-shape-identical to
+#     the single-job summary (the aggregator is a pure function of the rows);
+#   * the remaining log/manifest files from every shard are copied through so
+#     the re-uploaded artifact still carries them.
+#
+# The downloaded shard artifacts live under .canary-shards/<artifact-name>/...
+# (actions/download-artifact@v4 with merge-multiple: false).
+
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+SHARDS_DIR="${TSZ_CANARY_SHARDS_DIR:-$ROOT_DIR/.canary-shards}"
+FIXTURE_ROOT="${TSZ_PROJECT_COMPILE_FIXTURE_ROOT:-$ROOT_DIR/.target/project-compile-guard}"
+COMBINED_JSONL="$FIXTURE_ROOT/project-compatibility.jsonl"
+COMBINED_SUMMARY="$FIXTURE_ROOT/project-compatibility-summary.json"
+PROJECT_SET="${TSZ_PROJECT_COMPILE_SET:-canary}"
+PROJECT_FILTER="${TSZ_PROJECT_COMPILE_FILTER:-}"
+ALLOW_FAILURES="${TSZ_PROJECT_COMPILE_ALLOW_FAILURES:-1}"
+
+mkdir -p "$FIXTURE_ROOT"
+
+if [[ ! -d "$SHARDS_DIR" ]]; then
+  echo "error: canary shards directory does not exist: $SHARDS_DIR" >&2
+  exit 1
+fi
+
+# Discover the downloaded shard artifact directories, sorted so the combined
+# jsonl row order is deterministic across runs (shard 0, then 1, then 2 ...).
+shard_dirs=()
+while IFS= read -r dir; do
+  shard_dirs+=("$dir")
+done < <(find "$SHARDS_DIR" -mindepth 1 -maxdepth 1 -type d -name 'project-compile-canary-logs-*' | sort)
+
+if [[ "${#shard_dirs[@]}" -eq 0 ]]; then
+  echo "error: no project-compile-canary-logs-* shard directories found under $SHARDS_DIR" >&2
+  find "$SHARDS_DIR" -maxdepth 2 -print >&2 || true
+  exit 1
+fi
+
+echo "Found ${#shard_dirs[@]} canary shard artifact directories:"
+printf '  %s\n' "${shard_dirs[@]}"
+
+# Copy every shard's files into the combined fixture root first (logs,
+# manifests, type-challenges trees, etc.), preserving relative structure. Later
+# shards win on path collisions for non-jsonl files; the jsonl/summary are
+# rebuilt below so any copied copies of them are intentionally overwritten.
+for dir in "${shard_dirs[@]}"; do
+  # `cp -R <dir>/. <dest>` merges the shard tree into the fixture root.
+  cp -R "$dir/." "$FIXTURE_ROOT/" 2>/dev/null || true
+done
+
+# Concatenate the per-shard jsonl rows in shard order into the combined file.
+: > "$COMBINED_JSONL"
+total_rows=0
+for dir in "${shard_dirs[@]}"; do
+  shard_jsonl="$dir/project-compatibility.jsonl"
+  if [[ -f "$shard_jsonl" ]]; then
+    shard_rows="$(grep -c . "$shard_jsonl" 2>/dev/null || echo 0)"
+    total_rows=$((total_rows + shard_rows))
+    cat "$shard_jsonl" >> "$COMBINED_JSONL"
+    echo "  merged ${shard_rows} rows from $(basename "$dir")"
+  else
+    echo "  warning: shard $(basename "$dir") has no project-compatibility.jsonl" >&2
+  fi
+done
+echo "Combined ${total_rows} canary rows into $COMBINED_JSONL"
+
+# Sum the per-shard summary failure counters so the combined summary's
+# `failures` field equals what a single serial run would have reported.
+combined_failures=0
+for dir in "${shard_dirs[@]}"; do
+  shard_summary="$dir/project-compatibility-summary.json"
+  if [[ -f "$shard_summary" ]]; then
+    shard_failures="$(node -e '
+      const fs = require("node:fs");
+      try {
+        const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        const n = Number(data && data.failures);
+        process.stdout.write(String(Number.isFinite(n) ? n : 0));
+      } catch {
+        process.stdout.write("0");
+      }
+    ' "$shard_summary" 2>/dev/null || echo 0)"
+    combined_failures=$((combined_failures + shard_failures))
+  fi
+done
+echo "Combined canary failure count: ${combined_failures}"
+
+# Regenerate the summary from the combined jsonl. project-compatibility.mjs
+# summary is a pure function of the rows + these env knobs, so the output is
+# shape-identical to the single-job summary (same keys, same aggregation).
+SUMMARY_JSONL_FILE="$COMBINED_JSONL" \
+SUMMARY_OUTPUT_FILE="$COMBINED_SUMMARY" \
+SUMMARY_OUTPUT_ROOT="$FIXTURE_ROOT" \
+SUMMARY_PROJECT_SET="$PROJECT_SET" \
+SUMMARY_PROJECT_FILTER="$PROJECT_FILTER" \
+SUMMARY_ALLOW_FAILURES="$ALLOW_FAILURES" \
+SUMMARY_FAILURES="$combined_failures" \
+node scripts/ci/project-compatibility.mjs summary
+
+echo "Wrote combined canary summary to $COMBINED_SUMMARY"

--- a/scripts/ci/project-compile-guard.sh
+++ b/scripts/ci/project-compile-guard.sh
@@ -878,14 +878,35 @@ run_required_projects() {
   return 0
 }
 
+# True when the canary row at 0-based array position $1 belongs to this shard.
+# Sharding is keyed on the row's stable index in TSZ_COMPILE_GUARD_CANARY_ROWS
+# (a deterministic, ordered list) so the union of all shards equals the full
+# set with no overlap, independent of which rows are filtered out by
+# should_check_project. When _TSZ_CI_CANARY_SHARD_COUNT is unset (local and
+# `all`-set runs) every index is in-shard, preserving the serial behavior.
+canary_row_in_shard() {
+  local index="$1"
+  local count="${_TSZ_CI_CANARY_SHARD_COUNT:-}"
+  if [[ -z "$count" ]]; then
+    return 0
+  fi
+  local shard="${_TSZ_CI_CANARY_SHARD_INDEX:-0}"
+  if (( index % count == shard )); then
+    return 0
+  fi
+  return 1
+}
+
 run_canary_projects() {
   local name
+  local index=0
   for name in "${TSZ_COMPILE_GUARD_CANARY_ROWS[@]}"; do
-    if should_check_project "$name"; then
+    if canary_row_in_shard "$index" && should_check_project "$name"; then
       if ! run_project_row "$name"; then
         return 1
       fi
     fi
+    index=$((index + 1))
   done
   return 0
 }

--- a/scripts/ci/test-pr-ready-state.mjs
+++ b/scripts/ci/test-pr-ready-state.mjs
@@ -197,8 +197,8 @@ assert.doesNotMatch(
 
 assert.match(
   ciWorkflow,
-  /\n\s{2}ci-summary:\n[\s\S]+?needs:[\s\S]+?- project-compile-guard\s*\n\s+- project-compile-canary[\s\S]+?"project-compile-guard",\s*\n\s+"project-compile-canary",/,
-  "CI Summary must wait for the project compile canary before reporting required full-run success",
+  /\n\s{2}ci-summary:\n[\s\S]+?needs:[\s\S]+?- project-compile-guard\s*\n\s+- project-compile-canary-aggregate[\s\S]+?"project-compile-guard",\s*\n\s+"project-compile-canary-aggregate",/,
+  "CI Summary must wait for the project compile canary aggregate (the shard recombiner) before reporting required full-run success",
 );
 
 for (const job of ["lint", "cargo-shear", "cargo-deny"]) {


### PR DESCRIPTION
Shard the `project-compile-canary` CI job 3-way to cut the wave-2 CI tail.
The canary job runs ~30 corpus rows serially on a single self-hosted runner
and dominates the wave-2 tail. This mirrors the existing conformance shard
fan-out exactly: a `fail-fast: false` matrix `[0, 1, 2]` partitions the
ordered `TSZ_COMPILE_GUARD_CANARY_ROWS` set so three runners share the work
in parallel (~9-10 min off the tail), and a new
`project-compile-canary-aggregate` job recombines the per-shard results into
the single `project-compile-canary-logs` artifact downstream expects.

## What changed
- **`.github/workflows/ci.yml`** — `project-compile-canary` is now a
  `fail-fast: false` matrix `shard: [0, 1, 2]`, named
  `project-compile-canary-${{ matrix.shard }}`, passing
  `_TSZ_CI_CANARY_SHARD_INDEX`/`_TSZ_CI_CANARY_SHARD_COUNT: 3` and uploading a
  per-shard artifact `project-compile-canary-logs-${{ matrix.shard }}`. A new
  `project-compile-canary-aggregate` job (mirror of `conformance-aggregate`)
  waits for the shard artifacts to index, downloads them, recombines, and
  re-uploads `project-compile-canary-logs` under the same name.
- **`scripts/ci/project-compile-guard.sh`** — `run_canary_projects` consults a
  new `canary_row_in_shard` helper: when `_TSZ_CI_CANARY_SHARD_COUNT` is set,
  only rows whose 0-based index in `TSZ_COMPILE_GUARD_CANARY_ROWS` satisfy
  `index % COUNT == INDEX` run. Unset (local + `all`-set runs) runs every row,
  preserving existing behavior. Sharding is keyed on the stable array index, so
  the union of all shards is the full set with no overlap.
- **`scripts/ci/project-compile-canary-aggregate.sh`** (new) — concatenates the
  per-shard `project-compatibility.jsonl` in shard order into the combined
  jsonl, sums the per-shard `failures` counters, and regenerates
  `project-compatibility-summary.json` via `project-compatibility.mjs summary`
  (a pure function of the rows), so the combined output is byte-shape-identical
  to the pre-shard single-job output. Shard log/manifest files are carried
  through.
- **`scripts/ci/test-pr-ready-state.mjs`** — the `ci-summary` `needs:`/dict
  assertion now expects `project-compile-canary-aggregate` (the recombiner)
  rather than the bare matrix job.

## Consumers updated
- `ci-summary` `needs:` list -> `project-compile-canary-aggregate`.
- `ci-summary` `required.update({...})` dict -> `project-compile-canary-aggregate`.
- `test-pr-ready-state.mjs` assertion -> aggregate.

The `project-compile-canary-logs` artifact name is referenced only inside
`ci.yml` itself; nothing in the website data pipeline
(`crates/tsz-website/src/_data/*`) or `bench.yml`/`project-row-summary.mjs`
downloads it by name — `bench.yml` produces its own
`project-compatibility.jsonl`. So recombining into the same artifact name is a
clean mirror of `conformance-aggregate` with no website-data risk.

Goal: fast

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — valid.
- `bash -n` on both edited/new shell scripts — clean.
- Shard-partition simulation over the real runtime canary set (31 rows from
  `project-rows.mjs`): shards split 11/10/10, **union == full set, no overlap**;
  unset shard count runs all 31.
- `node scripts/ci/test-pr-ready-state.mjs` — pass.
- `node scripts/bench/test-project-rows.mjs`,
  `node scripts/ci/test-project-compatibility.mjs`,
  `node scripts/bench/test-merge-results.mjs` — pass.
- End-to-end aggregate smoke: fabricated 3 per-shard artifacts from the real
  `project-compatibility.mjs record` path, ran the aggregate, and diffed against
  a single serial run: combined jsonl row set, summary aggregate fields
  (`by_state`, `by_oracle_classification`, `failures`, `row_count`,
  `project_set`, `allow_failures`, `malformed`), and top-level summary keys all
  identical; shard logs carried through.
- CI: the full wave-2 fan-out + `project-compile-canary-aggregate` +
  `CI Summary` exercise the real sharded path (cannot run self-hosted locally).
