### PR TITLE
fix(binder): do not hoist namespace members into top-level module exports

### DIFF
--- a/crates/tsz-binder/src/state/core.rs
+++ b/crates/tsz-binder/src/state/core.rs
@@ -1252,9 +1252,28 @@ impl BinderState {
                         & (symbol_flags::VALUE_MODULE | symbol_flags::NAMESPACE_MODULE))
                         != 0
                 {
-                    // If the module has an exports table, merge it into file_exports
+                    // If the module has an exports table, merge it into file_exports.
+                    //
+                    // A symbol declared *inside* a namespace
+                    // (`export declare namespace X { export type Result = ... }`)
+                    // is a NAMESPACE MEMBER: its `parent` points at the namespace
+                    // symbol `X`. tsc exposes only the namespace `X` at the file's
+                    // top level (member access is qualified as `X.Result`), never the
+                    // bare member `Result`. Hoisting such members would leak them into
+                    // the file's top-level export set — under a barrel `export *` this
+                    // produces phantom TS2308 collisions and resolves bare imports to
+                    // the wrong (namespace-member) binding. So skip members whose
+                    // `parent` is this namespace symbol; the namespace symbol itself is
+                    // still exposed by the `is_exported` branch below.
                     if let Some(module_exports) = symbol.exports.as_ref() {
                         for (export_name, &export_sym_id) in module_exports.iter() {
+                            let is_namespace_member = self
+                                .symbols
+                                .get(export_sym_id)
+                                .is_some_and(|member| member.parent == sym_id);
+                            if is_namespace_member {
+                                continue;
+                            }
                             if !file_exports.has(export_name) {
                                 file_exports.set(export_name.clone(), export_sym_id);
                             }

--- a/crates/tsz-binder/src/state/tests/module_augments.rs
+++ b/crates/tsz-binder/src/state/tests/module_augments.rs
@@ -1138,3 +1138,144 @@ interface Foo {
         "should have at least 3 declarations for merged interface"
     );
 }
+
+// =============================================================================
+// 27. NAMESPACE MEMBERS MUST NOT LEAK INTO TOP-LEVEL MODULE EXPORTS
+// =============================================================================
+//
+// Regression for the "namespace-export leak": a member declared inside
+// `export declare namespace X { export type Result = ... }` is a NAMESPACE
+// MEMBER (its `parent` is the namespace symbol). tsc exposes only the namespace
+// `X` at the file's top level — member access is qualified as `X.Result`, never
+// the bare `Result`. When the file is consumed through a barrel `export *`, a
+// leaked bare `Result` collided with another file's top-level `export type
+// Result`, producing a phantom TS2308 and a TS2339 cascade on the wrongly
+// resolved binding.
+
+#[test]
+fn namespace_member_does_not_leak_into_module_exports() {
+    let (binder, _parser) = parse_and_bind(
+        r"
+export declare namespace StandardSchemaV1 {
+    export type Result<O> = { value: O };
+    export const tag: number;
+}
+",
+    );
+
+    let exports = binder
+        .module_exports
+        .get("test.ts")
+        .expect("module_exports should have an entry for test.ts");
+
+    assert!(
+        exports.has("StandardSchemaV1"),
+        "the namespace symbol itself must be exposed at the top level"
+    );
+    assert!(
+        !exports.has("Result"),
+        "namespace member type `Result` must NOT leak into top-level module exports"
+    );
+    assert!(
+        !exports.has("tag"),
+        "namespace member value `tag` must NOT leak into top-level module exports"
+    );
+}
+
+#[test]
+fn top_level_export_type_and_const_still_hoist() {
+    // Adjacent case: genuine top-level `export type` / `export const` must still
+    // appear in module_exports (the fix must not over-suppress).
+    let (binder, _parser) = parse_and_bind(
+        r"
+export type Result<T, E = unknown> =
+    | { ok: true; value: T }
+    | { ok: false; error: E };
+export const answer = 42;
+",
+    );
+
+    let exports = binder
+        .module_exports
+        .get("test.ts")
+        .expect("module_exports should have an entry for test.ts");
+
+    assert!(
+        exports.has("Result"),
+        "top-level `export type Result` must be hoisted to module exports"
+    );
+    assert!(
+        exports.has("answer"),
+        "top-level `export const answer` must be hoisted to module exports"
+    );
+}
+
+#[test]
+fn nested_namespace_members_do_not_leak() {
+    // Adjacent case: deeply nested namespace members must not leak either; only
+    // the outermost namespace symbol is exposed at the top level.
+    let (binder, _parser) = parse_and_bind(
+        r"
+export namespace Outer {
+    export namespace Inner {
+        export const deep = 1;
+    }
+    export const mid = 2;
+}
+",
+    );
+
+    let exports = binder
+        .module_exports
+        .get("test.ts")
+        .expect("module_exports should have an entry for test.ts");
+
+    assert!(
+        exports.has("Outer"),
+        "outer namespace symbol must be exposed at the top level"
+    );
+    assert!(
+        !exports.has("Inner"),
+        "nested namespace `Inner` must NOT leak to top-level module exports"
+    );
+    assert!(
+        !exports.has("mid"),
+        "namespace member `mid` must NOT leak to top-level module exports"
+    );
+    assert!(
+        !exports.has("deep"),
+        "deeply nested member `deep` must NOT leak to top-level module exports"
+    );
+}
+
+#[test]
+fn value_namespace_members_do_not_leak() {
+    // Adjacent case: a VALUE namespace (`export namespace N { export const x }`)
+    // exposes only `N` (consumed as `N.x`), never the bare member `x`.
+    let (binder, _parser) = parse_and_bind(
+        r"
+export namespace N {
+    export const x = 1;
+    export type T = string;
+}
+",
+    );
+
+    let exports = binder
+        .module_exports
+        .get("test.ts")
+        .expect("module_exports should have an entry for test.ts");
+
+    assert!(
+        exports.has("N"),
+        "value namespace symbol `N` must be exposed at the top level"
+    );
+    assert!(
+        !exports.has("x"),
+        "value namespace member `x` must NOT leak to top-level module exports"
+    );
+    assert!(
+        !exports.has("T"),
+        "value namespace member type `T` must NOT leak to top-level module exports"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the **namespace-export leak**: when a file declares
`export declare namespace X { export type/const ... }` and is consumed through a
barrel `export *`, tsz hoisted the namespace MEMBERS (e.g. `Result`) into the
enclosing file's top-level `module_exports`. `tsc` exposes only the namespace
symbol `X` at the top level (member access is qualified as `X.Result`), never
the bare member.

The leak produced a phantom **TS2308** ("already exported a member named
'Result'") when another barrel-re-exported file also declared a top-level
`export type Result`, and resolved the bare barrel import to the wrong
namespace-member binding, cascading into **TS2339** on `.ok`/`.error`/`.value`.

Minimal repro (tsc=0, tsz before=TS2308 + 2x TS2339, tsz after=0):
```ts
// spec.ts
export declare namespace StandardSchemaV1 { export type Result<O> = { value: O }; }
// types.ts
export type Result<T, E = unknown> = { ok: true; value: T } | { ok: false; error: E };
// barrel.ts
export * from './types'; export * from './spec';
// consumer.ts
import type { Result } from './barrel';
declare const r: Result<number>;
if (r.ok) { r.value; } else { r.error; }
```

## Structural rule

A namespace member exported only via `export declare namespace X` must not be
hoisted into the enclosing module's top-level exports under `export *`; only the
namespace symbol is hoisted.

Owner layer: **binder**. `crates/tsz-binder/src/state/core.rs`
`populate_module_exports_from_file_symbols`. The `VALUE_MODULE |
NAMESPACE_MODULE` merge now skips an exports-table entry whose member symbol's
`parent` is the namespace symbol itself (a true namespace member). The namespace
symbol is still exposed via the `is_exported` branch. The TS2308
collision-collection in `crates/tsz-checker/src/declarations/import/exports.rs`
`collect_exported_names_for_collision_check` consumed the leaked entry and is now
fed a correct top-level export set.

Goal: green

## Provenance
Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Verification

- **Minimal repro**: tsz now 0 errors, matches tsc (0).
- **Adjacent matrix vs tsc** (`strict`, `moduleResolution: bundler`):
  - barrel `export *` over namespace + top-level type leak: MATCH (0/0)
  - `export * as ns from './x'` namespace re-export (namespace SHOULD appear): MATCH (0/0)
  - value namespace consumed as `N.x`: MATCH (0/0)
  - direct member import `import { Result } from './spec'` fails TS2305: MATCH (1/1)
  - nested namespace `Outer.Inner.deep`: MATCH (0/0)
  - top-level `export const`/`export type` still hoist through barrel: MATCH (0/0)
  - genuine top-level collision still emits TS2308: MATCH (1/1)
  - `export { NamespaceMember } from './spec'` explicit named re-export: tsc=1
    (TS2305 — member is qualified `X.Result`, not a top-level export). tsz=2
    (correct TS2305 + a pre-existing downstream TS2339 on the failed
    re-export). Baseline pre-fix was tsz=0 (silently accepted the broken
    re-export); the fix is strictly closer to tsc (now emits the primary
    TS2305). The residual TS2339 is a pre-existing checker error-recovery
    behavior unrelated to the binder leak.
- **Broad conformance — 0 PASS->FAIL** (all 100%): `exportStar` 15/15,
  `namespace` 17/17, `moduleExport` 49/49, `reexport` 14/14,
  `exportDeclaration` 32/32, `exportAssignment` 32/32, `declarationMerging`
  28/28, `exportAsNamespace` 10/10, `nestedModules` 1/1, `ambientDeclarations`
  7/7, `importDeclaration` 9/9. (`importStar` matches only fourslash cases — no
  conformance compiler files.)
- **trpc delta**: 185 -> 180 errors. Cleared the phantom TS2308 in
  `unstable-core-do-not-import.ts` plus the 4 `Result.ok/.error/.value` TS2339
  FPs (observable.ts, ws.ts) and 1 downstream TS2322. Zero new errors (one
  TS2322 at observable.ts:176 is the same pre-existing diagnostic with a
  slightly different rendered type string).
- **Other barrel+namespace rows**: neverthrow 0 TS2308 (unchanged), valibot 0
  errors / 0 TS2308 (clean).
- **Binder tests**: 552/552 pass, including 4 new tests in
  `crates/tsz-binder/src/state/tests/module_augments.rs`
  (`namespace_member_does_not_leak_into_module_exports`,
  `top_level_export_type_and_const_still_hoist`,
  `nested_namespace_members_do_not_leak`, `value_namespace_members_do_not_leak`).
- **Checker tests**: no regressions. 7 pre-existing failures (env-specific,
  including a SIGABRT stack overflow) reproduce identically on origin/main with
  the binder change reverted.
- **arch_guard.py**: PASS. **clippy** `-p tsz-binder --lib` and `-p tsz-checker
  --lib`: clean.
