### PR TITLE
perf(solver): skip provably-disjoint cross-kind pairs in union subtype reduction

### DIFF
--- a/crates/tsz-core/benches/union_reduction_bench.rs
+++ b/crates/tsz-core/benches/union_reduction_bench.rs
@@ -1,9 +1,20 @@
 //! Union reduction microbenchmarks.
 //! Tests performance of `reduce_union_subtypes` for large unions of tuples/arrays.
+//!
+//! The `union_mixed_kind_*` group targets the large-ts-repo / ts-toolbelt
+//! `reduce_union_subtypes` quadratic sweep over a wide concrete union whose
+//! members span several disjoint structural kinds (objects with unique
+//! discriminants, distinct numeric/string literals, a widened primitive). That
+//! shape misses discriminant partitioning (no property covers half the members)
+//! and lands on the raw O(N²) pairwise `is_subtype_shallow` loop, where most
+//! pairs are cross-kind (object-vs-literal, primitive-vs-object) and provably
+//! cannot relate. The structural-bucket skip should drop
+//! `union_subtype_reduction_shallow_checks` toward the count of same-kind pairs
+//! while leaving the union result byte-identical.
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tsz_solver::construction::TypeInterner;
-use tsz_solver::{TupleElement, TypeId};
+use tsz_solver::{PropertyInfo, TupleElement, TypeId};
 
 /// Create N distinct tuple types like [Lit0, Lit1], [Lit2, Lit3], etc.
 /// This simulates enumLiteralsSubtypeReduction.ts which has 512 return types.
@@ -108,6 +119,70 @@ fn bench_union_512_identical(c: &mut Criterion) {
     });
 }
 
+/// Build a wide mixed-kind union member set of size ~`count`: objects with a
+/// unique single property each (so no discriminant covers half the members and
+/// partitioning is skipped), interleaved with distinct number and string
+/// literals. No widened `string`/`number` primitive is included, so the
+/// cross-domain literals are NOT absorbed in the pre-sweep pass and all members
+/// survive into the O(N²) reduction loop. This is the large-row "mixed
+/// object/primitive/literal" shape where most pairs are cross-kind
+/// (object-vs-literal, number-literal-vs-string-literal) and provably disjoint.
+fn create_mixed_kind_members(interner: &TypeInterner, count: usize) -> Vec<TypeId> {
+    let mut members = Vec::with_capacity(count);
+    for i in 0..count {
+        match i % 4 {
+            // Object with a unique property name + literal value type. No single
+            // property name is shared across members, so the discriminant
+            // partition pass returns None and the union lands on the quadratic
+            // path. Objects only ever relate to other objects in the shallow
+            // engine.
+            0 => {
+                let prop_name = interner.intern_string(&format!("p{i}"));
+                let val = interner.literal_number((1000 + i) as f64);
+                let obj = interner.object(vec![PropertyInfo::new(prop_name, val)]);
+                members.push(obj);
+            }
+            1 => {
+                let prop_name = interner.intern_string(&format!("q{i}"));
+                let val = interner.literal_string(&format!("v{i}"));
+                let obj = interner.object(vec![PropertyInfo::new(prop_name, val)]);
+                members.push(obj);
+            }
+            // Distinct number literal: survives (no widened `number` peer), only
+            // relates to a same-domain primitive or template, neither present.
+            2 => members.push(interner.literal_number((7_000_000 + i) as f64)),
+            // Distinct string literal: survives (no widened `string` peer).
+            _ => members.push(interner.literal_string(&format!("s{i}"))),
+        }
+    }
+    members
+}
+
+fn bench_mixed_kind(c: &mut Criterion, count: usize) {
+    c.bench_function(&format!("union_mixed_kind_{count}"), |b| {
+        b.iter_with_setup(
+            || {
+                // Fresh interner per iteration so the union-normalize memo never
+                // hides the reduction work across iterations.
+                let interner = TypeInterner::new();
+                let members = create_mixed_kind_members(&interner, count);
+                (interner, members)
+            },
+            |(interner, members)| black_box(interner.union(black_box(members))),
+        )
+    });
+}
+
+fn bench_union_mixed_kind_80(c: &mut Criterion) {
+    bench_mixed_kind(c, 80);
+}
+fn bench_union_mixed_kind_200(c: &mut Criterion) {
+    bench_mixed_kind(c, 200);
+}
+fn bench_union_mixed_kind_400(c: &mut Criterion) {
+    bench_mixed_kind(c, 400);
+}
+
 criterion_group!(
     benches,
     bench_union_512_tuples,
@@ -115,5 +190,8 @@ criterion_group!(
     bench_incremental_union_512,
     bench_union_100_tuples,
     bench_union_512_identical,
+    bench_union_mixed_kind_80,
+    bench_union_mixed_kind_200,
+    bench_union_mixed_kind_400,
 );
 criterion_main!(benches);

--- a/crates/tsz-solver/src/intern/normalize.rs
+++ b/crates/tsz-solver/src/intern/normalize.rs
@@ -8,6 +8,7 @@
 //! - Intersection-over-union distribution
 //! - Literal absorption into primitives
 
+use super::shallow_subtype::ShallowReduceKind;
 use super::{TypeInterner, TypeListBuffer};
 use crate::types::{
     CallableShape, IntrinsicKind, LiteralValue, ObjectShape, PropertyInfo, TemplateLiteralId,
@@ -1107,6 +1108,19 @@ impl TypeInterner {
         if len <= 64 {
             self.reduce_union_subtypes_quadratic(flat);
         } else {
+            // Precompute one coarse structural bucket per member (O(N)). A pair
+            // whose buckets cannot relate (e.g. object-vs-literal,
+            // primitive-vs-object) is skipped without the shallow subtype call:
+            // `is_subtype_shallow` would deterministically answer `false`. This
+            // collapses the dominant cross-kind term of the mixed
+            // object/primitive/literal large-row union shape from N(N-1) shallow
+            // calls toward the count of genuinely same-kind pairs, while
+            // object-vs-object / function-vs-function reductions are preserved
+            // exactly.
+            let kinds: Vec<ShallowReduceKind> = flat
+                .iter()
+                .map(|&id| self.shallow_reduce_kind(id))
+                .collect();
             let mut keep = vec![true; len];
             let shallow_checks = tsz_common::perf_counters::enabled_fast().then(|| {
                 &tsz_common::perf_counters::counters().union_subtype_reduction_shallow_checks
@@ -1117,6 +1131,20 @@ impl TypeInterner {
                 }
                 for j in 0..len {
                     if i == j || !keep[j] {
+                        continue;
+                    }
+                    if !ShallowReduceKind::may_relate(kinds[i], kinds[j]) {
+                        // The bucket skip must never hide a real subtype
+                        // relation: validate the over-approximation against the
+                        // shallow engine in debug/test builds across the whole
+                        // corpus. Release builds pay only the `may_relate` match.
+                        debug_assert!(
+                            !self.is_subtype_shallow(flat[i], flat[j]),
+                            "shallow_reduce_kind skipped a relating pair: \
+                             {:?} <: {:?}",
+                            kinds[i],
+                            kinds[j],
+                        );
                         continue;
                     }
                     if let Some(counter) = shallow_checks {
@@ -1229,6 +1257,13 @@ impl TypeInterner {
         } else {
             (1u64 << len) - 1
         };
+        // One coarse structural bucket per member (stack-allocated for the
+        // <=64-member partition). Pairs whose buckets cannot relate skip the
+        // shallow subtype call; see `ShallowReduceKind::may_relate`.
+        let kinds: SmallVec<[ShallowReduceKind; 64]> = flat
+            .iter()
+            .map(|&id| self.shallow_reduce_kind(id))
+            .collect();
         let shallow_checks = tsz_common::perf_counters::enabled_fast()
             .then(|| &tsz_common::perf_counters::counters().union_subtype_reduction_shallow_checks);
         for i in 0..len {
@@ -1237,6 +1272,15 @@ impl TypeInterner {
             }
             for j in 0..len {
                 if i == j || keep & (1u64 << j) == 0 {
+                    continue;
+                }
+                if !ShallowReduceKind::may_relate(kinds[i], kinds[j]) {
+                    debug_assert!(
+                        !self.is_subtype_shallow(flat[i], flat[j]),
+                        "shallow_reduce_kind skipped a relating pair: {:?} <: {:?}",
+                        kinds[i],
+                        kinds[j],
+                    );
                     continue;
                 }
                 if let Some(counter) = shallow_checks {
@@ -1547,6 +1591,105 @@ mod tests {
         assert!(
             !list.contains(&interner.literal_string("a")),
             "literal `\"a\"` must be absorbed by `string`"
+        );
+    }
+
+    fn obj_with_unique_prop(interner: &TypeInterner, i: usize) -> TypeId {
+        let name = interner.intern_string(&format!("p{i}"));
+        let val = interner.literal_number((1000 + i) as f64);
+        interner.object(vec![PropertyInfo::new(name, val)])
+    }
+
+    #[test]
+    fn structural_bucket_preserves_mixed_object_primitive_literal_union() {
+        // The large-row shape that reaches the O(N^2) pairwise sweep: a widened
+        // primitive (so the `all_non_reducible && !has_primitive` early return
+        // does not fire) beside distinct unique-prop objects and cross-domain
+        // literals. No member is a subtype of any other, so every member must
+        // survive — the structural-bucket skip must not drop any of them.
+        let interner = TypeInterner::new();
+        let mut members = vec![TypeId::BOOLEAN];
+        for i in 0..100 {
+            match i % 3 {
+                0 => members.push(obj_with_unique_prop(&interner, i)),
+                1 => members.push(interner.literal_number((7_000_000 + i) as f64)),
+                _ => members.push(interner.literal_string(&format!("s{i}"))),
+            }
+        }
+        let expected = members.len();
+        let union = interner.union(members);
+        let Some(TypeData::Union(list_id)) = interner.lookup(union) else {
+            panic!("expected a wide mixed-kind union to survive normalization");
+        };
+        assert_eq!(
+            interner.type_list(list_id).len(),
+            expected,
+            "every disjoint mixed-kind member must survive the bucketed sweep"
+        );
+    }
+
+    #[test]
+    fn structural_bucket_still_reduces_object_subtype_in_wide_union() {
+        // A wide union (so it takes the >64 bucketed path) carrying a genuine
+        // object-vs-object reduction: `{ a: 1 }` <: `{}` (every property of the
+        // empty target is satisfied vacuously — but the shallow engine requires
+        // property overlap, so use a real width-subtype instead). `{ a: 1 }` is a
+        // subtype of `{ a: 1 | 2 }` via the property type check, so the narrower
+        // object must be absorbed even surrounded by disjoint padding members.
+        let interner = TypeInterner::new();
+        let a = interner.intern_string("a");
+        let narrow = interner.object(vec![PropertyInfo::new(a, interner.literal_number(1.0))]);
+        let wide_val = interner.union(vec![
+            interner.literal_number(1.0),
+            interner.literal_number(2.0),
+        ]);
+        let wide = interner.object(vec![PropertyInfo::new(a, wide_val)]);
+
+        let mut members = vec![TypeId::BOOLEAN, narrow, wide];
+        // Disjoint padding to push the union onto the >64 bucketed path.
+        for i in 0..80 {
+            members.push(interner.literal_string(&format!("pad{i}")));
+        }
+        let union = interner.union(members);
+        let Some(TypeData::Union(list_id)) = interner.lookup(union) else {
+            panic!("expected the padded union to survive normalization");
+        };
+        let list = interner.type_list(list_id);
+        assert!(
+            list.contains(&wide),
+            "the wider object `{{ a: 1 | 2 }}` must survive"
+        );
+        assert!(
+            !list.contains(&narrow),
+            "the narrower object `{{ a: 1 }}` must be subtype-reduced away \
+             even on the bucketed >64 path"
+        );
+    }
+
+    #[test]
+    fn structural_bucket_skip_matches_unbucketed_reduction_small_partition() {
+        // Drive the <=64 quadratic partition path (via the `boolean` primitive
+        // keeping the early-return from firing) and assert the surviving set is
+        // exactly the disjoint members: the stack-allocated bucket precompute
+        // must not change reduction on the small path either.
+        let interner = TypeInterner::new();
+        let mut members = vec![TypeId::BOOLEAN];
+        for i in 0..40 {
+            if i % 2 == 0 {
+                members.push(obj_with_unique_prop(&interner, i));
+            } else {
+                members.push(interner.literal_number((9_000_000 + i) as f64));
+            }
+        }
+        let expected = members.len();
+        let union = interner.union(members);
+        let Some(TypeData::Union(list_id)) = interner.lookup(union) else {
+            panic!("expected the small mixed union to survive normalization");
+        };
+        assert_eq!(
+            interner.type_list(list_id).len(),
+            expected,
+            "disjoint members must all survive the small bucketed partition path"
         );
     }
 }

--- a/crates/tsz-solver/src/intern/shallow_subtype.rs
+++ b/crates/tsz-solver/src/intern/shallow_subtype.rs
@@ -600,4 +600,141 @@ impl TypeInterner {
                 | (LiteralDomain::Bigint, PrimitiveClass::Bigint)
         )
     }
+
+    /// Coarse structural bucket for a single union member, used to skip
+    /// `is_subtype_shallow` calls on pairs that provably cannot relate.
+    ///
+    /// Each variant mirrors exactly one branch of `is_subtype_shallow_depth`,
+    /// so `ShallowReduceKind::may_relate` is a sound over-approximation of that
+    /// relation: it returns `true` for every pair the shallow engine could ever
+    /// answer `true` on, and `false` only for pairs the engine answers `false`
+    /// on in both directions. `Wildcard` is the conservative catch-all for any
+    /// member that participates in a non-local branch (unions, or any leaf the
+    /// engine could traverse that this classifier does not model precisely), so
+    /// an unmodeled member never skips a check.
+    ///
+    /// Callers must classify a union **after** normalization has run its
+    /// sentinel removal, literal absorption, and sort+dedup passes (i.e. exactly
+    /// the input `reduce_union_subtypes` operates on). In that state
+    /// `any`/`unknown`/`never` are gone and identical members are deduped, so
+    /// the early identity / top / bottom branches of `is_subtype_shallow_depth`
+    /// never fire across a distinct pair.
+    pub(super) fn shallow_reduce_kind(&self, id: TypeId) -> ShallowReduceKind {
+        // A widened builtin primitive (string/number/... and the boolean-literal
+        // intrinsics) only relates upward into a union target, which is modeled
+        // as `Wildcard` on the other endpoint. Against any non-union peer it is
+        // disjoint, so it only ever needs a check versus a literal of its own
+        // domain (handled by `Literal -> Primitive`) or a `Wildcard`.
+        if let Some(class) = self.builtin_primitive_class(id) {
+            return ShallowReduceKind::Primitive(class);
+        }
+        match self.lookup(id) {
+            Some(TypeData::Literal(literal)) => {
+                let domain = match literal {
+                    LiteralValue::String(_) => LiteralDomain::String,
+                    LiteralValue::Number(_) => LiteralDomain::Number,
+                    LiteralValue::Boolean(_) => LiteralDomain::Boolean,
+                    LiteralValue::BigInt(_) => LiteralDomain::Bigint,
+                };
+                ShallowReduceKind::Literal(domain)
+            }
+            Some(TypeData::Object(_) | TypeData::ObjectWithIndex(_)) => ShallowReduceKind::Object,
+            Some(TypeData::Function(_)) => ShallowReduceKind::Function,
+            Some(TypeData::TemplateLiteral(_)) => ShallowReduceKind::Template,
+            // A union member recurses both directions in the shallow engine, and
+            // any leaf the classifier does not model (Array/Tuple/Enum/
+            // Application/Callable/intrinsics other than primitives/Readonly/
+            // NoInfer/...) is treated conservatively as relatable so a real
+            // relation is never skipped. These are rare relative to the
+            // object/primitive/literal members that dominate the large-row shape.
+            _ => ShallowReduceKind::Wildcard,
+        }
+    }
+
+    /// Classify the builtin widened primitives (and the boolean-literal
+    /// intrinsics) the shallow engine treats as absorbing targets for matching
+    /// literals. Returns `None` for everything else, including bare
+    /// `TypeData::Literal` (those are `ShallowReduceKind::Literal`).
+    const fn builtin_primitive_class(&self, id: TypeId) -> Option<PrimitiveClass> {
+        match id {
+            TypeId::STRING => Some(PrimitiveClass::String),
+            TypeId::NUMBER => Some(PrimitiveClass::Number),
+            TypeId::BIGINT => Some(PrimitiveClass::Bigint),
+            TypeId::SYMBOL => Some(PrimitiveClass::Symbol),
+            TypeId::BOOLEAN | TypeId::BOOLEAN_TRUE | TypeId::BOOLEAN_FALSE => {
+                Some(PrimitiveClass::Boolean)
+            }
+            TypeId::VOID | TypeId::UNDEFINED => Some(PrimitiveClass::Undefined),
+            TypeId::NULL => Some(PrimitiveClass::Null),
+            _ => None,
+        }
+    }
+}
+
+/// Coarse structural bucket used to skip provably-disjoint pairs in union
+/// subtype reduction. See `TypeInterner::shallow_reduce_kind`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(super) enum ShallowReduceKind {
+    /// A bare `TypeData::Literal` of the given domain.
+    Literal(LiteralDomain),
+    /// A widened builtin primitive (or boolean-literal intrinsic) of the class.
+    Primitive(PrimitiveClass),
+    /// `Object` / `ObjectWithIndex`.
+    Object,
+    /// `Function`.
+    Function,
+    /// `TemplateLiteral`.
+    Template,
+    /// Union, or any member not modeled precisely: always needs a real check.
+    Wildcard,
+}
+
+impl ShallowReduceKind {
+    /// Sound over-approximation of `is_subtype_shallow(source, target)` for a
+    /// distinct, post-normalization pair: `false` only when the shallow engine
+    /// provably answers `false` in this direction.
+    ///
+    /// The direction matters — `Literal(String)` as a *source* can be a subtype
+    /// of `Primitive(String)` / `Template`, but as a *target* a literal is only
+    /// matched by an identical literal (already deduped). Modeling the source
+    /// role lets the symmetric quadratic loop skip the reverse direction too.
+    pub(super) const fn may_relate(source: Self, target: Self) -> bool {
+        // Any union (or unmodeled leaf) on either side keeps the real check:
+        // the shallow engine recurses into unions both as source and target.
+        if matches!(source, Self::Wildcard) || matches!(target, Self::Wildcard) {
+            return true;
+        }
+        match source {
+            Self::Wildcard => true,
+            // A literal source relates to a same-domain primitive, or (string
+            // only) to a template literal. Never to another literal, object, or
+            // function.
+            Self::Literal(domain) => match target {
+                Self::Primitive(class) => primitive_class_matches_domain(class, domain),
+                Self::Template => matches!(domain, LiteralDomain::String),
+                _ => false,
+            },
+            // Objects relate only to objects; functions only to functions.
+            Self::Object => matches!(target, Self::Object),
+            Self::Function => matches!(target, Self::Function),
+            // A widened primitive source only relates upward into a union
+            // (Wildcard, handled above), and a template source is only a subtype
+            // by identity (already deduped) — the shallow engine has no
+            // template-as-source relation. Versus any concrete peer both are
+            // disjoint.
+            Self::Primitive(_) | Self::Template => false,
+        }
+    }
+}
+
+/// Domain/class match used by `ShallowReduceKind::may_relate`. Kept as a free
+/// function so the const matrix is shared without borrowing the interner.
+const fn primitive_class_matches_domain(class: PrimitiveClass, domain: LiteralDomain) -> bool {
+    matches!(
+        (domain, class),
+        (LiteralDomain::String, PrimitiveClass::String)
+            | (LiteralDomain::Number, PrimitiveClass::Number)
+            | (LiteralDomain::Boolean, PrimitiveClass::Boolean)
+            | (LiteralDomain::Bigint, PrimitiveClass::Bigint)
+    )
 }


### PR DESCRIPTION
## Summary

Skips provably-disjoint cross-kind pairs in the `reduce_union_subtypes` O(N²)
pairwise `is_subtype_shallow` sweep by precomputing one coarse structural bucket
per member.

For a wide concrete union that carries a widened primitive (so the
`all_non_reducible && !has_primitive` early return from #13149 does not fire),
misses discriminant partitioning, and exceeds 64 members, the reduction loop
runs N(N−1) shallow subtype calls. On the large-ts-repo / ts-toolbelt #13250
mixed object/primitive/literal shape, most of those pairs are cross-kind —
`primitive`-vs-`object`, `object`-vs-`literal`, number-literal-vs-string-literal
— and the shallow engine answers `false` in both directions. This complements
#13728's literal-pair skip (a special case of the bucket matrix) and #13667's
deferred short-circuit.

## Structural rule

When a union member pair's coarse structural buckets cannot relate, `tsc`/tsz's
shallow subtype relation is `false` in that direction, so the pair can never
reduce either member. `is_subtype_shallow_depth` only returns `true` (for a
distinct, post-normalization pair) when the (source, target) kinds are:
`Literal(d)` → `Primitive(matching d)` / `Template`(string only); `Object` →
`Object`; `Function` → `Function`; or anything involving a `Union` (which
recurses). Every other kind pairing — widened primitive as source, template as
source, object-vs-non-object, literal-vs-literal, and all
`Array`/`Tuple`/`Enum`/`Application`/`Callable`/... leaves (which the shallow
engine matches with `_ => false`) — is provably disjoint.

Owner layer: solver. `ShallowReduceKind` + `may_relate` in
`crates/tsz-solver/src/intern/shallow_subtype.rs` (one variant per
`is_subtype_shallow_depth` branch; `Wildcard` is the conservative catch-all for
unions and any unmodeled leaf, so a real relation is never skipped). The two
quadratic loops in `crates/tsz-solver/src/intern/normalize.rs`
(`reduce_union_subtypes` >64 path and `reduce_union_subtypes_quadratic`)
precompute the bucket vector once (O(N)) and gate each `is_subtype_shallow` call
on `may_relate`. Reduction output is byte-identical; the pairwise term drops
toward the count of genuinely same-kind pairs.

By construction this runs only **after** normalization's sentinel removal,
literal absorption, and sort+dedup, so the early identity / top / bottom branches
of the shallow engine never fire across a distinct pair — the classifier models
exactly the residual relatable cases.

## Soundness

A `debug_assert!` next to each skip asserts `!is_subtype_shallow(i, j)` whenever
`!may_relate`, so CI debug/test builds validate the over-approximation against
the real engine across the whole conformance/emit/fourslash corpus. Locally, a
debug-build randomized fuzz (4000 trials, n=65..184, exercising the >64 path
with objects under width-subtyping, primitives, cross-domain literals, arrays,
and small unions) held the assertion on every trial.

## Adjacent-case matrix

- **Cross-domain primitive + objects + literals** (`boolean | {p:1} | "x" | 7`):
  all members survive; cross-kind pairs skipped, object-vs-object kept.
  (`structural_bucket_preserves_mixed_object_primitive_literal_union`)
- **Object width subtyping in a wide union** (`{a:1} | {a:1|2}` + padding past
  64 members): narrower object still subtype-reduced away on the bucketed >64
  path. (`structural_bucket_still_reduces_object_subtype_in_wide_union`)
- **Small partition path** (<=64, primitive present): disjoint members all
  survive; the stack-allocated bucket precompute does not change reduction.
  (`structural_bucket_skip_matches_unbucketed_reduction_small_partition`)
- **Literal × template** (`"foo-1" | \`foo-${number}\``): template is not a bare
  `Literal`, so the `Literal(String) → Template` pair is NOT skipped; absorption
  preserved (existing `union_template_absorbs_matching_string_literal`).
- **All-literal, no primitive**: short-circuits before the sweep as before
  (#13149 early return), bucket path never entered.

## Verification

Synthetic in-process microbench (mixed object/primitive/literal shape, growing
N, `TSZ_PERF_COUNTERS=1`, min-of-200 wall, deterministic
`union_subtype_reduction_shallow_checks` counter):

| N | shallow_checks before → after | wall before → after |
|---|------|------|
| 80  | 6,480 → 1,560 (**-76%**)    | 66.3us → 38.5us (**1.72x**) |
| 120 | 14,520 → 3,540 (**-76%**)   | 140.4us → 79.8us (**1.76x**) |
| 200 | 40,200 → 9,900 (**-75%**)   | 367.5us → 195.3us (**1.88x**) |
| 300 | 90,300 → 22,350 (**-75%**)  | 791.7us → 410.5us (**1.93x**) |
| 400 | 160,400 → 39,800 (**-75%**) | 1372.5us → 714.7us (**1.92x**) |
| 600 | 360,600 → 89,700 (**-75%**) | 3077.6us → 1541.4us (**2.00x**) |

`pairwise_budget` (N(N−1)) is unchanged; the residual ~25% of checks are the
genuine object-vs-object pairs (half the members are objects → ~25% of pairs are
object-object), which still run the real check. Bench surface added to
`crates/tsz-core/benches/union_reduction_bench.rs` (`union_mixed_kind_*`).

Diagnostic parity (`tsz --noEmit --strict`): a mixed cross-domain union
`boolean | {p:1} | "x" | 7` is preserved with all members and elaborates
`TS2322` `Type 'Mixed' is not assignable to type 'string'. Type 'boolean' is not
assignable to type 'string'.` — byte-identical to baseline; the union is not
collapsed.

`cargo clippy --release -p tsz-solver --lib` and `-p tsz-core --benches` clean.
Solver/checker unit tests (`cfg(test)`, gated on `debug_assertions` which local
`--release` disables) deferred to ready-review CI; three regression tests added
in `normalize.rs`.

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Goal: fast

Issue: #13250
