### PR TITLE
refactor(lowering): replace TypeLowering's resolver callbacks with a LoweringHost trait (#13061)

### DIFF
--- a/crates/tsz-lowering/src/lower/advanced.rs
+++ b/crates/tsz-lowering/src/lower/advanced.rs
@@ -2,6 +2,7 @@
 //! literal parsing, type references, and remaining simple type forms.
 
 use super::core::*;
+use super::host::LoweringHost;
 
 use tsz_parser::parser::base::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
@@ -14,8 +15,7 @@ use tsz_solver::types::{
 impl<'a> TypeLowering<'a> {
     fn lower_lazy_def_reference(&self, def_id: tsz_solver::def::DefId) -> TypeId {
         let lazy = self.interner.lazy(def_id);
-        if let Some(resolve_params) = self.lazy_type_params_resolver
-            && let Some(type_params) = resolve_params(def_id)
+        if let Some(type_params) = self.host.resolve_lazy_type_params(def_id)
             && !type_params.is_empty()
             && type_params.iter().all(|param| param.default.is_some())
             && let Some(default_args) =
@@ -528,9 +528,8 @@ impl<'a> TypeLowering<'a> {
 
             // Module resolution requires &mut self (checker state); pick up the
             // checker's pre-resolved result before falling through to the generic lowering.
-            if let Some(resolver) = self.import_type_resolver
-                && self.has_import_call_in_type_name(data.type_name)
-                && let Some(resolved) = resolver(data.type_name)
+            if self.has_import_call_in_type_name(data.type_name)
+                && let Some(resolved) = self.host.resolve_import_type(data.type_name)
             {
                 if let Some(args) = &data.type_arguments
                     && !args.nodes.is_empty()
@@ -572,8 +571,7 @@ impl<'a> TypeLowering<'a> {
                 // params, so resolve them through the solver helper instead of
                 // copying the raw default type.
                 if let Some(tsz_solver::TypeData::Lazy(def_id)) = self.interner.lookup(base_type)
-                    && let Some(resolve_params) = self.lazy_type_params_resolver
-                    && let Some(type_params) = resolve_params(def_id)
+                    && let Some(type_params) = self.host.resolve_lazy_type_params(def_id)
                     && type_args.len() < type_params.len()
                     && type_params[type_args.len()..]
                         .iter()
@@ -590,8 +588,7 @@ impl<'a> TypeLowering<'a> {
             }
 
             if let Some(tsz_solver::TypeData::Lazy(def_id)) = self.interner.lookup(base_type)
-                && let Some(resolve_params) = self.lazy_type_params_resolver
-                && let Some(type_params) = resolve_params(def_id)
+                && let Some(type_params) = self.host.resolve_lazy_type_params(def_id)
                 && !type_params.is_empty()
                 && type_params.iter().all(|param| param.default.is_some())
                 && let Some(default_args) = tsz_solver::computation::fill_application_defaults(
@@ -832,9 +829,7 @@ impl<'a> TypeLowering<'a> {
             // Check for a pre-resolved type from the checker (e.g., flow-narrowed typeof).
             // This allows `typeof c` inside a type alias body to pick up the narrowed
             // type of `c` when control flow has narrowed it at the declaration site.
-            if let Some(override_fn) = &self.type_query_override
-                && let Some(resolved) = override_fn(data.expr_name)
-            {
+            if let Some(resolved) = self.host.resolve_type_query_override(data.expr_name) {
                 if let Some(args) = &data.type_arguments
                     && !args.nodes.is_empty()
                 {

--- a/crates/tsz-lowering/src/lower/core.rs
+++ b/crates/tsz-lowering/src/lower/core.rs
@@ -24,6 +24,8 @@ use tsz_solver::types::{
     Visibility,
 };
 
+use super::host::{ClosureLoweringHost, LoweringHost};
+
 mod signature_members;
 
 #[cfg(test)]
@@ -84,49 +86,13 @@ pub type LoweredInterfaceMemberTypes = (Vec<TypeParamInfo>, Vec<(NodeIndex, Type
 pub struct TypeLowering<'a> {
     pub(super) arena: &'a NodeArena,
     pub(super) interner: &'a dyn TypeDatabase,
-    /// Optional type resolver - resolves identifier nodes to `SymbolIds`.
-    /// If provided, this enables correct abstract class detection.
-    pub(super) type_resolver: Option<&'a NodeIndexResolver<'a, u32>>,
-    /// Optional `DefId` resolver - resolves identifier nodes to `DefIds`.
-    /// Resolves identifier nodes to `DefId`s for type identity.
-    pub(super) def_id_resolver: Option<&'a NodeIndexResolver<'a, DefId>>,
-    /// Optional resolver that returns a `DefId` only when a simple identifier
-    /// lexically resolves to a function- or block-local declaration shadowing a
-    /// same-named file-level type. Consulted before the name-first resolution in
-    /// `prefer_name_def_id_resolution` mode so local shadows win without
-    /// disturbing imported/lib name resolution. Returns `None` otherwise.
-    pub(super) local_shadow_def_id_resolver: Option<&'a NodeIndexResolver<'a, DefId>>,
-    /// Optional value resolver for typeof queries.
-    pub(super) value_resolver: Option<&'a NodeIndexResolver<'a, u32>>,
-    /// Optional name-based `DefId` resolver — fallback for cross-arena resolution.
-    ///
-    /// `NodeIndex` values are arena-specific: the same index means different things
-    /// in different arenas. When `with_arena()` switches the working arena, the
-    /// NodeIndex-based `def_id_resolver` can look up the wrong identifier because
-    /// its closure captured arenas from the ORIGINAL context. This name-based
-    /// resolver bypasses that problem by resolving directly from the identifier
-    /// text (which `lower_identifier_type` already extracts from `self.arena`).
-    pub(super) name_def_id_resolver: Option<&'a TypeIdResolver<'a>>,
-    /// Optional computed property name resolver — resolves computed property
-    /// expressions (e.g., `[k]` where k is a unique symbol) to property name atoms.
-    /// Used when the lowering can't determine the name from AST alone.
-    pub(super) computed_name_resolver: Option<&'a NodeIndexResolver<'a, Atom>>,
-    /// Arena-aware variant of `computed_name_resolver`. When set, receives
-    /// `(expr_idx, arena_ptr)` so the resolver can distinguish the same `NodeIndex`
-    /// value from different arenas (cross-arena merged-interface lowering).
-    /// Takes precedence over `computed_name_resolver` when both are set.
-    pub(super) computed_name_resolver_with_arena:
-        Option<&'a dyn Fn(NodeIndex, *const NodeArena) -> Option<Atom>>,
-    /// Optional metadata resolver for computed property expressions whose resolved
-    /// property name came from a symbol-valued computed name.
-    pub(super) computed_symbol_name_resolver: Option<&'a dyn Fn(NodeIndex) -> bool>,
-    /// Arena-aware variant of `computed_symbol_name_resolver`. Takes precedence
-    /// over `computed_symbol_name_resolver` when both are set.
-    pub(super) computed_symbol_name_resolver_with_arena:
-        Option<&'a dyn Fn(NodeIndex, *const NodeArena) -> bool>,
-    /// Optional resolver for lazy type parameter metadata. This is used when
-    /// a lowered lazy reference omits type arguments but all parameters have defaults.
-    pub(super) lazy_type_params_resolver: Option<&'a LazyTypeParamsResolver<'a>>,
+    /// Single resolver boundary. Replaces the former twelve `Option<&dyn Fn>`
+    /// callback fields: name/symbol/`DefId`/computed-name/lazy-type-param/
+    /// type-query/import-type resolution all dispatch through this host, so the
+    /// active capability set is a property of the host value rather than of each
+    /// construction site. The public `new`/`with_*` constructors and `with_*`
+    /// builders populate a `ClosureLoweringHost`.
+    pub(super) host: ClosureLoweringHost<'a>,
     /// Optional compiler-controlled intrinsic replacement for the lib-only
     /// `BuiltinIteratorReturn` alias.
     pub(super) builtin_iterator_return_type: Option<TypeId>,
@@ -144,20 +110,6 @@ pub struct TypeLowering<'a> {
     /// Whether strictNullChecks is enabled. When true, optional parameters
     /// in function types include `| undefined` in their type.
     pub(super) strict_null_checks: bool,
-    /// Optional override for type query resolution. When provided, this callback
-    /// is consulted before creating a `TypeQuery` type. If it returns `Some(type_id)`,
-    /// that type is used directly instead of creating a deferred `TypeQuery`.
-    /// This enables flow-sensitive narrowing for `typeof expr` in type positions
-    /// (e.g., inside type alias bodies where flow narrowing has already been computed).
-    pub(super) type_query_override: Option<&'a NodeIndexResolver<'a, TypeId>>,
-    /// Optional import type resolver — resolves `TYPE_REFERENCE` nodes whose `type_name`
-    /// is or starts with an `import()` `CALL_EXPRESSION` to a pre-computed `TypeId`.
-    ///
-    /// `TypeLowering` cannot perform module resolution; the checker pre-resolves import
-    /// type references and supplies them through this callback. The argument is the full
-    /// `type_name` `NodeIndex` (either the `CALL_EXPRESSION` itself or the `QUALIFIED_NAME`
-    /// rooted in it). Returns `Some` when pre-resolved, `None` to fall through to `ERROR`.
-    pub(super) import_type_resolver: Option<&'a NodeIndexResolver<'a, TypeId>>,
     /// Operation counter to prevent infinite loops
     pub(super) operations: Rc<RefCell<u32>>,
     /// Whether the operation limit has been exceeded
@@ -448,27 +400,21 @@ impl<'a> TypeLowering<'a> {
         TypeLowering {
             arena,
             interner: interner.as_type_database(),
-            type_resolver: resolvers.type_resolver,
-            def_id_resolver: resolvers.def_id_resolver,
-            local_shadow_def_id_resolver: None,
-            value_resolver: resolvers.value_resolver,
-            computed_name_resolver: None,
-            computed_name_resolver_with_arena: None,
-            computed_symbol_name_resolver: None,
-            computed_symbol_name_resolver_with_arena: None,
-            lazy_type_params_resolver: None,
+            host: ClosureLoweringHost {
+                type_resolver: resolvers.type_resolver,
+                def_id_resolver: resolvers.def_id_resolver,
+                value_resolver: resolvers.value_resolver,
+                ..ClosureLoweringHost::default()
+            },
             builtin_iterator_return_type: None,
             prefer_name_def_id_resolution: false,
             preferred_self_name: None,
             preferred_self_def_id: None,
-            name_def_id_resolver: None,
             strict_null_checks: false,
             type_param_scopes: Rc::new(RefCell::new(Vec::new())),
             typeof_param_scopes: Rc::new(RefCell::new(Vec::new())),
             operations: Rc::new(RefCell::new(0)),
             limit_exceeded: Rc::new(RefCell::new(false)),
-            type_query_override: None,
-            import_type_resolver: None,
         }
     }
 
@@ -565,23 +511,13 @@ impl<'a> TypeLowering<'a> {
         TypeLowering {
             arena,
             interner: self.interner,
-            type_resolver: self.type_resolver,
-            def_id_resolver: self.def_id_resolver,
-            local_shadow_def_id_resolver: self.local_shadow_def_id_resolver,
-            value_resolver: self.value_resolver,
-            computed_name_resolver: self.computed_name_resolver,
-            computed_name_resolver_with_arena: self.computed_name_resolver_with_arena,
-            computed_symbol_name_resolver: self.computed_symbol_name_resolver,
-            computed_symbol_name_resolver_with_arena: self.computed_symbol_name_resolver_with_arena,
-            lazy_type_params_resolver: self.lazy_type_params_resolver,
+            // The whole resolver set travels as one copy of the host.
+            host: self.host.clone(),
             builtin_iterator_return_type: self.builtin_iterator_return_type,
             prefer_name_def_id_resolution: self.prefer_name_def_id_resolution,
             preferred_self_name: self.preferred_self_name.clone(),
             preferred_self_def_id: self.preferred_self_def_id,
-            name_def_id_resolver: self.name_def_id_resolver,
             strict_null_checks: self.strict_null_checks,
-            type_query_override: self.type_query_override,
-            import_type_resolver: self.import_type_resolver,
             // Rc::clone() shares the underlying Rc instead of copying data
             type_param_scopes: Rc::clone(&self.type_param_scopes),
             typeof_param_scopes: Rc::clone(&self.typeof_param_scopes),
@@ -843,7 +779,7 @@ impl<'a> TypeLowering<'a> {
         mut self,
         resolver: &'a dyn Fn(NodeIndex) -> Option<Atom>,
     ) -> Self {
-        self.computed_name_resolver = Some(resolver);
+        self.host.computed_name_resolver = Some(resolver);
         self
     }
 
@@ -856,7 +792,7 @@ impl<'a> TypeLowering<'a> {
         mut self,
         resolver: &'a dyn Fn(NodeIndex, *const NodeArena) -> Option<Atom>,
     ) -> Self {
-        self.computed_name_resolver_with_arena = Some(resolver);
+        self.host.computed_name_resolver_with_arena = Some(resolver);
         self
     }
 
@@ -865,7 +801,7 @@ impl<'a> TypeLowering<'a> {
         mut self,
         resolver: &'a dyn Fn(NodeIndex) -> bool,
     ) -> Self {
-        self.computed_symbol_name_resolver = Some(resolver);
+        self.host.computed_symbol_name_resolver = Some(resolver);
         self
     }
 
@@ -875,7 +811,7 @@ impl<'a> TypeLowering<'a> {
         mut self,
         resolver: &'a dyn Fn(NodeIndex, *const NodeArena) -> bool,
     ) -> Self {
-        self.computed_symbol_name_resolver_with_arena = Some(resolver);
+        self.host.computed_symbol_name_resolver_with_arena = Some(resolver);
         self
     }
 
@@ -885,7 +821,7 @@ impl<'a> TypeLowering<'a> {
         mut self,
         resolver: &'a dyn Fn(DefId) -> Option<Vec<TypeParamInfo>>,
     ) -> Self {
-        self.lazy_type_params_resolver = Some(resolver);
+        self.host.lazy_type_params_resolver = Some(resolver);
         self
     }
 
@@ -902,7 +838,7 @@ impl<'a> TypeLowering<'a> {
         mut self,
         resolver: &'a dyn Fn(&str) -> Option<DefId>,
     ) -> Self {
-        self.name_def_id_resolver = Some(resolver);
+        self.host.name_def_id_resolver = Some(resolver);
         self
     }
 
@@ -914,7 +850,7 @@ impl<'a> TypeLowering<'a> {
         mut self,
         resolver: &'a dyn Fn(NodeIndex) -> Option<DefId>,
     ) -> Self {
-        self.local_shadow_def_id_resolver = Some(resolver);
+        self.host.local_shadow_def_id_resolver = Some(resolver);
         self
     }
 
@@ -937,7 +873,7 @@ impl<'a> TypeLowering<'a> {
         mut self,
         resolver: &'a dyn Fn(NodeIndex) -> Option<TypeId>,
     ) -> Self {
-        self.type_query_override = Some(resolver);
+        self.host.type_query_override = Some(resolver);
         self
     }
 
@@ -951,7 +887,7 @@ impl<'a> TypeLowering<'a> {
         mut self,
         resolver: &'a NodeIndexResolver<'a, TypeId>,
     ) -> Self {
-        self.import_type_resolver = Some(resolver);
+        self.host.import_type_resolver = Some(resolver);
         self
     }
 
@@ -964,8 +900,7 @@ impl<'a> TypeLowering<'a> {
 
     /// Resolve an identifier name to a `DefId` using the name-based resolver.
     pub(super) fn resolve_def_id_by_name(&self, name: &str) -> Option<DefId> {
-        self.name_def_id_resolver
-            .and_then(|resolver| resolver(name))
+        self.host.resolve_def_id_by_name(name)
     }
 
     /// Build the full text of an entity-name type node from the current arena.
@@ -1050,31 +985,26 @@ impl<'a> TypeLowering<'a> {
 
     /// Resolve a node to a type symbol ID if a resolver is provided.
     pub(super) fn resolve_type_symbol(&self, node_idx: NodeIndex) -> Option<u32> {
-        self.type_resolver.and_then(|resolver| resolver(node_idx))
+        self.host.resolve_type_symbol(node_idx)
     }
 
     /// Resolve a node to a `DefId` if a `DefId` resolver is provided.
     ///
     /// `DefIds` are Solver-owned identifiers that don't require Binder context.
     pub(super) fn resolve_def_id(&self, node_idx: NodeIndex) -> Option<DefId> {
-        self.def_id_resolver.and_then(|resolver| resolver(node_idx))
+        self.host.resolve_def_id(node_idx)
     }
 
     /// Resolve a node to the `DefId` of a function- or block-local declaration
     /// that shadows a same-named file-level type, if such a resolver is provided.
     /// Returns `None` for every non-shadowing reference.
     pub(super) fn resolve_local_shadow_def_id(&self, node_idx: NodeIndex) -> Option<DefId> {
-        self.local_shadow_def_id_resolver
-            .and_then(|resolver| resolver(node_idx))
+        self.host.resolve_local_shadow_def_id(node_idx)
     }
 
     /// Resolve a node to a value symbol ID if a resolver is provided.
     pub(super) fn resolve_value_symbol(&self, node_idx: NodeIndex) -> Option<u32> {
-        if let Some(resolver) = self.value_resolver {
-            resolver(node_idx)
-        } else {
-            self.resolve_type_symbol(node_idx)
-        }
+        self.host.resolve_value_symbol(node_idx)
     }
 
     pub(super) fn push_type_param_scope(&self) {

--- a/crates/tsz-lowering/src/lower/core/constructor_parity_tests.rs
+++ b/crates/tsz-lowering/src/lower/core/constructor_parity_tests.rs
@@ -6,15 +6,16 @@ fn assert_invariant_defaults(lowering: &TypeLowering<'_>) {
     assert!(lowering.type_param_scopes.borrow().is_empty());
     assert_eq!(*lowering.operations.borrow(), 0);
     assert!(!*lowering.limit_exceeded.borrow());
-    // Optional knobs default to disabled.
-    assert!(lowering.computed_name_resolver.is_none());
-    assert!(lowering.lazy_type_params_resolver.is_none());
+    // Optional knobs default to disabled. The resolver set now lives on the
+    // host; only the value knobs remain directly on `TypeLowering`.
+    assert!(lowering.host.computed_name_resolver.is_none());
+    assert!(lowering.host.lazy_type_params_resolver.is_none());
     assert!(!lowering.prefer_name_def_id_resolution);
     assert!(lowering.preferred_self_name.is_none());
     assert!(lowering.preferred_self_def_id.is_none());
-    assert!(lowering.name_def_id_resolver.is_none());
+    assert!(lowering.host.name_def_id_resolver.is_none());
     assert!(!lowering.strict_null_checks);
-    assert!(lowering.type_query_override.is_none());
+    assert!(lowering.host.type_query_override.is_none());
 }
 
 #[test]
@@ -23,9 +24,9 @@ fn new_initializes_invariant_defaults() {
     let interner = TypeInterner::new();
     let lowering = TypeLowering::new(&arena, &interner);
     assert_invariant_defaults(&lowering);
-    assert!(lowering.type_resolver.is_none());
-    assert!(lowering.def_id_resolver.is_none());
-    assert!(lowering.value_resolver.is_none());
+    assert!(lowering.host.type_resolver.is_none());
+    assert!(lowering.host.def_id_resolver.is_none());
+    assert!(lowering.host.value_resolver.is_none());
 }
 
 #[test]
@@ -36,9 +37,9 @@ fn with_resolver_initializes_invariant_defaults() {
     let lowering = TypeLowering::with_resolver(&arena, &interner, &resolver);
     assert_invariant_defaults(&lowering);
     // `with_resolver` wires the same closure into both type and value slots.
-    assert!(lowering.type_resolver.is_some());
-    assert!(lowering.def_id_resolver.is_none());
-    assert!(lowering.value_resolver.is_some());
+    assert!(lowering.host.type_resolver.is_some());
+    assert!(lowering.host.def_id_resolver.is_none());
+    assert!(lowering.host.value_resolver.is_some());
 }
 
 #[test]
@@ -49,9 +50,9 @@ fn with_resolvers_initializes_invariant_defaults() {
     let value_resolver = |_: NodeIndex| -> Option<u32> { None };
     let lowering = TypeLowering::with_resolvers(&arena, &interner, &type_resolver, &value_resolver);
     assert_invariant_defaults(&lowering);
-    assert!(lowering.type_resolver.is_some());
-    assert!(lowering.def_id_resolver.is_none());
-    assert!(lowering.value_resolver.is_some());
+    assert!(lowering.host.type_resolver.is_some());
+    assert!(lowering.host.def_id_resolver.is_none());
+    assert!(lowering.host.value_resolver.is_some());
 }
 
 #[test]
@@ -63,9 +64,9 @@ fn with_def_id_resolver_initializes_invariant_defaults() {
     let lowering =
         TypeLowering::with_def_id_resolver(&arena, &interner, &def_id_resolver, &value_resolver);
     assert_invariant_defaults(&lowering);
-    assert!(lowering.type_resolver.is_none());
-    assert!(lowering.def_id_resolver.is_some());
-    assert!(lowering.value_resolver.is_some());
+    assert!(lowering.host.type_resolver.is_none());
+    assert!(lowering.host.def_id_resolver.is_some());
+    assert!(lowering.host.value_resolver.is_some());
 }
 
 #[test]
@@ -83,9 +84,9 @@ fn with_hybrid_resolver_initializes_invariant_defaults() {
         &value_resolver,
     );
     assert_invariant_defaults(&lowering);
-    assert!(lowering.type_resolver.is_some());
-    assert!(lowering.def_id_resolver.is_some());
-    assert!(lowering.value_resolver.is_some());
+    assert!(lowering.host.type_resolver.is_some());
+    assert!(lowering.host.def_id_resolver.is_some());
+    assert!(lowering.host.value_resolver.is_some());
 }
 
 #[test]

--- a/crates/tsz-lowering/src/lower/core/signature_members.rs
+++ b/crates/tsz-lowering/src/lower/core/signature_members.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::lower::host::LoweringHost;
 
 impl<'a> TypeLowering<'a> {
     /// Lower a function-like declaration (Method, Constructor, Function) to a `TypeId`.
@@ -630,13 +631,9 @@ impl<'a> TypeLowering<'a> {
             // binding identity, which matters when user code shadows `Symbol`.
             // The arena-aware variant takes precedence: it distinguishes the same
             // NodeIndex value across different arenas (cross-arena lowering).
-            let arena_ptr: *const NodeArena = self.arena;
-            if let Some(resolver) = self.computed_name_resolver_with_arena
-                && let Some(name) = resolver(computed.expression, arena_ptr)
-            {
-                return Some(name);
-            } else if let Some(resolver) = self.computed_name_resolver
-                && let Some(name) = resolver(computed.expression)
+            if let Some(name) = self
+                .host
+                .resolve_computed_name(computed.expression, self.arena)
             {
                 return Some(name);
             }
@@ -668,12 +665,13 @@ impl<'a> TypeLowering<'a> {
         let Some(computed) = self.arena.get_computed_property(node) else {
             return false;
         };
-        let arena_ptr: *const NodeArena = self.arena;
-        if let Some(resolver) = self.computed_symbol_name_resolver_with_arena {
-            return resolver(computed.expression, arena_ptr);
-        }
-        if let Some(resolver) = self.computed_symbol_name_resolver {
-            return resolver(computed.expression);
+        // A wired symbol resolver answers outright; otherwise fall back to the
+        // syntax-only well-known-`Symbol` check.
+        if let Some(is_symbol) = self
+            .host
+            .computed_name_is_symbol(computed.expression, self.arena)
+        {
+            return is_symbol;
         }
         self.get_well_known_symbol_name(computed.expression)
             .is_some()

--- a/crates/tsz-lowering/src/lower/host.rs
+++ b/crates/tsz-lowering/src/lower/host.rs
@@ -1,0 +1,201 @@
+//! `LoweringHost`: the single capability boundary `TypeLowering` consults to
+//! resolve names, symbols, `DefId`s, computed property keys, lazy type-param
+//! metadata, type-query overrides, and import-type references.
+//!
+//! Historically `TypeLowering` carried twelve independent `Option<&dyn Fn>`
+//! resolver callbacks, wired ad hoc at each construction site. Which resolvers
+//! were active became a property of every call site rather than of the type,
+//! and the precedence between arena-aware and arena-blind variants lived only
+//! in comments. This module collapses that surface into one trait.
+//!
+//! [`LoweringHost`] declares every capability as a default-`None`/`false`
+//! method, so a host only overrides what it actually provides. Arena-aware
+//! capabilities take `&NodeArena` directly instead of a raw `*const NodeArena`.
+//!
+//! [`ClosureLoweringHost`] is the closure-backed adapter the existing checker
+//! construction sites build through the public `TypeLowering` constructors and
+//! `with_*` builders. It owns the twelve optional closures and implements the
+//! precedence rules (arena-aware variant first, value-resolver falling back to
+//! the type resolver) exactly as the previous inline field reads did, so the
+//! refactor is behavior-preserving.
+
+use tsz_common::interner::Atom;
+use tsz_parser::parser::base::NodeIndex;
+use tsz_parser::parser::node::NodeArena;
+use tsz_solver::def::DefId;
+use tsz_solver::types::{TypeId, TypeParamInfo};
+
+use super::core::{LazyTypeParamsResolver, NodeIndexResolver, TypeIdResolver};
+
+/// Single resolver boundary consulted by `TypeLowering`.
+///
+/// Every method defaults to "not provided" (`None`/`false`) so a host only
+/// implements the capabilities it actually backs. `TypeLowering` never reads a
+/// resolver field directly; it asks the host, so the active capability set is a
+/// property of the host value rather than of each construction site.
+pub trait LoweringHost {
+    /// Resolve an identifier node to a binder `SymbolId` (type position).
+    fn resolve_type_symbol(&self, _node: NodeIndex) -> Option<u32> {
+        None
+    }
+
+    /// Resolve an identifier node to a solver-owned `DefId`.
+    fn resolve_def_id(&self, _node: NodeIndex) -> Option<DefId> {
+        None
+    }
+
+    /// Resolve an identifier node to the `DefId` of a function- or block-local
+    /// declaration that shadows a same-named file-level type. Returns `None` for
+    /// every non-shadowing reference.
+    fn resolve_local_shadow_def_id(&self, _node: NodeIndex) -> Option<DefId> {
+        None
+    }
+
+    /// Resolve an identifier node to a binder `SymbolId` (value position, for
+    /// `typeof` queries). When no value resolver is provided, callers fall back
+    /// to [`LoweringHost::resolve_type_symbol`]; that fallback is implemented by
+    /// the concrete host so it can honor a shared type/value closure.
+    fn resolve_value_symbol(&self, _node: NodeIndex) -> Option<u32> {
+        None
+    }
+
+    /// Resolve an identifier's text to a `DefId` (cross-arena name-based path).
+    fn resolve_def_id_by_name(&self, _name: &str) -> Option<DefId> {
+        None
+    }
+
+    /// Resolve a computed property expression to a property-name atom, using the
+    /// active declaration `arena` to disambiguate cross-arena `NodeIndex` values.
+    fn resolve_computed_name(&self, _expr: NodeIndex, _arena: &NodeArena) -> Option<Atom> {
+        None
+    }
+
+    /// Whether a computed property expression resolves to a symbol-valued key,
+    /// using the active declaration `arena` for cross-arena disambiguation.
+    ///
+    /// Returns `None` when this host wires no symbol-name resolver, so the
+    /// caller falls back to its syntax-only well-known-`Symbol` check. A host
+    /// that does wire a resolver returns `Some(answer)` and that answer wins
+    /// outright (no fallback), matching the previous inline precedence.
+    fn computed_name_is_symbol(&self, _expr: NodeIndex, _arena: &NodeArena) -> Option<bool> {
+        None
+    }
+
+    /// Resolve lazy type-parameter metadata for a `DefId` (used to apply omitted
+    /// defaulted type arguments).
+    fn resolve_lazy_type_params(&self, _def_id: DefId) -> Option<Vec<TypeParamInfo>> {
+        None
+    }
+
+    /// Flow-sensitive override for `typeof expr` in type position. When it
+    /// returns `Some`, the result is used instead of a deferred `TypeQuery`.
+    fn resolve_type_query_override(&self, _node: NodeIndex) -> Option<TypeId> {
+        None
+    }
+
+    /// Resolve a `TYPE_REFERENCE` whose name is rooted in an `import()` call to a
+    /// pre-computed `TypeId` (module resolution is performed by the checker).
+    fn resolve_import_type(&self, _node: NodeIndex) -> Option<TypeId> {
+        None
+    }
+}
+
+/// Closure-backed [`LoweringHost`] used by the public `TypeLowering`
+/// constructors and `with_*` builders.
+///
+/// Each field mirrors one of the historical resolver callbacks. The two
+/// computed-name capabilities keep both an arena-aware and an arena-blind
+/// closure; the arena-aware variant takes precedence when both are set, exactly
+/// as the previous inline reads did.
+#[derive(Default, Clone)]
+pub struct ClosureLoweringHost<'a> {
+    pub(super) type_resolver: Option<&'a NodeIndexResolver<'a, u32>>,
+    pub(super) def_id_resolver: Option<&'a NodeIndexResolver<'a, DefId>>,
+    pub(super) local_shadow_def_id_resolver: Option<&'a NodeIndexResolver<'a, DefId>>,
+    pub(super) value_resolver: Option<&'a NodeIndexResolver<'a, u32>>,
+    pub(super) name_def_id_resolver: Option<&'a TypeIdResolver<'a>>,
+    pub(super) computed_name_resolver: Option<&'a NodeIndexResolver<'a, Atom>>,
+    pub(super) computed_name_resolver_with_arena:
+        Option<&'a dyn Fn(NodeIndex, *const NodeArena) -> Option<Atom>>,
+    pub(super) computed_symbol_name_resolver: Option<&'a dyn Fn(NodeIndex) -> bool>,
+    pub(super) computed_symbol_name_resolver_with_arena:
+        Option<&'a dyn Fn(NodeIndex, *const NodeArena) -> bool>,
+    pub(super) lazy_type_params_resolver: Option<&'a LazyTypeParamsResolver<'a>>,
+    pub(super) type_query_override: Option<&'a NodeIndexResolver<'a, TypeId>>,
+    pub(super) import_type_resolver: Option<&'a NodeIndexResolver<'a, TypeId>>,
+}
+
+impl LoweringHost for ClosureLoweringHost<'_> {
+    fn resolve_type_symbol(&self, node: NodeIndex) -> Option<u32> {
+        self.type_resolver.and_then(|resolver| resolver(node))
+    }
+
+    fn resolve_def_id(&self, node: NodeIndex) -> Option<DefId> {
+        self.def_id_resolver.and_then(|resolver| resolver(node))
+    }
+
+    fn resolve_local_shadow_def_id(&self, node: NodeIndex) -> Option<DefId> {
+        self.local_shadow_def_id_resolver
+            .and_then(|resolver| resolver(node))
+    }
+
+    fn resolve_value_symbol(&self, node: NodeIndex) -> Option<u32> {
+        // A value resolver wins; otherwise fall back to the type resolver,
+        // preserving the previous `resolve_value_symbol` behavior.
+        if let Some(resolver) = self.value_resolver {
+            resolver(node)
+        } else {
+            self.resolve_type_symbol(node)
+        }
+    }
+
+    fn resolve_def_id_by_name(&self, name: &str) -> Option<DefId> {
+        self.name_def_id_resolver
+            .and_then(|resolver| resolver(name))
+    }
+
+    fn resolve_computed_name(&self, expr: NodeIndex, arena: &NodeArena) -> Option<Atom> {
+        // The arena-aware variant takes precedence: it distinguishes the same
+        // NodeIndex value across different arenas (cross-arena lowering).
+        let arena_ptr: *const NodeArena = arena;
+        if let Some(resolver) = self.computed_name_resolver_with_arena
+            && let Some(name) = resolver(expr, arena_ptr)
+        {
+            return Some(name);
+        }
+        if let Some(resolver) = self.computed_name_resolver
+            && let Some(name) = resolver(expr)
+        {
+            return Some(name);
+        }
+        None
+    }
+
+    fn computed_name_is_symbol(&self, expr: NodeIndex, arena: &NodeArena) -> Option<bool> {
+        // The arena-aware variant takes precedence; either resolver's answer
+        // wins outright (no well-known fallback), exactly as the previous
+        // inline reads did. `None` means no symbol resolver is wired.
+        let arena_ptr: *const NodeArena = arena;
+        if let Some(resolver) = self.computed_symbol_name_resolver_with_arena {
+            return Some(resolver(expr, arena_ptr));
+        }
+        if let Some(resolver) = self.computed_symbol_name_resolver {
+            return Some(resolver(expr));
+        }
+        None
+    }
+
+    fn resolve_lazy_type_params(&self, def_id: DefId) -> Option<Vec<TypeParamInfo>> {
+        self.lazy_type_params_resolver
+            .and_then(|resolver| resolver(def_id))
+    }
+
+    fn resolve_type_query_override(&self, node: NodeIndex) -> Option<TypeId> {
+        self.type_query_override.and_then(|resolver| resolver(node))
+    }
+
+    fn resolve_import_type(&self, node: NodeIndex) -> Option<TypeId> {
+        self.import_type_resolver
+            .and_then(|resolver| resolver(node))
+    }
+}

--- a/crates/tsz-lowering/src/lower/mod.rs
+++ b/crates/tsz-lowering/src/lower/mod.rs
@@ -5,5 +5,7 @@
 
 mod advanced;
 mod core;
+mod host;
 
 pub use self::core::*;
+pub use self::host::{ClosureLoweringHost, LoweringHost};


### PR DESCRIPTION
Advances #13061.

Goal: hold

## Structural rule
TypeLowering depends on one LoweringHost trait instead of 12 separate resolver callbacks. The active resolver capability set is now a property of the host value, not of each construction site.

## What changed
- New `crates/tsz-lowering/src/lower/host.rs`:
  - `trait LoweringHost` — one default-`None`/`false` method per capability (`resolve_type_symbol`, `resolve_def_id`, `resolve_local_shadow_def_id`, `resolve_value_symbol`, `resolve_def_id_by_name`, `resolve_computed_name`, `computed_name_is_symbol`, `resolve_lazy_type_params`, `resolve_type_query_override`, `resolve_import_type`). Arena-aware methods take `&NodeArena`, not a raw `*const NodeArena`.
  - `ClosureLoweringHost` — the closure-backed adapter the existing public `new`/`with_*` constructors and `with_*` builders populate. It owns the twelve closures and implements the precedence rules exactly as the prior inline reads: the arena-aware computed-name/symbol variant wins over the arena-blind one, and `resolve_value_symbol` falls back to the type resolver when no value resolver is set.
- `TypeLowering` now holds a single `host: ClosureLoweringHost` field, replacing the twelve `Option<&dyn Fn>` fields. `new()`, the constructor family, `with_arena()`, and every `with_*` builder route through the host; `with_arena()` copies the whole resolver set as one host clone instead of a field-by-field copy.
- Every internal resolver read migrated to the host: `core.rs` (`resolve_*` helpers), `advanced.rs` (lazy type-params, import-type, type-query override), `core/signature_members.rs` (computed-name + symbol-name).
- `computed_name_is_symbol` returns `Option<bool>`: a wired resolver's answer wins outright, while an absent resolver still falls back to the syntax-only well-known-`Symbol` check — preserving the prior precedence exactly (the boolean-only form would have collapsed "no resolver" into "false" and wrongly triggered the fallback).
- `constructor_parity_tests` (the existing drift guard) updated to assert resolver wiring through `host.*`.

The public constructor/builder API is unchanged, so the 150+ checker construction sites compile untouched. This is the foundational trait + host slice; the per-context `CheckerLoweringHost` adapters and deletion of the arena-pointer variants / redundant constructors (later steps in the issue's plan) are follow-ups.

## Verification
- `cargo build -p tsz-lowering` — pass
- `cargo build -p tsz-checker` — pass (public API unchanged)
- `cargo clippy -p tsz-lowering --all-targets` — clean, no warnings
- `cargo nextest run -p tsz-lowering` — 166/167 pass; the 1 failure (`test_template_literal_only_interpolation`) reproduces identically on the clean base (revert-and-reproduce), pre-existing and unrelated.
- `cargo nextest run -p tsz-checker` host-path slice (`static_readonly_unique_symbol_tests`, `import_type_utility_identity_tests`, `cross_file_lib_interface_identity_tests`, `non_unique_symbol_late_bound_member_tests`, `keyof_class_unique_symbol_key_tests`, `keyof_well_known_symbol_key_tests`, `merged_namespace_typeof_display_tests`, `symbol_index_signature_tests`) — all pass except 2 `import_type_utility_identity_tests` cases that reproduce identically on the clean base (revert-and-reproduce), pre-existing and unrelated.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
