### PR TITLE
refactor(ci): remove unit-cloudbuild no-op shim and fold wasm-web into the wasm job (#13754)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1065,27 +1065,15 @@ jobs:
           fetch-depth: 1
       - name: Run wasm suite (nodejs + web targets)
         run: scripts/ci/github-suite.sh wasm-all
+      - name: Verify web WASM artifact
+        run: test -s pkg/web/tsz_wasm_bg.wasm
       - name: Upload web WASM artifact
         uses: actions/upload-artifact@v4
         with:
           name: wasm-web
           path: pkg/web/
           retention-days: 30
-
-  wasm-web:
-    name: wasm-web
-    needs: [gate, wasm]
-    if: needs.gate.outputs.full_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Download web WASM artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: wasm-web
-          path: pkg/web/
-      - name: Verify web WASM artifact
-        run: test -s pkg/web/tsz_wasm_bg.wasm
+          if-no-files-found: error
 
   node-harness-prep:
     name: node-harness-prep
@@ -1162,31 +1150,6 @@ jobs:
             --config=scripts/cloudbuild/cloudbuild-checker-integration.yaml \
             --gcs-source-staging-dir=gs://tsz-ci_cloudbuild/cb-source-staging \
             .
-
-  unit-cloudbuild:
-    # Compatibility status for dashboards and branch-protection rules that may
-    # still look for the old experimental Cloud Build context. The required
-    # Cloud Build checker integration slice is enforced by the required
-    # `unit-checker-integration` job above.
-    name: unit-cloudbuild
-    needs: [gate, unit-checker-integration]
-    if: always() && needs.gate.outputs.should_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-      - name: Report promoted unit path
-        env:
-          UNIT_RESULT: ${{ needs.unit-checker-integration.result }}
-        run: |
-          set -euo pipefail
-          if [[ "$UNIT_RESULT" != "success" ]]; then
-            echo "Required Cloud Build checker integration job did not pass: ${UNIT_RESULT}"
-            exit 1
-          fi
-          echo "Cloud Build checker integration suite is enforced by the required unit-checker-integration job."
 
   conformance:
     # Conformance shards consume the dist-fast binaries artifact and run the
@@ -1487,7 +1450,6 @@ jobs:
       - project-compile-guard
       - project-compile-canary-aggregate
       - wasm
-      - wasm-web
       - node-harness-prep
       - unit
       - unit-checker-integration
@@ -1653,7 +1615,6 @@ jobs:
               })
               required.update({
                   "wasm",
-                  "wasm-web",
                   "lsp-e2e",
                   "node-harness-prep",
                   "conformance-aggregate",

--- a/scripts/ci/test-pr-ready-state.mjs
+++ b/scripts/ci/test-pr-ready-state.mjs
@@ -229,12 +229,6 @@ assert.match(
 
 assert.match(
   ciWorkflow,
-  /\n\s{2}unit-cloudbuild:\n[\s\S]+?needs: \[gate, unit-checker-integration\][\s\S]+?UNIT_RESULT: \$\{\{ needs\.unit-checker-integration\.result \}\}[\s\S]+?Required Cloud Build checker integration job did not pass/,
-  "legacy unit-cloudbuild context should mirror the required checker integration Cloud Build job",
-);
-
-assert.match(
-  ciWorkflow,
   /\n\s{2}ci-summary:\n[\s\S]+?needs:[\s\S]+?- unit\s*\n\s+- unit-checker-integration[\s\S]+?required\.update\(\{"dist-binaries", "unit", "unit-checker-integration"\}\)/,
   "CI Summary should require both the Cloud Run unit slice and checker integration heavy slice",
 );


### PR DESCRIPTION
## Summary
Two DAG cleanups that trim required-set / scheduler noise without weakening assurance:

1. **Removed the `unit-cloudbuild` no-op shim job.** It only re-reported `unit-checker-integration`'s result (`exit 1` on non-success), performed zero independent validation, was absent from the ci-summary `needs:` list and the required set, and gated nothing (branch protection on `main` requires only `["CI Summary"]`). It trailed the 45-min unit job purely as scheduler/DAG noise.

2. **Folded `wasm-web` into the `wasm` job.** The `wasm-web` job round-tripped the `wasm-web` artifact through an upload+download just to `test -s pkg/web/tsz_wasm_bg.wasm`. The `wasm` job already builds and uploads `pkg/web/`. The assertion is now an inline step in `wasm`, and the upload sets `if-no-files-found: error` — preserving (and strengthening) the thin presence assurance `wasm-web` provided, while dropping a required critical-path tail job. The `wasm-web` *artifact* is still produced (consumed by `gh-pages.yml`).

`wasm-web` was removed from BOTH the ci-summary `needs:` list and the `required` set under `full_run`.

Closes #13754

## Structural rule
A CI job belongs in the DAG only if it performs validation no other job does. `unit-cloudbuild` re-derived an existing verdict and gated nothing — delete it. `wasm-web` asserted a property the producing `wasm` job can assert in-process — fold the assertion (`test -s` + `if-no-files-found: error`) into the producer and drop the artifact round-trip + ubuntu spin-up.

## Verification
Ran in a clean worktree off `origin/main`:
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → YAML OK
- `node --check scripts/ci/test-pr-ready-state.mjs` → syntax OK
- `node scripts/ci/test-pr-ready-state.mjs` → **PASSED** (after removing the `unit-cloudbuild` `assert.match` block; the remaining ci-summary required-set assertion still matches)
- `grep` confirms no remaining `unit-cloudbuild` references anywhere, and `wasm-web` remains only as the artifact name on the `wasm` job's upload step
- Confirmed `scripts/ci/test_suite_metadata.py:51` only asserts `wasm-web` is NOT a local suite entry point (unaffected), and `gh-pages.yml` consumes the `wasm-web` artifact (still produced)

ci-summary references updated: removed `- wasm-web` from the `needs:` list and `"wasm-web"` from the `required.update({...})` full-run set.

Goal: fast

## Provenance
Machine: MacBookPro.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

— AgentName: M1FableArchitect
