### PR TITLE
ci: reduce conformance shards 6→4 (free runner capacity)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1201,12 +1201,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5]
+        shard: [0, 1, 2, 3]
     env:
       SCCACHE_GCS_KEY_JSON: ${{ secrets.SCCACHE_GCS_KEY_JSON }}
       _TSZ_CI_CONFORMANCE_SHARD_INDEX: ${{ matrix.shard }}
-      _TSZ_CI_CONFORMANCE_SHARD_COUNT: 6
-      TSZ_CI_CONFORMANCE_SHARDS: 6
+      _TSZ_CI_CONFORMANCE_SHARD_COUNT: 4
+      TSZ_CI_CONFORMANCE_SHARDS: 4
       TSZ_CI_CONFORMANCE_SHARD_STRATEGY: weighted
       TSZ_CI_SKIP_DIST_RESTORE: "1"
       TSZ_CI_SKIP_TS_HARNESS_RESTORE: "1"
@@ -1245,8 +1245,8 @@ jobs:
     env:
       SCCACHE_GCS_KEY_JSON: ${{ secrets.SCCACHE_GCS_KEY_JSON }}
       GITHUB_SHA: ${{ github.sha }}
-      _TSZ_CI_CONFORMANCE_SHARD_COUNT: 6
-      TSZ_CI_CONFORMANCE_SHARDS: 6
+      _TSZ_CI_CONFORMANCE_SHARD_COUNT: 4
+      TSZ_CI_CONFORMANCE_SHARDS: 4
       TSZ_CI_CACHE_SAVE: "0"
     steps:
       - uses: actions/checkout@v4
@@ -1258,7 +1258,7 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          EXPECTED=6
+          EXPECTED=4
           MAX_WAIT=180
           INTERVAL=10
           elapsed=0


### PR DESCRIPTION
Goal: hold

CI capacity optimization (no compiler change), from the workflow audit.

Conformance shards run ~1.7m each, fully parallel and far under the CI poles (`unit` ~13.6m; the `dist`→harness wave ~18.5m). So conformance **shard count is a capacity/cost knob, not wall-clock** — reducing it frees self-hosted runner slots and lowers autoscale pressure (which *indirectly* speeds wall-clock under contention) at zero critical-path cost.

**Change:** 6 → 4 shards. Each shard rises to ~2.5m (still well under the poles); frees ~2 Cloud Run slots + runner-minutes per full run. Continues the established 32 → 16 → 6 → 4 trend.

**Why safe / coverage-preserving:**
- The weighted planner (`conformance-shard-weights.json`, deterministic per #13398/#13636) re-partitions ALL tests across any N — total coverage unchanged.
- `conformance-aggregate` sums whatever shards exist; `conformance-snapshot-gate`/`conformance-aggregate` (the CI Summary inputs) key on the aggregate *name*, not shard names — unaffected.
- All **6 literal sites** changed in lockstep (matrix, per-shard env ×2, aggregate env ×2, poller `EXPECTED=4`) so the artifact indexer never waits on phantom shards.
- `fourslash` left at 6 (the audit confirmed reducing it would push fourslash toward the pole — explicitly *not* done).

**Verification (this PR validates itself):** the `pull_request` run executes conformance with 4 shards; confirm `conformance-aggregate` sums 4 shards with `total_tests` within coverage tolerance and the poller does not stall. actionlint clean.

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-opus-4-8
Effort: max