### PR TITLE
fix(ci): record incomplete canary shard sets and make /retest survive expired wave-1 artifacts (#13749)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -804,6 +804,12 @@ jobs:
       TSZ_CI_CACHE_SAVE: "0"
       TSZ_PROJECT_COMPILE_SET: canary
       TSZ_PROJECT_COMPILE_ALLOW_FAILURES: "1"
+      # Expected canary shard count (mirrors the project-compile-canary matrix
+      # `shard: [0..5]` / `_TSZ_CI_CANARY_SHARD_COUNT: 6`). The aggregate script
+      # records shards_seen vs this expected count and emits a distinct
+      # CANARY_SHARDS_INCOMPLETE signal when a shard is missing, so a dead runner
+      # cannot produce a silently-green required check over a partial set.
+      TSZ_CANARY_SHARDS_EXPECTED: "6"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rerun-on-comment.yml
+++ b/.github/workflows/rerun-on-comment.yml
@@ -2,8 +2,12 @@ name: Re-run CI on PR comment
 
 # Lets PR contributors re-run failed CI without write access by commenting
 # `/retest` or `/ci` on their PR. The workflow itself runs from `main` (not
-# the PR head), reads the PR's most recent CI run, and calls
-# `gh run rerun --failed` on it. No contributor code is executed here.
+# the PR head), reads the PR's most recent CI run, and re-runs it. No
+# contributor code is executed here. If the run's short-lived wave-1 producer
+# artifacts (dist-fast-binaries, node-harness; retention-days:1) are missing or
+# expired it triggers a FULL `gh run rerun` (regenerates the producers) instead
+# of `gh run rerun --failed`, so a re-run >24h after the original run does not
+# fail on a missing-artifact download in the wave-2 shards.
 #
 # Permission gate: comment author must be the PR author OR a member with at
 # least `write` association (OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR with
@@ -95,8 +99,60 @@ jobs:
           echo "run_id=${run_id}" >> "$GITHUB_OUTPUT"
           echo "run_url=${run_url}" >> "$GITHUB_OUTPUT"
 
-      - name: Re-run failed jobs
+      - name: Decide re-run mode (full vs failed-only)
+        id: mode
         if: steps.run.outputs.active_run_id == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ steps.run.outputs.run_id }}
+        run: |
+          # `gh run rerun --failed` reuses the succeeded wave-1 producer
+          # artifacts (dist-fast-binaries, node-harness) without regenerating
+          # them. Those upload with retention-days:1, so a re-run >24h after the
+          # original run hits a hard missing-artifact download failure in the
+          # wave-2 shards instead of actually re-running the flake. When a
+          # required producer artifact is missing or expired we must do a FULL
+          # re-run (regenerates every job, including the producers) rather than
+          # `--failed`.
+          PRODUCERS="dist-fast-binaries node-harness"
+          artifacts_json=$(gh api --paginate \
+            "repos/${REPO}/actions/runs/${RUN_ID}/artifacts" \
+            --jq '[.artifacts[] | {name, expired}]' 2>/dev/null || echo '[]')
+
+          full=false
+          reason=""
+          for producer in ${PRODUCERS}; do
+            present=$(printf '%s' "${artifacts_json}" \
+              | jq -r --arg n "${producer}" 'map(select(.name == $n and .expired == false)) | length' 2>/dev/null || echo 0)
+            if [ "${present:-0}" -lt 1 ]; then
+              full=true
+              reason="${reason}${reason:+, }${producer} missing/expired"
+            fi
+          done
+
+          if [ "${full}" = "true" ]; then
+            echo "Wave-1 producer artifact(s) unavailable (${reason}); will full re-run." >&2
+          else
+            echo "All wave-1 producer artifacts present and unexpired; failed-only re-run is safe." >&2
+          fi
+          echo "full=${full}" >> "$GITHUB_OUTPUT"
+          echo "reason=${reason}" >> "$GITHUB_OUTPUT"
+
+      - name: Re-run all jobs (producers expired -> regenerate)
+        if: steps.run.outputs.active_run_id == '' && steps.mode.outputs.full == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ steps.run.outputs.run_id }}
+        run: |
+          # No `--failed`: a full re-run re-runs every job, so the short-lived
+          # wave-1 producers (dist-fast-binaries, node-harness) are regenerated
+          # and the wave-2 shards have fresh artifacts to download.
+          gh run rerun --repo "${REPO}" "${RUN_ID}"
+
+      - name: Re-run failed jobs (producers still available)
+        if: steps.run.outputs.active_run_id == '' && steps.mode.outputs.full != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -113,12 +169,19 @@ jobs:
           RUN_ID: ${{ steps.run.outputs.run_id }}
           RUN_URL: ${{ steps.run.outputs.run_url }}
           ACTIVE_RUN_URL: ${{ steps.run.outputs.active_run_url }}
+          RERUN_FULL: ${{ steps.mode.outputs.full }}
+          RERUN_REASON: ${{ steps.mode.outputs.reason }}
           JOB_STATUS: ${{ job.status }}
         run: |
+          run_link="${RUN_URL:-https://github.com/${REPO}/actions/runs/${RUN_ID}}"
           if [ -n "${ACTIVE_RUN_URL}" ]; then
             body="CI is already queued or running for the latest PR head; skipping a duplicate re-run: ${ACTIVE_RUN_URL}"
           elif [ "${JOB_STATUS}" = "success" ]; then
-            body="Re-running failed jobs on the latest CI run: ${RUN_URL:-https://github.com/${REPO}/actions/runs/${RUN_ID}}"
+            if [ "${RERUN_FULL}" = "true" ]; then
+              body="Re-running **all** jobs on the latest CI run (${RERUN_REASON:-wave-1 producer artifacts expired}, so failed-only would hit a missing-artifact download): ${run_link}"
+            else
+              body="Re-running failed jobs on the latest CI run: ${run_link}"
+            fi
           else
             body="Could not re-run CI. See workflow logs."
           fi

--- a/scripts/ci/project-compile-canary-aggregate.sh
+++ b/scripts/ci/project-compile-canary-aggregate.sh
@@ -33,6 +33,10 @@ COMBINED_SUMMARY="$FIXTURE_ROOT/project-compatibility-summary.json"
 PROJECT_SET="${TSZ_PROJECT_COMPILE_SET:-canary}"
 PROJECT_FILTER="${TSZ_PROJECT_COMPILE_FILTER:-}"
 ALLOW_FAILURES="${TSZ_PROJECT_COMPILE_ALLOW_FAILURES:-1}"
+# Number of canary shards the matrix is expected to produce. The aggregate job
+# passes the real count (TSZ_CANARY_SHARDS_EXPECTED) from ci.yml so a dead shard
+# is detectable; the default is a conservative fallback for standalone runs.
+SHARDS_EXPECTED="${TSZ_CANARY_SHARDS_EXPECTED:-3}"
 
 mkdir -p "$FIXTURE_ROOT"
 
@@ -54,7 +58,8 @@ if [[ "${#shard_dirs[@]}" -eq 0 ]]; then
   exit 1
 fi
 
-echo "Found ${#shard_dirs[@]} canary shard artifact directories:"
+SHARDS_SEEN="${#shard_dirs[@]}"
+echo "Found ${SHARDS_SEEN} canary shard artifact directories (expected ${SHARDS_EXPECTED}):"
 printf '  %s\n' "${shard_dirs[@]}"
 
 # Copy every shard's files into the combined fixture root first (logs,
@@ -116,3 +121,65 @@ SUMMARY_FAILURES="$combined_failures" \
 node scripts/ci/project-compatibility.mjs summary
 
 echo "Wrote combined canary summary to $COMBINED_SUMMARY"
+
+# Record shard-set completeness into the regenerated summary JSON so downstream
+# consumers can detect a silently-incomplete canary run. Unlike conformance /
+# fourslash / emit (which fail-closed), the canary is intentionally advisory and
+# continue-on-error: a hard `exit 1` here would let one dead self-hosted runner
+# wedge the required CI Summary on pure infra flakiness. So we record the gap and
+# emit a DISTINCT, greppable signal instead of failing.
+SHARDS_COMPLETE=1
+if [[ "$SHARDS_SEEN" -lt "$SHARDS_EXPECTED" ]]; then
+  SHARDS_COMPLETE=0
+fi
+
+if [[ -f "$COMBINED_SUMMARY" ]]; then
+  SUMMARY_SHARDS_SEEN="$SHARDS_SEEN" \
+  SUMMARY_SHARDS_EXPECTED="$SHARDS_EXPECTED" \
+  SUMMARY_SHARDS_COMPLETE="$SHARDS_COMPLETE" \
+  node -e '
+    const fs = require("node:fs");
+    const file = process.argv[1];
+    const data = JSON.parse(fs.readFileSync(file, "utf8"));
+    data.shards_seen = Number(process.env.SUMMARY_SHARDS_SEEN || 0);
+    data.shards_expected = Number(process.env.SUMMARY_SHARDS_EXPECTED || 0);
+    data.shards_complete = process.env.SUMMARY_SHARDS_COMPLETE === "1";
+    fs.writeFileSync(file, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  ' "$COMBINED_SUMMARY"
+  echo "Recorded shard completeness in summary: shards_seen=${SHARDS_SEEN} shards_expected=${SHARDS_EXPECTED} shards_complete=${SHARDS_COMPLETE}"
+else
+  echo "warning: combined summary $COMBINED_SUMMARY not found; cannot record shard completeness" >&2
+fi
+
+if [[ "$SHARDS_COMPLETE" -ne 1 ]]; then
+  # Distinct, greppable, non-warning-class marker. This is intentionally NOT a
+  # bare warning string: downstream tooling and humans can grep for
+  # `CANARY_SHARDS_INCOMPLETE` to know the required canary check passed over a
+  # silently-incomplete project set (a dead/missing shard) rather than a
+  # genuinely green full set.
+  echo "CANARY_SHARDS_INCOMPLETE shards_seen=${SHARDS_SEEN} shards_expected=${SHARDS_EXPECTED}"
+  echo "::warning title=Canary shard set incomplete::CANARY_SHARDS_INCOMPLETE: only ${SHARDS_SEEN}/${SHARDS_EXPECTED} canary shards aggregated; the required canary check covers a partial project set (likely a dead/missing self-hosted shard)."
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      echo "> [!WARNING]"
+      echo "> **CANARY_SHARDS_INCOMPLETE** — aggregated ${SHARDS_SEEN}/${SHARDS_EXPECTED} canary shards."
+      echo "> The required canary check passed over a partial project set (likely a dead/missing self-hosted shard)."
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "shards_seen=${SHARDS_SEEN}"
+      echo "shards_expected=${SHARDS_EXPECTED}"
+      echo "shards_complete=false"
+    } >> "$GITHUB_OUTPUT"
+  fi
+else
+  echo "Canary shard set complete: ${SHARDS_SEEN}/${SHARDS_EXPECTED}."
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "shards_seen=${SHARDS_SEEN}"
+      echo "shards_expected=${SHARDS_EXPECTED}"
+      echo "shards_complete=true"
+    } >> "$GITHUB_OUTPUT"
+  fi
+fi


### PR DESCRIPTION
## Summary
Closes #13749. Two input-completeness gaps that produce silently-wrong-but-green CI outcomes:

1. **Canary completeness.** `project-compile-canary-aggregate.sh` previously guarded only against ZERO shard dirs and never compared the discovered shard count to the expected matrix count, so one dead self-hosted shard yielded a PASSING required check computed over a silently-incomplete project set. The script now records `shards_seen`/`shards_expected`/`shards_complete` into the regenerated summary JSON and, when `seen < expected`, emits a DISTINCT greppable `CANARY_SHARDS_INCOMPLETE ...` line plus an annotated `::warning::` and step-summary note. It deliberately does NOT `exit 1` — the canary is advisory/continue-on-error and a hard fail would let one dead runner wedge the required CI Summary on pure infra flakiness. `EXPECTED` is passed from the aggregate job env (`TSZ_CANARY_SHARDS_EXPECTED: "6"`, matching the real `shard: [0..5]` / `_TSZ_CI_CANARY_SHARD_COUNT: 6` matrix); the script keeps a conservative default fallback for standalone runs.

2. **/retest robustness.** The wave-1 producer artifacts (`dist-fast-binaries`, `node-harness`) upload with `retention-days: 1`, so `gh run rerun --failed` on a run >24h old hits a hard missing-artifact download failure in the wave-2 shards instead of re-running the flake. `rerun-on-comment.yml` now checks producer-artifact presence/expiry via the artifacts API and, when any required producer is missing or expired, triggers a FULL `gh run rerun` (regenerates the producers) instead of `--failed`. The PR comment explains which path was taken.

## Structural rule
When the canary aggregate sees fewer shard artifacts than the matrix is expected to produce, the prior code silently passed the required check over a partial project set; tsz now records the gap (`shards_seen < shards_expected`) and emits a distinct non-warning marker so incompleteness is detectable downstream, without converting infra flakiness into a queue-blocking failure. When a `/retest` target run's short-lived wave-1 producer artifacts are expired, tsz re-runs the whole run to regenerate them rather than `--failed`, which would fail on a missing-artifact download.

Goal: hold

## Verification
- `bash -n scripts/ci/project-compile-canary-aggregate.sh` → OK
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/rerun-on-comment.yml')); yaml.safe_load(open('.github/workflows/ci.yml'))"` → OK
- Simulated the completeness branch: `shards_seen=5 shards_expected=6` writes `shards_complete:false` into the summary JSON and emits `CANARY_SHARDS_INCOMPLETE`; `6/6` writes `shards_complete:true` and no warning.
- Scope confirmed: diff touches only the 3 intended files (canary aggregate script, rerun-on-comment.yml, the canary-aggregate job env in ci.yml).
- shellcheck/actionlint not installed locally; commit hooks ran; CI lint/actionlint gates cover the workflows.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

— AgentName: M1FableArchitect

