### PR TITLE
fix(checker,solver): nested typeof X resolves to value/constructor side for merged interface+value symbols

### DIFF
--- a/crates/tsz-checker/src/context/resolver.rs
+++ b/crates/tsz-checker/src/context/resolver.rs
@@ -561,6 +561,31 @@ impl<'a> TypeResolver for CheckerContext<'a> {
         self.symbol_types.get(&sym_id).copied()
     }
 
+    /// Resolve a `typeof X` query to its VALUE-space type.
+    ///
+    /// For a merged interface+value symbol (declaration merging, e.g. lib
+    /// `Date`/`Request` or user `interface Foo {} declare var Foo: {...}`),
+    /// `resolve_ref`/`symbol_types` holds the TYPE-space (instance) type, which
+    /// is wrong for a `typeof` query. The checker records the value-space type
+    /// in the type environment's `typeof_value_types` map (see
+    /// `register_type_query_value_types`); prefer it here so nested `typeof`
+    /// positions (indexed-access, conditional, tuple) evaluated through this
+    /// resolver resolve to the value/constructor side. Falls back to the default
+    /// `resolve_ref` for all other symbols.
+    fn resolve_type_query(&self, symbol: SymbolRef, interner: &dyn TypeDatabase) -> Option<TypeId> {
+        if let Ok(env) = self.type_env.try_borrow()
+            && let Some(value_ty) = env.get_typeof_value_type(symbol)
+        {
+            return Some(value_ty);
+        }
+        if let Ok(env) = self.type_environment.try_borrow()
+            && let Some(value_ty) = env.get_typeof_value_type(symbol)
+        {
+            return Some(value_ty);
+        }
+        self.resolve_ref(symbol, interner)
+    }
+
     fn get_type_param_variance(&self, def_id: DefId) -> Option<Arc<[Variance]>> {
         let sym_id = self.def_to_symbol_id(def_id)?;
         let symbol = self.binder.get_symbol(sym_id)?;

--- a/crates/tsz-checker/src/state/type_analysis/core.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core.rs
@@ -1477,6 +1477,19 @@ impl<'a> CheckerState<'a> {
                 }
             });
 
+            // For a non-class symbol merged with an interface (declaration
+            // merging, e.g. lib `Date`/`Request` or `interface Foo {} declare
+            // var Foo: {...}`), `result` is the TYPE-space (instance) interface
+            // type, which is wrong for a `typeof` query. Compute the VALUE-space
+            // type now and register it in `typeof_value_types` so the resolver's
+            // `resolve_type_query` returns the value/constructor side for a
+            // deferred `TypeQuery(SymbolRef)` produced by nested `typeof`
+            // positions. Computed before the env borrow to avoid borrow
+            // conflicts during the value-space resolution.
+            let merged_interface_value_typeof = (class_env_entry.is_none())
+                .then(|| self.merged_interface_value_typeof_type(sym_id))
+                .flatten();
+
             // Use try_borrow_mut to avoid panic if type_env is already borrowed.
             // This can happen during recursive type resolution (e.g., class inheritance).
             // If we can't borrow, skip the cache update - the type is still computed correctly.
@@ -1613,6 +1626,12 @@ impl<'a> CheckerState<'a> {
                         env.insert_def_with_params(def_id, result, type_params);
                     }
                 }
+            }
+            // Register the merged interface+value `typeof` value type in both
+            // resolver environments so `resolve_type_query` returns the
+            // value/constructor side for `typeof X` (see `core_typeof_value`).
+            if let Some(value_type) = merged_interface_value_typeof {
+                self.register_typeof_value_type_in_envs(sym_id, value_type);
             }
             if class_env_entry.is_some()
                 && let Some(def_id) = self.ctx.get_existing_def_id(sym_id)

--- a/crates/tsz-checker/src/state/type_analysis/core_typeof_value.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_typeof_value.rs
@@ -1,0 +1,99 @@
+//! Value-space type resolution for `typeof X` queries on merged
+//! interface+value symbols (declaration merging).
+//!
+//! A symbol declared as both an interface and a value (e.g. lib `Date`/`Request`
+//! through `interface Date {} declare var Date: DateConstructor`, or user
+//! `interface Foo {} declare var Foo: {...}`) stores its TYPE-space (instance)
+//! interface type under the shared `SymbolRef`/`DefId`, because that is what
+//! type-position references (`x: Date`) need. A `typeof X` query needs the
+//! VALUE-space type (the var's type) instead. `get_type_of_symbol` registers
+//! the value type computed here in the environment's `typeof_value_types` map so
+//! the solver's `resolve_type_query` returns the value/constructor side for a
+//! deferred `TypeQuery(SymbolRef)` produced by nested `typeof` positions
+//! (indexed-access, conditional, tuple).
+
+use crate::state::CheckerState;
+use tsz_binder::{SymbolId, symbol_flags};
+use tsz_solver::TypeId;
+
+impl<'a> CheckerState<'a> {
+    /// Compute the VALUE-space type a `typeof X` query should resolve to for a
+    /// symbol declared as both an interface and a value.
+    ///
+    /// Returns the lib `*Constructor` companion when present (e.g. `Date` ->
+    /// `DateConstructor`), otherwise the value declaration's type. Returns `None`
+    /// for non-merged symbols, class+interface merges (whose constructor type is
+    /// already routed through the class env entry), and when no value type can be
+    /// determined — leaving the normal `SymbolRef`/`DefId` resolution untouched.
+    pub(crate) fn merged_interface_value_typeof_type(
+        &mut self,
+        sym_id: SymbolId,
+    ) -> Option<TypeId> {
+        let symbol = self.ctx.binder.get_symbol(sym_id)?;
+        if !(symbol.has_any_flags(symbol_flags::VALUE)
+            && symbol.has_any_flags(symbol_flags::INTERFACE))
+        {
+            return None;
+        }
+        // A class+interface merge already routes the constructor type through the
+        // class env entry; only non-class value merges need this.
+        if symbol.has_any_flags(symbol_flags::CLASS) {
+            return None;
+        }
+        let name = symbol.escaped_name.clone();
+        let value_decl = symbol.value_declaration;
+        let declarations = symbol.declarations.clone();
+
+        // Lib globals model the value side through a sibling `*Constructor`
+        // interface (e.g. `Date` -> `DateConstructor`). Prefer it so the value
+        // type is the constructor rather than the instance interface.
+        if self.ctx.symbol_is_from_actual_or_cloned_lib(sym_id)
+            && (self.is_known_global_value_name(&name)
+                || tsz_binder::lib_loader::is_es2015_plus_type(&name))
+        {
+            let constructor_name = format!("{name}Constructor");
+            if let Some(ctor) = self
+                .resolve_lib_type_by_name(&constructor_name)
+                .filter(|&ty| ty != TypeId::UNKNOWN && ty != TypeId::ERROR)
+            {
+                return Some(ctor);
+            }
+        }
+
+        // Otherwise use the value declaration's type (the `var`/`function`
+        // declaration), which carries the value-space type for the merge.
+        let preferred_value_decl = self
+            .preferred_value_declaration(sym_id, value_decl, &declarations)
+            .unwrap_or(value_decl);
+        let value_type = if let Some(file_idx) = self.ctx.resolve_symbol_file_index(sym_id)
+            && file_idx != self.ctx.current_file_idx
+        {
+            self.type_of_value_declaration_for_cross_file_symbol(
+                sym_id,
+                preferred_value_decl,
+                file_idx,
+            )
+        } else {
+            self.type_of_value_declaration_for_symbol(sym_id, preferred_value_decl)
+        };
+        (value_type != TypeId::UNKNOWN && value_type != TypeId::ERROR && value_type != TypeId::ANY)
+            .then_some(value_type)
+    }
+
+    /// Register a merged interface+value symbol's `typeof` value-space type in
+    /// both resolver environments (`type_env` for the evaluator, `type_environment`
+    /// for the flow analyzer) so `resolve_type_query` returns it consistently.
+    pub(crate) fn register_typeof_value_type_in_envs(
+        &mut self,
+        sym_id: SymbolId,
+        value_type: TypeId,
+    ) {
+        let symbol_ref = tsz_solver::SymbolRef(sym_id.0);
+        if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
+            env.insert_typeof_value_type(symbol_ref, value_type);
+        }
+        if let Ok(mut env) = self.ctx.type_environment.try_borrow_mut() {
+            env.insert_typeof_value_type(symbol_ref, value_type);
+        }
+    }
+}

--- a/crates/tsz-checker/src/state/type_analysis/core_typeof_value.rs
+++ b/crates/tsz-checker/src/state/type_analysis/core_typeof_value.rs
@@ -16,7 +16,7 @@ use crate::state::CheckerState;
 use tsz_binder::{SymbolId, symbol_flags};
 use tsz_solver::TypeId;
 
-impl<'a> CheckerState<'a> {
+impl CheckerState<'_> {
     /// Compute the VALUE-space type a `typeof X` query should resolve to for a
     /// symbol declared as both an interface and a value.
     ///

--- a/crates/tsz-checker/src/state/type_analysis/mod.rs
+++ b/crates/tsz-checker/src/state/type_analysis/mod.rs
@@ -14,6 +14,7 @@ mod computed_helpers_private;
 mod computed_loops;
 mod core;
 mod core_type_query;
+mod core_typeof_value;
 pub(crate) mod cross_file;
 mod cross_file_alias_cycle;
 mod cross_file_alias_shortcut;

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking.rs
@@ -304,6 +304,16 @@ impl<'a> CheckerState<'a> {
             && !is_generic_self_circular
             && !has_deferred_self_reference
             && self.type_alias_body_allows_lazy_generic_semantic_body(alias.type_node);
+        // Register value-space types for `typeof <merged interface+value>` query
+        // operands BEFORE eager body resolution. Body resolution evaluates a
+        // nested indexed-access / conditional over a deferred `TypeQuery`, and
+        // the resolver's `resolve_type_query` must already see the value side at
+        // that point (otherwise it falls back to the instance type and reports
+        // phantom TS2339s). This only populates the dedicated `typeof_value_types`
+        // map; flow narrowing for `typeof` in alias bodies is still computed by
+        // `precompute_type_query_flow_types` after validation.
+        self.register_type_query_value_types(alias.type_node);
+
         let body_timing_start = alias_timing_enabled.then(web_time::Instant::now);
         let body_type = {
             let _ = self.ctx.types.take_union_too_complex();

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking/type_query_flow.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking/type_query_flow.rs
@@ -5,7 +5,7 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::TypeId;
 
-impl<'a> CheckerState<'a> {
+impl CheckerState<'_> {
     /// Walk a type node AST subtree to find `TYPE_QUERY` nodes (`typeof expr`)
     /// and pre-compute the flow-narrowed type of each expression.
     ///

--- a/crates/tsz-checker/src/types/type_checking/type_alias_checking/type_query_flow.rs
+++ b/crates/tsz-checker/src/types/type_checking/type_alias_checking/type_query_flow.rs
@@ -118,4 +118,171 @@ impl<'a> CheckerState<'a> {
             _ => {}
         }
     }
+
+    /// Walk a type node subtree and, for every `typeof <merged interface+value>`
+    /// query operand, record the value-space type in the type environment so the
+    /// solver's `resolve_type_query` resolves the deferred `TypeQuery(SymbolRef)`
+    /// to the value/constructor side rather than the instance type.
+    ///
+    /// This mirrors the recursion of [`Self::precompute_type_query_flow_types`]
+    /// but runs BEFORE alias body validation and only populates the dedicated
+    /// `typeof_value_types` map (it does not touch `node_types` / flow narrowing).
+    /// Body validation eagerly evaluates nested indexed-access / conditional
+    /// types over deferred `TypeQuery` operands, so the value-space type must be
+    /// registered by this point.
+    pub(super) fn register_type_query_value_types(&mut self, node_idx: NodeIndex) {
+        if node_idx == NodeIndex::NONE {
+            return;
+        }
+        let Some(node) = self.ctx.arena.get(node_idx) else {
+            return;
+        };
+
+        if node.kind == syntax_kind_ext::TYPE_QUERY {
+            if let Some(type_query) = self.ctx.arena.get_type_query(node) {
+                self.register_merged_value_typeof_type(type_query.expr_name);
+            }
+            return;
+        }
+
+        match node.kind {
+            k if k == syntax_kind_ext::TYPE_LITERAL => {
+                if let Some(type_lit) = self.ctx.arena.get_type_literal(node) {
+                    for &member_idx in &type_lit.members.nodes {
+                        let Some(member) = self.ctx.arena.get(member_idx) else {
+                            continue;
+                        };
+                        if let Some(sig) = self.ctx.arena.get_signature(member) {
+                            if let Some(params) = &sig.parameters {
+                                for &p in &params.nodes {
+                                    if let Some(pn) = self.ctx.arena.get(p)
+                                        && let Some(pd) = self.ctx.arena.get_parameter(pn)
+                                    {
+                                        self.register_type_query_value_types(pd.type_annotation);
+                                    }
+                                }
+                            }
+                            self.register_type_query_value_types(sig.type_annotation);
+                        } else if let Some(prop) = self.ctx.arena.get_property_decl(member) {
+                            self.register_type_query_value_types(prop.type_annotation);
+                        } else if let Some(idx_sig) = self.ctx.arena.get_index_signature(member) {
+                            self.register_type_query_value_types(idx_sig.type_annotation);
+                        }
+                    }
+                }
+            }
+            k if k == syntax_kind_ext::UNION_TYPE || k == syntax_kind_ext::INTERSECTION_TYPE => {
+                if let Some(composite) = self.ctx.arena.get_composite_type(node) {
+                    for &child in &composite.types.nodes {
+                        self.register_type_query_value_types(child);
+                    }
+                }
+            }
+            k if k == syntax_kind_ext::ARRAY_TYPE => {
+                if let Some(arr) = self.ctx.arena.get_array_type(node) {
+                    self.register_type_query_value_types(arr.element_type);
+                }
+            }
+            k if k == syntax_kind_ext::TUPLE_TYPE => {
+                if let Some(tuple) = self.ctx.arena.get_tuple_type(node) {
+                    for &elem in &tuple.elements.nodes {
+                        self.register_type_query_value_types(elem);
+                    }
+                }
+            }
+            k if k == syntax_kind_ext::PARENTHESIZED_TYPE => {
+                if let Some(wrapped) = self.ctx.arena.get_wrapped_type(node) {
+                    self.register_type_query_value_types(wrapped.type_node);
+                }
+            }
+            k if k == syntax_kind_ext::INDEXED_ACCESS_TYPE => {
+                if let Some(indexed) = self.ctx.arena.get_indexed_access_type(node) {
+                    self.register_type_query_value_types(indexed.object_type);
+                    self.register_type_query_value_types(indexed.index_type);
+                }
+            }
+            k if k == syntax_kind_ext::CONDITIONAL_TYPE => {
+                if let Some(cond) = self.ctx.arena.get_conditional_type(node) {
+                    self.register_type_query_value_types(cond.check_type);
+                    self.register_type_query_value_types(cond.extends_type);
+                    self.register_type_query_value_types(cond.true_type);
+                    self.register_type_query_value_types(cond.false_type);
+                }
+            }
+            k if k == syntax_kind_ext::MAPPED_TYPE => {
+                if let Some(mapped) = self.ctx.arena.get_mapped_type(node) {
+                    self.register_type_query_value_types(mapped.type_node);
+                }
+            }
+            k if k == syntax_kind_ext::INFER_TYPE => {
+                // `infer T extends typeof X` — register the value-space type for
+                // a `typeof` query in the inferred type parameter's constraint so
+                // constraint-driven resolution sees the value/constructor side.
+                if let Some(infer) = self.ctx.arena.get_infer_type(node)
+                    && let Some(type_param) =
+                        self.ctx.arena.get_type_parameter_at(infer.type_parameter)
+                {
+                    self.register_type_query_value_types(type_param.constraint);
+                }
+            }
+            k if k == syntax_kind_ext::TYPE_REFERENCE => {
+                if let Some(type_ref) = self.ctx.arena.get_type_ref(node)
+                    && let Some(args) = &type_ref.type_arguments
+                {
+                    for &arg in &args.nodes {
+                        self.register_type_query_value_types(arg);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Register the VALUE-space type of a merged interface+value symbol for
+    /// `typeof` resolution.
+    ///
+    /// When `expr` is an identifier resolving to a symbol declared as both an
+    /// interface and a value (declaration merging, e.g. lib `Date`/`Request`,
+    /// or user `interface Foo {} declare var Foo: {...}`), its shared
+    /// `DefId`/`SymbolRef` holds the TYPE-space (instance) type. The value-space
+    /// type computed here (via the value-space identifier path, which models lib
+    /// globals through their `*Constructor` companion) is recorded in the type
+    /// environment so the solver's `resolve_type_query` returns the
+    /// value/constructor side for a deferred `TypeQuery(SymbolRef)` produced by
+    /// nested `typeof` positions (indexed-access, conditional, tuple). Pure
+    /// values (vars/functions/classes) already resolve correctly through the
+    /// normal `SymbolRef`/`DefId` paths and are left untouched.
+    fn register_merged_value_typeof_type(&mut self, expr: NodeIndex) {
+        use tsz_binder::symbol_flags;
+        if expr == NodeIndex::NONE {
+            return;
+        }
+        let Some(node) = self.ctx.arena.get(expr) else {
+            return;
+        };
+        if node.kind != tsz_scanner::SyntaxKind::Identifier as u16 {
+            return;
+        }
+        let Some(sym_id) = self.ctx.binder.resolve_identifier(self.ctx.arena, expr) else {
+            return;
+        };
+        let is_merged_interface_value = self.ctx.binder.get_symbol(sym_id).is_some_and(|symbol| {
+            symbol.has_any_flags(symbol_flags::VALUE)
+                && symbol.has_any_flags(symbol_flags::INTERFACE)
+        });
+        if !is_merged_interface_value {
+            return;
+        }
+        let value_type = self.get_type_of_identifier(expr);
+        if value_type == TypeId::ANY || value_type == TypeId::ERROR {
+            return;
+        }
+        let symbol_ref = tsz_solver::SymbolRef(sym_id.0);
+        if let Ok(mut env) = self.ctx.type_environment.try_borrow_mut() {
+            env.insert_typeof_value_type(symbol_ref, value_type);
+        }
+        if let Ok(mut env) = self.ctx.type_env.try_borrow_mut() {
+            env.insert_typeof_value_type(symbol_ref, value_type);
+        }
+    }
 }

--- a/crates/tsz-checker/src/types/type_node_advanced.rs
+++ b/crates/tsz-checker/src/types/type_node_advanced.rs
@@ -539,18 +539,31 @@ impl<'a, 'ctx> TypeNodeChecker<'a, 'ctx> {
                 }
             }
 
-            let mut declared_type: Option<TypeId> =
-                if sym_flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0
-                    && self.ctx.symbol_resolution_set.contains(&sym_id)
-                {
-                    None
-                } else {
-                    self.ctx
-                        .symbol_types
-                        .get(&sym_id)
-                        .copied()
-                        .filter(|&t| t != TypeId::ANY && t != TypeId::ERROR)
-                };
+            // For a value symbol merged with an interface (declaration merging,
+            // e.g. lib globals `interface Date {} declare var Date: DateConstructor`
+            // or `interface Foo {} declare var Foo: {...}`), `symbol_types[sym_id]`
+            // holds the TYPE-space (instance) type, not the VALUE-space type a
+            // `typeof` query needs. The value declaration (the `var`) carries the
+            // value-space type, so resolve through its annotation first; only fall
+            // back to `symbol_types` when the value side has no annotation. Without
+            // this, a nested `(typeof Date)['now']` / `[typeof Foo][0]` resolves the
+            // deferred query against the instance and reports phantom TS2339s.
+            let merged_value_with_interface = sym_flags & tsz_binder::symbol_flags::VALUE != 0
+                && sym_flags & tsz_binder::symbol_flags::INTERFACE != 0;
+
+            let mut declared_type: Option<TypeId> = if merged_value_with_interface {
+                self.declared_annotation_type_for_type_query_symbol(sym_id)
+            } else if sym_flags & tsz_binder::symbol_flags::TYPE_ALIAS != 0
+                && self.ctx.symbol_resolution_set.contains(&sym_id)
+            {
+                None
+            } else {
+                self.ctx
+                    .symbol_types
+                    .get(&sym_id)
+                    .copied()
+                    .filter(|&t| t != TypeId::ANY && t != TypeId::ERROR)
+            };
 
             if declared_type.is_none() {
                 declared_type = self.declared_annotation_type_for_type_query_symbol(sym_id);

--- a/crates/tsz-solver/src/def/resolver.rs
+++ b/crates/tsz-solver/src/def/resolver.rs
@@ -572,6 +572,22 @@ pub struct TypeEnvironment {
     /// Populated by checker-side computed-property resolution and consumed by
     /// solver-side `keyof` evaluation to preserve unique-symbol key identity.
     well_known_symbol_name_to_ref: FxHashMap<String, SymbolRef>,
+    /// Maps a merged interface+value `SymbolRef` to its VALUE-space type for
+    /// `typeof` queries.
+    ///
+    /// A symbol declared as both an interface and a value (declaration merging,
+    /// e.g. `interface Date {} declare var Date: DateConstructor`, or
+    /// `interface Foo {} declare var Foo: {...}`) stores its TYPE-space
+    /// (instance) type under the shared `SymbolRef`/`DefId`, because that is
+    /// what type-position references (`x: Date`) need. A `typeof X` query on
+    /// such a symbol needs the VALUE-space type (the var's type) instead. The
+    /// checker computes that value type via its value-space identifier path and
+    /// records it here so `resolve_type_query` returns it for the deferred
+    /// `TypeQuery(SymbolRef)` shape produced by nested `typeof` positions
+    /// (indexed-access, conditional, tuple). Consulted only by
+    /// `resolve_type_query`, leaving `resolve_lazy`/`resolve_ref`
+    /// (type-position) on the instance type.
+    typeof_value_types: FxHashMap<u32, TypeId>,
 }
 
 impl TypeEnvironment {
@@ -602,6 +618,7 @@ impl TypeEnvironment {
             this_type: None,
             unresolved_name_resolutions: FxHashMap::default(),
             well_known_symbol_name_to_ref: FxHashMap::default(),
+            typeof_value_types: FxHashMap::default(),
         }
     }
 
@@ -801,6 +818,22 @@ impl TypeEnvironment {
     /// Get a symbol's resolved type.
     pub fn get(&self, symbol: SymbolRef) -> Option<TypeId> {
         self.types.get(&symbol.0).copied()
+    }
+
+    /// Register the VALUE-space type a `typeof X` query should resolve to for a
+    /// merged interface+value symbol. See `typeof_value_types`.
+    pub fn insert_typeof_value_type(&mut self, symbol: SymbolRef, type_id: TypeId) {
+        if self.typeof_value_types.get(&symbol.0) == Some(&type_id) {
+            return;
+        }
+        self.typeof_value_types.insert(symbol.0, type_id);
+        self.bump_generation();
+    }
+
+    /// Get the registered `typeof` value-space type for a merged interface+value
+    /// symbol, if any.
+    pub fn get_typeof_value_type(&self, symbol: SymbolRef) -> Option<TypeId> {
+        self.typeof_value_types.get(&symbol.0).copied()
     }
 
     /// Get a symbol's type parameters.
@@ -1049,6 +1082,7 @@ impl TypeEnvironment {
         fill_map!(instance_type_to_class, copy);
         fill_map!(unresolved_name_resolutions, copy);
         fill_map!(well_known_symbol_name_to_ref, copy);
+        fill_map!(typeof_value_types, copy);
 
         for value in &source.numeric_enums {
             if self.numeric_enums.insert(*value) {
@@ -1338,6 +1372,13 @@ impl TypeResolver for TypeEnvironment {
         // The SymbolRef entry may contain the instance type (inserted by
         // type_reference_symbol_type via insert_type_env_symbol), but the DefId
         // entry always has the constructor type (inserted by get_type_of_symbol).
+        // A merged interface+value symbol stores its instance (type-space) type
+        // under the shared `DefId`. When the checker has recorded the distinct
+        // value-space type for the `typeof` query, prefer it so nested
+        // `typeof X` positions resolve to the value/constructor side.
+        if let Some(&value_ty) = self.typeof_value_types.get(&symbol.0) {
+            return Some(value_ty);
+        }
         if let Some(&def_id) = self.symbol_to_def.get(&symbol.0)
             && let Some(ty) = self.get_def(DefId(def_id.0))
         {


### PR DESCRIPTION
Goal: green

Fixes Bug A: a nested `typeof X` (inside indexed-access / conditional /
parenthesized / tuple positions) over a symbol declared as both an interface
and a value (declaration merging) resolved to the TYPE-space (instance) type
instead of the VALUE-space (var/constructor) type. A bare alias body
`type TD = typeof Date` already worked; the nested form was DEF-lowered to a
deferred `TypeData::TypeQuery(SymbolRef)` whose resolution yielded the instance.

Witnesses now matching `tsc` exactly:
- `type R = (typeof Date)['now']` — was false `TS2339: Property 'now' does not exist on type 'Date'`, now clean.
- `typeof Date extends (abstract new (...a:any)=>any) ? 1 : 0` — was wrongly `0`, now `1`.
- `[typeof Foo][0]`, `(typeof Foo)['bar']` for `interface Foo {} declare var Foo: {...}` — resolve to the var value type; the instance-only prop `(typeof Foo)['z']` correctly errors against `{ bar(): number; }`.
- Reproduces for lib globals (`Date`/`Request`) and user merged interface+var; verified parity for renamed binders (no name/file-name literals in the fix).

## Structural rule
When a symbol carries both `VALUE` and `INTERFACE` flags (declaration merging),
`symbol_types[sym]` / `get_def` / `resolve_ref` hold the TYPE-space (instance)
type, which is wrong for a `typeof` query. `get_type_of_symbol` (checker) now
computes the VALUE-space type — the lib `*Constructor` companion when present
(e.g. `Date` -> `DateConstructor`), else the value declaration's type — and
records it in the type environment's new `typeof_value_types` map.
`resolve_type_query` (owner: solver `TypeEnvironment`, plus the `CheckerContext`
resolver override) consults that map first, leaving `resolve_lazy`/`resolve_ref`
(type-position, `x: Date`) on the instance type. The eager
`get_type_from_type_query` additionally prefers the value declaration's
annotation for merged interface+value symbols. Type semantics stay in the
solver-backed resolver; the checker only computes/registers the value type.

Owner layers: solver `def/resolver.rs` (`TypeEnvironment.typeof_value_types` +
`resolve_type_query`); checker `context/resolver.rs` (`CheckerContext::resolve_type_query`),
`state/type_analysis/core.rs` + new `core_typeof_value.rs` (compute/register),
`types/type_node_advanced.rs` (eager value-side), and the alias-body pre-pass in
`type_alias_checking.rs` / `type_query_flow.rs` so the value type is registered
before eager body resolution.

Adjacent matrix: lib global (Date/Request), user `interface+var` (Foo), renamed
binder (Widget), plain class / plain var / function (must stay value-correct),
instance-only property (negative), bare-alias-then-index, tuple element,
conditional `extends`, and the ts-rest `FetchOptions = typeof globalThis extends
{ Request: infer T extends typeof Request } ? Omit<...> : never` shape.

Residual (out of scope, separate inference-layer sub-bug, documented not patched):
`infer T extends typeof globalThis.Request` inside a conditional whose check type
is `typeof globalThis` still leaves `ConstructorParameters<T>` deferred; the
direct `ConstructorParameters<typeof Request>` and `Test<{Request: typeof Request}>`
forms resolve correctly.

## Verification
- Minimal repros vs `tsc` 6.0.3: `(typeof Date)['now']`, abstract-ctor conditional, `[typeof Foo][0]`, `(typeof Foo)['bar']`/`['z']`, `typeof Request` index/ConstructorParameters, renamed-binder — all match `tsc` (the only deltas are the pre-existing indexed-access-of-missing-property `undefined`-vs-error cascade, identical with/without `typeof`).
- Conformance filters (0 regressions, 100%): `--filter typeQuery` 3/3, `--filter typeofOperator` 6/6, `--filter constructorType` 1/1, `--filter indexedAccess` 13/13; declaration-merging 28/28, mergedDeclarations 7/7, Promise 17/17.
- Full local conformance sweep: 12583/12585 (the 2 failures are the pre-existing accepted regressions `deeplyNestedMappedTypes` / `propTypeValidatorInference`); 0 crashes, 0 timeouts, 0 new regressions.
- `arch_guard.py`: PASS (split `core.rs` helper into new `core_typeof_value.rs` to stay under the size ratchet).
- `cargo clippy --lib -p tsz-checker -p tsz-solver`: clean.
- Solver typeof/resolver unit tests: 86/86 pass. The 9 checker unit failures under the `typeof`/`merged` filter are pre-existing (fail identically on `origin/main`, local lib-version env), not regressions.
- ts-rest canary: no regression (FP count unchanged at 17 under the bench config, where `dom` lib keeps `Request` resolvable; the fix improves `body`/`FetchOptions` resolution display from `error`/`{}` to the real type). True FetchOptions-collapse is fixed in the isolated repro.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
