### PR TITLE
fix(checker): recover cross-arena interface bodies instead of degrading to error (#13044)

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -691,6 +691,9 @@ mod contextual_return_wrapper_tests;
 #[path = "../tests/contextual_typing_tests.rs"]
 mod contextual_typing_tests;
 #[cfg(test)]
+#[path = "tests/cross_file_base_type_param_interface_member_tests.rs"]
+mod cross_file_base_type_param_interface_member_tests;
+#[cfg(test)]
 #[path = "../tests/cross_file_class_merge_tests.rs"]
 mod cross_file_class_merge_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/computed/mod.rs
@@ -1868,6 +1868,7 @@ impl<'a> CheckerState<'a> {
                 //  - Different NodeIndex (has_out_of_arena_decl): decl not in local arena
                 //  - Same NodeIndex collision (has_cross_file_same_index): decl IS in
                 //    local arena, but declaration_arenas has additional non-local arenas
+                let mut merged_cross_arena_decl = false;
                 if has_out_of_arena_decl || has_cross_file_same_index {
                     for &decl_idx in declarations.iter() {
                         let Some(arenas) =
@@ -1888,7 +1889,95 @@ impl<'a> CheckerState<'a> {
                                 if cross_type != TypeId::ERROR {
                                     interface_type =
                                         self.merge_interface_types(interface_type, cross_type);
+                                    merged_cross_arena_decl = true;
                                 }
+                            }
+                        }
+                    }
+                }
+
+                // Owner-arena fallback for cross-arena interface bodies.
+                //
+                // When an interface symbol is observed from an importing arena
+                // (`has_out_of_arena_decl`) but the binder recorded no
+                // `declaration_arenas` bridge for any of its declaration nodes,
+                // the loop above lowers nothing, and the local lowering against
+                // `self.ctx.arena` (where the declaration NodeIndex does not
+                // resolve to an interface) degrades to `TypeId::ERROR`. That
+                // `error` then leaks wherever the interface is read through
+                // inheritance — e.g. a base type parameter bound to this
+                // interface in a derived class member (zod `ZodType<_, Def>._def`
+                // with `Def = ZodStringDef`, kysely cross-file base members).
+                //
+                // The interface's body is a pure function of its own
+                // declaration regardless of the referencing file, so recover the
+                // owner arena from the symbol's file index and lower the
+                // declaration there. Structural (no name/file-string predicate):
+                // it fires only when the local lowering produced no usable shape,
+                // the declaration is genuinely out-of-arena, and the owner arena
+                // actually holds the interface node for this declaration index.
+                if !merged_cross_arena_decl
+                    && has_out_of_arena_decl
+                    && type_environment::object_shape(self.ctx.types, interface_type).is_none()
+                    && let Some(all_arenas) = self.ctx.all_arenas.clone()
+                {
+                    // Locate the arena that actually holds each unresolved
+                    // declaration's interface node by scanning every loaded
+                    // arena for the declaration `NodeIndex`. The binder did not
+                    // record a `declaration_arenas` bridge and the symbol's
+                    // file index points at the importing arena (where the index
+                    // does not resolve), so neither the per-decl loop above nor
+                    // an owner-file lookup recovers it. The scan is structural —
+                    // it matches on "this index resolves to an interface node
+                    // here", never on a name or file string — and is bounded by
+                    // the loaded-arena count, entered only on the degenerate
+                    // miss path that would otherwise mint `error`.
+                    for &decl_idx in declarations.iter() {
+                        if self
+                            .ctx
+                            .arena
+                            .get(decl_idx)
+                            .and_then(|n| self.ctx.arena.get_interface(n))
+                            .is_some()
+                        {
+                            continue; // resolvable locally; nothing to recover
+                        }
+                        for src_arena in all_arenas.iter() {
+                            if std::ptr::eq(src_arena.as_ref(), self.ctx.arena) {
+                                continue;
+                            }
+                            if src_arena
+                                .get(decl_idx)
+                                .and_then(|n| src_arena.get_interface(n))
+                                .is_none()
+                            {
+                                continue;
+                            }
+                            let cross_type =
+                                self.lower_cross_file_interface_decl(src_arena, decl_idx, sym_id);
+                            if cross_type != TypeId::ERROR {
+                                interface_type = if type_environment::object_shape(
+                                    self.ctx.types,
+                                    interface_type,
+                                )
+                                .is_some()
+                                {
+                                    self.merge_interface_types(interface_type, cross_type)
+                                } else {
+                                    cross_type
+                                };
+                                // Lower the interface's own members above does not
+                                // pull in `extends` bases (their members live in
+                                // the same out-of-arena declaration); merge them
+                                // from the discovered source arena so the recovered
+                                // type is not a weak own-members-only shape.
+                                let src_arena = src_arena.clone();
+                                interface_type = self.merge_interface_heritage_from_arena(
+                                    &src_arena,
+                                    decl_idx,
+                                    interface_type,
+                                );
+                                break;
                             }
                         }
                     }

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -1875,106 +1875,158 @@ impl<'a> CheckerState<'a> {
         sym_id: SymbolId,
         mut derived_type: TypeId,
     ) -> TypeId {
-        use tsz_scanner::SyntaxKind;
-
         for &decl_idx in declarations {
             let Some(arenas) = self.ctx.binder.declaration_arenas.get(&(sym_id, decl_idx)) else {
                 continue;
             };
-            for arena in arenas.iter() {
+            // Clone the arena handles so the immutable borrow of
+            // `declaration_arenas` is released before the mutable
+            // `merge_interface_heritage_from_arena` calls below.
+            let arenas: Vec<std::sync::Arc<tsz_parser::parser::node::NodeArena>> =
+                arenas.iter().cloned().collect();
+            for arena in arenas {
                 // Skip the local arena (already processed by merge_interface_heritage_types)
                 if std::ptr::eq(arena.as_ref(), self.ctx.arena) {
                     continue;
                 }
-                let Some(node) = arena.get(decl_idx) else {
+                derived_type =
+                    self.merge_interface_heritage_from_arena(&arena, decl_idx, derived_type);
+            }
+        }
+
+        derived_type
+    }
+
+    /// Resolve a type name in the binder that owns `arena`.
+    ///
+    /// `resolve_cross_file_global_type_symbol` only sees the current file's
+    /// `file_locals` plus globals, so a file-scoped type declared in another
+    /// arena (e.g. zod's `ZodTypeDef`, a non-exported interface read through a
+    /// cross-arena heritage clause) is invisible to it. This finds that type in
+    /// its declaring file's binder by mapping `arena -> file index -> binder`
+    /// and looking the name up in that binder's `file_locals`. Returns the raw
+    /// `SymbolId`, which `get_type_of_symbol` resolves through its existing
+    /// cross-file/cross-arena symbol paths.
+    pub(crate) fn resolve_type_symbol_in_arena_scope(
+        &self,
+        arena: &std::sync::Arc<tsz_parser::parser::node::NodeArena>,
+        name: &str,
+    ) -> Option<tsz_binder::SymbolId> {
+        let file_idx = self.ctx.get_file_idx_for_arena(arena.as_ref())?;
+        let binder = self.ctx.get_binder_for_file(file_idx)?;
+        let sym = binder.file_locals.get(name)?;
+        binder
+            .get_symbol(sym)
+            .filter(|symbol| symbol.has_any_flags(symbol_flags::TYPE))
+            .map(|_| sym)
+    }
+
+    /// Merge the heritage (`extends`) base types of a single interface
+    /// declaration read from `arena` into `derived_type`.
+    ///
+    /// Shared by `merge_cross_file_heritage` (which discovers the source arena
+    /// through `declaration_arenas`) and the all-arena recovery scan in the
+    /// interface-symbol computation (which discovers it by scanning loaded
+    /// arenas when the binder recorded no bridge). Base types are resolved by
+    /// name in the current binder's `file_locals`, so an interface whose
+    /// declaration lives in another arena still inherits its base members
+    /// instead of degrading to a weak own-members-only shape.
+    pub(crate) fn merge_interface_heritage_from_arena(
+        &mut self,
+        arena: &std::sync::Arc<tsz_parser::parser::node::NodeArena>,
+        decl_idx: NodeIndex,
+        mut derived_type: TypeId,
+    ) -> TypeId {
+        use tsz_scanner::SyntaxKind;
+
+        let Some(node) = arena.get(decl_idx) else {
+            return derived_type;
+        };
+        let Some(interface) = arena.get_interface(node) else {
+            return derived_type;
+        };
+        let Some(ref heritage_clauses) = interface.heritage_clauses else {
+            return derived_type;
+        };
+
+        for &clause_idx in &heritage_clauses.nodes {
+            let Some(clause_node) = arena.get(clause_idx) else {
+                continue;
+            };
+            let Some(heritage) = arena.get_heritage_clause(clause_node) else {
+                continue;
+            };
+            if heritage.token != SyntaxKind::ExtendsKeyword as u16 {
+                continue;
+            }
+
+            for &type_idx in &heritage.types.nodes {
+                let Some(type_node) = arena.get(type_idx) else {
                     continue;
                 };
-                let Some(interface) = arena.get_interface(node) else {
-                    continue;
-                };
-                let Some(ref heritage_clauses) = interface.heritage_clauses else {
-                    continue;
-                };
 
-                for &clause_idx in &heritage_clauses.nodes {
-                    let Some(clause_node) = arena.get(clause_idx) else {
-                        continue;
-                    };
-                    let Some(heritage) = arena.get_heritage_clause(clause_node) else {
-                        continue;
-                    };
-                    if heritage.token != SyntaxKind::ExtendsKeyword as u16 {
-                        continue;
-                    }
-
-                    for &type_idx in &heritage.types.nodes {
-                        let Some(type_node) = arena.get(type_idx) else {
-                            continue;
-                        };
-
-                        let (expr_idx, type_arguments) =
-                            if let Some(expr) = arena.get_expr_type_args(type_node) {
-                                (expr.expression, expr.type_arguments.as_ref())
-                            } else if type_node.kind == syntax_kind_ext::TYPE_REFERENCE {
-                                if let Some(type_ref) = arena.get_type_ref(type_node) {
-                                    (type_ref.type_name, type_ref.type_arguments.as_ref())
-                                } else {
-                                    (type_idx, None)
-                                }
-                            } else {
-                                (type_idx, None)
-                            };
-
-                        let Some(name) = expression_name_text_in_arena(arena, expr_idx) else {
-                            continue;
-                        };
-                        let Some(base_sym_id) = self.resolve_cross_file_global_type_symbol(&name)
-                        else {
-                            continue;
-                        };
-
-                        let mut base_type = self.get_type_of_symbol(base_sym_id);
-                        if base_type == TypeId::ERROR || base_type == TypeId::UNKNOWN {
-                            continue;
+                let (expr_idx, type_arguments) =
+                    if let Some(expr) = arena.get_expr_type_args(type_node) {
+                        (expr.expression, expr.type_arguments.as_ref())
+                    } else if type_node.kind == syntax_kind_ext::TYPE_REFERENCE {
+                        if let Some(type_ref) = arena.get_type_ref(type_node) {
+                            (type_ref.type_name, type_ref.type_arguments.as_ref())
+                        } else {
+                            (type_idx, None)
                         }
-                        if let Some(type_arguments) = type_arguments {
-                            let base_params = self.get_type_params_for_symbol(base_sym_id);
-                            if !base_params.is_empty() {
-                                let mut type_args = Vec::with_capacity(type_arguments.nodes.len());
-                                for &arg_idx in &type_arguments.nodes {
-                                    type_args.push(
-                                        self.resolve_cross_file_heritage_type_arg(arena, arg_idx),
-                                    );
-                                }
-                                while type_args.len() < base_params.len() {
-                                    let param = &base_params[type_args.len()];
-                                    type_args.push(
-                                        param
-                                            .default
-                                            .or(param.constraint)
-                                            .unwrap_or(TypeId::UNKNOWN),
-                                    );
-                                }
-                                if type_args.len() > base_params.len() {
-                                    type_args.truncate(base_params.len());
-                                }
-                                let substitution =
-                                    crate::query_boundaries::common::TypeSubstitution::from_args(
-                                        self.ctx.types,
-                                        &base_params,
-                                        &type_args,
-                                    );
-                                base_type = crate::query_boundaries::common::instantiate_type(
-                                    self.ctx.types,
-                                    base_type,
-                                    &substitution,
-                                );
-                            }
-                        }
+                    } else {
+                        (type_idx, None)
+                    };
 
-                        derived_type = self.merge_interface_types_heritage(derived_type, base_type);
+                let Some(name) = expression_name_text_in_arena(arena, expr_idx) else {
+                    continue;
+                };
+                let Some(base_sym_id) = self
+                    .resolve_cross_file_global_type_symbol(&name)
+                    .or_else(|| self.resolve_type_symbol_in_arena_scope(arena, &name))
+                else {
+                    continue;
+                };
+
+                let mut base_type = self.get_type_of_symbol(base_sym_id);
+                if base_type == TypeId::ERROR || base_type == TypeId::UNKNOWN {
+                    continue;
+                }
+                if let Some(type_arguments) = type_arguments {
+                    let base_params = self.get_type_params_for_symbol(base_sym_id);
+                    if !base_params.is_empty() {
+                        let mut type_args = Vec::with_capacity(type_arguments.nodes.len());
+                        for &arg_idx in &type_arguments.nodes {
+                            type_args
+                                .push(self.resolve_cross_file_heritage_type_arg(arena, arg_idx));
+                        }
+                        while type_args.len() < base_params.len() {
+                            let param = &base_params[type_args.len()];
+                            type_args.push(
+                                param
+                                    .default
+                                    .or(param.constraint)
+                                    .unwrap_or(TypeId::UNKNOWN),
+                            );
+                        }
+                        if type_args.len() > base_params.len() {
+                            type_args.truncate(base_params.len());
+                        }
+                        let substitution =
+                            crate::query_boundaries::common::TypeSubstitution::from_args(
+                                self.ctx.types,
+                                &base_params,
+                                &type_args,
+                            );
+                        base_type = crate::query_boundaries::common::instantiate_type(
+                            self.ctx.types,
+                            base_type,
+                            &substitution,
+                        );
                     }
                 }
+
+                derived_type = self.merge_interface_types_heritage(derived_type, base_type);
             }
         }
 

--- a/crates/tsz-checker/src/tests/cross_file_base_type_param_interface_member_tests.rs
+++ b/crates/tsz-checker/src/tests/cross_file_base_type_param_interface_member_tests.rs
@@ -1,0 +1,184 @@
+//! Cross-arena base type parameter bound to a cross-file interface (#13044, #13484).
+//!
+//! When a generic base class declares a member typed by one of its own type
+//! parameters (`abstract class Base<Out, Def extends BaseDef = BaseDef> {
+//! readonly _def!: Def }`), and a derived class binds that parameter to an
+//! interface (`class Str extends Base<string, StrDef>`), reading the inherited
+//! member on a derived instance (`this._def.checks`) must resolve `Def` to the
+//! derived class's type argument (`StrDef`).
+//!
+//! Historically, when the derived class and the bound interface were observed
+//! across arenas (multi-file, barrel-heavy graphs), the binder recorded a
+//! declaration `NodeIndex` for the interface that did not resolve in the
+//! importing arena and provided no `declaration_arenas` bridge, so the
+//! interface body degraded to `TypeId::ERROR`. That `error` then surfaced in a
+//! type-argument slot through inheritance — zod's
+//! `ZodType<_, Def>._def` with `Def = ZodStringDef` rendered `{ checks:
+//! error[] }` (the #13484 cross-canary witness). The interface body is a pure
+//! function of its own declaration regardless of the referencing file, so it is
+//! now recovered by lowering the declaration in the arena that actually holds
+//! it (and merging its `extends`-bases from that same arena).
+//!
+//! Binder names are varied (`Schema`/`StrShape`, `Parser`/`Cfg`) to prove the
+//! recovery follows the type shape, not any identifier or file-name string.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::{Diagnostic, diagnostic_codes};
+use crate::test_utils::check_multi_file;
+use tsz_common::common::ModuleKind;
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            strict: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+/// Any diagnostic whose rendered message mentions the internal `error` type in
+/// a member/argument position is the degradation witness.
+fn error_type_leak_messages(diagnostics: &[Diagnostic]) -> Vec<String> {
+    diagnostics
+        .iter()
+        .filter(|d| d.message_text.contains("error[]") || d.message_text.contains(": error"))
+        .map(|d| d.message_text.to_string())
+        .collect()
+}
+
+fn assignability_errors(diagnostics: &[Diagnostic]) -> Vec<(u32, String)> {
+    diagnostics
+        .iter()
+        .filter(|d| {
+            d.code == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE
+                || d.code
+                    == diagnostic_codes::ARGUMENT_OF_TYPE_IS_NOT_ASSIGNABLE_TO_PARAMETER_OF_TYPE
+                || d.code == diagnostic_codes::TYPE_HAS_NO_PROPERTIES_IN_COMMON_WITH_TYPE
+        })
+        .map(|d| (d.code, d.message_text.to_string()))
+        .collect()
+}
+
+/// The core #13484 witness: a derived class in a separate file reads a base
+/// member typed by a base type parameter that the derived class binds to a
+/// cross-file interface. The interface (and its `extends`-base members) must
+/// resolve so the spread `{ ...this._def, checks: [...this._def.checks, c] }`
+/// is `{ checks: StrShape["checks"] }`, never `{ checks: error[] }`.
+#[test]
+fn derived_reads_base_type_param_bound_to_cross_file_interface() {
+    let schema = r#"
+export interface BaseShape {
+  label?: string;
+  note?: string;
+}
+export interface StrShape extends BaseShape {
+  checks: number[];
+  kind: "str";
+}
+export abstract class Schema<Out, Shape extends BaseShape = BaseShape> {
+  readonly _shape!: Shape;
+  constructor(shape: Shape) {
+    this._shape = shape;
+  }
+}
+"#;
+    let main = r#"
+import { Schema, StrShape } from "./schema";
+export class Str extends Schema<string, StrShape> {
+  add(c: number): Str {
+    return new Str({ ...this._shape, checks: [...this._shape.checks, c] });
+  }
+}
+"#;
+    let diags = check(&[("./schema.ts", schema), ("./main.ts", main)], "./main.ts");
+
+    let leaks = error_type_leak_messages(&diags);
+    assert!(
+        leaks.is_empty(),
+        "base type parameter bound to a cross-file interface degraded to `error`: {leaks:?}",
+    );
+    let assignability = assignability_errors(&diags);
+    assert!(
+        assignability.is_empty(),
+        "expected the recovered interface to relate cleanly, got: {assignability:?}",
+    );
+}
+
+/// Same shape, different binder names and member spellings, proving the
+/// recovery is structural rather than keyed on any identifier.
+#[test]
+fn renamed_derived_reads_base_type_param_bound_to_cross_file_interface() {
+    let lib = r#"
+export interface CfgBase {
+  message?: string;
+}
+export interface NumCfg extends CfgBase {
+  bounds: number[];
+  tag: "num";
+}
+export abstract class Parser<Value, Cfg extends CfgBase = CfgBase> {
+  readonly _cfg!: Cfg;
+  constructor(cfg: Cfg) {
+    this._cfg = cfg;
+  }
+}
+"#;
+    let app = r#"
+import { Parser, NumCfg } from "./lib";
+export class NumParser extends Parser<number, NumCfg> {
+  widen(b: number): NumParser {
+    return new NumParser({ ...this._cfg, bounds: [...this._cfg.bounds, b] });
+  }
+}
+"#;
+    let diags = check(&[("./lib.ts", lib), ("./app.ts", app)], "./app.ts");
+
+    let leaks = error_type_leak_messages(&diags);
+    assert!(
+        leaks.is_empty(),
+        "renamed cross-file base-member interface degraded to `error`: {leaks:?}",
+    );
+    let assignability = assignability_errors(&diags);
+    assert!(
+        assignability.is_empty(),
+        "expected the recovered interface to relate cleanly, got: {assignability:?}",
+    );
+}
+
+/// The recovered interface must carry its `extends`-base members so a weak
+/// (all-optional) base type still relates by structural inheritance rather than
+/// firing TS2559 "no properties in common". This guards the heritage-merge half
+/// of the recovery specifically.
+#[test]
+fn cross_file_interface_recovery_preserves_extends_base_members() {
+    let schema = r#"
+export interface WeakBase {
+  errorMap?: string;
+  description?: string;
+}
+export interface FullShape extends WeakBase {
+  checks: number[];
+}
+export abstract class Holder<Shape extends WeakBase = WeakBase> {
+  readonly _shape!: Shape;
+}
+"#;
+    let main = r#"
+import { Holder, FullShape, WeakBase } from "./schema";
+export class FullHolder extends Holder<FullShape> {
+  read(): WeakBase {
+    return this._shape;
+  }
+}
+"#;
+    let diags = check(&[("./schema.ts", schema), ("./main.ts", main)], "./main.ts");
+
+    let assignability = assignability_errors(&diags);
+    assert!(
+        assignability.is_empty(),
+        "recovered interface lost its extends-base members (weak-type mismatch): {assignability:?}",
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes the zod canary red-row driver from #13044 / #13484: a generic base-class member typed by a base type parameter degrading to `error` in a type-argument slot across arenas (`ZodType<_, Def>._def` with `Def = ZodStringDef` rendering `{ checks: error[] }`).

## Root cause (traced, not hypothesized)

Release-surviving `tracing::warn!` instrumentation on the pinned zod fixture pinned the mint precisely:

- `this._def` on a `ZodString` instance resolves correctly to a `Lazy(DefId)` reference to the `ZodStringDef` interface.
- Accessing `.checks` on it resolves the lazy reference via `get_type_of_symbol(ZodStringDef)`, which returns **`TypeId::ERROR`** — and `.checks` on `error` is `error`, so the object spread `{ ...this._def, checks: [...this._def.checks, c] }` collapses to `{ checks: error[] }`.
- The interface computation took the lib-resolution / local-lowering path with `has_out_of_arena_decl=true`, `has_local_interface_decl=false`, and **no `declaration_arenas` bridge** — the declaration `NodeIndex` (1499) resolves to an interface node only in another loaded arena (file 7), never in the importing arena. The local lowering against the wrong arena degraded the whole interface to `error`. **No cycle was involved** (resolution stack was `[ZodStringDef]` only).

## Structural rule

When an interface symbol's declaration node does not resolve in the current arena and the binder recorded no `declaration_arenas` bridge, `tsc` still resolves the interface from its own declaration regardless of the referencing file. tsz must do the same: an interface body is a pure function of its own declaration. Owner: checker cross-arena interface body computation (`compute_type_of_symbol` INTERFACE block).

## Fix

In the INTERFACE block of `compute_type_of_symbol`, when the local lowering produced no object shape (would otherwise be `error`) and the declaration is genuinely out-of-arena, scan the loaded arenas for the one whose `NodeIndex` resolves to this interface declaration, lower it there, and merge its `extends`-bases from that same source arena. Heritage base type symbols are resolved in the declaring file's binder scope (new `resolve_type_symbol_in_arena_scope`) so file-scoped bases (zod `ZodTypeDef`) inherit correctly instead of producing a weak own-members-only shape (which surfaced a transient TS2559).

Anti-hardcoding: the recovery matches structurally on "this index resolves to an interface node in this arena", never on a name or file string. It fires only on the degenerate miss path that would otherwise mint `error` (guarded by `object_shape(interface_type).is_none()`), so interfaces that already lower correctly are untouched. Bounded by the loaded-arena count.

The per-arena heritage-merge body is extracted into a shared `merge_interface_heritage_from_arena` consumed by both the existing `merge_cross_file_heritage` and the new recovery scan, so both observe identical heritage facts.

## Verification

zod guard (pinned ref `93b0b689`, `tsz_write_zod_config`, `RAYON_NUM_THREADS=1`), A/B against this branch's merge base:

- Diagnostics: **51 -> 37** (−14). The 3 `{ checks: error[] }` TS2345 witnesses at `src/types.ts(520)/(762)/(777)` clear, and their downstream TS2345 cascade (20 -> 5) clears. No new diagnostic families; the transient TS2559 introduced by the partial fix is resolved by the heritage merge.
- Performance: **1.92s -> 1.70s user CPU (−11.2%, faster)** — the interface resolves and caches once instead of re-deriving `error` through the property-access fallback on every reference (interleaved 6-run A/B, clean baseline binary).

Adjacent-case matrix (new test module `cross_file_base_type_param_interface_member_tests`, 3 tests, binder names varied to prove structural behavior; PASS on this branch):
- `derived_reads_base_type_param_bound_to_cross_file_interface` — the core witness shape.
- `renamed_derived_reads_base_type_param_bound_to_cross_file_interface` — renamed binders/members.
- `cross_file_interface_recovery_preserves_extends_base_members` — pins the heritage-merge half (weak-base TS2559 guard).

Conformance delta (local, narrow `-p tsz-checker` filter): the 10 pre-existing `cross_file` local failures (jsdoc/jsx-react/lib-name/zod-partial-omit) fail identically on the merge base and on this branch — **zero new failures introduced**. Full conformance runs in CI.

Note: the two-file unit harness (`check_multi_file`) does not reproduce the real arena split (same pre-existing harness gap documented in `cross_file_type_param_decl_identity_tests`), so the included tests are regression guards; the measured flip is the zod canary row above.

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
