### PR TITLE
fix(checker): TS7006 deferred-contextual reduce-callback false positive

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs
@@ -1567,13 +1567,28 @@ impl<'a> CheckerState<'a> {
         }
 
         // Re-check closures whose TS7006 was emitted during return-type inference
-        // speculation and then rolled back. These closures had genuinely untyped
-        // parameters at the time of first processing (inside infer_return_type_from_body).
-        // Even if a later call inference retry provided contextual types (adding the
-        // closure to implicit_any_contextual_closures), tsc would have kept the TS7006
-        // from the initial inference pass. So we unconditionally re-emit here.
+        // speculation and then rolled back. These closures had untyped parameters at
+        // the time of the speculative processing inside `infer_return_type_from_body`,
+        // because that speculative re-evaluation did not re-establish a contextual
+        // callback signature for them.
+        //
+        // A closure that received genuine contextual parameter types in its real
+        // (non-speculative) syntactic position must NOT be re-emitted — tsc reports no
+        // TS7006 for it. `closure_has_contextual_type` consults the checked/contextual
+        // closure sets recorded during real statement checking; those marks persist
+        // past the speculative rollback, and this pass runs after all statements are
+        // checked, so the mark is authoritative. This mirrors the guard already applied
+        // to the deferred-closure loop above. It fixes false TS7006 on a contextually
+        // typed callback (e.g. an `Array.prototype.reduce` callback typed by the
+        // resolved overload) whose result later flows into a deferred-inference chain
+        // such as `let r = arr.reduce(cb, init); Promise.resolve(r).then(...)`, which
+        // re-evaluates the reduce call speculatively without re-applying its overload
+        // context.
         let speculative = std::mem::take(&mut self.ctx.speculative_implicit_any_closures);
         for func_idx in speculative {
+            if self.closure_has_contextual_type(func_idx) {
+                continue;
+            }
             if self.find_jsdoc_for_function(func_idx).is_some() {
                 continue;
             }

--- a/crates/tsz-checker/tests/speculation_rollback_tests.rs
+++ b/crates/tsz-checker/tests/speculation_rollback_tests.rs
@@ -12,6 +12,18 @@ fn check(source: &str) -> Vec<Diagnostic> {
     check_with(source, "test.ts", CheckerOptions::default())
 }
 
+/// Check under the default es2015+ lib set, so `Array.prototype.reduce`,
+/// `Promise`, etc. resolve. The bare [`check`] helper loads no libs.
+fn check_with_libs(source: &str) -> Vec<Diagnostic> {
+    let libs = tsz_checker::test_utils::load_default_lib_files();
+    tsz_checker::test_utils::check_source_with_libs(
+        source,
+        "test.ts",
+        CheckerOptions::default(),
+        &libs,
+    )
+}
+
 fn check_with(source: &str, file_name: &str, options: CheckerOptions) -> Vec<Diagnostic> {
     tsz_checker::test_utils::check_source(source, file_name, options)
 }
@@ -122,6 +134,54 @@ fn implicit_any_no_false_positive_with_contextual_type() {
     assert_eq!(
         ts7006_count, 0,
         "TS7006 should not be emitted when contextual type exists: {diags:?}"
+    );
+}
+
+/// A contextually-typed callback (here the `reduce` callback, typed by the
+/// resolved overload) whose result later flows through a deferred-inference
+/// chain (`let` → `Promise.resolve(...).then(cb)`) must not have its parameters
+/// re-flagged as implicit-any. The deferred `.then` inference re-evaluates the
+/// `reduce` call speculatively; the speculative pass leaves the callback without
+/// the overload contextual signature and queues a TS7006 that the recheck pass
+/// must drop because the callback was contextually typed in its real position.
+#[test]
+fn reduce_callback_deferred_inference_no_false_implicit_any() {
+    let diags = check_with_libs(
+        r#"
+        declare const init: any;
+        function run(path: string[]) {
+            let returnValue;
+            const rawValue = path.reduce((acc, key) => acc[key], init);
+            returnValue = rawValue;
+            Promise.resolve(returnValue).then((rv) => rv);
+            return returnValue;
+        }
+    "#,
+    );
+    let ts7006_count = diags.iter().filter(|d| d.code == 7006).count();
+    assert_eq!(
+        ts7006_count, 0,
+        "contextually-typed reduce callback must not be re-flagged TS7006 after a \
+         deferred-inference chain: {diags:?}"
+    );
+}
+
+/// Guard the true-positive direction: a callback argument to an `any`-typed
+/// function genuinely has no contextual parameter type, so TS7006 must still be
+/// emitted even though the speculative recheck guard now skips contextually
+/// typed closures.
+#[test]
+fn untyped_callback_argument_still_flags_implicit_any() {
+    let diags = check(
+        r#"
+        declare const f: any;
+        f(function (p) { return p; });
+    "#,
+    );
+    let ts7006_count = diags.iter().filter(|d| d.code == 7006).count();
+    assert!(
+        ts7006_count >= 1,
+        "genuinely untyped callback parameter must still emit TS7006: {diags:?}"
     );
 }
 


### PR DESCRIPTION
Goal: green

## Structural rule

When a callback receives genuine contextual parameter types in its real
syntactic position (e.g. an `Array.prototype.reduce` callback typed by the
resolved overload) and its result later flows through a deferred-inference
chain — `let r = arr.reduce((acc, x) => acc[x], init); Promise.resolve(r).then(cb)` —
`tsc` emits no TS7006 for the callback parameters; `tsz` did, through the
checker's speculative implicit-any re-emission pass.

The deferred `.then` inference re-evaluates the `reduce` call speculatively
without re-establishing the overload's callback signature, so the callback is
queued into `speculative_implicit_any_closures`. The recheck pass
(`recheck_deferred_implicit_any_closures`) then re-emitted TS7006
**unconditionally**. The earlier deferred-closure loop in the same function
already guards with `closure_has_contextual_type`; the speculative loop did not.

Owner layer: checker implicit-any diagnostic pass
(`crates/tsz-checker/src/state/state_checking_members/implicit_any_checks.rs`).
No solver/type semantics change — only which speculatively-queued closures are
re-flagged.

## What changed

- Guard the speculative TS7006 re-emission loop with `closure_has_contextual_type`,
  mirroring the deferred-closure loop above it. The contextual mark recorded
  during real (non-speculative) statement checking persists past the speculative
  rollback and is authoritative here because this pass runs after all statements
  are checked.
- Added two regression tests in `speculation_rollback_tests.rs`:
  - `reduce_callback_deferred_inference_no_false_implicit_any` (the FP, now 0)
  - `untyped_callback_argument_still_flags_implicit_any` (true-positive guard:
    a callback argument to an `any`-typed callee genuinely lacks a contextual
    signature and must still emit TS7006).

Adjacent matrix: positive (reduce/deferred FP cleared), true-negative (untyped
callback still flagged), renamed binders (param names vary; not name-driven).

## Verification

- `cargo nextest run -p tsz-checker --test speculation_rollback_tests` — 42/42
  pass (incl. 2 new).
- `cargo nextest run -p tsz-checker --test unannotated_callback_arity_tests
  --test window_indexed_access_callback_contextual_typing_tests` — 12/12 pass.
- `cargo clippy -p tsz-checker --lib` — clean.
- Conformance (main TS corpus): `--filter implicitAny` 73/73, `--filter contextual`
  287/287 — 0 regressions.
- Standalone repro `let r = path.reduce((acc,k)=>acc[k], init);
  Promise.resolve(r).then(v=>v)` under `--strict`: TS7006 2 -> 0; `tsc`-clean.

Scope note: this clears the standalone reduce/deferred-inference TS7006 variant.
The comlink canary's specific occurrence (the callback is a
function-expression argument to an `addEventListener`-on-`any` call, with the
deferred chain in the same statement) emits TS7006 at the source
`compute_function_type` path rather than the speculative recheck loop, so its
2 FPs are not yet cleared by this change; that deeper deferred-overload
contextual-application path is a separate follow-up.

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
