### PR TITLE
fix(solver): rest param must not count toward minimum call arity

### DIFF
--- a/crates/tsz-solver/src/contextual/extractors.rs
+++ b/crates/tsz-solver/src/contextual/extractors.rs
@@ -1449,8 +1449,12 @@ impl<'a> ParameterForCallExtractor<'a> {
     }
 
     fn signature_accepts_arg_count(&self, params: &[ParamInfo], arg_count: usize) -> bool {
-        // Count required (non-optional) parameters
-        let required_count = params.iter().filter(|p| !p.optional).count();
+        // Count required parameters. A rest parameter (`...a: T[]`) requires zero
+        // arguments, so it must never count toward the minimum arity — otherwise a
+        // call that omits the rest (e.g. `g(5)` for `g(e: 5, ...a: any[])`) is
+        // wrongly rejected, dropping contextual typing for the fixed params and
+        // widening fresh literal arguments.
+        let required_count = params.iter().filter(|p| !p.optional && !p.rest).count();
 
         // Check if there's a rest parameter
         let has_rest = params.iter().any(|p| p.rest);


### PR DESCRIPTION
Goal: green

## Structural rule

When a call signature has fixed parameters before a trailing **array** rest tail
(`g(e: 5, ...a: any[])`), `tsc` still applies contextual typing to the fixed
parameters and accepts a call that supplies only the fixed args (`g(5)`). tsz
dropped that contextual type through `ParameterForCallExtractor::signature_accepts_arg_count`
(`crates/tsz-solver/src/contextual/extractors.rs`): the trailing rest parameter
was counted toward the required-parameter minimum, so `g(5)` (1 arg) was judged
to under-supply a 2-required-param signature. The extractor returned `None`, the
contextual request became `NONE`, and the fresh literal argument widened
(`5` -> `number`), producing a false `TS2345: '5' is not assignable to '5'`.

Fix: exclude rest parameters from the required count
(`!p.optional && !p.rest`), matching the canonical minimum-arity pattern used
elsewhere in the checker/solver. A rest parameter requires zero arguments, so it
must never raise the minimum arity. Structural (keyed on the `rest` flag), no
name/file matching.

Owner layer: solver contextual extractor (`ParameterForCallExtractor`), which
feeds the checker's `base_contextual_param_types` for call arguments.

## Adjacent-case matrix (all match `tsc` exactly)

- `g(e: 5, ...a: any[]); g(5)` -> clean (was false `TS2345`)
- `h(s: 'a', ...r: string[]); h('a')` -> clean; `h('b')` -> still `TS2345` (negative control)
- string-literal-union fixed param + `string[]` rest: `s('a')`/`s('b')` clean, `s('c')` errors
- multiple fixed params before array rest: `multi(1, 2)` clean, `multi(1, 3)` errors
- tuple rest tail (`...a: [number]`): unchanged, still correct
- `as const` / `const v: 5` (non-fresh literals): unchanged, clean
- overloads (`o(x: 5, ...a: any[])` + `o(x: string)`): `o(5)`/`o('hi')` clean
- object fixed param negative control: `obj({ a: 1 })` clean, `obj({ b: 1 })` errors (`TS2353`)
- rest param itself still type-checked: `rt(1, 2, "bad")` errors
- exact mobx `die(error: string | keyof typeof errors, ...args: any[])` pattern:
  `die(23)`, `die(24, "thing")`, `die("msg")` clean, `die(999)` errors — identical to `tsc`

## Verification

- Minimal repro `g(5)` and the full adjacent matrix above match `tsc` byte-for-byte.
- Conformance (0 regressions): `--filter` restParameter (22/22), restArgs (1/1),
  contextualTyping (83/83), literalTypes (6/6), overloadResolution (9/9),
  callSignature (40/40), argumentExpression (1/1). Broad sweep also green:
  rest (69), spread (71), overload (62), contextual (193), signature (12),
  inference (23), assignment (161), functionCall (43), bind (9), optionalParam (12).
- Project corpus: net-zero (no regressions). Byte-identical diagnostics
  before/after on mobx (442/442 total, 97/97 TS2345), zod, ts-pattern, trpc,
  fp-ts, kysely, valibot, zustand, jotai, immer, io-ts, ofetch, ts-rest, msw;
  clean required rows (rxjs, type-fest, ts-toolbelt, comlink) stay 0/0.
- mobx FP delta: 0. The predicted ~79 `die(...)` FPs are NOT cleared by this fix;
  in-corpus the `die` calls misresolve to a `() => unknown` parameter type
  (a separate import/barrel-resolution + `keyof typeof` defect upstream), so they
  never reach this arity gate. The arity fix is nonetheless the correct general
  fix for the rest-param fresh-literal class, proven by the isolated `die` repro.
- `scripts/arch/arch_guard.py` PASS.
- `cargo clippy -p tsz-solver --lib` and `-p tsz-checker --lib` clean.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
