### PR TITLE
perf(solver): memoize Application display-reduction cascade per TypeId (#13480)

### DIFF
--- a/crates/tsz-solver/src/diagnostics/format/key.rs
+++ b/crates/tsz-solver/src/diagnostics/format/key.rs
@@ -203,32 +203,15 @@ impl<'a> TypeFormatter<'a> {
                     return Cow::Borrowed("error");
                 }
 
-                if let Some(evaluated) =
-                    self.scalar_mapped_alias_application_display(type_id, app.base, &app.args)
-                {
-                    return self.format(evaluated);
-                }
-
-                if let Some(distributed) =
-                    self.distributed_conditional_application_display(app.base, &app.args)
-                {
-                    return self.format(distributed);
-                }
-
-                // A non-distributive conditional-bodied alias application that
-                // resolves renders its resolved type structurally, not
-                // `Name<Args>` (issue #10914).
-                if let Some(evaluated) = self.reducing_conditional_application_display(type_id) {
-                    return self.format(evaluated);
-                }
-
-                // A variadic (spread) tuple alias instantiated with concrete
-                // arguments loses its alias symbol in tsc (spreading produces a
-                // fresh tuple), so render the flattened tuple form.
-                if let Some(flattened) =
-                    self.variadic_tuple_alias_application_display(app.base, &app.args)
-                {
-                    return self.format(flattened);
+                // A generic `Application` may lose its alias symbol and render
+                // structurally through one of four reduction strategies. Each
+                // strategy runs `instantiate_generic` + `evaluate_type` over the
+                // alias body, and the formatter re-reaches the same shared
+                // `Application` node across the receiver-type DAG, so the cascade
+                // is memoized per `Application` `TypeId` to avoid super-linear
+                // re-evaluation on deeply nested generics (#13480).
+                if let Some(reduced) = self.application_display_reduction(type_id, &app) {
+                    return self.format(reduced);
                 }
 
                 // Special handling for Application(Lazy(def_id), args)

--- a/crates/tsz-solver/src/diagnostics/format/mod.rs
+++ b/crates/tsz-solver/src/diagnostics/format/mod.rs
@@ -167,10 +167,52 @@ pub struct TypeFormatter<'a> {
     /// source/display origin was recorded. This is used by narrow diagnostic
     /// surfaces where tsc does not preserve source-written union order.
     ignore_union_origins: bool,
+    /// Per-formatter memo for the Application display-reduction decision.
+    ///
+    /// Formatting a generic `Application` attempts up to four alias-reduction
+    /// strategies (`scalar_mapped_alias_application_display`,
+    /// `distributed_conditional_application_display`,
+    /// `reducing_conditional_application_display`,
+    /// `variadic_tuple_alias_application_display`). Each strategy runs a fresh
+    /// `instantiate_generic` + `evaluate_type` over the alias body. Deeply
+    /// nested generic receiver types (e.g. drizzle's relational builders) form
+    /// a *DAG* of shared `Application` nodes, so the formatter — which walks
+    /// the type as a tree — re-reaches the same `Application` `TypeId` through
+    /// many parents and re-runs the whole cascade each time, turning display
+    /// formatting into super-linear re-evaluation (#13480).
+    ///
+    /// The reduction is a pure function of the input `TypeId` for a fixed
+    /// formatter configuration (the interner is immutable for the formatter's
+    /// lifetime and every reduction input derives from the `Application`'s base
+    /// and args). Memoizing it keyed on the `Application` `TypeId` collapses the
+    /// repeated cascade to one evaluation per distinct node. The cached value is
+    /// the reduced `TypeId` to format in place, or `None` to fall through to the
+    /// structural `Name<Args>` rendering. `RefCell` keeps the `&self` reduction
+    /// helpers untouched. Invalidation: none — the cache lives for the single
+    /// diagnostic the formatter instance serves.
+    application_reduction_cache: std::cell::RefCell<FxHashMap<TypeId, Option<TypeId>>>,
+    /// Per-formatter memo for `is_recursive_type_alias_application_base`, keyed
+    /// on the application *base* `TypeId`. The predicate runs an uncached
+    /// recursive `type_reaches_alias_def` walk over the alias body; the same
+    /// base recurs across the shared `Application` DAG, so memoizing the
+    /// boolean verdict removes the repeated graph walk. Same purity and
+    /// lifetime contract as `application_reduction_cache`.
+    recursive_alias_base_cache: std::cell::RefCell<FxHashMap<TypeId, bool>>,
 }
 
 impl<'a> TypeFormatter<'a> {
     pub(super) fn is_recursive_type_alias_application_base(&self, base: TypeId) -> bool {
+        if let Some(&cached) = self.recursive_alias_base_cache.borrow().get(&base) {
+            return cached;
+        }
+        let result = self.compute_is_recursive_type_alias_application_base(base);
+        self.recursive_alias_base_cache
+            .borrow_mut()
+            .insert(base, result);
+        result
+    }
+
+    fn compute_is_recursive_type_alias_application_base(&self, base: TypeId) -> bool {
         let Some(TypeData::Lazy(def_id)) = self.interner.lookup(base) else {
             return false;
         };
@@ -381,6 +423,40 @@ impl<'a> TypeFormatter<'a> {
         Some(evaluated)
     }
 
+    /// Memoized dispatch for the four `Application` display-reduction strategies.
+    ///
+    /// Tries, in order, `scalar_mapped_alias_application_display`,
+    /// `distributed_conditional_application_display`,
+    /// `reducing_conditional_application_display`, and
+    /// `variadic_tuple_alias_application_display`; the first that fires wins and
+    /// its reduced `TypeId` is returned for the caller to format in place of the
+    /// `Name<Args>` application surface. Each strategy runs `instantiate_generic`
+    /// then `evaluate_type` over the alias body, which is expensive; because the
+    /// formatter walks the receiver type as a tree but the type is a DAG, the
+    /// same `Application` `TypeId` is reached through many parents. The result is
+    /// memoized per `Application` `TypeId` so the cascade runs at most once per
+    /// distinct node (#13480). The verdict is a pure function of `type_id` for a
+    /// fixed formatter: every input derives from the application's base and args,
+    /// and the interner is immutable for the formatter's lifetime.
+    fn application_display_reduction(
+        &self,
+        type_id: TypeId,
+        app: &crate::types::TypeApplication,
+    ) -> Option<TypeId> {
+        if let Some(&cached) = self.application_reduction_cache.borrow().get(&type_id) {
+            return cached;
+        }
+        let reduced = self
+            .scalar_mapped_alias_application_display(type_id, app.base, &app.args)
+            .or_else(|| self.distributed_conditional_application_display(app.base, &app.args))
+            .or_else(|| self.reducing_conditional_application_display(type_id))
+            .or_else(|| self.variadic_tuple_alias_application_display(app.base, &app.args));
+        self.application_reduction_cache
+            .borrow_mut()
+            .insert(type_id, reduced);
+        reduced
+    }
+
     /// For Application-arg display: when the arg is an `IndexAccess(obj, idx)`
     /// whose `obj` is fully concrete (no type parameters, no infer
     /// placeholders) and `idx` is a literal, resolve the indexed access for
@@ -551,6 +627,8 @@ impl<'a> TypeFormatter<'a> {
             expand_scalar_mapped_alias_applications: false,
             expand_primitive_key_union: false,
             ignore_union_origins: false,
+            application_reduction_cache: std::cell::RefCell::new(FxHashMap::default()),
+            recursive_alias_base_cache: std::cell::RefCell::new(FxHashMap::default()),
         }
     }
 
@@ -842,6 +920,8 @@ impl<'a> TypeFormatter<'a> {
             expand_scalar_mapped_alias_applications: false,
             expand_primitive_key_union: false,
             ignore_union_origins: false,
+            application_reduction_cache: std::cell::RefCell::new(FxHashMap::default()),
+            recursive_alias_base_cache: std::cell::RefCell::new(FxHashMap::default()),
         }
     }
 

--- a/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
+++ b/crates/tsz-solver/src/diagnostics/format/tests_parts/part_02.rs
@@ -925,6 +925,86 @@ fn conditional_alias_application_resolving_to_tuple_renders_structurally() {
     );
 }
 
+// The Application display-reduction cascade is memoized per `Application`
+// `TypeId` (#13480). Re-reaching the same reducible Application through a
+// composite must produce byte-identical output to formatting it alone — the
+// cache must not change the rendering, only avoid re-running the
+// `instantiate_generic` + `evaluate_type` cascade. The binder is named `Wrap`
+// (not `Foo`) so the assertion cannot accidentally depend on a specific alias
+// identifier, per the anti-hardcoding rule.
+#[test]
+fn repeated_conditional_alias_application_renders_identically_when_memoized() {
+    let db = TypeInterner::new();
+    let def_store = crate::def::DefinitionStore::new();
+
+    let t_param = TypeParamInfo {
+        name: db.intern_string("T"),
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    };
+    let t = db.type_param(t_param);
+
+    // Wrap<T> = T extends boolean ? { kind: "b" } : { kind: "o" }
+    let true_branch = db.object(vec![PropertyInfo::new(
+        db.intern_string("kind"),
+        db.literal_string("b"),
+    )]);
+    let false_branch = db.object(vec![PropertyInfo::new(
+        db.intern_string("kind"),
+        db.literal_string("o"),
+    )]);
+    let cond = db.conditional(crate::types::ConditionalType {
+        check_type: t,
+        extends_type: TypeId::BOOLEAN,
+        true_type: true_branch,
+        false_type: false_branch,
+        is_distributive: true,
+    });
+    let wrap_def = def_store.register(crate::def::DefinitionInfo::type_alias(
+        db.intern_string("Wrap"),
+        vec![t_param],
+        cond,
+    ));
+
+    // Application(Wrap, [string]) resolves (non-distributively) to the false
+    // branch `{ kind: "o" }` and drops its alias symbol.
+    let app = db.application(db.lazy(wrap_def), vec![TypeId::STRING]);
+
+    // Baseline: format the application on its own.
+    let solo = {
+        let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+        fmt.format(app)
+    };
+    assert_eq!(solo, "{ kind: \"o\"; }");
+
+    // The same Application appears twice in a tuple: the second occurrence is a
+    // cache hit. The reduced branch must render identically at both positions.
+    let tuple = db.tuple(vec![
+        crate::types::TupleElement {
+            type_id: app,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        crate::types::TupleElement {
+            type_id: app,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+    let mut fmt = TypeFormatter::new(&db).with_def_store(&def_store);
+    let composite = fmt.format(tuple);
+    assert_eq!(
+        composite,
+        format!("[{solo}, {solo}]"),
+        "Memoized reduction must render the shared Application identically at \
+         every occurrence; got: {composite}"
+    );
+}
+
 // =====================================================================
 // Union containing a Lazy alias — TS2859 / general union-display parity
 // =====================================================================


### PR DESCRIPTION
## Summary
The diagnostic `TypeFormatter` re-ran the full four-strategy `Application`
display-reduction cascade (each a fresh `instantiate_generic` + `evaluate_type`
over the alias body) every time the tree-walking formatter re-reached the same
`Application` `TypeId`. Deeply nested generic receiver types (drizzle's
relational builders) form a DAG of shared `Application` nodes, so a node reached
through M parents pays the cascade M times — super-linear display re-evaluation.
Two per-formatter `TypeId`-keyed memos collapse the cascade (and the
`is_recursive_type_alias_application_base` graph walk) to once per distinct node.

Structural rule: When a generic `Application` is rendered in a diagnostic, tsc
reduces it at most once per distinct type; tsz now memoizes the reduction
verdict per `TypeId` through the `TypeFormatter` instead of re-running the
cascade on every DAG re-reach.

Owner layer: solver `diagnostics/format` (`TypeFormatter`). Cache key: input
`Application` `TypeId` (reduction) / base `TypeId` (recursive-base predicate).
Invalidation: none — caches live for the single diagnostic the formatter serves;
the interner is immutable for that lifetime, so the reduction is a pure function
of the input `TypeId`. The merge-base diff is exactly the three format-module
files; merging is non-destructive (the 3-way merge preserves all later main
additions the branch predates).

## Goal
Goal: fast

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- Conformance (release): 12585 → 12583 (−2, both pre-existing Mac-platform
  deltas: deeplyNestedMappedTypes, propTypeValidatorInference). **Zero new** —
  the memo is a pure function of `TypeId`, so diagnostic display is byte-identical.
- Build: `cargo build --release -p tsz-solver -p tsz-cli` clean.
- Correctness unit test (`tests_parts/part_02.rs`): the shared reducible
  `Application` renders identically at every re-reach (memoized == uncached).
- **Wall-clock perf verification is the CI canary project-row guard**
  (`drizzle-orm-project`, #13480, a CPU-bound check-phase timeout): the drizzle
  corpus is not checked out locally, and the redundant-cascade pathology is
  masked in synthetic witnesses by printer interning-dedup, depth truncation,
  and the alias-name shortcut. The structural redundancy removed (M cascade runs
  → 1 per distinct `TypeId`) is verifiable from the diff; the project-row guard
  in CI measures the drizzle impact authoritatively.