### PR TITLE
fix(checker): name-guard cross-arena type-param extraction for type-alias/class decls (#13599)

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/type_params.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_params.rs
@@ -66,6 +66,15 @@ impl<'a> CheckerState<'a> {
             if flags & symbol_flags::TYPE_ALIAS != 0
                 && let Some(type_alias) = checker.ctx.arena.get_type_alias(node)
             {
+                // Guard against a `decl_idx` from another file's arena landing on
+                // an unrelated type alias at the same numeric index (issue #13599).
+                if !Self::decl_name_matches_in_arena(
+                    checker.ctx.arena,
+                    type_alias.name,
+                    sym_escaped_name,
+                ) {
+                    return None;
+                }
                 let (params, updates) = checker.push_type_parameters(&type_alias.type_parameters);
                 checker.pop_type_parameters(updates);
                 return Some(params);
@@ -74,6 +83,13 @@ impl<'a> CheckerState<'a> {
                 && flags & symbol_flags::CLASS != 0
                 && let Some(class) = checker.ctx.arena.get_class(node)
             {
+                if !Self::decl_name_matches_in_arena(
+                    checker.ctx.arena,
+                    class.name,
+                    sym_escaped_name,
+                ) {
+                    return None;
+                }
                 let (params, updates) = checker.push_type_parameters(&class.type_parameters);
                 checker.pop_type_parameters(updates);
                 if !params.is_empty() {
@@ -91,14 +107,12 @@ impl<'a> CheckerState<'a> {
             if flags & symbol_flags::INTERFACE != 0
                 && let Some(iface) = checker.ctx.arena.get_interface(node)
             {
-                if let Some(name_node) = checker.ctx.arena.get(iface.name)
-                    && let Some(name_ident) = checker.ctx.arena.get_identifier(name_node)
-                {
-                    if name_ident.escaped_text.as_str() != sym_escaped_name {
-                        return None;
-                    }
-                } else {
-                    // Accept if name cannot be resolved for backward compatibility
+                if !Self::decl_name_matches_in_arena(
+                    checker.ctx.arena,
+                    iface.name,
+                    sym_escaped_name,
+                ) {
+                    return None;
                 }
                 let (params, updates) = checker.push_type_parameters(&iface.type_parameters);
                 checker.pop_type_parameters(updates);
@@ -201,12 +215,20 @@ impl<'a> CheckerState<'a> {
 
         let type_parameters = if flags & symbol_flags::TYPE_ALIAS != 0 {
             let type_alias = arena.get_type_alias(node)?;
+            // Guard against a `decl_idx` from another file's arena landing on an
+            // unrelated type alias at the same numeric index (issue #13599).
+            if !Self::decl_name_matches_in_arena(arena, type_alias.name, sym_escaped_name) {
+                return None;
+            }
             let Some(type_parameters) = type_alias.type_parameters.as_ref() else {
                 return Some(Vec::new());
             };
             type_parameters
         } else if !mixed_class_interface && flags & symbol_flags::CLASS != 0 {
             let class = arena.get_class(node)?;
+            if !Self::decl_name_matches_in_arena(arena, class.name, sym_escaped_name) {
+                return None;
+            }
             let Some(type_parameters) = class.type_parameters.as_ref() else {
                 // Class with no AST type-parameters: the slow path's only work
                 // is a JSDoc @template scan that already reads from the arena.
@@ -227,10 +249,7 @@ impl<'a> CheckerState<'a> {
                 // gets a chance to provide the real params.
                 return Some(Vec::new());
             };
-            if let Some(name_node) = arena.get(iface.name)
-                && let Some(name_ident) = arena.get_identifier(name_node)
-                && name_ident.escaped_text.as_str() != sym_escaped_name
-            {
+            if !Self::decl_name_matches_in_arena(arena, iface.name, sym_escaped_name) {
                 return None;
             }
             let Some(type_parameters) = iface.type_parameters.as_ref() else {
@@ -905,6 +924,7 @@ impl<'a> CheckerState<'a> {
     pub(crate) fn count_required_type_params_from_ast(&self, sym_id: SymbolId) -> Option<usize> {
         let symbol = self.get_symbol_globally(sym_id)?;
         let flags = symbol.flags;
+        let sym_escaped_name = symbol.escaped_name.as_str();
         let decl_candidates = symbol.all_declarations();
 
         // Track the minimum required count across all declarations.
@@ -915,31 +935,40 @@ impl<'a> CheckerState<'a> {
 
         for decl_idx in decl_candidates {
             // Try the current arena first, then cross-arena lookup for lib files.
-            let result = Self::count_required_params_in_arena(self.ctx.arena, flags, decl_idx)
-                .or_else(|| {
-                    // For lib file declarations, the node lives in a different arena.
-                    // Look up the correct arena via declaration_arenas.
-                    if let Some(arenas) =
-                        self.ctx.binder.declaration_arenas.get(&(sym_id, decl_idx))
-                    {
-                        for arena in arenas {
-                            if let Some(count) = Self::count_required_params_in_arena(
-                                arena.as_ref(),
-                                flags,
-                                decl_idx,
-                            ) {
-                                return Some(count);
-                            }
+            let result = Self::count_required_params_in_arena(
+                self.ctx.arena,
+                flags,
+                decl_idx,
+                sym_escaped_name,
+            )
+            .or_else(|| {
+                // For lib file declarations, the node lives in a different arena.
+                // Look up the correct arena via declaration_arenas.
+                if let Some(arenas) = self.ctx.binder.declaration_arenas.get(&(sym_id, decl_idx)) {
+                    for arena in arenas {
+                        if let Some(count) = Self::count_required_params_in_arena(
+                            arena.as_ref(),
+                            flags,
+                            decl_idx,
+                            sym_escaped_name,
+                        ) {
+                            return Some(count);
                         }
                     }
-                    self.ctx
-                        .binder
-                        .symbol_arenas
-                        .get(&sym_id)
-                        .and_then(|arena| {
-                            Self::count_required_params_in_arena(arena.as_ref(), flags, decl_idx)
-                        })
-                });
+                }
+                self.ctx
+                    .binder
+                    .symbol_arenas
+                    .get(&sym_id)
+                    .and_then(|arena| {
+                        Self::count_required_params_in_arena(
+                            arena.as_ref(),
+                            flags,
+                            decl_idx,
+                            sym_escaped_name,
+                        )
+                    })
+            });
 
             if let Some(required) = result {
                 best_required = Some(match best_required {
@@ -1008,24 +1037,36 @@ impl<'a> CheckerState<'a> {
     }
 
     /// Count required type params for a single declaration in a specific arena.
+    ///
+    /// The declaration name is validated against `sym_escaped_name` so a
+    /// `decl_idx` from another file's arena cannot be read against an unrelated
+    /// arena where the same numeric index lands on a foreign declaration
+    /// (issue #13599).
     fn count_required_params_in_arena(
         arena: &tsz_parser::parser::NodeArena,
         flags: u32,
         decl_idx: NodeIndex,
+        sym_escaped_name: &str,
     ) -> Option<usize> {
         let node = arena.get(decl_idx)?;
         let type_params_list = if flags & tsz_binder::symbol_flags::INTERFACE != 0 {
-            arena
-                .get_interface(node)
-                .and_then(|iface| iface.type_parameters.as_ref())
+            let iface = arena.get_interface(node)?;
+            if !Self::decl_name_matches_in_arena(arena, iface.name, sym_escaped_name) {
+                return None;
+            }
+            iface.type_parameters.as_ref()
         } else if flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0 {
-            arena
-                .get_type_alias(node)
-                .and_then(|ta| ta.type_parameters.as_ref())
+            let ta = arena.get_type_alias(node)?;
+            if !Self::decl_name_matches_in_arena(arena, ta.name, sym_escaped_name) {
+                return None;
+            }
+            ta.type_parameters.as_ref()
         } else if flags & tsz_binder::symbol_flags::CLASS != 0 {
-            arena
-                .get_class(node)
-                .and_then(|c| c.type_parameters.as_ref())
+            let class = arena.get_class(node)?;
+            if !Self::decl_name_matches_in_arena(arena, class.name, sym_escaped_name) {
+                return None;
+            }
+            class.type_parameters.as_ref()
         } else {
             None
         };
@@ -1046,6 +1087,30 @@ impl<'a> CheckerState<'a> {
         None
     }
 
+    /// Returns `true` when the declaration `name_idx` in `arena` resolves to an
+    /// identifier whose text equals `sym_escaped_name`, or when the name cannot
+    /// be resolved at all (anonymous/unnamed declarations are accepted for
+    /// backward compatibility).
+    ///
+    /// This guards against a `decl_idx` (a `NodeIndex` that is only meaningful
+    /// inside the arena that owns the symbol) being read against an unrelated
+    /// arena, where the same numeric index can land on a foreign declaration.
+    /// Without this check, a non-generic imported alias can inherit an unrelated
+    /// generic's type parameters (issue #13599).
+    fn decl_name_matches_in_arena(
+        arena: &tsz_parser::parser::NodeArena,
+        name_idx: NodeIndex,
+        sym_escaped_name: &str,
+    ) -> bool {
+        match arena
+            .get(name_idx)
+            .and_then(|name_node| arena.get_identifier(name_node))
+        {
+            Some(name_ident) => name_ident.escaped_text.as_str() == sym_escaped_name,
+            None => true,
+        }
+    }
+
     pub(crate) fn type_param_names_in_arena(
         arena: &tsz_parser::parser::NodeArena,
         flags: u32,
@@ -1055,21 +1120,22 @@ impl<'a> CheckerState<'a> {
         let node = arena.get(decl_idx)?;
         let type_params_list = if flags & tsz_binder::symbol_flags::INTERFACE != 0 {
             let iface = arena.get_interface(node)?;
-            if let Some(name_node) = arena.get(iface.name)
-                && let Some(name_ident) = arena.get_identifier(name_node)
-                && name_ident.escaped_text.as_str() != sym_escaped_name
-            {
+            if !Self::decl_name_matches_in_arena(arena, iface.name, sym_escaped_name) {
                 return None;
             }
             iface.type_parameters.as_ref()
         } else if flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0 {
-            arena
-                .get_type_alias(node)
-                .and_then(|ta| ta.type_parameters.as_ref())
+            let ta = arena.get_type_alias(node)?;
+            if !Self::decl_name_matches_in_arena(arena, ta.name, sym_escaped_name) {
+                return None;
+            }
+            ta.type_parameters.as_ref()
         } else if flags & tsz_binder::symbol_flags::CLASS != 0 {
-            arena
-                .get_class(node)
-                .and_then(|c| c.type_parameters.as_ref())
+            let class = arena.get_class(node)?;
+            if !Self::decl_name_matches_in_arena(arena, class.name, sym_escaped_name) {
+                return None;
+            }
+            class.type_parameters.as_ref()
         } else {
             None
         }?;

--- a/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
+++ b/crates/tsz-checker/src/tests/ref_type_params_cache_tests.rs
@@ -778,3 +778,165 @@ type UseLocal = Local<string>;
         "Current-file generic aliases must not read type parameters from a colliding cross-file raw SymbolId; got: {diags:#?}"
     );
 }
+
+/// Regression guard for #13599: the cross-arena type-parameter readers must
+/// validate the declaration name before attributing its parameters to a symbol.
+///
+/// A symbol's `decl_idx` is only meaningful inside the arena that owns the
+/// symbol. When an imported symbol's `decl_idx` is read against the importing
+/// file's arena, the same numeric index can land on an unrelated declaration; a
+/// non-generic imported alias then inherited a sibling generic's free type
+/// parameters and the polluted form was cached program-wide. The behavioral leak
+/// only surfaces at real multi-file program-graph depth (it is not reproducible
+/// through the unit-test program builder), so this guards the structural
+/// invariant directly: every arena reader name-guards its type-alias and class
+/// branches (the interface branch always did) via `decl_name_matches_in_arena`.
+#[test]
+fn cross_arena_type_param_readers_name_guard_type_alias_and_class() {
+    let source = std::fs::read_to_string("src/state/type_environment/type_params.rs")
+        .expect("read type_params helper module");
+
+    assert!(
+        source.contains("fn decl_name_matches_in_arena"),
+        "a shared declaration-name guard helper must exist so a foreign \
+         declaration at a colliding node index cannot leak its type parameters"
+    );
+
+    // Each arena-reading helper that extracts type parameters must run the guard.
+    for reader in [
+        "fn type_param_names_in_arena",
+        "fn count_required_params_in_arena",
+        "fn extract_simple_type_params_from_decl_in_arena",
+        "fn extract_type_params_from_decl",
+    ] {
+        let body_start = source
+            .find(reader)
+            .unwrap_or_else(|| panic!("expected reader `{reader}` to exist"));
+        // Look at a generous window of the function body for the guard call.
+        let window = &source[body_start..(body_start + 2200).min(source.len())];
+        assert!(
+            window.matches("decl_name_matches_in_arena").count() >= 1,
+            "reader `{reader}` must name-guard its declaration reads (issue #13599)"
+        );
+    }
+}
+
+/// Positive behavioral companion: a non-generic alias imported from another file
+/// and referenced bare inside a file that also declares an unrelated generic must
+/// produce no arity diagnostics. (Binder names are varied per the anti-hardcoding
+/// gate.)
+#[test]
+fn imported_non_generic_alias_bare_reference_has_no_arity_error() {
+    let diags = check_multi_file_with_global_index(
+        &[
+            (
+                "src/plain.ts",
+                r#"
+export type CharsetConfig = {
+    splitOnNumbers?: boolean;
+    splitOnPunctuation?: boolean;
+};
+export type CharsetDefaults = {
+    splitOnNumbers: true;
+    splitOnPunctuation: false;
+};
+"#,
+            ),
+            (
+                "src/casing.ts",
+                r#"
+import type { CharsetDefaults, CharsetConfig } from "./plain";
+
+export type WidenedConfig = CharsetConfig & {
+    preserveLeadingMarkers?: boolean;
+};
+
+export type WidenedDefaults = CharsetDefaults & {
+    preserveLeadingMarkers: false;
+};
+
+type LeadingMarkers<Type extends string, Markers extends string = ""> =
+    Type extends `_${infer Rest}` ? LeadingMarkers<Rest, `_${Markers}`> : Markers;
+"#,
+            ),
+        ],
+        "src/casing.ts",
+        CheckerOptions::default(),
+    );
+
+    let arity_errors: Vec<_> = diags
+        .iter()
+        .filter(|d| matches!(d.code, 2314 | 2315 | 2707))
+        .collect();
+    assert_eq!(
+        arity_errors.len(),
+        0,
+        "bare reference to a non-generic imported alias must not report arity \
+         errors; got: {diags:#?}"
+    );
+}
+
+/// Companion to the regression above: an imported *generic* alias keeps its own
+/// arity even when the importing file declares an unrelated generic, and a bare
+/// reference to it still produces the correct missing-argument diagnostic. This
+/// pins that the name guard rejects only foreign declarations, not the symbol's
+/// own cross-file declaration.
+#[test]
+fn imported_generic_alias_keeps_own_arity_across_unrelated_local_generic() {
+    let diags = check_multi_file_with_global_index(
+        &[
+            (
+                "src/shapes.ts",
+                r#"
+export type Wrapper<Payload, Extra = unknown> = {
+    readonly payload: Payload;
+    readonly extra: Extra;
+};
+"#,
+            ),
+            (
+                "src/site.ts",
+                r#"
+import type { Wrapper } from "./shapes";
+
+type GoodUse = Wrapper<string, number>;
+type DefaultedUse = Wrapper<string>;
+type MissingArgs = Wrapper;
+
+type TrimZeros<Whole extends string, Kept extends string = ""> =
+    Whole extends `0${infer Rest}`
+        ? TrimZeros<Rest, `0${Kept}`>
+        : Kept;
+"#,
+            ),
+        ],
+        "src/site.ts",
+        CheckerOptions::default(),
+    );
+
+    // `Wrapper` has one required param (Payload) and one defaulted (Extra), so a
+    // bare reference reports exactly one "between 1 and 2" diagnostic (TS2707) —
+    // and crucially the arity (and the displayed param names) come from Wrapper
+    // itself, not from the importer's local 2-param generic.
+    let arity_errors: Vec<_> = diags
+        .iter()
+        .filter(|d| matches!(d.code, 2314 | 2315 | 2707))
+        .collect();
+    assert_eq!(
+        arity_errors.len(),
+        1,
+        "Imported generic alias must keep its own arity (1 required of 2) for the \
+         bare reference, independent of the importer's local generic; got: {diags:#?}"
+    );
+    let arity = &arity_errors[0];
+    assert_eq!(
+        arity.code, 2707,
+        "single-required + one-defaulted generic should emit TS2707; got: {diags:#?}"
+    );
+    assert!(
+        arity.message_text.contains("Wrapper<Payload, Extra>"),
+        "the diagnostic must display Wrapper's own parameters, not the importer's \
+         local generic's; got: {:?}",
+        arity.message_text
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes #13599: a cross-file/cross-arena `NodeIndex` collision makes a non-generic imported type alias inherit an unrelated sibling generic's free type parameters, producing false `TS2707`/`TS2314`/`TS2344` and nondeterministic output.

## Structural rule
When type-param names are extracted for an imported symbol, `get_type_param_names_for_symbol_from_ast` reads the symbol's `decl_idx` against the **importing** file's arena. The arena readers (`type_param_names_in_arena`, `count_required_params_in_arena`, `extract_simple_type_params_from_decl_in_arena`, `extract_type_params_from_decl`) name-guarded only the **interface** branch — so for a `decl_idx` that happens to collide with an unrelated local **type-alias** or **class** declaration in that arena, the foreign declaration's type parameters were attributed to the imported symbol and cached program-wide.

Witness (delta-debugged from the real type-fest graph to 2 files): the non-generic `WordsOptions` (words.d.ts) is referenced inside the generic `LeadingUnderscores<Type, Underscores>` (camel-case.d.ts); their `decl_idx` values collide across arenas, so `WordsOptions` wrongly acquires `<Type, Underscores>` → `camel-case.d.ts(4,32): TS2707 'WordsOptions<Type, Underscores>' requires between 1 and 2 type arguments`. tsc/tsgo emit nothing. Renaming all binders preserves the leak (structural, not name-driven); reordering the declarations makes it vanish (confirming the NodeIndex collision).

## Fix
A shared `decl_name_matches_in_arena` helper, applied to the type-alias and class branches of all four arena readers (mirroring the existing interface guard). An imported non-generic alias now instantiates with no type arguments regardless of the referencing generic's free params; anonymous/default-export declarations are still accepted (verified). +120/−54.

## Verification
- type-fest 5.6.0 (`skipLibCheck:false`), clean-main vs this PR (multiple runs): phantom `<Type,Underscores>` signatures 7-8 → **0**; `TS2707` 2 → **0**; `TS2314` 1 → **0**; total errors **nondeterministic 19-26 → deterministic 20** (the remaining 18 `TS2344` are a *separate* `ApplyDefaultOptions`/`RequiredKeysOf` constraint defect present on main, filed separately — their displays are now correct). tsc reference: 0 of these families. Under the corpus guard's `skipLibCheck:true` both emit 0, so no project-corpus row color changes — this removes a false-positive class affecting any multi-file `.d.ts` checked with `skipLibCheck:false`.
- Full local conformance (release): 12583/12585, zero new vs accepted regressions (only the 2 accepted Mac-delta cases).
- `cargo nextest run -p tsz-checker` A/B vs clean main: byte-identical failure set (no new, no flipped); `ref_type_params_cache_tests` 31 existing + 3 new pass (34/34).
- New regression test varies binder names (anti-hardcoding); a source-invariant guard test asserts the name-guard is called from all four readers (fails pre-fix, passes post-fix) since the behavioral leak needs the real program-graph `decl_idx` allocation the unit harness doesn't reproduce.
- clippy --all-targets clean; no new `#[allow]`; arch_guard + 2000-line caps pass.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: max
