### PR TITLE
refactor(lsp): document implement-interface code-fix reroute blockers, keep parity-preserving synthetic path (#13063)

### DIFF
--- a/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes.rs
+++ b/crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes.rs
@@ -827,6 +827,28 @@ impl Server {
                 }));
             }
 
+            // `fixClassIncorrectlyImplementsInterface` is served here by the
+            // synthetic planner rather than `tsz_lsp`'s AST `implement_interface`
+            // provider (issue #13063). The two are NOT interchangeable yet:
+            //   - The synthetic planner resolves the interface across sibling
+            //     open files / imports and inserts the required `import { … }`
+            //     lines; the AST provider only handles same-file interfaces and
+            //     adds no imports.
+            //   - The synthetic planner emits the tsserver protocol shape this
+            //     family's fourslash baselines expect: `fixName`/`fixId`
+            //     `fixClassIncorrectlyImplementsInterface` plus
+            //     `fixAllDescription`, as a whole-file replacement. The AST
+            //     provider emits a cursor-positioned insertion titled
+            //     "Implement N missing member(s)" with `data: None`, which the
+            //     handler maps to a plain `quickfix` with no `fixId`.
+            // The same text-scraping helpers also back the cross-file `TS2420`
+            // diagnostic synthesis (`synthetic_implements_interface_diagnostics`)
+            // that this fix services, so they are not dead either. Rerouting is
+            // tracked in #13063 behind porting cross-file + import support and
+            // the protocol shape into the AST provider, gated on fourslash.
+            //
+            // The `retain` below de-dupes a provider-emitted action carrying this
+            // `fixId` should one ever appear, keeping a single canonical fix.
             if let Some(action) = self.synthetic_implement_interface_codefix(
                 file_path,
                 &content,


### PR DESCRIPTION
Advances #13063.

Goal: hold

## Structural rule
When a class incorrectly implements an interface (`TS2420`), tsserver returns a
`fixClassIncorrectlyImplementsInterface` quick-fix: a whole-file replacement
that adds member stubs plus any required `import { … }` lines, with `fixId` and
`fixAllDescription`. tsz produces this through the synthetic planner in
`handlers_code_fixes_implement_interface.rs`, **not** through tsz-lsp's AST
`CodeActionProvider::implement_interface`.

The investigation for #13063 found the reroute named in the assessment is **not
behavior-equivalent** and the text-scraping helpers are **not dead**, so the
override and helpers are deliberately preserved (conservative branch of the
issue's delete-first gate). This PR captures the blocking constraints in-code so
future agents do not regress the family by attempting the unsafe reroute.

## What changed
- `crates/tsz-cli/src/bin/tsz_server/handlers_code_fixes.rs`: added a precise
  comment at the `synthetic_implement_interface_codefix` override site
  documenting why the AST provider cannot currently replace it. No logic change.

Why the reroute is unsafe / helpers are not dead (verified against the live
worktree):
- `tsz_lsp ... code_action_implement.rs::implement_interface` emits a
  cursor-positioned **insertion** titled `"Implement N missing member(s)"` with
  `data: None`; the getCodeFixes handler maps `data: None` to a plain
  `fixName: "quickfix"` with no `fixId`. tsserver protocol and this family's
  fourslash baselines expect `fixName`/`fixId`
  `fixClassIncorrectlyImplementsInterface` + `fixAllDescription` as a
  **whole-file replacement**.
- The AST provider only resolves **same-file** interfaces and adds **no
  imports**; the synthetic planner resolves cross-file / imported interfaces and
  inserts the needed `import { … }` lines.
- `parse_interface_properties`, `class_body_has_member`, and
  `extract_type_identifiers` (`handlers_code_fixes_utils.rs`) are **still used**
  by `synthetic_implements_interface_diagnostics`
  (`handlers_code_fixes_synthetic.rs`), which synthesizes the cross-file
  `TS2420` diagnostic this very fix services (called from
  `handlers_code_fixes.rs:171` and `handlers_diagnostics.rs:165`), and by
  `type_identifier_spans` (synthetic `CANNOT_FIND_NAME`). Removing them would
  break diagnostic synthesis.

Because behavior-equivalence could not be established and fourslash is CI-owned
(cannot verify locally), per the issue's gate the override + helpers are kept.

## Residual (tracked in #13063)
The clean reroute requires first porting cross-file interface resolution +
auto-import insertion + the tsserver protocol shape
(`fixClassIncorrectlyImplementsInterface` whole-file edit, `fixId`,
`fixAllDescription`) into `tsz_lsp`'s AST provider, then deleting the synthetic
override and migrating the shared `TS2420` diagnostic synthesis off the
text-scraping helpers — gated on per-family fourslash verification. That, plus
the larger XL crate-extraction (`tsz-tsserver` library, remaining fix/completion
families, ~11K test relocation), remains the open scope of #13063.

## Verification
- `scripts/safe-run.sh cargo build -p tsz-lsp -p tsz-cli` — clean.
- `cargo clippy -p tsz-lsp --all-targets` — clean.
- `cargo nextest run -p tsz-cli --bin tsz-server implement` — 8/8 pass
  (all implement-interface code-fix + cross-file impl tests).
- Diff is comment-only (+22 lines, 0 deletions); behavior unchanged.
- Pre-existing unrelated local failure
  `collect_import_candidates_respects_node_next_package_exports_root_only`
  (package-exports subpath resolution, untouched by this change); broad
  fourslash/conformance owned by ready CI.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high