### PR TITLE
perf(ci): bake sccache into runner image, pin nextest/wasm-pack

### DIFF
--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -9,6 +9,12 @@ export CARGO_TERM_COLOR="${CARGO_TERM_COLOR:-never}"
 export CARGO_INCREMENTAL="${CARGO_INCREMENTAL:-1}"
 export CARGO_HOME="${TSZ_CI_CARGO_HOME:-$ROOT_DIR/.ci-cache/cargo-home}"
 SCCACHE_VERSION="${SCCACHE_VERSION:-0.9.1}"
+# Pinned fallback versions for environments that are not running the baked
+# cloud-run-gh-runner image. Keep these in sync with SCCACHE_VER / NEXTEST_VER /
+# WASM_PACK_VER in scripts/infra/cloud-run-gh-runner/Dockerfile. The baked image
+# is the source of truth; these only fire behind the `command -v` guards below.
+NEXTEST_VERSION="${NEXTEST_VERSION:-0.9.137}"
+WASM_PACK_VERSION="${WASM_PACK_VERSION:-0.15.0}"
 export CARGO_PROFILE_DIST_FAST_LTO="${CARGO_PROFILE_DIST_FAST_LTO:-false}"
 export RUST_MIN_STACK="${RUST_MIN_STACK:-16777216}"
 export RUST_TEST_TIMEOUT="${RUST_TEST_TIMEOUT:-300}"
@@ -178,11 +184,12 @@ ensure_host_tools() {
   fi
 
   if suite_needs_group "$suite" unit && ! command -v cargo-nextest >/dev/null 2>&1; then
-    curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C /usr/local/bin
+    curl -LsSf "https://get.nexte.st/${NEXTEST_VERSION}/linux" | tar zxf - -C /usr/local/bin
   fi
 
   if suite_needs_group "$suite" wasm && ! command -v wasm-pack >/dev/null 2>&1; then
-    curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+    curl -sL "https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+      | tar xz --strip-components=1 -C /usr/local/bin "wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl/wasm-pack"
   fi
 
   if suite_needs_group "$suite" rust_compile; then

--- a/scripts/infra/cloud-run-gh-runner/Dockerfile
+++ b/scripts/infra/cloud-run-gh-runner/Dockerfile
@@ -7,6 +7,11 @@ ENV DEBIAN_FRONTEND=noninteractive \
     RUSTUP_HOME=/home/runner/.rustup \
     PATH=/home/runner/.cargo/bin:/google-cloud-sdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+# All runtime tools are pinned and baked here so a rust_compile/unit/wasm job
+# does not download them from a GitHub release on the critical path. Keep
+# SCCACHE_VER / NEXTEST_VER / WASM_PACK_VER in sync with SCCACHE_VERSION /
+# NEXTEST_VERSION / WASM_PACK_VERSION in scripts/ci/gcp-full-ci.sh, which keeps
+# pinned `command -v`-guarded fallback downloads for non-baked environments.
 RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends \
       bash \
@@ -25,17 +30,24 @@ RUN apt-get update -qq \
       tar \
       unzip \
       xz-utils \
+      zstd \
     && HYPERFINE_VER=1.18.0 \
+    && SCCACHE_VER=0.9.1 \
+    && NEXTEST_VER=0.9.137 \
+    && WASM_PACK_VER=0.15.0 \
     && curl -sL "https://github.com/sharkdp/hyperfine/releases/download/v${HYPERFINE_VER}/hyperfine-v${HYPERFINE_VER}-x86_64-unknown-linux-musl.tar.gz" \
        | tar xz --strip-components=1 -C /usr/local/bin "hyperfine-v${HYPERFINE_VER}-x86_64-unknown-linux-musl/hyperfine" \
+    && curl -sL "https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VER}/sccache-v${SCCACHE_VER}-x86_64-unknown-linux-musl.tar.gz" \
+       | tar xz --strip-components=1 -C /usr/local/bin "sccache-v${SCCACHE_VER}-x86_64-unknown-linux-musl/sccache" \
     && curl -fsSL https://sdk.cloud.google.com > /tmp/install-gcloud.sh \
     && bash /tmp/install-gcloud.sh --disable-prompts --install-dir=/ \
     && rm -rf /tmp/install-gcloud.sh \
     && curl https://sh.rustup.rs -sSf | su runner -c 'sh -s -- -y --profile minimal --default-toolchain stable' \
     && su runner -c '/home/runner/.cargo/bin/rustup component add clippy rustfmt llvm-tools-preview' \
     && su runner -c '/home/runner/.cargo/bin/rustup target add wasm32-unknown-unknown' \
-    && curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C /usr/local/bin \
-    && curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh \
+    && curl -LsSf "https://get.nexte.st/${NEXTEST_VER}/linux" | tar zxf - -C /usr/local/bin \
+    && curl -sL "https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VER}/wasm-pack-v${WASM_PACK_VER}-x86_64-unknown-linux-musl.tar.gz" \
+       | tar xz --strip-components=1 -C /usr/local/bin "wasm-pack-v${WASM_PACK_VER}-x86_64-unknown-linux-musl/wasm-pack" \
     && npm install -g pnpm \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
Bakes a pinned `sccache` into the `cloud-run-gh-runner` image and pins the two
previously-unpinned runtime tool installs (`nextest`, `wasm-pack`), removing a
silent best-effort GitHub-release download from the `rust_compile` critical path
and making image rebuilds deterministic.

Resolves #13743.

## What changed
- **`scripts/infra/cloud-run-gh-runner/Dockerfile`**
  - Bake `sccache` `v0.9.1` (`x86_64-unknown-linux-musl`), matching
    `SCCACHE_VERSION` in `gcp-full-ci.sh`, via the same
    `curl | tar --strip-components=1` pattern already used for hyperfine.
  - Pin nextest: `get.nexte.st/latest` → `get.nexte.st/0.9.137`.
  - Pin wasm-pack: rolling `init.sh` installer → `v0.15.0` musl release tarball.
  - Add `zstd` — the image-only part of #13605 item 4, batched here so the
    cache-compression migration won't need a second image rebuild.
- **`scripts/ci/gcp-full-ci.sh`**
  - Add `NEXTEST_VERSION` (`0.9.137`) and `WASM_PACK_VERSION` (`0.15.0`)
    alongside `SCCACHE_VERSION`.
  - Pin the `command -v`-guarded nextest/wasm-pack runtime fallbacks to those
    versions.

## Why
- `setup_sccache` already short-circuits on `command -v sccache`, so baking the
  binary makes the runtime download dead code **and** eliminates the wasted
  dist-binaries download (it ran before the `TSZ_CI_DISABLE_SCCACHE` gate, so
  that job downloaded sccache and then never used it).
- The image is x86_64-only (the hyperfine URL hardcodes x86_64), so single-arch
  baking is trivially safe; the aarch64 branch in `setup_sccache` stays only as
  a fallback.
- Fallbacks are **pinned, not deleted**: `gcp-full-ci.sh` is defensively built to
  run in non-baked environments (apt/rustup `command -v` guards), so a
  deterministic fallback beats no fallback. This also makes the script changes
  safe to merge before the image is rebuilt.

Goal: fast

## Verification
- `bash -n scripts/ci/gcp-full-ci.sh` → clean.
- Ran the exact `curl | tar` pipelines from **both** files against the real
  release artifacts; each binary extracts to the expected path and runs:
  `sccache 0.9.1`, `wasm-pack 0.15.0`, `cargo-nextest 0.9.137`.
- Targeted CI-script tests green: `test_gcp_full_ci_conformance_artifacts.py` (7),
  `test_gcp_full_ci_emit_metrics.py` (2), `test_ci_resources.py` (28),
  `test-cloudbuild-config-paths.mjs`.
- Full CI on this PR exercises the changed `gcp-full-ci.sh` paths.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude
Effort: high

https://claude.ai/code/session_016MCAkRwZwJHak97J78QFyG

---
_Generated by [Claude Code](https://claude.ai/code/session_016MCAkRwZwJHak97J78QFyG)_