### PR TITLE
fix(solver,checker): isolate per-compilation thread-local state across batch reuse (#13368)

### DIFF
--- a/crates/tsz-checker/src/assignability/assignability_checker.rs
+++ b/crates/tsz-checker/src/assignability/assignability_checker.rs
@@ -15,6 +15,61 @@ use tsz_parser::parser::node::NodeAccess;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
+thread_local! {
+    /// `TypeId`s whose assignability-display evaluation is in flight on this
+    /// thread.
+    ///
+    /// Keys are interner-instance-local, so the set must be empty between
+    /// compilations: a leaked entry would make a fresh `TypeId` reusing the
+    /// same value read as `already_visiting` and return unevaluated,
+    /// suppressing the normalized form an assignability diagnostic depends on.
+    /// Membership is owned by the RAII [`AssignabilityEvalVisitGuard`], which
+    /// removes the entry on drop — on the normal return path, the fuel-bail
+    /// path, *and* when `evaluate_type_for_assignability_inner` unwinds via a
+    /// panic a caller (`try_tsz`, LSP) catches and swallows mid-recursion.
+    /// (Before #13368 the removals were manual post-call statements skipped on
+    /// unwind, leaking the key into the next compilation on a reused worker
+    /// thread.)
+    static ASSIGNABILITY_EVAL_VISITING: std::cell::RefCell<FxHashSet<TypeId>> =
+        std::cell::RefCell::new(FxHashSet::default());
+}
+
+/// RAII membership guard for the assignability-display evaluation walk.
+///
+/// [`enter`](Self::enter) returns `None` when `type_id` is already being
+/// evaluated on this thread; the caller returns the type unevaluated. Otherwise
+/// it records membership and clears it on drop, so the set is restored even if
+/// evaluation unwinds.
+#[must_use]
+struct AssignabilityEvalVisitGuard(TypeId);
+
+impl AssignabilityEvalVisitGuard {
+    fn enter(type_id: TypeId) -> Option<Self> {
+        ASSIGNABILITY_EVAL_VISITING.with(|visiting| {
+            if visiting.borrow_mut().insert(type_id) {
+                Some(Self(type_id))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Whether `type_id`'s evaluation is already in flight on this thread,
+    /// without taking membership. Used for the pre-memo cycle short-circuit
+    /// that must return the type opaque rather than serve a memoized result.
+    fn is_visiting(type_id: TypeId) -> bool {
+        ASSIGNABILITY_EVAL_VISITING.with(|visiting| visiting.borrow().contains(&type_id))
+    }
+}
+
+impl Drop for AssignabilityEvalVisitGuard {
+    fn drop(&mut self) {
+        ASSIGNABILITY_EVAL_VISITING.with(|visiting| {
+            visiting.borrow_mut().remove(&self.0);
+        });
+    }
+}
+
 impl<'a> CheckerState<'a> {
     /// Merge overflow flags into the checker context (sticky: only ever sets to `true`).
     ///
@@ -1393,14 +1448,10 @@ impl<'a> CheckerState<'a> {
             return cached;
         }
 
-        thread_local! {
-            static ASSIGNABILITY_EVAL_VISITING: std::cell::RefCell<FxHashSet<TypeId>> =
-                Default::default();
-        }
-
-        let already_visiting =
-            ASSIGNABILITY_EVAL_VISITING.with(|visiting| visiting.borrow().contains(&type_id));
-        if already_visiting {
+        // Re-entrant cycle: return the type opaque. This check precedes the
+        // memo lookup on purpose — an in-flight type must not be served a
+        // memoized result computed by a now-superseded outer evaluation.
+        if AssignabilityEvalVisitGuard::is_visiting(type_id) {
             return type_id;
         }
 
@@ -1414,19 +1465,17 @@ impl<'a> CheckerState<'a> {
             return memoized;
         }
 
-        let entered =
-            ASSIGNABILITY_EVAL_VISITING.with(|visiting| visiting.borrow_mut().insert(type_id));
-        if !entered {
+        // Take membership for the duration of the evaluation. The guard removes
+        // the entry on every exit below (normal return, fuel bail, or unwind).
+        let Some(_visit_guard) = AssignabilityEvalVisitGuard::enter(type_id) else {
             return type_id;
-        }
+        };
 
         if !crate::error_reporter::display_budget::try_consume_eval_fuel() {
-            ASSIGNABILITY_EVAL_VISITING.with(|visiting| visiting.borrow_mut().remove(&type_id));
             return type_id;
         }
 
         let result = self.evaluate_type_for_assignability_inner(type_id);
-        ASSIGNABILITY_EVAL_VISITING.with(|visiting| visiting.borrow_mut().remove(&type_id));
         // Cycle-truncated returns above are never recorded — only complete
         // results are safe to replay for later calls in this scope.
         crate::error_reporter::display_budget::record_eval(type_id, result);
@@ -1885,4 +1934,43 @@ fn signature_has_param_capacity(
         return true;
     }
     params.len() >= source_param_count
+}
+
+#[cfg(test)]
+mod assignability_eval_visit_guard_tests {
+    use super::{AssignabilityEvalVisitGuard, TypeId};
+
+    #[test]
+    fn reentry_of_in_flight_type_is_rejected() {
+        let t = TypeId(4242);
+        let outer = AssignabilityEvalVisitGuard::enter(t).expect("first entry succeeds");
+        assert!(AssignabilityEvalVisitGuard::is_visiting(t));
+        assert!(
+            AssignabilityEvalVisitGuard::enter(t).is_none(),
+            "re-entering an in-flight TypeId must short-circuit"
+        );
+        drop(outer);
+        assert!(
+            !AssignabilityEvalVisitGuard::is_visiting(t),
+            "drop must restore membership"
+        );
+    }
+
+    /// #13368: the guard must clear membership even when evaluation unwinds via
+    /// a panic a caller (`try_tsz`, LSP) catches, so a stale interner-local key
+    /// can never leak into the next compilation on a reused worker thread.
+    #[test]
+    fn membership_is_restored_on_unwind() {
+        let t = TypeId(99);
+        let result = std::panic::catch_unwind(|| {
+            let _guard = AssignabilityEvalVisitGuard::enter(t).expect("entry succeeds");
+            assert!(AssignabilityEvalVisitGuard::is_visiting(t));
+            panic!("simulated mid-evaluation panic");
+        });
+        assert!(result.is_err(), "the closure panicked");
+        assert!(
+            !AssignabilityEvalVisitGuard::is_visiting(t),
+            "guard Drop must remove the key during unwind"
+        );
+    }
 }

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/keys_guard.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped/keys_guard.rs
@@ -13,6 +13,53 @@ use crate::evaluation::evaluate::TypeEvaluator;
 use crate::relations::subtype::TypeResolver;
 use crate::types::TypeId;
 use rustc_hash::FxHashSet;
+use std::cell::RefCell;
+
+thread_local! {
+    /// `TypeId`s whose mapped-key extraction is in flight on this thread.
+    ///
+    /// Keys are interner-instance-local, so the set must be empty between
+    /// compilations: a leaked entry would make a fresh `TypeId` reusing the
+    /// same value re-enter as a false cycle and defer (`None`) for a type that
+    /// genuinely has extractable keys. Membership is therefore owned by the
+    /// RAII [`MappedKeysVisitGuard`], which removes the entry on drop — on the
+    /// normal return path *and* when extraction unwinds via a panic that a
+    /// caller (`try_tsz`, LSP) catches and swallows mid-recursion. (Before
+    /// #13368 the removal was a manual post-call statement skipped on unwind,
+    /// leaking the key into the next compilation on a reused worker thread.)
+    static EXTRACT_MAPPED_KEYS_VISITING: RefCell<FxHashSet<TypeId>> =
+        RefCell::new(FxHashSet::default());
+}
+
+/// RAII membership guard for the mapped-keys extraction walk.
+///
+/// [`enter`](Self::enter) returns `None` when `type_id`'s extraction is already
+/// in flight on this thread (a re-entrant resolution cycle); the caller defers
+/// with `None`, matching the existing "cannot extract keys" semantics.
+/// Otherwise it records membership and clears it on drop, so the set is
+/// restored even if `extract_mapped_keys_impl` unwinds.
+#[must_use]
+struct MappedKeysVisitGuard(TypeId);
+
+impl MappedKeysVisitGuard {
+    fn enter(type_id: TypeId) -> Option<Self> {
+        EXTRACT_MAPPED_KEYS_VISITING.with(|visiting| {
+            if visiting.borrow_mut().insert(type_id) {
+                Some(Self(type_id))
+            } else {
+                None
+            }
+        })
+    }
+}
+
+impl Drop for MappedKeysVisitGuard {
+    fn drop(&mut self) {
+        EXTRACT_MAPPED_KEYS_VISITING.with(|visiting| {
+            visiting.borrow_mut().remove(&self.0);
+        });
+    }
+}
 
 impl<R: TypeResolver> TypeEvaluator<'_, R> {
     /// Extract mapped keys from a type (for mapped type iteration), guarded
@@ -21,19 +68,47 @@ impl<R: TypeResolver> TypeEvaluator<'_, R> {
         &mut self,
         type_id: TypeId,
     ) -> Option<MappedKeys> {
-        thread_local! {
-            static EXTRACT_MAPPED_KEYS_VISITING: std::cell::RefCell<FxHashSet<u32>> =
-                std::cell::RefCell::new(FxHashSet::default());
-        }
-        let entered =
-            EXTRACT_MAPPED_KEYS_VISITING.with(|visiting| visiting.borrow_mut().insert(type_id.0));
-        if !entered {
-            return None;
-        }
-        let result = self.extract_mapped_keys_impl(type_id);
-        EXTRACT_MAPPED_KEYS_VISITING.with(|visiting| {
-            visiting.borrow_mut().remove(&type_id.0);
+        let _guard = MappedKeysVisitGuard::enter(type_id)?;
+        self.extract_mapped_keys_impl(type_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_visiting(type_id: TypeId) -> bool {
+        EXTRACT_MAPPED_KEYS_VISITING.with(|visiting| visiting.borrow().contains(&type_id))
+    }
+
+    #[test]
+    fn reentry_of_in_flight_type_is_rejected() {
+        let t = TypeId(4242);
+        let outer = MappedKeysVisitGuard::enter(t).expect("first entry succeeds");
+        assert!(is_visiting(t));
+        assert!(
+            MappedKeysVisitGuard::enter(t).is_none(),
+            "re-entering an in-flight TypeId must defer"
+        );
+        drop(outer);
+        assert!(!is_visiting(t), "drop must restore membership");
+    }
+
+    /// #13368: the guard must clear membership even when the guarded work
+    /// unwinds via a panic a caller catches, so a stale interner-local key can
+    /// never leak into the next compilation on a reused worker thread.
+    #[test]
+    fn membership_is_restored_on_unwind() {
+        let t = TypeId(99);
+        let result = std::panic::catch_unwind(|| {
+            let _guard = MappedKeysVisitGuard::enter(t).expect("entry succeeds");
+            assert!(is_visiting(t));
+            panic!("simulated mid-extraction panic");
         });
-        result
+        assert!(result.is_err(), "the closure panicked");
+        assert!(
+            !is_visiting(t),
+            "guard Drop must remove the key during unwind"
+        );
     }
 }

--- a/crates/tsz-solver/src/limits/mod.rs
+++ b/crates/tsz-solver/src/limits/mod.rs
@@ -223,6 +223,24 @@ impl LimitBudgets {
             solver_stack_frames: Cell::new(0),
         }
     }
+
+    /// Zero every transient budget/guard counter back to its fresh-process
+    /// value. All fields are per-compilation scratch state (chain depth/fuel,
+    /// per-query op budget, cross-evaluator depth, per-file evaluation fuel,
+    /// solver recursion frames, and the two cache-poisoning sentinels); none
+    /// of them carry meaning across a compilation boundary. New fields added
+    /// to [`LimitBudgets`] MUST be reset here so batch/row reuse stays
+    /// schedule-independent (see [`reset_subtype_thread_local_state`]).
+    fn reset_all(&self) {
+        self.subtype_state.set(0);
+        self.lazy_resolve_failures.set(0);
+        self.weak_type_sensitivity.set(0);
+        self.eval_query_active.set(0);
+        self.eval_query_ops.set(0);
+        self.global_eval_depth.set(0);
+        self.evaluation_fuel.set(0);
+        self.solver_stack_frames.set(0);
+    }
 }
 
 thread_local! {
@@ -360,15 +378,23 @@ pub(crate) fn poison_sentinel_counts() -> (u64, u64) {
     LIMIT_BUDGETS.with(|b| (b.lazy_resolve_failures.get(), b.weak_type_sensitivity.get()))
 }
 
-/// Reset subtype chain depth/fuel and the cache-poisoning sentinel counters.
-/// Called between compilation sessions to prevent stale state from a
-/// previous compilation (e.g., if it panicked and left counters dirty).
+/// Reset every transient thread-local limit budget to its fresh-process value.
+///
+/// Called between compilation sessions (batch/row reuse) to prevent stale
+/// state from a previous compilation leaking into the next on a reused worker
+/// thread. Originally this reset only the subtype chain depth/fuel and the two
+/// cache-poisoning sentinels, but [`LimitBudgets`] also carries the per-query
+/// op budget, the cross-evaluator eval depth, the per-file evaluation fuel, and
+/// the solver recursion-frame count. Some of those use manual (non-RAII)
+/// enter/leave, so a compilation that bailed via the stack/depth breaker or a
+/// caught-and-swallowed panic could leave them non-zero — making the next
+/// compilation's depth/fuel/op verdicts (and the eval-query-gated
+/// `reset_query_memo`, which only clears when the op-budget frame count
+/// transitions from zero) schedule-dependent (#13368). Resetting the whole
+/// struct keeps batch results byte-identical to a fresh process regardless of
+/// what ran before on the thread.
 pub fn reset_subtype_thread_local_state() {
-    LIMIT_BUDGETS.with(|b| {
-        b.subtype_state.set(0);
-        b.lazy_resolve_failures.set(0);
-        b.weak_type_sensitivity.set(0);
-    });
+    LIMIT_BUDGETS.with(LimitBudgets::reset_all);
 }
 
 // -----------------------------------------------------------------------------
@@ -579,6 +605,43 @@ pub(crate) fn limit_result_cache_enabled() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for #13368: batch/row reuse runs many compilations on
+    /// one worker thread and relies on [`reset_subtype_thread_local_state`] to
+    /// isolate them. A compilation that bailed via the depth/stack breaker or a
+    /// caught-and-swallowed panic can leave any [`LimitBudgets`] counter dirty.
+    /// Before the fix the reset cleared only three of the eight fields, so the
+    /// per-query op budget, cross-evaluator eval depth, per-file evaluation
+    /// fuel, and solver recursion-frame count leaked into the next compilation
+    /// and made its depth/fuel verdicts schedule-dependent. Dirty every field
+    /// the way an aborted mid-evaluation row would and assert the reset zeroes
+    /// all of them.
+    #[test]
+    fn reset_clears_every_limit_budget_field() {
+        LIMIT_BUDGETS.with(|b| {
+            b.subtype_state.set(pack_depth_fuel(7, 9));
+            b.lazy_resolve_failures.set(3);
+            b.weak_type_sensitivity.set(5);
+            b.eval_query_active.set(11);
+            b.eval_query_ops.set(13);
+            b.global_eval_depth.set(17);
+            b.evaluation_fuel.set(19);
+            b.solver_stack_frames.set(23);
+        });
+
+        reset_subtype_thread_local_state();
+
+        LIMIT_BUDGETS.with(|b| {
+            assert_eq!(b.subtype_state.get(), 0, "subtype chain state");
+            assert_eq!(b.lazy_resolve_failures.get(), 0, "lazy-resolve sentinel");
+            assert_eq!(b.weak_type_sensitivity.get(), 0, "weak-type sentinel");
+            assert_eq!(b.eval_query_active.get(), 0, "per-query active frames");
+            assert_eq!(b.eval_query_ops.get(), 0, "per-query op count");
+            assert_eq!(b.global_eval_depth.get(), 0, "cross-evaluator eval depth");
+            assert_eq!(b.evaluation_fuel.get(), 0, "per-file evaluation fuel");
+            assert_eq!(b.solver_stack_frames.get(), 0, "solver recursion frames");
+        });
+    }
 
     /// The packed subtype chain state round-trips depth and fuel through the
     /// consolidated accessors with the exact pre/post semantics the relation


### PR DESCRIPTION
## Summary

Conformance and project-corpus runs reuse one long-lived `tsz --batch` worker
process across many independent compilations, calling the compilation-boundary
reset between each so every result is byte-identical to a fresh process. Three
thread-local channels escaped that contract, so a compilation's diagnostics
could depend on **what ran before it on the same worker thread**. That is the
parallel-checking schedule-sensitivity family (#13255) that surfaces as the
intermittent `temporal.ts` conformance regression under heavy merge-queue load
(#13368): the heaviest, most generic-dense test inherits residual worker state
that flips a diagnostic, ejecting an innocent queue entry.

## Structural rule

When `tsc` checks an independent compilation, its diagnostics are a function of
that program alone — never of an unrelated program checked earlier in the same
process. tsz must match this for batch/row reuse: every per-compilation
thread-local must be empty/zero at the compilation boundary regardless of how
the previous compilation exited (normal return, depth/stack bail, or a panic a
caller catches and swallows mid-recursion).

## The three leak channels and owners

| Channel | Owner | Leak | Fix |
|---|---|---|---|
| `EXTRACT_MAPPED_KEYS_VISITING` | solver `evaluation/evaluate_rules/mapped/keys_guard.rs` | manual post-call `remove` skipped on unwind; stale interner-local `TypeId` makes a reused id read as a false cycle and **defer key extraction** | RAII `MappedKeysVisitGuard` |
| `ASSIGNABILITY_EVAL_VISITING` | checker `assignability/assignability_checker.rs` | same manual pattern; stale id reads as `already_visiting` and **returns the type unnormalized**, suppressing the display an assignability diagnostic depends on | RAII `AssignabilityEvalVisitGuard` |
| `LimitBudgets` (5 of 8 fields) | solver `limits/mod.rs` | the documented boundary reset zeroed only the subtype chain + 2 poison sentinels, leaving the per-query op budget, cross-evaluator eval depth, per-file evaluation fuel, and solver recursion-frame count to leak from a non-unwinding depth/stack bail | reset the whole struct via `LimitBudgets::reset_all` |

The two visiting guards now restore membership on **every** exit (normal,
fuel-bail, and panic unwind), matching the established `CrossEvalExpansionGuard`
convention — and are therefore deliberately **not** added to the
`clear_*_thread_local_state` reset lists (RAII self-cleans; registering them
too would be redundant). The widened `LimitBudgets` reset also hardens the
`eval_query_active`-gated `reset_query_memo` invariant noted in the audit.

## Why this altitude

- The visiting guards are membership sets with balanced enter/leave → RAII is
  the right primitive (fix at the source, not boundary mop-up).
- The `LimitBudgets` fields are semantic counters with intentionally
  *asymmetric* within-compilation lifecycles (subtype fuel persists across a
  chain; op count resets on a 0→1 transition; evaluation fuel resets per file).
  Making each RAII would break parity-critical fuel/op semantics, so the
  correct fix is a single whole-struct reset at the compilation boundary.
- No generic guard abstraction / thread-local registry was added: three
  ~25-line guards across the checker/solver crate boundary do not justify a
  shared mutable-state primitive (and CLAUDE.md forbids the checker reaching
  into solver internals for one).

## Anti-hardcoding

No identifier/file-name/printer-string predicates; the fix is purely structural
isolation of thread-local lifetimes. Tests vary `TypeId` values and assert on
membership/counter state, not on rendered messages.

## Verification

- `cargo test -p tsz-solver --lib -- limits::tests::reset_clears_every_limit_budget_field keys_guard::tests` — 3 pass (new: total-reset + RAII reentry + unwind-restoration).
- `cargo test -p tsz-checker --lib -- assignability_eval_visit_guard_tests clear_all_thread_local_state` — 4 pass (new RAII reentry + unwind, plus the existing reset-coverage guards).
- `cargo test -p tsz-checker --lib -- assignab` — the assignability refactor changes no behavior: the only branch-vs-base test delta (`passing_program_does_zero_reason_collection`) is the pre-existing parallel schedule-flakiness (#13255) and passes 3/3 isolated single-threaded; the other 8 failures reproduce identically on clean `main`.
- `cargo clippy -p tsz-solver -p tsz-checker --tests` — clean.
- Full conformance/merge-group determinism is empirical: per this issue's own removal condition, `temporal.ts` stability is confirmed over consecutive merge-group batches, which the ready-review CI owns.

Refs #13368, #13255.

Goal: hold

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoLSnHWGjtUyDQXdGbDhTH)_