### PR TITLE
hold(bench): subtract per-row tsc oracle from project-compile-guard FPs

### DIFF
--- a/scripts/ci/lib/project-tsc-oracle.sh
+++ b/scripts/ci/lib/project-tsc-oracle.sh
@@ -1,0 +1,227 @@
+# shellcheck shell=bash
+# Per-row tsc oracle helpers for scripts/ci/project-compile-guard.sh.
+#
+# This file is sourced (never executed) by the compile guard and by
+# scripts/ci/test-project-tsc-oracle.mjs so the tsz-only delta logic and the
+# oracle-cache key have a single, unit-tested home.
+#
+# Why a per-row tsc oracle exists: the project-compile guard runs only tsz and,
+# historically, counted every tsz diagnostic as a tsz false positive. That is
+# only correct when the fixture is tsc-clean. Some corpus rows have *genuine*
+# tsc errors in their own source (e.g. neverthrow, superstruct), so at perfect
+# tsz<->tsc parity those rows still emitted diagnostics and could never pass.
+#
+# The oracle subtracts tsc's own diagnostics from tsz's: a row passes the gate
+# when tsz's diagnostics MATCH tsc's (an empty tsz-only delta). tsc-clean rows
+# have an empty tsc side, so the delta equals tsz's full output and the gate is
+# unchanged (a no-op) for the required rows. Rows where tsc also errors only
+# need tsz to agree on the tsc-flagged locations.
+#
+# Diagnostic identity is (basename, line, column, code): tsz and tsc both
+# receive the *same* guard tsconfig, so a diagnostic they agree on shares that
+# 4-tuple. We match on location+code rather than message text so wording
+# differences between the two compilers never manufacture or hide a delta, and
+# we basename-normalize the path so an absolute-vs-relative emit difference
+# between the compilers does not split an otherwise-identical diagnostic.
+#
+# Portability: every awk program here stays within POSIX awk (no gawk-only
+# 3-argument match()/gensym extensions) so the helpers behave identically under
+# the Linux gawk in CI and the BSD awk used for local verification on macOS.
+
+# The shared awk parser body. Defines a `parse(line)` function that sets the
+# globals _ok/_base/_line/_col/_code for a recognized diagnostic line, or
+# _ok=0 otherwise. Recognizes both formatter shapes tsc/tsz emit:
+#   path(line,col): error TSnnnn        (default, used when output is piped)
+#   path:line:col - error TSnnnn        (pretty formatter)
+# Kept in one string so the identity-key and delta programs cannot drift.
+_TSZ_ORACLE_AWK_PARSER='
+function basename(p,   n, parts) {
+  n = split(p, parts, "/")
+  return parts[n]
+}
+function parse(line,   loc, before, a, code) {
+  _ok = 0
+  # path(line,col): (error|warning) TSnnnn
+  if (match(line, /\([0-9]+,[0-9]+\): (error|warning) TS[0-9]+/)) {
+    loc = substr(line, RSTART, RLENGTH)
+    before = substr(line, 1, RSTART - 1)
+    split(loc, a, /[(,)]/)   # a[2]=line a[3]=col
+    if (!match(loc, /TS[0-9]+/)) return
+    code = substr(loc, RSTART, RLENGTH)
+    _base = basename(before); _line = a[2]; _col = a[3]; _code = code; _ok = 1
+    return
+  }
+  # path:line:col - (error|warning) TSnnnn  (pretty formatter)
+  if (match(line, /:[0-9]+:[0-9]+ - (error|warning) TS[0-9]+/)) {
+    loc = substr(line, RSTART, RLENGTH)
+    before = substr(line, 1, RSTART - 1)
+    split(loc, a, /[: ]/)    # a[2]=line a[3]=col
+    if (!match(loc, /TS[0-9]+/)) return
+    code = substr(loc, RSTART, RLENGTH)
+    _base = basename(before); _line = a[2]; _col = a[3]; _code = code; _ok = 1
+    return
+  }
+}
+'
+
+# Resolve a tsc binary for the oracle. Prefers the vendored TypeScript submodule
+# (always present, no install needed), then the scripts/ and top-level
+# node_modules tsc shims. TSZ_PROJECT_TSC_ORACLE_BIN overrides for tests; when
+# it names a tsc.js it is run via node, when it names an executable it is run
+# directly. Emits the command words (one per line) so callers run it as an
+# array; emits nothing when no oracle is available.
+tsz_project_oracle_tsc_command() {
+  if [[ -n "${TSZ_PROJECT_TSC_ORACLE_BIN+x}" ]]; then
+    local override="$TSZ_PROJECT_TSC_ORACLE_BIN"
+    if [[ "$override" == *.js && -f "$override" ]]; then
+      printf 'node\n%s\n' "$override"
+    elif [[ -x "$override" ]]; then
+      printf '%s\n' "$override"
+    fi
+    return 0
+  fi
+  if [[ -f "${ROOT_DIR:-.}/typescript/lib/tsc.js" ]]; then
+    printf 'node\n%s\n' "${ROOT_DIR:-.}/typescript/lib/tsc.js"
+    return 0
+  fi
+  if [[ -x scripts/node_modules/.bin/tsc ]]; then
+    printf '%s\n' "scripts/node_modules/.bin/tsc"
+    return 0
+  fi
+  if [[ -x node_modules/.bin/tsc ]]; then
+    printf '%s\n' "node_modules/.bin/tsc"
+    return 0
+  fi
+}
+
+# Emit the canonical identity key (basename<TAB>line<TAB>col<TAB>code) for every
+# parsable diagnostic line on stdin, one key per line. Unparsable lines
+# (banners, "Found N errors", blanks) are dropped.
+tsz_diagnostic_identity_keys() {
+  awk "$_TSZ_ORACLE_AWK_PARSER"'
+    {
+      sub(/\r$/, "")
+      parse($0)
+      if (_ok) print _base "\t" _line "\t" _col "\t" _code
+    }
+  '
+}
+
+# Count parsable diagnostic lines on stdin.
+tsz_count_diagnostic_lines() {
+  tsz_diagnostic_identity_keys | awk 'END { print NR + 0 }'
+}
+
+# Write the tsz-only diagnostic delta to stdout: every parsable tsz diagnostic
+# line whose identity key is absent from the tsc oracle output. Unparsable tsz
+# lines (e.g. a crash banner) are preserved so a tsz-side hard failure is never
+# silently dropped by the subtraction. Usage:
+#   tsz_only_delta_lines <tsz_log> <tsc_log>
+tsz_only_delta_lines() {
+  local tsz_log="$1"
+  local tsc_log="$2"
+  # Materialize the tsc identity keys to a temp file and feed both files to a
+  # single awk via the portable FNR==NR two-file idiom. Passing a multi-line
+  # value through `awk -v` is rejected by BSD awk ("newline in string"), so the
+  # key set must arrive as a file, never as a variable.
+  local tsc_keys_file
+  tsc_keys_file="$(mktemp)"
+  tsz_diagnostic_identity_keys < "$tsc_log" > "$tsc_keys_file" 2>/dev/null || true
+  awk -v keyfile="$tsc_keys_file" "$_TSZ_ORACLE_AWK_PARSER"'
+    # First file (tsc identity keys): one TAB-joined key per line. Compared by
+    # FILENAME (not FNR==NR) so an empty key file does not misclassify the first
+    # tsz line as a key.
+    FILENAME == keyfile { if ($0 != "") seen[$0] = 1; next }
+    # Second file (tsz log): emit only the tsz-only lines.
+    {
+      sub(/\r$/, "")
+      if ($0 ~ /^[[:space:]]*$/) next
+      parse($0)
+      # Unparsable line: keep it (a banner or crash note must not be subtracted).
+      if (!_ok) { print; next }
+      key = _base "\t" _line "\t" _col "\t" _code
+      # Parsable line: keep it only when tsc did not flag the same identity.
+      if (!(key in seen)) print
+    }
+  ' "$tsc_keys_file" "$tsz_log" 2>/dev/null || true
+  rm -f "$tsc_keys_file"
+}
+
+# Emit a `source: line` prefixed body for every parsable diagnostic line in a
+# log, capped, so the recorder's per-source partition (project-compatibility.mjs)
+# attributes each line correctly. Unparsable lines (banners) are skipped.
+#   tsz_label_diagnostic_lines <source-label> <log> [max]
+tsz_label_diagnostic_lines() {
+  local label="$1" log="$2" max="${3:-20}"
+  awk "$_TSZ_ORACLE_AWK_PARSER"'
+    BEGIN { seen = 0 }
+    {
+      sub(/\r$/, "")
+      if ($0 ~ /^[[:space:]]*$/) next
+      parse($0)
+      if (!_ok) next
+      print label ": " $0
+      seen += 1
+      if (seen >= max) exit
+    }
+  ' label="$label" max="$max" "$log" 2>/dev/null || true
+}
+
+# Pass-case delta: the agreed-on diagnostics, labelled per source. Shows the tsc
+# errors first (the genuine fixture errors tsz reproduced) then the tsz lines, so
+# the green-row artifact records exactly what both compilers reported.
+tsc_and_tsz_oracle_delta() {
+  local tsz_log="$1" tsc_log="$2"
+  tsz_label_diagnostic_lines "tsc" "$tsc_log" 10
+  tsz_label_diagnostic_lines "tsz" "$tsz_log" 10
+}
+
+# Fail-case delta: the actionable tsz-only diagnostics (labelled `tsz:`) plus a
+# few tsc context lines (labelled `tsc:`) so triage sees both the divergence and
+# the tsc baseline it was measured against.
+tsz_only_and_tsc_context_delta() {
+  local tsz_log="$1" tsc_log="$2"
+  tsz_only_delta_lines "$tsz_log" "$tsc_log" | awk '
+    BEGIN { seen = 0 }
+    {
+      if ($0 ~ /^[[:space:]]*$/) next
+      print "tsz: " $0
+      seen += 1
+      if (seen >= 14) exit
+    }
+  '
+  tsz_label_diagnostic_lines "tsc" "$tsc_log" 6
+}
+
+# Oracle-cache fingerprint for a project row. Independent of the tsz binary
+# (tsc's result depends only on tsconfig content + compiled-source identity), so
+# the oracle cache survives tsz rebuilds. Reuses the source-identity helpers
+# from project-compile-fingerprint.sh (must be sourced first). Returns empty on
+# failure so callers treat the oracle cache as unavailable rather than stale.
+#   <name>|tsc|<tsc command hash>|<tsconfig hash>|<source identity>
+tsz_tsc_oracle_fingerprint() {
+  local name="$1" tsconfig="$2" src_dir="${3:-}" tsc_cmd_hash="${4:-}"
+
+  local tsconfig_hash=""
+  [[ -f "$tsconfig" ]] && tsconfig_hash="$(sha256_of_file "$tsconfig")"
+  [[ -f "$tsconfig" && -z "$tsconfig_hash" ]] && return
+
+  local fixture_dir fixture_phys
+  fixture_dir="$(dirname "$tsconfig")"
+  [[ -n "$src_dir" ]] || src_dir="$fixture_dir"
+  fixture_phys="$(tsz_fingerprint_resolve_physical "$fixture_dir" 2>/dev/null || true)"
+
+  local source_id="" toplevel=""
+  toplevel="$(git -C "$fixture_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "$toplevel" && -n "$fixture_phys" && "$toplevel" == "$fixture_phys" ]]; then
+    local git_ref="" dirty_marker="" source_tree_marker=""
+    git_ref="$(git -C "$fixture_dir" rev-parse HEAD 2>/dev/null || true)"
+    dirty_marker="$(git -C "$fixture_dir" diff HEAD 2>/dev/null | sha256_of_stdin)"
+    source_tree_marker="$(hash_source_tree "$src_dir")"
+    source_id="git:${git_ref}:${dirty_marker}:tree:${source_tree_marker}"
+  else
+    source_id="tree:$(hash_source_tree "$src_dir")"
+  fi
+
+  printf '%s' "${name}|tsc|${tsc_cmd_hash}|${tsconfig_hash}|${source_id}"
+}

--- a/scripts/ci/project-compile-guard.sh
+++ b/scripts/ci/project-compile-guard.sh
@@ -90,6 +90,36 @@ fi
 # shellcheck source=scripts/ci/lib/project-compile-fingerprint.sh
 source "$ROOT_DIR/scripts/ci/lib/project-compile-fingerprint.sh"
 
+# Per-row tsc oracle helpers (tsz_only_delta_lines, tsz_count_diagnostic_lines,
+# tsz_project_oracle_tsc_command, tsz_tsc_oracle_fingerprint). The gate counts a
+# tsz diagnostic as a false positive only when tsc does not flag the same
+# (basename, line, column, code). Sourced so the delta logic has one tested home.
+# shellcheck source=scripts/ci/lib/project-tsc-oracle.sh
+source "$ROOT_DIR/scripts/ci/lib/project-tsc-oracle.sh"
+
+# Whether to run the per-row tsc oracle to subtract genuine tsc errors from
+# tsz's diagnostics before deciding a row's pass/fail. On by default; disable
+# with TSZ_PROJECT_COMPILE_TSC_ORACLE=0 (e.g. when no tsc is available and every
+# fixture is known tsc-clean). The oracle only runs for rows where tsz exits
+# with diagnostics (a "nonzero exit"); crashes, timeouts, and OOMs are failures
+# regardless of what tsc does.
+TSC_ORACLE_ENABLED="${TSZ_PROJECT_COMPILE_TSC_ORACLE:-1}"
+TSC_ORACLE_RESULT_CACHE_DIR="${TSZ_PROJECT_COMPILE_TSC_ORACLE_CACHE_DIR:-$FIXTURE_ROOT/.tsc-oracle-cache}"
+# Resolved once: the tsc oracle command words and a content hash of the command
+# for the oracle-cache key. Empty TSC_ORACLE_CMD means no oracle is available,
+# in which case the gate falls back to counting every tsz diagnostic (the
+# pre-oracle behavior) so a missing tsc never silently passes a real FP.
+TSC_ORACLE_CMD=()
+TSC_ORACLE_CMD_HASH=""
+if [[ "$TSC_ORACLE_ENABLED" == "1" ]]; then
+  while IFS= read -r _oracle_word; do
+    [[ -n "$_oracle_word" ]] && TSC_ORACLE_CMD+=("$_oracle_word")
+  done < <(tsz_project_oracle_tsc_command)
+  if [[ "${#TSC_ORACLE_CMD[@]}" -gt 0 ]]; then
+    TSC_ORACLE_CMD_HASH="$(printf '%s\n' "${TSC_ORACLE_CMD[@]}" | sha256_of_stdin)"
+  fi
+fi
+
 mkdir -p "$FIXTURE_ROOT"
 
 # Snapshot the tsz binary to an immutable content-addressed copy and run that
@@ -110,6 +140,7 @@ else
   _TSZ_BINARY_HASH="$(sha256_of_file "$TSZ_BIN")"
 fi
 mkdir -p "$RESULT_CACHE_DIR"
+[[ -n "$TSC_ORACLE_CMD_HASH" ]] && mkdir -p "$TSC_ORACLE_RESULT_CACHE_DIR"
 validate_project_compatibility_artifact_paths
 rm -f "$FIXTURE_ROOT/type-challenges-readiness-pairing.json"
 rm -rf "$FIXTURE_ROOT/type-challenges-assertions"
@@ -524,6 +555,53 @@ write_compile_cache() {
     && mv "${_cf}.tmp" "$_cf" 2>/dev/null || true
 }
 
+# Run (or cache-hit) the per-row tsc oracle. tsc's stdout/stderr is captured to
+# the per-row $oracle_log; on return LAST_TSC_ORACLE_RC holds tsc's exit code.
+# The oracle is cached on (tsc command, tsconfig content, compiled-source
+# identity) — independent of the tsz binary — so the per-row tsc run is skipped
+# whenever the fixture and tsc are unchanged, keeping CI cost flat across tsz
+# rebuilds. Returns 0 when an oracle log was produced (fresh or cached), 1 when
+# no oracle is available so callers can fall back to counting all tsz lines.
+LAST_TSC_ORACLE_RC=""
+run_project_tsc_oracle() {
+  local name="$1" tsconfig="$2" src_dir="$3" oracle_log="$4"
+  LAST_TSC_ORACLE_RC=""
+  [[ "${#TSC_ORACLE_CMD[@]}" -gt 0 ]] || return 1
+
+  local _ofp="" _ocache=""
+  if [[ "${TSZ_PROJECT_COMPILE_TSC_ORACLE_CACHE:-1}" == "1" && -n "$TSC_ORACLE_CMD_HASH" ]]; then
+    _ofp="$(tsz_tsc_oracle_fingerprint "$name" "$tsconfig" "$src_dir" "$TSC_ORACLE_CMD_HASH" 2>/dev/null || true)"
+    [[ -n "$_ofp" ]] && _ocache="$TSC_ORACLE_RESULT_CACHE_DIR/${name}"
+  fi
+
+  if [[ -n "$_ocache" && -f "$_ocache" && -f "${_ocache}.log" ]]; then
+    local _cached_ofp=""
+    IFS= read -r _cached_ofp < "$_ocache" 2>/dev/null || true
+    _cached_ofp="${_cached_ofp#FINGERPRINT=}"
+    if [[ "$_cached_ofp" == "$_ofp" ]]; then
+      local _cached_orc=""
+      _cached_orc="$(awk -F= '/^RC=/{print $2; exit}' "$_ocache" 2>/dev/null || true)"
+      cp "${_ocache}.log" "$oracle_log" 2>/dev/null || true
+      LAST_TSC_ORACLE_RC="${_cached_orc:-0}"
+      echo "(tsc oracle cache hit: ${_ofp:0:12})"
+      return 0
+    fi
+  fi
+
+  local orc=0
+  echo "Running tsc oracle: ${TSC_ORACLE_CMD[*]} --noEmit -p $tsconfig"
+  run_with_timeout "$PROJECT_TIMEOUT" \
+    "${TSC_ORACLE_CMD[@]}" --noEmit -p "$tsconfig" >"$oracle_log" 2>&1 || orc=$?
+  LAST_TSC_ORACLE_RC="$orc"
+
+  if [[ -n "$_ocache" ]]; then
+    { printf 'FINGERPRINT=%s\nRC=%s\n' "$_ofp" "$orc"; } > "${_ocache}.tmp" 2>/dev/null \
+      && mv "${_ocache}.tmp" "$_ocache" 2>/dev/null || true
+    cp "$oracle_log" "${_ocache}.log" 2>/dev/null || true
+  fi
+  return 0
+}
+
 check_project() {
   local name="$1"
   local tsconfig="$2"
@@ -601,7 +679,6 @@ check_project() {
       "$TSZ_RUN_BIN" --noEmit -p "$tsconfig" >"$log" 2>&1 || rc=$?
 
   if [[ "$rc" -ne 0 ]]; then
-    FAILURES=$((FAILURES + 1))
     exit_class="$(project_failure_class "$([[ "$rc" -eq 124 ]] && echo "timeout" || echo "nonzero exit")" "$rc")"
     diagnostic_delta="$(diagnostic_lines_from_file "tsz" "$log")"
     local timeout_note=""
@@ -613,27 +690,73 @@ check_project() {
         timeout_unmeasured=1
       fi
     fi
-    record_project_compatibility \
-      "$name" \
-      "$exit_class" \
-      "check" \
-      "$(project_failure_status "$exit_class")" \
-      "$diagnostic_delta" \
-      "$file_count" \
-      "$LAST_PEAK_RSS_BYTES" \
-      "$rc" \
-      "$tsconfig" \
-      "$src_dir" \
-      "$tsc_exit_codes"
-    if [[ "$rc" -eq 124 ]]; then
-      echo "error: ${name} ${timeout_note}" >&2
-    else
-      echo "error: ${name} failed with exit code ${rc}" >&2
+
+    # tsc oracle: only a plain "nonzero exit" (tsz produced diagnostics, no
+    # crash/timeout/OOM) is a candidate for tsz<->tsc parity. Subtract tsc's own
+    # diagnostics; the row passes when the tsz-only delta is empty. Crashes,
+    # timeouts, and OOMs are failures regardless of what tsc reports.
+    #
+    # A caller that already passed static tsc exit codes (the type-challenges
+    # row, whose dedicated oracle runs and gates before check_project) is left
+    # untouched so that row keeps its bespoke oracle and we do not run tsc twice.
+    local oracle_consulted=0 tsz_only_count="" oracle_log=""
+    if [[ "$exit_class" == "nonzero exit" && -z "$tsc_exit_codes" && "${#TSC_ORACLE_CMD[@]}" -gt 0 ]]; then
+      oracle_log="$FIXTURE_ROOT/${name}.tsc.log"
+      if run_project_tsc_oracle "$name" "$tsconfig" "$src_dir" "$oracle_log"; then
+        oracle_consulted=1
+        tsc_exit_codes="$LAST_TSC_ORACLE_RC"
+        tsz_only_count="$(tsz_only_delta_lines "$log" "$oracle_log" | tsz_count_diagnostic_lines)"
+      fi
     fi
-    sed -n '1,160p' "$log" >&2 || true
-    echo "::endgroup::"
-    if [[ "$ALLOW_FAILURES" == "1" ]]; then
-      echo "::warning::${name} did not compile; continuing because TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1"
+
+    if [[ "$oracle_consulted" == "1" && "${tsz_only_count:-1}" -eq 0 ]]; then
+      # tsz matched tsc exactly: no tsz-only diagnostics. Record a green/pass
+      # row carrying both sides so the artifact shows the agreed-on tsc errors,
+      # and do NOT count a gate failure. rc is normalized to 0 so the cached
+      # decision replays as a pass and the row state derives to green.
+      rc=0
+      exit_class="exit success"
+      diagnostic_delta="$(tsc_and_tsz_oracle_delta "$log" "$oracle_log")"
+      record_project_compatibility "$name" "exit success" "check" "none" \
+        "$diagnostic_delta" "$file_count" "$LAST_PEAK_RSS_BYTES" "0" \
+        "$tsconfig" "$src_dir" "$tsc_exit_codes"
+      if [[ -n "$LAST_TSC_ORACLE_RC" && "$LAST_TSC_ORACLE_RC" != "0" ]]; then
+        echo "${name} matches tsc (tsc also reports errors; 0 tsz-only diagnostics)."
+      else
+        echo "${name} compiled successfully (tsc oracle clean)."
+      fi
+      echo "::endgroup::"
+    else
+      FAILURES=$((FAILURES + 1))
+      if [[ "$oracle_consulted" == "1" ]]; then
+        # Report only the tsz-only diagnostics as the actionable delta, with the
+        # tsc context preserved for triage.
+        diagnostic_delta="$(tsz_only_and_tsc_context_delta "$log" "$oracle_log")"
+      fi
+      record_project_compatibility \
+        "$name" \
+        "$exit_class" \
+        "check" \
+        "$(project_failure_status "$exit_class")" \
+        "$diagnostic_delta" \
+        "$file_count" \
+        "$LAST_PEAK_RSS_BYTES" \
+        "$rc" \
+        "$tsconfig" \
+        "$src_dir" \
+        "$tsc_exit_codes"
+      if [[ "$rc" -eq 124 ]]; then
+        echo "error: ${name} ${timeout_note}" >&2
+      elif [[ "$oracle_consulted" == "1" ]]; then
+        echo "error: ${name} has ${tsz_only_count} tsz-only diagnostic(s) tsc does not report" >&2
+      else
+        echo "error: ${name} failed with exit code ${rc}" >&2
+      fi
+      sed -n '1,160p' "$log" >&2 || true
+      echo "::endgroup::"
+      if [[ "$ALLOW_FAILURES" == "1" ]]; then
+        echo "::warning::${name} did not compile; continuing because TSZ_PROJECT_COMPILE_ALLOW_FAILURES=1"
+      fi
     fi
   else
     record_project_compatibility "$name" "exit success" "check" "none" "" \

--- a/scripts/ci/test-project-tsc-oracle.mjs
+++ b/scripts/ci/test-project-tsc-oracle.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// Unit tests for the per-row tsc oracle helpers in
+// scripts/ci/lib/project-tsc-oracle.sh.
+//
+// The gate's core contract: tsz_only_delta_lines subtracts tsc's own
+// diagnostics from tsz's by (basename, line, column, code) identity, so a row
+// passes when tsz MATCHES tsc (empty delta), and a tsc-clean row keeps every
+// tsz diagnostic (the gate is unchanged for the required rows).
+//
+// We drive the real, sourced library from bash so the contract is tested, not
+// a mirror of it. The awk programs must stay POSIX-portable (BSD awk on macOS,
+// gawk in CI); the multi-line key path in particular regresses under `awk -v`
+// ("newline in string"), which is why the delta uses a two-file FILENAME idiom.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
+const LIB = path.join(ROOT, "scripts", "ci", "lib", "project-tsc-oracle.sh");
+
+assert.ok(fs.existsSync(LIB), `tsc oracle library missing: ${LIB}`);
+
+// Run a delta+count for one (tsz, tsc) log pair. Returns the tsz-only count and
+// the raw delta body. tsz/tsc are arrays of diagnostic-log lines.
+function runDelta(tszLines, tscLines) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-oracle-"));
+  try {
+    const tszLog = path.join(dir, "tsz.log");
+    const tscLog = path.join(dir, "tsc.log");
+    fs.writeFileSync(tszLog, tszLines.join("\n") + (tszLines.length ? "\n" : ""));
+    fs.writeFileSync(tscLog, tscLines.join("\n") + (tscLines.length ? "\n" : ""));
+    const harness = `
+      set -Eeuo pipefail
+      source "${LIB}"
+      tsz_only_delta_lines "${tszLog}" "${tscLog}" > "${dir}/delta.out"
+      tsz_only_delta_lines "${tszLog}" "${tscLog}" | tsz_count_diagnostic_lines
+    `;
+    const result = spawnSync("bash", ["-c", harness], { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    const count = Number(String(result.stdout).trim());
+    const delta = fs.readFileSync(path.join(dir, "delta.out"), "utf8");
+    return { count, delta };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const D = (p, l, c, code) => `${p}(${l},${c}): error ${code}: message text`;
+const Dpretty = (p, l, c, code) => `${p}:${l}:${c} - error ${code}: message text`;
+
+// 1. tsz reproduces tsc's errors AND adds one of its own -> tsz-only is the one.
+{
+  const { count } = runDelta(
+    [D("src/r.ts", 27, 5, "TS2365"), D("src/a.ts", 50, 9, "TS2322"), D("src/x.ts", 3, 1, "TS2339"), "Found 3 errors."],
+    [D("src/r.ts", 27, 5, "TS2365"), D("src/a.ts", 50, 9, "TS2322"), "Found 2 errors."],
+  );
+  assert.equal(count, 1, "tsz-superset: only the extra tsz diagnostic remains");
+}
+
+// 2. tsz matches tsc exactly -> empty tsz-only delta (the row passes the gate).
+{
+  const { count } = runDelta(
+    [D("src/r.ts", 27, 5, "TS2365"), "Found 1 error."],
+    [D("src/r.ts", 27, 5, "TS2365"), "Found 1 error."],
+  );
+  assert.equal(count, 0, "exact match: tsz-only delta is empty");
+}
+
+// 3. tsc-clean fixture -> the gate is a no-op: every tsz diagnostic survives.
+{
+  const tsz = [D("src/a.ts", 1, 1, "TS2322"), D("src/b.ts", 2, 2, "TS2345")];
+  const { count, delta } = runDelta(tsz, []);
+  assert.equal(count, 2, "tsc-clean row keeps all tsz diagnostics");
+  for (const line of tsz) {
+    assert.ok(delta.includes(line), `tsc-clean delta must preserve: ${line}`);
+  }
+}
+
+// 4. tsz is a subset of tsc (tsc reports more) -> tsz-only is empty.
+{
+  const { count } = runDelta(
+    [D("src/r.ts", 1, 1, "TS2365")],
+    [D("src/r.ts", 1, 1, "TS2365"), D("src/o.ts", 9, 9, "TS2322"), "Found 2 errors."],
+  );
+  assert.equal(count, 0, "tsz-subset: no tsz-only diagnostics");
+}
+
+// 5. Same location, DIFFERENT code -> a genuine divergence is NOT subtracted.
+{
+  const { count } = runDelta(
+    [D("src/r.ts", 1, 1, "TS2345")],
+    [D("src/r.ts", 1, 1, "TS2365")],
+  );
+  assert.equal(count, 1, "same-location/different-code is a real tsz-only divergence");
+}
+
+// 6. Formatter independence: tsc pretty form, tsz paren form, same identity.
+{
+  const { count } = runDelta(
+    [D("src/r.ts", 1, 1, "TS2365")],
+    [Dpretty("src/r.ts", 1, 1, "TS2365")],
+  );
+  assert.equal(count, 0, "diagnostic identity is formatter-independent");
+}
+
+// 7. Path normalization: absolute vs relative path with the same basename.
+{
+  const { count } = runDelta(
+    [D("/abs/proj/src/r.ts", 1, 1, "TS2365")],
+    [D("src/r.ts", 1, 1, "TS2365")],
+  );
+  assert.equal(count, 0, "absolute vs relative path with same basename matches");
+}
+
+// 8. Portability regression: many tsc keys must not break the subtraction. A
+//    multi-line key set passed via `awk -v` fails under BSD awk; the FILENAME
+//    two-file idiom must keep all keys. Build 50 matched + 1 extra tsz line.
+{
+  const tsc = [];
+  const tsz = [];
+  for (let i = 1; i <= 50; i += 1) {
+    const line = D(`src/f${i}.ts`, i, 1, "TS2322");
+    tsc.push(line);
+    tsz.push(line);
+  }
+  tsz.push(D("src/only.ts", 999, 1, "TS2345"));
+  const { count } = runDelta(tsz, tsc);
+  assert.equal(count, 1, "large tsc key set: only the one genuinely-extra tsz line remains");
+}
+
+// 9. Identity-key extraction parses both formatter shapes, drops banners.
+{
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-oracle-keys-"));
+  try {
+    const log = path.join(dir, "log");
+    fs.writeFileSync(log, [
+      D("src/a.ts", 1, 2, "TS2322"),
+      Dpretty("src/b.ts", 3, 4, "TS2345"),
+      "Found 2 errors.",
+      "",
+    ].join("\n"));
+    const harness = `set -Eeuo pipefail; source "${LIB}"; tsz_diagnostic_identity_keys < "${log}"`;
+    const result = spawnSync("bash", ["-c", harness], { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    const keys = String(result.stdout).trim().split("\n").sort();
+    assert.deepEqual(keys, ["a.ts\t1\t2\tTS2322", "b.ts\t3\t4\tTS2345"].sort());
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log("test-project-tsc-oracle: all tests passed");


### PR DESCRIPTION
## Summary

The canary `project-compile-guard.sh` ran only tsz and counted every tsz
diagnostic as a false positive, assuming each fixture is tsc-clean. Some corpus
rows have **genuine tsc errors in their own source** — neverthrow (2 `TS2322`),
superstruct (9 = 7×`TS7053` + 2×`TS2365`) — so even at perfect tsz↔tsc parity
those rows still emitted diagnostics and could never pass the gate.

This adds a **per-row tsc oracle**: run the vendored `typescript/lib/tsc.js` on
the same guard tsconfig and subtract tsc's own diagnostics from tsz's. A row now
passes when tsz's diagnostics **match** tsc's (an empty tsz-only delta). It also
obviates fixture-stubbing workarounds for dependency-noise tsc errors.

Goal: green

## Structural rule

When tsz exits with diagnostics (a plain `nonzero exit`, not a crash/timeout/OOM)
on a project-compile-guard row, tsc may legitimately report some of the same
errors; tsc does X (flags the genuine fixture errors) and tsz should match it.
The gate now owns this in `scripts/ci`: it runs a tsc oracle, computes the
**tsz-only delta** = tsz diagnostics whose `(basename, line, column, code)`
identity is absent from tsc's output, and fails the row only on a non-empty
tsz-only delta. Crashes/timeouts/OOMs remain failures regardless of tsc.

- Identity is **location + code**, not message text, so wording differences
  between the compilers never manufacture or hide a delta. Path is
  **basename-normalized** so an absolute-vs-relative emit difference does not
  split an otherwise-shared diagnostic.
- tsc-clean rows have an empty tsc side, so the delta equals tsz's full output —
  the gate is a **no-op for the required rows** (they stay tsc-clean and pass).
- Owner layer: `scripts/ci` + `scripts/bench` harness. No tsz compiler change.
- New sourced lib `scripts/ci/lib/project-tsc-oracle.sh` (one tested home for the
  delta logic + oracle-cache key), unit-tested by
  `scripts/ci/test-project-tsc-oracle.mjs`.

### Adjacent cases handled
- tsz superset of tsc → tsz-only = the extra lines (fail).
- tsz exact match / subset of tsc → empty delta (pass).
- same location, different code → genuine divergence kept (fail).
- formatter independence (paren vs pretty), absolute vs relative path → matched.
- tsc unavailable → fall back to counting all tsz lines (a missing tsc never
  silently passes a real FP).
- type-challenges row keeps its bespoke pre-check oracle (skipped here via its
  static tsc-exit-codes caller arg) so tsc is never run twice for it.

### Performance / cost
Per-row tsc is cached on `(tsc command, tsconfig content, compiled-source
identity)` — **independent of the tsz binary** — so the oracle is skipped across
tsz rebuilds whenever the fixture and tsc are unchanged. The oracle only runs
for rows where tsz already produced diagnostics. awk stays POSIX-portable (BSD
awk on macOS, gawk in CI); the tsc key set is passed as a **file** via the
FILENAME two-file idiom because a multi-line `awk -v` value is rejected by BSD
awk (`newline in string`).

## Verification

- `node scripts/ci/test-project-tsc-oracle.mjs` — 9 cases (subtraction matrix,
  formatter/path normalization, large-key-set portability) pass.
- `node scripts/ci/test-project-compatibility.mjs`,
  `scripts/ci/test-project-compile-guard-readiness-artifacts.mjs`,
  `scripts/ci/test-project-compile-guard-fingerprint.mjs`,
  `scripts/ci/test-diagnostic-aggregator.mjs` — pass.
- `node scripts/bench/test-project-rows.mjs`,
  `scripts/bench/test-validate-project-metadata.mjs` — pass.
- `python3 scripts/arch/arch_guard.py` — pass.
  `python3 scripts/arch/test_arch_guard_project{,s}.py` — 63 tests OK.
- Full **required** set (8 rows) — all `compiled successfully`, 0 failures
  (oracle is a no-op for tsc-clean rows that pass in tsz).
- **Canary** survey: oracle correctly subtracts genuine tsc errors per row, e.g.
  msw `TS2307`, trpc `TS2591/TS2307`, tanstack-router `TS2664/TS2591` — these
  tsc-side errors are now excluded from the tsz-only delta. No harness-induced
  crash on any surveyed row.
- E2E (fake tsz + fake tsc): tsz matching tsc exactly → gate **passes** (exit 0);
  a tsz-only diagnostic tsc lacks → gate **fails** (exit 1).

### Oracle results on the motivating rows
The harness now subtracts the genuine tsc errors. Both rows still have *real*
tsz FPs beyond those, so they do not reach 0 tsz-only yet (separate tsz code
bugs, not harness bugs):
- **neverthrow**: tsc reports 2 (`result-async.ts(50,5)`, `result.ts(27,5)`) →
  subtracted; **11 tsz-only** remain (constructor-inference family).
- **superstruct**: tsc reports 9 (7×`TS7053` + 2×`TS2365`) → subtracted;
  **25 tsz-only** remain (28 tsz total − the tsc-shared identities).

## Provenance

Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
