### PR TITLE
fix(solver): contextual typing of overloaded callback params for comlink canary

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1092,7 +1092,7 @@ jobs:
             filter: 'Mapped complex template keys'
           - label: projects
             timeout: 120
-            filter: 'utility-types/|ts-toolbelt/|ts-essentials/|utility-types-project|ts-toolbelt-project|ts-essentials-project|rxjs-project|type-fest-project|zod-project|kysely-project|vite-vanilla-ts-app|nextjs-fresh-app|nextjs'
+            filter: 'utility-types/|ts-toolbelt/|ts-essentials/|utility-types-project|ts-toolbelt-project|ts-essentials-project|rxjs-project|type-fest-project|zod-project|kysely-project|comlink-project|vite-vanilla-ts-app|nextjs-fresh-app|nextjs'
           - label: large-ts-repo
             timeout: 120
             filter: '^large-ts-repo$'

--- a/crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs
@@ -644,6 +644,54 @@ impl<'a> CheckerState<'a> {
                 .contains(&node_idx)
     }
 
+    /// The enclosing call expression for which `func_idx` is a direct argument,
+    /// or `None` when `func_idx` is not a call argument.
+    fn enclosing_call_for_argument(&self, func_idx: NodeIndex) -> Option<NodeIndex> {
+        let call_idx = self.ctx.arena.get_extended(func_idx)?.parent;
+        let call_node = self.ctx.arena.get(call_idx)?;
+        if call_node.kind != tsz_parser::parser::syntax_kind_ext::CALL_EXPRESSION
+            && call_node.kind != tsz_parser::parser::syntax_kind_ext::NEW_EXPRESSION
+        {
+            return None;
+        }
+        let call = self.ctx.arena.get_call_expr(call_node)?;
+        let is_argument = call
+            .arguments
+            .as_ref()
+            .is_some_and(|args| args.nodes.contains(&func_idx));
+        is_argument.then_some(call_idx)
+    }
+
+    /// A deferred callback closure may be left without a recorded contextual type
+    /// when its enclosing call resolved to a cached result computed before the
+    /// call's contextual signature was available (e.g. a second `Array.reduce`
+    /// nested inside another function expression, whose call type is cached during
+    /// environment building and not re-resolved during statement checking). The
+    /// closure's parameters are nonetheless contextually typed by the resolved
+    /// signature, so tsc reports no TS7006. Re-resolve the enclosing call (with the
+    /// closure's stale cache invalidated) so the contextual-typing pass runs and
+    /// records the closure; diagnostics produced by the re-resolution are discarded
+    /// because they were already reported (or correctly suppressed) by the original
+    /// resolution. Returns whether the closure is now known to be contextually typed.
+    fn reresolve_enclosing_call_contextual_type(&mut self, func_idx: NodeIndex) -> bool {
+        let Some(call_idx) = self.enclosing_call_for_argument(func_idx) else {
+            return false;
+        };
+        let snap = self.ctx.snapshot_full();
+        self.invalidate_node_type_cache(call_idx);
+        self.invalidate_expression_for_contextual_retry(func_idx);
+        let _ = self.get_type_of_node(call_idx);
+        let contextual = self.closure_has_contextual_type(func_idx);
+        // Discard diagnostics/state mutations from the speculative re-resolution; it
+        // exists only to determine whether the closure is contextually typed. They
+        // were already reported (or correctly suppressed) by the original resolution.
+        self.ctx.rollback_full(&snap);
+        if contextual {
+            self.ctx.implicit_any_contextual_closures.insert(func_idx);
+        }
+        contextual
+    }
+
     pub(crate) fn maybe_report_implicit_any_parameter(
         &mut self,
         param: &tsz_parser::parser::node::ParameterData,
@@ -1519,6 +1567,16 @@ impl<'a> CheckerState<'a> {
         let deferred = std::mem::take(&mut self.ctx.deferred_implicit_any_closures);
         for func_idx in deferred {
             if self.closure_has_contextual_type(func_idx) {
+                continue;
+            }
+            // A deferred callback whose enclosing call resolved to a cached result
+            // (computed before the call's contextual signature was available) may not
+            // be recorded as contextually typed even though its parameters are. Give
+            // it one re-resolution so the contextual-typing pass can run before we
+            // commit to TS7006. This recovers parity for callbacks nested inside other
+            // function expressions (e.g. a second `Array.reduce` whose call type was
+            // cached during environment building).
+            if self.reresolve_enclosing_call_contextual_type(func_idx) {
                 continue;
             }
             // Skip closures with JSDoc annotations — JSDoc @param, @type, @template

--- a/crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs
@@ -4,6 +4,7 @@
 //! and emits the appropriate diagnostic for regular params, rest params, and
 //! destructuring patterns.
 
+use crate::context::speculation::FullSpeculationSnapshot;
 use crate::state::CheckerState;
 use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
@@ -677,7 +678,7 @@ impl<'a> CheckerState<'a> {
         let Some(call_idx) = self.enclosing_call_for_argument(func_idx) else {
             return false;
         };
-        let snap = self.ctx.snapshot_full();
+        let snap = FullSpeculationSnapshot::new(&self.ctx);
         self.invalidate_node_type_cache(call_idx);
         self.invalidate_expression_for_contextual_retry(func_idx);
         let _ = self.get_type_of_node(call_idx);
@@ -685,7 +686,7 @@ impl<'a> CheckerState<'a> {
         // Discard diagnostics/state mutations from the speculative re-resolution; it
         // exists only to determine whether the closure is contextually typed. They
         // were already reported (or correctly suppressed) by the original resolution.
-        self.ctx.rollback_full(&snap);
+        snap.rollback(&mut self.ctx.speculation_state());
         if contextual {
             self.ctx.implicit_any_contextual_closures.insert(func_idx);
         }

--- a/crates/tsz-solver/src/contextual/core.rs
+++ b/crates/tsz-solver/src/contextual/core.rs
@@ -232,6 +232,22 @@ impl<'a> ContextualTypeContext<'a> {
                     self.no_implicit_any,
                 );
                 match ctx.get_parameter_type(index) {
+                    // A member whose parameter type is one of that member's own
+                    // (un-instantiated) generic type parameters represents a generic
+                    // overload that tsc would instantiate before contextually typing
+                    // the callback. Its contextual contribution is the type parameter's
+                    // constraint, or `any` when unconstrained — not the bare type
+                    // parameter (which would otherwise read as a spurious "disagreement"
+                    // against a concrete sibling overload and block contextual typing,
+                    // e.g. `Array.reduce`'s `(prev: T, ...) => T | (prev: U, ...) => U`
+                    // contextual union for the `previousValue` slot when the
+                    // initializer is `any`).
+                    Some(ty) if self.is_signature_own_free_type_parameter(m, ty) => {
+                        param_types.push(
+                            crate::type_queries::get_type_parameter_constraint(self.interner, ty)
+                                .unwrap_or(TypeId::ANY),
+                        );
+                    }
                     Some(ty) => param_types.push(ty),
                     None => {
                         // Callable member returned None — either:
@@ -263,6 +279,16 @@ impl<'a> ContextualTypeContext<'a> {
             let first = param_types[0];
             if param_types.iter().all(|&t| t == first) {
                 return Some(first);
+            }
+            // If a member contributed `any` (from widening an un-instantiated generic
+            // overload's own type parameter above), the contextual parameter type is
+            // `any`: tsc selects and instantiates that generic overload, contextually
+            // typing the parameter as `any` rather than treating the mix of a concrete
+            // and a generic overload as an irreconcilable disagreement. This keeps the
+            // callback parameter contextually typed (no false TS7006) without affecting
+            // unions of purely-concrete callable members, which still return `None`.
+            if param_types.contains(&TypeId::ANY) {
+                return Some(TypeId::ANY);
             }
             return None;
         }
@@ -1582,6 +1608,38 @@ impl<'a> ContextualTypeContext<'a> {
 
     /// Check if a callable type has any call signature with a parameter at the given index.
     /// This distinguishes "no param at this index" (arity gap) from "params disagree."
+    /// Whether `param_type` is a bare type parameter declared by `member`'s own
+    /// (generic) signature — i.e. an un-instantiated overload type parameter
+    /// occupying a callback parameter slot. Such a parameter is not a concrete
+    /// contextual type; it is a placeholder tsc would instantiate from the
+    /// supplied argument. Used to widen it to its constraint (or `any`) instead of
+    /// treating it as a disagreement against a sibling overload's concrete slot.
+    fn is_signature_own_free_type_parameter(&self, member: TypeId, param_type: TypeId) -> bool {
+        use crate::types::TypeData;
+        let Some(TypeData::TypeParameter(param_info)) = self.interner.lookup(param_type) else {
+            return false;
+        };
+        let name = param_info.name;
+        if member.is_intrinsic() {
+            return false;
+        }
+        match self.interner.lookup(member) {
+            Some(TypeData::Function(func_id)) => self
+                .interner
+                .function_shape(func_id)
+                .type_params
+                .iter()
+                .any(|tp| tp.name == name),
+            Some(TypeData::Callable(callable_id)) => self
+                .interner
+                .callable_shape(callable_id)
+                .call_signatures
+                .iter()
+                .any(|sig| sig.type_params.iter().any(|tp| tp.name == name)),
+            _ => false,
+        }
+    }
+
     fn callable_has_param_at_index(&self, type_id: TypeId, index: usize) -> bool {
         use crate::types::TypeData;
         // Fast path: intrinsics are never `Function(_)` / `Callable(_)`.

--- a/scripts/bench/bench-vs-tsgo.sh
+++ b/scripts/bench/bench-vs-tsgo.sh
@@ -872,7 +872,6 @@ run_msw_project_benchmarks() {
 }
 
 run_comlink_project_benchmarks() {
-    should_run_compile_canary_project || return 0
     if ! is_benchmark_selected "comlink-project"; then
         return
     fi

--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -26,6 +26,7 @@ TSZ_COMPILE_GUARD_REQUIRED_ROWS=(
   "type-fest-project"
   "vite-vanilla-ts-app"
   "nextjs-fresh-app"
+  "comlink-project"
 )
 
 TSZ_COMPILE_GUARD_CANARY_ROWS=(
@@ -35,7 +36,6 @@ TSZ_COMPILE_GUARD_CANARY_ROWS=(
   "type-challenges-solutions-project"
   "valibot-project"
   "msw-project"
-  "comlink-project"
   "effect-project"
   "drizzle-orm-project"
   "ts-rest-project"

--- a/scripts/bench/project-rows.mjs
+++ b/scripts/bench/project-rows.mjs
@@ -231,8 +231,8 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref_env: "COMLINK_REF",
     repo: "https://github.com/GoogleChromeLabs/comlink.git",
     ref: "114a4a6448a855a613f1cb9a7c89290606c003cf",
-    guard_set: "canary",
-    benchmark_set: "canary",
+    guard_set: "required",
+    benchmark_set: "required",
     category: "external",
   },
   {


### PR DESCRIPTION
Goal: green

Makes the `comlink` canary compile like `tsc` (0 false positives) and promotes it to a required green row.

## Structural rule
When a callback argument is contextually typed from a union of overload signatures and one member is an un-instantiated generic overload whose parameter slot is that overload's own type parameter (e.g. `Array.prototype.reduce`'s `(previousValue: T, ...) => T | (previousValue: U, ...) => U` for the `previousValue` slot when the initial value is `any`), tsc instantiates the generic overload (`U = any`) and contextually types the callback parameter (as `any`/the constraint), so it reports no `TS7006`. tsz now does the same through the solver's contextual parameter-type extraction (`ContextualTypeContext::get_parameter_type`) plus a checker-side deferred-recheck re-resolution.

Previously tsz treated the free type parameter `U` as a hard "disagreement" against the concrete sibling overload's `string`, returned `None`, and fell the callback parameters back to implicit `any` → false `TS7006`. A second `reduce` nested inside another function expression additionally never re-ran its contextual-typing pass (its call type was cached during environment building), so its closure stayed unrecorded and the deferred implicit-any recheck emitted the diagnostic.

## What changed
- `crates/tsz-solver/src/contextual/core.rs` (`get_parameter_type`, union branch): when a union member's extracted parameter type is one of that member's own (un-instantiated) generic type parameters, widen it to the type parameter's constraint, or `any` when unconstrained, instead of recording the bare type parameter. If any member then contributes `any`, the contextual parameter type is `any` (the generic overload tsc would instantiate). Unions of purely-concrete disagreeing call signatures still return `None`, preserving the existing `TS7006` behavior for cases like `IWithCallSignatures | IWithCallSignatures3`.
- `crates/tsz-checker/.../implicit_any_checks.rs` (`recheck_deferred_implicit_any_closures`): a deferred callback closure that is a direct argument of a call whose result was cached before its contextual signature was available now gets one re-resolution of its enclosing call (with the stale cache invalidated) before committing to `TS7006`. This recovers parity for callbacks nested inside other function expressions (e.g. comlink's second `path.reduce` inside the `addEventListener` callback). Speculative diagnostics from the re-resolution are rolled back.
- Promotion: `scripts/bench/project-rows.mjs` flips `comlink-project` `guard_set` + `benchmark_set` to `required`; `scripts/bench/bench-vs-tsgo.sh` drops the `should_run_compile_canary_project` gate on `run_comlink_project_benchmarks`; `scripts/bench/project-fixtures.sh` moves `comlink-project` to the required fallback row group.

## Adjacent-case matrix (verified vs tsc oracle, TS 6.0.3)
- reduce with `any` initial, two calls + downstream `.apply`, top-level and nested in a function expression: now clean (matches tsc).
- renamed callback binders (`(acc, cur)`), `Array<number>`: clean.
- reduce with a concrete initial value (`reduce((a,c)=>a+c, 0)`): unchanged, params typed `number`.
- `reduceRight`: clean.
- NEGATIVE preserved: union of disagreeing concrete call signatures (`IA | IB`) still emits `TS7006`.

## Verification
- comlink false positives: 2 → 0. `scripts/ci/project-compile-guard.sh` with `TSZ_PROJECT_COMPILE_SET=required TSZ_PROJECT_COMPILE_FILTER=comlink` reports `comlink-project compiled successfully.`; tsc oracle (`node TypeScript/lib/tsc.js --noEmit -p <guard tsconfig>`) is clean.
- Promotion gates: `node scripts/bench/validate-project-metadata.mjs`, `node scripts/bench/test-project-rows.mjs`, `python3 scripts/arch/test_arch_guard_project.py` (63 tests) all pass.
- `cargo nextest -p tsz-solver -E 'test(contextual)'` (128) and `-p tsz-checker -E 'test(issue_9757_reduce) + test(implicit_any) + test(contextual_typing) + test(union_call_signatures)'` pass.
- Narrow conformance (`scripts/conformance/conformance.sh --filter`): `noImplicitAny` 37/37, `contextual` 193/193, `overload` 62/62, `callback` 11/11, `genericReduce` 1/1, `arrayLiteral` 19/19.
- `cargo clippy -p tsz-solver -p tsz-checker --profile dist-fast` clean.
- Three pre-existing local test failures (`contextual_nested_generator_return_inference_drops_stale_ts2345`, `class_tag_contextual_generator_callback_does_not_force_stale_ts2345`, `contextual_return_can_refine_transparent_wrapper_inference`) fail identically on the branch base without this change; not introduced here. CI owns the broad suites.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
