### PR TITLE
fix(checker): method/constructor overload-impl param bivariance for neverthrow canary

### DIFF
--- a/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
+++ b/crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs
@@ -690,7 +690,22 @@ impl<'a> CheckerState<'a> {
             // First check if return types are compatible in EITHER direction,
             // then check parameter-only assignability (ignoring return types).
             // This matches tsc's isImplementationCompatibleWithOverload.
-            if !self.is_implementation_compatible_with_overload(impl_type, overload_type) {
+            //
+            // Method/method-signature/constructor declarations compare parameters
+            // bivariantly (tsc's `compareSignaturesRelated` gates `strictVariance`
+            // off for those declaration kinds); plain function overloads stay
+            // strict. The implementation and overload share a declaration kind, so
+            // the implementation node is authoritative.
+            let bivariant_params = self.ctx.arena.get(impl_node_idx).is_some_and(|node| {
+                node.kind == syntax_kind_ext::METHOD_DECLARATION
+                    || node.kind == syntax_kind_ext::METHOD_SIGNATURE
+                    || node.kind == syntax_kind_ext::CONSTRUCTOR
+            });
+            if !self.is_implementation_compatible_with_overload_inner(
+                impl_type,
+                overload_type,
+                bivariant_params,
+            ) {
                 // TSC anchors the error at the function/method name, not the whole declaration.
                 if decl_in_current {
                     let error_node = self.get_declaration_name_node(decl_idx).unwrap_or(decl_idx);
@@ -857,6 +872,24 @@ impl<'a> CheckerState<'a> {
         impl_type: tsz_solver::TypeId,
         overload_type: tsz_solver::TypeId,
     ) -> bool {
+        self.is_implementation_compatible_with_overload_inner(impl_type, overload_type, false)
+    }
+
+    /// `bivariant_params`: when the overload/implementation are declared as
+    /// methods, method signatures, or constructors, tsc compares their
+    /// parameters bivariantly even under `strictFunctionTypes`
+    /// (`compareSignaturesRelated`'s `strictVariance` is gated off for those
+    /// declaration kinds). For plain function overloads it stays strict
+    /// (contravariant). Threading this through lets a static-method overload
+    /// like `fromSafePromise(p: PromiseLike<T>)` with implementation
+    /// `(p: Promise<T>)` be accepted — `Promise<T>` is assignable to
+    /// `PromiseLike<T>`, satisfying the bivariant direction — exactly as tsc.
+    pub(crate) fn is_implementation_compatible_with_overload_inner(
+        &mut self,
+        impl_type: tsz_solver::TypeId,
+        overload_type: tsz_solver::TypeId,
+        bivariant_params: bool,
+    ) -> bool {
         let constructors_only =
             crate::query_boundaries::common::is_constructor_like_type(self.ctx.types, impl_type)
                 && crate::query_boundaries::common::is_constructor_like_type(
@@ -914,11 +947,22 @@ impl<'a> CheckerState<'a> {
                     self.replace_return_type(impl_stripped, tsz_solver::TypeId::ANY);
                 let overload_with_any_ret =
                     self.replace_return_type(overload_stripped, tsz_solver::TypeId::ANY);
-                self.overload_implementation_parameter_relation_outcome(
-                    impl_with_any_ret,
-                    overload_with_any_ret,
-                )
-                .related
+                // Methods/method-signatures/constructors compare parameters
+                // bivariantly (tsc gates `strictVariance` off for those kinds);
+                // plain function overloads keep the strict contravariant check.
+                if bivariant_params || constructors_only {
+                    self.bivariant_callbacks_relation_outcome(
+                        impl_with_any_ret,
+                        overload_with_any_ret,
+                    )
+                    .related
+                } else {
+                    self.overload_implementation_parameter_relation_outcome(
+                        impl_with_any_ret,
+                        overload_with_any_ret,
+                    )
+                    .related
+                }
             }
             _ => {
                 // If we can't get return types, fall back to bivariant assignability


### PR DESCRIPTION
Goal: green

## Structural rule
`When an overload and its implementation are declared as a method,
method-signature, or constructor, tsc compares their parameters bivariantly
even under strictFunctionTypes; tsz always compared them strictly
(contravariant), so a method overload with a parameter WIDER than the
implementation's — but still assignable in one direction — was wrongly
rejected with TS2394.`

This mirrors tsc's `compareSignaturesRelated`, where
`strictVariance = strictFunctionTypes && kind !== MethodDeclaration &&
kind !== MethodSignature && kind !== Constructor`. With `strictVariance`
false, each parameter pair relates when EITHER direction holds
(`compareTypes(source, target) || compareTypes(target, source)`). Owner layer:
checker overload-implementation compatibility
(`state_checking_members::overload_compatibility`).

## What changed
`crates/tsz-checker/src/state/state_checking_members/overload_compatibility.rs`:
- `check_overload_compatibility` derives the declaration kind from the
  implementation node (implementation and overload share a kind) and passes a
  `bivariant_params` flag for `METHOD_DECLARATION` / `METHOD_SIGNATURE` /
  `CONSTRUCTOR`.
- `is_implementation_compatible_with_overload_inner` uses the
  bivariant-callbacks relation (which strips `STRICT_FUNCTION_TYPES`) for the
  parameter comparison when `bivariant_params` (or the existing
  constructors-only case) holds; plain function overloads keep the strict
  `overload_implementation_parameter` relation.

No name/file-string predicate; the decision is driven by AST declaration kind
and the existing relation policy.

## Verification
Witness (neverthrow `ResultAsync.fromSafePromise`), tsc-clean, was tsz TS2394:
```ts
class Box<A, B> {}
class Maker {
  static build<A, B = never>(thenable: PromiseLike<A>): Box<A, B>
  static build<A, B = never>(thenable: Promise<A>): Box<A, B> { return new Box() }
}
```
neverthrow canary FP (project-compile-guard `TSZ_PROJECT_COMPILE_SET=canary`
`TSZ_PROJECT_COMPILE_FILTER=neverthrow`): `result-async.ts(29,10)` and
`result-async.ts(36,10)` `TS2394` eliminated.

Adjacent matrix (each agrees with tsc 6.0.3):
- NEGATIVE method overload with disjoint param (`string` vs `number`) -> TS2394 (preserved)
- NEGATIVE constructor overload disjoint param -> TS2394 (preserved)
- NEGATIVE implementation requires more args than overload -> TS2394 (preserved)
- VALID method overload (narrower overload `"a"`, wider impl `string`) -> clean
- VALID generic static-method `PromiseLike`/`Promise` overload, renamed binders -> clean
- plain-function overload comparison unchanged (still strict).

Broad conformance/emit/fourslash owned by ready-review CI (local TypeScript
submodule `tests/cases` is unpopulated in this worktree).

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high