### PR TITLE
fix(checker): don't cache heritage-thin lib interface body on recursion-guard bail (#13652)

### DIFF
--- a/crates/tsz-checker/src/types/queries/lib_resolution_heritage.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution_heritage.rs
@@ -75,13 +75,18 @@ impl<'a> CheckerState<'a> {
         // (e.g., Array → ReadonlyArray → Iterable → ...), especially when child
         // CheckerStates are created for cross-arena type param resolution.
         //
-        // The same heritage-thin reasoning applies: the re-entrant call returns
-        // before merging heritage, so mark it incomplete so the thin body is not
-        // cached. The outer (non-re-entrant) resolution of this same name completes
-        // the merge and produces the cacheable body.
+        // Unlike the depth guard above, this bail must report `incomplete = false`:
+        // re-entry for the SAME name means an OUTER resolution of that exact name is
+        // already on the stack and WILL complete the heritage merge and cache the
+        // full body. The name guard is precisely the designed terminal that lets the
+        // outer call finish; its inner partial is meant to be discarded by the outer,
+        // not promoted to a global `Incomplete` mark — doing so removes the outer's
+        // in-progress cache entry and drops inherited members for self-referential
+        // lib interfaces (e.g. the DOM heritage graph; regresses the
+        // declarationFileForHtml* conformance rows).
         if !self.ctx.lib_heritage_in_progress.insert(name.to_string()) {
             self.ctx.leave_recursion();
-            return (derived_type, true);
+            return (derived_type, false);
         }
 
         let lib_contexts = self.ctx.lib_contexts.clone();

--- a/crates/tsz-checker/src/types/queries/lib_resolution_heritage.rs
+++ b/crates/tsz-checker/src/types/queries/lib_resolution_heritage.rs
@@ -52,9 +52,21 @@ impl<'a> CheckerState<'a> {
         name: &str,
     ) -> (TypeId, bool) {
         // Guard against infinite recursion in recursive generic hierarchies
-        // (e.g., interface B<T extends B<T,S>> extends A<B<T,S>, B<T,S>>)
+        // (e.g., interface B<T extends B<T,S>> extends A<B<T,S>, B<T,S>>).
+        //
+        // A bail here returns `derived_type` with its heritage loop NOT yet run,
+        // i.e. an own-members-only, heritage-THIN body. Report it as incomplete so
+        // the caller refuses to cache it (the #12299 taint contract): otherwise a
+        // body produced when the shared `CheckerRecursion` depth budget was already
+        // exhausted by unrelated deep recursion (e.g. jotai's mutually-recursive
+        // `Atom` graph) would be cached with inherited members un-substituted — a
+        // base interface's raw type parameter (`Iterator<T>.next(): IteratorResult<T>`)
+        // then leaks through a concrete `Map`/`Set` iteration into the checker as a
+        // bare `T` (false TS2488/TS2345, issue #13652). Recomputing once the budget
+        // has headroom yields the fully-merged body. O(1) at the bail site; no
+        // identifier/file-name predicate.
         if !self.ctx.enter_recursion() {
-            return (derived_type, false);
+            return (derived_type, true);
         }
 
         // Name-based cycle guard: prevent re-entrant heritage merging for the same
@@ -62,9 +74,14 @@ impl<'a> CheckerState<'a> {
         // mutual recursion that occurs through deep heritage chains
         // (e.g., Array → ReadonlyArray → Iterable → ...), especially when child
         // CheckerStates are created for cross-arena type param resolution.
+        //
+        // The same heritage-thin reasoning applies: the re-entrant call returns
+        // before merging heritage, so mark it incomplete so the thin body is not
+        // cached. The outer (non-re-entrant) resolution of this same name completes
+        // the merge and produces the cacheable body.
         if !self.ctx.lib_heritage_in_progress.insert(name.to_string()) {
             self.ctx.leave_recursion();
-            return (derived_type, false);
+            return (derived_type, true);
         }
 
         let lib_contexts = self.ctx.lib_contexts.clone();


### PR DESCRIPTION
Goal: green

Fixes #13652 — jotai's 6 false TS2488/TS2345 (`T` not iterable / `T` not assignable to `Atom`) at concrete `Map`/`Set` iteration sites.

## Structural rule
When a lib-interface heritage merge (`merge_lib_interface_heritage`) is pre-empted by the **shared `CheckerRecursion` depth guard** (a hard budget exhaustion with no outer call completing the type), the body it returns is **heritage-thin** (the `extends` loop has not run, so inherited members are absent or carry the base interface's un-substituted type parameter). `tsc` resolves the full heritage closure before using such a type; tsz must therefore **not cache** a heritage-thin body — it must report `incomplete = true` so the caller (`resolve_lib_type_by_name`) drops it and recomputes once the recursion budget has headroom.

## Wrong semantic operation
Symbol/type resolution caching — owner layer: **checker lib-interface heritage resolution** (`crates/tsz-checker/src/types/queries/lib_resolution_heritage.rs`), gated by the existing `incomplete` taint contract in `lib_resolution.rs:1248-1260`.

## Root cause
`merge_lib_interface_heritage`'s global `CheckerRecursion` depth-guard bail (`enter_recursion()`, shared limit **50**, `recursion.rs:159`) returned `(derived_type /* own-members only */, incomplete=false)`. Since `incomplete == false` means "fully resolved", the caller **cached** the heritage-thin body. jotai's deeply mutually-recursive `Atom` graph (`Atom → Read → Getter → Atom`) consumes the shared depth budget, so when `Map`/`MapIterator` heritage is merged mid-recursion the depth guard trips and a `MapIterator` body whose inherited `Iterator.next(): IteratorResult` is un-substituted gets cached. Every later concrete `Map`/`Set` `for…of` reads the poisoned body → `extract_iterator_result_value_types` returns the bare lib `T` → false TS2488/TS2345.

This matches the report exactly: the **shared budget consumed by earlier work** and the **non-monotonic head-truncation toggling** (`head -1000→0`, `-1030→4`, `-1050→0`, `-1100→6`) — impossible for a genuine per-site type error, characteristic of a schedule-dependent cache.

## Fix
Taint the **depth-guard** bail with `incomplete = true`. Bounded O(1) at the bail site; reuses the existing #12299 incomplete-taint mechanism (no new caching machinery); operates on the structural guard condition with **no identifier/file-name predicate**.

The sibling **name-based re-entrancy cycle guard** (`lib_heritage_in_progress`) is intentionally left `incomplete = false`: it is the designed terminal for same-name mutual recursion where an OUTER resolution of that exact name is already on the stack and completes/caches the full body. Tainting it would promote the inner partial to a global `Incomplete` mark, removing the outer's in-progress cache entry and dropping inherited members for self-referential lib interfaces (the DOM heritage graph). The two guards are different in kind; only the depth guard can cache a thin body as complete.

## Adjacent matrix / breadth
The fix is not jotai- or iterator-specific. It corrects **all** inherited-member resolution on lib generic interfaces when a heritage merge is pre-empted by depth-budget exhaustion under deep recursion:
- `[Symbol.iterator]()` / `keys()` / `values()` / `entries()` / `next()` on `Map`/`Set`/`ReadonlyMap`/`ReadonlySet`/`Array` over recursive element graphs;
- any `Derived<T> extends Base<T>` lib shape where `Base`'s member references `T`;
- the existing #12299 DOM diamond (`Element extends Node`, `Document` resolved before/after `HTMLElement`) — preserved (the name-guard revert keeps the `declarationFileForHtml*` rows green).
- Genuinely-generic iteration of a free `T` still reports TS2488/TS2345 (true positive); the change only stops a *concrete* receiver from reading a poisoned cache.

## Verification
No <40-line synthetic repro exists (issue-confirmed — the leak needs the full mutually-recursive graph), so the jotai project-compile rows are the CI-owned acceptance test.

CI (all green at head `4bb56e6`): `conformance-aggregate`, `project-compile-canary-aggregate` (jotai), `project-compile-guard`, `emit`, all `fourslash-*`, `unit`, `pr-body-gate`, `conformance-snapshot-gate`.

Local (targeted, green): `lib_heritage_cycle_dom_tests` (the #12299 DOM contract this change touches), `cross_file_lib_generic_heritage_tests`, `recursive_lib_type_relation_tests`, `homomorphic_mapped_symbol_iterator_tests`, `async_iterable_type_param_element_tests`, `recursive_generic_interface_application_display_tests`, `lib_resolution_identity_tests`, `variance_session_cache_parity_tests`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high