### PR TITLE
refactor(binder): atom-ize namespace export tables in the binder name universe (#13073)

### DIFF
--- a/crates/tsz-binder/src/nodes/binding_scope.rs
+++ b/crates/tsz-binder/src/nodes/binding_scope.rs
@@ -2,6 +2,7 @@
 
 use super::super::state::BinderState;
 use crate::{ContainerKind, SymbolTable, symbol_flags};
+use rustc_hash::FxHashSet;
 use tsz_parser::NodeIndex;
 use tsz_parser::parser::node::NodeArena;
 use tsz_scanner::SyntaxKind;
@@ -66,32 +67,37 @@ impl BinderState {
                                 });
 
                         // Filter exports: only include symbols with is_exported = true or EXPORT_VALUE flag.
-                        // Snapshot the (name, id) pairs first so the table borrow drops
-                        // before the mutable `self.symbols` accesses below.
-                        let scope_entries: Vec<(String, crate::SymbolId)> = self
+                        // Snapshot which child SymbolIds pass the export filter
+                        // first so the `self.symbols` borrow drops before the
+                        // scope-table copy and the mutable `self.symbols` access
+                        // below. The set is keyed by SymbolId, so the copy below
+                        // preserves the source scope's atom side-index.
+                        let exported_children: FxHashSet<crate::SymbolId> = self
                             .current_scope()
                             .iter()
-                            .map(|(name, &child_id)| (name.clone(), child_id))
+                            .map(|(_, &child_id)| child_id)
+                            .filter(|&child_id| {
+                                self.symbols.get(child_id).is_some_and(|child| {
+                                    // Check explicit export flag OR if it's an
+                                    // EXPORT_VALUE (from export {}).
+                                    export_all
+                                        || child.is_exported
+                                        || (child.flags & symbol_flags::EXPORT_VALUE) != 0
+                                })
+                            })
                             .collect();
+                        // Copy retained entries from the live scope table,
+                        // preserving both name keys and same-arena atom keys.
+                        let source = self.current_scope().clone();
                         let mut exports = SymbolTable::new();
-                        for (name, child_id) in scope_entries {
-                            if let Some(child) = self.symbols.get(child_id) {
-                                // Check explicit export flag OR if it's an EXPORT_VALUE (from export {})
-                                if export_all
-                                    || child.is_exported
-                                    || (child.flags & symbol_flags::EXPORT_VALUE) != 0
-                                {
-                                    exports.set(name, child_id);
-                                }
-                            }
-                        }
+                        exports.merge_filtered_from(&source, |child_id| {
+                            exported_children.contains(&child_id)
+                        });
 
                         // Persist filtered exports
                         if let Some(symbol) = self.symbols.get_mut(*sym_id) {
                             if let Some(ref mut existing) = symbol.exports {
-                                for (name, &child_id) in exports.iter() {
-                                    existing.set(name.clone(), child_id);
-                                }
+                                existing.merge_filtered_from(&exports, |_| true);
                             } else {
                                 symbol.exports = Some(Box::new(exports));
                             }

--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -753,6 +753,44 @@ impl SymbolTable {
         self.symbols.iter()
     }
 
+    /// Merge entries from `source` whose `SymbolId` satisfies `keep`, preserving
+    /// both the authoritative name keys and the same-arena `AstAtom` side-index.
+    ///
+    /// Used when promoting a namespace/module scope's declarations into its
+    /// export table at scope exit: the source scope table already carries atom
+    /// side-keys (populated by `declare_in_persistent_scope_with_atom`), and
+    /// copying them forward keeps export-table lookups atom-backed instead of
+    /// degrading to string-only on every namespace boundary. The name map stays
+    /// authoritative, so equality and iteration over names are byte-identical to
+    /// a plain string copy; the atom side-index is a pure accelerator that
+    /// resolves to the same strings within the same arena.
+    pub fn merge_filtered_from<F>(&mut self, source: &Self, mut keep: F)
+    where
+        F: FnMut(SymbolId) -> bool,
+    {
+        // First pass: copy the authoritative name entries for retained symbols.
+        // This mirrors the prior string-only copy exactly, including which
+        // names win on collision (later inserts overwrite earlier ones).
+        let names = Arc::make_mut(&mut self.symbols);
+        for (name, &sym_id) in source.symbols.iter() {
+            if keep(sym_id) {
+                names.insert(name.clone(), sym_id);
+            }
+        }
+        // Second pass: carry the same-arena atom side-keys for retained symbols.
+        // The atom map is keyed by `(arena_owner, AstAtom)` and never collides
+        // across arenas, so copying retained entries cannot resolve a foreign
+        // atom to a local symbol.
+        if !source.atom_symbols.is_empty() {
+            let atoms = Arc::make_mut(&mut self.atom_symbols);
+            for (&key, &sym_id) in source.atom_symbols.iter() {
+                if keep(sym_id) {
+                    atoms.insert(key, sym_id);
+                }
+            }
+        }
+    }
+
     /// Estimate the heap bytes owned by this table (map buckets + name
     /// strings). Capacity-based estimate for residency accounting (#13249
     /// step 1); called only at perf-counter snapshot time.


### PR DESCRIPTION
Advances #13073.

Goal: hold

## Structural rule
Binder namespace/module export tables carry the same-arena AstAtom side-index, not string-only; name map stays authoritative (byte-identical equality/order).

## What changed
- `SymbolTable::merge_filtered_from` (crates/tsz-binder/src/symbols.rs): copies entries from a source table whose `SymbolId` passes a `keep` predicate, in two passes. Pass one copies the authoritative `(name -> SymbolId)` entries exactly as the prior string-only copy did (later inserts win on name collision). Pass two carries the same-arena `(arena_owner, AstAtom) -> SymbolId` side-keys for retained symbols. The atom map is keyed by `(usize, AstAtom)` and never collides across arenas, so copying retained entries cannot resolve a foreign atom to a local symbol. The name map remains authoritative; the atom side-index is a pure accelerator resolving to the same strings within the same arena.
- `exit_scope` Module branch (crates/tsz-binder/src/nodes/binding_scope.rs): instead of snapshotting `(name, id)` pairs and re-inserting strings (which dropped the atom side-index at every namespace boundary), it now snapshots the set of exported child `SymbolId`s passing the export filter (`export_all || is_exported || EXPORT_VALUE`), clones the live scope table, and populates the export table via `merge_filtered_from`. Persisting into an existing `exports` table also routes through `merge_filtered_from(.., |_| true)`. Borrow ordering preserved: the `self.symbols` borrow drops before the scope-table clone and the mutable `self.symbols` access.

## Verification
- `scripts/safe-run.sh cargo build -p tsz-binder` -> Finished, clean.
- `scripts/safe-run.sh cargo clippy -p tsz-binder --all-targets` -> Finished, no warnings.
- `scripts/safe-run.sh cargo nextest run -p tsz-binder` -> 539 tests run: 539 passed, 0 skipped. No failures (no revert-and-reproduce needed).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high