### PR TITLE
fix(solver): defer conditionals over unresolved cross-module names (#13618)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -967,11 +967,13 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 return self.evaluate(cond.false_type);
             }
 
-            // tsc takes the false branch when the extends type is unresolvable
-            // (e.g. `Function` without lib types); this preserves structural
-            // modifiers (readonly) instead of collapsing the conditional to T.
-            if crate::visitor::is_error_type(self.interner(), extends_type) {
-                return self.evaluate(cond.false_type);
+            // A genuine error settles the conditional to its false branch; an
+            // unresolved cross-arena reference instead defers it (see
+            // `resolve_conditional_error_or_unresolved`).
+            if let Some(result) =
+                self.resolve_conditional_error_or_unresolved(cond, check_type, extends_type)
+            {
+                return result;
             }
 
             let is_sub = self.check_conditional_subtype(check_type, extends_type);

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -128,6 +128,61 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         }
     }
 
+    /// Settle a conditional whose evaluated operands carry an error or an
+    /// unresolved reference, before the structural relation check runs.
+    ///
+    /// - A *genuine* error type in the extends position (e.g. a failed indexed
+    ///   access that minted `TypeData::Error`) collapses the conditional to its
+    ///   false branch — tsc parity, and it preserves structural modifiers
+    ///   (readonly) instead of collapsing to `T`.
+    /// - An `UnresolvedTypeName` is NOT a genuine error: it is a cross-module /
+    ///   cross-arena reference the current resolver generation could not yet
+    ///   bind to a `DefId` (the same residue the check-side `visit_conditional`
+    ///   excludes via `is_genuine_error_type`). The relation machinery treats
+    ///   such a name as related to everything (error/`any`-like), so a definitive
+    ///   branch here would be schedule-dependent: `T extends Builtin ? T : …`
+    ///   over a still-unresolved imported `Builtin` reports `T <: Builtin` true
+    ///   and collapses to `T`, while `Filter extends AnyRecord ? {…} : never`
+    ///   collapses to `never`. Defer instead (mirroring the `Lazy`/`Application`
+    ///   deferral) so the resolver generation that binds the reference decides
+    ///   the branch, and mark the unresolved-reference event so the deferred
+    ///   result is not persisted to the depth-agnostic caches and a later pass
+    ///   recomputes it rather than reusing a stale deferral.
+    ///
+    /// Returns `Some(result)` when the conditional is settled or deferred here.
+    pub(super) fn resolve_conditional_error_or_unresolved(
+        &mut self,
+        cond: &ConditionalType,
+        check_type: TypeId,
+        extends_type: TypeId,
+    ) -> Option<TypeId> {
+        if crate::visitor::is_genuine_error_type(self.interner(), extends_type) {
+            return Some(self.evaluate(cond.false_type));
+        }
+
+        // Only a *bare* `UnresolvedTypeName` is intercepted here; an unresolved
+        // reference wrapped in an `Application`/`Lazy` is deferred downstream by
+        // the indeterminate-relation block after the subtype check.
+        if matches!(
+            self.interner().lookup(extends_type),
+            Some(TypeData::UnresolvedTypeName(_))
+        ) || matches!(
+            self.interner().lookup(check_type),
+            Some(TypeData::UnresolvedTypeName(_))
+        ) {
+            self.mark_unresolved_def_seen();
+            return Some(self.interner().conditional(ConditionalType {
+                check_type,
+                extends_type,
+                true_type: cond.true_type,
+                false_type: cond.false_type,
+                is_distributive: cond.is_distributive,
+            }));
+        }
+
+        None
+    }
+
     /// Subtype check with cache lookup and thread-local depth guard.
     ///
     /// Returns `true` if `check_type <: extends_type`, consulting the evaluator's

--- a/crates/tsz-solver/tests/conditional_deferred_return_tests.rs
+++ b/crates/tsz-solver/tests/conditional_deferred_return_tests.rs
@@ -88,3 +88,86 @@ fn infer_conditional_over_unresolved_application_pattern_stays_deferred() {
         interner.lookup(result)
     );
 }
+
+/// A distributive conditional whose check type is a *concrete* object and whose
+/// extends type is an unresolved cross-module reference (a bare
+/// `UnresolvedTypeName`, the pre-`DefId` form of an imported alias such as
+/// `AnyRecord`) must defer — not collapse to the false branch.
+///
+/// This is the `DeepPick<…, { k: never }>` family (issue #13618): the library's
+/// `Filter extends AnyRecord ? { …mapped… } : never` reports `Filter <: AnyRecord`
+/// as a definitive failure while `AnyRecord` is still an unresolved name, so the
+/// whole pick collapsed to `never` and a valid value was rejected with a false
+/// `TS2322 … not assignable to 'never'`. Folding an `UnresolvedTypeName` into the
+/// error/false branch is schedule-dependent; the conditional must stay deferred
+/// until a later resolver generation binds the reference.
+#[test]
+fn distributive_conditional_concrete_check_over_unresolved_extends_defers() {
+    for (extends_name, true_marker) in [("AnyRecord", TypeId::NUMBER), ("Marker", TypeId::BOOLEAN)]
+    {
+        let interner = TypeInterner::new();
+        let prop = interner.intern_string("id");
+        let check_type = interner.object(vec![PropertyInfo::new(prop, TypeId::STRING)]);
+        let extends_type = interner.unresolved_type_name(interner.intern_string(extends_name));
+
+        let result = evaluate_conditional(
+            &interner,
+            &ConditionalType {
+                check_type,
+                extends_type,
+                true_type: true_marker,
+                false_type: TypeId::NEVER,
+                is_distributive: true,
+            },
+        );
+
+        assert_ne!(
+            result,
+            TypeId::NEVER,
+            "unresolved extends '{extends_name}' must not collapse the conditional to the \
+             false (never) branch"
+        );
+        assert!(
+            conditional_type_id(&interner, result).is_some(),
+            "unresolved extends '{extends_name}' should stay deferred, got {:?}",
+            interner.lookup(result)
+        );
+    }
+}
+
+/// The symmetric case: a concrete check type whose extends is an unresolved
+/// reference must not eagerly take the *true* branch either. The relation
+/// machinery treats an `UnresolvedTypeName` as related to everything
+/// (error/`any`-like), so `T extends Builtin ? T : …` over a still-unresolved
+/// imported `Builtin` would otherwise report `T <: Builtin` as true and collapse
+/// to `T` (the second face of #13618, surfacing as a false `TS2741`).
+#[test]
+fn conditional_concrete_check_over_unresolved_extends_does_not_take_true_branch() {
+    for extends_name in ["Builtin", "Primitive"] {
+        let interner = TypeInterner::new();
+        let prop = interner.intern_string("id");
+        let check_type = interner.object(vec![PropertyInfo::new(prop, TypeId::STRING)]);
+        let extends_type = interner.unresolved_type_name(interner.intern_string(extends_name));
+
+        let result = evaluate_conditional(
+            &interner,
+            &ConditionalType {
+                check_type,
+                extends_type,
+                true_type: check_type,
+                false_type: TypeId::NEVER,
+                is_distributive: false,
+            },
+        );
+
+        assert_ne!(
+            result, check_type,
+            "unresolved extends '{extends_name}' must not eagerly take the true branch"
+        );
+        assert!(
+            conditional_type_id(&interner, result).is_some(),
+            "unresolved extends '{extends_name}' should stay deferred, got {:?}",
+            interner.lookup(result)
+        );
+    }
+}


### PR DESCRIPTION
Fixes the primary symptom of #13618.

Goal: green

## Structural rule
When a conditional type's check or extends operand evaluates to a bare
`UnresolvedTypeName` — an imported alias the current resolver generation has
not yet bound to a `DefId` — `tsc` resolves the reference and selects the
branch from the concrete type. tsz instead treated the unresolved name as a
*definitive* relation in two schedule-dependent ways:

- `is_error_type` folded `UnresolvedTypeName` into "error", so the extends-side
  shortcut took the **false** branch (`Filter extends AnyRecord ? {…} : never`
  → `never`);
- the subtype checker treats an unresolved name as related to everything
  (error/`any`-like), so when the shortcut did not fire the relation reported
  `true` and took the **true** branch (`Type extends Builtin ? Type : …`
  → whole `Type`).

This is the `DeepPick<T, { k: never }>` family: the ts-essentials micro bench
witness rejected a valid value with a false `TS2322 … not assignable to
'never'` (false branch) and a false `TS2741 Property 'right' is missing`
(true branch).

Owner layer: solver conditional evaluation
(`crates/tsz-solver/src/evaluation/evaluate_rules/conditional{.rs,/phases.rs}`).

## What changed
- The extends-side error shortcut now uses `is_genuine_error_type` (matching
  the check-side `visit_conditional`, which already excludes
  `UnresolvedTypeName`). A genuine `TypeData::Error` still collapses to the
  false branch and preserves structural modifiers; an unresolved name does not.
- Before the structural relation check, a conditional whose check or extends is
  a **bare** `UnresolvedTypeName` is deferred (it cannot be settled until the
  reference binds). The deferred result is marked via `mark_unresolved_def_seen`
  so it is not persisted to the depth-agnostic caches and a later resolver
  generation recomputes it instead of reusing a stale deferral.
- An unresolved reference wrapped in an `Application`/`Lazy` keeps using the
  existing post-subtype deferral; only the bare-name form is intercepted early.

## Adjacent matrix (manual, real ts-essentials `deep-pick` at the pinned ref)
- `DeepPick<User, { id: never }>` (object leaf): `never` → correct `{ id: string }` ✅
- `DeepPick<User[], { id: never }[]>` (array): now correct ✅
- README `EnglishClass` names-only example: clean ✅
- Both false-branch (`never`) and true-branch (`Type`) collapses fixed at the
  top level; renamed binders covered by the unit tests.

## Known residual (separate, pre-existing)
Deeply-nested multi-level recursion where a `DeepPick` application is left as an
unevaluated property value and later evaluated by the subtype checker under a
resolver that cannot bind the cross-module `Builtin`/`AnyRecord` names still
yields false positives. That is the cross-arena member/name resolution gap
tracked by #13044 / #13484 (both WIP) — out of scope here; this PR removes the
`never`/whole-`Type` collapse mechanism that sat on top of it.

## Verification
- `cargo test -p tsz-solver --test conditional_deferred_return_tests` — 4/4,
  including the two new regression tests (`distributive_conditional_concrete_
  check_over_unresolved_extends_defers`,
  `conditional_concrete_check_over_unresolved_extends_does_not_take_true_branch`),
  which were confirmed to FAIL without the fix and PASS with it.
- `cargo test -p tsz-solver --lib` — no new failures (6694 pass; the 3 failing
  are pre-existing on the base commit: `def/core.rs` size ceiling and two
  `operations::tests`).
- `cargo test -p tsz-checker --lib -- conditional|distributive|mapped|keyof|infer`
  — no new failures vs. the base commit.
- `cargo test -p tsz-cli --lib -- unresolved` — the existing
  unresolved-namespace-member conditional family still passes (12/12).
- Broad conformance/emit/project rows: ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

https://claude.ai/code/session_017xqhPzF1MexmQQDiUTvH3k

---
_Generated by [Claude Code](https://claude.ai/code/session_017xqhPzF1MexmQQDiUTvH3k)_