### PR TITLE
fix(checker): cross-arena FUNCTION local-pin node-symbol round-trip (mobx die cache poison)

### DIFF
--- a/crates/tsz-checker/Cargo.toml
+++ b/crates/tsz-checker/Cargo.toml
@@ -1121,6 +1121,9 @@ path = "tests/cross_module_unimported_name_resolution_tests.rs"
 name = "cross_file_intrinsic_identifier_tests"
 path = "tests/cross_file_intrinsic_identifier_tests.rs"
 [[test]]
+name = "cross_file_function_node_index_collision_tests"
+path = "tests/cross_file_function_node_index_collision_tests.rs"
+[[test]]
 name = "cross_file_type_params_cache_tests"
 path = "tests/cross_file_type_params_cache_tests.rs"
 [[test]]

--- a/crates/tsz-checker/src/state/type_analysis/cross_file.rs
+++ b/crates/tsz-checker/src/state/type_analysis/cross_file.rs
@@ -237,6 +237,22 @@ impl CheckerState<'_> {
 
         // When the user re-declares a lib global function, keep the user's overloads in scope
         // (delegating to the lib arena would drop them and mis-resolve calls).
+        //
+        // The pin must confirm genuine current-arena OWNERSHIP, not just the
+        // presence of *a* function node at the symbol's raw `NodeIndex`. A raw
+        // `NodeIndex` is arena-relative: `cross_file_symbol` here is the FOREIGN
+        // owner's symbol, so its declaration `NodeIndex`es are indices into the
+        // OWNER's arena. Reusing one as an index into the CURRENT arena can land
+        // on an unrelated function node that the current binder assigned to a
+        // DIFFERENT symbol (e.g. mobx `die` in `errors.ts` and `runInAction` in
+        // `api/action.ts` both declared at the same raw `NodeIndex(364)`).
+        // Pinning that collision locally computes the wrong function's signature
+        // for the foreign symbol and — because the result is then cached under
+        // the owner's `(file_idx, SymbolId)` key first-writer-wins — poisons every
+        // later reader of the real symbol. Require the current binder's
+        // `get_node_symbol` round-trip to map the node back to exactly `sym_id`,
+        // which holds for a genuine lib/local re-declaration (the binder assigned
+        // the merged symbol to that node) but rejects the cross-arena collision.
         {
             let sym_found = cross_file_symbol;
             if let Some(symbol) = sym_found
@@ -251,6 +267,7 @@ impl CheckerState<'_> {
                         .get(d)
                         .and_then(|n| self.ctx.arena.get_function(n))
                         .is_some()
+                        && self.ctx.binder.get_node_symbol(d) == Some(sym_id)
                 });
                 if has_function_in_current_arena {
                     return None; // Handle locally, don't delegate to lib arena
@@ -329,6 +346,14 @@ impl CheckerState<'_> {
         // so a current-file function declaration always pins resolution locally.
         // This covers both the lib-merge case (`declare function f` in current arena
         // overlapping a lib `declare function f`) and the multi-file collision case.
+        //
+        // As with the lib-redeclaration guard above, require the current binder's
+        // `get_node_symbol` round-trip to confirm the candidate function node in
+        // the current arena genuinely belongs to `sym_id`. A bare
+        // `arena.get_function(d)` presence test fires on a raw-`NodeIndex`
+        // collision — a function the current binder bound to a DIFFERENT symbol at
+        // the same index — and would pin a foreign symbol to the wrong local
+        // declaration.
         let mut function_has_local_decl = false;
         if let Some(symbol) = self.ctx.binder.get_symbol(sym_id)
             && symbol.has_any_flags(symbol_flags::FUNCTION)
@@ -341,6 +366,7 @@ impl CheckerState<'_> {
                     .get(d)
                     .and_then(|n| self.ctx.arena.get_function(n))
                     .is_some()
+                    && self.ctx.binder.get_node_symbol(d) == Some(sym_id)
             });
             if has_local_function_decl {
                 delegate_arena = None;

--- a/crates/tsz-checker/tests/cross_file_function_node_index_collision_tests.rs
+++ b/crates/tsz-checker/tests/cross_file_function_node_index_collision_tests.rs
@@ -130,7 +130,7 @@ fn die_resolution_is_order_independent() {
 
 /// Adjacent case with renamed binders: the colliding local function and the
 /// foreign function carry different user names and the barrel re-exports them,
-/// proving the fix is structural (NodeIndex round-trip) and not keyed on any
+/// proving the fix is structural (`NodeIndex` round-trip) and not keyed on any
 /// identifier string.
 #[test]
 fn renamed_binders_do_not_cross_contaminate_signatures() {

--- a/crates/tsz-checker/tests/cross_file_function_node_index_collision_tests.rs
+++ b/crates/tsz-checker/tests/cross_file_function_node_index_collision_tests.rs
@@ -1,0 +1,206 @@
+//! Regression: a cross-file FUNCTION symbol must not be pinned to a same-raw-
+//! `NodeIndex` function declaration in the *current* arena.
+//!
+//! `NodeIndex` is arena-relative. When a function owned by file A is resolved
+//! while checking file B (reached through an `export *` barrel cycle), the
+//! cross-arena delegation guard previously pinned resolution locally whenever
+//! *a* function node existed at the foreign symbol's declaration `NodeIndex`
+//! inside B's arena — without confirming that B's binder actually bound that
+//! node to the same symbol. Two functions declared at the same structural
+//! position in their respective files collide on that raw index, so the foreign
+//! function (e.g. mobx `die: (error, ...args) => never`) was typed with the
+//! local function's signature (e.g. `runInAction: <T>(fn: () => T) => T`). The
+//! wrong type was then cached under the owner's `(file_idx, SymbolId)` key
+//! first-writer-wins, poisoning every later reader and producing a cluster of
+//! false `TS2345` ("string is not assignable to `() => T`") at every `die(...)`
+//! call (mobx canary: ~69 false positives).
+//!
+//! The fix requires the current binder's `get_node_symbol` round-trip to map the
+//! candidate node back to exactly the symbol being resolved before pinning it
+//! locally, which holds for genuine lib/local re-declarations but rejects the
+//! cross-arena collision.
+//!
+//! These tests assert the structural invariants the fix protects: a function
+//! re-exported through an `export *` barrel cycle keeps its OWN signature at every
+//! call site (positive cases), the result is order-independent, the rule is
+//! identifier-agnostic (renamed-binder case), and a genuine local function
+//! re-declaration still resolves locally (negative/fallback case so the
+//! round-trip did not over-restrict the legitimate path). The raw `NodeIndex`
+//! collision itself is layout-sensitive and is reproduced end-to-end by the mobx
+//! canary project row (`die`-cluster: 69 false `TS2345` -> 0); these unit tests
+//! pin the semantic contract that the fix must preserve.
+
+use tsz_checker::context::CheckerOptions;
+use tsz_common::common::ModuleKind;
+
+fn check_all(files: &[(&str, &str)]) -> Vec<(u32, String)> {
+    tsz_checker::test_utils::check_all_multi_file_with_global_index(
+        files,
+        CheckerOptions {
+            module: ModuleKind::ESNext,
+            strict: true,
+            strict_null_checks: true,
+            ..CheckerOptions::default()
+        },
+    )
+    .into_iter()
+    .filter(|diag| diag.code != 2318)
+    .map(|diag| (diag.code, diag.message_text))
+    .collect()
+}
+
+/// mobx-shaped witness: `die` owned by `errors.ts`, `runInAction` owned by
+/// `action.ts` (which also imports `die`), both re-exported through an
+/// `export *` barrel that the owners import back from. A consumer of `die`
+/// must see `die`'s own signature, not `runInAction`'s.
+const ERRORS: &str = r#"
+export function die(error: string | number, ...args: any[]): never {
+    throw new Error("" + error)
+}
+"#;
+
+const ACTION: &str = r#"
+import { die } from "./internal"
+
+export function runInAction<T>(fn: () => T): T {
+    return fn()
+}
+
+export function actionDispatch() {
+    die("dispatch failed")
+}
+"#;
+
+const INTERNAL: &str = r#"
+export * from "./errors"
+export * from "./action"
+export * from "./utils"
+"#;
+
+const UTILS: &str = r#"
+import { die } from "./internal"
+
+export function assertProxies(hasProxy: boolean) {
+    if (!hasProxy) {
+        die("Proxy not available")
+    }
+}
+"#;
+
+fn witness_files() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("errors.ts", ERRORS),
+        ("action.ts", ACTION),
+        ("internal.ts", INTERNAL),
+        ("utils.ts", UTILS),
+    ]
+}
+
+/// Every `die("...")` call across the project must accept a string argument: it
+/// must resolve to `die`'s `(string | number, ...args) => never` signature,
+/// never `runInAction`'s `(fn: () => T) => T`. The poison surfaces as TS2345 on
+/// the string argument.
+#[test]
+fn die_calls_resolve_die_signature_not_runinaction() {
+    let diagnostics = check_all(&witness_files());
+    assert!(
+        !diagnostics.iter().any(|(code, _)| *code == 2345),
+        "die(\"...\") must accept a string (die's own signature), not be typed \
+         with runInAction's `() => T` parameter: {diagnostics:#?}"
+    );
+}
+
+/// Resolution must be order-independent: rotating the program file order must
+/// not flip `die`'s resolved signature (the poison was order-dependent because
+/// the first writer of the owner cache key won).
+#[test]
+fn die_resolution_is_order_independent() {
+    let base = witness_files();
+    for rotation in 0..base.len() {
+        let mut files = base.clone();
+        files.rotate_left(rotation);
+        let diagnostics = check_all(&files);
+        assert!(
+            !diagnostics.iter().any(|(code, _)| *code == 2345),
+            "die(\"...\") must resolve die's signature regardless of file order \
+             (rotation {rotation}): {diagnostics:#?}"
+        );
+    }
+}
+
+/// Adjacent case with renamed binders: the colliding local function and the
+/// foreign function carry different user names and the barrel re-exports them,
+/// proving the fix is structural (NodeIndex round-trip) and not keyed on any
+/// identifier string.
+#[test]
+fn renamed_binders_do_not_cross_contaminate_signatures() {
+    let raise = r#"
+export function raise(code: number, detail: string): never {
+    throw new Error(detail + code)
+}
+"#;
+    let scheduler = r#"
+import { raise } from "./barrel"
+
+export function schedule<R>(task: () => R): R {
+    return task()
+}
+
+export function runOrRaise() {
+    raise(7, "boom")
+}
+"#;
+    let barrel = r#"
+export * from "./raise_mod"
+export * from "./scheduler"
+export * from "./caller"
+"#;
+    let caller = r#"
+import { raise } from "./barrel"
+
+export function guard(ok: boolean) {
+    if (!ok) {
+        raise(42, "guard tripped")
+    }
+}
+"#;
+    let files = vec![
+        ("raise_mod.ts", raise),
+        ("scheduler.ts", scheduler),
+        ("barrel.ts", barrel),
+        ("caller.ts", caller),
+    ];
+    let diagnostics = check_all(&files);
+    assert!(
+        !diagnostics.iter().any(|(code, _)| *code == 2345),
+        "raise(number, string) must keep its own signature across the barrel \
+         cycle even with renamed binders: {diagnostics:#?}"
+    );
+}
+
+/// Negative/fallback case: a genuine local function re-declaration (no foreign
+/// collision) must still resolve locally and report a real argument-count
+/// mismatch, proving the round-trip guard did not over-restrict the legitimate
+/// "user re-declares a function, keep local overloads" path.
+#[test]
+fn genuine_local_function_call_still_type_checks() {
+    let lib = r#"
+export function format(value: number): string {
+    return "" + value
+}
+"#;
+    let app = r#"
+import { format } from "./lib"
+
+export const out: string = format(123)
+// real error: format expects a number, not a string
+export const bad: string = format("nope")
+"#;
+    let files = vec![("lib.ts", lib), ("app.ts", app)];
+    let diagnostics = check_all(&files);
+    assert!(
+        diagnostics.iter().any(|(code, _)| *code == 2345),
+        "format(\"nope\") must still report TS2345 (string not assignable to \
+         number) — the local-decl path must keep working: {diagnostics:#?}"
+    );
+}


### PR DESCRIPTION
Cross-file symbol-type cache poisoning eliminated the mobx `die` false-positive cluster (69 false `TS2345`).

## Root cause
A cross-file FUNCTION symbol owned by file A, resolved while checking file B (reached through an `export *` barrel cycle), was pinned to a LOCAL declaration whenever *a* function node existed at the foreign symbol's raw `NodeIndex` inside B's arena. `NodeIndex` is arena-relative, so the presence test fires on a collision: a function the current binder bound to a DIFFERENT symbol at the same index. The B-context result (the wrong function's signature) was then cached under the OWNER's `(file_idx, SymbolId)` key first-writer-wins (`def/core.rs` cross-file cache), poisoning every later reader.

Witness (root-caused via tracing): mobx `die` (`errors.ts`) and `runInAction` (`api/action.ts`) are both declared at raw `NodeIndex(364)` in their respective arenas. While checking `api/action.ts` (`current_idx=0`), `die` (`sym_id=17855`, owner=file 30) hit the early FUNCTION delegation guard; `arena.get_function(364)` found `runInAction`'s node in action.ts and pinned `die` locally, computing `runInAction`'s `<T>(fn: () => T) => T` for `die`. That signature was cached under die's owner key, so every `die("...")` call across the project saw `() => unknown` as the expected parameter -> 69 false `TS2345`. The trace proved `get_node_symbol(364)` in action.ts maps back to `runInAction`, not `die` (`roundtrip_owns=false`), while it maps correctly (`roundtrip_owns=true`) in die's own arena and for runInAction in its own arena.

## Structural rule
When a FUNCTION symbol owned by file A is type-checked while `current_file = B != A`, the cross-arena delegation must NOT pin resolution to a current-arena function node solely because *a* function node exists at the symbol's raw `NodeIndex`. tsc resolves the function to its OWN declaration everywhere. The pin is honored (`crates/tsz-checker/src/state/type_analysis/cross_file.rs`) only when the current binder's `get_node_symbol` round-trip maps that node back to exactly `sym_id` — true for a genuine lib/local re-declaration (the binder assigned the merged symbol to that node), false for the cross-arena raw-`NodeIndex` collision. Applied to both FUNCTION local-pin guards (lib-redeclaration guard and multi-file collision guard).

## Owner layer
Checker cross-arena symbol-resolution delegation (`delegate_cross_arena_symbol_resolution`). No solver/printer change; no identifier/file-name string checks (purely the binder's structural node->symbol map).

## Adjacent-case matrix
- die called from a third consumer file (positive)
- die called inside the runInAction-owning file (the colliding arena, positive)
- order-independence across all file rotations (positive)
- renamed binders (`raise`/`schedule`/`guard`) through a barrel cycle, proving the rule is identifier-agnostic
- genuine local function re-declaration still type-checks and reports a real `TS2345` (negative/fallback: round-trip did not over-restrict the legitimate path)

## Verification
- mobx canary fixture (pinned ref, gate tsconfig): die-cluster `TS2345 '() => unknown'` 69 -> 0; total diagnostics 442 -> 348; diagnostic-set diff = 95 removed, 0 genuinely new (the lone "added" line is the same pre-existing `spy.ts(45,15)` TS2345 with reordered property display, identical code/location).
- Cross-file conformance (load-bearing, REVERT-if-any-regress): `crossFile` 11/11, `reexport` 14/14, `exportStar` 15/15, `moduleExport` 49/49, `circularType` 5/5, `importDeclaration` 9/9 — all 100%, 0 PASS->FAIL.
- Broader: `function` 284/284, `import` 281/281, `export` 286/286, `module` 414/414, `namespace` 17/17, `overload` 62/62, `functionOverload` 58/58, `mergedDeclaration` 8/8, `exportAssignment` 32/32, `importAlias` 6/6, `declarationFunction` 2/2 — all 100%.
- New regression test `cross_file_function_node_index_collision_tests` (4 cases) passes; the NodeIndex collision itself is reproduced end-to-end by the mobx canary row.
- `arch_guard` PASS; `cargo clippy -p tsz-checker --lib` clean.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Goal: green
