### PR TITLE
fix(solver): resolve unique-symbol index through same-named typeof alias

### DIFF
--- a/crates/tsz-checker/src/tests/object_literal_computed_symbol_member_tests.rs
+++ b/crates/tsz-checker/src/tests/object_literal_computed_symbol_member_tests.rs
@@ -341,3 +341,61 @@ type Mit = (typeof oit)[typeof Symbol.iterator];
 "#,
     );
 }
+
+// ── unique-symbol index via a same-named `type X = typeof X` alias ───────────
+//
+// When a value `const s: unique symbol` and a type `type s = typeof s` share one
+// merged symbol (the HOTScript `rawArgs` pattern), indexing `Obj[s]` in type
+// position resolves the index through the alias body, which the resolver leaves
+// as a self-referential `TypeQuery(s)` rather than rewriting it to
+// `UniqueSymbol(s)`. The member is stored under `__unique_<s>`, so the indexed
+// access must map a unique-symbol-denoting `TypeQuery` to that same key — without
+// the fix the lookup misses and the access wrongly evaluates to `undefined`.
+#[test]
+fn unique_symbol_indexed_access_via_same_named_typeof_alias() {
+    assert_no_ts2322_or_2536(
+        "type literal indexed by same-named typeof alias",
+        r#"
+declare const sym: unique symbol;
+type sym = typeof sym;
+type WithSym = { [sym]: number };
+type Got = WithSym[sym];
+const ok: Got = 5;
+"#,
+    );
+    // Negative side: the access resolves to the real member type, so a mismatched
+    // assignment must still error (the value isn't silently widened to `unknown`).
+    let diags = crate::test_utils::check_source_diagnostics(
+        r#"
+declare const sym: unique symbol;
+type sym = typeof sym;
+type WithSym = { [sym]: number };
+type Got = WithSym[sym];
+const bad: Got = "x";
+"#,
+    );
+    assert!(
+        diags.iter().any(|d| d.code == 2322),
+        "expected TS2322 for string assigned to number-typed symbol member; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code, &d.message_text))
+            .collect::<Vec<_>>()
+    );
+}
+
+// Binder-name variation: the same shape must work regardless of the chosen
+// identifier, confirming the fix keys on the symbol binding, not the name text.
+#[test]
+fn unique_symbol_indexed_access_via_same_named_typeof_alias_renamed() {
+    assert_no_ts2322_or_2536(
+        "renamed binder, same-named typeof alias",
+        r#"
+declare const tag: unique symbol;
+type tag = typeof tag;
+interface Carrier { [tag]: string }
+type Inner = Carrier[tag];
+const ok: Inner = "hello";
+"#,
+    );
+}

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access.rs
@@ -1841,6 +1841,15 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         if let Some(TypeData::UniqueSymbol(sym)) = self.interner().lookup(index_type) {
             return Some(self.symbol_named_atom_from_unique_symbol_ref(sym));
         }
+        // A `typeof <uniqueSymbolConst>` index via a same-named `type X = typeof X`
+        // alias stays a self-referential `TypeQuery(sym)` (never rewritten to
+        // `UniqueSymbol(sym)`); its member is stored under the same `__unique_<sym>`/
+        // well-known atom, so map a symbol-denoting query to that key.
+        if let Some(TypeData::TypeQuery(sym)) = self.interner().lookup(index_type)
+            && self.type_query_denotes_symbol(sym)
+        {
+            return Some(self.symbol_named_atom_from_unique_symbol_ref(sym));
+        }
         crate::type_queries::get_literal_property_name(self.interner(), index_type)
     }
 
@@ -1925,10 +1934,7 @@ impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
         // If index is a literal string or unique symbol, look up the property first,
         // then fallback to string index.
         if let Some(name) = self.literal_property_lookup_atom(index_type) {
-            let is_symbol_key = matches!(
-                self.interner().lookup(index_type),
-                Some(TypeData::UniqueSymbol(_))
-            );
+            let is_symbol_key = self.index_type_is_symbol_key(index_type);
             for prop in &shape.properties {
                 if prop.name == name {
                     return self.optional_property_type(prop);

--- a/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs
+++ b/crates/tsz-solver/src/evaluation/evaluate_rules/index_access_keys.rs
@@ -3,15 +3,52 @@
 use crate::construction::TypeDatabase;
 use crate::objects::ApparentMemberKind;
 use crate::objects::apparent::is_member;
-use crate::types::{IntrinsicKind, LiteralValue, TupleElement, TypeData, TypeId, TypeListId};
+use crate::relations::subtype::TypeResolver;
+use crate::types::{
+    IntrinsicKind, LiteralValue, SymbolRef, TupleElement, TypeData, TypeId, TypeListId,
+};
 use crate::utils;
 use crate::visitor::{TypeVisitor, array_element_type, literal_number, tuple_list_id};
 
 use super::super::evaluate::{
     ARRAY_METHODS_RETURN_ANY, ARRAY_METHODS_RETURN_BOOLEAN, ARRAY_METHODS_RETURN_NUMBER,
-    ARRAY_METHODS_RETURN_STRING, ARRAY_METHODS_RETURN_VOID,
+    ARRAY_METHODS_RETURN_STRING, ARRAY_METHODS_RETURN_VOID, TypeEvaluator,
 };
 use super::apparent::make_apparent_method_type;
+
+impl<'a, R: TypeResolver> TypeEvaluator<'a, R> {
+    /// A symbol-typed index key (`UniqueSymbol`, or a unique-symbol-denoting
+    /// `typeof` query) — must route to a symbol index, never a string index.
+    pub(super) fn index_type_is_symbol_key(&self, index_type: TypeId) -> bool {
+        match self.interner().lookup(index_type) {
+            Some(TypeData::UniqueSymbol(_)) => true,
+            Some(TypeData::TypeQuery(sym)) => self.type_query_denotes_symbol(sym),
+            _ => false,
+        }
+    }
+
+    /// True when `typeof <sym>` denotes a `symbol`/`unique symbol` (a valid key),
+    /// not a class/function constructor. A unique-symbol const's query resolves
+    /// back to itself or to `UniqueSymbol`/`symbol`.
+    pub(super) fn type_query_denotes_symbol(&self, sym: SymbolRef) -> bool {
+        if self
+            .resolver()
+            .well_known_symbol_name_for_ref(sym)
+            .is_some()
+        {
+            return true;
+        }
+        match self.resolver().resolve_type_query(sym, self.interner()) {
+            Some(resolved) => {
+                matches!(
+                    self.interner().lookup(resolved),
+                    Some(TypeData::UniqueSymbol(_) | TypeData::Intrinsic(IntrinsicKind::Symbol))
+                ) || self.interner().lookup(resolved) == Some(TypeData::TypeQuery(sym))
+            }
+            None => false,
+        }
+    }
+}
 
 /// Lazily compute and cache array member types (length + apparent methods).
 /// Shared between `ArrayKeyVisitor` and `TupleKeyVisitor`.


### PR DESCRIPTION
Goal: green

## Summary

While chasing the final hotscript FP (`TS2344` at `Tuples.ts:750`), ddmin
decomposition surfaced a distinct, narrower defect on the path to that witness:
an indexed access `Obj[X]` where `X` is a `unique symbol` type referenced
through a **same-named** `type X = typeof X` alias (the HOTScript `rawArgs`
pattern, where the value `const` and the type alias share one merged binder
symbol) wrongly evaluated to `undefined`. This PR fixes that.

It does **not** graduate hotscript — see "Remaining hotscript blocker (bug-3)".
hotscript stays `canary`.

## Structural rule

When the index of an indexed access is a `typeof <uniqueSymbolConst>` routed
through a same-named `type X = typeof <const>` alias, `tsc` resolves it to the
const's unique symbol and looks the member up under that symbol's key; tsz now
does the same through `solver` indexed-access evaluation.

The merged value+type symbol makes `typeof X` self-referential, so the solver
resolver leaves the index as `TypeQuery(sym)` instead of rewriting it to
`UniqueSymbol(sym)`. The member is stored under the `__unique_<sym>` /
well-known atom that a `UniqueSymbol(sym)` index uses, so the lookup missed and
the access fell through to `undefined`. `literal_property_lookup_atom` now maps
a unique-symbol-denoting `TypeQuery` to that same atom, and
`evaluate_object_with_index` treats it as a symbol key (routes to a symbol
index, never a string index). Restricted to symbol-denoting queries
(`typeof <class/fn>` resolves to a constructor and is not a valid key), keyed on
the binder symbol, not the identifier text.

Owner layer: solver evaluation (indexed access).

Adjacent matrix: value/type alias index and direct `typeof` index; type-literal
and interface carriers; renamed binders; well-known `[Symbol.iterator]`
(unchanged); negative case (mismatched assignment still reports `TS2322`, i.e.
the member resolves to its real type, not silently widened).

## Remaining hotscript blocker (bug-3)

The hotscript witness needs an additional, deeper fix that is **not** in this
PR: a homomorphic mapped type `{ [K in keyof S]: V }` over a still-deferred,
array-constrained source `S` loses array-ness. In hotscript, `S` is
`(Fn & { [rawArgs]: args })[rawArgs]` with `args extends unknown[][]`. The
solver evaluation of that intersection-indexed-access collapses a
**generic-typed** symbol-keyed member (`{ [rawArgs]: args }` with `args` a free
type parameter) so the source evaluates to `unknown` rather than `args`, and the
homomorphic mapped over it then degrades to a `{ [x: string]; [x: number] }`
object instead of an array — the false `TS2344 ... does not satisfy 'unknown[]'`.

This is a multi-layer defect (generic-valued symbol-member collapse in
intersection-indexed-access + `instantiateMappedArrayType` preservation over a
deferred array-apparent source). Speculative fixes in mapped evaluation, the
mapped→array relation, and the TS2344 constraint-check base-type path were
prototyped and reverted because none safely resolved the witness without risk of
broad regression. Filed as a follow-up; hotscript remains `canary`.

## Verification

- Minimal repro (matches tsc): `type s = typeof s` over
  `declare const s: unique symbol`; `type W = { [s]: number }`; `W[s]`
  resolves to `number` (was `undefined`). Negative: `const bad: W[s] = "x"`
  still `TS2322`. Renamed-binder and interface-carrier variants verified.
- Regression tests added in
  `crates/tsz-checker/src/tests/object_literal_computed_symbol_member_tests.rs`.
- Conformance (`scripts/conformance/conformance.sh run --filter`), all 0
  regressions: `uniqueSymbol` 12/12, `symbolType` 20/20, `indexedAccess`
  13/13, `indexSignature` 24/24, `computedProperty` 146/146, `keyof` 14/14,
  `mappedType` 55/55, `homomorphic` 3/3, `conditionalType` 17/17,
  `keyofAndIndexed` 3/3, `genericIndexedAccess` 2/2, `wellKnownSymbol` 1/1,
  `accessorsOverrideProperty` 10/10, `objectSpread` 11/11.
- `arch_guard.py`: PASS (helpers moved to `index_access_keys.rs` to keep
  `index_access.rs` at its 2056-line ratchet).
- `cargo clippy --lib -p tsz-solver`: clean.
- `cargo nextest run -p tsz-solver --lib` (index/symbol/type_query filter):
  177/177.
- `scripts/ci/project-compile-guard.sh` (hotscript): still exactly 1 FP at
  `Tuples.ts:750` — no new regression, not graduated.

## Provenance
Machine: m4
Assistant: claude-code
Model: claude-opus-4-8[1m]
Effort: high
