### PR TITLE
fix(checker): defer TS2536 for generic indexed access rooted at polymorphic this

### DIFF
--- a/crates/tsz-checker/src/types/type_checking/indexed_access.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access.rs
@@ -1260,6 +1260,11 @@ impl<'a> CheckerState<'a> {
                     || crate::query_boundaries::common::is_conditional_type(self.ctx.types, ty)
                     || crate::query_boundaries::common::is_generic_application(self.ctx.types, ty)
                     || crate::query_boundaries::common::is_index_access_type(self.ctx.types, ty)
+                    // A still-deferred `keyof` (e.g. `keyof (this["arg0"])` or
+                    // `keyof T[K]`) is not a usable key space: it cannot reject an
+                    // index, so the check defers rather than emitting a spurious
+                    // TS2536.
+                    || crate::query_boundaries::common::is_keyof_type(self.ctx.types, ty)
             };
             let mut is_deferred_index_type = |ty: TypeId| -> bool {
                 ty == TypeId::ERROR

--- a/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
+++ b/crates/tsz-checker/src/types/type_checking/indexed_access/indexed_access_helpers.rs
@@ -162,7 +162,14 @@ impl<'a> CheckerState<'a> {
         if let Some((base, _index)) =
             crate::query_boundaries::common::index_access_types(self.ctx.types, ty)
         {
-            return crate::query_boundaries::common::is_type_parameter_like(self.ctx.types, base);
+            // A generic indexed access (`Base[I]`) defers its index-validity
+            // check to instantiation time (tsc's `checkIndexedAccessIndexType`).
+            // The base is generic when it is a type parameter or the polymorphic
+            // `this` type: tsc models `this` as a type parameter whose constraint
+            // is the enclosing class/interface, so `this["arg0"][number]` is as
+            // deferred as `T["arg0"][number]` and must not eagerly emit TS2536.
+            return crate::query_boundaries::common::is_type_parameter_like(self.ctx.types, base)
+                || crate::query_boundaries::common::is_this_type(self.ctx.types, base);
         }
         false
     }

--- a/crates/tsz-checker/tests/conformance_issues/types/indexed_access.rs
+++ b/crates/tsz-checker/tests/conformance_issues/types/indexed_access.rs
@@ -14,6 +14,37 @@ type PropertyType<T extends object, K extends keyof T> = T[K];
     );
 }
 
+// A generic indexed access rooted at the polymorphic `this` type
+// (`this["arg0"][number]`) is deferred to instantiation time, exactly like a
+// type-parameter-rooted access (`T["arg0"][number]`). `tsc` treats `this` as a
+// type parameter whose constraint is the enclosing class/interface, so it never
+// eagerly emits TS2536 here. Mirrors the hotscript `Tuples.ToUnionFn` shape.
+#[test]
+fn this_rooted_indexed_access_chain_no_ts2536() {
+    let diagnostics = compile_and_get_diagnostics(
+        r#"
+declare const rawArgs: unique symbol;
+interface Fn {
+  [rawArgs]: unknown;
+  arg0: this[typeof rawArgs] extends [infer a, ...any] ? a : never;
+}
+interface ToUnionFn extends Fn {
+  return: this["arg0"][number];
+}
+// Renamed binders + alternate index kinds must defer identically.
+interface OtherFn extends Fn {
+  collapse: this["arg0"][0];
+  width: this["arg0"]["length"];
+}
+"#,
+    );
+
+    assert!(
+        !has_error(&diagnostics, 2536),
+        "Should not emit TS2536 for a deferred indexed access rooted at the polymorphic `this` type.\nActual diagnostics: {diagnostics:#?}"
+    );
+}
+
 #[test]
 fn circular_interface_access_type_args_do_not_stack_overflow() {
     let diagnostics = compile_and_get_diagnostics(

--- a/scripts/arch/arch_guard_shared.py
+++ b/scripts/arch/arch_guard_shared.py
@@ -1420,7 +1420,21 @@ QUERY_BOUNDARY_COMMON_REFERENCE_COUNT_CHECKS = [
         # `is_keyof_type`) — all existing request-shaped boundary helpers, no new
         # quarantine entry. Removal condition remains #8225 narrowing this
         # quarantine.
-        3070,
+        #
+        # Bumped 3070→3072 for the polymorphic-`this` generic-indexed-access
+        # TS2536 deferral fix (#13720): `is_deferred_indexed_access_object` in
+        # `indexed_access/indexed_access_helpers.rs` adds one
+        # `is_this_type(base)` reference so a `this["arg0"][number]` base is
+        # recognized as a deferred generic indexed-access object, and the
+        # `key_space_is_unresolved` gate in `indexed_access.rs` adds one
+        # `is_keyof_type(ty)` reference so a still-deferred `keyof` key space is
+        # treated as unusable. Both route through the existing
+        # `query_boundaries::common` gateway and join the sibling structural
+        # predicates (`is_type_parameter_like`, `is_conditional_type`,
+        # `is_generic_application`, `is_index_access_type`) already called from
+        # `common` in the very same expressions — no new quarantine entry.
+        # Removal condition remains #8225 narrowing this quarantine.
+        3072,
     ),
 ]
 


### PR DESCRIPTION
Goal: grow

Fixes part of #13720.

## Structural rule

When an indexed-access type's object is a generic indexed access whose base is a
type parameter **or the polymorphic `this` type** (`this["arg0"][number]`), tsc
defers the index-validity check to instantiation time and emits no TS2536; tsz
must defer identically through the checker's `check_indexed_access_type`
suppression gate. tsc models `this` as a type parameter constrained to the
enclosing class/interface, so `this["arg0"][number]` is exactly as deferred as
`T["arg0"][number]`.

tsz's TS2536 suppression gate missed this on two structural counts:

1. `is_deferred_indexed_access_object` classified only a *type-parameter* base as
   a generic indexed-access object, so a `this`-rooted access was treated as
   resolved and validated eagerly.
2. `key_space_is_unresolved` did not treat a still-deferred `keyof` (e.g.
   `keyof (this["arg0"])`) as an unusable key space, so the deferral branch
   never fired even once the object was recognized as deferred.

## Owner layer

checker — `check_indexed_access_type` and its `is_deferred_indexed_access_object`
classifier (`crates/tsz-checker/src/types/type_checking/indexed_access*`). The
classification uses the solver-backed structural predicates
`is_type_parameter_like`, `is_this_type`, and `is_keyof_type`; no name, file, or
printer-output checks.

## Adjacent matrix

The new test (`this_rooted_indexed_access_chain_no_ts2536`) covers, with renamed
binders and multiple index kinds:

- `this["arg0"][number]` (the witness) — deferred, no TS2536.
- `this["arg0"][0]` (numeric literal) — deferred, no TS2536.
- `this["arg0"]["length"]` (string literal) — deferred, no TS2536.

Negative / fallback (unchanged, manually verified): a concrete object indexed by
a missing literal (`A["c"]`) still emits TS2536 + TS2339, and a type-parameter
index into an unrelated object (`A[K]`, `K extends "x"|"y"`) still emits TS2536.
Both suppression sub-conditions remain conjoined with `!index_is_concrete_literal`
and the deferred-object guard, so missing-key errors are preserved.

## Scope note

#13720 also tracks a primary `T[K1][K2]` constraint-chain family whose remaining
hotscript witnesses (`compare.ts`, `addition.ts`) only surface after the
unlanded #13712 namespace fix and are entangled with the separate #13086
flow/evaluator divergence; they do not reproduce in isolation on current `main`.
This PR lands the reproducible, independently-verifiable part — the
polymorphic-`this` sub-bug (`Tuples.ts(68,13)`) plus the deferred-`keyof`
key-space classification (issue point 2), shared machinery that benefits the
whole generic-indexed-access family.

## Verification

- `cargo test -p tsz-checker --test conformance_issues_types` — new test passes;
  the 3 remaining failures are pre-existing/environmental (two need the bundled
  `Pick` lib type → `TS2304`; one is the known #13086 flow/evaluator divergence
  debug-assert) and are identical on a clean `main` tree (confirmed by
  stash-and-rerun).
- `cargo test -p tsz-checker --test ts4105_this_type_indexed_access_tests` — 7/7
  pass (no regression to the sibling `this`-type indexed-access path).
- Manual CLI repro of `this["arg0"][number]`: spurious TS2536 before, clean
  after.
- Real hotscript project compile: the `Tuples.ts(68,13)` TS2536 FP is removed
  (31 → 30 diagnostics, no new errors).

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high