### PR TITLE
perf(solver): thread-local string→Atom cache for intern_string — ~26% on ts-toolbelt-flat

### DIFF
--- a/crates/tsz-common/src/perf_counters/dump.rs
+++ b/crates/tsz-common/src/perf_counters/dump.rs
@@ -65,6 +65,7 @@ impl PerfCounters {
              intern hits                {:>12}\n  \
              intern misses              {:>12}\n  \
              string intern calls        {:>12}\n  \
+             string intern cache hits   {:>12}\n  \
              type-list intern calls     {:>12}\n  \
              object-shape intern calls  {:>12}\n  \
              function-shape intern calls{:>12}\n  \
@@ -131,6 +132,7 @@ impl PerfCounters {
             snap.interner.intern_hits.unwrap_or(0),
             snap.interner.intern_misses.unwrap_or(0),
             snap.interner.string_intern_calls,
+            snap.interner.string_intern_cache_hits,
             snap.interner.type_list_intern_calls,
             snap.interner.object_shape_intern_calls,
             snap.interner.function_shape_intern_calls,

--- a/crates/tsz-common/src/perf_counters/recorders/interner_resolver.rs
+++ b/crates/tsz-common/src/perf_counters/recorders/interner_resolver.rs
@@ -18,6 +18,18 @@ pub fn record_interner_string_intern_call() {
         .fetch_add(1, Ordering::Relaxed);
 }
 
+/// Record a `TypeInterner::intern_string` call that was served from the
+/// thread-local string cache (no shard `RwLock`, no `ShardedInterner::intern`).
+#[inline]
+pub fn record_interner_string_intern_cache_hit() {
+    if !enabled_fast() {
+        return;
+    }
+    counters()
+        .interner_string_intern_cache_hits
+        .fetch_add(1, Ordering::Relaxed);
+}
+
 /// Record a `TypeInterner::intern_type_list` call (covers both the
 /// owning `Vec` entry point and the borrowed-slice entry point).
 #[inline]

--- a/crates/tsz-common/src/perf_counters/runtime.rs
+++ b/crates/tsz-common/src/perf_counters/runtime.rs
@@ -235,6 +235,10 @@ pub struct PerfCounters {
     pub interner_intern_hits: AtomicU64,
     pub interner_intern_misses: AtomicU64,
     pub interner_string_intern_calls: AtomicU64,
+    /// `intern_string` calls served from the thread-local string cache
+    /// (no shard `RwLock` / `ShardedInterner::intern`). The cache hit rate is
+    /// `interner_string_intern_cache_hits / interner_string_intern_calls`.
+    pub interner_string_intern_cache_hits: AtomicU64,
     pub interner_type_list_intern_calls: AtomicU64,
     pub interner_object_shape_intern_calls: AtomicU64,
     pub interner_function_shape_intern_calls: AtomicU64,
@@ -407,6 +411,7 @@ impl PerfCounters {
             interner_intern_hits: AtomicU64::new(0),
             interner_intern_misses: AtomicU64::new(0),
             interner_string_intern_calls: AtomicU64::new(0),
+            interner_string_intern_cache_hits: AtomicU64::new(0),
             interner_type_list_intern_calls: AtomicU64::new(0),
             interner_object_shape_intern_calls: AtomicU64::new(0),
             interner_function_shape_intern_calls: AtomicU64::new(0),

--- a/crates/tsz-common/src/perf_counters/snapshot.rs
+++ b/crates/tsz-common/src/perf_counters/snapshot.rs
@@ -581,6 +581,8 @@ pub struct InternerCounters {
     pub intern_hits: Option<u64>,
     pub intern_misses: Option<u64>,
     pub string_intern_calls: u64,
+    /// `intern_string` calls served from the thread-local string cache.
+    pub string_intern_cache_hits: u64,
     pub type_list_intern_calls: u64,
     pub object_shape_intern_calls: u64,
     pub function_shape_intern_calls: u64,
@@ -733,6 +735,7 @@ impl PerfCounters {
                 intern_hits: Some(load(&c.interner_intern_hits)),
                 intern_misses: Some(load(&c.interner_intern_misses)),
                 string_intern_calls: load(&c.interner_string_intern_calls),
+                string_intern_cache_hits: load(&c.interner_string_intern_cache_hits),
                 type_list_intern_calls: load(&c.interner_type_list_intern_calls),
                 object_shape_intern_calls: load(&c.interner_object_shape_intern_calls),
                 function_shape_intern_calls: load(&c.interner_function_shape_intern_calls),

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -740,10 +740,36 @@ impl TypeInterner {
 
     /// Intern a string into an Atom.
     /// This is used when constructing types with property names or string literals.
+    ///
+    /// Hot property and type-parameter names (`"T"`, `"length"`,
+    /// `"[Symbol.iterator]"`, ...) are re-interned tens of thousands of times on
+    /// type-heavy workloads. A thread-local direct-mapped cache scoped by this
+    /// interner's `instance_id` collapses repeats to a hash + array index + byte
+    /// compare, avoiding the shard `RwLock` and the double hash inside
+    /// `ShardedInterner::intern`. The cache only ever returns an `Atom` the
+    /// interner already minted, so interning stays deterministic (same string ->
+    /// same `Atom`); a full byte/length compare on hit rules out collisions.
     #[inline]
     pub fn intern_string(&self, s: &str) -> Atom {
         tsz_common::perf_counters::record_interner_string_intern_call();
-        self.string_interner.intern(s)
+
+        // The empty string is the zero `Atom` sentinel; skip the cache.
+        if s.is_empty() {
+            return Atom::NONE;
+        }
+
+        let mut hasher = FxHasher::default();
+        s.hash(&mut hasher);
+        let hash = hasher.finish();
+
+        if let Some(atom) = cache::string_probe(hash, self.instance_id, s) {
+            tsz_common::perf_counters::record_interner_string_intern_cache_hit();
+            return atom;
+        }
+
+        let atom = self.string_interner.intern(s);
+        cache::string_insert(hash, self.instance_id, s, atom);
+        atom
     }
 
     /// Resolve an Atom back to its string value.

--- a/crates/tsz-solver/src/intern/core/interner/cache.rs
+++ b/crates/tsz-solver/src/intern/core/interner/cache.rs
@@ -2,6 +2,7 @@
 
 use crate::types::{TypeData, TypeId};
 use std::cell::Cell;
+use tsz_common::interner::Atom;
 
 // ---------------------------------------------------------------------------
 // Thread-local direct-mapped lookup cache
@@ -59,6 +60,45 @@ struct InternCacheEntry {
     result: TypeId,
 }
 
+// ---------------------------------------------------------------------------
+// Thread-local direct-mapped cache for string interning (`intern_string`)
+// ---------------------------------------------------------------------------
+// `intern_string` is a top self-time leaf on type-heavy workloads: hot property
+// names and type-parameter names (`"T"`, `"length"`, `"[Symbol.iterator]"`,
+// `"value"`, ...) are re-interned tens of thousands of times. Each call hashes
+// the string twice (shard select + map probe) and takes the shard `RwLock`.
+// A small direct-mapped thread-local cache turns repeats into a single hash +
+// array index + byte compare, scoped by the owning interner's `instance_id`.
+//
+// The key string is stored inline (`Copy`, no allocation) so the array-of-`Cell`
+// layout matches the lookup/intern caches. Strings longer than
+// `STRING_KEY_INLINE_CAP` bypass the cache and fall through to the interner; the
+// cache only ever returns an `Atom` the interner already minted, so identity and
+// determinism are preserved (same string -> same `Atom`). A full byte/length
+// compare on hit makes hash collisions a miss, never a wrong `Atom`.
+
+const STRING_CACHE_BITS: u32 = 9;
+const STRING_CACHE_SIZE: usize = 1 << STRING_CACHE_BITS; // 512
+const STRING_CACHE_MASK: u64 = (STRING_CACHE_SIZE as u64) - 1;
+/// Inline capacity for the cached key bytes. Covers the hot short names
+/// (`"[Symbol.iterator]"` is 17 bytes, `"removeEventListener"` is 19); longer
+/// strings simply bypass the cache.
+const STRING_KEY_INLINE_CAP: usize = 23;
+
+#[derive(Clone, Copy)]
+struct StringCacheEntry {
+    /// `FxHash` of the key string, used as tag.
+    hash: u64,
+    /// Owning interner `instance_id` for cross-interner safety.
+    instance_id: u32,
+    /// Length of the cached key in `key_bytes` (`0` means empty/unused).
+    len: u8,
+    /// Inline key bytes (only `len` are meaningful).
+    key_bytes: [u8; STRING_KEY_INLINE_CAP],
+    /// The resulting `Atom`.
+    result: Atom,
+}
+
 /// Combined thread-local cache for both `lookup()` and `intern()` directions.
 ///
 /// Uses per-slot `Cell<T>` values for interior mutability. Both cache entry
@@ -68,6 +108,7 @@ struct InternCacheEntry {
 struct TypeInternerCache {
     lookup: [Cell<LookupCacheEntry>; LOOKUP_CACHE_SIZE],
     intern: [Cell<InternCacheEntry>; INTERN_CACHE_SIZE],
+    string: [Cell<StringCacheEntry>; STRING_CACHE_SIZE],
 }
 
 const EMPTY_LOOKUP_ENTRY: LookupCacheEntry = LookupCacheEntry {
@@ -83,12 +124,21 @@ const EMPTY_INTERN_ENTRY: InternCacheEntry = InternCacheEntry {
     result: TypeId::NONE,
 };
 
+const EMPTY_STRING_ENTRY: StringCacheEntry = StringCacheEntry {
+    hash: 0,
+    instance_id: 0,
+    len: 0,
+    key_bytes: [0; STRING_KEY_INLINE_CAP],
+    result: Atom::NONE,
+};
+
 #[allow(dead_code)]
 impl TypeInternerCache {
     const fn new() -> Self {
         Self {
             lookup: [const { Cell::new(EMPTY_LOOKUP_ENTRY) }; LOOKUP_CACHE_SIZE],
             intern: [const { Cell::new(EMPTY_INTERN_ENTRY) }; INTERN_CACHE_SIZE],
+            string: [const { Cell::new(EMPTY_STRING_ENTRY) }; STRING_CACHE_SIZE],
         }
     }
 
@@ -134,6 +184,49 @@ impl TypeInternerCache {
             result,
         });
     }
+
+    #[inline(always)]
+    fn string_probe(&self, hash: u64, instance_id: u32, s: &str) -> Option<Atom> {
+        // Strings longer than the inline cap are never inserted, so they can
+        // never hit. Returning early also keeps the `key_bytes[..len]` slice
+        // index below in bounds without relying on `&&` short-circuit order.
+        let len = s.len();
+        if len > STRING_KEY_INLINE_CAP {
+            return None;
+        }
+        let idx = (hash & STRING_CACHE_MASK) as usize;
+        let entry = self.string[idx].get();
+        // A length/byte compare on top of the hash + instance_id makes a hash
+        // collision a miss, never a wrong `Atom`.
+        if entry.hash == hash
+            && entry.instance_id == instance_id
+            && entry.len as usize == len
+            && entry.key_bytes[..len] == *s.as_bytes()
+        {
+            Some(entry.result)
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    fn string_insert(&self, hash: u64, instance_id: u32, s: &str, result: Atom) {
+        // Only short strings fit inline; longer ones are not cached.
+        let bytes = s.as_bytes();
+        if bytes.len() > STRING_KEY_INLINE_CAP {
+            return;
+        }
+        let idx = (hash & STRING_CACHE_MASK) as usize;
+        let mut key_bytes = [0u8; STRING_KEY_INLINE_CAP];
+        key_bytes[..bytes.len()].copy_from_slice(bytes);
+        self.string[idx].set(StringCacheEntry {
+            hash,
+            instance_id,
+            len: bytes.len() as u8,
+            key_bytes,
+            result,
+        });
+    }
 }
 
 thread_local! {
@@ -147,6 +240,9 @@ pub(super) fn clear_thread_local_cache() {
         }
         for cell in &cache.intern {
             cell.set(EMPTY_INTERN_ENTRY);
+        }
+        for cell in &cache.string {
+            cell.set(EMPTY_STRING_ENTRY);
         }
     });
 }
@@ -169,4 +265,14 @@ pub(super) fn intern_probe(hash: u64, instance_id: u32, key: &TypeData) -> Optio
 #[inline(always)]
 pub(super) fn intern_insert(hash: u64, instance_id: u32, key: TypeData, result: TypeId) {
     TL_CACHE.with(|cache| cache.intern_insert(hash, instance_id, key, result));
+}
+
+#[inline(always)]
+pub(super) fn string_probe(hash: u64, instance_id: u32, s: &str) -> Option<Atom> {
+    TL_CACHE.with(|cache| cache.string_probe(hash, instance_id, s))
+}
+
+#[inline(always)]
+pub(super) fn string_insert(hash: u64, instance_id: u32, s: &str, result: Atom) {
+    TL_CACHE.with(|cache| cache.string_insert(hash, instance_id, s, result));
 }

--- a/crates/tsz-solver/src/intern/core/interner/cache.rs
+++ b/crates/tsz-solver/src/intern/core/interner/cache.rs
@@ -2,12 +2,11 @@
 //!
 //! This module is the interner's thread-local fast path: small direct-mapped
 //! caches probed on every `lookup`, `intern`, and `intern_string` call. The
-//! `#[inline(always)]` on the probe/insert wrappers and the fixed-size backing
-//! arrays are deliberate, measured micro-optimizations (#12602, #13642), not
-//! debt to pay down — exempt the whole module from the pedantic warn-ratchet's
-//! `inline_always`/`large_stack_arrays` rather than tracking these intentional
-//! choices as a baseline that future hot-path additions must squeeze under.
-#![allow(clippy::inline_always, clippy::large_stack_arrays)]
+//! string cache (#13642) deliberately stays off the two existing pedantic
+//! tripwires without a suppression attribute: its probe/insert wrappers use a
+//! plain `#[inline]` hint (trivial bodies LLVM inlines anyway) so they do not
+//! add to the `inline_always` ratchet, and its backing array is sized to keep
+//! the per-thread allocation under the `large_stack_arrays` threshold.
 
 use crate::types::{TypeData, TypeId};
 use std::cell::Cell;
@@ -86,8 +85,13 @@ struct InternCacheEntry {
 // determinism are preserved (same string -> same `Atom`). A full byte/length
 // compare on hit makes hash collisions a miss, never a wrong `Atom`.
 
-const STRING_CACHE_BITS: u32 = 9;
-const STRING_CACHE_SIZE: usize = 1 << STRING_CACHE_BITS; // 512
+// 256 slots keep the per-thread `[StringCacheEntry; N]` allocation
+// (~40 bytes/entry) under the `large_stack_arrays` 16384-byte threshold so the
+// cache needs no lint suppression. The hot working set of interned names
+// (type-parameter and property identifiers) is a few dozen distinct strings, so
+// a 256-entry direct-mapped table still resolves the vast majority to one hit.
+const STRING_CACHE_BITS: u32 = 8;
+const STRING_CACHE_SIZE: usize = 1 << STRING_CACHE_BITS; // 256
 const STRING_CACHE_MASK: u64 = (STRING_CACHE_SIZE as u64) - 1;
 /// Inline capacity for the cached key bytes. Covers the hot short names
 /// (`"[Symbol.iterator]"` is 17 bytes, `"removeEventListener"` is 19); longer
@@ -194,7 +198,7 @@ impl TypeInternerCache {
         });
     }
 
-    #[inline(always)]
+    #[inline]
     fn string_probe(&self, hash: u64, instance_id: u32, s: &str) -> Option<Atom> {
         // Strings longer than the inline cap are never inserted, so they can
         // never hit. Returning early also keeps the `key_bytes[..len]` slice
@@ -218,7 +222,7 @@ impl TypeInternerCache {
         }
     }
 
-    #[inline(always)]
+    #[inline]
     fn string_insert(&self, hash: u64, instance_id: u32, s: &str, result: Atom) {
         // Only short strings fit inline; longer ones are not cached.
         let bytes = s.as_bytes();
@@ -276,12 +280,12 @@ pub(super) fn intern_insert(hash: u64, instance_id: u32, key: TypeData, result: 
     TL_CACHE.with(|cache| cache.intern_insert(hash, instance_id, key, result));
 }
 
-#[inline(always)]
+#[inline]
 pub(super) fn string_probe(hash: u64, instance_id: u32, s: &str) -> Option<Atom> {
     TL_CACHE.with(|cache| cache.string_probe(hash, instance_id, s))
 }
 
-#[inline(always)]
+#[inline]
 pub(super) fn string_insert(hash: u64, instance_id: u32, s: &str, result: Atom) {
     TL_CACHE.with(|cache| cache.string_insert(hash, instance_id, s, result));
 }

--- a/crates/tsz-solver/src/intern/core/interner/cache.rs
+++ b/crates/tsz-solver/src/intern/core/interner/cache.rs
@@ -1,4 +1,13 @@
 //! Thread-local direct-mapped caches for type interning and lookup.
+//!
+//! This module is the interner's thread-local fast path: small direct-mapped
+//! caches probed on every `lookup`, `intern`, and `intern_string` call. The
+//! `#[inline(always)]` on the probe/insert wrappers and the fixed-size backing
+//! arrays are deliberate, measured micro-optimizations (#12602, #13642), not
+//! debt to pay down — exempt the whole module from the pedantic warn-ratchet's
+//! `inline_always`/`large_stack_arrays` rather than tracking these intentional
+//! choices as a baseline that future hot-path additions must squeeze under.
+#![allow(clippy::inline_always, clippy::large_stack_arrays)]
 
 use crate::types::{TypeData, TypeId};
 use std::cell::Cell;

--- a/crates/tsz-solver/src/intern/core/interner_tests.rs
+++ b/crates/tsz-solver/src/intern/core/interner_tests.rs
@@ -479,3 +479,104 @@ mod shape_identity {
         );
     }
 }
+
+/// The thread-local string-intern cache must not change `Atom` identity:
+/// interning must stay deterministic (same string -> same `Atom`), and a hit
+/// must never return the `Atom` of a different string.
+mod string_cache {
+    use super::*;
+    use tsz_common::interner::Atom;
+
+    #[test]
+    fn repeated_intern_returns_identical_atom() {
+        let interner = TypeInterner::new();
+        // First call misses the cache and mints the atom; later calls hit it.
+        let a0 = interner.intern_string("length");
+        let a1 = interner.intern_string("length");
+        let a2 = interner.intern_string("length");
+        assert_eq!(a0, a1);
+        assert_eq!(a1, a2);
+        // The atom round-trips back to the original string.
+        assert_eq!(&*interner.resolve_atom_ref(a0), "length");
+    }
+
+    #[test]
+    fn distinct_strings_get_distinct_atoms_through_the_cache() {
+        let interner = TypeInterner::new();
+        let names = [
+            "T",
+            "U",
+            "length",
+            "value",
+            "[Symbol.iterator]",
+            "__@iterator",
+            "prototype",
+            "call",
+            "apply",
+            "bind",
+            "next",
+            "done",
+        ];
+        let mut atoms = Vec::new();
+        // Two interleaved passes exercise both the miss (first pass) and the
+        // hit (second pass) paths for every name.
+        for _ in 0..2 {
+            for (i, name) in names.iter().enumerate() {
+                let atom = interner.intern_string(name);
+                if atoms.len() <= i {
+                    atoms.push(atom);
+                } else {
+                    assert_eq!(atoms[i], atom, "cache changed the atom for {name:?}");
+                }
+                assert_eq!(&*interner.resolve_atom_ref(atom), *name);
+            }
+        }
+        // All distinct names must have distinct atoms (no collision aliasing).
+        for i in 0..atoms.len() {
+            for j in (i + 1)..atoms.len() {
+                assert_ne!(
+                    atoms[i], atoms[j],
+                    "distinct names {:?}/{:?} collapsed to one atom",
+                    names[i], names[j]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn cache_agrees_with_uncached_shard_interner() {
+        let interner = TypeInterner::new();
+        for name in [
+            "T",
+            "length",
+            "value",
+            "averylongpropertynamethatdoesnotfitinline",
+        ] {
+            // The cached entry point and the raw shard interner must agree.
+            let via_cache = interner.intern_string(name);
+            let via_shard = interner.string_interner.intern(name);
+            assert_eq!(
+                via_cache, via_shard,
+                "cache disagreed with shard for {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_string_is_the_none_atom() {
+        let interner = TypeInterner::new();
+        assert_eq!(interner.intern_string(""), Atom::NONE);
+    }
+
+    #[test]
+    fn long_strings_bypass_cache_but_stay_deterministic() {
+        let interner = TypeInterner::new();
+        // Longer than STRING_KEY_INLINE_CAP (23): never cached, always re-interned.
+        let long = "ThisIsAVeryLongTypeParameterOrPropertyNameExceedingInlineCap";
+        assert!(long.len() > 23);
+        let a0 = interner.intern_string(long);
+        let a1 = interner.intern_string(long);
+        assert_eq!(a0, a1);
+        assert_eq!(&*interner.resolve_atom_ref(a0), long);
+    }
+}


### PR DESCRIPTION
Goal: fast

Adds a thread-local string→`Atom` cache to `TypeInterner::intern_string`, eliminating redundant re-interning of hot property/type-parameter names on type-heavy workloads.

## Structural rule
The interner's thread-local fast-path cache (`intern/core/interner/cache.rs`) already covered `intern()`/`lookup()` of `TypeData` but NOT string interning — every `intern_string` fell through to `ShardedInterner::intern` (`tsz-common/src/interner/mod.rs:391`), which hashes the string twice (`shard_for` + `FxHashMap::get`) under a shard `RwLock` read. Hot constant/name strings are re-interned tens of thousands of times per check (on ts-toolbelt `"T"` alone = 10,779 calls of 271,204 total; on a synthetic union/template fixture `"T"`=19,952, `"length"`=9,524, `"[Symbol.iterator]"`=6,433).

This PR adds a thread-local direct-mapped `string→Atom` cache (mirroring the existing `intern`/`lookup` caches), scoped by the interner's `instance_id`, inline-keyed for strings ≤23 bytes (longer bypass), with a full byte+length compare on hit. Wired into `intern_string`.

## Cache contract
- **Key**: the string bytes (inline ≤23B) + interner `instance_id`. **Value**: the `Atom` the shard interner already minted.
- **Soundness**: a hit returns only an `Atom` the `ShardedInterner` already produced for that exact string (same string → same Atom); a hash collision is a **miss, never a wrong Atom** (full byte compare). Empty string short-circuits to `Atom::NONE` exactly as before.
- **Invalidation**: thread-local + instance-scoped; no cross-run aliasing. Behavior when absent: identical (recomputes via the shard interner).

## Performance (timing mode)
| Workload | intern calls reaching the shard leaf | wall |
|---|---|---|
| ts-toolbelt-flat | 271,204 → **61,023** (77.5% cached) | **0.58s → 0.43s (~26% faster)** |
| synthetic union/template/iterable | 143,577 → **6,643** (95.4% cached) | — |

Reproducible interleaved (not sub-noise) on these intern-heavy witnesses; ts-toolbelt-flat is the hardest real green row. A `interner_string_intern_cache_hits` perf counter is added to measure it.

## Verification
- Full local conformance (release): 12583/12585, zero new vs accepted regressions (only the 2 accepted Mac-delta cases).
- Byte-identical diagnostics on ts-toolbelt-flat and the synthetic fixture.
- `cargo nextest run -p tsz-solver`: zero new failures vs main (the 2 pre-existing order-dependent flakes verified identical on baseline); 5 new `string_cache` soundness tests pass (deterministic identity, distinct atoms, cache-vs-shard agreement, empty sentinel, long-string bypass).
- clippy --all-targets clean; no new `#[allow]`; 2000-line caps; arch_guard passes.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: max
