### PR TITLE
fix(checker,solver): zustand FPs — ambient module beats sibling bare-alias; optional-property infer drops spurious undefined

### DIFF
--- a/crates/tsz-checker/src/context/package_resolution.rs
+++ b/crates/tsz-checker/src/context/package_resolution.rs
@@ -45,6 +45,21 @@ impl<'a> CheckerContext<'a> {
             }
         }
 
+        // An ambient `declare module "<specifier>"` takes priority over the
+        // same-directory bare-alias file-index fallback below. tsc resolves a
+        // bare specifier through `paths`/`baseUrl`/`node_modules`/ambient
+        // declarations — never to a relative sibling source file whose basename
+        // happens to equal the specifier (a `react.ts` importing `'react'`, an
+        // `immer.ts` importing `'immer'`). The real resolver has already missed
+        // by the time we reach the file-index fallback, so the only remaining
+        // candidates are the ambient module (correct) or an accidental sibling
+        // (wrong); preferring the ambient declaration matches tsc. Skipping the
+        // file-index probe leaves the import unresolved here, which the import
+        // checker then binds against the ambient module declaration.
+        if is_bare_specifier && self.bare_specifier_is_declared_ambient_module(specifier) {
+            return None;
+        }
+
         if let Some(idx) = self.global_file_name_index.as_ref() {
             // Absolute paths (both POSIX `/` and Windows `\`): empty src_dir
             // causes resolve_specifier_via_file_index to use the specifier verbatim.
@@ -100,6 +115,23 @@ impl<'a> CheckerContext<'a> {
         }
 
         None
+    }
+
+    /// Whether `specifier` names a project-wide ambient `declare module "..."`
+    /// (an exact name or a matching wildcard pattern). Used to keep the
+    /// same-directory bare-alias file-index fallback in
+    /// `resolve_import_target_from_file` from shadowing an ambient module
+    /// declaration with a coincidentally-named sibling source file.
+    ///
+    /// Routes through the pre-built `global_declared_modules` index when present
+    /// (the program path); the binder-backed `declared_modules` set is consulted
+    /// separately by the import checker for the no-index standalone case, so a
+    /// missing index here simply leaves the fallback enabled.
+    fn bare_specifier_is_declared_ambient_module(&self, specifier: &str) -> bool {
+        let Some(declared) = self.global_declared_modules.as_ref() else {
+            return false;
+        };
+        declared.exact.contains(specifier) || declared.matches_wildcard(specifier)
     }
 
     pub(super) fn types_versions_redirected_target_index(

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/object_infer.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/object_infer.rs
@@ -329,6 +329,34 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             return InferPropertyResolution::Candidate(type_id);
         }
 
+        // Plain object/callable shapes carry each property's *declared* type
+        // directly, so resolve them through `property_candidate` before the
+        // `query_db` fallback. `resolve_property_access_atom` returns the
+        // property-ACCESS reading, which unions in the optionality `undefined`
+        // for an optional source property (`{ prop?: C }` → `C | undefined`).
+        // Conditional `infer` must capture the declared type (`C`), matching
+        // tsc's `inferFromProperties`/`getTypeOfSymbol`; routing optional
+        // properties through query_db corrupted `T['member']` and constrained
+        // `infer T extends ...` checks. The query_db path stays as the fallback
+        // for non-shape sources (lazy refs, instantiated/indexed forms).
+        match self.interner().lookup(source) {
+            Some(TypeData::Object(shape_id) | TypeData::ObjectWithIndex(shape_id)) => {
+                let shape = self.interner().object_shape(shape_id);
+                if let Some(found) = self.property_candidate(&shape.properties, prop_name, optional)
+                {
+                    return found;
+                }
+            }
+            Some(TypeData::Callable(callable_id)) => {
+                let shape = self.interner().callable_shape(callable_id);
+                if let Some(found) = self.property_candidate(&shape.properties, prop_name, optional)
+                {
+                    return found;
+                }
+            }
+            _ => {}
+        }
+
         if let Some(query_db) = self.query_db() {
             return match query_db.resolve_property_access_atom(source, prop_name) {
                 PropertyAccessResult::Success { type_id, .. } => {
@@ -478,18 +506,22 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         &self,
         properties: &[PropertyInfo],
         prop_name: Atom,
-        optional: bool,
+        _optional: bool,
     ) -> Option<InferPropertyResolution> {
+        // When the pattern property is PRESENT in the source, the inference
+        // candidate is the source property's declared type. The optionality of
+        // the pattern position (`{ prop?: infer T }`) governs only the *absent*
+        // case (handled by `NoCandidate`/`NoMatch`); it must not inject
+        // `undefined` into a present property's candidate. tsc's
+        // `inferFromProperties` reads the source symbol's declared type
+        // (`getTypeOfSymbol`), which does not carry the optionality `undefined`
+        // — so `W extends { prop?: infer T } ? T : never` over `{ prop?: C }`
+        // infers `T = C`, not `C | undefined`. Adding `undefined` here corrupted
+        // `T['member']` (TS2339) and constrained-infer constraint checks (TS2344).
         properties
             .iter()
             .find(|prop| prop.name == prop_name)
-            .map(|prop| {
-                InferPropertyResolution::Candidate(if optional {
-                    self.optional_property_type(prop)
-                } else {
-                    prop.type_id
-                })
-            })
+            .map(|prop| InferPropertyResolution::Candidate(prop.type_id))
     }
 
     /// Handle nested object infer pattern


### PR DESCRIPTION
Goal: green

Drive down tsz-only false-positive diagnostics on the **zustand** canary
project-corpus row. #13700 made the zustand fixture genuinely tsc-clean on the
compile-guard config (`node typescript/lib/tsc.js --noEmit -p
.target/project-compile-guard/zustand/tsconfig.tsz-guard.json` → 0 errors), so
every tsz diagnostic on this row is a true tsz-only FP. This PR fixes two
distinct root-cause families; the row drops 26 → 22, with net improvements on
sibling canary rows and zero canary/required/conformance regressions.

## Structural rule

**1. Module resolution (TS1192 react default ×2, TS2305 immer `produce` ×1).**
When a bare import specifier is a single segment that coincides with a
same-directory sibling source file's basename, tsc does X (resolves the bare
specifier through `paths`/`baseUrl`/`node_modules`/ambient `declare module`
declarations — never to a relative sibling), and tsz did NOT — the checker's
same-directory bare-alias file-index fallback in
`resolve_import_target_from_file` resolved `'react'` to the sibling `react.ts`
(and `'immer'` to `immer.ts`), shadowing the ambient `declare module 'react'` /
`'immer'` stubs. Witnessed minimally: a file `react.ts` importing `'react'`
errors, an identical file `notreact.ts` importing `'react'` is clean.
Fix through owner `tsz_checker::context::package_resolution`: when a bare
specifier names a project-wide ambient module (exact name or wildcard pattern,
via the pre-built `global_declared_modules` index), skip the file-index sibling
probe so the import binds against the ambient declaration. The real resolver has
already missed by the time this fallback runs, so the only remaining candidates
are the ambient module (correct) or an accidental sibling (wrong).

**2. Conditional `infer` from an optional pattern property (TS2344 + TS2339,
plus immer/ts-rest residuals).** When a conditional matches a source object
against a target pattern with an *optional* `infer` property
(`W extends { prop?: infer T } ? T : never` over `{ prop?: C }`), tsc does X
(infers `T = C` — `inferFromProperties` reads the source symbol's *declared*
type via `getTypeOfSymbol`, which does not carry the optionality `undefined`),
and tsz did NOT — it captured the property-ACCESS reading `C | undefined` (via
`resolve_property_access_atom`), so `T['member']` failed (TS2339) and constrained
`infer T extends (...args: any) => any` failed its constraint (TS2344). This is
exactly zustand's devtools `Config` type. Witnessed minimally:
`undefined extends (W extends { prop?: infer T } ? T : never)` was `true` in tsz
but `false` in tsc; the required-property form was already correct.
Fix through owner `tsz_solver` conditional `object_infer`: resolve plain
object/callable shapes through `property_candidate` (the declared `prop.type_id`)
before the `query_db` property-access fallback, and drop the optionality
`undefined` union for a *present* optional candidate. The optionality of the
pattern position governs only the *absent* case (`NoCandidate`/`NoMatch`); it
must never inject `undefined` into a present candidate. The `query_db` path
remains the fallback for non-shape sources (lazy refs, instantiated/indexed
forms).

No hardcoding: both fixes are structural (ambient-module-set membership;
declared-vs-access property type), with no user-name/file-name literals and no
diagnostic-string predicates.

## Adjacent cases

- Module res: file basename matching the specifier vs not; with/without a
  relative sibling co-import; ambient module declared vs absent. Required-set
  rows that legitimately resolve bare specifiers to real `node_modules`/`paths`
  targets are unaffected (the real resolver wins before this fallback).
- Conditional infer: required vs optional pattern property; present vs absent
  optional; plain `infer T` vs constrained `infer T extends C`; nested/multi
  infer slots (unchanged code paths).

## Before / after (compile-guard FP counts, tsc-clean fixtures)

| Row | before | after |
| --- | --- | --- |
| zustand (target) | 26 | 22 |
| immer | 13 | 6 |
| ts-rest | 21 | 18 |
| jotai | 38 | 38 |

Residual 22 zustand FPs are deep generic-instantiation issues concentrated in
`devtools.ts` (438 lines) and `persist.ts` (402 lines) — the curried
`SetStateInternal<T> = { _(...): ...; _(...): ... }['_']` overload machinery
(TS2488 `Parameters<>` spread, TS7006 contextual rest params, TS2352/TS2345
overload-shape mismatches, TS2454 try/catch CFA, TS18048 closure narrowing).
Each is a separate substantial solver investigation; left for follow-up.

No dep-noise found on this row: tsc on the guard config emits 0 errors, so the
former TS2305/TS1192 entries were genuine tsz-only FPs (now fixed), not
fixture/dep resolution noise.

## Verification

- zustand FP count: **26 → 22** (compile-guard, `TSZ_PROJECT_COMPILE_SET=canary
  TSZ_PROJECT_COMPILE_FILTER=zustand`).
- Full **canary** set (`ALLOW_FAILURES=1`): no row regressed; immer 13→6, ts-rest
  21→18 improved; all others unchanged. Pre-existing perf timeouts (kysely,
  valibot, effect, drizzle-orm, remeda, ts-morph, arktype, typebox, neverthrow,
  xstate) are unrelated to these correctness-only changes.
- Full **required** set (`ALLOW_FAILURES=1`): 9/9 compile successfully (comlink,
  nextjs-fresh-app, rxjs, ts-essentials, ts-toolbelt, type-challenges-solutions,
  type-fest, utility-types, vite-vanilla-ts-app).
- Conformance (`scripts/conformance/conformance.sh run --filter`): conditional
  51/51, infer 87/87, optional 64/64, mapped 60/60, keyofAndIndexed 3/3,
  moduleResolution 111/111, propertyAccess 26/26, contextualTyping 83/83,
  genericInference 4/4 — all 100%, 0 regressions.
- `python3 scripts/arch/arch_guard.py` — PASS.
- `cargo clippy --profile dist-fast -p tsz-checker --lib` and `-p tsz-solver
  --lib` — clean.

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high
