### PR TITLE
fix(ci): add a MemAvailable preflight and peak-cutting to the cache-save tar (#13748)

### DIFF
--- a/scripts/ci/ci-resources.sh
+++ b/scripts/ci/ci-resources.sh
@@ -192,6 +192,33 @@ ci_available_memory_mb() {
   fi
 }
 
+# Preflight memory gate for the best-effort CI cache save.
+#
+# The cache-save path tars a multi-GB target dir at post-build memory peak
+# (gcp-cache.sh save). On a memory-starved runner the kernel OOM-killer can
+# SIGKILL the build container mid-tar, failing an otherwise-green job and
+# wedging the merge queue (#13733). No after-the-fact `|| echo warning` can
+# catch a SIGKILL, so the only real lever is to refuse the tar before it runs.
+#
+# This mirrors bench-shard-prelude.sh's TSZ_BENCH_MIN_FREE_MB gate. The floor
+# is TSZ_CI_CACHE_SAVE_MIN_FREE_MB (default 2048 MiB). Setting it to 0 disables
+# the gate (always attempt the save).
+#
+# Returns 0 when there is enough headroom OR when MemAvailable is unknown
+# (fail open — never block a save on a host without /proc/meminfo). Returns 1
+# only when MemAvailable is a known positive value below the floor.
+ci_cache_save_memory_ok() {
+  local floor="${TSZ_CI_CACHE_SAVE_MIN_FREE_MB:-2048}"
+  local avail
+  avail="$(ci_available_memory_mb)"
+  if [[ "$floor" =~ ^[0-9]+$ && "$floor" -gt 0 \
+        && "$avail" =~ ^[0-9]+$ && "$avail" -gt 0 \
+        && "$avail" -lt "$floor" ]]; then
+    return 1
+  fi
+  return 0
+}
+
 # Prints a one-line memory status summary for CI diagnostic logs.
 # Optional argument is a label tag prepended to the line.
 ci_report_memory() {

--- a/scripts/ci/gcp-cache.sh
+++ b/scripts/ci/gcp-cache.sh
@@ -35,6 +35,7 @@ set -Eeuo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 source scripts/ci/suite-metadata.sh
+source scripts/ci/ci-resources.sh
 
 CACHE_BUCKET="${_TSZ_CI_CACHE_BUCKET:?_TSZ_CI_CACHE_BUCKET is required}"
 CACHE_BUCKET="${CACHE_BUCKET%/}"
@@ -203,7 +204,19 @@ tmp_archive() {
 create_archive() {
   local archive="$1" base="$2"
   shift 2
-  COPYFILE_DISABLE=1 tar --exclude='._*' -czf "$archive" -C "$base" "$@"
+  # Cut the in-process compression peak at tar time. The default tar `-z`
+  # uses gzip level 6, whose deflate path keeps large hash chains/window
+  # buffers; gzip levels 1-3 use the lighter `deflate_fast` algorithm with
+  # smaller tables and far less CPU. Since the save-path tar runs at
+  # post-build memory peak (#13733/#13748), pipe tar -> gzip with an explicit,
+  # tunable level so the compressor never inflates RSS at the worst moment.
+  # TSZ_CI_CACHE_GZIP_LEVEL tunes the size/speed tradeoff (default 1; raise it
+  # to trade CPU/RSS for a smaller blob). Note: this only lowers the
+  # compression level — it does NOT switch codecs (zstd is tracked separately
+  # in #13605 item 4).
+  local level="${TSZ_CI_CACHE_GZIP_LEVEL:-1}"
+  COPYFILE_DISABLE=1 tar --exclude='._*' -cf - -C "$base" "$@" \
+    | gzip -n -"${level}" > "$archive"
 }
 
 validate_typescript_cache_tree() {
@@ -561,6 +574,17 @@ restore_caches() {
 }
 
 save_caches() {
+  # Preflight: refuse the multi-GB save tar when MemAvailable is below the
+  # floor (default 2048 MiB, TSZ_CI_CACHE_SAVE_MIN_FREE_MB; 0 disables). The
+  # save is best-effort, so deferring it is always safe and avoids a kernel
+  # OOM SIGKILL that no `|| echo warning` can catch (#13733/#13748). This is a
+  # defense-in-depth gate; github-suite.sh also checks before invoking save.
+  if ! ci_cache_save_memory_ok; then
+    ci_report_memory "cache-save-skip"
+    echo "warning: CI cache save skipped — MemAvailable below floor (${TSZ_CI_CACHE_SAVE_MIN_FREE_MB:-2048}MB); deferring the cache-save tar to avoid an OOM SIGKILL at post-build memory peak (see #13733/#13748)" >&2
+    return 0
+  fi
+
   local cargo_hash node_hash ts_ref ts_deps_hash commit cargo_target_key wasm_pack_key
   cargo_hash="$(cargo_lock_hash)"
   node_hash="$(scripts_deps_hash)"

--- a/scripts/ci/github-suite.sh
+++ b/scripts/ci/github-suite.sh
@@ -47,6 +47,21 @@ stop_suite_heartbeat() {
   fi
 }
 
+# Best-effort cache save with a MemAvailable preflight. The save tars a
+# multi-GB target dir at post-build memory peak; on a starved runner the
+# kernel OOM-killer SIGKILLs the container mid-tar, failing a green job and
+# wedging the merge queue (#13733). ci_cache_save_memory_ok (ci-resources.sh)
+# refuses the tar when MemAvailable is below TSZ_CI_CACHE_SAVE_MIN_FREE_MB,
+# mirroring bench-shard-prelude's gate. The save itself stays best-effort.
+run_cache_save() {
+  ci_report_memory "pre-cache-save-${suite}"
+  if ! ci_cache_save_memory_ok; then
+    echo "warning: CI cache save skipped — MemAvailable below floor (${TSZ_CI_CACHE_SAVE_MIN_FREE_MB:-2048}MB); deferring the cache-save tar to avoid an OOM SIGKILL at post-build memory peak (see #13733/#13748)" >&2
+    return 0
+  fi
+  scripts/ci/gcp-cache.sh save || echo "warning: CI cache save failed" >&2
+}
+
 trap stop_suite_heartbeat EXIT
 start_suite_heartbeat
 
@@ -91,7 +106,7 @@ elif [[ "$rc" -ne 0 ]]; then
   if [[ "${TSZ_CI_CACHE_SAVE_ON_FAILURE:-0}" == "1" ]]; then
     echo "info: suite failed (rc=${rc}) but TSZ_CI_CACHE_SAVE_ON_FAILURE=1 — saving cache anyway"
     if command -v gsutil >/dev/null 2>&1; then
-      scripts/ci/gcp-cache.sh save || echo "warning: CI cache save failed" >&2
+      run_cache_save
     else
       echo "warning: gsutil is unavailable; skipping GCS CI cache save" >&2
     fi
@@ -99,7 +114,7 @@ elif [[ "$rc" -ne 0 ]]; then
     echo "info: GCS cache save skipped (suite failed with rc=${rc})"
   fi
 elif command -v gsutil >/dev/null 2>&1; then
-  scripts/ci/gcp-cache.sh save || echo "warning: CI cache save failed" >&2
+  run_cache_save
 else
   echo "warning: gsutil is unavailable; skipping GCS CI cache save" >&2
 fi


### PR DESCRIPTION
## Summary
The best-effort GCS cache-save tar runs at post-build memory peak with **no
MemAvailable floor**, unlike `bench-shard-prelude.sh` which already gates
exactly this. On a memory-starved runner the kernel OOM-killer SIGKILLs the
build container mid-tar — which no after-the-fact `|| echo warning` can catch —
failing an otherwise-green job and wedging the merge queue. This is the concrete
lever behind #13733's recurring `unit` exit-137 OOM during cache-save tar.

This PR adds a MemAvailable preflight (reusing the proven bench pattern) and
cuts the in-process compression peak, so a green build's best-effort cache save
cannot OOM-kill the container. It does **not** change what is cached or the
cache keys.

Closes #13748. Concrete lever for #13733 (symptom report); compression-level
cut is distinct from #13605 item 4 (zstd) — this only lowers the gzip level, it
does not switch codecs.

## Structural rule
When MemAvailable is below a configurable floor at cache-save time, the save is
best-effort and must be **skipped** rather than tarring a multi-GB target dir at
peak RSS (the only kill-safe lever, since a SIGKILL is uncatchable). When the
save does run, the compressor must not inflate RSS at the worst moment.

## Changes
- `scripts/ci/ci-resources.sh`: new `ci_cache_save_memory_ok` helper — mirrors
  `bench-shard-prelude.sh`'s `TSZ_BENCH_MIN_FREE_MB` gate using the existing
  `ci_available_memory_mb`. Floor is `TSZ_CI_CACHE_SAVE_MIN_FREE_MB` (default
  2048 MiB; set to 0 to disable). Fails **open** when MemAvailable is unknown
  (no `/proc/meminfo`) so it never blocks a save on a host without the metric.
- `scripts/ci/github-suite.sh`: new `run_cache_save` wrapper runs
  `ci_report_memory` + the preflight before invoking `gcp-cache.sh save`,
  emitting a distinct skip warning when below floor. Used at both save sites
  (normal + `TSZ_CI_CACHE_SAVE_ON_FAILURE`). Save stays best-effort.
- `scripts/ci/gcp-cache.sh`: defense-in-depth preflight at the top of
  `save_caches` (direct invocations are protected too); `create_archive` now
  pipes `tar -cf - | gzip -n -<level>` with `TSZ_CI_CACHE_GZIP_LEVEL` (default
  1 → lighter `deflate_fast` path, less CPU/RSS at peak; raise to trade CPU/RSS
  for a smaller blob). Sources `ci-resources.sh` for the shared helper.

## Verification
- `bash -n` on all three scripts: pass.
- `python3 scripts/ci/test_ci_resources.py`: 28 tests pass (1 skipped, Linux-only).
- Gate behavior unit-checked: low avail < floor → skip (rc 1); avail > floor →
  save (rc 0); unknown avail (0) → fail open (rc 0); floor=0 → disabled (rc 0);
  custom floor honored.
- `create_archive` gzip-pipe roundtrip verified (tar → gzip -1 → extract intact;
  `TSZ_CI_CACHE_GZIP_LEVEL` override produces a smaller blob at higher levels).

Goal: hold

## Provenance
Machine: MacBookPro.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

— AgentName: M1FableArchitect
