### PR TITLE
perf(solver): memoize contains_never structural walk per TypeId (#13097)

### DIFF
--- a/crates/tsz-solver/src/caches/db.rs
+++ b/crates/tsz-solver/src/caches/db.rs
@@ -94,6 +94,16 @@ pub trait TypePredicateCache {
     /// the shared interner cache. Default impl is a no-op.
     fn set_contains_type_query_full_cache(&self, _type_id: TypeId, _result: bool) {}
 
+    /// Look up a cached `contains_never_type_db(type_id)` result if available.
+    /// Default impl returns `None` (no caching).
+    fn contains_never_cached(&self, _type_id: TypeId) -> Option<bool> {
+        None
+    }
+
+    /// Record the result of `contains_never_type_db(type_id)` in the shared
+    /// interner cache. Default impl is a no-op.
+    fn set_contains_never_cache(&self, _type_id: TypeId, _result: bool) {}
+
     /// Look up a cached `contains_type_parameters_db(type_id)` result if
     /// available. Default impl returns `None` (no caching).
     fn contains_type_params_cached(&self, _type_id: TypeId) -> Option<bool> {
@@ -748,6 +758,14 @@ impl TypePredicateCache for TypeInterner {
 
     fn set_contains_type_query_full_cache(&self, type_id: TypeId, result: bool) {
         self.predicate_cache_set(type_id, PredicateCacheKind::ContainsTypeQueryFull, result);
+    }
+
+    fn contains_never_cached(&self, type_id: TypeId) -> Option<bool> {
+        self.predicate_cache_get(type_id, PredicateCacheKind::ContainsNever)
+    }
+
+    fn set_contains_never_cache(&self, type_id: TypeId, result: bool) {
+        self.predicate_cache_set(type_id, PredicateCacheKind::ContainsNever, result);
     }
 
     fn contains_type_params_cached(&self, type_id: TypeId) -> Option<bool> {

--- a/crates/tsz-solver/src/caches/query_cache.rs
+++ b/crates/tsz-solver/src/caches/query_cache.rs
@@ -609,6 +609,14 @@ impl TypePredicateCache for QueryCache<'_> {
             .set_contains_type_query_full_cache(type_id, result);
     }
 
+    fn contains_never_cached(&self, type_id: TypeId) -> Option<bool> {
+        self.interner.contains_never_cached(type_id)
+    }
+
+    fn set_contains_never_cache(&self, type_id: TypeId, result: bool) {
+        self.interner.set_contains_never_cache(type_id, result);
+    }
+
     fn contains_type_params_cached(&self, type_id: TypeId) -> Option<bool> {
         self.interner.contains_type_params_cached(type_id)
     }

--- a/crates/tsz-solver/src/intern/core/interner.rs
+++ b/crates/tsz-solver/src/intern/core/interner.rs
@@ -143,18 +143,29 @@ pub(crate) enum PredicateCacheKind {
     /// recorded identity result is a permanent structural fixed point. Backs the
     /// evaluator's resolver-independent fixed-point fast path (#13250 / #8356).
     StructurallyEvalInert = 15,
+    /// `type_id` contains the `never` intrinsic anywhere on its
+    /// [`ChildPolicy::CONTENT_PREDICATE`] surface. Structural and immutable per
+    /// `TypeId` (matches the bare `Intrinsic(Never)` leaf), so the deep walk is
+    /// memoized like the sibling `Contains*` predicates. Asked once per property
+    /// access to gate the `never`-receiver TS2339 path, which is O(members) over
+    /// the receiver shape — O(N^2) over an N-member class with N `this.x`
+    /// accesses without this memo (#13097 slope, parent #13250).
+    ///
+    /// [`ChildPolicy::CONTENT_PREDICATE`]:
+    ///     crate::visitors::child_policy::ChildPolicy::CONTENT_PREDICATE
+    ContainsNever = 16,
 }
 
 impl PredicateCacheKind {
-    const fn bit(self) -> u16 {
-        1u16 << (self as u8)
+    const fn bit(self) -> u32 {
+        1u32 << (self as u8)
     }
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub(crate) struct PredicateCacheEntry {
-    known: u16,
-    truthy: u16,
+    known: u32,
+    truthy: u32,
 }
 
 impl PredicateCacheEntry {

--- a/crates/tsz-solver/src/type_queries/data/content_predicates.rs
+++ b/crates/tsz-solver/src/type_queries/data/content_predicates.rs
@@ -1199,17 +1199,46 @@ pub fn contains_application_unknown_arg(db: &dyn TypeDatabase, type_id: TypeId) 
     })
 }
 
+/// `Never`-only content predicate plus its dedicated project-wide cache slot.
+struct NeverPredicate;
+impl ContentPredicate for NeverPredicate {
+    fn matches_node(&self, _db: &dyn TypeDatabase, key: &TypeData) -> bool {
+        matches!(key, TypeData::Intrinsic(IntrinsicKind::Never))
+    }
+    fn cached(&self, db: &dyn TypeDatabase, type_id: TypeId) -> Option<bool> {
+        db.contains_never_cached(type_id)
+    }
+    fn set_cache(&self, db: &dyn TypeDatabase, type_id: TypeId, result: bool) {
+        db.set_contains_never_cache(type_id, result);
+    }
+}
+
 /// Check if a type contains the `never` intrinsic.
 ///
-/// Delegates to `visitor_predicates::contains_type_matching` with a `Never`-only
-/// predicate, plus a fast path for the well-known `TypeId::NEVER`.
+/// `never` containment is a purely structural question over the immutable
+/// interned type (it matches the bare `Intrinsic(Never)` leaf), so the deep
+/// walk over the [`ChildPolicy::CONTENT_PREDICATE`] surface is memoized
+/// project-wide in the [`ContainsNever`] cache slot exactly like the sibling
+/// `Contains*` predicates. This collapses the per-property-access `never`-receiver
+/// gate from O(receiver-members) to amortized O(1) — the difference between an
+/// O(N^2) and O(N) sweep of an N-member class with N `this.x` accesses
+/// (#13097 slope, parent #13250). The cached walker uses the same child set as
+/// the prior `contains_type_matching` walk, so the answer is byte-identical;
+/// only provisional cycle-break results are withheld from the cache.
+///
+/// [`ChildPolicy::CONTENT_PREDICATE`]:
+///     crate::visitors::child_policy::ChildPolicy::CONTENT_PREDICATE
+/// [`ContainsNever`]: crate::intern::core::interner::PredicateCacheKind::ContainsNever
 pub fn contains_never_type_db(db: &dyn TypeDatabase, type_id: TypeId) -> bool {
     if type_id == TypeId::NEVER {
         return true;
     }
-    contains_type_matching(db, type_id, |key| {
-        matches!(key, TypeData::Intrinsic(IntrinsicKind::Never))
-    })
+    if type_id.is_intrinsic() {
+        // No non-`never` intrinsic contains `never`; the `NEVER` fast path
+        // above already handled the one that does.
+        return false;
+    }
+    contains_content_cached(db, type_id, &NeverPredicate)
 }
 
 /// Check whether a type is "deeply any" — i.e. `any` itself, or a composite


### PR DESCRIPTION
Goal: fast

Memoize the per-property-access `contains_never` structural walk so an
N-member class checked with N `this.x`-style accesses runs O(N) instead of
O(N^2). Parent #13250 (fast slope); same class/contextual property-access
slope as #13097.

## Background: why not the evaluator memo
#13097's evaluator-memo loss was already retired by #13275 (per-file clean
write-through + #13250's structural-inert bit). I re-measured both #13097
witnesses on current main with `TSZ_PERF_COUNTERS`:

- Contextual `take({p: s.a, q: s.b})` x N (no classes): wall is **flat**
  (~85ms across N=50..400); eval `compute_nodes` is linear and tiny. The
  eval-memo path is exhausted here — a shared clean-compute memo moves nothing.
- Class with N noinit fields + N `this.x` methods: wall is strongly
  superlinear (126/404/1181/2309/4518 ms at N=100/200/300/400/800) **but eval
  `compute_nodes` is constant (~36)**. The superlinearity is entirely outside
  the evaluation memo.

A `sample` profile of the class witness put the work in the checker
property-access path: `get_type_of_property_access_inner` ->
`resolve_identifier_property_access` -> the `never`-receiver gate
`contains_never_type(object_type)`, whose heaviest leaf was
`DeepContainsChecker::check` re-walking the whole class shape on every access.

## Structural rule
When a property access asks whether its receiver type contains `never` (the
TS2339 `never`-receiver gate in `property_access_type::resolve`), `tsc` answers
in time independent of how many times the same receiver type is accessed.
`tsz` answered by re-running an uncached `DeepContainsChecker`
(`ChildPolicy::CONTENT_PREDICATE`) over the whole receiver type each call —
O(receiver-members) per access, O(N^2) over an N-member class.

`never` containment is a purely structural, immutable-per-`TypeId` question
(it matches the bare `Intrinsic(Never)` leaf). So `contains_never_type_db` now
routes through the established `contains_content_cached` walker with a
dedicated `ContainsNever` predicate-cache slot — exactly the pattern the
sibling `contains_type_params` / `contains_type_query` / `contains_infer`
predicates already use. The cached walker descends the same child set as the
prior `contains_type_matching` walk, so every answer is byte-identical; only
provisional cycle-break results are withheld from the persistent cache.

## Owner layer
Solver. The cache slot lives in the interner's packed per-`TypeId`
`predicate_cache` (shared with the other content predicates: no new map, the
bit reuses the existing entry per `TypeId`). The packed `known`/`truthy`
bitset is widened from `u16` to `u32` to hold the 17th predicate kind. The
checker reads it through the unchanged `contains_never_type` query boundary.

## Soundness
- The walk is over the immutable interned structure; `never` is an intrinsic
  leaf, so the answer is a pure function of `TypeId` and resolver-independent
  (same invariant the sibling cached `Contains*` predicates rely on).
- Identical child policy (`CONTENT_PREDICATE`) to the prior uncached walk, so
  the cached result equals the recomputed one.
- The cached walker only persists untainted (non-cycle) per-node results; a
  provisional cycle-break answer is never stored.

## Conformance-neutrality
Behavior is unchanged (memo only). `never`-position matrix re-checked
(`{x:never}`, `never[]`, `()=>never`, method-returning-`never`,
`string|never` absorption, nested `never`, intersection `never & {b}`,
renamed binders): only the genuine `never` receiver emits TS2339, matching
`tsc`. Full conformance/emit/fourslash delegated to ready-review CI.

## Verification
Witness: class with N noinit fields + N `this.x` methods, min-of-N wall on a
release `tsz` build (studio):

| N | before | after | delta |
|---|---|---|---|
| 400 | 2309 ms | ~1300 ms | -43% |
| 800 | 4518 ms | ~3000 ms | -34% |

Profile after the fix: `DeepContainsChecker::check` is gone from the hot
leaves (the remaining superlinearity is a separate checker-side per-access
member-scan family — `find_member_access_info` /
`substitute_direct_this_property_shape_type` linear `.find()` over the member
list — left for a follow-up). Counters: eval `compute_nodes` unchanged
(this is not the eval path); type-interner residency bounded (~320KB for the
800-member class; the never bit shares the existing per-`TypeId` predicate
entry, zero new allocations).

`cargo clippy --release --workspace --lib --bins` clean; no new `#[allow]`.
(`--all-targets` hits the pre-existing `force_enable_perf_counters_for_tests`
`cfg(test, debug_assertions)` gate unrelated to this change; tests run under
debug in CI.)

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
