### PR TITLE
hold(bench): stub process global for tanstack-query guard config

### DIFF
--- a/scripts/bench/project-fixtures.sh
+++ b/scripts/bench/project-fixtures.sh
@@ -843,7 +843,21 @@ tsz_write_trpc_config() {
     ', "tsz-bench-globals.d.ts"'
 }
 tsz_write_tanstack_query_config() {
-  tsz_write_basic_external_project_config "$1" "packages/query-core/src"
+  # tanstack-query's real root tsconfig pins `"types": ["node"]`, so its build
+  # sees the `process` global via @types/node; several query-core sources read
+  # `process.env.NODE_ENV` (timeoutManager.ts, query.ts, utils.ts, etc.). The
+  # fixture clone runs no npm install and the bench baseline pins `"types": []`,
+  # so without a stub tsc emits spurious TS2591 "Cannot find name 'process'" and
+  # tsz matches that. A single ambient `process` stub reproduces what tsc sees
+  # when @types/node is present, leaving query-core's own source fully
+  # type-checked (matching the immer fixture's treatment of the same global).
+  local fixture_dir
+  fixture_dir="$(dirname "$1")"
+  cat > "$fixture_dir/tsz-bench-globals.d.ts" <<'TYPES'
+declare const process: any;
+TYPES
+  tsz_write_basic_external_project_config "$1" "packages/query-core/src" "" \
+    ', "tsz-bench-globals.d.ts"'
 }
 tsz_write_tanstack_router_config() {
   tsz_write_basic_external_project_config "$1" "packages/router-core/src"


### PR DESCRIPTION
Goal: green

Stub the `process` global in the tanstack-query project-compile-guard config so
the guard faithfully mirrors the real project's tsconfig and the per-row tsc
oracle is fully clean.

## Background

tanstack-query's real root `tsconfig.json` pins `"types": ["node"]`, so its
build resolves the `process` global via `@types/node`. Several `query-core`
sources read `process.env.NODE_ENV` (`timeoutManager.ts`, `query.ts`,
`utils.ts`, `hydration.ts`, `queriesObserver.ts`). The fixture clone runs no
`npm install` and the shared bench baseline pins `"types": []`, so
tsc-on-the-guard-config emitted 10 spurious `TS2591 Cannot find name 'process'`
errors. A single ambient `process` stub (the exact immer-fixture precedent)
reproduces what tsc sees with `@types/node` present.

Post-#13727 the per-row tsc oracle already subtracted those shared `TS2591`
(tsz emits them too), so this does NOT change the tsz-only delta. It makes the
oracle baseline fully clean (10 -> 0 tsc errors), so the row's residual is
unambiguously tsz-side false positives.

## Structural rule

When a project-corpus row's real tsconfig pins `"types": ["node"]` and its
source reads node globals (`process`), the guard config must supply an ambient
stub for those globals (owner: `scripts/bench/project-fixtures.sh` per-row
config writer), matching what tsc sees with `@types/node` installed. This is a
fixture-config faithfulness fix; it touches no solver/checker code.

## Measurement (tanstack-query, query-core/src)

- tsc oracle before: 10 errors (all `TS2591` process). after: 0 (clean).
- tsz-only delta: ~99 false positives, unchanged by this fix. Dominant codes
  `TS2345`/`TS2322`/`TS2339`. The board's "TS2591-dominant tsz-only" framing was
  pre-oracle; the oracle already subtracts the shared `TS2591`.

Residual tsz-only roots characterized (follow-up, not in scope here):
- `TS2349`/`TS2722`/`TS2345 -> 'undefined'`: narrowing bug. `typeof x ===
  'function'` fails to select the callable constituent of a union when the
  function member comes from an instantiated GENERIC type alias (e.g.
  `StaleTimeFunction<...>`); the whole union (incl. the param collapsing to
  `undefined`) is kept. Minimal repro: clean in tsc, errors in tsz.
- `TS2339` `_type`/`_defaulted`/`options`/`state`: heritage / interface-extension
  member resolution over deeply-nested instantiated generic interfaces
  (`InfiniteQueryObserverOptions extends QueryObserverOptions<...>`); type-name
  display truncates mid-instantiation.
- `TS2565` "used before being assigned": definite-assignment flow across a
  constructor-called private initializer.

## Verification

- `node scripts/bench/validate-project-metadata.mjs` (pass)
- `node scripts/bench/test-project-rows.mjs` (pass)
- full `scripts/bench/test-*.mjs` suite (all pass)
- `node scripts/bench/test-fixture-provenance.mjs` (pass)
- `node scripts/ci/test-project-tsc-oracle.mjs` (pass)
- `python3 scripts/arch/test_arch_guard_project.py` (63 tests, OK)
- `python3 scripts/arch/arch_guard.py` (passed)
- `bash -n scripts/bench/project-fixtures.sh` (OK)
- guard re-run: stub written, included in tsconfig, tsc oracle 10 -> 0; no
  other canary row config writer touched (single-function diff).

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

## Project corpus

claude-code:
- Row: tanstack-query-project
- Bug family: query-core process global stub (fixture-config faithfulness; real tsconfig pins "types": ["node"])
