### PR TITLE
perf(checker): hoist type-arg substitution across constraint-validation loop (#13250)

### DIFF
--- a/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/constraint_validation.rs
@@ -28,17 +28,33 @@ impl<'a> CheckerState<'a> {
             .map(|(param, &arg)| (param.name, arg))
             .collect::<Vec<_>>();
 
+        // Build the `{type-param-name -> type-arg}` substitution once for the
+        // whole call. Constraint instantiation re-asks for this same mapping at
+        // several points inside the per-parameter loop below; rebuilding it per
+        // iteration is O(D) map construction inside an O(D) loop, i.e. O(D^2)
+        // per textual type-reference occurrence for a depth-D bounded-parameter
+        // chain (`T0 extends Base, T1 extends T0, ...`). The mapping is
+        // invariant across iterations (it depends only on `type_params` /
+        // `type_args`), so hoisting it collapses the per-occurrence
+        // constraint-substitution cost back to O(D). It is built from the same
+        // zipped name/arg pairs the in-loop builders used, so the substitution —
+        // and therefore every diagnostic — is unchanged. (#13250)
+        let type_arg_subst = {
+            let mut subst = crate::query_boundaries::common::TypeSubstitution::new();
+            for (param, &arg) in type_params.iter().zip(type_args.iter()) {
+                subst.insert(param.name, arg);
+            }
+            subst
+        };
+
         for (i, (param, &type_arg)) in type_params.iter().zip(type_args.iter()).enumerate() {
             if let Some(constraint) = param.constraint {
                 if let Some(&arg_idx) = type_args_list.nodes.get(i)
                     && self.type_arg_is_unknown_keyword(arg_idx)
                 {
                     let constraint_resolved = self.resolve_lazy_type(constraint);
-                    let inst_constraint = self.instantiate_constraint_with_type_args(
-                        constraint_resolved,
-                        type_params,
-                        &type_args,
-                    );
+                    let inst_constraint = self
+                        .instantiate_constraint_with_subst(constraint_resolved, &type_arg_subst);
                     if !matches!(inst_constraint, TypeId::ANY | TypeId::UNKNOWN) {
                         let constraint_str =
                             self.format_type_diagnostic_constraint(inst_constraint);
@@ -81,11 +97,8 @@ impl<'a> CheckerState<'a> {
                     if constraint_resolved == TypeId::ANY {
                         continue;
                     }
-                    let inst_constraint = self.instantiate_constraint_with_type_args(
-                        constraint,
-                        type_params,
-                        &type_args,
-                    );
+                    let inst_constraint =
+                        self.instantiate_constraint_with_subst(constraint, &type_arg_subst);
                     if self.required_mapped_constraint_source_is_required_and_arg_satisfies(
                         type_arg,
                         inst_constraint,
@@ -278,21 +291,8 @@ impl<'a> CheckerState<'a> {
                 });
                 if concrete_application_args {
                     let constraint_resolved = self.resolve_lazy_type(constraint);
-                    let mut subst = crate::query_boundaries::common::TypeSubstitution::new();
-                    for (j, p) in type_params.iter().enumerate() {
-                        if let Some(&arg) = type_args.get(j) {
-                            subst.insert(p.name, arg);
-                        }
-                    }
-                    let inst_constraint = if subst.is_empty() {
-                        constraint_resolved
-                    } else {
-                        crate::query_boundaries::common::instantiate_type(
-                            self.ctx.types,
-                            constraint_resolved,
-                            &subst,
-                        )
-                    };
+                    let inst_constraint = self
+                        .instantiate_constraint_with_subst(constraint_resolved, &type_arg_subst);
                     if !query::contains_type_parameters(self.ctx.types, inst_constraint) {
                         self.ensure_relation_input_ready(type_arg);
                         self.ensure_relation_input_ready(inst_constraint);
@@ -335,11 +335,8 @@ impl<'a> CheckerState<'a> {
                     && query::is_application_type(self.ctx.types.as_type_database(), type_arg)
                 {
                     let constraint_resolved = self.resolve_lazy_type(constraint);
-                    let inst_constraint = self.instantiate_constraint_with_type_args(
-                        constraint_resolved,
-                        type_params,
-                        &type_args,
-                    );
+                    let inst_constraint = self
+                        .instantiate_constraint_with_subst(constraint_resolved, &type_arg_subst);
                     if self.generic_alias_application_satisfies_object_constraint(
                         type_arg,
                         inst_constraint,
@@ -495,11 +492,8 @@ impl<'a> CheckerState<'a> {
                 }
                 if type_arg_contains_type_parameters {
                     let constraint_resolved = self.resolve_lazy_type(constraint);
-                    let inst_constraint = self.instantiate_constraint_with_type_args(
-                        constraint_resolved,
-                        type_params,
-                        &type_args,
-                    );
+                    let inst_constraint = self
+                        .instantiate_constraint_with_subst(constraint_resolved, &type_arg_subst);
                     if self
                         .conditional_result_branches_satisfy_constraint(type_arg, inst_constraint)
                     {
@@ -961,11 +955,8 @@ impl<'a> CheckerState<'a> {
                                     continue;
                                 }
                             }
-                            let inst_constraint = self.instantiate_constraint_with_type_args(
-                                constraint,
-                                type_params,
-                                &type_args,
-                            );
+                            let inst_constraint =
+                                self.instantiate_constraint_with_subst(constraint, &type_arg_subst);
                             let inst_constraint = self.resolve_lazy_type(inst_constraint);
                             if query::contains_free_type_parameters(self.ctx.types, inst_constraint)
                             {
@@ -1344,10 +1335,9 @@ impl<'a> CheckerState<'a> {
                                 self.hidden_conditional_infer_constraint_type(arg_idx)
                         {
                             let constraint_resolved = self.resolve_lazy_type(constraint);
-                            let inst_constraint = self.instantiate_constraint_with_type_args(
+                            let inst_constraint = self.instantiate_constraint_with_subst(
                                 constraint_resolved,
-                                type_params,
-                                &type_args,
+                                &type_arg_subst,
                             );
                             if inst_constraint == TypeId::UNKNOWN
                                 || inst_constraint == TypeId::ANY
@@ -1407,12 +1397,10 @@ impl<'a> CheckerState<'a> {
                                         self.hidden_conditional_infer_constraint_type(arg_idx)
                                 {
                                     let constraint_resolved = self.resolve_lazy_type(constraint);
-                                    let inst_constraint = self
-                                        .instantiate_constraint_with_type_args(
-                                            constraint_resolved,
-                                            type_params,
-                                            &type_args,
-                                        );
+                                    let inst_constraint = self.instantiate_constraint_with_subst(
+                                        constraint_resolved,
+                                        &type_arg_subst,
+                                    );
                                     if inst_constraint != TypeId::UNKNOWN
                                         && inst_constraint != TypeId::ANY
                                         && !query::contains_type_parameters(
@@ -1537,11 +1525,8 @@ impl<'a> CheckerState<'a> {
                         {
                             continue;
                         }
-                        let inst_constraint = self.instantiate_constraint_with_type_args(
-                            constraint,
-                            type_params,
-                            &type_args,
-                        );
+                        let inst_constraint =
+                            self.instantiate_constraint_with_subst(constraint, &type_arg_subst);
                         let inst_constraint = self.resolve_lazy_type(inst_constraint);
                         if query::contains_type_parameters(self.ctx.types, inst_constraint) {
                             continue;
@@ -1658,7 +1643,7 @@ impl<'a> CheckerState<'a> {
                 let written_keyof_constraint_display =
                     self.written_keyof_constraint_display(constraint, type_params, type_args_list);
                 let constraint =
-                    self.instantiate_constraint_with_type_args(constraint, type_params, &type_args);
+                    self.instantiate_constraint_with_subst(constraint, &type_arg_subst);
                 let constraint = self.resolve_lazy_type(constraint);
                 let constraint = self
                     .resolve_well_known_lib_constraint_type(constraint)

--- a/crates/tsz-checker/src/checkers/generic_checker/infer_conditional_helpers.rs
+++ b/crates/tsz-checker/src/checkers/generic_checker/infer_conditional_helpers.rs
@@ -21,10 +21,28 @@ impl<'a> CheckerState<'a> {
         for (param, &arg) in type_params.iter().zip(type_args.iter()) {
             subst.insert(param.name, arg);
         }
+        self.instantiate_constraint_with_subst(constraint, &subst)
+    }
+
+    /// Instantiate a parameter `constraint` with a pre-built
+    /// `{type-param-name -> type-arg}` substitution.
+    ///
+    /// This is the substitution-reuse form of
+    /// [`Self::instantiate_constraint_with_type_args`]: the caller builds the
+    /// name/arg map once per type-reference occurrence and reuses it across the
+    /// per-parameter constraint-validation loop, instead of rebuilding the full
+    /// O(D) map on every parameter (which is O(D^2) per occurrence for a
+    /// depth-D bounded-parameter chain). The mapping and instantiation are
+    /// identical to the per-call form, so the result is unchanged.
+    pub(super) fn instantiate_constraint_with_subst(
+        &mut self,
+        constraint: TypeId,
+        subst: &crate::query_boundaries::common::TypeSubstitution,
+    ) -> TypeId {
         if subst.is_empty() {
             constraint
         } else {
-            crate::query_boundaries::common::instantiate_type(self.ctx.types, constraint, &subst)
+            crate::query_boundaries::common::instantiate_type(self.ctx.types, constraint, subst)
         }
     }
 


### PR DESCRIPTION
## Summary

`validate_type_args_against_params` (the TS2344 type-argument constraint
checker) rebuilt the `{type-param-name -> type-arg}` substitution map on **every
parameter iteration** of its per-parameter loop. Each
`instantiate_constraint_with_type_args` call — and one inline
concrete-application builder — re-zipped `type_params`/`type_args` into a fresh
`TypeSubstitution` (O(D) hashing/alloc) inside the O(D) loop, so validating a
generic reference whose declaration is a depth-D bounded-parameter chain
(`G<T0 extends Base, T1 extends T0, ...>`) cost **O(D^2) per textual
occurrence**.

The substitution depends only on `type_params`/`type_args`, both fixed for the
whole call, so it is invariant across the loop. This PR builds it **once** at the
top of `validate_type_args_against_params` and threads it through every
constraint-instantiation site via a new `instantiate_constraint_with_subst`
helper. The map (and therefore every emitted diagnostic) is byte-identical;
only the redundant per-iteration rebuilds are removed.

## Structural rule

When a generic type reference `G<A1..An>` is checked for type-argument
constraint satisfaction, the substitution mapping each type parameter to its
argument is a single invariant for the whole reference. tsz now builds that
mapping once per occurrence (owner: checker `generic_checker` constraint
validation) and reuses it across all parameters, instead of reconstructing the
full O(D) map for each of the D parameters.

Owner layer: checker — `crates/tsz-checker/src/checkers/generic_checker/`
(`constraint_validation.rs`, `infer_conditional_helpers.rs`). No solver
behavior changes; `instantiate_type`'s fast paths (TypeParameter-in-subst,
concrete short-circuit) are unchanged.

## Complexity

- Per type-reference occurrence, constraint validation over a depth-D chain:
  **O(D^2) -> O(D)** substitution construction (D constraint instantiations,
  each previously rebuilding the full D-entry map; now one shared map).
- No cache, no new state, no invalidation surface: the substitution is a
  function-local value with the same lifetime as before.

## Adjacent-case matrix

- Positive (valid chain `P<Base, Base, Base>`): no diagnostic — unchanged.
- Negative direct (`G<number, number>` where `T0 extends string`): TS2344
  `Type 'number' does not satisfy the constraint 'string'` — unchanged.
- Negative through substitution (`H<string, number>` where `B extends A`):
  TS2344 against the instantiated constraint `string` — unchanged (proves the
  shared substitution still resolves constraints that reference earlier
  parameters).

## Verification

BCT marginal-slope workload: N=3000 identical generic instantiations
`type Ui = G<Base,...>` of a depth-D bounded-parameter chain, pure type-level
(no value-level property access, so flow narrowing is not exercised). Release
build, `--noEmit --strict --extendedDiagnostics`, "Check:" phase time.

| depth D | before (origin/main) | after | speedup |
|---------|----------------------|-------|---------|
| 4  | 0.88s | 0.75s | 1.17x |
| 16 | 3.82s | 2.44s | 1.57x |
| 32 | 8.49s | 4.35s | 1.95x |

Per-depth marginal slope (d4 -> d32):
- before: (8.49 - 0.88) / 28 = **0.272 s/depth-unit**
- after:  (4.35 - 0.75) / 28 = **0.129 s/depth-unit**
- **-53% BCT marginal slope** (confirms the O(D^2) -> O(D) per-occurrence fix).

Correctness smoke (diagnostics byte-identical): TS2344 emitted with the correct
constraint display on both negative witnesses; positive chain checks clean.

Conformance: behavior-preserving substitution-reuse hoist; the substitution and
every diagnostic are identical. Targeted TS2344 unit/integration suites
(`ts2344_*`, `generic_tests`, constraint-validation tests) and the broad
conformance floor run in ready-review CI; zero new accepted regressions
expected.

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Goal: fast
