### PR TITLE
perf(checker): memoize module-specifier candidate generation

### DIFF
--- a/crates/tsz-checker/src/checkers/mod.rs
+++ b/crates/tsz-checker/src/checkers/mod.rs
@@ -118,6 +118,12 @@ pub fn clear_all_thread_local_state() {
     // mid-resolution bail-out could leave it non-zero and suppress the cycle
     // drain for every later row on this worker thread (#12299).
     crate::types_domain::queries::lib_resolution::reset_lib_resolution_state();
+
+    // Drop the module-specifier candidate memo. It is a pure function of the
+    // specifier text (no correctness dependence on row state), but clearing at
+    // row boundaries keeps it from accumulating every project's specifiers on a
+    // reused worker thread while preserving within-compilation cross-file reuse.
+    crate::module_resolution::reset_module_specifier_candidates_memo();
 }
 
 /// Explicit context for synthesized JSX children, threaded from dispatch

--- a/crates/tsz-checker/src/module_resolution.rs
+++ b/crates/tsz-checker/src/module_resolution.rs
@@ -673,6 +673,27 @@ fn insert(
 // Public specifier-lookup shim
 // ---------------------------------------------------------------------------
 
+thread_local! {
+    // Per-thread memo for `module_specifier_candidates`. The candidate set is a
+    // pure function of the specifier text, so it never needs invalidation.
+    // Modular projects (ts-toolbelt, etc.) re-resolve the same handful of
+    // relative specifiers (`../List/List`, …) across hundreds of files, so this
+    // compatibility shim is hit repeatedly with identical inputs; the memo
+    // collapses the normalize/strip/scan work to one hashmap probe. Bounded in
+    // practice by the project's distinct import specifiers.
+    static CANDIDATES_MEMO: std::cell::RefCell<FxHashMap<String, Vec<String>>> =
+        std::cell::RefCell::new(FxHashMap::default());
+}
+
+/// Clear the per-thread [`module_specifier_candidates`] memo. The candidate set
+/// is a pure function of the specifier so this is never needed for correctness;
+/// it is wired into `clear_all_thread_local_state` at project/row boundaries so
+/// the memo persists across a compilation's files (where the reuse is) but does
+/// not accumulate unbounded across projects on a reused worker thread.
+pub fn reset_module_specifier_candidates_memo() {
+    CANDIDATES_MEMO.with(|memo| memo.borrow_mut().clear());
+}
+
 /// Build lookup keys for a module specifier.
 ///
 /// This is a thin compatibility shim. New code should prefer
@@ -699,12 +720,25 @@ pub fn module_specifier_candidates(specifier: &str) -> Vec<String> {
     // compatibility shim — and the specifiers that drive it — are visible.
     // The audit's full solution collapses the legacy map and canonical-spec
     // resolver into one entrypoint with one normalized key model; this
-    // visibility hook prepares the migration by exposing call sites.
+    // visibility hook prepares the migration by exposing call sites. Kept ahead
+    // of the memo so hits stay visible to the audit.
     tracing::trace!(
         site = "module_resolution::module_specifier_candidates",
         specifier = specifier,
         "module-specifier compatibility-shim lookup"
     );
+    if let Some(cached) = CANDIDATES_MEMO.with(|memo| memo.borrow().get(specifier).cloned()) {
+        return cached;
+    }
+    let computed = compute_module_specifier_candidates(specifier);
+    CANDIDATES_MEMO.with(|memo| {
+        memo.borrow_mut()
+            .insert(specifier.to_string(), computed.clone());
+    });
+    computed
+}
+
+fn compute_module_specifier_candidates(specifier: &str) -> Vec<String> {
     let Some(canonical) = normalize_import_specifier(specifier) else {
         // Quotes-only or empty input: the raw string is the only key the
         // caller could realistically match on.


### PR DESCRIPTION
## Summary

`module_resolution::module_specifier_candidates` builds the 1–3 lookup-key spellings for an import specifier. It is a **pure function of the specifier text**, yet it was recomputed on *every* import resolution: `normalize_import_specifier` (allocation + trim/scan), a `strip_known_extension` loop over ~10 suffixes, and 1–3 `String` allocations.

Symbolicated wall-time profiling of **ts-toolbelt** (the worst green project row — 5.25× slower than `tsgo`) put this path at **8.3% inclusive**, dominated by *repeated identical calls*: ts-toolbelt is a deeply modular type library where hundreds of files re-import the same relative specifiers (`../List/List`, …), and there was no cache for candidate generation.

## Structural rule

When the same module specifier is resolved more than once, recompute nothing — return the cached candidate spellings. `tsc` does not regenerate these per reference; tsz now memoizes via a per-thread cache keyed by the specifier text. Owner layer: **checker** (`tsz_checker::module_resolution`).

## Cache / lifecycle plan

- **Key:** the raw specifier `&str` (probe is allocation-free via `Borrow`; only a miss allocates the key).
- **Invalidation:** none required for correctness — the candidate set depends only on the specifier text, never on file/config/row state.
- **Memory bound:** the memo is wired into `clear_all_thread_local_state`, which runs at **project/row boundaries** (`clear_batch_iteration_state`), so it persists across a compilation's files (where the reuse lives) but does not accumulate every project's specifiers on a reused worker thread — matching the existing `lib_resolution` thread-local-memo convention.
- **Complexity:** O(1) hashmap probe replaces O(extensions) `strip_suffix` + `normalize` + 1–3 allocations per repeated call.

## Not a fixture fast-path

The memo keys on *any* specifier string — no project/file-name literals, no rendered-output matching. Every import-heavy project benefits (ts-toolbelt, vite-vanilla, nextjs-fresh, …). Behavior is unchanged.

## Verification

- **Performance** (release + `perf-tools` binary, drift-controlled **alternating A/B**, quiet host, 40 rounds): ts-toolbelt **518.6 ms → 479.4 ms** median, **−7.6%** (min-to-min also −7.6%). `hyperfine` block-mode under load is unreliable for a sub-10% signal; alternating + min-to-min is the robust estimator.
- **Correctness:** `tsz -p` diagnostics on ts-toolbelt **byte-identical** before/after; `cargo nextest run -p tsz-checker module_resolution` → **113/113 pass**.
- Conformance/emit/fourslash parity owned by ready-review CI.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: max

Goal: fast
