### PR TITLE
perf(ci): persist ci-timing trends + sccache hit-rate floor + flaky-rate probe (#13753)

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -91,13 +91,79 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Pull the per-run timing JSON documents this job persisted on previous
+      # firings so the compare step has a trailing baseline. Each prior run's
+      # artifact is named `ci-timing`; older runs that predate this artifact are
+      # simply absent (continue-on-error), which the script treats as "no
+      # baseline yet".
+      - name: Download prior timing baselines
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          mkdir -p timing-baseline
+          # Most recent completed ci-health runs (this workflow), newest first.
+          run_ids="$(
+            gh run list --repo "${REPOSITORY}" --workflow ci-health.yml \
+              --status completed --limit 12 --json databaseId \
+              --jq '.[].databaseId' 2>/dev/null || true
+          )"
+          for rid in ${run_ids}; do
+            gh run download "${rid}" --repo "${REPOSITORY}" \
+              --name ci-timing --dir "timing-baseline/${rid}" 2>/dev/null || true
+          done
+          echo "baseline docs: $(find timing-baseline -name '*.json' | wc -l | tr -d ' ')"
+
       - name: Record per-job CI timing baseline
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+          mkdir -p ci-timing
           node scripts/ci/check-ci-job-timing.mjs --workflow ci.yml --branch main --max-runs 15 \
+            --json ci-timing/timing.json \
+            --baseline-dir timing-baseline \
+            --regress-threshold 30 --regress-min-seconds 60 \
+            | tee -a "${GITHUB_STEP_SUMMARY}"
+
+      # Persist this run's timing document so future firings can diff against it.
+      - name: Upload timing baseline
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-timing
+          path: ci-timing/timing.json
+          retention-days: 30
+          if-no-files-found: ignore
+
+  ci-flaky-rate:
+    name: ci-flaky-rate
+    runs-on: ubuntu-latest
+    # Pure advisory probe — a transient gh API error must not red the health
+    # workflow (matches ci-job-timing/bench-artifact-readiness). The script also
+    # retries transient transport; this is belt-and-suspenders.
+    continue-on-error: true
+    # Advisory: counts per-job pass<->fail conclusion flips across recent main CI
+    # runs and run_attempt re-runs, surfacing a standing flaky-rate signal so the
+    # determinism work (#13368/#13255) can be prioritized by impact. A flaky job
+    # wedges the merge queue both ways (flaky-pass lands a regression; flaky-fail
+    # ejects a good PR). No wall-clock change.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Report per-job flaky rate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          node scripts/ci/check-flaky-rate.mjs --workflow CI --branch main \
+            --max-runs 40 --threshold 0.15 --min-samples 4 \
             | tee -a "${GITHUB_STEP_SUMMARY}"
 
   health:

--- a/scripts/ci/check-ci-job-timing.mjs
+++ b/scripts/ci/check-ci-job-timing.mjs
@@ -20,6 +20,13 @@ import { spawnSync } from "node:child_process";
 const DEFAULT_WORKFLOW = "ci.yml";
 const DEFAULT_BRANCH = "main";
 const DEFAULT_MAX_RUNS = 15;
+// Regression alerting defaults (advisory). A job whose current run p50 exceeds
+// the trailing baseline median by more than DEFAULT_REGRESS_THRESHOLD_PCT is
+// flagged with a ::warning::. The DEFAULT_REGRESS_MIN_SECONDS floor suppresses
+// noise from short jobs where a few seconds is a large percentage.
+const DEFAULT_REGRESS_THRESHOLD_PCT = 30;
+const DEFAULT_REGRESS_MIN_SECONDS = 60;
+const JSON_SCHEMA_VERSION = 1;
 // Larger than the sibling probes' 16MB: this script reads the jobs payload for
 // up to DEFAULT_MAX_RUNS runs, each carrying every job's step list.
 const DEFAULT_GH_MAX_BUFFER_BYTES = 32 * 1024 * 1024;
@@ -27,9 +34,15 @@ const DEFAULT_GH_MAX_BUFFER_BYTES = 32 * 1024 * 1024;
 function usage() {
   return [
     "usage: check-ci-job-timing.mjs [--fixture path] [--repository owner/repo] [--workflow file] [--branch name] [--max-runs n]",
+    "                              [--json path] [--baseline-dir dir] [--regress-threshold pct] [--regress-min-seconds n]",
     "",
     "Reports per-job queue_wait and run-time distributions over recent",
     "successful workflow runs. Advisory: it never fails the workflow.",
+    "",
+    "  --json path             also write the structured findings document to path",
+    "  --baseline-dir dir      compare current run p50 against prior --json docs in dir",
+    "  --regress-threshold pct p50 regression warn threshold (default 30)",
+    "  --regress-min-seconds n ignore baselines below this many seconds (default 60)",
   ].join("\n");
 }
 
@@ -40,6 +53,10 @@ export function parseArgs(argv) {
     maxRuns: DEFAULT_MAX_RUNS,
     repository: process.env.REPOSITORY || process.env.GITHUB_REPOSITORY || null,
     workflow: DEFAULT_WORKFLOW,
+    jsonPath: null,
+    baselineDir: null,
+    regressThreshold: DEFAULT_REGRESS_THRESHOLD_PCT,
+    regressMinSeconds: DEFAULT_REGRESS_MIN_SECONDS,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -70,6 +87,32 @@ export function parseArgs(argv) {
         throw new Error("--max-runs requires a positive integer");
       }
       options.maxRuns = value;
+      continue;
+    }
+    if (arg === "--json") {
+      options.jsonPath = argv[++i];
+      if (!options.jsonPath) throw new Error("--json requires a path");
+      continue;
+    }
+    if (arg === "--baseline-dir") {
+      options.baselineDir = argv[++i];
+      if (!options.baselineDir) throw new Error("--baseline-dir requires a path");
+      continue;
+    }
+    if (arg === "--regress-threshold") {
+      const value = Number.parseFloat(argv[++i]);
+      if (!Number.isFinite(value) || value < 0) {
+        throw new Error("--regress-threshold requires a non-negative number");
+      }
+      options.regressThreshold = value;
+      continue;
+    }
+    if (arg === "--regress-min-seconds") {
+      const value = Number.parseInt(argv[++i], 10);
+      if (!Number.isInteger(value) || value < 0) {
+        throw new Error("--regress-min-seconds requires a non-negative integer");
+      }
+      options.regressMinSeconds = value;
       continue;
     }
     if (arg === "--help" || arg === "-h") {
@@ -295,6 +338,132 @@ export function formatReport(findings, options = {}) {
   return lines.join("\n");
 }
 
+// Structured, persistable view of one timing run. Persisting this per ci-health
+// firing gives the speed program a trend store: later runs diff their p50
+// against the trailing median of these documents (see compareToBaseline).
+export function buildJsonDocument(findings, options = {}) {
+  return {
+    schemaVersion: JSON_SCHEMA_VERSION,
+    workflow: options.workflow || DEFAULT_WORKFLOW,
+    branch: options.branch || DEFAULT_BRANCH,
+    runCount: options.runCount ?? null,
+    generatedAt: options.generatedAt ?? null,
+    findings,
+  };
+}
+
+// Load every prior timing document from a baseline directory. Files that are
+// absent/unparseable/wrong-shape are skipped — a baseline gap must never red an
+// advisory comparison. Returns the parsed documents that carry a findings array.
+export function loadBaselineDocs(dir, readDir = fs.readdirSync, readFile = fs.readFileSync) {
+  let entries;
+  try {
+    entries = readDir(dir, { recursive: true });
+  } catch {
+    return [];
+  }
+  const docs = [];
+  for (const entry of entries) {
+    if (!String(entry).endsWith(".json")) continue;
+    const full = `${dir}/${entry}`;
+    let parsed;
+    try {
+      parsed = JSON.parse(readFile(full, "utf8"));
+    } catch {
+      continue;
+    }
+    if (parsed && Array.isArray(parsed.findings)) docs.push(parsed);
+  }
+  return docs;
+}
+
+// Trailing baseline = per-job median of each prior document's run p50. Median
+// (not mean) so a single anomalous run does not move the baseline; nearest-rank
+// keeps it an exact member of the history.
+export function baselineMedianP50(docs) {
+  const byName = new Map();
+  for (const doc of docs) {
+    for (const finding of doc.findings || []) {
+      const p50 = finding?.runP50;
+      if (typeof p50 !== "number" || !Number.isFinite(p50)) continue;
+      const name = finding.name || "(unnamed)";
+      let samples = byName.get(name);
+      if (!samples) {
+        samples = [];
+        byName.set(name, samples);
+      }
+      samples.push(p50);
+    }
+  }
+  const baseline = new Map();
+  for (const [name, samples] of byName) {
+    const median = percentile(samples, 0.5);
+    if (median !== null) baseline.set(name, { median, samples: samples.length });
+  }
+  return baseline;
+}
+
+// Compare current findings against the trailing baseline. A regression is a job
+// whose current run p50 exceeds the baseline median by more than thresholdPct,
+// with the baseline at or above minSeconds so short jobs do not trip on noise.
+export function compareToBaseline(findings, baseline, options = {}) {
+  const thresholdPct = options.thresholdPct ?? DEFAULT_REGRESS_THRESHOLD_PCT;
+  const minSeconds = options.minSeconds ?? DEFAULT_REGRESS_MIN_SECONDS;
+  const regressions = [];
+  let compared = 0;
+  for (const finding of findings) {
+    const current = finding.runP50;
+    if (typeof current !== "number" || !Number.isFinite(current)) continue;
+    const base = baseline.get(finding.name);
+    if (!base || base.median < minSeconds) continue;
+    compared += 1;
+    const deltaPct = base.median > 0 ? ((current - base.median) / base.median) * 100 : 0;
+    if (deltaPct > thresholdPct) {
+      regressions.push({
+        name: finding.name,
+        current,
+        baseline: base.median,
+        baselineSamples: base.samples,
+        deltaPct,
+      });
+    }
+  }
+  regressions.sort((a, b) => b.deltaPct - a.deltaPct || a.name.localeCompare(b.name));
+  return { regressions, compared, thresholdPct, minSeconds };
+}
+
+export function formatComparison(comparison, baselineCount) {
+  const lines = ["", "### Timing Regression Check", ""];
+  if (baselineCount === 0) {
+    lines.push("No prior timing baseline documents found — recording this run as the first baseline.");
+    return lines.join("\n");
+  }
+  if (comparison.compared === 0) {
+    lines.push(`Compared against ${baselineCount} prior run(s); no job had a baseline at or above ${comparison.minSeconds}s to check.`);
+    return lines.join("\n");
+  }
+  if (comparison.regressions.length === 0) {
+    lines.push(
+      `✅ No job's run p50 exceeded its trailing baseline by more than ${comparison.thresholdPct}% ` +
+        `(${comparison.compared} job(s) checked against ${baselineCount} prior run(s)).`,
+    );
+    return lines.join("\n");
+  }
+  lines.push(`⚠️ ${comparison.regressions.length} job(s) regressed beyond ${comparison.thresholdPct}% over the trailing baseline:`);
+  lines.push("");
+  lines.push("| Job | Run p50 | Baseline p50 | Δ |");
+  lines.push("|-----|--------:|-------------:|--:|");
+  for (const r of comparison.regressions) {
+    lines.push([
+      escapeCell(r.name),
+      secondsLabel(Math.round(r.current)),
+      secondsLabel(Math.round(r.baseline)),
+      `+${r.deltaPct.toFixed(0)}%`,
+    ].join(" | ").replace(/^/, "| ").replace(/$/, " |"));
+  }
+  return lines.join("\n");
+}
+
 function readFixture(path) {
   const parsed = JSON.parse(fs.readFileSync(path, "utf8"));
   const runs = Array.isArray(parsed) ? parsed : parsed.runs;
@@ -311,6 +480,36 @@ function main() {
     : collectRunsWithJobs(options.repository, options);
   const findings = jobTimingFindings(runsWithJobs);
   console.log(formatReport(findings, { ...options, runCount: runsWithJobs.length }));
+
+  // Persist the structured document so future runs have a trailing baseline.
+  if (options.jsonPath) {
+    const document = buildJsonDocument(findings, {
+      workflow: options.workflow,
+      branch: options.branch,
+      runCount: runsWithJobs.length,
+      generatedAt: new Date().toISOString(),
+    });
+    fs.writeFileSync(options.jsonPath, `${JSON.stringify(document, null, 2)}\n`);
+  }
+
+  // Compare against the trailing baseline and emit advisory ::warning::s. A
+  // missing/unreadable baseline degrades to "first baseline", never an error.
+  if (options.baselineDir) {
+    const docs = loadBaselineDocs(options.baselineDir);
+    const baseline = baselineMedianP50(docs);
+    const comparison = compareToBaseline(findings, baseline, {
+      thresholdPct: options.regressThreshold,
+      minSeconds: options.regressMinSeconds,
+    });
+    console.log(formatComparison(comparison, docs.length));
+    for (const r of comparison.regressions) {
+      console.log(
+        `::warning::ci-job-timing: job "${r.name}" run p50 ${Math.round(r.current)}s exceeds ` +
+          `trailing baseline ${Math.round(r.baseline)}s by ${r.deltaPct.toFixed(0)}% ` +
+          `(threshold ${comparison.thresholdPct}%)`,
+      );
+    }
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/ci/check-flaky-rate.mjs
+++ b/scripts/ci/check-flaky-rate.mjs
@@ -1,0 +1,378 @@
+#!/usr/bin/env node
+// Per-job flaky-rate probe for the self-hosted CI fleet.
+//
+// Rationale: a flaky job wedges the merge queue in both directions — a flaky
+// *pass* at merge_group time lands a real regression, and a flaky *fail* ejects
+// a good PR. The fleet has determinism work in flight (#13368/#13255) but no
+// standing rate signal to prioritize it. This probe lists recent `main` CI runs
+// (push/merge_group), groups each job by name across runs and `run_attempt`
+// re-runs, and counts conclusion *flips* (success<->failure) between
+// consecutive conclusive results. A high flip rate means a job is
+// non-deterministic on an unchanging-ish tree.
+//
+// Advisory only: it emits a markdown table and `::warning::` lines, and never
+// fails the workflow. Pure functions (flakyFindings/formatReport) are unit
+// tested; gh I/O lives behind injectable fetchers, mirroring the sibling
+// ci-health probes.
+import fs from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const DEFAULT_WORKFLOW = "CI";
+const DEFAULT_BRANCH = "main";
+const DEFAULT_MAX_RUNS = 40;
+// Flip rate above this fraction (flips / conclusive-transitions) warns.
+const DEFAULT_THRESHOLD = 0.15;
+// Need at least this many conclusive results for a job before its flip rate is
+// meaningful — a 1-of-2 flip is not a trend.
+const DEFAULT_MIN_SAMPLES = 4;
+const DEFAULT_GH_MAX_BUFFER_BYTES = 32 * 1024 * 1024;
+const MAIN_EVENTS = new Set(["push", "merge_group"]);
+// Conclusions that represent a real verdict on the tree (others are ignored).
+const CONCLUSIVE = new Set(["success", "failure", "timed_out", "startup_failure"]);
+
+function usage() {
+  return [
+    "usage: check-flaky-rate.mjs [--fixture path] [--repository owner/repo] [--workflow name]",
+    "                           [--branch name] [--max-runs n] [--threshold f] [--min-samples n]",
+    "",
+    "Counts per-job conclusion flips across recent main CI runs and run_attempt",
+    "re-runs, and reports a flaky rate. Advisory: it never fails the workflow.",
+  ].join("\n");
+}
+
+export function parseArgs(argv) {
+  const options = {
+    fixture: null,
+    repository: process.env.REPOSITORY || process.env.GITHUB_REPOSITORY || null,
+    workflow: DEFAULT_WORKFLOW,
+    branch: DEFAULT_BRANCH,
+    maxRuns: DEFAULT_MAX_RUNS,
+    threshold: DEFAULT_THRESHOLD,
+    minSamples: DEFAULT_MIN_SAMPLES,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--fixture") {
+      options.fixture = argv[++i];
+      if (!options.fixture) throw new Error("--fixture requires a path");
+      continue;
+    }
+    if (arg === "--repository") {
+      options.repository = argv[++i];
+      if (!options.repository) throw new Error("--repository requires owner/repo");
+      continue;
+    }
+    if (arg === "--workflow") {
+      options.workflow = argv[++i];
+      if (!options.workflow) throw new Error("--workflow requires a name");
+      continue;
+    }
+    if (arg === "--branch") {
+      options.branch = argv[++i];
+      if (!options.branch) throw new Error("--branch requires a name");
+      continue;
+    }
+    if (arg === "--max-runs") {
+      const value = Number.parseInt(argv[++i], 10);
+      if (!Number.isInteger(value) || value <= 0) {
+        throw new Error("--max-runs requires a positive integer");
+      }
+      options.maxRuns = value;
+      continue;
+    }
+    if (arg === "--threshold") {
+      const value = Number.parseFloat(argv[++i]);
+      if (!Number.isFinite(value) || value < 0 || value > 1) {
+        throw new Error("--threshold requires a number in [0, 1]");
+      }
+      options.threshold = value;
+      continue;
+    }
+    if (arg === "--min-samples") {
+      const value = Number.parseInt(argv[++i], 10);
+      if (!Number.isInteger(value) || value <= 0) {
+        throw new Error("--min-samples requires a positive integer");
+      }
+      options.minSamples = value;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+// Bounded exponential backoff over transient gh transport failures (5xx,
+// secondary rate limit, transient network errors). Retries only the transport,
+// never a real finding, so this advisory probe survives a flaky GitHub API call
+// instead of reddening the workflow. See issue #13744.
+const GH_RETRY_ATTEMPTS = Math.max(1, Number.parseInt(process.env.GH_RETRY_ATTEMPTS || "", 10) || 4);
+const GH_RETRY_BASE_MS = Math.max(0, Number.parseInt(process.env.GH_RETRY_BASE_MS || "", 10) || 500);
+const GH_RETRY_MAX_MS = 8000;
+const TRANSIENT_NET_CODES = new Set([
+  "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EAI_AGAIN", "ENOTFOUND", "EPIPE",
+]);
+
+function sleepSync(ms) {
+  if (!(ms > 0)) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function isTransientGhResult(result) {
+  if (result.error) {
+    if (result.error.code === "ENOBUFS") return false;
+    return TRANSIENT_NET_CODES.has(result.error.code);
+  }
+  if ((result.status ?? 0) === 0) return false;
+  const text = `${result.stdout || ""}\n${result.stderr || ""}`;
+  return /\bHTTP\s+(?:408|425|429|5\d\d)\b/i.test(text)
+    || /secondary rate limit/i.test(text)
+    || /\b(?:Bad Gateway|Service Unavailable|Gateway Time-?out|Internal Server Error|Server Error)\b/i.test(text);
+}
+
+function spawnGh(args, spawnOptions) {
+  let result;
+  for (let attempt = 1; attempt <= GH_RETRY_ATTEMPTS; attempt += 1) {
+    result = spawnSync("gh", args, spawnOptions);
+    if (attempt === GH_RETRY_ATTEMPTS || !isTransientGhResult(result)) break;
+    sleepSync(Math.min(GH_RETRY_BASE_MS * 2 ** (attempt - 1), GH_RETRY_MAX_MS));
+  }
+  return result;
+}
+
+function runGhJson(args) {
+  const result = spawnGh(args, {
+    encoding: "utf8",
+    maxBuffer: DEFAULT_GH_MAX_BUFFER_BYTES,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) {
+    const command = `gh ${args.join(" ")}`;
+    if (result.error.code === "ENOBUFS") {
+      throw new Error(`${command} exceeded ${DEFAULT_GH_MAX_BUFFER_BYTES} bytes of output`);
+    }
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error([
+      `gh ${args.join(" ")} failed`,
+      result.stdout?.trim(),
+      result.stderr?.trim(),
+    ].filter(Boolean).join("\n"));
+  }
+  return JSON.parse(result.stdout);
+}
+
+function normalizeRuns(payload) {
+  const runs = Array.isArray(payload) ? payload : payload?.workflow_runs;
+  if (!Array.isArray(runs)) {
+    throw new Error("fixture or API response must be an array or contain workflow_runs");
+  }
+  return runs;
+}
+
+export function readMainRuns(repository, options, fetchJson = runGhJson) {
+  if (!repository) throw new Error("REPOSITORY or GITHUB_REPOSITORY is required");
+  const { branch, maxRuns } = options;
+  const payload = fetchJson([
+    "api",
+    "-H",
+    "Accept: application/vnd.github+json",
+    `repos/${repository}/actions/runs?branch=${encodeURIComponent(branch)}&per_page=${Math.min(100, maxRuns)}`,
+  ]);
+  return normalizeRuns(payload).slice(0, maxRuns);
+}
+
+export function readJobsForRun(repository, runId, fetchJson = runGhJson) {
+  const jobs = [];
+  for (let page = 1; page <= 10; page += 1) {
+    // filter=all captures every run_attempt's jobs, not just the latest, so a
+    // re-run-to-green (or re-run-to-red) shows up as a conclusion flip.
+    const payload = fetchJson([
+      "api",
+      "-H",
+      "Accept: application/vnd.github+json",
+      `repos/${repository}/actions/runs/${runId}/jobs?filter=all&per_page=100&page=${page}`,
+    ]);
+    const pageJobs = Array.isArray(payload?.jobs) ? payload.jobs : [];
+    jobs.push(...pageJobs);
+    if (pageJobs.length < 100) break;
+  }
+  return jobs;
+}
+
+function eventOf(run) {
+  return run.event ?? "";
+}
+
+function workflowOf(run) {
+  return run.name ?? run.workflow_name ?? run.workflowName ?? "";
+}
+
+function createdMs(run) {
+  const iso = run.created_at ?? run.createdAt ?? run.run_started_at ?? run.updated_at;
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms) ? ms : 0;
+}
+
+export function collectRunsWithJobs(repository, options, fetchJson = runGhJson) {
+  const runs = readMainRuns(repository, options, fetchJson)
+    .filter((run) => workflowOf(run) === options.workflow)
+    .filter((run) => MAIN_EVENTS.has(eventOf(run)));
+  return runs.map((run) => ({
+    id: run.id ?? run.databaseId ?? "",
+    createdMs: createdMs(run),
+    runAttempt: run.run_attempt ?? run.runAttempt ?? 1,
+    jobs: readJobsForRun(repository, run.id ?? run.databaseId, fetchJson),
+  }));
+}
+
+// A stable ordering key for a (run, job-attempt) data point: oldest run first,
+// then earliest attempt. Ties on identical timestamps fall back to id.
+function dataPointOrder(a, b) {
+  return a.createdMs - b.createdMs || a.runAttempt - b.runAttempt || String(a.id).localeCompare(String(b.id));
+}
+
+export function flakyFindings(runsWithJobs, options = {}) {
+  const minSamples = options.minSamples ?? DEFAULT_MIN_SAMPLES;
+
+  const byName = new Map();
+  for (const run of runsWithJobs) {
+    for (const job of run.jobs || []) {
+      const conclusion = job.conclusion;
+      if (!CONCLUSIVE.has(conclusion)) continue;
+      const name = job.name || "(unnamed)";
+      let series = byName.get(name);
+      if (!series) {
+        series = [];
+        byName.set(name, series);
+      }
+      series.push({
+        id: `${run.id}#${job.run_attempt ?? job.runAttempt ?? run.runAttempt ?? 1}`,
+        createdMs: run.createdMs ?? 0,
+        // Attempt-level ordering uses the job's own run_attempt when present.
+        runAttempt: job.run_attempt ?? job.runAttempt ?? run.runAttempt ?? 1,
+        // Normalize every non-success conclusive verdict to "fail" — what we
+        // care about is the pass/fail flip, not which failure flavor.
+        verdict: conclusion === "success" ? "pass" : "fail",
+      });
+    }
+  }
+
+  const findings = [];
+  for (const [name, series] of byName) {
+    series.sort(dataPointOrder);
+    const samples = series.length;
+    const passes = series.filter((s) => s.verdict === "pass").length;
+    const fails = samples - passes;
+    let flips = 0;
+    for (let i = 1; i < series.length; i += 1) {
+      if (series[i].verdict !== series[i - 1].verdict) flips += 1;
+    }
+    const transitions = Math.max(0, samples - 1);
+    const flipRate = transitions > 0 ? flips / transitions : 0;
+    findings.push({
+      name,
+      samples,
+      passes,
+      fails,
+      flips,
+      flipRate,
+      // A job is only ranked as flaky when it has both outcomes AND enough
+      // samples; an all-pass or all-fail job has flipRate 0 anyway.
+      enoughSamples: samples >= minSamples,
+    });
+  }
+
+  // Flakiest first; tie-break on more flips then name for stable output.
+  findings.sort((a, b) => b.flipRate - a.flipRate || b.flips - a.flips || a.name.localeCompare(b.name));
+  return findings;
+}
+
+function escapeCell(value) {
+  return String(value ?? "").replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+export function formatReport(findings, options = {}) {
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+  const workflow = options.workflow || DEFAULT_WORKFLOW;
+  const branch = options.branch || DEFAULT_BRANCH;
+  const lines = ["## CI Flaky-Rate Probe", ""];
+
+  if (findings.length === 0) {
+    lines.push(`No conclusive \`${workflow}\` jobs on \`${branch}\` were found to score.`);
+    return lines.join("\n");
+  }
+
+  const runs = options.runCount;
+  lines.push(
+    `Per-job conclusion-flip rate over recent \`${workflow}\` runs on \`${branch}\`` +
+      (runs ? ` (${runs} run${runs === 1 ? "" : "s"} sampled)` : "") +
+      `. Flip rate = pass↔fail transitions / conclusive transitions; warn threshold ${(threshold * 100).toFixed(0)}%.`,
+  );
+  lines.push("");
+  lines.push("| Job | Samples | Pass | Fail | Flips | Flip rate |");
+  lines.push("|-----|--------:|-----:|-----:|------:|----------:|");
+  for (const f of findings) {
+    const flagged = f.enoughSamples && f.flipRate > threshold;
+    lines.push([
+      escapeCell(f.name) + (flagged ? " ⚠️" : ""),
+      String(f.samples),
+      String(f.passes),
+      String(f.fails),
+      String(f.flips),
+      `${(f.flipRate * 100).toFixed(0)}%`,
+    ].join(" | ").replace(/^/, "| ").replace(/$/, " |"));
+  }
+  return lines.join("\n");
+}
+
+export function flaggedFindings(findings, options = {}) {
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+  return findings.filter((f) => f.enoughSamples && f.flipRate > threshold);
+}
+
+function readFixture(path) {
+  const parsed = JSON.parse(fs.readFileSync(path, "utf8"));
+  const runs = Array.isArray(parsed) ? parsed : parsed.runs;
+  if (!Array.isArray(runs)) {
+    throw new Error("fixture must be an array of runs or an object with a runs array");
+  }
+  return runs.map((run) => ({
+    id: run.id ?? "",
+    createdMs: run.createdMs ?? createdMs(run),
+    runAttempt: run.run_attempt ?? run.runAttempt ?? 1,
+    jobs: run.jobs || [],
+  }));
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const runsWithJobs = options.fixture
+    ? readFixture(options.fixture)
+    : collectRunsWithJobs(options.repository, options);
+  const findings = flakyFindings(runsWithJobs, options);
+  console.log(formatReport(findings, { ...options, runCount: runsWithJobs.length }));
+
+  for (const f of flaggedFindings(findings, options)) {
+    console.log(
+      `::warning::check-flaky-rate: job "${f.name}" flipped pass<->fail ${f.flips} time(s) ` +
+        `over ${f.samples} run(s) (${(f.flipRate * 100).toFixed(0)}% flip rate, ` +
+        `threshold ${(options.threshold * 100).toFixed(0)}%)`,
+    );
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/ci/gcp-full-ci.sh
+++ b/scripts/ci/gcp-full-ci.sh
@@ -1130,6 +1130,70 @@ show_sccache_stats() {
   fi
 }
 
+# Advisory sccache hit-rate floor. Reads the JSON stats sccache accumulated for
+# this suite's compiles, records the cache-hit ratio as a published metric, and
+# emits a ::warning:: when the ratio falls below SCCACHE_HIT_RATE_FLOOR. This
+# makes a silent cold-cache regression (key-namespace bump, GCS download failure)
+# visible fleet-wide instead of only surfacing as wall-clock drift (#13605 items
+# 3-4). Guarded on RUSTC_WRAPPER: dist-binaries disables sccache by design, so it
+# has no stats and is skipped. Never fails the suite.
+record_sccache_metric() {
+  local suite="${1:-unit}"
+  # No sccache, or sccache not actually wired as the rustc wrapper: nothing to do.
+  if ! command -v sccache >/dev/null 2>&1 || [[ -z "${RUSTC_WRAPPER:-}" ]]; then
+    return 0
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local stats_json
+  stats_json="$(sccache --show-stats --stats-format=json 2>/dev/null || true)"
+  if [[ -z "$stats_json" ]]; then
+    echo "sccache: no JSON stats available for ${suite} (non-fatal)"
+    return 0
+  fi
+
+  # cache_hits/cache_misses are objects of per-language counters; sum the values.
+  # compile_requests is the total work seen. Fall back to 0 on any parse miss so
+  # an sccache version change never breaks the suite.
+  local hits misses requests
+  hits="$(printf '%s' "$stats_json" | jq -r '[.stats.cache_hits.counts // {} | .[]] | add // 0' 2>/dev/null || echo 0)"
+  misses="$(printf '%s' "$stats_json" | jq -r '[.stats.cache_misses.counts // {} | .[]] | add // 0' 2>/dev/null || echo 0)"
+  requests="$(printf '%s' "$stats_json" | jq -r '.stats.compile_requests // 0' 2>/dev/null || echo 0)"
+  hits="$(num_or_zero "$hits")"
+  misses="$(num_or_zero "$misses")"
+  requests="$(num_or_zero "$requests")"
+
+  local total=$((hits + misses))
+  local hit_rate
+  hit_rate="$(awk -v h="$hits" -v t="$total" 'BEGIN { if (t > 0) printf "%.1f", (h / t) * 100; else print "0.0" }')"
+
+  local out="$METRICS_DIR/sccache-${suite}.json"
+  jq -n \
+    --arg suite "sccache-${suite}" \
+    --arg hit_rate "$hit_rate" \
+    --argjson hits "$hits" \
+    --argjson misses "$misses" \
+    --argjson requests "$requests" \
+    '{suite:$suite, hit_rate:$hit_rate, hits:$hits, misses:$misses, requests:$requests}' \
+    > "$out"
+  publish_latest_metric "sccache-${suite}" "$out"
+  echo "sccache ${suite}: hit_rate=${hit_rate}% hits=${hits} misses=${misses} requests=${requests}"
+
+  # Floor check is advisory and only meaningful once enough compiles ran — a
+  # near-empty suite (everything no-op) would otherwise trip on tiny denominators.
+  local floor="${SCCACHE_HIT_RATE_FLOOR:-40}"
+  local min_total="${SCCACHE_HIT_RATE_MIN_TOTAL:-50}"
+  if [[ "$total" -ge "$min_total" ]]; then
+    local below
+    below="$(awk -v r="$hit_rate" -v f="$floor" 'BEGIN { print (r + 0 < f + 0) ? 1 : 0 }')"
+    if [[ "$below" == "1" ]]; then
+      echo "::warning::sccache ${suite} hit-rate ${hit_rate}% is below the ${floor}% floor (hits=${hits} misses=${misses}); cache may be cold (key-namespace bump or GCS download failure)"
+    fi
+  fi
+}
+
 run_node_harness_prep() {
   ci_section "Prep node harnesses (emit + fourslash)"
   timed prep_node_artifacts prep_node_artifacts
@@ -1202,6 +1266,7 @@ main() {
       ;;
     unit)
       timed run_unit_tests run_unit_tests
+      record_sccache_metric unit
       ;;
     checker-integration)
       timed run_checker_integration_tests run_checker_integration_tests
@@ -1212,6 +1277,7 @@ main() {
     wasm-all)
       timed build_wasm_all build_wasm_all
       show_sccache_stats
+      record_sccache_metric wasm
       ;;
     conformance)
       timed build_test_binaries build_test_binaries

--- a/scripts/ci/test-check-ci-job-timing.mjs
+++ b/scripts/ci/test-check-ci-job-timing.mjs
@@ -6,9 +6,14 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import {
+  baselineMedianP50,
+  buildJsonDocument,
   collectRunsWithJobs,
+  compareToBaseline,
+  formatComparison,
   formatReport,
   jobTimingFindings,
+  loadBaselineDocs,
   parseArgs,
   readWorkflowRuns,
 } from "./check-ci-job-timing.mjs";
@@ -125,6 +130,123 @@ function job(overrides = {}) {
 
 assert.throws(() => parseArgs(["--max-runs", "0"]), /positive integer/);
 assert.throws(() => parseArgs(["--bogus"]), /unknown argument/);
+
+{
+  const options = parseArgs(["--json", "out.json", "--baseline-dir", "base", "--regress-threshold", "25", "--regress-min-seconds", "90"]);
+  assert.equal(options.jsonPath, "out.json");
+  assert.equal(options.baselineDir, "base");
+  assert.equal(options.regressThreshold, 25);
+  assert.equal(options.regressMinSeconds, 90);
+}
+
+assert.throws(() => parseArgs(["--json"]), /--json requires a path/);
+assert.throws(() => parseArgs(["--baseline-dir"]), /--baseline-dir requires a path/);
+assert.throws(() => parseArgs(["--regress-threshold", "-1"]), /non-negative/);
+
+// --- buildJsonDocument / baseline / compareToBaseline ----------------------
+
+{
+  const findings = jobTimingFindings([{ id: 1, jobs: [job()] }]);
+  const doc = buildJsonDocument(findings, { workflow: "ci.yml", branch: "main", runCount: 1, generatedAt: "2026-06-17T00:00:00Z" });
+  assert.equal(doc.schemaVersion, 1);
+  assert.equal(doc.workflow, "ci.yml");
+  assert.equal(doc.runCount, 1);
+  assert.equal(doc.findings.length, 1);
+  assert.equal(doc.findings[0].name, "conformance-0");
+}
+
+// baselineMedianP50: per-job median over prior docs; non-numeric p50 skipped.
+{
+  const docs = [
+    { findings: [{ name: "unit", runP50: 100 }, { name: "lint", runP50: 50 }] },
+    { findings: [{ name: "unit", runP50: 120 }, { name: "lint", runP50: null }] },
+    { findings: [{ name: "unit", runP50: 140 }] },
+  ];
+  const baseline = baselineMedianP50(docs);
+  assert.equal(baseline.get("unit").median, 120); // median of [100,120,140]
+  assert.equal(baseline.get("unit").samples, 3);
+  assert.equal(baseline.get("lint").median, 50); // only one numeric sample
+  assert.equal(baseline.get("lint").samples, 1);
+}
+
+// compareToBaseline: flags only jobs over threshold whose baseline >= minSeconds.
+{
+  const findings = [
+    { name: "unit", runP50: 200 }, // baseline 120 -> +66% -> regression
+    { name: "lint", runP50: 70 }, // baseline 50 (< minSeconds 60) -> skipped
+    { name: "stable", runP50: 130 }, // baseline 120 -> +8% -> ok
+    { name: "novel", runP50: 999 }, // no baseline -> skipped
+  ];
+  const baseline = baselineMedianP50([
+    { findings: [{ name: "unit", runP50: 120 }, { name: "lint", runP50: 50 }, { name: "stable", runP50: 120 }] },
+  ]);
+  const comparison = compareToBaseline(findings, baseline, { thresholdPct: 30, minSeconds: 60 });
+  assert.deepEqual(comparison.regressions.map((r) => r.name), ["unit"]);
+  assert.equal(comparison.compared, 2); // unit + stable (lint skipped by minSeconds, novel by no baseline)
+  assert.equal(Math.round(comparison.regressions[0].deltaPct), 67);
+}
+
+// formatComparison rendering across the three states.
+{
+  assert.match(formatComparison({ regressions: [], compared: 0, thresholdPct: 30, minSeconds: 60 }, 0), /first baseline/);
+  assert.match(formatComparison({ regressions: [], compared: 3, thresholdPct: 30, minSeconds: 60 }, 4), /No job's run p50 exceeded/);
+  const warn = formatComparison({
+    regressions: [{ name: "unit", current: 200, baseline: 120, deltaPct: 66.7 }],
+    compared: 2,
+    thresholdPct: 30,
+    minSeconds: 60,
+  }, 4);
+  assert.match(warn, /1 job\(s\) regressed/);
+  assert.match(warn, /unit/);
+  assert.match(warn, /\+67%/);
+}
+
+// loadBaselineDocs: reads *.json, skips unparseable/wrong-shape, missing dir ok.
+{
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-ci-timing-baseline-"));
+  try {
+    fs.writeFileSync(path.join(dir, "a.json"), JSON.stringify({ findings: [{ name: "unit", runP50: 100 }] }));
+    fs.writeFileSync(path.join(dir, "b.json"), "{not valid json");
+    fs.writeFileSync(path.join(dir, "c.json"), JSON.stringify({ noFindings: true }));
+    fs.writeFileSync(path.join(dir, "d.txt"), "ignored");
+    const docs = loadBaselineDocs(dir);
+    assert.equal(docs.length, 1);
+    assert.equal(docs[0].findings[0].name, "unit");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  assert.deepEqual(loadBaselineDocs(path.join(os.tmpdir(), "tsz-does-not-exist-xyz")), []);
+}
+
+// --- CLI: --json writes the document; --baseline-dir warns on regression ----
+
+{
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-ci-timing-json-"));
+  try {
+    const baselineDir = path.join(dir, "baseline");
+    fs.mkdirSync(baselineDir);
+    // Prior baseline: conformance-0 ran ~100s typically.
+    fs.writeFileSync(
+      path.join(baselineDir, "prior.json"),
+      JSON.stringify({ findings: [{ name: "conformance-0", runP50: 100 }] }),
+    );
+    const outJson = path.join(dir, "out.json");
+    // Current fixture: conformance-0 took 300s (job() default) -> +200% regression.
+    const fixture = path.join(dir, "runs.json");
+    fs.writeFileSync(fixture, JSON.stringify({ runs: [{ id: 1, jobs: [job()] }] }));
+    const result = spawnSync(process.execPath, [
+      SCRIPT, "--fixture", fixture, "--json", outJson, "--baseline-dir", baselineDir,
+    ], { cwd: ROOT, encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /::warning::ci-job-timing: job "conformance-0"/);
+    assert.match(result.stdout, /Timing Regression Check/);
+    const doc = JSON.parse(fs.readFileSync(outJson, "utf8"));
+    assert.equal(doc.schemaVersion, 1);
+    assert.equal(doc.findings[0].name, "conformance-0");
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
 
 // --- readWorkflowRuns: URL shape against an injected fetcher ----------------
 

--- a/scripts/ci/test-check-flaky-rate.mjs
+++ b/scripts/ci/test-check-flaky-rate.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  collectRunsWithJobs,
+  flaggedFindings,
+  flakyFindings,
+  formatReport,
+  parseArgs,
+  readMainRuns,
+} from "./check-flaky-rate.mjs";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(SCRIPT_DIR, "..", "..");
+const SCRIPT = path.join(ROOT, "scripts", "ci", "check-flaky-rate.mjs");
+
+// Build a run with one named job at a given conclusion. created drives ordering.
+function run(id, createdIso, jobs) {
+  return { id, createdMs: Date.parse(createdIso), runAttempt: 1, jobs };
+}
+function jb(name, conclusion, extra = {}) {
+  return { name, conclusion, ...extra };
+}
+
+// --- flakyFindings: flip counting + ordering -------------------------------
+
+{
+  // unit: pass, fail, pass, fail across 4 runs -> 3 flips over 3 transitions.
+  const runs = [
+    run(1, "2026-06-17T12:00:00Z", [jb("unit", "success")]),
+    run(2, "2026-06-17T12:15:00Z", [jb("unit", "failure")]),
+    run(3, "2026-06-17T12:30:00Z", [jb("unit", "success")]),
+    run(4, "2026-06-17T12:45:00Z", [jb("unit", "failure")]),
+  ];
+  const [unit] = flakyFindings(runs, { minSamples: 4 });
+  assert.equal(unit.name, "unit");
+  assert.equal(unit.samples, 4);
+  assert.equal(unit.passes, 2);
+  assert.equal(unit.fails, 2);
+  assert.equal(unit.flips, 3);
+  assert.equal(unit.flipRate, 1);
+  assert.equal(unit.enoughSamples, true);
+}
+
+// Order is by run creation time, not array order: an out-of-order all-rising
+// series has zero flips once sorted.
+{
+  const runs = [
+    run(3, "2026-06-17T12:30:00Z", [jb("lint", "success")]),
+    run(1, "2026-06-17T12:00:00Z", [jb("lint", "failure")]),
+    run(2, "2026-06-17T12:15:00Z", [jb("lint", "failure")]),
+  ];
+  const [lint] = flakyFindings(runs);
+  // sorted: fail(1), fail(2), success(3) -> one flip at the end.
+  assert.equal(lint.flips, 1);
+  assert.equal(lint.samples, 3);
+}
+
+// Inconclusive conclusions (skipped/cancelled/null) are ignored entirely.
+{
+  const runs = [
+    run(1, "2026-06-17T12:00:00Z", [jb("emit", "success"), jb("emit", "cancelled")]),
+    run(2, "2026-06-17T12:15:00Z", [jb("emit", "skipped")]),
+    run(3, "2026-06-17T12:30:00Z", [jb("emit", "success")]),
+  ];
+  const [emit] = flakyFindings(runs);
+  assert.equal(emit.samples, 2); // two success, cancelled/skipped dropped
+  assert.equal(emit.flips, 0);
+}
+
+// timed_out / startup_failure count as a fail verdict (flip vs success).
+{
+  const runs = [
+    run(1, "2026-06-17T12:00:00Z", [jb("dist", "success")]),
+    run(2, "2026-06-17T12:15:00Z", [jb("dist", "timed_out")]),
+    run(3, "2026-06-17T12:30:00Z", [jb("dist", "startup_failure")]),
+  ];
+  const [dist] = flakyFindings(runs);
+  assert.equal(dist.passes, 1);
+  assert.equal(dist.fails, 2);
+  assert.equal(dist.flips, 1); // success -> fail, then fail -> fail (no flip)
+}
+
+// Sort: flakiest (highest flip rate) first.
+{
+  const runs = [
+    run(1, "2026-06-17T12:00:00Z", [jb("steady", "success"), jb("flaky", "success")]),
+    run(2, "2026-06-17T12:15:00Z", [jb("steady", "success"), jb("flaky", "failure")]),
+    run(3, "2026-06-17T12:30:00Z", [jb("steady", "success"), jb("flaky", "success")]),
+  ];
+  const findings = flakyFindings(runs);
+  assert.deepEqual(findings.map((f) => f.name), ["flaky", "steady"]);
+}
+
+// --- flaggedFindings / threshold + min-samples -----------------------------
+
+{
+  const findings = [
+    { name: "a", flipRate: 0.5, enoughSamples: true },
+    { name: "b", flipRate: 0.9, enoughSamples: false }, // too few samples
+    { name: "c", flipRate: 0.1, enoughSamples: true }, // below threshold
+  ];
+  const flagged = flaggedFindings(findings, { threshold: 0.15 });
+  assert.deepEqual(flagged.map((f) => f.name), ["a"]);
+}
+
+// --- formatReport ----------------------------------------------------------
+
+{
+  const runs = [
+    run(1, "2026-06-17T12:00:00Z", [jb("unit", "success")]),
+    run(2, "2026-06-17T12:15:00Z", [jb("unit", "failure")]),
+    run(3, "2026-06-17T12:30:00Z", [jb("unit", "success")]),
+    run(4, "2026-06-17T12:45:00Z", [jb("unit", "failure")]),
+  ];
+  const report = formatReport(flakyFindings(runs, { minSamples: 4 }), {
+    workflow: "CI", branch: "main", runCount: 4, threshold: 0.15,
+  });
+  assert.match(report, /CI Flaky-Rate Probe/);
+  assert.match(report, /4 runs sampled/);
+  assert.match(report, /unit ⚠️/); // flagged
+  assert.match(report, /100%/);
+}
+
+{
+  const empty = formatReport([], { workflow: "CI", branch: "main" });
+  assert.match(empty, /No conclusive `CI` jobs on `main`/);
+}
+
+// --- parseArgs -------------------------------------------------------------
+
+{
+  const options = parseArgs(["--workflow", "CI", "--branch", "main", "--max-runs", "20", "--threshold", "0.25", "--min-samples", "6"]);
+  assert.equal(options.workflow, "CI");
+  assert.equal(options.maxRuns, 20);
+  assert.equal(options.threshold, 0.25);
+  assert.equal(options.minSamples, 6);
+}
+
+assert.throws(() => parseArgs(["--max-runs", "0"]), /positive integer/);
+assert.throws(() => parseArgs(["--threshold", "2"]), /\[0, 1\]/);
+assert.throws(() => parseArgs(["--min-samples", "0"]), /positive integer/);
+assert.throws(() => parseArgs(["--bogus"]), /unknown argument/);
+
+// --- readMainRuns: URL shape against an injected fetcher --------------------
+
+{
+  const calls = [];
+  const runs = readMainRuns("owner/repo", { branch: "main", maxRuns: 5 }, (args) => {
+    calls.push(args[args.length - 1]);
+    return { workflow_runs: [{ id: 1 }, { id: 2 }] };
+  });
+  assert.equal(calls.length, 1);
+  assert.match(calls[0], /repos\/owner\/repo\/actions\/runs\?branch=main&per_page=5/);
+  assert.deepEqual(runs.map((r) => r.id), [1, 2]);
+}
+
+// --- collectRunsWithJobs: filters to CI push/merge_group + joins jobs -------
+
+{
+  const fetchJson = (args) => {
+    const endpoint = args[args.length - 1];
+    if (endpoint.includes("/jobs")) {
+      const runId = /runs\/(\d+)\/jobs/.exec(endpoint)?.[1];
+      return { jobs: [jb("unit", "success", { run_attempt: 1 })] };
+    }
+    return {
+      workflow_runs: [
+        { id: 10, name: "CI", event: "push", created_at: "2026-06-17T12:00:00Z" },
+        { id: 11, name: "CI", event: "merge_group", created_at: "2026-06-17T12:15:00Z" },
+        { id: 12, name: "CI", event: "pull_request", created_at: "2026-06-17T12:30:00Z" }, // dropped
+        { id: 13, name: "bench", event: "push", created_at: "2026-06-17T12:45:00Z" }, // dropped
+      ],
+    };
+  };
+  const joined = collectRunsWithJobs("owner/repo", { workflow: "CI", branch: "main", maxRuns: 10 }, fetchJson);
+  assert.deepEqual(joined.map((r) => r.id), [10, 11]);
+}
+
+// --- CLI: fixture path ------------------------------------------------------
+
+function runFixture(runs, args = []) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-flaky-"));
+  try {
+    const fixture = path.join(dir, "runs.json");
+    fs.writeFileSync(fixture, `${JSON.stringify({ runs })}\n`);
+    return spawnSync(process.execPath, [SCRIPT, "--fixture", fixture, ...args], {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+{
+  const runs = [
+    run(1, "2026-06-17T12:00:00Z", [jb("unit", "success")]),
+    run(2, "2026-06-17T12:15:00Z", [jb("unit", "failure")]),
+    run(3, "2026-06-17T12:30:00Z", [jb("unit", "success")]),
+    run(4, "2026-06-17T12:45:00Z", [jb("unit", "failure")]),
+  ];
+  const result = runFixture(runs, ["--min-samples", "4", "--threshold", "0.15"]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /CI Flaky-Rate Probe/);
+  assert.match(result.stdout, /::warning::check-flaky-rate: job "unit"/);
+}
+
+{
+  const result = runFixture([]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /No conclusive `CI` jobs/);
+}
+
+// --- CLI: live path through a fake gh on PATH -------------------------------
+
+{
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tsz-flaky-gh-"));
+  try {
+    const fakeGh = path.join(dir, "gh");
+    fs.writeFileSync(fakeGh, `#!/bin/sh
+case "$*" in
+  *"/actions/runs?branch="*)
+    printf '%s\\n' '{"workflow_runs":[{"id":1,"name":"CI","event":"push","created_at":"2026-06-17T12:00:00Z"},{"id":2,"name":"CI","event":"push","created_at":"2026-06-17T12:15:00Z"}]}'
+    ;;
+  *"/runs/1/jobs"*)
+    printf '%s\\n' '{"jobs":[{"name":"unit","conclusion":"success","run_attempt":1}]}'
+    ;;
+  *"/runs/2/jobs"*)
+    printf '%s\\n' '{"jobs":[{"name":"unit","conclusion":"failure","run_attempt":1}]}'
+    ;;
+  *)
+    printf 'unexpected gh args %s\\n' "$*" >&2
+    exit 1
+    ;;
+esac
+`);
+    fs.chmodSync(fakeGh, 0o755);
+
+    const result = spawnSync(process.execPath, [
+      SCRIPT, "--repository", "owner/repo", "--max-runs", "2", "--min-samples", "2", "--threshold", "0.15",
+    ], {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${dir}${path.delimiter}${process.env.PATH || ""}` },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /unit/);
+    assert.match(result.stdout, /::warning::check-flaky-rate: job "unit"/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log("check-flaky-rate: all assertions passed");


### PR DESCRIPTION
## Summary
Additive, advisory CI observability for the fleet's speed/robustness program (issue #13753). Builds on #13744's resilience work — no resilience changes here. Three leading indicators, all advisory (never hard-fail ci-health):

1. **Timing trend persistence + regression warn.** `check-ci-job-timing.mjs` gains `--json <path>` (writes the structured findings document already built internally) plus `--baseline-dir`, `--regress-threshold`, `--regress-min-seconds`. The `ci-job-timing` job now downloads prior runs' `ci-timing` artifacts as a trailing baseline, computes the per-job **median** of prior run p50s, and emits `::warning::` when the current run p50 exceeds that baseline by >30% (jobs with a baseline <60s are ignored as noise). This run's document is uploaded as the `ci-timing` artifact (30-day retention) for the next firing. A missing/unparseable baseline degrades to "first baseline", never an error.

2. **sccache hit-rate visibility + floor.** New `record_sccache_metric <suite>` in `gcp-full-ci.sh` parses `sccache --show-stats --stats-format=json`, sums per-language `cache_hits`/`cache_misses` counts, records the hit ratio via the existing `publish_latest_metric`, and emits `::warning::` when the ratio falls below `SCCACHE_HIT_RATE_FLOOR` (default 40%, only checked once ≥50 compiles ran). Wired into the **unit** suite and **wasm-all**. Guarded on `RUSTC_WRAPPER` so dist-binaries (sccache disabled by design) is skipped, and on `jq`. Makes a silent cold-cache regression (key-namespace bump, GCS download failure) visible instead of only surfacing as wall-clock drift (#13605 items 3-4).

3. **Flaky-rate probe.** New `scripts/ci/check-flaky-rate.mjs` reuses check-main-red's run-listing approach: lists recent `main` CI runs (push/merge_group), groups each job by name across runs and `run_attempt` re-runs (jobs fetched with `filter=all`), counts pass↔fail conclusion flips between consecutive conclusive results, and reports a flip-rate table + `::warning::` over a threshold (default 15%, min 4 samples). `timed_out`/`startup_failure` count as fail; inconclusive verdicts are ignored. Wired as a new advisory `ci-flaky-rate` job (`continue-on-error`). Complements the determinism work in #13368/#13255 with a standing rate signal.

## Design notes
- The sccache floor `::warning::` lives in `gcp-full-ci.sh` (where `RUSTC_WRAPPER` and the stats exist), not ci-health.yml — ci-health runs on github-hosted `ubuntu-latest` with only `GITHUB_TOKEN` and cannot read the GCS metric. This matches the lead's "guard on RUSTC_WRAPPER" steer.
- Timing trend uses `actions/upload-artifact`/`gh run download` (the reliable sink on ubuntu-latest) rather than GCS, for the same reason.
- All comparison/aggregation logic lives in the scripts (testable), keeping the YAML thin.

Closes #13753

Goal: hold

## Provenance
Machine: MacBookPro.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

## Verification
Never ran full CI. Targeted (all green):
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-health.yml'))"` → yaml ok
- `bash -n scripts/ci/gcp-full-ci.sh` → ok
- `node --check` on all four edited/new `.mjs` → ok
- `node scripts/ci/test-check-ci-job-timing.mjs` → all assertions passed (added coverage for `--json`/baseline/compare + CLI regression warning)
- `node scripts/ci/test-check-flaky-rate.mjs` → all assertions passed (new fixture test: flip counting, ordering, threshold/min-samples, parseArgs, injected-fetcher URL shape, CLI fixture + fake-gh live path)
- jq sccache-stats parsing validated against representative `--stats-format=json` output (hits=80 misses=32) and a degraded-shape fallback (→ 0)
- actionlint not installed locally; skipped

Scope: only `.github/workflows/ci-health.yml`, `scripts/ci/check-ci-job-timing.mjs` (+ its test), `scripts/ci/gcp-full-ci.sh`, and new `scripts/ci/check-flaky-rate.mjs` (+ test).

— AgentName: M1FableArchitect
