### PR TITLE
fix(solver): default/optional param undefined-arg FP for neverthrow canary

### DIFF
--- a/crates/tsz-checker/src/types/computation/call_inference/argument_context.rs
+++ b/crates/tsz-checker/src/types/computation/call_inference/argument_context.rs
@@ -205,6 +205,28 @@ impl<'a> CheckerState<'a> {
                 continue;
             }
 
+            // A parameter that is optional (`?`) or carries a default initializer
+            // implicitly accepts `undefined` at the call site, so an argument of
+            // `T | undefined` is valid. The solver's `check_argument_types_with`
+            // strips `undefined` from such arguments before checking, but the
+            // post-inference recheck here builds its `expected` from the bare
+            // (non-widened) instantiated parameter type. Mirror the solver: when
+            // the matched parameter slot is optional, drop `undefined` from the
+            // argument so `ErrorConfig | undefined` is checked as `ErrorConfig`
+            // against an optional `ErrorConfig` parameter.
+            let param_is_optional = instantiated_params
+                .get(index)
+                .or_else(|| {
+                    let last = instantiated_params.last()?;
+                    last.rest.then_some(last)
+                })
+                .is_some_and(|param| param.optional);
+            let actual = if param_is_optional {
+                crate::query_boundaries::common::remove_undefined(self.ctx.types, actual)
+            } else {
+                actual
+            };
+
             let is_assignable = self
                 .call_arg_relation_outcome_with_env(actual, expected)
                 .related

--- a/crates/tsz-solver/src/operations/generic_call/resolve.rs
+++ b/crates/tsz-solver/src/operations/generic_call/resolve.rs
@@ -1073,12 +1073,35 @@ impl<'a, C: AssignabilityChecker> CallEvaluator<'a, C> {
                 placeholder_visited.clear();
                 if !self.type_contains_placeholder(target_type, &var_map, &mut placeholder_visited)
                 {
-                    // No placeholder in target_type - check assignability directly
+                    // No placeholder in target_type - check assignability directly.
+                    //
+                    // An optional parameter (`?`) or one carrying a default
+                    // initializer implicitly accepts `undefined` at the call site, so
+                    // an argument of `T | undefined` is valid against a `T` parameter.
+                    // The non-generic `check_argument_types_with` path strips
+                    // `undefined` from such arguments before checking; mirror that here
+                    // so the eager concrete-parameter check in generic inference does
+                    // not falsely reject `ErrorConfig | undefined` against an optional
+                    // `ErrorConfig` parameter.
+                    let param_is_optional = instantiated_params
+                        .get(i)
+                        .or_else(|| {
+                            let last = instantiated_params.last()?;
+                            last.rest.then_some(last)
+                        })
+                        .is_some_and(|param| param.optional);
+                    let arg_for_check = if param_is_optional {
+                        crate::narrowing::utils::remove_undefined(
+                            self.interner,
+                            contextual_arg_type,
+                        )
+                    } else {
+                        contextual_arg_type
+                    };
                     if !self
                         .checker
-                        .is_assignable_to(contextual_arg_type, contextual_target_type)
-                        && !self
-                            .is_function_union_compat(contextual_arg_type, contextual_target_type)
+                        .is_assignable_to(arg_for_check, contextual_target_type)
+                        && !self.is_function_union_compat(arg_for_check, contextual_target_type)
                     {
                         return CallResult::ArgumentTypeMismatch {
                             index: i,


### PR DESCRIPTION
Goal: green

## Structural rule
When a generic function parameter is optional (`?`) or carries a default
initializer, `tsc` treats it as implicitly accepting `undefined` at the call
site, so an argument of `T | undefined` is valid against a declared `T`
parameter. tsz already does this on the non-generic call path
(`check_argument_types_with` strips `undefined` from the argument when the
matched parameter slot is `optional`). The two generic-call inference sites did
not: they compared the raw argument union against the bare (non-widened)
parameter type and emitted a false `TS2345`. Owner layer: solver
(`generic_call` resolve/inference) plus the checker's post-inference real-type
recheck, which is the natural sibling of the same check.

`When a generic call supplies T | undefined to an optional/default-valued
parameter of type T, tsc accepts it; tsz now accepts it through the
generic-call argument check stripping undefined for optional param slots
(matching the non-generic check_argument_types_with path).`

## What changed
- `crates/tsz-solver/src/operations/generic_call/resolve.rs`: in the eager
  concrete-parameter assignability check (no-placeholder branch), strip
  `undefined` from the argument when the matched parameter slot is optional
  before the `is_assignable_to` check. This is the path that produced the FP.
- `crates/tsz-checker/src/types/computation/call_inference/argument_context.rs`:
  apply the same rule in `recheck_generic_call_arguments_with_real_types` (the
  post-inference recheck that rebuilds `expected` from the bare instantiated
  param), so the FP cannot reappear via the sanitized-inference / real-type
  recheck route.

Both sites read the existing `ParamInfo.optional` flag (already set from
`param.question_token || param.initializer.is_some()` in the signature
builder); no new flag, no name/file-string checks.

## Verification
neverthrow canary FP (project-compile-guard, `TSZ_PROJECT_COMPILE_SET=canary`
`TSZ_PROJECT_COMPILE_FILTER=neverthrow`):
- before: 14 diagnostics (13 genuine FPs; 1 strict-mode error shared with tsc)
- after: 12 diagnostics (11 genuine FPs) — `src/result.ts(410,77)` and
  `src/result.ts(506,75)` `TS2345 'ErrorConfig | undefined' not assignable to
  'ErrorConfig'` eliminated.

Adjacent-case matrix (each agrees with `tsc 6.0.3` oracle, `--strict`):
- generic fn + default-valued param + `T | undefined` arg (renamed binders) -> OK (was FP)
- generic fn + `?`-optional param (no default) + `T | undefined` arg -> OK
- non-generic control + default param -> OK (already OK; unchanged)
- default param in middle position -> OK
- callback-driven generic inference + default param -> OK
- NEGATIVE: required (non-optional, no default) param + `T | undefined` -> TS2345 (preserved)
- NEGATIVE: optional param + wrong-type `Other | undefined` -> TS2345 (preserved)

Broad conformance/emit/fourslash owned by ready-review CI (local TypeScript
submodule `tests/cases` is unpopulated in this worktree).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high