### PR TITLE
perf(checker): memoize contextual-callback mismatch derivation across re-entry (#13250)

### DIFF
--- a/crates/tsz-checker/src/checkers/call_checker/diagnostics.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/diagnostics.rs
@@ -18,9 +18,7 @@ fn callback_mismatch_memo_disabled() -> bool {
     use std::sync::OnceLock;
     static DISABLED: OnceLock<bool> = OnceLock::new();
     *DISABLED.get_or_init(|| {
-        std::env::var("TSZ_DISABLE_CALLBACK_MISMATCH_MEMO")
-            .map(|v| !v.is_empty() && v != "0")
-            .unwrap_or(false)
+        std::env::var("TSZ_DISABLE_CALLBACK_MISMATCH_MEMO").is_ok_and(|v| !v.is_empty() && v != "0")
     })
 }
 

--- a/crates/tsz-checker/src/checkers/call_checker/diagnostics.rs
+++ b/crates/tsz-checker/src/checkers/call_checker/diagnostics.rs
@@ -10,6 +10,20 @@ use tsz_parser::parser::NodeIndex;
 use tsz_parser::parser::syntax_kind_ext;
 use tsz_solver::{ParamInfo, TypeId};
 
+/// Kill-switch (#13250): set `TSZ_DISABLE_CALLBACK_MISMATCH_MEMO` to a
+/// non-empty, non-`0` value to bypass the contextual-callback mismatch memo and
+/// recompute the speculative derivation on every re-entry. Used to A/B the memo
+/// on a single binary and to prove byte-identical diagnostics when disabled.
+fn callback_mismatch_memo_disabled() -> bool {
+    use std::sync::OnceLock;
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| {
+        std::env::var("TSZ_DISABLE_CALLBACK_MISMATCH_MEMO")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false)
+    })
+}
+
 impl<'a> CheckerState<'a> {
     pub(crate) const fn should_preserve_speculative_call_diagnostic(
         diag: &crate::diagnostics::Diagnostic,
@@ -493,6 +507,23 @@ impl<'a> CheckerState<'a> {
             if expected == TypeId::ERROR || expected == TypeId::UNKNOWN || expected == TypeId::ANY {
                 return None;
             }
+            // Contextual-callback mismatch memo (#13250). Overload resolution and
+            // the union/signature-specific passes re-enter this derivation for
+            // the SAME `(callback arg, expected contextual type)` pair many
+            // times; each re-entry otherwise re-snapshots checker state,
+            // re-infers the callback body under contextual typing, and re-scans
+            // diagnostics. The result `(index, recovery_actual, expected)` is a
+            // pure function of that pair: the speculative inference is rolled
+            // back (incl. the saved `node_types[arg]`), so no durable state it
+            // reads varies between re-entries. Generator callbacks are excluded
+            // below because their `has_callback_body_diagnostic` term reads the
+            // durable diagnostic vector, which is not part of the key.
+            let memoizable = !callback_mismatch_memo_disabled() && !func.asterisk_token;
+            if memoizable
+                && let Some(&cached) = self.ctx.callback_mismatch_memo.get(&(arg_idx, expected))
+            {
+                return cached;
+            }
             let expected_is_concrete = expected != TypeId::ANY
                 && expected != TypeId::UNKNOWN
                 && expected != TypeId::ERROR
@@ -678,7 +709,18 @@ impl<'a> CheckerState<'a> {
             } else {
                 has_return_type_mismatch
             };
-            should_force_argument_mismatch.then_some((index, recovery_actual, expected))
+            let result = should_force_argument_mismatch.then_some((index, recovery_actual, expected));
+            // Publish the stable derivation. Only non-generator callbacks are
+            // memoized (the `memoizable` gate above excludes `func.asterisk_token`):
+            // the generator path's `has_callback_body_diagnostic` reads the
+            // durable diagnostic vector, which is not part of the `(arg,
+            // expected)` key.
+            if memoizable {
+                self.ctx
+                    .callback_mismatch_memo
+                    .insert((arg_idx, expected), result);
+            }
+            result
         })
     }
 

--- a/crates/tsz-checker/src/context/aliases.rs
+++ b/crates/tsz-checker/src/context/aliases.rs
@@ -1,14 +1,49 @@
 //! Type aliases and supporting types used across the checker context.
 //!
-//! Cross-binder index shapes, module-resolution caches, and the
+//! Cross-binder index shapes, module-resolution caches, the per-file
+//! member-access / accessor / callback-mismatch memo shapes, and the
 //! `ResolutionError` / `ResolutionModeOverride` helpers they depend on. Kept
 //! in one file so the `pub type`/helper-type surface doesn't dilute `mod.rs`.
 
 use rustc_hash::FxHashMap;
+use std::cell::RefCell;
 use std::sync::Arc;
 
 use tsz_binder::{ModuleAugmentation, SymbolId, SymbolTable};
+use tsz_common::interner::Atom;
+use tsz_parser::parser::NodeIndex;
 use tsz_solver::TypeId;
+
+/// Per-file memo value for `find_accessor_levels_in_hierarchy`: the resolved
+/// getter level, setter level, and the declaring-class node, or `None` when no
+/// getter/setter pair declares the requested name in the class chain. Keyed by
+/// `(class node, member-name Atom, is_static)` in
+/// [`crate::context::CheckerContext::accessor_levels_cache`].
+pub(crate) type AccessorLevelsCacheValue = Option<(
+    Option<crate::state::MemberAccessLevel>,
+    Option<crate::state::MemberAccessLevel>,
+    NodeIndex,
+)>;
+
+/// Per-file memo mapping `(class node, member-name Atom, is_static)` to the
+/// accessor-level classification produced by `find_accessor_levels_in_hierarchy`.
+/// Backs [`crate::context::CheckerContext::accessor_levels_cache`].
+pub(crate) type AccessorLevelsCache =
+    RefCell<FxHashMap<(NodeIndex, Atom, bool), AccessorLevelsCacheValue>>;
+
+/// Per-file memo mapping `(class node, member-name Atom, is_static)` to the
+/// access-restriction classification produced by `find_member_access_info`,
+/// or `None` when the member is public/absent. Backs
+/// [`crate::context::CheckerContext::member_access_info_cache`].
+pub(crate) type MemberAccessInfoCache =
+    RefCell<FxHashMap<(NodeIndex, Atom, bool), Option<crate::state::MemberAccessInfo>>>;
+
+/// Per-file memo for the contextual-callback return-type mismatch derivation
+/// (`raw_block_body_callback_mismatch`). Maps the inline callback argument node
+/// and its expected contextual type to the stable mismatch outcome
+/// `(arg index, recovery actual, expected)`, or `None` when no mismatch is
+/// forced. Backs [`crate::context::CheckerContext::callback_mismatch_memo`].
+pub type CallbackMismatchMemo = FxHashMap<(NodeIndex, TypeId), Option<(usize, TypeId, TypeId)>>;
 
 /// Flow-analysis result memo: `(FlowNodeId, SymbolId, InitialTypeId) ->
 /// NarrowedTypeId`.

--- a/crates/tsz-checker/src/context/checker_context_lifetimes.toml
+++ b/crates/tsz-checker/src/context/checker_context_lifetimes.toml
@@ -138,6 +138,7 @@ pending_implicit_any_vars = { lifetime = "SpeculationScoped", capability = "Spec
 pending_circular_return_sites = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 non_closure_circular_return_tracking_depth = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 inferred_return_type_memo = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "per-function resolved-return-type memo keyed by node, contextual type, and type-parameter-scope fingerprint; reset at file-session boundary" }
+callback_mismatch_memo = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "contextual-callback return-type mismatch memo keyed by callback argument node and expected contextual type; reset at file-session boundary" }
 reported_implicit_any_vars = { lifetime = "SpeculationScoped", capability = "SpeculationState", reason = "snapshot/rollback-sensitive state mutated during speculative checking" }
 inheritance_graph = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }
 node_resolution_stack = { lifetime = "FileLocalReset", capability = "FileTypeCache", reason = "checker-local mutable state tied to the active file or traversal; reset at file-session boundary" }

--- a/crates/tsz-checker/src/context/constructors.rs
+++ b/crates/tsz-checker/src/context/constructors.rs
@@ -370,6 +370,7 @@ impl<'a> CheckerContext<'a> {
             pending_circular_return_sites: PendingCircularReturnSites::default(),
             non_closure_circular_return_tracking_depth: 0,
             inferred_return_type_memo: FxHashMap::default(),
+            callback_mismatch_memo: FxHashMap::default(),
             reported_implicit_any_vars: crate::context::CowCache::default(),
             inheritance_graph: tsz_solver::classes::inheritance::InheritanceGraph::new(),
             node_resolution_stack: Vec::new(),

--- a/crates/tsz-checker/src/context/file_session_reset.rs
+++ b/crates/tsz-checker/src/context/file_session_reset.rs
@@ -266,6 +266,10 @@ impl<'a> CheckerContext<'a> {
         // The inferred-return-type memo keys on file-local node indices and
         // type-parameter `TypeId`s, so it shares the per-file lifecycle.
         self.inferred_return_type_memo.clear();
+        // The contextual-callback mismatch memo keys on file-local callback
+        // argument nodes and expected `TypeId`s, so it shares the same per-file
+        // lifecycle as the inferred-return-type memo.
+        self.callback_mismatch_memo.clear();
 
         // Symbol/circularity state whose keys or values are file-local
         // `SymbolId`s, plus string-name guards that are meaningful only inside

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -117,6 +117,13 @@ pub(crate) type AccessorLevelsCache =
 pub(crate) type MemberAccessInfoCache =
     RefCell<FxHashMap<(NodeIndex, Atom, bool), Option<crate::state::MemberAccessInfo>>>;
 
+/// Per-file memo for the contextual-callback return-type mismatch derivation
+/// (`raw_block_body_callback_mismatch`). Maps the inline callback argument node
+/// and its expected contextual type to the stable mismatch outcome
+/// `(arg index, recovery actual, expected)`, or `None` when no mismatch is
+/// forced. Backs [`CheckerContext::callback_mismatch_memo`].
+pub type CallbackMismatchMemo = FxHashMap<(NodeIndex, TypeId), Option<(usize, TypeId, TypeId)>>;
+
 /// Cache key for type-node results resolved under active generic bindings.
 ///
 /// Plain `node_types` entries are keyed only by `NodeIndex`, so they are safe
@@ -1367,6 +1374,18 @@ pub struct CheckerContext<'a> {
     /// provisional (in-progress) inference is never published. Cleared per file
     /// session like the other return-circularity caches.
     pub inferred_return_type_memo: FxHashMap<InferredReturnTypeKey, TypeId>,
+    /// Memo for the contextual-callback return-type mismatch derivation
+    /// (`raw_block_body_callback_mismatch`). Keyed by the inline callback
+    /// argument node and the expected contextual type for that argument. The
+    /// value is the stable mismatch outcome `(arg index, recovery actual,
+    /// expected)`, or `None` when no mismatch is forced. Overload resolution and
+    /// the union/signature-specific passes re-enter the derivation for the same
+    /// pair many times; the derivation snapshots and rolls back all speculative
+    /// state it touches, so its result is a pure function of the key. Only
+    /// non-generator callbacks are recorded (generator callbacks additionally
+    /// depend on the durable diagnostic vector). Cleared per file session like
+    /// `inferred_return_type_memo`.
+    pub callback_mismatch_memo: CallbackMismatchMemo,
     /// Variables that have already had TS7034 emitted, keyed by the deferred
     /// implicit-any classification that triggered it.
     pub reported_implicit_any_vars: CowCache<FxHashMap<SymbolId, PendingImplicitAnyKind>>,

--- a/crates/tsz-checker/src/context/mod.rs
+++ b/crates/tsz-checker/src/context/mod.rs
@@ -93,37 +93,6 @@ use tsz_parser::parser::node::NodeArena;
 pub type CrossFileTypeParamsCache =
     Arc<dashmap::DashMap<(u32, NodeIndex), Vec<tsz_solver::TypeParamInfo>>>;
 
-/// Per-file memo value for `find_accessor_levels_in_hierarchy`: the resolved
-/// getter level, setter level, and the declaring-class node, or `None` when no
-/// getter/setter pair declares the requested name in the class chain. Keyed by
-/// `(class node, member-name Atom, is_static)` in
-/// [`CheckerContext::accessor_levels_cache`].
-pub(crate) type AccessorLevelsCacheValue = Option<(
-    Option<crate::state::MemberAccessLevel>,
-    Option<crate::state::MemberAccessLevel>,
-    NodeIndex,
-)>;
-
-/// Per-file memo mapping `(class node, member-name Atom, is_static)` to the
-/// accessor-level classification produced by `find_accessor_levels_in_hierarchy`.
-/// Backs [`CheckerContext::accessor_levels_cache`].
-pub(crate) type AccessorLevelsCache =
-    RefCell<FxHashMap<(NodeIndex, Atom, bool), AccessorLevelsCacheValue>>;
-
-/// Per-file memo mapping `(class node, member-name Atom, is_static)` to the
-/// access-restriction classification produced by `find_member_access_info`,
-/// or `None` when the member is public/absent. Backs
-/// [`CheckerContext::member_access_info_cache`].
-pub(crate) type MemberAccessInfoCache =
-    RefCell<FxHashMap<(NodeIndex, Atom, bool), Option<crate::state::MemberAccessInfo>>>;
-
-/// Per-file memo for the contextual-callback return-type mismatch derivation
-/// (`raw_block_body_callback_mismatch`). Maps the inline callback argument node
-/// and its expected contextual type to the stable mismatch outcome
-/// `(arg index, recovery actual, expected)`, or `None` when no mismatch is
-/// forced. Backs [`CheckerContext::callback_mismatch_memo`].
-pub type CallbackMismatchMemo = FxHashMap<(NodeIndex, TypeId), Option<(usize, TypeId, TypeId)>>;
-
 /// Cache key for type-node results resolved under active generic bindings.
 ///
 /// Plain `node_types` entries are keyed only by `NodeIndex`, so they are safe

--- a/crates/tsz-core/Cargo.toml
+++ b/crates/tsz-core/Cargo.toml
@@ -119,5 +119,9 @@ harness = false
 name = "conditional_mapped_eval_bench"
 harness = false
 
+[[bench]]
+name = "contextual_callback_reentry_bench"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/tsz-core/benches/contextual_callback_reentry_bench.rs
+++ b/crates/tsz-core/benches/contextual_callback_reentry_bench.rs
@@ -1,0 +1,192 @@
+//! Contextual-callback re-entry microbench (#13250).
+//!
+//! Targets the `raw_block_body_callback_mismatch` re-entry surface in
+//! `call_checker/diagnostics.rs`. Deeply nested, overloaded generic callbacks
+//! force the block-body callback-mismatch derivation to re-run per overload
+//! candidate and per call site. Without an outer per-arg memo, each re-entry
+//! re-snapshots checker state, re-infers the callback body under contextual
+//! typing, and re-scans diagnostics.
+//!
+//! A/B is driven by the kill-switch env var on a single binary
+//! (`TSZ_DISABLE_CALLBACK_MISMATCH_MEMO=1` reverts to the legacy recompute) so
+//! the measurement isolates the memo from codegen drift.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use tsz_solver::construction::{QueryCache, TypeInterner};
+
+/// Emit an overload set whose callback parameter type differs per overload, so
+/// overload resolution re-derives the callback-mismatch check repeatedly for
+/// the same inline block-body argument.
+fn overloaded_pipe_decls() -> String {
+    let mut src = String::new();
+    // A function with many overloads, each taking a callback whose parameter
+    // and return shape differs.  Overload resolution evaluates every candidate
+    // that "succeeds" against the inline callback, re-running the mismatch
+    // derivation for the same callback node.
+    src.push_str(
+        r#"
+interface Box<T> { value: T; map<U>(f: (v: T) => U): Box<U>; }
+declare function pipe<A>(f: (a: A) => A): A;
+declare function pipe<A, B>(f1: (a: A) => B, f2: (b: B) => A): A;
+declare function pipe<A, B, C>(f1: (a: A) => B, f2: (b: B) => C, f3: (c: C) => A): A;
+declare function each<T>(xs: T[], f: (x: T) => void): void;
+declare function reduceTo<T, U>(xs: T[], f: (acc: U, x: T) => U, init: U): U;
+"#,
+    );
+    src
+}
+
+/// One deeply nested callback chain that re-enters the contextual-callback
+/// mismatch derivation many times: nested `map`/`reduce`/`pipe` block-body
+/// callbacks, each forcing a contextual re-inference of the inner callback.
+fn nested_callback_chain(i: usize) -> String {
+    format!(
+        r#"
+function chain{i}(box: Box<number>, items: number[]) {{
+    const r{i} = box
+        .map((v) => {{
+            const inner = reduceTo(items, (acc, x) => {{
+                const step = pipe(
+                    (a: number) => {{ return a + v; }},
+                    (b: number) => {{ return b * x; }},
+                    (c: number) => {{ return c - acc; }},
+                );
+                return acc + step;
+            }}, 0);
+            each(items, (y) => {{
+                const z = box.map((w) => {{ return w + y + inner; }});
+                void z;
+            }});
+            return inner + v;
+        }})
+        .map((n) => {{
+            return reduceTo(items, (acc, x) => {{ return acc + x + n; }}, 0);
+        }});
+    return r{i};
+}}
+"#
+    )
+}
+
+fn generate_source(chain_count: usize) -> String {
+    let mut src = String::with_capacity(chain_count * 800 + 512);
+    src.push_str(&overloaded_pipe_decls());
+    for i in 0..chain_count {
+        src.push_str(&nested_callback_chain(i));
+    }
+    src
+}
+
+/// A chain whose inline block-body callbacks force the mismatch derivation to
+/// return `Some` (a real callback return-type/body mismatch), so the parity
+/// dump also covers the error-emitting outcome of the memoized derivation.
+fn mismatching_callback_chain(i: usize) -> String {
+    format!(
+        r#"
+interface Typed{i} {{ map(f: (v: number) => string): void; }}
+declare const typed{i}: Typed{i};
+function mismatch{i}(items: number[]) {{
+    // Callback body returns `number` where `string` is expected.
+    typed{i}.map((v) => {{
+        const doubled = v * 2;
+        return doubled;
+    }});
+    // Overloaded call where every overload re-derives the callback mismatch.
+    each(items, (x) => {{
+        const r = reduceTo(items, (acc, y) => {{ return acc + y + x; }}, 0);
+        const bad: string = r;
+        void bad;
+    }});
+}}
+"#
+    )
+}
+
+fn generate_mismatch_source(chain_count: usize) -> String {
+    let mut src = String::with_capacity(chain_count * 600 + 512);
+    src.push_str(&overloaded_pipe_decls());
+    for i in 0..chain_count {
+        src.push_str(&mismatching_callback_chain(i));
+    }
+    src
+}
+
+fn check_diagnostics(source: &str) -> Vec<(u32, u32, u32, String)> {
+    let mut parser = tsz_core::parser::ParserState::new("bench.ts".to_string(), source.to_string());
+    let root = parser.parse_source_file();
+    let mut binder = tsz_core::binder::BinderState::new();
+    binder.bind_source_file(parser.get_arena(), root);
+    let interner = TypeInterner::new();
+    let query_cache = QueryCache::new(&interner);
+    let options = tsz_core::checker::context::CheckerOptions {
+        strict: true,
+        no_implicit_any: true,
+        strict_null_checks: true,
+        strict_function_types: true,
+        ..Default::default()
+    };
+    let mut checker = tsz_core::checker::state::CheckerState::new(
+        parser.get_arena(),
+        &binder,
+        &query_cache,
+        "bench.ts".to_string(),
+        options,
+    );
+    checker.check_source_file(root);
+    checker
+        .ctx
+        .diagnostics
+        .iter()
+        .map(|d| (d.code, d.start, d.length, d.message_text.clone()))
+        .collect()
+}
+
+fn check_once(source: &str) -> usize {
+    check_diagnostics(source).len()
+}
+
+fn bench_contextual_callback_reentry(c: &mut Criterion) {
+    // Parity-dump mode (#13250): write the normalized diagnostic set for each
+    // fixture size to /tmp so the memo-on and memo-off runs can be diffed for
+    // byte-identical output. Gated so it never affects timing samples.
+    if std::env::var_os("CBM_PARITY_DUMP").is_some() {
+        use std::fmt::Write as _;
+        let mut out = String::new();
+        for &n in &[20usize, 40, 80] {
+            let source = generate_source(n);
+            let diags = check_diagnostics(&source);
+            let _ = writeln!(out, "=== chains_{n}: {} diagnostics ===", diags.len());
+            for (code, start, length, msg) in &diags {
+                let _ = writeln!(out, "TS{code} @{start}+{length}: {msg}");
+            }
+        }
+        for &n in &[5usize, 20, 40] {
+            let source = generate_mismatch_source(n);
+            let diags = check_diagnostics(&source);
+            let _ = writeln!(out, "=== mismatch_{n}: {} diagnostics ===", diags.len());
+            for (code, start, length, msg) in &diags {
+                let _ = writeln!(out, "TS{code} @{start}+{length}: {msg}");
+            }
+        }
+        let path = std::env::var("CBM_PARITY_DUMP").unwrap_or_default();
+        let path = if path.is_empty() || path == "1" {
+            "/tmp/cbm_parity.txt".to_string()
+        } else {
+            path
+        };
+        std::fs::write(&path, out).expect("write parity dump");
+        return;
+    }
+    let mut group = c.benchmark_group("contextual_callback_reentry");
+    group.sample_size(20);
+    for &n in &[20usize, 40, 80] {
+        let source = generate_source(n);
+        group.bench_function(format!("chains_{n}"), |b| {
+            b.iter(|| criterion::black_box(check_once(&source)));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_contextual_callback_reentry);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Memoizes the contextual-callback return-type mismatch derivation
(`raw_block_body_callback_mismatch`) across its re-entry surface in
`call_checker/diagnostics.rs`. This is the live remaining half of the
`largerow-contextual-reentry-memo` aspect of #13250 (#13717 activated the inner
`inferred_return_type_memo`; this memoizes the outer derivation that re-snapshots
and re-scans around it).

## Structural rule

When an inline block-body callback argument is checked for a forced
return-type/body mismatch, overload resolution and the union/signature-specific
passes re-enter the derivation for the SAME `(callback arg node, expected
contextual type)` pair many times. `tsc` resolves each callback once; tsz was
re-running the full speculative re-inference (snapshot_full -> contextual
re-inference of the callback body -> diagnostic scan -> rollback_full) on every
re-entry. The owner layer is the checker call-diagnostics path; the result
`(arg index, recovery actual, expected)` is a pure function of the key because
the speculative inference (and the saved `node_types[arg]`) is rolled back, so
no durable state it reads varies between re-entries.

Fix: a per-file `callback_mismatch_memo: FxHashMap<(NodeIndex, TypeId),
Option<(usize, TypeId, TypeId)>>` keyed by `(callback arg node, expected)`,
`FileLocalReset` (cleared per file session like `inferred_return_type_memo`).

## Adjacent-case matrix / fallback

- Non-generator callbacks: memoized (the hot 93% path).
- Generator callbacks (`func.asterisk_token`): excluded — their
  `has_callback_body_diagnostic` term reads the durable diagnostic vector, which
  is not part of the key.
- `None` (no mismatch) and `Some` (mismatch fires, TS2345/TS2322) outcomes both
  covered and proven byte-identical.
- Kill-switch `TSZ_DISABLE_CALLBACK_MISMATCH_MEMO=1` reverts to recompute.

## Measurement (re-entry redundancy)

On a synthetic nested/overloaded contextual-callback fixture (40 chains, cold
check), the heavy per-arg path ran 5440 times; 5080 (93.4%) repeated an
already-seen `(arg, expected)` key, and the recomputed result was identical
every time (`result_mismatch=0`). This is the redundancy the memo eliminates.

## Performance (same-binary A/B, `contextual_callback_reentry_bench`)

Kill-switch toggled on one release binary (isolates the memo from codegen drift):

| fixture   | memo OFF | memo ON  | speedup       |
|-----------|----------|----------|---------------|
| chains_40 | 1.74 s   | 1.02 s   | 1.70x (-41%)  |
| chains_80 | 2.48 s   | 2.32 s   | 1.07-1.17x    |

chains_40 (callback-mismatch-dominated) is the cleanest signal; chains_80 has a
larger share of unrelated checking work so the relative win is smaller. Right
sign, reproducible across repeated runs.

## Verification

- Same-binary A/B above (`TSZ_DISABLE_CALLBACK_MISMATCH_MEMO` on/off).
- Diagnostics byte-identical memo-on vs memo-off across 6 fixtures (3 clean,
  3 error-emitting with TS2345/TS2322 callback-mismatch diagnostics) via the
  bench `CBM_PARITY_DUMP` mode -> `diff` IDENTICAL.
- `cargo clippy --profile ci-lint --workspace --exclude tsz-conformance
  --all-targets -- -D warnings`: clean.
- Clippy warn-ratchet: 109 below baseline (no rise).
- Broad conformance/emit/fourslash parity: ready-review CI.

## Provenance

Machine: studio
Assistant: claude-code
Model: claude-opus-4-8
Effort: high

Goal: fast
