### PR TITLE
perf(checker): activate inert return-type memo by excluding own resolution frame (#13246)

### DIFF
--- a/crates/tsz-checker/src/types/utilities/return_type.rs
+++ b/crates/tsz-checker/src/types/utilities/return_type.rs
@@ -739,8 +739,10 @@ impl<'a> CheckerState<'a> {
     /// memoization. The inference becomes resolution-state-dependent, and unsafe
     /// to cache, only in these cases:
     ///
-    /// - the function node is already on the resolution stack: a genuine
-    ///   re-entrant request, whose result is a provisional placeholder;
+    /// - the function node is *genuinely* re-entrant on the resolution stack
+    ///   (appears more than once): its result is a provisional placeholder.
+    ///   A single occurrence is the node's OWN in-progress resolution frame and
+    ///   is NOT re-entrancy — see the inline note below;
     /// - the body returns a still-resolving variable through a call-like return,
     ///   which `tsc` resolves on demand with `any` and refines later;
     /// - the body is directly self-recursive (`all_returns_are_direct_self_calls`):
@@ -758,8 +760,26 @@ impl<'a> CheckerState<'a> {
         if return_context.is_none() {
             return false;
         }
-        if self.ctx.node_resolution_stack.contains(&function_idx) {
-            return false;
+        // A function node is pushed onto `node_resolution_stack` by its own
+        // resolution frame (`get_type_of_node_with_request`) *before* this body
+        // inference runs, so a single occurrence is the node's OWN in-progress
+        // frame — the normal, complete inference, which is safe to memoize. Only
+        // a *second* occurrence means a genuine re-entrant request whose result
+        // is a provisional placeholder; reject memoization just for that. A plain
+        // `contains` test (`>= 1`) would reject every contextual inference,
+        // because the own frame is always present, leaving the memo permanently
+        // inert. (In practice the circular guard in `get_type_of_node_with_request`
+        // returns `ERROR` before re-entering this body, so the count rarely
+        // exceeds one, but the `> 1` test keeps the guard correct if that path
+        // changes.)
+        let mut seen_own_frame = false;
+        for &node in &self.ctx.node_resolution_stack {
+            if node == function_idx {
+                if seen_own_frame {
+                    return false;
+                }
+                seen_own_frame = true;
+            }
         }
         if self.return_body_has_resolving_var_in_call_like(body_idx) {
             return false;


### PR DESCRIPTION
## Summary

Activates the contextual return-type inference memo added in #13686, which was
**permanently inert** on the single-file nested-callback blowup that bottlenecks
the `large-ts-repo` row (#13246 — the worst row, >14.5x slower than tsgo, often
DNF). The row is rayon work-starvation: one file with a pathological nested
contextual-generic callback costs ~1000x the median, so 15 cores idle while one
grinds. The hot stack is `get_type_of_function_impl` -> `infer_return_type_from_body`
**re-entering** `get_type_of_function_impl` for each nested callback. #13686
added a memo meant to break this re-entry, but it never fired.

Goal: fast

## Structural rule

When inferring a **contextually-typed** function body whose node is on the
resolution stack **exactly once** (its own in-progress resolution frame), the
inference is the complete, stable result and is safe to memoize. tsz now
memoizes it through `CheckerState::inferred_return_type_is_memoizable`
(checker, return-type inference memo gate).

## Root cause

`inferred_return_type_is_memoizable` disqualified memoization with
`node_resolution_stack.contains(&function_idx)`. But `get_type_of_node_with_request`
pushes `function_idx` onto `node_resolution_stack` as the node's **own**
resolution frame **before** `infer_return_type_from_body` runs. So a single
occurrence is the normal, non-cyclic case and is present for *every* contextual
inference — the `.contains()` (`>= 1`) test therefore rejected all of them,
making the memo inert (instrumented: 100% of rejections were the node's single
own-frame; 0 hits, 0 memoizable misses on the witness).

A *genuine* re-entrant request is caught earlier: the circular guard in
`get_type_of_node_with_request` returns `TypeId::ERROR` before re-entering the
same node's body, so a provisional placeholder would only ever appear as a
**second** stack occurrence. The fix changes the gate from `contains` (`>= 1`)
to `> 1`, so only true re-entrancy is rejected and the node's own frame is
memoized. All other disqualifiers are unchanged (no contextual type,
resolving-var-in-call-like return, direct self-recursion).

## Soundness / diagnostic parity

The memo records **only** the inferred `TypeId`, never diagnostics. The
separate body-check pass still runs once per function and emits its diagnostics
unchanged — only pure inference is reused. The memo key
(`InferredReturnTypeKey`) captures every ambient input to inference (function
node, contextual return type, const-assertion/literal flags, `this` type,
type-parameter-scope fingerprint), so a hit is byte-equal to a recompute.
Genuine cycles and provisional results remain disqualified. Output is
byte-identical (verified below).

## Verification

Witness: deeply nested contextual-generic callbacks (callbacks returning
callbacks with contextual generic inference, the shape that triggers the
re-entry), parameterized by nesting depth. Min-of-3 wall clock, identical
release build settings, baseline = the same head with only this file reverted:

| depth | baseline | fixed  | speedup |
|-------|----------|--------|---------|
| 4     | 128 ms   | 60 ms  | 2.1x    |
| 6     | 860 ms   | 71 ms  | **12.2x** |
| 8     | 1494 ms  | 178 ms | **8.4x**  |
| 10    | 1751 ms  | 997 ms | 1.8x    |

Hot-leaf change: the before-profile (`sample`) is dominated by a 212-frame-deep
`get_type_of_function_impl` <-> `infer_return_type_from_body` recursion; after
the fix the depth-8 case completes in ~178 ms and `sample` no longer captures
that recursion (it has collapsed). Memo on depth 8: from 11022 inferences / 0
hits to ~632 inferences / 2116 hits.

Conformance-neutrality (byte-identical `--noEmit` diagnostics, baseline vs
fixed): the witness matrix at depths 3/4/6/8, a builder-DAG witness, and an
adjacent-case matrix exercising renamed binders, `type`-alias + wrapper +
deep nesting, generic vs concrete combinators, overloaded combinators
(overload-resolution recovery path), and positive + negative (wrong-shape
return) cases — all IDENTICAL. All 24 `crates/tsz-cli/tests/fixtures` `.ts`
files — all IDENTICAL. Full conformance/emit/fourslash run on ready-review CI.

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
