### PR TITLE
fix(checker): merge cross-file declare-module augmentations into interface body (#13653)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -521,6 +521,9 @@ path = "tests/export_star_module_augmentation_tests.rs"
 name = "hkt_self_augmentation_keyof_repro"
 path = "tests/hkt_self_augmentation_keyof_repro.rs"
 [[test]]
+name = "hkt_cross_file_augmentation_13653_repro"
+path = "tests/hkt_cross_file_augmentation_13653_repro.rs"
+[[test]]
 name = "cjs_object_export_module_augmentation_merge_tests"
 path = "tests/cjs_object_export_module_augmentation_merge_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1315,6 +1315,52 @@ impl<'a> CheckerState<'a> {
         let (result, type_params) = self.compute_type_of_symbol(sym_id);
         self.pop_symbol_dependency();
 
+        // Fold cross-file `declare module` augmentations into an exported
+        // interface's materialized body at this canonical resolution point, so
+        // every downstream cache (symbol_types, both type environments, the
+        // shared def store) observes the SAME augmented body. Doing it only on
+        // the type-reference path (`type_reference_symbol_type`) left this path —
+        // reached for the solver's def-store registration and cross-file
+        // delegation — publishing the un-augmented body, which then shadowed the
+        // augmented form at every `keyof` / Application / assignability site
+        // (#13653, extends the same-module #13509 fix to the cross-file path).
+        // `apply_self_module_augmentations` is a no-op unless the program has
+        // augmentations and the symbol is an exported, non-imported interface.
+        // The `program_has_module_augmentations` guard keeps augmentation-free
+        // programs from paying for the symbol lookup on every interface.
+        //
+        // Only merge when `result` is ALREADY a concrete object/callable shape:
+        // a `Lazy`/unresolved cross-file body (e.g. when this symbol's home file
+        // is not the file currently being checked) would otherwise fall into the
+        // augmentation intersection fallback and cache a degenerate type. Those
+        // cases are handled by the import/type-reference path once the body
+        // resolves; here we only need to keep the *materialized* body augmented
+        // so it cannot shadow that path's result in the shared def store.
+        // Cheap checks first: the program-wide augmentation guard, then the
+        // interface-flag test, and only then the per-`TypeId`
+        // `classify_for_augmentation` lookup — so non-interface symbols never pay
+        // for the classification.
+        let result = if self.ctx.program_has_module_augmentations()
+            && self
+                .ctx
+                .binder
+                .get_symbol(sym_id)
+                .or_else(|| self.get_cross_file_symbol(sym_id))
+                .is_some_and(|symbol| {
+                    symbol.has_any_flags(symbol_flags::INTERFACE)
+                        && !symbol.has_any_flags(symbol_flags::CLASS)
+                })
+            && matches!(
+                crate::query_boundaries::common::classify_for_augmentation(self.ctx.types, result),
+                crate::query_boundaries::common::AugmentationTargetKind::Object(_)
+                    | crate::query_boundaries::common::AugmentationTargetKind::ObjectWithIndex(_)
+                    | crate::query_boundaries::common::AugmentationTargetKind::Callable(_)
+            ) {
+            self.apply_self_module_augmentations(sym_id, result)
+        } else {
+            result
+        };
+
         // Pop from resolution stack
         if use_local_symbol_state {
             self.ctx.symbol_resolution_stack.pop();

--- a/crates/tsz-checker/src/types/module_augmentation.rs
+++ b/crates/tsz-checker/src/types/module_augmentation.rs
@@ -719,8 +719,8 @@ impl<'a> CheckerState<'a> {
                     if (member_node.kind == PROPERTY_SIGNATURE
                         || member_node.kind == METHOD_SIGNATURE)
                         && let Some(sig) = arena.get_signature(member_node)
-                        && let Some(name_node) = arena.get(sig.name)
-                        && let Some(id_data) = arena.get_identifier(name_node)
+                        && let Some(member_name) =
+                            self.augmentation_member_key_name(arena, sig.name)
                     {
                         let type_id = if std::ptr::eq(arena, self.ctx.arena) {
                             let mut type_id = if member_node.kind == PROPERTY_SIGNATURE
@@ -752,7 +752,7 @@ impl<'a> CheckerState<'a> {
 
                         aug_member_order += 1;
                         members.push(PropertyInfo {
-                            name: self.ctx.types.intern_string(&id_data.escaped_text),
+                            name: self.ctx.types.intern_string(&member_name),
                             type_id,
                             write_type: type_id,
                             optional: sig.question_token,
@@ -1327,6 +1327,66 @@ impl<'a> CheckerState<'a> {
         result
     }
 
+    /// Resolve an augmentation member's property-key name from the augmenting
+    /// file's own arena/binder, purely syntactically.
+    ///
+    /// Plain identifier, string-literal, and numeric-literal keys are read
+    /// directly. A computed key `[expr]` is resolved when `expr` is a string
+    /// literal or an identifier bound to a string-initialized `const` in the
+    /// augmenting file — the fp-ts `const URI = "X"; interface I { [URI]: ... }`
+    /// pattern. The resolution is deliberately syntactic (no expression type
+    /// evaluation): augmentation member collection runs *inside* interface body
+    /// resolution, so calling the evaluating `get_property_name_resolved` here
+    /// would re-enter interface resolution and recurse. It also works uniformly
+    /// for cross-arena augmentations whose key `const` lives in another file's
+    /// binder (#13653).
+    fn augmentation_member_key_name(
+        &mut self,
+        arena: &tsz_parser::parser::NodeArena,
+        name_idx: tsz_parser::parser::NodeIndex,
+    ) -> Option<String> {
+        Self::augmentation_member_key_name_in_arena(arena, name_idx, |ident_name| {
+            let binder = self.ctx.get_binder_for_arena(arena)?;
+            let sym_id = binder.file_locals.get(ident_name)?;
+            binder
+                .get_symbol(sym_id)
+                .and_then(|symbol| arena.get(symbol.value_declaration))
+                .and_then(|decl| arena.get_variable_declaration(decl))
+                .and_then(|var_decl| arena.get(var_decl.initializer))
+                .and_then(|init| arena.get_literal(init))
+                .map(|lit| lit.text.clone())
+        })
+    }
+
+    /// Pure-arena key resolution shared by all augmentation paths.
+    /// `resolve_const` maps a computed-key identifier to its string-`const`
+    /// value (so the same matching can be unit-tested without a live binder).
+    fn augmentation_member_key_name_in_arena(
+        arena: &tsz_parser::parser::NodeArena,
+        name_idx: tsz_parser::parser::NodeIndex,
+        resolve_const: impl FnOnce(&str) -> Option<String>,
+    ) -> Option<String> {
+        use tsz_parser::parser::syntax_kind_ext::COMPUTED_PROPERTY_NAME;
+        let name_node = arena.get(name_idx)?;
+        if let Some(ident) = arena.get_identifier(name_node) {
+            return Some(ident.escaped_text.clone());
+        }
+        if let Some(lit) = arena.get_literal(name_node) {
+            return Some(lit.text.clone());
+        }
+        if name_node.kind == COMPUTED_PROPERTY_NAME {
+            let computed = arena.get_computed_property(name_node)?;
+            let expr_node = arena.get(computed.expression)?;
+            if let Some(lit) = arena.get_literal(expr_node) {
+                return Some(lit.text.clone());
+            }
+            if let Some(ident) = arena.get_identifier(expr_node) {
+                return resolve_const(ident.escaped_text.as_str());
+            }
+        }
+        None
+    }
+
     /// Merge `declare module "./home" { interface I { ... } }` augmentations into
     /// the type of interface `I` declared (and exported) in its own home module,
     /// even when `I` is reached by reference within its declaring file rather than
@@ -1472,6 +1532,70 @@ mod tests {
     use std::sync::Arc;
     use tsz_binder::{BinderState, ModuleAugmentation};
     use tsz_parser::parser::{NodeArena, ParserState};
+
+    /// `augmentation_member_key_name_in_arena` resolves identifier, string-literal,
+    /// and computed string-`const` property keys, and leaves an unresolvable
+    /// computed key as `None`. The const resolver is renamed (`TAG`, not a
+    /// hard-coded fp-ts name) to lock the structural, name-independent contract.
+    #[test]
+    fn augmentation_member_key_name_resolves_identifier_string_and_computed_const() {
+        let source = r#"
+interface I {
+    foo: number;
+    "bar": number;
+    [TAG]: number;
+    [OTHER]: number;
+}
+"#;
+        let mut parser = ParserState::new("t.ts".to_string(), source.to_string());
+        parser.parse_source_file();
+        let arena = Arc::new(parser.into_arena());
+        let sf = arena.source_files.first().expect("source file");
+        let iface_idx = sf
+            .statements
+            .nodes
+            .iter()
+            .copied()
+            .find(|&idx| {
+                arena
+                    .get(idx)
+                    .and_then(|n| arena.get_interface(n))
+                    .is_some()
+            })
+            .expect("interface node");
+        let iface = arena
+            .get_interface(arena.get(iface_idx).expect("iface node"))
+            .expect("interface data");
+
+        let resolved: Vec<Option<String>> = iface
+            .members
+            .nodes
+            .iter()
+            .copied()
+            .filter_map(|member_idx| {
+                let member = arena.get(member_idx)?;
+                let sig = arena.get_signature(member)?;
+                Some(CheckerState::augmentation_member_key_name_in_arena(
+                    &arena,
+                    sig.name,
+                    // Only `TAG` is a known string const; `OTHER` is unknown.
+                    |name| (name == "TAG").then(|| "computed_tag".to_string()),
+                ))
+            })
+            .collect();
+
+        assert_eq!(
+            resolved,
+            vec![
+                Some("foo".to_string()),
+                Some("bar".to_string()),
+                Some("computed_tag".to_string()),
+                None,
+            ],
+            "key resolver must handle identifier, string-literal, and computed \
+             string-const keys, and drop unresolvable computed keys"
+        );
+    }
 
     #[test]
     fn module_augmentation_has_type_params_detects_type_alias_with_params() {

--- a/crates/tsz-checker/tests/hkt_cross_file_augmentation_13653_repro.rs
+++ b/crates/tsz-checker/tests/hkt_cross_file_augmentation_13653_repro.rs
@@ -1,0 +1,219 @@
+//! Repro + adjacent matrix for #13653: a cross-file `declare module` interface
+//! augmentation must be folded into the interface's materialized structural type
+//! at every use site — `keyof`, indexed access, AND structural assignability —
+//! not only the same-module path covered by #13509.
+//!
+//! Structural rule: when an exported interface `I` declared in home file `H` is
+//! augmented from a different file via `declare module "./H" { interface I { ... } }`,
+//! `keyof I`, `I[K]`, and assignability against `I` must all observe the merged
+//! members. The fix folds augmentations into the interface body at the canonical
+//! `get_type_of_symbol` resolution point so every shared def-store / type-env
+//! cache observes the same augmented body across files.
+//!
+//! These use `check_all_multi_file_with_global_index`, which checks every file
+//! through one shared definition store — the multi-file path where an
+//! un-augmented body registered while checking a consumer would otherwise shadow
+//! the augmented body (the regression this guards).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_all_multi_file_with_global_index;
+
+fn diagnostics(files: &[(&str, &str)]) -> Vec<(u32, String)> {
+    check_all_multi_file_with_global_index(
+        files,
+        CheckerOptions {
+            strict: true,
+            ..Default::default()
+        },
+    )
+    .into_iter()
+    .map(|d| (d.code, d.message_text))
+    .collect()
+}
+
+fn count_code(diags: &[(u32, String)], expected: u32) -> usize {
+    diags.iter().filter(|(code, _)| *code == expected).count()
+}
+
+/// Core fp-ts HKT witness: a 1-ary registry augmented cross-file, consumed via a
+/// conditional `Kind` that indexes the registry.
+#[test]
+fn cross_file_augmentation_seen_by_keyof_and_indexed_access() {
+    let diags = diagnostics(&[
+        (
+            "HKT.ts",
+            r#"
+export interface URItoKind<A> {}
+export type URIS = keyof URItoKind<unknown>;
+export type Kind<U extends URIS, A> = U extends URIS ? URItoKind<A>[U] : never;
+"#,
+        ),
+        (
+            "Array.ts",
+            r#"
+import { Kind, URItoKind } from "./HKT";
+declare module "./HKT" {
+    interface URItoKind<A> {
+        readonly MyArray: ReadonlyArray<A>;
+    }
+}
+export type MyArr = Kind<"MyArray", number>;
+"#,
+        ),
+    ]);
+
+    assert_eq!(
+        count_code(&diags, 2344),
+        0,
+        "cross-file augmented key missed by keyof/indexed-access; got {diags:#?}"
+    );
+}
+
+// Note: the computed-`[URI]`-key augmentation form (the faithful fp-ts `typeof
+// URI` tag) is exercised end-to-end via the CLI / fp-ts project-compile-guard
+// (see PR Verification) and unit-tested at the name-resolution layer in
+// `crates/tsz-checker/src/types/module_augmentation.rs`
+// (`augmentation_member_key_name_in_arena`). It is omitted from this lib-less
+// multi-file harness, which cannot materialize the lib-backed computed-key
+// member shape the real driver resolves.
+
+/// Anti-hardcoding: rename every binder (module, registry interface, key, alias);
+/// the rule is structural, not name-driven.
+#[test]
+fn cross_file_augmentation_is_binder_name_independent() {
+    let diags = diagnostics(&[
+        (
+            "registry.ts",
+            r#"
+export interface Slots<T> {}
+export type Tags = keyof Slots<unknown>;
+export type Lookup<K extends Tags, T> = K extends Tags ? Slots<T>[K] : never;
+"#,
+        ),
+        (
+            "widget.ts",
+            r#"
+import { Lookup, Slots } from "./registry";
+declare module "./registry" {
+    interface Slots<T> {
+        readonly Widget: ReadonlyArray<T>;
+    }
+}
+export type W = Lookup<"Widget", number>;
+"#,
+        ),
+    ]);
+
+    assert_eq!(
+        count_code(&diags, 2344),
+        0,
+        "renamed-binder registry should also see the augmented key; got {diags:#?}"
+    );
+}
+
+/// Augmentation declared in a THIRD file: home declares, a sibling augments, a
+/// consumer (neither home nor augmenter) reads the augmented key.
+#[test]
+fn cross_file_augmentation_visible_from_third_consumer_file() {
+    let diags = diagnostics(&[
+        (
+            "HKT.ts",
+            r#"
+export interface URItoKind<A> {}
+export type URIS = keyof URItoKind<unknown>;
+export type Kind<U extends URIS, A> = U extends URIS ? URItoKind<A>[U] : never;
+"#,
+        ),
+        (
+            "Array.ts",
+            r#"
+import { URItoKind } from "./HKT";
+declare module "./HKT" {
+    interface URItoKind<A> {
+        readonly MyArray: ReadonlyArray<A>;
+    }
+}
+export {};
+"#,
+        ),
+        (
+            "use.ts",
+            r#"
+import { Kind } from "./HKT";
+import "./Array";
+export type MyArr = Kind<"MyArray", number>;
+"#,
+        ),
+    ]);
+
+    assert_eq!(
+        count_code(&diags, 2344),
+        0,
+        "third-file consumer should see the augmentation; got {diags:#?}"
+    );
+}
+
+/// Structural assignability: the cross-file augmented member is REQUIRED, so an
+/// empty object literal assigned to the interface is TS2741 (missing member).
+/// tsz previously accepted this (the augmented member was absent from the
+/// materialized structural type cross-file).
+#[test]
+fn cross_file_augmentation_member_is_required_for_assignability() {
+    let diags = diagnostics(&[
+        (
+            "HKT.ts",
+            r#"
+export interface URItoKind<A> {}
+"#,
+        ),
+        (
+            "Array.ts",
+            r#"
+import { URItoKind } from "./HKT";
+declare module "./HKT" {
+    interface URItoKind<A> {
+        readonly MyArray: ReadonlyArray<A>;
+    }
+}
+export const r: URItoKind<number> = {};
+"#,
+        ),
+    ]);
+
+    assert_eq!(
+        count_code(&diags, 2741),
+        1,
+        "cross-file augmented member should be required (TS2741); got {diags:#?}"
+    );
+}
+
+/// Negative control (#6164): a NON-exported file-local interface that is
+/// self-augmented via `declare module "./self"` must NOT absorb the augmented
+/// member, so an object literal carrying that member stays an excess property
+/// (TS2353). Guards against over-merging.
+#[test]
+fn non_exported_self_augmented_interface_does_not_merge() {
+    let diags = diagnostics(&[(
+        "test.ts",
+        r#"
+interface Local {
+    a: number;
+}
+
+declare module "./test" {
+    interface Local {
+        b: string;
+    }
+}
+
+const v: Local = { a: 1, b: "x" };
+export {};
+"#,
+    )]);
+
+    assert_eq!(
+        count_code(&diags, 2353),
+        1,
+        "non-exported local interface must keep its self-augmentation isolated; got {diags:#?}"
+    );
+}


### PR DESCRIPTION
Goal: green

Closes #13653.

## Structural rule

When an exported interface `I` declared in home file `H` is augmented from a
**different** file via `declare module "./H" { interface I { ... } }`, `tsc`
merges those members into `I` so `keyof I`, indexed access `I[K]`, and
structural assignability against `I` all see them. tsz only merged
**same-module** augmentations (#13509); the cross-file members never reached
the solver's keyof / Application / assignability evaluation, so
`keyof URItoKind` collapsed to `never` and the fp-ts HKT pattern emitted false
`TS2344`.

Owner layer: **tsz-checker** symbol-type resolution, which feeds the
materialized interface body to the solver's keyof / Application /
structural-assignability queries.

## Root cause

The augmented body *was* published by the type-reference path
(`type_reference_symbol_type` → `apply_self_module_augmentations`), but
`get_type_of_symbol` — reached for the solver's def-store registration
(`resolve_and_insert_def_type`) and cross-file delegation — returned the
**un-augmented** interface body and registered it into the shared
`DefinitionStore`. `TypeEnvironment::get_def` (which the solver reads for
keyof / Application) then served that un-augmented body, shadowing the
augmented form. Result: `keyof URItoKind` evaluated against an empty `{}`
(→ `never`), so `"MyArray"` failed its constraint; and the augmented member
was not reported as required (missing `TS2741`).

## Fix

- Fold self-module augmentations into the interface's materialized body at the
  **canonical** `get_type_of_symbol` resolution point, so every downstream
  cache (`symbol_types`, both type environments, the shared def store) observes
  the same augmented body and no un-augmented registration can shadow it.
  - Gated on `program_has_module_augmentations()` (augmentation-free programs
    pay nothing) and on the symbol being an interface.
  - Only merges when the resolved body is already a concrete
    object/callable shape; a `Lazy`/unresolved cross-file body is left to the
    import/type-reference path (which materializes it before caching) to avoid
    the augmentation intersection fallback caching a degenerate type.
- Resolve computed augmentation member keys: `[URI]` where `URI` is a
  string-`const` (the faithful fp-ts `typeof URI` tag) — read syntactically
  from the augmenting file's arena/binder, alongside plain-identifier and
  string-literal keys. The resolution is deliberately non-evaluating so it
  cannot re-enter interface resolution (the evaluating `get_property_name_resolved`
  would recurse during augmentation member collection).

Anti-hardcoding: the fix is purely structural (DefId / module-graph /
member-map / arena-syntax driven). No `URItoKind` / `URI` / file-name string
checks; the computed-key resolver and its unit test use renamed binders
(`TAG`, `Slots`, `Widget`).

## Adjacent cases covered

Verified end-to-end (CLI, `--strict --lib es2022,dom`):
- 1-ary registry, literal-key augmentation, consumed via `keyof` + indexed
  access through a conditional `Kind`.
- Non-generic registry minimal repro from the issue.
- Computed-`[URI]`-key augmentation (faithful `typeof URI` form).
- Augmentation in a **third** file (home / augmenter / consumer), and
  consumer-first checking order.
- Structural assignability: `const r: URItoKind<number> = {}` now correctly
  reports `TS2741` (augmented member required).
- Negative controls preserved: same-file declaration merging unaffected;
  non-exported self-augmented interface stays isolated (`TS2353`, #6164).

## Verification

- New integration suite
  `crates/tsz-checker/tests/hkt_cross_file_augmentation_13653_repro.rs`
  (`check_all_multi_file_with_global_index`, shared def store across files):
  keyof/indexed-access, third-consumer-file, binder-name-independence, and the
  `TS2741` assignability guard — the assignability case fails without the fix.
- New pure-arena unit test
  `augmentation_member_key_name_resolves_identifier_string_and_computed_const`
  in `crates/tsz-checker/src/types/module_augmentation.rs`.
- Existing augmentation suites green: `module_augmentation_isolation_tests`,
  `self_module_augmentation_isolation_tests`, `ts2451_cross_file_augmentation_tests`,
  `export_star_module_augmentation_tests`, `hkt_self_augmentation_keyof_repro`,
  `ts2567_augmentation_enum_cross_arena_decl_tests`,
  `global_augmentation_lib_interface_merge_tests`, and the
  `module_augmentation` lib unit tests.
- `cargo clippy -p tsz-checker --lib` clean.
- fp-ts corpus row owned by CI:
  `TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_FILTER='^fp-ts-project$' bash scripts/ci/project-compile-guard.sh`.
- Broad conformance/emit/fourslash parity owned by ready-review CI on this PR.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVmeSN35o8WoZBktzox28a)_