### PR TITLE
fix(ci): keep advisory ci-health monitors green on transient gh errors + add concurrency guard (#13744)

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -6,6 +6,13 @@ on:
     - cron: '*/15 * * * *'
   workflow_dispatch:
 
+# Serialize overlapping firings (a slow */15 run must not race the next one over
+# the single main-red sentinel issue). Do NOT cancel-in-progress: a useful
+# health check should run to completion rather than be dropped. See issue #13744.
+concurrency:
+  group: ci-health
+  cancel-in-progress: false
+
 permissions:
   contents: read
   actions: read
@@ -21,6 +28,10 @@ jobs:
   wip-state-comments:
     name: wip-state-comments
     runs-on: ubuntu-latest
+    # Pure advisory probes (WIP-state + stale-run gaps). A transient gh API
+    # error must not red the health workflow — matches bench-artifact-readiness.
+    # The scripts already retry transient transport; this is belt-and-suspenders.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -67,6 +78,10 @@ jobs:
   ci-job-timing:
     name: ci-job-timing
     runs-on: ubuntu-latest
+    # Pure advisory baseline — a transient gh API error must not red the health
+    # workflow (matches bench-artifact-readiness). The script also retries
+    # transient transport; this is belt-and-suspenders.
+    continue-on-error: true
     # Advisory baseline: records per-job queue_wait + run seconds over recent
     # successful ci.yml runs so every other CI speed claim on this fleet can be
     # checked against measured numbers (issue #13605 item 2). No wall-clock

--- a/scripts/ci/check-ci-job-timing.mjs
+++ b/scripts/ci/check-ci-job-timing.mjs
@@ -82,8 +82,46 @@ export function parseArgs(argv) {
   return options;
 }
 
+// Bounded exponential backoff over transient gh transport failures (5xx,
+// secondary rate limit, transient network errors). Retries only the transport,
+// never a real finding, so this advisory baseline survives a flaky GitHub API
+// call instead of reddening the workflow. See issue #13744.
+const GH_RETRY_ATTEMPTS = Math.max(1, Number.parseInt(process.env.GH_RETRY_ATTEMPTS || "", 10) || 4);
+const GH_RETRY_BASE_MS = Math.max(0, Number.parseInt(process.env.GH_RETRY_BASE_MS || "", 10) || 500);
+const GH_RETRY_MAX_MS = 8000;
+const TRANSIENT_NET_CODES = new Set([
+  "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EAI_AGAIN", "ENOTFOUND", "EPIPE",
+]);
+
+function sleepSync(ms) {
+  if (!(ms > 0)) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function isTransientGhResult(result) {
+  if (result.error) {
+    if (result.error.code === "ENOBUFS") return false;
+    return TRANSIENT_NET_CODES.has(result.error.code);
+  }
+  if ((result.status ?? 0) === 0) return false;
+  const text = `${result.stdout || ""}\n${result.stderr || ""}`;
+  return /\bHTTP\s+(?:408|425|429|5\d\d)\b/i.test(text)
+    || /secondary rate limit/i.test(text)
+    || /\b(?:Bad Gateway|Service Unavailable|Gateway Time-?out|Internal Server Error|Server Error)\b/i.test(text);
+}
+
+function spawnGh(args, spawnOptions) {
+  let result;
+  for (let attempt = 1; attempt <= GH_RETRY_ATTEMPTS; attempt += 1) {
+    result = spawnSync("gh", args, spawnOptions);
+    if (attempt === GH_RETRY_ATTEMPTS || !isTransientGhResult(result)) break;
+    sleepSync(Math.min(GH_RETRY_BASE_MS * 2 ** (attempt - 1), GH_RETRY_MAX_MS));
+  }
+  return result;
+}
+
 function runGhJson(args) {
-  const result = spawnSync("gh", args, {
+  const result = spawnGh(args, {
     encoding: "utf8",
     maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "pipe"],

--- a/scripts/ci/check-main-red.mjs
+++ b/scripts/ci/check-main-red.mjs
@@ -89,8 +89,49 @@ function parseArgs(argv) {
   return options;
 }
 
+// Bounded exponential backoff over transient gh transport failures (5xx,
+// secondary rate limit, transient network errors). This retries only the
+// transport — never a real verdict/finding — so the sentinel's signal is
+// unchanged; it just survives a flaky GitHub API call instead of reddening the
+// advisory ci-health workflow. See issue #13744.
+const GH_RETRY_ATTEMPTS = Math.max(1, Number.parseInt(process.env.GH_RETRY_ATTEMPTS || "", 10) || 4);
+const GH_RETRY_BASE_MS = Math.max(0, Number.parseInt(process.env.GH_RETRY_BASE_MS || "", 10) || 500);
+const GH_RETRY_MAX_MS = 8000;
+const TRANSIENT_NET_CODES = new Set([
+  "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EAI_AGAIN", "ENOTFOUND", "EPIPE",
+]);
+
+function sleepSync(ms) {
+  if (!(ms > 0)) return;
+  // Synchronous sleep without busy-waiting; spawnSync gives us no async seam.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function isTransientGhResult(result) {
+  if (result.error) {
+    // ENOBUFS is a hard output-size error, not transient.
+    if (result.error.code === "ENOBUFS") return false;
+    return TRANSIENT_NET_CODES.has(result.error.code);
+  }
+  if ((result.status ?? 0) === 0) return false;
+  const text = `${result.stdout || ""}\n${result.stderr || ""}`;
+  return /\bHTTP\s+(?:408|425|429|5\d\d)\b/i.test(text)
+    || /secondary rate limit/i.test(text)
+    || /\b(?:Bad Gateway|Service Unavailable|Gateway Time-?out|Internal Server Error|Server Error)\b/i.test(text);
+}
+
+function spawnGh(args, spawnOptions) {
+  let result;
+  for (let attempt = 1; attempt <= GH_RETRY_ATTEMPTS; attempt += 1) {
+    result = spawnSync("gh", args, spawnOptions);
+    if (attempt === GH_RETRY_ATTEMPTS || !isTransientGhResult(result)) break;
+    sleepSync(Math.min(GH_RETRY_BASE_MS * 2 ** (attempt - 1), GH_RETRY_MAX_MS));
+  }
+  return result;
+}
+
 function runGhJson(args) {
-  const result = spawnSync("gh", args, {
+  const result = spawnGh(args, {
     encoding: "utf8",
     maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "pipe"],
@@ -104,7 +145,7 @@ function runGhJson(args) {
 }
 
 function runGh(args) {
-  const result = spawnSync("gh", args, {
+  const result = spawnGh(args, {
     encoding: "utf8",
     maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "pipe"],
@@ -274,6 +315,18 @@ export function formatReport(verdict, regressedTests = []) {
 
 // --- issue lifecycle (gh I/O) ---
 
+// The issue body always carries the tracked head commit in its "Head commit"
+// row (see formatIssueBody). Recover the short sha last recorded so we can post
+// the heartbeat comment only when the red head actually moved, not every cron
+// firing.
+const TRACKED_SHA_RE = /Head commit\s*\|\s*`([0-9a-f]+)`/i;
+
+function lastTrackedSha(issue) {
+  if (!issue || typeof issue.body !== "string") return "";
+  const match = issue.body.match(TRACKED_SHA_RE);
+  return match ? match[1] : "";
+}
+
 function findSentinelIssue(repository, fetchJson) {
   const issues = fetchJson([
     "api",
@@ -292,11 +345,18 @@ export function reconcileIssue(verdict, regressedTests, nowIso, ctx) {
 
   if (verdict.red) {
     if (existing) {
-      // Refresh the body and add a heartbeat comment if the red head changed.
+      // Always refresh the body (idempotent: same sha -> same body). Only add a
+      // heartbeat comment when the red head sha changed since the last recorded
+      // one, so a long-red `main` does not spam a comment every 15-min firing.
+      const currentSha = (verdict.run.sha || "").slice(0, 12);
+      const previousSha = lastTrackedSha(existing);
       runCommand(["issue", "edit", String(existing.number), "--repo", repository, "--body", body]);
-      runCommand(["issue", "comment", String(existing.number), "--repo", repository,
-        "--body", `Still red as of ${nowIso}: \`${(verdict.run.sha || "").slice(0, 12)}\` ([run](${verdict.run.url})).`]);
-      return { action: "updated", number: existing.number };
+      const headChanged = currentSha !== "" && currentSha !== previousSha;
+      if (headChanged) {
+        runCommand(["issue", "comment", String(existing.number), "--repo", repository,
+          "--body", `Still red as of ${nowIso}: \`${currentSha}\` ([run](${verdict.run.url})).`]);
+      }
+      return { action: "updated", number: existing.number, commented: headChanged };
     }
     const created = runCommand(["issue", "create", "--repo", repository,
       "--title", ISSUE_TITLE, "--body", body, "--label", "tech-debt"]);

--- a/scripts/ci/check-stale-ci-runs.mjs
+++ b/scripts/ci/check-stale-ci-runs.mjs
@@ -87,8 +87,46 @@ function parseArgs(argv) {
   return options;
 }
 
+// Bounded exponential backoff over transient gh transport failures (5xx,
+// secondary rate limit, transient network errors). Retries only the transport,
+// never a real finding, so an advisory ci-health firing survives a flaky
+// GitHub API call instead of reddening the workflow. See issue #13744.
+const GH_RETRY_ATTEMPTS = Math.max(1, Number.parseInt(process.env.GH_RETRY_ATTEMPTS || "", 10) || 4);
+const GH_RETRY_BASE_MS = Math.max(0, Number.parseInt(process.env.GH_RETRY_BASE_MS || "", 10) || 500);
+const GH_RETRY_MAX_MS = 8000;
+const TRANSIENT_NET_CODES = new Set([
+  "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EAI_AGAIN", "ENOTFOUND", "EPIPE",
+]);
+
+function sleepSync(ms) {
+  if (!(ms > 0)) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function isTransientGhResult(result) {
+  if (result.error) {
+    if (result.error.code === "ENOBUFS") return false;
+    return TRANSIENT_NET_CODES.has(result.error.code);
+  }
+  if ((result.status ?? 0) === 0) return false;
+  const text = `${result.stdout || ""}\n${result.stderr || ""}`;
+  return /\bHTTP\s+(?:408|425|429|5\d\d)\b/i.test(text)
+    || /secondary rate limit/i.test(text)
+    || /\b(?:Bad Gateway|Service Unavailable|Gateway Time-?out|Internal Server Error|Server Error)\b/i.test(text);
+}
+
+function spawnGh(args, spawnOptions) {
+  let result;
+  for (let attempt = 1; attempt <= GH_RETRY_ATTEMPTS; attempt += 1) {
+    result = spawnSync("gh", args, spawnOptions);
+    if (attempt === GH_RETRY_ATTEMPTS || !isTransientGhResult(result)) break;
+    sleepSync(Math.min(GH_RETRY_BASE_MS * 2 ** (attempt - 1), GH_RETRY_MAX_MS));
+  }
+  return result;
+}
+
 function runGhJson(args) {
-  const result = spawnSync("gh", args, {
+  const result = spawnGh(args, {
     encoding: "utf8",
     maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "pipe"],
@@ -113,7 +151,7 @@ function runGhJson(args) {
 }
 
 function runGh(args) {
-  const result = spawnSync("gh", args, {
+  const result = spawnGh(args, {
     encoding: "utf8",
     maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "pipe"],

--- a/scripts/ci/check-wip-state-comments.mjs
+++ b/scripts/ci/check-wip-state-comments.mjs
@@ -85,9 +85,49 @@ function parseArgs(argv) {
   return options;
 }
 
+// Bounded exponential backoff over transient gh transport failures (5xx,
+// secondary rate limit, transient network errors). Retries only the transport,
+// never a real finding, so this advisory probe survives a flaky GitHub API call
+// instead of reddening the workflow. See issue #13744.
+const GH_RETRY_ATTEMPTS = Math.max(1, Number.parseInt(process.env.GH_RETRY_ATTEMPTS || "", 10) || 4);
+const GH_RETRY_BASE_MS = Math.max(0, Number.parseInt(process.env.GH_RETRY_BASE_MS || "", 10) || 500);
+const GH_RETRY_MAX_MS = 8000;
+const TRANSIENT_NET_CODES = new Set([
+  "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EAI_AGAIN", "ENOTFOUND", "EPIPE",
+]);
+
+function sleepSync(ms) {
+  if (!(ms > 0)) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function isTransientGhResult(result) {
+  if (result.error) {
+    // ENOBUFS (size) and ETIMEDOUT (per-call deadline) get their own handling
+    // below; do not retry them here.
+    if (result.error.code === "ENOBUFS" || result.error.code === "ETIMEDOUT") return false;
+    return TRANSIENT_NET_CODES.has(result.error.code);
+  }
+  if ((result.status ?? 0) === 0) return false;
+  const text = `${result.stdout || ""}\n${result.stderr || ""}`;
+  return /\bHTTP\s+(?:408|425|429|5\d\d)\b/i.test(text)
+    || /secondary rate limit/i.test(text)
+    || /\b(?:Bad Gateway|Service Unavailable|Gateway Time-?out|Internal Server Error|Server Error)\b/i.test(text);
+}
+
+function spawnGh(args, spawnOptions) {
+  let result;
+  for (let attempt = 1; attempt <= GH_RETRY_ATTEMPTS; attempt += 1) {
+    result = spawnSync("gh", args, spawnOptions);
+    if (attempt === GH_RETRY_ATTEMPTS || !isTransientGhResult(result)) break;
+    sleepSync(Math.min(GH_RETRY_BASE_MS * 2 ** (attempt - 1), GH_RETRY_MAX_MS));
+  }
+  return result;
+}
+
 function runGhJson(args, options = {}) {
   const timeout = options.ghTimeoutMs || DEFAULT_GH_TIMEOUT_MS;
-  const result = spawnSync("gh", args, {
+  const result = spawnGh(args, {
     encoding: "utf8",
     maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## Summary
Keeps the advisory ci-health monitors green on transient `gh` API errors and stops overlapping `*/15` firings from racing the single main-red sentinel issue. The advisory monitors previously went RED on any transient 5xx / secondary-rate-limit from the `runs`/`jobs` REST API, training maintainers to ignore ci-health — exactly when the main-red sentinel must be trusted.

Three coordinated changes (no new metrics/observability — that is #13753):

1. **Bounded exponential-backoff retry on transient transport** in the shared `runGh`/`runGhJson` helpers of all four `.mjs` scripts (`check-main-red`, `check-stale-ci-runs`, `check-ci-job-timing`, `check-wip-state-comments`). A new `spawnGh()` wrapper retries only when the gh result is transient — HTTP 408/425/429/5xx, "secondary rate limit", or transient network codes (`ETIMEDOUT`/`ECONNRESET`/`EAI_AGAIN`/etc.). It never retries a real verdict/finding, a 4xx auth/permission/404, or `ENOBUFS`, so the main-red sentinel's signal is unchanged — it just survives a flaky API call. Tunable via `GH_RETRY_ATTEMPTS`/`GH_RETRY_BASE_MS` (default 4 attempts, 500ms base, 8s cap). This also protects main-red-sentinel and runner-health WITHOUT suppressing their real critical exits.
2. **Belt-and-suspenders `continue-on-error: true`** on the two pure-advisory jobs (`wip-state-comments`, which runs both the WIP-state and stale-runs probes, and `ci-job-timing`), matching the existing `bench-artifact-readiness` pattern. `main-red-sentinel` and `runner-health` keep hard-failing on their real critical conditions.
3. **Workflow-level concurrency guard** `concurrency: { group: ci-health, cancel-in-progress: false }` so a slow firing serializes with the next one instead of racing the sentinel issue (does NOT cancel-in-progress — a useful check runs to completion).
4. **Implemented the missing SHA-change gate** in `check-main-red.mjs reconcileIssue`: the heartbeat comment on the open sentinel issue is now posted only when the red head sha changed since the last recorded one (recovered from the issue body's "Head commit" row). The body is still refreshed every firing (idempotent), so a long-red `main` no longer spams a comment every 15 minutes. The code comment already claimed this behavior; it was not implemented.

Closes #13744

## Structural rule
When a ci-health advisory monitor's `gh` call fails with a transient transport error (5xx / 429 / secondary rate limit / transient network), the monitor retries the transport with bounded backoff and — for the three pure-advisory probes — never reds the workflow; it never retries or suppresses a real finding/verdict. When `main` stays red across firings, the sentinel posts a heartbeat comment only when the red head sha changes.

Goal: hold

## Provenance
Machine: MacBookPro.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
Local (never ran full CI):
- `node --check` on all four edited `.mjs` scripts — pass
- `node scripts/ci/test-check-stale-ci-runs.mjs` — pass
- `node scripts/ci/test-check-main-red.mjs` — 13 tests passed (incl. all `reconcileIssue` cases)
- `node scripts/ci/test-check-ci-job-timing.mjs` — all assertions passed
- `node scripts/ci/test-wip-state-comments.mjs` — pass
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-health.yml'))"` — YAML OK

— AgentName: M1FableArchitect
