### PR TITLE
fix(checker): poison type-position uses of unresolved-import members to error

### DIFF
--- a/crates/tsz-checker/src/symbols/symbol_resolver.rs
+++ b/crates/tsz-checker/src/symbols/symbol_resolver.rs
@@ -1628,6 +1628,17 @@ impl<'a> CheckerState<'a> {
             })
             .or_else(|| self.resolve_global_augmentation_root_symbol(root_name, &lib_binders))?;
 
+        // Bare reference to an import alias from an unresolved module: same
+        // poison-to-`any` rule as the `NodeIndex` path above (qualified members
+        // like `E.URI` fail in the segment walk below and return `None` there).
+        if segments.clone().next().is_none() && self.is_unresolved_import_symbol_id(current_sym) {
+            self.ctx
+                .lowering_entity_name_resolution_cache
+                .borrow_mut()
+                .insert(name.to_string(), None);
+            return None;
+        }
+
         for segment in segments {
             let mut visited_aliases = AliasCycleTracker::new();
             current_sym = self
@@ -1791,6 +1802,16 @@ impl<'a> CheckerState<'a> {
                 && let TypeSymbolResolution::Type(sym_id) =
                     self.resolve_identifier_symbol_in_type_position(idx)
             {
+                // An import alias from a module that never resolved (TS2307
+                // already emitted) must not bind to a stable `DefId`: lowering
+                // would build `Application(Lazy(alias_def), args)`, a non-error
+                // shape that keeps its type arguments for structural comparison
+                // (so two instantiations differing only in an argument fail to
+                // relate). tsc poisons it to `any`; `None` routes lowering to the
+                // error-like `UnresolvedTypeName`. See `is_unresolved_import_symbol_id`.
+                if self.is_unresolved_import_symbol_id(sym_id) {
+                    return None;
+                }
                 let lib_binders = self.get_lib_binders();
                 if let Some(alias_symbol) =
                     self.ctx.binder.get_symbol_with_libs(sym_id, &lib_binders)

--- a/crates/tsz-checker/src/types/type_literal_checker.rs
+++ b/crates/tsz-checker/src/types/type_literal_checker.rs
@@ -409,6 +409,40 @@ impl<'a> CheckerState<'a> {
                     return array_type;
                 }
 
+                // A reference whose name resolves to an import alias from a module
+                // that never resolved (TS2307 already emitted) must not bind to a
+                // stable `Lazy(DefId)` base here. `resolve_symbol_as_lazy_type_named`
+                // would yield `Application(Lazy(alias_def), args)`, a non-error shape
+                // that retains its type arguments for structural comparison; two
+                // instantiations differing only in an argument then fail to relate.
+                // tsc poisons such a reference to `any`, so the application relates
+                // freely. Route to `UnresolvedTypeName` (error-like for any args,
+                // display-preserving) to match tsc and prevent self-assignability
+                // cascades through generic interfaces parameterized by members of
+                // unresolved imports (e.g. `interface Decoder<I,A> extends
+                // K.Kleisli<E.URI, I, E, A>` where `E`/`Kind2` are unresolved).
+                if type_param.is_none() && self.is_unresolved_import_symbol(type_name_idx) {
+                    let lowered_args: Vec<TypeId> = type_ref
+                        .type_arguments
+                        .as_ref()
+                        .map(|args| {
+                            args.nodes
+                                .iter()
+                                .map(|&arg_idx| {
+                                    self.get_type_from_type_node_in_type_literal(arg_idx)
+                                })
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let atom = self.ctx.types.intern_string(name);
+                    let base = self.ctx.types.unresolved_type_name(atom);
+                    return if lowered_args.is_empty() {
+                        base
+                    } else {
+                        self.ctx.types.application(base, lowered_args)
+                    };
+                }
+
                 // Validate type arguments against constraints (TS2344)
                 // This mirrors the check in get_type_from_type_reference for the
                 // normal type resolution path. Without this, type references inside


### PR DESCRIPTION
Goal: green

## Structural rule

When an import alias resolves to a module that never resolved (TS2307
already emitted) and that alias is then used in TYPE position — bare or with
type arguments (e.g. `Kind2<M, E, A>` from `import { Kind2 } from 'fp-ts/lib/HKT'`,
or `E.URI` as a type argument to a generic heritage base) — `tsc` poisons the
reference to `any`, so any application of it relates bidirectionally and a
generic interface parameterized by such members self-assigns freely.

`tsz` instead bound the alias to a stable `Lazy(DefId)` and lowered the
reference to `Application(Lazy(alias_def), args)`. That is a non-error shape
that retains its type arguments for structural comparison, so two
instantiations differing only in an argument (`Kind2<any, string, A>` vs
`Kind2<any, unknown, A>`) failed to relate, cascading into ~55 false `TS2322`
"`Kleisli<error, ...>` is not assignable to `Decoder<I,A>`" diagnostics in
io-ts `Decoder.ts` / `TaskDecoder.ts`.

Owner layer: checker type-position resolution / lowering symbol resolution.
The fix routes the reference to the error-like `UnresolvedTypeName` (which
`is_error_type` already accepts through `Application` bases), matching tsc's
`any`. Three resolvers needed the gate because interface members lower through
a different path than variable/object-type-literal annotations:

- `type_literal_checker::get_type_from_type_reference_in_type_literal`
  (variable / object-type-literal annotations).
- `symbol_resolver::resolve_type_symbol_for_lowering` (NodeIndex path used by
  interface-declaration lowering).
- `symbol_resolver::resolve_entity_name_text_to_def_id_for_lowering` (bare-root
  name fallback used when the NodeIndex path returns `None`).

This is the heavier face of the #13755 import-failure recovery defect: it
extends the `any`-poison from the entity-name import-equals VALUE form to
TYPE-position uses of unresolved-import members.

## Adjacent-case matrix

- Bare unresolved-import member as type, no args: already error-like (kept).
- Unresolved-import member with type args (`Kind2<...>`): now error-like (fixed).
- Unresolved-import member as a type ARGUMENT to a generic heritage base
  (`extends K.Kleisli<E.URI, ...>`): self-assigns like tsc (fixed).
- As a variable/object-type-literal annotation vs as an interface member: both
  paths now poison consistently.
- Renamed binder (`Kind2` -> any name) / qualified (`E.URI`) forms: covered by
  the structural `is_unresolved_import_symbol_id` check, not name literals.
- NEGATIVE (no over-suppression): a RESOLVED import (`Box<string>` vs
  `Box<number>`) still emits the real `TS2322`.

## Verification

- Repro (task minimal): `import * as E from 'missing'; interface D<I,A> extends
  E.Kleisli<E.URI,I,A> {}; declare const d: D<string,number>; const d2:
  D<string,number> = d;` -> only `TS2307`, no false `TS2322` (matches tsc).
- io-ts Decoder family (real source at pinned ref `864a3a2f`, 6-file subset):
  `TS2322` 55 -> 16; the dominant `Kleisli<error,...>` self-assignability
  family collapsed. Residual `TS2322` are a distinct mechanism (generic
  inference through unresolved `MonadThrow2C<M,E>` yielding `unknown` for the
  `E` param, and the `declare module 'fp-ts/lib/HKT'` HKT augmentation family).
- Negative: resolved `Box<string>` vs `Box<number>` still errors (TS2322).
- Conformance (no PASS->FAIL): `moduleResolution` 111/111, `import` 281/281,
  `heritage` 1/1, `genericInterface` 4/4, `assignmentCompat` 128/128,
  `declarationEmit` 276/276, `ambientModule` 7/7, `untyped` 11/11,
  `unresolved` 1/1, `isolatedModules` 36/36, `generic` 240/240,
  `typeReference` 21/21, `moduleAugmentation` 46/46, `namespace` 17/17,
  `typeAlias` 23/23, `intersection` 44/44, `union` 60/60, `mappedType` 55/55,
  `conditionalType` 17/17, `importDeclaration` 9/9, `exportImport` 7/7,
  `aliasUsage` 9/9 — all 100%.
- `arch_guard` PASS; `cargo clippy --lib -p tsz-checker` clean.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high
