### PR TITLE
ci(health): record per-job CI timing baseline (queue_wait + run seconds)

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -64,6 +64,27 @@ jobs:
           node scripts/ci/check-main-red.mjs --file-issue --max-runs 60 \
             | tee -a "${GITHUB_STEP_SUMMARY}"
 
+  ci-job-timing:
+    name: ci-job-timing
+    runs-on: ubuntu-latest
+    # Advisory baseline: records per-job queue_wait + run seconds over recent
+    # successful ci.yml runs so every other CI speed claim on this fleet can be
+    # checked against measured numbers (issue #13605 item 2). No wall-clock
+    # change; the runner-acquisition (queue_wait) column surfaces pool pressure.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Record per-job CI timing baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          node scripts/ci/check-ci-job-timing.mjs --workflow ci.yml --branch main --max-runs 15 \
+            | tee -a "${GITHUB_STEP_SUMMARY}"
+
   health:
     name: runner-health
     runs-on: ubuntu-latest

--- a/scripts/ci/check-ci-job-timing.mjs
+++ b/scripts/ci/check-ci-job-timing.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+// Per-job wall-time baseline for the self-hosted CI fleet.
+//
+// Pulls the most recent successful runs of a workflow (default ci.yml on main),
+// joins each run with its jobs, and reports per-job-name timing distributions:
+//   - queue_wait seconds = job.started_at - job.created_at
+//     (time a job spent eligible-but-waiting for a runner; the fleet-capacity
+//     signal — high queue_wait means the runner pool is the bottleneck, not the
+//     work)
+//   - run seconds = job.completed_at - job.started_at
+//     (the actual work; the wall-time signal for "which job defines run end")
+//
+// Advisory only: this changes no wall-clock behavior. It is the measurement
+// baseline that every other CI speed claim on this fleet is checked against
+// (issue #13605 item 2), so percentiles are computed deterministically
+// (nearest-rank) and the output is a stable markdown table.
+import fs from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const DEFAULT_WORKFLOW = "ci.yml";
+const DEFAULT_BRANCH = "main";
+const DEFAULT_MAX_RUNS = 15;
+// Larger than the sibling probes' 16MB: this script reads the jobs payload for
+// up to DEFAULT_MAX_RUNS runs, each carrying every job's step list.
+const DEFAULT_GH_MAX_BUFFER_BYTES = 32 * 1024 * 1024;
+
+function usage() {
+  return [
+    "usage: check-ci-job-timing.mjs [--fixture path] [--repository owner/repo] [--workflow file] [--branch name] [--max-runs n]",
+    "",
+    "Reports per-job queue_wait and run-time distributions over recent",
+    "successful workflow runs. Advisory: it never fails the workflow.",
+  ].join("\n");
+}
+
+export function parseArgs(argv) {
+  const options = {
+    branch: DEFAULT_BRANCH,
+    fixture: null,
+    maxRuns: DEFAULT_MAX_RUNS,
+    repository: process.env.REPOSITORY || process.env.GITHUB_REPOSITORY || null,
+    workflow: DEFAULT_WORKFLOW,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--fixture") {
+      options.fixture = argv[++i];
+      if (!options.fixture) throw new Error("--fixture requires a path");
+      continue;
+    }
+    if (arg === "--repository") {
+      options.repository = argv[++i];
+      if (!options.repository) throw new Error("--repository requires owner/repo");
+      continue;
+    }
+    if (arg === "--workflow") {
+      options.workflow = argv[++i];
+      if (!options.workflow) throw new Error("--workflow requires a file name");
+      continue;
+    }
+    if (arg === "--branch") {
+      options.branch = argv[++i];
+      if (!options.branch) throw new Error("--branch requires a name");
+      continue;
+    }
+    if (arg === "--max-runs") {
+      const value = Number.parseInt(argv[++i], 10);
+      if (!Number.isInteger(value) || value <= 0) {
+        throw new Error("--max-runs requires a positive integer");
+      }
+      options.maxRuns = value;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function runGhJson(args) {
+  const result = spawnSync("gh", args, {
+    encoding: "utf8",
+    maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) {
+    const command = `gh ${args.join(" ")}`;
+    if (result.error.code === "ENOBUFS") {
+      throw new Error(`${command} exceeded ${DEFAULT_GH_MAX_BUFFER_BYTES} bytes of output`);
+    }
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      [
+        `gh ${args.join(" ")} failed`,
+        result.stdout.trim(),
+        result.stderr.trim(),
+      ].filter(Boolean).join("\n"),
+    );
+  }
+  return JSON.parse(result.stdout);
+}
+
+function asArray(payload, key) {
+  const value = payload?.[key];
+  if (!Array.isArray(value)) {
+    throw new Error(`API response did not contain an array of ${key}`);
+  }
+  return value;
+}
+
+export function readWorkflowRuns(repository, options, fetchJson = runGhJson) {
+  if (!repository) {
+    throw new Error("REPOSITORY or GITHUB_REPOSITORY is required");
+  }
+  const { workflow, branch, maxRuns } = options;
+  const payload = fetchJson([
+    "api",
+    "-H",
+    "Accept: application/vnd.github+json",
+    `repos/${repository}/actions/workflows/${encodeURIComponent(workflow)}/runs?status=success&branch=${encodeURIComponent(branch)}&per_page=${maxRuns}`,
+  ]);
+  return asArray(payload, "workflow_runs").slice(0, maxRuns);
+}
+
+export function readJobsForRun(repository, runId, fetchJson = runGhJson) {
+  const jobs = [];
+  for (let page = 1; page <= 10; page += 1) {
+    const payload = fetchJson([
+      "api",
+      "-H",
+      "Accept: application/vnd.github+json",
+      `repos/${repository}/actions/runs/${runId}/jobs?per_page=100&page=${page}`,
+    ]);
+    const pageJobs = asArray(payload, "jobs");
+    jobs.push(...pageJobs);
+    if (pageJobs.length < 100) break;
+  }
+  return jobs;
+}
+
+export function collectRunsWithJobs(repository, options, fetchJson = runGhJson) {
+  const runs = readWorkflowRuns(repository, options, fetchJson);
+  return runs.map((run) => ({
+    id: run.id ?? run.databaseId ?? "",
+    jobs: readJobsForRun(repository, run.id ?? run.databaseId, fetchJson),
+  }));
+}
+
+function secondsBetween(startIso, endIso) {
+  if (typeof startIso !== "string" || typeof endIso !== "string") return null;
+  const start = Date.parse(startIso);
+  const end = Date.parse(endIso);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
+  return Math.max(0, Math.round((end - start) / 1000));
+}
+
+// Nearest-rank percentile over an unsorted sample. p in [0, 1].
+function percentile(values, p) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = Math.ceil(p * sorted.length);
+  const index = Math.min(sorted.length - 1, Math.max(0, rank - 1));
+  return sorted[index];
+}
+
+export function jobTimingFindings(runsWithJobs) {
+  const byName = new Map();
+
+  for (const run of runsWithJobs) {
+    for (const job of run.jobs || []) {
+      const name = job.name || "(unnamed)";
+      // Only successful, fully-timed jobs contribute to the baseline; failed or
+      // cancelled jobs have truncated or missing completion times that would
+      // skew the distribution.
+      if (job.conclusion !== "success") continue;
+      const runSeconds = secondsBetween(job.started_at, job.completed_at);
+      const queueSeconds = secondsBetween(job.created_at, job.started_at);
+      if (runSeconds === null) continue;
+
+      let bucket = byName.get(name);
+      if (!bucket) {
+        bucket = { name, runSamples: [], queueSamples: [] };
+        byName.set(name, bucket);
+      }
+      bucket.runSamples.push(runSeconds);
+      if (queueSeconds !== null) bucket.queueSamples.push(queueSeconds);
+    }
+  }
+
+  const findings = [];
+  for (const bucket of byName.values()) {
+    findings.push({
+      name: bucket.name,
+      samples: bucket.runSamples.length,
+      runP50: percentile(bucket.runSamples, 0.5),
+      runP95: percentile(bucket.runSamples, 0.95),
+      runMax: percentile(bucket.runSamples, 1),
+      queueP50: percentile(bucket.queueSamples, 0.5),
+      queueMax: percentile(bucket.queueSamples, 1),
+    });
+  }
+
+  // Slowest-by-typical-run first: the job that most often defines run end is the
+  // one worth attacking. Tie-break on name for stable output.
+  findings.sort((a, b) => (b.runP50 ?? 0) - (a.runP50 ?? 0) || a.name.localeCompare(b.name));
+  return findings;
+}
+
+function escapeCell(value) {
+  return String(value ?? "").replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+function secondsLabel(value) {
+  if (value === null || value === undefined) return "—";
+  if (value < 60) return `${value}s`;
+  const minutes = Math.floor(value / 60);
+  const seconds = value % 60;
+  return `${minutes}m${String(seconds).padStart(2, "0")}s`;
+}
+
+export function formatReport(findings, options = {}) {
+  const workflow = options.workflow || DEFAULT_WORKFLOW;
+  const branch = options.branch || DEFAULT_BRANCH;
+  const lines = ["## CI Job Timing Baseline", ""];
+
+  if (findings.length === 0) {
+    lines.push(`No successful \`${workflow}\` jobs on \`${branch}\` were found to time.`);
+    return lines.join("\n");
+  }
+
+  const runs = options.runCount;
+  lines.push(
+    `Per-job timing over the latest successful \`${workflow}\` runs on \`${branch}\`` +
+      (runs ? ` (${runs} run${runs === 1 ? "" : "s"} sampled).` : "."),
+  );
+  lines.push("");
+  lines.push("| Job | Samples | Run p50 | Run p95 | Run max | Queue p50 | Queue max |");
+  lines.push("|-----|--------:|--------:|--------:|--------:|----------:|----------:|");
+  for (const finding of findings) {
+    lines.push([
+      escapeCell(finding.name),
+      String(finding.samples),
+      secondsLabel(finding.runP50),
+      secondsLabel(finding.runP95),
+      secondsLabel(finding.runMax),
+      secondsLabel(finding.queueP50),
+      secondsLabel(finding.queueMax),
+    ].join(" | ").replace(/^/, "| ").replace(/$/, " |"));
+  }
+  return lines.join("\n");
+}
+
+function readFixture(path) {
+  const parsed = JSON.parse(fs.readFileSync(path, "utf8"));
+  const runs = Array.isArray(parsed) ? parsed : parsed.runs;
+  if (!Array.isArray(runs)) {
+    throw new Error("fixture must be an array of runs or an object with a runs array");
+  }
+  return runs.map((run) => ({ id: run.id ?? "", jobs: run.jobs || [] }));
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const runsWithJobs = options.fixture
+    ? readFixture(options.fixture)
+    : collectRunsWithJobs(options.repository, options);
+  const findings = jobTimingFindings(runsWithJobs);
+  console.log(formatReport(findings, { ...options, runCount: runsWithJobs.length }));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -423,6 +423,7 @@ run_lint() {
   node scripts/ci/test-pr-ready-state.mjs || return $?
   node scripts/ci/test-refresh-green-prs.mjs || return $?
   node scripts/ci/test-check-stale-ci-runs.mjs || return $?
+  node scripts/ci/test-check-ci-job-timing.mjs || return $?
   node scripts/ci/test-check-main-red.mjs || return $?
   node scripts/ci/test-cloudbuild-config-paths.mjs || return $?
   node scripts/ci/test-wip-state-comments.mjs || return $?

--- a/scripts/ci/test-check-ci-job-timing.mjs
+++ b/scripts/ci/test-check-ci-job-timing.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  collectRunsWithJobs,
+  formatReport,
+  jobTimingFindings,
+  parseArgs,
+  readWorkflowRuns,
+} from "./check-ci-job-timing.mjs";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
+const SCRIPT = path.join(ROOT, "scripts", "ci", "check-ci-job-timing.mjs");
+
+function job(overrides = {}) {
+  return {
+    name: "conformance-0",
+    conclusion: "success",
+    // created -> started is 30s queue wait; started -> completed is 300s run.
+    created_at: "2026-05-20T12:00:00Z",
+    started_at: "2026-05-20T12:00:30Z",
+    completed_at: "2026-05-20T12:05:30Z",
+    ...overrides,
+  };
+}
+
+// --- jobTimingFindings: core arithmetic and aggregation -------------------
+
+{
+  const findings = jobTimingFindings([{ id: 1, jobs: [job()] }]);
+  assert.deepEqual(findings, [{
+    name: "conformance-0",
+    samples: 1,
+    runP50: 300,
+    runP95: 300,
+    runMax: 300,
+    queueP50: 30,
+    queueMax: 30,
+  }]);
+}
+
+// Multiple samples of the same job name aggregate into one row; percentiles use
+// nearest-rank so the values are exact members of the sample.
+{
+  const runs = [60, 120, 180, 240, 300].map((runSecs, i) => ({
+    id: i,
+    jobs: [job({
+      created_at: "2026-05-20T12:00:00Z",
+      started_at: "2026-05-20T12:00:00Z",
+      completed_at: new Date(Date.parse("2026-05-20T12:00:00Z") + runSecs * 1000).toISOString(),
+    })],
+  }));
+  const [finding] = jobTimingFindings(runs);
+  assert.equal(finding.samples, 5);
+  assert.equal(finding.runP50, 180);
+  assert.equal(finding.runP95, 300);
+  assert.equal(finding.runMax, 300);
+  assert.equal(finding.queueP50, 0);
+}
+
+// Slowest-by-p50 first; tie-break on name. Failed/cancelled jobs are excluded.
+{
+  const findings = jobTimingFindings([{
+    id: 1,
+    jobs: [
+      job({ name: "fast", completed_at: "2026-05-20T12:00:40Z" }), // 10s run
+      job({ name: "slow", completed_at: "2026-05-20T12:10:30Z" }), // 600s run
+      job({ name: "failed-row", conclusion: "failure" }),
+      job({ name: "cancelled-row", conclusion: "cancelled" }),
+    ],
+  }]);
+  assert.deepEqual(findings.map((f) => f.name), ["slow", "fast"]);
+}
+
+// Jobs still missing a completion time are dropped (no run seconds); a missing
+// created_at degrades only the queue column, not the run sample.
+{
+  const findings = jobTimingFindings([{
+    id: 1,
+    jobs: [
+      job({ name: "incomplete", completed_at: null }),
+      job({ name: "no-queue", created_at: null }),
+    ],
+  }]);
+  assert.deepEqual(findings.map((f) => f.name), ["no-queue"]);
+  const [noQueue] = findings;
+  assert.equal(noQueue.runP50, 300);
+  assert.equal(noQueue.queueP50, null);
+  assert.equal(noQueue.queueMax, null);
+}
+
+// --- formatReport ----------------------------------------------------------
+
+{
+  const report = formatReport(jobTimingFindings([{ id: 1, jobs: [job()] }]), {
+    workflow: "ci.yml",
+    branch: "main",
+    runCount: 1,
+  });
+  assert.match(report, /CI Job Timing Baseline/);
+  assert.match(report, /1 run sampled/);
+  assert.match(report, /conformance-0/);
+  assert.match(report, /5m00s/); // 300s run rendered as minutes/seconds
+  assert.match(report, /30s/); // 30s queue wait
+}
+
+{
+  const empty = formatReport([], { workflow: "ci.yml", branch: "main" });
+  assert.match(empty, /No successful `ci.yml` jobs on `main`/);
+}
+
+// --- parseArgs -------------------------------------------------------------
+
+{
+  const options = parseArgs(["--workflow", "bench.yml", "--branch", "release", "--max-runs", "7"]);
+  assert.equal(options.workflow, "bench.yml");
+  assert.equal(options.branch, "release");
+  assert.equal(options.maxRuns, 7);
+}
+
+assert.throws(() => parseArgs(["--max-runs", "0"]), /positive integer/);
+assert.throws(() => parseArgs(["--bogus"]), /unknown argument/);
+
+// --- readWorkflowRuns: URL shape against an injected fetcher ----------------
+
+{
+  const calls = [];
+  const runs = readWorkflowRuns("owner/repo", { workflow: "ci.yml", branch: "main", maxRuns: 5 }, (args) => {
+    calls.push(args[args.length - 1]);
+    return { workflow_runs: [{ id: 100 }, { id: 101 }] };
+  });
+  assert.equal(calls.length, 1);
+  assert.match(calls[0], /repos\/owner\/repo\/actions\/workflows\/ci\.yml\/runs\?status=success&branch=main&per_page=5/);
+  assert.deepEqual(runs.map((r) => r.id), [100, 101]);
+}
+
+// --- collectRunsWithJobs: join runs with their paginated jobs ---------------
+
+{
+  const fetchJson = (args) => {
+    const endpoint = args[args.length - 1];
+    if (endpoint.includes("/workflows/")) {
+      return { workflow_runs: [{ id: 100 }, { id: 101 }] };
+    }
+    const runId = /runs\/(\d+)\/jobs/.exec(endpoint)?.[1];
+    return { jobs: [job({ name: `job-for-${runId}` })] };
+  };
+  const joined = collectRunsWithJobs("owner/repo", { workflow: "ci.yml", branch: "main", maxRuns: 5 }, fetchJson);
+  assert.deepEqual(joined.map((r) => r.id), [100, 101]);
+  assert.deepEqual(joined.flatMap((r) => r.jobs.map((j) => j.name)), ["job-for-100", "job-for-101"]);
+}
+
+// --- CLI: fixture path ------------------------------------------------------
+
+function runFixture(runs, args = []) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-ci-job-timing-"));
+  try {
+    const fixture = path.join(dir, "runs.json");
+    fs.writeFileSync(fixture, `${JSON.stringify({ runs })}\n`);
+    return spawnSync(process.execPath, [SCRIPT, "--fixture", fixture, ...args], {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+{
+  const result = runFixture([{ id: 1, jobs: [job()] }]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /CI Job Timing Baseline/);
+  assert.match(result.stdout, /conformance-0/);
+}
+
+{
+  const result = runFixture([]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /No successful `ci.yml` jobs/);
+}
+
+// --- CLI: live path through a fake gh on PATH -------------------------------
+
+{
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-ci-job-timing-gh-"));
+  try {
+    const fakeGh = path.join(dir, "gh");
+    fs.writeFileSync(fakeGh, `#!/bin/sh
+case "$*" in
+  *"/workflows/"*)
+    printf '%s\\n' '{"workflow_runs":[{"id":555}]}'
+    ;;
+  *"/jobs"*)
+    case "$*" in
+      *"page=1"*)
+        printf '%s\\n' '{"jobs":[{"name":"unit","conclusion":"success","created_at":"2026-05-20T12:00:00Z","started_at":"2026-05-20T12:00:10Z","completed_at":"2026-05-20T12:02:10Z"}]}'
+        ;;
+      *)
+        printf '%s\\n' '{"jobs":[]}'
+        ;;
+    esac
+    ;;
+  *)
+    printf 'unexpected gh args %s\\n' "$*" >&2
+    exit 1
+    ;;
+esac
+`);
+    fs.chmodSync(fakeGh, 0o755);
+
+    const result = spawnSync(process.execPath, [
+      SCRIPT,
+      "--repository",
+      "owner/repo",
+      "--max-runs",
+      "1",
+    ], {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${dir}${path.delimiter}${process.env.PATH || ""}` },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /unit/);
+    assert.match(result.stdout, /2m00s/); // 120s run
+    assert.match(result.stdout, /10s/); // 10s queue wait
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log("check-ci-job-timing: all assertions passed");


### PR DESCRIPTION
Goal: fast

## Summary

Implements item 2 of #13605 — the per-job wall-time measurement baseline for
the self-hosted CI fleet. `ci-health.yml` previously tracked only runner/run
counts, with no per-job timing, so every speed claim about the fleet (sharding
wins, sccache A/B, zstd cache) had no measured baseline to be checked against.
This adds a scheduled, advisory job that samples recent successful `ci.yml`
runs and reports per-job timing. It changes no wall-clock behavior.

Item 1 of #13605 (3-way shard of `project-compile-canary` + aggregate) already
landed on `main`; this PR is scoped to item 2 only. Items 3–5 (sccache A/B,
zstd, bucket co-location) explicitly require draft/measurement loops and are
left for follow-ups.

## What it records

For each job over the latest successful `ci.yml` runs on `main`:

- **queue_wait** = `started_at - created_at` — time a job spent
  eligible-but-waiting for a runner. The fleet-capacity signal: high queue_wait
  means the runner pool is the bottleneck, not the work.
- **run** = `completed_at - started_at` — the actual work. The wall-time signal
  for "which job defines run end".

Aggregated per job name as p50 / p95 / max (run) and p50 / max (queue), slowest
typical-run first, rendered as a markdown table into the step summary.

## Owner layer / structure

CI tooling only — no compiler/semantic change.

- `scripts/ci/check-ci-job-timing.mjs` — joins recent successful workflow runs
  with their jobs and aggregates timing. Mirrors the existing
  `check-stale-ci-runs.mjs` advisory-script shape: injected-`fetchJson` test
  seam, `--fixture` path, `import.meta.url` entry guard, markdown-table output.
  Percentiles are nearest-rank for deterministic output. Only successful,
  fully-timed jobs contribute (failed/cancelled jobs have truncated times).
- `.github/workflows/ci-health.yml` — dedicated `ci-job-timing` job
  (`ubuntu-latest`, free runner; the workflow already runs on the 15-min
  schedule), consistent with the one-concern-per-job pattern
  (`main-red-sentinel`, `runner-health`, `dns-health`, `bench-artifact-readiness`).
  Reuses the granted `actions: read` permission.
- `scripts/ci/gcp-full-ci.sh` — registers the new fixture-driven test in
  `run_lint` next to its siblings.

No fixture-name / source-text fast paths; the metric is derived purely from the
GitHub job timestamps.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: medium

## Verification

- `node scripts/ci/test-check-ci-job-timing.mjs` — fixture-driven unit coverage
  of the arithmetic (queue/run seconds, nearest-rank percentiles, slowest-first
  ordering, failed/cancelled exclusion, missing-timestamp degradation),
  `formatReport`, `parseArgs`, the `readWorkflowRuns` URL shape, the
  `collectRunsWithJobs` run↔jobs join, the CLI `--fixture` path, and a
  fake-`gh`-on-`PATH` live path. Passes.
- `node --check scripts/ci/check-ci-job-timing.mjs` — clean.
- `.github/workflows/ci-health.yml` parses as valid YAML; the new test is wired
  into `run_lint` (lint suite), so ready-review CI exercises it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HbLjuenhzcJgjpKFNAuz4b)_