### PR TITLE
refactor(binder): own pristine-lib-prefix predicate in SymbolArena toward layered shared-lib symbol arena (#13047)

### DIFF
--- a/crates/tsz-binder/src/symbols.rs
+++ b/crates/tsz-binder/src/symbols.rs
@@ -996,10 +996,24 @@ impl SymbolArena {
         self.symbols.iter()
     }
 
-    /// Number of symbols held in the shared prefix.
+    /// Whether the shared prefix still holds exactly the pristine premerged lib
+    /// universe, i.e. all `lib_symbol_count` lib symbols reside untouched in the
+    /// immutable `shared_prefix` and none were materialized back into the
+    /// private `symbols` segment.
+    ///
+    /// A premerged-lib binder cloned for a user file moves the whole lib
+    /// universe into `shared_prefix` (see
+    /// [`Self::share_current_symbols_for_append`]). Any in-place mutation of a
+    /// lib symbol via [`Self::get_mut`]/[`Self::iter_mut`] collapses the prefix
+    /// (see `materialize_shared_prefix`), after which this returns `false`.
+    ///
+    /// Compaction uses this to choose between the cheap "iterate only private
+    /// appended symbols" path and the full filtered scan. Centralizing the test
+    /// here keeps the prefix/private layering representation owned by the arena
+    /// instead of leaking a raw length comparison to `tsz-core`.
     #[must_use]
-    pub fn shared_prefix_len(&self) -> usize {
-        self.shared_prefix.len()
+    pub fn lib_prefix_is_pristine(&self, lib_symbol_count: usize) -> bool {
+        self.shared_prefix.len() == lib_symbol_count
     }
 
     /// Estimate the heap bytes owned by this arena: symbol slots, per-symbol
@@ -1474,5 +1488,47 @@ mod tests {
             arena.name_index.get("Iterator").map(Vec::as_slice),
             Some([shared_id, local_id].as_slice())
         );
+    }
+
+    #[test]
+    fn lib_prefix_is_pristine_tracks_shared_prefix_state() {
+        let mut arena = SymbolArena::new();
+        arena.alloc(0, "Array".to_owned());
+        arena.alloc(0, "Promise".to_owned());
+
+        // Before sharing, nothing is in the prefix.
+        assert!(!arena.lib_prefix_is_pristine(2));
+        assert!(arena.lib_prefix_is_pristine(0));
+
+        arena.share_current_symbols_for_append();
+        let local = arena.alloc(0, "Local".to_owned());
+
+        // Two lib symbols sit untouched in the shared prefix; the private
+        // append (`Local`) does not affect the prefix.
+        assert!(arena.lib_prefix_is_pristine(2));
+        // A different reported lib count must not match the prefix.
+        assert!(!arena.lib_prefix_is_pristine(3));
+
+        // Mutating the private symbol keeps the prefix pristine.
+        arena.get_mut(local).expect("local symbol").flags = 1;
+        assert!(arena.lib_prefix_is_pristine(2));
+    }
+
+    #[test]
+    fn lib_prefix_is_pristine_false_after_lib_symbol_materialized() {
+        let mut arena = SymbolArena::new();
+        let array_id = arena.alloc(0, "Array".to_owned());
+        arena.alloc(0, "Promise".to_owned());
+        arena.share_current_symbols_for_append();
+        arena.alloc(0, "Local".to_owned());
+
+        assert!(arena.lib_prefix_is_pristine(2));
+
+        // Mutating a shared-prefix (lib) symbol materializes the prefix back
+        // into `symbols`, collapsing the shared prefix to empty. The pristine
+        // invariant must then report `false`, routing compaction to its full
+        // filtered scan instead of the private-only fast path.
+        arena.get_mut(array_id).expect("array symbol").flags = 1;
+        assert!(!arena.lib_prefix_is_pristine(2));
     }
 }

--- a/crates/tsz-core/src/parallel/core/parse_and_libs.rs
+++ b/crates/tsz-core/src/parallel/core/parse_and_libs.rs
@@ -1784,7 +1784,7 @@ fn collect_retained_lib_symbol_refs(
         retain_if_lib(sym_id, lib_symbol_ids, retained);
     }
 
-    if binder.symbols.shared_prefix_len() == lib_symbol_ids.len() {
+    if binder.symbols.lib_prefix_is_pristine(lib_symbol_ids.len()) {
         for sym in binder.symbols.iter_private_symbols() {
             retain_if_lib(sym.parent, lib_symbol_ids, retained);
             if let Some(exports) = sym.exports.as_ref() {

--- a/crates/tsz-core/src/parallel/core/premerged_lib_compaction.rs
+++ b/crates/tsz-core/src/parallel/core/premerged_lib_compaction.rs
@@ -4,7 +4,7 @@ fn for_each_densify_source_symbol(
     retained_lib_symbols: &FxHashSet<SymbolId>,
     mut visit: impl FnMut(&crate::binder::Symbol),
 ) {
-    if symbols.shared_prefix_len() == lib_symbol_ids.len() {
+    if symbols.lib_prefix_is_pristine(lib_symbol_ids.len()) {
         let mut retained_prefix_ids: Vec<_> = retained_lib_symbols.iter().copied().collect();
         retained_prefix_ids.sort_unstable();
         for sym_id in retained_prefix_ids {


### PR DESCRIPTION
Advances #13047.

Goal: hold

## Structural rule
When a premerged-lib binder is cloned for a user file, `share_current_symbols_for_append` moves the entire pristine lib symbol universe into the arena's immutable `shared_prefix`; per-file compaction must distinguish "the shared prefix still holds exactly the lib universe" (cheap private-only iteration) from "a lib symbol was mutated in place and the prefix collapsed via `materialize_shared_prefix`" (full filtered scan). `tsc` has no equivalent; this is purely tsz's per-file shared-lib layering bookkeeping. Owner: `tsz-binder` `SymbolArena` (the layering representation), not `tsz-core`.

## What changed
- Added `SymbolArena::lib_prefix_is_pristine(lib_symbol_count)` to `crates/tsz-binder/src/symbols.rs`, encapsulating the invariant "all lib symbols reside untouched in `shared_prefix`".
- Replaced the two raw `shared_prefix_len() == lib_symbol_ids.len()` comparisons in `tsz-core` compaction (`parse_and_libs.rs` `collect_retained_lib_symbol_refs`, `premerged_lib_compaction.rs` `for_each_densify_source_symbol`) with calls to the new predicate.
- Removed the now-unused `shared_prefix_len()` accessor so callers cannot reconstruct the layering invariant from raw lengths, keeping the prefix/private representation owned by the arena (architecture boundary: `tsz-core` no longer pattern-matches arena internals).
- Pinned the invariant with two `SymbolArena` unit tests, including the materialize-collapse case (a mutated lib symbol must report non-pristine so compaction routes to the full filtered scan).

Behavior-preserving: the predicate returns the identical boolean as the prior comparison; the same compaction branch is taken in every case. No symbol-resolution, diagnostic, or emit behavior changes. This is an accessor-extraction slice toward the layered shared-lib arena; the XL pieces (layered `file_locals`, deleting `compact_premerged_lib_state` + the `lib_symbol_ids`/`lib_symbol_reverse_remap` bookkeeping that is still wired into the checker cross-file path and reducer) remain.

## Verification
- `scripts/safe-run.sh cargo build -p tsz-binder` — clean.
- `scripts/safe-run.sh cargo build -p tsz-core` — clean (both call sites compile).
- `scripts/safe-run.sh cargo clippy -p tsz-binder --all-targets` — no warnings.
- `scripts/safe-run.sh cargo nextest run -p tsz-binder` — 541 passed (incl. 2 new `lib_prefix_is_pristine` tests).
- `scripts/safe-run.sh cargo nextest run -p tsz-core premerged_lib_compaction` — 2 passed (behavior unchanged).
- `cargo fmt --check`; `git diff --check origin/main...HEAD`; `python3 scripts/arch/arch_guard.py` — all clean.
- Per repo policy, checker/conformance/emit suites are not run locally; ready-review CI owns them.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
