### PR TITLE
perf(solver): reuse type_id on unchanged instantiation paths instead of re-interning

### DIFF
--- a/crates/tsz-solver/src/instantiation/instantiate.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate.rs
@@ -642,7 +642,11 @@ impl<'a> TypeInstantiator<'a> {
                 }
             }
 
-            // Intrinsics don't change
+            // Intrinsics don't change. `type_id` is the canonical id for each
+            // of these keys (none are `intern_fresh`), so re-interning `*key`
+            // would recompute the same id; reuse it directly. These kinds are
+            // also instantiation leaves, so this arm is normally reached only on
+            // a direct `instantiate_key` call.
             TypeData::Intrinsic(_)
             | TypeData::Literal(_)
             | TypeData::UnresolvedTypeName(_)
@@ -653,7 +657,7 @@ impl<'a> TypeInstantiator<'a> {
             | TypeData::BoundParameter(_)
             | TypeData::TypeQuery(_)
             | TypeData::UniqueSymbol(_)
-            | TypeData::ModuleNamespace(_) => self.interner.intern(*key),
+            | TypeData::ModuleNamespace(_) => type_id,
 
             // Enum types: instantiate the member type (structural part)
             // The DefId (nominal identity) stays the same
@@ -668,7 +672,7 @@ impl<'a> TypeInstantiator<'a> {
                 let base = self.instantiate(app.base);
                 let args = self.instantiate_type_list_if_changed(&app.args);
                 if base == app.base && args.is_none() {
-                    self.interner.intern(*key)
+                    type_id
                 } else {
                     self.interner
                         .application(base, args.unwrap_or_else(|| app.args.clone()))
@@ -680,7 +684,7 @@ impl<'a> TypeInstantiator<'a> {
                 if let Some(this_type) = self.this_type {
                     this_type
                 } else {
-                    self.interner.intern(*key)
+                    type_id
                 }
             }
 
@@ -696,7 +700,7 @@ impl<'a> TypeInstantiator<'a> {
                     self.interner.store_union_origin(result, instantiated);
                     result
                 } else {
-                    self.interner.intern(*key)
+                    type_id
                 }
             }
 
@@ -710,14 +714,19 @@ impl<'a> TypeInstantiator<'a> {
                     self.propagate_display_properties_for_intersection(members.as_ref(), result);
                     result
                 } else {
-                    self.interner.intern(*key)
+                    type_id
                 }
             }
 
-            // Array: instantiate element type
+            // Array: instantiate element type. When the element is unchanged the
+            // re-interned array is the same canonical id we already hold.
             TypeData::Array(elem) => {
                 let instantiated_elem = self.instantiate(*elem);
-                self.interner.array(instantiated_elem)
+                if instantiated_elem == *elem {
+                    type_id
+                } else {
+                    self.interner.array(instantiated_elem)
+                }
             }
 
             TypeData::Tuple(elements) => {
@@ -796,7 +805,7 @@ impl<'a> TypeInstantiator<'a> {
                     }
                 }
                 if !changed {
-                    return self.interner.intern(*key);
+                    return type_id;
                 }
                 crate::intern::tuple_normalized(self.interner, instantiated)
             }
@@ -811,7 +820,11 @@ impl<'a> TypeInstantiator<'a> {
                 // of an intersection. Anonymous Object literals (no symbol)
                 // share the outer `this` scope.
                 if self.shallow_this_only && shape.symbol.is_some() {
-                    return self.interner.intern(*key);
+                    // `type_id` is the canonical id for this Object key (Object
+                    // shapes are never `intern_fresh`), so re-interning `*key`
+                    // would recompute the same id. Reuse it directly to avoid a
+                    // redundant hash + intern-cache probe on the hot path.
+                    return type_id;
                 }
                 if let Some(instantiated) =
                     self.instantiate_properties_if_changed(&shape.properties)
@@ -821,12 +834,14 @@ impl<'a> TypeInstantiator<'a> {
                         shape.flags,
                         shape.symbol,
                     );
-                    let original = self.interner.intern(*key);
-                    self.propagate_instantiated_display_properties(original, result);
-                    self.propagate_instantiated_application_origin(original, result);
+                    // `type_id` already names the original (pre-substitution)
+                    // Object; no need to re-intern `*key` to recover it before
+                    // propagating display/application provenance.
+                    self.propagate_instantiated_display_properties(type_id, result);
+                    self.propagate_instantiated_application_origin(type_id, result);
                     result
                 } else {
-                    self.interner.intern(*key)
+                    type_id
                 }
             }
 
@@ -834,7 +849,7 @@ impl<'a> TypeInstantiator<'a> {
             TypeData::ObjectWithIndex(shape_id) => {
                 let shape = self.interner.object_shape(*shape_id);
                 if self.shallow_this_only && shape.symbol.is_some() {
-                    return self.interner.intern(*key);
+                    return type_id;
                 }
                 let instantiated_props =
                     self.instantiate_properties_if_changed(&shape.properties);
@@ -857,21 +872,20 @@ impl<'a> TypeInstantiator<'a> {
                         number_index: instantiated_number_idx.or(shape.number_index),
                         symbol: shape.symbol,
                     });
-                    let original = self.interner.intern(*key);
-                    self.propagate_instantiated_display_properties(original, result);
-                    self.propagate_instantiated_application_origin(original, result);
+                    self.propagate_instantiated_display_properties(type_id, result);
+                    self.propagate_instantiated_application_origin(type_id, result);
                     result
                 } else {
-                    self.interner.intern(*key)
+                    type_id
                 }
             }
 
             // Function: instantiate params and return type
             // Note: Type params in the function create a new scope - don't substitute those
-            TypeData::Function(shape_id) => self.instantiate_function(shape_id, key),
+            TypeData::Function(shape_id) => self.instantiate_function(shape_id, type_id),
 
             // Callable: instantiate all signatures and properties
-            TypeData::Callable(shape_id) => self.instantiate_callable(shape_id, key),
+            TypeData::Callable(shape_id) => self.instantiate_callable(shape_id, type_id),
 
             // Conditional: instantiate all parts
             TypeData::Conditional(cond_id) => self.instantiate_conditional(type_id, cond_id),
@@ -891,7 +905,7 @@ impl<'a> TypeInstantiator<'a> {
             TypeData::ReadonlyType(operand) => {
                 let inst_operand = self.instantiate(*operand);
                 if inst_operand == *operand {
-                    self.interner.intern(*key)
+                    type_id
                 } else {
                     self.interner.readonly_type(inst_operand)
                 }
@@ -901,7 +915,7 @@ impl<'a> TypeInstantiator<'a> {
             TypeData::NoInfer(inner) => {
                 let inst_inner = self.instantiate(*inner);
                 if inst_inner == *inner {
-                    self.interner.intern(*key)
+                    type_id
                 } else {
                     self.interner.no_infer(inst_inner)
                 }
@@ -939,7 +953,7 @@ impl<'a> TypeInstantiator<'a> {
                         });
                     }
                 }
-                self.interner.intern(*key)
+                type_id
             }
         }
     }

--- a/crates/tsz-solver/src/instantiation/instantiate/signatures.rs
+++ b/crates/tsz-solver/src/instantiation/instantiate/signatures.rs
@@ -87,7 +87,7 @@ impl<'a> TypeInstantiator<'a> {
     pub(super) fn instantiate_function(
         &mut self,
         shape_id: &FunctionShapeId,
-        key: &TypeData,
+        type_id: TypeId,
     ) -> TypeId {
         let shape = self.interner.function_shape(*shape_id);
         // Shallow-this mode: substitute `this:` parameter slot,
@@ -144,7 +144,9 @@ impl<'a> TypeInstantiator<'a> {
                     is_method: shape.is_method,
                 });
             }
-            return self.interner.intern(*key);
+            // Function shapes are canonically interned, so `type_id` already
+            // names this key; skip the redundant re-intern.
+            return type_id;
         }
         let (shadowed_len, saved_visiting) = self.enter_shadowing_scope(&shape.type_params);
 
@@ -188,7 +190,7 @@ impl<'a> TypeInstantiator<'a> {
                 is_method: shape.is_method,
             })
         } else {
-            self.interner.intern(*key)
+            type_id
         }
     }
 
@@ -196,7 +198,7 @@ impl<'a> TypeInstantiator<'a> {
     pub(super) fn instantiate_callable(
         &mut self,
         shape_id: &CallableShapeId,
-        key: &TypeData,
+        type_id: TypeId,
     ) -> TypeId {
         let shape = self.interner.callable_shape(*shape_id);
         // Shallow-this mode: substitute the `this:` slot and
@@ -268,7 +270,9 @@ impl<'a> TypeInstantiator<'a> {
                     is_abstract: shape.is_abstract,
                 });
             }
-            return self.interner.intern(*key);
+            // Callable shapes are canonically interned, so `type_id` already
+            // names this key; skip the redundant re-intern.
+            return type_id;
         }
         let instantiated_call = self.instantiate_call_signatures_if_changed(&shape.call_signatures);
         let instantiated_construct =
@@ -300,7 +304,7 @@ impl<'a> TypeInstantiator<'a> {
                 is_abstract: shape.is_abstract,
             })
         } else {
-            self.interner.intern(*key)
+            type_id
         }
     }
 }


### PR DESCRIPTION
## Summary

Reduces the per-instantiation constant factor in `TypeInstantiator` by eliminating
redundant `interner.intern(*key)` round-trips on every instantiation node whose
structural key is unchanged (or whose `Object`/`ObjectWithIndex`/`Function`/`Callable`
shape was rebuilt). This is the generics marginal-slope lever from #13250: it is NOT
a new cache — it lowers the per-call cost of `instantiate` itself.

## Structural rule

`instantiate_key` receives both the `type_id` being walked and the `key`
(`= interner.lookup(type_id)`). On the unchanged path (and after rebuilding a shape)
it recovered the result id by calling `interner.intern(*key)` — a full `FxHash` over
the `TypeData` plus an intern-cache probe — to recompute an id it already held.

For **every** kind reachable in `instantiate_key` except `TypeParameter`, the key is
canonically interned (the `TypeData → TypeId` map is a bijection on the canonical
subset), so `intern(*key) == type_id` by construction. The only `intern_fresh`
(non-canonical, declaration-scoped) kind is `TypeParameter`, and that arm already
returns the original `type_id` directly. So:

> When `instantiate` reaches a non-`TypeParameter` node and the substitution does not
> rewrite it (or rebuilds it into a fresh shape), `tsc` returns the node unchanged;
> tsz now returns the `type_id` already in hand through the solver instantiator,
> instead of re-interning `*key` to recompute the same id.

Owner layer: solver instantiation (`crates/tsz-solver/src/instantiation/`).

## What was eliminated

Per unchanged node: one `FxHash(TypeData)` + one intern thread-local-cache probe.
Across a body, this drops the interner work from **O(total nodes)** to
**O(changed nodes)**: a mostly-concrete generic body (a few type-parameter leaves,
many concrete subtrees — the ts-toolbelt/kysely/zod shape) no longer re-interns
every concrete subtree it walks. Two redundant `intern(*key)` calls per rebuilt
`Object`/`ObjectWithIndex` (the `original` recovery before provenance propagation)
are also removed. No allocation/clone counts change — this is pure redundant-compute
elimination, not a shape change.

Goal: fast

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

Measured with a no-query-cache instantiation micro-benchmark (growing-N synthetic
generic bodies; `min`-of-7 wall-clock to suppress system noise; a counting global
allocator for alloc churn; and the deterministic `interner_intern_calls` perf
counter under `TSZ_PERF_COUNTERS=1` for a load-immune work count).

**Deterministic interner-work count (intern calls per instantiation; load-immune).**
`alloc/call` is byte-identical before/after, confirming no behavior change.

| config (w×d, concrete_every) | nodes | BEFORE intern/call | AFTER intern/call | eliminated |
|---|---|---|---|---|
| all-changed 8×8 (ce=1) | 17 | 24 | 16 | −33% |
| all-changed 16×16 (ce=1) | 33 | 48 | 32 | −33% |
| all-changed 32×32 (ce=1) | 65 | 82 | 50 | −39% |
| mostly-concrete 8×8 (ce=4) | 58 | 65 | 8 | −88% |
| mostly-concrete 16×16 (ce=4) | 210 | 225 | 16 | −93% |
| mostly-concrete 32×32 (ce=4) | 802 | 833 | 32 | −96% |
| mostly-concrete 16×16 (ce=8) | 242 | 257 | 16 | −94% |
| mostly-concrete 32×32 (ce=8) | 930 | 961 | 32 | −97% |

The BEFORE intern-call count tracks **total** node count; AFTER it tracks only the
**changed** node count — the structural rule, proven directly.

**Wall-clock marginal slope (ns/node, min/7; quietest interleaved run).**

| config | BEFORE ns/node | AFTER ns/node | Δ |
|---|---|---|---|
| all-changed 16×16 | 1031 | 789 | −24% |
| all-changed 32×32 | 1977 | 1321 | −33% |
| mostly-concrete 8×8 (ce=4) | 473 | 265 | −44% |
| mostly-concrete 16×16 (ce=4) | 490 | 303 | −38% |
| mostly-concrete 32×32 (ce=4) | 557 | 452 | −19% |
| mostly-concrete 16×16 (ce=8) | 521 | 437 | −16% |

(Absolute wall-clock varies with machine load — 5 concurrent agents — so the
deterministic intern-call count above is the authoritative metric; the timing
table is the quietest interleaved BEFORE/AFTER pair.)

**Correctness:** an in-harness self-check asserts identity preservation (concrete
subtrees and identity substitution `T:=T` return the SAME `TypeId`) and idempotence
(re-instantiating a now-concrete result is a no-op), all of which exercise the
unchanged-path `intern(*key) → type_id` equivalence the fix relies on. Passes on
both BEFORE and AFTER builds.

**Conformance delta:** no behavior change is possible by construction
(`intern(*key) == type_id` for every affected kind; `TypeParameter` untouched), so
zero conformance movement is expected. Full conformance/emit/fourslash run on
ready-review CI (the solver test harness does not build under `--release` locally
due to a pre-existing `#[cfg(test, debug_assertions)]` perf-counter gate, unrelated
to this change; CI uses the test profile).
