### PR TITLE
fix(config): expand TS 5.5 ${configDir} tsconfig template variable (#13768)

### DIFF
--- a/crates/tsz-core/src/config/extends.rs
+++ b/crates/tsz-core/src/config/extends.rs
@@ -323,6 +323,113 @@ fn anchor_relative_path_option(option: &mut Option<String>, base_dir: &Path) {
     *option = Some(normalized.to_string_lossy().into_owned());
 }
 
+/// The TypeScript 5.5 `${configDir}` tsconfig template variable.
+///
+/// When a path-shaped tsconfig field begins with this token, `tsc` substitutes
+/// it with the directory of the config file that is being compiled in this
+/// invocation — i.e. for an `extends` chain it resolves to the *inheriting*
+/// (leaf) config's directory, never the base config's own directory. That is
+/// the whole point of the feature: a shared base config can write
+/// `"${configDir}/src"` and have every consumer resolve it against the
+/// consumer's directory.
+const CONFIG_DIR_TEMPLATE: &str = "${configDir}";
+
+/// Substitute the `${configDir}` template in every path-shaped tsconfig field
+/// against `config_dir`, the directory of the root config being compiled.
+///
+/// `config_dir` is the same value for every config in an `extends` chain (the
+/// leaf/inheriting config's directory), so callers thread the root directory
+/// through the recursion unchanged. Substitution must run *before* the
+/// `extends` anchoring helpers: it rewrites a leading `${configDir}` into an
+/// absolute, lexically-normalized path, which the `anchor_*` helpers then leave
+/// untouched (they skip already-absolute values). Fields whose value does not
+/// start with the template are left exactly as written so ordinary relative
+/// paths keep being anchored at their declaring config's directory.
+pub(super) fn substitute_config_dir_templates(config: &mut TsConfig, config_dir: &Path) {
+    // Root file selectors may carry glob metacharacters (`**`, `*.ts`), so they
+    // are normalized lexically (never canonicalized) just like the anchoring
+    // path for inherited selectors.
+    for selectors in [
+        config.files.as_mut(),
+        config.include.as_mut(),
+        config.exclude.as_mut(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        for selector in selectors {
+            substitute_config_dir_in_place(selector, config_dir);
+        }
+    }
+
+    let Some(opts) = config.compiler_options.as_mut() else {
+        return;
+    };
+    for option in [
+        &mut opts.base_url,
+        &mut opts.root_dir,
+        &mut opts.out_dir,
+        &mut opts.declaration_dir,
+        &mut opts.out_file,
+        &mut opts.ts_build_info_file,
+    ] {
+        if let Some(value) = option.as_mut() {
+            substitute_config_dir_in_place(value, config_dir);
+        }
+    }
+    for list in [opts.root_dirs.as_mut(), opts.type_roots.as_mut()]
+        .into_iter()
+        .flatten()
+    {
+        for entry in list {
+            substitute_config_dir_in_place(entry, config_dir);
+        }
+    }
+    if let Some(paths) = opts.paths.as_mut() {
+        for substitutions in paths.values_mut() {
+            for substitution in substitutions {
+                substitute_config_dir_in_place(substitution, config_dir);
+            }
+        }
+    }
+}
+
+/// Rewrite a single string in place when it begins with `${configDir}`.
+fn substitute_config_dir_in_place(value: &mut String, config_dir: &Path) {
+    if let Some(replaced) = substitute_config_dir(value, config_dir) {
+        *value = replaced;
+    }
+}
+
+/// Replace a leading `${configDir}` token with `config_dir` and lexically
+/// normalize the result. Returns `None` when the value does not start with the
+/// template, so non-template paths are left byte-for-byte unchanged.
+///
+/// Mirrors `tsc`'s `getSubstitutedPathWithConfigDirTemplate`, which rewrites the
+/// template to `./` and resolves it against the config directory: a bare
+/// `${configDir}` becomes the directory itself, and `${configDir}/src` becomes
+/// `<config_dir>/src`. The template is honored only at the start of the value
+/// (the TS spec restricts it to the leading segment).
+fn substitute_config_dir(value: &str, config_dir: &Path) -> Option<String> {
+    let rest = value.strip_prefix(CONFIG_DIR_TEMPLATE)?;
+    // Drop the single separator that follows the token so the remainder joins
+    // as a relative path; `${configDir}` on its own resolves to the directory.
+    let rest = rest
+        .strip_prefix('/')
+        .or_else(|| rest.strip_prefix('\\'))
+        .unwrap_or(rest);
+    let joined = if rest.is_empty() {
+        config_dir.to_path_buf()
+    } else {
+        config_dir.join(rest)
+    };
+    Some(
+        lexically_normalize_selector(&joined)
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
 pub(super) fn anchor_inherited_root_selectors(config: &mut TsConfig, config_path: &Path) {
     let Some(parent) = config_path.parent() else {
         return;
@@ -547,6 +654,79 @@ mod tests {
     use super::super::TsConfigReference;
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn substitute_config_dir_expands_root_selectors_and_path_options() {
+        let config_dir = Path::new("/proj/app");
+        let mut config = TsConfig {
+            include: Some(vec![
+                "${configDir}/src".to_string(),
+                "src/**/*.ts".to_string(),
+            ]),
+            exclude: Some(vec!["${configDir}/dist".to_string()]),
+            files: Some(vec!["${configDir}/entry.ts".to_string()]),
+            compiler_options: Some(CompilerOptions {
+                base_url: Some("${configDir}".to_string()),
+                out_dir: Some("${configDir}/dist".to_string()),
+                type_roots: Some(vec![
+                    "${configDir}/types".to_string(),
+                    "./node_modules/@types".to_string(),
+                ]),
+                paths: Some(
+                    [("@app/*".to_string(), vec!["${configDir}/src/*".to_string()])]
+                        .into_iter()
+                        .collect(),
+                ),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        substitute_config_dir_templates(&mut config, config_dir);
+
+        let include = config.include.as_ref().unwrap();
+        assert_eq!(
+            include[0], "/proj/app/src",
+            "${{configDir}}/src resolves against the root config dir"
+        );
+        assert_eq!(
+            include[1], "src/**/*.ts",
+            "non-template selectors are left for the extends anchoring step"
+        );
+        assert_eq!(config.exclude.as_ref().unwrap()[0], "/proj/app/dist");
+        assert_eq!(config.files.as_ref().unwrap()[0], "/proj/app/entry.ts");
+
+        let opts = config.compiler_options.as_ref().unwrap();
+        assert_eq!(
+            opts.base_url.as_deref(),
+            Some("/proj/app"),
+            "bare ${{configDir}} resolves to the directory itself"
+        );
+        assert_eq!(opts.out_dir.as_deref(), Some("/proj/app/dist"));
+        let type_roots = opts.type_roots.as_ref().unwrap();
+        assert_eq!(type_roots[0], "/proj/app/types");
+        assert_eq!(
+            type_roots[1], "./node_modules/@types",
+            "non-template entries untouched"
+        );
+        assert_eq!(opts.paths.as_ref().unwrap()["@app/*"][0], "/proj/app/src/*");
+    }
+
+    #[test]
+    fn substitute_config_dir_only_matches_leading_token() {
+        let config_dir = Path::new("/proj");
+        let mut config = TsConfig {
+            // The TS spec only honors `${configDir}` at the start of a value.
+            include: Some(vec!["src/${configDir}/x".to_string()]),
+            ..Default::default()
+        };
+        substitute_config_dir_templates(&mut config, config_dir);
+        assert_eq!(
+            config.include.as_ref().unwrap()[0],
+            "src/${configDir}/x",
+            "a non-leading template is left literal, matching tsc"
+        );
+    }
 
     #[test]
     fn merge_configs_child_overrides_base_compiler_options() {

--- a/crates/tsz-core/src/config/mod.rs
+++ b/crates/tsz-core/src/config/mod.rs
@@ -17,7 +17,7 @@ mod lib_resolution;
 
 use extends::{
     anchor_inherited_path_options, anchor_inherited_root_selectors, merge_configs,
-    resolve_extends_path,
+    resolve_extends_path, substitute_config_dir_templates,
 };
 use lib_offsets::find_lib_entry_offset;
 
@@ -1177,13 +1177,26 @@ fn known_compiler_option(key_lower: &str) -> Option<&'static str> {
 
 pub fn load_tsconfig(path: &Path) -> Result<TsConfig> {
     let mut visited = FxHashSet::default();
-    load_tsconfig_inner(path, &mut visited, false)
+    let config_dir = root_config_dir(path);
+    load_tsconfig_inner(path, &mut visited, false, &config_dir)
 }
 
 /// Load tsconfig.json and collect config-level diagnostics.
 pub fn load_tsconfig_with_diagnostics(path: &Path) -> Result<ParsedTsConfig> {
     let mut visited = FxHashSet::default();
-    load_tsconfig_inner_with_diagnostics(path, &mut visited, false)
+    let config_dir = root_config_dir(path);
+    load_tsconfig_inner_with_diagnostics(path, &mut visited, false, &config_dir)
+}
+
+/// Absolute directory of the root config being compiled. Every `${configDir}`
+/// template in this config and in any config it `extends` resolves against this
+/// single directory (the inheriting/leaf config's directory), so it is computed
+/// once at the entry point and threaded through the `extends` recursion
+/// unchanged. Canonicalization falls back to the lexical path off the
+/// filesystem (e.g. on `wasm32`), matching the existing anchoring helpers.
+fn root_config_dir(path: &Path) -> PathBuf {
+    let parent = path.parent().unwrap_or_else(|| Path::new(""));
+    std::fs::canonicalize(parent).unwrap_or_else(|_| parent.to_path_buf())
 }
 
 fn config_ignore_deprecations_silences_6_0(config: &TsConfig) -> bool {
@@ -1206,6 +1219,7 @@ fn load_tsconfig_inner(
     path: &Path,
     visited: &mut FxHashSet<PathBuf>,
     inherited: bool,
+    config_dir: &Path,
 ) -> Result<TsConfig> {
     let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     if !visited.insert(canonical.clone()) {
@@ -1216,6 +1230,9 @@ fn load_tsconfig_inner(
         .with_context(|| format!("failed to read tsconfig: {}", path.display()))?;
     let mut config = parse_tsconfig(&source)
         .with_context(|| format!("failed to parse tsconfig: {}", path.display()))?;
+    // Resolve `${configDir}` against the root config's directory before any
+    // `extends` anchoring, which only fires on the leftover relative paths.
+    substitute_config_dir_templates(&mut config, config_dir);
     anchor_inherited_path_options(&mut config, path);
     if inherited {
         anchor_inherited_root_selectors(&mut config, path);
@@ -1232,7 +1249,7 @@ fn load_tsconfig_inner(
         let mut accumulated: Option<TsConfig> = None;
         for extends_path_str in &extends_paths {
             let base_path = resolve_extends_path(path, extends_path_str)?;
-            let base_config = load_tsconfig_inner(&base_path, visited, true)?;
+            let base_config = load_tsconfig_inner(&base_path, visited, true, config_dir)?;
             accumulated = Some(match accumulated {
                 Some(acc) => merge_configs(acc, base_config),
                 None => base_config,
@@ -1251,6 +1268,7 @@ fn load_tsconfig_inner_with_diagnostics(
     path: &Path,
     visited: &mut FxHashSet<PathBuf>,
     inherited: bool,
+    config_dir: &Path,
 ) -> Result<ParsedTsConfig> {
     let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     if !visited.insert(canonical.clone()) {
@@ -1262,6 +1280,9 @@ fn load_tsconfig_inner_with_diagnostics(
     let file_display = path.display().to_string();
     let mut parsed = parse_tsconfig_with_diagnostics(&source, &file_display)
         .with_context(|| format!("failed to parse tsconfig: {}", path.display()))?;
+    // Resolve `${configDir}` against the root config's directory before any
+    // `extends` anchoring, which only fires on the leftover relative paths.
+    substitute_config_dir_templates(&mut parsed.config, config_dir);
     anchor_inherited_path_options(&mut parsed.config, path);
     if inherited {
         anchor_inherited_root_selectors(&mut parsed.config, path);
@@ -1292,7 +1313,8 @@ fn load_tsconfig_inner_with_diagnostics(
             // `verbatimModuleSyntax` replacement). The post-merge block below
             // owns that re-emission; letting the base's per-option TS5102
             // through would double-report and anchor at the wrong file.
-            let base_parsed = load_tsconfig_inner_with_diagnostics(&base_path, visited, true)?;
+            let base_parsed =
+                load_tsconfig_inner_with_diagnostics(&base_path, visited, true, config_dir)?;
             parsed
                 .diagnostics
                 .extend(base_parsed.diagnostics.into_iter().filter(|d| {

--- a/crates/tsz-core/src/config/tests/module_resolution.rs
+++ b/crates/tsz-core/src/config/tests/module_resolution.rs
@@ -1429,3 +1429,98 @@ fn test_resolve_extends_path_uses_package_exports_mapping() {
 
     assert_eq!(resolved, expected);
 }
+
+#[test]
+fn config_dir_template_expands_against_leaf_config_dir() {
+    // TS 5.5 `${configDir}`: a root config's template resolves to its own
+    // directory and produces absolute selectors/paths.
+    let temp = tempdir().expect("create temp dir");
+    let project_dir = temp.path().join("project");
+    std::fs::create_dir_all(project_dir.join("src")).expect("create src dir");
+
+    let config_path = project_dir.join("tsconfig.json");
+    std::fs::write(
+        &config_path,
+        r#"{
+"compilerOptions": { "noEmit": true, "outDir": "${configDir}/dist" },
+"include": ["${configDir}/src"]
+}"#,
+    )
+    .expect("write config");
+
+    let merged = load_tsconfig(&config_path).expect("load config");
+    let canonical_project = std::fs::canonicalize(&project_dir).unwrap_or(project_dir);
+    let expected_src = canonical_project.join("src").to_string_lossy().into_owned();
+    let expected_dist = canonical_project
+        .join("dist")
+        .to_string_lossy()
+        .into_owned();
+
+    assert_eq!(
+        merged.include.as_deref(),
+        Some(&[expected_src][..]),
+        "${{configDir}}/src must expand to the config's own directory"
+    );
+    assert_eq!(
+        merged
+            .compiler_options
+            .as_ref()
+            .and_then(|o| o.out_dir.as_deref()),
+        Some(expected_dist.as_str()),
+    );
+}
+
+#[test]
+fn config_dir_template_in_base_resolves_to_inheriting_config_dir() {
+    // The defining behavior of `${configDir}`: a shared base config can write
+    // `${configDir}/...` and every consumer resolves it against the consumer's
+    // (leaf) directory, NOT the base config's own directory.
+    let temp = tempdir().expect("create temp dir");
+    let base_dir = temp.path().join("shared");
+    let app_dir = temp.path().join("app");
+    std::fs::create_dir_all(app_dir.join("src")).expect("create app src");
+    std::fs::create_dir_all(&base_dir).expect("create base dir");
+
+    let base_path = base_dir.join("tsconfig.base.json");
+    std::fs::write(
+        &base_path,
+        r#"{
+"compilerOptions": { "outDir": "${configDir}/dist", "baseUrl": "${configDir}" },
+"include": ["${configDir}/src"]
+}"#,
+    )
+    .expect("write base");
+
+    let child_path = app_dir.join("tsconfig.json");
+    std::fs::write(
+        &child_path,
+        r#"{ "extends": "../shared/tsconfig.base.json", "compilerOptions": { "noEmit": true } }"#,
+    )
+    .expect("write child");
+
+    let merged = load_tsconfig(&child_path).expect("load child");
+    let canonical_app = std::fs::canonicalize(&app_dir).unwrap_or(app_dir.clone());
+    let canonical_base = std::fs::canonicalize(&base_dir).unwrap_or(base_dir);
+
+    let include = merged.include.expect("inherited include present");
+    assert_eq!(
+        include[0],
+        canonical_app.join("src").to_string_lossy(),
+        "${{configDir}} in the base must resolve to the inheriting config's dir"
+    );
+    assert!(
+        !include[0].starts_with(canonical_base.to_string_lossy().as_ref()),
+        "${{configDir}} must not anchor at the base config's own directory: {:?}",
+        include[0]
+    );
+
+    let opts = merged.compiler_options.expect("compiler options merged");
+    assert_eq!(
+        opts.out_dir.as_deref(),
+        Some(canonical_app.join("dist").to_string_lossy().as_ref()),
+    );
+    assert_eq!(
+        opts.base_url.as_deref(),
+        Some(canonical_app.to_string_lossy().as_ref()),
+    );
+}

--- a/crates/tsz-core/src/config/tests/module_resolution.rs
+++ b/crates/tsz-core/src/config/tests/module_resolution.rs
@@ -1499,7 +1499,7 @@ fn config_dir_template_in_base_resolves_to_inheriting_config_dir() {
     .expect("write child");
 
     let merged = load_tsconfig(&child_path).expect("load child");
-    let canonical_app = std::fs::canonicalize(&app_dir).unwrap_or(app_dir.clone());
+    let canonical_app = std::fs::canonicalize(&app_dir).unwrap_or(app_dir);
     let canonical_base = std::fs::canonicalize(&base_dir).unwrap_or(base_dir);
 
     let include = merged.include.expect("inherited include present");


### PR DESCRIPTION
Goal: grow

Fixes #13768.

## Structural rule
When a tsconfig path field (`include`/`exclude`/`files`, `baseUrl`, `rootDir`,
`rootDirs`, `outDir`, `declarationDir`, `outFile`, `tsBuildInfoFile`,
`typeRoots`, or a `paths` substitution) **begins with** the TypeScript 5.5
`${configDir}` template variable, `tsc` substitutes it with the directory of
the config file being compiled in this invocation. In an `extends` chain this
is the **inheriting (leaf) config's directory**, never the base config's own
directory — the whole point of the feature is that a shared base config can
write `"${configDir}/src"` and have every consumer resolve it against the
consumer's directory. `tsz` previously passed the literal `${configDir}`
segment straight to the filesystem, so `payload`/`medusa`-style roots failed
before type-checking with `failed to read directory entry … /${configDir}/src`.

## Owner layer
The substitution is owned by the **tsz-core config loader** (`config/extends.rs`
`substitute_config_dir_templates`), invoked from `load_tsconfig_inner` and
`load_tsconfig_inner_with_diagnostics` right after parse and **before** the
existing `extends`-anchoring pass. The root config's directory is computed
once (`root_config_dir`) and threaded unchanged through the recursion, so a
leading `${configDir}` in any config in the chain resolves against the leaf
config's directory. Substitution rewrites the value to an absolute,
lexically-normalized path (preserving glob metacharacters such as `**`/`*.ts`,
mirroring the sibling selector-anchoring helper). Because the result is already
absolute, the downstream `anchor_*` helpers leave it untouched — non-template
relative paths keep being anchored at their declaring config's directory, as
before. Per the TS spec, the template is honored only at the *start* of a
value; a non-leading `${configDir}` is left literal (matching `tsc`).

## Adjacent-case matrix
- **Root selectors**: `${configDir}/src` in `include`/`exclude`/`files`.
- **Single path options**: `baseUrl` (bare `${configDir}` → the directory
  itself), `rootDir`, `outDir`, `declarationDir`, `outFile`, `tsBuildInfoFile`.
- **Array path options**: `rootDirs`, `typeRoots` (per-entry; non-template
  entries untouched).
- **`paths`**: per-substitution expansion.
- **`extends`**: `${configDir}` in a base config resolves to the inheriting
  config's directory, not the base's.
- **Negative**: non-leading `${configDir}` left literal; non-template paths
  byte-for-byte unchanged so existing anchoring still applies.

## Cache/order plan
Substitution runs once per path field at parse time (O(paths), no per-file or
per-resolution cost). `root_config_dir` performs a single `canonicalize` per
top-level config load and is threaded by reference; no per-recursion
recomputation, no per-selector filesystem hit (lexical normalization only).

## Verification
- New unit tests (`crates/tsz-core/src/config/extends.rs`):
  `substitute_config_dir_expands_root_selectors_and_path_options`,
  `substitute_config_dir_only_matches_leading_token`.
- New integration tests (`crates/tsz-core/src/config/tests/module_resolution.rs`):
  `config_dir_template_expands_against_leaf_config_dir`,
  `config_dir_template_in_base_resolves_to_inheriting_config_dir`.
- `cargo test -p tsz-core --lib config::` → 219 passed, 0 failed.
- `cargo clippy -p tsz-core --lib` → clean.
- End-to-end: the issue's minimal repro (`include: ["${configDir}/src"]`) now
  resolves sources (`tsz --noEmit -p tsconfig.json` exits 0; a deliberate type
  error in `src` surfaces `TS2322`, proving the glob resolves and the file is
  checked). Previously it failed with the `${configDir}` IO error.
- Project-corpus smoke (CI): `TSZ_PROJECT_COMPILE_SET=canary
  TSZ_PROJECT_COMPILE_FILTER='^(payload|medusa)-project$'
  bash scripts/ci/project-compile-guard.sh`.

## Provenance
Machine: cloud
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1ovhAWpEPSq3kn9d9skd9)_