### PR TITLE
fix(checker): resolve polymorphic `this` arguments to the instance type for generic inference

### DIFF
--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1270,6 +1270,9 @@ mod synthetic_unique_atom_union_display_tests;
 #[path = "tests/this_context_self_type_tests.rs"]
 mod this_context_self_type_tests;
 #[cfg(test)]
+#[path = "tests/this_source_inference_tests.rs"]
+mod this_source_inference_tests;
+#[cfg(test)]
 #[path = "tests/this_void_method_call_tests.rs"]
 mod this_void_method_call_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/tests/this_source_inference_tests.rs
+++ b/crates/tsz-checker/src/tests/this_source_inference_tests.rs
@@ -1,0 +1,213 @@
+//! Inferring a type parameter from a polymorphic `this` argument.
+//!
+//! Structural rule: when the inference *source* is a polymorphic `this` type
+//! and the corresponding target is (or structurally contains) a type parameter
+//! being inferred, `tsc` resolves `this` to the enclosing class/interface
+//! instance type and produces inference candidates from that resolved type.
+//! Without this resolution the solver reaches candidate collection with an
+//! unresolved `ThisType` source, collects zero candidates, and the inference
+//! variable falls back to its constraint (`unknown`). In a covariant position
+//! the fallback is invisible; in a contravariant (function-parameter) position
+//! it surfaces as a false `TS2345`.
+//!
+//! Owning layer: `tsz-solver` inference — `infer_from_types_inner` resolves the
+//! `ThisType` source via the resolver's active `this` binding before any
+//! candidate collection.
+//!
+//! The matrix below intentionally varies binder names (function, type
+//! parameter, interface, class, property) so the fix cannot be keyed on any
+//! identifier, and pairs each positive case with a negative one so the fix is
+//! a real inference, not a blanket `any`/`unknown` suppression.
+
+use crate::test_utils::check_source_diagnostics;
+
+fn diagnostic_codes(source: &str) -> Vec<u32> {
+    check_source_diagnostics(source)
+        .into_iter()
+        .map(|diag| diag.code)
+        .collect()
+}
+
+// (B) Non-generic class, `this` source, contravariant (function-parameter)
+// target position. This is the minimal witness of the bug: `U` must infer to
+// the resolved member type (`string`), not fall back to `unknown`.
+#[test]
+fn this_source_contravariant_infers_member_type_no_error() {
+    let codes = diagnostic_codes(
+        r#"
+interface Box<U> { fn: (value: U) => void }
+declare function check<U>(b: Box<U>): void;
+class Foo {
+  fn!: (value: string) => void;
+  m() { check(this); }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "expected no diagnostics inferring U from a `this` source in a contravariant position; got {codes:?}"
+    );
+}
+
+// (C) The SAME resolved instance type passed *explicitly* already inferred
+// correctly; this guards that the `this` path now matches the explicit path.
+#[test]
+fn explicit_self_param_contravariant_no_error() {
+    let codes = diagnostic_codes(
+        r#"
+interface Box<U> { fn: (value: U) => void }
+declare function check<U>(b: Box<U>): void;
+class Foo {
+  fn!: (value: string) => void;
+  m(self: Foo) { check(self); }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "expected no diagnostics inferring U from an explicit `self: Foo` source; got {codes:?}"
+    );
+}
+
+// Covariant control: must remain clean. `this` resolves to the instance type
+// and `U` infers to the member type, but the position is covariant so the
+// result was already accepted — this guards against a regression in the
+// opposite variance.
+#[test]
+fn this_source_covariant_control_no_error() {
+    let codes = diagnostic_codes(
+        r#"
+interface CovBox<U> { val: U }
+declare function check2<U>(value: unknown, b: CovBox<U>): void;
+class Bar<T> {
+  val!: T;
+  assert(value: unknown) { return check2(value, this); }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "expected no diagnostics for the covariant `this`-source control; got {codes:?}"
+    );
+}
+
+// Renamed binders: vary every identifier (function `verify`, type param `S`,
+// interface `Sink`, class `Widget`, method `run`, property `handle`). A fix
+// keyed on any name would miss this; a structural fix must accept it.
+#[test]
+fn this_source_renamed_binders_no_error() {
+    let codes = diagnostic_codes(
+        r#"
+interface Sink<S> { handle: (value: S) => void }
+declare function verify<S>(target: Sink<S>): void;
+class Widget {
+  handle!: (value: number) => void;
+  run() { verify(this); }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "expected no diagnostics with renamed binders; got {codes:?}"
+    );
+}
+
+// `this` nested one level inside an object-literal argument: the resolved
+// instance type must still be reachable for candidate collection through the
+// wrapping property.
+#[test]
+fn this_source_nested_in_object_literal_no_error() {
+    let codes = diagnostic_codes(
+        r#"
+interface Box<U> { fn: (value: U) => void }
+declare function checkWrap<U>(w: { self: Box<U> }): void;
+class Foo {
+  fn!: (value: string) => void;
+  m() { checkWrap({ self: this }); }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "expected no diagnostics inferring through `{{ self: this }}`; got {codes:?}"
+    );
+}
+
+// `this` inside an array argument: element-level inference must resolve the
+// `this` element source.
+#[test]
+fn this_source_in_array_argument_no_error() {
+    let codes = diagnostic_codes(
+        r#"
+interface Box<U> { fn: (value: U) => void }
+declare function checkAll<U>(items: Box<U>[]): void;
+class Foo {
+  fn!: (value: string) => void;
+  m() { checkAll([this]); }
+}
+"#,
+    );
+    assert!(
+        codes.is_empty(),
+        "expected no diagnostics inferring through `[this]`; got {codes:?}"
+    );
+}
+
+// Negative: a genuine contravariant mismatch must STILL error after the fix.
+// `Bad.fn` takes `number`; the target demands a `string` consumer, so the
+// resolved `this` (= `Bad`) really is incompatible. No blanket suppression.
+#[test]
+fn this_source_genuine_mismatch_still_errors() {
+    let codes = diagnostic_codes(
+        r#"
+interface Box<U> { fn: (value: U) => void }
+declare function checkString(b: Box<string>): void;
+class Bad {
+  fn!: (value: number) => void;
+  m() { checkString(this); }
+}
+"#,
+    );
+    assert!(
+        codes.contains(&2345),
+        "expected TS2345 for a genuine contravariant mismatch through `this`; got {codes:?}"
+    );
+}
+
+// Negative read-back: capture the inferred `U` into an incompatible
+// annotation. The diagnostic must report the *resolved* member type
+// (`string`), proving `U` was inferred from the resolved `this`, not left as
+// `unknown`.
+#[test]
+fn this_source_readback_reports_resolved_member_type() {
+    let diags = check_source_diagnostics(
+        r#"
+interface CovBox<U> { val: U }
+declare function pick<U>(b: CovBox<U>): U;
+class Baz {
+  val!: string;
+  m() {
+    const out: number = pick(this);
+    return out;
+  }
+}
+"#,
+    );
+    // Collect the top-level message plus any nested elaboration so the
+    // assertion sees the full "Type 'string' is not assignable to ..." chain.
+    let messages: Vec<String> = diags
+        .iter()
+        .flat_map(|d| {
+            std::iter::once(d.message_text.clone())
+                .chain(d.related_information.iter().map(|r| r.message_text.clone()))
+        })
+        .collect();
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "expected TS2322 assigning the inferred result to `number`; got {messages:?}"
+    );
+    assert!(
+        messages.iter().any(|m| m.contains("string")),
+        "diagnostic must reference the resolved member type `string`, not `unknown`; got {messages:?}"
+    );
+}

--- a/crates/tsz-checker/src/types/computation/call_inference.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference.rs
@@ -1308,16 +1308,40 @@ impl<'a> CheckerState<'a> {
                 original_arg_type
             };
 
-            if self
-                .ctx
-                .arena
-                .get(arg_idx)
-                .is_some_and(|node| node.kind == tsz_scanner::SyntaxKind::ThisKeyword as u16)
-                && self.ctx.enclosing_class.is_some()
+            // Resolve polymorphic `this` references inside an argument to the
+            // concrete enclosing class/interface instance type for inference.
+            // The flow type of a `this` reference is the bare `ThisType` marker,
+            // which carries no structure: matched against a generic parameter
+            // the constraint walker collects zero candidates, so the inferred
+            // type parameter falls back to its constraint (`unknown`) — an
+            // invisible result in covariant positions but a false TS2345 in a
+            // contravariant (function-parameter) position. `tsc` resolves a
+            // `this` argument to the enclosing instance type before inference;
+            // mirror that using the active `this` binding (the concrete receiver
+            // pushed while checking the member body).
+            //
+            // The substitution is deep, so it also reaches `this` nested inside
+            // a freshly built argument (e.g. `[this]` → `Foo[]`), not just a
+            // top-level `this` argument. It is gated on the argument type
+            // actually containing a `ThisType` (so a Lazy reference to another
+            // class with fluent `this`-returning methods is untouched — its
+            // `this` stays opaque inside the unresolved reference) and on a
+            // concrete enclosing `this` being available, so it never rewrites a
+            // marker into another marker. The separate final assignability
+            // recheck reads the original argument types, so it still re-resolves
+            // `this` against the receiver and is unaffected.
+            if self.ctx.enclosing_class.is_some()
+                && common::contains_this_type(self.ctx.types, arg_type)
                 && !self.is_this_in_nested_function_without_own_this_binding(arg_idx)
+                && let Some(resolved_this) = self.current_this_type()
+                && !common::is_this_type(self.ctx.types, resolved_this)
             {
-                changed = true;
-                arg_type = self.ctx.types.this_type();
+                let substituted =
+                    common::substitute_this_type(self.ctx.types, arg_type, resolved_this);
+                if substituted != arg_type {
+                    changed = true;
+                    arg_type = substituted;
+                }
             }
 
             if let Some(declared) =


### PR DESCRIPTION
Goal: green

Fixes #13651.

## Summary

When a polymorphic `this` is passed as an argument to a generic call, the
checker's argument-normalization pass (`sanitize_generic_inference_arg_types`)
replaced the argument's type with the bare `ThisType` marker. That marker
carries no structure, so the solver's constraint walker collects **zero**
inference candidates and the type parameter falls back to its constraint
(`unknown`). The fallback is invisible in covariant positions but surfaces as a
false `TS2345` in a contravariant (function-parameter) position — the
**superstruct** blocker `is(value, this)` / `validate(value, this, options)`,
where the contravariant `refiner` field makes `Struct` appear not assignable to
`Struct`.

## Structural rule

When the inference source is a polymorphic `this`, `tsc` resolves it to the
enclosing class/interface instance type and produces candidates from that
resolved type; tsz instead handed the bare `ThisType` to the constraint walker,
which has no matching arm and collects no candidate.

`When a generic-inference argument type contains a polymorphic this, tsc
resolves this to the enclosing instance type before collecting candidates; tsz
now does the same through the checker argument-normalization boundary.`

- Wrong semantic operation: **inference — candidate collection from a `this` source**.
- Owner layer: **checker argument-type-resolution boundary**
  (`sanitize_generic_inference_arg_types`), the existing pre-inference argument
  normalizer (already special-cases enums and readonly annotations).

The fix deep-substitutes `ThisType` with the active `this` binding (the concrete
receiver pushed while checking the member body), so it also reaches `this`
nested inside a freshly built argument (`[this]`, `{ self: this }`), not just a
top-level `this` argument. It is gated on the argument actually containing a
`ThisType` and on a concrete enclosing `this` being available, and the separate
final assignability recheck reads the *original* argument types, so it still
re-resolves `this` against the receiver and is unaffected. This generalizes and
fixes the previous special-case that only matched a top-level `this` keyword
argument and downgraded it to the bare marker.

## Adjacent-case matrix (all verified against the built binary)

- (B) non-generic class, `this` source, contravariant target → was false TS2345, now clean.
- (C) explicit `self: Foo` param (same resolved type, explicit) → still clean.
- Covariant control (`{ val: U }`) → still clean.
- Renamed binders (function / type-param / interface / class / property all varied) → clean.
- `this` nested in object-literal arg `{ self: this }` → clean.
- `this` nested in array arg `[this]` → was false TS2322, now clean.
- Generic class (`class Gen<T> { fn!: (v: T) => void }`) → clean (infers `U = T`).
- Negative: genuine contravariant mismatch (`fn: (v: number)` vs `Box<string>`) → still reports TS2345.
- Read-back: capturing the inferred `U` into an incompatible annotation reports the **resolved** member type (`string`), not `unknown`.

## Anti-hardcoding

Structural throughout: no user-name / file-name / type-parameter-name checks; no
formatted-diagnostic predicate; tests vary every binder name. The resolution
uses the solver `substitute_this_type` query boundary keyed on the enclosing
`this` binding.

## Performance

One memoized `contains_this_type` scan per generic-call argument (intrinsic
fast-path + per-node memoization) gates the work; `substitute_this_type` (cached)
runs only for the rare arguments that actually contain a `this`. Cheapest checks
short-circuit first (`enclosing_class.is_some()` → memoized type scan → AST walk
→ O(1) stack peek). No new cache surface or invalidation path.

## Provenance

Machine: cloud
Assistant: claude-code
Model: opus
Effort: high

## Verification

- `cargo test -p tsz-checker --lib this_source_inference` — 8 new tests pass
  (matrix above, binder names varied).
- `cargo test -p tsz-checker --lib this_` / `polymorphic` / `builder` /
  `fluent` / `overload` / `this_param` — green; no regressions.
- `infer_` / `assignab` / `argument_` failures are pre-existing (require the
  `es2015.promise` lib, not checked out locally) — identical counts with and
  without this change.
- Targeted standalone repros flip `EXIT 2 → EXIT 0`; covariant control and the
  genuine-mismatch negative stay unchanged.
- Broad conformance / emit / fourslash owned by ready-review CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XL4194C2QjNqPqyPUmMZUi)_