### PR TITLE
ci: double project-compile-canary shards 3→6 (faster canary wave)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,7 +736,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2]
+        shard: [0, 1, 2, 3, 4, 5]
     env:
       npm_config_cache: ${{ github.workspace }}/.ci-cache/npm-project-compile-canary
       TSZ_CI_CACHE_SAVE: "0"
@@ -744,7 +744,7 @@ jobs:
       TSZ_PROJECT_COMPILE_ALLOW_FAILURES: "1"
       TSZ_PROJECT_COMPILE_INCLUDE_GENERATED_APPS: "0"
       _TSZ_CI_CANARY_SHARD_INDEX: ${{ matrix.shard }}
-      _TSZ_CI_CANARY_SHARD_COUNT: 3
+      _TSZ_CI_CANARY_SHARD_COUNT: 6
     steps:
       - uses: actions/checkout@v4
         with:
@@ -814,7 +814,7 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          EXPECTED=3
+          EXPECTED=6
           MAX_WAIT=180
           INTERVAL=10
           elapsed=0


### PR DESCRIPTION
Goal: hold

CI parallelism win (no compiler change) — the first half of the "run canaries faster" ask.

The `project-compile-canary` wave sits on the CI critical path (`dist-binaries` → harness), and its tail was ~7.5m because the ~150s timeout rows (remeda/ts-morph/typebox) clustered on one of **3** round-robin shards. Doubling to **6** halves rows/shard (~29 canary rows: ~10/shard → ~5/shard) and spreads the heavy rows across more runners.

**Lockstep change (3 literals):** matrix `shard` list, per-shard `_TSZ_CI_CANARY_SHARD_COUNT`, and the aggregate poller `EXPECTED=6` (never waits on phantom shards).

**Safe:** `canary_row_in_shard` (round-robin `index % count`) and `project-compile-canary-aggregate.sh` are count-agnostic; the CI Summary input is the aggregate *name*, not shard names — coverage + required gate unaffected. conformance (4) and fourslash (6) untouched.

A cost-aware **LPT weight-map** shard assignment will follow alongside the heavier application canary rows (which most need balancing) — this PR is the shard-count half.

**Verification:** the `pull_request` run executes canary with 6 shards; confirm `project-compile-canary-aggregate` recombines 6 shard artifacts and the poller does not stall. actionlint clean.

## Provenance
Machine: Mohsens-MacBook-Pro
Assistant: claude-code
Model: claude-opus-4-8
Effort: max