### PR TITLE
fix(checker): suppress false TS2344 under per-file evaluation-fuel exhaustion (#13609)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -938,6 +938,9 @@ path = "tests/ts2340_super_accessor_tests.rs"
 name = "ts2344_infer_conditional_constraint"
 path = "tests/ts2344_infer_conditional_constraint.rs"
 [[test]]
+name = "ts2344_fuel_exhaustion_suppression"
+path = "tests/ts2344_fuel_exhaustion_suppression.rs"
+[[test]]
 name = "ts2344_generic_ref_scoped_param_concrete_constraint"
 path = "tests/ts2344_generic_ref_scoped_param_concrete_constraint.rs"
 [[test]]

--- a/crates/tsz-checker/src/error_reporter/generics.rs
+++ b/crates/tsz-checker/src/error_reporter/generics.rs
@@ -573,6 +573,24 @@ impl<'a> CheckerState<'a> {
             return;
         }
 
+        // Suppress when the per-file evaluation-fuel budget was exhausted. The
+        // fuel cap (`MAX_EVALUATION_FUEL`) bails an in-flight evaluation by
+        // returning `TypeId::ERROR`; for key-space helpers such as
+        // `RequiredKeysOf<O>` / `OptionalKeysOf<O>` that bail is then absorbed by
+        // the surrounding `Omit`/`Record`/`Simplify` into a structurally-degraded
+        // *but error-free* constraint bound, so the `contains_error_type` guard
+        // above no longer catches it. A "does not satisfy" decision computed
+        // against such a truncated bound (or arg) is unreliable: `tsc` surfaces
+        // excessively-deep instantiation as TS2589 and never derives a false
+        // TS2344 from it. This is schedule-independent — a cold per-file checker
+        // re-evaluates the whole helper chain from scratch and exhausts the
+        // budget where a cache-warmed run stays under it, which is exactly why the
+        // same project flips between clean and false-positive depending on which
+        // file warmed the caches first.
+        if self.ctx.types.is_evaluation_fuel_exhausted() {
+            return;
+        }
+
         self.ensure_refs_resolved(type_arg);
         self.ensure_refs_resolved(constraint);
         let ready_constraint = self.resolve_lazy_type(constraint);

--- a/crates/tsz-checker/tests/ts2344_fuel_exhaustion_suppression.rs
+++ b/crates/tsz-checker/tests/ts2344_fuel_exhaustion_suppression.rs
@@ -22,7 +22,7 @@ use tsz_parser::parser::ParserState;
 use tsz_solver::TypeId;
 use tsz_solver::construction::TypeInterner;
 
-/// Larger than `MAX_EVALUATION_FUEL` (2_000_000) so the per-file budget reads
+/// Larger than `MAX_EVALUATION_FUEL` (`2_000_000`) so the per-file budget reads
 /// as exhausted without depending on the exact crate-private constant.
 const FUEL_OVER_BUDGET: u32 = 3_000_000;
 

--- a/crates/tsz-checker/tests/ts2344_fuel_exhaustion_suppression.rs
+++ b/crates/tsz-checker/tests/ts2344_fuel_exhaustion_suppression.rs
@@ -1,0 +1,95 @@
+//! Regression test for #13609: false TS2344 from key-space constraint
+//! evaluation (type-fest `ApplyDefaultOptions` / `RequiredKeysOf` /
+//! `OptionalKeysOf`) under per-file evaluation-fuel exhaustion.
+//!
+//! Root cause: a cold per-file checker re-evaluates the deep key-space helper
+//! chain from scratch and exhausts the per-file `MAX_EVALUATION_FUEL` budget.
+//! The bail returns `TypeId::ERROR`, which the surrounding `Omit`/`Record`/
+//! `Simplify` then absorb into a structurally-degraded — but error-free —
+//! constraint bound, so the existing `contains_error_type` guard no longer
+//! catches it and a false "does not satisfy" (TS2344) is reported. `tsc`
+//! surfaces excessively-deep instantiation as TS2589 and never derives a false
+//! TS2344 from it, so the TS2344 emitter must suppress once the per-file fuel
+//! budget is exhausted. This also explains the schedule-dependence reported in
+//! the issue: whichever file warms the shared eval caches first stays under the
+//! budget and is exempt, while every cold sibling exhausts it.
+
+use tsz_binder::BinderState;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
+use tsz_checker::test_utils::diagnostic_code_messages;
+use tsz_parser::parser::ParserState;
+use tsz_solver::TypeId;
+use tsz_solver::construction::TypeInterner;
+
+/// Larger than `MAX_EVALUATION_FUEL` (2_000_000) so the per-file budget reads
+/// as exhausted without depending on the exact crate-private constant.
+const FUEL_OVER_BUDGET: u32 = 3_000_000;
+
+/// Control: with fuel available, an unsatisfied constraint still reports
+/// TS2344. This guards against the suppression below over-firing (e.g. if the
+/// fuel flag were stuck on).
+#[test]
+fn ts2344_emitted_when_fuel_available() {
+    let mut parser = ParserState::new("test.ts".to_string(), "type T = string;".to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    types.reset_evaluation_fuel();
+    assert!(!types.is_evaluation_fuel_exhausted());
+    // `string` does not satisfy a `number` constraint.
+    checker.error_type_constraint_not_satisfied(TypeId::STRING, TypeId::NUMBER, root);
+
+    let ts2344: Vec<_> = diagnostic_code_messages(checker.ctx.diagnostics)
+        .into_iter()
+        .filter(|(code, _)| *code == 2344)
+        .collect();
+    assert_eq!(
+        ts2344.len(),
+        1,
+        "control: TS2344 should be emitted when fuel is available, got: {ts2344:?}"
+    );
+}
+
+/// Regression: once the per-file evaluation-fuel budget is exhausted, the
+/// constraint result is unreliable (the bound may have been truncated to a
+/// degraded form), so no TS2344 must be emitted.
+#[test]
+fn ts2344_suppressed_when_fuel_exhausted() {
+    let mut parser = ParserState::new("test.ts".to_string(), "type T = string;".to_string());
+    let root = parser.parse_source_file();
+    let mut binder = BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let types = TypeInterner::new();
+    let mut checker = CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &types,
+        "test.ts".to_string(),
+        CheckerOptions::default(),
+    );
+
+    types.reset_evaluation_fuel();
+    types.consume_evaluation_fuel(FUEL_OVER_BUDGET);
+    assert!(types.is_evaluation_fuel_exhausted());
+    // Same unsatisfied (`string` vs `number`) constraint as the control.
+    checker.error_type_constraint_not_satisfied(TypeId::STRING, TypeId::NUMBER, root);
+
+    let ts2344: Vec<_> = diagnostic_code_messages(checker.ctx.diagnostics)
+        .into_iter()
+        .filter(|(code, _)| *code == 2344)
+        .collect();
+    assert!(
+        ts2344.is_empty(),
+        "TS2344 must be suppressed under evaluation-fuel exhaustion (#13609), got: {ts2344:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes #13609 — false `TS2344` on type-fest `ApplyDefaultOptions` / `RequiredKeysOf` / `OptionalKeysOf` constraints under `skipLibCheck:false`.

## Root cause

The per-file evaluation-fuel budget (`MAX_EVALUATION_FUEL` = 2M, `crates/tsz-solver/src/limits/mod.rs`) bails an in-flight evaluation by returning `TypeId::ERROR`. For the key-space helpers, a **cold** per-file checker re-evaluates the whole `RequiredKeysOf<O>`/`OptionalKeysOf<O>` chain from scratch and exhausts that budget where a cache-warmed run stays under it. The bail's `ERROR` is then absorbed by the surrounding `Omit`/`Record`/`Simplify` into a structurally-degraded **but error-free** constraint bound (e.g. `RequiredKeysOf<SplitOptions>` collapses to `error`, so the bound becomes `{ strictLiteralChecks?: never }`), so the existing `contains_error_type` guard no longer catches it and a false `TS2344` is reported against the well-typed `Default*Options`.

This also explains the schedule-dependence noted in the issue: whichever file warms the shared eval caches first stays under the budget and is exempt, while every cold sibling exhausts it and flips to a false positive. Confirmed by binary search: raising the fuel cap makes the fixture emit `0` of these `TS2344` (at a large perf cost), proving exhaustion — not a key-set logic error — is the proximate cause.

## Structural rule

When evaluation is truncated by the resource limit, a "does not satisfy" decision computed against the resulting bound is unreliable. `tsc` surfaces excessively-deep instantiation as `TS2589` and never derives a false `TS2344` from it (it compiles type-fest clean). So the `TS2344` emitter — `error_type_constraint_not_satisfied_with_constraint_display`, the single chokepoint for every constraint-not-satisfied diagnostic (call/new/type-ref, JSDoc heritage, class implements) — gates on `is_evaluation_fuel_exhausted()`. This is the same predicate the shared relation-proof cache already uses to refuse trusting fuel-exhausted results (`relation_outcome_helpers.rs`, `failure_memo.rs`), placed before the expensive `ensure_refs_resolved`/`evaluate_type_for_assignability` work.

Owner layer: checker diagnostic boundary. No solver/eval bail change (the `ERROR` is intentional runaway protection; the bug is deriving a definitive diagnostic from it). No fixture-name or printer-string predicates.

## Adjacent matrix

- Cold per-file checker, fuel exhausted, bound degraded → suppressed (was the false `TS2344`).
- Warm / small project, fuel available, genuinely-unsatisfied constraint → still emits `TS2344` (control test).
- Both the object-bound family (`Default*Options`) and the `… does not satisfy the constraint 'string'` family in the fixture route through the same emitter → both clear.

## Verification

- Real type-fest v5.6.0 fixture (`a5491644`, its own `skipLibCheck:false` / `exactOptionalPropertyTypes` tsconfig), dev `tsz --noEmit -p`: **~18 false `TS2344` → 0**.
- New unit regression `crates/tsz-checker/tests/ts2344_fuel_exhaustion_suppression.rs` (`cargo test -p tsz-checker --test ts2344_fuel_exhaustion_suppression`): **2 passed** — control asserts `TS2344` is emitted with fuel available (guards against over-suppression); regression exhausts fuel via `consume_evaluation_fuel` and asserts suppression.
- Existing `ts2344_infer_conditional_constraint` constraint tests are unaffected (their sources never approach the 2M budget).
- Broad conformance / emit / fourslash / project-compile owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3Fymhk1e7M4FwLrC2Dkx9)_