### PR TITLE
perf(checker): memoize root re-export resolution to collapse barrel export-star re-walks (#13508)

### DIFF
--- a/crates/tsz-checker/src/context/aliases.rs
+++ b/crates/tsz-checker/src/context/aliases.rs
@@ -69,6 +69,19 @@ pub type GlobalModuleExportsIndex = Arc<ModuleExportsIndexMap>;
 /// Per-checker cache: (requesting file, module specifier) → resolved cross-file namespace exports.
 pub type NamespaceExportsCache = FxHashMap<(usize, String), Option<SymbolTable>>;
 
+/// Per-checker cache: (target file, export name) → fully-resolved re-export target.
+///
+/// Maps a `(file_idx, export_name)` pair to the `(SymbolId, owning_file_idx)`
+/// that the re-export walker resolves it to (or `None` when the name is not
+/// exported). Only **root** resolutions — entered with an empty `visited`
+/// path and no module-key override — populate this cache: at that boundary the
+/// answer is the canonical, path-independent result for `(file, name)` and can
+/// never be the cycle-break sentinel, so it is safe to reuse across the many
+/// import/usage sites that resolve the same barrel export. Barrel-heavy
+/// programs (e.g. `ts-morph`) otherwise re-walk the entire `export *` graph
+/// from scratch for every distinct name, costing `O(names × export-edges)`.
+pub type ReexportResolutionCache = FxHashMap<(usize, String), Option<(SymbolId, usize)>>;
+
 #[must_use]
 pub(crate) fn namespace_exports_cache_entries(cache: &NamespaceExportsCache) -> usize {
     cache.len()

--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -38,6 +38,7 @@ jsdoc_global_typedef_lookup_cache = { lifetime = "FileLocalReset", capability = 
 nested_namespace_candidates_cache_complete = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 lowering_entity_name_resolution_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 namespace_exports_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
+reexport_resolution_cache = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local re-export chain resolution memo; populated only by root resolutions, reset at file-session boundary" }
 shared_lib_type_cache = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }
 shared_constraint_proofs = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "program-wide append-only success tier for constraint proofs; entries are file-independent by construction and valid for the whole compilation" }
 cross_file_type_params_cache = { lifetime = "ProgramStable", capability = "ProgramLookupContext", reason = "shared immutable program data; valid until the compilation or project version changes" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -266,6 +266,7 @@ impl<'a> CheckerContext<'a> {
             nested_namespace_candidates_cache_complete: Cell::new(false),
             lowering_entity_name_resolution_cache: RefCell::new(crate::context::CowCache::default()),
             namespace_exports_cache: RefCell::new(FxHashMap::default()),
+            reexport_resolution_cache: RefCell::new(FxHashMap::default()),
             shared_lib_type_cache: None,
             shared_constraint_proofs: None,
             cross_file_type_params_cache: None,

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -576,6 +576,7 @@ impl<'a> CheckerContext<'a> {
             .borrow_mut()
             .clear();
         self.namespace_exports_cache.borrow_mut().clear();
+        self.reexport_resolution_cache.borrow_mut().clear();
         // `def_type_params` and `def_no_type_params` are keyed by
         // globally-stable `DefId`. The values are program-stable
         // type-param info (interned `Atom` names, solver `TypeId`
@@ -709,6 +710,9 @@ mod tests {
             .borrow_mut()
             .insert("JSX".to_string(), vec![(0, tsz_binder::SymbolId(3))]);
         ctx.nested_namespace_candidates_cache_complete.set(true);
+        ctx.reexport_resolution_cache
+            .borrow_mut()
+            .insert((0, "Thing".to_string()), Some((tsz_binder::SymbolId(4), 1)));
         ctx.jsdoc_global_typedef_lookup_cache
             .miss_cache
             .borrow_mut()
@@ -737,6 +741,7 @@ mod tests {
         assert!(ctx.export_equals_named_cache.borrow().is_empty());
         assert!(ctx.nested_namespace_candidates_cache.borrow().is_empty());
         assert!(!ctx.nested_namespace_candidates_cache_complete.get());
+        assert!(ctx.reexport_resolution_cache.borrow().is_empty());
         assert!(
             ctx.jsdoc_global_typedef_lookup_cache
                 .miss_cache

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -759,6 +759,14 @@ pub struct CheckerContext<'a> {
     /// specifiers are resolved from the current file.
     pub namespace_exports_cache: RefCell<NamespaceExportsCache>,
 
+    /// Per-checker memo for re-export chain resolution, keyed by
+    /// `(target file, export name)`. Populated only by root resolutions of
+    /// [`crate::state::CheckerState::resolve_export_in_file`] (entered with an
+    /// empty `visited` path), whose answer is the canonical, path-independent
+    /// result for that pair. Collapses the `O(names × export-edges)` re-walk of
+    /// barrel `export *` graphs to a single walk per distinct `(file, name)`.
+    pub reexport_resolution_cache: RefCell<ReexportResolutionCache>,
+
     /// Shared lib type resolution cache across parallel file checks.
     /// Uses `DashMap` for thread-safe concurrent access.
     pub shared_lib_type_cache: Option<Arc<dashmap::DashMap<String, Option<TypeId>>>>,

--- a/crates/tsz-checker/src/lib.rs
+++ b/crates/tsz-checker/src/lib.rs
@@ -1201,6 +1201,9 @@ mod recursive_tuple_alias_diagnostic_display_tests;
 #[path = "tests/recursive_tuple_rest_cycle_tests.rs"]
 mod recursive_tuple_rest_cycle_tests;
 #[cfg(test)]
+#[path = "tests/reexport_resolution_cache_tests.rs"]
+mod reexport_resolution_cache_tests;
+#[cfg(test)]
 #[path = "tests/ref_type_params_cache_tests.rs"]
 mod ref_type_params_cache_tests;
 #[cfg(test)]

--- a/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
+++ b/crates/tsz-checker/src/state/type_resolution/module/reexports.rs
@@ -35,6 +35,46 @@ impl<'a> CheckerState<'a> {
         export_name: &str,
         visited: &mut rustc_hash::FxHashSet<usize>,
     ) -> Option<(tsz_binder::SymbolId, usize)> {
+        // Memoize only *root* resolutions: those entered with an empty `visited`
+        // path and no module-key override. At that boundary the entry cycle
+        // guard cannot fire (the root file is inserted fresh), so the result is
+        // never the cycle-break sentinel `None`, and no inherited `visited`
+        // truncation can perturb the traversal — the answer is the canonical,
+        // path-independent target for `(file_idx, export_name)`. Inner recursive
+        // calls (non-empty `visited`, or a `Some` module key) are path-sensitive
+        // and bypass the cache entirely. This collapses the `O(names ×
+        // export-edges)` re-walk barrel `export *` graphs otherwise pay when the
+        // same export name is resolved from many import/usage sites.
+        if !(visited.is_empty() && module_key.is_none()) {
+            return self.resolve_export_in_file_uncached(
+                file_idx,
+                module_key,
+                export_name,
+                visited,
+            );
+        }
+
+        let cache_key = (file_idx, export_name.to_owned());
+        if let Some(cached) = self.ctx.reexport_resolution_cache.borrow().get(&cache_key) {
+            return *cached;
+        }
+
+        let result =
+            self.resolve_export_in_file_uncached(file_idx, module_key, export_name, visited);
+        self.ctx
+            .reexport_resolution_cache
+            .borrow_mut()
+            .insert(cache_key, result);
+        result
+    }
+
+    fn resolve_export_in_file_uncached(
+        &self,
+        file_idx: usize,
+        module_key: Option<&str>,
+        export_name: &str,
+        visited: &mut rustc_hash::FxHashSet<usize>,
+    ) -> Option<(tsz_binder::SymbolId, usize)> {
         if !visited.insert(file_idx) {
             return None;
         }

--- a/crates/tsz-checker/src/tests/reexport_resolution_cache_tests.rs
+++ b/crates/tsz-checker/src/tests/reexport_resolution_cache_tests.rs
@@ -1,0 +1,218 @@
+//! Regression + parity tests for the re-export resolution memo.
+//!
+//! `resolve_export_in_file` walks `export *` / named-re-export chains across
+//! binder boundaries. Barrel-heavy programs resolve the *same* export name from
+//! many import/usage sites; without a memo each resolution re-walks the entire
+//! `export *` graph (`O(names × export-edges)` — the `ts-morph` canary timeout,
+//! issue #13508 root cause A). The fix memoizes root resolutions keyed by
+//! `(file_idx, export_name)`.
+//!
+//! These tests pin the *behavior* the memo must preserve: a name is resolved to
+//! the same target however many times it is requested, the cache never collapses
+//! a re-exported binding to `any`, a genuinely absent name still reports
+//! `TS2305`, and the result is identical whether or not the `export *` graph
+//! contains a cycle (the case where a naive memo would otherwise poison itself
+//! with the cycle-break sentinel). Binder names are varied across cases so the
+//! behavior follows structure, not identifier text.
+
+use crate::context::CheckerOptions;
+use crate::diagnostics::{Diagnostic, diagnostic_codes};
+use crate::test_utils::check_multi_file;
+use tsz_common::common::ModuleKind;
+
+fn check(files: &[(&str, &str)], entry: &str) -> Vec<Diagnostic> {
+    check_multi_file(
+        files,
+        entry,
+        CheckerOptions {
+            module: ModuleKind::CommonJS,
+            strict: true,
+            no_implicit_any: true,
+            ..CheckerOptions::default()
+        },
+    )
+}
+
+fn codes(diags: &[Diagnostic]) -> Vec<u32> {
+    diags.iter().map(|d| d.code).collect()
+}
+
+fn assert_no_code(diags: &[Diagnostic], code: u32) {
+    assert!(
+        !codes(diags).contains(&code),
+        "did not expect diagnostic {code}, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+fn assert_has_code(diags: &[Diagnostic], code: u32) {
+    assert!(
+        codes(diags).contains(&code),
+        "expected diagnostic {code}, got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+/// A name re-exported through a barrel `export *` resolves to its real declared
+/// type — repeatedly, from several usage sites in the same file — and never
+/// collapses to `any`. The first usage misuse is a genuine `TS2322`; if the memo
+/// served `any` for later usages those mismatches would be silently dropped.
+#[test]
+fn barrel_export_star_resolves_named_type_every_usage() {
+    let diags = check(
+        &[
+            (
+                "./index.ts",
+                r#"export * from "./shapes";
+export * from "./colors";
+"#,
+            ),
+            (
+                "./shapes.ts",
+                r#"export interface Shape { sides: number; }
+"#,
+            ),
+            (
+                "./colors.ts",
+                r#"export type Color = "red" | "green";
+"#,
+            ),
+            (
+                "./consumer.ts",
+                r#"import { Shape, Color } from "./index";
+const a: Shape = { sides: 3 };
+const b: Shape = { sides: 4 };
+const c: Color = "red";
+const bad: Shape = { sides: "no" };
+const wrongColor: Color = "purple";
+"#,
+            ),
+        ],
+        "./consumer.ts",
+    );
+    // Real declared types resolve every time (not `any`): both misuses report.
+    assert_has_code(&diags, diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE);
+    let assignability_errors = codes(&diags)
+        .iter()
+        .filter(|&&c| c == diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE)
+        .count();
+    assert!(
+        assignability_errors >= 2,
+        "both the bad Shape and the bad Color should report; got {assignability_errors}: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, d.message_text.clone()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+/// `export *` cycle (the immer/ts-morph shape): `barrel.ts` re-exports `leaf.ts`
+/// while `leaf.ts` imports back from `barrel.ts`. The re-exported name must still
+/// resolve to its real type. A memo that cached the cycle-break sentinel `None`
+/// would make the import report a spurious `TS2305`.
+#[test]
+fn cyclic_export_star_still_resolves_reexported_name() {
+    let diags = check(
+        &[
+            (
+                "./barrel.ts",
+                r#"export * from "./leaf";
+export const VERSION = 1;
+"#,
+            ),
+            (
+                "./leaf.ts",
+                r#"import { VERSION } from "./barrel";
+export interface Widget { id: number; }
+export const tag = VERSION;
+"#,
+            ),
+            (
+                "./app.ts",
+                r#"import { Widget } from "./barrel";
+const w: Widget = { id: 7 };
+const w2: Widget = { id: 8 };
+const broken: Widget = { id: "x" };
+"#,
+            ),
+        ],
+        "./app.ts",
+    );
+    assert_no_code(&diags, diagnostic_codes::MODULE_HAS_NO_EXPORTED_MEMBER);
+    // The cycle does not erase the type: the bad assignment still reports.
+    assert_has_code(&diags, diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE);
+}
+
+/// A genuinely absent name still reports `TS2305` even when the barrel sits over
+/// a cycle — i.e. the memo caches a real "not exported" miss, not a transient
+/// cycle-break `None`, and never invents an export.
+#[test]
+fn cyclic_barrel_missing_name_reports_no_exported_member() {
+    let diags = check(
+        &[
+            (
+                "./hub.ts",
+                r#"export * from "./node";
+export const SEED = 0;
+"#,
+            ),
+            (
+                "./node.ts",
+                r#"import { SEED } from "./hub";
+export interface Known { ok: boolean; }
+export const seedEcho = SEED;
+"#,
+            ),
+            (
+                "./client.ts",
+                r#"import { Known, Missing } from "./hub";
+const k: Known = { ok: true };
+"#,
+            ),
+        ],
+        "./client.ts",
+    );
+    assert_has_code(&diags, diagnostic_codes::MODULE_HAS_NO_EXPORTED_MEMBER);
+}
+
+/// Renamed binders: the resolution/memo follows the `export *` structure, not the
+/// `Shape`/`index` identifier text used above.
+#[test]
+fn renamed_binders_resolve_through_nested_barrels() {
+    let diags = check(
+        &[
+            (
+                "./top.ts",
+                r#"export * from "./mid";
+"#,
+            ),
+            (
+                "./mid.ts",
+                r#"export * from "./bottom";
+"#,
+            ),
+            (
+                "./bottom.ts",
+                r#"export interface Gizmo { weight: number; }
+"#,
+            ),
+            (
+                "./use.ts",
+                r#"import { Gizmo } from "./top";
+const g: Gizmo = { weight: 1 };
+const g2: Gizmo = { weight: 2 };
+const wrong: Gizmo = { weight: true };
+"#,
+            ),
+        ],
+        "./use.ts",
+    );
+    assert_no_code(&diags, diagnostic_codes::MODULE_HAS_NO_EXPORTED_MEMBER);
+    assert_has_code(&diags, diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE);
+}


### PR DESCRIPTION
Goal: green

## Summary

Root cause A of #13508 (the `ts-morph` canary CPU-bound timeout): the
cross-binder re-export walker `resolve_export_in_file`
(`crates/tsz-checker/src/state/type_resolution/module/reexports.rs`) has **no
result memo**, unlike its sibling resolvers (`export_equals_named_cache`,
`namespace_exports_cache`). Barrel-heavy programs resolve the same `export *`
name from many import/usage sites, and each resolution re-walks the entire
export-star graph from scratch — `O(names × export-edges)`. With `ts-morph`'s
671 `export *` lines across 98 barrels and ~1007 files this reaches the project
compile wall (`exit_class=timeout`, ~150s CPU).

## Structural rule

When the same `(file, export_name)` is resolved repeatedly from a root context,
its re-export target is a deterministic, path-independent fact. tsz now resolves
it once and reuses the result, owned by the checker re-export resolver — instead
of re-walking the `export *` graph per request.

## Owner layer

Checker re-export resolution (`state/type_resolution/module/reexports.rs`),
backed by a per-checker cache on `CheckerContext`. No solver, emitter, or
diagnostic-string involvement; no fixture-name or identifier-text predicate.

## Change

Add `reexport_resolution_cache`, a per-checker
`(file_idx, export_name) -> Option<(SymbolId, owning_file_idx)>` memo, populated
**only by root resolutions** — those entered with an empty `visited` path and no
module-key override. At that boundary:

- the entry cycle guard cannot fire (the root file is inserted fresh), so the
  cached value is never the cycle-break sentinel `None` (the documented
  poisoning hazard);
- no inherited `visited` truncation can perturb the traversal, so the answer is
  the canonical, path-independent target for the pair.

Inner recursive calls (non-empty `visited`, or a `Some` module key) remain
path-sensitive and bypass the cache entirely, preserving exact resolution
semantics. Each distinct `(file, name)` now resolves once instead of once per
request, taking the dominant barrel cost from `O(requests × edges)` toward
`O(unique(file,name) × edges)`.

The cache mirrors its siblings' lifetime: per-checker, **not** inherited by
child checkers, cleared at the file-session boundary (`reset_for_next_file`),
and registered in `checker_context_lifetimes.toml` as `FileLocalReset` /
`FileTypeCache`.

## Adjacent-case matrix (tests)

`crates/tsz-checker/src/tests/reexport_resolution_cache_tests.rs`:

- **Resolved every usage**: a name re-exported through a barrel `export *`
  yields its real declared type on every usage site — never collapses to `any`
  (both misuses report `TS2322`).
- **Cycle, present name**: across an `export *` cycle (immer/ts-morph shape) the
  re-exported name still resolves to its real type; the cycle-break sentinel is
  never cached.
- **Cycle, absent name**: a genuinely absent name still reports `TS2305`
  through a cyclic barrel (real miss cached, not a transient sentinel).
- **Renamed binders / nested barrels**: resolution follows `export *` structure,
  not identifier text.

## Verification

- `cargo test -p tsz-checker --lib reexport_resolution_cache` → 4 passed.
- `cargo test -p tsz-checker --lib -- reset_for_next_file reexport export_star namespace_export module_reexport circular_export barrel` → 35 passed (existing re-export / barrel / cycle / file-session-reset coverage, incl. the zod re-export-cycle regression).
- `cargo check -p tsz-checker` clean.
- Ready-review CI owns the broad suites and the `ts-morph` project-compile guard
  (`TSZ_PROJECT_COMPILE_FILTER='^ts-morph-project$'`); not run locally per repo
  policy.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_014mZMeefYdnfYfrPxgrQo21)_