### PR TITLE
green(canary): fix immer TS2790 element-access delete false positive

### DIFF
--- a/crates/tsz-checker/src/types/computation/delete_optionality.rs
+++ b/crates/tsz-checker/src/types/computation/delete_optionality.rs
@@ -42,16 +42,50 @@ impl<'a> CheckerState<'a> {
             return;
         };
 
-        let prop_name = self
-            .ctx
-            .arena
-            .get_identifier_at(access.name_or_argument)
-            .map(|ident| ident.escaped_text.clone())
-            .or_else(|| self.get_literal_string_from_node(access.name_or_argument))
-            .or_else(|| {
-                self.get_literal_index_from_node(access.name_or_argument)
-                    .map(|idx| idx.to_string())
-            });
+        // tsc keys TS2790 off `getNodeLinks(expr).resolvedSymbol`: the check
+        // only runs when the access resolves to a single concrete declared
+        // property symbol. A property access (`obj.name`) always names a
+        // property. An element access resolves a symbol only when its argument
+        // denotes a single literal property name — a string/number literal
+        // (`obj["x"]`, `obj[0]`), a `const`-typed identifier whose type is a
+        // literal (`KEY: "k"`), or a well-known/unique symbol. When the
+        // element-access argument is a wider expression — a `string`/`number`
+        // variable, or a generic key `K extends keyof T` — its type is not a
+        // single literal, so tsc resolves no symbol and never reports TS2790.
+        // The argument's *type* (not its syntactic identifier text) is what
+        // decides this.
+        let is_property_access = operand_node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION;
+        let prop_name = if is_property_access {
+            self.ctx
+                .arena
+                .get_identifier_at(access.name_or_argument)
+                .map(|ident| ident.escaped_text.clone())
+                .or_else(|| self.get_literal_string_from_node(access.name_or_argument))
+                .or_else(|| {
+                    self.get_literal_index_from_node(access.name_or_argument)
+                        .map(|idx| idx.to_string())
+                })
+        } else {
+            // Element access: a syntactic string/number literal, a well-known
+            // symbol (`get_literal_string_from_node` recovers `[Symbol.x]`),
+            // or — failing those — a single literal property name recovered
+            // from the *type* of the argument expression (so a const-literal
+            // identifier `KEY: "k"` resolves to `"k"`, but a generic-key or
+            // wide-primitive index resolves to nothing).
+            self.get_literal_string_from_node(access.name_or_argument)
+                .or_else(|| {
+                    self.get_literal_index_from_node(access.name_or_argument)
+                        .map(|idx| idx.to_string())
+                })
+                .or_else(|| {
+                    let arg_type = self.get_type_of_node(access.name_or_argument);
+                    crate::query_boundaries::type_computation::access::literal_property_name(
+                        self.ctx.types,
+                        arg_type,
+                    )
+                    .map(|atom| self.ctx.types.resolve_atom(atom))
+                })
+        };
         let Some(prop_name) = prop_name else {
             return;
         };


### PR DESCRIPTION
Goal: green

Drives the **immer** canary row toward green. immer's fixture was made tsc-clean
by #13700, so every tsz diagnostic on it is a true tsz-only false positive.

## Re-measurement (current main `6231320658`)

The board's stale count was 13 FPs (predating #13693/#13701/#13702/#13677).
Re-measuring off current main gives **6** true FPs. tsc on the exact guard
tsconfig is clean (exit 0), confirming all are tsz-only:

| File:line | Code | Family |
| --- | --- | --- |
| src/utils/plugins.ts:69 | TS2790 | delete operand optionality — **FIXED here** |
| src/core/proxy.ts:234 | TS2322 | object-literal assignability (computed keys / freshness) — residual |
| src/immer.ts:54 | TS2322 | generic conditional assignability (`InferCurriedFromRecipe`) — residual |
| src/plugins/patches.ts:39 | TS2345 | `never`-parameter arg assignability — residual |
| src/plugins/patches.ts:410 | TS2345 | tuple-destructure callback param vs `unknown` — residual |
| src/utils/common.ts:254 | TS2353 | excess property vs `PropertyDescriptorMap` index sig — residual |

This PR fixes the TS2790 family (1 FP). immer is now at **5** residual FPs.

## Structural rule

`When the operand of a delete expression is an element access whose argument
does not denote a single literal property name, tsc resolves no property symbol
(`getNodeLinks(expr).resolvedSymbol` is undefined) and never reports TS2790.`

tsc's `checkDeleteExpression` only calls `checkDeleteExpressionMustBeOptional`
when `links.resolvedSymbol` is set. For an element access that symbol is set
only when the argument is a single literal property name — a string/number
literal, a `const`-typed identifier whose type is a literal (`KEY: "k"`), or a
well-known/unique symbol. A generic key (`K extends keyof T`) or a wide-primitive
index (`s: string`, `n: number`) has a non-literal type, so no symbol resolves
and tsc reports nothing.

Owner layer: checker (`delete_optionality.rs`). Previously the element-access
path read the argument's *syntactic identifier text* as the property name, so
`delete plugins[pluginKey]` (`pluginKey: K extends keyof Plugins`, all-optional
members) and `delete arr[n]` (`n: number`) were false TS2790s. The path now
recovers the name from the argument expression's *type* via
`literal_property_name`, which yields a name only for single-literal types.

## Adjacent-case matrix (all match tsc)

- `delete plugins[pluginKey]`, `K extends keyof Plugins` (all-optional): no error
- `delete mixed[k]`, `K extends keyof {x;y?}` (mixed optionality): no error
- `delete arr[n]`, `n: number` (numeric index sig): no error
- `delete obj.x`, `delete obj["x"]` (required literal prop): TS2790 (preserved)
- `delete obj[KEY]`, `KEY: "k"` const-literal (required prop): TS2790 (preserved)
- `delete i[sym]`, required `unique symbol` prop: TS2790 (preserved)
- `delete j[sym]`, optional `unique symbol` prop: no error (preserved)

## Residual (not fixed)

The 5 remaining FPs (2× TS2322, 2× TS2345, 1× TS2353) only manifest in immer's
full 11-module circular `export *` graph; none reproduces in an isolated fixture
despite extensive minimal-repro attempts. They share deep cross-module generic-
instantiation / circular-barrel roots. Per the anti-hardcoding gate they are not
fixed speculatively here; immer remains canary with a documented residual.

## Verification

- immer guard re-measured: TS2790 cleared (6 -> 5 FPs); tsc on guard tsconfig exit 0
- Repro parity: `delete plugins[K]`, `delete arr[n]`, `delete obj[KEY]`, `delete i[sym]` all match tsc exactly
- `scripts/conformance/conformance.sh --filter delete` -> 13/13 pass
- `--filter indexedAccess` -> 13/13 pass
- `--filter mappedType` -> 55/55 pass
- `python3 scripts/arch/arch_guard.py` -> Architecture guardrails passed
- `cargo clippy -p tsz-checker --lib` and `-p tsz-solver --lib` -> clean

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
