### PR TITLE
fix(solver): resolve generic function-alias members in typeof-function narrowing

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1354,6 +1354,9 @@ path = "tests/jsx_pragma_boundary_tests.rs"
 name = "discriminant_narrow_function_lazy_preserved_tests"
 path = "tests/discriminant_narrow_function_lazy_preserved_tests.rs"
 [[test]]
+name = "typeof_function_generic_alias_narrowing_tests"
+path = "tests/typeof_function_generic_alias_narrowing_tests.rs"
+[[test]]
 name = "discriminant_literal_reference_narrowing_tests"
 path = "tests/discriminant_literal_reference_narrowing_tests.rs"
 [[test]]

--- a/crates/tsz-checker/tests/typeof_function_generic_alias_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/typeof_function_generic_alias_narrowing_tests.rs
@@ -1,0 +1,87 @@
+use tsz_checker::context::CheckerOptions;
+use tsz_checker::test_utils::check_source;
+
+/// Regression: `typeof x === "function"` narrowing over a union member that is
+/// a generic type-alias instantiation (`TypeData::Application`) must resolve the
+/// alias to its underlying shape before classifying it. A generic alias whose
+/// body is a function type (`type Fn<A> = (a: A) => R`) was previously dropped
+/// from the function branch because the structural function predicate cannot see
+/// through a deferred `Application` and `evaluate_type` leaves it deferred
+/// without a resolver — producing a spurious TS2349 ("not callable") on the
+/// narrowed call and a TS2322 on the conditional result.
+///
+/// Mirrors `resolveStaleTime`/`resolveQueryBoolean` in the `TanStack` Query
+/// `query-core` package. Binder names are intentionally varied from the corpus
+/// witness so the fix cannot key off any identifier.
+#[test]
+fn typeof_function_narrows_generic_function_alias() {
+    let source = r#"
+type Callback<A> = (input: A) => number
+function run<A>(cb: undefined | Callback<A>, arg: A): number | undefined {
+    return typeof cb === 'function' ? cb(arg) : cb
+}
+"#;
+    let diags = check_source(source, "test.ts", CheckerOptions::default());
+    let relevant: Vec<_> = diags
+        .iter()
+        .filter(|d| matches!(d.code, 2349 | 2322))
+        .collect();
+    assert!(
+        relevant.is_empty(),
+        "Expected no TS2349/TS2322 narrowing a generic function alias, got: {diags:#?}"
+    );
+}
+
+/// The corpus witness shape: the alias body is itself a UNION that contains a
+/// function arm (`Primitive | ((q) => Primitive)`). The true branch must keep
+/// only the callable arm; the false branch must keep only the non-callable
+/// arms. The `if`/`else` form exercises both `narrow_to_function` and
+/// `narrow_excluding_function`.
+#[test]
+fn typeof_function_narrows_alias_to_union_with_function_arm() {
+    let source = r#"
+type Stale = number | 'static'
+type StaleOption<A> = Stale | ((input: A) => Stale)
+function resolve<A>(opt: undefined | StaleOption<A>, arg: A): Stale | undefined {
+    if (typeof opt === 'function') {
+        return opt(arg)
+    }
+    return opt
+}
+"#;
+    let diags = check_source(source, "test.ts", CheckerOptions::default());
+    let relevant: Vec<_> = diags
+        .iter()
+        .filter(|d| matches!(d.code, 2349 | 2322))
+        .collect();
+    assert!(
+        relevant.is_empty(),
+        "Expected no TS2349/TS2322 for alias-to-union narrowing, got: {diags:#?}"
+    );
+}
+
+/// Negative guard: a generic alias whose body is a plain object (no call
+/// signature) must NOT be treated as callable by `typeof === "function"`. The
+/// fix only promotes members that genuinely resolve to a function shape, so the
+/// false branch keeps the object and the true branch is `never`.
+#[test]
+fn typeof_function_does_not_promote_generic_object_alias() {
+    let source = r#"
+type Box<A> = { value: A }
+function pick<A>(maybe: undefined | Box<A>): A | undefined {
+    if (typeof maybe === 'function') {
+        return undefined
+    }
+    return maybe?.value
+}
+"#;
+    let diags = check_source(source, "test.ts", CheckerOptions::default());
+    let relevant: Vec<_> = diags
+        .iter()
+        .filter(|d| matches!(d.code, 2349 | 2322 | 2339))
+        .collect();
+    assert!(
+        relevant.is_empty(),
+        "Expected no spurious diagnostics for a non-function generic alias, got: {diags:#?}"
+    );
+}

--- a/crates/tsz-checker/tests/typeof_function_generic_alias_narrowing_tests.rs
+++ b/crates/tsz-checker/tests/typeof_function_generic_alias_narrowing_tests.rs
@@ -2,7 +2,7 @@ use tsz_checker::context::CheckerOptions;
 use tsz_checker::test_utils::check_source;
 
 /// Regression: `typeof x === "function"` narrowing over a union member that is
-/// a generic type-alias instantiation (`TypeData::Application`) must resolve the
+/// a generic type-alias instantiation (a deferred `Application`) must resolve the
 /// alias to its underlying shape before classifying it. A generic alias whose
 /// body is a function type (`type Fn<A> = (a: A) => R`) was previously dropped
 /// from the function branch because the structural function predicate cannot see


### PR DESCRIPTION
Goal: green

## Summary

Audit + light attack on the `tanstack-query` canary row. The board listed
~115 unaudited FPs. tsc oracle on the guard config emits only 10 diagnostics
(all `TS2591` `Cannot find name 'process'` — the fixture excludes `@types/node`
via `types: []`, matching tsc), so tsz had **100 true FPs**.

This PR fixes the dominant shared narrowing defect in that set.

### Wrong semantic operation
Narrowing: `typeof x === "function"` (and `!== "function"`) over a union whose
member is a generic type-alias instantiation.

### Root cause
A union member that is a generic type-alias instantiation
(`TypeData::Application`), e.g. `Fn<A>` for `type Fn<A> = (a: A) => R`, is a
*deferred* application. `narrow_to_function` classified members via the raw
structural function predicate, which cannot see through a deferred
`Application`, and `db.evaluate_type` leaves the application deferred when no
resolver is present. The function-typed member was therefore dropped from the
true branch and kept whole in the false branch:
- the narrowed call `x(arg)` became spuriously **not callable** (`TS2349`)
- the conditional result kept the full union (`TS2322`)

The TanStack Query witnesses are `resolveStaleTime` / `resolveQueryBoolean` in
`packages/query-core/src/utils.ts`, where the param is
`undefined | StaleTimeFunction<...>` and `StaleTimeFunction<...>` is itself an
alias to a union `StaleTime | ((q) => StaleTime)`.

### Fix
`narrow_to_function` / `narrow_excluding_function` now resolve an `Application`
member through the narrowing context's resolver-aware `resolve_type` before
classifying it. An alias to a function — or an alias to a union *containing* a
function arm — keeps exactly its callable arm in the true branch and its
non-callable arms in the false branch. The original alias member is preserved
when it is itself purely a function (no display/type churn). Non-function
generic aliases are not promoted (negative case covered).

## Structural rule
When `typeof x === "function"` narrows a union whose member is a generic
type-alias instantiation that resolves (directly or via its body union) to a
function type, tsc keeps that callable arm in the true branch and the
non-callable arms in the false branch; tsz now does the same through the
solver narrowing owner (`narrowing/core/helpers.rs`,
`narrow_to_function` / `narrow_excluding_function`), resolving the deferred
`Application` via the narrowing resolver instead of the resolver-less
`evaluate_type`.

## Verification
- tanstack-query canary FPs: **100 -> 95** (110 -> 105 total diagnostics; the
  remaining 10 are the `TS2591 process` diagnostics tsc also emits). The 5
  resolved are the `typeof === 'function'` family in `utils.ts`/`query.ts`.
- No regression across the **full canary set** (all clean rows stay 0 FP) and
  the **full required set** (xstate, utility-types, type-fest,
  type-challenges-solutions, ts-toolbelt, ts-essentials, rxjs, comlink all 0 FP).
- `scripts/conformance/conformance.sh` for `typeof` (33/33), `narrow` (56/56),
  `narrowing` (29/29), `typeGuard` (86/86), `controlFlow` (94/94): all pass.
- `cargo nextest run -p tsz-solver narrowing`: 302/302 pass.
- New regression tests
  `crates/tsz-checker/tests/typeof_function_generic_alias_narrowing_tests.rs`
  (function-alias, alias-to-union-with-function-arm, non-function-alias
  negative; binder names varied from the corpus witness): pass.
- `python3 scripts/arch/arch_guard.py`: PASS.
- `cargo clippy -p tsz-solver --lib`: clean (no new allows).

## Remaining tanstack-query FPs (out of scope, separate root causes)
- `TS2345` x26 / `TS2322` x22: generic query-options assignability and the
  `parameter of type 'undefined'` degenerate-signature family.
- `TS2339` x18: property lookup on under-applied generic class instances
  (`Mutation<any, any>`) under the circular `mutation -> removable -> utils`
  import cycle; not reproducible in isolation.

## Provenance
Machine: Mac
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
