### PR TITLE
fix(bench): corpus-harness accuracy — config-noise removal + guard robustness

### DIFF
--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -1262,7 +1262,9 @@ run_mobx_project_benchmarks() {
 }
 
 run_nextjs_benchmarks() {
-    if [ "$NEXTJS_BENCHMARK_ENABLED" != "1" ]; then
+    # nextjs fixture is gated off by default (kill-switch for an unstable sparse fixture),
+    # but an explicit --filter must still reach the row for local debugging.
+    if [ "$NEXTJS_BENCHMARK_ENABLED" != "1" ] && [ -z "$FILTER" ]; then
         return
     fi
 

--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -1310,8 +1310,31 @@ tsz_write_ts_pattern_config() {
   tsz_write_basic_external_project_config "$1" "src"
 }
 
+tsz_write_trpc_external_stubs() {
+  # trpc's real root tsconfig sets `"types": ["node", "vitest/globals"]`, so the
+  # upstream build resolves `NodeJS.Timeout` (used in packages/server/src/adapters/ws.ts)
+  # via @types/node. The shared bench baseline pins `"types": []` and the fixture
+  # clone has no node_modules, so without a stub tsz/tsc both emit spurious
+  # TS2833 "Cannot find namespace 'NodeJS'". Mirror the kysely/type-graphql stub
+  # pattern: alias the referenced members as `= any` so the global resolves
+  # without unmasking unrelated assignability diffs.
+  local output="$1"
+  local fixture_dir
+  fixture_dir="$(dirname "$output")"
+  cat > "$fixture_dir/tsz-bench-globals.d.ts" <<'TYPES'
+declare namespace NodeJS {
+  type Timeout = any;
+  type Timer = any;
+  type Immediate = any;
+  type ErrnoException = any;
+}
+TYPES
+}
+
 tsz_write_trpc_config() {
-  tsz_write_basic_external_project_config "$1" "packages/server/src"
+  tsz_write_trpc_external_stubs "$1"
+  tsz_write_basic_external_project_config "$1" "packages/server/src" "" \
+    ', "tsz-bench-globals.d.ts"'
 }
 tsz_write_tanstack_query_config() {
   tsz_write_basic_external_project_config "$1" "packages/query-core/src"
@@ -1499,6 +1522,13 @@ declare module 'class-validator' {
   export const validate: any;
   export type validate = any;
 }
+
+declare namespace NodeJS {
+  type ErrnoException = any;
+  type Timeout = any;
+  interface ProcessEnv { [k: string]: string | undefined }
+}
+declare var global: any;
 TYPES
 }
 
@@ -1510,6 +1540,7 @@ tsz_write_type_graphql_config() {
   tsz_write_type_graphql_external_stubs "$1"
   tsz_write_basic_external_project_config "$1" "src" \
     '    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["src/*"],
       "*": ["tsz-bench-external-module.d.ts"]

--- a/scripts/bench/test-validate-project-metadata.mjs
+++ b/scripts/bench/test-validate-project-metadata.mjs
@@ -196,6 +196,22 @@ assert.deepEqual(
 );
 
 assert.deepEqual(
+  validate([
+    (() => {
+      const row = validRow({ name: "generated-without-provenance", category: "generated" });
+      delete row.repo;
+      delete row.ref;
+      delete row.repo_env;
+      delete row.ref_env;
+      return row;
+    })(),
+  ]),
+  [
+    "generated-without-provenance: generated row must declare generated_by or a repo/ref pin",
+  ],
+);
+
+assert.deepEqual(
   validate([validRow({ readme_candidates: [] })]),
   ["example-project: readme_candidates must be a non-empty array"],
 );

--- a/scripts/bench/validate-project-metadata.mjs
+++ b/scripts/bench/validate-project-metadata.mjs
@@ -231,6 +231,14 @@ export function validateProjectMetadata({
       }
     }
 
+    if (row.category === "generated") {
+      const hasGeneratedBy = row.generated_by !== undefined;
+      const hasRepoPin = row.repo !== undefined && row.ref !== undefined;
+      if (!hasGeneratedBy && !hasRepoPin) {
+        failures.push(`${row.name}: generated row must declare generated_by or a repo/ref pin`);
+      }
+    }
+
     if (row.generated_by === undefined) continue;
     const generatedByPathIsInvalid =
       typeof row.generated_by !== "string" ||

--- a/scripts/ci/project-compile-guard.sh
+++ b/scripts/ci/project-compile-guard.sh
@@ -251,8 +251,9 @@ count_ts_files() {
 diagnostic_lines_from_file() {
   local label="$1"
   local file="$2"
+  local max="${3:-20}"
 
-  awk -v label="$label" '
+  awk -v label="$label" -v max="$max" '
     {
       sub(/\r$/, "")
       if ($0 ~ /^[[:space:]]*$/) {
@@ -260,7 +261,7 @@ diagnostic_lines_from_file() {
       }
       print label ": " $0
       seen += 1
-      if (seen >= 20) {
+      if (seen >= max) {
         exit
       }
     }
@@ -345,6 +346,7 @@ record_project_compatibility() {
   COMPAT_SOURCE_ROOT="$source_root" \
   COMPAT_FIXTURE_ROOT="$FIXTURE_ROOT" \
   COMPAT_FIXTURE_SOURCES="$fixture_sources" \
+  COMPAT_TSZ_COMMAND_ENV_PREFIX="TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=${TSZ_RUST_MIN_STACK:-536870912}" \
   node scripts/ci/project-compatibility.mjs record
 }
 
@@ -606,7 +608,7 @@ check_project() {
     if [[ "$rc" -eq 124 ]]; then
       timeout_note="$(tsz_timeout_contention_note "$PROJECT_TIMEOUT" \
         "$LAST_TIMEOUT_CPU_SECONDS" "$MIN_CPU_SHARE_PCT")"
-      diagnostic_delta="tsz: ${timeout_note}"$'\n'"$diagnostic_delta"
+      diagnostic_delta="tsz: ${timeout_note}"$'\n'"$(diagnostic_lines_from_file "tsz" "$log" 19)"
       if ! tsz_timeout_is_cpu_bound "$PROJECT_TIMEOUT" "$LAST_TIMEOUT_CPU_SECONDS" "$MIN_CPU_SHARE_PCT"; then
         timeout_unmeasured=1
       fi
@@ -890,7 +892,13 @@ canary_row_in_shard() {
   if [[ -z "$count" ]]; then
     return 0
   fi
+  if [[ ! "$count" =~ ^[1-9][0-9]*$ ]]; then
+    fail "_TSZ_CI_CANARY_SHARD_COUNT must be a positive integer, got: $count"
+  fi
   local shard="${_TSZ_CI_CANARY_SHARD_INDEX:-0}"
+  if [[ ! "$shard" =~ ^(0|[1-9][0-9]*)$ ]] || (( shard >= count )); then
+    fail "_TSZ_CI_CANARY_SHARD_INDEX must be an integer in [0, $count), got: $shard"
+  fi
   if (( index % count == shard )); then
     return 0
   fi


### PR DESCRIPTION
Goal: grow

Fixes to the bench/corpus **harness** (no compiler change) surfaced by a multi-agent audit of `scripts/bench/` + `scripts/ci/` — 8 verified fixes of 21 candidates, each adversarially checked and (where applicable) run against a fresh `dist-fast` build. These remove false signal from the grow canary rows and harden the compile guard, so corpus diagnostics reflect real `tsz` behavior rather than fixture-config gaps.

## What and why
- **type-graphql `ignoreDeprecations`**: it was the *only* `baseUrl` config wrapper missing `"ignoreDeprecations": "6.0"` (drizzle/nextjs pair them). `tsz` correctly implements the TS6.0 `baseUrl` deprecation (`TS5101`), which is a **fatal config error that aborts before type-checking** — so the row looked like "1 error from green" while masking ~59 real errors. Pairing it gives an honest signal.
- **type-graphql + trpc NodeJS/global stubs**: the sources reference `NodeJS.*` / `global` (real tsconfigs set `types:["node",...]`); the minimal bench baseline (`types:[]`, no `node_modules`) made both `tsz` and `tsc` emit spurious `TS2833`/`TS2552`. Per-fixture `= any` stubs (mirroring the kysely/type-graphql precedent) clear them without unmasking unrelated diffs. type-graphql 59→54, trpc `TS2833`→0.
- **guard `repro.command` records its env prefix** (`TSZ_USE_EMBEDDED_LIBS=1 RUST_MIN_STACK=…`) so a pasted repro reproduces (the bare command runs with the ~8 MiB default stack and can spuriously overflow).
- **timeout diagnostic cap**: the timeout note + 20 diagnostics overflowed the recorder’s 20-line ceiling, silently dropping the 20th real diagnostic (which feeds `diagnostic_codes` aggregation); reserve one slot.
- **`canary_row_in_shard`**: fail loudly on an invalid `_TSZ_CI_CANARY_SHARD_COUNT/INDEX` instead of a silent divide-by-zero that runs every row on every shard.
- **`--filter` reaches the default-gated nextjs row** (the enable kill-switch ran before `is_benchmark_selected`).
- **validator**: a `category:"generated"` row must declare `generated_by` or a repo/ref pin (+ negative test).

## Notably NOT included (verified, deliberately excluded)
- **arktype `@ark/*` → real-source mapping**: clears ~95 false `TS2307`, **but tested → `tsz` then times out (>160s) on the full `@ark/util`+`@ark/schema` type graph**. That converts a diagnostic row into a timeout row, so it is *not* a harness win — arktype is actually a perf/timeout blocker (recursive type-level family, cf #13508). Left unmapped; recorded for the perf track.
- An `export = any` arktype stub (raised errors 294→335) and a `Reflect.getMetadata` stub (inert — the 2 remaining `TS2339` are a real `tsz` bug, not a stub gap) were proposed and **rejected** by verification.

## Verification
- `node scripts/bench/validate-project-metadata.mjs` — exit 0
- `node scripts/bench/test-project-rows.mjs` (row-sync invariant) — exit 0
- `node scripts/bench/test-validate-project-metadata.mjs` — exit 0
- `node scripts/ci/test-project-compatibility.mjs` — exit 0
- `bash -n` on all three edited shell scripts — clean
- `tsz --noEmit -p` on regenerated fixtures: type-graphql 59→54 (TS5101/TS2833/global gone), trpc TS2833→0

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-opus-4-8
Effort: max