### PR TITLE
fix(ci): decouple bench shard/wait/build timeouts to prevent near-budget false negatives (#13751)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1057,6 +1057,11 @@ jobs:
     needs: bench-prep-artifact
     if: always() && needs.bench-prep-artifact.result == 'success'
     runs-on: [self-hosted, tsz-cloud-run]
+    # Outermost ceiling of the decoupled budget (#13751): build (105m) <
+    # wait-deadline (115m) < this GitHub job timeout (135m). The extra slack
+    # over the wait deadline covers pre-wait overhead (checkout, prep-artifact
+    # download, validate, and the 600s submit cap) so a near-budget shard can
+    # download artifacts after SUCCESS instead of being killed mid-poll.
     timeout-minutes: ${{ matrix.timeout }}
     strategy:
       fail-fast: false
@@ -1070,31 +1075,31 @@ jobs:
       matrix:
         include:
           - label: compiler-files
-            timeout: 120
+            timeout: 135
             filter: 'conditionalTypeDiscriminatingLargeUnionRegularTypeFetchingSpeedReasonable\.ts|manyConstExports\.ts|binderBinaryExpressionStress\.ts|binderBinaryExpressionStressJs\.ts|enumLiteralsSubtypeReduction\.ts|binaryArithmeticControlFlowGraphNotTooLarge\.ts|privacyFunctionParameterDeclFile\.ts|privacyGloFunc\.ts|privacyTypeParameterOfFunctionDeclFile\.ts|typedArrays\.ts|controlFlowArrays\.ts'
           - label: synthetic
-            timeout: 120
+            timeout: 135
             filter: '[0-9]+ classes|[0-9]+ generic functions|DeepPartial optional-chain|Shallow optional-chain|[0-9]+ union members'
           - label: project-hotspots
-            timeout: 120
+            timeout: 135
             filter: 'Recursive utility aliases|Indexed access hotspot|Remapped accessor hotspot|Conditional infer hotspot|Object spread hotspot|Contextual callback hotspot'
           - label: solver-stress
-            timeout: 120
+            timeout: 135
             filter: 'Recursive generic depth|Conditional dist N|Mapped type keys|Template literal N|Deep subtype depth|Intersection N|Infer stress N|CFA branches'
           - label: algorithmic-bct
-            timeout: 120
+            timeout: 135
             filter: 'BCT candidates'
           - label: algorithmic-constraint
-            timeout: 120
+            timeout: 135
             filter: 'Constraint conflicts N'
           - label: algorithmic-mapped
-            timeout: 120
+            timeout: 135
             filter: 'Mapped complex template keys'
           - label: projects
-            timeout: 120
+            timeout: 135
             filter: 'utility-types/|ts-toolbelt/|ts-essentials/|utility-types-project|ts-toolbelt-project|ts-essentials-project|rxjs-project|type-fest-project|zod-project|kysely-project|comlink-project|vite-vanilla-ts-app|nextjs-fresh-app|nextjs'
           - label: large-ts-repo
-            timeout: 120
+            timeout: 135
             filter: '^large-ts-repo$'
     steps:
       - uses: actions/checkout@v4
@@ -1300,7 +1305,18 @@ jobs:
           NODE
           }
 
-          deadline=$((SECONDS + ${{ matrix.timeout }} * 60))
+          # Decoupled timeout budget (#13751): build-timeout < wait-deadline <
+          # github-job-timeout. The Cloud Build shard self-terminates at 6300s
+          # (105m, cloudbuild-bench-shard.yaml), so this wait deadline must be
+          # strictly *longer* than that — otherwise the poll loop would give up
+          # before a near-budget-but-successful build reaches SUCCESS, killing it
+          # mid-poll before artifacts download (the false-negative this fixes).
+          # SECONDS counts from this wait step's start (after checkout/download/
+          # submit, ~10m into the job), so a 6900s (115m) wait window ends well
+          # inside the 135m GitHub job timeout (timeout-minutes above) while
+          # still outlasting the 105m Cloud Build ceiling.
+          wait_deadline_seconds=6900
+          deadline=$((SECONDS + wait_deadline_seconds))
           while true; do
             status="$(cloudbuild_status)"
             if [[ "$status" == "SUCCESS" ]]; then
@@ -1339,6 +1355,10 @@ jobs:
             esac
 
             if (( SECONDS >= deadline )); then
+              # Note: the wait window is wait_deadline_seconds (115m), which is
+              # decoupled from and shorter than matrix.timeout (the 135m GitHub
+              # job timeout) per #13751. The message reuses matrix.timeout as a
+              # stable label; the effective wait deadline is 115 minutes.
               echo "No finished Cloud Build benchmark shard artifact is available for ${{ matrix.label }} after ${{ matrix.timeout }} minutes."
               [[ -z "$status" ]] || echo "Last Cloud Build benchmark shard status: ${status} (${{ steps.cloudbuild-submit.outputs.build_id }})."
               capture_cloudbuild_log

--- a/scripts/cloudbuild/cloudbuild-bench-shard.yaml
+++ b/scripts/cloudbuild/cloudbuild-bench-shard.yaml
@@ -212,4 +212,18 @@ options:
     name: projects/tsz-ci/locations/us-central1/workerPools/tsz-ci-build-pool
   logging: CLOUD_LOGGING_ONLY
 
-timeout: 7200s
+# Decoupled timeout budget (#13751): the bench-shard timeouts must satisfy
+# build-timeout < wait-deadline < github-job-timeout so a build that runs near
+# budget still reaches a terminal SUCCESS, gets observed by the poll loop, and
+# has its artifacts downloaded before any ceiling trips. This Cloud Build
+# timeout (105m) is the *earliest* ceiling: the build is guaranteed to reach a
+# terminal state by here, after which the bench.yml wait loop (115m deadline)
+# downloads artifacts well inside the 135m GitHub job timeout. Keep this value
+# strictly below the bench.yml wait-loop deadline.
+#
+# Follow-up (infra, out of scope for this file-only PR): a dedicated
+# tsz-ci-merge-pool so a bench burst cannot throttle the required
+# unit-checker-integration merge-queue submit, and a prebuilt image baking
+# hyperfine/jq/xz-utils/Node 22/pnpm to remove the per-shard apt/curl/npm
+# bootstrap network SPOF (see #13751 proposed fixes 1 and 3).
+timeout: 6300s


### PR DESCRIPTION
## Summary
Decouples the three coupled 120-minute bench-shard timeouts so the ordering is now **build-timeout (105m) < wait-deadline (115m) < GitHub job-timeout (135m)**, eliminating the false-negative where a Cloud Build shard legitimately running near budget was killed mid-poll (by the binding GitHub job timeout) before its SUCCESS status was observed and its artifacts downloaded — which dropped the run below the 9-shard publish gate and forced a wasteful catch-up bench.

File-only, surgical changes (no GCP infra). This implements **proposed fix #2** of the issue. The pool-isolation (proposed fix #1) and prebuilt-image bootstrap removal (proposed fix #3) require GCP infrastructure and are out of scope for a code PR — they are documented inline as follow-ups in `cloudbuild-bench-shard.yaml`.

### Before → after
| Knob | File | Before | After |
|---|---|---|---|
| Cloud Build shard `timeout` | `cloudbuild-bench-shard.yaml` | `7200s` (120m) | `6300s` (105m) |
| Wait-loop deadline | `bench.yml` poll loop | `matrix.timeout * 60` (7200s/120m, coupled) | `wait_deadline_seconds=6900` (115m, decoupled) |
| Shard GitHub job `timeout-minutes` | `bench.yml` matrix (×9) | `120` | `135` |

The wait-loop deadline was previously `${{ matrix.timeout }} * 60`, coupling it to the job timeout; it is now an explicit `6900s` constant so all three knobs move independently while preserving the ordering.

### Structural rule
When a Cloud Build bench shard runs near its time budget, `tsc`-style correctness requires that a SUCCESSFUL build's artifacts are observed and downloaded before any ceiling trips. The three ceilings must satisfy **build-timeout < wait-deadline < job-timeout**: the build self-terminates first (guaranteeing a terminal SUCCESS/TIMEOUT state), the poll loop must still be alive to observe it (wait-deadline > build-timeout), and the GitHub job must outlast the poll plus pre-wait overhead (job-timeout > wait-deadline + checkout/download/validate/600s-submit). Owner: bench CI workflow + Cloud Build shard config.

Note: the issue prose contains an internal contradiction ("lower the wait deadline below the CB timeout" vs. the stated order "build < wait < job"). The stated **order** is the one that actually fixes the false negative — a wait deadline *below* the build timeout would make the poll give up before a near-budget build finishes, re-creating the bug. This PR implements `build < wait < job`.

### Preserved invariants
- One-active-benchmark-run gate, `max-parallel: 4` submit cap, and all #13306 catch-up/publish logic are untouched.
- `cloudbuild-bench-prepare.yaml` is left unchanged: its prep wait loops already use a `9000s` deadline > the `7200s` prepare CB timeout, so the prep path already satisfies the ordering and has no false-negative.
- The timeout-branch echo still reuses `${{ matrix.timeout }}` as a stable label (a guardrail test pins that exact string); a code comment clarifies the real wait window is 115m.

## Verification
- `python3 -c "import yaml; ..."` on all three YAMLs → `YAML_OK`.
- `node scripts/bench/test-bench-workflow-cloudbuild-shards.mjs` → PASS
- `node scripts/bench/test-bench-workflow-cloudbuild-prep.mjs` → PASS
- `node scripts/bench/test-timeout-runner.mjs` → PASS
- `actionlint` not installed locally (skipped); ready-review CI owns it.
- Did NOT run the bench suite or full CI (per repo policy).

Part of #13751 (timeout-decoupling part only). The pool-isolation (dedicated `tsz-ci-merge-pool`) and prebuilt-image bootstrap (proposed fixes #1 and #3) are GCP-infra follow-ups, documented inline in `cloudbuild-bench-shard.yaml`.

Goal: hold

## Provenance
Machine: MacBookPro.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

— AgentName: M1FableArchitect
