### PR TITLE
refactor(checker): unify the dual TypeEnvironment instances in CheckerContext (#13086)

### DIFF
--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -783,8 +783,25 @@ pub struct CheckerContext<'a> {
     /// Internal counters for request-aware cache usage and cache-clear churn.
     pub request_cache_counters: RequestCacheCounters,
 
-    /// Cached type environment for resolving Ref types during assignability checks.
-    /// Used by `FlowAnalyzer` (via borrowed reference) for type narrowing during control flow analysis.
+    /// Flow-analyzer `TypeEnvironment` (#13086).
+    ///
+    /// One of the context's two `TypeEnvironment` instances. This one is owned
+    /// by the flow analyzer: `FlowAnalyzer::from_ctx` borrows it via
+    /// `with_type_environment(&ctx.type_environment)` and holds that borrow live
+    /// while narrowing reads types. It also carries the legacy `SymbolRef`-keyed
+    /// entries the evaluator env never uses.
+    ///
+    /// It is *not* a redundant copy of [`Self::type_env`]: the two are separate
+    /// `RefCell`s on purpose. While the flow analyzer holds this env borrowed,
+    /// the evaluator must still be able to `try_borrow_mut` [`Self::type_env`] to
+    /// publish freshly resolved `DefId -> TypeId` bodies; collapsing both into
+    /// one cell would make that mutable borrow fail and silently drop writes.
+    /// The dual-write registration helpers (`register_*_in_envs`) mirror every
+    /// `DefId`-keyed registration into both envs (deferring the mirror when this
+    /// cell is borrowed, never dropping it), and `overlay_missing_from` performs
+    /// a vacancy-fill reconciliation at the file-preparation boundary. After
+    /// that boundary the two envs must agree on every shared `DefId` entry; the
+    /// debug assertion in `prepare_source_file_for_checking` enforces it.
     pub type_environment: RefCell<TypeEnvironment>,
 
     /// Dual-env registrations whose mirror-write into `type_environment` lost
@@ -1357,8 +1374,14 @@ pub struct CheckerContext<'a> {
     /// enclosing class in the inheritance hierarchy when code is inside nested classes.
     pub enclosing_class_chain: Vec<NodeIndex>,
 
-    /// Type environment for symbol resolution with type parameters.
-    /// Used by the evaluator to expand Application types.
+    /// Evaluator `TypeEnvironment` (#13086) — the authoritative env.
+    ///
+    /// The second of the context's two `TypeEnvironment` instances. The
+    /// evaluator/`state`/`types`/`assignability` paths use this one to resolve
+    /// symbols and expand `Application` types; it is the source of truth for
+    /// `DefId -> TypeId` resolution. `register_*_in_envs` write it directly and
+    /// mirror into [`Self::type_environment`]. See that field's doc for why the
+    /// two are kept as separate `RefCell`s rather than unified into one.
     pub type_env: RefCell<TypeEnvironment>,
 
     // --- DefId Migration Infrastructure ---

--- a/crates/tsz-checker/src/state/state_checking/source_file.rs
+++ b/crates/tsz-checker/src/state/state_checking/source_file.rs
@@ -101,10 +101,28 @@ impl<'a> CheckerState<'a> {
         self.ctx.flush_deferred_flow_env_writes();
         {
             let type_env_snapshot = self.ctx.type_env.borrow();
-            self.ctx
-                .type_environment
-                .borrow_mut()
-                .overlay_missing_from(&type_env_snapshot);
+            let mut flow_env = self.ctx.type_environment.borrow_mut();
+            flow_env.overlay_missing_from(&type_env_snapshot);
+
+            // The two envs (#13086) are deliberately separate `RefCell`s with
+            // distinct borrow lifecycles — the flow-analyzer holds
+            // `type_environment` borrowed during narrowing while the evaluator
+            // mutates `type_env`, so they cannot share one cell without dropping
+            // writes. They are kept consistent by dual-write helpers and the
+            // vacancy-fill `overlay_missing_from` above. After reconciliation
+            // they must *agree* on every shared `DefId -> TypeId` entry; a
+            // disagreement is the silent divergence #13086 guards against, so
+            // turn it into a loud failure in debug builds.
+            if cfg!(debug_assertions)
+                && let Some((map, key, lhs, rhs)) =
+                    flow_env.first_def_divergence_from(&type_env_snapshot)
+            {
+                debug_assert!(
+                    false,
+                    "flow-analyzer env diverges from evaluator env after reconciliation \
+                     (#13086): {map}[{key}] is {lhs} in type_environment vs {rhs} in type_env"
+                );
+            }
         }
         debug_assert_eq!(
             self.ctx.deferred_flow_env_write_count(),

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -1056,6 +1056,52 @@ impl TypeEnvironment {
         }
     }
 
+    /// Return the first `DefId`-keyed entry on which `self` and `other` disagree.
+    ///
+    /// The checker owns two `TypeEnvironment` instances with distinct
+    /// lifecycles: the evaluator env (`type_env`, authoritative) and the
+    /// flow-analyzer env (`type_environment`, reconciled from the evaluator env
+    /// via [`Self::overlay_missing_from`] at the file-preparation boundary).
+    /// Because `overlay_missing_from` is a vacancy-only superset merge that
+    /// keeps `self`'s value on key collisions, after reconciliation the two
+    /// envs must *agree* on every shared `DefId -> TypeId` (and the related
+    /// `DefId`-keyed structural) entry. A disagreement means a mirror-write was
+    /// applied to one env but not the other with a different value — exactly the
+    /// silent `DefId -> TypeId` divergence that produces query-site-dependent
+    /// wrong types.
+    ///
+    /// Returns `None` when the two envs are consistent. The returned tuple is
+    /// `(map_name, raw_key, self_value, other_value)` for diagnostics. This is a
+    /// read-only consistency probe used by the checker's debug-mode reconciliation
+    /// assertion; it never mutates either env and is not on any hot path.
+    #[must_use]
+    pub fn first_def_divergence_from(&self, other: &Self) -> Option<(&'static str, u32, u32, u32)> {
+        // Only keys present in *both* maps can disagree; vacancy-fill cannot
+        // create a conflicting value, so missing-on-one-side is not divergence.
+        for (&key, &value) in &self.def_types {
+            if let Some(&other_value) = other.def_types.get(&key)
+                && other_value != value
+            {
+                return Some(("def_types", key, value.0, other_value.0));
+            }
+        }
+        for (&key, &value) in &self.class_instance_types {
+            if let Some(&other_value) = other.class_instance_types.get(&key)
+                && other_value != value
+            {
+                return Some(("class_instance_types", key, value.0, other_value.0));
+            }
+        }
+        for (&key, &value) in &self.class_extends {
+            if let Some(&other_value) = other.class_extends.get(&key)
+                && other_value != value
+            {
+                return Some(("class_extends", key, value.0, other_value.0));
+            }
+        }
+        None
+    }
+
     /// Snapshot the local DefId -> TypeId cache for downstream consumers like declaration emit.
     pub fn snapshot_def_types(&self) -> FxHashMap<u32, TypeId> {
         self.def_types.clone()
@@ -1784,6 +1830,52 @@ mod tests {
             target.get_def(shared_def),
             Some(TypeId(301)),
             "existing target value must not be overwritten on key collision"
+        );
+    }
+
+    #[test]
+    fn first_def_divergence_from_detects_conflicting_shared_def_body() {
+        let shared_def = DefId(42);
+
+        let mut evaluator = TypeEnvironment::new();
+        evaluator.insert_def(shared_def, TypeId(100));
+        // An evaluator-only entry the flow env never received: not a divergence.
+        evaluator.insert_def(DefId(7), TypeId(101));
+
+        let mut flow = TypeEnvironment::new();
+        flow.insert_def(shared_def, TypeId(200));
+
+        // Probe is order-symmetric on the conflicting key.
+        let divergence = flow.first_def_divergence_from(&evaluator);
+        assert_eq!(
+            divergence,
+            Some(("def_types", shared_def.0, 200, 100)),
+            "conflicting shared def body must be reported"
+        );
+    }
+
+    #[test]
+    fn first_def_divergence_from_clean_after_overlay() {
+        let shared_def = DefId(42);
+        let eval_only_def = DefId(7);
+        let flow_only_class = DefId(99);
+
+        let mut evaluator = TypeEnvironment::new();
+        evaluator.insert_def(shared_def, TypeId(100));
+        evaluator.insert_def(eval_only_def, TypeId(101));
+
+        let mut flow = TypeEnvironment::new();
+        // Flow-analyzer-only mapping the evaluator never wrote.
+        flow.register_class_extends(flow_only_class, DefId(98));
+        // After the production reconciliation step, the flow env is overlaid
+        // from the evaluator env. With no conflicting writes this must leave the
+        // two envs consistent on every shared key.
+        flow.overlay_missing_from(&evaluator);
+
+        assert_eq!(
+            flow.first_def_divergence_from(&evaluator),
+            None,
+            "post-overlay envs must agree on every shared DefId entry"
         );
     }
 }


### PR DESCRIPTION
Closes #13086.

Goal: hold

## Structural rule
One TypeEnvironment owns DefId->TypeId resolution in CheckerContext.

## What changed
`CheckerContext` carries two `TypeEnvironment` `RefCell`s — `type_env` (evaluator, authoritative) and `type_environment` (flow-analyzer). Issue #13086 asked to either merge them or, per its own proposed option 3, document the distinct lifecycle and add phase-boundary consistency assertions.

Investigation showed they cannot be collapsed into a single `RefCell`: `FlowAnalyzer::from_ctx` borrows `type_environment` via `with_type_environment(&ctx.type_environment)` and holds that shared borrow live throughout narrowing (e.g. `types/type_node_helpers.rs`, `flow/reachability_checker.rs`). Concurrently the evaluator/resolution paths must `type_env.try_borrow_mut()` to publish freshly resolved `DefId -> TypeId` bodies (`register_in_envs`). Sharing one cell would make that mutable borrow fail while narrowing holds the read borrow, and writes would be dropped/deferred — reintroducing the very divergence the issue targets. So the two cells are correct by design; the real debt is the *unproven invariant* that they agree on shared keys after reconciliation.

This change makes that invariant authoritative and enforced rather than implicit:
- Documents both fields (`type_env` = authoritative evaluator env, `type_environment` = flow-analyzer mirror) with why they are separate cells, how `register_*_in_envs` dual-write + defer + `overlay_missing_from` keep them consistent.
- Adds `TypeEnvironment::first_def_divergence_from` (solver) — a read-only, non-hot-path probe returning the first `DefId`-keyed entry (`def_types` / `class_instance_types` / `class_extends`) on which two envs disagree, with `(map, key, lhs, rhs)` for diagnostics.
- Wires a `cfg!(debug_assertions)` consistency assertion at the file-preparation reconciliation boundary in `state/state_checking/source_file.rs`, right after `overlay_missing_from`. Since the overlay is a vacancy-only superset merge, any *conflicting* shared value is a silent mirror-write divergence and is now a loud debug failure.
- Adds solver unit tests: detects a conflicting shared def body; confirms post-overlay envs are clean (evaluator-only and flow-only entries are not divergence).

Behavior-preserving: release builds gain only docs and a `#[must_use]` read-only method that is never called outside the debug-assertion path. No resolution order, registration, or borrow lifecycle changes.

## Verification
- `scripts/safe-run.sh cargo build -p tsz-checker` — lib build OK.
- `scripts/safe-run.sh cargo clippy -p tsz-checker` (lib only) — clean, no warnings.
- New solver unit tests (`first_def_divergence_from_*`) — deferred to CI alongside the full checker test/conformance suite (local full test build is disk-prohibitive).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high