### PR TITLE
fix(solver): accept ApplyDefaultOptions/RequiredKeysOf key-space constraints (#13609)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -316,21 +316,57 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 // expanded arg and share the `application_eval_cache` entry,
                 // preventing alias fan-out from triggering repeated evaluations
                 // of the same logical type (#10826).
-                let mut current_def = def_id;
-                for _ in 0..MAX_LAZY_CHAIN_DEPTH {
-                    let Some(body) = self.resolver.resolve_lazy(current_def, self.interner) else {
-                        return arg;
-                    };
-                    match self.interner.lookup(body) {
-                        Some(TypeData::Lazy(next_def)) => current_def = next_def,
-                        _ => return body,
-                    }
+                self.expand_lazy_arg_chain(def_id, arg)
+            }
+            TypeData::UnresolvedTypeName(atom) => {
+                // A type-argument carried as `UnresolvedTypeName(name)` is the
+                // display-preserving residue of a cross-file reference lowered
+                // before the referenced declaration's name was resolvable in
+                // this checker. The application *base* already resolves this
+                // shape through `resolve_unresolved_type_name`
+                // (see `resolve_application_def_id`); the *argument* path must
+                // do the same. Without it, a generic whose body is a
+                // distributive conditional over the argument
+                // (`OptionalKeysOf<O> = O extends unknown ? ... : never`)
+                // substitutes the still-unresolved name, cannot reduce the
+                // key-space, and bails opaque — the well-typed default then
+                // false-fails its constraint (`TS2344` on type-fest's
+                // `ApplyDefaultOptions`/`RequiredKeysOf`, #13609). Resolve the
+                // name to its def and follow the same alias-chain expansion as
+                // the `Lazy` arm; keep the name opaque only when it genuinely
+                // does not resolve (registration-window artifact, preserved by
+                // the `else => arg` fallthrough below).
+                let name = self.interner.resolve_atom(atom);
+                if let Some(def_id) = self.resolver.resolve_unresolved_type_name(&name) {
+                    self.expand_lazy_arg_chain(def_id, arg)
+                } else {
+                    arg
                 }
-                // Circular or unusually deep alias chain.
-                arg
             }
             _ => arg,
         }
+    }
+
+    /// Resolve an alias `DefId` to its canonical structural body, following a
+    /// bounded chain of `Lazy` indirections (`A = B = T`). Returns `fallback`
+    /// (the original argument) when the def has no resolvable body yet or the
+    /// chain is circular/too deep, keeping the argument opaque so a later
+    /// resolver pass can expand it. Shared by the `Lazy` and
+    /// `UnresolvedTypeName` arms of [`Self::try_expand_type_arg`] so both
+    /// argument shapes expand identically (#10826, #13609).
+    fn expand_lazy_arg_chain(&mut self, def_id: DefId, fallback: TypeId) -> TypeId {
+        let mut current_def = def_id;
+        for _ in 0..MAX_LAZY_CHAIN_DEPTH {
+            let Some(body) = self.resolver.resolve_lazy(current_def, self.interner) else {
+                return fallback;
+            };
+            match self.interner.lookup(body) {
+                Some(TypeData::Lazy(next_def)) => current_def = next_def,
+                _ => return body,
+            }
+        }
+        // Circular or unusually deep alias chain.
+        fallback
     }
 
     /// Check if a type is "complex" and requires full evaluation for identity.


### PR DESCRIPTION
Refs #13609. (Scoped forward step — does not fully close the witness; see
**Scope and remaining work**. Deliberately not `Closes` so the issue stays
open for the remaining `#13232`-family cold-evaluation work.)

Goal: green

## Structural rule

When a generic alias whose body is a distributive conditional over its
type parameter (e.g. type-fest's `OptionalKeysOf<O> = O extends unknown ? ... : never`,
and the `RequiredKeysOf<O> = O extends unknown ? Exclude<keyof O, OptionalKeysOf<O>> : never`
chain built on it) is applied to a type argument carried as
`UnresolvedTypeName(name)`, and `name` is resolvable by the current
resolver, tsc evaluates the alias over the resolved type and reduces the
key space; tsz must do the same through the solver evaluator's
`try_expand_type_arg` argument path.

Owner layer: solver — `crates/tsz-solver/src/evaluation/evaluate/support.rs`,
`TypeEvaluator::try_expand_type_arg`.

The application **base** already resolves `UnresolvedTypeName` through
`resolve_unresolved_type_name` (in `resolve_application_def_id`). The
type-**argument** path did not: `try_expand_type_arg` had arms for
`Lazy`, `TypeQuery`, `Application`/`Conditional`/`IndexAccess`/`Mapped`/
`TemplateLiteral`/`KeyOf`, and a `_ => arg` fallthrough — but no
`UnresolvedTypeName` arm. So an argument like `OptionalKeysOf<PathsOptions>`,
where `PathsOptions` reached the conditional body as
`UnresolvedTypeName("PathsOptions")` (a cross-file reference lowered
before its declaration's name resolved in this checker) but **was**
resolvable, kept the argument unresolved, the distributive
`O extends unknown` conditional could not reduce the key space, and the
utility bailed opaque (`unresolved_def_seen` set). That opacity is one
contributor to the false `TS2344` on `ApplyDefaultOptions`/`RequiredKeysOf`
constraints under `skipLibCheck:false`.

## What changed

- Added the missing `TypeData::UnresolvedTypeName(atom)` arm to
  `try_expand_type_arg`: resolve the name via
  `resolver.resolve_unresolved_type_name`, and on success follow the same
  alias-chain expansion as the `Lazy` arm; keep the argument opaque only
  when the name genuinely does not resolve (registration-window artifact),
  preserving the prior `_ => arg` behavior for that case.
- Extracted the shared `Lazy`/`UnresolvedTypeName` alias-chain unfold into
  `expand_lazy_arg_chain` (behavior-preserving for the existing `Lazy`
  arm).

Adjacent cases covered by the resolve-gated arm: renamed binders (the arm
keys on resolvability, not any name literal), generic + concrete forms
(both reach `try_expand_type_arg` for a conditional-bodied alias), and
the negative/fallback case (unresolvable name stays opaque).

## Scope and remaining work

This fixes a real, isolated asymmetry in the key-space constraint-
evaluation path and eliminates the `OptionalKeysOf<UnresolvedTypeName>`
opaque results observed in the real fixture trace. It does **not** by
itself clear every `TS2344` in the full type-fest v5.6.0
`skipLibCheck:false` graph: the deepest witnesses
(`is-tuple`, `kebab-case`, `delimiter-cased-properties-deep`, etc.) fail
because the fully-nested constraint
`Simplify<Omit<Required<O>, RequiredKeysOf<O>> & Partial<Record<RequiredKeysOf<O>, never>>>`
only collapses to its structural object after the per-file env has grown
enough that a re-evaluation pass can complete; a single **cold** pass
(the state at the constraint-relation/diagnostic site) leaves the
key-space subterms unreduced. That is the documented `#13232`-family
cold-evaluation / staged-resolver-threading limitation (the constraint
relation runs against an env-generation-stamped form that the cold
checker cannot reduce). Verified locally that re-evaluating the
instantiated constraint at the relation site and at the emission gate —
with single-pass, double-pass, and env-backed **uncached** evaluation —
does not collapse it cold, so a localized checker-side re-validation gate
is not a reliable fix and is intentionally not included here (a fragile
localized patch also risks unmasking `#13232`'s relation defect).

The project-corpus guard runs type-fest with `skipLibCheck:true`
(0 errors), so no required green row is affected; this is a latent
correctness gap under `skipLibCheck:false`. Full conformance is gated by
CI.

## Verification

- `scripts/safe-run.sh cargo build -p tsz-solver -p tsz-checker` — clean.
- `cargo nextest run -p tsz-solver -E 'test(keyof) or test(optional_keys) or test(required_keys) or test(conditional) or test(application_eval) or test(type_arg)'` — 737 passed, 0 failed.
- `cargo nextest run -p tsz-solver -E 'test(expand) or test(type_arg) or test(unresolved) or test(application)'` — 191 passed, 0 failed.
- Real-fixture repro (type-fest v5.6.0 `4005f60b`/`a5491644`, `files:["source/split.d.ts"]` over `source/**`, strict + `exactOptionalPropertyTypes` + `skipLibCheck:false`, `RAYON_NUM_THREADS=1`): dev-build trace confirms the fix removes the `OptionalKeysOf<UnresolvedTypeName(...)>` opaque results (all post-fix opaque key-space results are over a still-generic `TypeParameter`, which is correct deferral). tsc oracle on the same config emits 0 `TS2344` (only the expected 2 `TS2307` for the unresolvable `tagged-tag` module).
- The full `skipLibCheck:false` witness count is unchanged by this scoped change; the remaining `TS2344` are the `#13232`-family cold-evaluation issue described above. Broad conformance/emit/fourslash are CI's job.

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
