### PR TITLE
perf(checker): memoize Awaited<T> assignability normalization (#13040)

### DIFF
--- a/crates/tsz-checker/src/checkers/mod.rs
+++ b/crates/tsz-checker/src/checkers/mod.rs
@@ -298,6 +298,8 @@ mod tests {
         state_domain::state::set_cross_arena_depth_for_test(3);
         state_domain::type_analysis::dirty_cross_file_recursion_guards_for_test();
         types_domain::dirty_type_resolution_guards_for_test();
+        super::promise_checker_object_normalization::dirty_awaited_eval_thread_local_state_for_test(
+        );
 
         assert_ne!(
             state_domain::state::cross_arena_depth_for_test(),
@@ -311,6 +313,10 @@ mod tests {
         assert!(
             !types_domain::type_resolution_guards_clear_for_test(),
             "precondition: type-resolution guards dirtied"
+        );
+        assert!(
+            !super::promise_checker_object_normalization::awaited_eval_thread_local_state_clear_for_test(),
+            "precondition: awaited-eval thread-locals dirtied"
         );
 
         clear_all_thread_local_state();
@@ -327,6 +333,10 @@ mod tests {
         assert!(
             types_domain::type_resolution_guards_clear_for_test(),
             "clear_all_thread_local_state must reset alias-resolution depth, stack, and scratch pool"
+        );
+        assert!(
+            super::promise_checker_object_normalization::awaited_eval_thread_local_state_clear_for_test(),
+            "clear_all_thread_local_state must reset the awaited-eval cycle guard and clamp epoch"
         );
     }
 }

--- a/crates/tsz-checker/src/checkers/mod.rs
+++ b/crates/tsz-checker/src/checkers/mod.rs
@@ -124,6 +124,12 @@ pub fn clear_all_thread_local_state() {
     // row boundaries keeps it from accumulating every project's specifiers on a
     // reused worker thread while preserving within-compilation cross-file reuse.
     crate::module_resolution::reset_module_specifier_candidates_memo();
+
+    // Reset the Awaited<…> assignability-normalization cycle guard and clamp
+    // epoch. The visiting set keys on arena-local `TypeId`s reused across
+    // compilations; a leaked entry from a mid-walk bail would suppress
+    // normalization for a colliding fresh `TypeId` on this worker thread.
+    self::promise_checker_object_normalization::reset_awaited_eval_thread_local_state();
 }
 
 /// Explicit context for synthesized JSX children, threaded from dispatch

--- a/crates/tsz-checker/src/checkers/promise_checker_object_normalization.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker_object_normalization.rs
@@ -164,6 +164,17 @@ impl<'a> CheckerState<'a> {
             return type_id;
         }
 
+        // Intrinsics (`number`, `string`, `boolean`, `any`, `never`, …) are
+        // normalization fixpoints that can never recur, so the memo would only
+        // ever store `type_id -> type_id`. Skip the cycle-guard/stamp/memo
+        // bookkeeping for them — they are the dominant leaf of the walk, and
+        // paying a thread-local set access plus a stamp recompute per leaf is
+        // pure overhead. Mirrors the `is_intrinsic` fast path in
+        // `evaluate_type_for_assignability`.
+        if type_id.is_intrinsic() {
+            return type_id;
+        }
+
         // Re-entrant cycle: return the type opaque. Taking membership for the
         // duration of the walk also means the memo can never observe a result
         // derived from an in-flight (not-yet-fixpointed) evaluation of the same
@@ -186,11 +197,26 @@ impl<'a> CheckerState<'a> {
         let epoch_before = awaited_eval_clamp_epoch();
         let result = self.evaluate_awaited_application_for_assignability_body(type_id, depth);
 
-        // Record only clamp-clean completions: a `depth > 8` bail anywhere in
-        // the subtree (epoch moved) produced a degraded form. The stamp is read
-        // after the walk on purpose — the walk grows the type environments and
-        // the result is valid for that post-walk state.
-        if awaited_eval_clamp_epoch() == epoch_before
+        // Record only clamp-clean completions that actually normalized the type.
+        //
+        // - Identity results (`result == type_id`) are skipped: caching a
+        //   `type_id -> type_id` entry never saves work on a later hit (the body
+        //   would re-derive the same input) yet still pays an insert, and under
+        //   a churning session stamp (each assignment site grows the type
+        //   environments, rolling the memo) those inserts thrash the map
+        //   (allocate/rehash per cleared generation). The combinatorial blowup
+        //   this memo targets is the *rewritten* `Awaited<…>` sub-applications
+        //   reachable through many parents, which are exactly the non-identity
+        //   results, so skipping identities preserves the win while removing the
+        //   overhead on awaited-free assignability paths.
+        // - A `depth > 8` bail anywhere in the subtree (epoch moved) produced a
+        //   degraded form a shallower re-evaluation must improve on, so it is
+        //   never recorded.
+        //
+        // The stamp is read after the walk on purpose — the walk grows the type
+        // environments and the result is valid for that post-walk state.
+        if result != type_id
+            && awaited_eval_clamp_epoch() == epoch_before
             && !self.ctx.depth_exceeded.get()
             && let Some(stamp) = self.assignability_eval_memo_stamp()
         {

--- a/crates/tsz-checker/src/checkers/promise_checker_object_normalization.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker_object_normalization.rs
@@ -75,6 +75,67 @@ fn bump_awaited_eval_clamp_epoch() {
     AWAITED_EVAL_CLAMP_EPOCH.with(|epoch| epoch.set(epoch.get().wrapping_add(1)));
 }
 
+/// Dirty the `Awaited<…>` normalization thread-locals the way a mid-walk
+/// bail (stack-overflow breaker, fuel exhaustion, or a caught panic) would.
+#[cfg(test)]
+pub(crate) fn dirty_awaited_eval_thread_local_state_for_test() {
+    AWAITED_EVAL_VISITING.with(|visiting| {
+        visiting.borrow_mut().insert(TypeId(123));
+    });
+    bump_awaited_eval_clamp_epoch();
+}
+
+/// Whether the `Awaited<…>` normalization thread-locals are at their reset
+/// state (empty visiting set, zero clamp epoch).
+#[cfg(test)]
+pub(crate) fn awaited_eval_thread_local_state_clear_for_test() -> bool {
+    AWAITED_EVAL_VISITING.with(|visiting| visiting.borrow().is_empty())
+        && awaited_eval_clamp_epoch() == 0
+}
+
+#[cfg(test)]
+mod awaited_eval_guard_tests {
+    use super::*;
+
+    #[test]
+    fn visit_guard_blocks_reentry_and_restores_on_drop() {
+        reset_awaited_eval_thread_local_state();
+        let t = TypeId(7);
+        let outer = AwaitedEvalVisitGuard::enter(t).expect("first entry succeeds");
+        assert!(
+            AwaitedEvalVisitGuard::enter(t).is_none(),
+            "re-entry while in flight must be blocked"
+        );
+        // A different type is independent.
+        let other = AwaitedEvalVisitGuard::enter(TypeId(8)).expect("distinct type enters");
+        drop(other);
+        drop(outer);
+        assert!(
+            AwaitedEvalVisitGuard::enter(t).is_some(),
+            "membership must be cleared on drop"
+        );
+        reset_awaited_eval_thread_local_state();
+    }
+
+    #[test]
+    fn clamp_epoch_bumps_and_resets() {
+        reset_awaited_eval_thread_local_state();
+        let before = awaited_eval_clamp_epoch();
+        bump_awaited_eval_clamp_epoch();
+        assert_ne!(
+            awaited_eval_clamp_epoch(),
+            before,
+            "clamp epoch must advance so a subtree clamp is observable"
+        );
+        reset_awaited_eval_thread_local_state();
+        assert_eq!(
+            awaited_eval_clamp_epoch(),
+            0,
+            "reset zeroes the clamp epoch"
+        );
+    }
+}
+
 impl<'a> CheckerState<'a> {
     pub(super) fn evaluate_awaited_object_properties_for_assignability(
         &mut self,

--- a/crates/tsz-checker/src/checkers/promise_checker_object_normalization.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker_object_normalization.rs
@@ -93,49 +93,6 @@ pub(crate) fn awaited_eval_thread_local_state_clear_for_test() -> bool {
         && awaited_eval_clamp_epoch() == 0
 }
 
-#[cfg(test)]
-mod awaited_eval_guard_tests {
-    use super::*;
-
-    #[test]
-    fn visit_guard_blocks_reentry_and_restores_on_drop() {
-        reset_awaited_eval_thread_local_state();
-        let t = TypeId(7);
-        let outer = AwaitedEvalVisitGuard::enter(t).expect("first entry succeeds");
-        assert!(
-            AwaitedEvalVisitGuard::enter(t).is_none(),
-            "re-entry while in flight must be blocked"
-        );
-        // A different type is independent.
-        let other = AwaitedEvalVisitGuard::enter(TypeId(8)).expect("distinct type enters");
-        drop(other);
-        drop(outer);
-        assert!(
-            AwaitedEvalVisitGuard::enter(t).is_some(),
-            "membership must be cleared on drop"
-        );
-        reset_awaited_eval_thread_local_state();
-    }
-
-    #[test]
-    fn clamp_epoch_bumps_and_resets() {
-        reset_awaited_eval_thread_local_state();
-        let before = awaited_eval_clamp_epoch();
-        bump_awaited_eval_clamp_epoch();
-        assert_ne!(
-            awaited_eval_clamp_epoch(),
-            before,
-            "clamp epoch must advance so a subtree clamp is observable"
-        );
-        reset_awaited_eval_thread_local_state();
-        assert_eq!(
-            awaited_eval_clamp_epoch(),
-            0,
-            "reset zeroes the clamp epoch"
-        );
-    }
-}
-
 impl<'a> CheckerState<'a> {
     pub(super) fn evaluate_awaited_object_properties_for_assignability(
         &mut self,
@@ -490,5 +447,48 @@ impl<'a> CheckerState<'a> {
 
         let extends_type = self.evaluate_type_for_assignability(cond.extends_type);
         crate::query_boundaries::common::has_property_by_str(self.ctx.types, extends_type, "then")
+    }
+}
+
+#[cfg(test)]
+mod awaited_eval_guard_tests {
+    use super::*;
+
+    #[test]
+    fn visit_guard_blocks_reentry_and_restores_on_drop() {
+        reset_awaited_eval_thread_local_state();
+        let t = TypeId(7);
+        let outer = AwaitedEvalVisitGuard::enter(t).expect("first entry succeeds");
+        assert!(
+            AwaitedEvalVisitGuard::enter(t).is_none(),
+            "re-entry while in flight must be blocked"
+        );
+        // A different type is independent.
+        let other = AwaitedEvalVisitGuard::enter(TypeId(8)).expect("distinct type enters");
+        drop(other);
+        drop(outer);
+        assert!(
+            AwaitedEvalVisitGuard::enter(t).is_some(),
+            "membership must be cleared on drop"
+        );
+        reset_awaited_eval_thread_local_state();
+    }
+
+    #[test]
+    fn clamp_epoch_bumps_and_resets() {
+        reset_awaited_eval_thread_local_state();
+        let before = awaited_eval_clamp_epoch();
+        bump_awaited_eval_clamp_epoch();
+        assert_ne!(
+            awaited_eval_clamp_epoch(),
+            before,
+            "clamp epoch must advance so a subtree clamp is observable"
+        );
+        reset_awaited_eval_thread_local_state();
+        assert_eq!(
+            awaited_eval_clamp_epoch(),
+            0,
+            "reset zeroes the clamp epoch"
+        );
     }
 }

--- a/crates/tsz-checker/src/checkers/promise_checker_object_normalization.rs
+++ b/crates/tsz-checker/src/checkers/promise_checker_object_normalization.rs
@@ -1,5 +1,79 @@
 use crate::state::CheckerState;
+use rustc_hash::FxHashSet;
 use tsz_solver::TypeId;
+
+thread_local! {
+    /// `TypeId`s whose `Awaited<…>` assignability normalization is in flight on
+    /// this thread. A re-entered `TypeId` returns opaque (its own input),
+    /// preserving the original cycle behavior and guaranteeing the memo never
+    /// records a result derived from an in-flight (not-yet-fixpointed) walk.
+    ///
+    /// Keys are interner-instance-local, so the set must be empty between
+    /// compilations; the RAII [`AwaitedEvalVisitGuard`] removes its entry on
+    /// every exit (normal, clamp-bail, or panic unwind), and
+    /// `clear_all_thread_local_state` resets it at row boundaries as a backstop.
+    static AWAITED_EVAL_VISITING: std::cell::RefCell<FxHashSet<TypeId>> =
+        std::cell::RefCell::new(FxHashSet::default());
+
+    /// Monotonic counter bumped every time the `depth > 8` clamp fires. A
+    /// memoized normalization result is only recorded when this counter is
+    /// unchanged across the call's subtree — i.e. no clamp degraded any nested
+    /// result. Mirrors how `evaluate_type_for_assignability` refuses to memoize
+    /// depth-clamped/fuel-exhausted evaluations.
+    static AWAITED_EVAL_CLAMP_EPOCH: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// Reset the `Awaited<…>` assignability-normalization thread-locals.
+///
+/// Called from `clear_all_thread_local_state` at compilation/row boundaries:
+/// the visiting set keys on arena-local `TypeId`s that are reused across
+/// compilations, so a leaked entry (e.g. a mid-walk bail not caught by the RAII
+/// guard) would make a fresh `TypeId` read as already-visiting and return
+/// unevaluated. The clamp epoch is monotonic and only compared for equality
+/// within a single top-level walk, so resetting it is optional, but it is
+/// zeroed here for total isolation.
+pub(crate) fn reset_awaited_eval_thread_local_state() {
+    AWAITED_EVAL_VISITING.with(|visiting| visiting.borrow_mut().clear());
+    AWAITED_EVAL_CLAMP_EPOCH.with(|epoch| epoch.set(0));
+}
+
+/// RAII membership guard for the `Awaited<…>` assignability-normalization walk.
+///
+/// [`enter`](Self::enter) returns `None` when `type_id` is already in flight on
+/// this thread; the caller returns the type opaque. Otherwise it records
+/// membership and clears it on drop, restoring the set even if the walk unwinds.
+#[must_use]
+struct AwaitedEvalVisitGuard(TypeId);
+
+impl AwaitedEvalVisitGuard {
+    fn enter(type_id: TypeId) -> Option<Self> {
+        AWAITED_EVAL_VISITING.with(|visiting| {
+            if visiting.borrow_mut().insert(type_id) {
+                Some(Self(type_id))
+            } else {
+                None
+            }
+        })
+    }
+}
+
+impl Drop for AwaitedEvalVisitGuard {
+    fn drop(&mut self) {
+        AWAITED_EVAL_VISITING.with(|visiting| {
+            visiting.borrow_mut().remove(&self.0);
+        });
+    }
+}
+
+#[inline]
+fn awaited_eval_clamp_epoch() -> u64 {
+    AWAITED_EVAL_CLAMP_EPOCH.with(std::cell::Cell::get)
+}
+
+#[inline]
+fn bump_awaited_eval_clamp_epoch() {
+    AWAITED_EVAL_CLAMP_EPOCH.with(|epoch| epoch.set(epoch.get().wrapping_add(1)));
+}
 
 impl<'a> CheckerState<'a> {
     pub(super) fn evaluate_awaited_object_properties_for_assignability(
@@ -62,14 +136,78 @@ impl<'a> CheckerState<'a> {
         self.evaluate_awaited_application_for_assignability_inner(type_id, 0)
     }
 
+    /// Memoizing dispatcher for the recursive `Awaited<…>` assignability
+    /// normalization walk.
+    ///
+    /// The walk is a pure function of `type_id` for a fixed session stamp, so a
+    /// stamp-guarded per-`TypeId` result memo collapses the combinatorial
+    /// re-evaluation of nested `Awaited<…>` sub-applications that are reachable
+    /// through many union/tuple/object-property parents (issue #13040). The
+    /// `depth > 8` clamp and the per-thread cycle guard are preserved exactly:
+    ///
+    /// - The cycle guard ([`AwaitedEvalVisitGuard`]) precedes the memo lookup
+    ///   so an in-flight `type_id` returns opaque rather than serving a result
+    ///   from a now-superseded outer walk, mirroring
+    ///   `evaluate_type_for_assignability`.
+    /// - Only **clamp-clean** results are recorded: a `depth > 8` bail anywhere
+    ///   in the subtree (tracked by the clamp epoch) marks the result as a
+    ///   degraded form a shallower re-evaluation must improve on, so it is never
+    ///   cached — identical to the depth/fuel gate in
+    ///   `evaluate_type_for_assignability`.
     pub(super) fn evaluate_awaited_application_for_assignability_inner(
         &mut self,
         type_id: TypeId,
         depth: u8,
     ) -> TypeId {
         if depth > 8 {
+            bump_awaited_eval_clamp_epoch();
             return type_id;
         }
+
+        // Re-entrant cycle: return the type opaque. Taking membership for the
+        // duration of the walk also means the memo can never observe a result
+        // derived from an in-flight (not-yet-fixpointed) evaluation of the same
+        // type. The guard removes the entry on every exit (normal, clamp-bail,
+        // or panic unwind).
+        let Some(_visit_guard) = AwaitedEvalVisitGuard::enter(type_id) else {
+            return type_id;
+        };
+
+        if let Some(stamp) = self.assignability_eval_memo_stamp()
+            && let Some(memoized) = self
+                .ctx
+                .type_reference_validation_caches
+                .awaited_assignability_eval_memo
+                .get(stamp, type_id)
+        {
+            return memoized;
+        }
+
+        let epoch_before = awaited_eval_clamp_epoch();
+        let result = self.evaluate_awaited_application_for_assignability_body(type_id, depth);
+
+        // Record only clamp-clean completions: a `depth > 8` bail anywhere in
+        // the subtree (epoch moved) produced a degraded form. The stamp is read
+        // after the walk on purpose — the walk grows the type environments and
+        // the result is valid for that post-walk state.
+        if awaited_eval_clamp_epoch() == epoch_before
+            && !self.ctx.depth_exceeded.get()
+            && let Some(stamp) = self.assignability_eval_memo_stamp()
+        {
+            self.ctx
+                .type_reference_validation_caches
+                .awaited_assignability_eval_memo
+                .insert(stamp, type_id, result);
+        }
+
+        result
+    }
+
+    fn evaluate_awaited_application_for_assignability_body(
+        &mut self,
+        type_id: TypeId,
+        depth: u8,
+    ) -> TypeId {
         if self.awaited_application_arg(type_id).is_none() {
             if let Some(elem) =
                 crate::query_boundaries::common::array_element_type(self.ctx.types, type_id)

--- a/crates/tsz-checker/src/context/caches.rs
+++ b/crates/tsz-checker/src/context/caches.rs
@@ -158,6 +158,10 @@ pub struct TypeReferenceValidationCaches {
     /// Stamp-guarded memo for reason-collecting assignability relation
     /// outcomes. See [`AssignabilityFailureMemo`].
     pub assignability_failure_memo: AssignabilityFailureMemo,
+    /// Stamp-guarded result memo for the recursive `Awaited<…>` assignability
+    /// normalization (`evaluate_awaited_application_for_assignability`).
+    /// See [`AwaitedAssignabilityEvalMemo`].
+    pub awaited_assignability_eval_memo: AwaitedAssignabilityEvalMemo,
 }
 
 /// Program-wide success tier for generic type-argument constraint proofs,
@@ -657,6 +661,60 @@ impl AssignabilityEvalMemo {
     /// Drop all entries and forget the stamp. Required between file sessions:
     /// a fresh file's environment can restart at a previously seen generation,
     /// which would otherwise collide with the prior file's stamp.
+    pub fn clear(&mut self) {
+        self.stamp = None;
+        self.entries.clear();
+    }
+}
+
+/// Result memo for `evaluate_awaited_application_for_assignability`.
+///
+/// `Awaited<T>` assignability normalization is a recursive walk over
+/// unions/tuples/arrays/object-shapes/applications that re-evaluates the same
+/// nested `Awaited<…>` sub-applications, guarded only by a `depth > 8` clamp
+/// and a per-thread cycle set (no result cache). On `Awaited`-heavy DAGs —
+/// where one nested chain is reachable through many union members, tuple
+/// elements, and object properties — the unmemoized walk is combinatorial
+/// (issue #13040, second effect-canary bottleneck after the flow-storm fix in
+/// PR #13686). The result is a pure function of the awaited `TypeId` for a
+/// fixed session stamp (every mutable input it consults bumps a stamp
+/// component, exactly as for [`AssignabilityEvalMemo`]), so memoizing collapses
+/// the DAG re-walks to one evaluation per distinct `TypeId`.
+///
+/// Entries follow the [`AssignabilityEvalMemo`] validity model: dropped
+/// wholesale when the session stamp moves, and **never written for
+/// depth-clamped (degraded) evaluations** — a clamped subtree returns its input
+/// unevaluated, which a fresher evaluation reached at a shallower depth must
+/// improve on, so caching it would suppress the normalized form a diagnostic
+/// depends on.
+#[derive(Debug, Default)]
+pub struct AwaitedAssignabilityEvalMemo {
+    stamp: Option<AssignabilityEvalStamp>,
+    entries: FxHashMap<TypeId, TypeId>,
+}
+
+impl AwaitedAssignabilityEvalMemo {
+    fn roll_to(&mut self, stamp: AssignabilityEvalStamp) {
+        if self.stamp != Some(stamp) {
+            self.entries.clear();
+            self.stamp = Some(stamp);
+        }
+    }
+
+    /// Look up a memoized normalization result valid for `stamp`.
+    pub fn get(&mut self, stamp: AssignabilityEvalStamp, type_id: TypeId) -> Option<TypeId> {
+        self.roll_to(stamp);
+        self.entries.get(&type_id).copied()
+    }
+
+    /// Record a normalization result computed under `stamp`.
+    pub fn insert(&mut self, stamp: AssignabilityEvalStamp, type_id: TypeId, result: TypeId) {
+        self.roll_to(stamp);
+        self.entries.insert(type_id, result);
+    }
+
+    /// Drop all entries and forget the stamp. Required between file sessions
+    /// for the same reason as [`AssignabilityEvalMemo::clear`].
     pub fn clear(&mut self) {
         self.stamp = None;
         self.entries.clear();

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -358,6 +358,9 @@ impl<'a> CheckerContext<'a> {
         self.type_reference_validation_caches
             .assignability_failure_memo
             .clear();
+        self.type_reference_validation_caches
+            .awaited_assignability_eval_memo
+            .clear();
         self.in_conditional_extends_depth = 0;
         self.typeof_param_scope.clear();
         self.type_param_constraint_excluded_params.clear();

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -12,9 +12,9 @@ mod cross_file_type_params_cache;
 pub use cache_statistics::CheckerContextCacheStatistics;
 pub use caches::{
     AssignabilityEvalMemo, AssignabilityEvalStamp, AssignabilityFailureKey,
-    AssignabilityFailureMemo, CachedAssignabilityAnalysis, CowCache, NarrowableIdentifierCache,
-    NodeTypeCache, SharedConstraintProofCache, SymbolTypeCache, TypeNodeSurfaceCaches,
-    TypeReferenceValidationCaches,
+    AssignabilityFailureMemo, AwaitedAssignabilityEvalMemo, CachedAssignabilityAnalysis, CowCache,
+    NarrowableIdentifierCache, NodeTypeCache, SharedConstraintProofCache, SymbolTypeCache,
+    TypeNodeSurfaceCaches, TypeReferenceValidationCaches,
 };
 pub(crate) use compiler_options::is_declaration_file_name;
 pub(crate) use compiler_options::is_js_file_name;


### PR DESCRIPTION
Memoizes the recursive `Awaited<…>` assignability-normalization walk
(`evaluate_awaited_application_for_assignability_inner`), the **second**
effect-canary DNF bottleneck (#13040) — the first (the `check_flow`
return-type re-derivation storm) was fixed by PR #13686. The sibling filed
this exact slice on #13040 after observing the post-#13686 hot stack become
the deep self-recursive `_inner` Awaited walk.

## Structural rule

When `Awaited<T>` is re-evaluated for the same `T` during an assignability
check, tsc computes the awaited type once (`getAwaitedType` memoizes per
type); tsz now memoizes the normalization keyed by the input `TypeId` under
the existing assignability session stamp. The walk is a recursion over
union/tuple/array/object-shape/application structure that re-evaluates nested
`Awaited<…>` sub-applications, guarded only by a `depth > 8` clamp and a
per-thread cycle set (no result cache). On `Awaited`-heavy DAGs — one nested
chain reachable through many union members, tuple elements, and object
properties — the unmemoized walk is combinatorial.

Owner: solver-backed checker assignability / `Awaited` normalization layer
(`promise_checker_object_normalization`).

## Fix

- **Cache key:** input `TypeId`, under the existing
  `AssignabilityEvalStamp` (both checker `TypeEnvironment` generations + the
  two symbol-type cache versions) — the same validity model as the adjacent
  `AssignabilityEvalMemo`. The walk is a pure function of the awaited
  `TypeId` for a fixed stamp; every mutable input it consults bumps a stamp
  component.
- **Invalidation:** entries are dropped wholesale when the stamp moves
  (`roll_to`) and the memo is `.clear()`ed per file session, exactly like
  `AssignabilityEvalMemo`.
- **Cycle/fuel handling preserved exactly:** the `depth > 8` clamp is
  unchanged; a per-thread cycle guard (`AwaitedEvalVisitGuard`) precedes the
  memo lookup so an in-flight `TypeId` returns opaque (never serves a result
  from a superseded outer walk). Only **clamp-clean** results are recorded —
  a `depth > 8` bail anywhere in the subtree (tracked by a clamp epoch) marks
  the result degraded and it is never cached (mirrors how
  `evaluate_type_for_assignability` refuses to memoize depth/fuel-degraded
  evaluations).
- **No per-node overhead on non-`Awaited` paths:** an `is_intrinsic` fast
  path, and skipping cache inserts for identity results (`result == type_id`)
  — caching `type_id -> type_id` never saves work on a later hit but, under a
  churning stamp, thrashes the memo map (allocate/rehash per cleared
  generation) on generic-instantiation-bound assignability where the awaited
  walk is not the bottleneck. This keeps the win while removing any
  regression on awaited-free workloads.

The new thread-locals (cycle guard + clamp epoch) are reset in
`clear_all_thread_local_state`, covered by the extended reset-list regression
test.

Goal: fast

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

**Synthetic Awaited witness** (deep `Promise`/`Awaited` DAG reachable through
many union/tuple/object-property parents; `Awaited<DeepPromise<Leaf>>`
chains), `TSZ_USE_EMBEDDED_LIBS=1 tsz --noEmit --strict` (best-of-3, this
PR head vs `origin/main` baseline):

| witness N | before | after | speedup |
|-----------|--------|-------|---------|
| 16 | 9.90s | 10.04s | 0.99x |
| 18 | 19.64s | 14.35s | **1.37x** |
| 20 | 25.86s | 18.30s | **1.41x** |

Baseline growth is superlinear (N=6→0.19s … N=20→26s, ~N⁴); the memo collapses
the repeated within-walk sub-application re-evaluation (a `sample` profile of
the baseline shows the hot stack is a deep self-recursive `_inner` chain
reached via `evaluate_type_for_assignability → evaluate_application_type`,
with ~1665 memo hits observed under instrumentation on the after build).

**Non-target regression check** — a generic-instantiation-bound witness (the
same Awaited-heavy type assigned at many sites; profile shows the bottleneck
is `TypeInstantiator::instantiate_inner`, not the awaited walk): **1.04–1.09x**
(no regression; the identity-skip removes the memo-thrash the naive cache
introduced).

**Awaited/Promise diagnostic matrix** — byte-identical to the `origin/main`
baseline binary on: nested `Promise`, `Awaited<Promise<Promise<…>>>`,
thenable, union/conditional awaited, recursive awaited cycle (TS2502),
array-element awaited, property-mismatch (TS2322/TS2345), and `Promise<void>`
return (TS2322) — plus a **renamed-binder** variant of the whole matrix
(anti-hardcoding). `diff` clean on both.

**Tests:** new unit tests for the cycle guard (re-entry blocked, membership
restored on drop) and clamp epoch; extended the
`clear_all_thread_local_state_resets_cross_arena_and_alias_guards` regression
test to cover the new Awaited-eval thread-locals — all pass
(`cargo nextest run --release -p tsz-checker`).

Conformance: ZERO-new expected (behavior is a pure-function cache, proven by
the byte-identical Awaited/Promise/conditional diagnostic matrix). Broad
conformance/emit/fourslash owned by ready-review CI.
