### PR TITLE
refactor(checker,solver): drop dead-code allows (#13440)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -13,6 +13,15 @@
 //! Note: The thin checker is the unified checker pipeline; `CheckerState`
 //! is an alias to the thin checker.
 
+// XL: crate-wide `dead_code` is suppressed because lifting it surfaces ~149
+// item-level warnings across ~70 files in this crate (counted via a lib build
+// pass for #13440). Each needs case-by-case judgment (delete vs. local allow
+// vs. intended API) and several candidates are only reachable through tests or
+// macros that a `--lib` pass cannot see, so a safe audit is its own campaign.
+// Scoping per-module would reproduce the blanket across most of the tree. The
+// solver half of #13440 (false `InferenceError` "reserved" label + dead
+// `ConstraintSet` methods) is already resolved by #13534; this crate-wide allow
+// is the remaining XL item tracked by #13440.
 #![allow(dead_code)]
 
 extern crate self as tsz_checker;

--- a/crates/tsz-checker/src/types/computation/complex.rs
+++ b/crates/tsz-checker/src/types/computation/complex.rs
@@ -300,11 +300,6 @@ impl<'a> CheckerState<'a> {
         Some(ty)
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn get_type_of_new_expression(&mut self, idx: NodeIndex) -> TypeId {
-        self.get_type_of_new_expression_with_request(idx, &TypingRequest::NONE)
-    }
-
     pub(crate) fn get_type_of_new_expression_with_request(
         &mut self,
         idx: NodeIndex,


### PR DESCRIPTION
Advances #13440.

Goal: hold

## Structural rule

When code is unused but deliberately retained, idiomatic Rust scopes
`#[allow(dead_code)]` to that single item with a truthful reason. tsz-checker
instead blanket-allows the whole crate (`lib.rs`), which renders the crate's
48 item-level allows inert and lets orphaned wrappers accumulate undetected.
This removes one confirmed orphan masked by that blanket and documents the
crate-wide allow as a tracked XL follow-up; the solver half of #13440 is
already resolved.

## What changed

- Delete the confirmed checker orphan `get_type_of_new_expression`
  (`types/computation/complex.rs`): a `NONE`-forwarding wrapper with zero
  callers anywhere in `crates/` (production or test). The live new-expression
  dispatch calls `get_type_of_new_expression_with_request` directly
  (`dispatch/mod.rs`), so the wrapper is a dead second entry point. It is
  `pub(crate)`, so it is not external API.
- Document on the crate-wide `#![allow(dead_code)]` (`lib.rs`) why it remains:
  lifting it surfaces ~149 item-level `dead_code` warnings across ~70 files in
  this crate (counted via a `cargo build -p tsz-checker --lib` pass). Each needs
  case-by-case judgment (delete vs. local allow vs. intended API), and several
  candidates are only reachable through tests or macros a `--lib` pass cannot
  see, so a safe audit is its own XL campaign. Per-module scoping would
  reproduce the blanket across most of the tree, so it is not a meaningful
  intermediate step.

### Why not the full crate-wide removal (part A)

The issue's proposed fix sequences the checker blanket-allow removal behind a
compile pass to enumerate orphans. That pass yields ~149 warnings across ~70
files — an XL audit that cannot be landed safely in one behavior-preserving PR
(misjudging reachability of any one item risks changing compiler output). Per
the issue's own guidance ("If removing the blanket allow surfaces a large
orphan set, split"), this PR lands the self-contained, confirmed deletion and
records the count; the crate-wide removal remains tracked by #13440.

The solver half of #13440 (the false `InferenceError` "reserved" label and the
dead `ConstraintSet::new` / single-arg mutators) was already resolved by #13534,
so no solver change is needed here.

## Verification

- `scripts/safe-run.sh cargo build -p tsz-checker --lib` — clean, 0 warnings
  (with the wrapper deleted and the documented allow in place).
- `scripts/safe-run.sh cargo clippy -p tsz-checker --lib` — clean.
- `scripts/safe-run.sh cargo build -p tsz-solver` — clean.
- `scripts/safe-run.sh cargo clippy -p tsz-solver --all-targets` — clean.
- `rg 'get_type_of_new_expression\b' crates/` confirms zero callers of the
  deleted wrapper before removal.
- Behavior-preserving: the deleted wrapper had zero callers, so output cannot
  change. No type algorithm changes. CI runs the full checker/solver suites.

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
