### PR TITLE
fix(solver,checker): read def params through shared-store fallback to match body reads (#13255)

### DIFF
--- a/crates/tsz-checker/src/context/deferred_flow_env_write.rs
+++ b/crates/tsz-checker/src/context/deferred_flow_env_write.rs
@@ -110,9 +110,13 @@ fn apply_augmented_def(
     if is_class || env.get_class_instance_type(def_id).is_some() {
         env.insert_class_instance_type(def_id, augmented);
     } else {
-        let params: Option<Vec<tsz_solver::TypeParamInfo>> =
-            env.get_def_params(def_id).map(<[_]>::to_vec);
-        if let Some(params) = params {
+        // Read params through the shared-store fallback (`get_def_params_owned`)
+        // rather than the local-only `get_def_params`: when a sibling fresh
+        // checker derived the def, its param list lives only in the shared
+        // `DefinitionStore`, and a local-only read would drop the arity here and
+        // re-insert the augmented body as if non-generic (#13255 shared-def
+        // observation family).
+        if let Some(params) = env.get_def_params_owned(def_id) {
             env.insert_def_with_params(def_id, augmented, params);
         } else {
             env.insert_def(def_id, augmented);

--- a/crates/tsz-solver/src/relations/judge.rs
+++ b/crates/tsz-solver/src/relations/judge.rs
@@ -361,12 +361,21 @@ impl<'a> DefaultJudge<'a> {
             return TypeId::ERROR;
         };
 
-        // Try to get type params from Lazy - use DefId directly
+        // Try to get type params from Lazy - use DefId directly.
+        //
+        // Both the body and the parameter list must be read through the same
+        // local-then-shared-store fallback. `get_def` already falls back to the
+        // shared `DefinitionStore` for the body, so the param read must do the
+        // same (`get_def_params_owned`): a generic def derived by a sibling
+        // fresh checker publishes its (schedule-stable) param list only into the
+        // shared store, and the local-only `get_def_params` would miss it,
+        // collapsing the chain to the un-instantiated fallback and leaking raw
+        // type parameters in a schedule-dependent way (#13255).
         if let TypeData::Lazy(def_id) = &key
-            && let Some(params) = self.env.get_def_params(*def_id)
             && let Some(resolved) = self.env.get_def(*def_id)
+            && let Some(params) = self.env.get_def_params_owned(*def_id)
         {
-            return instantiate_generic(self.db, resolved, params, args);
+            return instantiate_generic(self.db, resolved, &params, args);
         }
 
         // Fallback: can't instantiate


### PR DESCRIPTION
Goal: fast

Part of the #13255 shared-`DefinitionStore` schedule-independence workstream (blocker family for the #13244/#13245 parallel-gate lifts). The four named in-repo witnesses (`parallel_agreement`, `…_lib_iter`, `…_disposable`, `…_scope_registry`) are already stable; this PR removes a residual body/params **read asymmetry** in the store-observation path so cross-checker generic identity does not depend on which checker derived a def.

## Structural rule
When a consumer resolves a definition's body through the local-then-shared-store fallback (`TypeEnvironment::get_def`) but resolves its type-parameter list through the **local-only** `get_def_params`, a generic def derived by a sibling fresh checker — whose param list is published only into the shared `DefinitionStore` — is observed as if it had **no type parameters**. tsc treats the def's arity as a stable structural fact; tsz must read body and params through the *same* fallback. The param list is structural and schedule-stable (every checker derives it from the same declaration), so reading it from the store cannot change any value a single-checker run computes — it only stops dropping arity when the deriving checker is a sibling.

## Owner layer
Solver / checker, at the shared-store observation boundary. The codebase already provides the canonical body/params-symmetric helper `get_def_params_owned` (`crates/tsz-solver/src/def/resolver.rs:936`), whose doc states it "mirrors how `get_def` falls back to the store for type bodies." Two consumers were still on the local-only variant:

- `DefaultJudge::instantiate` (`crates/tsz-solver/src/relations/judge.rs`): read the body via store-backed `get_def` but params via local-only `get_def_params`, so a `Lazy(def)` whose params were store-only collapsed the `if let` chain to the un-instantiated fallback and returned the **raw generic**, leaking free type parameters.
- `apply_augmented_def` (`crates/tsz-checker/src/context/deferred_flow_env_write.rs`): re-inserted the augmented body **without** params when the def's params were store-only, dropping the def's arity in that environment.

Both now read params through `get_def_params_owned`, matching their existing store-backed body reads.

## Adjacent cases / scope boundary
- The remaining two callers of the local-only `get_def_params` (`crates/tsz-checker/src/state/type_resolution/core.rs:1394,1423`) are **intentionally** local: they probe whether the local flow-env snapshot is fully registered to decide whether to run the repair path. Redirecting them to the store would mask incomplete local registration and defeat the trigger, so they are deliberately left as-is.
- No fixture-name fast paths, no store-side gates (the rejected `monotone-completion` family), no diagnostic-string predicates — only a read-symmetry change using an existing helper.

## Verification
- `cargo test -p tsz-cli --test parallel_sequential_agreement_tests` — 4/4 pass (all four #13255 witness families), and a 20×-per-fixture forced-parallel md5 sweep (`RAYON_NUM_THREADS=16`) shows 1 distinct output per fixture.
- `cargo test -p tsz-checker --test global_augmentation_lib_interface_merge_tests --test self_module_augmentation_isolation_tests --test cross_file_lib_generic_heritage_tests` — 18/18 pass (the augmentation/generic-heritage path touched by `apply_augmented_def`).
- Broad conformance/emit/fourslash owned by ready-review CI.

## Provenance
Machine: cloud
Assistant: claude-code
Model: Claude Opus 4.8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_015QGALv8tUCuwPch15fHMYh)_