### PR TITLE
refactor(core): relocate remaining checker test mounts out of the tsz-core facade (#13109)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -33,6 +33,18 @@ dashmap = { workspace = true }
 web-time = { workspace = true }
 stacker = "0.1.23"
 [[test]]
+name = "any_propagation"
+path = "tests/any_propagation.rs"
+[[test]]
+name = "any_propagation_tests"
+path = "tests/any_propagation_tests.rs"
+[[test]]
+name = "const_assertion_tests"
+path = "tests/const_assertion_tests.rs"
+[[test]]
+name = "freshness_stripping_tests"
+path = "tests/freshness_stripping_tests.rs"
+[[test]]
 name = "any_user_predicate_keeps_any_for_object_function_tests"
 path = "tests/any_user_predicate_keeps_any_for_object_function_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/any_propagation.rs
+++ b/crates/tsz-checker/tests/any_propagation.rs
@@ -3,8 +3,7 @@
 //! These tests verify that `any` behaves as both Top and Bottom type
 //! in the Lawyer layer, respecting strict mode settings.
 
-use crate::checker::context::CheckerOptions;
-use crate::test_fixtures::TestContext;
+use tsz_checker::context::CheckerOptions;
 
 /// Workaround for TS2318 (Cannot find global type) errors in test infrastructure.
 const GLOBAL_TYPE_MOCKS: &str = r#"
@@ -20,17 +19,16 @@ interface IArguments {}
 
 fn test_no_errors(source: &str) {
     let source = format!("// @strictFunctionTypes: true\n{GLOBAL_TYPE_MOCKS}\n{source}");
-    let ctx = TestContext::new();
-    let diagnostics = crate::checker::test_utils::check_source_with_libs(
+    let diagnostics = tsz_checker::test_utils::check_source_with_libs(
         &source,
         "test.ts",
         CheckerOptions::default(),
-        &ctx.lib_files,
+        &[],
     );
     let errors: Vec<_> = diagnostics
         .iter()
         .filter(|d| {
-            d.category == crate::checker::diagnostics::DiagnosticCategory::Error && d.code != 2318
+            d.category == tsz_checker::diagnostics::DiagnosticCategory::Error && d.code != 2318
         })
         .collect();
 

--- a/crates/tsz-checker/tests/any_propagation_tests.rs
+++ b/crates/tsz-checker/tests/any_propagation_tests.rs
@@ -12,8 +12,7 @@
 //! - any in function signatures
 //! - any with strict mode pragmas
 
-use crate::checker::context::CheckerOptions;
-use crate::test_fixtures::TestContext;
+use tsz_checker::context::CheckerOptions;
 
 /// Workaround for TS2318 (Cannot find global type) errors in test infrastructure.
 const GLOBAL_TYPE_MOCKS: &str = r#"
@@ -30,12 +29,11 @@ interface Promise<T> {}
 
 fn test_no_errors(source: &str) {
     let source = format!("{GLOBAL_TYPE_MOCKS}\n{source}");
-    let ctx = TestContext::new();
-    let diagnostics = crate::checker::test_utils::check_source_with_libs(
+    let diagnostics = tsz_checker::test_utils::check_source_with_libs(
         &source,
         "test.ts",
         CheckerOptions::default(),
-        &ctx.lib_files,
+        &[],
     );
     let semantic_errors: Vec<_> = diagnostics.iter().filter(|d| d.code != 2318).collect();
     if !semantic_errors.is_empty() {
@@ -52,12 +50,11 @@ fn test_no_errors(source: &str) {
 
 fn test_expect_error(source: &str, expected_error_substring: &str) {
     let source = format!("{GLOBAL_TYPE_MOCKS}\n{source}");
-    let ctx = TestContext::new();
-    let diagnostics = crate::checker::test_utils::check_source_with_libs(
+    let diagnostics = tsz_checker::test_utils::check_source_with_libs(
         &source,
         "test.ts",
         CheckerOptions::default(),
-        &ctx.lib_files,
+        &[],
     );
     let found_error = diagnostics
         .iter()

--- a/crates/tsz-checker/tests/const_assertion_tests.rs
+++ b/crates/tsz-checker/tests/const_assertion_tests.rs
@@ -6,8 +6,7 @@
 //! - Object properties become readonly recursively
 //! - Nested structures are handled correctly
 
-use crate::checker::context::CheckerOptions;
-use crate::test_fixtures::TestContext;
+use tsz_checker::context::CheckerOptions;
 
 /// Workaround for TS2318 (Cannot find global type) errors in test infrastructure.
 const GLOBAL_TYPE_MOCKS: &str = r#"
@@ -24,12 +23,11 @@ interface Promise<T> {}
 
 fn test_no_errors(source: &str) {
     let source = format!("// @strictFunctionTypes: true\n{GLOBAL_TYPE_MOCKS}\n{source}");
-    let ctx = TestContext::new();
-    let diagnostics = crate::checker::test_utils::check_source_with_libs(
+    let diagnostics = tsz_checker::test_utils::check_source_with_libs(
         &source,
         "test.ts",
         CheckerOptions::default(),
-        &ctx.lib_files,
+        &[],
     );
     let errors: Vec<_> = diagnostics
         .iter()
@@ -50,12 +48,11 @@ fn test_no_errors(source: &str) {
 
 fn test_expect_error(source: &str, expected_error_substring: &str) {
     let source = format!("// @strictFunctionTypes: true\n{GLOBAL_TYPE_MOCKS}\n{source}");
-    let ctx = TestContext::new();
-    let diagnostics = crate::checker::test_utils::check_source_with_libs(
+    let diagnostics = tsz_checker::test_utils::check_source_with_libs(
         &source,
         "test.ts",
         CheckerOptions::default(),
-        &ctx.lib_files,
+        &[],
     );
     let found_error = diagnostics
         .iter()

--- a/crates/tsz-checker/tests/freshness_stripping_tests.rs
+++ b/crates/tsz-checker/tests/freshness_stripping_tests.rs
@@ -4,8 +4,7 @@
 //! to widened variables, preventing excess property checking when the variable
 //! is used as a source in subsequent assignments.
 
-use crate::checker::context::CheckerOptions;
-use crate::test_fixtures::TestContext;
+use tsz_checker::context::CheckerOptions;
 
 /// Workaround for TS2318 (Cannot find global type) errors in test infrastructure.
 const GLOBAL_TYPE_MOCKS: &str = r#"
@@ -22,12 +21,11 @@ interface Promise<T> {}
 
 fn test_no_errors(source: &str) {
     let source = format!("// @strictFunctionTypes: true\n{GLOBAL_TYPE_MOCKS}\n{source}");
-    let ctx = TestContext::new();
-    let diagnostics = crate::checker::test_utils::check_source_with_libs(
+    let diagnostics = tsz_checker::test_utils::check_source_with_libs(
         &source,
         "test.ts",
         CheckerOptions::default(),
-        &ctx.lib_files,
+        &[],
     );
     let errors: Vec<_> = diagnostics
         .iter()
@@ -48,12 +46,11 @@ fn test_no_errors(source: &str) {
 
 fn test_expect_error(source: &str, expected_error_substring: &str) {
     let source = format!("// @strictFunctionTypes: true\n{GLOBAL_TYPE_MOCKS}\n{source}");
-    let ctx = TestContext::new();
-    let diagnostics = crate::checker::test_utils::check_source_with_libs(
+    let diagnostics = tsz_checker::test_utils::check_source_with_libs(
         &source,
         "test.ts",
         CheckerOptions::default(),
-        &ctx.lib_files,
+        &[],
     );
     let found_error = diagnostics
         .iter()

--- a/crates/tsz-core/src/lib.rs
+++ b/crates/tsz-core/src/lib.rs
@@ -314,25 +314,17 @@ mod constructor_accessibility;
 #[path = "../../tsz-checker/tests/void_return_exception.rs"]
 mod void_return_exception;
 
-// Any-propagation tests
-#[cfg(test)]
-#[path = "../../tsz-checker/tests/any_propagation.rs"]
-mod any_propagation;
-
-// Tests that depend on test_fixtures (require root crate context)
-#[cfg(test)]
-#[path = "../../tsz-checker/tests/any_propagation_tests.rs"]
-mod any_propagation_tests;
-#[cfg(test)]
-#[path = "../../tsz-checker/tests/const_assertion_tests.rs"]
-mod const_assertion_tests;
-#[cfg(test)]
-#[path = "../../tsz-checker/tests/freshness_stripping_tests.rs"]
-mod freshness_stripping_tests;
-// `function_bivariance`, `global_type_tests`, and `ts2304_tests` are owned by
-// `tsz-checker` (they depend only on `tsz_checker::*`, not on `tsz-core`'s
-// `test_fixtures`). They run in `tsz-checker`'s own test runner; do not
-// re-mount them here (#13109).
+// `function_bivariance`, `global_type_tests`, and `ts2304_tests` (#13633), plus
+// `any_propagation`, `any_propagation_tests`, `const_assertion_tests`, and
+// `freshness_stripping_tests` (#13109) are owned by `tsz-checker`: they depend
+// only on `tsz_checker::*` (via `tsz_checker::test_utils::check_source_with_libs`
+// with no lib files), not on `tsz-core`'s `test_fixtures`. They run in
+// `tsz-checker`'s own test runner via `[[test]]` entries; do not re-mount here.
+//
+// The remaining mounts below still depend on `tsz-core`'s `test_fixtures`
+// (`TestContext`, `setup_lib_contexts`, `merge_shared_lib_symbols`), which load
+// embedded lib symbols and have no `tsz_checker::test_utils` equivalent. They
+// cannot relocate until those fixtures move into `tsz-checker` (#13109).
 #[cfg(test)]
 #[path = "../../tsz-checker/tests/symbol_resolution_tests.rs"]
 mod symbol_resolution_tests;


### PR DESCRIPTION
Advances #13109.

Goal: hold

## Structural rule
tsz-core does not own downstream-crate test mounts; a checker test that depends only on `tsz_checker::*` (not on tsz-core's `test_fixtures`) lives in and runs from tsz-checker via a `[[test]]` entry. Following the #13633 pattern.

## What changed
Four cross-crate `#[path = "../../tsz-checker/tests/*"]` test mounts were stripped from the tsz-core god-facade (`crates/tsz-core/src/lib.rs`). Each used `TestContext::new()` only to source an empty `&ctx.lib_files` slice for `tsz_checker::test_utils::check_source_with_libs(...)`; `TestContext::new()` returns an empty `lib_files` vec, so the call was already lib-free. They depend solely on `tsz_checker::*`.

Relocated (mount removed from `crates/tsz-core/src/lib.rs`, `[[test]]` entry added in `crates/tsz-checker/Cargo.toml`, internal `crate::checker::*` rewritten to `tsz_checker::*` and `&ctx.lib_files` -> `&[]`):
- `any_propagation` (`tests/any_propagation.rs`)
- `any_propagation_tests` (`tests/any_propagation_tests.rs`)
- `const_assertion_tests` (`tests/const_assertion_tests.rs`)
- `freshness_stripping_tests` (`tests/freshness_stripping_tests.rs`)

Behavior-preserving: each was already calling `check_source_with_libs` with empty libs; swapping `&ctx.lib_files` (empty) for `&[]` hits the same empty-libs branch. Coverage is preserved — the four suites now run from tsz-checker's own runner.

Could NOT relocate yet (7 mounts left in place, comment added explaining why): `constructor_accessibility`, `void_return_exception`, `widening_integration_tests` (drive a manual parser->binder->checker pipeline backed by `TestContext`'s arena/binder/types fields), and `symbol_resolution_tests`, `ts2305_tests`, `ts2306_tests`, `ts2498_export_star_export_equals_tests` (use `setup_lib_contexts` / `merge_shared_lib_symbols`, which load embedded ES5+ES2015 lib symbols). These tsz-core `test_fixtures` helpers have no `tsz_checker::test_utils` equivalent; relocating them requires moving the fixtures into tsz-checker first (tracked under #13109).

## Verification
- `scripts/safe-run.sh cargo build -p tsz-core` — Finished, clean.
- `scripts/safe-run.sh cargo clippy -p tsz-core --all-targets` — Finished, no warnings. `--all-targets` compiles tsz-core's test targets, confirming the 7 still-mounted files still compile under the core test runner and the 4 relocated files are no longer mounted.
- The 4 relocated files reference only confirmed-public paths (`tsz_checker::context::CheckerOptions`, `tsz_checker::diagnostics::DiagnosticCategory`, `tsz_checker::test_utils::check_source_with_libs`) — structurally identical to dozens of existing tsz-checker integration tests. Per the disk rule, the full tsz-checker test build (~56GB) is left to CI.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
