### PR TITLE
fix(bench): project-compatibility gap must not block the timing publish (closes #13607)

### DIFF
--- a/scripts/bench/merge-results.mjs
+++ b/scripts/bench/merge-results.mjs
@@ -359,11 +359,23 @@ function validateMeasurementProfileConsistency(profiles) {
   return warnings;
 }
 
+// Project-compatibility validation is split into two severities (issue #13607):
+//   - blocking: conditions that make the merged artifact itself unsafe to trust,
+//     so the merge step must exit non-zero. Today this is only DUPLICATE project
+//     rows (a corrupt/double-counted artifact).
+//   - advisory: project-compatibility metadata gaps (a project row absent, a
+//     missing compatibility object/field, fixture-source or red/yellow blocker
+//     metadata gaps). These degrade a row to non-green/incomplete downstream but
+//     must NOT block publishing the benchmark TIMING data, which is the website's
+//     primary content. The genuinely-unsafe TIMING conditions (fewer than the
+//     expected shards, a missing REQUIRED timing row) are enforced independently
+//     by the bench.yml shard-count gate and check-artifact-readiness.mjs.
 function collectProjectCompatibilityFailures(rows) {
+  const blocking = [];
+  const advisory = [];
   const projectRows = rows.filter((row) => PROJECT_COMPATIBILITY_ROW_SET.has(row?.name));
-  if (projectRows.length === 0) return [];
+  if (projectRows.length === 0) return { blocking, advisory };
 
-  const failures = [];
   const seenNames = new Set();
   const duplicateNames = new Set();
 
@@ -374,14 +386,16 @@ function collectProjectCompatibilityFailures(rows) {
       seenNames.add(row.name);
     }
   }
+  // Duplicate rows are always blocking: a duplicated project row means the
+  // artifact double-counts a benchmark, which corrupts win/timing totals.
   for (const name of [...duplicateNames].sort()) {
-    failures.push(`${name}: duplicate project row`);
+    blocking.push(`${name}: duplicate project row`);
   }
 
   if (projectRows.some((row) => REQUIRED_PROJECT_ROW_SET.has(row.name))) {
     for (const name of REQUIRED_PROJECT_ROWS) {
       if (!seenNames.has(name)) {
-        failures.push(`${name}: missing project row`);
+        advisory.push(`${name}: missing project row`);
       }
     }
   }
@@ -392,32 +406,32 @@ function collectProjectCompatibilityFailures(rows) {
     // before the artifact step ran). They must never appear as speed wins.
     if (row.artifact_missing === true) continue;
     if (!row.compatibility || typeof row.compatibility !== "object") {
-      failures.push(`${row.name}: missing compatibility object`);
+      advisory.push(`${row.name}: missing compatibility object`);
       continue;
     }
     for (const field of REQUIRED_COMPATIBILITY_FIELDS) {
       if (!Object.hasOwn(row.compatibility, field)) {
-        failures.push(`${row.name}: missing compatibility.${field}`);
+        advisory.push(`${row.name}: missing compatibility.${field}`);
       }
     }
-    failures.push(...collectFixtureSourceFailures(row.name, row.compatibility.fixture_sources));
+    advisory.push(...collectFixtureSourceFailures(row.name, row.compatibility.fixture_sources));
     const state = String(row.compatibility.state || "").toLowerCase();
     if (state === "red" || state === "yellow") {
       if (!isNonEmptyString(row.compatibility.first_failure_class)) {
-        failures.push(`${row.name}: red/yellow compatibility.first_failure_class must name the first blocker`);
+        advisory.push(`${row.name}: red/yellow compatibility.first_failure_class must name the first blocker`);
       }
       if (!isNonEmptyStringArray(row.compatibility.known_blockers)) {
-        failures.push(`${row.name}: red/yellow compatibility.known_blockers must name at least one blocker`);
+        advisory.push(`${row.name}: red/yellow compatibility.known_blockers must name at least one blocker`);
       } else if (
         isNonEmptyString(row.compatibility.first_failure_class) &&
         row.compatibility.first_failure_class.trim() !== row.compatibility.known_blockers.find(isNonEmptyString).trim()
       ) {
-        failures.push(`${row.name}: red/yellow compatibility.first_failure_class must match the first known blocker`);
+        advisory.push(`${row.name}: red/yellow compatibility.first_failure_class must match the first known blocker`);
       }
     }
   }
 
-  return failures;
+  return { blocking, advisory };
 }
 
 function firstNonEmpty(...values) {
@@ -517,10 +531,19 @@ function main() {
     compatibilityJsonlFiles,
   );
 
-  const failures = collectProjectCompatibilityFailures(results);
-  if (failures.length > 0) {
-    console.error("Project compatibility artifact validation failed:");
-    for (const failure of failures) {
+  const { blocking: compatBlocking, advisory: compatAdvisory } = collectProjectCompatibilityFailures(results);
+  if (compatAdvisory.length > 0) {
+    // Advisory project-compatibility gaps must NOT block publishing benchmark
+    // timing data (issue #13607). Surface them as GitHub annotations and keep
+    // going so the merged artifact is still written and published.
+    console.warn("::warning::Project compatibility validation found advisory gaps; publishing benchmark timing data anyway:");
+    for (const failure of compatAdvisory) {
+      console.warn(`  - ${failure}`);
+    }
+  }
+  if (compatBlocking.length > 0) {
+    console.error("Project compatibility artifact validation failed (blocking):");
+    for (const failure of compatBlocking) {
       console.error(`  - ${failure}`);
     }
     process.exit(1);
@@ -562,6 +585,7 @@ function main() {
       runner_signature_required: requireRunnerSignature,
       runner_environment_warnings: runnerEnvironmentWarnings,
       measurement_profile_warnings: measurementProfileWarnings,
+      project_compatibility_advisory: compatAdvisory,
     },
     ...(runnerEnvironment ? { runner_environment: runnerEnvironment } : {}),
     ...(measurementProfile ? { measurement_profile: measurementProfile } : {}),

--- a/scripts/bench/test-merge-results.mjs
+++ b/scripts/bench/test-merge-results.mjs
@@ -227,13 +227,26 @@ withTempDir((dir) => {
   assert.equal(merged.run_status, "completed");
 });
 
+// Issue #13607: a missing project row is an advisory compatibility gap, not a
+// blocking one. The merge must publish the benchmark timing data anyway and
+// surface the gap as a ::warning:: (the missing-required-TIMING-row floor is
+// owned independently by check-artifact-readiness.mjs).
 withTempDir((dir) => {
   const missingRow = REQUIRED_PROJECT_ROWS[0];
   const rows = REQUIRED_PROJECT_ROWS.filter((name) => name !== missingRow)
     .map((name) => projectRow(name));
   const result = runMerge(dir, rows);
-  assert.equal(result.status, 1);
-  assert.match(result.stderr, new RegExp(`${missingRow}: missing project row`));
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(fs.existsSync(result.output), "advisory gap must still write bench-results.json");
+  assert.match(
+    result.stderr,
+    new RegExp(`::warning::[\\s\\S]*${missingRow}: missing project row`),
+  );
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  assert.ok(
+    merged.validation.project_compatibility_advisory.includes(`${missingRow}: missing project row`),
+    "advisory gap must be recorded in merged.validation.project_compatibility_advisory",
+  );
 });
 
 withTempDir((dir) => {
@@ -243,8 +256,12 @@ withTempDir((dir) => {
     return projectRow(name, compatibility);
   });
   const result = runMerge(dir, rows);
-  assert.equal(result.status, 1);
-  assert.match(result.stderr, /rxjs-project: missing compatibility\.peak_memory_bytes/);
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(fs.existsSync(result.output));
+  assert.match(
+    result.stderr,
+    /::warning::[\s\S]*rxjs-project: missing compatibility\.peak_memory_bytes/,
+  );
 });
 
 withTempDir((dir) => {
@@ -258,6 +275,9 @@ withTempDir((dir) => {
   assert.match(result.stderr, new RegExp(`${duplicateRow}: duplicate project row`));
 });
 
+// Duplicate rows stay BLOCKING even for a canary-only row. This is the floor
+// that check-artifact-readiness.mjs does NOT cover (it only inspects REQUIRED
+// rows), so the merge step must remain the authoritative duplicate guard.
 withTempDir((dir) => {
   const canaryRow = COMPILE_ONLY_CANARY_PROJECT_ROWS[0];
   const result = runMerge(dir, [
@@ -268,6 +288,35 @@ withTempDir((dir) => {
   assert.match(
     result.stderr,
     new RegExp(`${canaryRow}: duplicate project row`),
+  );
+});
+
+// Issue #13607 witness: a compile-only canary row with a compatibility gap,
+// paired with the full REQUIRED set (complete timing), must publish. The merge
+// exits 0, writes the artifact, preserves the canary row, and warns.
+withTempDir((dir) => {
+  const canaryRow = COMPILE_ONLY_CANARY_PROJECT_ROWS[0];
+  const { peak_memory_bytes: _peakMemoryBytes, ...compatibility } = SAMPLE_COMPATIBILITY;
+  const rows = [
+    ...REQUIRED_PROJECT_ROWS.map((name) => projectRow(name)),
+    projectRow(canaryRow, compatibility),
+  ];
+  const result = runMerge(dir, rows);
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(fs.existsSync(result.output), "compat gap must still write bench-results.json");
+  const merged = JSON.parse(fs.readFileSync(result.output, "utf8"));
+  assert.ok(
+    merged.results.some((r) => r.name === canaryRow),
+    "canary row must survive into the published artifact",
+  );
+  assert.match(
+    result.stderr,
+    new RegExp(`::warning::[\\s\\S]*${canaryRow}: missing compatibility\\.peak_memory_bytes`),
+  );
+  assert.ok(
+    merged.validation.project_compatibility_advisory.includes(
+      `${canaryRow}: missing compatibility.peak_memory_bytes`,
+    ),
   );
 });
 
@@ -355,10 +404,11 @@ withTempDir((dir) => {
   const canaryRow = COMPILE_ONLY_CANARY_PROJECT_ROWS[0];
   const { diagnostic_subsystems: _diagnosticSubsystems, ...compatibility } = SAMPLE_COMPATIBILITY;
   const result = runMerge(dir, [projectRow(canaryRow, compatibility)]);
-  assert.equal(result.status, 1);
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(fs.existsSync(result.output));
   assert.match(
     result.stderr,
-    new RegExp(`${canaryRow}: missing compatibility\\.diagnostic_subsystems`),
+    new RegExp(`::warning::[\\s\\S]*${canaryRow}: missing compatibility\\.diagnostic_subsystems`),
   );
 });
 
@@ -369,10 +419,11 @@ withTempDir((dir) => {
     fixture_sources: [],
   };
   const result = runMerge(dir, [projectRow(canaryRow, compatibility)]);
-  assert.equal(result.status, 1);
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(fs.existsSync(result.output));
   assert.match(
     result.stderr,
-    new RegExp(`${canaryRow}: compatibility\\.fixture_sources must name at least one source`),
+    new RegExp(`::warning::[\\s\\S]*${canaryRow}: compatibility\\.fixture_sources must name at least one source`),
   );
 });
 
@@ -386,10 +437,11 @@ withTempDir((dir) => {
     ],
   };
   const result = runMerge(dir, [projectRow(canaryRow, compatibility)]);
-  assert.equal(result.status, 1);
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(fs.existsSync(result.output));
   assert.match(
     result.stderr,
-    new RegExp(`${canaryRow}: compatibility\\.fixture_sources\\[0\\]\\.ref must be a non-empty string`),
+    new RegExp(`::warning::[\\s\\S]*${canaryRow}: compatibility\\.fixture_sources\\[0\\]\\.ref must be a non-empty string`),
   );
   assert.match(
     result.stderr,
@@ -405,10 +457,11 @@ withTempDir((dir) => {
   const canaryRow = COMPILE_ONLY_CANARY_PROJECT_ROWS[0];
   const { owner_track: _ownerTrack, ...compatibility } = SAMPLE_COMPATIBILITY;
   const result = runMerge(dir, [projectRow(canaryRow, compatibility)]);
-  assert.equal(result.status, 1);
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(fs.existsSync(result.output));
   assert.match(
     result.stderr,
-    new RegExp(`${canaryRow}: missing compatibility\\.owner_track`),
+    new RegExp(`::warning::[\\s\\S]*${canaryRow}: missing compatibility\\.owner_track`),
   );
 });
 
@@ -422,10 +475,11 @@ withTempDir((dir) => {
     known_blockers: ["relations-assignability"],
   };
   const result = runMerge(dir, [projectRow(canaryRow, compatibility)]);
-  assert.equal(result.status, 1);
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(fs.existsSync(result.output));
   assert.match(
     result.stderr,
-    new RegExp(`${canaryRow}: red/yellow compatibility\\.first_failure_class must name the first blocker`),
+    new RegExp(`::warning::[\\s\\S]*${canaryRow}: red/yellow compatibility\\.first_failure_class must name the first blocker`),
   );
 });
 
@@ -439,10 +493,11 @@ withTempDir((dir) => {
     known_blockers: [],
   };
   const result = runMerge(dir, [projectRow(canaryRow, compatibility)]);
-  assert.equal(result.status, 1);
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(fs.existsSync(result.output));
   assert.match(
     result.stderr,
-    new RegExp(`${canaryRow}: red/yellow compatibility\\.known_blockers must name at least one blocker`),
+    new RegExp(`::warning::[\\s\\S]*${canaryRow}: red/yellow compatibility\\.known_blockers must name at least one blocker`),
   );
 });
 
@@ -456,10 +511,11 @@ withTempDir((dir) => {
     known_blockers: ["evaluation-inference-instantiation", "relations-assignability"],
   };
   const result = runMerge(dir, [projectRow(canaryRow, compatibility)]);
-  assert.equal(result.status, 1);
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(fs.existsSync(result.output));
   assert.match(
     result.stderr,
-    new RegExp(`${canaryRow}: red/yellow compatibility\\.first_failure_class must match the first known blocker`),
+    new RegExp(`::warning::[\\s\\S]*${canaryRow}: red/yellow compatibility\\.first_failure_class must match the first known blocker`),
   );
 });
 
@@ -973,13 +1029,19 @@ withTempDir((dir) => {
   assert.equal(result.status, 0, result.stderr);
 });
 
-// Non-artifact_missing rows must still fail if they have missing required fields.
+// Non-artifact_missing rows with a missing required compatibility field are an
+// advisory gap (issue #13607): the merge must publish timing data and warn,
+// not block. (artifact_missing rows above are exempt entirely.)
 withTempDir((dir) => {
   const canaryRow = COMPILE_ONLY_CANARY_PROJECT_ROWS[0];
   const { peak_memory_bytes: _peakMemoryBytes, ...compatibility } = SAMPLE_COMPATIBILITY;
   const result = runMerge(dir, [projectRow(canaryRow, compatibility)]);
-  assert.equal(result.status, 1);
-  assert.match(result.stderr, new RegExp(`${canaryRow}: missing compatibility\\.peak_memory_bytes`));
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(fs.existsSync(result.output), "advisory gap must still write bench-results.json");
+  assert.match(
+    result.stderr,
+    new RegExp(`::warning::[\\s\\S]*${canaryRow}: missing compatibility\\.peak_memory_bytes`),
+  );
 });
 
 // artifact_missing row mixed with required green rows: the artifact_missing


### PR DESCRIPTION
## Summary

Fixes the bench-publish failure that left the website benchmark data stale (#13607). The 2026-06-14 Bench run computed all timings, but `bench-publish` → step *Merge benchmark results* → `scripts/bench/merge-results.mjs` hard-`exit 1`'d on `collectProjectCompatibilityFailures` with `type-challenges-solutions-project: missing project row` (a `benchmark_set` required/canary classification drift at the run's commit). The validation returned one flat list and `main()` exited **before** `writeFileSync`, so a project-compatibility gap killed the entire timing publish and the site went ≥6h stale.

### Change (entirely in `merge-results.mjs`; `bench.yml` unchanged)
Split `collectProjectCompatibilityFailures` into two buckets, `{fatal, advisory}`:
- **fatal** (exit 1, pre-write, identical to today): **duplicate project rows** — the merge step's unique safety floor (readiness only inspects required rows).
- **advisory** (`::warning::` + still write/publish): missing project row, missing compatibility object/field, fixture_sources errors, red/yellow metadata.

Advisory gaps are recorded in `merged.validation.project_compatibility_advisory` and surfaced as a GitHub annotation.

### Safety — all hard-fail guarantees preserved (outside the demoted path)
- **Incomplete timing shards** → `expected_shards=9` shell check (`bench.yml`) sets `complete=false` → partial-artifact guard halts publish (independent of merge exit code).
- **Missing required *timing* row** → `check-artifact-readiness.mjs --require-project-timing-pairs` recomputes missing required rows and exits 1 → halts publish. ("missing project row" in the merge is membership-only, unrelated to timing presence, so it's advisory.)
- **Duplicate rows** → kept fatal (exit 1, pre-write).
- **Runner-signature** (`--require-runner-signature`) → separate code path, untouched, still exits 1.
- Green/win eligibility (`isGreen`/`rowState`) renders partial-compat rows gray and never a speed win, so degrading compat validation to warnings cannot promote bad data. The improvement also means advisory cases now reach `writeFileSync`, so the diagnostic artifact uploads instead of the job aborting.

The website was separately republished from this run (GCS `latest.json` + `gh-pages` redeploy) — see #13607 — so this PR is the durable prevention.

Goal: hold

## Provenance

Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- `node scripts/bench/test-merge-results.mjs` — passes (advisory cases flipped to exit 0 + output written + `::warning::`; duplicate-row and runner-signature cases still exit 1; new test: the #13607 witness — a canary row missing `peak_memory_bytes` — publishes with exit 0 + annotation + recorded advisory).
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs` — passes.
- Reproduced the exact witness: missing compat → exit 0, `bench-results.json` written, `::warning::` emitted; duplicate canary row → exit 1, output not written (unchanged).

Closes #13607.
