### PR TITLE
test(bench): make ofetch canary fixture tsc-clean (undici + @types/node stubs)

### DIFF
--- a/scripts/bench/lib/project-fixture-stubs.sh
+++ b/scripts/bench/lib/project-fixture-stubs.sh
@@ -969,3 +969,55 @@ declare namespace NodeJS {
 declare var global: any;
 TYPES
 }
+
+tsz_write_ofetch_external_stubs() {
+  # ofetch's real tsconfig sets `"types": ["node"]`, so its upstream build sees
+  # the node typings and the `undici` peer dependency. The shared bench baseline
+  # pins `"types": []` and the fixture clone runs no npm install, so without a
+  # stub tsc emits five spurious diagnostics, all from absent ambient typings
+  # rather than ofetch's own source:
+  #   * src/types.ts imports `undici` for `InstanceType<typeof
+  #     import("undici").Dispatcher>` -> TS2307 "Cannot find module 'undici'".
+  #   * src/fetch.ts imports `node:stream` for the `Readable` body cast ->
+  #     TS2591 "Cannot find name 'node:stream'".
+  #   * src/fetch.ts annotates `let abortTimeout: NodeJS.Timeout` -> TS2503
+  #     "Cannot find namespace 'NodeJS'".
+  #   * src/fetch.ts guards `Error.captureStackTrace` (a V8/@types/node global
+  #     augmentation) -> TS2339 "Property 'captureStackTrace' does not exist on
+  #     type 'ErrorConstructor'".
+  # Mirror the trpc/type-graphql stub convention: provide named ambient
+  # any-modules for the external deps plus the node global augmentations the
+  # @types/node-backed build would supply. `Dispatcher` is a class so the
+  # `typeof ... ` + `InstanceType<...>` resolves; `Readable` carries the `.pipe`
+  # member the source casts to. ofetch's own `./*.ts` source stays real-checked.
+  local output="$1"
+  local fixture_dir
+  fixture_dir="$(dirname "$output")"
+  cat > "$fixture_dir/tsz-bench-globals.d.ts" <<'TYPES'
+declare module 'undici' {
+  // ofetch reads `InstanceType<typeof import("undici").Dispatcher>`, so the
+  // export must be a constructable value (a class) rather than bare `any`.
+  export class Dispatcher {
+    [key: string]: any;
+  }
+}
+
+declare module 'node:stream' {
+  // ofetch casts a request body to `Readable` and reads `.pipe`; an interface
+  // with the referenced member resolves the cast without unmasking unrelated
+  // assignability diffs.
+  export interface Readable {
+    pipe(...args: any[]): any;
+    [key: string]: any;
+  }
+}
+
+declare namespace NodeJS {
+  type Timeout = any;
+}
+
+interface ErrorConstructor {
+  captureStackTrace?(targetObject: object, constructorOpt?: Function): void;
+}
+TYPES
+}

--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -740,9 +740,17 @@ tsz_write_ofetch_config() {
   # the option tsc emits TS5097 on every such import and cascades into
   # TS2304/TS2339; tsz matches that tsc behavior, so the guard config must
   # carry the option the upstream project actually sets.
+  #
+  # ofetch also depends on the `undici` peer package and the node typings
+  # (`node:stream`, `NodeJS`, `Error.captureStackTrace`) that its real tsconfig
+  # pulls in via `"types": ["node"]`. The shared bench baseline pins
+  # `"types": []` and the clone installs nothing, so those resolve to spurious
+  # TS2307/TS2591/TS2503/TS2339 unless stubbed; the stub writer supplies them.
+  tsz_write_ofetch_external_stubs "$1"
   tsz_write_basic_external_project_config "$1" "src" \
     '    "allowImportingTsExtensions": true,
-'
+' \
+    ', "tsz-bench-globals.d.ts"'
 }
 
 tsz_write_ts_pattern_config() {


### PR DESCRIPTION
Goal: green

Makes the **ofetch** canary fixture genuinely tsc-clean so the canary
tsz-only-diagnostic gate stops counting dependency noise as tsz false positives.

## Structural rule
A canary fixture must be tsc-clean for the tsz-only-diagnostic gate to be
meaningful. ofetch's guard config (`"types": []`, no npm install) lacked
`undici` and `@types/node` typings, so **tsc itself** emitted five spurious
diagnostics — TS2307 (`undici`), TS2591 (`node:stream`), TS2503 (`NodeJS`),
TS2339 (`Error.captureStackTrace`) — that the gate misattributed to tsz. This
PR adds external-module stubs so both tsc and tsz resolve those externals; the
project's own `src/*.ts` source stays real-checked. No tsz code changed.

When a canary fixture's real tsconfig pulls in peer deps / node typings that the
shared bench baseline omits, the fixture writer must supply ambient stubs for
those externals (mirroring drizzle/trpc/type-graphql) so tsc is clean and only
tsz-vs-tsc diagnostic deltas surface. Owner: `scripts/bench/lib/project-fixture-stubs.sh`
(the established stub-writer home; new `tsz_write_ofetch_external_stubs`) wired
through `tsz_write_ofetch_config` in `scripts/bench/project-fixtures.sh`.

Stubs added (named ambient any-modules + node global augmentations, matching
what ofetch's real `"types": ["node"]` build supplies):
- `undici` — `Dispatcher` as a class so `InstanceType<typeof import("undici").Dispatcher>` resolves.
- `node:stream` — `Readable` interface carrying the `.pipe` member the body cast reads.
- `NodeJS.Timeout` namespace member.
- `ErrorConstructor.captureStackTrace?` global augmentation.

ofetch's own relative `./*.ts` imports remain real (filesystem-resolved); only
external deps are any-stubbed.

## Verification
- tsc before (un-stubbed guard config): **5 errors** (TS2307 undici, TS2591 node:stream, TS2503 NodeJS, 2x TS2339 captureStackTrace).
- tsc after (`node typescript/lib/tsc.js --noEmit -p .target/project-compile-guard/ofetch*/tsconfig.tsz-guard.json`): **0 errors**.
- tsz residual (true ofetch FPs now cleanly exposed for a follow-up): **37** — 27x TS2339, 4x TS18048, 2x TS2345, 2x TS2322, 1x TS7053, 1x TS2454. The compatibility summary classifies the row `yellow` (tsz-only diagnostics, no dep-noise). NOT promoting the row in this PR.
- Bench gates: `node scripts/bench/validate-project-metadata.mjs` PASS; `node scripts/bench/test-project-rows.mjs` PASS; all `scripts/bench/test-*.mjs` PASS except `test-measure-tsz.mjs`/`test-timeout-runner.mjs` (pre-existing CPU-contention flakes in the timeout-classification harness — unrelated files, not touched here).
- `python3 scripts/arch/test_arch_guard_project.py` PASS (63 tests); `python3 scripts/arch/arch_guard.py` PASS ("Architecture guardrails passed.").
- `bash -n` clean on both edited shell files; both stay under the 2000-line shard ceiling (project-fixtures.sh 1161, lib/project-fixture-stubs.sh 1023).
- Full canary guard re-run to confirm no other row's fixture regressed.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high

AgentName: claude-code-ofetch-fixture

- Row: ofetch-project
- Bug family: fixture dep-noise
