### PR TITLE
fix(checker): propagate any/error through entity-name import-equals from unresolved modules

### DIFF
--- a/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver_utils.rs
@@ -551,35 +551,105 @@ impl<'a> CheckerState<'a> {
             };
             if decl_node.kind == syntax_kind_ext::IMPORT_EQUALS_DECLARATION
                 && let Some(import) = self.ctx.arena.get_import_decl(decl_node)
-                && let Some(ref_node) = self.ctx.arena.get(import.module_specifier)
-                && ref_node.kind == SyntaxKind::StringLiteral as u16
-                && let Some(lit) = self.ctx.arena.get_literal(ref_node)
             {
-                let module_name = &lit.text;
-                if !self
-                    .ctx
-                    .module_exports_contains_module(self.ctx.binder, module_name)
-                    && !self
-                        .ctx
-                        .binder
-                        .shorthand_ambient_modules
-                        .contains(module_name)
-                    && !self
-                        .ctx
-                        .declared_modules_contains(self.ctx.binder, module_name)
-                    && !self
-                        .ctx
-                        .resolved_modules
-                        .as_ref()
-                        .is_some_and(|r| r.contains(module_name))
-                    && self.ctx.resolve_import_target(module_name).is_none()
+                if let Some(ref_node) = self.ctx.arena.get(import.module_specifier)
+                    && ref_node.kind == SyntaxKind::StringLiteral as u16
+                    && let Some(lit) = self.ctx.arena.get_literal(ref_node)
                 {
+                    let module_name = &lit.text;
+                    if !self
+                        .ctx
+                        .module_exports_contains_module(self.ctx.binder, module_name)
+                        && !self
+                            .ctx
+                            .binder
+                            .shorthand_ambient_modules
+                            .contains(module_name)
+                        && !self
+                            .ctx
+                            .declared_modules_contains(self.ctx.binder, module_name)
+                        && !self
+                            .ctx
+                            .resolved_modules
+                            .as_ref()
+                            .is_some_and(|r| r.contains(module_name))
+                        && self.ctx.resolve_import_target(module_name).is_none()
+                    {
+                        return true;
+                    }
+                }
+
+                // `import X = E.Member` (entity-name import-equals). The RHS is a
+                // qualified/property-access name rather than a `require("…")`
+                // string. When the entity name's leftmost root is itself an
+                // unresolved module import (its TS2307 was already emitted), the
+                // alias inherits the error/any poison: `E.Member` is a member of
+                // an `any` namespace, so `X` is `any` and downstream member
+                // access / type-argument instantiation must not cascade. This
+                // mirrors tsc, which types members reached through an unresolved
+                // import as `any`.
+                if self.import_equals_entity_name_root_is_unresolved(import.module_specifier) {
                     return true;
                 }
             }
         }
 
         false
+    }
+
+    /// For an `import X = <entity-name>` declaration, return `true` when the
+    /// entity name (`E`, `E.M`, `E.M.N`, …) is rooted in an unresolved module
+    /// import — i.e. the leftmost identifier resolves to an alias whose module
+    /// could not be resolved (TS2307 already emitted). String-literal
+    /// `require("…")` forms are handled separately by the caller.
+    fn import_equals_entity_name_root_is_unresolved(&self, entity_name_idx: NodeIndex) -> bool {
+        let mut current = entity_name_idx;
+        let mut iterations = 0;
+        loop {
+            iterations += 1;
+            if iterations > MAX_TREE_WALK_ITERATIONS {
+                return false;
+            }
+            let Some(node) = self.ctx.arena.get(current) else {
+                return false;
+            };
+            if node.kind == syntax_kind_ext::QUALIFIED_NAME {
+                let Some(qn) = self.ctx.arena.get_qualified_name(node) else {
+                    return false;
+                };
+                current = qn.left;
+                continue;
+            }
+            if node.kind == syntax_kind_ext::PROPERTY_ACCESS_EXPRESSION {
+                let Some(access) = self.ctx.arena.get_access_expr(node) else {
+                    return false;
+                };
+                current = access.expression;
+                continue;
+            }
+            if node.kind == SyntaxKind::Identifier as u16 {
+                let Some(root_sym_id) = self.resolve_identifier_symbol(current) else {
+                    return false;
+                };
+                // The root must be a direct module import (`import * as E from
+                // "mod"` / `import E from "mod"` / `import E = require("mod")`)
+                // whose module is unresolved. Restricting to aliases that carry
+                // a module specifier keeps this a single, non-recursive check:
+                // `is_unresolved_import_symbol_id` resolves the module without
+                // re-entering the entity-name walk, so chained or cyclic
+                // entity-name import-equals aliases cannot loop.
+                let Some(root_symbol) = self.ctx.binder.get_symbol(root_sym_id) else {
+                    return false;
+                };
+                if !root_symbol.has_any_flags(symbol_flags::ALIAS)
+                    || root_symbol.import_module().is_none()
+                {
+                    return false;
+                }
+                return self.is_unresolved_import_symbol_id(root_sym_id);
+            }
+            return false;
+        }
     }
 
     /// Check if a module specifier matches a declared or shorthand ambient module pattern.

--- a/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
+++ b/crates/tsz-cli/tests/driver_tests_parts/part_13.rs
@@ -78,3 +78,115 @@ var visModel = new moduleMap[moduleName].VisualizationModel();
         result.diagnostics
     );
 }
+
+/// `import X = E.Member` whose root `E` is an unresolved namespace import
+/// (`import * as E from 'missing'`, TS2307 emitted) must bind `X` to the
+/// error/`any` type: tsc types members reached through the `any` namespace as
+/// `any`, so `X<args>.member` access does not cascade into TS2339. tsz
+/// previously lowered `X<args>` to a real generic application (e.g. `Eq<number>`)
+/// with no members, producing a false TS2339.
+#[test]
+fn compile_import_equals_member_of_unresolved_namespace_suppresses_member_access_cascade() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "es2015",
+            "module": "commonjs",
+            "strict": true,
+            "moduleResolution": "node10",
+            "ignoreDeprecations": "6.0",
+            "noEmit": true
+          },
+          "files": ["importEqualsUnresolvedRoot.ts"]
+        }"#,
+    );
+    write_file(
+        &base.join("importEqualsUnresolvedRoot.ts"),
+        r#"import * as E from 'totally-missing-pkg/lib/Eq';
+import Eq = E.Eq;
+declare const e: Eq<number>;
+e.equals(1, 2);
+"#,
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+
+    assert_eq!(
+        codes.iter().filter(|&&c| c == diagnostic_codes::CANNOT_FIND_MODULE_OR_ITS_CORRESPONDING_TYPE_DECLARATIONS).count(),
+        1,
+        "Expected exactly one TS2307 for the missing module. Diagnostics: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE),
+        "Expected no TS2339 cascade on the any-typed alias member. Diagnostics: {:?}",
+        result.diagnostics
+    );
+}
+
+/// Renamed binders plus an assignment-position use of the unresolved-rooted
+/// alias: the alias is `any`, so assigning it to a concrete annotation does not
+/// cascade into TS2322. Also exercises a deep `Pkg.Inner.Leaf` entity name.
+#[test]
+fn compile_import_equals_unresolved_namespace_suppresses_assignment_and_deep_cascade() {
+    let temp = TempDir::new().expect("temp dir");
+    let base = &temp.path;
+
+    write_file(
+        &base.join("tsconfig.json"),
+        r#"{
+          "compilerOptions": {
+            "target": "es2015",
+            "module": "commonjs",
+            "strict": true,
+            "moduleResolution": "node10",
+            "ignoreDeprecations": "6.0",
+            "noEmit": true
+          },
+          "files": ["importEqualsRenamedRoot.ts", "importEqualsDeepRoot.ts"]
+        }"#,
+    );
+    write_file(
+        &base.join("importEqualsRenamedRoot.ts"),
+        r#"import * as NS from 'another-missing/Codec';
+import Codec = NS.Type;
+declare const c: Codec<string>;
+const n: number = c;
+"#,
+    );
+    write_file(
+        &base.join("importEqualsDeepRoot.ts"),
+        r#"import * as Pkg from 'deep-missing/mod';
+import Deep = Pkg.Inner.Leaf;
+declare const d: Deep<string>;
+d.foo.bar;
+"#,
+    );
+
+    let args = default_args();
+    let result = compile(&args, base).expect("compile should succeed");
+    let codes: Vec<u32> = result.diagnostics.iter().map(|d| d.code).collect();
+
+    assert_eq!(
+        codes.iter().filter(|&&c| c == diagnostic_codes::CANNOT_FIND_MODULE_OR_ITS_CORRESPONDING_TYPE_DECLARATIONS).count(),
+        2,
+        "Expected one TS2307 per missing module. Diagnostics: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::TYPE_IS_NOT_ASSIGNABLE_TO_TYPE),
+        "Expected no TS2322 cascade assigning an any-typed alias. Diagnostics: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        !codes.contains(&diagnostic_codes::PROPERTY_DOES_NOT_EXIST_ON_TYPE),
+        "Expected no TS2339 cascade on the deep any-typed alias member. Diagnostics: {:?}",
+        result.diagnostics
+    );
+}


### PR DESCRIPTION
Goal: green

## Summary

When `import X = E.Member` aliases an entity name whose leftmost root is an
**unresolved** module import (`import * as E from 'missing'`, for which TS2307
is already emitted), `tsc` types members reached through the resulting `any`
namespace as `any`. That poison suppresses downstream member-access and
generic type-argument-instantiation diagnostics. `tsz` previously treated such
an alias as a real generic, lowering `X<args>` to `Application(Lazy(X), args)`
(displayed e.g. `Eq<number>`) with no members, producing a false
TS2339/TS2322 cascade that `tsc` never emits.

The unresolved-import guards in type-reference resolution already return the
error/`any` sentinel — but only when `is_unresolved_import_symbol_id` flags the
alias. That predicate recognized ES6/namespace module imports and
`import X = require("str")`, but **missed the entity-name `import X = E.Member`
form** (RHS is a `QualifiedName`, not a string literal). The fix walks the
entity name to its leftmost root identifier and reports the alias as an
unresolved import when that root is itself an unresolved module import.

## Structural rule

When a module import fails to resolve (TS2307), `tsc` binds the imported
binding — and members reached through it, including an
`import X = E.Member` entity-name alias rooted in that import — to the
error/`any` type, suppressing downstream cascades; `tsz` now does the same
through `is_unresolved_import_symbol_id` (checker symbol resolution), so the
existing type-reference unresolved-import guards return the error/`any`
sentinel and match `tsc`.

Owner layer: checker import / symbol resolution
(`is_unresolved_import_symbol_id`).

Adjacent matrix (all verified `tsz` == `tsc`, only TS2307):
- bare alias `import Eq = E.Eq` member access `e.equals`
- renamed binders (namespace `NS`, alias `Codec`, member `Type`), assignment
  position `const n: number = c`
- deep entity name `import Deep = Pkg.Inner.Leaf`
- `import X = require("./missing")` (pre-existing string-literal branch, still
  works)

Fallback / no over-suppression: when the root namespace **resolves** (real
module), the alias is unchanged — `e.nonexistent` still reports TS2339 and a
bad assignment still reports TS2322, matching `tsc`. The guard only fires when
the root module is unresolved.

No hardcoding: no identifier/module-name/file-name literals; the decision is
structural (alias flag + `import_module` unresolved at the entity-name root).

## Verification

- Minimal 2-file repro (`import * as E from 'missing'; import Eq = E.Eq;
  declare const e: Eq<number>; e.equals(...)` plus named-import, namespace, and
  assignment positions): `tsz` now emits only TS2307, matching `tsc` 6.0.3.
- Tests: end-to-end CLI driver tests in
  `crates/tsz-cli/tests/driver_tests_parts/part_13.rs` (member-access cascade;
  renamed binders + assignment cascade + deep `Pkg.Inner.Leaf` entity name) —
  assert exactly the TS2307(s) and no TS2339/TS2322 cascade. (These exercise
  real module resolution; an in-process `CheckerState` harness does not emit
  TS2307, so the CLI driver harness is the faithful site.)
- Conformance (no PASS→FAIL regressions; the 2 `import`-filter failures are
  pre-existing — confirmed failing on the baseline binary too):
  - `--filter moduleResolution`: 111/111
  - `--filter import`: 12583/12585 (deeplyNestedMappedTypes,
    propTypeValidatorInference pre-existing)
  - `--filter ambientModule`: 7/7
  - `--filter exportImport`: 7/7
  - `--filter unresolved`: 1/1
  - `--filter cannotFindModule`: 0 matched
- Project rows (`include` = source dir, deps absent, vs `tsc` oracle;
  per-code symmetric delta = tsz-over (FP-ish) / tsz-under (FN-ish)):
  - **io-ts**: FP 244 → 239 (−5), FN 31 → 25 (−6). The `import Eq = E.Eq`
    witness in `src/Eq.ts` collapses (TS2339 5→1; TS7006 3→9 toward the
    oracle's 12). Note: the dominant io-ts TS2322 cascade in
    `Decoder.ts`/`TaskDecoder.ts` is a **separate** deeper mechanism (generic
    interfaces extending types parameterized by unresolved-import members) and
    is intentionally out of scope here.
  - **trpc / msw / ofetch**: no change (these rows do not use the entity-name
    `import X = E.Member` pattern); no regression.
- `scripts/arch/arch_guard.py`: PASS.
- `cargo clippy --profile dev-fast -p tsz-checker --lib`: clean (0 warnings).

## Provenance

Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
