### PR TITLE
refactor(lsp): relocate text_edits helper from tsz-cli bin to tsz-lsp providers (#13063)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_structure.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_structure.rs
@@ -3,9 +3,9 @@
 //! Handles formatting, inlay hints, selection ranges, call hierarchy,
 //! outlining spans, brace matching, refactoring stubs, and related commands.
 
-use super::text_edits::narrow_indentation_only_edit;
 use super::{Server, TsServerRequest, TsServerResponse};
 use tsz::emitter::{ModuleKind, Printer, PrinterOptions};
+use tsz::lsp::text_edits::narrow_indentation_only_edit;
 
 struct CompileOnSaveProject {
     config_path: String,

--- a/crates/tsz-cli/src/bin/tsz_server/main.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/main.rs
@@ -57,7 +57,6 @@ mod handlers_project_info;
 mod handlers_quickinfo;
 mod handlers_quickinfo_text;
 mod handlers_structure;
-mod text_edits;
 
 use anyhow::{Context, Result};
 use clap::Parser;

--- a/crates/tsz-lsp/src/lib.rs
+++ b/crates/tsz-lsp/src/lib.rs
@@ -49,6 +49,7 @@ pub mod rename;
 pub mod resolver;
 pub mod signature_help;
 pub mod symbols;
+pub mod text_edits;
 pub mod utils;
 
 pub mod fourslash;

--- a/crates/tsz-lsp/src/text_edits.rs
+++ b/crates/tsz-lsp/src/text_edits.rs
@@ -1,12 +1,19 @@
-//! Text edit utilities shared by tsserver handlers.
+//! Text edit utilities shared by LSP and tsserver handlers.
+//!
+//! These helpers operate purely on `TextEdit` geometry (ranges and replacement
+//! text) and do not encode any protocol-specific behavior. They were relocated
+//! from the `tsz-server` binary so that AST-based providers and protocol
+//! adapters can share a single implementation (issue #13063).
 
-use tsz::lsp::formatting::TextEdit;
-use tsz::lsp::position::{LineMap, Range};
+use crate::formatting::TextEdit;
+use crate::position::{LineMap, Range};
 
+/// A `TextEdit` narrowed down to the minimal changed span, decoupled from the
+/// original edit's identity so callers can serialize the trimmed result.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct NarrowedTextEdit {
-    pub(crate) range: Range,
-    pub(crate) new_text: String,
+pub struct NarrowedTextEdit {
+    pub range: Range,
+    pub new_text: String,
 }
 
 impl NarrowedTextEdit {
@@ -18,7 +25,16 @@ impl NarrowedTextEdit {
     }
 }
 
-pub(crate) fn narrow_indentation_only_edit(
+/// Trim an indentation-only edit down to the smallest range that actually
+/// differs.
+///
+/// Formatting and refactor passes frequently emit edits that replace an entire
+/// leading-whitespace run even when only a few characters change. For
+/// single-line, whitespace-only edits this strips the common prefix and suffix
+/// so the resulting edit touches the minimal span. Any edit that spans multiple
+/// lines, is zero-width, or whose offsets cannot be resolved is returned
+/// unchanged.
+pub fn narrow_indentation_only_edit(
     source_text: &str,
     line_map: &LineMap,
     edit: &TextEdit,
@@ -90,7 +106,7 @@ pub(crate) fn narrow_indentation_only_edit(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tsz::lsp::position::Position;
+    use crate::position::Position;
 
     fn edit_for_offsets(source_text: &str, start: u32, end: u32, new_text: &str) -> TextEdit {
         let line_map = LineMap::build(source_text);


### PR DESCRIPTION
Advances #13063.

Goal: hold

Relocates one self-contained, behavior-neutral utility module out of the
`tsz-cli/src/bin/tsz_server/` binary directory into the `tsz-lsp` library,
proving the migration path described in #13063 without touching any LSP or
tsserver behavior. This is the smallest clean slice of the XL refactor; the
bulk (handler protocol adapters, code-fix/completion engine consolidation,
test relocation) is intentionally out of scope.

## Structural rule
When a text-edit utility operates purely on `TextEdit` geometry (ranges and
replacement text) and carries no protocol-specific behavior, it belongs in the
`tsz-lsp` library so AST-based providers and the tsserver protocol adapter
share one implementation, not duplicated/buried inside the CLI binary. Here
`narrow_indentation_only_edit` / `NarrowedTextEdit` move from
`crates/tsz-cli/src/bin/tsz_server/text_edits.rs` to
`crates/tsz-lsp/src/text_edits.rs`.

## What changed
- Moved `crates/tsz-cli/src/bin/tsz_server/text_edits.rs` (the only external
  consumer was a single call site) to `crates/tsz-lsp/src/text_edits.rs` as a
  new `pub mod text_edits;` in `tsz-lsp`.
- Switched the module's imports from the `tsz::lsp::formatting` /
  `tsz::lsp::position` facade paths to crate-relative `crate::formatting` /
  `crate::position`.
- Widened visibility from `pub(crate)` to `pub` so the function/type are
  reachable from the binary (and future WASM/LSP consumers).
- Updated the one call site in `handlers_structure.rs` to import
  `tsz::lsp::text_edits::narrow_indentation_only_edit`; removed the
  `mod text_edits;` declaration from the binary's `main.rs`.
- The 4 unit tests moved with the module unchanged (other than the
  `crate::position::Position` import) and pass in their new home.

No public surface was dropped: the helper is now part of the `tsz-lsp` public
API and the binary call site resolves through the existing `tsz::lsp` facade.

## Verification
- `scripts/safe-run.sh cargo build -p tsz-lsp -p tsz-cli` — clean (builds both
  the library and the `tsz-server` binary that consumes the relocated helper).
- `scripts/safe-run.sh cargo clippy -p tsz-lsp --all-targets` — clean.
- `scripts/safe-run.sh cargo nextest run -p tsz-lsp text_edits` — 4 tests pass
  (the relocated unit tests).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
