### PR TITLE
perf(ci): measure cargo-target-deps staleness + opt-in workspace-rlib refresh, preflight-gated (#13747)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,6 +609,16 @@ jobs:
       # when Cargo.lock/profile inputs changed and the gate intentionally ran
       # main CI to refresh the exact shared cache key.
       TSZ_CI_CACHE_SAVE_CARGO_TARGETS: ${{ needs.gate.outputs.rust_cache_refresh == 'true' && '1' || '0' }}
+      # Opt-in, default-off broader-refresh for #13747 (constraint: #13733 OOM).
+      # When the `TSZ_CI_REFRESH_WORKSPACE_RLIBS` repo variable is set to '1',
+      # green main builds republish the workspace-rlib (dist-fast) blob on EVERY
+      # source-only push, not only on Cargo.lock/profile changes, so PR
+      # dist-binaries restores a fresher incremental base. Unset → '0' → no
+      # behavior change. gcp-cache.sh bounds this: dist-fast blob only, same
+      # cache key, gated by the MemAvailable cache-save preflight. Flip only
+      # after reading the `cargo-target-deps staleness` marker in dist-binaries
+      # logs and confirming main cache-save RSS headroom.
+      TSZ_CI_CACHE_REFRESH_WORKSPACE_RLIBS: ${{ vars.TSZ_CI_REFRESH_WORKSPACE_RLIBS || '0' }}
       # Keep artifact production independent from sccache service hangs. The
       # dist-fast build is short enough without sccache, and all harness suites
       # are blocked until this artifact uploads.

--- a/scripts/ci/gcp-cache.sh
+++ b/scripts/ci/gcp-cache.sh
@@ -331,6 +331,33 @@ refresh_rust_source_mtimes_after_target_restore() {
   echo "Refreshed Rust source mtimes after Cargo target cache restore"
 }
 
+# Observability for #13747: how stale is the restored workspace-rlib baseline?
+#
+# The cargo-target-deps (dist-fast) blob is the only cross-commit reuse the
+# sccache-disabled dist-binaries job gets. Its refresh is gated on
+# rust_cache_refresh (Cargo.lock/Cargo.toml/.cargo/config.toml changes only),
+# so on a long run of source-only main pushes the workspace .rlibs inside it
+# drift many commits behind HEAD and Cargo recompiles the hot crates against an
+# old baseline every PR. We pack a tiny `.tsz-cache-commit` marker into the
+# blob at save time (no extra GCS object) and read it back here so the staleness
+# is measurable before we decide whether to broaden the save trigger.
+#
+# Best-effort: never fails the build. dist-binaries checks out fetch-depth:1, so
+# `git rev-list` usually cannot resolve the blob commit — in that case we still
+# log both SHAs and report distance as unknown.
+log_cargo_target_deps_staleness() {
+  local marker=".target/dist-fast/.tsz-cache-commit"
+  if [[ ! -f "$marker" ]]; then
+    echo "cargo-target-deps staleness: no commit marker in restored blob (pre-#13747 blob or cache miss)"
+    return 0
+  fi
+  local blob_commit head_commit distance
+  blob_commit="$(tr -d '[:space:]' < "$marker" 2>/dev/null || true)"
+  head_commit="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+  distance="$(git rev-list --count "${blob_commit}..HEAD" 2>/dev/null || echo unknown)"
+  echo "cargo-target-deps staleness: blob built at ${blob_commit:-unknown}; HEAD ${head_commit}; workspace-rlib baseline is ${distance} commit(s) behind (#13747)"
+}
+
 # save_archive <label> <gs://...> <base> <path...>
 #
 # Cache write policy: only push-on-main runs publish blobs. PRs and
@@ -500,6 +527,7 @@ restore_caches() {
     # accepting stale workspace test binaries from the cache. This is the
     # inverse of the old backdating trick: correctness first, sccache for reuse.
     refresh_rust_source_mtimes_after_target_restore
+    log_cargo_target_deps_staleness
   else
     echo "Cache restore skipped: cargo-home + cargo-target (suite does not compile Rust)"
   fi
@@ -609,12 +637,46 @@ save_caches() {
     # blob; new write policy (main-only) plus profile isolation makes
     # the dedicated lint cache redundant.
     cargo_target_key="$(cargo_target_cache_key)"
-    if [[ "${TSZ_CI_CACHE_SAVE_CARGO_TARGETS:-1}" == "1" ]]; then
+
+    # Lock-gated trigger (set from gate.outputs.rust_cache_refresh in ci.yml):
+    # save every profile blob when the dep graph changed.
+    local save_cargo_targets="${TSZ_CI_CACHE_SAVE_CARGO_TARGETS:-1}"
+
+    # Opt-in, default-off broader-refresh path for #13747. When enabled, the
+    # workspace-rlib (dist-fast) blob is republished on EVERY green main build,
+    # not only on Cargo.lock/profile changes, so PR dist-binaries restores a
+    # fresher incremental base instead of a many-commits-stale one.
+    #
+    # Bounded by construction, so it cannot reintroduce the #13733/#13748 OOM:
+    #   * default off — main-push behavior is unchanged until an operator reads
+    #     the staleness marker (log_cargo_target_deps_staleness) and flips the
+    #     repo variable, so this ships measured rather than as a blind change;
+    #   * gated by the MemAvailable preflight at the top of save_caches (and the
+    #     duplicate gate in github-suite.sh run_cache_save) — the save defers
+    #     instead of risking a kernel SIGKILL at post-build memory peak;
+    #   * scoped to the dist-fast blob only — the unit/wasm profile blobs stay
+    #     lock-gated, so this does not broaden the whole target tree;
+    #   * reuses the existing cargo-target-deps key — no namespace bump, so
+    #     existing blobs remain valid and are simply overwritten by a fresher
+    #     green main build.
+    local refresh_workspace_rlibs="${TSZ_CI_CACHE_REFRESH_WORKSPACE_RLIBS:-0}"
+
+    if [[ "$save_cargo_targets" == "1" || "$refresh_workspace_rlibs" == "1" ]]; then
+      # Pack a tiny provenance marker into the blob so the next restore can
+      # measure how stale this workspace-rlib baseline is (#13747). Best-effort.
+      if [[ -d .target/dist-fast ]]; then
+        printf '%s\n' "$commit" > .target/dist-fast/.tsz-cache-commit 2>/dev/null || true
+      fi
       save_archive \
         "cargo-target-deps-${cargo_target_key}" \
         "$(cache_uri "cargo-target-deps/${cargo_target_key}.tar.gz")" \
         "." \
         .target/dist-fast
+    else
+      echo "Cache save skipped: cargo-target-deps (TSZ_CI_CACHE_SAVE_CARGO_TARGETS=0, TSZ_CI_CACHE_REFRESH_WORKSPACE_RLIBS=0)"
+    fi
+
+    if [[ "$save_cargo_targets" == "1" ]]; then
       save_archive \
         "cargo-target-unit-${cargo_target_key}" \
         "$(cache_uri "cargo-target-unit/${cargo_target_key}.tar.gz")" \
@@ -626,7 +688,7 @@ save_caches() {
         "." \
         .target/wasm32-unknown-unknown
     else
-      echo "Cache save skipped: cargo-target-* (TSZ_CI_CACHE_SAVE_CARGO_TARGETS=0)"
+      echo "Cache save skipped: cargo-target-unit/wasm (TSZ_CI_CACHE_SAVE_CARGO_TARGETS=0)"
     fi
   fi
 


### PR DESCRIPTION
Goal: fast

## Summary
`dist-binaries` is the wave-2 gate nearly every harness job depends on, and it compiles the hot workspace crates with sccache disabled. Its only cross-commit reuse is the `cargo-target-deps` (`.target/dist-fast`) blob, whose refresh is gated on `rust_cache_refresh` — set ONLY when a diff touches `Cargo.lock` / `Cargo.toml` / `.cargo/config.toml`. So a source-only main push never republishes the blob, and PR `dist-binaries` restores a workspace-rlib baseline that can be many commits stale, forcing an oversized incremental recompile every run (#13747).

This PR ships the **safe, measured subset** of the fix (per #13747 proposed fix items 1–2), not the risky unconditional whole-dir save:

1. **Observability (always-on, ~zero cost):** pack a tiny `.tsz-cache-commit` provenance marker *inside* the `cargo-target-deps` blob at save time (no extra GCS object). On restore, `log_cargo_target_deps_staleness` reads it back and logs the blob's build commit, current `HEAD`, and the commit distance — so the staleness lever is **measurable** in `dist-binaries` logs before anyone broadens the save trigger. (`dist-binaries` checks out `fetch-depth:1`, so the distance often resolves to `unknown`; the two SHAs are still logged for comparison.)
2. **Opt-in, default-off broader-refresh path:** a new `TSZ_CI_CACHE_REFRESH_WORKSPACE_RLIBS` env (wired from the `TSZ_CI_REFRESH_WORKSPACE_RLIBS` repo variable, default `'0'`). When flipped to `'1'`, green main builds republish the `dist-fast` blob on **every** source-only push, not only on lock changes.

No `gate-path-classifier.mjs` change is needed — the opt-in path keys off a repo variable, not path classification — so it is left untouched.

## How the save is bounded (respects #13733 / #13748 OOM constraint)
The broadened save cannot reintroduce the recurring exit-137 cache-save OOM:
- **Default off** — main-push behavior is unchanged until an operator reads the staleness marker and flips the repo variable. Ships measured, not blind.
- **Reuses #13763's MemAvailable preflight** — `save_caches` already returns early via `ci_cache_save_memory_ok` (floor `TSZ_CI_CACHE_SAVE_MIN_FREE_MB`), and `github-suite.sh run_cache_save` re-checks. The save defers instead of risking a kernel SIGKILL at post-build memory peak. This PR adds **no** new save that bypasses that gate.
- **Scoped to the `dist-fast` blob only** — the `cargo-target-unit` / `cargo-target-wasm` profile blobs stay lock-gated; the opt-in flag does **not** broaden the whole target tree.
- **Same cache key, no namespace bump** — reuses the existing `cargo-target-deps/<lock-profile-rustc>.tar.gz` key, so existing blobs stay valid and are simply overwritten by a fresher green main build. Green-only save is preserved (`github-suite.sh` already skips save on non-zero suite rc).

## Scope
Only `dist-binaries` env + `gcp-cache.sh`:
```
 .github/workflows/ci.yml | 10 ++++++++
 scripts/ci/gcp-cache.sh  | 66 ++++++++++++++++++++++++++++++++++++++++++++++--
```

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → OK
- `bash -n scripts/ci/gcp-cache.sh` → OK
- `node --check scripts/ci/gate-path-classifier.mjs` → OK (file unchanged)
- `node scripts/ci/test-gate-path-classifier.mjs` → `test-gate-path-classifier: ok`
- `shellcheck` not installed locally; ready-review CI runs it.
- Logic review: existing `TSZ_CI_CACHE_SAVE_CARGO_TARGETS=1` path (lock-change main + unit/wasm jobs) still saves deps+unit+wasm exactly as before; `=0` with the flag off preserves the skip log; `=0` with the flag on saves only `dist-fast`. The marker is written only when `.target/dist-fast` exists, so unit/wasm jobs never create a spurious marker.

Part of #13747 (measured + opt-in subset; the workspace-rlib-only physical subset of the save is deferred follow-up). References #13733 / #13748 (cache-save OOM) as the binding constraint and reuses the #13763 preflight.

## Provenance
Machine: MacBookPro.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

— AgentName: M1FableArchitect
