### PR TITLE
fix(solver): preserve symbol-keyed method in non-recursive homomorphic mapped over Iterable (partial #13619)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -956,6 +956,9 @@ path = "tests/mapped_type_interface_tests.rs"
 name = "homomorphic_mapped_empty_keyspace_tests"
 path = "tests/homomorphic_mapped_empty_keyspace_tests.rs"
 [[test]]
+name = "homomorphic_mapped_symbol_iterator_tests"
+path = "tests/homomorphic_mapped_symbol_iterator_tests.rs"
+[[test]]
 name = "homomorphic_mapped_union_distribution_tests"
 path = "tests/homomorphic_mapped_union_distribution_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/checkers/iterable_checker.rs
+++ b/crates/tsz-checker/src/checkers/iterable_checker.rs
@@ -97,7 +97,18 @@ impl<'a> CheckerState<'a> {
                 // Lazy(DefId) bases that can't be resolved through the type classification.
                 // Use the full property access resolution which handles all the complex
                 // resolution paths including Application types with Lazy bases from lib files.
-                self.type_has_symbol_iterator_via_property_access(type_id)
+                if self.type_has_symbol_iterator_via_property_access(type_id) {
+                    return true;
+                }
+                // A mapped-type alias application such as `DeepReadonlyObject<Iterable<T>>`
+                // (the homomorphic branch a recursive conditional like `DeepReadonly`
+                // selects) does not expose `[Symbol.iterator]` until its mapped body is
+                // instantiated and evaluated. `tsc` checks iterability against the
+                // apparent type, so resolve the alias application the same way a
+                // property-access receiver is resolved, then re-classify. The
+                // `resolved != type_id` guard avoids looping when it stays opaque.
+                let resolved = self.resolve_type_for_property_access(type_id);
+                resolved != type_id && self.is_iterable_type(resolved)
             }
             FullIterableTypeKind::TypeParameter { constraint } => {
                 if let Some(c) = constraint {
@@ -112,8 +123,18 @@ impl<'a> CheckerState<'a> {
                 // Unwrap readonly wrapper and check inner type
                 self.is_iterable_type(inner)
             }
-            // Index access, Conditional, Mapped - not directly iterable
-            FullIterableTypeKind::ComplexType => false,
+            // Index access, Conditional, Mapped: not iterable in their deferred
+            // form, but `tsc` checks iterability against the *apparent* type. A
+            // mapped type like `{ [K in keyof Iterable<T>]: ... }` resolves to an
+            // object that keeps the `[Symbol.iterator]` method, so for-of must see
+            // through it. Resolve the receiver the same way property access does
+            // and re-classify; the `resolved != type_id` guard prevents looping
+            // on a form that stays deferred (e.g. a conditional that genuinely
+            // depends on a free type parameter).
+            FullIterableTypeKind::ComplexType => {
+                let resolved = self.resolve_type_for_property_access(type_id);
+                resolved != type_id && self.is_iterable_type(resolved)
+            }
             // Functions, classes without Symbol.iterator are not iterable
             FullIterableTypeKind::FunctionOrCallable => {
                 // Callable types can have properties (including [Symbol.iterator])

--- a/crates/tsz-checker/tests/homomorphic_mapped_symbol_iterator_tests.rs
+++ b/crates/tsz-checker/tests/homomorphic_mapped_symbol_iterator_tests.rs
@@ -1,0 +1,141 @@
+//! Regression tests for issue #13619: a homomorphic mapped type over a
+//! symbol-keyed lib interface (`Iterable<T>`, whose sole member is the
+//! well-known `[Symbol.iterator]` method) must preserve that symbol-keyed
+//! method so the result stays iterable.
+//!
+//! Root cause: when the mapped-type evaluator emitted a symbol-keyed output
+//! property it looked the source method up by a synthetic `__unique_<id>`
+//! atom instead of the canonical `"[Symbol.iterator]"` atom the lib interface
+//! stores it under. The lookup missed, so `T[Symbol.iterator]` resolved to
+//! `undefined` and the homomorphic result silently dropped the iterator
+//! method — producing a false `TS2488` at a `for-of` over the result and a
+//! false `TS7053`/widened `symbol` for `keyof`.
+//!
+//! The witnesses use the *real* embedded lib `Iterable` (a `Lazy(DefId)` from
+//! the lib snapshot); an inline interface does not reproduce because its
+//! symbol member is stored under a fresh local atom. Binder names are varied
+//! to prove the fix is structural, not name-driven.
+
+use std::sync::Arc;
+use tsz_binder::lib_loader::LibFile;
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source_with_libs, load_default_lib_files};
+
+fn strict_codes(source: &str, libs: &[Arc<LibFile>]) -> Vec<u32> {
+    let options = CheckerOptions {
+        strict: true,
+        strict_null_checks: true,
+        ..CheckerOptions::default()
+    };
+    check_source_with_libs(source, "test.ts", options, libs)
+        .into_iter()
+        .map(|diag| diag.code)
+        .collect()
+}
+
+/// Simple identity homomorphic mapped type over the lib `Iterable<T>` must keep
+/// `[Symbol.iterator]`, so a `for-of` over the result is valid (no TS2488) and
+/// the symbol index access resolves (no TS7053).
+#[test]
+fn identity_mapped_over_iterable_preserves_symbol_iterator() {
+    let libs = load_default_lib_files();
+    let codes = strict_codes(
+        r#"
+type Mirror<Container> = { readonly [Slot in keyof Container]: Container[Slot] };
+function walk<Payload>(seq: Mirror<Iterable<Payload>>) {
+  for (const item of seq) {
+  }
+  const probe = seq[Symbol.iterator];
+}
+"#,
+        &libs,
+    );
+    assert!(
+        !codes.contains(&2488),
+        "homomorphic mapped over Iterable should stay iterable (no TS2488); got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&7053),
+        "the preserved [Symbol.iterator] key must be symbol-indexable (no TS7053); got {codes:?}"
+    );
+}
+
+/// Concrete instantiation: `Mirror<Iterable<number>>` must also be iterable.
+#[test]
+fn identity_mapped_over_concrete_iterable_preserves_symbol_iterator() {
+    let libs = load_default_lib_files();
+    let codes = strict_codes(
+        r#"
+type Copy<Source> = { readonly [Field in keyof Source]: Source[Field] };
+function scan(seq: Copy<Iterable<number>>) {
+  for (const item of seq) {
+    const keep: number = item;
+  }
+}
+"#,
+        &libs,
+    );
+    assert!(
+        !codes.contains(&2488),
+        "homomorphic mapped over concrete Iterable<number> should stay iterable; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&7053),
+        "the preserved [Symbol.iterator] key must be symbol-indexable; got {codes:?}"
+    );
+}
+
+/// A mapped type whose template branches on `Slot extends typeof Symbol.iterator`
+/// (the `DeepReadonlyObject` shape from ts-essentials) must still preserve the
+/// symbol-keyed iterator method.
+#[test]
+fn symbol_iterator_conditional_template_mapped_preserves_iterator() {
+    let libs = load_default_lib_files();
+    let codes = strict_codes(
+        r#"
+type DeepCopyObject<Node> = {
+  readonly [Slot in keyof Node]: Slot extends typeof Symbol.iterator
+    ? Node[Slot] extends () => Iterator<infer Yielded, infer Ret, infer Sent>
+      ? () => Iterator<Yielded, Ret, Sent>
+      : Node[Slot]
+    : Node[Slot];
+};
+function traverse<Payload>(seq: DeepCopyObject<Iterable<Payload>>) {
+  for (const item of seq) {
+  }
+}
+"#,
+        &libs,
+    );
+    assert!(
+        !codes.contains(&2488),
+        "symbol-iterator-aware mapped over Iterable should stay iterable; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&7053),
+        "the preserved [Symbol.iterator] key must be symbol-indexable; got {codes:?}"
+    );
+}
+
+/// Negative/leaf guard: a mapped type over an object that has NO
+/// `[Symbol.iterator]` is correctly NOT iterable (TS2488 still fires). The fix
+/// must not make every mapped object spuriously iterable.
+#[test]
+fn mapped_over_non_iterable_object_still_reports_ts2488() {
+    let libs = load_default_lib_files();
+    let codes = strict_codes(
+        r#"
+interface Plain { value: number; }
+type Echo<Shape> = { readonly [Member in keyof Shape]: Shape[Member] };
+function loop(notSeq: Echo<Plain>) {
+  for (const item of notSeq) {
+  }
+}
+"#,
+        &libs,
+    );
+    assert!(
+        codes.contains(&2488),
+        "a mapped object without [Symbol.iterator] must NOT be iterable (expect TS2488); got {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs
@@ -427,6 +427,22 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 resolved_source,
                 &mut source_props,
             );
+            // Map each symbol-named source property's `SymbolRef` to the atom it
+            // is stored under (e.g. `Symbol.iterator` -> `"[Symbol.iterator]"`).
+            // The symbol-key emission loop below looks `source_prop_map` up by
+            // this atom to recover the declared method type; without the mapping
+            // it falls back to the synthetic `__unique_<id>` atom, which is not a
+            // `source_prop_map` key, so `T[Symbol.iterator]` resolved to
+            // `undefined` and the homomorphic result silently dropped the
+            // iterator method. This must run for every homomorphic mapped type,
+            // not only the `as`-clause (name_type) path.
+            for prop in &source_props {
+                if prop.is_symbol_named
+                    && let Some(sym_ref) = self.unique_symbol_ref_from_symbol_named_atom(prop.name)
+                {
+                    source_symbol_prop_names.entry(sym_ref).or_insert(prop.name);
+                }
+            }
             if mapped.name_type.is_some() {
                 let mut seen_string_keys: FxHashSet<Atom> =
                     key_set.keys.iter().map(|key| key.name).collect();

--- a/crates/tsz-solver/src/objects/collect.rs
+++ b/crates/tsz-solver/src/objects/collect.rs
@@ -361,16 +361,24 @@ impl<'a, R: TypeResolver> PropertyCollector<'a, R> {
     }
 
     fn collect_finite_mapped_properties(&mut self, mapped_id: crate::types::MappedTypeId) {
-        let Some(names) =
-            crate::type_queries::collect_finite_mapped_property_names(self.interner, mapped_id)
+        // Collect keys (not just names) so symbol-keyed output properties keep
+        // their `is_symbol_named` identity. A homomorphic mapped type over a
+        // symbol-keyed source (e.g. `{ [K in keyof Iterable<T>]: ... }`, whose
+        // sole key is `[Symbol.iterator]`) must surface that member as a
+        // symbol-named property. Dropping the flag reshaped the key into a plain
+        // string-named `__unique_<id>` property, which made the result fail the
+        // for-of iterability query (false TS2488) and `keyof` widen to `symbol`.
+        let Some(keys) =
+            crate::type_queries::collect_finite_mapped_property_keys(self.interner, mapped_id)
         else {
             return;
         };
 
         let mapped = self.interner.mapped_type(mapped_id);
-        let mut properties = Vec::with_capacity(names.len());
+        let mut properties = Vec::with_capacity(keys.len());
 
-        for name in names {
+        for key in keys {
+            let name = key.name;
             let name_text = self.interner.resolve_atom(name);
             let Some(type_id) = crate::type_queries::get_finite_mapped_property_type(
                 self.interner,
@@ -392,7 +400,7 @@ impl<'a, R: TypeResolver> PropertyCollector<'a, R> {
                 parent_id: None,
                 declaration_order: 0,
                 is_string_named: false,
-                is_symbol_named: false,
+                is_symbol_named: key.is_symbol_named,
                 single_quoted_name: false,
             });
         }


### PR DESCRIPTION
Goal: green

Partial fix toward #13619: a homomorphic mapped type over an `Iterable` dropped the symbol-keyed `[Symbol.iterator]` method, making the result non-iterable (false TS2488 in `for-of`).

## Structural rule
When a homomorphic mapped type maps over a source carrying a symbol-keyed method (e.g. `[Symbol.iterator](): Iterator<T>`), the output property for that symbol key must look up the source member by the **symbol** key, not a string key. The symbol-key emission loop in `crates/tsz-solver/src/evaluation/evaluate_rules/mapped.rs` consulted a `source_symbol_prop_names` map that was only populated in a narrower branch, so the symbol member was dropped and the mapped result lost iterability.

## Verification
- New witness `homomorphic_mapped_symbol_iterator_tests` (renamed binders): identity `Mirror<Iterable<T>>` with `for-of` + symbol-index goes from 2 errors (TS2488 + TS7053) to **0**, matching tsgo.
- Full local conformance (release): 12583/12585, zero new vs accepted regressions (only the 2 accepted Mac-delta cases).
- `cargo nextest run -p tsz-solver`: only the 3 known pre-existing failures (A/B-identical on clean main).
- clippy clean; no new `#[allow]`; 2000-line caps.

## Honest scope note (#13619 stays open)
This closes the **non-recursive** homomorphic-mapped-over-Iterable case. The original `ts-essentials/deep-readonly.ts` micro row uses the **recursive** `DeepReadonly<Iterable<Type>>` / `DeepReadonly<IterableWithExtraProp<Type>>` (lines 115/126), which still emit the false TS2488 — the recursive DeepReadonly interaction with the symbol-keyed method is a distinct remaining case. The micro row stays at tsz=3 vs tsgo=1 until that lands; #13619 remains open with this as partial progress.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: max
