### PR TITLE
green(canary): promote ts-toolbelt-project to required (0 FPs vs tsc)

### DIFF
--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -22,6 +22,7 @@ TSZ_PROJECT_ROWS_MJS="$TSZ_PROJECT_FIXTURES_ROOT/scripts/bench/project-rows.mjs"
 TSZ_COMPILE_GUARD_REQUIRED_ROWS=(
   "utility-types-project"
   "ts-essentials-project"
+  "ts-toolbelt-project"
   "rxjs-project"
   "type-fest-project"
   "vite-vanilla-ts-app"
@@ -30,7 +31,6 @@ TSZ_COMPILE_GUARD_REQUIRED_ROWS=(
 )
 
 TSZ_COMPILE_GUARD_CANARY_ROWS=(
-  "ts-toolbelt-project"
   "zod-project"
   "kysely-project"
   "type-challenges-solutions-project"

--- a/scripts/bench/project-rows.mjs
+++ b/scripts/bench/project-rows.mjs
@@ -75,7 +75,7 @@ export const PROJECT_ROW_DEFINITIONS = [
     ref_env: "TS_TOOLBELT_REF",
     repo: "https://github.com/millsp/ts-toolbelt.git",
     ref: "b8a49285e3ed3a7d8bb8e0b433389eac46a5f140",
-    guard_set: "canary",
+    guard_set: "required",
     benchmark_set: "required",
     category: "external",
   },

--- a/scripts/bench/test-merge-results.mjs
+++ b/scripts/bench/test-merge-results.mjs
@@ -349,9 +349,18 @@ withTempDir((dir) => {
 });
 
 withTempDir((dir) => {
-  const requiredCanaryRow = "ts-toolbelt-project";
-  assert.ok(COMPILE_CANARY_PROJECT_ROWS.includes(requiredCanaryRow));
-  assert.ok(REQUIRED_PROJECT_ROWS.includes(requiredCanaryRow));
+  // Pick any row that is benchmark-required yet still a compile canary, rather
+  // than hardcoding one: a row graduates out of COMPILE_CANARY_PROJECT_ROWS the
+  // moment its guard_set flips to "required", so a literal name breaks on every
+  // promotion. The merge behavior under test depends only on the required-canary
+  // category, not on which row fills it.
+  const requiredCanaryRow = REQUIRED_PROJECT_ROWS.find((name) =>
+    COMPILE_CANARY_PROJECT_ROWS.includes(name),
+  );
+  assert.ok(
+    requiredCanaryRow,
+    "expected at least one benchmark-required compile-canary row",
+  );
   const slowdownCompatibility = {
     ...SAMPLE_COMPATIBILITY,
     state: "red",


### PR DESCRIPTION
Goal: green

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Structural rule
When a canary row compiles with 0 tsz-only diagnostics vs the tsc oracle, it graduates to required Green via the drift-tested project-rows.mjs + bench.yml edit.

For `ts-toolbelt-project` this is the asymmetric one-line `guard_set` flip: `benchmark_set` was already `"required"` (so the row already lives in `allTrackedRows = required ∪ canary` and `COMPATIBILITY_CORPUS_ROWS`), so only `guard_set: "canary"` → `"required"` was needed. The row's bench function (`run_ts_toolbelt_project_benchmarks`) gates on `is_benchmark_selected` (benchmark_set), NOT `should_run_compile_canary_project`, so no canary-gate adjustment was required. `bench.yml` already lists `ts-toolbelt-project` in the single `projects` matrix filter alongside `rxjs-project`/`type-fest-project`, so no workflow edit was needed. The static fallback arrays in `project-fixtures.sh` (node-unavailable fallback; runtime is repacked from project-rows.mjs) were synced to keep the fallback honest: moved `ts-toolbelt-project` from the canary array to the required array.

## Verification
0-FP compile guard (fast dist-fast CLI, fresh fixture clone at pinned ref b8a49285):
- `scripts/safe-run.sh cargo build --profile dist-fast -p tsz-cli --bin tsz` — built
- `TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 TSZ_PROJECT_COMPILE_FILTER=ts-toolbelt TSZ_PROJECT_COMPILE_TIMEOUT=120 scripts/ci/project-compile-guard.sh` → "ts-toolbelt-project compiled successfully." — 0 `error TS` lines

Metadata + drift + arch gates (all green):
- `node scripts/bench/validate-project-metadata.mjs` — pass
- `node scripts/bench/test-project-rows.mjs` — pass (project-fixtures.sh runtime row groups sync from project-rows.mjs)
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs` — ok
- `python3 scripts/arch/test_arch_guard_project.py` — Ran 63 tests, OK
- `python3 scripts/arch/arch_guard.py` — Architecture guardrails passed.