### PR TITLE
fix(solver): keep primitive union member subsumed only by a weak object (#13650 Face 2)

### DIFF
--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part4.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part4.rs
@@ -521,3 +521,74 @@ export const r = x["a"];
         );
     }
 
+    /// Regression for #13650 (Face 2): a `primitive | <weak object>` parameter
+    /// of a *generic* signature must accept a primitive argument. tsc evaluates
+    /// `boolean | Opts` as a two-member union and `false`/`boolean` is assignable
+    /// to the `boolean` member. tsz used to re-normalize the union during the
+    /// generic-call instantiation pass and drop the primitive member, because
+    /// the structural `Judge` reports `boolean <: { capture?: boolean }` (true
+    /// set-theoretically). tsc's union reduction uses the *strict* subtype
+    /// relation, which honors the weak-type rule: a source sharing no property
+    /// with a weak object is NOT a strict subtype of it, so the member survives.
+    /// Binder names vary so the rule is structural, not name-driven.
+    #[test]
+    fn generic_signature_primitive_or_weak_union_keeps_primitive_member() {
+        let diagnostics = collect_test_diagnostics(&[(
+            "main.ts",
+            r#"
+interface Flags { lazy?: boolean; eager?: boolean }
+declare function reg<P extends string>(p: P, f?: boolean | Flags): void;
+reg("a", false);
+reg("a", true);
+const widened: boolean = false;
+reg("a", widened);
+
+declare function regNum<Q extends string>(q: Q, f?: number | Flags): void;
+regNum("a", 5);
+
+declare function regStr<S extends string>(s: S, f?: string | Flags): void;
+regStr("a", "x");
+"#,
+        )]);
+        assert!(
+            !diagnostics.iter().any(|d| d.code == 2345 || d.code == 2769),
+            "primitive arg to a generic `primitive | weak` union param must be accepted \
+             (no false TS2345/TS2769): {diagnostics:?}"
+        );
+    }
+
+    /// Companion negative control for #13650 (Face 2): the weak-type rule must
+    /// still reject a primitive against a *weak-only* union member (no sibling
+    /// primitive) and against a bare weak object — keeping the union reduction
+    /// fix from silently disabling weak enforcement. tsc rejects both (TS2559);
+    /// tsz rejects both as well (the union-member case currently surfaces as
+    /// TS2345, the direct case as TS2559) — what matters is that they stay
+    /// errors, never accepted.
+    #[test]
+    fn weak_only_targets_stay_rejected_after_union_reduction_fix() {
+        let diagnostics = collect_test_diagnostics(&[(
+            "main.ts",
+            r#"
+interface Flags { lazy?: boolean; eager?: boolean }
+declare function regWeak<P extends string>(p: P, f?: Flags): void;
+regWeak("a", false);
+const direct: Flags = true;
+"#,
+        )]);
+        // The direct `const direct: Flags = true` assignment must stay TS2559.
+        assert!(
+            diagnostics.iter().any(|d| d.code == 2559),
+            "primitive vs bare weak object must stay TS2559: {diagnostics:?}"
+        );
+        // Both the weak-only union-member call and the direct assignment must be
+        // rejected — never silently accepted by the union-reduction fix.
+        let weak_rejections = diagnostics
+            .iter()
+            .filter(|d| matches!(d.code, 2559 | 2345 | 2322))
+            .count();
+        assert!(
+            weak_rejections >= 2,
+            "both weak-only targets must stay rejected (>=2 weak diagnostics): {diagnostics:?}"
+        );
+    }
+

--- a/crates/tsz-solver/src/evaluation/evaluate/support.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate/support.rs
@@ -797,11 +797,27 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             }
         }
 
-        use crate::relations::subtype::{MAX_SUBTYPE_DEPTH, SubtypeChecker};
-        let mut checker = SubtypeChecker::with_resolver(self.interner, self.resolver);
-        checker.bypass_evaluation = true;
-        checker.max_depth = MAX_SUBTYPE_DEPTH;
-        checker.no_unchecked_indexed_access = self.no_unchecked_indexed_access;
+        use crate::relations::subtype::MAX_SUBTYPE_DEPTH;
+        // tsc reduces a union with the *strict* subtype relation, which honors
+        // the weak-type rule: a source that shares no property with a weak object
+        // target (all-optional, ≥1 property, no signatures) is NOT a strict
+        // subtype of it, even though it is one set-theoretically (the structural
+        // `Judge`). Without this, `boolean | { capture?: boolean }` would collapse
+        // to just `{ capture?: boolean }` (`boolean <: weak` holds structurally),
+        // and a later `boolean` argument would then fail against the surviving
+        // weak member with a false TS2345/TS2559. The union arm reuses the same
+        // weak-violation predicate that drives the diagnostic so reduction and
+        // assignability agree; intersection reduction keeps its own
+        // member-preservation guards below.
+        //
+        // `CompatChecker` embeds the `SubtypeChecker` both directions need, so
+        // drive the structural `is_subtype_of` through `compat.subtype` rather
+        // than allocating a second checker.
+        let mut compat =
+            crate::relations::compat::CompatChecker::with_resolver(self.interner, self.resolver);
+        compat.subtype.bypass_evaluation = true;
+        compat.subtype.max_depth = MAX_SUBTYPE_DEPTH;
+        compat.subtype.no_unchecked_indexed_access = self.no_unchecked_indexed_access;
 
         // Pre-compute property name sets for all members once, avoiding O(N²) FxHashSet
         // allocations in the inner loop. Each entry is None for non-object types.
@@ -851,7 +867,11 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
 
                 let is_subtype = match direction {
                     SubtypeDirection::SourceSubsumedByOther => {
-                        checker.is_subtype_of(members[i], members[j])
+                        compat.subtype.is_subtype_of(members[i], members[j])
+                            // Weak-type guard (mirrors tsc's strictSubtypeRelation):
+                            // do not drop members[i] in favor of a weak object member
+                            // it shares no property with — tsc keeps both.
+                            && !compat.is_weak_union_violation(members[i], members[j])
                             && !Self::has_unique_properties_cached(&prop_names[i], &prop_names[j])
                             // Don't remove a member with an index signature when the
                             // subsuming member lacks one. The index signature carries
@@ -893,7 +913,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
                         // Skip the drop so `Application(stripPath<U>) & {path?: _}` keeps
                         // both members and downstream property collection sees the union.
                         !Self::is_opaque_under_bypass_eval(self.interner, members[i])
-                            && checker.is_subtype_of(members[j], members[i])
+                            && compat.subtype.is_subtype_of(members[j], members[i])
                             && !Self::has_unique_properties_cached(&prop_names[i], &prop_names[j])
                             // Modifier-preservation guard: in an intersection a shared
                             // property is readonly/optional only when ALL contributors


### PR DESCRIPTION
Goal: green

Fixes Face 2 of #13650 (Face 1 already landed in #13666). Unblocks the
`nextjs-fresh-app` corpus row, whose `@tanstack/react-query` /
`addEventListener`-shaped `boolean | AddEventListenerOptions` arguments hit this
defect.

## Structural rule

When tsc reduces a union it uses the **strict** subtype relation, which honors
the weak-type rule: a source that shares no property with a weak object type
(all-optional, ≥1 property, no call/construct/index signatures) is **not** a
strict subtype of it — even though it is one set-theoretically. tsz's union
subtype reduction used only the structural `Judge`
(`SubtypeChecker::is_subtype_of`), for which `boolean <: { capture?: boolean }`
holds (a `boolean` value has no `capture`, so it is in the set). So
`remove_redundant_members` dropped the `boolean` member and
`boolean | { capture?: boolean }` collapsed to `{ capture?: boolean }`.

The collapse only surfaced when `evaluate_type` re-normalized a parameter union
during a **generic** call (the non-generic path uses the interned union as-is,
where the weak object is still an unresolved `Lazy` ref and is not dropped). A
later `boolean`/`false` argument then failed against the surviving weak member
with a false **TS2345** (or **TS2769** under overloads).

`When a union contains a primitive (or any property-free) member A and a weak
object member B, tsc keeps both (A is not a strict subtype of B); tsz now keeps
both through the union reduction's weak-type guard in the solver evaluator.`

## Fix

`crates/tsz-solver/src/evaluation/evaluate/support.rs` —
`remove_redundant_members` (`SourceSubsumedByOther`/union direction) now also
requires `!CompatChecker::is_weak_union_violation(A, B)` before dropping `A`,
reusing the exact predicate that drives the weak-type diagnostic so reduction
and assignability agree. The guard runs only after the structural
`is_subtype_of` short-circuits true. `CompatChecker` embeds the `SubtypeChecker`
both reduction directions already needed, so the structural check now routes
through `compat.subtype` and no second checker is allocated. Intersection
reduction (`OtherSubsumedBySource`) is untouched — it keeps its own
modifier/index-signature/branded-primitive guards.

Owner layer: **solver, relations (union subtype reduction)**.

## Adjacent matrix (verified error→clean, structural not name-driven)

- Renamed binders (`Flags`/`reg`/`lazy`/`eager` vs the report's `Opts`/`on`).
- `boolean | Weak`, `number | Weak`, `string | Weak` under a generic signature.
- Alias / `Wrap<T>` (weak member reached through a `Lazy`/Application) / nested
  generic instantiation.
- Already-widened (non-fresh) `const b: boolean = false` argument.
- Direct `const x: T = true/false` assignment of a union member.

## Negative controls (verified stay rejected, parity with tsc 6.0.x)

- `const x: Opts = true` → stays **TS2559** (primitive vs bare weak object).
- weak-only union member `o?: Opts; on("x", false)` → stays rejected.
- plain weak-from-function `const y: Weak = () => {}` → stays **TS2559**.
- non-empty array vs weak object → stays **TS2559**.

## Verification

- `crates/tsz-cli` regression tests (added):
  `cargo nextest run -p tsz-cli -E 'test(generic_signature_primitive_or_weak_union_keeps_primitive_member) or test(weak_only_targets_stay_rejected_after_union_reduction_fix)'`
  → 2 passed.
- `cargo nextest run -p tsz-solver` → 6725 passed; the only 3 failures
  (`test_generic_call_widening_applies_when_constraint_satisfied`,
  `higher_order_generic_pipe_regeneralizes_through_shared_middle_placeholder`,
  `test_solver_oversized_file_size_ceilings`) are pre-existing on `main` in this
  environment, unchanged by this PR.
- `cargo nextest run -p tsz-solver weak` → 44 passed (weak-type suite intact).
- `cargo clippy -p tsz-solver -p tsz-cli` → clean.
- Standalone repros (`tsc` 6.0.x cross-checked): Face 2 witnesses flip
  error→clean; all four negative controls stay errored.
- Ready-review CI owns the broad conformance/emit/fourslash + project-compile
  guard suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgY9xBVEhrvFa7AXG4jgbC)_