### PR TITLE
perf(ci): move project-compile-canary-aggregate to ubuntu-latest (#13745)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1206,13 +1206,7 @@ jobs:
     name: conformance-aggregate
     needs: [gate, conformance]
     if: needs.gate.outputs.full_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true' && !cancelled() && needs.conformance.result != 'skipped' && needs.conformance.result != 'cancelled'
-    # Artifact-driven aggregate: run_conformance_aggregate prefers the downloaded
-    # .conformance-shards dir and the per-shard failure lists travel inside those
-    # artifacts, so the gate is computed without gsutil. The remaining GCS calls
-    # are guarded fallbacks (publish_latest_metric gates on `command -v gsutil`;
-    # the timings publish + total-artifact-loss recovery degrade non-fatally), so
-    # a free ubuntu-latest runner is sufficient and frees a scarce Cloud Run slot.
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, tsz-cloud-run]
     timeout-minutes: 15
     env:
       SCCACHE_GCS_KEY_JSON: ${{ secrets.SCCACHE_GCS_KEY_JSON }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -791,7 +791,10 @@ jobs:
     name: project-compile-canary-aggregate
     needs: [gate, project-compile-canary]
     if: needs.gate.outputs.full_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true' && !cancelled() && needs.project-compile-canary.result != 'skipped' && needs.project-compile-canary.result != 'cancelled'
-    runs-on: [self-hosted, tsz-cloud-run]
+    # Pure-IO aggregate: consumes ONLY the downloaded .canary-shards artifacts
+    # (project-compile-canary-aggregate.sh reads no GCS and no dist binary), so a
+    # free ubuntu-latest runner is sufficient and frees a scarce Cloud Run slot.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     continue-on-error: true
     env:
@@ -1203,7 +1206,13 @@ jobs:
     name: conformance-aggregate
     needs: [gate, conformance]
     if: needs.gate.outputs.full_run == 'true' && needs.gate.outputs.compiler_checks_required == 'true' && !cancelled() && needs.conformance.result != 'skipped' && needs.conformance.result != 'cancelled'
-    runs-on: [self-hosted, tsz-cloud-run]
+    # Artifact-driven aggregate: run_conformance_aggregate prefers the downloaded
+    # .conformance-shards dir and the per-shard failure lists travel inside those
+    # artifacts, so the gate is computed without gsutil. The remaining GCS calls
+    # are guarded fallbacks (publish_latest_metric gates on `command -v gsutil`;
+    # the timings publish + total-artifact-loss recovery degrade non-fatally), so
+    # a free ubuntu-latest runner is sufficient and frees a scarce Cloud Run slot.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       SCCACHE_GCS_KEY_JSON: ${{ secrets.SCCACHE_GCS_KEY_JSON }}


### PR DESCRIPTION
## Summary
The `project-compile-canary-aggregate` job burned a scarce ephemeral Cloud Run runner only to download and concatenate shard artifacts. It builds no dist binary and reads no GCS — its work is `bash`/`node`/`python3` over the downloaded `.canary-shards`. This moves it to free `ubuntu-latest`, freeing a Cloud Run slot and removing container-provision + start.sh jitter from the CI Summary tail.

Goal: fast

## Changes (`.github/workflows/ci.yml` only)
- **`project-compile-canary-aggregate`: `[self-hosted, tsz-cloud-run]` → `ubuntu-latest`.** `project-compile-canary-aggregate.sh` reads ONLY the downloaded `.canary-shards` artifacts (no GCS, no dist binary) and uses bash/node/python3 — all preinstalled on `ubuntu-latest`. Job is `continue-on-error: true` (advisory). Kept the artifact-index poll + `download-artifact` (the poll guards against indexing lag before download; with artifacts now the sole source, dropping it would risk an incomplete set — stability over the ceiling-case idle savings). Verified passing on ubuntu.

### Left self-hosted (deferred follow-up)
- **`conformance-aggregate`: unchanged (`[self-hosted, tsz-cloud-run]`).** An initial move to ubuntu was reverted: when there is a conformance deficit, `run_conformance_aggregate` needs the per-shard failure lists, and the regression-allowlist detail path falls back to GCS via `gsutil` (`gcp-full-ci-conformance.sh:402-407`) — unavailable on stock `ubuntu-latest` (observed: `error: conformance regression deficit 2, but per-shard failure lists are unavailable`). Moving it requires a GitHub-artifact handoff for the failure lists or `setup-gcloud` auth — out of this conservative scope.
- **`fourslash-aggregate`: unchanged.** `run_fourslash_aggregate` (`gcp-full-ci.sh:1038-1058`) reads shard data EXCLUSIVELY from GCS via `gsutil`, which `ubuntu-latest` lacks.

Job names are unchanged, so `ci-summary` needs/required wiring is unaffected.

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → YAML OK
- `node scripts/ci/test-pr-ready-state.mjs` → exit 0 (needs-order assertion passes)
- `git diff --stat origin/main...HEAD` → only `.github/workflows/ci.yml`.
- Per-job `runs-on` confirmed: only `project-compile-canary-aggregate` is on `ubuntu-latest`; `conformance-aggregate` and `fourslash-aggregate` remain self-hosted.

## Risk
Low. Only the artifact-only, `continue-on-error` canary aggregate is moved; its happy path is gsutil-free and fully artifact-driven, and the retained poll loop preserves indexing-lag resilience. The two jobs that need gsutil/GCS for per-shard failure-list detail stay self-hosted.

Part of #13745 (canary-aggregate moved; conformance-aggregate + fourslash-aggregate remain self-hosted as deferred follow-up — both need gsutil/GCS for per-shard failure lists).

## Provenance
Machine: MacBookPro.fritz.box
Assistant: claude-code
Model: claude-opus-4-8
Effort: max

— AgentName: M1FableArchitect
