### PR TITLE
fix(ci): automate runner-image build/deploy with provenance + document the fleet (#13750)

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -1,0 +1,152 @@
+# Build (and, when explicitly requested, deploy) the self-hosted GitHub Actions
+# runner image for the Cloud Run fleet.
+#
+# This workflow is intentionally SEPARATE from ci.yml / bench.yml and is NOT a
+# required check. It cannot affect PR CI status. The build step is safe to run
+# automatically (it only produces a SHA-tagged image); the deploy step touches
+# live infrastructure and is therefore gated behind a manual workflow_dispatch
+# input AND the `runner-image-deploy` environment (configure it with required
+# reviewers for manual approval).
+#
+# Configuration: this workflow no-ops with a clear message unless the repo
+# variables below are configured by a maintainer (see
+# scripts/infra/cloud-run-gh-runner/README.md):
+#   vars.RUNNER_IMAGE_GCP_PROJECT          (required to build)
+#   vars.RUNNER_IMAGE_REPO                 (required to build; image repo path)
+#   vars.RUNNER_IMAGE_GCP_REGION           (optional; defaults to us-central1)
+#   vars.RUNNER_IMAGE_CLOUD_RUN_SERVICE    (required to deploy)
+#   vars.RUNNER_IMAGE_MIN_INSTANCES        (optional; defaults to 0)
+#   vars.RUNNER_IMAGE_MAX_INSTANCES        (optional; defaults to 50)
+name: runner-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy:
+        description: "Deploy the freshly built SHA-tagged image to the Cloud Run runner service (requires the runner-image-deploy approval environment)."
+        type: boolean
+        default: false
+      reason:
+        description: "Provenance note: why are you rebuilding / deploying?"
+        type: string
+        default: "manual rebuild"
+  push:
+    paths:
+      - 'scripts/infra/cloud-run-gh-runner/Dockerfile'
+      - 'scripts/infra/cloud-run-gh-runner/start.sh'
+      - 'scripts/cloudbuild/cloudbuild-runner-image.yaml'
+      - '.github/workflows/runner-image.yml'
+  schedule:
+    # Weekly rebuild to pick up base-image / OS security updates. Build only;
+    # the scheduled run can never deploy (deploy requires workflow_dispatch).
+    - cron: '0 7 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: runner-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build-runner-image
+    runs-on: [self-hosted, tsz-cloud-run]
+    timeout-minutes: 60
+    outputs:
+      configured: ${{ steps.config.outputs.configured }}
+      image_sha_tag: ${{ steps.build.outputs.image_sha_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - id: config
+        name: Resolve GCP configuration
+        env:
+          GCP_PROJECT: ${{ vars.RUNNER_IMAGE_GCP_PROJECT }}
+          IMAGE_REPO: ${{ vars.RUNNER_IMAGE_REPO }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GCP_PROJECT}" || -z "${IMAGE_REPO}" ]]; then
+            echo "::notice title=runner-image not configured::Set repo variables RUNNER_IMAGE_GCP_PROJECT and RUNNER_IMAGE_REPO (and optionally RUNNER_IMAGE_GCP_REGION / RUNNER_IMAGE_CLOUD_RUN_SERVICE) to enable runner-image builds. See scripts/infra/cloud-run-gh-runner/README.md. No-op for now."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "runner-image build is configured (project=${GCP_PROJECT})."
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - id: build
+        if: steps.config.outputs.configured == 'true'
+        name: Build and push runner image (SHA-tagged for provenance)
+        env:
+          GCP_PROJECT: ${{ vars.RUNNER_IMAGE_GCP_PROJECT }}
+          GCP_REGION: ${{ vars.RUNNER_IMAGE_GCP_REGION || 'us-central1' }}
+          IMAGE_REPO: ${{ vars.RUNNER_IMAGE_REPO }}
+        run: |
+          set -euo pipefail
+          sha="${GITHUB_SHA}"
+          image_sha_tag="${IMAGE_REPO}:${sha}"
+          echo "Building runner image ${image_sha_tag} (region=${GCP_REGION})"
+          gcloud builds submit \
+            --project="${GCP_PROJECT}" \
+            --region="${GCP_REGION}" \
+            --config=scripts/cloudbuild/cloudbuild-runner-image.yaml \
+            --substitutions=_IMAGE="${IMAGE_REPO}",_SHA="${sha}" \
+            .
+          echo "image_sha_tag=${image_sha_tag}" >> "$GITHUB_OUTPUT"
+          echo "Built and pushed ${image_sha_tag} (and :latest)."
+
+  deploy:
+    name: deploy-runner-image
+    needs: build
+    # Deploy only on an explicit manual dispatch with deploy=true, and only when
+    # the build actually ran. The environment adds a manual-approval gate.
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.deploy == true &&
+      needs.build.outputs.configured == 'true'
+    runs-on: [self-hosted, tsz-cloud-run]
+    timeout-minutes: 30
+    environment: runner-image-deploy
+    steps:
+      - id: config
+        name: Verify Cloud Run service is configured
+        env:
+          SERVICE: ${{ vars.RUNNER_IMAGE_CLOUD_RUN_SERVICE }}
+          IMAGE_SHA_TAG: ${{ needs.build.outputs.image_sha_tag }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SERVICE}" ]]; then
+            echo "::error title=runner-image deploy not configured::Set repo variable RUNNER_IMAGE_CLOUD_RUN_SERVICE to the Cloud Run runner service name before deploying."
+            exit 1
+          fi
+          if [[ -z "${IMAGE_SHA_TAG}" ]]; then
+            echo "::error::No image tag was produced by the build job."
+            exit 1
+          fi
+
+      - name: Deploy SHA-tagged image to Cloud Run runner service
+        env:
+          GCP_PROJECT: ${{ vars.RUNNER_IMAGE_GCP_PROJECT }}
+          GCP_REGION: ${{ vars.RUNNER_IMAGE_GCP_REGION || 'us-central1' }}
+          SERVICE: ${{ vars.RUNNER_IMAGE_CLOUD_RUN_SERVICE }}
+          IMAGE_SHA_TAG: ${{ needs.build.outputs.image_sha_tag }}
+          MIN_INSTANCES: ${{ vars.RUNNER_IMAGE_MIN_INSTANCES || '0' }}
+          MAX_INSTANCES: ${{ vars.RUNNER_IMAGE_MAX_INSTANCES || '50' }}
+        run: |
+          set -euo pipefail
+          echo "Deploying ${IMAGE_SHA_TAG} to Cloud Run service ${SERVICE}"
+          # Update only the image and scaling policy; existing env vars and
+          # secret bindings on the service (e.g. GITHUB_TOKEN) are preserved.
+          # The scaling flags here mirror cloud-run-service.yaml so the live
+          # service tracks the version-controlled policy.
+          gcloud run deploy "${SERVICE}" \
+            --project="${GCP_PROJECT}" \
+            --region="${GCP_REGION}" \
+            --image="${IMAGE_SHA_TAG}" \
+            --concurrency=1 \
+            --timeout=3600 \
+            --min-instances="${MIN_INSTANCES}" \
+            --max-instances="${MAX_INSTANCES}"
+          echo "Deployed ${IMAGE_SHA_TAG} to ${SERVICE}."

--- a/scripts/ci/test-cloudbuild-config-paths.mjs
+++ b/scripts/ci/test-cloudbuild-config-paths.mjs
@@ -12,6 +12,10 @@ const workflowConfigs = new Map([
     ["cloudbuild-bench-prepare.yaml", "cloudbuild-bench-shard.yaml"],
   ],
   [".github/workflows/ci.yml", ["cloudbuild-checker-integration.yaml"]],
+  [
+    ".github/workflows/runner-image.yml",
+    ["cloudbuild-runner-image.yaml"],
+  ],
 ]);
 const workflowDir = path.join(ROOT, ".github", "workflows");
 const workflowFiles = fs

--- a/scripts/cloudbuild/cloudbuild-runner-image.yaml
+++ b/scripts/cloudbuild/cloudbuild-runner-image.yaml
@@ -1,0 +1,37 @@
+# Cloud Build config that rebuilds and pushes the self-hosted GitHub Actions
+# runner image from scripts/infra/cloud-run-gh-runner/Dockerfile.
+#
+# Invoked by .github/workflows/runner-image.yml via `gcloud builds submit`. The
+# workflow passes the destination image path and the commit SHA as
+# substitutions so every build is SHA-tagged for provenance. The `latest` tag
+# is updated alongside the SHA tag so the Cloud Run service can track the most
+# recent build when a maintainer chooses not to pin a specific SHA.
+#
+# Substitutions (all required, supplied by the workflow):
+#   _IMAGE  fully-qualified image repository, e.g.
+#           us-central1-docker.pkg.dev/<project>/<repo>/tsz-cloud-run-runner
+#   _SHA    git commit SHA the image is built from (provenance tag)
+
+steps:
+  - id: build-runner-image
+    name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - --tag
+      - '${_IMAGE}:${_SHA}'
+      - --tag
+      - '${_IMAGE}:latest'
+      - --file
+      - scripts/infra/cloud-run-gh-runner/Dockerfile
+      - scripts/infra/cloud-run-gh-runner
+
+images:
+  - '${_IMAGE}:${_SHA}'
+  - '${_IMAGE}:latest'
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+
+# The base image install (rust toolchain, nextest, wasm-pack, gcloud SDK, apt
+# packages) is heavy; allow generous headroom.
+timeout: 2400s

--- a/scripts/infra/cloud-run-gh-runner/README.md
+++ b/scripts/infra/cloud-run-gh-runner/README.md
@@ -1,0 +1,104 @@
+# Cloud Run self-hosted GitHub Actions runner
+
+This directory holds the image and entrypoint for the self-hosted GitHub
+Actions runner fleet that backs jobs labeled `[self-hosted, tsz-cloud-run]`.
+
+| File | Purpose |
+| --- | --- |
+| `Dockerfile` | Runner image: `ghcr.io/actions/actions-runner:2.334.0` base + Rust toolchain, `nextest`, `wasm-pack`, `pnpm`, `gcloud` SDK, and build deps. |
+| `start.sh` | Entrypoint: registers an **ephemeral** runner, runs one job, deregisters, and clears local state so a reused Cloud Run instance never reuses credentials. |
+| `cloud-run-service.yaml` | Version-controlled scaling-policy skeleton (IaC reference; **not** auto-applied). |
+
+## Why this exists
+
+The runner image and its Cloud Run scaling policy previously lived only as
+opaque GCP-side state — there was no in-repo build/push pipeline, no provenance
+trail of what was actually deployed, and no reviewable scaler config. See
+issue #13750.
+
+## Runner version pin and the auto-update gap
+
+- The runner version is pinned to **`2.334.0`** in `Dockerfile:1`.
+- Auto-update is **disabled**: `start.sh` sets `DISABLE_RUNNER_UPDATE=1` and
+  passes `--disableupdate` to `config.sh`. This keeps the toolchain stable but
+  means the fleet does **not** follow GitHub's runner-version floor on its own.
+- **Risk:** when GitHub raises its required minimum runner version, a pinned +
+  auto-update-disabled fleet can hard-fail registration en masse with no in-repo
+  remediation. Bumping the `FROM` tag here and rebuilding/redeploying is the
+  remediation.
+- **TODO (version-floor alert):** extend the existing `runner-health` job in
+  `.github/workflows/ci-health.yml` to compare the deployed runner version
+  against GitHub's current required minimum and warn *before* the fleet
+  hard-fails. Not implemented here to keep this change scoped to the
+  build/deploy pipeline and avoid editing the health workflow. Tracked under
+  issue #13750.
+
+## Build / deploy pipeline
+
+`.github/workflows/runner-image.yml` builds (and optionally deploys) the image:
+
+- **Triggers:** `workflow_dispatch`, `push` touching the `Dockerfile`,
+  `start.sh`, the cloudbuild config, or the workflow itself, and a weekly cron
+  (build-only, for base-image security updates).
+- **Build** (`build` job): submits
+  `scripts/cloudbuild/cloudbuild-runner-image.yaml` via `gcloud builds submit`,
+  producing an image tagged with the commit SHA (provenance) **and** `latest`.
+- **Deploy** (`deploy` job): runs **only** on a manual `workflow_dispatch` with
+  the `deploy` input set to `true`, and is further gated by the
+  `runner-image-deploy` environment (add required reviewers for manual
+  approval). It updates the Cloud Run service to the SHA-tagged image plus the
+  scaling flags from `cloud-run-service.yaml`; existing env/secret bindings on
+  the service are preserved.
+
+This workflow is **separate from CI**, is **not** a required check, and cannot
+affect PR status. If the GCP configuration below is absent, the build job
+**no-ops with a notice** instead of failing.
+
+### Required GCP configuration (repo variables)
+
+A maintainer must set these repository **variables** (Settings → Secrets and
+variables → Actions → Variables) before the workflow does anything:
+
+| Variable | Required for | Example / default |
+| --- | --- | --- |
+| `RUNNER_IMAGE_GCP_PROJECT` | build | `tsz-ci` |
+| `RUNNER_IMAGE_REPO` | build | `us-central1-docker.pkg.dev/tsz-ci/runners/tsz-cloud-run-runner` |
+| `RUNNER_IMAGE_GCP_REGION` | build/deploy | defaults to `us-central1` |
+| `RUNNER_IMAGE_CLOUD_RUN_SERVICE` | deploy | the Cloud Run service name |
+| `RUNNER_IMAGE_MIN_INSTANCES` | deploy | defaults to `0` (scale-to-zero) |
+| `RUNNER_IMAGE_MAX_INSTANCES` | deploy | defaults to `50` |
+
+Authentication uses the **ambient gcloud credentials** already present on the
+self-hosted runners (the same mechanism `ci.yml` / `bench.yml` rely on for
+`gcloud builds submit`); no extra service-account secret is wired here. The
+runner registration PAT (`GITHUB_TOKEN`) is consumed by `start.sh` at container
+start and should be supplied to the Cloud Run service via Secret Manager — see
+`cloud-run-service.yaml`.
+
+### Manual deploy
+
+```bash
+gh workflow run runner-image.yml -f deploy=true -f reason="bump runner to <ver>"
+# then approve the runner-image-deploy environment when prompted
+```
+
+## Scaling policy (IaC)
+
+`cloud-run-service.yaml` captures the intended scaling policy
+(`concurrency=1`, `minScale=0`, `maxScale=50`, `timeoutSeconds=3600`) as a
+reviewable skeleton. It is **not** applied automatically. Before adopting it as
+the source of truth, reconcile it with the live service
+(`gcloud run services describe <service> --format export`) and wire the
+`GITHUB_TOKEN` secret reference. Treat any `minScale>0` warm pool as a measured
+cost decision (per-job queue-wait data, #13715), since `minScale>0` defeats
+scale-to-zero.
+
+## Related follow-ups (issue #13750)
+
+- **Wire `scripts/ci/cleanup-stale-runners.sh` into the ci-health cron.** It
+  safely removes only `offline` runner registrations but is currently
+  detection-only (`ci-health.yml` merely prints a suggestion to run it), so
+  stale ephemeral registrations accumulate until a human runs it by hand.
+- **Add the runner-version-floor check** described above to `runner-health`.
+- **Make the low-runner-count health response actionable** rather than
+  observe-only.

--- a/scripts/infra/cloud-run-gh-runner/cloud-run-service.yaml
+++ b/scripts/infra/cloud-run-gh-runner/cloud-run-service.yaml
@@ -1,0 +1,57 @@
+# Version-controlled scaling policy (IaC skeleton) for the self-hosted GitHub
+# Actions runner fleet backed by Cloud Run.
+#
+# STATUS: reviewable reference / template. This file is NOT applied
+# automatically by any workflow. Before adopting it as the source of truth,
+# a maintainer must reconcile it with the currently deployed service
+# (`gcloud run services describe <service> --region <region> --format export`)
+# so the committed spec matches live state, then wire secrets/env explicitly.
+#
+# Rationale for the values below (see issue #13750):
+#   * concurrency=1  - each runner process handles exactly one ephemeral job,
+#                      matching `--ephemeral` in start.sh.
+#   * minScale=0     - scale-to-zero by default. Treat any minScale>0 warm pool
+#                      as a measured cost decision using per-job queue_wait data
+#                      (#13715); minScale>0 defeats scale-to-zero.
+#   * maxScale=50    - upper bound on concurrent runners; tune to the fleet's
+#                      observed peak (health probe warns at online<20/online<5).
+#   * timeoutSeconds=3600 - a runner job may run up to 60 minutes before the
+#                      platform reclaims the instance.
+#
+# Replacing PLACEHOLDER_* values and applying with:
+#   gcloud run services replace cloud-run-service.yaml \
+#     --project <project> --region <region>
+# will overwrite the live service, so confirm env/secret blocks first.
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: PLACEHOLDER_SERVICE_NAME
+  annotations:
+    run.googleapis.com/launch-stage: GA
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "0"
+        autoscaling.knative.dev/maxScale: "50"
+    spec:
+      containerConcurrency: 1
+      timeoutSeconds: 3600
+      containers:
+        - image: PLACEHOLDER_IMAGE  # e.g. us-central1-docker.pkg.dev/<project>/<repo>/tsz-cloud-run-runner:latest
+          env:
+            - name: GITHUB_REPO
+              value: tsz-org/tsz
+            # GITHUB_TOKEN MUST be supplied as a Secret Manager reference, not a
+            # plaintext value. Configure the secret in GCP and reference it here:
+            # - name: GITHUB_TOKEN
+            #   valueFrom:
+            #     secretKeyRef:
+            #       key: latest
+            #       name: PLACEHOLDER_RUNNER_PAT_SECRET
+            - name: RUNNER_LABELS
+              value: tsz-cloud-run
+          resources:
+            limits:
+              cpu: "8"
+              memory: 32Gi


### PR DESCRIPTION
## Summary
Adds an automated, provenance-tracked build/deploy pipeline for the self-hosted
Cloud Run GitHub Actions runner image, plus in-repo documentation and a
version-controlled scaling-policy skeleton. Closes the "runner image + scaler
live only as opaque GCP-side state" gap in #13750.

New files (no existing workflow touched):
- `.github/workflows/runner-image.yml` — separate, non-required workflow.
  Triggers: `workflow_dispatch`, `push` paths-filter on the Dockerfile /
  `start.sh` / cloudbuild config / the workflow itself, and a weekly cron
  (build-only). The **build** job submits the image via `gcloud builds submit`
  and SHA-tags it for provenance. The **deploy** job is gated behind a manual
  `workflow_dispatch` input (`deploy=true`) **and** the `runner-image-deploy`
  environment (manual approval); the scheduled/push runs can never deploy.
- `scripts/cloudbuild/cloudbuild-runner-image.yaml` — Cloud Build config that
  builds `scripts/infra/cloud-run-gh-runner/Dockerfile` and pushes
  `${_IMAGE}:${_SHA}` and `:latest`.
- `scripts/infra/cloud-run-gh-runner/README.md` — documents the image purpose,
  build/deploy procedure, the GCP service-name placeholder, the `2.334.0`
  runner version pin and the `--disableupdate` auto-update gap, a documented
  TODO for a runner-version-floor check, and the follow-up to wire
  `scripts/ci/cleanup-stale-runners.sh` into ci-health.
- `scripts/infra/cloud-run-gh-runner/cloud-run-service.yaml` — version-controlled
  scaling-policy skeleton (`concurrency=1`, `minScale=0`, `maxScale=50`,
  `timeoutSeconds=3600`) as reviewable IaC; **not** auto-applied.

## Structural rule
When the runner image's Dockerfile/entrypoint changes (or on weekly cron), CI
rebuilds a SHA-tagged image via Cloud Build for provenance; promotion to the
live Cloud Run service happens only through an explicit, approval-gated manual
dispatch — image lifecycle and scaling policy now live in-repo instead of as
opaque GCP-side state.

## Safety / non-breaking
- This is a **separate** workflow; it is **not** added to any required-check set
  and cannot affect PR CI status (verified: no other workflow references it).
- The **deploy** step (the only step that touches live infra) requires a manual
  `workflow_dispatch` with `deploy=true` **and** approval via the
  `runner-image-deploy` environment.
- If the required GCP repo variables are absent, the build job **no-ops with a
  `::notice::`** instead of failing.

## Maintainer action required (GCP configuration)
The deploy (and build) are inert until a maintainer sets these repo **variables**
(Settings → Secrets and variables → Actions → Variables):
- `RUNNER_IMAGE_GCP_PROJECT` — required to build (e.g. `tsz-ci`).
- `RUNNER_IMAGE_REPO` — required to build; full image repo path
  (e.g. `us-central1-docker.pkg.dev/tsz-ci/runners/tsz-cloud-run-runner`).
- `RUNNER_IMAGE_GCP_REGION` — optional; defaults to `us-central1`.
- `RUNNER_IMAGE_CLOUD_RUN_SERVICE` — required to deploy; Cloud Run service name.
- `RUNNER_IMAGE_MIN_INSTANCES` / `RUNNER_IMAGE_MAX_INSTANCES` — optional;
  default `0` / `50`.

Authentication reuses the **ambient gcloud credentials** already on the
self-hosted runners (same mechanism `ci.yml`/`bench.yml` use for
`gcloud builds submit`); no new service-account secret is hardcoded. The runner
PAT is supplied to the Cloud Run service via Secret Manager (documented in
`cloud-run-service.yaml`). No guessed secret names are referenced.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` passes for the workflow, the
  cloudbuild config, and the service skeleton.
- `actionlint` was unavailable on this machine; validated via the YAML parse +
  manual review against the existing `gcloud builds submit` jobs in `ci.yml`
  (unit-checker-integration) and `bench.yml`.
- Confirmed the new workflow is not referenced by any other workflow and is not
  in any required-check set (`grep -rn runner-image .github/workflows`).

The runner-version-floor health check and wiring `cleanup-stale-runners.sh`
into the ci-health cron remain documented TODOs (would require editing
`ci-health.yml`, out of scope here), so this is **Part of #13750** rather than a
full close.

Part of #13750

Goal: hold

## Provenance
Machine: MacBookPro.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

— AgentName: M1FableArchitect
