### PR TITLE
fix(solver): keep indexed access deferred over a deferred conditional base (#13654)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -599,6 +599,9 @@ path = "tests/conditional_extends_readonly_variance_tests.rs"
 name = "deferred_conditional_identity_extends_tests"
 path = "tests/deferred_conditional_identity_extends_tests.rs"
 [[test]]
+name = "deferred_conditional_indexed_access_tests"
+path = "tests/deferred_conditional_indexed_access_tests.rs"
+[[test]]
 name = "ts2322_property_decl_annotation_tests"
 path = "tests/ts2322_property_decl_annotation_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/assignability/constrained_type_param_assertion.rs
+++ b/crates/tsz-checker/src/assignability/constrained_type_param_assertion.rs
@@ -61,6 +61,109 @@ impl<'a> CheckerState<'a> {
         saw_required
     }
 
+    /// Assertion overlap when `source` (or `target`) is a *deferred conditional*
+    /// or an indexed access whose object is one. tsc compares against the
+    /// conditional's base constraint — the union of its branch results — so
+    /// resolve that base constraint *with the resolver* (the solver-only
+    /// comparability path cannot expand `keyof`/index access without it) and
+    /// retry the overlap check.
+    ///
+    /// Covers `Box<T>[keyof Box<T>] as string` (tanstack-router `Matches.ts:96`)
+    /// where `Box<T> = T extends string ? { a: T } : { a: string }`: the base
+    /// constraint indexed by `keyof` is `T | string`, a string-domain type that
+    /// overlaps `string`.
+    pub(crate) fn deferred_conditional_assertion_overlaps(
+        &mut self,
+        source: TypeId,
+        target: TypeId,
+    ) -> bool {
+        if let Some(resolved) = self.deferred_conditional_assertion_constraint(source)
+            && resolved != source
+            && self.deferred_conditional_constraint_overlaps(resolved, target)
+        {
+            return true;
+        }
+        if let Some(resolved) = self.deferred_conditional_assertion_constraint(target)
+            && resolved != target
+            && self.deferred_conditional_constraint_overlaps(source, resolved)
+        {
+            return true;
+        }
+        false
+    }
+
+    /// Overlap check against a resolved deferred-conditional base constraint.
+    ///
+    /// When the resolved constraint still contains a free type parameter (e.g.
+    /// `T | string`), tsc treats the assertion permissively — the type parameter
+    /// could instantiate to overlap the other side — so report overlap. This
+    /// mirrors the permissive `generic_indexed_assertion_source` path for an
+    /// indexed access that surfaces only after alias expansion. Otherwise fall
+    /// back to the structural comparability check.
+    fn deferred_conditional_constraint_overlaps(&mut self, source: TypeId, target: TypeId) -> bool {
+        if crate::query_boundaries::common::contains_free_type_parameters(self.ctx.types, source)
+            || crate::query_boundaries::common::contains_free_type_parameters(
+                self.ctx.types,
+                target,
+            )
+        {
+            return true;
+        }
+        crate::query_boundaries::common::types_are_comparable_for_assertion(
+            self.ctx.types,
+            source,
+            target,
+        )
+    }
+
+    /// Resolve a deferred conditional (or `Obj[Key]` over one) to its base
+    /// constraint using the resolver-backed evaluator, so a deferred `keyof`
+    /// index collapses to a concrete key space.
+    fn deferred_conditional_assertion_constraint(&mut self, type_id: TypeId) -> Option<TypeId> {
+        let evaluated = self.evaluate_type_with_resolution(type_id);
+
+        if let Some(constraint) =
+            crate::query_boundaries::common::conditional_branch_union_constraint(
+                self.ctx.types,
+                evaluated,
+            )
+        {
+            return Some(self.evaluate_type_with_resolution(constraint));
+        }
+
+        let (object_type, key_type) =
+            crate::query_boundaries::common::index_access_types(self.ctx.types, evaluated)?;
+        let object_constraint =
+            crate::query_boundaries::common::conditional_branch_union_constraint(
+                self.ctx.types,
+                self.evaluate_type_with_resolution(object_type),
+            )?;
+        // Resolve the index key against the branch-union's key space. A deferred
+        // `keyof Box<T>` index has no concrete keys until the conditional
+        // resolves; over the branch-union it becomes `keyof ({ a: T } | { a: string })`
+        // = `'a'`, so the access yields the value domain `T | string`. A concrete
+        // (already-resolved) key indexes the union directly.
+        let resolved_key = if crate::query_boundaries::common::is_keyof_type(
+            self.ctx.types,
+            self.evaluate_type_with_resolution(key_type),
+        ) {
+            self.ctx.types.evaluate_keyof(object_constraint)
+        } else {
+            key_type
+        };
+        let indexed = self
+            .ctx
+            .types
+            .factory()
+            .index_access(object_constraint, resolved_key);
+        let resolved = self.evaluate_type_with_env(indexed);
+        if resolved != evaluated && resolved != type_id && resolved != TypeId::ERROR {
+            Some(resolved)
+        } else {
+            None
+        }
+    }
+
     fn constrained_type_param_constraint_provides_member(
         &mut self,
         constraint: TypeId,

--- a/crates/tsz-checker/src/dispatch/mod.rs
+++ b/crates/tsz-checker/src/dispatch/mod.rs
@@ -498,6 +498,12 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                                     );
                                 }
                                 if !have_overlap {
+                                    have_overlap =
+                                        self.checker.deferred_conditional_assertion_overlaps(
+                                            expr_type, jsdoc_type,
+                                        );
+                                }
+                                if !have_overlap {
                                     self.checker.error_type_assertion_no_overlap(
                                         expr_type, jsdoc_type, idx,
                                     );
@@ -1142,6 +1148,17 @@ impl<'a, 'b> ExpressionDispatcher<'a, 'b> {
                                             .assertion_source_fits_constrained_type_param(
                                                 expr_type,
                                                 asserted_type,
+                                            );
+                                    }
+                                    // Deferred-conditional base constraint overlap
+                                    // (#13654): `Box<T>[keyof Box<T>] as string`
+                                    // resolves the conditional's branch-union
+                                    // constraint with the resolver and retries.
+                                    if !have_overlap {
+                                        have_overlap =
+                                            self.checker.deferred_conditional_assertion_overlaps(
+                                                expr_type,
+                                                effective_asserted,
                                             );
                                     }
                                     if have_overlap

--- a/crates/tsz-checker/src/query_boundaries/common.rs
+++ b/crates/tsz-checker/src/query_boundaries/common.rs
@@ -953,6 +953,17 @@ pub(crate) fn is_conditional_type(db: &dyn TypeDatabase, type_id: TypeId) -> boo
     tsz_solver::type_queries::is_conditional_type(db, type_id)
 }
 
+/// Base constraint of a deferred conditional, computed as the union of its two
+/// branch results (tsc's `getBaseConstraintOfType` of a conditional). Used to
+/// validate an index-access key / assertion source against a deferred
+/// conditional without forcing the conditional itself.
+pub(crate) fn conditional_branch_union_constraint(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    tsz_solver::type_queries::conditional_branch_union_constraint(db, type_id)
+}
+
 pub(crate) fn is_evaluable_meta_type(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     is_conditional_type(db, type_id)
         || is_index_access_type(db, type_id)

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -356,6 +356,76 @@ impl<'a> CheckerState<'a> {
         false
     }
 
+    /// When the indexed-access object base is a *deferred* conditional, validate
+    /// the index key against the conditional's base constraint — the union of
+    /// its two branch results (tsc's `getBaseConstraintOfType` of a conditional).
+    ///
+    /// tsc keeps `C<T>['x']` deferred (so a concrete `C<string>['x']` still
+    /// resolves to the selected branch), but validates `'x'` against
+    /// `keyof ({ x: 1; y: 2 } | { x: 3; y: 4 })` = `'x' | 'y'`. The key is valid
+    /// iff it lies in *every* branch's key space (the union's keyof is the
+    /// intersection of member keys), so `C<T>['z']` and a key present in only
+    /// one branch still correctly produce `TS2536`.
+    ///
+    /// A generic `Application` whose body is a conditional (e.g. `C<T>`) is
+    /// expanded to that conditional first. Returns `true` when the key validates
+    /// and `TS2536` should be suppressed.
+    fn deferred_conditional_index_key_is_valid(
+        &mut self,
+        object_type: TypeId,
+        object_type_for_check: TypeId,
+        index_type_for_check: TypeId,
+    ) -> bool {
+        let resolve_conditional = |this: &mut Self, ty: TypeId| -> Option<TypeId> {
+            if crate::query_boundaries::common::is_conditional_type(this.ctx.types, ty) {
+                return Some(ty);
+            }
+            if crate::query_boundaries::common::is_generic_application(this.ctx.types, ty) {
+                let expanded = this.evaluate_application_type(ty);
+                if crate::query_boundaries::common::is_conditional_type(this.ctx.types, expanded) {
+                    return Some(expanded);
+                }
+            }
+            None
+        };
+
+        let Some(conditional) = resolve_conditional(self, object_type_for_check)
+            .or_else(|| resolve_conditional(self, object_type))
+        else {
+            return false;
+        };
+
+        let Some(base_constraint) =
+            crate::query_boundaries::common::conditional_branch_union_constraint(
+                self.ctx.types,
+                conditional,
+            )
+        else {
+            return false;
+        };
+        // Only trust the branch union when its *key space* resolved concretely:
+        // a base constraint that is still a conditional / indexed access has no
+        // computable key set. Generic *value* types are fine — an object whose
+        // values are `infer` variables (e.g. `{ yield: Y; return: R }`) still has
+        // a concrete key set `'yield' | 'return'`, so the key validates.
+        if crate::query_boundaries::common::is_conditional_type(self.ctx.types, base_constraint)
+            || crate::query_boundaries::common::is_index_access_type(
+                self.ctx.types,
+                base_constraint,
+            )
+        {
+            return false;
+        }
+        let keyof_constraint = self.ctx.types.evaluate_keyof(base_constraint);
+        // The key space itself must be concrete (not a deferred `keyof T`) for a
+        // concrete-literal index validation to be meaningful.
+        if crate::query_boundaries::common::is_keyof_type(self.ctx.types, keyof_constraint) {
+            return false;
+        }
+        self.indexed_access_key_space_relation_outcome(index_type_for_check, keyof_constraint)
+            .related
+    }
+
     /// Collect all `INFER_TYPE` node indices in a subtree, using parent-tracking.
     /// Walks all nodes whose parent chain leads back to `root_idx`.
     fn collect_infer_nodes_in_subtree(&self, root_idx: NodeIndex) -> Vec<NodeIndex> {
@@ -1373,6 +1443,23 @@ impl<'a> CheckerState<'a> {
                     && !index_is_concrete_literal)
                 || crate::query_boundaries::common::is_index_access_type(self.ctx.types, index_type_for_check)
                 || crate::query_boundaries::common::is_index_access_type(self.ctx.types, index_type))
+            {
+                return;
+            }
+            // The gate above intentionally lets a concrete-literal (or
+            // literal-union) index defeat suppression for a deferred object
+            // (`!index_is_concrete_literal`). For a deferred *conditional* base
+            // that is wrong: tsc validates the literal key against the
+            // conditional's base constraint (the union of both branch results).
+            // Validate against that branch-union constraint here so a key that
+            // lies in every branch is accepted while a missing key still emits
+            // TS2536.
+            if !foreign_keyof_indexed_constraint
+                && self.deferred_conditional_index_key_is_valid(
+                    object_type,
+                    object_type_for_check,
+                    index_type_for_check,
+                )
             {
                 return;
             }

--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -5,6 +5,7 @@ use tsz_scanner::SyntaxKind;
 use tsz_solver::TypeId;
 
 mod indexed_access_helpers;
+mod infer_node_walk;
 mod mapped_key_check;
 mod object_format;
 
@@ -424,102 +425,6 @@ impl<'a> CheckerState<'a> {
         }
         self.indexed_access_key_space_relation_outcome(index_type_for_check, keyof_constraint)
             .related
-    }
-
-    /// Collect all `INFER_TYPE` node indices in a subtree, using parent-tracking.
-    /// Walks all nodes whose parent chain leads back to `root_idx`.
-    fn collect_infer_nodes_in_subtree(&self, root_idx: NodeIndex) -> Vec<NodeIndex> {
-        let mut result = Vec::new();
-        let mut stack = vec![root_idx];
-        while let Some(idx) = stack.pop() {
-            if idx == NodeIndex::NONE {
-                continue;
-            }
-            let Some(node) = self.ctx.arena.get(idx) else {
-                continue;
-            };
-            if node.kind == syntax_kind_ext::INFER_TYPE {
-                result.push(idx);
-                // Nested `infer Y` inside the constraint is in the same scope.
-                if let Some(infer_data) = self.ctx.arena.get_infer_type(node) {
-                    stack.push(infer_data.type_parameter);
-                }
-                continue;
-            }
-            // Push children based on node type
-            self.push_type_node_children(idx, node, &mut stack);
-        }
-        result
-    }
-
-    /// Push child indices of a type node onto the stack for traversal.
-    fn push_type_node_children(
-        &self,
-        _idx: NodeIndex,
-        node: &tsz_parser::parser::node::Node,
-        stack: &mut Vec<NodeIndex>,
-    ) {
-        // Tuple type: push elements
-        if let Some(tuple) = self.ctx.arena.get_tuple_type(node) {
-            stack.extend(tuple.elements.nodes.iter().copied());
-            return;
-        }
-        // Array type
-        if let Some(arr) = self.ctx.arena.get_array_type(node) {
-            stack.push(arr.element_type);
-            return;
-        }
-        // Union/intersection type (both use CompositeTypeData)
-        if let Some(composite) = self.ctx.arena.get_composite_type(node) {
-            stack.extend(composite.types.nodes.iter().copied());
-            return;
-        }
-        // Type reference with type arguments
-        if let Some(type_ref) = self.ctx.arena.get_type_ref(node) {
-            if let Some(ref args) = type_ref.type_arguments {
-                stack.extend(args.nodes.iter().copied());
-            }
-            return;
-        }
-        // Wrapped types: rest, optional, parenthesized (all share WrappedTypeData)
-        if let Some(wrapped) = self.ctx.arena.get_wrapped_type(node) {
-            stack.push(wrapped.type_node);
-            return;
-        }
-        // Conditional type
-        if let Some(cond) = self.ctx.arena.get_conditional_type(node) {
-            stack.push(cond.check_type);
-            stack.push(cond.extends_type);
-            stack.push(cond.true_type);
-            stack.push(cond.false_type);
-            return;
-        }
-        // Indexed access type
-        if let Some(iat) = self.ctx.arena.get_indexed_access_type(node) {
-            stack.push(iat.object_type);
-            stack.push(iat.index_type);
-            return;
-        }
-        // Type operator (keyof, readonly, unique)
-        if let Some(type_op) = self.ctx.arena.get_type_operator(node) {
-            stack.push(type_op.type_node);
-            return;
-        }
-        if let Some(tp) = self.ctx.arena.get_type_parameter(node) {
-            stack.extend_from_slice(&[tp.constraint, tp.default]);
-        }
-    }
-
-    /// Check if `node_a` is a descendant of `node_b` in the AST.
-    fn is_descendant_of(&self, node_a: NodeIndex, node_b: NodeIndex) -> bool {
-        let mut current = Some(node_a);
-        while let Some(idx) = current {
-            if idx == node_b {
-                return true;
-            }
-            current = self.ctx.arena.parent_of(idx);
-        }
-        false
     }
 
     /// Check if the index type parameter has a `keyof` constraint targeting the object type,

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/infer_node_walk.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/infer_node_walk.rs
@@ -1,0 +1,108 @@
+//! AST-walk helpers for locating `infer` type nodes and testing AST descendancy
+//! while validating indexed-access types.
+//!
+//! Extracted from `indexed_access.rs` to keep that file under the 2000-line
+//! checker-boundary limit enforced by `scripts/arch/arch_guard.py`. Pure code
+//! motion: these are arena-only traversals with no type semantics.
+
+use crate::state::CheckerState;
+use tsz_parser::parser::NodeIndex;
+use tsz_parser::parser::syntax_kind_ext;
+
+impl<'a> CheckerState<'a> {
+    /// Collect all `INFER_TYPE` node indices in a subtree, using parent-tracking.
+    /// Walks all nodes whose parent chain leads back to `root_idx`.
+    pub(super) fn collect_infer_nodes_in_subtree(&self, root_idx: NodeIndex) -> Vec<NodeIndex> {
+        let mut result = Vec::new();
+        let mut stack = vec![root_idx];
+        while let Some(idx) = stack.pop() {
+            if idx == NodeIndex::NONE {
+                continue;
+            }
+            let Some(node) = self.ctx.arena.get(idx) else {
+                continue;
+            };
+            if node.kind == syntax_kind_ext::INFER_TYPE {
+                result.push(idx);
+                // Nested `infer Y` inside the constraint is in the same scope.
+                if let Some(infer_data) = self.ctx.arena.get_infer_type(node) {
+                    stack.push(infer_data.type_parameter);
+                }
+                continue;
+            }
+            // Push children based on node type
+            self.push_type_node_children(idx, node, &mut stack);
+        }
+        result
+    }
+
+    /// Push child indices of a type node onto the stack for traversal.
+    pub(super) fn push_type_node_children(
+        &self,
+        _idx: NodeIndex,
+        node: &tsz_parser::parser::node::Node,
+        stack: &mut Vec<NodeIndex>,
+    ) {
+        // Tuple type: push elements
+        if let Some(tuple) = self.ctx.arena.get_tuple_type(node) {
+            stack.extend(tuple.elements.nodes.iter().copied());
+            return;
+        }
+        // Array type
+        if let Some(arr) = self.ctx.arena.get_array_type(node) {
+            stack.push(arr.element_type);
+            return;
+        }
+        // Union/intersection type (both use CompositeTypeData)
+        if let Some(composite) = self.ctx.arena.get_composite_type(node) {
+            stack.extend(composite.types.nodes.iter().copied());
+            return;
+        }
+        // Type reference with type arguments
+        if let Some(type_ref) = self.ctx.arena.get_type_ref(node) {
+            if let Some(ref args) = type_ref.type_arguments {
+                stack.extend(args.nodes.iter().copied());
+            }
+            return;
+        }
+        // Wrapped types: rest, optional, parenthesized (all share WrappedTypeData)
+        if let Some(wrapped) = self.ctx.arena.get_wrapped_type(node) {
+            stack.push(wrapped.type_node);
+            return;
+        }
+        // Conditional type
+        if let Some(cond) = self.ctx.arena.get_conditional_type(node) {
+            stack.push(cond.check_type);
+            stack.push(cond.extends_type);
+            stack.push(cond.true_type);
+            stack.push(cond.false_type);
+            return;
+        }
+        // Indexed access type
+        if let Some(iat) = self.ctx.arena.get_indexed_access_type(node) {
+            stack.push(iat.object_type);
+            stack.push(iat.index_type);
+            return;
+        }
+        // Type operator (keyof, readonly, unique)
+        if let Some(type_op) = self.ctx.arena.get_type_operator(node) {
+            stack.push(type_op.type_node);
+            return;
+        }
+        if let Some(tp) = self.ctx.arena.get_type_parameter(node) {
+            stack.extend_from_slice(&[tp.constraint, tp.default]);
+        }
+    }
+
+    /// Check if `node_a` is a descendant of `node_b` in the AST.
+    pub(super) fn is_descendant_of(&self, node_a: NodeIndex, node_b: NodeIndex) -> bool {
+        let mut current = Some(node_a);
+        while let Some(idx) = current {
+            if idx == node_b {
+                return true;
+            }
+            current = self.ctx.arena.parent_of(idx);
+        }
+        false
+    }
+}

--- a/crates/tsz-checker/tests/deferred_conditional_indexed_access_tests.rs
+++ b/crates/tsz-checker/tests/deferred_conditional_indexed_access_tests.rs
@@ -1,0 +1,147 @@
+//! Regression coverage for #13654: indexed access / assertion comparability on a
+//! deferred conditional base.
+//!
+//! Structural rule: when the base of an indexed access (or the source of an `as`
+//! / comparability check) is a *deferred conditional* (or a generic application
+//! whose body is a conditional with an unresolved check type), `tsc` validates
+//! the index key / assertion against `getBaseConstraintOfType` — the union of
+//! both branch result constraints. The conditional stays deferred so a later
+//! concrete instantiation still resolves to the selected branch; only the
+//! key/overlap *validation* uses the branch union.
+//!
+//! Before the fix, the checker let a concrete-literal (or literal-union) index
+//! key defeat the deferred-object `TS2536` suppression, and the solver had no
+//! branch-union base constraint for a deferred conditional, so:
+//! - `C<T>['x']` emitted a false `TS2536`,
+//! - `Box<T>[keyof Box<T>] as string` emitted a false `TS2352`.
+//!
+//! Verified against `tsc` 6.0.3 (all positive cases exit 0; the missing-key and
+//! key-in-only-one-branch cases still report `TS2536`).
+
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::{check_source, diagnostic_codes};
+
+fn codes(source: &str) -> Vec<u32> {
+    let options = CheckerOptions {
+        strict: true,
+        ..CheckerOptions::default()
+    };
+    diagnostic_codes(&check_source(source, "test.ts", options))
+}
+
+fn count(source: &str, code: u32) -> usize {
+    codes(source).into_iter().filter(|&c| c == code).count()
+}
+
+// ── Indexed access into a deferred conditional ──
+
+#[test]
+fn concrete_literal_index_into_deferred_conditional_is_valid() {
+    // 'x' is a key of both branch results, so it is a key of the branch-union
+    // base constraint `{ x: 1; y: 2 } | { x: 3; y: 4 }`.
+    let src = "type C<T> = T extends string ? { x: 1; y: 2 } : { x: 3; y: 4 };\n\
+               type X<T> = C<T>['x'];";
+    assert_eq!(count(src, 2536), 0, "no TS2536 expected: {:?}", codes(src));
+}
+
+#[test]
+fn literal_union_index_into_deferred_conditional_is_valid() {
+    let src = "type C<T> = T extends string ? { x: 1; y: 2 } : { x: 3; y: 4 };\n\
+               type X<T> = C<T>['x' | 'y'];";
+    assert_eq!(count(src, 2536), 0, "no TS2536 expected: {:?}", codes(src));
+}
+
+#[test]
+fn renamed_binders_index_into_deferred_conditional_is_valid() {
+    // Binder names vary; the structural rule must not depend on identifiers.
+    let src = "type Cond<Foo> = Foo extends number ? { p: 'a' } : { p: 'b' };\n\
+               type Pick1<Bar> = Cond<Bar>['p'];";
+    assert_eq!(count(src, 2536), 0, "no TS2536 expected: {:?}", codes(src));
+}
+
+#[test]
+fn non_distributive_conditional_index_is_valid() {
+    // `[T] extends [string]` is non-distributive; the branch-union rule still
+    // applies.
+    let src = "type C<T> = [T] extends [string] ? { x: 1 } : { x: 3 };\n\
+               type X<T> = C<T>['x'];";
+    assert_eq!(count(src, 2536), 0, "no TS2536 expected: {:?}", codes(src));
+}
+
+#[test]
+fn never_false_branch_infer_value_index_is_valid() {
+    // trpc `inferAsyncIterable` shape: false branch is `never`, true branch has
+    // `infer` value types. The key set is still concrete.
+    let src = "interface AIter<Y, R = any, N = any> { __y: Y; __r: R; __n: N }\n\
+               type Infer<T> = T extends AIter<infer Y, infer R, infer N> ? { yield: Y; return: R; next: N } : never;\n\
+               type Yld<T> = Infer<T>['yield'];\n\
+               type Ret<T> = Infer<T>['return'];\n\
+               type Nxt<T> = Infer<T>['next'];";
+    assert_eq!(count(src, 2536), 0, "no TS2536 expected: {:?}", codes(src));
+}
+
+#[test]
+fn recursive_conditional_index_is_valid() {
+    // tanstack-router `ParsePathParams` shape: recursive template-literal split
+    // chained through nested conditional false branches. The branch-union must
+    // flatten nested conditionals (bounded by the fuel guard) so `'param'`
+    // validates.
+    let src = "type ParsePathParams<T extends string> =\n\
+               T extends `${string}/$${infer Param}/${infer Rest}`\n\
+               ? { param: Param; rest: ParsePathParams<Rest> }\n\
+               : T extends `${string}/$${infer Param}`\n\
+               ? { param: Param; rest: never }\n\
+               : { param: never; rest: never };\n\
+               type FirstParam<T extends string> = ParsePathParams<T>['param'];";
+    assert_eq!(count(src, 2536), 0, "no TS2536 expected: {:?}", codes(src));
+}
+
+#[test]
+fn keyof_index_into_deferred_conditional_still_passes() {
+    // Control: `keyof C<T>` and `C<T>[keyof C<T>]` already exit 0; the fix must
+    // not regress this path.
+    let src = "type C<T> = T extends string ? { x: 1; y: 2 } : { x: 3; y: 4 };\n\
+               type K<T> = keyof C<T>;\n\
+               type ByKeyof<T> = C<T>[keyof C<T>];";
+    assert_eq!(count(src, 2536), 0, "no TS2536 expected: {:?}", codes(src));
+}
+
+// ── Negative cases: the key must still be rejected when missing ──
+
+#[test]
+fn missing_key_into_deferred_conditional_still_reports_ts2536() {
+    // 'z' is a key of neither branch result.
+    let src = "type C<T> = T extends string ? { x: 1; y: 2 } : { x: 3; y: 4 };\n\
+               type Bad<T> = C<T>['z'];";
+    assert_eq!(count(src, 2536), 1, "TS2536 expected: {:?}", codes(src));
+}
+
+#[test]
+fn key_in_only_one_branch_still_reports_ts2536() {
+    // 'y' is in the true branch only; the union's key space (intersection of
+    // member keys) excludes it, matching tsc.
+    let src = "type C<T> = T extends string ? { x: 1; y: 2 } : { x: 3 };\n\
+               type Partial1<T> = C<T>['y'];";
+    assert_eq!(count(src, 2536), 1, "TS2536 expected: {:?}", codes(src));
+}
+
+// ── Assertion / comparability over a deferred conditional ──
+
+#[test]
+fn assertion_of_deferred_conditional_indexed_result_is_valid() {
+    // tanstack-router `Matches.ts:96` shape: the indexed-access result of a
+    // deferred conditional is string-domain, so `as string` overlaps.
+    let src = "type Box<T> = T extends string ? { a: T } : { a: string };\n\
+               type Member<T> = Box<T>[keyof Box<T>];\n\
+               export const h = <T,>(v: Member<T>) => (v as string);";
+    assert_eq!(count(src, 2352), 0, "no TS2352 expected: {:?}", codes(src));
+}
+
+#[test]
+fn assertion_into_deferred_conditional_is_valid() {
+    // Casting-into sibling: the source object overlaps the deferred conditional's
+    // branch-union base constraint.
+    let src = "type Box<T> = T extends string ? { a: T } : { a: string };\n\
+               export const g = <T,>(b: Box<T>) => (b as { a: string });";
+    assert_eq!(count(src, 2352), 0, "no TS2352 expected: {:?}", codes(src));
+}

--- a/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
+++ b/crates/tsz-solver/src/type_queries/data/signatures_and_advanced.rs
@@ -145,6 +145,77 @@ pub fn get_base_constraint_of_type(db: &dyn TypeDatabase, type_id: TypeId) -> Ty
     }
 }
 
+/// Base constraint of a deferred conditional type, computed as the union of its
+/// two branch results (`getBaseConstraintOfType` of a conditional in tsc, which
+/// is `getUnionType([trueType, falseType])`).
+///
+/// This is the apparent type used to validate an index-access key or an
+/// assertion source against a *deferred* conditional whose check type still
+/// contains unresolved type parameters — e.g. `C<T>['x']` where
+/// `C<T> = T extends string ? { x: 1 } : { x: 3 }` validates `'x'` against
+/// `keyof ({ x: 1 } | { x: 3 })`. The conditional itself stays deferred so a
+/// later concrete instantiation still resolves to the selected branch; only the
+/// key/overlap *validation* uses this union.
+///
+/// A branch that is itself a *deferred conditional* (e.g. a recursive
+/// `ParsePathParams<Rest>` chained through `extends` clauses) is flattened into
+/// its own branch results, bounded by a small depth/fuel guard so a recursive
+/// conditional alias cannot re-enter unboundedly. Only the key/value *domain*
+/// is collected this way — branches are not distributed into instantiations.
+///
+/// Returns `None` when the type is not a `Conditional`, or when a branch is a
+/// bare type parameter / `infer` placeholder (tsc keeps those branches'
+/// constraints opaque, so a union-of-branches check would be unreliable — mirror
+/// the property-access deferral in `operations::property`).
+pub fn conditional_branch_union_constraint(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    fn collect(
+        db: &dyn TypeDatabase,
+        type_id: TypeId,
+        out: &mut Vec<TypeId>,
+        depth: u8,
+    ) -> Option<()> {
+        let cond = get_conditional_type(db, type_id)?;
+        let is_bare_param = |t: TypeId| {
+            matches!(
+                db.lookup(t),
+                Some(TypeData::TypeParameter(_) | TypeData::Infer(_))
+            )
+        };
+        if is_bare_param(cond.true_type) || is_bare_param(cond.false_type) {
+            return None;
+        }
+        for branch in [cond.true_type, cond.false_type] {
+            // Descend into a nested conditional branch (recursive utility types),
+            // bounded by the depth/fuel guard. Self-referential branches that
+            // re-intern to the outer conditional contribute nothing new.
+            if depth < 8
+                && branch != type_id
+                && get_conditional_type(db, branch).is_some()
+                && collect(db, branch, out, depth + 1).is_some()
+            {
+                continue;
+            }
+            out.push(branch);
+        }
+        Some(())
+    }
+
+    let mut branches = Vec::new();
+    collect(db, type_id, &mut branches, 0)?;
+    if branches.is_empty() {
+        return None;
+    }
+    let union = db.union(branches);
+    // No progress (e.g. one branch is the conditional itself) — keep deferred.
+    if union == type_id {
+        return None;
+    }
+    Some(union)
+}
+
 /// Resolve a type to its base constraint for display purposes, recursively reducing
 /// type parameters inside unions and intersections.
 ///

--- a/crates/tsz-solver/src/type_queries/flow/comparability.rs
+++ b/crates/tsz-solver/src/type_queries/flow/comparability.rs
@@ -242,9 +242,90 @@ pub(in crate::type_queries) fn types_are_comparable_for_assertion_inner(
         return true;
     }
 
+    // A deferred conditional (or an indexed access whose object base is a
+    // deferred conditional) has no extractable properties, so it would fall
+    // through to the property-overlap check and report a false TS2352. tsc
+    // compares against `getBaseConstraintOfType` — the union of both branch
+    // results — so resolve that base constraint and retry the overlap check.
+    // This covers `Box<T>[keyof Box<T>] as string` (tanstack-router
+    // `Matches.ts`) and the casting-into sibling.
+    if let Some(source_constraint) = deferred_conditional_assertion_constraint(db, source)
+        && source_constraint != source
+        && types_are_comparable_for_assertion_inner(
+            db,
+            source_constraint,
+            target,
+            depth + 1,
+            nested,
+        )
+    {
+        return true;
+    }
+    if let Some(target_constraint) = deferred_conditional_assertion_constraint(db, target)
+        && target_constraint != target
+        && types_are_comparable_for_assertion_inner(
+            db,
+            source,
+            target_constraint,
+            depth + 1,
+            nested,
+        )
+    {
+        return true;
+    }
+
     // For type assertions, only check that overlapping properties are comparable.
     // Do NOT require all target properties to exist in the source.
     super::super::assertion_overlap::types_have_common_properties_relaxed(db, source, target, depth)
+}
+
+/// Base constraint of a deferred conditional (or an indexed access whose object
+/// is a deferred conditional), for assertion comparability.
+///
+/// For a `Conditional`, this is the union of its branch results (tsc's
+/// `getBaseConstraintOfType`). For `Obj[Key]` where `Obj` is a deferred
+/// conditional, it is `branchUnion[Key]` evaluated — e.g.
+/// `Box<T>[keyof Box<T>]` with `Box<T> = T extends string ? { a: T } : { a: string }`
+/// resolves to `({ a: T } | { a: string })[keyof …]` = `T | string`, a
+/// string-domain type comparable to `string`. Returns `None` when no deferred
+/// conditional base is involved (so non-conditional types skip the work).
+fn deferred_conditional_assertion_constraint(
+    db: &dyn TypeDatabase,
+    type_id: TypeId,
+) -> Option<TypeId> {
+    use crate::evaluation::evaluate::{evaluate_index_access, evaluate_type};
+    use crate::type_queries::conditional_branch_union_constraint;
+
+    // Resolve the conditional base constraint of `ty`, evaluating it first so an
+    // alias `Application` (e.g. `Box<T>`) collapses to its `Conditional` body.
+    let conditional_constraint = |db: &dyn TypeDatabase, ty: TypeId| -> Option<TypeId> {
+        conditional_branch_union_constraint(db, ty)
+            .or_else(|| conditional_branch_union_constraint(db, evaluate_type(db, ty)))
+    };
+
+    if let Some(constraint) = conditional_constraint(db, type_id) {
+        return Some(evaluate_type(db, constraint));
+    }
+    // `Obj[Key]` where `Obj` is a deferred conditional: substitute the object's
+    // branch-union base constraint and re-evaluate the indexed access. Evaluate
+    // `type_id` first so an alias application surfaces the underlying indexed
+    // access (`Member<T>` -> `Box<T>[keyof Box<T>]`).
+    let evaluated = evaluate_type(db, type_id);
+    let ia = match db.lookup(evaluated) {
+        Some(TypeData::IndexAccess(o, k)) => Some((o, k)),
+        _ => match db.lookup(type_id) {
+            Some(TypeData::IndexAccess(o, k)) => Some((o, k)),
+            _ => None,
+        },
+    };
+    if let Some((object_type, key_type)) = ia {
+        let object_constraint = conditional_constraint(db, object_type)?;
+        let resolved = evaluate_index_access(db, object_constraint, key_type);
+        if resolved != evaluated && resolved != type_id && resolved != TypeId::ERROR {
+            return Some(resolved);
+        }
+    }
+    None
 }
 
 fn type_param_primitive_comparable_with_constraint(

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1378,7 +1378,18 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # only sanctioned exposure of those solver structural queries to the
         # checker, matching the direct-call pattern already used throughout these
         # files. No new quarantine entry.
-        3045,
+        #
+        # Bumped 3045->3057 for the deferred-conditional indexed-access parity
+        # fix (#13654): keeping `O[K]` deferred over a deferred conditional base
+        # adds request-shaped `query_boundaries::common` reads in
+        # `indexed_access.rs`, `constrained_type_param_assertion.rs`,
+        # `signatures_and_advanced.rs`, and `comparability.rs`
+        # (`contains_free_type_parameters`, `types_are_comparable_for_assertion`,
+        # `conditional_branch_union_constraint`, `index_access_types`,
+        # `is_keyof_type`, `is_conditional_type`, `is_generic_application`,
+        # `is_index_access_type`). All are existing request-shaped boundary
+        # helpers already used throughout the checker — no new quarantine entry.
+        3057,
     ),
 ]
 


### PR DESCRIPTION
Closes #13654.

Goal: green

## Structural rule

When the base of an indexed access — or the source of a comparability (`as`)
check — is a **deferred conditional** (or a generic application whose body is a
conditional with an unresolved check type), `tsc` validates the index key /
assertion against `getBaseConstraintOfType` = the **union of both branch result
constraints**, while keeping the conditional itself deferred so a later concrete
instantiation still resolves to the selected branch. tsz had no branch-union
base constraint for a deferred conditional and let a concrete-literal /
literal-union index key defeat the deferred-object `TS2536` suppression, so:

- `C<T>['x']` (with `C<T> = T extends string ? { x: 1; y: 2 } : { x: 3; y: 4 }`)
  emitted a false `TS2536`, and
- `Box<T>[keyof Box<T>] as string` emitted a false `TS2352`.

The key is valid iff it lies in the key space of the branch union — for a union
that is the **intersection of member keys** — so a missing key (`C<T>['z']`) or a
key present in only one branch (`{x:1;y:2} | {x:3}` indexed by `'y'`) still
correctly reports `TS2536`, matching `tsc`. Instantiation is unchanged:
`C<string>['x']` still resolves to the true-branch value (the conditional is not
collapsed to the branch union).

## What changed

- **solver `type_queries` (`signatures_and_advanced.rs`)** — new
  `conditional_branch_union_constraint`: the union of a conditional's branch
  results (tsc's `getBaseConstraintOfType` of a conditional). Nested conditional
  branches (recursive utility types like `ParsePathParams`) are flattened under a
  small depth/fuel guard; branches that are a bare type parameter / `infer`
  placeholder keep the access deferred (mirrors the property-access deferral in
  `operations::property`).
- **checker indexed-access gate (`types/type_checking/indexed_access.rs`)** —
  `deferred_conditional_index_key_is_valid`: for a deferred conditional /
  generic-application object base, validate the literal (or literal-union) index
  against `keyof(branch-union)` via the existing key-space relation, so the
  concrete-literal key no longer defeats suppression when it is in every branch.
- **comparability (`type_queries/flow/comparability.rs`)** — a
  `Conditional` / `IndexAccess`-over-conditional arm resolves the source's (or
  target's) branch-union base constraint before the property-overlap fallback.
- **checker assertion path (`assignability/constrained_type_param_assertion.rs`,
  `dispatch/mod.rs`)** — `deferred_conditional_assertion_overlaps` resolves
  `Obj[Key]` over a deferred conditional **with the resolver** (the solver-only
  path cannot expand `keyof`/index access), so `Box<T>[keyof Box<T>]` collapses
  to its string-domain value (`T | string`) for the overlap check.

No user-name / file-name / printer-output predicates; all decisions are
structural via solver / query-boundary helpers.

## Verification

Repros (all match `tsc` 6.0.3; `--noEmit --strict --target es2022 --lib es2022,dom`):

| case | before | after / tsc |
| --- | --- | --- |
| `C<T>['x']` | false TS2536 | exit 0 |
| `C<T>['x' \| 'y']` | false TS2536 | exit 0 |
| `Infer<T>['yield']` (trpc never-branch) | false TS2536 | exit 0 |
| `Box<T>[keyof Box<T>] as string` (tanstack `Matches.ts:96`) | false TS2352 | exit 0 |
| `ParsePathParams<T>['param']` (tanstack recursive) | false TS2536 | exit 0 |
| `C<T>['z']` (missing key) | TS2536 | TS2536 (kept) |
| `C<T>['y']`, false branch `{x:3}` | TS2536 | TS2536 (kept) |
| `C<T>[keyof C<T>]`, `keyof C<T>` (control) | exit 0 | exit 0 (no regress) |
| `C<string>['x'] = 3` (instantiation) | TS2322 | TS2322 (branch resolved) |

- New checker test: `crates/tsz-checker/tests/deferred_conditional_indexed_access_tests.rs` (11 tests, all pass) — covers concrete-literal, literal-union, renamed binders, non-distributive, never-branch infer, recursive conditional, keyof control, missing/single-branch negatives, and both assertion directions.
- `cargo nextest run -p tsz-solver -E 'test(/conditional/) or test(/index_access/) or test(/comparab/) or test(/assertion/) or test(/keyof/)'` — 874 passed.
- Checker integration tests (keyof / conditional / assertion / deferred families) — 74 passed.
- `scripts/conformance/conformance.sh run --filter` for `conditional` (51/51), `indexedAccess` (13/13), `keyof` (14/14), `Assertion` (70/70), `mappedType` (55/55) — 0 regressions.
- `cargo clippy -p tsz-solver -p tsz-checker --tests` — clean.
- Corpus smoke (CI gate): `TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_FILTER='^(trpc|tanstack-router)-project$' bash scripts/ci/project-compile-guard.sh`.

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
