### PR TITLE
fix(solver): tuple/array constraint literal-preservation requires a primitive-constrained type param, not a bare primitive element

### DIFF
--- a/crates/tsz-solver/src/operations/generic_call/mod.rs
+++ b/crates/tsz-solver/src/operations/generic_call/mod.rs
@@ -206,13 +206,77 @@ fn constraint_is_primitive_type_inner(
                 .iter()
                 .any(|&m| constraint_is_primitive_type_inner(interner, resolver, m, depth + 1))
         }
-        // Variadic-tuple constraints `[T, ...T[]]` and array constraints carry
-        // the primitive-constrained parameter in their element/rest types.
+        // Variadic-tuple constraints `[T, ...T[]]` and array constraints preserve
+        // literal inferences only when an element carries a *primitive-constrained
+        // type parameter* (the `T` in `U extends [T, ...T[]]`, `T extends string`).
+        // A tuple/array of bare concrete primitives like `[string, string]` must
+        // NOT preserve literals: tsc widens `["hello", "world"]` to `[string,
+        // string]` against such a constraint. The top-level primitive
+        // short-circuit (`string`/`number`/...) is only correct for a constraint
+        // that IS the primitive (`T extends string`); reaching a bare primitive
+        // through a tuple/array wrapper is a concrete element, not a literal-
+        // preserving parameter, so use the container-only check here.
         Some(TypeData::Tuple(list_id)) => interner.tuple_list(list_id).iter().any(|element| {
-            constraint_is_primitive_type_inner(interner, resolver, element.type_id, depth + 1)
+            tuple_or_array_element_preserves_literals(
+                interner,
+                resolver,
+                element.type_id,
+                depth + 1,
+            )
         }),
         Some(TypeData::Array(element) | TypeData::ReadonlyType(element)) => {
-            constraint_is_primitive_type_inner(interner, resolver, element, depth + 1)
+            tuple_or_array_element_preserves_literals(interner, resolver, element, depth + 1)
+        }
+        _ => false,
+    }
+}
+
+/// Whether a tuple/array constraint *element* implies literal preservation for
+/// the inferred type parameter.
+///
+/// Mirrors [`constraint_is_primitive_type_inner`] but, unlike the top-level
+/// gate, does NOT treat a bare primitive (`string`, `number`, …) element as
+/// literal-preserving: an element that is concretely `string` is just a normal
+/// tuple/array slot, and tsc widens literal arguments against it (`["hello",
+/// "world"]` against `[string, string]` → `[string, string]`). Literal
+/// preservation through a tuple/array applies only when an element reaches a
+/// primitive-constrained type parameter (`U extends [T, ...T[]]`,
+/// `T extends string`) or a literal/`keyof` form that already preserves
+/// literals. This matches the inference-side sibling
+/// `InferenceContext::constraint_contains_type_param_with_primitive_constraint`.
+fn tuple_or_array_element_preserves_literals(
+    interner: &dyn crate::construction::QueryDatabase,
+    resolver: &dyn TypeResolver,
+    type_id: TypeId,
+    depth: u32,
+) -> bool {
+    if depth > 8 || type_id.is_intrinsic() {
+        return false;
+    }
+    match interner.lookup(type_id) {
+        // Literal / `keyof T` elements already preserve fresh literal candidates.
+        Some(TypeData::Literal(_) | TypeData::KeyOf(_)) => true,
+        // A type parameter whose own constraint is primitive (the `T` in
+        // `U extends [T, ...T[]]`). Reuse the full gate for the constraint so a
+        // `T extends string` element correctly preserves literals.
+        Some(TypeData::TypeParameter(info)) => info.constraint.is_some_and(|constraint| {
+            constraint_is_primitive_type_inner(interner, resolver, constraint, depth + 1)
+        }),
+        // Nested containers may still wrap a primitive-constrained type parameter.
+        Some(TypeData::Union(list_id) | TypeData::Intersection(list_id)) => interner
+            .type_list(list_id)
+            .iter()
+            .any(|&m| tuple_or_array_element_preserves_literals(interner, resolver, m, depth + 1)),
+        Some(TypeData::Tuple(list_id)) => interner.tuple_list(list_id).iter().any(|element| {
+            tuple_or_array_element_preserves_literals(
+                interner,
+                resolver,
+                element.type_id,
+                depth + 1,
+            )
+        }),
+        Some(TypeData::Array(element) | TypeData::ReadonlyType(element)) => {
+            tuple_or_array_element_preserves_literals(interner, resolver, element, depth + 1)
         }
         _ => false,
     }

--- a/crates/tsz-solver/tests/operations_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/operations_tests_parts/part_00.rs
@@ -498,6 +498,100 @@ fn test_generic_call_widening_applies_when_constraint_satisfied() {
     }
 }
 
+/// Adjacent negative control to the bare-primitive tuple case above: when a
+/// tuple constraint's element is a *type parameter with a primitive constraint*
+/// (`U extends [E, E]` with `E extends string`), tsc preserves the literal
+/// element types inferred for `U` (the zod `arrayToEnum` family, #13175). The
+/// solver-side literal-preservation gate (`constraint_is_primitive_type_inner`)
+/// must therefore still fire for this shape — unlike `[string, string]`, where
+/// the element is a bare concrete primitive and widening applies. Guards against
+/// the fix for the bare-primitive case (which excludes plain `string` elements)
+/// from also breaking the type-parameter-element case.
+#[test]
+fn test_generic_call_preserves_literals_for_primitive_constrained_tuple_param() {
+    let interner = TypeInterner::new();
+    let mut checker = CompatChecker::new(&interner);
+    let mut evaluator = CallEvaluator::new(&interner, &mut checker);
+
+    // E extends string
+    let e_name = interner.intern_string("E");
+    let e_tp = TypeParamInfo {
+        is_const: false,
+        name: e_name,
+        constraint: Some(TypeId::STRING),
+        default: None,
+        origin: crate::types::TypeParamOrigin::User,
+    };
+    let e_id = interner.type_param(e_tp);
+
+    // U extends [E, E]
+    let constraint = interner.tuple(vec![
+        TupleElement {
+            type_id: e_id,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: e_id,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+    let u_name = interner.intern_string("U");
+    let u_tp = TypeParamInfo {
+        is_const: false,
+        name: u_name,
+        constraint: Some(constraint),
+        default: None,
+        origin: crate::types::TypeParamOrigin::User,
+    };
+    let u_id = interner.type_param(u_tp);
+
+    // <E extends string, U extends [E, E]>(x: U): U
+    let func = interner.function(FunctionShape {
+        params: vec![ParamInfo::unnamed(u_id)],
+        this_type: None,
+        return_type: u_id,
+        type_params: vec![e_tp, u_tp],
+        type_predicate: None,
+        is_constructor: false,
+        is_method: false,
+    });
+
+    // Call with ["hello", "world"] — literal tuple. The primitive-constrained
+    // type-parameter element preserves the literals (NOT widened to [string,
+    // string]).
+    let hello_lit = interner.literal_string("hello");
+    let world_lit = interner.literal_string("world");
+    let arg = interner.tuple(vec![
+        TupleElement {
+            type_id: hello_lit,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: world_lit,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+
+    let result = evaluator.resolve_call(func, &[arg]);
+    match result {
+        CallResult::Success(ret) => {
+            assert_eq!(
+                ret, arg,
+                "Expected literal tuple preserved for primitive-constrained type-parameter element"
+            );
+        }
+        other => panic!("Expected Success with preserved literal tuple, got {other:?}"),
+    }
+}
+
 #[test]
 fn test_generic_call_widens_fresh_object_union_inferred_type() {
     let interner = TypeInterner::new();


### PR DESCRIPTION
Restores correct generic-call literal widening that regressed in #13175. The
companion `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`
target was found to be a never-passing latent failure (not a #13473 regression);
its precise root cause and recommended approach are documented below for a
follow-up.

Goal: hold

## Structural rule
When a generic call's type parameter has a tuple/array `extends` constraint
(`<T extends [string, string]>`, `<U extends T[]>`), tsc preserves the literal
element types inferred for the parameter ONLY when an element is a
*primitive-constrained type parameter* (`U extends [T, ...T[]]`, `T extends
string` — the zod `arrayToEnum` family); a constraint whose elements are bare
concrete primitives (`[string, string]`, `string[]`) is widened
(`f(["hello","world"])` -> `[string, string]`). tsz does this through the
generic-call literal-preservation gate
`generic_call::constraint_is_primitive_type_inner`.

#13175 broke it: its new `Tuple`/`Array`/`ReadonlyType` arms recursed each
element back through the full gate, which short-circuits `true` on a bare
primitive (`string`/`number`/...). So `[string, string]` was misclassified as
literal-preserving and the literal tuple was never widened. The fix adds a
container-only element check (`tuple_or_array_element_preserves_literals`) that
does not treat a bare primitive element as literal-preserving — mirroring the
already-correct inference-side sibling
`InferenceContext::constraint_contains_type_param_with_primitive_constraint`.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification
- `cargo nextest run -p tsz-solver`: before = 3 failing
  (`test_generic_call_widening_applies_when_constraint_satisfied`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`,
  `solver_file_size_ceiling_tests::test_solver_oversized_file_size_ceilings`);
  after = 2 failing (the latter two only; widening now PASSES). Zero new
  failures introduced. Added adjacent test
  `test_generic_call_preserves_literals_for_primitive_constrained_tuple_param`
  locking the `<E extends string, U extends [E, E]>` preservation direction so
  the bare-primitive carve-out cannot over-revert it;
  `test_generic_call_widening_falls_back_when_constraint_violated` (literal-union
  element) still passes.
- Conformance (final binary, all 100%, zero known-failures): genericCall 50/50,
  widening 8/8, typeInference 64/64, variadicTuple 3/3, tuple 37/37,
  literalTypes 6/6, generic 240/240, contextualTyping 83/83. Zero regressions.
- `python3 scripts/arch/arch_guard.py`: PASS.
- `cargo clippy -p tsz-solver --lib`: clean, no new `#[allow]`.
- Canary FP delta (neverthrow|ts-pattern): NONE. Inspected the TS2345/TS2322
  lines on both rows; the failures are union-member-access (TS2339), ResultAsync
  structural (TS2322/TS2740), Matcher/Chainable (TS2344/TS2345), symbol-keyed
  member (`__unique_*`), and implicit-any (TS7006) — none match the
  widening-collapse signature this fix targets. Hence `Goal: hold`, not `green`.

## Follow-up: `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`
This test was added already-failing in #12749 (verified on its own PR-branch
commit `c6fee1b9f0`) and stayed red because `gcp-full-ci.sh::run_unit_tests`
swallows the nextest rc under `TSZ_CI_UNIT_SKIP_CHECKER_INTEGRATION=1`. It is
NOT a #13473 regression (bisect confirms it fails before and after 13473). tsc's
result for `pipe(list, wrap)` is `<X>(value: X) => X[][]`; tsz collapses the
nested element to `unknown`.

Root cause (precise): the wrapper `wrap` is a deferred generic-function argument.
In Round 2 its target parameter is re-instantiated from the bare shared-middle
placeholder `B` to `B`'s Round-1 value `X[]` (`X = __infer_src_3#X`).
`instantiate_generic_function_argument_against_target`'s HOFI Case 1b only
recognizes a *bare* current-call placeholder as a re-generalization carrier, not
a structure CONTAINING a free source placeholder (`Array(__infer_src_*)`), so it
collapses `wrap`'s naked `Y` against `X[]` and loses `X`. A local fix to Case 1b
(also accept positions that contain a free `is_infer_source` placeholder) is
conformance-clean (generic 240/240, typeInference 64/64) and produces the
*correct* candidate `C = X[][]`, BUT a stale `C = unknown[][]` candidate and a
partial `C = Y[]` candidate also remain, and `best_common_type` picks the
`unknown`-polluted one. Completing the fix additionally requires preventing/
deprioritizing the `unknown`-polluted candidate during candidate resolution —
a deep change to candidate priority/combination with broad HOFI-surface risk
that warrants its own PR with full-suite conformance validation. Deferred here
to keep this PR a focused, zero-risk regression fix.

## CI integrity (separate follow-up)
On a fresh `origin/main` worktree the solver suite has 3 pre-existing failures
masked by the swallowed-rc bug: the two above plus the file-size-ceiling
baseline `solver_file_size_ceiling_tests::test_solver_oversized_file_size_ceilings`.
The prior agent's "~41 failures" count was not reproduced here (clean main shows
3). Recommend a separate campaign to (a) stop `run_unit_tests` swallowing the
nextest rc, and (b) triage the file-size-ceiling baseline.
