### PR TITLE
perf(lsp): cache parse/bind/interner state across tsz_server requests (#13114)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_implement_interface_tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_implement_interface_tests.rs
@@ -20,6 +20,7 @@ fn make_server() -> Server {
         external_project_files: FxHashMap::default(),
         completion_project_cache: None,
         project_cache: std::cell::RefCell::new(None),
+        parse_bind_cache: std::cell::RefCell::new(crate::ParseBindCache::default()),
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_nested_pkg_tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_nested_pkg_tests.rs
@@ -33,6 +33,7 @@ fn make_server() -> Server {
         external_project_files: FxHashMap::default(),
         completion_project_cache: None,
         project_cache: std::cell::RefCell::new(None),
+        parse_bind_cache: std::cell::RefCell::new(crate::ParseBindCache::default()),
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests.rs
@@ -23,6 +23,7 @@ fn make_server() -> Server {
         external_project_files: FxHashMap::default(),
         completion_project_cache: None,
         project_cache: std::cell::RefCell::new(None),
+        parse_bind_cache: std::cell::RefCell::new(crate::ParseBindCache::default()),
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,

--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests_part2.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes_tests_part2.rs
@@ -24,6 +24,7 @@ fn make_server() -> Server {
         external_project_files: FxHashMap::default(),
         completion_project_cache: None,
         project_cache: std::cell::RefCell::new(None),
+        parse_bind_cache: std::cell::RefCell::new(crate::ParseBindCache::default()),
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,

--- a/crates/tsz-cli/src/bin/tsz_server/main.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/main.rs
@@ -109,6 +109,62 @@ pub(crate) struct ServerProjectCache {
     pub(crate) project: tsz::lsp::Project,
 }
 
+/// A single cached parse+bind result for one file.
+///
+/// Keyed in [`ParseBindCache`] by file path; the `content_hash` discriminates
+/// stale entries so an edited/closed-and-reopened file with the same path but
+/// different content re-parses instead of returning a stale AST. The heavy
+/// payload fields (`NodeArena`, `BinderState`) are `Arc`-backed internally, so
+/// handing a clone back to a handler is a handful of refcount bumps rather than
+/// a deep copy or a re-parse + re-bind.
+pub(crate) struct ParseBindEntry {
+    pub(crate) content_hash: u64,
+    pub(crate) arena: NodeArena,
+    pub(crate) binder: BinderState,
+    pub(crate) root: NodeIndex,
+    pub(crate) content: String,
+}
+
+/// Per-file parse+bind cache for the tsz-server request loop.
+///
+/// LSP requests re-enter `parse_and_bind_file` many times per request (handlers
+/// scan related files) and again across requests over unchanged files. Without
+/// a cache each call re-runs scanner + parser + binder for the same content.
+/// This cache stores the most recent parse+bind per file path and reuses it
+/// when the current content hashes equal — correctness is preserved because a
+/// content change yields a different hash and forces a fresh parse.
+///
+/// Bounded by `MAX_ENTRIES` so a session that touches very many files cannot
+/// grow the cache without limit; the cache is also dropped wholesale on any
+/// file mutation / session reset via `clear_completion_project_cache`.
+#[derive(Default)]
+pub(crate) struct ParseBindCache {
+    entries: FxHashMap<String, ParseBindEntry>,
+}
+
+impl ParseBindCache {
+    /// Upper bound on cached files. Past this we drop the cache to keep server
+    /// memory bounded; the hot working set for an LSP session is small.
+    const MAX_ENTRIES: usize = 256;
+
+    fn get(&self, file_path: &str, content_hash: u64) -> Option<&ParseBindEntry> {
+        self.entries
+            .get(file_path)
+            .filter(|entry| entry.content_hash == content_hash)
+    }
+
+    fn insert(&mut self, file_path: String, entry: ParseBindEntry) {
+        if self.entries.len() >= Self::MAX_ENTRIES && !self.entries.contains_key(&file_path) {
+            self.entries.clear();
+        }
+        self.entries.insert(file_path, entry);
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+    }
+}
+
 fn deserialize_target_option<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -613,6 +669,11 @@ pub(crate) struct Server {
     /// Reused by project-backed navigation operations such as references,
     /// type-definition, implementations, and file references.
     pub(crate) project_cache: RefCell<Option<ServerProjectCache>>,
+    /// Per-file parse+bind cache. `parse_and_bind_file` consults this before
+    /// re-running scanner + parser + binder for a file whose content is
+    /// unchanged. Content-hash keyed, so an edited file re-parses; cleared on
+    /// any file mutation / session reset alongside the project caches.
+    pub(crate) parse_bind_cache: RefCell<ParseBindCache>,
     /// Completion preference: import module specifier ending (e.g. "js")
     pub(crate) completion_import_module_specifier_ending: Option<String>,
     /// Completion/codefix preference: import module specifier preference.
@@ -727,6 +788,7 @@ impl Server {
             external_project_files: FxHashMap::default(),
             completion_project_cache: None,
             project_cache: RefCell::new(None),
+            parse_bind_cache: RefCell::new(ParseBindCache::default()),
             completion_import_module_specifier_ending: None,
             import_module_specifier_preference: None,
             organize_imports_type_order: None,
@@ -800,6 +862,7 @@ impl Server {
     pub(crate) fn clear_completion_project_cache(&mut self) {
         self.completion_project_cache = None;
         self.project_cache.borrow_mut().take();
+        self.parse_bind_cache.borrow_mut().clear();
     }
 
     fn handle_reset(&mut self, seq: u64, request: &TsServerRequest) -> TsServerResponse {
@@ -829,12 +892,48 @@ impl Server {
             let raw = Self::read_virtual_harness_path(file_path)?;
             Self::normalize_fourslash_virtual_content(file_path, &raw)
         };
+
+        // Reuse a prior parse+bind for this exact content. The cached payload is
+        // `Arc`-backed (`NodeArena`, `BinderState`'s symbol storage), so the
+        // clone we hand back is refcount bumps rather than a re-parse + re-bind.
+        // Content-hash keying makes this self-invalidating: an edited file (or a
+        // different file at the same virtual path) hashes differently and falls
+        // through to a fresh parse.
+        let content_hash = Self::hash_parse_bind_content(&content);
+        if let Some(entry) = self.parse_bind_cache.borrow().get(file_path, content_hash) {
+            return Some((
+                entry.arena.clone(),
+                entry.binder.clone(),
+                entry.root,
+                entry.content.clone(),
+            ));
+        }
+
         let mut parser = ParserState::new(file_path.to_string(), content.clone());
         let root = parser.parse_source_file();
         let arena = parser.into_arena();
         let mut binder = BinderState::new();
         binder.bind_source_file(&arena, root);
+
+        self.parse_bind_cache.borrow_mut().insert(
+            file_path.to_string(),
+            ParseBindEntry {
+                content_hash,
+                arena: arena.clone(),
+                binder: binder.clone(),
+                root,
+                content: content.clone(),
+            },
+        );
+
         Some((arena, binder, root, content))
+    }
+
+    fn hash_parse_bind_content(content: &str) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        content.hash(&mut hasher);
+        hasher.finish()
     }
 
     fn read_virtual_harness_path(file_path: &str) -> Option<String> {

--- a/crates/tsz-cli/src/bin/tsz_server/tests_support.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/tests_support.rs
@@ -17,6 +17,7 @@ pub(super) fn make_server() -> Server {
         external_project_files: FxHashMap::default(),
         completion_project_cache: None,
         project_cache: std::cell::RefCell::new(None),
+        parse_bind_cache: std::cell::RefCell::new(crate::ParseBindCache::default()),
         _server_mode: ServerMode::Semantic,
         _log_config: LogConfig {
             level: LogLevel::Off,


### PR DESCRIPTION
Advances #13114.

Goal: hold

## Structural rule
When a tsz-server request handler asks `parse_and_bind_file(path)` for a file
whose content is byte-for-byte unchanged since the last parse, tsc-equivalent
tooling reuses the existing parse + bind state; tsz now does the same through a
content-hash-keyed per-file cache on `Server` instead of re-running scanner +
parser + binder per call. A content change yields a different hash and forces a
fresh parse, so a stale AST/binder can never be returned.

## What changed
- Added `ParseBindCache` / `ParseBindEntry` (in `tsz_server::main`): a
  `FxHashMap<String, ParseBindEntry>` keyed by file path, with each entry
  carrying a content hash plus the cached `NodeArena`, `BinderState`, root
  `NodeIndex`, and source text.
- `parse_and_bind_file` now hashes the resolved content, returns a clone of the
  cached entry on a hash match, and otherwise parses + binds, stores, and
  returns. The cached `NodeArena` and `BinderState` symbol storage are
  `Arc`-backed, so the returned clone is refcount bumps (and the arena's
  `atom_owner_key` identity is preserved across clones, keeping the binder's
  atom-keyed side index valid), not a deep copy or a re-parse.
- Correctness/bounding: the cache is bounded (`MAX_ENTRIES = 256`) and cleared
  wholesale in `clear_completion_project_cache`, which every `open_files`
  mutation and `reset_session_state` already calls — so edits, closes, and
  session resets drop stale state in addition to the self-invalidating hash key.
- Slice scope: this is the `parse_and_bind_file` hotspot used by quickinfo,
  definition, navigation, structure, completion-display, and code-fix handlers.
  It complements the already-merged project-state caches for completions (#13340)
  and navigation (#13521).

## Verification
- `scripts/safe-run.sh cargo build -p tsz-cli` — clean.
- `scripts/safe-run.sh cargo clippy -p tsz-cli --all-targets` — clean.
- `cargo nextest run -p tsz-cli --bin tsz-server -E 'test(quickinfo) or test(definition) or test(navigation) or test(structure)'` — 69 passed.
- `cargo nextest run -p tsz-cli --bin tsz-server -E 'test(code_fix) or test(completion) or test(diagnostic) or test(import) or test(rename) or test(references)'` — 224 passed, 1 failed. The single failure (`collect_import_candidates_respects_node_next_package_exports_root_only`) reproduces identically on `origin/main` with these files reverted, and that test never calls `parse_and_bind_file`; it is a pre-existing baseline failure, not introduced here.
- Did not run tsz-checker / full conformance / fourslash locally (disk rule); ready-review CI owns those.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
