### PR TITLE
perf(ci): shard the emit suite 4-way with an emit-aggregate recombiner (#13746)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
                     if [[ -n "$compiler_paths_on_pr" ]]; then
                       heavy_checks_passed=$(gh api \
                         "repos/${{ github.repository }}/actions/runs/${latest_ci_run_id}/jobs?per_page=100" \
-                        --jq '[.jobs[] | select((.name == "conformance-snapshot-gate" or .name == "conformance-aggregate" or .name == "fourslash-aggregate" or .name == "emit") and .conclusion == "success")] | length' \
+                        --jq '[.jobs[] | select((.name == "conformance-snapshot-gate" or .name == "conformance-aggregate" or .name == "fourslash-aggregate" or .name == "emit-aggregate") and .conclusion == "success")] | length' \
                         2>/dev/null || echo "0")
                       if [[ "${heavy_checks_passed}" -ge 4 ]]; then
                         echo "Latest required PR CI summary and heavy compiler gates for #${pr_number} head ${pr_head_sha} passed — skipping redundant main CI"
@@ -1301,14 +1301,22 @@ jobs:
         run: echo "Conformance snapshot gate is enforced for pull_request events."
 
   emit:
-    name: emit
+    # Each matrix shard runs scripts/emit/run.sh over a chunk of the corpus
+    # (EMIT_CHUNK=4000). The corpus is jsTotal=13530, so ceil(13530/4000)=4
+    # shards give full coverage; fewer would silently drop tests and fail the
+    # emit-aggregate full-corpus floor. emit-aggregate recombines the shards.
+    name: emit-${{ matrix.shard }}
     needs: [gate, dist-binaries, node-harness-prep]
     if: needs.gate.outputs.full_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true'
     runs-on: [self-hosted, tsz-cloud-run]
-    timeout-minutes: 30
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     env:
-      _TSZ_CI_EMIT_SHARD_INDEX: 0
-      _TSZ_CI_EMIT_SHARD_COUNT: 1
+      _TSZ_CI_EMIT_SHARD_INDEX: ${{ matrix.shard }}
+      _TSZ_CI_EMIT_SHARD_COUNT: 4
       TSZ_CI_SKIP_DIST_RESTORE: "1"
       TSZ_CI_TRUST_DIST_FAST_CACHE: "1"
       TSZ_CI_SKIP_TS_HARNESS_RESTORE: "1"
@@ -1337,17 +1345,97 @@ jobs:
           path: .
       - name: Unpack node harness
         run: tar -xf node-harness.tar
-      - name: Run emit suite
+      - name: Run emit shard
         run: scripts/ci/github-suite.sh emit-shard
-      - name: Upload emit details
+      - name: Upload emit shard result
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: emit-details
+          name: emit-shard-${{ matrix.shard }}
           path: |
-            ci-metrics/emit*.json
+            ci-metrics/emit-shard-${{ matrix.shard }}.json
+            ci-metrics/emit-detail-${{ matrix.shard }}.json
             .ci-logs/emit/*.log
-          if-no-files-found: ignore
+          if-no-files-found: warn
+          retention-days: 1
+
+  emit-aggregate:
+    name: emit-aggregate
+    needs: [gate, emit]
+    if: needs.gate.outputs.full_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true' && !cancelled() && needs.emit.result != 'skipped' && needs.emit.result != 'cancelled'
+    runs-on: [self-hosted, tsz-cloud-run]
+    timeout-minutes: 15
+    env:
+      GITHUB_SHA: ${{ github.sha }}
+      _TSZ_CI_EMIT_SHARD_COUNT: 4
+      TSZ_CI_CACHE_SAVE: "0"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Wait for emit shard artifacts to be indexed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          EXPECTED=4
+          MAX_WAIT=180
+          INTERVAL=10
+          elapsed=0
+          count=0
+          echo "Polling for all ${EXPECTED} emit-shard-* artifacts (max ${MAX_WAIT}s)..."
+          while [ "$elapsed" -lt "$MAX_WAIT" ]; do
+            api_response=$(curl -sf \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}/artifacts?per_page=100" \
+              2>/dev/null || echo '{}')
+            count=$(echo "$api_response" | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          c = sum(1 for a in data.get('artifacts', []) if a['name'].startswith('emit-shard-'))
+          print(c)
+          " 2>/dev/null || echo 0)
+            echo "  ${count}/${EXPECTED} shard artifacts indexed (${elapsed}s elapsed)"
+            if [ "${count}" -ge "${EXPECTED}" ]; then
+              echo "All ${EXPECTED} shard artifacts indexed after ${elapsed}s."
+              break
+            fi
+            jobs_response=$(curl -sf \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+              2>/dev/null || echo '{}')
+            shard_summary=$(echo "$jobs_response" | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          jobs = [j for j in data.get('jobs', []) if j.get('name','').startswith('emit-')]
+          done = [j for j in jobs if j.get('status') == 'completed']
+          failed = [j['name'] for j in done if j.get('conclusion') not in ('success','skipped')]
+          print(f'done={len(done)} failed={len(failed)} names={failed}')
+          " 2>/dev/null || echo 'done=0 failed=0 names=[]')
+            echo "  shard jobs: ${shard_summary}"
+            done_count=$(echo "$shard_summary" | grep -oP 'done=\K[0-9]+' || echo 0)
+            failed_count=$(echo "$shard_summary" | grep -oP 'failed=\K[0-9]+' || echo 0)
+            if [ "${done_count}" -ge "${EXPECTED}" ] && [ "${failed_count}" -gt 0 ]; then
+              echo "warning: ${failed_count} shard job(s) failed (runner issue); artifact(s) will not appear — proceeding with ${count} available" >&2
+              break
+            fi
+            sleep "${INTERVAL}"
+            elapsed=$(( elapsed + INTERVAL ))
+          done
+          if [ "${count}" -lt "${EXPECTED}" ]; then
+            echo "warning: only ${count}/${EXPECTED} shard artifacts indexed after ${elapsed}s; proceeding" >&2
+          fi
+      - name: Download emit shard results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: emit-shard-*
+          path: .emit-shards
+          merge-multiple: false
+      - name: Aggregate emit results
+        run: scripts/ci/github-suite.sh emit-aggregate
 
   fourslash:
     # Each matrix shard runs on its own 8-vCPU cloud runner. Run 25058599510
@@ -1439,7 +1527,7 @@ jobs:
       - unit-checker-integration
       - conformance-aggregate
       - conformance-snapshot-gate
-      - emit
+      - emit-aggregate
       - fourslash-aggregate
     if: always()
     runs-on: ubuntu-latest
@@ -1602,7 +1690,7 @@ jobs:
                   "lsp-e2e",
                   "node-harness-prep",
                   "conformance-aggregate",
-                  "emit",
+                  "emit-aggregate",
                   "fourslash-aggregate",
               })
 

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -964,6 +964,100 @@ run_emit_shard() {
   return 0
 }
 
+# Recombine the per-shard emit results (uploaded by run_emit_shard as both a
+# GitHub Actions artifact and a GCS object) and re-run the full-corpus floor
+# over the summed counts. This is the required emit leaf for multi-shard runs;
+# single-shard runs validate inline in run_emit_shard above.
+run_emit_aggregate() {
+  ci_section "Emit aggregate"
+  local expected_shards="${_TSZ_CI_EMIT_SHARD_COUNT:-1}"
+  expected_shards="$(num_or_zero "$expected_shards")"
+  [[ "$expected_shards" -lt 1 ]] && expected_shards=1
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  local bucket="${_TSZ_CI_CACHE_BUCKET:-${TSZ_CI_CACHE_BUCKET:-}}"
+  local run_key="${GITHUB_SHA:-${REVISION_ID:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}}"
+  local prefix=""
+  if [[ -n "$bucket" && "$run_key" != "unknown" ]]; then
+    prefix="${bucket%/}/emit-runs/${run_key}"
+  fi
+
+  # Prefer GitHub Actions artifacts (downloaded by the workflow's
+  # download-artifact step) over GCS, which requires SA key permissions that may
+  # not be available. upload-artifact@v4 preserves the workspace-relative path,
+  # so the file lands at emit-shard-N/ci-metrics/emit-shard-N.json.
+  local artifacts_dir=".emit-shards"
+  local using_artifacts=0
+  if [[ -d "$artifacts_dir" ]]; then
+    local found=0
+    for shard_dir in "$artifacts_dir"/emit-shard-*/; do
+      [[ -d "$shard_dir" ]] || continue
+      local json
+      json="$(find "$shard_dir" -name "emit-shard-*.json" -maxdepth 4 2>/dev/null | head -1)"
+      [[ -f "$json" ]] || continue
+      local shard_name
+      shard_name="$(basename "$shard_dir")"
+      cp "$json" "$tmp_dir/shard-${shard_name#emit-shard-}.json"
+      found=$(( found + 1 ))
+    done
+    if [[ "$found" -gt 0 ]]; then
+      echo "Using ${found} GitHub Actions artifact shard results from ${artifacts_dir}/"
+      using_artifacts=1
+    else
+      echo "warning: ${artifacts_dir}/ exists but no emit-shard-*.json files found; falling back to GCS" >&2
+      ls -la "$artifacts_dir"/ 2>/dev/null || true
+    fi
+  fi
+
+  if [[ "$using_artifacts" -eq 0 ]]; then
+    if [[ -z "$prefix" ]]; then
+      echo "error: cannot aggregate — no artifact dir and no GCS bucket/run key available" >&2
+      return 1
+    fi
+    echo "Downloading emit shard results from ${prefix}/shard-*.json ..."
+    local dl_attempt dl_rc=1
+    for dl_attempt in 1 2 3; do
+      if gsutil -q cp "${prefix}/shard-*.json" "$tmp_dir/" 2>/dev/null; then
+        dl_rc=0
+        break
+      fi
+      echo "warning: GCS download attempt ${dl_attempt}/3 failed" >&2
+      [[ "$dl_attempt" -lt 3 ]] && sleep "$((dl_attempt * 5))"
+    done
+    if [[ "$dl_rc" -ne 0 ]]; then
+      echo "error: failed to download emit shard results from GCS after 3 attempts" >&2
+      return 1
+    fi
+  fi
+
+  local js_p=0 js_t=0 js_s=0 js_to=0 dts_p=0 dts_t=0 dts_s=0
+  local shard_count=0 failed_shards=0
+  for f in "$tmp_dir"/shard-*.json; do
+    [[ -f "$f" ]] || continue
+    js_p=$(( js_p   + $(num_or_zero "$(jq -r '.js_passed // 0'   "$f" 2>/dev/null)") ))
+    js_t=$(( js_t   + $(num_or_zero "$(jq -r '.js_total // 0'    "$f" 2>/dev/null)") ))
+    js_s=$(( js_s   + $(num_or_zero "$(jq -r '.js_skipped // 0'  "$f" 2>/dev/null)") ))
+    js_to=$(( js_to + $(num_or_zero "$(jq -r '.js_timeouts // 0' "$f" 2>/dev/null)") ))
+    dts_p=$(( dts_p + $(num_or_zero "$(jq -r '.dts_passed // 0'  "$f" 2>/dev/null)") ))
+    dts_t=$(( dts_t + $(num_or_zero "$(jq -r '.dts_total // 0'   "$f" 2>/dev/null)") ))
+    dts_s=$(( dts_s + $(num_or_zero "$(jq -r '.dts_skipped // 0' "$f" 2>/dev/null)") ))
+    if [[ "$(num_or_zero "$(jq -r '.rc // 0' "$f" 2>/dev/null)")" -ne 0 ]]; then
+      failed_shards=$(( failed_shards + 1 ))
+    fi
+    shard_count=$(( shard_count + 1 ))
+  done
+
+  if [[ "$failed_shards" -gt 0 ]]; then
+    echo "warning: ${failed_shards} emit shard(s) returned non-zero rc; aggregate still applies the full-corpus floor" >&2
+  fi
+
+  validate_emit_aggregate_counts "$js_p" "$js_t" "$js_s" "$js_to" "$dts_p" "$dts_t" "$dts_s" "$shard_count" "$expected_shards"
+  write_emit_metric "$METRICS_DIR/emit.json" \
+    "$js_p" "$js_t" "$js_s" "$js_to" \
+    "$dts_p" "$dts_t" "$dts_s"
+  publish_latest_metric emit "$METRICS_DIR/emit.json"
+}
+
 run_fourslash_shard() {
   ci_section "Fourslash shard"
   local bucket run_key shard_index shard_count
@@ -1224,6 +1318,9 @@ main() {
       timed build_test_binaries build_test_binaries
       timed maybe_prep_node_artifacts maybe_prep_node_artifacts
       timed run_emit_shard run_emit_shard
+      ;;
+    emit-aggregate)
+      timed run_emit_aggregate run_emit_aggregate
       ;;
     fourslash-shard)
       timed build_test_binaries build_test_binaries

--- a/scripts/ci/suite-metadata.sh
+++ b/scripts/ci/suite-metadata.sh
@@ -10,6 +10,7 @@ _TSZ_CI_GITHUB_SUITES=(
   conformance
   conformance-aggregate
   emit-shard
+  emit-aggregate
   fourslash-shard
   fourslash-aggregate
 )
@@ -160,7 +161,7 @@ ci_suite_caches() {
       # from TypeScript source. No npm/harness restore needed.
       echo "typescript-source dist-fast-commit"
       ;;
-    conformance-aggregate|fourslash-aggregate)
+    conformance-aggregate|emit-aggregate|fourslash-aggregate)
       # Aggregates only download per-shard JSONs from GCS.
       echo ""
       ;;

--- a/scripts/ci/test-pr-ready-state.mjs
+++ b/scripts/ci/test-pr-ready-state.mjs
@@ -232,3 +232,15 @@ assert.match(
   /\n\s{2}ci-summary:\n[\s\S]+?needs:[\s\S]+?- unit\s*\n\s+- unit-checker-integration[\s\S]+?required\.update\(\{"dist-binaries", "unit", "unit-checker-integration"\}\)/,
   "CI Summary should require both the Cloud Run unit slice and checker integration heavy slice",
 );
+
+assert.match(
+  ciWorkflow,
+  /\n\s{2}ci-summary:\n[\s\S]+?needs:[\s\S]+?- emit-aggregate\s*\n\s+- fourslash-aggregate[\s\S]+?"emit-aggregate",\s*\n\s+"fourslash-aggregate",/,
+  "CI Summary must require the emit-aggregate recombiner (not a raw emit shard) as the required emit leaf before reporting required full-run success",
+);
+
+assert.doesNotMatch(
+  ciWorkflow,
+  /\n\s{2}ci-summary:\n[\s\S]+?required\.update\(\{[\s\S]*?"emit",/,
+  "CI Summary must not require a raw emit shard leaf; the sharded emit suite is gated through emit-aggregate",
+);


### PR DESCRIPTION
Goal: fast

## Summary
`emit` ran as a single unsharded self-hosted job (`_TSZ_CI_EMIT_SHARD_COUNT: 1`, `timeout-minutes: 30`) on the wave-2 critical path, even though the harness already implements per-shard chunking (`run_emit_shard` reads `_TSZ_CI_EMIT_SHARD_INDEX/COUNT` and passes `--max/--offset`). This converts emit to a 4-way matrix and adds an `emit-aggregate` recombiner, mirroring `conformance`/`fourslash`:

- **emit** → `strategy: { fail-fast: false, matrix: { shard: [0,1,2,3] } }`, `_TSZ_CI_EMIT_SHARD_COUNT: 4`, `_TSZ_CI_EMIT_SHARD_INDEX: ${{ matrix.shard }}`, renamed `emit-${{ matrix.shard }}`, `timeout-minutes: 20` (was 30). Each shard uploads a per-shard `emit-shard-<shard>` artifact (`ci-metrics/emit-shard-<shard>.json` + detail + log).
- **emit-aggregate** (new job) — waits for/indexes the 4 shard artifacts, downloads `emit-shard-*`, and runs `scripts/ci/github-suite.sh emit-aggregate`. The new `run_emit_aggregate` sums the per-shard JSON (prefers GitHub artifacts, falls back to the GCS `emit-runs/<sha>` prefix the shards already upload to) and re-runs `validate_emit_aggregate_counts` over the summed counts, enforcing the full-corpus floor (jsPass ≥ 13530, dtsPass ≥ 1669).
- Rewired the required leaf from raw `emit` to `emit-aggregate`: the ci-summary `needs:` list, the full-run `required.update({...})` set, and the heavy-checks main-CI skip-gate `--jq select(.name == ...)` filter all now reference `emit-aggregate`.
- Registered `emit-aggregate` as a known GitHub suite in `suite-metadata.sh` (required — `github-suite.sh` rejects unknown suites with exit 2; aggregates declare no cache, matching `conformance-aggregate|fourslash-aggregate`).

Single-shard local runs still validate inline in `run_emit_shard` (unchanged), so `test_gcp_full_ci_emit_metrics.py` ordering holds.

## Shard-count math
`EMIT_CHUNK=4000`, corpus `jsTotal=13530` (`scripts/emit/emit-snapshot.json`). `ceil(13530/4000)=4` shards for full coverage; `4*4000=16000 ≥ 13530`. A 3-shard matrix would cover only 12000 and silently drop ~1530 tests, failing the aggregate floor.

Closes #13746

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — OK
- `bash -n scripts/ci/gcp-full-ci.sh` and `bash -n scripts/ci/suite-metadata.sh` — OK
- `node --check scripts/ci/test-pr-ready-state.mjs` — OK
- `node scripts/ci/test-pr-ready-state.mjs` — **PASS** (added an emit-aggregate needs-order + required-leaf assertion and a negative assertion that no raw `emit` leaf is required)
- `python3 scripts/ci/test_gcp_full_ci_emit_metrics.py` — OK (2 tests); `test_gcp_full_ci_conformance_artifacts.py` — OK (7 tests, unaffected)
- Shard math confirmed against `emit-snapshot.json`: jsTotal=13530, dtsTotal=1669, `4*4000=16000 ≥ 13530`.
- Did not run the emit suite or full CI locally (ready-review CI owns broad suites).

## Provenance
Machine: MacBookPro.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

— AgentName: M1FableArchitect
