### PR TITLE
fix(binder): module-local namespace shadows colliding global lib type (hotscript FPs)

### DIFF
--- a/crates/tsz-binder/src/nodes/binding.rs
+++ b/crates/tsz-binder/src/nodes/binding.rs
@@ -68,6 +68,19 @@ impl BinderState {
             return None;
         }
 
+        // A module-local namespace (`namespace X { ... }`) is a file-scope
+        // type-and-namespace binding that shadows the same-named global lib
+        // symbol entirely in both meanings — re-attaching the lib's interface
+        // declaration would leak the global type into the shadow and (because
+        // the shadow keeps the lib symbol id off the export surface) is also
+        // never needed. Preserve nothing for namespaces, matching tsc's
+        // file-scope-before-global resolution. Note: uninstantiated namespaces
+        // carry only `NAMESPACE_MODULE`, which is not part of `VALUE`, so the
+        // `local_has_value` check below does not cover them.
+        if (local_flags & symbol_flags::MODULE) != 0 {
+            return None;
+        }
+
         let local_has_value = (local_flags & symbol_flags::VALUE) != 0;
         let local_has_type = (local_flags & (symbol_flags::TYPE | symbol_flags::TYPE_ALIAS)) != 0;
 
@@ -1471,6 +1484,11 @@ impl BinderState {
                     // ALIAS (import declarations) must shadow to prevent cross-file contamination:
                     // without this, `import self = require(...)` in two separate modules would
                     // both merge into the global lib `self` symbol, causing false TS2300 duplicates.
+                    // MODULE (namespace) declarations likewise shadow: a module-local
+                    // `namespace Iterator { ... }` is a file-scope type-namespace, not an
+                    // augmentation of the global lib `Iterator` interface, so it must be
+                    // exported under that name (otherwise `populate_module_exports_from_file_symbols`
+                    // drops the lib-id-merged symbol and named imports surface a false TS2305).
                     //
                     // EXCEPTION: When inside `declare global { ... }`, interfaces and other
                     // declarations should MERGE with lib symbols, not shadow. The `declare global`
@@ -1481,6 +1499,7 @@ impl BinderState {
                             | symbol_flags::INTERFACE
                             | symbol_flags::TYPE_ALIAS
                             | symbol_flags::ALIAS
+                            | symbol_flags::MODULE
                             | symbol_flags::BLOCK_SCOPED_VARIABLE))
                         != 0
                 } else {

--- a/crates/tsz-binder/src/nodes/binding.rs
+++ b/crates/tsz-binder/src/nodes/binding.rs
@@ -68,19 +68,25 @@ impl BinderState {
             return None;
         }
 
-        // A module-local namespace (`namespace X { ... }`) is a file-scope
-        // type-and-namespace binding that shadows the same-named global lib
-        // symbol entirely in both meanings — re-attaching the lib's interface
-        // declaration would leak the global type into the shadow and (because
-        // the shadow keeps the lib symbol id off the export surface) is also
-        // never needed. Preserve nothing for namespaces, matching tsc's
-        // file-scope-before-global resolution. Note: uninstantiated namespaces
-        // carry only `NAMESPACE_MODULE`, which is not part of `VALUE`, so the
-        // `local_has_value` check below does not cover them.
-        if (local_flags & symbol_flags::MODULE) != 0 {
-            return None;
-        }
-
+        // A module-local namespace (`namespace X { ... }`) occupies only the
+        // NAMESPACE meaning of its name plus its own qualified members
+        // (`X.Member`). It does NOT supply a bare-type meaning for `X` itself
+        // (you cannot write `X<T>` unless `X` merges with a class/enum), and it
+        // only supplies a VALUE meaning when *instantiated* (`VALUE_MODULE`).
+        // So a module-local namespace colliding with a global lib `interface
+        // X`, `type X`, or `var X` must keep the lib's TYPE and/or VALUE
+        // meanings visible: `Pick<T, K>` must still resolve to the lib `type
+        // Pick` alias even when a module declares an (empty) `namespace
+        // Pick {}` (the `utility-types` row), and a global value like `var
+        // Event` must stay callable through the shadow. Treat the namespace as
+        // occupying neither the bare TYPE slot nor (when uninstantiated) the
+        // VALUE slot, so both lib meanings are preserved below. Note:
+        // `NAMESPACE_MODULE` is in neither `VALUE` nor `TYPE`, and
+        // `VALUE_MODULE` is in `VALUE`, so the bitmask checks already classify
+        // instantiated-vs-uninstantiated value occupancy correctly; the
+        // namespace never contributes a bare-type meaning, so it must not flip
+        // `local_has_type`.
+        let local_is_module = (local_flags & symbol_flags::MODULE) != 0;
         let local_has_value = (local_flags & symbol_flags::VALUE) != 0;
         let local_has_type = (local_flags & (symbol_flags::TYPE | symbol_flags::TYPE_ALIAS)) != 0;
 
@@ -133,9 +139,17 @@ impl BinderState {
 
             let (declares_type, declares_value) = match kind {
                 k if k == syntax_kind_ext::INTERFACE_DECLARATION => (true, false),
-                // Skip TYPE_ALIAS_DECLARATION: carrying a lib type alias onto
-                // a module-local shadow symbol pollutes its declarations vec
-                // for indexed-access traversal (see #4687).
+                // A lib type alias is normally skipped: carrying it onto a
+                // module-local shadow symbol pollutes its declarations vec for
+                // indexed-access traversal (see #4687). But when the shadow is
+                // a *namespace* (which never supplies a bare-type meaning), the
+                // lib alias must be preserved so `Pick<T, K>` still resolves to
+                // the global `type Pick` alias (the `utility-types` row). A
+                // namespace's own members live behind `X.Member`, so the alias
+                // does not collide with the namespace's indexed-access surface.
+                k if k == syntax_kind_ext::TYPE_ALIAS_DECLARATION && local_is_module => {
+                    (true, false)
+                }
                 k if k == syntax_kind_ext::VARIABLE_DECLARATION => (false, true),
                 k if k == syntax_kind_ext::FUNCTION_DECLARATION => (false, true),
                 _ => continue,

--- a/crates/tsz-binder/tests/lib_merge_external_module_tests.rs
+++ b/crates/tsz-binder/tests/lib_merge_external_module_tests.rs
@@ -566,3 +566,122 @@ fn declare_global_namespace_still_augments_lib_type() {
         "declare-global namespace augmentation must preserve the lib INTERFACE meaning"
     );
 }
+
+/// A module-local `namespace X` colliding with a global lib `interface X` +
+/// `var X` must shadow the *export surface* (so `X` is the module's export) yet
+/// keep BOTH the lib's TYPE and VALUE meanings visible through the shadow
+/// symbol. A namespace only occupies the NAMESPACE slot (and its own
+/// `X.Member` members); it supplies neither a bare-type meaning nor (when
+/// uninstantiated) a value, so dropping the lib interface/var would lose the
+/// global `Event` type and constructor that tsc keeps visible
+/// (the `isolatedModulesShadowGlobalTypeNotValue` family).
+#[test]
+fn module_namespace_preserves_colliding_lib_type_and_value() {
+    let (binder, file_name) = bind_module_with_lib(
+        "interface Event { readonly type: string; }
+         declare var Event: { new (type: string): Event };",
+        "export {};
+         export namespace Event {
+             export type T = any;
+         }",
+    );
+
+    let exports = binder
+        .module_exports
+        .get(&file_name)
+        .expect("module should have an export surface");
+    let sym_id = exports.get("Event").expect("Event export symbol");
+    assert!(
+        !binder.lib_symbol_ids.contains(&sym_id),
+        "the exported `Event` must be the module-local namespace symbol"
+    );
+    let sym = binder.symbols.get(sym_id).expect("Event symbol exists");
+    assert!(
+        sym.has_any_flags(symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE),
+        "the exported symbol must carry namespace/module flags"
+    );
+    // The lib's VALUE side (the `var Event` constructor) is re-attached so the
+    // name keeps resolving as a value — the namespace did not occupy VALUE.
+    assert!(
+        sym.has_any_flags(symbol_flags::VALUE),
+        "an uninstantiated namespace must preserve the colliding lib VALUE meaning"
+    );
+    // The lib's INTERFACE TYPE meaning is also re-attached — a namespace does
+    // not supply a bare-type meaning for `Event`, so bare `Event` must still
+    // resolve to the global interface.
+    assert!(
+        sym.has_any_flags(symbol_flags::INTERFACE),
+        "the lib INTERFACE meaning must remain visible through the namespace shadow"
+    );
+}
+
+/// Renamed-binder variant: the type+value preservation rule must hold for any
+/// lib name carrying both an interface and a global value, not a hardcoded one.
+#[test]
+fn module_namespace_preserves_colliding_lib_type_and_value_renamed_binder() {
+    for lib_name in ["Event", "Symbol", "Proxy"] {
+        let (binder, file_name) = bind_module_with_lib(
+            &format!(
+                "interface {lib_name} {{ readonly tag: string; }}
+                 declare var {lib_name}: {{ new (): {lib_name} }};"
+            ),
+            &format!(
+                "export {{}};
+                 export namespace {lib_name} {{
+                     export type T = any;
+                 }}"
+            ),
+        );
+        let exports = binder
+            .module_exports
+            .get(&file_name)
+            .unwrap_or_else(|| panic!("module should have exports for {lib_name}"));
+        let sym_id = exports
+            .get(lib_name)
+            .unwrap_or_else(|| panic!("{lib_name} export symbol"));
+        let sym = binder.symbols.get(sym_id).expect("symbol exists");
+        assert!(
+            sym.has_any_flags(symbol_flags::VALUE),
+            "uninstantiated namespace `{lib_name}` must preserve the lib VALUE meaning"
+        );
+        assert!(
+            sym.has_any_flags(symbol_flags::INTERFACE),
+            "the lib INTERFACE meaning for `{lib_name}` must remain visible through the shadow"
+        );
+    }
+}
+
+/// A module-local (empty, non-exported) `namespace X` colliding with a global
+/// lib *type alias* `type X<...>` must keep the alias's TYPE meaning so generic
+/// uses `X<A, B>` still resolve — the `utility-types` `namespace Pick {}` case.
+/// Without preserving the alias, the namespace shadow surfaces TS2315 ("not
+/// generic") / TS2709 ("Cannot use namespace as a type").
+#[test]
+fn module_namespace_preserves_colliding_lib_type_alias() {
+    for lib_name in ["Pick", "Record", "Omit"] {
+        let (binder, _file_name) = bind_module_with_lib(
+            &format!("type {lib_name}<T, K extends keyof T> = {{ [P in K]: T[P] }};"),
+            &format!(
+                "export {{}};
+                 namespace {lib_name} {{}}
+                 export type Use<T> = {lib_name}<T, keyof T>;"
+            ),
+        );
+        // The locally-bound `X` symbol must retain the lib TYPE_ALIAS meaning so
+        // the checker can resolve the generic `X<T, keyof T>` reference.
+        let sym_id = binder
+            .file_locals
+            .get(lib_name)
+            .unwrap_or_else(|| panic!("{lib_name} should be in file_locals"));
+        let sym = binder.symbols.get(sym_id).expect("symbol exists");
+        assert!(
+            sym.has_any_flags(symbol_flags::TYPE_ALIAS),
+            "module-local `namespace {lib_name} {{}}` must preserve the colliding lib \
+             TYPE_ALIAS meaning so `{lib_name}<...>` still resolves"
+        );
+        assert!(
+            sym.has_any_flags(symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE),
+            "the symbol must still carry the namespace meaning"
+        );
+    }
+}

--- a/crates/tsz-binder/tests/lib_merge_external_module_tests.rs
+++ b/crates/tsz-binder/tests/lib_merge_external_module_tests.rs
@@ -435,3 +435,134 @@ fn resolve_name_in_lib_module_locals_callback_can_substitute_sym_id() {
         });
     assert_eq!(result, Some(substitute_id));
 }
+
+/// Bind a user external module (`.ts`, with `export {}` so it is a module)
+/// against a lib that already declares `lib_decl`. Returns the bound binder
+/// and the module's file name for `module_exports` lookups.
+fn bind_module_with_lib(lib_decl: &str, module_source: &str) -> (BinderState, String) {
+    let lib = Arc::new(LibFile::from_source(
+        "lib.test.d.ts".to_string(),
+        lib_decl.to_string(),
+    ));
+    let file_name = "user-module.ts".to_string();
+    let mut parser = ParserState::new(file_name.clone(), module_source.to_string());
+    let root = parser.parse_source_file();
+    let arena = Arc::new(parser.get_arena().clone());
+    let mut binder = BinderState::new();
+    binder.bind_source_file_with_libs(&arena, root, &[lib]);
+    (binder, file_name)
+}
+
+/// A module-local `namespace X` whose name collides with a global lib type must
+/// still appear in the module's export surface. tsc resolves the file-scope
+/// namespace declaration before the global, so `import { X } from "./mod"`
+/// resolves to the namespace; without shadowing, the namespace symbol merges
+/// into the lib symbol id and is dropped from `module_exports`, surfacing a
+/// false TS2305 (the hotscript `Iterator` / `StringIterator` family). The exact
+/// names below are not special — see the renamed/control cases that follow.
+#[test]
+fn module_namespace_colliding_with_lib_type_stays_in_module_exports() {
+    let (binder, file_name) = bind_module_with_lib(
+        "interface Iterator<T, TReturn = any, TNext = any> { next(): T; }",
+        "export {};
+         export namespace Iterator {
+             export type Get<it extends readonly any[]> = it[\"length\"];
+         }",
+    );
+
+    let exports = binder
+        .module_exports
+        .get(&file_name)
+        .expect("module should have an export surface");
+    assert!(
+        exports.has("Iterator"),
+        "module-local `namespace Iterator` must be exported even though it \
+         collides with the global lib `interface Iterator`"
+    );
+    let sym_id = exports.get("Iterator").expect("Iterator export symbol");
+    assert!(
+        !binder.lib_symbol_ids.contains(&sym_id),
+        "the exported `Iterator` must be the module-local namespace symbol, \
+         not the merged lib symbol id"
+    );
+    let sym = binder.symbols.get(sym_id).expect("Iterator symbol exists");
+    assert!(
+        sym.has_any_flags(symbol_flags::NAMESPACE_MODULE | symbol_flags::VALUE_MODULE),
+        "the exported symbol must carry namespace/module flags"
+    );
+}
+
+/// Renamed-binder variant: the same structural rule must hold for any global
+/// lib type name, not a hardcoded `Iterator`. `StringIterator` is also a lib
+/// type (es2015.iterable). Binder names must not drive the decision.
+#[test]
+fn module_namespace_colliding_with_lib_type_renamed_binder() {
+    for lib_name in ["StringIterator", "Iterator"] {
+        let (binder, file_name) = bind_module_with_lib(
+            &format!("interface {lib_name}<T> {{ next(): T; }}"),
+            &format!(
+                "export {{}};
+                 export namespace {lib_name} {{
+                     export type Value = number;
+                 }}"
+            ),
+        );
+        let exports = binder
+            .module_exports
+            .get(&file_name)
+            .unwrap_or_else(|| panic!("module should have exports for {lib_name}"));
+        assert!(
+            exports.has(lib_name),
+            "module-local `namespace {lib_name}` colliding with the lib type \
+             must remain exported"
+        );
+    }
+}
+
+/// Control: a namespace whose name does NOT collide with any lib type was
+/// already exported correctly — the fix must not change that path.
+#[test]
+fn module_namespace_without_lib_collision_still_exported() {
+    let (binder, file_name) = bind_module_with_lib(
+        "interface SomeUnrelatedLibType {}",
+        "export {};
+         export namespace Helpers {
+             export type Value = number;
+         }",
+    );
+    let exports = binder
+        .module_exports
+        .get(&file_name)
+        .expect("module should have exports");
+    assert!(
+        exports.has("Helpers"),
+        "a non-colliding module namespace must be exported"
+    );
+}
+
+/// `declare global { namespace X {} }` inside a module must still MERGE with the
+/// global lib type (true augmentation), not shadow it — the shadow path is
+/// gated on `!in_global_augmentation`.
+#[test]
+fn declare_global_namespace_still_augments_lib_type() {
+    let (binder, _file_name) = bind_module_with_lib(
+        "interface Iterator<T> { next(): T; }",
+        "export {};
+         declare global {
+             namespace Iterator {
+                 export type Augmented = number;
+             }
+         }",
+    );
+    // The global `Iterator` remains in file_locals (merged), carrying the lib
+    // INTERFACE meaning — augmentation did not shadow it away.
+    let sym_id = binder
+        .file_locals
+        .get("Iterator")
+        .expect("global Iterator should remain in file_locals after augmentation");
+    let sym = binder.symbols.get(sym_id).expect("Iterator symbol exists");
+    assert!(
+        sym.has_any_flags(symbol_flags::INTERFACE),
+        "declare-global namespace augmentation must preserve the lib INTERFACE meaning"
+    );
+}


### PR DESCRIPTION
Drives the **hotscript** canary row toward 0 false positives. An independent
tsc-oracle audit confirmed the fixture is tsc-clean (0 tsc errors), so every tsz
diagnostic on it is a true tsz-only FP. This PR fixes the dominant
namespace-resolution family: **31 → 2 FPs**.

Goal: green

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Structural rule

### Namespace-resolution family (TS2694 x15 + TS2503 x8 + cascaded TS2589 x4 + TS2305 x2)
When a module declares a top-level `namespace X { ... }` whose name collides with
a **global lib type** of the same name (hotscript uses `Iterator` and
`StringIterator`, both `interface`s in `es2015.iterable.d.ts`), tsc resolves the
file-scope declaration before the global, so the module exports `X` and
`import { X } from "./mod"` binds to the namespace.

tsz instead **merged** the namespace into the lib symbol: `should_shadow_lib`
listed `FUNCTION | CLASS | INTERFACE | TYPE_ALIAS | ALIAS | BLOCK_SCOPED_VARIABLE`
but not `MODULE`. The merged symbol kept the lib symbol id, which
`populate_module_exports_from_file_symbols` skips (lib ids are excluded from a
user module's export surface) — so the module appeared to export nothing of that
name, producing a false **TS2305** on the named import and cascading **TS2694**
("namespace has no exported member") / **TS2503** ("cannot find namespace") on
every qualified reference (`StrIter.Iterator`, `Iterator.Get`, ...). The 4
**TS2589** ("excessively deep") were further cascades: with the namespace member
types unresolved, the recursive `LengthUp`/`LengthDown`/`DropImpl`/`TakeImpl`
conditional types lost their termination structure and hit the depth limit.

Owner: **binder** symbol resolution (`BinderState::should_shadow_lib` and
`collect_preserved_lib_meaning`).
- Added `symbol_flags::MODULE` to the external-module shadow set (gated on
  `!in_global_augmentation`, so `declare global { namespace X {} }` still
  augments). This is what puts the namespace on the module export surface.
- `collect_preserved_lib_meaning` re-attaches the colliding lib symbol's TYPE
  and VALUE meanings onto the shadowing namespace. A namespace occupies only the
  NAMESPACE meaning of its name plus its own qualified members (`X.Member`); it
  supplies no bare-type meaning for `X` itself and no value unless instantiated
  (`VALUE_MODULE`). So the lib `interface X`, `type X`, and `var X` meanings must
  stay visible. It also re-attaches a colliding lib **TYPE_ALIAS** (otherwise
  skipped per #4687) specifically for namespace shadows.

No hardcoding: the decision is on the `MODULE` symbol flag, not any name/file
string. Adjacent coverage varies the binder name (`Iterator` vs `StringIterator`
vs `Helpers`; `Pick`/`Record`/`Omit`; `Event`/`Symbol`/`Proxy`) and proves the
renamed/control/`declare global` cases.

### Regression fix folded in (project-compile-guard `utility-types`, required row)
The first iteration of this fix (commit `68d345c`) made
`collect_preserved_lib_meaning` early-return `None` for any `MODULE` local,
dropping **all** lib meaning when a namespace shadowed a global. That regressed
the `utility-types` required row: an empty module-local `namespace Pick {}` (a
JSDoc anchor in `src/mapped-types.ts`) shadowed the global `type Pick` alias, so
every generic `Pick<T, K>` surfaced **TS2315** ("not generic") / **TS2709**
("cannot use namespace as a type"). The current commit replaces the blanket
early-return with the meaning-preserving classification above, so
`Pick<T, K>` resolves to the global alias again while the hotscript namespace
export win is unchanged.

## Residual (2 FPs, deferred — independent of this family)
Both remaining FPs are deep solver-parity issues in `Tuples.ts`, unrelated to
namespace resolution:
- **TS2536** `Tuples.ts(68,13)` — `this["arg0"][number]` (where `arg0` is an
  array-typed member of the `Fn` base). tsc indexes the inner access's apparent
  type (`unknown[]`, numerically indexable); tsz's index-validity checker does
  not resolve the `this`-rooted indexed-access base in interface-member
  annotation context. Investigated; the suppression needs the polymorphic-`this`
  base resolved to the enclosing interface instance type, which is not available
  on the grammar-check path — left for a focused follow-up.
- **TS2344** `Tuples.ts(750,19)` — `Tuples.Map<Tuples.At<Index>, arrs>` not
  satisfying `unknown[]`; a deep instantiation/constraint-satisfaction parity
  gap (the printed type even references unrelated `Match`-module `EveryFn`,
  suggesting an instantiation/cache bleed).

## Verification
- hotscript compile-guard:
  `TSZ_PROJECT_COMPILE_SET=canary TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1 TSZ_PROJECT_COMPILE_FILTER=hotscript scripts/ci/project-compile-guard.sh`
  → **31 FPs before → 2 after** (cleared 15x TS2694, 8x TS2503, 4x TS2589, 2x TS2305).
- `utility-types` required compile-guard (the regressed row):
  `TSZ_PROJECT_COMPILE_FILTER=utility-types TSZ_PROJECT_COMPILE_SET=required scripts/ci/project-compile-guard.sh`
  → **compiled successfully** (was TS2315/TS2709 on `Pick<...>` at PR-head).
- Confirmed at PR-head (commit `68d345c` binary) that `utility-types` produced
  the TS2315/TS2709 cluster, and that the current commit clears it; hotscript
  stays at 2 FPs in both.
- Conformance (0 regressions, targeted): `isolatedModulesShadowGlobalTypeNotValue`
  1/1, `declarationMerging` 28/28, `moduleAugmentation` 46/46, `namespace` 17/17,
  `globalAugmentation` 1/1, `typeAlias` 23/23, `exportNamespace` 14/14,
  `mergedDeclarations` 7/7, `iterable` 49/49, `jsxFactory` 14/14, plus
  `module_augment*`, `bluebirdStaticThis`, `complexRecursiveCollections`,
  `symbolProperty51`, `superInStaticMembers1`. (CI: conformance-aggregate and all
  conformance shards were already green at PR-head; the only PR-head failures were
  project-compile-guard `utility-types` and the infra runner-comms-loss on
  project-compile-canary-2.)
- `python3 scripts/arch/arch_guard.py` → PASS.
- `cargo clippy -p tsz-binder --lib` → clean (no new `#[allow]`).
- Owning-crate tests (`crates/tsz-binder/tests/lib_merge_external_module_tests.rs`,
  15/15 in file): export-surface cases
  `module_namespace_colliding_with_lib_type_stays_in_module_exports`,
  `module_namespace_colliding_with_lib_type_renamed_binder`,
  `module_namespace_without_lib_collision_still_exported`,
  `declare_global_namespace_still_augments_lib_type`; meaning-preservation cases
  `module_namespace_preserves_colliding_lib_type_and_value` (+`_renamed_binder`)
  and `module_namespace_preserves_colliding_lib_type_alias` (Pick/Record/Omit).

