### PR TITLE
fix(checker): preserve flow narrowing across await/yield suspension points

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core.rs
@@ -1346,8 +1346,22 @@ impl<'a> FlowAnalyzer<'a> {
                 })
         };
 
+        // An `await`/`yield` suspension point is a pure value pass-through (it
+        // carries no narrowing of its own) but, exactly like a pass-through CALL,
+        // it must force a defer when its OWN antecedent carries narrowing — e.g.
+        // `if (x.isErr()) return; await p; const y = 1; x.value`, where the
+        // narrowing guard sits behind the suspension point. Without this the
+        // dependent reader's flow node finalizes before the suspension point's
+        // antecedent is resolved and the narrowing is dropped.
+        let ant_is_deferring_suspension =
+            (ant_flags & (flow_flags::AWAIT_POINT | flow_flags::YIELD_POINT)) != 0
+                && ant_flow.antecedent.first().is_some_and(|&grandparent| {
+                    self.antecedent_requires_defer(grandparent, reference, symbol_id)
+                });
+
         (ant_flags & flow_flags::CONDITION) != 0
             || ant_is_deferring_call
+            || ant_is_deferring_suspension
             || (ant_flags & flow_flags::LOOP_LABEL) != 0
             || (ant_flags & flow_flags::BRANCH_LABEL) != 0
             || ant_is_targeting_assignment

--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -791,7 +791,9 @@ impl<'a> FlowAnalyzer<'a> {
                                             flow_flags::CONDITION
                                                 | flow_flags::CALL
                                                 | flow_flags::LOOP_LABEL
-                                                | flow_flags::ASSIGNMENT,
+                                                | flow_flags::ASSIGNMENT
+                                                | flow_flags::AWAIT_POINT
+                                                | flow_flags::YIELD_POINT,
                                         )
                                     });
                                 if ant_needs_defer {
@@ -838,7 +840,9 @@ impl<'a> FlowAnalyzer<'a> {
                                             | flow_flags::BRANCH_LABEL
                                             | flow_flags::LOOP_LABEL
                                             | flow_flags::ASSIGNMENT
-                                            | flow_flags::SWITCH_CLAUSE,
+                                            | flow_flags::SWITCH_CLAUSE
+                                            | flow_flags::AWAIT_POINT
+                                            | flow_flags::YIELD_POINT,
                                     )
                                 });
                             if ant_needs_defer {
@@ -992,6 +996,24 @@ impl<'a> FlowAnalyzer<'a> {
                         // before its outer antecedent, so the result wouldn't propagate back.
                         self.check_flow(reference, initial_type, outer_flow, _visited, symbol_id)
                     }
+                } else {
+                    current_type
+                }
+            } else if flow.has_any_flags(flow_flags::AWAIT_POINT | flow_flags::YIELD_POINT) {
+                // `await`/`yield` suspension points carry no narrowing of their own
+                // and tsc does not model them as flow nodes. They must resolve to
+                // their single antecedent's (possibly narrowed) type. The generic
+                // default handler below would finalize this node with the antecedent's
+                // result ONLY when it is already in `results`; on the common first
+                // visit (antecedent not yet processed) it falls back to the
+                // un-narrowed `current_type` and then marks this node finalized,
+                // permanently dropping any guard-applied narrowing that lives on the
+                // antecedent. Resolve the antecedent directly so the narrowed type is
+                // always carried through the suspension point. (The pass-through
+                // splice in `chase_linear_passthrough` handles the concrete, cacheable
+                // walks; this branch covers the generic / non-spliced walks.)
+                if let Some(&ant) = flow.antecedent.first() {
+                    self.get_flow_type(reference, current_type, ant)
                 } else {
                     current_type
                 }
@@ -1277,6 +1299,30 @@ impl<'a> FlowAnalyzer<'a> {
                     == 0
         };
 
+        // An `await`/`yield` suspension point carries no narrowing of its own and
+        // tsc does not model it as a flow node at all: it is a pure value
+        // pass-through whose flow type equals its single antecedent's. Without
+        // splicing it the worklist's "default" handler returns the antecedent's
+        // result only when that antecedent is already finalized, otherwise it falls
+        // back to the un-narrowed `current_type`, so an `await` (or `yield`) placed
+        // after a narrowing guard and before a later read of the narrowed variable
+        // silently drops the narrowing. Splice it just like a pure pass-through
+        // CALL. A suspension node is splice-eligible only when it carries no other
+        // flow-relevant flag.
+        let pure_passthrough_suspension = |flags: u32| -> bool {
+            flags & (flow_flags::AWAIT_POINT | flow_flags::YIELD_POINT) != 0
+                && flags
+                    & (flow_flags::BRANCH_LABEL
+                        | flow_flags::LOOP_LABEL
+                        | flow_flags::SWITCH_CLAUSE
+                        | flow_flags::CONDITION
+                        | flow_flags::CALL
+                        | flow_flags::ASSIGNMENT
+                        | flow_flags::ARRAY_MUTATION
+                        | flow_flags::START)
+                    == 0
+        };
+
         let mut current = entry;
         loop {
             let Some(flow) = self.binder.flow_nodes.get(current) else {
@@ -1291,6 +1337,39 @@ impl<'a> FlowAnalyzer<'a> {
                 if self.call_node_may_narrow_or_divert(flow) {
                     return current;
                 }
+                let [ant] = flow.antecedent.as_slice() else {
+                    return current;
+                };
+                let ant = *ant;
+                if self.antecedent_requires_defer_cached(
+                    ant,
+                    reference,
+                    symbol_id,
+                    antecedent_defer_memo,
+                ) || visited.contains(&ant)
+                    || results.contains_key(&ant)
+                {
+                    return current;
+                }
+                if let Some(cache) = self.flow_cache()
+                    && cache
+                        .borrow()
+                        .contains_key(&(ant, cache_symbol, initial_type))
+                {
+                    return current;
+                }
+                if current == alias_flow_id {
+                    *run_contains_alias_flow_id = true;
+                }
+                current = ant;
+                continue;
+            }
+            // Splice a pure pass-through `await`/`yield` suspension point. Mirrors
+            // the pure-pass-through CALL handling above: a suspension point with a
+            // single antecedent that neither carries pending narrowing nor is
+            // already finalized/cached is transparent and can be skipped in O(1),
+            // so the chase lands directly on the narrowing-bearing antecedent.
+            if pure_passthrough_suspension(flow.flags) {
                 let [ant] = flow.antecedent.as_slice() else {
                     return current;
                 };


### PR DESCRIPTION
Goal: green

## Structural rule
`When a control-flow guard narrows a variable, an intervening await/yield
suspension point precedes a later read of that variable, tsc keeps the
narrowing; tsz dropped it through the flow-narrowing chase.`

`AWAIT_POINT`/`YIELD_POINT` are flow nodes tsz creates but `tsc` does not model
at all. They are pure value pass-throughs: their flow type equals their single
antecedent's. The narrowing chase did not classify them, so a dependent
reader's flow node (e.g. an intervening `const` assignment that does not target
the narrowed variable) finalized with the un-narrowed antecedent fallback
*before* the suspension point's narrowing-bearing antecedent (the guard
CONDITION/CALL) was resolved by the worklist. Owner layer: checker control-flow
narrowing (`flow_domain::control_flow`).

## What changed
Treat suspension points as pure pass-throughs at every site that classifies
antecedents, mirroring the existing pure-pass-through CALL handling:
- `core/flow_traversal.rs` `chase_linear_passthrough`: splice a pure
  pass-through suspension point (concrete/cacheable walks).
- `core/flow_traversal.rs` worklist main switch: resolve a suspension point via
  its single antecedent (generic / non-spliced walks) instead of the generic
  default that finalizes with the un-narrowed fallback.
- `core.rs` `antecedent_requires_defer`: a suspension point forces a defer iff
  its own antecedent requires one (identical to the pass-through CALL rule).
- `core/flow_traversal.rs`: add `AWAIT_POINT | YIELD_POINT` to the two
  ASSIGNMENT pass-through `ant_needs_defer` flag sets.

No flag is special-cased by name/file; all sites read the existing
`flow_flags::AWAIT_POINT`/`YIELD_POINT` bits the binder already sets.

## Verification
Minimal repro (tsc-clean, was tsz `TS2339`), `--strict`:
```ts
type Result<T,E> = Ok<T,E> | Err<T,E>
class Ok<T,E>{constructor(readonly value:T){} isErr():this is Err<T,E>{return false}}
class Err<T,E>{constructor(readonly error:E){} isErr():this is Err<T,E>{return true}}
async function f<T,E>(res: Result<T,E>, p: Promise<void>): Promise<T|undefined> {
  if (res.isErr()) return undefined
  const nxt = await p
  return res.value          // tsz reverted res to Result<T,E>; now keeps Ok<T,E>
}
```
Adjacent matrix (each agrees with tsc 6.0.3):
- `let`/`const` binding from await; await of `Promise<void>` and of a generic
  union; await followed by an intervening statement; generic and concrete forms;
  renamed binders -> all OK (were FP for the generic forms).
- yield variant in a generator -> OK.
- NEGATIVE: reassignment between guard and await still clears narrowing.
- NEGATIVE: reading an un-narrowed union member after await still errors
  (verified via `@ts-expect-error` that tsc does not flag as unused).

Found while reducing the neverthrow canary (its async `this is`-guard-then-await
shape in `ResultAsync`). Broad conformance/emit/fourslash owned by ready-review
CI (local TypeScript submodule `tests/cases` is unpopulated in this worktree).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high