### PR TITLE
techdebt(repo): port solver-internal-imports from regex arch_guard to an ast-grep AST rule (#13451)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -71,7 +71,8 @@ scripts/
 ### Architecture & Linting
 | Script | Purpose |
 |--------|---------|
-| `scripts/arch/arch_guard.py` | Architecture boundary violation detection |
+| `scripts/arch/arch_guard.py` | Architecture boundary violation detection (regex policy) |
+| `scripts/arch/run-ast-grep.sh` | AST-native architecture invariants via ast-grep (#13451) |
 | `scripts/arch/check-checker-boundaries.sh` | Checker boundary enforcement |
 | `scripts/arch/render_architecture_report.py` | Render architecture guard markdown report |
 

--- a/scripts/arch/arch_guard_policy.toml
+++ b/scripts/arch/arch_guard_policy.toml
@@ -99,17 +99,16 @@ pattern = '\buse\s+tsz_solver::.*TypeKey|\bintern\(\s*TypeKey::|\bintern\(\s*tsz
 exclude_dirs = ["tests"]
 ignore_comment_lines = true
 
-[[pattern_checks]]
-name = "Checker boundary: direct solver internal imports"
-base = "crates/tsz-checker"
-pattern = '\btsz_solver::types::'
-exclude_dirs = ["tests"]
-ignore_comment_lines = true
-exclude_files = [
-  # Pre-existing baseline debt
-  "crates/tsz-checker/src/query_boundaries/class.rs",
-  "crates/tsz-checker/src/query_boundaries/property_access.rs",
-]
+# MIGRATED to ast-grep (#13451): "Checker boundary: direct solver internal
+# imports" (pattern '\btsz_solver::types::') is now the AST rule
+# `scripts/arch/ast-grep/rules/checker-solver-internal-imports.yml`, run by
+# `scripts/arch/run-ast-grep.sh`. The AST rule matches the
+# `tsz_solver::types` path node structurally, so the regex's
+# `ignore_comment_lines = true` is no longer needed (the comment in
+# `crates/tsz-checker/src/context/resolver.rs` is parsed as a comment, not a
+# path). The two `exclude_files` baseline-debt entries are preserved as
+# `ignores` in the YAML rule. Violation-set parity (net empty after excludes)
+# is verified in the PR.
 
 [[pattern_checks]]
 name = "Checker boundary: ObjectFlags must not be imported (use ObjectShape builder methods)"

--- a/scripts/arch/ast-grep/rule-tests/__snapshots__/checker-solver-internal-imports-snapshot.yml
+++ b/scripts/arch/ast-grep/rule-tests/__snapshots__/checker-solver-internal-imports-snapshot.yml
@@ -1,0 +1,32 @@
+id: checker-solver-internal-imports
+snapshots:
+  'fn f(x: tsz_solver::types::MappedType) {}':
+    labels:
+    - source: tsz_solver::types
+      style: primary
+      start: 8
+      end: 25
+  fn g() -> Option<tsz_solver::types::TypeParamInfo> { None }:
+    labels:
+    - source: tsz_solver::types
+      style: primary
+      start: 17
+      end: 34
+  'fn h(x: &tsz_solver::types::CallSignature) {}':
+    labels:
+    - source: tsz_solver::types
+      style: primary
+      start: 9
+      end: 26
+  use tsz_solver::types::MappedType;:
+    labels:
+    - source: tsz_solver::types
+      style: primary
+      start: 4
+      end: 21
+  use tsz_solver::types::{CallSignature, CallableShape};:
+    labels:
+    - source: tsz_solver::types
+      style: primary
+      start: 4
+      end: 21

--- a/scripts/arch/ast-grep/rule-tests/checker-solver-internal-imports-test.yml
+++ b/scripts/arch/ast-grep/rule-tests/checker-solver-internal-imports-test.yml
@@ -1,0 +1,31 @@
+# `sg test` fixtures for the `checker-solver-internal-imports` rule.
+#
+# `valid` snippets must NOT match (no violation); `invalid` snippets MUST match.
+# These pin the AST advantage over regex: comments and string literals that
+# textually contain the forbidden path are `valid` because they are not real
+# path syntax.
+#
+# Run:  ast-grep test -c scripts/arch/ast-grep/sgconfig.yml
+id: checker-solver-internal-imports
+valid:
+  # Doc comment mentioning the path (this is the resolver.rs case the regex
+  # rule had to skip via ignore_comment_lines).
+  - "//! reach into solver internals (`tsz_solver::types::Foo`)"
+  # Line comment.
+  - "// use tsz_solver::types::MappedType;"
+  # String literal containing the path text.
+  - 'let s = "tsz_solver::types::InString";'
+  # A different, allowed solver path -- only the `types` submodule is forbidden.
+  - "use tsz_solver::OtherThing;"
+  - "fn f(x: tsz_solver::CompatChecker) {}"
+invalid:
+  # use with brace list.
+  - "use tsz_solver::types::{CallSignature, CallableShape};"
+  # use single item.
+  - "use tsz_solver::types::MappedType;"
+  # type annotation.
+  - "fn f(x: tsz_solver::types::MappedType) {}"
+  # generic argument position.
+  - "fn g() -> Option<tsz_solver::types::TypeParamInfo> { None }"
+  # reference type.
+  - "fn h(x: &tsz_solver::types::CallSignature) {}"

--- a/scripts/arch/ast-grep/rules/checker-solver-internal-imports.yml
+++ b/scripts/arch/ast-grep/rules/checker-solver-internal-imports.yml
@@ -1,0 +1,53 @@
+# Checker boundary: direct solver internal imports (`tsz_solver::types::...`).
+#
+# Ported from the regex `[[pattern_checks]]` named
+# "Checker boundary: direct solver internal imports" in
+# `scripts/arch/arch_guard_policy.toml` (#13451).
+#
+# Structural rule:
+#   When checker production code names the solver's internal `types` submodule
+#   path (`tsz_solver::types::X`) outside the query-boundary layer, that is a
+#   layering violation -- the checker must consume solver types through the
+#   query boundary, never reach into solver submodule internals.
+#
+# Why AST, not regex:
+#   The path prefix `tsz_solver::types` is the inner `scoped_identifier` node
+#   shared by every surface form -- `use tsz_solver::types::{A, B};`,
+#   `use tsz_solver::types::X;`, the type annotation `&tsz_solver::types::T`,
+#   and a generic argument `Option<tsz_solver::types::T>`. Matching that one
+#   node covers them all while a `tsz_solver::types` mention inside a doc
+#   comment (e.g. `crates/tsz-checker/src/context/resolver.rs`) or a string
+#   literal is parsed as a comment/string token and is therefore never a
+#   match. The regex rule needs `ignore_comment_lines = true` to approximate
+#   that; ast-grep gets it for free.
+#
+# Path scope mirrors the regex rule:
+#   base                = crates/tsz-checker  -> `files` glob below
+#   exclude_dirs        = ["tests"]           -> `ignores` `**/tests/**`
+#   exclude_files       = the two pre-existing baseline-debt query_boundaries
+#                         files               -> `ignores` exact paths below
+id: checker-solver-internal-imports
+language: rust
+severity: error
+message: >-
+  Checker must not name the solver internal `types` submodule path
+  (`tsz_solver::types::...`). Consume solver types through the
+  `query_boundaries` layer instead.
+files:
+  - "crates/tsz-checker/**/*.rs"
+ignores:
+  # exclude_dirs = ["tests"] in the regex policy.
+  - "**/tests/**"
+  # exclude_files: pre-existing baseline debt carried over verbatim so the
+  # ported rule has the same violation set as the regex it replaces. Remove
+  # these as #8223 retires the debt.
+  - "crates/tsz-checker/src/query_boundaries/class.rs"
+  - "crates/tsz-checker/src/query_boundaries/property_access.rs"
+rule:
+  # The shared inner path-prefix node. `tsz_solver::types::Foo` parses as a
+  # `scoped_identifier`/`scoped_type_identifier` whose `path` field is this
+  # node; `use tsz_solver::types::{...}` parses as a `scoped_use_list` whose
+  # `path` field is this node. Anchoring on the prefix matches every form
+  # exactly once, with no expression-vs-type kind ambiguity.
+  kind: scoped_identifier
+  regex: '^tsz_solver::types$'

--- a/scripts/arch/ast-grep/sgconfig.yml
+++ b/scripts/arch/ast-grep/sgconfig.yml
@@ -1,0 +1,24 @@
+# ast-grep project config for tsz architecture invariants (#13451).
+#
+# This is the AST-native successor to the regex `pattern_checks` in
+# `scripts/arch/arch_guard_policy.toml`. ast-grep keys on real tree-sitter Rust
+# syntax nodes, so a forbidden token inside a comment, string literal, or
+# `trace!(...)` macro is never a match -- the exact failure mode that forces the
+# regex policy to carry `exclude_files`/`ignore_comment_lines` allowlists.
+#
+# Invocation (always from the repo root so rule `files`/`ignores` globs resolve
+# against repo-root-relative paths):
+#
+#   scripts/arch/run-ast-grep.sh
+#
+# which is equivalent to:
+#
+#   ast-grep scan -c scripts/arch/ast-grep/sgconfig.yml --error
+#
+# Rule directories and test fixture directories are resolved relative to THIS
+# file's location, per ast-grep semantics.
+ruleDirs:
+  - rules
+
+testConfigs:
+  - testDir: rule-tests

--- a/scripts/arch/check-checker-boundaries.sh
+++ b/scripts/arch/check-checker-boundaries.sh
@@ -14,6 +14,21 @@ python3 scripts/arch/render_architecture_report.py
 echo "Architecture guard report: $REPORT_PATH"
 echo "Architecture markdown report: $REPORT_MD_PATH"
 
+# AST-native architecture invariants (#13451). The ast-grep rules under
+# `scripts/arch/ast-grep/` are the structural successors to the regex
+# `pattern_checks` in `arch_guard_policy.toml`. Enforced wherever ast-grep (or
+# npx, which fetches the pinned @ast-grep/cli) is available; skipped with a
+# notice otherwise so environments without node/npx are not blocked. A dedicated
+# `sg scan` CI job is the long-term home (#13451 proposal step 3).
+if command -v ast-grep >/dev/null 2>&1 \
+  || command -v sg >/dev/null 2>&1 \
+  || command -v npx >/dev/null 2>&1; then
+  echo "Running AST-native architecture invariants (ast-grep)..."
+  scripts/arch/run-ast-grep.sh scan
+else
+  echo "ast-grep/npx not found; skipping AST-native architecture invariants." >&2
+fi
+
 # T2.1.A field-lifetime inventory: every CheckerContext field must be
 # classified in `crates/tsz-checker/src/context/checker_context_lifetimes.toml`.
 # See `docs/plan/PERFORMANCE_PLAN.md` §6.

--- a/scripts/arch/run-ast-grep.sh
+++ b/scripts/arch/run-ast-grep.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Run the AST-native architecture invariants (ast-grep) over the repo (#13451).
+#
+# This is the AST-native successor to the regex `pattern_checks` in
+# `scripts/arch/arch_guard_policy.toml`. It scans real tree-sitter Rust syntax,
+# so a forbidden token inside a comment, string literal, or `trace!(...)` macro
+# is never a match.
+#
+# Usage:
+#   scripts/arch/run-ast-grep.sh           # scan: fail (exit 1) on any violation
+#   scripts/arch/run-ast-grep.sh test      # run the rule pass/fail fixtures
+#   scripts/arch/run-ast-grep.sh scan      # explicit scan (same as no arg)
+#
+# ast-grep is pinned to AST_GREP_VERSION for reproducibility (cf. the repo's
+# baseline-staleness traps with unpinned tooling). The runner prefers a
+# locally installed `ast-grep`/`sg` binary at the pinned version; otherwise it
+# falls back to `npx -p @ast-grep/cli@<version> ast-grep`, which downloads the
+# pinned package on demand without a persistent install.
+set -euo pipefail
+
+AST_GREP_VERSION="0.43.0"
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SGCONFIG="scripts/arch/ast-grep/sgconfig.yml"
+
+cd "$ROOT_DIR"
+
+# Resolve an ast-grep runner pinned to AST_GREP_VERSION.
+resolve_ast_grep() {
+  local candidate
+  for candidate in ast-grep sg; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      if "$candidate" --version 2>/dev/null | grep -q "${AST_GREP_VERSION}\$"; then
+        AST_GREP=("$candidate")
+        return 0
+      fi
+    fi
+  done
+  if command -v npx >/dev/null 2>&1; then
+    # npx invokes the `ast-grep` bin from the @ast-grep/cli package; the package
+    # name differs from the binary name, so -p is required.
+    AST_GREP=(npx --yes -p "@ast-grep/cli@${AST_GREP_VERSION}" ast-grep)
+    return 0
+  fi
+  echo "error: ast-grep ${AST_GREP_VERSION} not found and npx unavailable." >&2
+  echo "       install with: npm install -g @ast-grep/cli@${AST_GREP_VERSION}" >&2
+  return 127
+}
+
+resolve_ast_grep
+
+mode="${1:-scan}"
+case "$mode" in
+  test)
+    exec "${AST_GREP[@]}" test -c "$SGCONFIG"
+    ;;
+  scan)
+    # --error promotes every rule's severity to error so any match exits 1.
+    exec "${AST_GREP[@]}" scan -c "$SGCONFIG" --error
+    ;;
+  *)
+    echo "usage: $0 [scan|test]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Advances #13451.

Goal: hold

## Structural rule

When checker production code names the solver's internal `types` submodule path
(`tsz_solver::types::X`) outside the `query_boundaries` layer, that is a layering
violation — the checker must consume solver types through the query boundary,
never reach into solver submodule internals. This was enforced by the regex
`[[pattern_checks]]` named "Checker boundary: direct solver internal imports"
(`pattern = '\btsz_solver::types::'`); it is now an AST-native `ast-grep` rule.
Owner: `scripts/arch/ast-grep/` (the structural successor to the regex
`pattern_checks` in `scripts/arch/arch_guard_policy.toml`).

The rule keys on the shared inner path-prefix node: `tsz_solver::types::Foo`
parses as a `scoped_identifier`/`scoped_type_identifier` whose `path` field is
the `scoped_identifier` `tsz_solver::types`, and `use tsz_solver::types::{...}`
parses as a `scoped_use_list` whose `path` field is the same node. Anchoring on
that prefix (`kind: scoped_identifier`, `regex: '^tsz_solver::types$'`) matches
every surface form exactly once — `use` brace-list, `use` single-item, type
annotation, reference type, generic argument — with no expression-vs-type kind
ambiguity, and a `tsz_solver::types` mention inside a doc comment or string
literal is parsed as a comment/string token and is therefore never a match. The
regex needed `ignore_comment_lines = true` to approximate that; ast-grep gets it
structurally.

Adjacent matrix (pinned by `sg test` fixtures + snapshot):
- invalid (must match): `use tsz_solver::types::{A, B};`,
  `use tsz_solver::types::X;`, `fn f(x: tsz_solver::types::T)`,
  `Option<tsz_solver::types::T>`, `&tsz_solver::types::T`.
- valid (must NOT match): doc comment and line comment containing the path,
  string literal containing the path, and the allowed sibling paths
  `tsz_solver::OtherThing` / `tsz_solver::CompatChecker` (only the `types`
  submodule is forbidden).

Path scope mirrors the regex rule exactly: `base = crates/tsz-checker` →
`files: crates/tsz-checker/**/*.rs`; `exclude_dirs = ["tests"]` →
`ignores: **/tests/**`; the two pre-existing baseline-debt `exclude_files`
(`query_boundaries/class.rs`, `query_boundaries/property_access.rs`) are carried
over verbatim as `ignores`, so the ported rule has the same violation set as the
regex it replaces (remove as #8223 retires the debt).

## What changed

- `scripts/arch/ast-grep/sgconfig.yml` — ast-grep project config (`ruleDirs` +
  `testConfigs`); the AST-native scaffolding the issue asks for.
- `scripts/arch/ast-grep/rules/checker-solver-internal-imports.yml` — the ported
  rule with documented structural rationale and path scope.
- `scripts/arch/ast-grep/rule-tests/checker-solver-internal-imports-test.yml`
  plus `__snapshots__/…-snapshot.yml` — `sg test` pass/fail fixtures and the
  snapshot baseline.
- `scripts/arch/run-ast-grep.sh` — runner pinned to `@ast-grep/cli@0.43.0`
  (prefers a local `ast-grep`/`sg` binary at that version, falls back to
  `npx -p @ast-grep/cli@0.43.0 ast-grep`); `scan` and `test` modes.
- `scripts/arch/check-checker-boundaries.sh` — runs the AST scan when
  ast-grep/npx is available (skips with a notice otherwise); a dedicated
  `sg scan` CI job is the long-term home (issue step 3).
- `scripts/arch/arch_guard_policy.toml` — the regex `pattern_check` entry +
  its `exclude_files` deleted in the same change, replaced with a migration
  note, so the regex and the AST rule never disagree (issue step 3).
- `scripts/README.md` — documents `run-ast-grep.sh`.

ast-grep (tree-sitter Rust) needs zero nightly toolchain; `dylint` remains the
documented escalation path for the future rules that need resolved-type
information (none of the current 37 do).

## Verification

No cargo build. Ran with ast-grep 0.43.0 (via `npm install @ast-grep/cli@0.43.0`):

- `scripts/arch/run-ast-grep.sh test` → `1 passed; 0 failed` — all 5 invalid
  snippets match, all 5 valid snippets (comments, string literal, sibling
  paths) do not.
- `scripts/arch/run-ast-grep.sh scan` over the repo → exit 0, **zero
  violations**: parity with the regex policy whose net violation set is also
  empty after its excludes.
- Parity proof: scanning `crates/tsz-checker` **without** the baseline excludes
  surfaces exactly the 2 known offenders
  (`query_boundaries/class.rs` ×6, `query_boundaries/property_access.rs` ×1) and
  **never** the doc-comment occurrence in `context/resolver.rs` — confirming the
  AST rule is strictly more precise than the regex (no `ignore_comment_lines`
  needed) while preserving the same enforced set.
- `python3 -m py_compile scripts/arch/*.py` OK; arch test suite re-run: the only
  2 failures (`scan_query_boundary_common_reference_count` "cap has slack"
  ratchets) are pre-existing on a clean checkout (reproduced with the policy
  change stashed) and unrelated to this change.
- `bash -n` clean on both shell scripts.

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
