### PR TITLE
fix(solver): defer conditional over opaque resolver-less Application check type (#13609)

### DIFF
--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -983,6 +983,16 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 is_subtype = is_sub,
                 "conditional subtype check result"
             );
+
+            // A conditional whose evaluated CHECK type is an opaque, resolver-less
+            // `Application` must defer rather than vacuously take its true branch
+            // (#13609). See `defer_resolver_less_application_check`.
+            if let Some(deferred) =
+                self.defer_resolver_less_application_check(cond, check_type, extends_type, is_sub)
+            {
+                return deferred;
+            }
+
             let result_branch = if is_sub {
                 // T <: U -> true branch
                 cond.true_type

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -218,15 +218,86 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             Some(TypeData::UnresolvedTypeName(_))
         ) {
             self.mark_unresolved_def_seen();
-            return Some(self.interner().conditional(ConditionalType {
-                check_type,
-                extends_type,
-                true_type: cond.true_type,
-                false_type: cond.false_type,
-                is_distributive: cond.is_distributive,
-            }));
+            return Some(self.deferred_conditional(cond, check_type, extends_type));
         }
 
+        None
+    }
+
+    /// Re-intern `cond` as a deferred conditional carrying the *evaluated*
+    /// `check_type`/`extends_type` while preserving its original branches and
+    /// distributivity. Shared by the operand-deferral sites in this module so the
+    /// five-field reconstruction lives in one place.
+    fn deferred_conditional(
+        &self,
+        cond: &ConditionalType,
+        check_type: TypeId,
+        extends_type: TypeId,
+    ) -> TypeId {
+        self.interner().conditional(ConditionalType {
+            check_type,
+            extends_type,
+            true_type: cond.true_type,
+            false_type: cond.false_type,
+            is_distributive: cond.is_distributive,
+        })
+    }
+
+    /// Defer a conditional whose evaluated CHECK type is an opaque, resolver-less
+    /// `Application`, instead of letting it vacuously take its true branch.
+    ///
+    /// A resolvable application evaluates to its structural form, so an
+    /// `Application` that *survives* evaluation in the check position is opaque:
+    /// the active resolver lacked the body needed to reduce it (e.g. a
+    /// distributive utility whose body could not expand because an inner
+    /// reference was still unresolved under this resolver — the
+    /// `resolver_generation()==0` / registration-window family). With no
+    /// structure to compare, the structural subtype walk degrades the opaque
+    /// application toward the bottom type, so `is_sub` is vacuously `true` and the
+    /// conditional collapses into its TRUE branch. That is the mechanism by which
+    /// the mapped key-remap `IsOptionalKeyOf<O, K> extends false ? never : K`
+    /// filters every key to `never`, leaving `RequiredKeysOf`/`OptionalKeysOf`
+    /// with the wrong key set and false-failing `TS2344` against a well-typed
+    /// default-options argument (#13609).
+    ///
+    /// The guard is gated on [`Self::unresolved_def_seen`] so it fires only in
+    /// that resolver-less window — a *generic* application whose base the resolver
+    /// can expand (deferred only pending instantiation) is left to the normal
+    /// branch logic, which is what keeps generic-call inference / higher-order
+    /// re-generalization unaffected. (The extends-side `Application` guard in
+    /// `conditional.rs` needs no such gate: it lives in the `is_sub == false`
+    /// branch where deferring is already the conservative choice, whereas this
+    /// check-side guard must override a vacuous `is_sub == true` and so requires
+    /// the resolver-less signal to tell that apart from a genuine match.) When it
+    /// does fire it mirrors that extends-side guard and the
+    /// bare-`UnresolvedTypeName` deferral: defer so a later resolver pass expands
+    /// the application and decides the branch, and
+    /// re-mark the unresolved-def event so neither this evaluator nor the
+    /// top-level evaluator that commits its results persists the resolver-less
+    /// branch into the substitution-independent / application caches (a cold pass
+    /// that left the application opaque must not shadow the answer a resolved pass
+    /// derives). The `TS2589` depth-detection pass is exempt: it intentionally
+    /// drives recursive alias bodies with their parameters left free.
+    ///
+    /// Returns `Some(deferred_conditional)` when the guard applies.
+    pub(super) fn defer_resolver_less_application_check(
+        &mut self,
+        cond: &ConditionalType,
+        check_type: TypeId,
+        extends_type: TypeId,
+        is_sub: bool,
+    ) -> Option<TypeId> {
+        if is_sub
+            && self.unresolved_def_seen()
+            && !self.is_depth_detection_pass()
+            && matches!(
+                self.interner().lookup(check_type),
+                Some(TypeData::Application(_))
+            )
+        {
+            self.mark_unresolved_def_seen();
+            return Some(self.deferred_conditional(cond, check_type, extends_type));
+        }
         None
     }
 

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/tests.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/tests.rs
@@ -215,3 +215,52 @@ fn test_is_generic_ref_intrinsics_are_never_generic() {
         );
     }
 }
+
+/// An `Application` whose base alias the active resolver cannot expand survives
+/// evaluation as an opaque `Application`. When such an opaque application sits
+/// in a conditional's CHECK position, the structural relation has no structure
+/// to compare and degrades the application toward the bottom type, so the
+/// subtype check is vacuously satisfied and the conditional would take its TRUE
+/// branch. That is the mechanism by which the key filter
+/// `IsOptionalKeyOf<O, K> extends false ? never : K` collapses every key to
+/// `never` and corrupts `RequiredKeysOf`/`OptionalKeysOf` (#13609). The
+/// evaluator must instead DEFER the conditional (keep it a `Conditional`) so a
+/// later resolver pass that can expand the application decides the branch.
+///
+/// `extends unknown` is used only because every type — including the
+/// degraded-to-bottom opaque application — is a subtype of `unknown`, which
+/// deterministically forces the vacuous-true path the guard intercepts without
+/// depending on how a particular resolver treats an unresolvable base. The
+/// real-world witness is the `extends false` key filter above. The alias
+/// `DefId` and the branch types carry no special spelling (name-agnostic).
+#[test]
+fn opaque_application_check_type_defers_instead_of_taking_true_branch() {
+    let interner = TypeInterner::new();
+    // Opaque check type: `Unresolvable<string>` whose base `Lazy(DefId)` has no
+    // body under the default `NoopResolver`.
+    let unresolvable_base = interner.lazy(crate::def::DefId(4242));
+    let opaque_app = interner.application(unresolvable_base, vec![TypeId::STRING]);
+    // `<opaque> extends unknown ? never : string`.
+    let cond = interner.conditional(crate::types::ConditionalType {
+        check_type: opaque_app,
+        extends_type: TypeId::UNKNOWN,
+        true_type: TypeId::NEVER,
+        false_type: TypeId::STRING,
+        is_distributive: false,
+    });
+
+    let mut evaluator = TypeEvaluator::<crate::relations::subtype::NoopResolver>::new(&interner);
+    let result = evaluator.evaluate(cond);
+
+    // A deferred `Conditional` (rather than the `never` true branch or the
+    // `string` false branch) proves the evaluator did not vacuously collapse the
+    // opaque check type into a branch.
+    assert!(
+        matches!(
+            interner.lookup(result),
+            Some(crate::types::TypeData::Conditional(_))
+        ),
+        "opaque-application check type must keep the conditional deferred, got {:?}",
+        interner.lookup(result)
+    );
+}


### PR DESCRIPTION
Fixes the check-side arm of the opaque-`Application` conditional deferral defect tracked in #13609.

Goal: green

## Structural rule
When a conditional's evaluated **check** type survives evaluation as an `Application`, the active resolver lacked the body needed to reduce it (the `resolver_generation()==0` / registration-window family — `unresolved_def_seen`). `tsc` defers such a conditional; tsz instead let the structural subtype walk degrade the opaque application toward the bottom type, so the relation was vacuously satisfied and the conditional collapsed into its TRUE branch.

Owner layer: solver `evaluation/evaluate_rules/conditional`.

## Witness
With the opaque check-side application, the `ApplyDefaultOptions` key filter
`IsOptionalKeyOf<O, K> extends false ? never : K` filters **every** key to `never`, so `RequiredKeysOf<O>` / `OptionalKeysOf<O>` resolve to the wrong key set and the well-typed `Default*Options` argument false-fails its constraint with **TS2344** (type-fest v5.6.0 under `skipLibCheck:false`).

## Fix
Add the symmetric **check-side** guard — the evaluator already defers on a surviving `Application` in the *extends* position; this mirrors it for the *check* position. When the subtype check is only vacuously true over an opaque check-side application during the resolver-less window, defer the conditional and re-mark the unresolved-def event so neither this evaluator nor the top-level committing evaluator persists the resolver-less branch into the substitution-independent / application caches (the prior root-cause passes traced this cache-poisoning vector; closed-eval already gates on `unresolved_def_seen`, the application memo via `limit_epoch`).

The guard is gated on `unresolved_def_seen` so a genuinely **generic** application whose base the resolver *can* expand is left to the normal branch logic — that is what keeps generic-call inference and higher-order re-generalization unaffected. The `TS2589` depth-detection pass is exempt.

Also extracts a shared `deferred_conditional` helper for the operand-deferral sites (DRY) — name/structure-driven, no formatted-string or identifier predicates (anti-hardcoding gate clean).

## Adjacent-case matrix
- **extends-side** opaque `Application` deferral — unchanged; check-side now symmetric.
- **bare `UnresolvedTypeName`** deferral — unchanged; now shares the `deferred_conditional` helper.
- **generic (resolver-expandable) `Application`** check — unaffected (gate excludes it); confirms the fix does not over-defer.
- **depth-detection (`TS2589`)** pass — exempt, recursive alias bodies still drive their recursive branch.

## Verification
- `cargo test -p tsz-solver --lib` — 6710 passed; new name-agnostic regression test `opaque_application_check_type_defers_instead_of_taking_true_branch` passes. The only 3 failures are **pre-existing on `main`** (two generic-call `operations` tests + the file-size ceiling baseline) and are byte-identical with/without this change.
- `cargo clippy -p tsz-solver --tests` clean; `cargo fmt` applied.
- Broad conformance / emit / fourslash / project-corpus parity owned by ready CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_014tQmsmj5d25aK9deuNXMye)_