### PR TITLE
fix(checker,solver): preserve user unique-symbol members; resolve generic-tuple infer conditionals

### DIFF
--- a/crates/tsz-checker/src/types/computed_names.rs
+++ b/crates/tsz-checker/src/types/computed_names.rs
@@ -223,6 +223,18 @@ fn any_declaration_matches(
         .get_binder_for_file(symbol.decl_file_idx as usize)
         .unwrap_or(ctx.binder);
 
+    // The declaration node lives in the *current* checker arena when the
+    // symbol is declared in the file under check. Pointer-equality between
+    // `owner_binder` (resolved via `get_binder_for_file`, an `Arc`-backed
+    // binder from `all_binders`) and `ctx.binder` does not always hold even
+    // for that file, so also admit `ctx.arena` whenever the symbol's
+    // declaration file is the current file. Without this, a symbol whose
+    // `declaration_arenas`/`symbol_arenas` maps were not populated (e.g. a
+    // top-level `declare const s: unique symbol` consulted from a
+    // `TypeNodeChecker` lowering path) had no candidate arena, so its
+    // declaration was never inspected and `unique symbol` identity queries
+    // silently returned `false`.
+    let decl_is_current_file = symbol.decl_file_idx as usize == ctx.current_file_idx;
     symbol.all_declarations().into_iter().any(|decl_idx| {
         let mut candidate_arenas: Vec<&NodeArena> = Vec::new();
         if let Some(arenas) = owner_binder.declaration_arenas.get(&(sym_id, decl_idx)) {
@@ -231,7 +243,7 @@ fn any_declaration_matches(
         if let Some(symbol_arena) = owner_binder.symbol_arenas.get(&sym_id) {
             candidate_arenas.push(symbol_arena.as_ref());
         }
-        if std::ptr::eq(owner_binder, ctx.binder) {
+        if decl_is_current_file || std::ptr::eq(owner_binder, ctx.binder) {
             candidate_arenas.push(ctx.arena);
         }
 

--- a/crates/tsz-checker/src/types/type_node_property_names.rs
+++ b/crates/tsz-checker/src/types/type_node_property_names.rs
@@ -59,6 +59,24 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             return Some(name);
         }
 
+        // A computed name `[s]` whose identifier resolves to a user binding with
+        // unique-symbol identity (`const s: unique symbol` / a verified global
+        // `Symbol(...)`/`Symbol.for(...)` const) keys the member under the
+        // canonical `__unique_<id>` binding-identity atom. The strong
+        // `CheckerState` lowering path (`computed_identifier_unique_symbol_property_ref`)
+        // already does this; without the same leg here, an *inline* object type
+        // literal `{ [s]: T }` reached through the `TypeNodeChecker` path (e.g. as
+        // the object operand of an indexed-access type `{ [s]: T }[typeof s]`, or
+        // nested inside a union/intersection) silently dropped the symbol member,
+        // collapsing the shape to `{}` and yielding false TS2536/TS2339. Resolve
+        // the value symbol scope-aware (matching the strong path) and emit the
+        // binding-identity key so both lowering paths agree on the member atom.
+        if let Some(sym_id) = self.resolve_computed_name_value_symbol(computed.expression)
+            && let Some(sym_ref) = computed_names::unique_symbol_property_ref(self.ctx, sym_id)
+        {
+            return Some(format!("__unique_{}", sym_ref.0));
+        }
+
         if let Some(atom) = self.computed_property_expression_name_atom(computed.expression) {
             let name = self.ctx.types.resolve_atom(atom);
             if name.starts_with("[Symbol.")
@@ -110,6 +128,29 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
             |idx| self.resolve_computed_property_symbol(idx),
             expr_idx,
         )
+    }
+
+    /// Resolve the binding a computed-name expression refers to, mirroring the
+    /// strong `CheckerState` path's `resolve_computed_name_expression_symbol`:
+    /// scope-aware `resolve_identifier` with a `file_locals` fallback (no
+    /// VALUE-flag filtering, no eager import-alias following — the canonical key
+    /// helpers in `computed_names` own alias hops). Used only for the
+    /// unique-symbol binding-identity key leg, so both lowering paths agree on
+    /// the same symbol and therefore the same `__unique_<id>` member atom.
+    fn resolve_computed_name_value_symbol(&self, expr_idx: NodeIndex) -> Option<SymbolId> {
+        let node = self.ctx.arena.get(expr_idx)?;
+        if node.kind == syntax_kind_ext::PARENTHESIZED_EXPRESSION {
+            let paren = self.ctx.arena.get_parenthesized(node)?;
+            return self.resolve_computed_name_value_symbol(paren.expression);
+        }
+        if let Some(ident) = self.ctx.arena.get_identifier(node) {
+            return self
+                .ctx
+                .binder
+                .resolve_identifier(self.ctx.arena, expr_idx)
+                .or_else(|| self.ctx.binder.file_locals.get(&ident.escaped_text));
+        }
+        self.resolve_computed_property_symbol(expr_idx)
     }
 
     fn resolve_computed_property_symbol(&self, expr_idx: NodeIndex) -> Option<SymbolId> {

--- a/crates/tsz-checker/tests/ts2490_unique_symbol_iterator_tests.rs
+++ b/crates/tsz-checker/tests/ts2490_unique_symbol_iterator_tests.rs
@@ -473,3 +473,62 @@ for (const x of badIterable) {}
         "TS2490 or TS2488 must fire for iterator missing 'value'; got: {codes:?}"
     );
 }
+
+// ============================================================
+// Inline symbol-keyed object literal in compound type positions
+// (regression: weak `TypeNodeChecker` lowering dropped user
+// unique-symbol members, collapsing `{ [s]: T }` to `{}`).
+// ============================================================
+
+#[test]
+fn inline_unique_symbol_literal_indexed_access_preserves_member() {
+    // `{ [s]: T }[typeof s]` lowers the object operand through the
+    // `TypeNodeChecker` path; the symbol member must survive so the index
+    // resolves to `T` rather than `undefined` (false TS2536/TS2339/TS2322).
+    let codes = diagnostic_codes(
+        r#"
+declare const rawArgs: unique symbol;
+type A = { [rawArgs]: number }[typeof rawArgs];
+const a: number = null as any as A;
+"#,
+    );
+    assert!(
+        !codes.contains(&2536) && !codes.contains(&2339) && !codes.contains(&2322),
+        "inline symbol-keyed literal indexed access must preserve the member; got: {codes:?}"
+    );
+}
+
+#[test]
+fn inline_unique_symbol_literal_in_union_indexed_access_preserves_member() {
+    let codes = diagnostic_codes(
+        r#"
+declare const rawArgs: unique symbol;
+type U = { [rawArgs]: number } | { [rawArgs]: string };
+type A = U[typeof rawArgs];
+const a: number | string = null as any as A;
+"#,
+    );
+    assert!(
+        !codes.contains(&2536) && !codes.contains(&2339) && !codes.contains(&2322),
+        "inline symbol-keyed literal in a union indexed access must preserve the member; got: {codes:?}"
+    );
+}
+
+#[test]
+fn inline_unique_symbol_literal_intersection_with_interface_member() {
+    // The interface declares the same symbol member; the inline literal in the
+    // intersection must also keep its member so the indexed access resolves to
+    // the intersected value type.
+    let codes = diagnostic_codes(
+        r#"
+declare const rawArgs: unique symbol;
+interface Fn { [rawArgs]: unknown; }
+type A = (Fn & { [rawArgs]: [number, string] })[typeof rawArgs];
+const a: [number, string] = null as any as A;
+"#,
+    );
+    assert!(
+        !codes.contains(&2536) && !codes.contains(&2339) && !codes.contains(&2322),
+        "inline symbol-keyed literal in an intersection must preserve the member; got: {codes:?}"
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional.rs
@@ -396,7 +396,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
             };
 
             if extends_has_infer
-                && (self.type_is_generic_tuple(cond.check_type)
+                && (self.generic_tuple_infer_defer_required(cond.check_type, extends_unwrapped)
                     || crate::contains_this_type(self.interner(), cond.check_type))
             {
                 return self.interner().conditional(*cond);

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/conditional/phases.rs
@@ -75,6 +75,114 @@ pub(super) enum TailCallStep {
 }
 
 impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+    /// Decide whether a conditional with an `infer`-bearing extends pattern and a
+    /// generic-tuple check type must stay deferred.
+    ///
+    /// tsc only defers a conditional whose check type is generic when the
+    /// extends relation's outcome actually depends on how the free type
+    /// parameter is later instantiated. For a tuple check type matched against a
+    /// tuple `infer` pattern, that dependence exists only when a generic element
+    /// is aligned with a pattern position that imposes a structural shape or a
+    /// constraint the element might not satisfy (e.g. `[T] extends [[infer U]]`,
+    /// where `T` may or may not be a one-tuple). When every generic element lines
+    /// up with an `infer` position it always satisfies (a bare `infer`, or a
+    /// constrained `infer X extends C` whose `C` already bounds the element),
+    /// the pattern matches for any instantiation, so tsc resolves the true
+    /// branch eagerly with the element captured by the `infer`. Deferring in that
+    /// case strands the `infer` variables unbound in the true branch.
+    ///
+    /// The relaxation is intentionally conservative: it only skips deferral for
+    /// rest-free, equal-length positional tuples whose every generic element
+    /// faces such an always-matching `infer`. Any rest element, length mismatch,
+    /// or generic element facing a non-`infer` / not-provably-satisfied position
+    /// keeps the original deferral so shape/constraint-dependent patterns
+    /// (`[T] extends [[infer U]]`) are unaffected. The downstream infer-pattern
+    /// match (Step 3) and its own generic-check-type deferral then own the
+    /// resolved case.
+    pub(super) fn generic_tuple_infer_defer_required(
+        &self,
+        check_type: TypeId,
+        extends_unwrapped: TypeId,
+    ) -> bool {
+        let Some(TypeData::Tuple(check_list)) = self.interner().lookup(check_type) else {
+            return false;
+        };
+        let check_elems = self.interner().tuple_list(check_list);
+        let has_generic_element = check_elems
+            .iter()
+            .any(|element| Self::is_generic_ref(self.interner(), element.type_id));
+        if !has_generic_element {
+            // Not a generic tuple at all — the original gate would not fire.
+            return false;
+        }
+
+        // Only relax for a rest-free, equal-length positional tuple pattern.
+        let Some(TypeData::Tuple(pattern_list)) = self.interner().lookup(extends_unwrapped) else {
+            return true;
+        };
+        let pattern_elems = self.interner().tuple_list(pattern_list);
+        if check_elems.len() != pattern_elems.len() {
+            return true;
+        }
+        if check_elems.iter().any(|e| e.rest) || pattern_elems.iter().any(|e| e.rest) {
+            return true;
+        }
+
+        // Defer unless every generic check element faces an `infer` position
+        // that matches it for *every* instantiation. A bare (unconstrained)
+        // `infer` matches any type. A constrained `infer X extends C` matches the
+        // generic element for all instantiations only when the element's own
+        // upper bound is already a subtype of `C` (so no instantiation can fall
+        // outside `C`). Both cases make the conditional resolve identically
+        // regardless of the free parameter, so eager resolution is sound and
+        // matches tsc; deferring would strand the `infer` variables unbound.
+        for (check_elem, pattern_elem) in check_elems.iter().zip(pattern_elems.iter()) {
+            if !Self::is_generic_ref(self.interner(), check_elem.type_id) {
+                continue;
+            }
+            let Some(TypeData::Infer(info)) = self.interner().lookup(pattern_elem.type_id) else {
+                return true;
+            };
+            let Some(infer_constraint) = info.constraint else {
+                // Bare infer: matches any instantiation of the element.
+                continue;
+            };
+            // Constrained infer: only safe when the element provably satisfies
+            // the constraint for every instantiation, i.e. its upper bound is a
+            // subtype of the infer's constraint.
+            if !self
+                .generic_element_satisfies_infer_constraint(check_elem.type_id, infer_constraint)
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// True when a generic check-tuple element provably satisfies a constrained
+    /// `infer`'s upper bound for *every* instantiation — i.e. the element's own
+    /// declared constraint (upper bound) is assignable to `infer_constraint`.
+    /// Used by [`Self::generic_tuple_infer_defer_required`] to decide whether a
+    /// constrained `infer` position matches unconditionally. A `false` result
+    /// keeps the conditional deferred, never widening the resolved set.
+    fn generic_element_satisfies_infer_constraint(
+        &self,
+        element: TypeId,
+        infer_constraint: TypeId,
+    ) -> bool {
+        let Some(TypeData::TypeParameter(param)) = self.interner().lookup(element) else {
+            return false;
+        };
+        let Some(element_constraint) = param.constraint else {
+            // An unconstrained type parameter's upper bound is `unknown`, which
+            // is not a subtype of a non-trivial `infer_constraint`.
+            return false;
+        };
+        let mut checker = self.conditional_subtype_checker();
+        checker.allow_bivariant_rest = true;
+        checker.is_subtype_of(element_constraint, infer_constraint)
+    }
+
     /// Resolve and pre-compute operands for one conditional evaluation step.
     ///
     /// Evaluates `check_type` and `extends_type`, normalises object shapes, expands

--- a/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_arrays.rs
+++ b/crates/tsz-solver/tests/evaluate_tests_parts/conditional_infer_arrays.rs
@@ -1465,3 +1465,163 @@ fn test_conditional_infer_template_literal_union_input_distributive() {
 
     assert_eq!(result, TypeId::STRING);
 }
+
+#[test]
+fn test_conditional_generic_tuple_bare_infer_pattern_resolves_true_branch() {
+    // `[unknown, A] extends [infer F, infer Tuple] ? Tuple : never` where `A` is
+    // a free type parameter. The pattern is a rest-free tuple of *bare* infers,
+    // so it matches for any instantiation of `A`; the conditional must resolve
+    // the true branch with `Tuple` bound to `A` rather than staying deferred
+    // (which would strand the `infer` variables unbound).
+    let interner = TypeInterner::new();
+
+    let (_a_name, a_param) = test_type_param(&interner, "A");
+    let (_f_name, infer_f) = test_infer_param(&interner, "F");
+    let (_t_name, infer_t) = test_infer_param(&interner, "Tuple");
+
+    let check = interner.tuple(vec![
+        TupleElement {
+            type_id: TypeId::UNKNOWN,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: a_param,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+    let extends = interner.tuple(vec![
+        TupleElement {
+            type_id: infer_f,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: infer_t,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+    let cond = ConditionalType {
+        check_type: check,
+        extends_type: extends,
+        true_type: infer_t,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let result = evaluate_type(&interner, interner.conditional(cond));
+    assert_eq!(result, a_param);
+}
+
+#[test]
+fn test_conditional_generic_tuple_constrained_infer_satisfied_resolves_true_branch() {
+    // `[object, A] extends [infer F, infer Tuple extends unknown[]] ? Tuple : never`
+    // where `A extends unknown[]`. The constrained `infer Tuple extends unknown[]`
+    // is provably satisfied by `A`'s own upper bound for every instantiation, so
+    // the conditional resolves the true branch (`Tuple = A`) instead of deferring.
+    let interner = TypeInterner::new();
+
+    let array_unknown = interner.array(TypeId::UNKNOWN);
+    let a_name = interner.intern_string("A");
+    let a_param = interner.intern(TypeData::TypeParameter(TypeParamInfo {
+        name: a_name,
+        constraint: Some(array_unknown),
+        default: None,
+        is_const: false,
+        origin: crate::types::TypeParamOrigin::User,
+    }));
+
+    let (_f_name, infer_f) = test_infer_param(&interner, "F");
+    let (_t_name, infer_t) = test_constrained_infer_param(&interner, "Tuple", array_unknown);
+
+    let check = interner.tuple(vec![
+        TupleElement {
+            type_id: TypeId::OBJECT,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: a_param,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+    let extends = interner.tuple(vec![
+        TupleElement {
+            type_id: infer_f,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+        TupleElement {
+            type_id: infer_t,
+            name: None,
+            optional: false,
+            rest: false,
+        },
+    ]);
+    let cond = ConditionalType {
+        check_type: check,
+        extends_type: extends,
+        true_type: infer_t,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let result = evaluate_type(&interner, interner.conditional(cond));
+    assert_eq!(result, a_param);
+}
+
+#[test]
+fn test_conditional_generic_tuple_shape_pattern_still_defers() {
+    // `[A] extends [[infer U]] ? U : never` where `A` is a free type parameter.
+    // The pattern position is a *nested tuple* shape, not a bare/constrained
+    // `infer`, so whether `A` matches depends on its instantiation. The
+    // conditional must stay deferred (returns a `Conditional`), preserving the
+    // existing shape/constraint-dependent behavior.
+    let interner = TypeInterner::new();
+
+    let (_a_name, a_param) = test_type_param(&interner, "A");
+    let (_u_name, infer_u) = test_infer_param(&interner, "U");
+
+    let check = interner.tuple(vec![TupleElement {
+        type_id: a_param,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+    let inner = interner.tuple(vec![TupleElement {
+        type_id: infer_u,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+    let extends = interner.tuple(vec![TupleElement {
+        type_id: inner,
+        name: None,
+        optional: false,
+        rest: false,
+    }]);
+    let cond = ConditionalType {
+        check_type: check,
+        extends_type: extends,
+        true_type: infer_u,
+        false_type: TypeId::NEVER,
+        is_distributive: false,
+    };
+
+    let result = evaluate_type(&interner, interner.conditional(cond));
+    assert!(
+        matches!(interner.lookup(result), Some(TypeData::Conditional(_))),
+        "shape-pattern conditional over a generic tuple must stay deferred; got {:?}",
+        interner.lookup(result)
+    );
+}


### PR DESCRIPTION
Two independent, well-scoped `tsc`-parity fixes uncovered while driving the
**hotscript** canary row toward green. Both fix real adjacent-case bugs and have
regression tests. They reduce hotscript's single residual diagnostic's failure
chain by two layers but do **not** fully clear it — a third, deeper blocker
remains (documented below), so this PR does **not** promote hotscript.

Goal: green

## Structural rule

Fix 1 (checker, symbol member drop):
When an inline object **type literal** `{ [s]: T }` whose computed key `s` is a
user `unique symbol` binding is lowered through the weak `TypeNodeChecker` path
— the object operand of an indexed-access type (`{ [s]: T }[typeof s]`) or a
literal nested in a union/intersection — `tsc` keeps the symbol member; tsz
dropped it (the shape collapsed to `{}`), yielding false `TS2536`/`TS2339`/
`TS2322`. Owner: checker type-node lowering. The weak `get_property_name_resolved`
now resolves user unique-symbol identifiers to the same `__unique_<id>`
binding-identity key the strong `CheckerState` path uses, and
`any_declaration_matches` admits the current-file arena whenever a symbol is
declared in the file under check (an `Arc`-backed `get_binder_for_file` binder is
not pointer-equal to `ctx.binder`, which previously hid top-level
`declare const s: unique symbol` declarations from unique-symbol identity
queries).

Fix 2 (solver, conditional deferral):
When a conditional `[..., A, ...] extends [..., infer X, ...]` has a check type
that is a concrete tuple containing a free type parameter `A`, and the extends
pattern is a tuple of `infer`s, `tsc` resolves the true branch (the inference is
independent of how `A` is later instantiated); tsz deferred unconditionally,
stranding the `infer` variables unbound in the true branch. Owner: solver
conditional evaluation. tsz now resolves the true branch when every generic
element faces an `infer` position it always satisfies (a bare `infer`, or a
constrained `infer X extends C` whose `C` already bounds the element's upper
type). Shape/constraint-dependent patterns such as `[T] extends [[infer U]]`
still defer.

Both fixes are structural (no user-name/file-name/printer-string predicates;
built-in identity via binder symbols and solver structural helpers only).

## Remaining hotscript blocker (not in this PR)

hotscript's residual `TS2344` at `Tuples.ts:750`
(`Apply<fn, Call<Tuples.Map<Tuples.At<Index>, arrs>>>`) needs a third fix: a
homomorphic mapped type `{ [K in keyof tuple]: tuple[K] }` whose `tuple` is bound
(via a constrained `infer`) to a generic array-constrained parameter does not
preserve array-ness when the result is the *direct* result of a conditional fed
through the `Apply`/`this[rawArgs]` intersection-indexed-access indirection
(`keyof tuple` widens to `keyof unknown[]` instead of `keyof <param>`). The same
machinery resolves correctly when the result is nested in an object property, so
this is a top-level-result evaluation quirk in the deep Apply context. It is left
for a follow-up; this PR lands the two clean prerequisites.

## Verification

- `cargo build --profile dist-fast -p tsz-cli --bin tsz` (clean)
- `cargo nextest run -p tsz-solver test_conditional_generic_tuple` — 3/3 pass
  (incl. negative `..._shape_pattern_still_defers`)
- `cargo nextest run -p tsz-checker --test ts2490_unique_symbol_iterator_tests inline_unique_symbol` — 3/3 pass
- `cargo nextest run -p tsz-solver conditional` — 481/482 (the 1 failure,
  `test_conditional_infer_optional_property_present_distributive`, is pre-existing
  on `origin/main`, verified by stashing this PR's conditional change)
- `cargo clippy -p tsz-solver -p tsz-checker --profile dist-fast` — clean
- `python3 scripts/arch/arch_guard.py` — passed (conditional.rs kept under its
  line budget by moving both new helpers into the `conditional/phases.rs`
  submodule)
- CLI repros (strict, es2022): inline symbol-keyed literal indexed/union/
  intersection access now resolve; generic-tuple infer conditionals resolve true
  branch; `[T] extends [[infer U]]` still defers.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high
