### PR TITLE
refactor(core): relocate redundant checker test mounts out of the tsz-core facade (#13109)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -389,6 +389,9 @@ path = "tests/ts2636_method_bivariance_tests.rs"
 name = "function_bivariance"
 path = "tests/function_bivariance.rs"
 [[test]]
+name = "global_type_tests"
+path = "tests/global_type_tests.rs"
+[[test]]
 name = "ts6133_unused_type_params_tests"
 path = "tests/ts6133_unused_type_params_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/global_type_tests.rs
+++ b/crates/tsz-checker/tests/global_type_tests.rs
@@ -6,11 +6,11 @@
 //!
 //! Note: These tests simulate missing lib.d.ts by not loading lib files.
 
-use crate::checker::context::CheckerOptions;
-use crate::checker::state::CheckerState;
 use std::sync::Arc;
 use tsz_binder::BinderState;
 use tsz_binder::lib_loader::LibFile;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::state::CheckerState;
 use tsz_checker::test_utils::load_compiled_lib_files;
 use tsz_parser::parser::ParserState;
 use tsz_solver::construction::TypeInterner;
@@ -19,15 +19,15 @@ use tsz_solver::construction::TypeInterner;
 /// `lib_contexts` on the checker). Routes through the shared
 /// `test_utils::check_with_options` — that helper also leaves
 /// `lib_contexts` empty by default, matching the original local helper.
-fn check_without_lib(source: &str) -> Vec<crate::checker::diagnostics::Diagnostic> {
+fn check_without_lib(source: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
     check_without_lib_with_options(source, CheckerOptions::default())
 }
 
 fn check_without_lib_with_options(
     source: &str,
     options: CheckerOptions,
-) -> Vec<crate::checker::diagnostics::Diagnostic> {
-    crate::checker::test_utils::check_with_options(source, options)
+) -> Vec<tsz_checker::diagnostics::Diagnostic> {
+    tsz_checker::test_utils::check_with_options(source, options)
 }
 
 const MINIMAL_CORE_GLOBAL_DECLS: &[(&str, &str)] = &[
@@ -45,14 +45,14 @@ const MINIMAL_CORE_GLOBAL_DECLS: &[(&str, &str)] = &[
 
 fn check_without_lib_with_minimal_core_globals(
     source: &str,
-) -> Vec<crate::checker::diagnostics::Diagnostic> {
+) -> Vec<tsz_checker::diagnostics::Diagnostic> {
     check_without_lib_with_minimal_core_globals_except(&[], source)
 }
 
 fn check_without_lib_with_minimal_core_globals_except(
     omitted: &[&str],
     source: &str,
-) -> Vec<crate::checker::diagnostics::Diagnostic> {
+) -> Vec<tsz_checker::diagnostics::Diagnostic> {
     let mut full_source = String::new();
     for &(name, decl) in MINIMAL_CORE_GLOBAL_DECLS {
         if omitted.iter().any(|omitted_name| omitted_name == &name) {
@@ -395,9 +395,9 @@ fn load_lib_files_for_global_type_tests() -> Vec<Arc<LibFile>> {
 }
 
 /// Helper function to create a checker WITH lib.d.ts and check source code.
-fn check_with_lib(source: &str) -> Vec<crate::checker::diagnostics::Diagnostic> {
+fn check_with_lib(source: &str) -> Vec<tsz_checker::diagnostics::Diagnostic> {
     let lib_files = load_lib_files_for_global_type_tests();
-    crate::checker::test_utils::check_source_with_libs(
+    tsz_checker::test_utils::check_source_with_libs(
         source,
         "test.ts",
         CheckerOptions::default(),
@@ -513,8 +513,8 @@ class C {
 fn test_decorator_ts2318_with_lib_contexts() {
     // Simulate the multi-file test: a.ts has core interfaces, b.ts has decorated class
     // This tests that lib_contexts don't wrongly suppress the TS2318 error
-    use crate::checker::context::LibContext;
     use std::sync::Arc;
+    use tsz_checker::context::LibContext;
 
     let options = CheckerOptions {
         experimental_decorators: true,

--- a/crates/tsz-core/src/lib.rs
+++ b/crates/tsz-core/src/lib.rs
@@ -329,18 +329,13 @@ mod const_assertion_tests;
 #[cfg(test)]
 #[path = "../../tsz-checker/tests/freshness_stripping_tests.rs"]
 mod freshness_stripping_tests;
-#[cfg(test)]
-#[path = "../../tsz-checker/tests/function_bivariance.rs"]
-mod function_bivariance;
-#[cfg(test)]
-#[path = "../../tsz-checker/tests/global_type_tests.rs"]
-mod global_type_tests;
+// `function_bivariance`, `global_type_tests`, and `ts2304_tests` are owned by
+// `tsz-checker` (they depend only on `tsz_checker::*`, not on `tsz-core`'s
+// `test_fixtures`). They run in `tsz-checker`'s own test runner; do not
+// re-mount them here (#13109).
 #[cfg(test)]
 #[path = "../../tsz-checker/tests/symbol_resolution_tests.rs"]
 mod symbol_resolution_tests;
-#[cfg(test)]
-#[path = "../../tsz-checker/tests/ts2304_tests.rs"]
-mod ts2304_tests;
 #[cfg(test)]
 #[path = "../../tsz-checker/tests/ts2305_tests.rs"]
 mod ts2305_tests;


### PR DESCRIPTION
Advances #13109.

Goal: hold

## Structural rule
tsz-core does not own downstream-crate test mounts; checker-only tests live in and run from tsz-checker.

## What changed
Three cross-crate `#[path = "../../tsz-checker/tests/*"]` test mounts were stripped from the `tsz-core` god-facade (`crates/tsz-core/src/lib.rs`). Each depends only on `tsz_checker::*` (not on `tsz-core`'s `test_fixtures`), so re-mounting them in `tsz-core`'s test runner was redundant.

- `function_bivariance` (`tests/function_bivariance.rs`) — already had a `tsz-checker` `[[test]]` entry; mount removed.
- `ts2304_tests` (`tests/ts2304_tests.rs`) — already had a `tsz-checker` `[[test]]` entry; mount removed.
- `global_type_tests` (`tests/global_type_tests.rs`) — mount removed; added a `tsz-checker` `[[test]]` entry (`crates/tsz-checker/Cargo.toml`) and rewrote the test's internal references from `crate::checker::*` to `tsz_checker::*` so it runs as a `tsz-checker` integration test.

Coverage is preserved: all three suites now run from `tsz-checker`'s own runner via `[[test]]` entries. An explanatory comment replaces the removed mounts in `crates/tsz-core/src/lib.rs`.

## Verification
- `scripts/safe-run.sh cargo build -p tsz-core` — Finished (clean).
- `scripts/safe-run.sh cargo clippy -p tsz-core --all-targets` — Finished, no warnings.
- `scripts/safe-run.sh cargo nextest run -p tsz-core` — 3148 passed, 31 failed, 2 skipped. The 31 failures are all in `source_map_tests_*`, `scanner_impl_tests`, `parallel::{residency,core}`, and `checker_state_tests::test_abstract_property_negative_errors` — unrelated to this change. Confirmed pre-existing via revert-and-reproduce: a representative subset (`test_non_identifier_atom_is_none`, `high_pressure_above_watermark`, `test_abstract_property_negative_errors`) reproduces identically on clean `origin/main` (`0f8c40d718`), 0 passed / 3 failed. CI owns full-suite validation.
- Relocated coverage check: `cargo nextest run -p tsz-checker -E 'binary(function_bivariance) or binary(global_type_tests) or binary(ts2304_tests)'` — 85 passed, 0 failed.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
