### PR TITLE
techdebt(repo): declarative clippy.toml prevention bans for soundness/determinism/panic discipline (#13452)

### DIFF
--- a/crates/clippy.toml
+++ b/crates/clippy.toml
@@ -23,8 +23,37 @@ doc-valid-idents = [
     "TS",
     "JSDoc",
 ]
+# Declarative bans for footguns that have a sanctioned replacement. Each entry
+# carries a `reason` so the rule is self-documenting and enforced in-editor
+# (and at `-D warnings` in CI) instead of relying on a reviewer remembering it.
+# Every entry below has zero current call sites, so these are pure prevention:
+# they guard against future regressions without touching any existing code.
 disallowed-methods = [
-    "std::mem::transmute",
+    { path = "std::mem::transmute", reason = "type-punning bypasses the type system; use a checked conversion (`as`, `From`/`TryFrom`, `bytemuck`) or an explicit, audited `unsafe` boundary" },
+    # Soundness: the `*_unchecked` variants are instantaneous undefined behavior
+    # on the bad path. Prefer the checked form so a logic error panics loudly
+    # instead of silently invoking UB.
+    { path = "std::option::Option::unwrap_unchecked", reason = "UB on `None`; use `unwrap()`/`expect()` so a logic bug panics instead of invoking UB" },
+    { path = "std::result::Result::unwrap_unchecked", reason = "UB on `Err`; use `unwrap()`/`expect()` so a logic bug panics instead of invoking UB" },
+    { path = "core::hint::unreachable_unchecked", reason = "UB if reached; use `unreachable!()` so a logic bug panics instead of invoking UB" },
+    # Panic discipline: aborting skips unwinding and `Drop`. Propagate a
+    # `Result`/diagnostic to the caller instead of killing the process.
+    { path = "std::process::abort", reason = "bypasses unwinding and `Drop`; return a `Result`/diagnostic instead of aborting the process" },
+]
+
+# Determinism is load-bearing for a compiler: diagnostic order and emit output
+# must be reproducible run to run. The default `HashMap`/`HashSet` hasher
+# (`RandomState`) seeds randomly, so its iteration order changes between runs.
+disallowed-types = [
+    { path = "std::collections::hash_map::RandomState", reason = "non-deterministic hash seed breaks reproducible diagnostic/emit order; use `rustc_hash::FxBuildHasher` / `FxHashMap` (the workspace standard) for stable iteration" },
+]
+
+# No unfinished stubs on shipped compiler paths: a `todo!()`/`unimplemented!()`
+# that reaches production panics at runtime. Implement the case or return a
+# typed error/diagnostic.
+disallowed-macros = [
+    { path = "std::todo", reason = "no `todo!()` stubs on shipped compiler paths; implement the case or return a typed error/diagnostic" },
+    { path = "std::unimplemented", reason = "no `unimplemented!()` stubs on shipped compiler paths; implement the case or return a typed error/diagnostic" },
 ]
 
 # Avoiding hidden convenience that masks missing boundary discipline.


### PR DESCRIPTION
Slice of #13452 (expand `clippy.toml` declarative custom rules). Encodes "never call X" conventions as enforced lints instead of tribal review knowledge.

Goal: hold

## Structural rule
When a "never call Z" / "prefer X over Z" convention is currently tribal knowledge enforced only in code review, it should be a `clippy.toml` entry with an explicit `reason`, so the compiler enforces it (in-editor and at `-D warnings` in CI) rather than relying on a reviewer remembering it. Owner layer: workspace lint posture (`crates/clippy.toml`).

## What changed
`crates/clippy.toml` only — no compiler code touched, **zero behavior change**:

- **disallowed-methods** (soundness / panic discipline): `Option::unwrap_unchecked`, `Result::unwrap_unchecked`, `core::hint::unreachable_unchecked` (each is instantaneous UB on the bad path — prefer the checked form so a logic bug panics loudly instead of invoking UB); `std::process::abort` (skips unwinding/`Drop`). Also gives the pre-existing `std::mem::transmute` ban a `reason`, so the array is uniform and self-documenting.
- **disallowed-types** (determinism): `std::collections::hash_map::RandomState` — its random seed makes `HashMap`/`HashSet` iteration order vary run to run, breaking reproducible diagnostic/emit order; the workspace standard is `rustc_hash` `FxHashMap`/`FxBuildHasher`. Determinism is load-bearing for `tsc` parity.
- **disallowed-macros** (no shipped stubs): `todo!` / `unimplemented!`.

Every added path has **zero current call sites** (verified by grep across the workspace, `tsz-conformance` excluded as CI excludes it), so this is pure prevention and cannot avalanche — the issue's "land one family per PR, fix existing violations first" guidance is satisfied trivially because there are no violations. The noisy families the issue also lists (`HashMap`/`HashSet`, `print_stdout`, `process::exit`) are deliberately **out of scope**: they have hundreds of legitimate call sites (CLI/binary output, established `FxHashMap` migration debt) and need a separate audited sweep, not a blanket ban here.

## Verification
- `cargo clippy -p tsz-common --all-targets` — clean; confirms the new `clippy.toml` parses and the `{ path, reason }` schema for all three `disallowed-*` families is accepted (a malformed/unknown-key config would error for every crate).
- Throwaway probe exercising all seven banned items → clippy flags **each** with its configured `reason` (paths confirmed live and correct, not silently inert), then reverted; tree left clean.
- `cargo clippy --workspace --exclude tsz-conformance --all-targets -- -D warnings` (the CI `lint` gate): expected green — zero matching call sites in the tree (re-grepped including test targets).
- Behavior-preserving refactor: config-only, no semantic/conformance/emit impact.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: medium

---
_Generated by [Claude Code](https://claude.ai/code/session_01LD3PwU2ekSNYc5616vLCzY)_