### PR TITLE
fix(solver): don't leak un-substituted free type param on instantiation depth bail (#13652)

### DIFF
--- a/crates/tsz-solver/src/caches/instantiation_cache_test.rs
+++ b/crates/tsz-solver/src/caches/instantiation_cache_test.rs
@@ -507,9 +507,10 @@ fn mode_bits_isolate_preserving_from_default() {
 
 #[test]
 fn depth_exceeded_result_is_not_cached() {
-    // A depth-overflow walk returns TypeId::ERROR, but that recovery value
-    // must not poison the cross-call cache. Repeating the same request should
-    // miss again and recompute instead of hitting a cached ERROR.
+    // A depth-overflow walk returns a relation-preserving partial type (no
+    // longer the `TypeId::ERROR` sentinel; see #13652), but that recovery
+    // value must not poison the cross-call cache. Repeating the same request
+    // should miss again and recompute instead of hitting a cached result.
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);
 
@@ -530,8 +531,9 @@ fn depth_exceeded_result_is_not_cached() {
     let r1 = instantiate_type_cached(&interner, Some(&db), body, &subst);
     let r2 = instantiate_type_cached(&interner, Some(&db), body, &subst);
 
-    assert_eq!(r1, TypeId::ERROR);
-    assert_eq!(r2, TypeId::ERROR);
+    // The bail no longer surfaces the ERROR sentinel.
+    assert_ne!(r1, TypeId::ERROR);
+    assert_eq!(r1, r2);
 
     let stats1 = db.statistics();
     assert_eq!(
@@ -753,10 +755,11 @@ fn instantiate_generic_cached_no_query_db_disables_cache() {
 
 #[test]
 fn instantiate_generic_cached_depth_overflow_not_cached() {
-    // A depth-overflow walk returns TypeId::ERROR but must not poison the
+    // A depth-overflow walk returns a relation-preserving partial type (no
+    // longer the `TypeId::ERROR` sentinel; see #13652) but must not poison the
     // cache: re-requesting the same (body, args) must miss again. Otherwise a
-    // single spurious overflow would lock the alias to ERROR for the lifetime
-    // of the QueryCache.
+    // single spurious overflow would lock the alias to that value for the
+    // lifetime of the QueryCache.
     let interner = TypeInterner::new();
     let db = QueryCache::new(&interner);
 
@@ -774,8 +777,8 @@ fn instantiate_generic_cached_depth_overflow_not_cached() {
     let r1 = instantiate_generic_cached(&interner, Some(&db), body, &[param], &[TypeId::STRING]);
     let r2 = instantiate_generic_cached(&interner, Some(&db), body, &[param], &[TypeId::STRING]);
 
-    assert_eq!(r1, TypeId::ERROR);
-    assert_eq!(r2, TypeId::ERROR);
+    assert_ne!(r1, TypeId::ERROR);
+    assert_eq!(r1, r2);
 
     let stats1 = db.statistics();
     assert_eq!(

--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -107,6 +107,15 @@ impl<'a> TypeInstantiator<'a> {
         self.shadowed.contains(&name)
     }
 
+    /// Pre-trip the sticky depth-exceeded guard so the very next
+    /// `instantiate` call takes the bail path. Test-only helper used to
+    /// exercise `bail_value` deterministically without constructing a type
+    /// deeper than `MAX_INSTANTIATION_DEPTH`.
+    #[cfg(test)]
+    pub(crate) const fn force_depth_exceeded_for_test(&mut self) {
+        self.depth_exceeded = true;
+    }
+
     /// Restore the homomorphic modifier source of a self-indexed mapped type
     /// `{ [Q in P]: T[P] }` when its constraint parameter `P` is substituted by a
     /// single property key.
@@ -435,12 +444,12 @@ impl<'a> TypeInstantiator<'a> {
         }
 
         if self.depth_exceeded {
-            return TypeId::ERROR;
+            return self.bail_value(type_id);
         }
 
         if self.depth >= self.max_depth {
             self.depth_exceeded = true;
-            return TypeId::ERROR;
+            return self.bail_value(type_id);
         }
 
         // Shared cross-operation stack-frame breaker. The per-instance `depth`
@@ -458,8 +467,51 @@ impl<'a> TypeInstantiator<'a> {
         })
         .unwrap_or_else(|| {
             self.depth_exceeded = true;
-            TypeId::ERROR
+            self.bail_value(type_id)
         })
+    }
+
+    /// Relation-preserving value returned when the per-instance substitution
+    /// depth cap or the shared cross-operation stack-frame budget is exhausted.
+    ///
+    /// The historical sentinel was `TypeId::ERROR`. That dropped the active
+    /// substitution: a downstream consumer (e.g. iterator-element resolution on
+    /// a fully-concrete `Map<K, V>`) would then fall back to the *original*,
+    /// un-instantiated element type and surface a bare bound type parameter
+    /// (`T`) into a concrete context, producing false TS2488 / TS2345 (#13652).
+    ///
+    /// tsc returns the type un-instantiated/deferred at its instantiation-depth
+    /// cap; no free inner type parameter that the substitution binds escapes.
+    /// To match that — and to never leak a substitution-domain parameter — the
+    /// bail applies only the *head* substitution:
+    ///
+    /// - A bailing `TypeParameter` whose name is bound by the substitution
+    ///   resolves to its binding (so `T` with `{T: number}` becomes `number`,
+    ///   never a leaked `T`). A bound name resolved through a fresh local scope
+    ///   or constraint fallback is handled the same as the normal walk.
+    /// - A `TypeParameter` not bound by the substitution is genuinely free at
+    ///   this scope; returning it unchanged preserves true positives (an
+    ///   actually-generic iteration still reports the diagnostic).
+    /// - Any other shape is returned opaque (un-walked). This is
+    ///   relation-preserving: the outer wrapper sees the original closed type
+    ///   rather than a half-substituted shape that mixes `ERROR` and stale
+    ///   inner parameters.
+    ///
+    /// O(1) at the bail site; no throughput cost on the success path.
+    fn bail_value(&self, type_id: TypeId) -> TypeId {
+        let Some(TypeData::TypeParameter(info)) = self.interner.lookup(type_id) else {
+            // Non-parameter shapes are returned opaque: the substitution can
+            // only introduce a free parameter by rewriting a `TypeParameter`
+            // node, and we are not walking into the structure here.
+            return type_id;
+        };
+        if let Some(local_type_param) = self.lookup_local_type_param(info.name) {
+            return local_type_param;
+        }
+        if self.is_shadowed(info.name) {
+            return type_id;
+        }
+        self.substitution.get(info.name).unwrap_or(type_id)
     }
 
     fn instantiate_inner(&mut self, type_id: TypeId) -> TypeId {

--- a/crates/tsz-solver/src/instantiation/instantiate/api.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/api.rs
@@ -880,11 +880,10 @@ pub(crate) fn instantiate_type_with_shadowed(
     }
     let mut instantiator = TypeInstantiator::new(interner, substitution);
     instantiator.shadowed.extend_from_slice(shadowed_params);
-    let result = instantiator.instantiate(type_id);
-    if instantiator.depth_exceeded {
-        return TypeId::ERROR;
-    }
-    result
+    // The walk returns a relation-preserving value on a depth/frame bail (it
+    // never surfaces a substitution-bound free type parameter), so keep it
+    // rather than collapsing to `TypeId::ERROR`; see #13652 / `bail_value`.
+    instantiator.instantiate(type_id)
 }
 
 /// Like [`instantiate_type_preserving`] but also replaces every
@@ -911,12 +910,8 @@ pub(crate) fn instantiate_type_preserving_with_declared(
     let mut instantiator = TypeInstantiator::new(interner, substitution);
     instantiator.preserve_unsubstituted_type_params = true;
     instantiator.declared_index_type = Some((source, iter_var, declared_type));
-    let result = instantiator.instantiate(type_id);
-    if instantiator.depth_exceeded {
-        TypeId::ERROR
-    } else {
-        result
-    }
+    // Keep the relation-preserving bail value on overflow (see #13652).
+    instantiator.instantiate(type_id)
 }
 
 /// Cache-aware variant of [`instantiate_type`].
@@ -1100,11 +1095,10 @@ pub fn instantiate_type_with_depth_status(
     }
     let mut instantiator = TypeInstantiator::new(interner, substitution);
     let result = instantiator.instantiate(type_id);
-    if instantiator.depth_exceeded {
-        (TypeId::ERROR, true)
-    } else {
-        (result, false)
-    }
+    // Report the overflow bool for callers that gate on it, but hand back the
+    // relation-preserving bail value (never a substitution-bound free type
+    // parameter) instead of the `TypeId::ERROR` sentinel (#13652).
+    (result, instantiator.depth_exceeded)
 }
 
 /// Convenience function for instantiating a type while preserving meta-type

--- a/crates/tsz-solver/src/instantiation/result.rs
+++ b/crates/tsz-solver/src/instantiation/result.rs
@@ -28,12 +28,29 @@ impl InstantiationResult {
         }
     }
 
-    /// Construct a result that hit the recursion-depth guard. Callers should
-    /// flatten this to [`TypeId::ERROR`] via [`Self::into_type_id`] when they
-    /// need a single `TypeId` to hand to legacy code paths.
+    /// Construct a result that hit the recursion-depth guard with no usable
+    /// partial type. Reserved for callers that have nothing better than the
+    /// `TypeId::ERROR` sentinel to report; prefer [`Self::overflow_with`].
     pub const fn overflow() -> Self {
+        Self::overflow_with(TypeId::ERROR)
+    }
+
+    /// Construct a result that hit the recursion-depth guard but carries a
+    /// relation-preserving partial type from the walk.
+    ///
+    /// The depth/frame guard now bails through
+    /// `TypeInstantiator::bail_value`, which never surfaces a
+    /// substitution-bound type parameter, so the partial `type_id` is a safe
+    /// (deferred/opaque) approximation rather than a leak. We keep it instead
+    /// of collapsing to `TypeId::ERROR` so a downstream consumer (e.g.
+    /// iterator-element resolution on a fully-concrete `Map<K, V>`) does not
+    /// fall back to the original un-instantiated declaration and resurface a
+    /// free `T` into a concrete context (#13652). The `overflowed` flag is
+    /// still set so the cross-call cache refuses to memoize a budget-limited
+    /// result.
+    pub const fn overflow_with(type_id: TypeId) -> Self {
         Self {
-            type_id: TypeId::ERROR,
+            type_id,
             overflowed: true,
         }
     }
@@ -42,7 +59,7 @@ impl InstantiationResult {
     /// raw instantiator walk.
     pub const fn from_walk(type_id: TypeId, depth_exceeded: bool) -> Self {
         if depth_exceeded {
-            Self::overflow()
+            Self::overflow_with(type_id)
         } else {
             Self::ok(type_id)
         }
@@ -56,15 +73,15 @@ impl InstantiationResult {
         self.overflowed
     }
 
-    /// Collapse the result to a single `TypeId`, replacing depth-exceeded
-    /// failures with `TypeId::ERROR`. This is the conversion every legacy
-    /// `_cached` entry performed inline before this refactor.
+    /// Collapse the result to a single `TypeId`.
+    ///
+    /// On overflow this now returns the relation-preserving partial type from
+    /// the walk (see [`Self::overflow_with`]) rather than `TypeId::ERROR`, so
+    /// consumers that lack a depth-aware path still receive a leak-free
+    /// approximation instead of a sentinel that triggers an un-instantiated
+    /// fallback.
     pub const fn into_type_id(self) -> TypeId {
-        if self.overflowed {
-            TypeId::ERROR
-        } else {
-            self.type_id
-        }
+        self.type_id
     }
 }
 
@@ -82,10 +99,22 @@ mod tests {
     }
 
     #[test]
-    fn overflow_result_collapses_to_error() {
+    fn overflow_result_reports_sentinel_when_no_partial() {
         let r = InstantiationResult::overflow();
         assert!(r.depth_exceeded());
+        // `overflow()` (no partial) still surfaces the `ERROR` sentinel.
         assert_eq!(r.into_type_id(), TypeId::ERROR);
+    }
+
+    #[test]
+    fn overflow_with_keeps_partial_type() {
+        // A depth/frame bail carries its relation-preserving partial type
+        // (never a substitution-bound free param) instead of collapsing to
+        // `ERROR`, so consumers do not fall back to an un-instantiated
+        // original and resurface a free `T` (#13652).
+        let r = InstantiationResult::overflow_with(TypeId::STRING);
+        assert!(r.depth_exceeded());
+        assert_eq!(r.into_type_id(), TypeId::STRING);
     }
 
     #[test]
@@ -93,10 +122,11 @@ mod tests {
         let ok = InstantiationResult::from_walk(TypeId::STRING, false);
         assert_eq!(ok.into_type_id(), TypeId::STRING);
 
-        // A depth-exceeded walk discards whatever partial type the
-        // instantiator produced and reports `ERROR`.
+        // A depth-exceeded walk keeps the partial type the instantiator
+        // produced (the relation-preserving bail value) while still flagging
+        // the overflow so the cross-call cache refuses to memoize it.
         let bad = InstantiationResult::from_walk(TypeId::STRING, true);
         assert!(bad.depth_exceeded());
-        assert_eq!(bad.into_type_id(), TypeId::ERROR);
+        assert_eq!(bad.into_type_id(), TypeId::STRING);
     }
 }

--- a/crates/tsz-solver/tests/instantiate_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/instantiate_tests_parts/part_00.rs
@@ -809,7 +809,15 @@ fn test_instantiate_mapped_with_lazy_application_in_as_clause_defers() {
 }
 
 #[test]
-fn test_instantiation_depth_limit_returns_error() {
+fn test_instantiation_depth_limit_bails_without_error_sentinel() {
+    // Regression for #13652: a depth/frame bail must NOT collapse to the
+    // `TypeId::ERROR` sentinel. The sentinel dropped the active substitution
+    // and let a downstream consumer fall back to the original declaration and
+    // resurface a free `T` into a concrete context (false TS2488 / TS2345).
+    //
+    // The bail now returns a relation-preserving partial walk. For a deeply
+    // nested closed shape the worst case is a deferred/opaque approximation,
+    // but it must never be `ERROR`.
     let interner = TypeInterner::new();
     let t_name = interner.intern_string("T");
 
@@ -831,7 +839,60 @@ fn test_instantiation_depth_limit_returns_error() {
     subst.insert(t_name, TypeId::NUMBER);
     let result = instantiate_type(&interner, deep_type, &subst);
 
-    assert_eq!(result, TypeId::ERROR);
+    assert_ne!(
+        result,
+        TypeId::ERROR,
+        "depth bail must not surface the ERROR sentinel"
+    );
+    // The result is still an array shape (relation-preserving), not an error.
+    assert!(
+        matches!(interner.lookup(result), Some(TypeData::Array(_))),
+        "expected a relation-preserving array shape, got {:?}",
+        interner.lookup(result)
+    );
+}
+
+#[test]
+fn test_depth_bail_leaf_type_param_resolves_to_substitution() {
+    // When the bail fires directly on a bound `TypeParameter` node, the bail
+    // value resolves it from the substitution so a substitution-bound `T`
+    // never escapes (the leaf case of the #13652 leak).
+    use crate::instantiation::instantiate::TypeInstantiator;
+
+    let interner = TypeInterner::new();
+    let t_name = interner.intern_string("T");
+    let type_param_t = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: t_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    }));
+
+    let mut subst = TypeSubstitution::new();
+    subst.insert(t_name, TypeId::NUMBER);
+
+    let mut instantiator = TypeInstantiator::new(&interner, &subst);
+    instantiator.force_depth_exceeded_for_test();
+    // With the budget already exhausted, instantiating the bound parameter
+    // must resolve to its binding, not leak a free `T` and not return ERROR.
+    let result = instantiator.instantiate(type_param_t);
+    assert_eq!(result, TypeId::NUMBER);
+    assert_ne!(result, TypeId::ERROR);
+
+    // An unbound parameter is genuinely free at this scope: returning it
+    // unchanged preserves true positives.
+    let u_name = interner.intern_string("U");
+    let type_param_u = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: u_name,
+        constraint: None,
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    }));
+    let mut instantiator2 = TypeInstantiator::new(&interner, &subst);
+    instantiator2.force_depth_exceeded_for_test();
+    assert_eq!(instantiator2.instantiate(type_param_u), type_param_u);
 }
 
 #[test]


### PR DESCRIPTION
Refs #13652.

Hardens the solver instantiation depth/frame bail so it can no longer surface
an un-substituted free type parameter. This is exactly the issue's
"Suggested fix (a)".

> Important scoping note (verified by tracing): this change does NOT close
> jotai's 6 false positives. The issue's stated root cause — that the leaked
> `T` comes from a `TypeInstantiator` depth/frame bail returning
> `TypeId::ERROR` — is empirically false. A `warn`-level trace at every solver
> bail site (instantiate depth + frame, evaluate frame + global-eval-depth +
> per-eval depth, subtype frame) shows **zero** bails fire during the full
> jotai compile, while `[Symbol.iterator]` resolution fires 21 times with
> concrete inputs. Bumping `TSZ_MAX_EVAL_OPS` from 1e5 to 1e7 leaves the count
> at 6, and `internals.ts` alone (no file-order dependence) reproduces all 6.
> The leak is an **order-sensitive evaluation/inference-cache** interaction in
> jotai's mutually-recursive `Atom<Value>` graph (the leaked param surfaces
> into `for (const [a, n] of atomState.d)` member/call expression typing), not
> a budget bail. Tracked findings posted to #13652 for re-scoping.

This PR still lands on its own merit: it removes a real ERROR-leak class and
aligns the bail with its documented contract.

Goal: green

## Structural rule

When `TypeInstantiator` hits its per-instance substitution-depth cap
(`MAX_TYPE_SUBSTITUTION_DEPTH = 50`) or the shared cross-operation stack-frame
budget (`MAX_SOLVER_STACK_FRAMES = 2000`) mid-walk, `tsc` returns the type
un-instantiated/deferred — no free inner type parameter that the substitution
binds escapes. `tsz` returned the `TypeId::ERROR` sentinel through
`crates/tsz-solver/src/instantiation/instantiate.rs`, which dropped the active
substitution and let a downstream consumer fall back to the original
un-instantiated declaration and resurface a bound type parameter into a
concrete context. The fix routes the bail through `bail_value`, which resolves
a bailing `TypeParameter` from the substitution (or its fresh local binding)
and otherwise returns the input opaque, so no substitution-bound parameter can
escape; the partial walk is preserved instead of collapsing to `ERROR`.

Owner layer: solver, instantiation depth/frame guard.

## What changed

- `instantiation/instantiate.rs`: new `bail_value(type_id)` helper. Both the
  per-instance depth cap and the shared frame-breaker bail through it instead
  of returning `TypeId::ERROR`. A bailing bound `TypeParameter` resolves to its
  substitution/local binding; an unbound parameter stays free (true-positive
  preservation); any other shape is returned opaque (relation-preserving).
- `instantiation/result.rs`: `InstantiationResult` keeps the relation-preserving
  partial type on overflow (`overflow_with`); `from_walk` / `into_type_id` no
  longer force `ERROR`. The `overflowed` flag is retained so the cross-call
  cache still refuses to memoize a budget-limited result.
- `instantiation/instantiate/api.rs`: the three inline
  `depth_exceeded -> TypeId::ERROR` sites now return the partial bail value;
  `instantiate_type_with_depth_status` reports the bool but hands back the
  partial type.

## Adjacent cases covered

- Leaf bound `TypeParameter` resolves to its binding (no leak).
- Unbound `TypeParameter` stays free (genuinely-generic iteration still reports
  TS2488/TS2345 — true positive preserved).
- Deeply nested closed shape bails to a relation-preserving array shape, never
  `ERROR`.
- Renamed binders: `bail_value` is keyed on the substitution/local scope, no
  identifier/file-name predicate (anti-hardcoding safe).
- Negative/fallback: a genuinely-unresolvable budget bail degrades to a
  relation-preserving opaque type, never a structural false error and never an
  unsound `any`.
- Cache suppression invariant intact: depth-overflow results are still not
  memoized (cache-wiring tests updated to assert non-ERROR + suppression).

## Verification

- `scripts/safe-run.sh cargo build -p tsz-solver` — clean.
- `scripts/safe-run.sh cargo clippy -p tsz-solver --all-targets` — clean.
- `cargo nextest run -p tsz-solver -E 'test(overflow) + test(from_walk) +
  test(depth_bail) + test(depth_exceeded) + test(depth_overflow) +
  test(instantiation_depth) + test(returns_error) + test(double_spread_over_limit)'`
  — 24 passed (includes the rewritten depth-bail and cache-suppression tests).
- `cargo nextest run -p tsz-solver -E 'test(instantiat) + test(depth) +
  test(overflow) + test(recursion) + test(iterator) + test(stack_frame)'`
  — 328 passed (no regression in the #7574 stack-frame guard family).
- jotai (witness, unchanged by design): 6 FPs before and after — this PR does
  not close them; corrected root cause posted to #13652.
- Full conformance / emit / fourslash: CI ready-review gate.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
