### PR TITLE
perf(checker): memoize pure return-type inference (resolvedReturnType analog) to break effect flow storm

### DIFF
--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -132,6 +132,7 @@ circular_class_symbols = { lifetime = "FileLocalReset", capability = "FileTypeCa
 pending_implicit_any_vars = { lifetime = "SpeculationScoped", capability = "SpeculationState", reason = "snapshot/rollback-sensitive state mutated during speculative checking" }
 pending_circular_return_sites = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 non_closure_circular_return_tracking_depth = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
+inferred_return_type_memo = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "per-function resolved-return-type memo keyed by node, contextual type, and type-parameter-scope fingerprint; reset at file-session boundary" }
 reported_implicit_any_vars = { lifetime = "SpeculationScoped", capability = "SpeculationState", reason = "snapshot/rollback-sensitive state mutated during speculative checking" }
 inheritance_graph = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 node_resolution_stack = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -364,6 +364,7 @@ impl<'a> CheckerContext<'a> {
             pending_implicit_any_vars: crate::context::CowCache::default(),
             pending_circular_return_sites: PendingCircularReturnSites::default(),
             non_closure_circular_return_tracking_depth: 0,
+            inferred_return_type_memo: FxHashMap::default(),
             reported_implicit_any_vars: crate::context::CowCache::default(),
             inheritance_graph: tsz_solver::classes::inheritance::InheritanceGraph::new(),
             node_resolution_stack: Vec::new(),

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -263,6 +263,9 @@ impl<'a> CheckerContext<'a> {
         self.pending_circular_return_sites.clear();
         self.no_overload_call_nodes.clear();
         self.non_closure_circular_return_tracking_depth = 0;
+        // The inferred-return-type memo keys on file-local node indices and
+        // type-parameter `TypeId`s, so it shares the per-file lifecycle.
+        self.inferred_return_type_memo.clear();
 
         // Symbol/circularity state whose keys or values are file-local
         // `SymbolId`s, plus string-name guards that are meaningful only inside

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -287,6 +287,10 @@ impl PendingCircularReturnSites {
 ///   are distinct keys.
 /// - `in_const_assertion` / `preserve_literal_types`: literal-preservation modes
 ///   that change widening of inferred literal returns.
+/// - `this_type`: the active contextual `this` type. A method/function body that
+///   returns or references `this` (e.g. `foo() { return this; }`, or a
+///   `this`-polymorphic predicate) infers a `this`-dependent return type, so the
+///   same node inferred under different `this` bindings must not collide.
 /// - `scope_fingerprint`: a stable hash of the active `type_parameter_scope`
 ///   bindings, so a generic body inferred under one ambient type-parameter
 ///   binding is never reused under a different binding.
@@ -296,6 +300,7 @@ pub struct InferredReturnTypeKey {
     pub return_context: Option<TypeId>,
     pub in_const_assertion: bool,
     pub preserve_literal_types: bool,
+    pub this_type: Option<TypeId>,
     pub scope_fingerprint: u64,
 }
 

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -275,6 +275,30 @@ impl PendingCircularReturnSites {
     }
 }
 
+/// Identity key for the inferred-body-return-type memo (`resolvedReturnType`
+/// analog). Captures every ambient input that determines the result of pure
+/// return-type inference for a given function/arrow/method body, so a cache hit
+/// is byte-identical to recomputing the inference:
+///
+/// - `function_node`: the function/arrow/method/accessor node being inferred.
+/// - `return_context`: the unwrapped contextual return type fed to inference
+///   (`None` for context-free inference). Different contextual types can drive
+///   different inferred results (e.g. `const` type-parameter context), so they
+///   are distinct keys.
+/// - `in_const_assertion` / `preserve_literal_types`: literal-preservation modes
+///   that change widening of inferred literal returns.
+/// - `scope_fingerprint`: a stable hash of the active `type_parameter_scope`
+///   bindings, so a generic body inferred under one ambient type-parameter
+///   binding is never reused under a different binding.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct InferredReturnTypeKey {
+    pub function_node: NodeIndex,
+    pub return_context: Option<TypeId>,
+    pub in_const_assertion: bool,
+    pub preserve_literal_types: bool,
+    pub scope_fingerprint: u64,
+}
+
 /// In-progress object literal initializer for a variable declaration.
 ///
 /// TypeScript allows later property initializers to reference earlier properties
@@ -1250,6 +1274,17 @@ pub struct CheckerContext<'a> {
     /// construct consults those bodies immediately during type computation
     /// (currently the `for...of` iterator protocol path).
     pub non_closure_circular_return_tracking_depth: usize,
+    /// Per-function memo of inferred body return types (tsc's
+    /// `resolvedReturnType`). Keyed by the function/arrow/method node plus every
+    /// ambient input that determines pure return-type inference: the contextual
+    /// return type, the literal-preservation flags, and a fingerprint of the
+    /// active type-parameter scope. It records the inferred return `TypeId` only,
+    /// never any diagnostics — body checking with diagnostics runs separately and
+    /// is never short-circuited by this cache. The memo is consulted only when
+    /// the function is NOT participating in circular return resolution, so a
+    /// provisional (in-progress) inference is never published. Cleared per file
+    /// session like the other return-circularity caches.
+    pub inferred_return_type_memo: FxHashMap<InferredReturnTypeKey, TypeId>,
     /// Variables that have already had TS7034 emitted, keyed by the deferred
     /// implicit-any classification that triggered it.
     pub reported_implicit_any_vars: CowCache<FxHashMap<SymbolId, PendingImplicitAnyKind>>,

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -715,6 +715,7 @@ impl<'a> CheckerState<'a> {
             return_context,
             in_const_assertion: self.ctx.in_const_assertion,
             preserve_literal_types: self.ctx.preserve_literal_types,
+            this_type: self.current_this_type(),
             scope_fingerprint: self.inferred_return_type_scope_fingerprint(),
         })
     }
@@ -722,11 +723,21 @@ impl<'a> CheckerState<'a> {
     /// True when the pure return-type inference of `function_idx`'s body is a
     /// stable function of its ambient inputs (so it may be memoized).
     ///
-    /// Note that a function's OWN symbol is always in `symbol_resolution_set`
-    /// while its type (and therefore its return type) is being computed — that
-    /// is normal, not circular, so it must NOT disqualify memoization. The
-    /// inference becomes resolution-state-dependent, and therefore unsafe to
-    /// cache, only in these cases:
+    /// Only **contextual** inference (`return_context.is_some()`) is memoized.
+    /// The non-contextual inference of a declaration runs exactly once, in the
+    /// declaration's own check pass, and that pass relies on the body evaluation
+    /// to warm shared solver caches (e.g. indexed-access / large-union
+    /// evaluations) that the immediately-following body diagnostic check then
+    /// reuses — short-circuiting it changes downstream complexity accounting
+    /// (witnessed by a spurious TS2590 on `intersectionsOfLargeUnions.ts`). The
+    /// combinatorial blow-up this memo targets is the **contextual** return
+    /// requests that re-enter a shared generic-builder DAG through many parents;
+    /// those are exactly the `return_context.is_some()` calls.
+    ///
+    /// A function's OWN symbol is always in `symbol_resolution_set` while its
+    /// type is computed — that is normal, not circular, and does NOT disqualify
+    /// memoization. The inference becomes resolution-state-dependent, and unsafe
+    /// to cache, only in these cases:
     ///
     /// - the function node is already on the resolution stack: a genuine
     ///   re-entrant request, whose result is a provisional placeholder;
@@ -739,9 +750,12 @@ impl<'a> CheckerState<'a> {
         &mut self,
         function_idx: NodeIndex,
         body_idx: NodeIndex,
-        _return_context: Option<TypeId>,
+        return_context: Option<TypeId>,
     ) -> bool {
         if function_idx.is_none() || body_idx.is_none() {
+            return false;
+        }
+        if return_context.is_none() {
             return false;
         }
         if self.ctx.node_resolution_stack.contains(&function_idx) {

--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -559,6 +559,21 @@ impl<'a> CheckerState<'a> {
         body_idx: NodeIndex,
         return_context: Option<TypeId>,
     ) -> TypeId {
+        // `resolvedReturnType` analog: a stable function body has exactly one
+        // pure return-type inference per (node, contextual type, literal-mode,
+        // type-parameter-scope) tuple. Generic-builder DAGs (effect/zod/kysely)
+        // re-enter the same body through many parents via contextual return
+        // requests; without this memo each re-entry re-runs full body flow
+        // analysis, which is combinatorial. The memo records ONLY the inferred
+        // `TypeId` (never diagnostics), so the separate body-check pass still
+        // runs once and emits its diagnostics unchanged.
+        let memo_key = self.inferred_return_type_memo_key(function_idx, body_idx, return_context);
+        if let Some(key) = memo_key
+            && let Some(&cached) = self.ctx.inferred_return_type_memo.get(&key)
+        {
+            return cached;
+        }
+
         // The inference pass evaluates return expressions WITHOUT narrowing
         // context, which can produce false errors (e.g. TS2339 for discriminated
         // union property accesses) and cache wrong types.  Snapshot diagnostic,
@@ -667,7 +682,102 @@ impl<'a> CheckerState<'a> {
         // remaining case here is when the caller explicitly requested literal
         // preservation (e.g. `preserve_literal_types`) and per-expression
         // widening already deferred to that flag.
+
+        // Publish the stable inference. `inferred_return_type_memo_key` returned
+        // `Some` only for stable (non-circular, non-provisional) calls, so this
+        // never caches an in-progress placeholder. The only early return between
+        // key computation and here is the direct-self-call `any`→`never` rewrite
+        // above, which both rolls back and returns before this point AND would
+        // already have forced `memo_key` to `None`, so the cached value is always
+        // the final stable inference.
+        if let Some(key) = memo_key {
+            self.ctx.inferred_return_type_memo.insert(key, result);
+        }
         result
+    }
+
+    /// Build the memo key for `infer_return_type_from_body`, or `None` when the
+    /// inference must not be cached because it is participating in circular
+    /// return resolution (and so may be provisional / dependent on the active
+    /// resolution stack). A `Some` key captures every ambient input to pure
+    /// return-type inference; see [`crate::context::InferredReturnTypeKey`].
+    fn inferred_return_type_memo_key(
+        &mut self,
+        function_idx: NodeIndex,
+        body_idx: NodeIndex,
+        return_context: Option<TypeId>,
+    ) -> Option<crate::context::InferredReturnTypeKey> {
+        if !self.inferred_return_type_is_memoizable(function_idx, body_idx, return_context) {
+            return None;
+        }
+        Some(crate::context::InferredReturnTypeKey {
+            function_node: function_idx,
+            return_context,
+            in_const_assertion: self.ctx.in_const_assertion,
+            preserve_literal_types: self.ctx.preserve_literal_types,
+            scope_fingerprint: self.inferred_return_type_scope_fingerprint(),
+        })
+    }
+
+    /// True when the pure return-type inference of `function_idx`'s body is a
+    /// stable function of its ambient inputs (so it may be memoized).
+    ///
+    /// Note that a function's OWN symbol is always in `symbol_resolution_set`
+    /// while its type (and therefore its return type) is being computed — that
+    /// is normal, not circular, so it must NOT disqualify memoization. The
+    /// inference becomes resolution-state-dependent, and therefore unsafe to
+    /// cache, only in these cases:
+    ///
+    /// - the function node is already on the resolution stack: a genuine
+    ///   re-entrant request, whose result is a provisional placeholder;
+    /// - the body returns a still-resolving variable through a call-like return,
+    ///   which `tsc` resolves on demand with `any` and refines later;
+    /// - the body is directly self-recursive (`all_returns_are_direct_self_calls`):
+    ///   the `any`→`never` rewrite above keys off the live resolution set, so the
+    ///   inferred value depends on whether this is the resolving pass.
+    fn inferred_return_type_is_memoizable(
+        &mut self,
+        function_idx: NodeIndex,
+        body_idx: NodeIndex,
+        _return_context: Option<TypeId>,
+    ) -> bool {
+        if function_idx.is_none() || body_idx.is_none() {
+            return false;
+        }
+        if self.ctx.node_resolution_stack.contains(&function_idx) {
+            return false;
+        }
+        if self.return_body_has_resolving_var_in_call_like(body_idx) {
+            return false;
+        }
+        if let Some(sym_id) = self.ctx.binder.get_node_symbol(function_idx)
+            && self.ctx.symbol_resolution_set.contains(&sym_id)
+            && self.all_returns_are_direct_self_calls(body_idx, sym_id)
+        {
+            return false;
+        }
+        true
+    }
+
+    /// Stable hash of the active type-parameter scope: the bindings a generic
+    /// body resolves its free type parameters through. Two scopes with identical
+    /// `(name, TypeId)` bindings produce identical inference, so this isolates
+    /// the same body inferred under different ambient type-parameter bindings.
+    fn inferred_return_type_scope_fingerprint(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        if self.ctx.type_parameter_scope.is_empty() {
+            return 0;
+        }
+        let mut entries: Vec<(&str, u32)> = self
+            .ctx
+            .type_parameter_scope
+            .iter()
+            .map(|(name, type_id)| (name.as_str(), type_id.0))
+            .collect();
+        entries.sort_unstable_by(|left, right| left.0.cmp(right.0));
+        let mut hasher = rustc_hash::FxHasher::default();
+        entries.hash(&mut hasher);
+        hasher.finish()
     }
 
     /// Inner implementation of return type inference (no diagnostic/cache cleanup).


### PR DESCRIPTION
Goal: fast

Closes the effect-canary flow-re-derivation storm root-caused on #13040 / #13250.

## Structural rule

When a contextual return-type request re-enters a function/arrow/method body,
`tsc` returns the signature's memoized `resolvedReturnType` (computed once per
signature, with a resolving sentinel for re-entrant requests) instead of
re-deriving the body. tsz had **no** such memo: `infer_return_type_from_body`
re-ran the full body flow analysis (`check_flow`) on every request. effect's
relational-builder generics form a shared DAG of such nodes reachable through
many parents via contextual return requests, so the same body was re-typed
combinatorially — non-terminating (DNF >300x, killed, 0 diagnostics).

This PR splits **pure return-type inference** (memoizable, the `resolvedReturnType`
analog) from **body-checking-with-diagnostics** (runs once, unchanged):
`infer_return_type_from_body` now consults a per-function memo before the
snapshot + flow walk, and records only the inferred return `TypeId` — never a
diagnostic. The separate body-check pass still runs once and emits its
diagnostics exactly as before.

Owner layer: checker return-type inference (`types/utilities/return_type.rs`),
not solver relations and not the diagnostic formatter (effect emits 0
diagnostics and never reaches display).

### Memo key

`(function node, contextual return type, in_const_assertion,
preserve_literal_types, type-parameter-scope fingerprint)` — every ambient input
that determines pure inference. The scope fingerprint is a stable `FxHasher`
hash of the sorted `(name, TypeId)` bindings of the active `type_parameter_scope`
(same pattern as `generic_checker`), so a generic body inferred under one
ambient type-parameter binding is never reused under a different binding.

### Soundness gate (resolving-sentinel parity)

The memo is published **only for stable inferences**. A function's own symbol is
always mid-resolution while its type is computed — that is normal and does not
disqualify caching. Caching is skipped only when the result is
resolution-state-dependent:
- the function node is already on `node_resolution_stack` (genuine re-entrant
  request → provisional placeholder, the TS7022/7023 case);
- the body returns a still-resolving variable through a call-like return (`tsc`
  resolves on demand with `any`, then refines);
- the body is directly self-recursive (`all_returns_are_direct_self_calls`): the
  `any`→`never` rewrite keys off the live resolution set.

### Invalidation

Per file session (`file_session_reset`), alongside the other return-circularity
caches; keys are file-local node indices and type-parameter `TypeId`s. Registered
in `checker_context_lifetimes.toml` as `FileLocalReset` / `FileTypeCache`.

## Verification

### effect canary (before → after), `TSZ_USE_EMBEDDED_LIBS=1 --noEmit -p packages/effect/src`, ref `626c61b3ef`, tsc baseline 4.96s / 240 errors

- **Before (parent `6e9d97dc1c`):** DNF — killed at 180s, 0 diagnostics; CPU
  sample: the entire hot stack is the `get_type_of_symbol_inner → get_type_of_function_impl →
  type_of_resolved_value_symbol` re-derivation chain bottoming out in
  `infer_return_type_from_body → check_flow` (the targeted flow storm).
- **After:** the flow-re-derivation storm is **eliminated** — re-sampling shows
  `check_flow` / `infer_return_type_from_body` gone from the hot path (CPU at a
  fixed wall window dropped ~2.5x: 80s→32s user). effect now DNFs on a
  **distinct, downstream** bottleneck: `evaluate_awaited_application_for_assignability_inner`
  (the original #13040 `Awaited<…>` evaluation-churn theory), an unmemoized
  recursive `Awaited` walk in the assignability layer with only a `depth>8`
  guard. That is a separate owner (assignability/Awaited normalization) and a
  separate PR; this PR removes the return-type-inference storm it was masking.

### Conformance delta — diagnostic identity (memo binary vs parent-commit baseline binary)

Byte-identical diagnostics on the function-return-inference matrix and corpus:
- 8-case matrix (generic builder DAGs, direct/wrapped recursive returns
  TS7023, mutually-recursive arrows, contextual overloads, const-context
  callbacks, circular TS7022/TS2448), incl. a renamed-binder variant set:
  **all IDENTICAL**.
- type-fest source (generic-heavy, 123 files individually + whole-project):
  **0 differ**.
- comlink (whole-project + per-file): **0 differ**.
- effect source itself: 60 sampled `.ts` files individually compared, **0 differ**.
- Small-project timing unchanged (type-fest ~0.13s both).

Full conformance / fourslash / emit owned by ready-review CI (zero-new target).

### Conformance regression fix (post-merge)

Two tests regressed on the first full-CI run and are now fixed:
- `thisType/typeRelationships.ts` — a body that returns/references `this` infers
  a `this`-dependent return type; the memo key now includes the active `this`
  type, so the same node under different `this` bindings no longer collides.
- `intersectionsOfLargeUnions.ts` (spurious TS2590) — the once-per-declaration
  **non-contextual** inference warms shared solver caches (indexed-access /
  large-union evaluations) that the immediately-following body diagnostic check
  reuses; short-circuiting it changed downstream union-complexity accounting.
  The memo is now restricted to **contextual** inference (`return_context.is_some()`)
  — exactly the re-entrant generic-builder-DAG explosion this memo targets — so
  context-free inference still warms caches unchanged.

Re-verified via the conformance harness (pinned lib): intersectionsOfLargeUnions
**2/2 PASS**, typeRelationships **1/1 PASS**; thisType **32/32**, contextual
**193/193**, generic **240/240**, typeGuard **86/86** — all PASS. effect flow
storm remains eliminated (CPU sample: `check_flow`/`infer` gone; Awaited-eval
bottleneck unchanged). Return-type matrix diagnostics unchanged.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

