### PR TITLE
fix(checker): lower parenthesized `typeof` array elements via the binder path (#8432)

### DIFF
--- a/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
+++ b/crates/tsz-checker/src/state/type_environment/type_node_resolution.rs
@@ -62,6 +62,27 @@ impl<'a> CheckerState<'a> {
     /// // Type literals
     /// let c: { x: number };    // → Object type with property x: number
     /// ```
+    /// If `idx` is a `PARENTHESIZED_TYPE` wrapping (through any number of
+    /// nested parentheses) a `TYPE_QUERY` (`typeof ...`), return the inner
+    /// `TYPE_QUERY` node index; otherwise `None`. Used to resolve a parenthesized
+    /// `typeof` array element directly through the binder-aware path instead of
+    /// the leaner parenthesized-type lowering.
+    fn unwrap_parenthesized_type_query(&self, idx: NodeIndex) -> Option<NodeIndex> {
+        let mut current = idx;
+        let mut unwrapped_paren = false;
+        for _ in 0..crate::state::MAX_TREE_WALK_ITERATIONS {
+            let node = self.ctx.arena.get(current)?;
+            if node.kind == syntax_kind_ext::PARENTHESIZED_TYPE {
+                current = self.ctx.arena.get_wrapped_type(node)?.type_node;
+                unwrapped_paren = true;
+                continue;
+            }
+            return (unwrapped_paren && node.kind == syntax_kind_ext::TYPE_QUERY)
+                .then_some(current);
+        }
+        None
+    }
+
     pub fn get_type_from_type_node(&mut self, idx: NodeIndex) -> TypeId {
         #[cfg(test)]
         self.ctx.record_type_node_resolution_for_test(idx);
@@ -435,7 +456,24 @@ impl<'a> CheckerState<'a> {
                         }
                     }
 
-                    let elem_type = self.get_type_from_type_node(array_type.element_type);
+                    // When the element is a parenthesized `typeof` (`(typeof X.y)[]`),
+                    // resolve the `typeof` operand directly through the rich,
+                    // binder-aware path. A parenthesized element otherwise routes
+                    // through the leaner `TypeNodeChecker::check` lowering (via the
+                    // delegated PARENTHESIZED_TYPE node), leaving the `typeof`
+                    // operand in an under-evaluated deferred form; when its apparent
+                    // type is a deeply-nested generic application the subtype
+                    // relation then mis-accepts it against a structurally-equal
+                    // target via the `isDeeplyNestedType` one-sided expansion
+                    // bailout, dropping an expected diagnostic. Unwrapping here
+                    // makes `(typeof X.y)[]` relate like `Array<typeof X.y>` and a
+                    // `type E = typeof X.y; E[]` alias. Scoped to a `typeof` element
+                    // of an array so every other parenthesized/element type keeps
+                    // its existing lowering and diagnostics.
+                    let element_node = self
+                        .unwrap_parenthesized_type_query(array_type.element_type)
+                        .unwrap_or(array_type.element_type);
+                    let elem_type = self.get_type_from_type_node(element_node);
                     let result = self.ctx.types.factory().array(elem_type);
                     self.ctx.node_types.insert(idx.0, result);
                     return result;

--- a/crates/tsz-checker/tests/deeply_nested_mapped_types_tests.rs
+++ b/crates/tsz-checker/tests/deeply_nested_mapped_types_tests.rs
@@ -578,13 +578,27 @@ function f3(ors: (typeof Input.static)[]): Output[] { return ors; }
     );
 }
 
-/// KNOWN FALSE-NEGATIVE (accepted-regression `deeplyNestedMappedTypes.ts`).
+/// PARTIAL witness (still accepted-regression `deeplyNestedMappedTypes.ts`).
 ///
 /// The authoritative tsc baseline emits TS2322 for `problematicFunction1` and
 /// `problematicFunction3` (`Input[]` is not assignable to `Output[]` because
-/// `Output.static` carries a `bar` property that `Input.static` lacks). tsz
-/// currently MISSES both, while correctly emitting the other three baseline
-/// errors (`foo2`, `foo4`, `problematicFunction2`).
+/// `Output.static` carries a `bar` property that `Input.static` lacks).
+/// `problematicFunction1` and the `const Readonly` shadowing analysis below were
+/// fixed separately. `problematicFunction3` is the parenthesized-`typeof`-array
+/// element gap (`(typeof Input.static)[]`): the `ARRAY_TYPE` branch of
+/// `CheckerState::get_type_from_type_node` now unwraps a parenthesized `typeof`
+/// element and resolves the operand through the rich path so it is evaluated like
+/// `Array<typeof X.y>`/an alias rather than left under-evaluated for the
+/// `isDeeplyNestedType` relation bailout to mis-accept (see the driver test
+/// `parenthesized_typeof_array_element_relates_like_alias_and_array_generic`).
+/// That lowering fix resolves the simplified/embedded-lib reducer, but with the
+/// full pinned `lib.es5`/`lib.es2015` utilities the `Static`/`PropertiesReduce`
+/// reducer is deeper and STILL trips `isDeeplyNestedType`, so
+/// `problematicFunction3` remains a real-lib miss and the row stays accepted
+/// pending the deeper relation/evaluation work.
+///
+/// The original `const Readonly` shadowing analysis below is retained as
+/// historical context.
 ///
 /// Root cause (verified by one-variable isolation — see the companion test
 /// `renaming_readonly_unique_symbol_restores_ts2322`): the fixture declares

--- a/crates/tsz-cli/src/driver/check_tests/check_tests_part4.rs
+++ b/crates/tsz-cli/src/driver/check_tests/check_tests_part4.rs
@@ -521,3 +521,78 @@ export const r = x["a"];
         );
     }
 
+    // ------------------------------------------------------------------
+    // A parenthesized `typeof value.prop` used as a postfix-array element
+    // (`(typeof X.p)[]`) must lower its `typeof` operand through the rich,
+    // binder-aware resolution path — the same one `Array<typeof X.p>` and a
+    // `type E = typeof X.p; E[]` alias already use — so it relates like those
+    // forms. Before the fix the parenthesized element fell to the leaner
+    // `TypeNodeChecker::check` path and stayed in an under-evaluated deferred
+    // form; when its evaluated apparent type is a deeply-nested generic
+    // application (a TypeBox-style `Static`/`PropertiesReduce` reducer) the
+    // relation then mis-accepted it against a structurally-equal target via the
+    // `isDeeplyNestedType` one-sided expansion bailout, dropping the expected
+    // TS2322 (conformance `deeplyNestedMappedTypes.ts`, `problematicFunction3`).
+    //
+    // Renamed binders + non-colliding key symbols make the coverage structural.
+    #[test]
+    fn parenthesized_typeof_array_element_relates_like_alias_and_array_generic() {
+        let lib_files = tsz::checker::test_utils::load_lib_files(&["es5.d.ts"]);
+        assert!(
+            !lib_files.is_empty(),
+            "es5.d.ts must be available to provide Readonly/Pick/Omit/Required/Record/Partial"
+        );
+        let options = project_mode_es2015_strict_options();
+
+        let diagnostics = collect_test_diagnostics_with_lib_files_and_options(
+            &[(
+                "/p/main.ts",
+                r#"
+export type Flatten<G> = G extends infer O ? { [K in keyof O]: O[K] } : never
+export declare const RoMark: unique symbol;
+export declare const OptMark: unique symbol;
+export declare const KindMark: unique symbol;
+export interface NodeKind { [KindMark]: string }
+export interface SchemaNode extends NodeKind { [RoMark]?: string; [OptMark]?: string; slots: unknown[]; resolved: unknown }
+export type RoNode<N extends SchemaNode> = N & { [RoMark]: 'ro' }
+export type OptNode<N extends SchemaNode> = N & { [OptMark]: 'opt' }
+export interface StrNode extends SchemaNode { [KindMark]: 'Str'; resolved: string; tag: 'string' }
+export type RoOptKeys<M extends PropMap> = { [K in keyof M]: M[K] extends RoNode<SchemaNode> ? (M[K] extends OptNode<M[K]> ? K : never) : never }[keyof M]
+export type RoKeys<M extends PropMap> = { [K in keyof M]: M[K] extends RoNode<SchemaNode> ? (M[K] extends OptNode<M[K]> ? never : K) : never }[keyof M]
+export type OptKeys<M extends PropMap> = { [K in keyof M]: M[K] extends OptNode<SchemaNode> ? (M[K] extends RoNode<M[K]> ? never : K) : never }[keyof M]
+export type ReqKeys<M extends PropMap> = keyof Omit<M, RoOptKeys<M> | RoKeys<M> | OptKeys<M>>
+export type FoldReducer<M extends PropMap, R extends Record<keyof any, unknown>> = Flatten<(
+    Readonly<Partial<Pick<R, RoOptKeys<M>>>> &
+    Readonly<Pick<R, RoKeys<M>>> &
+    Partial<Pick<R, OptKeys<M>>> &
+    Required<Pick<R, ReqKeys<M>>>
+)>
+export type FoldProps<M extends PropMap, P extends unknown[]> = FoldReducer<M, { [K in keyof M]: Resolve<M[K], P> }>
+export type PropMap = Record<string | number, SchemaNode>
+export interface ObjNode<M extends PropMap = PropMap> extends SchemaNode { [KindMark]: 'Obj'; resolved: FoldProps<M, this['slots']>; tag: 'object'; fields: M }
+export type Resolve<N extends SchemaNode, P extends unknown[] = []> = (N & { slots: P; })['resolved']
+declare namespace Make { function Obj<M extends PropMap>(fields: M): ObjNode<M>; function Str(): StrNode }
+export type Alpha = Resolve<typeof Alpha>
+export const Alpha = Make.Obj({ a: Make.Obj({ b: Make.Obj({ foo: Make.Str() }) }) })
+export type Beta = Resolve<typeof Beta>
+export const Beta = Make.Obj({ a: Make.Obj({ b: Make.Obj({ foo: Make.Str(), bar: Make.Str() }) }) })
+function viaAlias(xs: Alpha[]): Beta[] { return xs; }
+function viaTypeofArray(xs: (typeof Alpha.resolved)[]): Beta[] { return xs; }
+function viaArrayGeneric(xs: Array<typeof Alpha.resolved>): Beta[] { return xs; }
+"#,
+            )],
+            &lib_files,
+            &options,
+        );
+
+        // `Alpha` lacks the required `bar` that `Beta` carries, so every form
+        // of `Alpha[] -> Beta[]` is a structural mismatch. The bug dropped the
+        // TS2322 only for the parenthesized-`typeof`-array form; assert all
+        // three return sites now report it.
+        let ts2322_count = diagnostics.iter().filter(|d| d.code == 2322).count();
+        assert_eq!(
+            ts2322_count, 3,
+            "all three Alpha[] -> Beta[] return sites (alias, parenthesized typeof[], Array<typeof>) must report TS2322; got {ts2322_count} from {diagnostics:?}"
+        );
+    }
+

--- a/scripts/conformance/conformance-accepted-regressions.txt
+++ b/scripts/conformance/conformance-accepted-regressions.txt
@@ -65,38 +65,29 @@
 #      existing leading-zero exception). Covered by
 #      parser_improvement_class_member_recovery_tests::misplaced_case_clause_* and
 #      parser_improvement_expression_recovery_tests::empty_element_access_*.
-TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 TypeScript/tests/cases/compiler/propTypeValidatorInference.ts
-# deeplyNestedMappedTypes.ts: RE-JUSTIFIED (failure mode corrected). Earlier
-# evidence described spurious TS2344/TS2464; tsz no longer emits those. Verified
-# against the authoritative tsc baseline
-# (`deeplyNestedMappedTypes.errors.txt`, TypeScript 6.0.3): tsc emits exactly 5
-# TS2322 errors — `foo2` (Id), `foo4` (Id2), and the three `problematicFunction`
-# returns. Notably tsc emits NO error on the `bar2` NestedRecord line despite the
-# fixture's `// Error expected` comment: the recursion-identity / deeply-nested
-# bailout treats the deep path-splitting conditional alias as related after three
-# object hops. tsz currently emits 3 of the 5 expected TS2322 (`foo2`, `foo4`,
-# `problematicFunction2`) and correctly matches tsc on `bar2` (no error).
-# REMAINING GAP: tsz MISSES TS2322 on `problematicFunction1` and
-# `problematicFunction3` (`Input[]` not assignable to `Output[]`). Root cause
-# (verified by one-variable isolation): the fixture declares
-# `const Readonly: unique symbol`, whose name collides with the global lib
-# `Readonly<T>` utility type. When the deferred generic `PropertiesReducer` body
-# instantiates `Readonly<Pick<R, ...>>` (R/T still free type parameters), tsz
-# mis-resolves the `Readonly` reference to the shadowing value instead of the lib
-# type, corrupting the reduced object so `Input.static`/`Output.static` both lose
-# the `bar` discriminator and compare as assignable. Renaming ONLY the `Readonly`
-# unique symbol (to a non-lib name) restores the expected TS2322. A simple
-# `type Foo = Readonly<{ a: string }>` with `const Readonly` in scope resolves
-# correctly, so the divergence is specific to lazy instantiation of a
-# globally-shadowed lib utility type inside a generic alias body. Owner layer:
-# type-vs-value name resolution for shadowed global lib types (checker/binder),
-# NOT the solver index-access path. The minimal unit-test lib lacks the lib
-# utility types this repro needs, so the runnable parity gate is this conformance
-# row; the inline witness is the ignored
-# `deeply_nested_mapped_types_tests::readonly_pick_never_under_evaluate_loses_property_mismatch`.
-# Reproduce with the full lib via `tsz` on that snippet (renaming the `Readonly`
-# unique symbol to a non-lib name flips the result to the expected TS2322).
+TypeScript/tests/cases/compiler/deeplyNestedMappedTypes.ts
+# deeplyNestedMappedTypes.ts: PARTIAL. tsc 6.0.3 emits 5 TS2322 (`foo2`, `foo4`,
+# and the three `problematicFunction` returns; no error on `bar2`). The earlier
+# `const Readonly`-shadows-lib-`Readonly<T>` defect and `problematicFunction1`
+# already passed. `problematicFunction3` — whose parameter `(typeof Input.static)[]`
+# is a parenthesized `typeof`-property-access used as a postfix-array element —
+# was the residual miss: `CheckerState::get_type_from_type_node`'s ARRAY_TYPE
+# branch resolved the element directly, but a parenthesized element delegated to
+# the leaner `TypeNodeChecker::check` lowering, leaving the `typeof` operand in an
+# under-evaluated deferred form, so the relation mis-accepted it against a
+# structurally-equal target via the `isDeeplyNestedType` one-sided expansion
+# bailout. The ARRAY_TYPE branch now unwraps a parenthesized `typeof` element and
+# resolves the operand through the rich, binder-aware path (so `(typeof X.y)[]`
+# relates like `Array<typeof X.y>` and a `type E = typeof X.y; E[]` alias; covered
+# by `parenthesized_typeof_array_element_relates_like_alias_and_array_generic`).
+# That fixes the simplified/embedded-lib reducer, but with the full pinned
+# `lib.es5`/`lib.es2015` `Readonly`/`Pick`/`Omit`/`Required` the `Static`/
+# `PropertiesReduce` reducer is deeper and STILL trips `isDeeplyNestedType`, so
+# `problematicFunction3` remains a real-lib miss. Retiring this row needs the
+# deeper relation/evaluation work (the `isDeeplyNestedType` family), so the entry
+# stays accepted; the parenthesized-`typeof`-array-element lowering fix lands as
+# independent progress.
 # intersectionsOfLargeUnions.ts: RESOLVED. Two-part fix: (1) IndexAccess structural
 # comparison (PR #13146) distinguishes `ElementTagNameMap[T]` from
 # `HTMLElementTagNameMap[T]` when both sides are IndexAccess types; (2)


### PR DESCRIPTION
Makes a parenthesized `typeof` used as a postfix-array element relate like the
equivalent `Array<typeof ...>` and type-alias forms. **Partial progress** on the
`deeplyNestedMappedTypes.ts` accepted regression (issue #8432) — it does **not**
retire the row; see scope below.

Goal: hold

## Structural rule
When `(typeof X.y)[]` is lowered, its `typeof` operand must go through the rich,
binder-aware `CheckerState::get_type_from_type_node` path so it is evaluated to
its apparent type — the same result `Array<typeof X.y>` and a
`type E = typeof X.y; E[]` alias already produce. The `ARRAY_TYPE` branch
resolved its element node directly, but a parenthesized element delegated to the
leaner `TypeNodeChecker::check` lowering, leaving the `typeof` operand in an
under-evaluated deferred form. That let the subtype relation mis-accept it
against a structurally-equal target via the `isDeeplyNestedType` one-sided
expansion bailout, dropping an expected diagnostic.

## Owner layer
`CheckerState::get_type_from_type_node` `ARRAY_TYPE` branch. The unwrap is scoped
to a parenthesized `typeof` **array element**, so parenthesized types elsewhere —
e.g. `InstanceType<(typeof Anon<T>)>` in `varianceAnnotations.ts` — keep their
existing lowering and diagnostics (an earlier, broader `PARENTHESIZED_TYPE`
branch perturbed those and was narrowed after CI caught it).

## Scope — why it does not retire the row (honest)
The lowering fix resolves the simplified/embedded-lib reducer (new driver test).
But with the full pinned `lib.es5`/`lib.es2015` `Readonly`/`Pick`/`Omit`/
`Required`, `deeplyNestedMappedTypes.ts`'s `Static`/`PropertiesReduce` reducer is
deeper and `problematicFunction3` **still** trips `isDeeplyNestedType` — verified
by running tsz against the real pinned libs (4 of 5 errors). Retiring the row
needs the deeper relation/evaluation work; the ledger entry is therefore kept
with an updated note, and this PR lands the lowering fix as independent progress.

## Verification
- New driver regression test
  `parenthesized_typeof_array_element_relates_like_alias_and_array_generic`
  (renamed binders, non-colliding key symbols).
- `varianceAnnotations.ts`: byte-identical to base (verified by rebuilding the
  base version of the file) — the prior CI conformance regression is gone.
- `cargo test -p tsz-checker --lib`: 0 regressions vs base; conformance aggregate
  has no unlisted regressions with the ledger entry retained.
- `cargo clippy -p tsz-checker -p tsz-cli --all-targets -- -D warnings` clean;
  `cargo fmt` clean.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high