### PR TITLE
fix(checker): merge cross-file generic interface heritage on the type-reference path

### DIFF
--- a/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
+++ b/crates/tsz-checker/src/state/type_resolution/symbol_types.rs
@@ -1654,6 +1654,19 @@ impl<'a> CheckerState<'a> {
                     };
                     merged = self.merge_lib_interface_heritage(merged, &name).0;
                 }
+                // The arena-local merges above read `extends` clauses through the
+                // current file's arena, so a *generic* interface imported from
+                // another module drops every member it inherits from a base
+                // declared in that module (or a lib/global base reached through
+                // it). The value/property-access path resolves this through
+                // `merge_cross_file_heritage`; mirror it here on the type-reference
+                // path so the inherited member set is present in relation/weak-type
+                // contexts too (otherwise `Derived<T>` looks like a bare `{ own?:
+                // .. }` weak type and mis-flags TS2559/TS2322 against a source that
+                // structurally satisfies the inherited base — #13232 line-12).
+                if has_declaration_arenas {
+                    merged = self.merge_cross_file_heritage(&symbol.declarations, sym_id, merged);
+                }
                 self.pop_type_parameters(updates);
                 if let Some(def_id) = self.ctx.get_existing_def_id(sym_id) {
                     let canonical_params = self.get_type_params_for_symbol(sym_id);


### PR DESCRIPTION
Goal: green

Fixes the **line-12** facet of #13232 (the cross-file lib-base heritage false positive). The #13232 line-16 resolver-less conditional residual is **not** addressed here and remains open.

## Symptom

A **generic** interface imported from another module dropped every member it inherits via `extends` from a base declared in that module — or a lib/global base (`extends Response`) reached through it — when resolved on the **type-reference/annotation** path. The relation then saw a bare `{ own?: .. }` shape, the solver's weak-type check misclassified it as a weak type, and a source that structurally satisfies the inherited base was mis-flagged **TS2559 / TS2322**. `tsc` is clean.

### 2-file witness (`tsc` 6.0.2 clean)

```ts
// types.ts
export interface FR<T> extends Response { _data?: T; }
// main.ts
import type { FR } from "./types.ts";
declare const r: Response;
let v: FR<any>;
v = r;            // before: tsz false TS2559 "Response has no properties in common with FR<any>"
```

### Decisive bisection (each row vs `tsc`)

| variant | tsc | tsz before | tsz after |
|---|---|---|---|
| `FR<T> extends Response`, cross-file, assignment `v = r` | clean | **TS2559** | clean |
| same, const-init `const x: FR<any> = r` | clean | clean | clean |
| same, property access `fr.status` | clean | clean | clean |
| non-generic `interface FR extends Response`, cross-file | clean | clean | clean |
| same-file generic `FR<T> extends Response` | clean | clean | clean |
| user (program) base cross-file | clean | clean | clean |

So the failure was unique to **generic + cross-file + lib/global base + relation path**.

## Structural rule

When a generic interface reference is resolved cross-file, `tsc` binds the full `extends`-inherited member set, including lib/global bases. tsz resolved the reference through `type_reference_symbol_type_with_params`, whose arena-local `merge_interface_heritage_types` and lib-aware fallback both read the **importing** file's arena, so the inherited members were absent on the relation/weak-type path. The value/property-access path already binds them through `merge_cross_file_heritage`, which is why property access and const-init were clean but plain assignment was not.

When `Derived<T>` extends a base in another module and is related as a target, `tsc` keeps the inherited members; tsz now does too on the type-reference path.

## Owner layer / fix

`type_reference_symbol_type_with_params` (`crates/tsz-checker/src/state/type_resolution/symbol_types.rs`) now mirrors the value-path call to the existing `merge_cross_file_heritage` (`state/type_analysis/cross_file_lowering.rs`), gated on cross-file declarations (`has_declaration_arenas`). That helper reads each `extends` clause from the owner arena, resolves bases through `resolve_cross_file_global_type_symbol` (program-file **and** lib/global), instantiates them in the current type-parameter scope, and merges structurally.

The change is **order-independent**: it reuses the direct cross-arena merge rather than the order-sensitive heritage publish/consume recovery, and it does not touch the still-open #13232 **line-16** conditional-evaluation residual (verified below: line-16 `TS2322` is still emitted and remains tracked).

## Anti-hardcoding

No identifier/file-name/printer-string predicates. Bases are resolved through binder symbol tables and instantiated through the solver's substitution primitives; the merge keys on the structural `extends` clause. Behavior follows the interface shape, not any name (the matrix includes program/lib bases, generic/non-generic, and renamed forms).

## Verification

- Witness + adjacent matrix above vs `tsc` 6.0.2 — all rows match after the fix; the ofetch 2-file witness's line-12 `TS2322` clears (line-16 conditional residual intentionally remains).
- `cargo test -p tsz-checker --lib` (full, 6686 tests): **deterministic failure set identical to `main`** (79 pre-existing failures on both; the single parallel-run flip in `source_option_bag_tests` is a pre-existing **global perf-counter ordering artifact** — confirmed identical single-threaded on both branches).
- `cargo fmt -p tsz-checker --check`: clean. `symbol_types.rs` is 1980 lines (under the 2000 cap).
- Broad conformance / emit / fourslash parity owned by ready-review CI.

## Provenance

Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_012uiM1UP3vPSsDMR5hhZzBb)_