### PR TITLE
refactor(checker): consolidate raw assignability TypeFormatter construction onto a factory (#13081)

### DIFF
--- a/crates/tsz-checker/src/context/def_mapping.rs
+++ b/crates/tsz-checker/src/context/def_mapping.rs
@@ -1472,6 +1472,42 @@ impl<'a> CheckerContext<'a> {
             .with_exact_optional_property_types(self.compiler_options.exact_optional_property_types)
     }
 
+    /// Create a `TypeFormatter` configured for assignability (`TS2322`/`TS2345`)
+    /// diagnostic surfaces.
+    ///
+    /// Unlike [`Self::create_diagnostic_type_formatter`], this factory deliberately
+    /// omits the module-name / current-file qualification context: assignability
+    /// messages render type names structurally and must not pick up
+    /// `import("<specifier>")` or namespace prefixes that the hover-style factory
+    /// adds. It does enable diagnostic mode, optional-parameter surface syntax
+    /// (`(a?: T)`), the `BuiltinIteratorReturn` substitution, and the strict-null /
+    /// exact-optional flags so optional members render exactly as tsc prints them.
+    ///
+    /// This is the single construction site for the assignability formatter base;
+    /// callers that need an extra policy flag (e.g.
+    /// `with_skip_application_display_alias_chase`) chain it onto the returned
+    /// builder.
+    pub fn create_assignability_type_formatter(
+        &self,
+    ) -> crate::query_boundaries::common::TypeFormatter<'_> {
+        use crate::query_boundaries::common::TypeFormatter;
+
+        TypeFormatter::with_symbols(self.types, &self.binder.symbols)
+            .with_def_store(&self.definition_store)
+            .with_diagnostic_mode()
+            // Match tsc: optional parameters display as `(a?: T)`.
+            .with_preserve_optional_parameter_surface_syntax(true)
+            .with_strict_null_checks(self.compiler_options.strict_null_checks)
+            .with_builtin_iterator_return_type(
+                if self.compiler_options.strict_builtin_iterator_return {
+                    tsz_solver::TypeId::UNDEFINED
+                } else {
+                    tsz_solver::TypeId::ANY
+                },
+            )
+            .with_exact_optional_property_types(self.compiler_options.exact_optional_property_types)
+    }
+
     /// Register a resolved type in the `TypeEnvironment` for both `SymbolRef` and `DefId`.
     ///
     /// This ensures that both the old `TypeData::Ref(SymbolRef)` and new `TypeData::Lazy(DefId)`

--- a/crates/tsz-checker/src/error_reporter/core_formatting.rs
+++ b/crates/tsz-checker/src/error_reporter/core_formatting.rs
@@ -201,23 +201,7 @@ impl<'a> CheckerState<'a> {
         // `format_type_for_diagnostic_role` (issue #13040).
         let _budget_scope = crate::error_reporter::display_budget::DisplayBudgetScope::enter();
         let format_with_def_store = |state: &Self, type_id: TypeId| {
-            let mut formatter =
-                tsz_solver::TypeFormatter::with_symbols(state.ctx.types, &state.ctx.binder.symbols)
-                    .with_def_store(&state.ctx.definition_store)
-                    .with_diagnostic_mode()
-                    // Match tsc: optional parameters display as `(a?: T)`.
-                    .with_preserve_optional_parameter_surface_syntax(true)
-                    .with_strict_null_checks(state.ctx.compiler_options.strict_null_checks)
-                    .with_builtin_iterator_return_type(
-                        if state.ctx.compiler_options.strict_builtin_iterator_return {
-                            TypeId::UNDEFINED
-                        } else {
-                            TypeId::ANY
-                        },
-                    )
-                    .with_exact_optional_property_types(
-                        state.ctx.compiler_options.exact_optional_property_types,
-                    );
+            let mut formatter = state.ctx.create_assignability_type_formatter();
             formatter.format(type_id).into_owned()
         };
         let is_generic_callable = |state: &Self, type_id: TypeId| {
@@ -958,23 +942,10 @@ impl<'a> CheckerState<'a> {
         ty: TypeId,
     ) -> String {
         self.ensure_relation_input_ready(ty);
-        let mut formatter =
-            tsz_solver::TypeFormatter::with_symbols(self.ctx.types, &self.ctx.binder.symbols)
-                .with_def_store(&self.ctx.definition_store)
-                .with_diagnostic_mode()
-                .with_skip_application_display_alias_chase()
-                .with_preserve_optional_parameter_surface_syntax(true)
-                .with_strict_null_checks(self.ctx.compiler_options.strict_null_checks)
-                .with_builtin_iterator_return_type(
-                    if self.ctx.compiler_options.strict_builtin_iterator_return {
-                        TypeId::UNDEFINED
-                    } else {
-                        TypeId::ANY
-                    },
-                )
-                .with_exact_optional_property_types(
-                    self.ctx.compiler_options.exact_optional_property_types,
-                );
+        let mut formatter = self
+            .ctx
+            .create_assignability_type_formatter()
+            .with_skip_application_display_alias_chase();
         formatter.format(ty).into_owned()
     }
 


### PR DESCRIPTION
Advances #13081.

Goal: hold

## Structural rule
Assignability diagnostics construct their TypeFormatter via one checker-owned factory (byte-identical builder chain); printer reads types, types never read printer output.

## What changed
- Added `CheckerContext::create_assignability_type_formatter()` in `crates/tsz-checker/src/context/def_mapping.rs`: a single checker-owned factory that builds the assignability `TypeFormatter` base (diagnostic mode, preserve-optional-parameter surface syntax, strict-null-checks, builtin-iterator-return substitution, exact-optional-property-types). It deliberately omits module-name/current-file qualification so assignability messages render type names structurally rather than picking up `import("...")`/namespace prefixes.
- Consolidated the two raw assignability `TypeFormatter` construction sites in `crates/tsz-checker/src/error_reporter/core_formatting.rs` onto the factory. The chains are byte-identical to the prior inline builders; the second site (`format_type_for_assignability_message`) additionally chains `.with_skip_application_display_alias_chase()` onto the factory return value.
- The dead `DiagnosticTypeDisplayRole::Assignability` variant was left in place: it is `#[allow(dead_code)]` but still woven into three behavior-adjacent match arms in `type_display_policy.rs` (including a live call to `format_type_for_assignability_message`), so removing it is out of scope for this byte-identical consolidation.

## Verification
- `scripts/safe-run.sh cargo build -p tsz-checker` (lib): passes.
- `scripts/safe-run.sh cargo clippy -p tsz-checker` (lib only, no `--all-targets`): clean, no warnings.
- Full checker test + conformance/emit suites deferred to ready-review CI (the validation gate); not run locally per disk constraints.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high