### PR TITLE
fix(solver): keep primitive union members through subtype reduction over weak objects (#13650)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -135,6 +135,9 @@ path = "tests/large_union_conditional_distribution_tests.rs"
 name = "union_protected_intersection_property_tests"
 path = "tests/union_protected_intersection_property_tests.rs"
 [[test]]
+name = "weak_object_union_member_subtype_reduction_tests"
+path = "tests/weak_object_union_member_subtype_reduction_tests.rs"
+[[test]]
 name = "tuple_element_mismatch_tests"
 path = "tests/tuple_element_mismatch_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/weak_object_union_member_subtype_reduction_tests.rs
+++ b/crates/tsz-checker/tests/weak_object_union_member_subtype_reduction_tests.rs
@@ -1,0 +1,171 @@
+//! Regression coverage for issue #13650 Face 2: a primitive union member must
+//! survive union subtype reduction even when a sibling weak (all-optional)
+//! object member structurally subsumes it.
+//!
+//! Rule: `tsc`'s `removeSubtypes` only drops a union member as a subtype when
+//! that member is structured/instantiable, or when the union contains an empty
+//! object type. A bare primitive keyword (`boolean`, `number`, `string`, …)
+//! vacuously satisfies an all-optional object structurally, but `tsc` keeps it
+//! in the union — so `boolean | { x?: T }` stays a two-member union and a
+//! `boolean` argument is assignable to it. Previously tsz reduced the
+//! instantiated parameter union `boolean | Opts` down to `Opts` (the primitive
+//! was dropped), then rejected the `boolean`/`false` argument with a false
+//! TS2345. The reduction only fired under a generic signature, because the
+//! object member is a resolved structural type there rather than an opaque
+//! `Lazy` reference.
+//!
+//! The behavior keys on type structure (primitive vs object, presence of an
+//! all-optional sibling), never on identifier/property/type-parameter names, so
+//! these tests vary all of those.
+
+use tsz_checker::test_utils::check_source_code_messages;
+
+fn ts2345_count(diags: &[(u32, String)]) -> usize {
+    diags.iter().filter(|(code, _)| *code == 2345).count()
+}
+
+#[test]
+fn boolean_arg_against_generic_boolean_or_weak_object_union_is_accepted() {
+    // The exact `addEventListener`-shaped repro from the issue: a fresh `false`
+    // against `boolean | Opts` under a generic signature.
+    let diags = check_source_code_messages(
+        r#"
+interface Opts { capture?: boolean; once?: boolean }
+declare function on<K extends string>(type: K, options?: boolean | Opts): void;
+on("visibilitychange", false);
+"#,
+    );
+    assert_eq!(
+        ts2345_count(&diags),
+        0,
+        "a boolean is assignable to the `boolean` member of `boolean | Opts`: {diags:?}"
+    );
+}
+
+#[test]
+fn number_arg_against_generic_number_or_weak_object_union_is_accepted() {
+    // The defect is not boolean-specific: any primitive paired with a weak
+    // object member must survive the reduction.
+    let diags = check_source_code_messages(
+        r#"
+interface Settings { retries?: number; cache?: boolean }
+declare function run<T extends string>(name: T, settings?: number | Settings): void;
+run("job", 5);
+"#,
+    );
+    assert_eq!(
+        ts2345_count(&diags),
+        0,
+        "a number is assignable to the `number` member of `number | Settings`: {diags:?}"
+    );
+}
+
+#[test]
+fn string_arg_against_generic_string_or_weak_object_union_is_accepted() {
+    let diags = check_source_code_messages(
+        r#"
+interface Wibble { aaa?: string; bbb?: number }
+declare function listen<X extends string>(channel: X, mode?: string | Wibble): void;
+listen("evt", "fast");
+"#,
+    );
+    assert_eq!(
+        ts2345_count(&diags),
+        0,
+        "a string is assignable to the `string` member of `string | Wibble`: {diags:?}"
+    );
+}
+
+#[test]
+fn non_fresh_primitive_against_generic_primitive_or_weak_object_union_is_accepted() {
+    // Freshness is not the trigger — an already-widened, non-fresh `boolean`
+    // local must also be accepted under the generic signature.
+    let diags = check_source_code_messages(
+        r#"
+interface Cfg { passive?: boolean; signal?: boolean }
+declare function bind<E extends string>(event: E, cfg?: boolean | Cfg): void;
+const flag: boolean = false;
+bind("ready", flag);
+bind("ready", true);
+bind("ready", { passive: true });
+"#,
+    );
+    assert_eq!(
+        ts2345_count(&diags),
+        0,
+        "non-fresh boolean and the object member both stay assignable: {diags:?}"
+    );
+}
+
+#[test]
+fn weak_object_only_union_member_still_rejects_primitive_argument() {
+    // Negative control: with NO sibling primitive member, a `boolean` argument
+    // against a weak-object-only parameter must still be rejected (both tsc and
+    // tsz reject — tsc TS2559, tsz TS2345). The fix must not over-correct into
+    // accepting this.
+    let diags = check_source_code_messages(
+        r#"
+interface Opts { capture?: boolean; once?: boolean }
+declare function on<K extends string>(type: K, options?: Opts): void;
+on("x", false);
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 2345),
+        "a boolean against a weak-object-only parameter must still be rejected: {diags:?}"
+    );
+}
+
+#[test]
+fn plain_weak_object_from_function_value_still_reports_ts2559() {
+    // Negative control: assigning a function value to a plain (non-intersection)
+    // weak object must still produce the weak-type TS2559 diagnostic.
+    let diags = check_source_code_messages(
+        r#"
+type Weak = { p?: number };
+const y: Weak = () => {};
+"#,
+    );
+    assert!(
+        diags.iter().any(|(code, _)| *code == 2559),
+        "a function value assigned to a plain weak object must still report TS2559: {diags:?}"
+    );
+}
+
+#[test]
+fn wrong_object_property_through_generic_union_still_errors() {
+    // Negative control: the object union member is still checked structurally —
+    // a wrong property type must still surface a diagnostic, proving the fix
+    // only restores the primitive member rather than disabling the object arm.
+    let diags = check_source_code_messages(
+        r#"
+interface Opts { capture: boolean }
+declare function on<K extends string>(type: K, options?: boolean | Opts): void;
+on("x", { capture: 1 });
+"#,
+    );
+    assert!(
+        !diags.is_empty(),
+        "passing a wrong-typed object property must still error: {diags:?}"
+    );
+}
+
+#[test]
+fn boolean_or_empty_object_union_still_collapses_to_empty_object() {
+    // The `has_empty_object` exception must remain: when the union literally
+    // contains an empty object type, the primitive IS subsumed and collapsed,
+    // matching tsc (`boolean | {}` → `{}`). A string is assignable to `{}`.
+    let diags = check_source_code_messages(
+        r#"
+type U = boolean | {};
+const a: U = false;
+const b: U = {};
+const c: U = "anything";
+"#,
+    );
+    assert_eq!(
+        ts2345_count(&diags),
+        0,
+        "boolean | {{}} collapses to {{}} which accepts any non-nullish value: {diags:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -833,6 +833,23 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                 Vec::new()
             };
 
+        // Union subtype reduction only removes a member that is structured or
+        // instantiable, or — when the union contains an empty object type — any
+        // member subsumed by that empty object. This mirrors tsc's
+        // `removeSubtypes`, which gates removal on
+        // `hasEmptyObject || source.flags & StructuredOrInstantiable`: a bare
+        // primitive keyword (`boolean`, `number`, `string`, …) vacuously
+        // satisfies a weak (all-optional) object member structurally, but tsc
+        // never drops it via that subsumption. Literal members are still removed
+        // here because tsz folds tsc's separate literal-absorption pass
+        // (`"a" | string` → `string`) into this loop; literals are recognized
+        // below and stay removable. `has_empty_object` is only consulted in the
+        // union direction; intersection simplification keeps its own rules.
+        let has_empty_object = matches!(direction, SubtypeDirection::SourceSubsumedByOther)
+            && members.iter().any(|&id| {
+                crate::visitors::visitor_predicates::is_empty_object_type(self.interner, id)
+            });
+
         // Use mark-and-compact instead of Vec::remove() which is O(N) per removal.
         // Since max size is 25 (from guard above), a u32 bitset avoids heap allocation.
         let len = members.len();
@@ -841,6 +858,19 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             if keep & (1u32 << i) == 0 {
                 continue;
             }
+            // Union subtype-removal eligibility depends only on `members[i]`
+            // (structured/instantiable, or any member when the union holds an
+            // empty object — a bare primitive keyword is kept even when it
+            // structurally satisfies a weak object sibling). Compute it once per
+            // `i` instead of per `(i, j)`. Intersection simplification does not
+            // consult it, so the `matches!` short-circuits the helper away.
+            let union_candidate_removable =
+                matches!(direction, SubtypeDirection::SourceSubsumedByOther)
+                    && Self::union_member_removable_as_subtype(
+                        self.interner,
+                        members[i],
+                        has_empty_object,
+                    );
             for j in 0..len {
                 if i == j || keep & (1u32 << j) == 0 {
                     continue;
@@ -851,7 +881,8 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
                 let is_subtype = match direction {
                     SubtypeDirection::SourceSubsumedByOther => {
-                        checker.is_subtype_of(members[i], members[j])
+                        union_candidate_removable
+                            && checker.is_subtype_of(members[i], members[j])
                             && !Self::has_unique_properties_cached(&prop_names[i], &prop_names[j])
                             // Don't remove a member with an index signature when the
                             // subsuming member lacks one. The index signature carries
@@ -970,6 +1001,46 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return true; // Candidate has properties but subsuming doesn't
         };
         candidate.iter().any(|name| !subsuming.contains(name))
+    }
+
+    /// Decide whether a union member may be dropped by subtype reduction when a
+    /// sibling member structurally subsumes it.
+    ///
+    /// Mirrors the eligibility gate in tsc's `removeSubtypes`
+    /// (`hasEmptyObject || source.flags & StructuredOrInstantiable`):
+    /// - Object / intersection / instantiable members (anything that is not a
+    ///   bare intrinsic keyword) are eligible — `{ a; b } | { a }` reduces to
+    ///   `{ a }`, `T | { a }` reduces when `T <: { a }`, etc.
+    /// - Literal members stay eligible because tsz folds tsc's separate literal
+    ///   absorption pass (`"a" | string` → `string`, `1 | number` → `number`)
+    ///   into this same loop.
+    /// - A bare primitive keyword (`boolean`, `number`, `string`, `symbol`,
+    ///   `bigint`, `void`, `null`, `undefined`, `object`, …) is NOT eligible:
+    ///   it vacuously satisfies a weak (all-optional) object member
+    ///   structurally, yet tsc keeps it in the union (`boolean | { x?: T }`
+    ///   stays a union). The sole exception is `has_empty_object`: when the
+    ///   union literally contains an empty object type, everything it subsumes
+    ///   is collapsed into it (`boolean | {}` → `{}`), matching tsc.
+    fn union_member_removable_as_subtype(
+        db: &dyn crate::caches::db::TypeDatabase,
+        member: TypeId,
+        has_empty_object: bool,
+    ) -> bool {
+        if has_empty_object {
+            return true;
+        }
+        if crate::visitors::visitor_predicates::is_literal_type(db, member) {
+            return true;
+        }
+        // Reserved intrinsic TypeIds (`boolean`, `number`, `string`, `object`,
+        // …) are bare keyword types and stay protected. They are checked
+        // explicitly because they do not always resolve through `lookup`.
+        if member.is_intrinsic() {
+            return false;
+        }
+        // Bare intrinsic keyword types (non-literal) are protected from
+        // object-subsumption removal; structured/instantiable members are not.
+        !crate::visitors::visitor_predicates::is_intrinsic_or_literal_type(db, member)
     }
 
     /// Check whether a (candidate, subsuming) pair forms the branded-primitive


### PR DESCRIPTION
Goal: green

Fixes Face 2 of #13650 (Face 1 was fixed by #13666). Unblocks the
`nextjs-fresh-app` corpus row, which installs `@tanstack/react-query` whose
`addEventListener`-shaped `boolean | AddEventListenerOptions` parameter hit this
false positive.

## Structural rule

When a union contains a primitive member and a sibling weak (all-optional)
object member (`primitive | WeakObject`), `tsc` keeps the primitive — a value
of the union may be that primitive. tsz dropped it during union subtype
reduction because a primitive vacuously satisfies an all-optional object
structurally, so the resolved object member "subsumed" the primitive. After the
primitive was gone, a `boolean`/`number`/`string` argument was checked against
the object member alone and rejected with a false **TS2345**.

`When a union member is a bare primitive keyword that is only structurally
subsumed by a weak object sibling, tsc keeps it (removeSubtypes), and tsz keeps
it through the union subtype-reduction gate in the solver.`

Owner layer: **solver, evaluation (union subtype reduction)**. Wrong operation:
a bare primitive treated as a removable subtype of a weak object during union
simplification.

## Why it only fired under a generic signature

The declared/aliased union (`type U = boolean | Opts`) keeps the primitive
because the object member is an opaque `Lazy(DefId)` reference that the
bypass-evaluation `SubtypeChecker` cannot expand, so `boolean <: Opts` is not
proven. During generic-call instantiation the object member is a resolved
structural shape, so `boolean <: { ... all optional }` returns true and the
primitive was dropped. The fix removes the asymmetry: the primitive is kept in
both paths.

## Fix

Mirrors tsc's `removeSubtypes` eligibility gate
(`hasEmptyObject || source.flags & StructuredOrInstantiable`) in
`remove_redundant_members` (`crates/tsz-solver/src/evaluation/evaluate/support.rs`):

- Only structured/instantiable members are eligible for subtype removal.
- Literal members stay removable so tsz's folded literal-absorption pass
  (`"a" | string` -> `string`, `1 | number` -> `number`) is unchanged.
- Bare primitive keywords (`boolean`, `number`, `string`, `symbol`, `bigint`,
  `void`, `null`, `undefined`, `object`) are kept.
- Exception preserved: when the union literally contains an empty object type,
  everything it subsumes is collapsed into it (`boolean | {}` -> `{}`).

The eligibility check depends only on the candidate member, so it is computed
once per outer index rather than per pair in the O(n^2) loop. No new cache key;
the change only widens acceptance along the paths tsc already accepts, and only
in the union direction (intersection simplification is untouched).

## Adjacent-case matrix

Covered by `crates/tsz-checker/tests/weak_object_union_member_subtype_reduction_tests.rs`:

- Renamed binders / properties / type parameters across `boolean`, `number`,
  `string` × weak object — all accepted (structure-keyed, not name-keyed).
- Non-fresh primitive (`const flag: boolean = false`) under the generic
  signature — accepted; freshness is not the trigger.
- The object union arm still type-checks structurally (wrong property type
  still errors).
- `boolean | {}` still collapses to `{}` (empty-object exception).

Negative controls (must stay rejected):

- Weak-object-only parameter (no sibling primitive) + primitive arg — still
  rejected.
- Function value assigned to a plain weak object — still TS2559.

## Verification

```
cargo nextest run -p tsz-checker --test weak_object_union_member_subtype_reduction_tests   # 8/8 pass
cargo nextest run -p tsz-solver                                                            # no new failures
cargo clippy -p tsz-solver                                                                 # clean
```

Standalone repros flip from error to clean while negative controls stay errored:

```
tsz --noEmit --strict 'on<K extends string>(type: K, options?: boolean | Opts); on("x", false)'   # exit 0
tsz --noEmit --strict 'on<K extends string>(type: K, options?: number  | Opts); on("x", 5)'        # exit 0
tsz --noEmit --strict 'const y: { p?: number } = () => {}'                                          # TS2559 (unchanged)
```

The full `tsz-solver` suite shows only 3 failures that are identical on `main`
at the PR base (`higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`,
`test_generic_call_widening_applies_when_constraint_satisfied`, and the
`mapped.rs` file-size baseline) — none touched by this diff.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high


---
_Generated by [Claude Code](https://claude.ai/code/session_01UTt2m257h1migZ3Lc916f8)_