### PR TITLE
fix(solver): narrow x == null true branch to the source's nullish facet, preserving any

### DIFF
--- a/crates/tsz-solver/src/narrowing/core.rs
+++ b/crates/tsz-solver/src/narrowing/core.rs
@@ -1271,6 +1271,26 @@ impl<'a> NarrowingContext<'a> {
         }
     }
 
+    /// Narrow a type to its nullish facet for the true branch of a loose
+    /// `x == null` / `x != null` comparison, which matches both `null` and
+    /// `undefined`.
+    ///
+    /// This is the exact dual of [`Self::narrow_excluding_type`] used in the
+    /// inequality (false) branch: where exclusion drops the `null`/`undefined`
+    /// members, this keeps only them. As with that branch, `any` is preserved
+    /// unchanged — tsc's `narrowTypeByEquality` returns the type as-is when it
+    /// is `any`, so the nullish branch must not collapse `any` to
+    /// `null | undefined`. Every other source keeps only its `null`/`undefined`
+    /// members, so a non-nullable source narrows to `never` (the true branch is
+    /// unreachable) while e.g. `string | null` narrows to `null`.
+    pub(crate) fn narrow_to_nullish(&self, source_type: TypeId) -> TypeId {
+        if self.resolve_type(source_type) == TypeId::ANY {
+            return source_type;
+        }
+        let nullish = self.db.union2(TypeId::NULL, TypeId::UNDEFINED);
+        self.narrow_to_type(source_type, nullish)
+    }
+
     /// Check if a literal type is assignable to a target for narrowing purposes.
     ///
     /// Handles union decomposition: if the target is a union, checks each member.
@@ -1730,8 +1750,10 @@ impl<'a> NarrowingContext<'a> {
 
             TypeGuard::NullishEquality => {
                 if sense {
-                    // Equality with null: narrow to null | undefined
-                    self.db.union2(TypeId::NULL, TypeId::UNDEFINED)
+                    // Equality `x == null` (true branch): keep only the nullish
+                    // facet of the source. `any` is preserved (not collapsed to
+                    // `null | undefined`); see `narrow_to_nullish`.
+                    self.narrow_to_nullish(source_type)
                 } else {
                     // Inequality: exclude null and undefined — resolve Lazy types first
                     let resolved = self.resolve_for_exclusion_narrowing(source_type);

--- a/crates/tsz-solver/tests/narrowing_tests_parts/part_00.rs
+++ b/crates/tsz-solver/tests/narrowing_tests_parts/part_00.rs
@@ -1391,7 +1391,47 @@ fn test_type_guard_nullish_equality() {
     let guard = TypeGuard::NullishEquality;
     let narrowed = ctx.narrow_type(union, &guard, GuardSense::Positive);
 
-    // Should narrow to null | undefined
+    // Keeps only the nullish facet. The source carries `null` but not
+    // `undefined`, so the true branch narrows to `null` (matching tsc's
+    // `getTypeWithFacts(string | null, EQUndefinedOrNull)`), not the wider
+    // `null | undefined`.
+    assert_eq!(narrowed, TypeId::NULL);
+}
+
+#[test]
+fn test_type_guard_nullish_equality_preserves_any() {
+    let interner = TypeInterner::new();
+    let ctx = NarrowingContext::new(&interner);
+
+    // x == null where x: any — tsc's narrowTypeByEquality returns the type
+    // unchanged for `any`, so the true branch must stay `any` rather than
+    // collapsing to `null | undefined`.
+    let guard = TypeGuard::NullishEquality;
+    let narrowed = ctx.narrow_type(TypeId::ANY, &guard, GuardSense::Positive);
+    assert_eq!(narrowed, TypeId::ANY);
+}
+
+#[test]
+fn test_type_guard_nullish_equality_non_nullable_is_never() {
+    let interner = TypeInterner::new();
+    let ctx = NarrowingContext::new(&interner);
+
+    // x == null where x: string — the value can never be nullish, so the true
+    // branch is unreachable and narrows to `never`.
+    let guard = TypeGuard::NullishEquality;
+    let narrowed = ctx.narrow_type(TypeId::STRING, &guard, GuardSense::Positive);
+    assert_eq!(narrowed, TypeId::NEVER);
+}
+
+#[test]
+fn test_type_guard_nullish_equality_keeps_both_nullish_members() {
+    let interner = TypeInterner::new();
+    let ctx = NarrowingContext::new(&interner);
+
+    // string | null | undefined — both nullish members survive.
+    let union = interner.union(vec![TypeId::STRING, TypeId::NULL, TypeId::UNDEFINED]);
+    let guard = TypeGuard::NullishEquality;
+    let narrowed = ctx.narrow_type(union, &guard, GuardSense::Positive);
     let nullish = interner.union(vec![TypeId::NULL, TypeId::UNDEFINED]);
     assert_eq!(narrowed, nullish);
 }


### PR DESCRIPTION
Goal: hold

## Summary

The `TypeGuard::NullishEquality` positive (true) branch — the `x == null` /
`x != null` true branch, which matches both `null` and `undefined` — returned a
**constant** `null | undefined`, ignoring the source type entirely
(`crates/tsz-solver/src/narrowing/core.rs`). This is asymmetric with the false
branch, which already keeps `any` as `any` and excludes only the real nullish
members via `narrow_excluding_type`.

Surfaced (unfiled) by the grow corpus-readiness survey on #13512 — the
class-transformer `any`-narrowing cluster — which pinpointed the positive branch
collapsing `any` to `null | undefined`. Confirmed against tsc and fixed
generally here, not just for the witness.

## Structural rule

When the operand of a loose `x == null` is narrowed in the true branch, tsc's
`narrowTypeByEquality` returns the type unchanged if it is `any`, and otherwise
keeps only the parts that can be `null`/`undefined`
(`getTypeWithFacts(type, EQUndefinedOrNull)`). tsz now does this through the
solver narrowing owner: a new `narrow_to_nullish` preserves `any` (mirroring the
`any` guard in `narrow_excluding_type`) and otherwise delegates to the canonical
`narrow_to_type(source, null | undefined)`.

Behavior delta (all toward tsc parity; the true branch of `== null` only ever
loses or refines members, so this can only remove tsz-only diagnostics):

| Source | before | after (tsc) |
|---|---|---|
| `any` | `null \| undefined` | `any` |
| `string \| null` | `null \| undefined` | `null` |
| `string` (non-nullable) | `null \| undefined` | `never` |
| `string \| null \| undefined` | `null \| undefined` | `null \| undefined` |
| `unknown` | `null \| undefined` | `null \| undefined` (unchanged) |

## Adjacent-case matrix

Solver unit tests in `crates/tsz-solver/tests/narrowing_tests_parts/part_00.rs`:
- `any` source preserves `any` (`test_type_guard_nullish_equality_preserves_any`).
- non-nullable source → `never` (`test_type_guard_nullish_equality_non_nullable_is_never`).
- `string | null` → `null` (updated `test_type_guard_nullish_equality`, which
  previously asserted the buggy `null | undefined`).
- both nullish members survive (`test_type_guard_nullish_equality_keeps_both_nullish_members`).
- `unknown == null` → `null | undefined` preserved (existing checker tests).

## Verification

- `cargo test -p tsz-solver --lib narrow` → 313 passed, 0 failed.
- `cargo test -p tsz-solver --lib nullish` → 25 passed, 0 failed.
- `cargo test -p tsz-checker --test equality_narrow_unknown_to_const_intrinsic_tests`
  → 20 passed, 0 failed (`unknown == null` behavior unchanged).
- Ready-review CI owns the broad conformance/emit/fourslash suites.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQ8dT4e2nRRSDChqeY8E7Q)_