### PR TITLE
fix(checker): preserve narrowing across a conditional-expression initializer (zod TS2339)

### DIFF
--- a/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
+++ b/crates/tsz-checker/src/flow/control_flow/core/flow_traversal.rs
@@ -1488,6 +1488,78 @@ impl<'a> FlowAnalyzer<'a> {
         result
     }
 
+    /// Whether `label` is the merge `BRANCH_LABEL` of a *conditional/short-circuit
+    /// expression* (`a ? b : c`, `a && b`, `a || b`, `a ?? b`) rather than a
+    /// statement-level control-flow merge (the join after an `if`, `switch`,
+    /// `try`/`catch`, or loop).
+    ///
+    /// Both kinds merge two CONDITION antecedents, so the flow flags alone do not
+    /// distinguish them. The discriminator is the AST parent of the condition
+    /// expression each arm records: a ternary's condition parents to a
+    /// `ConditionalExpression`, and a logical operator's left operand parents to a
+    /// logical `BinaryExpression`. A statement `if`/`while` condition parents to
+    /// the statement node instead.
+    ///
+    /// This matters for narrowing: a non-targeting `const t = <ternary>`
+    /// initializer produces an ASSIGNMENT whose antecedent is this merge, and that
+    /// merge carries the narrowing established before the conditional. A following
+    /// CONDITION node (the next `if`) must defer through the assignment to the
+    /// merge so it narrows from the merged type rather than the declared type.
+    /// Statement merges are deliberately excluded: deferring through them
+    /// re-routes resolution order for targeting-assignment chains inside
+    /// `try`/`catch` and over-narrows (e.g. `controlFlowForCatchAndFinally`).
+    fn is_conditional_expression_merge(&self, label: FlowNodeId) -> bool {
+        let Some(flow) = self.binder.flow_nodes.get(label) else {
+            return false;
+        };
+        if !flow.has_any_flags(flow_flags::BRANCH_LABEL) || flow.antecedent.is_empty() {
+            return false;
+        }
+        // Every antecedent must be a CONDITION arm whose recorded condition
+        // expression is a sub-expression of a conditional or logical-binary
+        // expression. A statement merge fails this because at least one arm is a
+        // non-condition block flow or its condition parents to a statement.
+        flow.antecedent.iter().all(|&ant| {
+            let Some(ant_flow) = self.binder.flow_nodes.get(ant) else {
+                return false;
+            };
+            if !ant_flow.has_any_flags(flow_flags::CONDITION) {
+                return false;
+            }
+            self.condition_node_is_expression_operand(ant_flow.node)
+        })
+    }
+
+    /// Whether `condition` (a CONDITION flow node's recorded AST node) is the
+    /// condition of a `ConditionalExpression` or an operand of a logical
+    /// `&&`/`||`/`??` `BinaryExpression`, as opposed to a statement condition.
+    fn condition_node_is_expression_operand(&self, condition: NodeIndex) -> bool {
+        if condition.is_none() {
+            return false;
+        }
+        let Some(ext) = self.arena.get_extended(condition) else {
+            return false;
+        };
+        if ext.parent.is_none() {
+            return false;
+        }
+        let Some(parent) = self.arena.get(ext.parent) else {
+            return false;
+        };
+        if parent.kind == syntax_kind_ext::CONDITIONAL_EXPRESSION {
+            return true;
+        }
+        if parent.kind == syntax_kind_ext::BINARY_EXPRESSION
+            && let Some(binary) = self.arena.get_binary_expr(parent)
+        {
+            return binary.operator_token
+                == tsz_scanner::SyntaxKind::AmpersandAmpersandToken as u16
+                || binary.operator_token == tsz_scanner::SyntaxKind::BarBarToken as u16
+                || binary.operator_token == tsz_scanner::SyntaxKind::QuestionQuestionToken as u16;
+        }
+        false
+    }
+
     fn condition_antecedent_requires_defer_cached(
         &self,
         antecedent: FlowNodeId,
@@ -1524,6 +1596,15 @@ impl<'a> FlowAnalyzer<'a> {
         // where the non-targeting ASSIGNMENT (var b = x) passes
         // through to the targeting ASSIGNMENT (x = 10). Without
         // deferring, the CONDITION uses the stale initial_type.
+        //
+        // A conditional/short-circuit-expression initializer
+        // (`const t = a ? b : c`, `const t = a && b`) produces a non-targeting
+        // ASSIGNMENT whose antecedent is the BRANCH_LABEL merging the
+        // expression's arms. That merge carries the narrowing established before
+        // the conditional (e.g. inside `if (x.kind === "min")`), so the next
+        // CONDITION must defer through the assignment to the merge. Only
+        // conditional-EXPRESSION merges qualify — statement merges (`if`/`switch`/
+        // `try`) are excluded to avoid re-ordering targeting-assignment chains.
         let ant_is_passthrough_assignment = !ant_is_targeting_assignment
             && ant_is_assignment
             && ant_flow.antecedent.first().is_some_and(|&grandparent| {
@@ -1534,7 +1615,7 @@ impl<'a> FlowAnalyzer<'a> {
                             | flow_flags::ASSIGNMENT
                             | flow_flags::LOOP_LABEL,
                     )
-                })
+                }) || self.is_conditional_expression_merge(grandparent)
             });
         (ant_flags & flow_flags::CONDITION) != 0
             // Closure START nodes may carry the enclosing flow

--- a/crates/tsz-checker/tests/conditional_initializer_preserves_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/conditional_initializer_preserves_narrowing_tests.rs
@@ -1,0 +1,216 @@
+//! Regression coverage for narrowing that must survive a conditional /
+//! short-circuit *expression initializer* placed between a type guard and a
+//! later read of the guarded reference.
+//!
+//! Structural rule (matches `tsc`): inside `if (x.kind === "min") { ... }`, a
+//! statement such as `const t = cond ? a : b;` (or `const t = a && b;`) does not
+//! widen `x`. The conditional expression's flow merge carries the narrowing
+//! established by the guard, so a following `if (...) { x.value }` still reads
+//! the narrowed member type.
+//!
+//! Owner: `tsz_checker` control-flow worklist
+//! (`flow/control_flow/core/flow_traversal.rs`). The CONDITION node for the inner
+//! `if` reaches the guard through a *non-targeting* `const t` ASSIGNMENT whose
+//! antecedent is the conditional-expression merge `BRANCH_LABEL`. Previously the
+//! worklist did not defer through that assignment to the merge, so the inner
+//! CONDITION read the *declared* (un-narrowed) union and produced a false
+//! `TS2339`. The fix defers when the non-targeting assignment's antecedent is a
+//! conditional-EXPRESSION merge specifically; statement merges (`if`/`switch`/
+//! `try`) are excluded so targeting-assignment chains (e.g. the
+//! `controlFlowForCatchAndFinally` try/catch pattern) are not re-ordered.
+//!
+//! Binder names are varied per case so coverage is structural, not keyed to a
+//! particular identifier.
+
+use tsz_checker::test_utils::check_source_strict_codes;
+
+const TS2339: u32 = 2339; // Property does not exist on type
+
+fn codes(source: &str) -> Vec<u32> {
+    check_source_strict_codes(source)
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases: narrowing survives a conditional-expression initializer.
+// `tsc` is clean on all of these.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ternary_initializer_then_if_preserves_discriminant_narrowing() {
+    // The zod `ZodNumber._parse` witness, minimized: a `const` whose initializer
+    // is a ternary, followed by a nested `if` that does not re-narrow.
+    let diags = codes(
+        r#"
+type Check =
+  | { kind: "min"; value: number; inclusive: boolean }
+  | { kind: "int" };
+declare const checks: Check[];
+for (const check of checks) {
+  if (check.kind === "min") {
+    const tooSmall = check.inclusive ? check.value > 0 : check.value >= 0;
+    if (tooSmall) {
+      const v: number = check.value;
+      const b: boolean = check.inclusive;
+    }
+  }
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2339),
+        "ternary initializer must not widen the narrowed discriminant, got {diags:?}"
+    );
+}
+
+#[test]
+fn logical_and_initializer_then_if_preserves_narrowing_renamed() {
+    // Short-circuit `&&` initializer, different binder names.
+    let diags = codes(
+        r#"
+type Rule =
+  | { tag: "lo"; bound: number; strict: boolean }
+  | { tag: "hi" };
+declare const rules: Rule[];
+for (const entry of rules) {
+  if (entry.tag === "lo") {
+    const triggered = entry.strict && entry.bound > 0;
+    if (triggered) {
+      const n: number = entry.bound;
+    }
+  }
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2339),
+        "`&&` initializer must not widen the narrowed member, got {diags:?}"
+    );
+}
+
+#[test]
+fn logical_or_and_nullish_initializers_preserve_narrowing() {
+    // `||` and `??` short-circuit initializers, both followed by a nested `if`.
+    let diags = codes(
+        r#"
+type Spec =
+  | { sort: "asc"; weight: number }
+  | { sort: "none" };
+declare const specs: Spec[];
+for (const s of specs) {
+  if (s.sort === "asc") {
+    const fallbackOr = s.weight > 0 || false;
+    const fallbackNullish = (s.weight > 0 ? 1 : null) ?? 0;
+    if (fallbackOr) {
+      const a: number = s.weight;
+    }
+    if (fallbackNullish > 0) {
+      const b: number = s.weight;
+    }
+  }
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2339),
+        "`||`/`??` initializers must not widen the narrowed member, got {diags:?}"
+    );
+}
+
+#[test]
+fn ternary_initializer_then_if_in_generic_method_class() {
+    // Generic class form: `this._def.checks` element is a discriminated union;
+    // the conditional initializer sits between the guard and the read, exactly as
+    // in zod's class methods.
+    let diags = codes(
+        r#"
+interface Def<C> { checks: C[]; }
+type NumCheck =
+  | { kind: "min"; value: number; inclusive: boolean }
+  | { kind: "int" };
+abstract class Base<D> { readonly _def!: D; abstract run(d: number): void; }
+class NumType extends Base<Def<NumCheck>> {
+  run(data: number): void {
+    for (const check of this._def.checks) {
+      if (check.kind === "min") {
+        const small = check.inclusive ? data < check.value : data <= check.value;
+        if (small) {
+          const v: number = check.value;
+          const incl: boolean = check.inclusive;
+        }
+      }
+    }
+  }
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2339),
+        "generic-class method must preserve narrowing past a ternary initializer, got {diags:?}"
+    );
+}
+
+#[test]
+fn nested_conditional_initializers_chain_preserves_narrowing() {
+    // Multiple conditional initializers in sequence before the read.
+    let diags = codes(
+        r#"
+type TreeCell =
+  | { type: "leaf"; payload: number }
+  | { type: "branch" };
+declare const cells: TreeCell[];
+for (const cell of cells) {
+  if (cell.type === "leaf") {
+    const a = cell.payload > 0 ? 1 : 2;
+    const b = a > 0 && cell.payload < 10;
+    const c = b || cell.payload === 0;
+    if (c) {
+      const p: number = cell.payload;
+    }
+  }
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2339),
+        "chained conditional initializers must preserve narrowing, got {diags:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Negative / fallback: a statement-level merge (try/catch) between a targeting
+// assignment guard must NOT be over-narrowed by the same defer logic. `tsc`
+// accepts the inner `.abort()` call (narrowed to the class type, not `never`).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn try_catch_targeting_assignment_does_not_over_narrow() {
+    // controlFlowForCatchAndFinally witness: the conditional-expression-merge
+    // defer must not bleed into statement (`try`/`catch`) merges, which would
+    // re-order the targeting-assignment chain and narrow to `never`.
+    let diags = codes(
+        r#"
+declare class Aborter { abort(): void }
+declare function make(): Aborter;
+class Holder {
+  controller: Aborter | undefined = undefined;
+  run(): void {
+    if (this.controller !== undefined) {
+      this.controller.abort();
+      this.controller = undefined;
+    }
+    try {
+      this.controller = make();
+    } catch (error) {
+      if (this.controller !== undefined) {
+        this.controller.abort();
+      }
+    }
+  }
+}
+"#,
+    );
+    assert!(
+        !diags.contains(&TS2339),
+        "try/catch targeting-assignment narrowing must stay accurate (no `never`), got {diags:?}"
+    );
+}


### PR DESCRIPTION
Goal: green

Fixes a control-flow narrowing false positive blocking the zod canary row.

## Summary

zod's fixture is tsc-clean (0 tsc errors); every tsz diagnostic on it is a true
tsz-only false positive. This PR clears the dominant **TS2339** sub-family:
discriminant narrowing that was being discarded across a conditional-expression
`const` initializer in `ZodNumber._parse`.

zod canary false positives: **28 -> 24** (TS2339 **9 -> 5**). The four fixed
witnesses are `src/types.ts(682,30)`, `(684,32)`, `(700,30)`, `(702,32)` —
`check.value` / `check.inclusive` after `check.kind === "min"`.

## Structural rule

When a discriminated-union reference is narrowed by a guard and a following
statement is `const t = <ternary>` / `const t = a && b` (a non-targeting
assignment whose initializer is a conditional / short-circuit expression), tsc
keeps the narrowing for a subsequent nested `if` that reads the guarded member;
tsz widened back to the declared union and emitted a false TS2339.

Owner layer: `tsz_checker` control-flow worklist
(`flow/control_flow/core/flow_traversal.rs`). The inner-`if` CONDITION node
reaches the guard through the non-targeting `const t` ASSIGNMENT whose antecedent
is the conditional-expression flow merge (`BRANCH_LABEL`). The
condition-antecedent defer predicate did not treat that pass-through assignment
as deferrable, so the CONDITION read the un-narrowed declared type. The fix
defers when the assignment's antecedent is a conditional-EXPRESSION merge,
identified structurally (the AST parent of each CONDITION arm's recorded
condition is a `ConditionalExpression` or a logical `&&`/`||`/`??`
`BinaryExpression`). Statement-level merges (`if`/`switch`/`try`) are
deliberately excluded so targeting-assignment chains inside `try`/`catch` are not
re-ordered and over-narrowed to `never`.

No hardcoding: purely flow-flag + AST-shape predicates; no identifier/file-name
strings, no printer-output inspection, no single-test suppression.

## Adjacent coverage

`crates/tsz-checker/tests/conditional_initializer_preserves_narrowing_tests.rs`:
ternary / `&&` / `||` / `??` initializers, renamed binders, generic-class method
form (`this._def.checks`), chained conditional initializers, and the negative
`try`/`catch` targeting-assignment case that must NOT over-narrow.

## Residual (documented, not regressions of this PR)

20 remaining zod tsz-only FPs are separate, deeper families left for follow-up:
- TS2345 x8 + TS2322 x3: effect-union / error-map param assignability
  (`RefinementEffect | Effect`, `Partial<Omit<ParseParams,"data">>`).
- TS2416 x5: `_parse` method-override variance on `ZodTuple/Record/Map/Set/Function`.
- TS2339 x5: `instanceof`-narrowing of generic classes in `deepPartialify`
  (`.shape`/`.items`/`.innerType`/`._parseSync`) — does not reproduce in
  isolation; a whole-file interaction needing dedicated investigation.
- TS7023 x1 (`path` implicit-any recursion), TS2358 x1, TS18047 x1.

## Verification

- zod compile-guard (`TSZ_PROJECT_COMPILE_FILTER=zod`): 28 -> 24 FPs, TS2339 9 -> 5.
- Conformance (no regressions): controlFlow 94/94, narrowing 29/29, discriminant
  9/9, conditional 51/51, typeGuard 86/86, assignment 161/161, instanceof 14/14,
  switch 15/15, tryCatch 2/2, definiteAssignment 4/4, constEnum 30/30,
  unionType 30/30. `controlFlowForCatchAndFinally` (the negative case) stays green.
- `python3 scripts/arch/arch_guard.py`: pass.
- `cargo clippy -p tsz-checker --lib` and `-p tsz-solver --lib`: clean, no new `#[allow]`.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
