### PR TITLE
refactor(checker): share equality-operator classification across condition pipelines (#13084)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_narrowing.rs
@@ -1236,19 +1236,14 @@ impl<'a> FlowAnalyzer<'a> {
             return self.narrow_by_in_operator(type_id, bin, target, is_true_branch);
         }
 
-        let (is_equals, is_strict) = match operator {
-            k if k == SyntaxKind::EqualsEqualsEqualsToken as u16 => (true, true),
-            k if k == SyntaxKind::ExclamationEqualsEqualsToken as u16 => (false, true),
-            k if k == SyntaxKind::EqualsEqualsToken as u16 => (true, false),
-            k if k == SyntaxKind::ExclamationEqualsToken as u16 => (false, false),
-            _ => return type_id,
+        let Some(comparison) =
+            crate::query_boundaries::operator_wrappers::classify_equality_comparison(operator)
+        else {
+            return type_id;
         };
+        let is_strict = comparison.is_strict;
 
-        let effective_truth = if is_equals {
-            is_true_branch
-        } else {
-            !is_true_branch
-        };
+        let effective_truth = comparison.effective_truth(is_true_branch);
         let mut type_id = type_id;
 
         // Optional-chain equality transport:
@@ -1591,14 +1586,9 @@ impl<'a> FlowAnalyzer<'a> {
         visited_aliases: &mut AliasCycleTracker,
     ) -> Option<TypeId> {
         // Only handle strict/loose equality/inequality operators
-        let is_strict_eq = bin.operator_token == SyntaxKind::EqualsEqualsEqualsToken as u16;
-        let is_strict_neq = bin.operator_token == SyntaxKind::ExclamationEqualsEqualsToken as u16;
-        let is_loose_eq = bin.operator_token == SyntaxKind::EqualsEqualsToken as u16;
-        let is_loose_neq = bin.operator_token == SyntaxKind::ExclamationEqualsToken as u16;
-
-        if !is_strict_eq && !is_strict_neq && !is_loose_eq && !is_loose_neq {
-            return None;
-        }
+        let comparison = crate::query_boundaries::operator_wrappers::classify_equality_comparison(
+            bin.operator_token,
+        )?;
 
         // Check for true/false on either side
         let (guard_expr, is_compared_to_true) = if self.is_boolean_literal(bin.right) {
@@ -1635,7 +1625,7 @@ impl<'a> FlowAnalyzer<'a> {
         // `expr === false` in true branch → narrow as if expr is false
         // `expr !== true` in true branch → narrow as if expr is false
         // `expr !== false` in true branch → narrow as if expr is true
-        let is_negated = is_strict_neq || is_loose_neq;
+        let is_negated = !comparison.is_equals;
         let effective_sense = if is_compared_to_true {
             if is_negated {
                 !is_true_branch

--- a/crates/tsz-checker/src/flow/control_flow/condition_nullish.rs
+++ b/crates/tsz-checker/src/flow/control_flow/condition_nullish.rs
@@ -2,7 +2,6 @@ use super::FlowAnalyzer;
 use super::flow_dp::{DpMemo, resolve_backward_dp};
 use tsz_binder::{FlowNodeId, flow_flags};
 use tsz_parser::parser::NodeIndex;
-use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
 impl<'a> FlowAnalyzer<'a> {
@@ -93,22 +92,19 @@ impl<'a> FlowAnalyzer<'a> {
         let Some(bin) = self.arena.get_binary_expr(node) else {
             return false;
         };
-        let (is_equals, is_strict) = match bin.operator_token {
-            k if k == SyntaxKind::EqualsEqualsEqualsToken as u16 => (true, true),
-            k if k == SyntaxKind::ExclamationEqualsEqualsToken as u16 => (false, true),
-            k if k == SyntaxKind::EqualsEqualsToken as u16 => (true, false),
-            k if k == SyntaxKind::ExclamationEqualsToken as u16 => (false, false),
-            _ => return false,
+        let Some(comparison) =
+            crate::query_boundaries::operator_wrappers::classify_equality_comparison(
+                bin.operator_token,
+            )
+        else {
+            return false;
         };
+        let is_strict = comparison.is_strict;
         let Some(nullish) = self.nullish_comparison(bin.left, bin.right, target) else {
             return false;
         };
         let is_true_branch = flow.has_any_flags(flow_flags::TRUE_CONDITION);
-        let effective_truth = if is_equals {
-            is_true_branch
-        } else {
-            !is_true_branch
-        };
+        let effective_truth = comparison.effective_truth(is_true_branch);
 
         if is_strict {
             nullish == TypeId::NULL && !effective_truth

--- a/crates/tsz-checker/src/flow/control_flow/type_guards.rs
+++ b/crates/tsz-checker/src/flow/control_flow/type_guards.rs
@@ -649,8 +649,10 @@ impl<'a> FlowAnalyzer<'a> {
 
         // Check for loose equality with null/undefined: x == null, x != null, x == undefined, x != undefined
         // TypeScript treats these as nullish equality (narrows to null | undefined)
-        let is_loose_equality = bin.operator_token == SyntaxKind::EqualsEqualsToken as u16
-            || bin.operator_token == SyntaxKind::ExclamationEqualsToken as u16;
+        let is_loose_equality =
+            crate::query_boundaries::operator_wrappers::is_loose_equality_operator(
+                bin.operator_token,
+            );
         if is_loose_equality
             && let Some(_nullish_type) = self.nullish_comparison(bin.left, bin.right, target)
         {
@@ -1827,11 +1829,9 @@ impl<'a> FlowAnalyzer<'a> {
         &self,
         bin: &tsz_parser::parser::node::BinaryExprData,
     ) -> Option<(TypeGuard, NodeIndex)> {
-        let is_equality = bin.operator_token == SyntaxKind::EqualsEqualsEqualsToken as u16
-            || bin.operator_token == SyntaxKind::EqualsEqualsToken as u16
-            || bin.operator_token == SyntaxKind::ExclamationEqualsEqualsToken as u16
-            || bin.operator_token == SyntaxKind::ExclamationEqualsToken as u16;
-        if !is_equality {
+        if !crate::query_boundaries::operator_wrappers::is_equality_comparison_operator(
+            bin.operator_token,
+        ) {
             return None;
         }
 

--- a/crates/tsz-checker/src/flow/control_flow/var_utils.rs
+++ b/crates/tsz-checker/src/flow/control_flow/var_utils.rs
@@ -602,15 +602,15 @@ impl<'a> FlowAnalyzer<'a> {
         }
 
         // typeof: check operator polarity
-        let is_positive_equality = bin.operator_token == SyntaxKind::EqualsEqualsEqualsToken as u16
-            || bin.operator_token == SyntaxKind::EqualsEqualsToken as u16;
-        let is_negative_equality = bin.operator_token
-            == SyntaxKind::ExclamationEqualsEqualsToken as u16
-            || bin.operator_token == SyntaxKind::ExclamationEqualsToken as u16;
-
-        if !is_positive_equality && !is_negative_equality {
+        let Some(comparison) =
+            crate::query_boundaries::operator_wrappers::classify_equality_comparison(
+                bin.operator_token,
+            )
+        else {
             return false;
-        }
+        };
+        let is_positive_equality = comparison.is_equals;
+        let is_negative_equality = !comparison.is_equals;
 
         // Determine if this is the "positive sense" branch:
         // - `=== "type"` + TRUE_CONDITION → positive

--- a/crates/tsz-checker/src/query_boundaries/operator_wrappers.rs
+++ b/crates/tsz-checker/src/query_boundaries/operator_wrappers.rs
@@ -15,3 +15,81 @@ pub(crate) const fn is_assignment_operator(operator_token: u16) -> bool {
 pub(crate) const fn map_compound_assignment_to_binary(operator_token: u16) -> Option<&'static str> {
     tsz_solver::operations::compound_assignment::map_compound_assignment_to_binary(operator_token)
 }
+
+/// Classification of a binary equality/inequality comparison operator
+/// (`===`, `!==`, `==`, `!=`).
+///
+/// This is the single source of truth for decoding the four equality operator
+/// tokens used by the condition-interpretation narrowing pipelines. Both the
+/// `TypeGuard`-producing classifier (`extract_type_guard`) and the direct
+/// flow narrowing path (`narrow_by_binary_expr`) — plus the nullish, boolean,
+/// and assignment-proving helpers — previously re-encoded this decode
+/// independently, which let coverage drift between sites. Keeping the decode in
+/// one place means a new operator form (or a change to equality polarity) is
+/// added once, not in every pattern matcher.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct EqualityComparison {
+    /// `true` for `===`/`==` (equals), `false` for `!==`/`!=` (not-equals).
+    pub(crate) is_equals: bool,
+    /// `true` for `===`/`!==` (strict), `false` for `==`/`!=` (loose).
+    pub(crate) is_strict: bool,
+}
+
+impl EqualityComparison {
+    /// Effective truth of the underlying comparison for a given branch.
+    ///
+    /// On an equality operator the comparison is true exactly on the true
+    /// branch; on an inequality operator the polarity flips. This mirrors the
+    /// `if is_equals { is_true_branch } else { !is_true_branch }` decode that
+    /// each narrowing site applied locally.
+    pub(crate) const fn effective_truth(self, is_true_branch: bool) -> bool {
+        if self.is_equals {
+            is_true_branch
+        } else {
+            !is_true_branch
+        }
+    }
+}
+
+/// Classify a binary operator token as an equality/inequality comparison.
+///
+/// Returns `None` for any operator that is not one of `===`, `!==`, `==`, `!=`.
+pub(crate) const fn classify_equality_comparison(
+    operator_token: u16,
+) -> Option<EqualityComparison> {
+    use tsz_scanner::SyntaxKind;
+    match operator_token {
+        k if k == SyntaxKind::EqualsEqualsEqualsToken as u16 => Some(EqualityComparison {
+            is_equals: true,
+            is_strict: true,
+        }),
+        k if k == SyntaxKind::ExclamationEqualsEqualsToken as u16 => Some(EqualityComparison {
+            is_equals: false,
+            is_strict: true,
+        }),
+        k if k == SyntaxKind::EqualsEqualsToken as u16 => Some(EqualityComparison {
+            is_equals: true,
+            is_strict: false,
+        }),
+        k if k == SyntaxKind::ExclamationEqualsToken as u16 => Some(EqualityComparison {
+            is_equals: false,
+            is_strict: false,
+        }),
+        _ => None,
+    }
+}
+
+/// `true` when the operator is any equality/inequality comparison
+/// (`===`, `!==`, `==`, `!=`).
+pub(crate) const fn is_equality_comparison_operator(operator_token: u16) -> bool {
+    classify_equality_comparison(operator_token).is_some()
+}
+
+/// `true` when the operator is a loose equality/inequality comparison
+/// (`==`, `!=`).
+pub(crate) const fn is_loose_equality_operator(operator_token: u16) -> bool {
+    match classify_equality_comparison(operator_token) {
+        Some(comparison) => !comparison.is_strict,
+        None => false,
+    }
+}


### PR DESCRIPTION
Advances #13084.

Goal: hold

## Structural rule
Both condition-interpretation pipelines decode equality operators through one shared classifier; their divergent application paths are intentionally NOT merged (a separate effort).

## What changed
Added a single shared equality-operator classifier in `crates/tsz-checker/src/query_boundaries/operator_wrappers.rs`:
- `EqualityComparison { is_equals, is_strict }` plus `EqualityComparison::effective_truth(is_true_branch)` (the `if is_equals { is_true_branch } else { !is_true_branch }` polarity decode that each site previously inlined).
- `classify_equality_comparison(operator_token) -> Option<EqualityComparison>` — the single source of truth decoding `===`/`!==`/`==`/`!=` from a binary operator token.
- Thin predicates over it: `is_equality_comparison_operator` and `is_loose_equality_operator`.

Routed the divergent condition-narrowing decode sites through the classifier:
- `condition_narrowing.rs` `narrow_by_binary_expr` (strict/effective-truth) and the boolean-literal guard path (derives `is_negated` from `!comparison.is_equals` rather than re-checking the two `!==`/`!=` tokens).
- `condition_nullish.rs` nullish-equality path (`is_strict` + `effective_truth`); its now-unused `SyntaxKind` import was dropped.
- `type_guards.rs` loose-nullish check (`is_loose_equality_operator`) and the equality-guard extractor (`is_equality_comparison_operator`).
- `var_utils.rs` `typeof` polarity decode (`is_positive_equality = comparison.is_equals`, `is_negative_equality = !comparison.is_equals`).

Deliberately untouched: the divergent application paths downstream of the decode (the `TypeGuard`-producing path in `extract_type_guard` vs. the direct flow-narrowing path in `narrow_by_binary_expr`, and the nullish/boolean/typeof handlers) are left as-is and were NOT merged — that consolidation is a separate effort. Behavior-preserving: only the operator decode is shared; every consumer applies the same polarity it did before.

## Verification
- `scripts/safe-run.sh cargo build -p tsz-checker` (lib) — clean.
- `scripts/safe-run.sh cargo clippy -p tsz-checker` (lib only) — no warnings.
- Full narrowing test/conformance suite deferred to CI (disk-constrained locally).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
