### PR TITLE
ci(perf): enable sccache on dist-binaries (cut the harness-blocking critical path)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,10 +625,15 @@ jobs:
       # when Cargo.lock/profile inputs changed and the gate intentionally ran
       # main CI to refresh the exact shared cache key.
       TSZ_CI_CACHE_SAVE_CARGO_TARGETS: ${{ needs.gate.outputs.rust_cache_refresh == 'true' && '1' || '0' }}
-      # Keep artifact production independent from sccache service hangs. The
-      # dist-fast build is short enough without sccache, and all harness suites
-      # are blocked until this artifact uploads.
-      TSZ_CI_DISABLE_SCCACHE: "1"
+      # dist-fast (lto=false, codegen-units=8) is built for sccache, yet it is the
+      # longest artifact-blocking job (~11m cold) and recompiles the same
+      # first-party crates unit/lint already populate in the shared GCS cache.
+      # Enable sccache for warm-cache reuse. PRs run READ_ONLY so the job that
+      # gates every harness suite never stalls on the sccache write path; merge_group
+      # and push run READ_WRITE to keep the dist-fast cache warm. configure_sccache
+      # falls back to no wrapper if the server fails to start, and a mid-build GCS
+      # stall is bounded by this job's timeout-minutes: 30.
+      SCCACHE_GCS_RW_MODE: ${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/scripts/ci/ci-resources.sh
+++ b/scripts/ci/ci-resources.sh
@@ -73,11 +73,12 @@ default_cargo_build_jobs() {
       mem_per_job_mb="${TSZ_CI_UNIT_CARGO_MB_PER_JOB:-24576}"
       ;;
     dist-binaries)
-      # sccache is disabled for dist-binaries (TSZ_CI_DISABLE_SCCACHE=1 in
-      # GitHub CI) so every codegen unit compiles from scratch. Keep the
-      # default 7168 MiB/job budget so the 8 vCPU x 32 GiB Cloud Run runner can
-      # build at -j4; -j3 has repeatedly finished cargo just after the runner's
-      # external cancellation window and before artifact upload.
+      # sccache is enabled for dist-binaries (READ_ONLY on PRs, READ_WRITE on
+      # merge_group/push) so warm codegen units are reused from the shared GCS
+      # cache instead of recompiling from scratch. Keep the default 7168 MiB/job
+      # budget so the 8 vCPU x 32 GiB Cloud Run runner can build at -j4; -j3 has
+      # repeatedly finished cargo just after the runner's external cancellation
+      # window and before artifact upload.
       mem_per_job_mb="${TSZ_CI_DIST_CARGO_MB_PER_JOB:-7168}"
       ;;
     *)


### PR DESCRIPTION
Goal: hold

CI-infrastructure perf change (no compiler behavior change). Surfaced by a multi-agent audit of the workflows.

## The bottleneck
A full CI run is **not** bottlenecked by `unit` (~13.6m) as it appears — the real critical path is the **`dist-binaries` (~11m) → harness wave**. `dist-binaries` is the sole producer of `dist-fast-binaries.tar`, which **8 downstream jobs** (conformance/emit/fourslash/lsp-e2e/project-compile-guard/canary) block on, so the dist→harness chain reaches **~18.5m** — longer than `unit`. `dist-binaries` recompiles the same first-party crates `unit`/`lint` already populate in the shared GCS sccache bucket, yet it alone opted out (`TSZ_CI_DISABLE_SCCACHE=1`).

## Change (one env line + two stale comments)
Enable sccache on `dist-binaries`. The original opt-out cited write-path stall risk on this all-harness-blocking job, so I keep that protection:
- **PRs** → `SCCACHE_GCS_RW_MODE=READ_ONLY` (warm-cache reuse, never stalls on writes)
- **merge_group / push** → `READ_WRITE` (keeps the dist-fast cache warm)

The `dist-fast` profile (`lto=false`, `codegen-units=8`) was explicitly designed for sccache. `configure_sccache` falls back to no-wrapper on server-start failure; a mid-build GCS stall is bounded by `timeout-minutes: 30` (same exposure unit already tolerates).

## Why safe
- Failure mode is *"no speedup"*, not *"broken binary"* — sccache is content-addressed and cargo re-fingerprints.
- READ_ONLY on PRs eliminates the write path that motivated the original opt-out.
- GCS bucket verified live (warm sccache objects present from unit/lint/wasm).
- Rejected alternatives from the audit (do **not** do these): gating `dist-binaries` off PRs (it is the sole artifact producer for 8 jobs); raising `unit -j` (OOM-locked at -j1, #7600); re-coupling lint/dist to unit (#7512).

## Verification (this PR validates itself)
`pull_request` runs the modified `ci.yml`, so `dist-binaries` here runs sccache READ_ONLY against the warm cache. Check on this run:
- `dist-binaries` wall-clock drops materially vs baseline (~11m → projected ~4-6m)
- `show_sccache_stats` reports non-zero cache hits
- all 8 downstream harness jobs consume the artifact and pass (binary not corrupt)
Projected net: ~5-6m off the CI critical path, leaving `unit` (~13.6m) as the floor. Revert is a one-line restore if no gain.

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-opus-4-8
Effort: max