### PR TITLE
refactor(emitter): replace one DTS type-text string surgery with a TypeId transform (#13048)

### DIFF
--- a/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
+++ b/crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs
@@ -656,11 +656,21 @@ impl<'a> DeclarationEmitter<'a> {
     }
 
     /// Print a `TypeId` as TypeScript syntax using `TypePrinter`.
+    ///
+    /// The generic (non-inferred) printer path lets the solver's
+    /// `TypeEvaluator` (run inside `print_type_id_with_policy`) resolve any
+    /// in-interner `IndexAccess(object, key)` to its member type before the
+    /// `TypePrinter` renders it. Cross-file imported indexed accesses whose
+    /// member type lives in a foreign arena (the only case the rendered-text
+    /// pass `expand_imported_indexed_access_type_text` can still resolve)
+    /// reach declaration emit through the inferred-declaration and raw
+    /// expression-text paths, not through this generic resolved-`TypeId`
+    /// entry point; this path therefore does not post-process its own
+    /// rendering. See `print_type_id_for_inferred_declaration_with_optional_setter_names`
+    /// and the `preferred_expression_type_text` callers for the surviving
+    /// text-pass sites tracked by #13048.
     pub(crate) fn print_type_id(&self, type_id: tsz_solver::types::TypeId) -> String {
-        let printed = self
-            .print_type_id_with_policy(type_id, Self::should_preserve_named_application_for_emit);
-        self.expand_imported_indexed_access_type_text(&printed)
-            .unwrap_or(printed)
+        self.print_type_id_with_policy(type_id, Self::should_preserve_named_application_for_emit)
     }
 
     pub(crate) fn print_type_id_for_inferred_declaration(


### PR DESCRIPTION
Advances #13048.

Goal: hold

## Structural rule
DTS display transforms operate on `TypeId` before printing, not on rendered type text. The generic (non-inferred) `print_type_id` path runs the solver `TypeEvaluator` inside `print_type_id_with_policy`, which resolves any in-interner `IndexAccess(object, key)` to its member type before the `TypePrinter` renders it. The only imported-indexed-access case the rendered-text pass `expand_imported_indexed_access_type_text` can still resolve is a cross-file member whose type lives in a foreign arena, and those reach declaration emit through the inferred-declaration and raw expression-text paths -- not through this generic resolved-`TypeId` entry point. So when `tsc` resolves `import("mod").Iface["m"]` to its member type for a resolved declaration type, tsz already does so through the solver evaluator (printer policy applied while printing a `TypeId`), and the post-print text re-scan on this path was a redundant no-op safety net over already-correct printer output. This mirrors the first-generic-argument parenthesization retirement (#13596) and the `elide_type_reference_names` retirement (#13254): retire one redundant chained text pass whose effect is already owned structurally before/during printing.

## What changed
- `crates/tsz-emitter/src/declaration_emitter/helpers/type_printing.rs`: `print_type_id` no longer chains `expand_imported_indexed_access_type_text` over its own rendered output; it returns the printer result directly. Added a doc comment recording why the generic resolved-`TypeId` path needs no post-print text pass and where the surviving text-pass sites live.

The `expand_imported_indexed_access_type_text` helper itself is unchanged and still backs the genuinely text-driven sites that this campaign must convert next: the inferred-declaration chains (`print_type_id_for_inferred_declaration_with_optional_setter_names`, `print_type_id_for_inferred_predicate_declaration`) and the raw `preferred_expression_type_text` paths in `exports/mod.rs` and `variable_decl.rs`. Those, plus `simplify_inexact_optional_mapped_intersection_text` and `expand_portable_intersection_type_text`, are the remaining (and larger) follow-up slices because they depend on resolving foreign-arena member types into the current interner -- the XL body of #13048.

## Verification
- `cargo build -p tsz-emitter`: clean.
- `cargo clippy -p tsz-emitter --all-targets`: clean, no new warnings.
- `cargo nextest run -p tsz-emitter` (full crate, 4303 tests incl. emit-parity): byte-identical -- only the 3 pre-existing base failures (`take_diagnostics_keeps_ts2883_when_swapped_seen_before_canonical_duplicate`, `take_diagnostics_drops_swapped_ts2883_when_canonical_exists`, `fix_generic_rest_identity_preserves_parameters_tuple_labels`), confirmed present on the unmodified base branch via the pre-edit baseline run. No new failures, no output changes.
- Broad conformance/emit/fourslash parity is owned by ready CI.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
