### PR TITLE
fix(solver): accept generic indexed access into a concrete tuple base (#13655)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -36,6 +36,9 @@ stacker = "0.1.23"
 name = "any_user_predicate_keeps_any_for_object_function_tests"
 path = "tests/any_user_predicate_keeps_any_for_object_function_tests.rs"
 [[test]]
+name = "concrete_tuple_generic_index_chain_ts2536_tests"
+path = "tests/concrete_tuple_generic_index_chain_ts2536_tests.rs"
+[[test]]
 name = "cross_file_delegation_lookup_consolidation_tests"
 path = "tests/cross_file_delegation_lookup_consolidation_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -5,6 +5,7 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
 mod indexed_access_helpers;
+mod infer_node_walk;
 mod mapped_key_check;
 mod object_format;
 
@@ -354,90 +355,6 @@ impl<'a> CheckerState<'a> {
             }
         }
         false
-    }
-
-    /// Collect all `INFER_TYPE` node indices in a subtree, using parent-tracking.
-    /// Walks all nodes whose parent chain leads back to `root_idx`.
-    fn collect_infer_nodes_in_subtree(&self, root_idx: NodeIndex) -> Vec<NodeIndex> {
-        let mut result = Vec::new();
-        let mut stack = vec![root_idx];
-        while let Some(idx) = stack.pop() {
-            if idx == NodeIndex::NONE {
-                continue;
-            }
-            let Some(node) = self.ctx.arena.get(idx) else {
-                continue;
-            };
-            if node.kind == syntax_kind_ext::INFER_TYPE {
-                result.push(idx);
-                // Nested `infer Y` inside the constraint is in the same scope.
-                if let Some(infer_data) = self.ctx.arena.get_infer_type(node) {
-                    stack.push(infer_data.type_parameter);
-                }
-                continue;
-            }
-            // Push children based on node type
-            self.push_type_node_children(idx, node, &mut stack);
-        }
-        result
-    }
-
-    /// Push child indices of a type node onto the stack for traversal.
-    fn push_type_node_children(
-        &self,
-        _idx: NodeIndex,
-        node: &tsz_parser::parser::node::Node,
-        stack: &mut Vec<NodeIndex>,
-    ) {
-        // Tuple type: push elements
-        if let Some(tuple) = self.ctx.arena.get_tuple_type(node) {
-            stack.extend(tuple.elements.nodes.iter().copied());
-            return;
-        }
-        // Array type
-        if let Some(arr) = self.ctx.arena.get_array_type(node) {
-            stack.push(arr.element_type);
-            return;
-        }
-        // Union/intersection type (both use CompositeTypeData)
-        if let Some(composite) = self.ctx.arena.get_composite_type(node) {
-            stack.extend(composite.types.nodes.iter().copied());
-            return;
-        }
-        // Type reference with type arguments
-        if let Some(type_ref) = self.ctx.arena.get_type_ref(node) {
-            if let Some(ref args) = type_ref.type_arguments {
-                stack.extend(args.nodes.iter().copied());
-            }
-            return;
-        }
-        // Wrapped types: rest, optional, parenthesized (all share WrappedTypeData)
-        if let Some(wrapped) = self.ctx.arena.get_wrapped_type(node) {
-            stack.push(wrapped.type_node);
-            return;
-        }
-        // Conditional type
-        if let Some(cond) = self.ctx.arena.get_conditional_type(node) {
-            stack.push(cond.check_type);
-            stack.push(cond.extends_type);
-            stack.push(cond.true_type);
-            stack.push(cond.false_type);
-            return;
-        }
-        // Indexed access type
-        if let Some(iat) = self.ctx.arena.get_indexed_access_type(node) {
-            stack.push(iat.object_type);
-            stack.push(iat.index_type);
-            return;
-        }
-        // Type operator (keyof, readonly, unique)
-        if let Some(type_op) = self.ctx.arena.get_type_operator(node) {
-            stack.push(type_op.type_node);
-            return;
-        }
-        if let Some(tp) = self.ctx.arena.get_type_parameter(node) {
-            stack.extend_from_slice(&[tp.constraint, tp.default]);
-        }
     }
 
     /// Check if `node_a` is a descendant of `node_b` in the AST.

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -1577,6 +1577,24 @@ impl<'a> CheckerState<'a> {
                 return;
             }
 
+            // Concrete-tuple base indexed by a generic type-param chain
+            // (`Table[D1][0]`, `AddDigitTable[Carry][T][U]`): `tsc` resolves the
+            // chain to the tuple's element-value union (`Base[number]`), whose
+            // key-space accepts the outer index. The generic recovery above keys
+            // off `Base[keyof Base]`, which pollutes the value union with
+            // `length`/array-method values for a tuple base and so spuriously
+            // rejects the element index. Derive the element-value key-space
+            // directly, validating each intermediate index against the tuple's
+            // numeric index domain so out-of-range / `keyof`-based inner
+            // constraints still emit the genuine `TS2536`.
+            if self.generic_tuple_chain_index_access_allows_index(
+                data.object_type,
+                data.index_type,
+                index_type,
+            ) {
+                return;
+            }
+
             let obj_type_str = self.format_ts2536_object_type(data.object_type, object_type);
             let evaluated_index_type = self.evaluate_type_for_assignability(index_type);
             let prefer_evaluated_index = (evaluated_index_type != TypeId::ERROR

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -1009,6 +1009,186 @@ impl<'a> CheckerState<'a> {
             )
     }
 
+    /// The number of fixed (non-rest) elements of a concrete tuple value, and
+    /// whether it has an open rest tail (`[A, ...B[]]`). Returns `None` when
+    /// `tuple_value` is not a concrete tuple (or a union of concrete tuples).
+    ///
+    /// For a union of tuples the fixed length is the maximum across members (an
+    /// index in any member's range is acceptable) and the rest flag is the OR,
+    /// mirroring `tsc`'s apparent-type behavior where `(A | B)[I]` is valid for
+    /// any index in either operand's range.
+    fn tuple_fixed_length(&mut self, tuple_value: TypeId) -> Option<(usize, bool)> {
+        if let Some(members) =
+            crate::query_boundaries::common::union_members(self.ctx.types, tuple_value)
+        {
+            let members: Vec<TypeId> = members.iter().copied().collect();
+            let mut max_len = 0usize;
+            let mut any_rest = false;
+            let mut saw_tuple = false;
+            for member in members {
+                let (len, rest) = self.tuple_fixed_length(member)?;
+                saw_tuple = true;
+                max_len = max_len.max(len);
+                any_rest |= rest;
+            }
+            return saw_tuple.then_some((max_len, any_rest));
+        }
+
+        let elements =
+            crate::query_boundaries::common::tuple_elements(self.ctx.types, tuple_value)?;
+        let mut fixed_len = 0usize;
+        let mut has_rest = false;
+        for element in &elements {
+            if element.rest {
+                has_rest = true;
+            } else {
+                fixed_len += 1;
+            }
+        }
+        Some((fixed_len, has_rest))
+    }
+
+    /// Whether the index constraint `index_for_check` stays within a concrete
+    /// tuple's element-index domain: every union member must be either the
+    /// abstract `number` primitive (which `tsc` resolves to the element value)
+    /// or a numeric literal `0 <= n < len`. An out-of-range literal, a string
+    /// key, or `keyof Base` (which includes `length`/method names) escapes the
+    /// domain, so the chain no longer resolves to an element value and the
+    /// caller keeps the genuine `TS2536`. With an open rest tail any numeric
+    /// literal is in range.
+    fn index_within_tuple_element_domain(
+        &mut self,
+        index_for_check: TypeId,
+        tuple_value: TypeId,
+    ) -> bool {
+        let Some((len, has_rest)) = self.tuple_fixed_length(tuple_value) else {
+            return false;
+        };
+        let members: Vec<TypeId> =
+            crate::query_boundaries::common::union_members(self.ctx.types, index_for_check)
+                .map(|members| members.iter().copied().collect())
+                .unwrap_or_else(|| vec![index_for_check]);
+        if members.is_empty() {
+            return false;
+        }
+        members.into_iter().all(|member| {
+            if member == TypeId::NUMBER {
+                return true;
+            }
+            if let Some(value) =
+                crate::query_boundaries::common::number_literal_value(self.ctx.types, member)
+            {
+                return value.fract() == 0.0
+                    && value >= 0.0
+                    && (has_rest || (value as usize) < len);
+            }
+            false
+        })
+    }
+
+    /// Resolve the apparent value-type union of a generic indexed-access chain
+    /// `Base[I]`, `Base[I][J]`, … whose innermost base is a concrete tuple, when
+    /// every intermediate index stays within the tuple element-index domain.
+    ///
+    /// This mirrors `tsc`: indexing a concrete tuple `Base` with a generic index
+    /// `I extends C` where `C` lies in the tuple's numeric index space yields the
+    /// element-value union `Base[number]`; a further index `Base[I][J]` then
+    /// indexes that union. When an intermediate index constraint escapes the
+    /// numeric index domain (e.g. an out-of-range literal, `keyof Base`, or a
+    /// string key), the chain no longer resolves to an element value and the
+    /// helper returns `None`, so the caller keeps the genuine `TS2536`.
+    ///
+    /// Returns `None` when `node_idx` is not such a chain. Bounded by chain depth
+    /// and tuple length; no unbounded instantiation.
+    fn generic_tuple_chain_value_type(&mut self, node_idx: NodeIndex) -> Option<TypeId> {
+        let node = self.ctx.arena.get(node_idx)?;
+        let indexed = self.ctx.arena.get_indexed_access_type(node)?;
+        let inner_node_idx = indexed.object_type;
+        let index_node_idx = indexed.index_type;
+
+        // Resolve the base value union: either a concrete tuple directly, or a
+        // nested generic chain that itself bottoms out at a concrete tuple.
+        let base_value = if let Some(parent) = self.generic_tuple_chain_value_type(inner_node_idx) {
+            parent
+        } else {
+            let resolved = self.get_type_from_type_node(inner_node_idx);
+            let resolved = self.evaluate_type_with_env(resolved);
+            (resolved != TypeId::ERROR && self.tuple_fixed_length(resolved).is_some())
+                .then_some(resolved)?
+        };
+
+        // The index at this level must stay within the tuple element-index domain.
+        let mut index_constraint = crate::query_boundaries::common::type_parameter_constraint(
+            self.ctx.types,
+            self.get_type_from_type_node(index_node_idx),
+        );
+        if index_constraint.is_none()
+            && crate::query_boundaries::common::is_type_parameter_like(
+                self.ctx.types,
+                self.get_type_from_type_node(index_node_idx),
+            )
+        {
+            index_constraint =
+                self.resolve_index_constraint_from_declaration(index_node_idx, inner_node_idx);
+        }
+        let index_for_check =
+            index_constraint.unwrap_or_else(|| self.get_type_from_type_node(index_node_idx));
+        let index_for_check = self.evaluate_type_with_env(index_for_check);
+        if !self.index_within_tuple_element_domain(index_for_check, base_value) {
+            return None;
+        }
+
+        // The resolved value is the tuple's element-value union (`base[number]`).
+        let element_union = self
+            .ctx
+            .types
+            .factory()
+            .index_access(base_value, TypeId::NUMBER);
+        let element_union = self.evaluate_type_with_env(element_union);
+        if matches!(element_union, TypeId::ERROR | TypeId::UNDEFINED) {
+            return None;
+        }
+        Some(element_union)
+    }
+
+    /// Whether `Chain[J]` is a valid indexed access where `Chain` is a generic
+    /// indexed-access chain rooted at a concrete tuple base (e.g.
+    /// `Table[D1][0]`, `AddDigitTable[Carry][T][U]`). The chain's apparent value
+    /// type is the element-value union of the tuple; the outer index `J` must lie
+    /// in `keyof` of that union. Returns `false` (keeping any genuine `TS2536`)
+    /// when the chain is not tuple-rooted or `J` is out of the value key-space.
+    pub(super) fn generic_tuple_chain_index_access_allows_index(
+        &mut self,
+        object_type_node_idx: NodeIndex,
+        outer_index_node_idx: NodeIndex,
+        outer_index_type: TypeId,
+    ) -> bool {
+        let Some(value_union) = self.generic_tuple_chain_value_type(object_type_node_idx) else {
+            return false;
+        };
+        let value_keyof = self.ctx.types.evaluate_keyof(value_union);
+
+        let mut outer_index_constraint = crate::query_boundaries::common::type_parameter_constraint(
+            self.ctx.types,
+            outer_index_type,
+        );
+        if outer_index_constraint.is_none()
+            && crate::query_boundaries::common::is_type_parameter_like(
+                self.ctx.types,
+                outer_index_type,
+            )
+        {
+            outer_index_constraint = self.resolve_index_constraint_from_declaration(
+                outer_index_node_idx,
+                object_type_node_idx,
+            );
+        }
+        let outer_for_check = outer_index_constraint.unwrap_or(outer_index_type);
+        let outer_for_check = self.evaluate_type_with_env(outer_for_check);
+        self.indexed_access_key_space_relation_outcome(outer_for_check, value_keyof)
+            .related
+    }
+
     fn array_like_kind_has_length(
         &self,
         kind: crate::query_boundaries::type_checking_utilities::ArrayLikeKind,

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/infer_node_walk.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/infer_node_walk.rs
@@ -1,0 +1,94 @@
+//! AST traversal helpers for locating `infer` type nodes within an indexed
+//! access constraint subtree. Split out of `indexed_access.rs` to keep that
+//! file under the per-file LOC ceiling; behavior is unchanged.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> CheckerState<'a> {
+    /// Collect every `infer` type node within the subtree rooted at `root_idx`,
+    /// walking the type-node children explicitly so nested `infer Y`
+    /// constraints in the same scope are also captured.
+    pub(super) fn collect_infer_nodes_in_subtree(&self, root_idx: NodeIndex) -> Vec<NodeIndex> {
+        let mut result = Vec::new();
+        let mut stack = vec![root_idx];
+        while let Some(idx) = stack.pop() {
+            if idx == NodeIndex::NONE {
+                continue;
+            }
+            let Some(node) = self.ctx.arena.get(idx) else {
+                continue;
+            };
+            if node.kind == syntax_kind_ext::INFER_TYPE {
+                result.push(idx);
+                // Nested `infer Y` inside the constraint is in the same scope.
+                if let Some(infer_data) = self.ctx.arena.get_infer_type(node) {
+                    stack.push(infer_data.type_parameter);
+                }
+                continue;
+            }
+            // Push children based on node type
+            self.push_type_node_children(idx, node, &mut stack);
+        }
+        result
+    }
+
+    /// Push child indices of a type node onto the stack for traversal.
+    fn push_type_node_children(
+        &self,
+        _idx: NodeIndex,
+        node: &tsz_parser::parser::node::Node,
+        stack: &mut Vec<NodeIndex>,
+    ) {
+        // Tuple type: push elements
+        if let Some(tuple) = self.ctx.arena.get_tuple_type(node) {
+            stack.extend(tuple.elements.nodes.iter().copied());
+            return;
+        }
+        // Array type
+        if let Some(arr) = self.ctx.arena.get_array_type(node) {
+            stack.push(arr.element_type);
+            return;
+        }
+        // Union/intersection type (both use CompositeTypeData)
+        if let Some(composite) = self.ctx.arena.get_composite_type(node) {
+            stack.extend(composite.types.nodes.iter().copied());
+            return;
+        }
+        // Type reference with type arguments
+        if let Some(type_ref) = self.ctx.arena.get_type_ref(node) {
+            if let Some(ref args) = type_ref.type_arguments {
+                stack.extend(args.nodes.iter().copied());
+            }
+            return;
+        }
+        // Wrapped types: rest, optional, parenthesized (all share WrappedTypeData)
+        if let Some(wrapped) = self.ctx.arena.get_wrapped_type(node) {
+            stack.push(wrapped.type_node);
+            return;
+        }
+        // Conditional type
+        if let Some(cond) = self.ctx.arena.get_conditional_type(node) {
+            stack.push(cond.check_type);
+            stack.push(cond.extends_type);
+            stack.push(cond.true_type);
+            stack.push(cond.false_type);
+            return;
+        }
+        // Indexed access type
+        if let Some(iat) = self.ctx.arena.get_indexed_access_type(node) {
+            stack.push(iat.object_type);
+            stack.push(iat.index_type);
+            return;
+        }
+        // Type operator (keyof, readonly, unique)
+        if let Some(type_op) = self.ctx.arena.get_type_operator(node) {
+            stack.push(type_op.type_node);
+            return;
+        }
+        if let Some(tp) = self.ctx.arena.get_type_parameter(node) {
+            stack.extend_from_slice(&[tp.constraint, tp.default]);
+        }
+    }
+}

--- a/crates/tsz-checker/tests/concrete_tuple_generic_index_chain_ts2536_tests.rs
+++ b/crates/tsz-checker/tests/concrete_tuple_generic_index_chain_ts2536_tests.rs
@@ -1,0 +1,234 @@
+//! A concrete tuple base indexed by a generic type-parameter chain
+//! (`Table[D1][0]`, `AddDigitTable[Carry][T][U]`) must derive the tuple's
+//! element-value key-space, accepting the further index exactly as `tsc` does —
+//! not a spurious TS2536.
+//!
+//! Structural rule: when `Base[I]` has a concrete tuple base `Base` and a
+//! generic index `I extends C` whose constraint lies in the tuple's numeric
+//! element-index domain (`number`, or numeric literals `0..len`), `tsc` resolves
+//! `Base[I]` to the tuple's element-value union (`Base[number]`), whose key-space
+//! includes the element indices, so a chained index `Base[I][J]` is valid. Owner:
+//! solver-backed checker indexed-access constraint recovery
+//! (`indexed_access_helpers::generic_tuple_chain_index_access_allows_index`).
+//!
+//! Previously `tsz`'s last-resort recovery keyed the value union off
+//! `Base[keyof Base]`, which for a tuple base pollutes the union with
+//! `length`/array-method values and so spuriously rejected the element index.
+//!
+//! Negative controls (must still emit TS2536): an out-of-range inner literal
+//! constraint, an inner constraint of `keyof Base` (which includes
+//! `length`/methods), and an outer index that is genuinely absent from the
+//! element-value key-space. Binder names are varied so the fix cannot be a
+//! spelling-specific point patch.
+
+use tsz_common::diagnostics::Diagnostic;
+
+fn check(source: &str) -> Vec<Diagnostic> {
+    tsz_checker::test_utils::check_source_diagnostics(source)
+}
+
+fn codes(diags: &[Diagnostic]) -> Vec<u32> {
+    diags.iter().map(|d| d.code).collect()
+}
+
+fn has_code(diags: &[Diagnostic], code: u32) -> bool {
+    diags.iter().any(|d| d.code == code)
+}
+
+/// Reported repro (#13655): a tuple-of-tuples indexed by a generic param chain.
+/// Varied alias/param spellings prove the rule is structural.
+#[test]
+fn concrete_tuple_generic_index_chain_is_accepted() {
+    for (alias, param) in [("Table", "D1"), ("Lookup", "Row"), ("Grid", "Ix")] {
+        let src = format!(
+            r#"
+type {alias} = [[10, 11], [20, 21]];
+type Nested<{param} extends 0 | 1> = {alias}[{param}][0];
+"#
+        );
+        let diags = check(&src);
+        assert!(
+            !has_code(&diags, 2536),
+            "concrete tuple chain (alias {alias}, param {param}) must not emit TS2536, got: {:?}",
+            codes(&diags)
+        );
+    }
+}
+
+/// The faithful `hotscript` `AddDigitTable[Carry][T][U]` shape: a 3-level chain
+/// over a carry x digit x digit lookup tuple.
+#[test]
+fn three_level_concrete_tuple_chain_is_accepted() {
+    let diags = check(
+        r#"
+type Digit = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+type AddDigitTable = [
+  [
+    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [1, 2, 3, 4, 5, 6, 7, 8, 9, 0],
+    [2, 3, 4, 5, 6, 7, 8, 9, 0, 1], [3, 4, 5, 6, 7, 8, 9, 0, 1, 2],
+    [4, 5, 6, 7, 8, 9, 0, 1, 2, 3], [5, 6, 7, 8, 9, 0, 1, 2, 3, 4],
+    [6, 7, 8, 9, 0, 1, 2, 3, 4, 5], [7, 8, 9, 0, 1, 2, 3, 4, 5, 6],
+    [8, 9, 0, 1, 2, 3, 4, 5, 6, 7], [9, 0, 1, 2, 3, 4, 5, 6, 7, 8]
+  ],
+  [
+    [1, 2, 3, 4, 5, 6, 7, 8, 9, 0], [2, 3, 4, 5, 6, 7, 8, 9, 0, 1],
+    [3, 4, 5, 6, 7, 8, 9, 0, 1, 2], [4, 5, 6, 7, 8, 9, 0, 1, 2, 3],
+    [5, 6, 7, 8, 9, 0, 1, 2, 3, 4], [6, 7, 8, 9, 0, 1, 2, 3, 4, 5],
+    [7, 8, 9, 0, 1, 2, 3, 4, 5, 6], [8, 9, 0, 1, 2, 3, 4, 5, 6, 7],
+    [9, 0, 1, 2, 3, 4, 5, 6, 7, 8], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+  ]
+];
+type AddDigit<T extends Digit, U extends Digit, Carry extends 0 | 1 = 0> =
+  AddDigitTable[Carry][T][U];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536),
+        "AddDigitTable[Carry][T][U] must not emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// A `readonly` tuple of `readonly` tuples behaves identically to the mutable
+/// form (the gap was tuple-specific, both variants must apply).
+#[test]
+fn readonly_concrete_tuple_chain_is_accepted() {
+    let diags = check(
+        r#"
+type Table = readonly [readonly [10, 11], readonly [20, 21]];
+type Nested<D1 extends 0 | 1> = Table[D1][0];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536),
+        "readonly tuple chain must not emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// An inner index constrained to the abstract `number` domain (rather than a
+/// literal union) still resolves to the element value and is accepted.
+#[test]
+fn number_constrained_inner_index_is_accepted() {
+    let diags = check(
+        r#"
+type Table = [[10, 11], [20, 21]];
+type Nested<D1 extends number> = Table[D1][0];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536),
+        "number-constrained inner index must not emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// The outer index is checked against the element-value key-space, which for a
+/// tuple element includes any numeric index (array-like leniency), even one past
+/// the element's own length — matching `tsc`.
+#[test]
+fn outer_numeric_index_past_element_length_is_accepted() {
+    let diags = check(
+        r#"
+type Table = [[10, 11], [20, 21]];
+type Nested<D1 extends 0 | 1> = Table[D1][5];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536),
+        "outer numeric index past element length must not emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Tuple of objects: the outer string key is valid only when present on every
+/// element of the value union (the key-space is the intersection).
+#[test]
+fn tuple_of_objects_common_outer_key_is_accepted() {
+    let diags = check(
+        r#"
+type Table = [{ a: 1 }, { a: 2 }];
+type Nested<D1 extends 0 | 1> = Table[D1]["a"];
+"#,
+    );
+    assert!(
+        !has_code(&diags, 2536),
+        "common outer key on tuple-of-objects must not emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+}
+
+// -------------------------------------------------------------------------
+// Negative controls: genuine TS2536 must still fire (no over-suppression).
+// -------------------------------------------------------------------------
+
+/// An inner index constraint with an out-of-range literal (`0 | 1 | 2` over a
+/// 2-tuple) genuinely escapes the element-index domain — `tsc` emits TS2536.
+#[test]
+fn out_of_range_inner_literal_still_errors() {
+    for param in ["D1", "Sel"] {
+        let src = format!(
+            r#"
+type Table = [[10, 11], [20, 21]];
+type Bad<{param} extends 0 | 1 | 2> = Table[{param}][0];
+"#
+        );
+        let diags = check(&src);
+        assert!(
+            has_code(&diags, 2536),
+            "out-of-range inner literal (param {param}) must still emit TS2536, got: {:?}",
+            codes(&diags)
+        );
+    }
+}
+
+/// An inner constraint of `keyof Base` includes `length`/array-method names, so
+/// `Base[I]` is not guaranteed to be an element value — `tsc` emits TS2536.
+#[test]
+fn keyof_constrained_inner_index_still_errors() {
+    let diags = check(
+        r#"
+type Table = [[10, 11], [20, 21]];
+type Bad<D1 extends keyof Table> = Table[D1][0];
+"#,
+    );
+    assert!(
+        has_code(&diags, 2536),
+        "keyof-constrained inner index must still emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// An outer string key that is genuinely absent from the element-value union
+/// (a tuple of numeric-literal tuples has no string keys) — `tsc` emits TS2536.
+#[test]
+fn absent_outer_string_key_still_errors() {
+    let diags = check(
+        r#"
+type Table = [[10, 11], [20, 21]];
+type Bad<D1 extends 0 | 1> = Table[D1]["nope"];
+"#,
+    );
+    assert!(
+        has_code(&diags, 2536),
+        "absent outer string key must still emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+}
+
+/// Tuple of objects where the outer key is present on only one element: the
+/// element-value key-space is the intersection, so the key is absent — TS2536.
+#[test]
+fn partial_outer_key_on_tuple_of_objects_still_errors() {
+    let diags = check(
+        r#"
+type Table = [{ a: 1 }, { b: 2 }];
+type Bad<D1 extends 0 | 1> = Table[D1]["a"];
+"#,
+    );
+    assert!(
+        has_code(&diags, 2536),
+        "partial outer key on tuple-of-objects must still emit TS2536, got: {:?}",
+        codes(&diags)
+    );
+}

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1378,7 +1378,17 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # only sanctioned exposure of those solver structural queries to the
         # checker, matching the direct-call pattern already used throughout these
         # files. No new quarantine entry.
-        3045,
+        #
+        # Bumped 3045→3051 for the #13655 concrete-tuple generic-index-chain
+        # TS2536 parity fix: the new tuple-chain key-space derivation in
+        # `indexed_access/indexed_access_helpers.rs` adds 6 direct references
+        # (`union_members`, `tuple_elements`, `number_literal_value`,
+        # `type_parameter_constraint`, `is_type_parameter_like`) plus the
+        # current-main live slack the prior 3040→3045 ratchet anticipated. Every
+        # route is an existing request-shaped helper already used throughout the
+        # indexed-access checker — no new quarantine entry. Removal condition
+        # remains #8225 narrowing this quarantine.
+        3051,
     ),
 ]
 


### PR DESCRIPTION
Closes #13655.

Goal: green

A concrete tuple base indexed by a generic type-parameter chain
(`Table[D1][0]`, `AddDigitTable[Carry][T][U]`) emitted a false `TS2536`. This
blocks the `hotscript` grow row, whose type-level arithmetic indexes concrete
lookup tuples (`AddDigitTable`, `SubDigitTable`, `DigitCompareTable`) with
generic params. `tsc` accepts the same code (verified against the pinned
submodule, `tsc` 6.0.3).

## Structural rule

When `Base[I]` has a concrete tuple base `Base` (not a type parameter, not a
mapped type) and a generic index `I extends C` whose constraint `C` lies in the
tuple's numeric element-index domain (the abstract `number` primitive, or
numeric literals `0..len`), `tsc` resolves `Base[I]` to the tuple's
element-value union (`Base[number]`), whose key-space includes the element
indices, so a chained index `Base[I][J]` is valid (`J` is checked against
`keyof(Base[number])`). When `C` escapes that domain (an out-of-range literal,
`keyof Base` — which includes `length`/array-method names — or a string key),
`Base[I]` is no longer guaranteed to be an element value and `tsc` keeps the
genuine `TS2536`.

tsz routed `Base[I][J]` (where `Base[I]` is a deferred indexed-access type)
into the last-resort recovery, which derived the value union as
`Base[keyof Base]`. For a tuple base `keyof Base` includes `"length"`/`"map"`/…,
so the value union mixed in `number`/function values whose intersected key-space
excludes the element index, producing a spurious `TS2536`.

Owner: solver-backed checker indexed-access constraint recovery,
`indexed_access_helpers::generic_tuple_chain_index_access_allows_index`.

## What changed

- `crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs`
  - `generic_tuple_chain_value_type`: recursively resolves the apparent
    value-union of a generic-indexed chain rooted at a concrete tuple
    (handles arbitrary depth: `Base[I]`, `Base[I][J]`, `Base[I][J][K]`),
    validating each intermediate index against the tuple element-index domain
    and resolving the value to `Base[number]` (the element-value union).
  - `index_within_tuple_element_domain` / `tuple_fixed_length`: member-wise
    domain check — each union member of the index constraint must be the
    `number` primitive or a numeric literal `< len` (or any literal with an open
    rest tail). Unions of tuples take the max length / OR of rest, mirroring
    `(A | B)[I]`.
  - `generic_tuple_chain_index_access_allows_index`: validates the outer index
    against `keyof` of the resolved element-value union.
- `crates/tsz-checker/src/types/type_checking/indexed_access.rs`: call the new
  helper in the last-resort recovery, before the `TS2536` emission.
- Tests + Cargo target.

No user-name/file-name literals, no printer-output predicates; all decisions
use solver structural queries (`tuple_elements`, `evaluate_keyof`,
`index_access`, relation outcomes). Performance: O(chain depth x tuple length)
static key checks, bounded by the index-param constraint size; no unbounded
instantiation, only adds a previously-`false` recovery arm.

## Verification

Oracle: `tsc` 6.0.3 (pinned submodule). 24/24 cases match `tsc` exactly
(positive, adjacent, and negative controls). Selected:

| Case | tsc | tsz before | tsz after |
| --- | --- | --- | --- |
| `Table[D1][0]`, `D1 extends 0\|1` | clean | TS2536 | clean |
| `AddDigitTable[Carry][T][U]` (10x10) | clean | TS2536 x2 | clean |
| `T3[A][B][C]` (3-level) | clean | TS2536 x2 | clean |
| `readonly` tuple `Table[D1][0]` | clean | TS2536 | clean |
| `Table[D1][0]`, `D1 extends number` | clean | TS2536 | clean |
| `Table[D1][5]` (outer past element len) | clean | TS2536 | clean |
| `[{a:1},{a:2}][D1]["a"]` | clean | TS2536 | clean |
| `Table[D1][0]`, `D1 extends 0\|1\|2` (out of range) | **TS2536** | TS2536 | **TS2536** |
| `Table[D1][0]`, `D1 extends keyof Table` | **TS2536** | TS2536 | **TS2536** |
| `Table[D1]["nope"]` (absent outer key) | **TS2536** | TS2536 | **TS2536** |
| `[{a:1},{b:2}][D1]["a"]` (partial key) | **TS2536** | TS2536 | **TS2536** |
| `Table[0][K]`, `K extends "foo"\|"bar"` | **TS2536** | TS2536 | **TS2536** |

Commands (no full suite per disk policy; broad conformance owned by ready CI):
- `scripts/safe-run.sh cargo build -p tsz-checker` (clean)
- `cargo nextest run -p tsz-checker --test concrete_tuple_generic_index_chain_ts2536_tests` (10/10 pass)
- Related registered targets (indexed-access / keyof / tuple / mapped): 221 pass
  (`homomorphic_indexed_access*`, `indexed_access_*`, `keyof_*`,
  `tuple_index_access_tests`, `mapped_*tuple*`, `recursive_tuple_mapped_index_tests`,
  `ts2322_indexed_access_type_param_tests`, etc.). Two
  `mapped_keyof_typeof_inferred_value_resolves*` fail on baseline too
  (pre-existing local cross-file lib-resolution env failure, unrelated).
- `cargo nextest run -p tsz-solver -E 'test(tuple) or test(indexed_access) or test(index_access)'` (761 pass)
- `cargo clippy -p tsz-checker` (clean on changed code)

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
